### PR TITLE
perf(mitm-addon): adapt zstd stream input chunks

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -32,7 +32,10 @@ _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
 _ZSTD_STREAM_DECODE_MIN_INPUT_CHUNK_SIZE = 4
-_ZSTD_STREAM_DECODE_MAX_INPUT_CHUNK_SIZE = 4 * 1024
+# The streaming zstd API does not expose a per-call output limit. Keep the
+# adaptive ceiling small so a low-ratio prefix cannot make a later high-ratio
+# block materialise a multi-MB decoded ``bytes`` object before _feed_chunks().
+_ZSTD_STREAM_DECODE_MAX_INPUT_CHUNK_SIZE = 12
 _ZSTD_STREAM_DECODE_INPUT_GROWTH_FACTOR = 2
 _ZSTD_STREAM_DECODE_LOW_EXPANSION_RATIO = 2
 

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -31,7 +31,10 @@ from body_limits import (
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
-_ZSTD_STREAM_DECODE_INPUT_CHUNK_SIZE = 4
+_ZSTD_STREAM_DECODE_MIN_INPUT_CHUNK_SIZE = 4
+_ZSTD_STREAM_DECODE_MAX_INPUT_CHUNK_SIZE = 4 * 1024
+_ZSTD_STREAM_DECODE_INPUT_GROWTH_FACTOR = 2
+_ZSTD_STREAM_DECODE_LOW_EXPANSION_RATIO = 2
 
 INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
@@ -85,6 +88,33 @@ def _feed_chunks(feed: _StreamDecodeFeed, data: bytes, max_decoded_chunk: int) -
 
 def _no_stream_decode_error() -> str | None:
     return None
+
+
+class _ZstdStreamDecodeInputSizer:
+    def __init__(self, *, max_decoded_chunk: int) -> None:
+        self._max_decoded_chunk = max_decoded_chunk
+        self._input_chunk_size = _ZSTD_STREAM_DECODE_MIN_INPUT_CHUNK_SIZE
+
+    @property
+    def input_chunk_size(self) -> int:
+        return self._input_chunk_size
+
+    def reset(self) -> None:
+        self._input_chunk_size = _ZSTD_STREAM_DECODE_MIN_INPUT_CHUNK_SIZE
+
+    def observe(self, source: bytes, decoded: bytes) -> None:
+        if not decoded:
+            return
+        if (
+            len(decoded) >= self._max_decoded_chunk
+            or len(decoded) > len(source) * _ZSTD_STREAM_DECODE_LOW_EXPANSION_RATIO
+        ):
+            self.reset()
+            return
+        self._input_chunk_size = min(
+            _ZSTD_STREAM_DECODE_MAX_INPUT_CHUNK_SIZE,
+            self._input_chunk_size * _ZSTD_STREAM_DECODE_INPUT_GROWTH_FACTOR,
+        )
 
 
 def _create_zlib_stream_decode_session(
@@ -141,6 +171,7 @@ def _create_zstd_stream_decode_session(
     feed: _StreamDecodeFeed, *, max_decoded_chunk: int
 ) -> StreamDecodeSession:
     obj = zstandard.ZstdDecompressor().decompressobj()
+    input_sizer = _ZstdStreamDecodeInputSizer(max_decoded_chunk=max_decoded_chunk)
     decode_error: str | None = None
     frame_in_progress = False
     saw_input = False
@@ -153,8 +184,9 @@ def _create_zstd_stream_decode_session(
             saw_input = True
         data = chunk
         while data:
-            source = data[:_ZSTD_STREAM_DECODE_INPUT_CHUNK_SIZE]
-            remainder = data[_ZSTD_STREAM_DECODE_INPUT_CHUNK_SIZE:]
+            input_chunk_size = input_sizer.input_chunk_size
+            source = data[:input_chunk_size]
+            remainder = data[input_chunk_size:]
             frame_in_progress = True
             try:
                 decoded = obj.decompress(source)
@@ -162,11 +194,13 @@ def _create_zstd_stream_decode_session(
                 decode_error = INVALID_COMPRESSED_BODY
                 _log_streaming_decode_error("zstd", exc)
                 return
+            input_sizer.observe(source, decoded)
             if decoded:
                 _feed_chunks(feed, decoded, max_decoded_chunk)
             if obj.eof:
                 data = obj.unused_data + remainder
                 obj = zstandard.ZstdDecompressor().decompressobj()
+                input_sizer.reset()
                 frame_in_progress = False
                 continue
             if obj.unconsumed_tail:
@@ -214,9 +248,10 @@ def create_stream_decode_session(
 
     Usage parsers are bounded-state scanners and may need to inspect long
     responses, so this helper does not enforce a total decoded-byte cap. It
-    bounds each decoded chunk before parser entry to prevent high-ratio
-    compressed input from materialising one large ``bytes`` object. Returns
-    None when a content encoding cannot be safely decoded incrementally.
+    bounds each decoded chunk before parser entry. Codecs without a per-call
+    output cap still use small adaptive input slices as a best-effort guard
+    against high-ratio compressed input. Returns None when a content encoding
+    cannot be safely decoded incrementally.
 
     The returned session exposes ``finish_error()`` so billing paths can reject
     parser state from compressed streams that never reached a valid frame/member

--- a/crates/runner/mitm-addon/tests/body_decode_helpers.py
+++ b/crates/runner/mitm-addon/tests/body_decode_helpers.py
@@ -1,6 +1,19 @@
 """Shared compression helpers for mitm-addon body decoding tests."""
 
+from dataclasses import dataclass, field
+
 import brotli
+import zstandard
+
+
+@dataclass
+class ZstdDecompressStats:
+    calls: int = 0
+    decompressobj_calls: int = 0
+    max_input: int = 0
+    max_output: int = 0
+    input_sizes: list[int] = field(default_factory=list, repr=False)
+    output_sizes: list[int] = field(default_factory=list, repr=False)
 
 
 def track_brotli_decompressor(monkeypatch):
@@ -22,6 +35,51 @@ def track_brotli_decompressor(monkeypatch):
             return self._inner.is_finished()
 
     monkeypatch.setattr("body_decoding.brotli.Decompressor", CountingDecompressor)
+    return stats
+
+
+def track_zstd_decompressor(monkeypatch) -> ZstdDecompressStats:
+    real_decompressor = zstandard.ZstdDecompressor
+    stats = ZstdDecompressStats()
+
+    class CountingDecompressionObj:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def decompress(self, chunk: bytes) -> bytes:
+            stats.calls += 1
+            stats.input_sizes.append(len(chunk))
+            stats.max_input = max(stats.max_input, len(chunk))
+            try:
+                decoded = self._inner.decompress(chunk)
+            except zstandard.ZstdError:
+                stats.output_sizes.append(0)
+                raise
+            stats.output_sizes.append(len(decoded))
+            stats.max_output = max(stats.max_output, len(decoded))
+            return decoded
+
+        @property
+        def eof(self):
+            return self._inner.eof
+
+        @property
+        def unused_data(self):
+            return self._inner.unused_data
+
+        @property
+        def unconsumed_tail(self):
+            return self._inner.unconsumed_tail
+
+    class CountingZstdDecompressor:
+        def __init__(self, *args, **kwargs):
+            self._inner = real_decompressor(*args, **kwargs)
+
+        def decompressobj(self, *args, **kwargs):
+            stats.decompressobj_calls += 1
+            return CountingDecompressionObj(self._inner.decompressobj(*args, **kwargs))
+
+    monkeypatch.setattr("body_decoding.zstandard.ZstdDecompressor", CountingZstdDecompressor)
     return stats
 
 

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -1,6 +1,7 @@
 """Tests for shared HTTP body decoding helpers."""
 
 import gzip
+import hashlib
 import zlib
 
 import brotli
@@ -14,7 +15,20 @@ from body_decoding import (
     decompress_body,
 )
 from body_limits import DEFAULT_BODY_DECODE_LIMIT, STREAM_DECODE_CHUNK_LIMIT
-from tests.body_decode_helpers import pseudo_random_ascii, track_brotli_decompressor
+from tests.body_decode_helpers import (
+    pseudo_random_ascii,
+    track_brotli_decompressor,
+    track_zstd_decompressor,
+)
+
+
+def _deterministic_low_ratio_bytes(size: int) -> bytes:
+    data = bytearray()
+    counter = 0
+    while len(data) < size:
+        data.extend(hashlib.sha256(counter.to_bytes(8, "little")).digest())
+        counter += 1
+    return bytes(data[:size])
 
 
 class TestStreamDecodeFeed:
@@ -150,6 +164,48 @@ class TestStreamDecodeFeed:
         assert len(chunks) > 1
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
 
+    def test_zstd_large_low_ratio_input_ramps_up(self, headers, monkeypatch):
+        plaintext = _deterministic_low_ratio_bytes(512 * 1024)
+        compressed = zstandard.ZstdCompressor().compress(plaintext)
+        stats = track_zstd_decompressor(monkeypatch)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext
+        assert session.finish_error() is None
+        assert stats.max_input > 4
+        assert stats.calls < len(compressed) // 64
+
+    def test_zstd_high_ratio_input_stays_small_before_large_output(self, headers, monkeypatch):
+        plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 4 + 123)
+        compressed = zstandard.ZstdCompressor().compress(plaintext)
+        stats = track_zstd_decompressor(monkeypatch)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext
+        assert session.finish_error() is None
+        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+        assert stats.max_input <= 16
+
+    def test_concatenated_zstd_frames_same_callback(self, headers):
+        first = zstandard.ZstdCompressor().compress(b"hello ")
+        second = zstandard.ZstdCompressor().compress(b"world")
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert session is not None
+
+        session.feed(first + second)
+
+        assert b"".join(chunks) == b"hello world"
+        assert session.finish_error() is None
+
     def test_zstd_streaming_uses_decompressobj_for_finalization(self, headers, monkeypatch):
         real_decompressor = zstandard.ZstdDecompressor
         stats = {"stream_writer": 0, "decompressobj": 0}
@@ -201,7 +257,8 @@ class TestStreamDecodeFeed:
         assert "br" in log.debug.call_args[0][0]
         assert chunks == []
 
-    def test_zstd_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
+    def test_zstd_error_logs_once_and_short_circuits(self, headers, mitm_ctx, monkeypatch):
+        stats = track_zstd_decompressor(monkeypatch)
         chunks: list[bytes] = []
         with mitm_ctx() as log:
             parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
@@ -210,6 +267,7 @@ class TestStreamDecodeFeed:
             parse(b"more garbage")
         assert log.debug.call_count == 1
         assert "zstd" in log.debug.call_args[0][0]
+        assert stats.calls == 1
         assert chunks == []
 
     def test_error_without_ctx_log_does_not_raise(self, headers):

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -177,7 +177,7 @@ class TestStreamDecodeFeed:
         assert b"".join(chunks) == plaintext
         assert session.finish_error() is None
         assert stats.max_input > 4
-        assert stats.calls < len(compressed) // 64
+        assert stats.calls < len(compressed) // 8
 
     def test_zstd_high_ratio_input_stays_small_before_large_output(self, headers, monkeypatch):
         plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 4 + 123)
@@ -192,7 +192,25 @@ class TestStreamDecodeFeed:
         assert b"".join(chunks) == plaintext
         assert session.finish_error() is None
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
-        assert stats.max_input <= 16
+        assert stats.max_input <= 12
+
+    def test_zstd_mixed_ratio_input_keeps_transient_output_small(self, headers, monkeypatch):
+        plaintext = _deterministic_low_ratio_bytes(256 * 1024) + (
+            b"A" * (STREAM_DECODE_CHUNK_LIMIT * 64)
+        )
+        compressed = zstandard.ZstdCompressor().compress(plaintext)
+        stats = track_zstd_decompressor(monkeypatch)
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert session is not None
+
+        session.feed(compressed)
+
+        assert b"".join(chunks) == plaintext
+        assert session.finish_error() is None
+        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
+        assert stats.max_input <= 12
+        assert stats.max_output <= STREAM_DECODE_CHUNK_LIMIT * 4
 
     def test_concatenated_zstd_frames_same_callback(self, headers):
         first = zstandard.ZstdCompressor().compress(b"hello ")


### PR DESCRIPTION
Summary
- Add adaptive zstd streaming input sizing so low-ratio payloads ramp beyond fixed 4-byte slices.
- Keep the adaptive ceiling deliberately small because zstandard streaming decompression has no per-call output cap; this avoids a low-ratio prefix making a later high-ratio block materialise multi-MB decoded bytes before chunking.
- Reset to tiny slices when decoded output is high-ratio or a new zstd frame starts.
- Add decoder instrumentation coverage for low-ratio ramp-up, high-ratio guard behavior, mixed-ratio transient output, concatenated frames, and error short-circuiting.

Tests
- python3 -m pytest tests/test_body_decoding.py tests/test_model_provider_json_streaming.py -v
- python3 -m pytest tests/ -q
- ruff check .
- ruff format --check .
- basedpyright -p .

Closes #19801.

Note: #19843 tracks the follow-up for a strict zstd decoded-output hard bound.