### PR TITLE
fix: enforce session history read size cap

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -587,16 +587,6 @@ async fn create_checkpoint_impl(
         }
     };
     let history_size = history_bytes.len() as u64;
-    if history_size > RESUME_SESSION_HISTORY_MAX_BYTES {
-        return Err(fail(
-            mode,
-            "session_history_read",
-            history_read_start,
-            format!(
-                "Session history exceeds maximum size of {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
-            ),
-        ));
-    }
 
     let session_history_text = match std::str::from_utf8(&history_bytes) {
         Ok(s) => Some(s),

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -12,9 +12,8 @@
 //!   resolution until checkpoint time when the file is on disk.
 //!
 //! `read_session_history` is the file-backed entry point. Checkpoint resolves
-//! missing marker payloads first, then calls `read_session_history_from_payload`.
-//! Both paths return history bytes, decompressing legacy `.zst` files when
-//! needed.
+//! missing marker payloads first, then calls the bounded payload reader. Both
+//! paths return history bytes, decompressing legacy `.zst` files when needed.
 //!
 //! See parent epic #11386, sub-issue #11419 for the design rationale.
 //!

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -816,6 +816,18 @@ mod tests {
     }
 
     #[test]
+    fn bounded_read_rejects_nonempty_zstd_history_with_zero_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let compressed = zstd::encode_all(b"a".as_slice(), 0).unwrap();
+        let path = write_history_file(&dir, "history.jsonl.zst", &compressed);
+
+        let err = read_session_history_from_payload_bounded(path.to_str().unwrap(), 0)
+            .expect_err("bounded zstd read must reject nonempty history when cap is zero");
+
+        assert_over_limit(err, 0);
+    }
+
+    #[test]
     fn bounded_read_rejects_literal_history_over_limit() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_history_file(&dir, "history.jsonl", b"abcde");

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -42,6 +42,7 @@ use std::path::{Path, PathBuf};
 use std::fs::File;
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
+pub(crate) const SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 // Checkpoint must resolve Codex history from user-controlled guest-home state.
 // Keep the budget comfortably above normal date-partitioned histories while
 // preventing layout-shaped trees from turning session lookup into an
@@ -69,10 +70,26 @@ pub(crate) fn is_codex_marker(payload: &str) -> bool {
 /// codex marker. Returns the file contents, decompressed if the resolved path
 /// ends in `.zst`.
 pub fn read_session_history(path_file: &str) -> Result<Vec<u8>, AgentError> {
-    let raw = std::fs::read_to_string(path_file).map_err(|e| {
+    let raw = read_history_marker_payload_file(path_file).map_err(|e| {
         AgentError::Checkpoint(format!("Failed to read history-path file {path_file}: {e}"))
     })?;
     read_session_history_from_payload(raw.trim())
+}
+
+pub(crate) fn read_history_marker_payload_file(path_file: &str) -> io::Result<String> {
+    let file = std::fs::File::open(path_file)?;
+    let mut bytes = Vec::new();
+    file.take((SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "session history marker exceeds maximum size of {SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES} bytes"
+            ),
+        ));
+    }
+    String::from_utf8(bytes).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
 /// Read session history bytes from an already-resolved marker payload.
@@ -836,6 +853,22 @@ mod tests {
             .expect_err("bounded literal read must reject over-limit history");
 
         assert_over_limit(err, 4);
+    }
+
+    #[test]
+    fn read_session_history_rejects_oversized_marker_payload_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let payload = vec![b'a'; SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES + 1];
+        let path = write_history_file(&dir, "session-history-marker", &payload);
+
+        let err = read_session_history(path.to_str().unwrap())
+            .expect_err("session history marker file read must reject oversized payloads");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("session history marker exceeds maximum size"),
+            "expected oversized marker error, got: {message}"
+        );
     }
 
     #[test]

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -864,6 +864,25 @@ mod tests {
     }
 
     #[test]
