### PR TITLE
perf: split fresh sandbox preparation telemetry

### DIFF
--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -30,12 +30,28 @@ use crate::proxy;
 use crate::telemetry::JobTelemetry;
 use crate::types::ExecutionContext;
 use crate::workspace_image_cache::{
-    WorkspaceImageLease, WorkspaceImageLeaseIdentity, WorkspaceImagePrepareRequest,
+    WorkspaceCacheCheckoutResult, WorkspaceImageLease, WorkspaceImageLeaseIdentity,
+    WorkspaceImagePrepareRequest,
 };
 use crate::workspace_mount::ensure_workspace_drive_mounted;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
 const SLOW_PROXY_REGISTER_THRESHOLD: Duration = Duration::from_secs(3);
+const RUNNER_FRESH_WORKSPACE_IMAGE_PREPARE: &str = "runner_fresh_workspace_image_prepare";
+const RUNNER_FRESH_SANDBOX_FACTORY_CREATE: &str = "runner_fresh_sandbox_factory_create";
+const RUNNER_FRESH_SANDBOX_PROXY_REGISTER: &str = "runner_fresh_sandbox_proxy_register";
+const RUNNER_FRESH_SANDBOX_START: &str = "runner_fresh_sandbox_start";
+const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE: &str =
+    "runner_fresh_sandbox_retry_without_workspace_image";
+
+const WORKSPACE_IMAGE_PREPARE_INVALID_WORKING_DIR: &str =
+    "workspace_image_prepare_invalid_working_dir";
+const WORKSPACE_IMAGE_PREPARE_LOCK_BUSY: &str = "workspace_image_prepare_lock_busy";
+const WORKSPACE_IMAGE_PREPARE_INVALID_METADATA: &str = "workspace_image_prepare_invalid_metadata";
+const WORKSPACE_IMAGE_PREPARE_DISK_PRESSURE: &str = "workspace_image_prepare_disk_pressure";
+const SANDBOX_FACTORY_CREATE_FAILED: &str = "sandbox_factory_create_failed";
+const SANDBOX_PROXY_REGISTER_FAILED: &str = "sandbox_proxy_register_failed";
+const SANDBOX_START_FAILED: &str = "sandbox_start_failed";
 
 #[cfg(test)]
 pub(super) async fn execute_new_sandbox(
@@ -122,6 +138,12 @@ pub(super) async fn execute_new_sandbox_with_prepared_notifier(
                 sandbox_id = %sandbox_id,
                 error = %error,
                 "workspace image cache hit failed during sandbox preparation; retrying with fresh workspace image"
+            );
+            telemetry.record(
+                RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE,
+                Duration::ZERO,
+                true,
+                None,
             );
             workspace_image = None;
             match create_started_sandbox(
@@ -234,6 +256,7 @@ pub(super) async fn prepare_workspace_image(
     telemetry: &mut JobTelemetry,
 ) -> Option<WorkspaceImageLease> {
     let cache = config.workspace_cache.as_ref()?;
+    let prepare_started = Instant::now();
     let lease = cache
         .prepare(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
@@ -247,8 +270,31 @@ pub(super) async fn prepare_workspace_image(
             workspace_drive_required: true,
         })
         .await;
+    let prepare_error = workspace_image_prepare_error(lease.result());
+    telemetry.record(
+        RUNNER_FRESH_WORKSPACE_IMAGE_PREPARE,
+        prepare_started.elapsed(),
+        prepare_error.is_none(),
+        prepare_error,
+    );
     record_workspace_cache_result(telemetry, lease.result());
     Some(lease)
+}
+
+fn workspace_image_prepare_error(result: WorkspaceCacheCheckoutResult) -> Option<&'static str> {
+    match result {
+        WorkspaceCacheCheckoutResult::Hit
+        | WorkspaceCacheCheckoutResult::Miss
+        | WorkspaceCacheCheckoutResult::NoSession => None,
+        WorkspaceCacheCheckoutResult::InvalidWorkingDir => {
+            Some(WORKSPACE_IMAGE_PREPARE_INVALID_WORKING_DIR)
+        }
+        WorkspaceCacheCheckoutResult::LockBusy => Some(WORKSPACE_IMAGE_PREPARE_LOCK_BUSY),
+        WorkspaceCacheCheckoutResult::InvalidMetadata => {
+            Some(WORKSPACE_IMAGE_PREPARE_INVALID_METADATA)
+        }
+        WorkspaceCacheCheckoutResult::DiskPressure => Some(WORKSPACE_IMAGE_PREPARE_DISK_PRESSURE),
+    }
 }
 
 async fn create_started_sandbox(
@@ -284,9 +330,24 @@ async fn create_started_sandbox(
 
     info!(run_id = %context.run_id, sandbox_id = %sandbox_id, "creating sandbox");
     let t = Instant::now();
+    let factory_create_started = Instant::now();
     let mut sandbox = match factory.create(sandbox_config).await {
-        Ok(s) => s,
+        Ok(s) => {
+            telemetry.record(
+                RUNNER_FRESH_SANDBOX_FACTORY_CREATE,
+                factory_create_started.elapsed(),
+                true,
+                None,
+            );
+            s
+        }
         Err(e) => {
+            telemetry.record(
+                RUNNER_FRESH_SANDBOX_FACTORY_CREATE,
+                factory_create_started.elapsed(),
+                false,
+                Some(SANDBOX_FACTORY_CREATE_FAILED),
+            );
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
             return Err(SandboxPrepareError::retry(e.into()));
         }
@@ -296,20 +357,34 @@ async fn create_started_sandbox(
     let proxy_register_started = Instant::now();
     let network_log_session = match register_proxy(config, context, &source_ip).await {
         Ok(session) => {
+            let proxy_register_elapsed = proxy_register_started.elapsed();
+            telemetry.record(
+                RUNNER_FRESH_SANDBOX_PROXY_REGISTER,
+                proxy_register_elapsed,
+                true,
+                None,
+            );
             log_proxy_register_success(
                 context.run_id,
                 sandbox_id,
                 &params.profile_name,
-                proxy_register_started.elapsed(),
+                proxy_register_elapsed,
             );
             session
         }
         Err(e) => {
+            let proxy_register_elapsed = proxy_register_started.elapsed();
+            telemetry.record(
+                RUNNER_FRESH_SANDBOX_PROXY_REGISTER,
+                proxy_register_elapsed,
+                false,
+                Some(SANDBOX_PROXY_REGISTER_FAILED),
+            );
             log_proxy_register_failure(
                 context.run_id,
                 sandbox_id,
                 &params.profile_name,
-                proxy_register_started.elapsed(),
+                proxy_register_elapsed,
                 &e.to_string(),
             );
             telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
@@ -318,7 +393,14 @@ async fn create_started_sandbox(
         }
     };
 
+    let sandbox_start_started = Instant::now();
     if let Err(e) = sandbox.start().await {
+        telemetry.record(
+            RUNNER_FRESH_SANDBOX_START,
+            sandbox_start_started.elapsed(),
+            false,
+            Some(SANDBOX_START_FAILED),
+        );
         telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
         if let Err(unregister_error) = unregister_proxy_registry(config, &source_ip).await {
             warn!(
@@ -333,6 +415,12 @@ async fn create_started_sandbox(
         destroy_sandbox_panic_safe(factory, sandbox).await;
         return Err(SandboxPrepareError::retry(e.into()));
     }
+    telemetry.record(
+        RUNNER_FRESH_SANDBOX_START,
+        sandbox_start_started.elapsed(),
+        true,
+        None,
+    );
     telemetry.record("vm_create", t.elapsed(), true, None);
 
     let mount_started = Instant::now();

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -425,6 +425,24 @@ async fn execute_inner_start_failure_destroy_panic_returns_start_error() {
             .await,
         "start failure should close inline network-log attribution",
     );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_factory_create",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_proxy_register",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_start",
+        false,
+        Some("sandbox_start_failed"),
+    );
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -52,3 +52,37 @@ mod idle_pool;
 mod proxy_registry;
 mod reuse;
 mod workspace_cache;
+
+fn assert_telemetry_action(
+    telemetry: &crate::telemetry::JobTelemetry,
+    action: &str,
+    success: bool,
+    error: Option<&str>,
+) {
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter().any(|(op_action, op_success, op_error)| {
+            op_action == action && *op_success == success && op_error.as_deref() == error
+        }),
+        "expected telemetry action {action} success={success} error={error:?}, got: {ops:?}"
+    );
+}
+
+fn assert_no_telemetry_action(telemetry: &crate::telemetry::JobTelemetry, action: &str) {
+    let ops = telemetry.pending_ops_snapshot();
+    assert!(
+        ops.iter().all(|(op_action, _, _)| op_action != action),
+        "unexpected telemetry action {action}, got: {ops:?}"
+    );
+}
+
+fn telemetry_action_outcomes(
+    telemetry: &crate::telemetry::JobTelemetry,
+    action: &str,
+) -> Vec<(bool, Option<String>)> {
+    telemetry
+        .pending_ops_snapshot()
+        .into_iter()
+        .filter_map(|(op_action, success, error)| (op_action == action).then_some((success, error)))
+        .collect()
+}

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -62,6 +62,29 @@ async fn execute_inner_retries_fresh_after_workspace_cache_hit_create_failure() 
         !expected_seed.exists(),
         "failed cache hit should invalidate the unusable baseline"
     );
+
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_workspace_image_prepare",
+        true,
+        None,
+    );
+    assert_telemetry_action(&telemetry, "workspace_image_cache_hit", true, None);
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_workspace_image",
+        true,
+        None,
+    );
+    let factory_create_outcomes =
+        telemetry_action_outcomes(&telemetry, "runner_fresh_sandbox_factory_create");
+    assert_eq!(
+        factory_create_outcomes,
+        vec![
+            (false, Some("sandbox_factory_create_failed".into())),
+            (true, None)
+        ]
+    );
 }
 
 #[tokio::test]
@@ -112,6 +135,95 @@ async fn execute_inner_uses_workspace_cache_when_configured() {
             seed_image: Some(sandbox::WorkspaceDriveSeedImage::Move(seeded_cache)),
         })
     );
+
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_workspace_image_prepare",
+        true,
+        None,
+    );
+    assert_telemetry_action(&telemetry, "workspace_image_cache_hit", true, None);
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_factory_create",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_proxy_register",
+        true,
+        None,
+    );
+    assert_telemetry_action(&telemetry, "runner_fresh_sandbox_start", true, None);
+}
+
+#[tokio::test]
+async fn execute_inner_records_workspace_cache_lock_busy_prepare_telemetry() {
+    let dir = tempfile::tempdir().unwrap();
+    let runner_paths = RunnerPaths::new(dir.path().join("runner"));
+    let cache = SessionWorkspaceCache::new(runner_paths.clone());
+    let mut config = test_executor_config(dir.path()).await;
+    config.workspace_cache = Some(cache);
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+    let mut ctx = minimal_context();
+    let session_id = "sess-cache-lock-busy-prepare";
+    ctx.resume_session = Some(ResumeSession::inline(
+        session_id.into(),
+        r#"{"type":"init"}"#.into(),
+    ));
+    let params = JobParams {
+        workspace_disk_mb: 16,
+        ..default_params()
+    };
+    let cache_key = scoped_session_workspace_cache_key(
+        "",
+        &params.profile_name,
+        session_id,
+        CANONICAL_WORKING_DIR,
+        u64::from(params.workspace_disk_mb) * 1024 * 1024,
+    );
+    let _held_lock = crate::lock::acquire(crate::paths::workspace_image_cache_lock_path(
+        &runner_paths.base_dir().join("locks"),
+        &cache_key,
+    ))
+    .await
+    .unwrap();
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let outcome = execute_new_sandbox(
+        &factory,
+        &ctx,
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &params,
+        &mut telemetry,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(outcome.exit_code(), 0);
+    let configs = overrides.create_configs();
+    assert_eq!(configs.len(), 1);
+    assert_eq!(
+        configs[0].workspace_drive,
+        Some(sandbox::WorkspaceDriveConfig {
+            size_mb: 16,
+            seed_image: None,
+        })
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_workspace_image_prepare",
+        false,
+        Some("workspace_image_prepare_lock_busy"),
+    );
+    assert_telemetry_action(&telemetry, "workspace_image_cache_lock_busy", true, None);
 }
 
 #[tokio::test]
@@ -175,6 +287,22 @@ async fn execute_inner_does_not_retry_workspace_cache_hit_after_proxy_register_f
     assert!(
         expected_seed.exists(),
         "proxy registration failure must not invalidate the unrelated workspace cache hit"
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_factory_create",
+        true,
+        None,
+    );
+    assert_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_proxy_register",
+        false,
+        Some("sandbox_proxy_register_failed"),
+    );
+    assert_no_telemetry_action(
+        &telemetry,
+        "runner_fresh_sandbox_retry_without_workspace_image",
     );
 }
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -249,6 +249,9 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "runner_executor_start_to_spawn",
         "runner_claim_to_spawn",
         "runner_fresh_sandbox_prepare",
