### PR TITLE
fix: align chat video attachment preview size

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -849,6 +849,49 @@ describe("zero attachment chips", () => {
     ).toBeTruthy();
   });
 
+  it("renders user video attachments at the same size as image attachments", async () => {
+    const imageUrl = "https://cdn.vm7.io/artifacts/test/media/photo.png";
+    const videoUrl = "https://cdn.vm7.io/artifacts/test/media/screencast.mp4";
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-image-video-attachments",
+          role: "user",
+          content: "this is the screencast",
+          attachFiles: [
+            {
+              id: "attachment-photo",
+              filename: "photo.png",
+              contentType: "image/png",
+              size: 2048,
+              url: imageUrl,
+            },
+            {
+              id: "attachment-screencast",
+              filename: "screencast.mp4",
+              contentType: "video/mp4",
+              size: 4096,
+              url: videoUrl,
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+    const imagePreview = await screen.findByLabelText("Preview photo.png");
+    const videoPreview = screen.getByLabelText("Preview screencast.mp4");
+
+    expect(imagePreview).toHaveClass("aspect-[10/9]", "w-[50px]", "max-w-full");
+    expect(videoPreview).toHaveClass("aspect-[10/9]", "w-[50px]", "max-w-full");
+    expect(videoPreview).toHaveClass("cursor-pointer", "bg-muted/30");
+    expect(videoPreview).not.toHaveClass("w-[min(100%,400px)]");
+    expect(screen.getByText("this is the screencast")).toBeInTheDocument();
+  });
+
   it("opens persisted audio, video, and document attachments from chat history", async () => {
     const audioUrl =
       "https://cdn.vm7.io/artifacts/test/attachment-audio/briefing.mp3";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -885,9 +885,18 @@ describe("zero attachment chips", () => {
     const imagePreview = await screen.findByLabelText("Preview photo.png");
     const videoPreview = screen.getByLabelText("Preview screencast.mp4");
 
-    expect(imagePreview).toHaveClass("aspect-[10/9]", "w-[50px]", "max-w-full");
-    expect(videoPreview).toHaveClass("aspect-[10/9]", "w-[50px]", "max-w-full");
-    expect(videoPreview).toHaveClass("cursor-pointer", "bg-muted/30");
+    const inlineMediaPreviewSizeClasses = [
+      "aspect-[10/9]",
+      "w-[50px]",
+      "max-w-full",
+    ];
+
+    expect(imagePreview).toHaveClass(...inlineMediaPreviewSizeClasses);
+    expect(videoPreview).toHaveClass(...inlineMediaPreviewSizeClasses);
+    expect(videoPreview).toHaveClass("cursor-pointer", "bg-black");
+    expect(
+      within(videoPreview).getByTestId("chat-video-preview-poster"),
+    ).toHaveClass("h-full", "w-full");
     expect(videoPreview).not.toHaveClass("w-[min(100%,400px)]");
     expect(screen.getByText("this is the screencast")).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -897,6 +897,9 @@ describe("zero attachment chips", () => {
     expect(
       within(videoPreview).getByTestId("chat-video-preview-poster"),
     ).toHaveClass("h-full", "w-full");
+    expect(
+      within(videoPreview).getByTestId("chat-video-preview-poster"),
+    ).toBeEmptyDOMElement();
     expect(videoPreview).not.toHaveClass("w-[min(100%,400px)]");
     expect(screen.getByText("this is the screencast")).toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1788,13 +1788,8 @@ function ChatVideoPreviewButton({
     >
       <span
         data-testid="chat-video-preview-poster"
-        className={cn(
-          "flex items-center justify-center bg-black text-white/70",
-          posterClassName,
-        )}
-      >
-        <IconVideo size={22} stroke={1.5} />
-      </span>
+        className={cn("block bg-black", posterClassName)}
+      />
       <video
         src={posterVideoUrl}
         preload="metadata"

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1647,11 +1647,15 @@ type ChatImagePreviewLinkProps = {
   url: string;
 };
 
-const CHAT_INLINE_MEDIA_PREVIEW_CLASS =
-  "inline-flex aspect-[16/10] w-[min(100%,400px)] items-center justify-center rounded-lg border border-foreground/10 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
+const CHAT_INLINE_PREVIEW_SIZE_CLASS = "aspect-[10/9] w-[50px] max-w-full";
+const CHAT_INLINE_PREVIEW_FRAME_CLASS =
+  "rounded-lg border border-foreground/10 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
 
-const CHAT_INLINE_IMAGE_PREVIEW_CLASS =
-  "aspect-[10/9] w-[50px] max-w-full cursor-pointer rounded-lg border border-foreground/10 bg-muted/30 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
+const CHAT_INLINE_IMAGE_PREVIEW_CLASS = cn(
+  CHAT_INLINE_PREVIEW_SIZE_CLASS,
+  "cursor-pointer bg-muted/30",
+  CHAT_INLINE_PREVIEW_FRAME_CLASS,
+);
 
 const ARTIFACT_FULLSCREEN_SHELL_CLASSNAME =
   "fixed inset-0 z-[100] flex min-h-0 flex-col bg-background pt-[var(--sat)] pb-[var(--sab)]";
@@ -1774,7 +1778,7 @@ function ChatVideoPreviewButton({
       title={filename}
       aria-label={ariaLabel}
       className={cn(
-        "group/video-preview relative overflow-hidden bg-black",
+        "group/video-preview relative inline-flex items-center justify-center overflow-hidden",
         buttonClassName,
       )}
     >
@@ -5609,7 +5613,7 @@ function BodyContentBlocks({
             <ChatVideoPreviewButton
               key={block.id}
               ariaLabel={`Preview ${block.preview.filename}`}
-              buttonClassName={CHAT_INLINE_MEDIA_PREVIEW_CLASS}
+              buttonClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
               filename={block.preview.filename}
               onPreview={() => {
                 openVideoLightbox({
@@ -6940,7 +6944,7 @@ function UserMessageAttachments({
             <ChatVideoPreviewButton
               key={a.url}
               ariaLabel={`Preview ${a.filename}`}
-              buttonClassName={CHAT_INLINE_MEDIA_PREVIEW_CLASS}
+              buttonClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
               filename={a.filename}
               onPreview={() => {
                 openVideoLightbox({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1647,14 +1647,18 @@ type ChatImagePreviewLinkProps = {
   url: string;
 };
 
-const CHAT_INLINE_PREVIEW_SIZE_CLASS = "aspect-[10/9] w-[50px] max-w-full";
-const CHAT_INLINE_PREVIEW_FRAME_CLASS =
-  "rounded-lg border border-foreground/10 shadow-sm transition-all duration-200 hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30";
-
+const CHAT_INLINE_MEDIA_PREVIEW_CLASS = cn(
+  "aspect-[10/9] w-[50px] max-w-full cursor-pointer rounded-lg",
+  "border border-foreground/10 shadow-sm transition-all duration-200",
+  "hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30",
+);
 const CHAT_INLINE_IMAGE_PREVIEW_CLASS = cn(
-  CHAT_INLINE_PREVIEW_SIZE_CLASS,
-  "cursor-pointer bg-muted/30",
-  CHAT_INLINE_PREVIEW_FRAME_CLASS,
+  CHAT_INLINE_MEDIA_PREVIEW_CLASS,
+  "bg-muted/30",
+);
+const CHAT_INLINE_VIDEO_PREVIEW_CLASS = cn(
+  CHAT_INLINE_MEDIA_PREVIEW_CLASS,
+  "bg-black",
 );
 
 const ARTIFACT_FULLSCREEN_SHELL_CLASSNAME =
@@ -5613,7 +5617,7 @@ function BodyContentBlocks({
             <ChatVideoPreviewButton
               key={block.id}
               ariaLabel={`Preview ${block.preview.filename}`}
-              buttonClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
+              buttonClassName={CHAT_INLINE_VIDEO_PREVIEW_CLASS}
               filename={block.preview.filename}
               onPreview={() => {
                 openVideoLightbox({
@@ -6944,7 +6948,7 @@ function UserMessageAttachments({
             <ChatVideoPreviewButton
               key={a.url}
               ariaLabel={`Preview ${a.filename}`}
-              buttonClassName={CHAT_INLINE_IMAGE_PREVIEW_CLASS}
+              buttonClassName={CHAT_INLINE_VIDEO_PREVIEW_CLASS}
               filename={a.filename}
               onPreview={() => {
                 openVideoLightbox({


### PR DESCRIPTION
## Summary
- Align inline chat video previews with the image preview dimensions for both parsed body preview links and user attachments.
- Split shared inline media preview frame and size styles from image/video-specific backgrounds so video no longer reuses an image-named class.
- Keep video empty states to a single play affordance by removing the extra video-type icon from the poster placeholder.
- Add regression coverage for user messages that include both image and video attachments.

Fixes #19825

## Verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `pnpm -F @vm0/app lint`