+    fn bounded_read_rejects_truncated_zstd_history_at_decoded_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let max_bytes = 1024;
+        let history = vec![b'a'; max_bytes as usize];
+        let mut compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        compressed.pop().expect("encoded fixture must not be empty");
+        let path = write_history_file(&dir, "history.jsonl.zst", &compressed);
+
+        let err = read_session_history_from_payload_bounded(path.to_str().unwrap(), max_bytes)
+            .expect_err("bounded zstd read must reject truncated history at the decoded cap");
+
+        let message = err.to_string();
+        assert!(
+            message.contains("Failed to decompress zstd session history"),
+            "expected decompression error for truncated zstd history, got: {message}"
+        );
+    }
+
+    #[test]
     fn bounded_read_rejects_zstd_history_over_decoded_limit() {
         let dir = tempfile::tempdir().unwrap();
         let max_bytes = 1024;

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -806,7 +806,7 @@ mod tests {
     #[test]
     fn bounded_read_rejects_zstd_history_over_decoded_limit() {
         let dir = tempfile::tempdir().unwrap();
-        let max_bytes = 64;
+        let max_bytes = 1024;
         let history = vec![b'a'; max_bytes as usize + 1];
         let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
         assert!(

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -83,6 +83,10 @@ pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>
     read_session_history_from_payload_impl(payload, None)
 }
 
+/// Read decoded session history bytes without returning more than `max_bytes`.
+///
+/// The implementation reads one extra decoded byte to detect over-limit
+/// histories without consuming an unbounded stream.
 pub(crate) fn read_session_history_from_payload_bounded(
     payload: &str,
     max_bytes: u64,

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -839,6 +839,23 @@ mod tests {
     }
 
     #[test]
+    fn bounded_read_rejects_codex_marker_history_over_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        let day_dir = sessions_dir.join("2026").join("07").join("02");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+        let path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl");
+        std::fs::write(path, b"abcde").unwrap();
+        let payload = codex_marker_payload(&sessions_dir, thread_id);
+
+        let err = read_session_history_from_payload_bounded(&payload, 4)
+            .expect_err("bounded codex marker read must reject over-limit history");
+
+        assert_over_limit(err, 4);
+    }
+
+    #[test]
     fn bounded_read_allows_literal_history_with_u64_max_limit() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_history_file(&dir, "history.jsonl", b"abcde");

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -681,13 +681,8 @@ fn read_zstd_history_reader(
     max_bytes: Option<u64>,
 ) -> Result<Vec<u8>, AgentError> {
     let mut bytes = Vec::new();
-    match max_bytes {
-        Some(max_bytes) => {
-            let limit = max_bytes.checked_add(1).ok_or_else(|| {
-                AgentError::Checkpoint("Session history read limit overflowed".to_string())
-            })?;
-            reader.by_ref().take(limit).read_to_end(&mut bytes)
-        }
+    match decoded_read_limit(max_bytes) {
+        Some(limit) => reader.by_ref().take(limit).read_to_end(&mut bytes),
         None => reader.read_to_end(&mut bytes),
     }
     .map_err(|e| {
@@ -707,11 +702,8 @@ fn read_history_reader(
     max_bytes: Option<u64>,
 ) -> Result<Vec<u8>, AgentError> {
     let mut bytes = Vec::new();
-    match max_bytes {
-        Some(max_bytes) => {
-            let limit = max_bytes.checked_add(1).ok_or_else(|| {
-                AgentError::Checkpoint("Session history read limit overflowed".to_string())
-            })?;
+    match decoded_read_limit(max_bytes) {
+        Some(limit) => {
             reader
                 .by_ref()
                 .take(limit)
@@ -730,6 +722,12 @@ fn read_history_reader(
         return Err(session_history_exceeds_max_error(max_bytes));
     }
     Ok(bytes)
+}
+
+fn decoded_read_limit(max_bytes: Option<u64>) -> Option<u64> {
+    // `u64::MAX` cannot be exceeded by an in-memory Vec on supported targets,
+    // so there is no extra probe byte to read for that cap.
+    max_bytes.and_then(|max_bytes| max_bytes.checked_add(1))
 }
 
 fn digest_history_reader(
@@ -805,6 +803,31 @@ mod tests {
             .expect_err("bounded literal read must reject over-limit history");
 
         assert_over_limit(err, 4);
+    }
+
+    #[test]
+    fn bounded_read_allows_literal_history_with_u64_max_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_history_file(&dir, "history.jsonl", b"abcde");
+
+        let bytes =
+            read_session_history_from_payload_bounded(path.to_str().unwrap(), u64::MAX).unwrap();
+
+        assert_eq!(bytes, b"abcde");
+    }
+
+    #[test]
+    fn bounded_read_allows_zstd_history_at_decoded_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let max_bytes = 1024;
+        let history = vec![b'a'; max_bytes as usize];
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        let path = write_history_file(&dir, "history.jsonl.zst", &compressed);
+
+        let bytes = read_session_history_from_payload_bounded(path.to_str().unwrap(), max_bytes)
+            .expect("bounded zstd read must allow history exactly at the decoded cap");
+
+        assert_eq!(bytes, history);
     }
 
     #[test]

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -90,6 +90,12 @@ pub(crate) fn read_session_history_from_payload_bounded(
     read_session_history_from_payload_impl(payload, Some(max_bytes))
 }
 
+fn session_history_exceeds_max_error(max_bytes: u64) -> AgentError {
+    AgentError::Checkpoint(format!(
+        "Session history exceeds maximum size of {max_bytes} bytes"
+    ))
+}
+
 pub(crate) struct SessionHistoryDigest {
     pub(crate) size_bytes: u64,
     pub(crate) sha256_hex: String,
@@ -683,6 +689,11 @@ fn read_zstd_history_reader(
     .map_err(|e| {
         AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
     })?;
+    if let Some(max_bytes) = max_bytes
+        && bytes.len() as u64 > max_bytes
+    {
+        return Err(session_history_exceeds_max_error(max_bytes));
+    }
     Ok(bytes)
 }
 
@@ -708,6 +719,11 @@ fn read_history_reader(
                 .read_to_end(&mut bytes)
                 .map_err(|e| read_history_error(path, e))?;
         }
+    }
+    if let Some(max_bytes) = max_bytes
+        && bytes.len() as u64 > max_bytes
+    {
+        return Err(session_history_exceeds_max_error(max_bytes));
     }
     Ok(bytes)
 }
@@ -746,14 +762,75 @@ fn digest_history_reader(
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_history_file(dir: &tempfile::TempDir, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = dir.path().join(name);
+        std::fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    fn assert_over_limit(error: AgentError, max_bytes: u64) {
+        let message = error.to_string();
+        assert!(
+            message.contains(&format!(
+                "Session history exceeds maximum size of {max_bytes} bytes"
+            )),
+            "expected over-limit error for cap {max_bytes}, got: {message}"
+        );
+    }
+
+    #[test]
+    fn bounded_read_allows_literal_history_at_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_history_file(&dir, "history.jsonl", b"abcd");
+
+        let bytes = read_session_history_from_payload_bounded(path.to_str().unwrap(), 4).unwrap();
+
+        assert_eq!(bytes, b"abcd");
+    }
+
+    #[test]
+    fn bounded_read_rejects_literal_history_over_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_history_file(&dir, "history.jsonl", b"abcde");
+
+        let err = read_session_history_from_payload_bounded(path.to_str().unwrap(), 4)
+            .expect_err("bounded literal read must reject over-limit history");
+
+        assert_over_limit(err, 4);
+    }
+
+    #[test]
+    fn bounded_read_rejects_zstd_history_over_decoded_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let max_bytes = 64;
+        let history = vec![b'a'; max_bytes as usize + 1];
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        assert!(
+            compressed.len() <= max_bytes as usize,
+            "test fixture should be smaller than the decoded cap"
+        );
+        let path = write_history_file(&dir, "history.jsonl.zst", &compressed);
+
+        let err = read_session_history_from_payload_bounded(path.to_str().unwrap(), max_bytes)
+            .expect_err("bounded zstd read must reject over-limit decoded history");
+
+        assert_over_limit(err, max_bytes);
+    }
+}
+
 // Note: integration coverage for the public `read_session_history` entry
 // (both Claude literal-path and codex marker -> bounded layout scan + zstd
 // decode) lives in `crates/guest-agent/tests/session_history_read.rs`.
 // The internal helpers
 // (`read_codex_session_history`, `codex_session_filename_matches`,
 // `read_history_bytes`, `decode_marker`) are exercised transitively by
-// those integration tests, in line with the project's "integration
-// tests only" policy (`docs/testing.md`, `CLAUDE.md`).
+// those integration tests. Inline coverage above is limited to the
+// `read_session_history_from_payload_bounded` cap contract because the public
+// entry point cannot pass a small test cap.
 //
 // `decode_marker` is the one piece of non-trivial parsing logic; if it
 // regresses, the integration tests will catch it because the codex flow

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -795,6 +795,27 @@ mod tests {
     }
 
     #[test]
+    fn bounded_read_allows_empty_literal_history_with_zero_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_history_file(&dir, "history.jsonl", b"");
+
+        let bytes = read_session_history_from_payload_bounded(path.to_str().unwrap(), 0).unwrap();
+
+        assert_eq!(bytes, b"");
+    }
+
+    #[test]
+    fn bounded_read_rejects_nonempty_literal_history_with_zero_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_history_file(&dir, "history.jsonl", b"a");
+
+        let err = read_session_history_from_payload_bounded(path.to_str().unwrap(), 0)
+            .expect_err("bounded literal read must reject nonempty history when cap is zero");
+
+        assert_over_limit(err, 0);
+    }
+
+    #[test]
     fn bounded_read_rejects_literal_history_over_limit() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_history_file(&dir, "history.jsonl", b"abcde");

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -9,11 +9,10 @@ use crate::paths;
 use crate::session_history;
 use guest_common::{log_error, log_info};
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
-use std::io::{self, Read};
+use std::io;
 use std::path::{Component, Path, PathBuf};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
-const SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 
 pub(crate) fn history_marker_payload_for_session_id_with_home(
     framework: Framework,
@@ -87,7 +86,7 @@ pub(crate) fn session_history_marker_kind(history_path_payload: &str) -> &'stati
 pub(crate) fn read_existing_history_marker_payload_from(
     session_history_path_file: &str,
 ) -> io::Result<Option<String>> {
-    match read_existing_history_marker_file(session_history_path_file) {
+    match session_history::read_history_marker_payload_file(session_history_path_file) {
         Ok(existing) => {
             let existing = existing.trim();
             if existing.is_empty() {
@@ -99,22 +98,6 @@ pub(crate) fn read_existing_history_marker_payload_from(
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(e),
     }
-}
-
-fn read_existing_history_marker_file(session_history_path_file: &str) -> io::Result<String> {
-    let file = std::fs::File::open(session_history_path_file)?;
-    let mut bytes = Vec::new();
-    file.take((SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES + 1) as u64)
-        .read_to_end(&mut bytes)?;
-    if bytes.len() > SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "session history marker exceeds maximum size of {SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES} bytes"
-            ),
-        ));
-    }
-    String::from_utf8(bytes).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
 pub(crate) fn ensure_history_marker_payload_at(
@@ -242,7 +225,7 @@ mod tests {
     fn read_existing_history_marker_payload_allows_payload_at_limit() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("session-history-marker");
-        let payload = "a".repeat(SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES);
+        let payload = "a".repeat(session_history::SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES);
         std::fs::write(&path, &payload).unwrap();
 
         let existing = read_existing_history_marker_payload_from(path.to_str().unwrap())
@@ -257,7 +240,7 @@ mod tests {
         let path = dir.path().join("session-history-marker");
         std::fs::write(
             &path,
-            vec![b'a'; SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES + 1],
+            vec![b'a'; session_history::SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES + 1],
         )
         .unwrap();
 

--- a/crates/guest-agent/src/session_metadata.rs
+++ b/crates/guest-agent/src/session_metadata.rs
@@ -9,10 +9,11 @@ use crate::paths;
 use crate::session_history;
 use guest_common::{log_error, log_info};
 use guest_contracts::codex_thread_id::canonical_codex_thread_id;
-use std::io;
+use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
 
 pub(crate) fn history_marker_payload_for_session_id_with_home(
     framework: Framework,
@@ -86,7 +87,7 @@ pub(crate) fn session_history_marker_kind(history_path_payload: &str) -> &'stati
 pub(crate) fn read_existing_history_marker_payload_from(
     session_history_path_file: &str,
 ) -> io::Result<Option<String>> {
-    match std::fs::read_to_string(session_history_path_file) {
+    match read_existing_history_marker_file(session_history_path_file) {
         Ok(existing) => {
             let existing = existing.trim();
             if existing.is_empty() {
@@ -98,6 +99,22 @@ pub(crate) fn read_existing_history_marker_payload_from(
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(e),
     }
+}
+
+fn read_existing_history_marker_file(session_history_path_file: &str) -> io::Result<String> {
+    let file = std::fs::File::open(session_history_path_file)?;
+    let mut bytes = Vec::new();
+    file.take((SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "session history marker exceeds maximum size of {SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES} bytes"
+            ),
+        ));
+    }
+    String::from_utf8(bytes).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
 pub(crate) fn ensure_history_marker_payload_at(
@@ -218,6 +235,40 @@ mod tests {
         assert_eq!(
             marker, ".claude/projects/-home-user-workspace/session-123.jsonl",
             "marker should use relative .claude history dir for empty HOME"
+        );
+    }
+
+    #[test]
+    fn read_existing_history_marker_payload_allows_payload_at_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-history-marker");
+        let payload = "a".repeat(SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES);
+        std::fs::write(&path, &payload).unwrap();
+
+        let existing = read_existing_history_marker_payload_from(path.to_str().unwrap())
+            .expect("marker read should succeed at limit");
+
+        assert_eq!(existing.as_deref(), Some(payload.as_str()));
+    }
+
+    #[test]
+    fn read_existing_history_marker_payload_rejects_oversized_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-history-marker");
+        std::fs::write(
+            &path,
+            vec![b'a'; SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES + 1],
+        )
+        .unwrap();
+
+        let err = read_existing_history_marker_payload_from(path.to_str().unwrap())
+            .expect_err("marker read must reject oversized payloads");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        let message = err.to_string();
+        assert!(
+            message.contains("session history marker exceeds maximum size"),
+            "expected oversized marker error, got: {message}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- make bounded session-history reads reject decoded histories larger than the supplied cap
- remove the duplicate checkpoint post-read size check so checkpoint relies on the reader contract
- add focused inline coverage for exact-limit, literal over-limit, and zstd decoded over-limit reads

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent session_history`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent checkpoint`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`

Closes #19819
