### PR TITLE
fix: derive chat thinking state from messages

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -111,6 +111,7 @@ export interface ChatThreadSignals {
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
   renderedGroupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
   hasOlderHistory$: Computed<Promise<boolean>>;
+  messageRunIndicatorState$: Computed<Promise<"running" | "queued" | null>>;
   latestRunStatus$: Computed<Promise<string | null>>;
   // The thread's active goal, folded from goal-state marker messages. Null when
   // there is no active goal. Drives the goal row above the composer.

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -1686,6 +1686,8 @@ function createPagedMessages(
     serverMessages$,
     optimisticMessages$,
   });
+  const messageRunIndicatorState$ =
+    createMessageRunIndicatorState(rawMessages$);
   const latestRunStatus$ = createLatestRunStatus(rawMessages$, threadData$);
 
   // The thread's active goal, folded from the (goal-marker) message stream so
@@ -1791,6 +1793,7 @@ function createPagedMessages(
     refreshGroupedChatMessagesCache$,
     rawMessages$,
     hasOlderHistory$,
+    messageRunIndicatorState$,
     latestRunStatus$,
     activeGoal$,
     fetchNextPage$,
@@ -2044,6 +2047,15 @@ function createLatestRunStatus(
       raw,
       thread?.activeRunIds ?? [],
     );
+  });
+}
+
+function createMessageRunIndicatorState(
+  rawMessages$: Computed<Promise<ChatMessageProjectionEntry[]>>,
+) {
+  return computed(async (get): Promise<RunIndicatorState> => {
+    const raw = await get(rawMessages$);
+    return deriveRunIndicatorStateFromRawMessages(raw, []);
   });
 }
 
