### PR TITLE
fix(desktop): bundle workspace packages into electron main process

### DIFF
--- a/turbo/apps/desktop/tsup.electron.config.js
+++ b/turbo/apps/desktop/tsup.electron.config.js
@@ -12,7 +12,7 @@ module.exports = defineConfig({
   sourcemap: true,
   clean: true,
   external: ["electron"],
-  noExternal: ["update-electron-app", "@sentry/electron"],
+  noExternal: ["update-electron-app", "@sentry/electron", /^@vm0\//],
   define: {
     __DESKTOP_VERSION__: JSON.stringify(pkg.version),
     __DESKTOP_SENTRY_DSN__: JSON.stringify(


### PR DESCRIPTION
## Problem

Packaged ZeroDesktop.app crashes on launch with:

```
Uncaught Exception:
Error: Cannot find module '@vm0/api-contracts/contracts/zero-computer-use-plugins'
Require stack:
- /Applications/ZeroDesktop.app/Contents/Resources/app/dist/main.js
```

## Root cause

PR #19814 added the first `@vm0/api-contracts` import to the desktop main process (`src/main.ts`). The main process is bundled with tsup (`tsup.electron.config.js`), which by default externalizes packages listed in `package.json` dependencies — including the workspace dependency `@vm0/api-contracts` — leaving it as a runtime `require`.

However, `forge.config.js` packager `ignore` rules exclude all of `/node_modules` from the packaged app, so the packaged bundle has nothing to resolve that `require` against. Dev mode (`electron-forge start`) works because node_modules exists on disk, so CI never catches it — only the packaged app crashes.

## Fix

Add `/^@vm0\//` to tsup `noExternal` so all workspace packages are bundled into `dist/main.js`. This also future-proofs against the same crash when any other workspace import is added to the main process.

## Verification

- `pnpm -F @vm0/desktop build:electron` bundles the contract module into `dist/main.js` instead of leaving a bare `require`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)