### PR TITLE
feat: refine workflow automation row actions

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1117,8 +1117,8 @@ describe("workflow detail page", () => {
     expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/automations`);
     expect(search()).toBe("");
     expect(screen.queryByText("Schedule")).not.toBeInTheDocument();
-    expect(screen.getByText("Last run")).toBeInTheDocument();
-    expect(screen.getByText("Next run")).toBeInTheDocument();
+    expect(screen.getByText("Last")).toBeInTheDocument();
+    expect(screen.getByText("Next")).toBeInTheDocument();
     expect(screen.queryByText("Active")).not.toBeInTheDocument();
     expect(
       screen.getByRole("switch", { name: "Disable Every weekday at 9:00 AM" }),

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1117,8 +1117,8 @@ describe("workflow detail page", () => {
     expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/automations`);
     expect(search()).toBe("");
     expect(screen.queryByText("Schedule")).not.toBeInTheDocument();
-    expect(screen.queryByText("Last run")).not.toBeInTheDocument();
-    expect(screen.queryByText("Next run")).not.toBeInTheDocument();
+    expect(screen.getByText("Last run")).toBeInTheDocument();
+    expect(screen.getByText("Next run")).toBeInTheDocument();
     expect(screen.queryByText("Active")).not.toBeInTheDocument();
     expect(
       screen.getByRole("switch", { name: "Disable Every weekday at 9:00 AM" }),

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1116,10 +1116,18 @@ describe("workflow detail page", () => {
     });
     expect(pathname()).toBe(`/workflows/${SALES_WORKFLOW_ID}/automations`);
     expect(search()).toBe("");
-    expect(screen.getByText("Schedule")).toBeInTheDocument();
-    expect(screen.getAllByText("Last run").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Next run").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Schedule")).not.toBeInTheDocument();
+    expect(screen.queryByText("Last run")).not.toBeInTheDocument();
+    expect(screen.queryByText("Next run")).not.toBeInTheDocument();
+    expect(screen.queryByText("Active")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Disable Every weekday at 9:00 AM" }),
+    ).toBeInTheDocument();
     expect(buttonByText("Run now")).toBeInTheDocument();
+    expect(screen.queryByText("Delete automation")).not.toBeInTheDocument();
+    click(buttonByText("More actions"));
+    expect(menuItemByText("Delete automation")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
     click(buttonByText("Settings"));
     await waitFor(() => {
       expect(screen.getAllByText("Visibility").length).toBeGreaterThan(0);
@@ -1982,7 +1990,7 @@ describe("workflow detail page", () => {
       expect(screen.getByText("Every weekday at 9:00 AM")).toBeInTheDocument();
     });
 
-    click(buttonByText("Edit"));
+    click(buttonByText("Edit automation"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update schedule automation",
@@ -2034,7 +2042,7 @@ describe("workflow detail page", () => {
       expect(screen.getByText("Every 1 hour")).toBeInTheDocument();
     });
 
-    click(buttonByText("Edit"));
+    click(buttonByText("Edit automation"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update schedule automation",
@@ -2089,7 +2097,7 @@ describe("workflow detail page", () => {
       );
     });
 
-    click(buttonByText("Edit"));
+    click(buttonByText("Edit automation"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update Gmail new message automation",
@@ -2145,7 +2153,7 @@ describe("workflow detail page", () => {
       expect(screen.getByText("Gmail label applied")).toBeInTheDocument();
     });
 
-    click(buttonByText("Edit"));
+    click(buttonByText("Edit automation"));
 
     const updateTriggerForm = screen.getByRole("form", {
       name: "Update Gmail label automation",

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -4368,7 +4368,7 @@ function TriggerControls({
 
   return (
     <div className="flex min-w-0 items-center justify-end">
-      <div className="pointer-events-none flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+      <div className="flex items-center justify-end gap-1 opacity-100 transition-opacity pointer-events-auto [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:pointer-events-auto [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-focus-within:pointer-events-auto [@media(hover:hover)]:group-focus-within:opacity-100">
         <Button
           type="button"
           variant="ghost"

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -34,10 +34,12 @@ import {
   IconPlayerPause,
   IconPlayerPlay,
   IconPlus,
+  IconPencil,
   IconRepeat,
   IconRoute,
   IconTrash,
   IconUpload,
+  IconDotsVertical,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
@@ -147,6 +149,7 @@ import {
   DetailPageMain,
   DetailPageShell,
 } from "../components/detail-page-layout.tsx";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { TiptapInstructionsEditor } from "../zero-page/tiptap-instructions-editor.tsx";
 import { ZeroUnsavedBar } from "../zero-page/zero-unsaved-bar.tsx";
 import { InlineSettingsRow } from "../zero-page/components/zero-inline-settings-row.tsx";
@@ -156,12 +159,9 @@ import {
   formatWorkflowIntervalSeconds,
   getWorkflowIntervalSecondOptions,
   isMarkdownPath,
+  triggerKindLabel,
   workflowTitle,
 } from "./workflow-shared.tsx";
-import {
-  WorkflowTriggerCard,
-  type WorkflowTriggerCardRow,
-} from "./workflow-trigger-card.tsx";
 
 const FIELD_CLASS =
   "h-9 w-full rounded-md border border-border/60 bg-background px-2.5 text-sm outline-none focus:border-primary";
@@ -2701,16 +2701,19 @@ function TriggersSection({
       </div>
       <div className="flex flex-col gap-2">
         {triggers.length > 0 ? (
-          triggers.map((trigger) => {
-            return (
-              <TriggerRow
-                key={trigger.id}
-                trigger={trigger}
-                canManage={trigger.ownerUserId === currentUserId}
-                displayTimezone={displayTimezone}
-              />
-            );
-          })
+          <div className="zero-card overflow-visible">
+            {triggers.map((trigger, index) => {
+              return (
+                <TriggerRow
+                  key={trigger.id}
+                  trigger={trigger}
+                  canManage={trigger.ownerUserId === currentUserId}
+                  displayTimezone={displayTimezone}
+                  showDivider={index < triggers.length - 1}
+                />
+              );
+            })}
+          </div>
         ) : (
           <div className="zero-card px-5 py-4">
             <p className="text-sm text-muted-foreground">No automations.</p>
@@ -4178,30 +4181,78 @@ function TriggerRow({
   trigger,
   canManage,
   displayTimezone,
+  showDivider,
 }: {
   readonly trigger: ZeroWorkflowTriggerSummary;
   readonly canManage: boolean;
   readonly displayTimezone: string;
+  readonly showDivider: boolean;
 }) {
   const editingTriggerId = useGet(editingWorkflowTriggerId$);
   const setEditingTriggerId = useSet(setEditingWorkflowTriggerId$);
   const editing = editingTriggerId === trigger.id;
-  const rows = triggerCardRows(trigger, displayTimezone);
+  const title = workflowScheduleTitle(trigger, displayTimezone);
+  const subtitle = workflowTriggerSubtitle(trigger);
 
   return (
     <>
-      <WorkflowTriggerCard
-        rows={rows}
-        dimmed={!trigger.enabled}
-        actions={
-          canManage ? (
-            <TriggerControls
-              trigger={trigger}
-              displayTimezone={displayTimezone}
-            />
-          ) : null
-        }
-      />
+      <div
+        className={cn(
+          "group grid min-w-0 grid-cols-1 gap-3 px-5 py-4 transition-colors first:rounded-t-2xl last:rounded-b-2xl hover:bg-gray-50 sm:grid-cols-[minmax(0,2fr)_minmax(8rem,0.8fr)_minmax(8rem,0.8fr)_auto_6.5rem] sm:items-center sm:gap-4",
+          showDivider && "border-b border-border/50",
+          !trigger.enabled && "opacity-75",
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          <span
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-gray-50 text-muted-foreground group-hover:bg-background"
+            aria-hidden="true"
+          >
+            <IconRepeat size={15} stroke={1.5} />
+          </span>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-foreground">
+              {title}
+            </div>
+            {subtitle ? (
+              <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                {subtitle}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div
+          className="truncate text-sm font-medium text-foreground"
+          aria-label={`Last run ${formatWorkflowTriggerRun(
+            trigger.lastRunAt,
+            displayTimezone,
+          )}`}
+        >
+          {formatWorkflowTriggerRun(trigger.lastRunAt, displayTimezone)}
+        </div>
+        <div
+          className="truncate text-sm font-medium text-foreground"
+          aria-label={`Next run ${formatWorkflowTriggerNextRun(
+            trigger.nextRunAt,
+            displayTimezone,
+          )}`}
+        >
+          {formatWorkflowTriggerNextRun(trigger.nextRunAt, displayTimezone)}
+        </div>
+        <TriggerStatusSwitch
+          trigger={trigger}
+          title={title}
+          canManage={canManage}
+        />
+        {canManage ? (
+          <TriggerControls
+            trigger={trigger}
+            displayTimezone={displayTimezone}
+          />
+        ) : (
+          <div aria-hidden="true" />
+        )}
+      </div>
       {canManage ? (
         <EditWorkflowTriggerDialog
           trigger={trigger}
@@ -4218,38 +4269,17 @@ function TriggerRow({
   );
 }
 
-function triggerCardRows(
+function workflowTriggerSubtitle(
   trigger: ZeroWorkflowTriggerSummary,
-  displayTimezone: string,
-): readonly WorkflowTriggerCardRow[] {
-  const rows: WorkflowTriggerCardRow[] = [
-    {
-      label: trigger.kind === "schedule" ? "Schedule" : "Automation",
-      value: workflowScheduleTitle(trigger, displayTimezone),
-    },
-    {
-      label: "Last run",
-      value: formatWorkflowTriggerRun(trigger.lastRunAt, displayTimezone),
-    },
-    {
-      label: "Next run",
-      value: formatWorkflowTriggerNextRun(trigger.nextRunAt, displayTimezone),
-    },
-  ];
-
+): string | null {
   const matchSummary = workflowTriggerSummary(trigger);
   if (matchSummary) {
-    rows.splice(1, 0, { label: "Match", value: matchSummary });
+    return matchSummary;
   }
-
   if (isWebhookWorkflowTrigger(trigger)) {
-    rows.splice(1, 0, {
-      label: "Webhook",
-      value: trigger.webhookUrl,
-    });
+    return trigger.webhookUrl;
   }
-
-  return rows;
+  return triggerKindLabel(trigger);
 }
 
 function formatWorkflowTriggerRun(
@@ -4283,11 +4313,36 @@ function formatWorkflowTriggerNextRun(
   return formatWorkflowTriggerRun(value, displayTimezone);
 }
 
-function TriggerToggleIcon({ enabled }: { readonly enabled: boolean }) {
-  return enabled ? (
-    <IconPlayerPause size={13} stroke={1.5} />
-  ) : (
-    <IconPlayerPlay size={13} stroke={1.5} />
+function TriggerStatusSwitch({
+  trigger,
+  title,
+  canManage,
+}: {
+  readonly trigger: ZeroWorkflowTriggerSummary;
+  readonly title: string;
+  readonly canManage: boolean;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [enabledLoadable, setEnabled] = useLoadableSet(
+    setWorkflowTriggerEnabled$,
+  );
+  const toggling = enabledLoadable.state === "loading";
+
+  return (
+    <div className="flex items-center justify-start sm:justify-center">
+      <LoadingSwitch
+        checked={trigger.enabled}
+        loading={toggling}
+        disabled={!canManage}
+        ariaLabel={`${trigger.enabled ? "Disable" : "Enable"} ${title}`}
+        onCheckedChange={(enabled) => {
+          detach(
+            setEnabled({ triggerId: trigger.id, enabled }, pageSignal),
+            Reason.DomCallback,
+          );
+        }}
+      />
+    </div>
   );
 }
 
@@ -4302,49 +4357,25 @@ function TriggerControls({
   const navigate = useSet(detachedNavigateTo$);
   const setEditingTriggerId = useSet(setEditingWorkflowTriggerId$);
   const setEditingScheduleCronFields = useSet(setEditingScheduleCronFields$);
-  const [enabledLoadable, setEnabled] = useLoadableSet(
-    setWorkflowTriggerEnabled$,
-  );
   const [deleteLoadable, deleteTrigger] = useLoadableSet(
     deleteWorkflowTrigger$,
   );
   const [runNowLoadable, runNow] = useLoadableSet(runWorkflowTriggerNow$);
   const busy =
-    enabledLoadable.state === "loading" ||
-    deleteLoadable.state === "loading" ||
-    runNowLoadable.state === "loading";
+    deleteLoadable.state === "loading" || runNowLoadable.state === "loading";
   const running = runNowLoadable.state === "loading";
   const canEdit = canEditWorkflowTrigger(trigger);
 
   return (
-    <>
-      {canEdit ? (
-        <button
-          type="button"
-          disabled={busy}
-          className="rounded-md px-1 py-1 text-sm font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline disabled:opacity-60"
-          onClick={() => {
-            if (
-              trigger.kind === "schedule" &&
-              trigger.schedule.type === "cron"
-            ) {
-              setEditingScheduleCronFields(
-                parseWorkflowCronFields(trigger.schedule, displayTimezone),
-              );
-            }
-            setEditingTriggerId(trigger.id);
-          }}
-        >
-          Edit
-        </button>
-      ) : null}
-      <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2">
+    <div className="flex min-w-0 items-center justify-end">
+      <div className="pointer-events-none flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
         <Button
           type="button"
-          variant="outline"
-          size="sm"
+          variant="ghost"
+          size="icon"
           disabled={busy}
-          className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
+          aria-label="Run now"
+          className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-50 hover:text-foreground"
           onClick={() => {
             detach(
               (async () => {
@@ -4359,46 +4390,69 @@ function TriggerControls({
           }}
         >
           {running ? (
-            <IconLoader2 size={13} className="animate-spin" />
+            <IconLoader2 size={14} className="animate-spin" />
           ) : (
-            <IconPlayerPlay size={13} stroke={1.5} />
+            <IconPlayerPlay size={14} stroke={1.5} />
           )}
-          <span>{running ? "Starting..." : "Run now"}</span>
         </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={busy}
-          className="zero-btn-morandi h-8 gap-1.5 rounded-lg px-3 text-xs font-medium"
-          onClick={() => {
-            detach(
-              setEnabled(
-                { triggerId: trigger.id, enabled: !trigger.enabled },
-                pageSignal,
-              ),
-              Reason.DomCallback,
-            );
-          }}
-        >
-          <TriggerToggleIcon enabled={trigger.enabled} />
-          <span>{trigger.enabled ? "Pause" : "Resume"}</span>
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          disabled={busy}
-          className="h-8 gap-1.5 rounded-lg px-3 text-xs font-medium text-destructive/80 hover:bg-destructive/10 hover:text-destructive"
-          onClick={() => {
-            detach(deleteTrigger(trigger.id, pageSignal), Reason.DomCallback);
-          }}
-        >
-          <IconTrash size={13} stroke={1.5} />
-          <span>Delete</span>
-        </Button>
+        {canEdit ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            disabled={busy}
+            aria-label="Edit automation"
+            className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-50 hover:text-foreground"
+            onClick={() => {
+              if (
+                trigger.kind === "schedule" &&
+                trigger.schedule.type === "cron"
+              ) {
+                setEditingScheduleCronFields(
+                  parseWorkflowCronFields(trigger.schedule, displayTimezone),
+                );
+              }
+              setEditingTriggerId(trigger.id);
+            }}
+          >
+            <IconPencil size={14} stroke={1.5} />
+          </Button>
+        ) : null}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              disabled={busy}
+              aria-label="More actions"
+              className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-50 hover:text-foreground data-[state=open]:bg-gray-50 data-[state=open]:text-foreground"
+            >
+              <IconDotsVertical size={14} stroke={1.5} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuItem
+              disabled={deleteLoadable.state === "loading"}
+              className="gap-2 text-destructive focus:text-destructive"
+              onClick={() => {
+                detach(
+                  deleteTrigger(trigger.id, pageSignal),
+                  Reason.DomCallback,
+                );
+              }}
+            >
+              {deleteLoadable.state === "loading" ? (
+                <IconLoader2 size={14} className="animate-spin" />
+              ) : (
+                <IconTrash size={14} stroke={1.5} />
+              )}
+              Delete automation
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -26,6 +26,7 @@ import {
   IconClock,
   IconCopy,
   IconFileText,
+  IconHistory,
   IconInfoCircle,
   IconLink,
   IconLoader2,
@@ -4198,7 +4199,7 @@ function TriggerRow({
     <>
       <div
         className={cn(
-          "group grid min-w-0 grid-cols-1 gap-3 px-5 py-4 transition-colors first:rounded-t-2xl last:rounded-b-2xl hover:bg-gray-50 sm:grid-cols-[minmax(0,1.5fr)_minmax(7.5rem,0.9fr)_minmax(9rem,0.9fr)_auto_7.75rem] sm:items-center sm:gap-4",
+          "group grid min-w-0 grid-cols-1 gap-3 px-5 py-4 transition-colors first:rounded-t-2xl last:rounded-b-2xl hover:bg-gray-50 sm:grid-cols-[minmax(0,1.2fr)_minmax(9rem,0.9fr)_minmax(13.5rem,1.1fr)_auto_7.75rem] sm:items-center sm:gap-4",
           showDivider && "border-b border-border/50",
           !trigger.enabled && "opacity-75",
         )}
@@ -4222,28 +4223,38 @@ function TriggerRow({
           </div>
         </div>
         <div
-          className="min-w-0"
+          className="flex min-w-0 items-center gap-1.5"
           aria-label={`Last run ${formatWorkflowTriggerRun(
             trigger.lastRunAt,
             displayTimezone,
           )}`}
         >
-          <div className="text-xs text-muted-foreground">Last run</div>
-          <div className="mt-0.5 truncate text-sm font-medium text-foreground">
+          <IconHistory
+            size={14}
+            stroke={1.5}
+            className="shrink-0 text-muted-foreground"
+          />
+          <span className="shrink-0 text-sm text-muted-foreground">Last</span>
+          <span className="min-w-0 truncate text-sm font-medium text-foreground">
             {formatWorkflowTriggerRun(trigger.lastRunAt, displayTimezone)}
-          </div>
+          </span>
         </div>
         <div
-          className="min-w-0"
+          className="flex min-w-0 items-center gap-1.5"
           aria-label={`Next run ${formatWorkflowTriggerNextRun(
             trigger.nextRunAt,
             displayTimezone,
           )}`}
         >
-          <div className="text-xs text-muted-foreground">Next run</div>
-          <div className="mt-0.5 truncate text-sm font-medium text-foreground">
+          <IconClock
+            size={14}
+            stroke={1.5}
+            className="shrink-0 text-muted-foreground"
+          />
+          <span className="shrink-0 text-sm text-muted-foreground">Next</span>
+          <span className="min-w-0 truncate text-sm font-medium text-foreground">
             {formatWorkflowTriggerNextRun(trigger.nextRunAt, displayTimezone)}
-          </div>
+          </span>
         </div>
         <TriggerStatusSwitch
           trigger={trigger}

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -4222,22 +4222,28 @@ function TriggerRow({
           </div>
         </div>
         <div
-          className="truncate text-sm font-medium text-foreground"
+          className="min-w-0"
           aria-label={`Last run ${formatWorkflowTriggerRun(
             trigger.lastRunAt,
             displayTimezone,
           )}`}
         >
-          {formatWorkflowTriggerRun(trigger.lastRunAt, displayTimezone)}
+          <div className="text-xs text-muted-foreground">Last run</div>
+          <div className="mt-0.5 truncate text-sm font-medium text-foreground">
+            {formatWorkflowTriggerRun(trigger.lastRunAt, displayTimezone)}
+          </div>
         </div>
         <div
-          className="truncate text-sm font-medium text-foreground"
+          className="min-w-0"
           aria-label={`Next run ${formatWorkflowTriggerNextRun(
             trigger.nextRunAt,
             displayTimezone,
           )}`}
         >
-          {formatWorkflowTriggerNextRun(trigger.nextRunAt, displayTimezone)}
+          <div className="text-xs text-muted-foreground">Next run</div>
+          <div className="mt-0.5 truncate text-sm font-medium text-foreground">
+            {formatWorkflowTriggerNextRun(trigger.nextRunAt, displayTimezone)}
+          </div>
         </div>
         <TriggerStatusSwitch
           trigger={trigger}

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -421,6 +421,9 @@ function DetailHeader({
           </div>
           <div className="mt-4 flex items-center gap-2 sm:mt-6">
             <WorkflowTabNav activeTab={activeTab} onTabChange={onTabChange} />
+            {activeTab === "automations" ? (
+              <WorkflowAddAutomationButton />
+            ) : null}
             <WorkflowChatButton detail={detail} />
           </div>
         </>
@@ -488,6 +491,22 @@ function WorkflowTabNav({
         </TabsTrigger>
       </TabsList>
     </Tabs>
+  );
+}
+
+function WorkflowAddAutomationButton() {
+  const features = useGet(featureSwitch$);
+  const setCreateDialog = useSet(setWorkflowTriggerCreateDialog$);
+  const workflowAutomationEnabled =
+    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
+
+  return (
+    <TriggerCreateMenu
+      onSelect={setCreateDialog}
+      githubLabelTriggersEnabled={workflowAutomationEnabled}
+      googleCalendarTriggersEnabled={workflowAutomationEnabled}
+      webhookTriggersEnabled={workflowAutomationEnabled}
+    />
   );
 }
 
@@ -2671,34 +2690,15 @@ function TriggersSection({
 }) {
   const createDialog = useGet(workflowTriggerCreateDialog$);
   const setCreateDialog = useSet(setWorkflowTriggerCreateDialog$);
-  const features = useGet(featureSwitch$);
   const userLoadable = useLoadable(user$);
   const preferences = useLastResolved(userPreferences$);
   const currentUserId =
     userLoadable.state === "hasData" ? (userLoadable.data?.id ?? "") : "";
   const displayTimezone = preferences?.timezone ?? browserTimezone();
   const triggers = detail.triggers;
-  const workflowAutomationEnabled =
-    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
 
   return (
     <section className="mx-auto flex max-w-[900px] flex-col gap-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="text-sm font-medium text-foreground">
-            Automations
-          </span>
-          <span className="text-xs text-muted-foreground">
-            {triggers.length}
-          </span>
-        </div>
-        <TriggerCreateMenu
-          onSelect={setCreateDialog}
-          githubLabelTriggersEnabled={workflowAutomationEnabled}
-          googleCalendarTriggersEnabled={workflowAutomationEnabled}
-          webhookTriggersEnabled={workflowAutomationEnabled}
-        />
-      </div>
       <div className="flex flex-col gap-2">
         {triggers.length > 0 ? (
           <div className="zero-card overflow-visible">
@@ -4198,7 +4198,7 @@ function TriggerRow({
     <>
       <div
         className={cn(
-          "group grid min-w-0 grid-cols-1 gap-3 px-5 py-4 transition-colors first:rounded-t-2xl last:rounded-b-2xl hover:bg-gray-50 sm:grid-cols-[minmax(0,2fr)_minmax(8rem,0.8fr)_minmax(8rem,0.8fr)_auto_6.5rem] sm:items-center sm:gap-4",
+          "group grid min-w-0 grid-cols-1 gap-3 px-5 py-4 transition-colors first:rounded-t-2xl last:rounded-b-2xl hover:bg-gray-50 sm:grid-cols-[minmax(0,1.5fr)_minmax(7.5rem,0.9fr)_minmax(9rem,0.9fr)_auto_7.75rem] sm:items-center sm:gap-4",
           showDivider && "border-b border-border/50",
           !trigger.enabled && "opacity-75",
         )}

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -407,25 +407,24 @@ function DetailHeader({
     <DetailPageHeader>
       {detail ? (
         <>
-          <div className="min-w-0">
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <h1 className="truncate text-lg font-semibold tracking-tight text-foreground sm:text-xl">
-                {workflowTitle(detail)}
-              </h1>
-              <span className="inline-flex max-w-full shrink-0 items-center rounded-md border border-border/60 bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                /{detail.name}
-              </span>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <h1 className="truncate text-lg font-semibold tracking-tight text-foreground sm:text-xl">
+                  {workflowTitle(detail)}
+                </h1>
+                <span className="inline-flex max-w-full shrink-0 items-center rounded-md border border-border/60 bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                  /{detail.name}
+                </span>
+              </div>
+              <p className="mt-1.5 line-clamp-2 text-sm leading-tight text-muted-foreground">
+                {detail.description || "No description yet"}
+              </p>
             </div>
-            <p className="mt-1.5 line-clamp-2 text-sm leading-tight text-muted-foreground">
-              {detail.description || "No description yet"}
-            </p>
+            <WorkflowChatButton detail={detail} />
           </div>
           <div className="mt-4 flex items-center gap-2 sm:mt-6">
             <WorkflowTabNav activeTab={activeTab} onTabChange={onTabChange} />
-            {activeTab === "automations" ? (
-              <WorkflowAddAutomationButton />
-            ) : null}
-            <WorkflowChatButton detail={detail} />
           </div>
         </>
       ) : (
@@ -492,22 +491,6 @@ function WorkflowTabNav({
         </TabsTrigger>
       </TabsList>
     </Tabs>
-  );
-}
-
-function WorkflowAddAutomationButton() {
-  const features = useGet(featureSwitch$);
-  const setCreateDialog = useSet(setWorkflowTriggerCreateDialog$);
-  const workflowAutomationEnabled =
-    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
-
-  return (
-    <TriggerCreateMenu
-      onSelect={setCreateDialog}
-      githubLabelTriggersEnabled={workflowAutomationEnabled}
-      googleCalendarTriggersEnabled={workflowAutomationEnabled}
-      webhookTriggersEnabled={workflowAutomationEnabled}
-    />
   );
 }
 
@@ -2697,9 +2680,23 @@ function TriggersSection({
     userLoadable.state === "hasData" ? (userLoadable.data?.id ?? "") : "";
   const displayTimezone = preferences?.timezone ?? browserTimezone();
   const triggers = detail.triggers;
+  const features = useGet(featureSwitch$);
+  const workflowAutomationEnabled =
+    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
 
   return (
     <section className="mx-auto flex max-w-[900px] flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <p className="min-w-0 text-sm text-muted-foreground">
+          Automations run this workflow whenever their trigger fires
+        </p>
+        <TriggerCreateMenu
+          onSelect={setCreateDialog}
+          githubLabelTriggersEnabled={workflowAutomationEnabled}
+          googleCalendarTriggersEnabled={workflowAutomationEnabled}
+          webhookTriggersEnabled={workflowAutomationEnabled}
+        />
+      </div>
       <div className="flex flex-col gap-2">
         {triggers.length > 0 ? (
           <div className="zero-card overflow-visible">


### PR DESCRIPTION
## Summary
- Replace workflow detail automation cards with a compact row card without table headers
- Move enabled state into a status toggle without the visible Active label
- Reveal Run/Edit/More actions on row hover and move Delete automation into the More menu
- Update workflow page tests for the new aria-label based actions and menu placement

## Verification
- `git diff --check`
- `pnpm dlx prettier@3.8.1 --write apps/platform/src/views/workflows-page/workflow-detail-page.tsx apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm -C turbo -F @vm0/app check-types` could not run locally because this checkout has no `node_modules` and `tsc` is unavailable; PR CI should run the full check
