### PR TITLE
style: rename Agents "Create" button to "New agent"

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -2,7 +2,7 @@ import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { IconLoader2, IconWand } from "@tabler/icons-react";
+import { IconLoader2, IconPlus, IconWand } from "@tabler/icons-react";
 import {
   Card,
   CardContent,
@@ -214,13 +214,14 @@ function AgentTabsView({
         <Button
           variant="outline"
           size="sm"
-          className="zero-btn-morandi h-9 shrink-0 rounded-lg border"
+          className="zero-btn-morandi h-9 gap-2 shrink-0 rounded-lg border"
           disabled={createDisabled}
           onClick={() => {
             return onCreate(activeTab);
           }}
         >
-          Create
+          <IconPlus size={14} stroke={2} />
+          New agent
         </Button>
       </div>
 


### PR DESCRIPTION
## What

The **Agents** section action button read "Create", while the connectors surface uses a "**+ New connector**" button. This aligns the Agents button with that pattern: it now shows the plus icon and reads "**New agent**".

Before: `Create`
After: `+ New agent`

The styling (`zero-btn-morandi`, `gap-2`, `IconPlus size={14}`) now matches `zero-connectors-page.tsx`'s "New connector" button exactly.

## Why

UI consistency — both top-level "create a new X" actions should look and read the same. Requested by Ming.

## Changes

- `turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx`: import `IconPlus`, add the icon + `gap-2`, change label to "New agent".

🤖 Generated with [Claude Code](https://claude.com/claude-code)