### PR TITLE
feat: enable data export for everyone

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -12,6 +12,7 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.ChatInitialThinkingIndicator, {}),
     ).toBe(true);
+    expect(isFeatureEnabled(FeatureSwitchKey.DataExport, {})).toBe(true);
   });
 
   it("should return true for globally enabled switch even with context", () => {
@@ -91,6 +92,7 @@ describe("getAllFeatureStates", () => {
     // Globally enabled switches should be true
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     expect(states[FeatureSwitchKey.ChatInitialThinkingIndicator]).toBe(true);
+    expect(states[FeatureSwitchKey.DataExport]).toBe(true);
   });
 
   it("should enable switches when orgId matches enabledOrgIdHashes", () => {
@@ -131,6 +133,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.ChatInitialThinkingIndicator]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.DataExport]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -150,6 +153,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.ChatInitialThinkingIndicator]).toBe(
       true,
     );
+    expect(otherOrgStates[FeatureSwitchKey.DataExport]).toBe(true);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -173,7 +173,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.DataExport]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the data export option in account menu",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.ZeroDebug]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Enable the `DataExport` feature switch globally.
- Add assertions covering the new global rollout state.

## Verification
- `pnpm exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm exec vitest run packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/core lint`

Full local vitest and local dev server were not run per vm0 PR verification preference.
