### PR TITLE
feat: move workflow prompt action to composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4003,7 +4003,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("starts a workflow prompt from an assistant message when the composer is empty", async () => {
+  it("starts a workflow prompt from the composer when the composer is empty", async () => {
     const user = userEvent.setup({ delay: null });
     const threadId = "assistant-message-create-workflow-empty";
     const assistantReply = "We can turn this into a workflow.";
@@ -4042,11 +4042,13 @@ describe("chat lifecycle", () => {
     if (!(assistantGroup instanceof HTMLElement)) {
       throw new Error("assistant message group not found");
     }
-    const copyButton = within(assistantGroup).getByLabelText("Copy message");
-    const workflowButton =
-      within(assistantGroup).getByLabelText("Create workflow");
     expect(
-      copyButton.compareDocumentPosition(workflowButton) &
+      within(assistantGroup).queryByLabelText("Create workflow"),
+    ).not.toBeInTheDocument();
+    const templateButton = buttonByLabel("Template");
+    const workflowButton = buttonByLabel("Create workflow");
+    expect(
+      templateButton.compareDocumentPosition(workflowButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
@@ -4110,13 +4112,8 @@ describe("chat lifecycle", () => {
       expect(editor).toHaveTextContent(draft);
     });
 
-    const assistantMessage = await screen.findByText(assistantReply);
-    const assistantGroup = assistantMessage.closest('[data-role="assistant"]');
-    if (!(assistantGroup instanceof HTMLElement)) {
-      throw new Error("assistant message group not found");
-    }
-    const workflowButton =
-      within(assistantGroup).getByLabelText("Create workflow");
+    await screen.findByText(assistantReply);
+    const workflowButton = buttonByLabel("Create workflow");
 
     click(workflowButton);
 
@@ -4181,14 +4178,8 @@ describe("chat lifecycle", () => {
       },
     });
 
-    const assistantMessage = await screen.findByText(assistantReply);
-    const assistantGroup = assistantMessage.closest('[data-role="assistant"]');
-    if (!(assistantGroup instanceof HTMLElement)) {
-      throw new Error("assistant message group not found");
-    }
-    expect(
-      within(assistantGroup).queryByLabelText("Create workflow"),
-    ).not.toBeInTheDocument();
+    await screen.findByText(assistantReply);
+    expect(screen.queryByLabelText("Create workflow")).not.toBeInTheDocument();
   });
 
   it("shows linked automations from the chat header sidebar", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -322,6 +322,7 @@ interface ZeroChatComposerProps {
     value: GenerationTemplateRequest | undefined;
     onChange: (value: GenerationTemplateRequest | undefined) => void;
   };
+  onCreateWorkflowPrompt?: () => void;
   computerUse?: {
     hosts: readonly ComposerComputerUseHost[];
     loading: boolean;
@@ -5393,6 +5394,49 @@ function ComposerTemplatePickerSlot({
   );
 }
 
+function CreateWorkflowPromptButton({
+  onCreateWorkflowPrompt,
+}: {
+  onCreateWorkflowPrompt: () => void;
+}) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 hover:bg-accent hover:text-foreground sm:h-9 sm:w-9"
+            aria-label="Create workflow"
+            onClick={onCreateWorkflowPrompt}
+          >
+            <IconRoute size={18} stroke={1.5} aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          Create workflow
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function ComposerWorkflowPromptSlot({
+  workflowAutomationEnabled,
+  onCreateWorkflowPrompt,
+}: {
+  workflowAutomationEnabled: boolean;
+  onCreateWorkflowPrompt: (() => void) | undefined;
+}) {
+  if (!workflowAutomationEnabled || !onCreateWorkflowPrompt) {
+    return null;
+  }
+  return (
+    <CreateWorkflowPromptButton
+      onCreateWorkflowPrompt={onCreateWorkflowPrompt}
+    />
+  );
+}
+
 function ConnectorTriggerIcons({
   connectors,
   hasComputerUse,
@@ -6445,6 +6489,7 @@ export function ZeroChatComposer({
   actionsLoading = false,
   modelPicker,
   templatePicker,
+  onCreateWorkflowPrompt,
   computerUse,
   modelPickerLoading = false,
   submitBlocker,
@@ -6906,6 +6951,10 @@ export function ZeroChatComposer({
                   <ComposerTemplatePickerSlot
                     picker={templatePicker}
                     workflowAutomationEnabled={workflowAutomationEnabled}
+                  />
+                  <ComposerWorkflowPromptSlot
+                    workflowAutomationEnabled={workflowAutomationEnabled}
+                    onCreateWorkflowPrompt={onCreateWorkflowPrompt}
                   />
                   <ConnectorsPopoverButton
                     agentConnectors={agentConnectors}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4850,6 +4850,96 @@ function useChatThreadComposerFeedback(
   };
 }
 
+function useChatThreadComposerWorkflowPrompt({
+  thread,
+  input,
+  pageSignal,
+}: {
+  thread: ChatThreadSignals;
+  input: string;
+  pageSignal: AbortSignal;
+}): {
+  onCreateWorkflowPrompt: (() => void) | undefined;
+  replaceDraftDialogOpen: boolean;
+  onConfirmReplaceDraft: () => void;
+  onReplaceDialogOpenChange: (open: boolean) => void;
+} {
+  const attachments = useGet(thread.draft.attachments$);
+  const setInput = useSet(thread.draft.setInput$);
+  const clearDraft = useSet(thread.draft.clear$);
+  const queueDraftSync = useSet(thread.queueDraftSync$);
+  const focusComposer = useSet(thread.focusInput$);
+  const features = useGet(featureSwitch$);
+  const replaceDraftTarget = useGet(replaceWorkflowPromptDraftTarget$);
+  const setReplaceDraftTarget = useSet(setReplaceWorkflowPromptDraftTarget$);
+  const workflowAutomationEnabled =
+    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
+  const workflowPromptDraftTarget = `composer:${thread.threadId}`;
+  const hasComposerDraft = input.trim().length > 0 || attachments.length > 0;
+  const replaceDraftDialogOpen =
+    replaceDraftTarget === workflowPromptDraftTarget;
+
+  const applyWorkflowPrompt = () => {
+    clearDraft();
+    setInput(CREATE_WORKFLOW_WITH_CHAT_PROMPT);
+    detach(queueDraftSync(pageSignal), Reason.DomCallback);
+    focusComposer();
+  };
+
+  const handleCreateWorkflowPrompt = () => {
+    if (hasComposerDraft) {
+      setReplaceDraftTarget(workflowPromptDraftTarget);
+      return;
+    }
+    applyWorkflowPrompt();
+  };
+
+  const handleConfirmReplaceDraft = () => {
+    setReplaceDraftTarget(null);
+    applyWorkflowPrompt();
+  };
+
+  const handleReplaceDialogOpenChange = (open: boolean) => {
+    setReplaceDraftTarget(open ? workflowPromptDraftTarget : null);
+  };
+
+  return {
+    onCreateWorkflowPrompt: workflowAutomationEnabled
+      ? handleCreateWorkflowPrompt
+      : undefined,
+    replaceDraftDialogOpen,
+    onConfirmReplaceDraft: handleConfirmReplaceDraft,
+    onReplaceDialogOpenChange: handleReplaceDialogOpenChange,
+  };
+}
+
+function resolveChatThreadComposerActivity({
+  groups,
+  sending,
+}: {
+  groups: readonly GroupedChatMessageGroup[];
+  sending: boolean;
+}): {
+  composerSending: boolean;
+  queueWhileSending: boolean;
+} {
+  const lastGroup = groups[groups.length - 1];
+  const lastIsAssistant = lastGroup?.role === "assistant";
+  const lastAssistantMessage =
+    lastIsAssistant && lastGroup
+      ? lastGroup.messages[lastGroup.messages.length - 1]
+      : undefined;
+  const lastAssistantCancelled =
+    isCancelledAssistantMessage(lastAssistantMessage);
+  const composerSending = sending && !lastAssistantCancelled;
+  return {
+    composerSending,
+    queueWhileSending: canQueueMessage({
+      sending: composerSending,
+    }),
+  };
+}
+
 function ChatThreadComposer({
   thread,
   autoFocus: autoFocusProp = true,
@@ -4905,18 +4995,11 @@ function ChatThreadComposer({
     });
   const sending = (allFinishedResolved && !allFinished) || sendLoading;
   const skeletonVisible = useGet(thread.skeletonVisible$);
-  const lastGroup = groups[groups.length - 1];
-  const lastIsAssistant = lastGroup?.role === "assistant";
-  const lastAssistantMessage =
-    lastIsAssistant && lastGroup
-      ? lastGroup.messages[lastGroup.messages.length - 1]
-      : undefined;
-  const lastAssistantCancelled =
-    isCancelledAssistantMessage(lastAssistantMessage);
-  const composerSending = sending && !lastAssistantCancelled;
-  const queueWhileSending = canQueueMessage({
-    sending: composerSending,
-  });
+  const { composerSending, queueWhileSending } =
+    resolveChatThreadComposerActivity({
+      groups,
+      sending,
+    });
 
   const handleInputChange = (text: string) => {
     setInput(text);
@@ -4928,6 +5011,11 @@ function ChatThreadComposer({
   };
 
   const feedback = useChatThreadComposerFeedback(thread, modelSelection);
+  const workflowPrompt = useChatThreadComposerWorkflowPrompt({
+    thread,
+    input,
+    pageSignal,
+  });
 
   return (
     <footer
@@ -4968,6 +5056,7 @@ function ChatThreadComposer({
             actionsLoading={skeletonVisible}
             modelPicker={modelPicker}
             templatePicker={templatePicker}
+            onCreateWorkflowPrompt={workflowPrompt.onCreateWorkflowPrompt}
             computerUse={computerUse}
             modelPickerLoading={modelPickerLoading}
             submitBlocker={submitBlockerProps}
@@ -4976,6 +5065,11 @@ function ChatThreadComposer({
             activeGoal={activeGoal}
             onCancelActiveGoal={onCancelActiveGoal}
             feedback={feedback}
+          />
+          <ReplaceComposerDraftDialog
+            open={workflowPrompt.replaceDraftDialogOpen}
+            onOpenChange={workflowPrompt.onReplaceDialogOpenChange}
+            onConfirm={workflowPrompt.onConfirmReplaceDraft}
           />
           <PersonalClaudeCodeDeviceAuthDialog />
           <PersonalCodexDeviceAuthDialog />
@@ -7601,16 +7695,12 @@ function PagedGroupPrimaryActions({
   usage,
   copied,
   onCopy,
-  workflowAutomationEnabled,
-  onCreateWorkflow,
 }: {
   firstRunId: string | undefined;
   hasContent: boolean;
   usage: ChatMessageUsagePayload | undefined;
   copied: boolean;
   onCopy: () => void;
-  workflowAutomationEnabled: boolean;
-  onCreateWorkflow: () => void;
 }) {
   return (
     <div className="flex items-center gap-1" data-testid="chat-message-actions">
@@ -7653,23 +7743,6 @@ function PagedGroupPrimaryActions({
             <TooltipContent side="bottom">
               {copied ? "Copied!" : "Copy message"}
             </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      )}
-      {workflowAutomationEnabled && (
-        <TooltipProvider delayDuration={300}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={onCreateWorkflow}
-                className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors duration-150"
-                aria-label="Create workflow"
-              >
-                <IconRoute size={18} stroke={1.5} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Create workflow</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       )}
@@ -7729,26 +7802,12 @@ function PagedGroupActions({
   const copiedId = useGet(thread.copiedMessageId$);
   const copied = copiedId === group.beginMessageId;
   const copyMessage = useSet(thread.copyMessage$);
-  const composerInput = useGet(thread.draft.input$);
-  const composerAttachments = useGet(thread.draft.attachments$);
-  const setComposerInput = useSet(thread.draft.setInput$);
-  const clearComposerDraft = useSet(thread.draft.clear$);
-  const queueDraftSync = useSet(thread.queueDraftSync$);
-  const focusComposer = useSet(thread.focusInput$);
-  const features = useGet(featureSwitch$);
-  const replaceDraftTarget = useGet(replaceWorkflowPromptDraftTarget$);
-  const setReplaceDraftTarget = useSet(setReplaceWorkflowPromptDraftTarget$);
 
   const firstRunId = group.messages.find((m) => {
     return m.runId;
   })?.runId;
   const usage = group.usage;
   const hasContent = content.length > 0;
-  const workflowAutomationEnabled =
-    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
-  const hasComposerDraft =
-    composerInput.trim().length > 0 || composerAttachments.length > 0;
-  const replaceDraftDialogOpen = replaceDraftTarget === group.beginMessageId;
 
   if (group.role === "user") {
     return null;
@@ -7768,51 +7827,18 @@ function PagedGroupActions({
     );
   };
 
-  const applyWorkflowPrompt = () => {
-    clearComposerDraft();
-    setComposerInput(CREATE_WORKFLOW_WITH_CHAT_PROMPT);
-    detach(queueDraftSync(pageSignal), Reason.DomCallback);
-    focusComposer();
-  };
-
-  const handleCreateWorkflow = () => {
-    if (hasComposerDraft) {
-      setReplaceDraftTarget(group.beginMessageId);
-      return;
-    }
-    applyWorkflowPrompt();
-  };
-
-  const handleConfirmReplaceDraft = () => {
-    setReplaceDraftTarget(null);
-    applyWorkflowPrompt();
-  };
-
-  const handleReplaceDialogOpenChange = (open: boolean) => {
-    setReplaceDraftTarget(open ? group.beginMessageId : null);
-  };
-
   return (
-    <>
-      <div className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]">
-        <div className="hidden @[900px]:block" />
-        <div className="flex items-center justify-between pt-2 pb-1 gap-2 -ml-1">
-          <PagedGroupPrimaryActions
-            firstRunId={firstRunId}
-            hasContent={hasContent}
-            usage={usage}
-            copied={copied}
-            onCopy={handleCopy}
-            workflowAutomationEnabled={workflowAutomationEnabled}
-            onCreateWorkflow={handleCreateWorkflow}
-          />
-        </div>
+    <div className="@[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px]">
+      <div className="hidden @[900px]:block" />
+      <div className="flex items-center justify-between pt-2 pb-1 gap-2 -ml-1">
+        <PagedGroupPrimaryActions
+          firstRunId={firstRunId}
+          hasContent={hasContent}
+          usage={usage}
+          copied={copied}
+          onCopy={handleCopy}
+        />
       </div>
-      <ReplaceComposerDraftDialog
-        open={replaceDraftDialogOpen}
-        onOpenChange={handleReplaceDialogOpenChange}
-        onConfirm={handleConfirmReplaceDraft}
-      />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- move the Create workflow prompt action from assistant message actions onto the chat composer next to Template
- reuse the existing workflow prompt draft replacement confirmation flow from the composer
- update chat lifecycle coverage for the new composer placement and feature-switch hiding

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "workflow prompt"
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx --max-warnings 0
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/zero-chat-thread-page.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx