### PR TITLE
fix(api): refresh API release marker comment

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op touch to exercise the full Turbo build pipeline)
+// (no-op API release marker to exercise the full release pipeline)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary
- Refresh a no-op API TypeScript comment so release-please creates a new API release PR.

## Testing
- Not run; comment-only API package change.

## Release intent
- This is intentionally scoped to `turbo/apps/api` and uses a `fix(api):` title so the next release PR includes the API package.