### PR TITLE
ci: fix runtime api schema artifact path

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -787,7 +787,7 @@ jobs:
 
       - name: Build Runtime API Schema
         working-directory: turbo
-        run: pnpm --filter @vm0/api-contracts run build:runtime-api-schema -- --out runtime-api-schema.json
+        run: pnpm --filter @vm0/api-contracts run build:runtime-api-schema -- --out "$GITHUB_WORKSPACE/turbo/runtime-api-schema.json"
 
       - name: Upload Runtime API Schema Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a


### PR DESCRIPTION
## Summary
- write the runtime API schema to the exact workspace path uploaded by the release workflow
- keep the artifact download/publish path unchanged

## Release pipeline finding
- release-please run 28588394677 failed in `build-api-production`
- `Build Runtime API Schema` succeeded and wrote to `turbo/packages/api-contracts/runtime-api-schema.json`
- `Upload Runtime API Schema Artifact` looked for `turbo/runtime-api-schema.json` and failed with no files found

## Verification
- `export GITHUB_WORKSPACE=/home/user/workspace/vm0; pnpm --filter @vm0/api-contracts run build:runtime-api-schema -- --out "$GITHUB_WORKSPACE/turbo/runtime-api-schema.json"`
- `git diff --check`