### PR TITLE
ci: publish runtime api schema reports

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -785,6 +785,18 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
 
+      - name: Build Runtime API Schema
+        working-directory: turbo
+        run: pnpm --filter @vm0/api-contracts run build:runtime-api-schema -- --out runtime-api-schema.json
+
+      - name: Upload Runtime API Schema Artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: runtime-api-schema
+          path: turbo/runtime-api-schema.json
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Install neonctl
         run: npm install -g neonctl@2.15.0
 
@@ -1226,6 +1238,69 @@ jobs:
                 text:
                   type: mrkdwn
                   text: "*API* ❌ Promote failed\n📦 Version: `${{ needs.release-please.outputs.api_version }}`\n⏱️ `${{ steps.duration.outputs.text }}`\n🔗 <${{ github.server_url }}/${{ github.repository }}/releases/tag/api-v${{ needs.release-please.outputs.api_version }}|View Release>\n🔗 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Logs>"
+
+  deploy-api-schema:
+    needs: [release-please, build-api-production, promote-api-production]
+    if: >-
+      always() &&
+      needs.release-please.outputs.api_deploy_required == 'true' &&
+      needs.promote-api-production.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Runtime API Schema Artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          name: runtime-api-schema
+          path: /tmp/runtime-api-schema
+
+      - name: Publish Runtime API Schema
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SCHEMA_RELEASE_TAG: runtime-api-schema-prod
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          API_VERSION: ${{ needs.release-please.outputs.api_version }}
+        run: |
+          set -euo pipefail
+
+          schema_path="/tmp/runtime-api-schema/runtime-api-schema.json"
+          if [ ! -f "$schema_path" ]; then
+            echo "::error::Runtime API schema artifact is missing: $schema_path"
+            exit 1
+          fi
+
+          if ! gh release view "$SCHEMA_RELEASE_TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$SCHEMA_RELEASE_TAG" \
+              --repo "$REPO" \
+              --target "$RELEASE_SHA" \
+              --title "Runtime API Schema (Production)" \
+              --notes "Mutable pointer to the runtime API schema currently deployed to production."
+          fi
+
+          cp "$schema_path" /tmp/runtime-api-schema/current.json
+          cp "$schema_path" "/tmp/runtime-api-schema/runtime-api-schema-${RELEASE_SHA}.json"
+
+          cat > /tmp/runtime-api-schema/release-notes.md <<EOF
+          Mutable pointer to the runtime API schema currently deployed to production.
+
+          Last updated by release-please workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          API version: ${API_VERSION:-unknown}
+          Commit: ${RELEASE_SHA}
+          EOF
+
+          gh release upload "$SCHEMA_RELEASE_TAG" \
+            /tmp/runtime-api-schema/current.json \
+            "/tmp/runtime-api-schema/runtime-api-schema-${RELEASE_SHA}.json" \
+            --repo "$REPO" \
+            --clobber
+
+          gh release edit "$SCHEMA_RELEASE_TAG" \
+            --repo "$REPO" \
+            --notes-file /tmp/runtime-api-schema/release-notes.md
+
+          echo "Published runtime API schema for $RELEASE_SHA"
 
   # Build app (Vite SPA) production deployment (Staged)
   build-app-production:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2005,6 +2005,76 @@ jobs:
       - name: Build summary
         run: echo "✅ E2B templates built successfully (development account)"
 
+  lint-runtime-api-compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    needs: [detect-release]
+    if: needs.detect-release.outputs.skip != 'true'
+    # Report-only: this surfaces schema generation/compat issues without blocking CI.
+    continue-on-error: true
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260622
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: ./.github/actions/toolchain-init
+
+      - name: Download online runtime API schema
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SCHEMA_RELEASE_TAG: runtime-api-schema-prod
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/runtime-api-schema
+
+          if gh release view "$SCHEMA_RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            if gh release download "$SCHEMA_RELEASE_TAG" \
+              --repo "${{ github.repository }}" \
+              --pattern current.json \
+              --dir /tmp/runtime-api-schema \
+              --clobber; then
+              echo "Downloaded online runtime API schema"
+            else
+              echo "::warning::Runtime API schema release exists, but current.json is not available yet."
+            fi
+          else
+            echo "::warning::Runtime API schema release $SCHEMA_RELEASE_TAG does not exist yet; compatibility report will be skipped."
+          fi
+
+      - name: Check runtime API compatibility (report only)
+        working-directory: turbo
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/runtime-api-schema
+
+          pnpm --filter @vm0/api-contracts run build:runtime-api-schema -- --out /tmp/runtime-api-schema/candidate.json
+
+          if [ -f /tmp/runtime-api-schema/current.json ]; then
+            pnpm --filter @vm0/api-contracts run lint-runtime-api-compat -- \
+              --against /tmp/runtime-api-schema/current.json \
+              --current /tmp/runtime-api-schema/candidate.json \
+              --report-out /tmp/runtime-api-schema/report.json \
+              --warn-only
+          else
+            echo "::warning::No online runtime API schema found. Generated candidate schema only."
+            printf '{"findings":[],"skipped":"online schema not found"}\n' > /tmp/runtime-api-schema/report.json
+          fi
+
+      - name: Upload runtime API compatibility report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: runtime-api-compat-report
+          path: |
+            /tmp/runtime-api-schema/candidate.json
+            /tmp/runtime-api-schema/current.json
+            /tmp/runtime-api-schema/report.json
+          if-no-files-found: warn
+          retention-days: 14
+
   # Lighthouse CI audit for web homepage (failure blocks merge, skip is allowed)
   ci-gate-turbo:
     runs-on: ubuntu-latest

