### PR TITLE
fix(app): reveal full agent name on hover when truncated on agent card

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -662,7 +662,10 @@ function AgentCard({ agent, creator, hasUnread, showCreator }: AgentProps) {
                 </Tooltip>
               </TooltipProvider>
             ) : (
-              <span className="block truncate text-sm font-medium text-foreground">
+              <span
+                className="block truncate text-sm font-medium text-foreground"
+                title={displayName}
+              >
                 {displayName}
               </span>
             )}


### PR DESCRIPTION
## What

On the agent card, when an agent has no creator to show (`showCreator` is false), the name is rendered with `truncate` but has no tooltip — so a truncated name can't be read in full. The creator branch already exposes a hover tooltip; this adds a native `title` on the no-creator branch so the full name is still discoverable on hover.

## Why

- Small UX/a11y consistency fix for the agent card name, following up on the recent underline/tooltip work (#19885).
- Uses a native `title` (not the custom Tooltip) to avoid a double-tooltip on the creator branch.

## Note

This is a `fix:` in `turbo/apps/platform` (the `app` package), so it will trigger the next `app` release-please PR. That release will also carry #19885 (`style:`), which merged just after the last `app` tag and does not bump a version on its own.