+        "runner_fresh_sandbox_factory_create",
+        "runner_fresh_sandbox_proxy_register",
+        "runner_fresh_sandbox_start",
         "runner_guest_timezone_sync",
         "runner_user_env_write",
         "runner_agent_env_build",
@@ -262,6 +265,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     }
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
+    assert_lacks_action(&telemetry, "runner_fresh_workspace_image_prepare");
     assert_lacks_action(&telemetry, "runner_guest_state_restore");
 }
 
@@ -321,6 +325,9 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     }
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_prepare");
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_factory_create");
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_proxy_register");
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
     assert_lacks_action(&telemetry, "runner_guest_timezone_sync");
 }
 


### PR DESCRIPTION
## Summary

- Add fresh sandbox preparation sub-spans for workspace image prepare, sandbox factory create, proxy registration, and sandbox start.
- Emit a fixed retry marker when a consumed workspace-image cache hit retries without the workspace image.
- Keep existing `runner_fresh_sandbox_prepare`, `vm_create`, `workspace_drive_mount`, and `workspace_image_cache_*` telemetry for continuity.
- Use static error categories for the new sub-spans instead of raw error strings.

## Problem

Fresh sandbox preparation is currently a broad runner-local p95 tail, and `vm_create` mixes factory creation, proxy registration, and sandbox start. Without lower-level timing, the next optimization could target the wrong block.

## Solution

This PR adds low-cardinality timing attribution without changing runtime behavior. The new spans make post-deploy analysis able to decide whether the next behavior issue should focus on sandbox start/prewarming, proxy registration, or workspace image preparation.

Closes #19886.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::telemetry_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::sandbox_run_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --tests -- -D warnings`
- pre-commit: cargo-doc, cargo-clippy
