### PR TITLE
fix: refresh connector status after aborted connect

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -22,6 +22,10 @@ import {
   zeroConnectorsMainContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import type {
+  InitClientArgs,
+  InitClientReturn,
+} from "@vm0/api-contracts/contracts/trpc-contract";
+import type {
   ConnectorOauthDeviceAuthSessionPollResponse,
   ConnectorListResponse,
   ConnectorReconnectReason,
@@ -898,6 +902,7 @@ export const submitManualGrant$ = command(
 
     const flow = createConnectorConnectFlowState(type);
     set(internalConnectFlowState$, flow);
+    let connectorStateChanged = false;
     return await withCleanup(
       (async () => {
         const createClient = get(zeroClient$);
@@ -913,9 +918,11 @@ export const submitManualGrant$ = command(
           }),
           [200],
         );
+        connectorStateChanged = true;
         signal.throwIfAborted();
         set(finishConnectorConnection$, type, {
           ...options,
+          reloadConnectors: false,
           toastMessage: `${options.connectorLabel ?? type} connected successfully`,
         });
         return true;
@@ -924,6 +931,9 @@ export const submitManualGrant$ = command(
         set(internalConnectFlowState$, (current) => {
           return current?.id === flow.id ? null : current;
         });
+        if (connectorStateChanged) {
+          set(reloadConnectors$);
+        }
       },
     );
   },
@@ -1075,6 +1085,24 @@ type ConnectConnectorOAuthDeviceAuthParams = {
   readonly startOptions?: ConnectorDeviceAuthStartOptions;
 };
 
+type ConnectorOAuthDeviceAuthSessionClient = InitClientReturn<
+  typeof zeroConnectorOauthDeviceAuthSessionContract,
+  InitClientArgs
+>;
+
+type PollConnectorOAuthDeviceAuthIterationArgs = Omit<
+  PollConnectorOAuthDeviceAuthArgs,
+  "createClient"
+> & {
+  readonly client: ConnectorOAuthDeviceAuthSessionClient;
+};
+
+type PollConnectorOAuthDeviceAuthIterationOutcome = {
+  readonly stop: boolean;
+  readonly completed?: true;
+  readonly expired?: true;
+};
+
 function createConnectorOAuthDeviceAuthRequestId(type: ConnectorType): string {
   return `${type}-oauth-device-${now()}-${Math.random().toString(36).slice(2)}`;
 }
@@ -1166,6 +1194,140 @@ export const openConnectorOAuthDeviceAuthVerificationPage$ = command(
   },
 );
 
+const pollConnectorOAuthDeviceAuthOnce$ = command(
+  async (
+    { get, set },
+    {
+      client,
+      type,
+      authMethod,
+      requestId,
+      options,
+    }: PollConnectorOAuthDeviceAuthIterationArgs,
+    signal: AbortSignal,
+  ): Promise<PollConnectorOAuthDeviceAuthIterationOutcome> => {
+    let connectorStateChanged = false;
+    return await withCleanup(
+      (async () => {
+        const current = get(internalConnectorOAuthDeviceAuthState$);
+        if (
+          !isCurrentConnectorOAuthDeviceAuthRequest(
+            current,
+            type,
+            authMethod,
+            requestId,
+          )
+        ) {
+          return { stop: true };
+        }
+
+        const remainingMs = current.expiresAtMs - now();
+        if (remainingMs <= 0) {
+          return { stop: true, expired: true };
+        }
+
+        if (!current.approvalOpened) {
+          await delay(
+            Math.min(OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS, remainingMs),
+            { signal },
+          );
+          signal.throwIfAborted();
+          return { stop: false };
+        }
+
+        set(internalConnectorOAuthDeviceAuthState$, {
+          ...current,
+          status: "polling",
+        });
+
+        const acceptPoll = async () => {
+          const response = await accept(
+            client.poll({
+              params: { type, sessionId: current.sessionId },
+              body: { sessionToken: current.sessionToken },
+              fetchOptions: { signal },
+            }),
+            [200],
+          );
+          if (response.body.status === "complete") {
+            connectorStateChanged = true;
+          }
+          return response;
+        };
+        const pollSettled = await settle(acceptPoll(), signal);
+        const pollResult = pollSettled.ok
+          ? pollSettled.value.body
+          : {
+              status: "error" as const,
+              errorMessage: oauthDeviceAuthErrorMessage(pollSettled.error),
+            };
+
+        const latest = get(internalConnectorOAuthDeviceAuthState$);
+        if (
+          !isCurrentConnectorOAuthDeviceAuthRequest(
+            latest,
+            type,
+            authMethod,
+            requestId,
+          )
+        ) {
+          return { stop: true };
+        }
+
+        if (pollResult.status === "complete") {
+          signal.throwIfAborted();
+          set(finishConnectorConnection$, type, {
+            ...options,
+            clearSelectedConnector: true,
+            reloadConnectors: false,
+          });
+          set(
+            internalConnectorOAuthDeviceAuthState$,
+            createIdleConnectorOAuthDeviceAuthState(),
+          );
+          return { stop: true, completed: true };
+        }
+
+        signal.throwIfAborted();
+
+        if (pollResult.status !== "pending") {
+          set(internalConnectorOAuthDeviceAuthState$, {
+            status: pollResult.status,
+            connectorType: type,
+            authMethod,
+            message: getOAuthDeviceAuthTerminalMessage(pollResult),
+          });
+          return { stop: true };
+        }
+
+        const pollIntervalMs = Math.max(
+          secondsToMilliseconds(pollResult.interval),
+          OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS,
+        );
+        set(internalConnectorOAuthDeviceAuthState$, {
+          ...latest,
+          status: "pending",
+          pollIntervalMs,
+          errorMessage: null,
+        });
+
+        const nextRemainingMs = latest.expiresAtMs - now();
+        if (nextRemainingMs <= 0) {
+          return { stop: true, expired: true };
+        }
+        await delay(Math.min(pollIntervalMs, nextRemainingMs), { signal });
+        signal.throwIfAborted();
+        return { stop: false };
+      })(),
+      () => {
+        if (connectorStateChanged) {
+          set(reloadConnectors$);
+        }
+      },
+    );
+  },
+);
+
 const pollConnectorOAuthDeviceAuth$ = command(
   async (
     { get, set },
@@ -1194,100 +1356,24 @@ const pollConnectorOAuthDeviceAuth$ = command(
 
     await setLoop(
       async (sig) => {
-        const current = get(internalConnectorOAuthDeviceAuthState$);
-        if (!isCurrentRequest(current)) {
-          return true;
-        }
-
-        const remainingMs = current.expiresAtMs - now();
-        if (remainingMs <= 0) {
-          expired = true;
-          return true;
-        }
-
-        if (!current.approvalOpened) {
-          await delay(
-            Math.min(OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS, remainingMs),
-            { signal: sig },
-          );
-          sig.throwIfAborted();
-          return false;
-        }
-
-        set(internalConnectorOAuthDeviceAuthState$, {
-          ...current,
-          status: "polling",
-        });
-
-        const pollSettled = await settle(
-          accept(
-            client.poll({
-              params: { type, sessionId: current.sessionId },
-              body: { sessionToken: current.sessionToken },
-              fetchOptions: { signal: sig },
-            }),
-            [200],
-          ),
+        const outcome = await set(
+          pollConnectorOAuthDeviceAuthOnce$,
+          { client, type, authMethod, requestId, options },
           sig,
         );
-        const pollResult = pollSettled.ok
-          ? pollSettled.value.body
-          : {
-              status: "error" as const,
-              errorMessage: oauthDeviceAuthErrorMessage(pollSettled.error),
-            };
-
-        const latest = get(internalConnectorOAuthDeviceAuthState$);
-        if (!isCurrentRequest(latest)) {
-          return true;
-        }
-
-        if (pollResult.status === "complete") {
-          set(finishConnectorConnection$, type, {
-            ...options,
-            clearSelectedConnector: true,
-          });
-          set(
-            internalConnectorOAuthDeviceAuthState$,
-            createIdleConnectorOAuthDeviceAuthState(),
-          );
-          completed = true;
-          return true;
-        }
-
-        if (pollResult.status !== "pending") {
-          set(internalConnectorOAuthDeviceAuthState$, {
-            status: pollResult.status,
-            connectorType: type,
-            authMethod,
-            message: getOAuthDeviceAuthTerminalMessage(pollResult),
-          });
-          return true;
-        }
-
-        const pollIntervalMs = Math.max(
-          secondsToMilliseconds(pollResult.interval),
-          OAUTH_DEVICE_AUTH_MIN_POLL_INTERVAL_MS,
-        );
-        set(internalConnectorOAuthDeviceAuthState$, {
-          ...latest,
-          status: "pending",
-          pollIntervalMs,
-          errorMessage: null,
-        });
-
-        const nextRemainingMs = latest.expiresAtMs - now();
-        if (nextRemainingMs <= 0) {
-          expired = true;
-          return true;
-        }
-        await delay(Math.min(pollIntervalMs, nextRemainingMs), { signal: sig });
         sig.throwIfAborted();
-        return false;
+        if (outcome.completed) {
+          completed = true;
+        }
+        if (outcome.expired) {
+          expired = true;
+        }
+        return outcome.stop;
       },
       0,
       signal,
     );
+    signal.throwIfAborted();
 
     const latest = get(internalConnectorOAuthDeviceAuthState$);
     if (expired && isCurrentRequest(latest)) {
@@ -1709,61 +1795,74 @@ const completeConnectorExternalCode$ = command(
       errorMessage: null,
     });
 
-    const flowSignal = set(resetConnectorExternalCodeFlowSignal$, signal);
-    const createClient = get(zeroClient$);
-    const client = createClient(zeroConnectorExternalCodeSessionContract, {
-      apiBase: OAUTH_WEB_API_BASE,
-    });
-    const completeSettled = await settle(
-      accept(
-        client.complete({
-          params: { type, sessionId: current.sessionId },
-          body: {
-            sessionToken: current.sessionToken,
-            code,
-          },
-          fetchOptions: { signal: flowSignal },
-        }),
-        [200],
-        { toast: false },
-      ),
-      flowSignal,
-    );
-    signal.throwIfAborted();
-    flowSignal.throwIfAborted();
-    const latest = get(internalConnectorExternalCodeState$);
-    if (
-      !isCurrentConnectorExternalCodeRequest(
-        latest,
-        type,
-        authMethod,
-        current.requestId,
-      )
-    ) {
-      return false;
-    }
+    let connectorStateChanged = false;
+    return await withCleanup(
+      (async () => {
+        const flowSignal = set(resetConnectorExternalCodeFlowSignal$, signal);
+        const createClient = get(zeroClient$);
+        const client = createClient(zeroConnectorExternalCodeSessionContract, {
+          apiBase: OAUTH_WEB_API_BASE,
+        });
+        const completeSettled = await settle(
+          accept(
+            client.complete({
+              params: { type, sessionId: current.sessionId },
+              body: {
+                sessionToken: current.sessionToken,
+                code,
+              },
+              fetchOptions: { signal: flowSignal },
+            }),
+            [200],
+            { toast: false },
+          ),
+        );
+        if (completeSettled.ok) {
+          connectorStateChanged = true;
+        }
+        signal.throwIfAborted();
+        flowSignal.throwIfAborted();
+        const latest = get(internalConnectorExternalCodeState$);
+        if (
+          !isCurrentConnectorExternalCodeRequest(
+            latest,
+            type,
+            authMethod,
+            current.requestId,
+          )
+        ) {
+          return false;
+        }
 
-    if (!completeSettled.ok) {
-      if (flowSignal.aborted) {
-        return false;
-      }
-      set(internalConnectorExternalCodeState$, {
-        ...latest,
-        status: "pending",
-        errorMessage: externalCodeErrorMessage(completeSettled.error),
-      });
-      return false;
-    }
+        if (!completeSettled.ok) {
+          if (flowSignal.aborted) {
+            return false;
+          }
+          set(internalConnectorExternalCodeState$, {
+            ...latest,
+            status: "pending",
+            errorMessage: externalCodeErrorMessage(completeSettled.error),
+          });
+          return false;
+        }
 
-    set(finishConnectorConnection$, type, {
-      ...options,
-      clearSelectedConnector: true,
-    });
-    set(
-      internalConnectorExternalCodeState$,
-      createIdleConnectorExternalCodeState(),
+        set(finishConnectorConnection$, type, {
+          ...options,
+          clearSelectedConnector: true,
+          reloadConnectors: false,
+        });
+        set(
+          internalConnectorExternalCodeState$,
+          createIdleConnectorExternalCodeState(),
+        );
+        return true;
+      })(),
+      () => {
+        if (connectorStateChanged) {
+          set(reloadConnectors$);
+        }
+      },
     );
-    return true;
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -37,10 +37,13 @@ import { search } from "../../../signals/location.ts";
 import { setFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
 import { ROUTES } from "../../../signals/route-paths.ts";
+import { resetSignalScope } from "../../../signals/utils.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { reloadAgentConnectorAuthorizations$ } from "../../../signals/zero-page/agent-connector-authorizations.ts";
+import { submitManualGrant$ } from "../../../signals/zero-page/settings/connectors.ts";
 
 const context = testContext();
+const abortAfterManualGrantConnectSignalScope$ = resetSignalScope();
 
 function createMockAuthWindow(): Window {
   const authWindow = context.mocks.browser.authWindow();
@@ -1481,6 +1484,120 @@ describe("connectors page", () => {
     await waitFor(() => {
       expect(submittedValues).toStrictEqual({ apiToken: "xaat-test" });
       expect(submitCount).toBe(1);
+      expect(
+        within(connectorCardByLabel("Public Axiom")).getByText("Connected"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("reloads manual connector status after success if post-success signal aborts", async () => {
+    mockConnectors([]);
+    const disconnectedAxiom = publicStatusItem({
+      connectorRef: "axiom",
+      label: "Public Axiom",
+      description: "Public Axiom description",
+      authMethods: [
+        {
+          id: "api-token",
+          label: "Public API Token",
+          description: null,
+          grantKind: "manual",
+          manualFields: [
+            {
+              id: "apiToken",
+              label: "Public API token",
+              required: true,
+              placeholder: "public-xaat",
+              inputType: "password",
+            },
+          ],
+          startOptions: [],
+        },
+      ],
+    });
+    let catalogStatusItems: readonly PublicConnectorCatalogStatusItem[] = [
+      disconnectedAxiom,
+    ];
+    let catalogStatusRequestCount = 0;
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      catalogStatusRequestCount += 1;
+      return respond(200, { connectors: [...catalogStatusItems] });
+    });
+    context.mocks.api(
+      zeroConnectorManualGrantContract.connect,
+      ({ body, params, respond }) => {
+        expect(params.type).toBe("axiom");
+        expect(body.values).toStrictEqual({ apiToken: "xaat-test" });
+        catalogStatusItems = [
+          {
+            ...disconnectedAxiom,
+            connection: {
+              authMethod: body.authMethod,
+              externalUsername: null,
+              externalEmail: null,
+              reconnectReason: null,
+            },
+            connected: true,
+            connectionStatus: "connected",
+          },
+        ];
+        return respond(200, {
+          id: crypto.randomUUID(),
+          type: "axiom",
+          authMethod: body.authMethod,
+          externalId: null,
+          externalUsername: null,
+          externalEmail: null,
+          oauthScopes: null,
+          connectionStatus: "connected",
+          reconnectReason: null,
+          tokenExpiresAt: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        });
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Connect Public Axiom")).toBeInTheDocument();
+    });
+    expect(
+      within(connectorCardByLabel("Public Axiom")).queryByText("Connected"),
+    ).not.toBeInTheDocument();
+
+    const abortScope = context.store.set(
+      abortAfterManualGrantConnectSignalScope$,
+      context.signal,
+    );
+    const originalThrowIfAborted = abortScope.signal.throwIfAborted.bind(
+      abortScope.signal,
+    );
+    Object.defineProperty(abortScope.signal, "throwIfAborted", {
+      value: () => {
+        abortScope.abort(
+          new DOMException("Aborted after connector connect", "AbortError"),
+        );
+        originalThrowIfAborted();
+      },
+    });
+
+    await expect(
+      context.store.set(
+        submitManualGrant$,
+        {
+          type: "axiom",
+          authMethod: "api-token",
+          inputValues: { apiToken: "xaat-test" },
+          options: { connectorLabel: "Public Axiom" },
+        },
+        abortScope.signal,
+      ),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    await waitFor(() => {
+      expect(catalogStatusRequestCount).toBeGreaterThan(1);
       expect(
         within(connectorCardByLabel("Public Axiom")).getByText("Connected"),
       ).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- reload connector catalog/status after manual grant success even if the later page signal aborts before UI finish
- reload connector status after successful external-code completion and completed device-auth polling while keeping UI-only success effects behind existing abort checks
- add a page-level regression for manual grant success followed by a post-success abort

## Scope

- no API contract changes
- no database or persistent data changes
- directed connect/authorize follow-up authorization semantics remain unchanged
- OAuth auth-code was reviewed and left unchanged because it already reloads before reading refreshed connector state

## Validation

- pnpm format
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/db db:migrate

## Note

Local pre-commit was bypassed because the repo-wide knip hook currently reports unrelated unused exports in apps/platform/src/signals/zero-page/zero-editable-image-canvas.ts from merged PR #19873. The staged changes for this PR only touch connector status code and its page test.

Closes #19863