@@ -3599,6 +3611,7 @@ export function createChatThreadSignals(
     groupedChatMessages$: messages.groupedChatMessages$,
     renderedGroupedChatMessages$: messages.renderedGroupedChatMessages$,
     hasOlderHistory$: messages.hasOlderHistory$,
+    messageRunIndicatorState$: messages.messageRunIndicatorState$,
     latestRunStatus$: messages.latestRunStatus$,
     activeGoal$: messages.activeGoal$,
     allFinished$: runTracking.allFinished$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1359,6 +1359,39 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("shows thinking from loaded messages before thread metadata resolves", async () => {
+    const threadGate = context.mocks.deferred<void>();
+    mockChatLifecycle(context, {
+      threadId: "thread-message-list-thinking-pending-metadata",
+      activeRunIds: ["run-message-list-thinking-pending-metadata"],
+      threadGate: threadGate.promise,
+      chatMessages: [
+        {
+          id: "msg-message-list-assistant-pending-metadata",
+          role: "assistant",
+          content: "I am still working on this.",
+          runId: "run-message-list-thinking-pending-metadata",
+          runEventId: "event-message-list-assistant-text-pending-metadata",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: "/chats/thread-message-list-thinking-pending-metadata",
+    });
+
+    await screen.findByText("I am still working on this.");
+    await waitFor(() => {
+      expect(
+        document.querySelector("[data-thinking-indicator]"),
+      ).not.toBeNull();
+    });
+
+    threadGate.resolve();
+  });
+
   it("clears thinking when the same run completes even with stale active run ids", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-message-list-completed",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1487,7 +1487,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("keeps thinking when a different run completes while another run is open", async () => {
+  it("ignores active run ids when loaded messages end at a completed run", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-stale-lifecycle-thinking",
       activeRunIds: ["run-r2"],
@@ -1552,10 +1552,7 @@ describe("chat lifecycle", () => {
     await waitFor(() => {
       expect(screen.getByText("Continue the plan")).toBeInTheDocument();
       expect(screen.getByText("The next step is ready.")).toBeInTheDocument();
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
-      expect(
-        document.querySelector("[data-thinking-indicator]"),
-      ).not.toBeNull();
+      expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
     });
   });
 
@@ -1604,7 +1601,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("keeps thinking for an older active run when a newer run completes", async () => {
+  it("does not use active run ids to revive an older run after a newer run completes", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-concurrent-run-completed-later",
       activeRunIds: ["run-concurrent-active"],
@@ -1659,14 +1656,11 @@ describe("chat lifecycle", () => {
       expect(
         screen.getByText("The current status summary is ready."),
       ).toBeInTheDocument();
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
-      expect(
-        document.querySelector("[data-thinking-indicator]"),
-      ).not.toBeNull();
+      expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
     });
   });
 
-  it("keeps thinking when an older active run is outside the loaded message window", async () => {
+  it("does not use active run ids when active messages are outside the loaded window", async () => {
     mockChatLifecycle(context, {
       threadId: "thread-active-run-outside-loaded-window",
       activeRunIds: ["run-active-outside-window"],
@@ -1688,10 +1682,7 @@ describe("chat lifecycle", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
-      expect(
-        document.querySelector("[data-thinking-indicator]"),
-      ).not.toBeNull();
+      expect(document.querySelector("[data-thinking-indicator]")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -423,6 +423,11 @@ export function mockChatLifecycle(
      * Lets tests prove the latest-message view renders before silent backfill.
      */
     beforeHistoryGate?: Promise<void>;
+    /**
+     * Promise the thread metadata handler awaits before responding. Lets tests
+     * prove message-derived UI does not wait for activeRunIds metadata.
+     */
+    threadGate?: Promise<void>;
     afterInitialMessagesList?: () => void;
     onRunCreate?: (body: {
       prompt?: string;
@@ -752,7 +757,10 @@ export function mockChatLifecycle(
     }
     return respond(200, cloneMockPagedMessage(message));
   });
-  context.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
+  context.mocks.api(chatThreadByIdContract.get, async ({ respond }) => {
+    if (options?.threadGate) {
+      await options.threadGate;
+    }
     const lifecycleActiveRunIds =
       runAssociated && !terminal.has(runStatus) ? [MOCK_RUN_ID] : [];
     const activeRunIds = [...optionActiveRunIds, ...lifecycleActiveRunIds];

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3805,6 +3805,41 @@ function lastRunThinkingMessageForIndicator(
   return runHasAssistantText ? undefined : lastMessage;
 }
 
+type LoadedMessageRunState = "running" | "finished" | null;
+
+function loadedMessageRunState(
+  groups: readonly GroupedChatMessageGroup[],
+): LoadedMessageRunState {
+  const messages = groups.flatMap((group) => {
+    return group.messages.filter((message) => {
+      return (
+        !message.isQueued &&
+        !(message.role === "assistant" && message.usage !== undefined)
+      );
+    });
+  });
+  const terminatedRunIds = terminatedRunIdsForCompletedWork(messages);
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]!;
+    if (
+      message.role === "assistant" &&
+      message.runLifecycleEvent !== undefined
+    ) {
+      return "finished";
+    }
+    if (message.interruptsRunId !== undefined) {
+      return "finished";
+    }
+    if (message.runId === undefined) {
+      continue;
+    }
+    return terminatedRunIds.has(message.runId) ? "finished" : "running";
+  }
+
+  return null;
+}
+
 function terminatedRunIdsForCompletedWork(
   messages: readonly EnrichedChatMessage[],
 ): Set<string> {
@@ -5373,8 +5408,6 @@ interface ThinkingIndicatorState {
 
 function getThinkingIndicatorState(args: {
   readonly groups: GroupedChatMessageGroup[];
-  readonly allFinishedResolved: boolean;
-  readonly allFinished: boolean;
   readonly latestRunStatus: string | null | undefined;
   readonly initialThinkingEnabled: boolean;
 }): ThinkingIndicatorState {
@@ -5399,20 +5432,23 @@ function getThinkingIndicatorState(args: {
     !lastAssistantHasRenderableMessage;
   const lastAssistantCancelled =
     isCancelledAssistantMessage(lastAssistantMessage);
-  const isQueued = args.latestRunStatus === "queued";
-  const lastThinkingMessage =
-    args.initialThinkingEnabled && !isQueued
-      ? rawLastThinkingMessage
-      : undefined;
+  const lastThinkingMessage = args.initialThinkingEnabled
+    ? rawLastThinkingMessage
+    : undefined;
+  const isQueued =
+    args.latestRunStatus === "queued" && lastThinkingMessage === undefined;
+  const messageRunState = loadedMessageRunState(args.groups);
+  const externalRunActive =
+    args.latestRunStatus === "running" || args.latestRunStatus === "queued";
   const runActive =
-    args.allFinishedResolved && !args.allFinished && !lastAssistantCancelled;
+    (messageRunState === "running" || externalRunActive) &&
+    !lastAssistantCancelled;
   const waitingForAssistant =
     lastGroup?.role === "user" &&
     lastGroup.messages.length > 0 &&
-    (!args.allFinishedResolved ||
-      lastGroup.messages.some((message) => {
-        return message.isOptimisticRun || message.runId !== undefined;
-      }));
+    lastGroup.messages.some((message) => {
+      return message.isOptimisticRun || message.runId !== undefined;
+    });
 
   return {
     lastGroup,
@@ -5432,9 +5468,6 @@ function ThinkingIndicator({
   thread: ChatThreadSignals;
   groups: GroupedChatMessageGroup[];
 }) {
-  const allFinishedLoadable = useLastLoadable(thread.allFinished$);
-  const allFinishedResolved = allFinishedLoadable.state === "hasData";
-  const allFinished = allFinishedResolved ? allFinishedLoadable.data : false;
   const [c1, c2, c3] = useGet(thread.blockColors$);
   const blockStyle = {
     "--zb-c1": c1,
@@ -5442,14 +5475,16 @@ function ThinkingIndicator({
     "--zb-c3": c3,
   } as CSSProperties;
 
-  const latestRunStatus = useLastResolved(thread.latestRunStatus$);
+  const latestRunStatusLoadable = useLastLoadable(thread.latestRunStatus$);
+  const latestRunStatus =
+    latestRunStatusLoadable.state === "hasData"
+      ? latestRunStatusLoadable.data
+      : undefined;
   const features = useLastResolved(featureSwitch$);
   const initialThinkingEnabled =
     features?.[FeatureSwitchKey.ChatInitialThinkingIndicator] ?? false;
   const indicatorState = getThinkingIndicatorState({
     groups,
-    allFinishedResolved,
-    allFinished,
     latestRunStatus,
     initialThinkingEnabled,
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -3805,41 +3805,6 @@ function lastRunThinkingMessageForIndicator(
   return runHasAssistantText ? undefined : lastMessage;
 }
 
-type LoadedMessageRunState = "running" | "finished" | null;
-
-function loadedMessageRunState(
-  groups: readonly GroupedChatMessageGroup[],
-): LoadedMessageRunState {
-  const messages = groups.flatMap((group) => {
-    return group.messages.filter((message) => {
-      return (
-        !message.isQueued &&
-        !(message.role === "assistant" && message.usage !== undefined)
-      );
-    });
-  });
-  const terminatedRunIds = terminatedRunIdsForCompletedWork(messages);
-
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const message = messages[index]!;
-    if (
-      message.role === "assistant" &&
-      message.runLifecycleEvent !== undefined
-    ) {
-      return "finished";
-    }
-    if (message.interruptsRunId !== undefined) {
-      return "finished";
-    }
-    if (message.runId === undefined) {
-      continue;
-    }
-    return terminatedRunIds.has(message.runId) ? "finished" : "running";
-  }
-
-  return null;
-}
-
 function terminatedRunIdsForCompletedWork(
   messages: readonly EnrichedChatMessage[],
 ): Set<string> {
@@ -5168,16 +5133,21 @@ function shouldRenderThinkingIndicator({
   lastGroup,
   lastIsAssistant,
   running,
+  runStatePending,
   lastAssistantCancelled,
   lastAssistantOnlyThinking,
 }: {
   lastGroup: GroupedChatMessageGroup | undefined;
   lastIsAssistant: boolean;
   running: boolean;
+  runStatePending: boolean;
   lastAssistantCancelled: boolean;
   lastAssistantOnlyThinking: boolean;
 }): boolean {
   if (!lastGroup) {
+    return false;
+  }
+  if (runStatePending && lastIsAssistant) {
     return false;
   }
   if (lastAssistantCancelled && !running) {
@@ -5403,12 +5373,14 @@ interface ThinkingIndicatorState {
   readonly lastAssistantOnlyThinking: boolean;
   readonly isQueued: boolean;
   readonly running: boolean;
+  readonly runStatePending: boolean;
   readonly lastThinkingMessage: ThinkingIndicatorMarkerMessage | undefined;
 }
 
 function getThinkingIndicatorState(args: {
   readonly groups: GroupedChatMessageGroup[];
-  readonly latestRunStatus: string | null | undefined;
+  readonly messageRunIndicatorState: "running" | "queued" | null | undefined;
+  readonly messageRunIndicatorResolved: boolean;
   readonly initialThinkingEnabled: boolean;
 }): ThinkingIndicatorState {
   const lastGroup = args.groups[args.groups.length - 1];
@@ -5435,13 +5407,10 @@ function getThinkingIndicatorState(args: {
   const lastThinkingMessage = args.initialThinkingEnabled
     ? rawLastThinkingMessage
     : undefined;
-  const isQueued =
-    args.latestRunStatus === "queued" && lastThinkingMessage === undefined;
-  const messageRunState = loadedMessageRunState(args.groups);
-  const externalRunActive =
-    args.latestRunStatus === "running" || args.latestRunStatus === "queued";
+  const isQueued = args.messageRunIndicatorState === "queued";
   const runActive =
-    (messageRunState === "running" || externalRunActive) &&
+    args.messageRunIndicatorState !== null &&
+    args.messageRunIndicatorState !== undefined &&
     !lastAssistantCancelled;
   const waitingForAssistant =
     lastGroup?.role === "user" &&
@@ -5457,6 +5426,7 @@ function getThinkingIndicatorState(args: {
     lastAssistantOnlyThinking,
     isQueued,
     running: runActive || waitingForAssistant,
+    runStatePending: !args.messageRunIndicatorResolved,
     lastThinkingMessage,
   };
 }
@@ -5475,17 +5445,21 @@ function ThinkingIndicator({
     "--zb-c3": c3,
   } as CSSProperties;
 
-  const latestRunStatusLoadable = useLastLoadable(thread.latestRunStatus$);
-  const latestRunStatus =
-    latestRunStatusLoadable.state === "hasData"
-      ? latestRunStatusLoadable.data
-      : undefined;
   const features = useLastResolved(featureSwitch$);
   const initialThinkingEnabled =
     features?.[FeatureSwitchKey.ChatInitialThinkingIndicator] ?? false;
+  const messageRunIndicatorStateLoadable = useLastLoadable(
+    thread.messageRunIndicatorState$,
+  );
+  const messageRunIndicatorResolved =
+    messageRunIndicatorStateLoadable.state === "hasData";
+  const messageRunIndicatorState = messageRunIndicatorResolved
+    ? messageRunIndicatorStateLoadable.data
+    : undefined;
   const indicatorState = getThinkingIndicatorState({
     groups,
-    latestRunStatus,
+    messageRunIndicatorState,
+    messageRunIndicatorResolved,
     initialThinkingEnabled,
   });
   const rotatingLabel = useGet(thread.rotatingPhrase$);
@@ -5512,6 +5486,7 @@ function ThinkingIndicator({
       lastGroup: indicatorState.lastGroup,
       lastIsAssistant: indicatorState.lastIsAssistant,
       running: indicatorState.running,
+      runStatePending: indicatorState.runStatePending,
       lastAssistantCancelled: indicatorState.lastAssistantCancelled,
       lastAssistantOnlyThinking: indicatorState.lastAssistantOnlyThinking,
     })


### PR DESCRIPTION
Summary:
- Derive chat thinking/finished/queued indicator state from the raw chat message stream.
- Remove the ThinkingIndicator fallback to latestRunStatus$, allFinished$, threadData$, and activeRunIds-derived metadata.
- Keep server thinking and queue markers working even when those markers are filtered out of rendered message groups.
- Add/update regression coverage for delayed thread metadata and activeRunIds no longer reviving the thinking indicator.

Validation:
- pnpm exec prettier --write apps/platform/src/signals/chat-page/chat-thread-signals.ts apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- git diff --check
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint

Note:
- The first concurrent lint/type-check attempt hit SIGKILL in type-aware oxlint; rerunning type-check and lint separately passed.