### PR TITLE
test: assert affinity metadata seed run status

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1410,6 +1410,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       prompt: "start affinity-protected session",
       modelProvider: "anthropic-api-key",
     });
+    expect(first).toMatchObject({ status: "pending" });
     const firstClaim = await api.claimRunnerJob(first.runId);
     const cliAgentSessionId = `bdd-affinity-cli-${first.runId}`;
     const history = `bdd affinity history ${first.runId}`;

--- a/turbo/apps/platform/src/signals/zero-page/zero-editable-image-canvas.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-editable-image-canvas.ts
@@ -3,8 +3,8 @@ import { command, computed, state } from "ccstate";
 export const PRIMARY_IMAGE_ITEM_ID = "primary-image";
 export const DEFAULT_CANVAS_WIDTH = 1600;
 export const DEFAULT_CANVAS_HEIGHT = 1200;
-export const DEFAULT_IMAGE_WIDTH = 720;
-export const DEFAULT_IMAGE_HEIGHT = 540;
+const DEFAULT_IMAGE_WIDTH = 720;
+const DEFAULT_IMAGE_HEIGHT = 540;
 
 const DUPLICATE_OFFSET = 24;
 


### PR DESCRIPTION
## Summary
- Assert the seed run reaches pending before the affinity metadata test claims it, so create-run failures surface at the real setup step.
- Remove unused exports from image canvas defaults so full Knip passes on current main.

## Verification
- pnpm -C turbo -F @vm0/db db:migrate
- pnpm -C turbo -F api exec vitest src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "exposes same-session affinity metadata"
- pnpm -C turbo -F api check-types
- pnpm -C turbo knip
- pnpm -C turbo -F @vm0/app check-types
- pre-commit: full Knip and check-types