--- a/turbo/packages/api-contracts/package.json
+++ b/turbo/packages/api-contracts/package.json
@@ -27,11 +27,13 @@
     "./firewalls/*": null
   },
   "scripts": {
+    "build:runtime-api-schema": "tsx src/runtime-api-schema/cli.ts build",
     "generate:rust": "tsx src/rust-bindings/generate.ts",
+    "lint-runtime-api-compat": "tsx src/runtime-api-schema/cli.ts lint",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && oxlint --type-aware -c ../../.oxlintrc.typeaware.json && eslint . --max-warnings 0",
-    "check-types": "tsc -p tsconfig.contracts.json --noEmit && tsc -p tsconfig.rust-bindings.json --noEmit"
+    "check-types": "tsc -p tsconfig.contracts.json --noEmit && tsc -p tsconfig.rust-bindings.json --noEmit && tsc -p tsconfig.runtime-api-schema.json --noEmit"
   },
   "dependencies": {
     "@trpc/server": "11.18.0",

--- a/turbo/packages/api-contracts/src/runtime-api-schema/__tests__/compat.test.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/__tests__/compat.test.ts
@@ -1,0 +1,170 @@
+import {
+  compareRuntimeApiSchemas,
+  type RuntimeApiCompatFinding,
+} from "../compat";
+import {
+  type JsonObject,
+  runtimeApiSchemaFormatVersion,
+  type RuntimeApiSchemaDocument,
+} from "../schema";
+
+function documentWithBody(bodySchema: JsonObject): RuntimeApiSchemaDocument {
+  return {
+    schemaFormatVersion: runtimeApiSchemaFormatVersion,
+    packageName: "@vm0/api-contracts",
+    packageVersion: "0.0.0",
+    generatedAt: "2026-07-02T00:00:00.000Z",
+    routes: [
+      {
+        id: "webhooks.agent.example",
+        owner: "guest-agent",
+        method: "POST",
+        path: "/api/webhooks/agent/example",
+        request: {
+          body: {
+            kind: "json-schema",
+            schema: bodySchema,
+          },
+        },
+        responses: {
+          "200": {
+            kind: "json-schema",
+            schema: {
+              type: "object",
+              properties: {
+                ok: { type: "boolean" },
+              },
+              required: ["ok"],
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+function objectSchema(
+  properties: Record<string, JsonObject>,
+  required: readonly string[],
+): JsonObject {
+  return {
+    type: "object",
+    properties,
+    required: [...required],
+  };
+}
+
+function findingKinds(
+  findings: readonly RuntimeApiCompatFinding[],
+): readonly string[] {
+  return findings.map((finding) => {
+    return finding.kind;
+  });
+}
+
+describe("runtime API compatibility diff", () => {
+  it("allows required request fields to become optional", () => {
+    const online = documentWithBody(
+      objectSchema({ a: { type: "string" } }, ["a"]),
+    );
+    const current = documentWithBody(
+      objectSchema({ a: { type: "string" } }, []),
+    );
+
+    expect(compareRuntimeApiSchemas(online, current)).toEqual([]);
+  });
+
+  it("allows optional request fields to be removed", () => {
+    const online = documentWithBody(
+      objectSchema({ a: { type: "string" } }, []),
+    );
+    const current = documentWithBody(objectSchema({}, []));
+
+    expect(compareRuntimeApiSchemas(online, current)).toEqual([]);
+  });
+
+  it("rejects required request field removal", () => {
+    const online = documentWithBody(
+      objectSchema({ a: { type: "string" } }, ["a"]),
+    );
+    const current = documentWithBody(objectSchema({}, []));
+
+    expect(findingKinds(compareRuntimeApiSchemas(online, current))).toContain(
+      "request-required-field-removed",
+    );
+  });
+
+  it("rejects adding a required request field", () => {
+    const online = documentWithBody(objectSchema({}, []));
+    const current = documentWithBody(
+      objectSchema({ a: { type: "string" } }, ["a"]),
+    );
+
+    expect(findingKinds(compareRuntimeApiSchemas(online, current))).toContain(
+      "request-required-field-added",
+    );
+  });
+
+  it("rejects removing a required response field", () => {
+    const online = documentWithBody(objectSchema({}, []));
+    const route = online.routes[0];
+    if (!route) {
+      throw new Error("missing test route");
+    }
+
+    const current: RuntimeApiSchemaDocument = {
+      ...online,
+      routes: [
+        {
+          ...route,
+          responses: {
+            "200": {
+              kind: "json-schema" as const,
+              schema: {
+                type: "object",
+                properties: {},
+                required: [],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    expect(findingKinds(compareRuntimeApiSchemas(online, current))).toContain(
+      "response-required-field-removed",
+    );
+  });
+
+  it("allows adding a required response field", () => {
+    const online = documentWithBody(objectSchema({}, []));
+    const route = online.routes[0];
+    if (!route) {
+      throw new Error("missing test route");
+    }
+
+    const current: RuntimeApiSchemaDocument = {
+      ...online,
+      routes: [
+        {
+          ...route,
+          responses: {
+            "200": {
+              kind: "json-schema",
+              schema: {
+                type: "object",
+                properties: {
+                  ok: { type: "boolean" },
+                  id: { type: "string" },
+                },
+                required: ["ok", "id"],
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    expect(compareRuntimeApiSchemas(online, current)).toEqual([]);
+  });
+});

--- a/turbo/packages/api-contracts/src/runtime-api-schema/cli.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/cli.ts
@@ -1,0 +1,141 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import {
+  compareRuntimeApiSchemas,
+  renderCompatReport,
+  renderCompatReportJson,
+} from "./compat";
+import {
+  buildRuntimeApiSchemaDocument,
+  readRuntimeApiSchemaDocument,
+  renderRuntimeApiSchemaDocument,
+} from "./schema";
+
+interface ParsedArgs {
+  readonly command: string | undefined;
+  readonly options: Readonly<Record<string, string | boolean>>;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.command === "build") {
+    await buildCommand(args.options);
+    return;
+  }
+
+  if (args.command === "lint") {
+    await lintCommand(args.options);
+    return;
+  }
+
+  printUsage();
+  process.exitCode = 2;
+}
+
+async function buildCommand(
+  options: Readonly<Record<string, string | boolean>>,
+): Promise<void> {
+  const out = readStringOption(options, "out") ?? "runtime-api-schema.json";
+  const outputPath = resolve(out);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, renderRuntimeApiSchemaDocument());
+  console.log(`Runtime API schema written to ${outputPath}`);
+}
+
+async function lintCommand(
+  options: Readonly<Record<string, string | boolean>>,
+): Promise<void> {
+  const against = readStringOption(options, "against");
+  if (!against) {
+    throw new Error("Missing required --against <path> option");
+  }
+
+  const currentPath = readStringOption(options, "current");
+  const reportOut = readStringOption(options, "report-out");
+  const warnOnly = options["warn-only"] === true;
+
+  let online;
+  try {
+    online = await readRuntimeApiSchemaDocument(resolve(against));
+  } catch (error) {
+    console.warn(
+      `::warning::Online runtime API schema could not be read from ${against}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.warn(
+      "Runtime API compatibility report skipped because no online schema is available yet.",
+    );
+    return;
+  }
+
+  const current = currentPath
+    ? await readRuntimeApiSchemaDocument(resolve(currentPath))
+    : buildRuntimeApiSchemaDocument();
+
+  const findings = compareRuntimeApiSchemas(online, current);
+  const report = renderCompatReport(findings);
+  console.log(report);
+
+  if (reportOut) {
+    const reportPath = resolve(reportOut);
+    await mkdir(dirname(reportPath), { recursive: true });
+    await writeFile(reportPath, renderCompatReportJson(findings));
+    console.log(
+      `Runtime API compatibility JSON report written to ${reportPath}`,
+    );
+  }
+
+  for (const finding of findings) {
+    console.error(
+      `::error title=Runtime API compatibility break::${finding.route} ${finding.path}: ${finding.problem} Impact: ${finding.impact}`,
+    );
+  }
+
+  if (findings.length > 0 && !warnOnly) {
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(argv: readonly string[]): ParsedArgs {
+  const [command, ...rest] = argv;
+  const options: Record<string, string | boolean> = {};
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (!arg) {
+      continue;
+    }
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const key = arg.slice(2);
+    const next = rest[index + 1];
+    if (!next || next.startsWith("--")) {
+      options[key] = true;
+      continue;
+    }
+
+    options[key] = next;
+    index += 1;
+  }
+
+  return { command, options };
+}
+
+function readStringOption(
+  options: Readonly<Record<string, string | boolean>>,
+  key: string,
+): string | undefined {
+  const value = options[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function printUsage(): void {
+  console.log(`Usage:
+  tsx src/runtime-api-schema/cli.ts build --out runtime-api-schema.json
+  tsx src/runtime-api-schema/cli.ts lint --against online-schema.json [--current current-schema.json] [--report-out report.json] [--warn-only]
+`);
+}
+
+await main();

--- a/turbo/packages/api-contracts/src/runtime-api-schema/compat.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/compat.ts
@@ -1,0 +1,616 @@
+import {
+  type JsonObject,
+  type JsonValue,
+  type RuntimeApiRouteSnapshot,
+  type RuntimeApiSchemaDocument,
+  type RuntimeSchemaSnapshot,
+  stableStringify,
+} from "./schema";
+
+export interface RuntimeApiCompatFinding {
+  readonly severity: "error";
+  readonly route: string;
+  readonly routeId: string;
+  readonly direction: "request" | "response" | "route";
+  readonly path: string;
+  readonly kind: string;
+  readonly problem: string;
+  readonly impact: string;
+  readonly recommendation: string;
+  readonly agentPrompt: string;
+}
+
+interface CompareContext {
+  readonly route: string;
+  readonly routeId: string;
+  readonly direction: RuntimeApiCompatFinding["direction"];
+  readonly findings: RuntimeApiCompatFinding[];
+}
+
+export function compareRuntimeApiSchemas(
+  online: RuntimeApiSchemaDocument,
+  current: RuntimeApiSchemaDocument,
+): readonly RuntimeApiCompatFinding[] {
+  const findings: RuntimeApiCompatFinding[] = [];
+  const currentRoutes = new Map(
+    current.routes.map((route) => {
+      return [route.id, route];
+    }),
+  );
+
+  for (const onlineRoute of online.routes) {
+    const currentRoute = currentRoutes.get(onlineRoute.id);
+    if (!currentRoute) {
+      findings.push(
+        routeFinding(onlineRoute, {
+          direction: "route",
+          path: "$",
+          kind: "route-removed",
+          problem:
+            "The runtime API route exists in production schema but is missing from the current schema.",
+          recommendation:
+            "Keep the route for one release, or add an explicit compatibility shim that preserves the old path.",
+        }),
+      );
+      continue;
+    }
+
+    compareRouteIdentity(onlineRoute, currentRoute, findings);
+    compareRequestPart(onlineRoute, currentRoute, "headers", findings);
+    compareRequestPart(onlineRoute, currentRoute, "query", findings);
+    compareRequestPart(onlineRoute, currentRoute, "pathParams", findings);
+    compareRequestPart(onlineRoute, currentRoute, "body", findings);
+    compareResponses(onlineRoute, currentRoute, findings);
+  }
+
+  return findings;
+}
+
+export function renderCompatReport(
+  findings: readonly RuntimeApiCompatFinding[],
+): string {
+  if (findings.length === 0) {
+    return "Runtime API schema compatibility check passed.\n";
+  }
+
+  const sections = findings.map((finding, index) => {
+    return [
+      `Runtime API compatibility break ${index + 1}/${findings.length}`,
+      "",
+      `Route: ${finding.route}`,
+      `Direction: ${finding.direction}`,
+      `Path: ${finding.path}`,
+      `Kind: ${finding.kind}`,
+      "",
+      `Problem: ${finding.problem}`,
+      "",
+      `Impact: ${finding.impact}`,
+      "",
+      `Suggested fix: ${finding.recommendation}`,
+      "",
+      "Agent prompt:",
+      finding.agentPrompt,
+    ].join("\n");
+  });
+
+  return `${sections.join("\n\n---\n\n")}\n`;
+}
+
+export function renderCompatReportJson(
+  findings: readonly RuntimeApiCompatFinding[],
+): string {
+  return `${stableStringify({ findings })}\n`;
+}
+
+function compareRouteIdentity(
+  online: RuntimeApiRouteSnapshot,
+  current: RuntimeApiRouteSnapshot,
+  findings: RuntimeApiCompatFinding[],
+): void {
+  if (online.method !== current.method) {
+    findings.push(
+      routeFinding(online, {
+        direction: "route",
+        path: "method",
+        kind: "method-changed",
+        problem: `The route method changed from ${online.method} to ${current.method}.`,
+        recommendation:
+          "Keep the previous method/path live for one release and add a new route separately.",
+      }),
+    );
+  }
+
+  if (online.path !== current.path) {
+    findings.push(
+      routeFinding(online, {
+        direction: "route",
+        path: "path",
+        kind: "path-changed",
+        problem: `The route path changed from ${online.path} to ${current.path}.`,
+        recommendation:
+          "Keep the previous method/path live for one release and add a new route separately.",
+      }),
+    );
+  }
+}
+
+function compareRequestPart(
+  online: RuntimeApiRouteSnapshot,
+  current: RuntimeApiRouteSnapshot,
+  part: keyof RuntimeApiRouteSnapshot["request"],
+  findings: RuntimeApiCompatFinding[],
+): void {
+  const onlineSchema = online.request[part];
+  if (!onlineSchema) {
+    return;
+  }
+
+  const currentSchema = current.request[part];
+  const context: CompareContext = {
+    route: routeLabel(online),
+    routeId: online.id,
+    direction: "request",
+    findings,
+  };
+
+  compareSchemaSubset(onlineSchema, currentSchema, `request.${part}`, context);
+}
+
+function compareResponses(
+  online: RuntimeApiRouteSnapshot,
+  current: RuntimeApiRouteSnapshot,
+  findings: RuntimeApiCompatFinding[],
+): void {
+  for (const [status, onlineSchema] of Object.entries(online.responses)) {
+    if (!status.startsWith("2")) {
+      continue;
+    }
+
+    const currentSchema = current.responses[status];
+    const context: CompareContext = {
+      route: routeLabel(online),
+      routeId: online.id,
+      direction: "response",
+      findings,
+    };
+
+    compareSchemaSubset(
+      currentSchema,
+      onlineSchema,
+      `responses.${status}`,
+      context,
+    );
+  }
+}
+
+function compareSchemaSubset(
+  subset: RuntimeSchemaSnapshot | undefined,
+  superset: RuntimeSchemaSnapshot | undefined,
+  path: string,
+  context: CompareContext,
+): void {
+  if (!subset) {
+    return;
+  }
+
+  if (!superset) {
+    pushFinding(context, {
+      path,
+      kind: `${context.direction}-schema-removed`,
+      problem:
+        context.direction === "request"
+          ? "The current API schema removed a request part that production runtime clients may still send."
+          : "The current API schema removed a response schema that production runtime clients may still expect.",
+      recommendation:
+        "Keep the old schema shape accepted for one release before removing it.",
+    });
+    return;
+  }
+
+  if (subset.kind === "opaque" || superset.kind === "opaque") {
+    return;
+  }
+
+  compareJsonSchemaSubset(subset.schema, superset.schema, path, context);
+}
+
+function compareJsonSchemaSubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  compareTypeSubset(subset, superset, path, context);
+  compareEnumSubset(subset, superset, path, context);
+  compareConstSubset(subset, superset, path, context);
+  compareObjectSubset(subset, superset, path, context);
+  compareArraySubset(subset, superset, path, context);
+  compareBoundsSubset(subset, superset, path, context);
+  compareUnionSubset(subset, superset, path, context);
+}
+
+function compareTypeSubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  const subsetTypes = readTypeSet(subset);
+  const supersetTypes = readTypeSet(superset);
+  if (!subsetTypes || !supersetTypes) {
+    return;
+  }
+
+  for (const type of subsetTypes) {
+    if (!supersetTypes.has(type)) {
+      pushFinding(context, {
+        path,
+        kind: `${context.direction}-type-narrowed`,
+        problem: `The current schema no longer accepts type ${type} at ${path}.`,
+        recommendation:
+          "Keep the old type accepted for one release, usually with a union or compatibility parser.",
+      });
+    }
+  }
+}
+
+function compareEnumSubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  const subsetEnum = readStringArray(subset.enum);
+  const supersetEnum = readStringArray(superset.enum);
+  if (!subsetEnum || !supersetEnum) {
+    return;
+  }
+
+  for (const value of subsetEnum) {
+    if (!supersetEnum.includes(value)) {
+      pushFinding(context, {
+        path,
+        kind: `${context.direction}-enum-value-removed`,
+        problem: `Enum value ${JSON.stringify(value)} is present in production schema but not in the current schema.`,
+        recommendation:
+          "Keep accepting the previous enum value for one release before removing it.",
+      });
+    }
+  }
+}
+
+function compareConstSubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  if (!("const" in subset) || !("const" in superset)) {
+    return;
+  }
+
+  if (subset.const !== superset.const) {
+    pushFinding(context, {
+      path,
+      kind: `${context.direction}-const-changed`,
+      problem: `Const value changed from ${JSON.stringify(subset.const)} to ${JSON.stringify(superset.const)}.`,
+      recommendation:
+        "Keep the previous const value accepted for one release, usually by widening to an enum/union.",
+    });
+  }
+}
+
+function compareObjectSubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  if (!isObjectSchema(subset) || !isObjectSchema(superset)) {
+    return;
+  }
+
+  const subsetProperties = readProperties(subset.properties);
+  const supersetProperties = readProperties(superset.properties);
+  const subsetRequired = new Set(readStringArray(subset.required) ?? []);
+  const supersetRequired = new Set(readStringArray(superset.required) ?? []);
+
+  for (const requiredField of supersetRequired) {
+    if (!subsetRequired.has(requiredField)) {
+      pushFinding(context, {
+        path: `${path}.${requiredField}`,
+        kind:
+          context.direction === "request"
+            ? "request-required-field-added"
+            : "response-required-field-removed",
+        problem:
+          context.direction === "request"
+            ? `Field ${requiredField} is required by the current schema but was not required by the production schema.`
+            : `Field ${requiredField} is required by production clients but may be missing from the current response schema.`,
+        recommendation:
+          context.direction === "request"
+            ? "Make the new request field optional, provide a default, or accept both old and new request shapes."
+            : "Keep returning the field for one release, or make sure runtime clients no longer require it first.",
+      });
+    }
+  }
+
+  for (const [field, subsetFieldSchema] of Object.entries(subsetProperties)) {
+    const fieldPath = `${path}.${field}`;
+    const supersetFieldSchema = supersetProperties[field];
+
+    if (!supersetFieldSchema) {
+      if (context.direction === "request" && subsetRequired.has(field)) {
+        pushFinding(context, {
+          path: fieldPath,
+          kind: "request-required-field-removed",
+          problem: `Required field ${field} exists in production request schema but is missing from the current schema.`,
+          recommendation:
+            "Keep accepting this field for one release. For renames, accept the old alias and normalize it in the handler.",
+        });
+      }
+      continue;
+    }
+
+    compareJsonSchemaSubset(
+      subsetFieldSchema,
+      supersetFieldSchema,
+      fieldPath,
+      context,
+    );
+  }
+}
+
+function compareArraySubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  const subsetItems = readObject(subset.items);
+  const supersetItems = readObject(superset.items);
+  if (!subsetItems || !supersetItems) {
+    return;
+  }
+  compareJsonSchemaSubset(subsetItems, supersetItems, `${path}[]`, context);
+}
+
+function compareBoundsSubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  compareLowerBound(subset, superset, "minimum", path, context);
+  compareLowerBound(subset, superset, "minLength", path, context);
+  compareLowerBound(subset, superset, "minItems", path, context);
+  compareUpperBound(subset, superset, "maximum", path, context);
+  compareUpperBound(subset, superset, "maxLength", path, context);
+  compareUpperBound(subset, superset, "maxItems", path, context);
+}
+
+function compareLowerBound(
+  subset: JsonObject,
+  superset: JsonObject,
+  key: string,
+  path: string,
+  context: CompareContext,
+): void {
+  const subsetValue = readNumber(subset[key]);
+  const supersetValue = readNumber(superset[key]);
+  if (subsetValue === undefined || supersetValue === undefined) {
+    return;
+  }
+
+  if (subsetValue < supersetValue) {
+    pushFinding(context, {
+      path,
+      kind: `${context.direction}-lower-bound-tightened`,
+      problem: `The lower bound ${key} changed from ${subsetValue} to ${supersetValue}.`,
+      recommendation:
+        "Keep the previous lower bound accepted for one release before tightening it.",
+    });
+  }
+}
+
+function compareUpperBound(
+  subset: JsonObject,
+  superset: JsonObject,
+  key: string,
+  path: string,
+  context: CompareContext,
+): void {
+  const subsetValue = readNumber(subset[key]);
+  const supersetValue = readNumber(superset[key]);
+  if (subsetValue === undefined || supersetValue === undefined) {
+    return;
+  }
+
+  if (subsetValue > supersetValue) {
+    pushFinding(context, {
+      path,
+      kind: `${context.direction}-upper-bound-tightened`,
+      problem: `The upper bound ${key} changed from ${subsetValue} to ${supersetValue}.`,
+      recommendation:
+        "Keep the previous upper bound accepted for one release before tightening it.",
+    });
+  }
+}
+
+function compareUnionSubset(
+  subset: JsonObject,
+  superset: JsonObject,
+  path: string,
+  context: CompareContext,
+): void {
+  const subsetBranches =
+    readSchemaArray(subset.anyOf) ?? readSchemaArray(subset.oneOf);
+  const supersetBranches =
+    readSchemaArray(superset.anyOf) ?? readSchemaArray(superset.oneOf);
+
+  if (!subsetBranches || !supersetBranches) {
+    return;
+  }
+
+  for (const [index, branch] of subsetBranches.entries()) {
+    const compatible = supersetBranches.some((candidate) => {
+      const nestedFindings: RuntimeApiCompatFinding[] = [];
+      compareJsonSchemaSubset(branch, candidate, path, {
+        ...context,
+        findings: nestedFindings,
+      });
+      return nestedFindings.length === 0;
+    });
+
+    if (!compatible) {
+      pushFinding(context, {
+        path: `${path}.anyOf[${index}]`,
+        kind: `${context.direction}-union-branch-removed`,
+        problem:
+          "A union branch present in the production schema is not accepted by the current schema.",
+        recommendation:
+          "Keep the previous union branch accepted for one release before removing it.",
+      });
+    }
+  }
+}
+
+function routeFinding(
+  route: RuntimeApiRouteSnapshot,
+  input: Omit<
+    RuntimeApiCompatFinding,
+    "severity" | "route" | "routeId" | "impact" | "agentPrompt"
+  >,
+): RuntimeApiCompatFinding {
+  return buildFinding({
+    route: routeLabel(route),
+    routeId: route.id,
+    ...input,
+  });
+}
+
+function pushFinding(
+  context: CompareContext,
+  input: Omit<
+    RuntimeApiCompatFinding,
+    "severity" | "route" | "routeId" | "direction" | "impact" | "agentPrompt"
+  >,
+): void {
+  context.findings.push(
+    buildFinding({
+      route: context.route,
+      routeId: context.routeId,
+      direction: context.direction,
+      ...input,
+    }),
+  );
+}
+
+function buildFinding(
+  input: Omit<RuntimeApiCompatFinding, "severity" | "impact" | "agentPrompt">,
+): RuntimeApiCompatFinding {
+  const impact = impactFor(input.direction);
+  const agentPrompt = [
+    "You are fixing a one-version runtime API compatibility break.",
+    `Route: ${input.route}.`,
+    `Problem: ${input.problem}`,
+    `Impact: ${impact}`,
+    `Fix guidance: ${input.recommendation}`,
+    "Preserve compatibility with the online production schema. Prefer accepting both old and new request shapes, using optional fields, aliases, defaults, or a union/preprocess compatibility layer. Add a targeted test for the old production payload before tightening the contract in a later release.",
+  ].join(" ");
+
+  return {
+    severity: "error",
+    impact,
+    agentPrompt,
+    ...input,
+  };
+}
+
+function impactFor(direction: RuntimeApiCompatFinding["direction"]): string {
+  if (direction === "request") {
+    return "Existing production runner, guest-agent, or MITM clients may receive HTTP 400 from the new API during an otherwise healthy container run, causing run execution, checkpointing, telemetry, or completion to be marked failed.";
+  }
+
+  if (direction === "response") {
+    return "Existing production runner, guest-agent, or MITM clients may fail to decode the new API response during container execution, causing the task to fail after deployment.";
+  }
+
+  return "Existing production runner, guest-agent, or MITM clients may keep calling the old method/path during a rolling release and fail against the new API.";
+}
+
+function routeLabel(route: RuntimeApiRouteSnapshot): string {
+  return `${route.method} ${route.path}`;
+}
+
+function isObjectSchema(schema: JsonObject): boolean {
+  const types = readTypeSet(schema);
+  return (
+    types?.has("object") === true || readObject(schema.properties) !== undefined
+  );
+}
+
+function readTypeSet(schema: JsonObject): ReadonlySet<string> | undefined {
+  const type = schema.type;
+  if (typeof type === "string") {
+    return new Set([type]);
+  }
+  const types = readStringArray(type);
+  return types ? new Set(types) : undefined;
+}
+
+function readProperties(
+  value: JsonValue | undefined,
+): Record<string, JsonObject> {
+  const properties = readObject(value);
+  if (!properties) {
+    return {};
+  }
+
+  const result: Record<string, JsonObject> = {};
+  for (const [key, schema] of Object.entries(properties)) {
+    const objectSchema = readObject(schema);
+    if (objectSchema) {
+      result[key] = objectSchema;
+    }
+  }
+  return result;
+}
+
+function readSchemaArray(
+  value: JsonValue | undefined,
+): readonly JsonObject[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const schemas = value.map(readObject);
+  return schemas.every((schema): schema is JsonObject => {
+    return schema !== undefined;
+  })
+    ? schemas
+    : undefined;
+}
+
+function readObject(value: JsonValue | undefined): JsonObject | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : undefined;
+}
+
+function readStringArray(
+  value: JsonValue | undefined,
+): readonly string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.every((item) => {
+    return typeof item === "string";
+  })
+    ? (value as readonly string[])
+    : undefined;
+}
+
+function readNumber(value: JsonValue | undefined): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}

--- a/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
@@ -1,0 +1,127 @@
+import { runnerRealtimeTokenContract } from "../contracts/realtime";
+import {
+  runnersHeartbeatContract,
+  runnersJobClaimContract,
+  runnersPollContract,
+} from "../contracts/runners";
+import {
+  webhookCheckpointsContract,
+  webhookCheckpointsPrepareHistoryContract,
+  webhookCompleteContract,
+  webhookEventsContract,
+  webhookFirewallAuthContract,
+  webhookHeartbeatContract,
+  webhookModelUsageObservationContract,
+  webhookStoragesCommitContract,
+  webhookStoragesContract,
+  webhookStoragesIncrementalContract,
+  webhookStoragesPrepareContract,
+  webhookTelemetryContract,
+  webhookUsageEventContract,
+} from "../contracts/webhooks";
+
+export interface RuntimeApiRouteLike {
+  readonly method?: unknown;
+  readonly path?: unknown;
+  readonly summary?: unknown;
+  readonly headers?: unknown;
+  readonly query?: unknown;
+  readonly pathParams?: unknown;
+  readonly body?: unknown;
+  readonly contentType?: unknown;
+  readonly responses?: unknown;
+}
+
+export interface RuntimeApiRouteBinding {
+  readonly id: string;
+  readonly owner: "runner" | "guest-agent" | "mitm-addon";
+  readonly route: RuntimeApiRouteLike;
+}
+
+export const runtimeApiRouteBindings = [
+  {
+    id: "runners.poll",
+    owner: "runner",
+    route: runnersPollContract.poll,
+  },
+  {
+    id: "runners.jobs.claim",
+    owner: "runner",
+    route: runnersJobClaimContract.claim,
+  },
+  {
+    id: "runners.heartbeat",
+    owner: "runner",
+    route: runnersHeartbeatContract.heartbeat,
+  },
+  {
+    id: "runners.realtime.token",
+    owner: "runner",
+    route: runnerRealtimeTokenContract.create,
+  },
+  {
+    id: "webhooks.agent.events",
+    owner: "guest-agent",
+    route: webhookEventsContract.send,
+  },
+  {
+    id: "webhooks.agent.checkpoints",
+    owner: "guest-agent",
+    route: webhookCheckpointsContract.create,
+  },
+  {
+    id: "webhooks.agent.checkpoints.prepareHistory",
+    owner: "guest-agent",
+    route: webhookCheckpointsPrepareHistoryContract.prepare,
+  },
+  {
+    id: "webhooks.agent.complete",
+    owner: "guest-agent",
+    route: webhookCompleteContract.complete,
+  },
+  {
+    id: "webhooks.agent.heartbeat",
+    owner: "guest-agent",
+    route: webhookHeartbeatContract.send,
+  },
+  {
+    id: "webhooks.agent.telemetry",
+    owner: "guest-agent",
+    route: webhookTelemetryContract.send,
+  },
+  {
+    id: "webhooks.agent.storages",
+    owner: "guest-agent",
+    route: webhookStoragesContract.upload,
+  },
+  {
+    id: "webhooks.agent.storages.incremental",
+    owner: "guest-agent",
+    route: webhookStoragesIncrementalContract.upload,
+  },
+  {
+    id: "webhooks.agent.storages.prepare",
+    owner: "guest-agent",
+    route: webhookStoragesPrepareContract.prepare,
+  },
+  {
+    id: "webhooks.agent.storages.commit",
+    owner: "guest-agent",
+    route: webhookStoragesCommitContract.commit,
+  },
+  {
+    id: "webhooks.agent.firewall.auth",
+    owner: "mitm-addon",
+    route: webhookFirewallAuthContract.resolve,
+  },
+  {
+    id: "webhooks.agent.usageEvent",
+    owner: "mitm-addon",
+    route: webhookUsageEventContract.send,
+  },
+  {
+    id: "webhooks.agent.modelUsageObservation",
+    owner: "mitm-addon",
+    route: webhookModelUsageObservationContract.send,
+  },
+] as const satisfies readonly RuntimeApiRouteBinding[];

--- a/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
@@ -1,0 +1,260 @@
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+import packageJson from "../../package.json" with { type: "json" };
+import { type RuntimeApiRouteBinding, runtimeApiRouteBindings } from "./routes";
+
+export const runtimeApiSchemaFormatVersion = 1;
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export interface JsonObject {
+  readonly [key: string]: JsonValue;
+}
+
+export interface RuntimeApiSchemaDocument {
+  readonly schemaFormatVersion: number;
+  readonly packageName: string;
+  readonly packageVersion: string;
+  readonly generatedAt: string;
+  readonly routes: readonly RuntimeApiRouteSnapshot[];
+}
+
+export interface RuntimeApiRouteSnapshot {
+  readonly id: string;
+  readonly owner: RuntimeApiRouteBinding["owner"];
+  readonly method: string;
+  readonly path: string;
+  readonly summary?: string;
+  readonly contentType?: string;
+  readonly request: {
+    readonly headers?: RuntimeSchemaSnapshot;
+    readonly query?: RuntimeSchemaSnapshot;
+    readonly pathParams?: RuntimeSchemaSnapshot;
+    readonly body?: RuntimeSchemaSnapshot;
+  };
+  readonly responses: Readonly<Record<string, RuntimeSchemaSnapshot>>;
+}
+
+export type RuntimeSchemaSnapshot =
+  | {
+      readonly kind: "json-schema";
+      readonly schema: JsonObject;
+    }
+  | {
+      readonly kind: "opaque";
+      readonly reason: string;
+    };
+
+export function buildRuntimeApiSchemaDocument(
+  generatedAt = new Date().toISOString(),
+): RuntimeApiSchemaDocument {
+  const routes = runtimeApiRouteBindings
+    .map(normalizeRuntimeApiRoute)
+    .sort((left, right) => {
+      return left.id.localeCompare(right.id);
+    });
+
+  return {
+    schemaFormatVersion: runtimeApiSchemaFormatVersion,
+    packageName: packageJson.name,
+    packageVersion: packageJson.version,
+    generatedAt,
+    routes,
+  };
+}
+
+export function renderRuntimeApiSchemaDocument(
+  document = buildRuntimeApiSchemaDocument(),
+): string {
+  return `${stableStringify(document)}\n`;
+}
+
+export async function readRuntimeApiSchemaDocument(
+  path: string,
+): Promise<RuntimeApiSchemaDocument> {
+  const raw = await readFile(path, "utf8");
+  return parseRuntimeApiSchemaDocument(JSON.parse(raw));
+}
+
+function parseRuntimeApiSchemaDocument(
+  value: unknown,
+): RuntimeApiSchemaDocument {
+  const document = runtimeApiSchemaDocumentSchema.parse(
+    value,
+  ) as unknown as RuntimeApiSchemaDocument;
+  if (document.schemaFormatVersion !== runtimeApiSchemaFormatVersion) {
+    throw new Error(
+      `Unsupported runtime API schema format version ${document.schemaFormatVersion}`,
+    );
+  }
+  return document;
+}
+
+function normalizeRuntimeApiRoute(
+  binding: RuntimeApiRouteBinding,
+): RuntimeApiRouteSnapshot {
+  const { route } = binding;
+  const method = validateString(route.method, `${binding.id}.method`);
+  const path = validateString(route.path, `${binding.id}.path`);
+  const summary = optionalString(route.summary);
+  const contentType = optionalString(route.contentType);
+
+  return {
+    id: binding.id,
+    owner: binding.owner,
+    method,
+    path,
+    ...(summary ? { summary } : {}),
+    ...(contentType ? { contentType } : {}),
+    request: {
+      ...(route.headers
+        ? { headers: normalizeSchema(route.headers, `${binding.id}.headers`) }
+        : {}),
+      ...(route.query
+        ? { query: normalizeSchema(route.query, `${binding.id}.query`) }
+        : {}),
+      ...(route.pathParams
+        ? {
+            pathParams: normalizeSchema(
+              route.pathParams,
+              `${binding.id}.pathParams`,
+            ),
+          }
+        : {}),
+      ...(route.body
+        ? { body: normalizeSchema(route.body, `${binding.id}.body`) }
+        : {}),
+    },
+    responses: normalizeResponses(route.responses, binding.id),
+  };
+}
+
+function normalizeResponses(
+  responses: unknown,
+  routeId: string,
+): Readonly<Record<string, RuntimeSchemaSnapshot>> {
+  if (!responses || typeof responses !== "object" || Array.isArray(responses)) {
+    throw new Error(`${routeId}.responses must be an object`);
+  }
+
+  const normalized: Record<string, RuntimeSchemaSnapshot> = {};
+  for (const [status, schema] of Object.entries(responses)) {
+    const responseBodySchema = normalizeResponseSchema(schema);
+    normalized[status] = normalizeSchema(
+      responseBodySchema,
+      `${routeId}.responses.${status}`,
+    );
+  }
+  return normalized;
+}
+
+function normalizeResponseSchema(responseSchema: unknown): unknown {
+  if (
+    responseSchema &&
+    typeof responseSchema === "object" &&
+    !Array.isArray(responseSchema) &&
+    "body" in responseSchema
+  ) {
+    return (responseSchema as { readonly body?: unknown }).body;
+  }
+  return responseSchema;
+}
+
+function normalizeSchema(
+  schema: unknown,
+  label: string,
+): RuntimeSchemaSnapshot {
+  if (isZodSchema(schema)) {
+    return {
+      kind: "json-schema",
+      schema: normalizeJsonValue(z.toJSONSchema(schema), label),
+    };
+  }
+
+  return {
+    kind: "opaque",
+    reason: `Schema at ${label} cannot be represented as JSON Schema`,
+  };
+}
+
+function isZodSchema(schema: unknown): schema is z.ZodType {
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    "safeParse" in schema &&
+    typeof (schema as { readonly safeParse?: unknown }).safeParse === "function"
+  );
+}
+
+function normalizeJsonValue(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} JSON Schema must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function validateString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortJsonValue(value), null, 2);
+}
+
+function sortJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortJsonValue);
+  }
+
+  if (value && typeof value === "object") {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortJsonValue((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+
+  return value;
+}
+
+const runtimeSchemaSnapshotSchema = z.union([
+  z.object({
+    kind: z.literal("json-schema"),
+    schema: z.record(z.string(), z.unknown()),
+  }),
+  z.object({
+    kind: z.literal("opaque"),
+    reason: z.string(),
+  }),
+]);
+
+const runtimeApiRouteSnapshotSchema = z.object({
+  id: z.string().min(1),
+  owner: z.enum(["runner", "guest-agent", "mitm-addon"]),
+  method: z.string().min(1),
+  path: z.string().min(1),
+  summary: z.string().optional(),
+  contentType: z.string().optional(),
+  request: z.object({
+    headers: runtimeSchemaSnapshotSchema.optional(),
+    query: runtimeSchemaSnapshotSchema.optional(),
+    pathParams: runtimeSchemaSnapshotSchema.optional(),
+    body: runtimeSchemaSnapshotSchema.optional(),
+  }),
+  responses: z.record(z.string(), runtimeSchemaSnapshotSchema),
+});
+
+const runtimeApiSchemaDocumentSchema = z.object({
+  schemaFormatVersion: z.number(),
+  packageName: z.string(),
+  packageVersion: z.string(),
+  generatedAt: z.string(),
+  routes: z.array(runtimeApiRouteSnapshotSchema),
+});

--- a/turbo/packages/api-contracts/tsconfig.runtime-api-schema.json
+++ b/turbo/packages/api-contracts/tsconfig.runtime-api-schema.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/runtime-api-schema/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -273,6 +273,10 @@
     "lint": {
       "dependsOn": ["^lint"]
     },
+    "lint-runtime-api-compat": {
+      "cache": false,
+      "outputs": []
+    },
     "check-types": {
       "dependsOn": ["^check-types", "^build"]
     },


### PR DESCRIPTION
## Summary
- restore runtime API schema generation for runner, guest-agent, and MITM webhook contracts
- publish the built runtime API schema as a production release asset after API promotion
- add a Turbo runtime API schema compatibility report job that builds the schema before release
- keep the Turbo schema compatibility job report-only with job-level `continue-on-error: true` and no `ci-gate-turbo` dependency

## Verification
- `git diff --cached --check`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @vm0/api-contracts run build:runtime-api-schema -- --out /tmp/runtime-api-schema-candidate.json`
- `pnpm --filter @vm0/api-contracts run lint-runtime-api-compat -- --against /tmp/runtime-api-schema-candidate.json --current /tmp/runtime-api-schema-candidate.json --report-out /tmp/runtime-api-schema-report.json --warn-only`
- `pnpm --filter @vm0/api-contracts run check-types`
- `pnpm --filter @vm0/api-contracts exec vitest run src/runtime-api-schema/__tests__/compat.test.ts`
- `pnpm --filter @vm0/api-contracts run lint`
- `pnpm exec prettier --check --ignore-unknown ../.github/workflows/release-please.yml ../.github/workflows/turbo.yml packages/api-contracts/package.json packages/api-contracts/src/runtime-api-schema/__tests__/compat.test.ts packages/api-contracts/src/runtime-api-schema/cli.ts packages/api-contracts/src/runtime-api-schema/compat.ts packages/api-contracts/src/runtime-api-schema/routes.ts packages/api-contracts/src/runtime-api-schema/schema.ts packages/api-contracts/tsconfig.runtime-api-schema.json turbo.json`