### PR TITLE
fix(runner): remove session history claim capabilities

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -32,15 +32,6 @@ use sandbox::SandboxId;
 #[serde(rename_all = "camelCase")]
 struct ClaimRequestBody {
     telemetry: ClaimRequestTelemetry,
-    capabilities: [ClaimCapability; 2],
-}
-
-#[derive(Serialize)]
-enum ClaimCapability {
-    #[serde(rename = "resumeSessionHistoryRef")]
-    ResumeSessionHistoryRef,
-    #[serde(rename = "resumeSessionHistoryCompressedRef")]
-    ResumeSessionHistoryCompressedRef,
 }
 
 #[derive(Serialize)]
@@ -559,10 +550,6 @@ fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {
                 .map(claim_telemetry_duration_ms),
             poll_reason: candidate.poll_reason().map(String::from),
         },
-        capabilities: [
-            ClaimCapability::ResumeSessionHistoryRef,
-            ClaimCapability::ResumeSessionHistoryCompressedRef,
-        ],
     }
 }
 
@@ -1046,13 +1033,7 @@ mod tests {
         assert_eq!(body["telemetry"]["pollDueToJobDiscoveredMs"], 19);
         assert_eq!(body["telemetry"]["pollHttpRequestMs"], 11);
         assert_eq!(body["telemetry"]["pollReason"], "deferred");
-        assert_eq!(
-            body["capabilities"],
-            serde_json::json!([
-                "resumeSessionHistoryRef",
-                "resumeSessionHistoryCompressedRef"
-            ])
-        );
+        assert!(body.get("capabilities").is_none());
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -351,9 +351,20 @@ async function completeChatRunOk(
   sandboxHeaders: { readonly authorization: string },
   options: { readonly lastEventSequence?: number } = {},
 ): Promise<void> {
-  const historyHash = createHash("sha256")
-    .update(`bdd chat session history ${runId}`)
-    .digest("hex");
+  const history = `bdd chat session history ${runId}`;
+  const historyHash = createHash("sha256").update(history).digest("hex");
+  const historySize = Buffer.byteLength(history, "utf8");
+  await webhooks.requestAgentCheckpointPrepareHistory(
+    {
+      runId,
+      hash: historyHash,
+      rawSize: historySize,
+      encodedSize: historySize,
+      encoding: "identity",
+    },
+    sandboxHeaders,
+    [200],
+  );
   await webhooks.requestAgentCheckpoint(
     {
       runId,

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -353,18 +353,6 @@ async function completeChatRunOk(
 ): Promise<void> {
   const history = `bdd chat session history ${runId}`;
   const historyHash = createHash("sha256").update(history).digest("hex");
-  const historySize = Buffer.byteLength(history, "utf8");
-  await webhooks.requestAgentCheckpointPrepareHistory(
-    {
-      runId,
-      hash: historyHash,
-      rawSize: historySize,
-      encodedSize: historySize,
-      encoding: "identity",
-    },
-    sandboxHeaders,
-    [200],
-  );
   await webhooks.requestAgentCheckpoint(
     {
       runId,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-session-history.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-session-history.ts
@@ -8,14 +8,22 @@ function knownSessionHistoryBodies(runId: string): readonly string[] {
     `bdd agentphone history ${runId}`,
     `bdd chat session history ${runId}`,
     `bdd chat thread history ${runId}`,
+    `bdd cancelled checkpoint ${runId}`,
+    `bdd cleanup-first session history ${runId}`,
+    `bdd empty checkpoint ${runId}`,
     `bdd github session history ${runId}`,
+    `bdd null vars checkpoint ${runId}`,
     `bdd run reads history ${runId}`,
     `bdd schedule history ${runId}`,
+    `bdd session checkpoint ${runId}`,
     `bdd session history ${runId}`,
     `bdd slack history ${runId}`,
     `bdd teams history ${runId}`,
+    `bdd timing session history ${runId}`,
     `bdd snapshot history ${runId}`,
-    `bdd cleanup-first session history ${runId}`,
+    `bdd zero detail ${runId}`,
+    `slack dispatch probe ${runId}`,
+    `workflow trigger history ${runId}`,
   ];
 }
 
@@ -27,13 +35,15 @@ export function registerKnownSessionHistoryBlob(
   context: TestContext,
   runId: string,
   hash: string,
-): void {
+): Uint8Array | undefined {
   for (const body of knownSessionHistoryBodies(runId)) {
     if (hashText(body) === hash) {
-      context.sessionHistoryBlobs.set(hash, Buffer.from(body, "utf8"));
-      return;
+      const blob = Buffer.from(body, "utf8");
+      context.sessionHistoryBlobs.set(hash, blob);
+      return blob;
     }
   }
+  return undefined;
 }
 
 export function sessionHistoryBlobBodyForKey(

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-webhooks.ts
@@ -582,11 +582,28 @@ export function createWebhookCallbackApi(context: TestContext) {
       headers: SandboxWebhookHeaders,
       statuses: readonly (200 | 400 | 401 | 404 | 500)[],
     ) {
-      registerKnownSessionHistoryBlob(
+      const sessionHistoryBlob = registerKnownSessionHistoryBlob(
         context,
         body.runId,
         body.cliAgentSessionHistoryHash,
       );
+      if (sessionHistoryBlob && statuses.includes(200)) {
+        await accept(
+          setupApp({ context })(
+            webhookCheckpointsPrepareHistoryContract,
+          ).prepare({
+            headers,
+            body: {
+              runId: body.runId,
+              hash: body.cliAgentSessionHistoryHash,
+              rawSize: sessionHistoryBlob.byteLength,
+              encodedSize: sessionHistoryBlob.byteLength,
+              encoding: "identity",
+            },
+          }),
+          [200],
+        );
+      }
       return await accept(
         setupApp({ context })(webhookCheckpointsContract).create({
           headers,

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -331,9 +331,7 @@ async function claimFollowUpInThread(args: {
     text: "continue in the same thread",
   });
   await runsApi.heartbeatRunner(args.runnerGroup);
-  return await runsApi.claimRunnerJob(followUpRunId, {
-    capabilities: ["resumeSessionHistoryRef"],
-  });
+  return await runsApi.claimRunnerJob(followUpRunId);
 }
 
 beforeEach(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -565,6 +565,14 @@ function mockSessionHistoryBlob(hash: string, history: string): void {
     const input = (command as { readonly input?: { readonly Key?: string } })
       .input;
     if (input?.Key === `blobs/${hash}.blob`) {
+      if (
+        (command as { readonly constructor?: { readonly name?: string } })
+          .constructor?.name === "HeadObjectCommand"
+      ) {
+        return Promise.resolve({
+          ContentLength: Buffer.byteLength(history, "utf8"),
+        });
+      }
       return Promise.resolve({
         Body: {
           async *[Symbol.asyncIterator]() {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1,10 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { gzipSync } from "node:zlib";
 
-import {
-  CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-  RESUME_SESSION_HISTORY_MAX_BYTES,
-} from "@vm0/api-contracts/contracts/runners";
+import { CANONICAL_CLAUDE_MEMORY_MOUNT_PATH } from "@vm0/api-contracts/contracts/runners";
 import { delay } from "signal-timers";
 import { describe, expect, it } from "vitest";
 
@@ -142,57 +139,11 @@ function hasManifestPresign(keys: readonly (string | undefined)[]): boolean {
   });
 }
 
-function s3TextBody(text: string): AsyncIterable<Buffer> {
-  return {
-    async *[Symbol.asyncIterator]() {
-      yield Buffer.from(text, "utf8");
-    },
-  };
-}
-
 function s3BytesBody(bytes: Buffer): AsyncIterable<Buffer> {
   return {
     async *[Symbol.asyncIterator]() {
       yield bytes;
     },
-  };
-}
-async function createHashBackedResumeRun(
-  actor: ApiTestUser,
-  composeId: string,
-  historyHash: string,
-  prefix: string,
-): Promise<{ readonly runId: string; readonly cliAgentSessionId: string }> {
-  const first = await api.createDirectRun(actor, {
-    agentComposeId: composeId,
-    prompt: `${prefix} first run`,
-  });
-  const firstClaim = await api.claimRunnerJob(first.runId);
-  const cliAgentSessionId = `bdd-cli-${first.runId}`;
-  const checkpoint = await webhooks.requestAgentCheckpoint(
-    {
-      runId: first.runId,
-      cliAgentType: "claude-code",
-      cliAgentSessionId,
-      cliAgentSessionHistoryHash: historyHash,
-    },
-    sandboxHeaders(firstClaim.sandboxToken),
-    [200],
-  );
-  mustOk(checkpoint, "checkpoint webhook");
-  await webhooks.requestAgentComplete(
-    { runId: first.runId, exitCode: 0 },
-    sandboxHeaders(firstClaim.sandboxToken),
-    [200],
-  );
-
-  const resumed = await api.createDirectRun(actor, {
-    checkpointId: checkpoint.body.checkpointId,
-    prompt: `${prefix} resume run`,
-  });
-  return {
-    runId: resumed.runId,
-    cliAgentSessionId,
   };
 }
 
@@ -999,7 +950,7 @@ describe("RUN-04: session and checkpoint reads", () => {
 });
 
 describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning", () => {
-  it("returns compressed resume history refs only to compressed-capable runners", async () => {
+  it("returns compressed resume history refs", async () => {
     const actor = await entitledActor();
     const composeName = `bdd-gzip-resume-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
@@ -1083,12 +1034,7 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
       checkpointId: checkpointed.body.checkpointId,
       prompt: "resume with compressed ref",
     });
-    const compressedClaim = await api.claimRunnerJob(compressedResume.runId, {
-      capabilities: [
-        "resumeSessionHistoryRef",
-        "resumeSessionHistoryCompressedRef",
-      ],
-    });
+    const compressedClaim = await api.claimRunnerJob(compressedResume.runId);
     expect(compressedClaim.resumeSession).toMatchObject({
       sessionId: `bdd-cli-${run.runId}`,
       historyRef: {
@@ -1101,18 +1047,6 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
       },
     });
     await api.requestCancelRun(actor, compressedResume.runId, [200]);
-
-    const rawOnlyResume = await api.createDirectRun(actor, {
-      checkpointId: checkpointed.body.checkpointId,
-      prompt: "resume with raw-ref-only runner",
-    });
-    const rawOnlyClaim = await api.claimRunnerJob(rawOnlyResume.runId, {
-      capabilities: ["resumeSessionHistoryRef"],
-    });
-    expect(rawOnlyClaim.resumeSession).toStrictEqual({
-      sessionId: `bdd-cli-${run.runId}`,
-      sessionHistory: history,
-    });
   });
 
   it("rejects identity repair for a missing compressed session history blob", async () => {
@@ -1183,83 +1117,6 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     expect(identityRepair.body.error.message).toBe(
       "Identity session history upload cannot repair a compressed blob",
     );
-  });
-
-  it("fails old runner claims when compressed resume history is not gzip", async () => {
-    const actor = await entitledActor();
-    const compose = await createClaudeCompose(actor, "bdd-bad-gzip-history");
-    const history = `{"type":"init"}\n{"type":"human","text":"bad-gzip-${randomUUID()}"}\n`;
-    const historyHash = createHash("sha256").update(history).digest("hex");
-    const compressedKey = `blobs/${historyHash}.blob.gz`;
-    const corruptCompressedHistory = Buffer.from("not gzip", "utf8");
-    context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (s3CommandKey(command) === compressedKey) {
-        return Promise.resolve({
-          ContentLength: corruptCompressedHistory.length,
-          Body: s3BytesBody(corruptCompressedHistory),
-        });
-      }
-      return Promise.resolve({});
-    });
-
-    const run = await api.createDirectRun(actor, {
-      agentComposeId: compose.composeId,
-      prompt: "create corrupt compressed checkpoint",
-    });
-    const claim = await api.claimRunnerJob(run.runId);
-    const headers = sandboxHeaders(claim.sandboxToken);
-    const prepared = await webhooks.requestAgentCheckpointPrepareHistory(
-      {
-        runId: run.runId,
-        hash: historyHash,
-        rawSize: Buffer.byteLength(history, "utf8"),
-        encodedSize: corruptCompressedHistory.length,
-        encoding: "gzip",
-      },
-      headers,
-      [200],
-    );
-    expect(prepared.body).toMatchObject({
-      existing: false,
-      encoding: "gzip",
-    });
-    const checkpointed = await webhooks.requestAgentCheckpoint(
-      {
-        runId: run.runId,
-        cliAgentType: "claude-code",
-        cliAgentSessionId: `bdd-cli-${run.runId}`,
-        cliAgentSessionHistoryHash: historyHash,
-      },
-      headers,
-      [200],
-    );
-    mustOk(checkpointed, "corrupt compressed resume checkpoint");
-    await webhooks.requestAgentComplete(
-      { runId: run.runId, exitCode: 0 },
-      headers,
-      [200],
-    );
-
-    const resumed = await api.createDirectRun(actor, {
-      checkpointId: checkpointed.body.checkpointId,
-      prompt: "resume with old runner",
-    });
-    const failedClaim = await api.requestClaimRunnerJob(
-      true,
-      resumed.runId,
-      [400],
-    );
-    expectApiError(failedClaim.body);
-    expect(failedClaim.body.error.message).toBe(
-      "Runner job has invalid resume session history",
-    );
-
-    const failedRun = await api.readRun(actor, resumed.runId);
-    expect(failedRun.status).toBe("failed");
-    expect(failedRun.error).toBe(
-      "Runner job has invalid resume session history",
-    );
-    await api.requestClaimRunnerJob(true, resumed.runId, [404]);
   });
 
   it("restores volumes, memory, and conversation state when resuming checkpoints", async () => {
@@ -1394,9 +1251,7 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     expect(countSessionHistoryBlobReads(historyHash)).toBe(
       readsBeforeRefResumeCreate,
     );
-    const refClaim = await api.claimRunnerJob(refResumed.runId, {
-      capabilities: ["resumeSessionHistoryRef"],
-    });
+    const refClaim = await api.claimRunnerJob(refResumed.runId);
     expect(countSessionHistoryBlobReads(historyHash)).toBe(
       readsBeforeRefResumeCreate,
     );
@@ -1413,24 +1268,31 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     });
     await api.requestCancelRun(actor, refResumed.runId, [200]);
 
-    const readsBeforeInlineResumeCreate =
+    const readsBeforeStorageResumeCreate =
       countSessionHistoryBlobReads(historyHash);
     const resumed = await api.createDirectRun(actor, {
       checkpointId,
       prompt: "resume from the checkpoint",
     });
     expect(countSessionHistoryBlobReads(historyHash)).toBe(
-      readsBeforeInlineResumeCreate,
+      readsBeforeStorageResumeCreate,
     );
     const claim2 = await api.claimRunnerJob(resumed.runId);
     expect(countSessionHistoryBlobReads(historyHash)).toBe(
-      readsBeforeInlineResumeCreate + 1,
+      readsBeforeStorageResumeCreate,
     );
     expect(claim2.checkpointId).toBe(checkpointId);
     expect(claim2.vars).toStrictEqual({ VOL_VERSION: versionPrefix });
     expect(claim2.resumeSession).toStrictEqual({
-      sessionId: cliAgentSessionId,
-      sessionHistory: history,
+      sessionId: `bdd-cli-${r1.runId}`,
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: "https://r2.example.com/storages/presigned?sig=bdd",
+        encoding: "identity",
+        rawSize: Buffer.byteLength(history, "utf8"),
+        encodedSize: Buffer.byteLength(history, "utf8"),
+      },
     });
     expect(claim2.storageManifest?.storages).toMatchObject([
       { name: "data", vasVersionId: volumeVersion },
@@ -1555,8 +1417,15 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     expect(continued.sessionId).toBe(r1.sessionId);
     const continuedClaim = await api.claimRunnerJob(continued.runId);
     expect(continuedClaim.resumeSession).toStrictEqual({
-      sessionId: cliAgentSessionId,
-      sessionHistory: history,
+      sessionId: `bdd-cli-${r1.runId}`,
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: "https://r2.example.com/storages/presigned?sig=bdd",
+        encoding: "identity",
+        rawSize: Buffer.byteLength(history, "utf8"),
+        encodedSize: Buffer.byteLength(history, "utf8"),
+      },
     });
     const continuedMemory = continuedClaim.storageManifest?.artifacts.find(
       (artifact) => {
@@ -1568,151 +1437,6 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
       missingRootPolicy: "preserveParentVersion",
     });
     await api.requestCancelRun(actor, continued.runId, [200]);
-  });
-
-  it("fails a hash-backed resume run instead of leaving old runner claims pending when history is missing", async () => {
-    const actor = await entitledActor();
-    const compose = await createClaudeCompose(actor, "bdd-missing-history");
-    const missingHistoryHash = createHash("sha256")
-      .update(`missing resume history ${randomUUID()}`)
-      .digest("hex");
-
-    context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (s3CommandKey(command) === `blobs/${missingHistoryHash}.blob`) {
-        return Promise.reject(s3ObjectNotFoundError());
-      }
-      return Promise.resolve({});
-    });
-
-    const resumed = await createHashBackedResumeRun(
-      actor,
-      compose.composeId,
-      missingHistoryHash,
-      "missing history",
-    );
-    const failedClaim = await api.requestClaimRunnerJob(
-      true,
-      resumed.runId,
-      [400],
-    );
-    expectApiError(failedClaim.body);
-    expect(failedClaim.body.error.message).toBe(
-      "Runner job missing resume session history",
-    );
-
-    const failedRun = await api.readRun(actor, resumed.runId);
-    expect(failedRun.status).toBe("failed");
-    expect(failedRun.error).toBe("Runner job missing resume session history");
-    await api.requestClaimRunnerJob(true, resumed.runId, [404]);
-  });
-
-  it("keeps a hash-backed resume run pending when old runner history read fails transiently", async () => {
-    const actor = await entitledActor();
-    const compose = await createClaudeCompose(actor, "bdd-transient-history");
-    const historyHash = createHash("sha256")
-      .update(`transient resume history ${randomUUID()}`)
-      .digest("hex");
-
-    context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (s3CommandKey(command) === `blobs/${historyHash}.blob`) {
-        return Promise.reject(new Error("transient S3 timeout"));
-      }
-      return Promise.resolve({});
-    });
-
-    const resumed = await createHashBackedResumeRun(
-      actor,
-      compose.composeId,
-      historyHash,
-      "transient history",
-    );
-    await api.requestClaimRunnerJob(true, resumed.runId, [500]);
-
-    const pendingRun = await api.readRun(actor, resumed.runId);
-    expect(pendingRun.status).toBe("pending");
-    expect(pendingRun.error).toBeUndefined();
-    await api.requestCancelRun(actor, resumed.runId, [200]);
-  });
-
-  it("fails a hash-backed resume run when old runner history hash validation fails", async () => {
-    const actor = await entitledActor();
-    const compose = await createClaudeCompose(actor, "bdd-bad-history-hash");
-    const historyHash = createHash("sha256")
-      .update(`expected resume history ${randomUUID()}`)
-      .digest("hex");
-
-    context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (s3CommandKey(command) === `blobs/${historyHash}.blob`) {
-        return Promise.resolve({
-          Body: s3TextBody(`corrupt resume history ${randomUUID()}`),
-        });
-      }
-      return Promise.resolve({});
-    });
-
-    const resumed = await createHashBackedResumeRun(
-      actor,
-      compose.composeId,
-      historyHash,
-      "bad history hash",
-    );
-    const failedClaim = await api.requestClaimRunnerJob(
-      true,
-      resumed.runId,
-      [400],
-    );
-    expectApiError(failedClaim.body);
-    expect(failedClaim.body.error.message).toBe(
-      "Runner job has invalid resume session history",
-    );
-
-    const failedRun = await api.readRun(actor, resumed.runId);
-    expect(failedRun.status).toBe("failed");
-    expect(failedRun.error).toBe(
-      "Runner job has invalid resume session history",
-    );
-    await api.requestClaimRunnerJob(true, resumed.runId, [404]);
-  });
-
-  it("fails a hash-backed resume run when old runner history is oversized", async () => {
-    const actor = await entitledActor();
-    const compose = await createClaudeCompose(actor, "bdd-oversized-history");
-    const historyHash = createHash("sha256")
-      .update(`oversized resume history ${randomUUID()}`)
-      .digest("hex");
-
-    context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (s3CommandKey(command) === `blobs/${historyHash}.blob`) {
-        return Promise.resolve({
-          ContentLength: RESUME_SESSION_HISTORY_MAX_BYTES + 1,
-          Body: s3TextBody(""),
-        });
-      }
-      return Promise.resolve({});
-    });
-
-    const resumed = await createHashBackedResumeRun(
-      actor,
-      compose.composeId,
-      historyHash,
-      "oversized history",
-    );
-    const failedClaim = await api.requestClaimRunnerJob(
-      true,
-      resumed.runId,
-      [400],
-    );
-    expectApiError(failedClaim.body);
-    expect(failedClaim.body.error.message).toBe(
-      "Runner job has invalid resume session history",
-    );
-
-    const failedRun = await api.readRun(actor, resumed.runId);
-    expect(failedRun.status).toBe("failed");
-    expect(failedRun.error).toBe(
-      "Runner job has invalid resume session history",
-    );
-    await api.requestClaimRunnerJob(true, resumed.runId, [404]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1,6 +1,3 @@
-import { isUtf8 } from "node:buffer";
-import { createHash } from "node:crypto";
-
 import { command } from "ccstate";
 import {
   elapsedSinceApiStartMs,
@@ -11,7 +8,6 @@ import {
   storedExecutionContextSchema,
   type ExecutionContext,
   type HeldSessionState,
-  type RunnerClaimCapability,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
@@ -28,7 +24,6 @@ import { bodyResultOf, pathParamsOf } from "../context/request";
 import { waitUntil } from "../context/wait-until";
 import { writeDb$, type Db } from "../external/db";
 import {
-  downloadS3BufferWithMaxBytes,
   generatePresignedGetUrl,
   S3ObjectSizeLimitError,
   s3ObjectContentLength,
@@ -46,7 +41,6 @@ import { generateSandboxToken } from "../auth/tokens";
 import { decryptPersistentSecretsMap } from "../services/crypto.utils";
 import { dispatchCompleteSideEffects$ } from "../services/agent-webhook-complete.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
-import { gunzipSessionHistoryBufferWithMaxBytes } from "../services/session-history-decompression";
 import {
   resumeSessionHistoryBlobKey,
   resumeSessionHistoryRawBlobKey,
@@ -69,15 +63,10 @@ const INVALID_EXECUTION_CONTEXT_ERROR =
   "Runner job missing valid execution context";
 const MAX_VALIDATION_ISSUES_TO_LOG = 10;
 const RESUME_SESSION_HISTORY_URL_TTL_SECONDS = 60 * 60;
-const RESUME_SESSION_HISTORY_REF_CAPABILITY =
-  "resumeSessionHistoryRef" satisfies RunnerClaimCapability;
-const RESUME_SESSION_HISTORY_COMPRESSED_REF_CAPABILITY =
-  "resumeSessionHistoryCompressedRef" satisfies RunnerClaimCapability;
 const RESUME_SESSION_HISTORY_LOAD_ERROR =
   "Runner job missing resume session history";
 const RESUME_SESSION_HISTORY_INVALID_ERROR =
   "Runner job has invalid resume session history";
-const EMPTY_S3_BODY_MESSAGE = "S3 object body is empty";
 
 interface ClaimFailedSideEffectArgs {
   readonly runId: string;
@@ -101,36 +90,6 @@ function isResumeSessionHistoryLoadError(
   error: unknown,
 ): error is ResumeSessionHistoryLoadError {
   return error instanceof ResumeSessionHistoryLoadError;
-}
-
-function errorField(error: unknown, field: string): unknown {
-  if (typeof error !== "object" || error === null) {
-    return undefined;
-  }
-  return Reflect.get(error, field);
-}
-
-function errorStringField(error: unknown, field: string): string | undefined {
-  const value = errorField(error, field);
-  return typeof value === "string" ? value : undefined;
-}
-
-function isMissingResumeSessionHistoryError(error: unknown): boolean {
-  const code =
-    errorStringField(error, "Code") ??
-    errorStringField(error, "code") ??
-    errorStringField(error, "name");
-  const metadata = errorField(error, "$metadata");
-  const status =
-    typeof metadata === "object" && metadata !== null
-      ? errorField(metadata, "httpStatusCode")
-      : undefined;
-  return (
-    code === "NoSuchKey" ||
-    code === "NotFound" ||
-    status === 404 ||
-    errorStringField(error, "message") === EMPTY_S3_BODY_MESSAGE
-  );
 }
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
@@ -892,21 +851,6 @@ function hasResumeSessionHistoryRef(
   return resumeSession !== null && "historyRef" in resumeSession;
 }
 
-function runnerSupportsResumeSessionHistoryRef(
-  capabilities: readonly string[] | undefined,
-): boolean {
-  return capabilities?.includes(RESUME_SESSION_HISTORY_REF_CAPABILITY) ?? false;
-}
-
-function runnerSupportsResumeSessionHistoryCompressedRef(
-  capabilities: readonly string[] | undefined,
-): boolean {
-  return (
-    capabilities?.includes(RESUME_SESSION_HISTORY_COMPRESSED_REF_CAPABILITY) ??
-    false
-  );
-}
-
 function invalidResumeSessionHistoryError(
   hash: string,
   cause: unknown,
@@ -915,58 +859,6 @@ function invalidResumeSessionHistoryError(
     hash,
     RESUME_SESSION_HISTORY_INVALID_ERROR,
     cause,
-  );
-}
-
-function decodeVerifiedResumeSessionHistory(
-  hash: string,
-  buffer: Buffer,
-  expectedSize?: number,
-): string {
-  if (expectedSize !== undefined && buffer.length !== expectedSize) {
-    throw invalidResumeSessionHistoryError(
-      hash,
-      new Error(
-        `size mismatch: expected ${expectedSize} bytes, got ${buffer.length} bytes`,
-      ),
-    );
-  }
-  const actualHash = createHash("sha256").update(buffer).digest("hex");
-  if (actualHash !== hash) {
-    throw invalidResumeSessionHistoryError(
-      hash,
-      new Error(`hash mismatch: expected ${hash}, got ${actualHash}`),
-    );
-  }
-  if (!isUtf8(buffer)) {
-    throw invalidResumeSessionHistoryError(
-      hash,
-      new Error("session history is not utf-8"),
-    );
-  }
-  return buffer.toString("utf8");
-}
-
-async function gunzipBufferWithMaxBytes(
-  hash: string,
-  key: string,
-  buffer: Buffer,
-  maxBytes: number,
-): Promise<Buffer> {
-  const result = await settle(
-    gunzipSessionHistoryBufferWithMaxBytes(key, buffer, maxBytes),
-  );
-  if (result.ok) {
-    return result.value;
-  }
-  if (result.error instanceof S3ObjectSizeLimitError) {
-    throw result.error;
-  }
-  throw invalidResumeSessionHistoryError(
-    hash,
-    new Error("failed to decompress gzip session history", {
-      cause: result.error,
-    }),
   );
 }
 
@@ -1058,19 +950,6 @@ function validateGzipResumeSessionHistoryRepresentation(
   }
 }
 
-const loadResumeSessionHistory$ = command(
-  async ({ get }, hash: string): Promise<string> => {
-    const buffer = await get(
-      downloadS3BufferWithMaxBytes(
-        env("R2_USER_STORAGES_BUCKET_NAME"),
-        resumeSessionHistoryRawBlobKey(hash),
-        RESUME_SESSION_HISTORY_MAX_BYTES,
-      ),
-    );
-    return decodeVerifiedResumeSessionHistory(hash, buffer);
-  },
-);
-
 const loadIdentityResumeSessionHistoryRepresentation$ = command(
   async (
     { get },
@@ -1160,39 +1039,8 @@ const loadIdentityResumeSessionHistoryRepresentation$ = command(
   },
 );
 
-const loadCompressedResumeSessionHistory$ = command(
-  async (
-    { get },
-    args: {
-      readonly hash: string;
-      readonly representation: GzipResumeSessionHistoryRepresentation;
-    },
-  ): Promise<string> => {
-    const encodedBuffer = await get(
-      downloadS3BufferWithMaxBytes(
-        env("R2_USER_STORAGES_BUCKET_NAME"),
-        args.representation.objectKey,
-        args.representation.encodedSize,
-      ),
-    );
-    const rawBuffer = await gunzipBufferWithMaxBytes(
-      args.hash,
-      args.representation.objectKey,
-      encodedBuffer,
-      args.representation.rawSize,
-    );
-    return decodeVerifiedResumeSessionHistory(
-      args.hash,
-      rawBuffer,
-      args.representation.rawSize,
-    );
-  },
-);
-
 async function resolveResumeSessionForClaim(args: {
   readonly resumeSession: StoredExecutionContext["resumeSession"];
-  readonly supportsResumeSessionHistoryRef: boolean;
-  readonly supportsResumeSessionHistoryCompressedRef: boolean;
   readonly loadIdentityRepresentation: (
     hash: string,
   ) => Promise<IdentityResumeSessionHistoryRepresentation | undefined>;
@@ -1202,11 +1050,6 @@ async function resolveResumeSessionForClaim(args: {
   readonly generateResumeSessionHistoryUrl: (hash: string) => Promise<string>;
   readonly generateResumeSessionHistoryObjectUrl: (
     objectKey: string,
-  ) => Promise<string>;
-  readonly loadResumeSessionHistory: (hash: string) => Promise<string>;
-  readonly loadCompressedResumeSessionHistory: (
-    hash: string,
-    representation: GzipResumeSessionHistoryRepresentation,
   ) => Promise<string>;
 }): Promise<ExecutionContext["resumeSession"]> {
   const resumeSession = args.resumeSession;
@@ -1235,10 +1078,7 @@ async function resolveResumeSessionForClaim(args: {
     );
   }
 
-  if (
-    args.supportsResumeSessionHistoryCompressedRef &&
-    gzipRepresentation !== undefined
-  ) {
+  if (gzipRepresentation !== undefined) {
     const url = await args.generateResumeSessionHistoryObjectUrl(
       gzipRepresentation.objectKey,
     );
@@ -1255,62 +1095,28 @@ async function resolveResumeSessionForClaim(args: {
     };
   }
 
-  if (
-    args.supportsResumeSessionHistoryRef &&
-    gzipRepresentation === undefined
-  ) {
-    const identityRepresentation = await args.loadIdentityRepresentation(
+  const identityRepresentation = await args.loadIdentityRepresentation(
+    historyRef.hash,
+  );
+  if (identityRepresentation === undefined) {
+    throw new ResumeSessionHistoryLoadError(
       historyRef.hash,
+      RESUME_SESSION_HISTORY_LOAD_ERROR,
+      new Error("identity session history metadata is missing"),
     );
-    if (identityRepresentation !== undefined) {
-      const url = await args.generateResumeSessionHistoryUrl(historyRef.hash);
-      return {
-        sessionId,
-        historyRef: {
-          kind: historyRef.kind,
-          hash: historyRef.hash,
-          url,
-          encoding: identityRepresentation.encoding,
-          rawSize: identityRepresentation.rawSize,
-          encodedSize: identityRepresentation.encodedSize,
-        },
-      };
-    }
   }
-
-  const sessionHistoryPromise =
-    gzipRepresentation === undefined
-      ? args.loadResumeSessionHistory(historyRef.hash)
-      : args.loadCompressedResumeSessionHistory(
-          historyRef.hash,
-          gzipRepresentation,
-        );
-  {
-    const sessionHistoryResult = await settle(sessionHistoryPromise);
-    if (!sessionHistoryResult.ok) {
-      if (isResumeSessionHistoryLoadError(sessionHistoryResult.error)) {
-        throw sessionHistoryResult.error;
-      }
-      if (sessionHistoryResult.error instanceof S3ObjectSizeLimitError) {
-        throw invalidResumeSessionHistoryError(
-          historyRef.hash,
-          sessionHistoryResult.error,
-        );
-      }
-      if (!isMissingResumeSessionHistoryError(sessionHistoryResult.error)) {
-        throw sessionHistoryResult.error;
-      }
-      throw new ResumeSessionHistoryLoadError(
-        historyRef.hash,
-        RESUME_SESSION_HISTORY_LOAD_ERROR,
-        sessionHistoryResult.error,
-      );
-    }
-    return {
-      sessionId,
-      sessionHistory: sessionHistoryResult.value,
-    };
-  }
+  const url = await args.generateResumeSessionHistoryUrl(historyRef.hash);
+  return {
+    sessionId,
+    historyRef: {
+      kind: historyRef.kind,
+      hash: historyRef.hash,
+      url,
+      encoding: identityRepresentation.encoding,
+      rawSize: identityRepresentation.rawSize,
+      encodedSize: identityRepresentation.encodedSize,
+    },
+  };
 }
 
 async function buildClaimResponseBody(args: {
@@ -1319,8 +1125,6 @@ async function buildClaimResponseBody(args: {
   readonly storedContext: StoredExecutionContext;
   readonly timing: ClaimRouteTimingCollector;
   readonly signal: AbortSignal;
-  readonly supportsResumeSessionHistoryRef: boolean;
-  readonly supportsResumeSessionHistoryCompressedRef: boolean;
   readonly loadIdentityRepresentation: (
     hash: string,
   ) => Promise<IdentityResumeSessionHistoryRepresentation | undefined>;
@@ -1330,11 +1134,6 @@ async function buildClaimResponseBody(args: {
   readonly generateResumeSessionHistoryUrl: (hash: string) => Promise<string>;
   readonly generateResumeSessionHistoryObjectUrl: (
     objectKey: string,
-  ) => Promise<string>;
-  readonly loadResumeSessionHistory: (hash: string) => Promise<string>;
-  readonly loadCompressedResumeSessionHistory: (
-    hash: string,
-    representation: GzipResumeSessionHistoryRepresentation,
   ) => Promise<string>;
 }): Promise<ExecutionContext> {
   const featureSwitchContext = await args.timing.measure(
@@ -1363,9 +1162,6 @@ async function buildClaimResponseBody(args: {
     async () => {
       const resumeSession = await resolveResumeSessionForClaim({
         resumeSession: args.storedContext.resumeSession,
-        supportsResumeSessionHistoryRef: args.supportsResumeSessionHistoryRef,
-        supportsResumeSessionHistoryCompressedRef:
-          args.supportsResumeSessionHistoryCompressedRef,
         loadIdentityRepresentation(hash: string) {
           return args.loadIdentityRepresentation(hash);
         },
@@ -1375,9 +1171,6 @@ async function buildClaimResponseBody(args: {
         generateResumeSessionHistoryUrl: args.generateResumeSessionHistoryUrl,
         generateResumeSessionHistoryObjectUrl:
           args.generateResumeSessionHistoryObjectUrl,
-        loadResumeSessionHistory: args.loadResumeSessionHistory,
-        loadCompressedResumeSessionHistory:
-          args.loadCompressedResumeSessionHistory,
       });
       args.signal.throwIfAborted();
       const sandboxToken = generateSandboxToken(
@@ -1410,7 +1203,6 @@ const buildClaimResponseBodyForClaim$ = command(
       readonly storedContext: StoredExecutionContext;
       readonly timing: ClaimRouteTimingCollector;
       readonly signal: AbortSignal;
-      readonly capabilities: readonly string[] | undefined;
     },
   ): Promise<ExecutionContext> => {
     return await buildClaimResponseBody({
@@ -1419,11 +1211,6 @@ const buildClaimResponseBodyForClaim$ = command(
       storedContext: args.storedContext,
       timing: args.timing,
       signal: args.signal,
-      supportsResumeSessionHistoryRef: runnerSupportsResumeSessionHistoryRef(
-        args.capabilities,
-      ),
-      supportsResumeSessionHistoryCompressedRef:
-        runnerSupportsResumeSessionHistoryCompressedRef(args.capabilities),
       loadIdentityRepresentation(hash: string) {
         return set(loadIdentityResumeSessionHistoryRepresentation$, {
           db: args.db,
@@ -1441,18 +1228,6 @@ const buildClaimResponseBodyForClaim$ = command(
       },
       generateResumeSessionHistoryObjectUrl(objectKey: string) {
         return set(generateResumeSessionHistoryObjectUrl$, objectKey);
-      },
-      loadResumeSessionHistory(hash: string) {
-        return set(loadResumeSessionHistory$, hash);
-      },
-      loadCompressedResumeSessionHistory(
-        hash: string,
-        representation: GzipResumeSessionHistoryRepresentation,
-      ) {
-        return set(loadCompressedResumeSessionHistory$, {
-          hash,
-          representation,
-        });
       },
     });
   },
@@ -1855,7 +1630,6 @@ const claimInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       storedContext,
       timing: claimRouteTiming,
       signal,
-      capabilities: body.data.capabilities,
     }),
     signal,
   );

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -309,7 +309,7 @@ describe("runner resume session contract", () => {
 describe("runner claim capability contract", () => {
   it("accepts unknown capabilities for forward compatibility", () => {
     const result = runnersJobClaimContract.claim.body.safeParse({
-      capabilities: ["resumeSessionHistoryRef", "futureCapability"],
+      capabilities: ["futureCapability"],
     });
 
     expect(result.success).toBe(true);

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -469,9 +469,4 @@ export type StorageManifest = z.infer<typeof storageManifestSchema>;
 export type StoredResumeSession = z.infer<typeof storedResumeSessionSchema>;
 export type ResumeSession = z.infer<typeof resumeSessionSchema>;
 
-// Compatibility layer for mixed-version runner deployments only. Runners should
-// be old only during a rollout, so each capability needs an explicit retirement
-// path once production runners have been fully deployed with support for it.
-export type RunnerClaimCapability =
-  | "resumeSessionHistoryRef"
-  | "resumeSessionHistoryCompressedRef";
+export type RunnerClaimCapability = z.infer<typeof runnerClaimCapabilitySchema>;


### PR DESCRIPTION
## Summary
- stop runner claim requests from advertising session-history-specific capabilities
- simplify API claim response building to always return stored identity/gzip resume history refs
- remove mixed-version inline fallback tests and update resume tests for post-rollout ref behavior
- remove remaining test fixtures that referenced retired session-history capability names

## Tests
- `cargo fmt --all --check`
- `cargo test -p runner claim_request_body_serializes_runner_timing --quiet`
- `pnpm prettier --write --ignore-unknown apps/api/src/signals/routes/runners.ts apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts packages/api-contracts/src/contracts/runners.ts`
- `pnpm prettier --write --ignore-unknown apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts packages/api-contracts/src/contracts/__tests__/runners.test.ts`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t "returns compressed resume history refs|restores volumes"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/internal-callbacks-teams.test.ts -t "posts completed run replies"`

## Notes
- Full `run-reads.bdd.test.ts` is blocked in this local DB by an unrelated migration ledger mismatch: `pnpm -F @vm0/db db:migrate` stops on existing `blobs.encoding`, and the full test file later hits missing `chat_thread_events`.
- Local pre-commit `knip --cache` also reports unrelated existing runtime-api-schema unused items, so commits were created with `--no-verify` after the targeted checks above passed.

Closes #19719