### PR TITLE
test: cover ExecTermination deserialization contract

### DIFF
--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -921,6 +921,18 @@ mod tests {
     }
 
     #[test]
+    fn exec_termination_rejects_non_exited_unknown_fields() {
+        for kind in ["timed_out", "cancelled", "start_failed", "wait_failed"] {
+            let value = serde_json::json!({
+                "kind": kind,
+                "signal": 9,
+            });
+
+            assert!(serde_json::from_value::<ExecTermination>(value).is_err());
+        }
+    }
+
+    #[test]
     fn exec_termination_rejects_duplicate_fields() {
         for value in [
             r#"{"kind":"exited","kind":"timed_out","exit_code":0}"#,

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -880,6 +880,14 @@ mod tests {
     }
 
     #[test]
+    fn exec_termination_deserializes_exited_fields_in_any_order() {
+        let decoded =
+            serde_json::from_str::<ExecTermination>(r#"{"exit_code":0,"kind":"exited"}"#).unwrap();
+
+        assert_eq!(decoded, ExecTermination::Exited { exit_code: 0 });
+    }
+
+    #[test]
     fn exec_termination_rejects_invalid_shapes() {
         for value in [
             serde_json::json!({
@@ -901,6 +909,18 @@ mod tests {
                 "exit_code": 0,
                 "signal": 9,
             }),
+        ] {
+            assert!(serde_json::from_value::<ExecTermination>(value).is_err());
+        }
+    }
+
+    #[test]
+    fn exec_termination_rejects_non_object_shapes() {
+        for value in [
+            serde_json::Value::Null,
+            serde_json::json!("exited"),
+            serde_json::json!(0),
+            serde_json::json!(["exited"]),
         ] {
             assert!(serde_json::from_value::<ExecTermination>(value).is_err());
         }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -833,6 +833,97 @@ mod tests {
     }
 
     #[test]
+    fn exec_termination_deserializes_valid_shapes() {
+        for (value, expected) in [
+            (
+                serde_json::json!({
+                    "kind": "exited",
+                    "exit_code": 0,
+                }),
+                ExecTermination::Exited { exit_code: 0 },
+            ),
+            (
+                serde_json::json!({
+                    "kind": "timed_out",
+                }),
+                ExecTermination::TimedOut,
+            ),
+            (
+                serde_json::json!({
+                    "kind": "cancelled",
+                }),
+                ExecTermination::Cancelled,
+            ),
+            (
+                serde_json::json!({
+                    "kind": "start_failed",
+                }),
+                ExecTermination::StartFailed,
+            ),
+            (
+                serde_json::json!({
+                    "kind": "wait_failed",
+                }),
+                ExecTermination::WaitFailed,
+            ),
+        ] {
+            let decoded = serde_json::from_value::<ExecTermination>(value).unwrap();
+            assert_eq!(decoded, expected);
+        }
+    }
+
+    #[test]
+    fn exec_termination_rejects_invalid_shapes() {
+        for value in [
+            serde_json::json!({
+                "exit_code": 0,
+            }),
+            serde_json::json!({
+                "kind": "unknown",
+                "exit_code": 0,
+            }),
+            serde_json::json!({
+                "kind": "exited",
+            }),
+            serde_json::json!({
+                "kind": "exited",
+                "exit_code": null,
+            }),
+            serde_json::json!({
+                "kind": "exited",
+                "exit_code": 0,
+                "signal": 9,
+            }),
+        ] {
+            assert!(serde_json::from_value::<ExecTermination>(value).is_err());
+        }
+    }
+
+    #[test]
+    fn exec_termination_rejects_non_exited_exit_code() {
+        for kind in ["timed_out", "cancelled", "start_failed", "wait_failed"] {
+            for exit_code in [serde_json::json!(124), serde_json::Value::Null] {
+                let value = serde_json::json!({
+                    "kind": kind,
+                    "exit_code": exit_code,
+                });
+
+                assert!(serde_json::from_value::<ExecTermination>(value).is_err());
+            }
+        }
+    }
+
+    #[test]
+    fn exec_termination_rejects_duplicate_fields() {
+        for value in [
+            r#"{"kind":"exited","kind":"timed_out","exit_code":0}"#,
+            r#"{"kind":"exited","exit_code":0,"exit_code":1}"#,
+        ] {
+            assert!(serde_json::from_str::<ExecTermination>(value).is_err());
+        }
+    }
+
+    #[test]
     fn exec_result_new_defaults_to_exited() {
         let result = ExecResult::new(7, b"out".to_vec(), b"err".to_vec());
 

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -844,6 +844,13 @@ mod tests {
             ),
             (
                 serde_json::json!({
+                    "kind": "exited",
+                    "exit_code": -1,
+                }),
+                ExecTermination::Exited { exit_code: -1 },
+            ),
+            (
+                serde_json::json!({
                     "kind": "timed_out",
                 }),
                 ExecTermination::TimedOut,
@@ -917,7 +924,9 @@ mod tests {
     fn exec_termination_rejects_duplicate_fields() {
         for value in [
             r#"{"kind":"exited","kind":"timed_out","exit_code":0}"#,
+            r#"{"kind":"exited","kind":"exited","exit_code":0}"#,
             r#"{"kind":"exited","exit_code":0,"exit_code":1}"#,
+            r#"{"kind":"exited","exit_code":0,"exit_code":0}"#,
         ] {
             assert!(serde_json::from_str::<ExecTermination>(value).is_err());
         }

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -851,6 +851,24 @@ mod tests {
             ),
             (
                 serde_json::json!({
+                    "kind": "exited",
+                    "exit_code": i32::MIN,
+                }),
+                ExecTermination::Exited {
+                    exit_code: i32::MIN,
+                },
+            ),
+            (
+                serde_json::json!({
+                    "kind": "exited",
+                    "exit_code": i32::MAX,
+                }),
+                ExecTermination::Exited {
+                    exit_code: i32::MAX,
+                },
+            ),
+            (
+                serde_json::json!({
                     "kind": "timed_out",
                 }),
                 ExecTermination::TimedOut,
@@ -908,6 +926,22 @@ mod tests {
                 "kind": "exited",
                 "exit_code": 0,
                 "signal": 9,
+            }),
+        ] {
+            assert!(serde_json::from_value::<ExecTermination>(value).is_err());
+        }
+    }
+
+    #[test]
+    fn exec_termination_rejects_out_of_range_exit_code() {
+        for value in [
+            serde_json::json!({
+                "kind": "exited",
+                "exit_code": 2_147_483_648_i64,
+            }),
+            serde_json::json!({
+                "kind": "exited",
+                "exit_code": -2_147_483_649_i64,
             }),
         ] {
             assert!(serde_json::from_value::<ExecTermination>(value).is_err());


### PR DESCRIPTION
## Summary

- Add direct `ExecTermination` serde contract tests in the defining `sandbox` crate.
- Cover valid terminal states, missing/null `exit_code`, non-`exited` states with `exit_code`, unknown fields, unknown kind, and duplicate fields.
- Keep the custom deserializer because derive + `deny_unknown_fields` is not equivalent: it accepts a non-`exited` unit variant with `exit_code: null`.

Closes #19799

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox --lib`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::protocol`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox --all-targets --all-features -- -D warnings`
- pre-commit hook: cargo fmt, cargo doc, cargo clippy
