### PR TITLE
refactor(desktop): share single-flight async guards

### DIFF
--- a/turbo/apps/desktop/src/desktop-async-control.test.ts
+++ b/turbo/apps/desktop/src/desktop-async-control.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  latestWinsGuard,
+  latestWinsSingleFlight,
+  singleFlight,
+} from "./desktop-async-control";
+
+function deferred<TResult>() {
+  let resolve: (value: TResult) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<TResult>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("singleFlight", () => {
+  it("shares one in-flight task and clears after it settles", async () => {
+    const firstRefresh = deferred<string>();
+    const task = vi
+      .fn<() => Promise<string>>()
+      .mockReturnValueOnce(firstRefresh.promise)
+      .mockResolvedValueOnce("second");
+    const refresh = singleFlight(task);
+
+    const first = refresh();
+    const second = refresh();
+
+    expect(first).toBe(second);
+    expect(refresh.inFlight).toBe(true);
+    expect(task).toHaveBeenCalledOnce();
+
+    firstRefresh.resolve("first");
+    await expect(first).resolves.toBe("first");
+    expect(refresh.inFlight).toBe(false);
+
+    await expect(refresh()).resolves.toBe("second");
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a cleared old task unset a newer in-flight task", async () => {
+    const firstRefresh = deferred<string>();
+    const secondRefresh = deferred<string>();
+    const task = vi
+      .fn<() => Promise<string>>()
+      .mockReturnValueOnce(firstRefresh.promise)
+      .mockReturnValueOnce(secondRefresh.promise);
+    const refresh = singleFlight(task);
+
+    const first = refresh();
+    refresh.clear();
+    const second = refresh();
+
+    expect(task).toHaveBeenCalledTimes(2);
+
+    firstRefresh.resolve("first");
+    await expect(first).resolves.toBe("first");
+    expect(refresh.inFlight).toBe(true);
+
+    secondRefresh.resolve("second");
+    await expect(second).resolves.toBe("second");
+    expect(refresh.inFlight).toBe(false);
+  });
+});
+
+describe("latestWinsSingleFlight", () => {
+  it("coalesces repeated requests into one rerun after the current task", async () => {
+    const firstRun = deferred<void>();
+    const task = vi
+      .fn<() => Promise<void>>()
+      .mockReturnValueOnce(firstRun.promise)
+      .mockResolvedValueOnce(undefined);
+    const run = latestWinsSingleFlight(task);
+
+    run();
+    run();
+    run();
+
+    expect(task).toHaveBeenCalledOnce();
+
+    firstRun.resolve();
+    await flushPromises();
+
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports task errors and still runs the latest requested task", async () => {
+    const error = new Error("refresh failed");
+    const onError = vi.fn<(error: unknown) => void>();
+    const task = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const run = latestWinsSingleFlight(task, { onError });
+
+    run();
+    run();
+    await flushPromises();
+
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("latestWinsGuard", () => {
+  it("marks older tokens stale when a newer token is created", () => {
+    const next = latestWinsGuard();
+
+    const first = next();
+    expect(first.isCurrent()).toBe(true);
+
+    const second = next();
+
+    expect(first.isCurrent()).toBe(false);
+    expect(second.isCurrent()).toBe(true);
+  });
+});

--- a/turbo/apps/desktop/src/desktop-async-control.ts
+++ b/turbo/apps/desktop/src/desktop-async-control.ts
@@ -1,4 +1,4 @@
-export interface SingleFlightTask<TResult> {
+interface SingleFlightTask<TResult> {
   (): Promise<TResult>;
   clear: () => void;
   readonly inFlight: boolean;
@@ -72,7 +72,7 @@ export function latestWinsSingleFlight(
   };
 }
 
-export interface LatestWinsToken {
+interface LatestWinsToken {
   isCurrent: () => boolean;
 }
 

--- a/turbo/apps/desktop/src/desktop-async-control.ts
+++ b/turbo/apps/desktop/src/desktop-async-control.ts
@@ -1,0 +1,89 @@
+export interface SingleFlightTask<TResult> {
+  (): Promise<TResult>;
+  clear: () => void;
+  readonly inFlight: boolean;
+}
+
+export function singleFlight<TResult>(
+  task: () => Promise<TResult>,
+): SingleFlightTask<TResult> {
+  let inFlight: Promise<TResult> | null = null;
+
+  const run = (() => {
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const current = (async () => task())().finally(() => {
+      if (inFlight === current) {
+        inFlight = null;
+      }
+    });
+    inFlight = current;
+    return current;
+  }) as SingleFlightTask<TResult>;
+
+  run.clear = () => {
+    inFlight = null;
+  };
+
+  Object.defineProperty(run, "inFlight", {
+    get() {
+      return inFlight !== null;
+    },
+  });
+
+  return run;
+}
+
+export function latestWinsSingleFlight(
+  task: () => Promise<void>,
+  options: {
+    readonly onError?: (error: unknown) => void;
+  } = {},
+): () => void {
+  let running = false;
+  let rerunRequested = false;
+
+  const drain = async () => {
+    while (true) {
+      rerunRequested = false;
+      try {
+        await task();
+      } catch (error) {
+        options.onError?.(error);
+      }
+
+      if (!rerunRequested) {
+        running = false;
+        return;
+      }
+    }
+  };
+
+  return () => {
+    if (running) {
+      rerunRequested = true;
+      return;
+    }
+
+    running = true;
+    void drain();
+  };
+}
+
+export interface LatestWinsToken {
+  isCurrent: () => boolean;
+}
+
+export function latestWinsGuard(): () => LatestWinsToken {
+  let version = 0;
+
+  return () => {
+    version += 1;
+    const currentVersion = version;
+    return {
+      isCurrent: () => currentVersion === version,
+    };
+  };
+}

--- a/turbo/apps/desktop/src/desktop-auth-session.ts
+++ b/turbo/apps/desktop/src/desktop-auth-session.ts
@@ -4,6 +4,7 @@ import {
   headersWithSessionCookies,
   type DesktopSessionCookieSource,
 } from "./desktop-session-cookies";
+import { singleFlight } from "./desktop-async-control";
 
 const AUTH_ME_PATH = "/api/auth/me";
 const ZERO_ORG_PATH = "/api/zero/org";
@@ -96,7 +97,7 @@ export class DesktopAuthSession {
   private readonly onAuthCompleted: () => Promise<void> | void;
 
   private token: string | null = null;
-  private tokenRefresh: Promise<string | null> | null = null;
+  private readonly tokenRefresh = singleFlight(() => this.refreshToken());
   private pendingCallback: DesktopAuthCallback | null = null;
   private signingIn = false;
   private acceptsSignInCompletions = true;
@@ -211,7 +212,7 @@ export class DesktopAuthSession {
 
   signOut(): void {
     this.token = null;
-    this.tokenRefresh = null;
+    this.tokenRefresh.clear();
     this.pendingCallback = null;
     this.signingIn = false;
     this.acceptsSignInCompletions = false;
@@ -258,30 +259,22 @@ export class DesktopAuthSession {
   }
 
   private async refresh(): Promise<string | null> {
-    if (this.tokenRefresh) {
-      return await this.tokenRefresh;
-    }
+    return await this.tokenRefresh();
+  }
 
-    this.tokenRefresh = (async () => {
-      const before = this.token;
-      await this.runAuthWindow({
-        url: this.tokenUrl,
-        visible: false,
-        allowInteractiveFallbacks: false,
-      });
-      const after = this.token;
-      // completeSignIn() is the token's only write path. If the refresh window
-      // reached a completion navigation without ever delivering a token, the
-      // token is unchanged, so surface an explicit null instead of the stale
-      // value the 401 retry would otherwise resend.
-      return after === before ? null : after;
-    })();
-
-    try {
-      return await this.tokenRefresh;
-    } finally {
-      this.tokenRefresh = null;
-    }
+  private async refreshToken(): Promise<string | null> {
+    const before = this.token;
+    await this.runAuthWindow({
+      url: this.tokenUrl,
+      visible: false,
+      allowInteractiveFallbacks: false,
+    });
+    const after = this.token;
+    // completeSignIn() is the token's only write path. If the refresh window
+    // reached a completion navigation without ever delivering a token, the
+    // token is unchanged, so surface an explicit null instead of the stale
+    // value the 401 retry would otherwise resend.
+    return after === before ? null : after;
   }
 
   private setSigningIn(value: boolean): void {

--- a/turbo/apps/desktop/src/desktop-tray.ts
+++ b/turbo/apps/desktop/src/desktop-tray.ts
@@ -12,6 +12,7 @@ import {
   type DesktopTrayMenuActions,
   type DesktopTrayMenuItem,
 } from "./desktop-tray-menu";
+import { latestWinsGuard } from "./desktop-async-control";
 
 interface DesktopTrayControllerOptions {
   readonly displayName: string;
@@ -117,7 +118,7 @@ export class DesktopTrayController {
   private authState: DesktopAuthState | null = null;
   private authLoading = true;
   private authError: string | null = null;
-  private authRefreshVersion = 0;
+  private readonly nextAuthRefresh = latestWinsGuard();
   private iconFrame: DesktopTrayIconFrame | null = null;
   private readonly iconCache = new Map<DesktopTrayIconFrame, NativeImage>();
   private runningActivityUntilMs: number | null = null;
@@ -281,14 +282,13 @@ export class DesktopTrayController {
   }
 
   refreshAuth(): void {
-    const version = this.authRefreshVersion + 1;
-    this.authRefreshVersion = version;
+    const refresh = this.nextAuthRefresh();
     this.authLoading = true;
     this.refresh();
     void this.options
       .getAuthState()
       .then((authState) => {
-        if (version !== this.authRefreshVersion) {
+        if (!refresh.isCurrent()) {
           return;
         }
         this.authState = authState;
@@ -297,7 +297,7 @@ export class DesktopTrayController {
         this.refresh();
       })
       .catch((error: unknown) => {
-        if (version !== this.authRefreshVersion) {
+        if (!refresh.isCurrent()) {
           return;
         }
         this.authError = error instanceof Error ? error.message : String(error);

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -104,6 +104,7 @@ import {
   showDockForVisibleMainWindow,
 } from "./desktop-window-lifecycle";
 import { buildDesktopWindowChromeOptions } from "./desktop-window-chrome";
+import { latestWinsSingleFlight } from "./desktop-async-control";
 import {
   desktopRendererFilePath,
   desktopRendererUrl,
@@ -151,8 +152,6 @@ let keepAwakeController: DesktopKeepAwakeController | null = null;
 let filesystemPluginManager: DesktopFilesystemPluginManager | null = null;
 let developerToolsAvailable = false;
 let developerToolsEnabled = false;
-let developerToolsRefresh: Promise<void> | null = null;
-let developerToolsRefreshRequested = false;
 let desktopAutoUpdatesInstalled = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 let computerUseRuntime: ComputerUseHostRuntime | null = null;
@@ -300,24 +299,15 @@ async function refreshDeveloperToolsAvailability(): Promise<void> {
   );
 }
 
-function refreshDeveloperToolsAvailabilityForState(): void {
-  if (developerToolsRefresh) {
-    developerToolsRefreshRequested = true;
-    return;
-  }
-  developerToolsRefresh = refreshDeveloperToolsAvailability()
-    .catch((error) => {
+const refreshDeveloperToolsAvailabilityForState = latestWinsSingleFlight(
+  refreshDeveloperToolsAvailability,
+  {
+    onError: (error) => {
       console.warn("Unable to refresh desktop developer tools state", error);
       setDeveloperToolsAvailability(false);
-    })
-    .finally(() => {
-      developerToolsRefresh = null;
-      if (developerToolsRefreshRequested) {
-        developerToolsRefreshRequested = false;
-        refreshDeveloperToolsAvailabilityForState();
-      }
-    });
-}
+    },
+  },
+);
 
 async function runAuthWindow(request: {
   readonly url: string;


### PR DESCRIPTION
## Summary
- add shared desktop async-control helpers for single-flight, latest queued reruns, and latest-wins stale guards
- migrate DesktopAuthSession, developer-tools availability refresh, and DesktopTrayController to the shared helpers
- add focused unit tests for the shared concurrency semantics

Fixes #19840

## Testing
- pnpm exec prettier --write apps/desktop/src/desktop-async-control.ts apps/desktop/src/desktop-async-control.test.ts apps/desktop/src/desktop-auth-session.ts apps/desktop/src/desktop-tray.ts apps/desktop/src/main.ts
- pnpm -F @vm0/desktop lint
- pnpm -F @vm0/desktop check-types
- pnpm -F @vm0/desktop exec vitest run src/desktop-async-control.test.ts src/desktop-auth-session.test.ts src/desktop-tray.test.ts