### PR TITLE
style: match agent card name underline to dotted list-row style

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -626,7 +626,7 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
               <TooltipProvider delayDuration={200}>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="block w-fit max-w-full truncate text-sm font-medium text-foreground underline decoration-dashed decoration-[hsl(var(--gray-400))] underline-offset-4">
+                    <span className="block w-fit max-w-full truncate text-sm font-medium text-foreground underline decoration-dotted decoration-foreground/40 decoration-[1px] underline-offset-2">
                       {displayName}
                     </span>
                   </TooltipTrigger>


### PR DESCRIPTION
## What

The agent card name underline (in the redesigned agents page, `AgentsPageRedesign` variant) used a **dashed** underline, which looked inconsistent with the **dotted** underline used on list-row titles elsewhere (usage/insight/network-insights tables).

This aligns the agent card name to the standard dotted list-row style.

### Before
`underline decoration-dashed decoration-[hsl(var(--gray-400))] underline-offset-4`

### After
`underline decoration-dotted decoration-foreground/40 decoration-[1px] underline-offset-2`

## Scope

- `turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx:629` — the name span shown when the card carries the creator tooltip (the underlined variant in the screenshot).

## Notes

Purely a Tailwind className change; no logic touched. Prettier + package-local oxlint pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)