### PR TITLE
refactor(cli): use public connector catalog

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
@@ -1,0 +1,97 @@
+import { http, HttpResponse } from "msw";
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogManualField,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+
+function permissionSummary(): PublicConnectorCatalogStatusItem["permissionSummary"] {
+  return {
+    hasPermissions: false,
+    permissionCount: 0,
+    hasCategories: false,
+    hasDefaultPolicyOverrides: false,
+  };
+}
+
+function manualField(
+  id: string,
+  label = id,
+): PublicConnectorCatalogManualField {
+  return {
+    id,
+    label,
+    required: true,
+    placeholder: null,
+    inputType: "password",
+  };
+}
+
+export function manualAuthMethod(
+  id = "api-token",
+  fields: readonly PublicConnectorCatalogManualField[] = [
+    manualField("apiKey"),
+  ],
+): PublicConnectorCatalogAuthMethodDetail {
+  return {
+    id,
+    label: id,
+    description: null,
+    grantKind: "manual",
+    manualFields: [...fields],
+    startOptions: [],
+  };
+}
+
+export function authCodeMethod(
+  id = "oauth",
+): PublicConnectorCatalogAuthMethodDetail {
+  return {
+    id,
+    label: id,
+    description: null,
+    grantKind: "auth-code",
+    manualFields: [],
+    startOptions: [],
+  };
+}
+
+export function catalogStatusItem(
+  overrides: Partial<PublicConnectorCatalogStatusItem> & {
+    readonly connectorRef: string;
+  },
+): PublicConnectorCatalogStatusItem {
+  const connection = overrides.connection ?? null;
+  const connectionStatus =
+    overrides.connectionStatus ?? (connection ? "connected" : "not-connected");
+  return {
+    connectorRef: overrides.connectorRef,
+    label: overrides.label ?? overrides.connectorRef,
+    description: overrides.description ?? `${overrides.connectorRef} connector`,
+    category: overrides.category ?? "developer-tools",
+    generation: overrides.generation ?? [],
+    tags: overrides.tags ?? [],
+    authMethods: overrides.authMethods ?? [],
+    permissionSummary: overrides.permissionSummary ?? permissionSummary(),
+    connection,
+    connected: overrides.connected ?? connection !== null,
+    connectionStatus,
+    scopeMismatch:
+      overrides.scopeMismatch ?? connectionStatus === "scope-mismatch",
+    authMethodSupportsRefresh: overrides.authMethodSupportsRefresh ?? false,
+    tokenExpiresAt: overrides.tokenExpiresAt ?? null,
+    singleAuthCodeAuthMethodId: overrides.singleAuthCodeAuthMethodId ?? null,
+    connectNotice: overrides.connectNotice ?? null,
+  };
+}
+
+export function stubConnectorCatalogStatus(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+) {
+  return http.get(
+    "http://localhost:3000/api/zero/connector-catalog/status",
+    () => {
+      return HttpResponse.json({ connectors });
+    },
+  );
+}

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
@@ -1,6 +1,8 @@
 import { http, HttpResponse } from "msw";
 import type {
   PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogAuthMethodSummary,
+  PublicConnectorCatalogItem,
   PublicConnectorCatalogManualField,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
@@ -56,6 +58,34 @@ export function authCodeMethod(
   };
 }
 
+function authMethodSummary(
+  method: PublicConnectorCatalogAuthMethodSummary,
+): PublicConnectorCatalogAuthMethodSummary {
+  return {
+    id: method.id,
+    label: method.label,
+    description: method.description,
+    grantKind: method.grantKind,
+  };
+}
+
+export function catalogItem(
+  overrides: Partial<PublicConnectorCatalogItem> & {
+    readonly connectorRef: string;
+  },
+): PublicConnectorCatalogItem {
+  return {
+    connectorRef: overrides.connectorRef,
+    label: overrides.label ?? overrides.connectorRef,
+    description: overrides.description ?? `${overrides.connectorRef} connector`,
+    category: overrides.category ?? "developer-tools",
+    generation: overrides.generation ?? [],
+    tags: overrides.tags ?? [],
+    authMethods: (overrides.authMethods ?? []).map(authMethodSummary),
+    permissionSummary: overrides.permissionSummary ?? permissionSummary(),
+  };
+}
+
 export function catalogStatusItem(
   overrides: Partial<PublicConnectorCatalogStatusItem> & {
     readonly connectorRef: string;
@@ -83,6 +113,14 @@ export function catalogStatusItem(
     singleAuthCodeAuthMethodId: overrides.singleAuthCodeAuthMethodId ?? null,
     connectNotice: overrides.connectNotice ?? null,
   };
+}
+
+export function stubConnectorCatalog(
+  connectors: readonly PublicConnectorCatalogItem[],
+) {
+  return http.get("http://localhost:3000/api/zero/connector-catalog", () => {
+    return HttpResponse.json({ connectors });
+  });
 }
 
 export function stubConnectorCatalogStatus(

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
@@ -68,19 +68,19 @@ describe("zero connector connect command", () => {
       "cli",
       "zendesk",
       "--value",
-      "ZENDESK_API_TOKEN=secret-token",
+      "apiToken=secret-token",
       "--value",
-      "ZENDESK_SUBDOMAIN=example",
+      "subdomain=example",
       "--value",
-      "ZENDESK_EMAIL=support@example.com",
+      "email=support@example.com",
     ]);
 
     expect(receivedBody).toStrictEqual({
       authMethod: "api-token",
       values: {
-        ZENDESK_API_TOKEN: "secret-token",
-        ZENDESK_SUBDOMAIN: "example",
-        ZENDESK_EMAIL: "support@example.com",
+        apiToken: "secret-token",
+        subdomain: "example",
+        email: "support@example.com",
       },
     });
     const output = mockConsoleLog.mock.calls.flat().join("\n");
@@ -108,13 +108,13 @@ describe("zero connector connect command", () => {
       "--auth-method",
       "api-token",
       "--value",
-      "OPENAI_TOKEN=sk-test",
+      "apiKey=sk-test",
     ]);
 
     expect(receivedBody).toStrictEqual({
       authMethod: "api-token",
       values: {
-        OPENAI_TOKEN: "sk-test",
+        apiKey: "sk-test",
       },
     });
   });
@@ -134,7 +134,7 @@ describe("zero connector connect command", () => {
       "cli",
       "openai",
       "--value",
-      "OPENAI_TOKEN=sk-test",
+      "apiKey=sk-test",
       "--json",
     ]);
 
@@ -170,13 +170,7 @@ describe("zero connector connect command", () => {
     );
 
     await expect(
-      connectCommand.parseAsync([
-        "node",
-        "cli",
-        "openai",
-        "--value",
-        "OPENAI_TOKEN",
-      ]),
+      connectCommand.parseAsync(["node", "cli", "openai", "--value", "apiKey"]),
     ).rejects.toThrow("process.exit called");
 
     expect(requestCalled).toBeFalsy();
@@ -205,7 +199,7 @@ describe("zero connector connect command", () => {
         "--auth-method",
         "api-token",
         "--value",
-        "GITHUB_TOKEN=ghp-test",
+        "apiToken=ghp-test",
       ]),
     ).rejects.toThrow("process.exit called");
 
@@ -237,7 +231,7 @@ describe("zero connector connect command", () => {
         "--auth-method",
         "oauth",
         "--value",
-        "STRIPE_TOKEN=sk-test",
+        "apiKey=sk-test",
       ]),
     ).rejects.toThrow("process.exit called");
 
@@ -257,8 +251,7 @@ describe("zero connector connect command", () => {
           return HttpResponse.json(
             {
               error: {
-                message:
-                  "Missing required manual grant field(s): ZENDESK_EMAIL",
+                message: "Missing required manual grant field(s): email",
                 code: "BAD_REQUEST",
               },
             },
@@ -274,7 +267,7 @@ describe("zero connector connect command", () => {
         "cli",
         "zendesk",
         "--value",
-        "ZENDESK_API_TOKEN=secret-token",
+        "apiToken=secret-token",
       ]),
     ).rejects.toThrow("process.exit called");
 
@@ -307,7 +300,7 @@ describe("zero connector connect command", () => {
         "cli",
         "zendesk",
         "--value",
-        "ZENDESK_API_TOKEN=secret-token",
+        "apiToken=secret-token",
       ]),
     ).rejects.toThrow("process.exit called");
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/list.test.ts
@@ -12,6 +12,11 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { listCommand } from "../list";
 import chalk from "chalk";
+import {
+  authCodeMethod,
+  catalogStatusItem,
+  stubConnectorCatalogStatus,
+} from "../../__tests__/helpers/connector-catalog";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
@@ -29,15 +34,45 @@ const connectedGithub = {
   updatedAt: "2025-01-01T00:00:00Z",
 };
 
-function stubConnectors(connectors: Array<Record<string, unknown>>) {
-  return http.get("http://localhost:3000/api/zero/connectors", () => {
-    return HttpResponse.json({
-      connectors,
-      configuredTypes: connectors.map((c) => {
-        return c.type as string;
-      }),
-    });
+function statusItemFromConnector(connector: Record<string, unknown>) {
+  return catalogStatusItem({
+    connectorRef: connector.type as string,
+    authMethods: [authCodeMethod(connector.authMethod as string)],
+    connection: {
+      authMethod: connector.authMethod as string,
+      externalUsername: (connector.externalUsername as string | null) ?? null,
+      externalEmail: (connector.externalEmail as string | null) ?? null,
+      reconnectReason: null,
+    },
+    connected: true,
+    connectionStatus:
+      (connector.connectionStatus as "connected" | "reconnect-required") ??
+      "connected",
   });
+}
+
+function stubConnectors(connectors: Array<Record<string, unknown>>) {
+  const connectedByType = new Map(
+    connectors.map((connector) => {
+      return [connector.type as string, statusItemFromConnector(connector)];
+    }),
+  );
+  const visibleTypes = new Set([
+    "github",
+    "mercury",
+    ...connectedByType.keys(),
+  ]);
+  return stubConnectorCatalogStatus(
+    [...visibleTypes].map((type) => {
+      return (
+        connectedByType.get(type) ??
+        catalogStatusItem({
+          connectorRef: type,
+          authMethods: [authCodeMethod("oauth")],
+        })
+      );
+    }),
+  );
 }
 
 function stubAgent(id: string, displayName: string | null) {
@@ -63,18 +98,14 @@ function stubUserConnectors(id: string, enabledTypes: string[]) {
 }
 
 function stubAvailableConnectors(types: string[]) {
-  return http.get("http://localhost:3000/api/zero/connectors/search", () => {
-    return HttpResponse.json({
-      connectors: types.map((type) => {
-        return {
-          id: type,
-          label: type,
-          description: type,
-          authMethods: ["oauth"],
-        };
-      }),
-    });
-  });
+  return stubConnectorCatalogStatus(
+    types.map((type) => {
+      return catalogStatusItem({
+        connectorRef: type,
+        authMethods: [authCodeMethod("oauth")],
+      });
+    }),
+  );
 }
 
 describe("zero connector list command", () => {
@@ -225,17 +256,20 @@ describe("zero connector list command", () => {
   describe("error handling", () => {
     it("should handle authentication error", async () => {
       server.use(
-        http.get("http://localhost:3000/api/zero/connectors", () => {
-          return HttpResponse.json(
-            {
-              error: {
-                message: "Not authenticated",
-                code: "UNAUTHORIZED",
+        http.get(
+          "http://localhost:3000/api/zero/connector-catalog/status",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Not authenticated",
+                  code: "UNAUTHORIZED",
+                },
               },
-            },
-            { status: 401 },
-          );
-        }),
+              { status: 401 },
+            );
+          },
+        ),
       );
 
       await expect(async () => {
@@ -278,7 +312,7 @@ describe("zero connector list command", () => {
     });
 
     it("uses the server-visible catalog for feature-gated oauth connectors", async () => {
-      server.use(stubConnectors([]), stubAvailableConnectors(["google-ads"]));
+      server.use(stubAvailableConnectors(["google-ads"]));
 
       await listCommand.parseAsync(["node", "cli"]);
 

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -268,6 +268,23 @@ describe("zero connector search command", () => {
         ]);
       }).rejects.toThrow();
     });
+
+    it.each(["1abc", "1.5"])(
+      "rejects malformed --limit value %s",
+      async (limit) => {
+        await expect(async () => {
+          await searchCommand.parseAsync([
+            "node",
+            "cli",
+            "github",
+            "--limit",
+            limit,
+          ]);
+        }).rejects.toThrow(
+          `--limit must be a positive integer, got "${limit}"`,
+        );
+      },
+    );
   });
 
   describe("with agent context", () => {

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/search.test.ts
@@ -12,6 +12,11 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { searchCommand } from "../search";
 import chalk from "chalk";
+import {
+  authCodeMethod,
+  catalogStatusItem,
+  stubConnectorCatalogStatus,
+} from "../../__tests__/helpers/connector-catalog";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
@@ -30,15 +35,53 @@ const connectedGithub = {
 };
 
 function stubConnectors(connectors: Array<Record<string, unknown>>) {
-  return http.get("http://localhost:3000/api/zero/connectors", () => {
-    return HttpResponse.json({
-      connectors,
-      configuredTypes: connectors.map((c) => {
-        return c.type as string;
-      }),
-      connectorProvidedBindings: [],
-    });
-  });
+  const connectedByType = new Map(
+    connectors.map((connector) => {
+      const scopeMismatch =
+        Array.isArray(connector.oauthScopes) &&
+        connector.oauthScopes.length === 1 &&
+        connector.oauthScopes[0] === "repo";
+      return [
+        connector.type as string,
+        catalogStatusItem({
+          connectorRef: connector.type as string,
+          authMethods: [authCodeMethod(connector.authMethod as string)],
+          tags: connector.type === "github" ? ["vcs"] : [],
+          connection: {
+            authMethod: connector.authMethod as string,
+            externalUsername:
+              (connector.externalUsername as string | null) ?? null,
+            externalEmail: (connector.externalEmail as string | null) ?? null,
+            reconnectReason: null,
+          },
+          connected: true,
+          connectionStatus: scopeMismatch
+            ? "scope-mismatch"
+            : ((connector.connectionStatus as
+                | "connected"
+                | "reconnect-required") ?? "connected"),
+          scopeMismatch,
+        }),
+      ] as const;
+    }),
+  );
+  const visibleTypes = new Set([
+    "github",
+    "mercury",
+    ...connectedByType.keys(),
+  ]);
+  return stubConnectorCatalogStatus(
+    [...visibleTypes].map((type) => {
+      return (
+        connectedByType.get(type) ??
+        catalogStatusItem({
+          connectorRef: type,
+          authMethods: [authCodeMethod("oauth")],
+          tags: type === "github" ? ["vcs"] : [],
+        })
+      );
+    }),
+  );
 }
 
 function stubAgent(id: string, displayName: string | null) {
@@ -64,18 +107,16 @@ function stubUserConnectors(id: string, enabledTypes: string[]) {
 }
 
 function stubAvailableConnectors(types: string[]) {
-  return http.get("http://localhost:3000/api/zero/connectors/search", () => {
-    return HttpResponse.json({
-      connectors: types.map((type) => {
-        return {
-          id: type,
-          label: type,
-          description: type,
-          authMethods: ["oauth"],
-        };
-      }),
-    });
-  });
+  return stubConnectorCatalogStatus(
+    types.map((type) => {
+      return catalogStatusItem({
+        connectorRef: type,
+        label: type.replaceAll("-", " "),
+        authMethods: [authCodeMethod("oauth")],
+        tags: type === "google-ads" ? ["ads"] : [],
+      });
+    }),
+  );
 }
 
 function findDataRows(lines: readonly string[]): string[] {
@@ -140,24 +181,24 @@ describe("zero connector search command", () => {
       expect(dataRows[0]).toMatch(/^github\s/);
     });
 
-    it("returns github for an environment name exact match (GH_TOKEN)", async () => {
+    it("does not match private environment names (GH_TOKEN)", async () => {
       await searchCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
 
       const lines = mockConsoleLog.mock.calls.flat() as string[];
       const output = lines.join("\n");
-      expect(output).not.toContain("No exact match");
+      expect(output).toContain("No matches found.");
       const dataRows = findDataRows(lines);
-      expect(dataRows[0]).toMatch(/^github\s/);
+      expect(dataRows).toHaveLength(0);
     });
 
-    it("returns github with No-exact-match banner for tag match GH_API_KEY", async () => {
+    it("does not match private secret names (GH_API_KEY)", async () => {
       await searchCommand.parseAsync(["node", "cli", "GH_API_KEY"]);
 
       const lines = mockConsoleLog.mock.calls.flat() as string[];
       const output = lines.join("\n");
-      expect(output).toContain("No exact match. Showing closest:");
+      expect(output).toContain("No matches found.");
       const dataRows = findDataRows(lines);
-      expect(dataRows[0]).toMatch(/^github\s/);
+      expect(dataRows).toHaveLength(0);
     });
 
     it("matches multiple connectors by shared tag vcs", async () => {
@@ -407,7 +448,7 @@ describe("zero connector search command", () => {
     });
 
     it("uses the server-visible catalog for feature-gated oauth connectors", async () => {
-      server.use(stubConnectors([]), stubAvailableConnectors(["google-ads"]));
+      server.use(stubAvailableConnectors(["google-ads"]));
 
       await searchCommand.parseAsync(["node", "cli", "google ads"]);
 
@@ -418,16 +459,19 @@ describe("zero connector search command", () => {
   });
 
   describe("error handling", () => {
-    it("surfaces auth errors from listZeroConnectors", async () => {
+    it("surfaces auth errors from public connector catalog status", async () => {
       server.use(
-        http.get("http://localhost:3000/api/zero/connectors", () => {
-          return HttpResponse.json(
-            {
-              error: { message: "Not authenticated", code: "UNAUTHORIZED" },
-            },
-            { status: 401 },
-          );
-        }),
+        http.get(
+          "http://localhost:3000/api/zero/connector-catalog/status",
+          () => {
+            return HttpResponse.json(
+              {
+                error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+              },
+              { status: 401 },
+            );
+          },
+        ),
       );
 
       await expect(async () => {

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/status.test.ts
@@ -12,6 +12,11 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { statusCommand } from "../status";
 import chalk from "chalk";
+import {
+  authCodeMethod,
+  catalogStatusItem,
+  stubConnectorCatalogStatus,
+} from "../../__tests__/helpers/connector-catalog";
 
 const AGENT_UUID = "550e8400-e29b-41d4-a716-446655440000";
 const ALT_AGENT_UUID = "550e8400-e29b-41d4-a716-446655440099";
@@ -29,14 +34,45 @@ const connectedGithub = {
   updatedAt: "2025-01-01T00:00:00Z",
 };
 
+function statusItemFromConnector(connector: Record<string, unknown>) {
+  return catalogStatusItem({
+    connectorRef: connector.type as string,
+    authMethods: [authCodeMethod(connector.authMethod as string)],
+    connection: {
+      authMethod: connector.authMethod as string,
+      externalUsername: (connector.externalUsername as string | null) ?? null,
+      externalEmail: (connector.externalEmail as string | null) ?? null,
+      reconnectReason: null,
+    },
+    connected: true,
+    connectionStatus:
+      (connector.connectionStatus as "connected" | "reconnect-required") ??
+      "connected",
+  });
+}
+
 function stubConnector(
   body: Record<string, unknown>,
   status = 200,
   type = "github",
 ) {
-  return http.get(`http://localhost:3000/api/zero/connectors/${type}`, () => {
-    return HttpResponse.json(body, { status });
-  });
+  if (status === 200) {
+    return stubConnectorCatalogStatus([statusItemFromConnector(body)]);
+  }
+  if (status === 404) {
+    return stubConnectorCatalogStatus([
+      catalogStatusItem({
+        connectorRef: type,
+        authMethods: [authCodeMethod("oauth")],
+      }),
+    ]);
+  }
+  return http.get(
+    "http://localhost:3000/api/zero/connector-catalog/status",
+    () => {
+      return HttpResponse.json(body, { status });
+    },
+  );
 }
 
 function stubAgent(id: string, displayName: string | null) {
@@ -62,18 +98,14 @@ function stubUserConnectors(id: string, enabledTypes: string[]) {
 }
 
 function stubAvailableConnectors(types: string[]) {
-  return http.get("http://localhost:3000/api/zero/connectors/search", () => {
-    return HttpResponse.json({
-      connectors: types.map((type) => {
-        return {
-          id: type,
-          label: type,
-          description: type,
-          authMethods: ["oauth"],
-        };
-      }),
-    });
-  });
+  return stubConnectorCatalogStatus(
+    types.map((type) => {
+      return catalogStatusItem({
+        connectorRef: type,
+        authMethods: [authCodeMethod("oauth")],
+      });
+    }),
+  );
 }
 
 describe("zero connector status command", () => {
@@ -132,22 +164,15 @@ describe("zero connector status command", () => {
     });
 
     it("does not print connect guidance for unavailable connectors", async () => {
-      server.use(
-        stubAvailableConnectors([]),
-        stubConnector(
-          { error: { message: "Not found", code: "NOT_FOUND" } },
-          404,
-        ),
-      );
+      server.use(stubAvailableConnectors([]));
 
-      await statusCommand.parseAsync(["node", "cli", "github"]);
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "github"]);
+      }).rejects.toThrow("process.exit called");
 
-      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "The github connector is not available for this account.",
-      );
-      expect(logCalls).not.toContain("[Connect github]");
-      expect(logCalls).not.toContain("/connectors/github/connect");
+      const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
+      expect(errorOutput).toContain("Unknown or unavailable connector: github");
+      expect(errorOutput).toContain("Available connectors:");
     });
 
     it("shows reconnect guidance when connector needs reconnect", async () => {
@@ -386,13 +411,15 @@ describe("zero connector status command", () => {
   });
 
   describe("input validation", () => {
-    it("should reject invalid connector type", async () => {
+    it("should reject unavailable connector refs", async () => {
       await expect(async () => {
         await statusCommand.parseAsync(["node", "cli", "invalid-type"]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Unknown connector type: invalid-type"),
+        expect.stringContaining(
+          "Unknown or unavailable connector: invalid-type",
+        ),
       );
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Available connectors:"),

--- a/turbo/apps/cli/src/commands/zero/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connect.ts
@@ -1,18 +1,17 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import {
-  CONNECTOR_TYPE_KEYS,
-  CONNECTOR_TYPES,
-  connectorTypeSchema,
-  type ConnectorAuthMethodId,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import {
-  getConfiguredConnectorAuthMethodIds,
-  getConnectorAuthMethod,
-} from "@vm0/connectors/connector-utils";
-import { connectZeroConnectorManualGrant } from "../../../lib/api";
+  connectZeroConnectorManualGrant,
+  listZeroConnectorCatalogStatus,
+} from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import {
+  availableConnectorRefs,
+  findConnectorStatusItem,
+  parseConnectorAuthMethodIdForAction,
+  parseConnectorTypeForAction,
+  resolveManualGrantAuthMethod,
+} from "./public-catalog";
 
 interface ConnectOptions {
   readonly authMethod?: string;
@@ -28,7 +27,7 @@ function parseConnectorValues(rawValues: readonly string[] | undefined) {
   if (!rawValues || rawValues.length === 0) {
     throw new Error("At least one --value NAME=VALUE is required", {
       cause: new Error(
-        "Example: zero connector connect zendesk --value ZENDESK_API_TOKEN=token",
+        "Example: zero connector connect zendesk --value apiToken=token",
       ),
     });
   }
@@ -55,77 +54,6 @@ function parseConnectorValues(rawValues: readonly string[] | undefined) {
   return values;
 }
 
-function parseConnectorType(type: string): ConnectorType {
-  const parsed = connectorTypeSchema.safeParse(type);
-  if (parsed.success) {
-    return parsed.data;
-  }
-
-  throw new Error(`Unknown connector type: ${type}`, {
-    cause: new Error(`Available connectors: ${CONNECTOR_TYPE_KEYS.join(", ")}`),
-  });
-}
-
-function parseConfiguredAuthMethod(
-  type: ConnectorType,
-  rawAuthMethod: string,
-): ConnectorAuthMethodId {
-  const configuredAuthMethodIds = getConfiguredConnectorAuthMethodIds(type);
-  const authMethod = configuredAuthMethodIds.find((method) => {
-    return method === rawAuthMethod;
-  });
-  if (authMethod) {
-    return authMethod;
-  }
-
-  throw new Error(
-    `${type} connector does not have ${rawAuthMethod} auth method`,
-    {
-      cause: new Error(
-        `Available auth methods: ${configuredAuthMethodIds.join(", ")}`,
-      ),
-    },
-  );
-}
-
-function getManualGrantAuthMethods(
-  type: ConnectorType,
-): ConnectorAuthMethodId[] {
-  return getConfiguredConnectorAuthMethodIds(type).filter((authMethod) => {
-    return getConnectorAuthMethod(type, authMethod)?.grant.kind === "manual";
-  });
-}
-
-function parseManualGrantAuthMethod(
-  type: ConnectorType,
-  rawAuthMethod: string | undefined,
-): ConnectorAuthMethodId {
-  if (rawAuthMethod) {
-    const authMethod = parseConfiguredAuthMethod(type, rawAuthMethod);
-    if (getConnectorAuthMethod(type, authMethod)?.grant.kind === "manual") {
-      return authMethod;
-    }
-
-    throw new Error(
-      `${type} ${authMethod} auth method does not use a manual grant`,
-    );
-  }
-
-  const authMethods = getManualGrantAuthMethods(type);
-  const authMethod = authMethods[0];
-  if (authMethods.length === 1 && authMethod) {
-    return authMethod;
-  }
-
-  if (authMethods.length === 0) {
-    throw new Error(`${type} connector does not use a manual grant`);
-  }
-
-  throw new Error(`${type} connector has multiple manual grant auth methods`, {
-    cause: new Error(`Pass --auth-method ${authMethods.join("|")}`),
-  });
-}
-
 export const connectCommand = new Command()
   .name("connect")
   .description("Connect a connector with manual grant values")
@@ -140,15 +68,31 @@ export const connectCommand = new Command()
   .option("--json", "Print the connector response as JSON")
   .action(
     withErrorHandler(async (type: string, options: ConnectOptions) => {
-      const connectorType = parseConnectorType(type);
-      const authMethod = parseManualGrantAuthMethod(
-        connectorType,
+      const values = parseConnectorValues(options.value);
+      const catalog = await listZeroConnectorCatalogStatus();
+      const connectorMetadata = findConnectorStatusItem(
+        catalog.connectors,
+        type,
+      );
+      if (!connectorMetadata) {
+        throw new Error(`Unknown or unavailable connector: ${type}`, {
+          cause: new Error(
+            `Available connectors: ${availableConnectorRefs(catalog.connectors)}`,
+          ),
+        });
+      }
+
+      const connectorType = parseConnectorTypeForAction(
+        connectorMetadata.connectorRef,
+      );
+      const authMethod = resolveManualGrantAuthMethod(
+        connectorMetadata,
         options.authMethod,
       );
       const connector = await connectZeroConnectorManualGrant(
         connectorType,
-        authMethod,
-        parseConnectorValues(options.value),
+        parseConnectorAuthMethodIdForAction(authMethod.id),
+        values,
       );
 
       if (options.json) {
@@ -156,9 +100,7 @@ export const connectCommand = new Command()
         return;
       }
 
-      console.log(
-        chalk.green(`✓ ${CONNECTOR_TYPES[connectorType].label} connected`),
-      );
+      console.log(chalk.green(`✓ ${connectorMetadata.label} connected`));
       console.log(chalk.dim(`  Type: ${connector.type}`));
       console.log(chalk.dim(`  Auth Method: ${connector.authMethod}`));
       console.log(chalk.dim(`  Run: zero connector status ${connector.type}`));

--- a/turbo/apps/cli/src/commands/zero/connector/connected-as.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connected-as.ts
@@ -1,29 +1,29 @@
 import chalk from "chalk";
-import { hasRequiredConnectorAuthMethodScopes } from "@vm0/connectors/connector-utils";
-import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import type { PublicConnectorStatus } from "./public-catalog";
 
-type Connector = ConnectorListResponse["connectors"][number];
-
-function renderIdentity(connector: Connector): string {
-  if (connector.externalUsername) return `@${connector.externalUsername}`;
-  if (connector.externalEmail) return connector.externalEmail;
+function renderIdentity(connector: PublicConnectorStatus): string {
+  if (connector.connection?.externalUsername) {
+    return `@${connector.connection.externalUsername}`;
+  }
+  if (connector.connection?.externalEmail)
+    return connector.connection.externalEmail;
   return "-";
 }
 
 export function renderConnectedAsCell(
-  connector: Connector | undefined,
+  connector: PublicConnectorStatus | undefined,
 ): string {
-  if (!connector) return chalk.dim("(not connected)");
+  if (!connector || connector.connectionStatus === "not-connected") {
+    return chalk.dim("(not connected)");
+  }
   const identity = renderIdentity(connector);
   if (connector.connectionStatus === "reconnect-required") {
     return chalk.yellow(`${identity} (reconnect needed)`);
   }
-  const scopeMismatch = !hasRequiredConnectorAuthMethodScopes(
-    connector.type,
-    connector.authMethod,
-    connector.oauthScopes,
-  );
-  if (scopeMismatch) {
+  if (
+    connector.scopeMismatch ||
+    connector.connectionStatus === "scope-mismatch"
+  ) {
     return chalk.yellow(`${identity} (permissions update available)`);
   }
   return identity;

--- a/turbo/apps/cli/src/commands/zero/connector/list.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/list.ts
@@ -1,17 +1,9 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import { listZeroConnectors, searchZeroConnectors } from "../../../lib/api";
+import { listZeroConnectorCatalogStatus } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { resolveAgentContext } from "./agent-context";
 import { padEndAnsi, renderConnectedAsCell, stripAnsi } from "./connected-as";
-
-function isConnectorType(type: string): type is ConnectorType {
-  return type in CONNECTOR_TYPES;
-}
 
 export const listCommand = new Command()
   .name("list")
@@ -20,22 +12,14 @@ export const listCommand = new Command()
   .option("--agent <id>", "Show per-agent authorization column")
   .action(
     withErrorHandler(async (options: { agent?: string }) => {
-      const [{ connectors }, availableCatalog, agentCtx] = await Promise.all([
-        listZeroConnectors(),
-        searchZeroConnectors(),
+      const [{ connectors }, agentCtx] = await Promise.all([
+        listZeroConnectorCatalogStatus(),
         resolveAgentContext(options.agent),
       ]);
-      const connectedMap = new Map(
-        connectors.map((c) => {
-          return [c.type, c];
-        }),
-      );
 
-      const allTypes = availableCatalog.connectors
-        .map((connector) => {
-          return connector.id;
-        })
-        .filter(isConnectorType);
+      const allTypes = connectors.map((connector) => {
+        return connector.connectorRef;
+      });
 
       const typeWidth = Math.max(
         4,
@@ -45,8 +29,8 @@ export const listCommand = new Command()
       );
 
       const connectedAsHeader = "CONNECTED AS";
-      const connectedCells = allTypes.map((type) => {
-        return renderConnectedAsCell(connectedMap.get(type));
+      const connectedCells = connectors.map((connector) => {
+        return renderConnectedAsCell(connector);
       });
       const connectedAsWidth = Math.max(
         connectedAsHeader.length,

--- a/turbo/apps/cli/src/commands/zero/connector/public-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/public-catalog.ts
@@ -1,0 +1,352 @@
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogItem,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
+  connectorAuthMethodIdSchema,
+  connectorTypeSchema,
+  type ConnectorAuthMethodId,
+  type ConnectorType,
+} from "@vm0/connectors/connectors";
+
+export type PublicConnectorStatus = PublicConnectorCatalogStatusItem;
+
+interface PublicConnectorSearchResult {
+  readonly connector: PublicConnectorStatus;
+  readonly score: number;
+  readonly matchedField: string;
+}
+
+interface PublicConnectorSearchOutput {
+  readonly results: readonly PublicConnectorSearchResult[];
+  readonly total: number;
+}
+
+const TOKEN_BOUNDARY = /[_\-\s]+/;
+const CASE_BOUNDARY = /(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/;
+const MIN_SCORE = 10;
+
+function tokenize(input: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const chunk of input.split(TOKEN_BOUNDARY)) {
+    if (!chunk) continue;
+    for (const sub of chunk.split(CASE_BOUNDARY)) {
+      const lower = sub.toLowerCase();
+      if (lower) tokens.add(lower);
+    }
+  }
+  return tokens;
+}
+
+function publicStrings(connector: PublicConnectorCatalogItem): string[] {
+  return [
+    connector.connectorRef,
+    connector.label,
+    connector.description,
+    connector.category,
+    ...connector.tags,
+    ...connector.generation,
+    ...connector.authMethods.flatMap((authMethod) => {
+      return [
+        authMethod.id,
+        authMethod.label,
+        ...(authMethod.description ? [authMethod.description] : []),
+      ];
+    }),
+  ];
+}
+
+type ScoreHit = { score: number; matchedField: string };
+
+function best(candidates: readonly (ScoreHit | null)[]): ScoreHit | null {
+  return candidates.reduce<ScoreHit | null>((bestHit, hit) => {
+    if (!hit) return bestHit;
+    if (!bestHit || hit.score > bestHit.score) return hit;
+    return bestHit;
+  }, null);
+}
+
+function scoreExact(
+  keywordLower: string,
+  skipPrivateIdentifierMatches: boolean,
+  connector: PublicConnectorStatus,
+): ScoreHit | null {
+  if (connector.connectorRef.toLowerCase() === keywordLower) {
+    return { score: 100, matchedField: "connectorRef" };
+  }
+  if (connector.label.toLowerCase() === keywordLower) {
+    return { score: 80, matchedField: "label" };
+  }
+  for (const tag of connector.tags) {
+    if (skipPrivateIdentifierMatches && tag.includes("_")) continue;
+    if (tag.toLowerCase() === keywordLower) {
+      return { score: 70, matchedField: `tag:${tag}` };
+    }
+  }
+  for (const generationType of connector.generation) {
+    if (generationType.toLowerCase() === keywordLower) {
+      return { score: 65, matchedField: `generation:${generationType}` };
+    }
+  }
+  for (const authMethod of connector.authMethods) {
+    if (authMethod.id.toLowerCase() === keywordLower) {
+      return { score: 60, matchedField: `auth-method:${authMethod.id}` };
+    }
+    if (authMethod.label.toLowerCase() === keywordLower) {
+      return { score: 60, matchedField: `auth-method:${authMethod.label}` };
+    }
+  }
+  if (connector.category.toLowerCase() === keywordLower) {
+    return { score: 55, matchedField: "category" };
+  }
+  return null;
+}
+
+function scoreSubstring(
+  keywordLower: string,
+  skipPrivateIdentifierMatches: boolean,
+  connector: PublicConnectorStatus,
+): ScoreHit | null {
+  const candidates: ScoreHit[] = [];
+  if (connector.connectorRef.toLowerCase().includes(keywordLower)) {
+    candidates.push({ score: 50, matchedField: "connectorRef" });
+  }
+  if (connector.label.toLowerCase().includes(keywordLower)) {
+    candidates.push({ score: 50, matchedField: "label" });
+  }
+  for (const tag of connector.tags) {
+    if (skipPrivateIdentifierMatches && tag.includes("_")) continue;
+    if (tag.toLowerCase().includes(keywordLower)) {
+      candidates.push({ score: 25, matchedField: `tag:${tag}` });
+    }
+  }
+  for (const generationType of connector.generation) {
+    if (generationType.toLowerCase().includes(keywordLower)) {
+      candidates.push({
+        score: 25,
+        matchedField: `generation:${generationType}`,
+      });
+    }
+  }
+  for (const authMethod of connector.authMethods) {
+    if (
+      authMethod.id.toLowerCase().includes(keywordLower) ||
+      authMethod.label.toLowerCase().includes(keywordLower)
+    ) {
+      candidates.push({
+        score: 20,
+        matchedField: `auth-method:${authMethod.id}`,
+      });
+    }
+  }
+  if (connector.category.toLowerCase().includes(keywordLower)) {
+    candidates.push({ score: 20, matchedField: "category" });
+  }
+  if (connector.description.toLowerCase().includes(keywordLower)) {
+    candidates.push({ score: 15, matchedField: "description" });
+  }
+
+  return best(candidates);
+}
+
+function scoreTokens(
+  keywordTokens: ReadonlySet<string>,
+  connector: PublicConnectorStatus,
+): ScoreHit | null {
+  const candidateTokens = new Set<string>();
+  for (const source of publicStrings(connector)) {
+    for (const token of tokenize(source)) {
+      candidateTokens.add(token);
+    }
+  }
+
+  let intersection = 0;
+  let firstCommon = "";
+  for (const token of keywordTokens) {
+    if (candidateTokens.has(token)) {
+      intersection++;
+      if (!firstCommon) firstCommon = token;
+    }
+  }
+  if (intersection === 0) return null;
+  return { score: 10 * intersection, matchedField: `token:${firstCommon}` };
+}
+
+function scoreConnector(
+  keywordLower: string,
+  keyword: string,
+  keywordTokens: ReadonlySet<string>,
+  connector: PublicConnectorStatus,
+): ScoreHit | null {
+  const skipPrivateIdentifierMatches =
+    /^[A-Za-z0-9_]+$/.test(keyword) && keyword.includes("_");
+  const tokenHit = skipPrivateIdentifierMatches
+    ? null
+    : scoreTokens(keywordTokens, connector);
+  const hit = best([
+    scoreExact(keywordLower, skipPrivateIdentifierMatches, connector),
+    scoreSubstring(keywordLower, skipPrivateIdentifierMatches, connector),
+    tokenHit,
+  ]);
+  if (!hit || hit.score < MIN_SCORE) return null;
+  return hit;
+}
+
+export function searchPublicConnectorCatalog(
+  connectors: readonly PublicConnectorStatus[],
+  keyword: string,
+  limit: number,
+): PublicConnectorSearchOutput {
+  const trimmed = keyword.trim();
+  if (!trimmed) return { results: [], total: 0 };
+
+  const keywordLower = trimmed.toLowerCase();
+  const keywordTokens = tokenize(trimmed);
+  const hits = connectors.flatMap(
+    (connector): PublicConnectorSearchResult[] => {
+      const hit = scoreConnector(
+        keywordLower,
+        trimmed,
+        keywordTokens,
+        connector,
+      );
+      if (!hit) return [];
+      return [
+        {
+          connector,
+          score: hit.score,
+          matchedField: hit.matchedField,
+        },
+      ];
+    },
+  );
+
+  hits.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.connector.connectorRef.localeCompare(b.connector.connectorRef);
+  });
+
+  return {
+    results: hits.slice(0, limit),
+    total: hits.length,
+  };
+}
+
+export function findConnectorStatusItem(
+  connectors: readonly PublicConnectorStatus[],
+  connectorRef: string,
+): PublicConnectorStatus | null {
+  const exact = connectors.find((connector) => {
+    return connector.connectorRef === connectorRef;
+  });
+  if (exact) return exact;
+
+  const lower = connectorRef.toLowerCase();
+  return (
+    connectors.find((connector) => {
+      return connector.connectorRef.toLowerCase() === lower;
+    }) ?? null
+  );
+}
+
+export function availableConnectorRefs(
+  connectors: readonly PublicConnectorStatus[],
+): string {
+  return connectors
+    .map((connector) => {
+      return connector.connectorRef;
+    })
+    .join(", ");
+}
+
+export function parseConnectorTypeForAction(
+  connectorRef: string,
+): ConnectorType {
+  const parsed = connectorTypeSchema.safeParse(connectorRef);
+  if (parsed.success) return parsed.data;
+
+  throw new Error(
+    `Connector ${connectorRef} cannot be used by this CLI action`,
+    {
+      cause: new Error(
+        "This action still uses the connector action API, which only accepts built-in connector refs.",
+      ),
+    },
+  );
+}
+
+export function parseConnectorAuthMethodIdForAction(
+  authMethodId: string,
+): ConnectorAuthMethodId {
+  const parsed = connectorAuthMethodIdSchema.safeParse(authMethodId);
+  if (parsed.success) return parsed.data;
+
+  throw new Error(
+    `Auth method ${authMethodId} cannot be used by this CLI action`,
+    {
+      cause: new Error(
+        "This action still uses the connector action API, which only accepts built-in auth method ids.",
+      ),
+    },
+  );
+}
+
+export function resolveManualGrantAuthMethod(
+  connector: PublicConnectorStatus,
+  rawAuthMethod: string | undefined,
+): PublicConnectorCatalogAuthMethodDetail {
+  if (rawAuthMethod) {
+    const authMethod = connector.authMethods.find((method) => {
+      return method.id === rawAuthMethod;
+    });
+    if (!authMethod) {
+      throw new Error(
+        `${connector.connectorRef} connector does not have ${rawAuthMethod} auth method`,
+        {
+          cause: new Error(
+            `Available auth methods: ${connector.authMethods
+              .map((method) => {
+                return method.id;
+              })
+              .join(", ")}`,
+          ),
+        },
+      );
+    }
+
+    if (authMethod.grantKind === "manual") {
+      return authMethod;
+    }
+
+    throw new Error(
+      `${connector.connectorRef} ${authMethod.id} auth method does not use a manual grant`,
+    );
+  }
+
+  const manualAuthMethods = connector.authMethods.filter((method) => {
+    return method.grantKind === "manual";
+  });
+  const authMethod = manualAuthMethods[0];
+  if (manualAuthMethods.length === 1 && authMethod) {
+    return authMethod;
+  }
+  if (manualAuthMethods.length === 0) {
+    throw new Error(
+      `${connector.connectorRef} connector does not use a manual grant`,
+    );
+  }
+
+  throw new Error(
+    `${connector.connectorRef} connector has multiple manual grant auth methods`,
+    {
+      cause: new Error(
+        `Pass --auth-method ${manualAuthMethods
+          .map((method) => {
+            return method.id;
+          })
+          .join("|")}`,
+      ),
+    },
+  );
+}

--- a/turbo/apps/cli/src/commands/zero/connector/search.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/search.ts
@@ -1,21 +1,13 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import { searchConnectors } from "@vm0/connectors/connector-search";
-import { listZeroConnectors, searchZeroConnectors } from "../../../lib/api";
+import { listZeroConnectorCatalogStatus } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { resolveAgentContext } from "./agent-context";
 import { padEndAnsi, renderConnectedAsCell, stripAnsi } from "./connected-as";
+import { searchPublicConnectorCatalog } from "./public-catalog";
 
 const DEFAULT_LIMIT = 5;
 const EXACT_MATCH_THRESHOLD = 80;
-
-function isConnectorType(type: string): type is ConnectorType {
-  return type in CONNECTOR_TYPES;
-}
 
 function parseLimit(raw: string): number {
   const n = Number.parseInt(raw, 10);
@@ -28,7 +20,7 @@ function parseLimit(raw: string): number {
 export const searchCommand = new Command()
   .name("search")
   .description(
-    "Search connectors by type, label, environment name, secret, or tag",
+    "Search connectors by type, label, category, generation type, or tag",
   )
   .argument("<keyword>", "Search keyword (case-insensitive)")
   .option("--agent <id>", "Show per-agent authorization column")
@@ -46,31 +38,14 @@ export const searchCommand = new Command()
           throw new Error("Keyword cannot be empty.");
         }
 
-        const [{ connectors }, availableCatalog, agentCtx] = await Promise.all([
-          listZeroConnectors(),
-          searchZeroConnectors(),
+        const [{ connectors }, agentCtx] = await Promise.all([
+          listZeroConnectorCatalogStatus(),
           resolveAgentContext(options.agent),
         ]);
-        const connectedMap = new Map(
-          connectors.map((c) => {
-            return [c.type, c];
-          }),
-        );
-
-        const availableTypes = new Set(
-          availableCatalog.connectors
-            .map((connector) => {
-              return connector.id;
-            })
-            .filter(isConnectorType),
-        );
-
-        const { results, total } = searchConnectors(
+        const { results, total } = searchPublicConnectorCatalog(
+          connectors,
           trimmed,
           options.limit,
-          (type) => {
-            return availableTypes.has(type);
-          },
         );
 
         if (results.length === 0) {
@@ -90,13 +65,13 @@ export const searchCommand = new Command()
         const connectedAsHeader = "CONNECTED AS";
 
         const connectedCells = results.map((r) => {
-          return renderConnectedAsCell(connectedMap.get(r.type));
+          return renderConnectedAsCell(r.connector);
         });
 
         const typeWidth = Math.max(
           typeHeader.length,
           ...results.map((r) => {
-            return r.type.length;
+            return r.connector.connectorRef.length;
           }),
         );
         const connectedAsWidth = Math.max(
@@ -118,12 +93,12 @@ export const searchCommand = new Command()
         for (let i = 0; i < results.length; i++) {
           const result = results[i]!;
           const parts = [
-            result.type.padEnd(typeWidth),
+            result.connector.connectorRef.padEnd(typeWidth),
             padEndAnsi(connectedCells[i]!, connectedAsWidth),
           ];
           if (agentCtx) {
             parts.push(
-              agentCtx.authorizedTypes.has(result.type)
+              agentCtx.authorizedTypes.has(result.connector.connectorRef)
                 ? chalk.green("✓")
                 : chalk.dim("-"),
             );

--- a/turbo/apps/cli/src/commands/zero/connector/search.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/search.ts
@@ -10,8 +10,9 @@ const DEFAULT_LIMIT = 5;
 const EXACT_MATCH_THRESHOLD = 80;
 
 function parseLimit(raw: string): number {
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n <= 0) {
+  const trimmed = raw.trim();
+  const n = Number(trimmed);
+  if (!/^\d+$/.test(trimmed) || !Number.isSafeInteger(n) || n <= 0) {
     throw new Error(`--limit must be a positive integer, got "${raw}".`);
   }
   return n;

--- a/turbo/apps/cli/src/commands/zero/connector/status.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/status.ts
@@ -1,117 +1,70 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import {
-  CONNECTOR_TYPE_KEYS,
-  CONNECTOR_TYPES,
-  type ConnectorType,
-  connectorTypeSchema,
-} from "@vm0/connectors/connectors";
-import {
-  getConnectorAuthMethodScopeDiff,
-  hasRequiredConnectorAuthMethodScopes,
-} from "@vm0/connectors/connector-utils";
-import { getZeroConnector, searchZeroConnectors } from "../../../lib/api";
-import { formatDateTime } from "../../../lib/domain/schedule-utils";
+import { listZeroConnectorCatalogStatus } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import { resolveAgentContext } from "./agent-context";
 import { getPlatformOrigin } from "../doctor/platform-url";
+import {
+  availableConnectorRefs,
+  findConnectorStatusItem,
+  type PublicConnectorStatus,
+} from "./public-catalog";
 
 const LABEL_WIDTH = 16;
 
-type Connector = NonNullable<Awaited<ReturnType<typeof getZeroConnector>>>;
 type AgentContext = NonNullable<
   Awaited<ReturnType<typeof resolveAgentContext>>
 >;
 
-function isConnectorType(type: string): type is ConnectorType {
-  return type in CONNECTOR_TYPES;
-}
-
-async function availableConnectorTypes(): Promise<Set<ConnectorType>> {
-  const catalog = await searchZeroConnectors();
-  return new Set(
-    catalog.connectors
-      .map((connector) => {
-        return connector.id;
-      })
-      .filter(isConnectorType),
-  );
-}
-
-function printConnectorDetails(
-  type: ConnectorType,
-  connector: Connector | null,
-): void {
-  if (connector) {
-    console.log(
-      `${"Status:".padEnd(LABEL_WIDTH)}${
-        connector.connectionStatus === "reconnect-required"
-          ? chalk.yellow("reconnect needed")
-          : chalk.green("connected")
-      }`,
-    );
-    console.log(
-      `${"Account:".padEnd(LABEL_WIDTH)}@${connector.externalUsername}`,
-    );
-    console.log(`${"Auth Method:".padEnd(LABEL_WIDTH)}${connector.authMethod}`);
-
-    if (connector.oauthScopes && connector.oauthScopes.length > 0) {
-      console.log(
-        `${"OAuth Scopes:".padEnd(LABEL_WIDTH)}${connector.oauthScopes.join(", ")}`,
-      );
-    }
-
-    if (
-      !hasRequiredConnectorAuthMethodScopes(
-        type,
-        connector.authMethod,
-        connector.oauthScopes,
-      )
-    ) {
-      const diff = getConnectorAuthMethodScopeDiff(
-        type,
-        connector.authMethod,
-        connector.oauthScopes,
-      );
-      console.log(
-        `${"Permissions:".padEnd(LABEL_WIDTH)}${chalk.yellow("update available")}`,
-      );
-      if (diff.addedScopes.length > 0) {
-        console.log(
-          `${"  Added:".padEnd(LABEL_WIDTH)}${diff.addedScopes.join(", ")}`,
-        );
-      }
-      if (diff.removedScopes.length > 0) {
-        console.log(
-          `${"  Removed:".padEnd(LABEL_WIDTH)}${diff.removedScopes.join(", ")}`,
-        );
-      }
-    }
-
-    console.log(
-      `${"Connected:".padEnd(LABEL_WIDTH)}${formatDateTime(connector.createdAt)}`,
-    );
-
-    if (connector.updatedAt !== connector.createdAt) {
-      console.log(
-        `${"Last Updated:".padEnd(LABEL_WIDTH)}${formatDateTime(connector.updatedAt)}`,
-      );
-    }
-  } else {
+function printConnectorDetails(connector: PublicConnectorStatus): void {
+  if (connector.connectionStatus === "not-connected") {
     console.log(
       `${"Status:".padEnd(LABEL_WIDTH)}${chalk.dim("not connected")}`,
+    );
+    return;
+  }
+
+  console.log(
+    `${"Status:".padEnd(LABEL_WIDTH)}${
+      connector.connectionStatus === "reconnect-required"
+        ? chalk.yellow("reconnect needed")
+        : chalk.green("connected")
+    }`,
+  );
+  if (connector.connection?.externalUsername) {
+    console.log(
+      `${"Account:".padEnd(LABEL_WIDTH)}@${connector.connection.externalUsername}`,
+    );
+  } else if (connector.connection?.externalEmail) {
+    console.log(
+      `${"Account:".padEnd(LABEL_WIDTH)}${connector.connection.externalEmail}`,
+    );
+  }
+  if (connector.connection?.authMethod) {
+    console.log(
+      `${"Auth Method:".padEnd(LABEL_WIDTH)}${connector.connection.authMethod}`,
+    );
+  }
+  if (connector.scopeMismatch) {
+    console.log(
+      `${"Permissions:".padEnd(LABEL_WIDTH)}${chalk.yellow("update available")}`,
+    );
+  }
+  if (connector.tokenExpiresAt) {
+    console.log(
+      `${"Token Expires:".padEnd(LABEL_WIDTH)}${connector.tokenExpiresAt}`,
     );
   }
 }
 
 async function printAgentAction(
-  type: ConnectorType,
-  connector: Connector | null,
+  connector: PublicConnectorStatus,
   agentCtx: AgentContext,
 ): Promise<void> {
-  const authorized = agentCtx.authorizedTypes.has(type);
-  const isConnected = connector !== null;
-  const needsReconnect = connector?.connectionStatus === "reconnect-required";
+  const connectorRef = connector.connectorRef;
+  const authorized = agentCtx.authorizedTypes.has(connectorRef);
+  const isConnected = connector.connected;
+  const needsReconnect = connector.connectionStatus === "reconnect-required";
   const agentLabel =
     agentCtx.displayName === agentCtx.agentId
       ? agentCtx.agentId
@@ -122,52 +75,61 @@ async function printAgentAction(
     const origin = await getPlatformOrigin();
     const url = `${origin}/connectors`;
     console.log(
-      `The ${type} connector is connected but needs to be reconnected before agent ${agentLabel} can use it.`,
+      `The ${connectorRef} connector is connected but needs to be reconnected before agent ${agentLabel} can use it.`,
     );
-    console.log(`Reconnect it at: [Reconnect ${type}](${url})`);
+    console.log(`Reconnect it at: [Reconnect ${connectorRef}](${url})`);
   } else if (authorized && !isConnected) {
     const origin = await getPlatformOrigin();
-    const url = `${origin}/connectors/${type}/connect?agentId=${agentCtx.agentId}`;
+    const url = `${origin}/connectors/${connectorRef}/connect?agentId=${agentCtx.agentId}`;
     console.log(
-      `The ${type} connector is authorized for agent ${agentLabel}, but it is not connected.`,
+      `The ${connectorRef} connector is authorized for agent ${agentLabel}, but it is not connected.`,
     );
-    console.log(`Connect it at: [Connect ${type}](${url})`);
+    console.log(`Connect it at: [Connect ${connectorRef}](${url})`);
   } else if (authorized) {
-    console.log(`The ${type} connector is authorized for agent ${agentLabel}.`);
+    console.log(
+      `The ${connectorRef} connector is authorized for agent ${agentLabel}.`,
+    );
   } else if (!isConnected) {
     const origin = await getPlatformOrigin();
-    const url = `${origin}/connectors/${type}/connect?agentId=${agentCtx.agentId}`;
+    const url = `${origin}/connectors/${connectorRef}/connect?agentId=${agentCtx.agentId}`;
     console.log(
-      `The ${type} connector is not connected. Once connected, it will be authorized for agent ${agentLabel}.`,
+      `The ${connectorRef} connector is not connected. Once connected, it will be authorized for agent ${agentLabel}.`,
     );
-    console.log(`Connect and authorize it at: [Connect ${type}](${url})`);
+    console.log(
+      `Connect and authorize it at: [Connect ${connectorRef}](${url})`,
+    );
   } else {
     const origin = await getPlatformOrigin();
-    const url = `${origin}/connectors/${type}/authorize?agentId=${agentCtx.agentId}`;
+    const url = `${origin}/connectors/${connectorRef}/authorize?agentId=${agentCtx.agentId}`;
     console.log(
-      `The ${type} connector is not authorized for agent ${agentLabel}.`,
+      `The ${connectorRef} connector is not authorized for agent ${agentLabel}.`,
     );
-    console.log(`Authorize it at: [Authorize ${type}](${url})`);
+    console.log(`Authorize it at: [Authorize ${connectorRef}](${url})`);
   }
 }
 
 async function printStandaloneAction(
-  type: ConnectorType,
-  connector: Connector | null,
+  connector: PublicConnectorStatus,
 ): Promise<void> {
-  if (connector?.connectionStatus === "connected") return;
+  const connectorRef = connector.connectorRef;
+  if (
+    connector.connectionStatus === "connected" ||
+    connector.connectionStatus === "scope-mismatch"
+  ) {
+    return;
+  }
 
   const origin = await getPlatformOrigin();
   console.log();
-  if (connector?.connectionStatus === "reconnect-required") {
+  if (connector.connectionStatus === "reconnect-required") {
     const url = `${origin}/connectors`;
     console.log(
-      `The ${type} connector is connected but needs to be reconnected.`,
+      `The ${connectorRef} connector is connected but needs to be reconnected.`,
     );
-    console.log(`Reconnect it at: [Reconnect ${type}](${url})`);
+    console.log(`Reconnect it at: [Reconnect ${connectorRef}](${url})`);
   } else {
-    const url = `${origin}/connectors/${type}/connect`;
-    console.log(`Connect it at: [Connect ${type}](${url})`);
+    const url = `${origin}/connectors/${connectorRef}/connect`;
+    console.log(`Connect it at: [Connect ${connectorRef}](${url})`);
   }
 }
 
@@ -178,35 +140,28 @@ export const statusCommand = new Command()
   .option("--agent <id>", "Show authorization state for the given agent")
   .action(
     withErrorHandler(async (type: string, options: { agent?: string }) => {
-      const parseResult = connectorTypeSchema.safeParse(type);
-      if (!parseResult.success) {
-        const available = CONNECTOR_TYPE_KEYS.join(", ");
-        throw new Error(`Unknown connector type: ${type}`, {
-          cause: new Error(`Available connectors: ${available}`),
+      const [catalog, agentCtx] = await Promise.all([
+        listZeroConnectorCatalogStatus(),
+        resolveAgentContext(options.agent),
+      ]);
+      const connector = findConnectorStatusItem(catalog.connectors, type);
+      if (!connector) {
+        throw new Error(`Unknown or unavailable connector: ${type}`, {
+          cause: new Error(
+            `Available connectors: ${availableConnectorRefs(catalog.connectors)}`,
+          ),
         });
       }
 
-      const [connector, availableTypes, agentCtx] = await Promise.all([
-        getZeroConnector(parseResult.data),
-        availableConnectorTypes(),
-        resolveAgentContext(options.agent),
-      ]);
-      const available = availableTypes.has(parseResult.data);
-
-      console.log(`Connector: ${chalk.cyan(type)}`);
+      console.log(`Connector: ${chalk.cyan(connector.connectorRef)}`);
       console.log();
 
-      printConnectorDetails(parseResult.data, connector);
-      if (!available) {
-        console.log();
-        console.log(`The ${type} connector is not available for this account.`);
-        return;
-      }
+      printConnectorDetails(connector);
 
       if (agentCtx) {
-        await printAgentAction(parseResult.data, connector, agentCtx);
+        await printAgentAction(connector, agentCtx);
       } else {
-        await printStandaloneAction(parseResult.data, connector);
+        await printStandaloneAction(connector);
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -3,8 +3,35 @@ import { http, HttpResponse } from "msw";
 import chalk from "chalk";
 import { server } from "../../../../mocks/server";
 import { generateCommand } from "../index";
+import {
+  catalogStatusItem,
+  manualAuthMethod,
+  stubConnectorCatalogStatus,
+} from "../../__tests__/helpers/connector-catalog";
 
 const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const CONNECTOR_LABELS: Record<string, string> = {
+  elevenlabs: "ElevenLabs",
+  fal: "fal.ai",
+  hume: "Hume",
+  "luma-ai": "Luma AI",
+  minimax: "MiniMax",
+  openai: "OpenAI",
+  replicate: "Replicate",
+  runway: "Runway",
+};
+
+const CONNECTOR_GENERATION: Record<string, readonly string[]> = {
+  elevenlabs: ["audio"],
+  fal: ["image", "video"],
+  hume: ["audio"],
+  "luma-ai": ["image", "video"],
+  minimax: ["audio"],
+  openai: ["audio", "image", "text"],
+  replicate: ["image", "video"],
+  runway: ["image", "video"],
+};
 
 function connector(
   type: string,
@@ -39,13 +66,44 @@ function stubConnectorsWithConfiguredTypes(
   connectors: Array<Record<string, unknown>>,
   configuredTypes: string[],
 ) {
-  return http.get("http://localhost:3000/api/zero/connectors", () => {
-    return HttpResponse.json({
-      connectors,
-      configuredTypes,
-      connectorProvidedBindings: [],
-    });
-  });
+  const connectedByType = new Map(
+    connectors.map((item) => {
+      const type = item.type as string;
+      return [
+        type,
+        catalogStatusItem({
+          connectorRef: type,
+          label: CONNECTOR_LABELS[type] ?? type,
+          generation: [...(CONNECTOR_GENERATION[type] ?? [])],
+          authMethods: [manualAuthMethod()],
+          connection: {
+            authMethod: item.authMethod as string,
+            externalUsername: (item.externalUsername as string | null) ?? null,
+            externalEmail: (item.externalEmail as string | null) ?? null,
+            reconnectReason: null,
+          },
+          connected: true,
+          connectionStatus:
+            (item.connectionStatus as "connected" | "reconnect-required") ??
+            "connected",
+        }),
+      ] as const;
+    }),
+  );
+  const visibleTypes = new Set([...configuredTypes, ...connectedByType.keys()]);
+  return stubConnectorCatalogStatus(
+    [...visibleTypes].map((type) => {
+      return (
+        connectedByType.get(type) ??
+        catalogStatusItem({
+          connectorRef: type,
+          label: CONNECTOR_LABELS[type] ?? type,
+          generation: [...(CONNECTOR_GENERATION[type] ?? [])],
+          authMethods: [manualAuthMethod()],
+        })
+      );
+    }),
+  );
 }
 
 function stubUserConnectors(enabledTypes: string[]) {
@@ -58,18 +116,16 @@ function stubUserConnectors(enabledTypes: string[]) {
 }
 
 function stubAvailableConnectors(types: string[]) {
-  return http.get("http://localhost:3000/api/zero/connectors/search", () => {
-    return HttpResponse.json({
-      connectors: types.map((type) => {
-        return {
-          id: type,
-          label: type,
-          description: type,
-          authMethods: ["api-token"],
-        };
-      }),
-    });
-  });
+  return stubConnectorCatalogStatus(
+    types.map((type) => {
+      return catalogStatusItem({
+        connectorRef: type,
+        label: CONNECTOR_LABELS[type] ?? type,
+        generation: [...(CONNECTOR_GENERATION[type] ?? [])],
+        authMethods: [manualAuthMethod()],
+      });
+    }),
+  );
 }
 
 describe("zero generate lister", () => {
@@ -176,18 +232,14 @@ describe("zero generate lister", () => {
     );
   });
 
-  it("does not mark runtime-configured but unavailable connectors as connectable", async () => {
-    server.use(
-      stubConnectorsWithConfiguredTypes([], ["bentoml"]),
-      stubAvailableConnectors([]),
-      stubUserConnectors([]),
-    );
+  it("does not list providers that are absent from the public catalog", async () => {
+    server.use(stubAvailableConnectors([]), stubUserConnectors([]));
 
     await generateCommand.parseAsync(["node", "cli", "text", "--all"]);
 
     const text = output();
-    expect(text).toContain("bentoml");
-    expect(text).toContain("not available for this account");
+    expect(text).toContain("No ready text generation connectors found.");
+    expect(text).not.toContain("bentoml");
     expect(text).not.toContain("/connectors/bentoml");
   });
 

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/lister.test.ts
@@ -4,8 +4,10 @@ import chalk from "chalk";
 import { server } from "../../../../mocks/server";
 import { generateCommand } from "../index";
 import {
+  catalogItem,
   catalogStatusItem,
   manualAuthMethod,
+  stubConnectorCatalog,
   stubConnectorCatalogStatus,
 } from "../../__tests__/helpers/connector-catalog";
 
@@ -241,6 +243,64 @@ describe("zero generate lister", () => {
     expect(text).toContain("No ready text generation connectors found.");
     expect(text).not.toContain("bentoml");
     expect(text).not.toContain("/connectors/bentoml");
+  });
+
+  it("prints connector guidance from the public catalog when --provider supports the generation type", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({
+          connectorRef: "replicate",
+          label: "Replicate",
+          generation: ["image"],
+          authMethods: [manualAuthMethod()],
+        }),
+      ]),
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image",
+      "--provider",
+      "replicate",
+    ]);
+
+    const text = output();
+    expect(text).toContain(
+      'Replicate (replicate) handles image generation through its own connector skill, not through "zero generate".',
+    );
+    expect(text).toContain('Use the "replicate" skill in this session.');
+    expect(text).toContain("zero connector status replicate");
+    expect(text).not.toContain("Built-in command:");
+  });
+
+  it("uses the public catalog when --provider names a connector that does not advertise the generation type", async () => {
+    server.use(
+      stubConnectorCatalog([
+        catalogItem({
+          connectorRef: "elevenlabs",
+          label: "ElevenLabs",
+          generation: ["audio"],
+          authMethods: [manualAuthMethod()],
+        }),
+      ]),
+    );
+
+    await generateCommand.parseAsync([
+      "node",
+      "cli",
+      "image",
+      "--provider",
+      "elevenlabs",
+    ]);
+
+    const text = output();
+    expect(text).toContain(
+      "ElevenLabs (elevenlabs) does not advertise image generation.",
+    );
+    expect(text).toContain(
+      'Run "zero generate image" to see every provider that supports this generation type.',
+    );
   });
 
   it("suggests the built-in video command when no video connector is ready", async () => {

--- a/turbo/apps/cli/src/commands/zero/generate/lib/connector-guidance.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/connector-guidance.ts
@@ -1,9 +1,5 @@
-import {
-  CONNECTOR_TYPES,
-  type ConnectorConfig,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import { getConnectorGenerationTypes } from "@vm0/connectors/connector-utils";
+import type { PublicConnectorCatalogItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { listZeroConnectorCatalog } from "../../../../lib/api";
 import type { GenerationType } from "./lister";
 
 function toConnectorGenerationType(
@@ -17,47 +13,70 @@ function toConnectorGenerationType(
     case "docs-design":
     case "mobile-app-design":
     case "poster":
+    case "presentation":
     case "report":
+    case "sprite":
+    case "website":
       return null;
-    default:
+    case "audio":
+    case "code":
+    case "document":
+    case "image":
+    case "text":
+    case "video":
       return generationType;
   }
 }
 
-function isConnectorType(value: string): value is ConnectorType {
-  return value in CONNECTOR_TYPES;
+function findConnector(
+  connectors: readonly PublicConnectorCatalogItem[],
+  provider: string,
+): PublicConnectorCatalogItem | null {
+  const exact = connectors.find((connector) => {
+    return connector.connectorRef === provider;
+  });
+  if (exact) return exact;
+
+  const lower = provider.toLowerCase();
+  return (
+    connectors.find((connector) => {
+      return connector.connectorRef.toLowerCase() === lower;
+    }) ?? null
+  );
 }
 
 interface ConnectorGuidance {
-  readonly type: ConnectorType;
+  readonly type: string;
   readonly label: string;
   readonly supportsGenerationType: boolean;
 }
 
-function resolveConnector(
+async function resolveConnector(
   provider: string,
   generationType: GenerationType,
-): ConnectorGuidance | null {
-  if (!isConnectorType(provider)) return null;
-  const config: ConnectorConfig = CONNECTOR_TYPES[provider];
+): Promise<ConnectorGuidance | null> {
+  const catalog = await listZeroConnectorCatalog();
+  const connector = findConnector(catalog.connectors, provider);
+  if (!connector) return null;
+
   const connectorGenerationType = toConnectorGenerationType(generationType);
   const supports =
     connectorGenerationType !== null &&
-    getConnectorGenerationTypes(provider).some((entry) => {
+    connector.generation.some((entry) => {
       return entry === connectorGenerationType;
     });
   return {
-    type: provider,
-    label: config.label,
+    type: connector.connectorRef,
+    label: connector.label,
     supportsGenerationType: supports,
   };
 }
 
-export function printConnectorGuidance(
+export async function printConnectorGuidance(
   generationType: GenerationType,
   provider: string,
-): void {
-  const guidance = resolveConnector(provider, generationType);
+): Promise<void> {
+  const guidance = await resolveConnector(provider, generationType);
 
   if (!guidance) {
     console.log(`Provider "${provider}" is not a known connector.`);

--- a/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
@@ -25,7 +25,7 @@ export async function dispatchGenerate(
   const provider = options.provider?.trim();
 
   if (provider && provider !== "built-in") {
-    printConnectorGuidance(options.generationType, provider);
+    await printConnectorGuidance(options.generationType, provider);
     return { outcome: "handled" };
   }
 

--- a/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/lister.ts
@@ -1,19 +1,18 @@
 import chalk from "chalk";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
-  CONNECTOR_TYPE_KEYS,
-  CONNECTOR_TYPES,
-  type ConnectorConfig,
-  type ConnectorGenerationType,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
-import { getConnectorGenerationTypes } from "@vm0/connectors/connector-utils";
-import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connector-schemas";
-import { getZeroAgentUserConnectors } from "../../../../lib/api/domains/zero-agents";
-import {
-  listZeroConnectors,
-  searchZeroConnectors,
-} from "../../../../lib/api/domains/zero-connectors";
+  getZeroAgentUserConnectors,
+  listZeroConnectorCatalogStatus,
+} from "../../../../lib/api";
 import { getPlatformOrigin } from "../../doctor/platform-url";
+
+type ConnectorGenerationType =
+  | "audio"
+  | "code"
+  | "document"
+  | "image"
+  | "text"
+  | "video";
 
 type BuiltInGenerationType =
   | "dashboard-design"
@@ -247,21 +246,18 @@ const GENERATION_TYPE_LABELS: Record<GenerationType, string> = {
   website: "Website",
 };
 
-type ConnectedConnector = ConnectorListResponse["connectors"][number];
-
 type CandidateStatus =
   | "ready"
   | "needs-reconnect"
   | "not-authorized"
-  | "not-connected"
-  | "not-available";
+  | "not-connected";
 
 interface ListerOptions {
   all?: boolean;
 }
 
 interface GenerationCandidate {
-  type: ConnectorType;
+  type: string;
   label: string;
   status: CandidateStatus;
   reason: string;
@@ -317,45 +313,32 @@ function getGenerationContext(
 
 function getGenerationConnectors(
   generationType: ConnectorGenerationType,
-): Array<[ConnectorType, ConnectorConfig]> {
-  return CONNECTOR_TYPE_KEYS.map((type): [ConnectorType, ConnectorConfig] => {
-    return [type, CONNECTOR_TYPES[type]];
-  })
-    .filter(([type]) => {
-      return getConnectorGenerationTypes(type).includes(generationType);
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+): PublicConnectorCatalogStatusItem[] {
+  return connectors
+    .filter((connector) => {
+      return connector.generation.includes(generationType);
     })
-    .sort(([a], [b]) => {
-      return a.localeCompare(b);
+    .sort((a, b) => {
+      return a.connectorRef.localeCompare(b.connectorRef);
     });
 }
 
-function isConnectorType(type: string): type is ConnectorType {
-  return type in CONNECTOR_TYPES;
-}
-
-async function getFeatureAvailableConnectorTypes(): Promise<
-  Set<ConnectorType>
-> {
-  const catalog = await searchZeroConnectors();
-  return new Set(
-    catalog.connectors
-      .map((connector) => {
-        return connector.id;
-      })
-      .filter(isConnectorType),
-  );
-}
-
-function formatAccount(connector: ConnectedConnector): string | undefined {
-  if (connector.externalUsername) return `@${connector.externalUsername}`;
-  if (connector.externalEmail) return connector.externalEmail;
-  if (connector.externalId) return connector.externalId;
+function formatAccount(
+  connector: PublicConnectorCatalogStatusItem,
+): string | undefined {
+  if (connector.connection?.externalUsername) {
+    return `@${connector.connection.externalUsername}`;
+  }
+  if (connector.connection?.externalEmail) {
+    return connector.connection.externalEmail;
+  }
   return undefined;
 }
 
 function getAction(
   status: CandidateStatus,
-  type: ConnectorType,
+  type: string,
   label: string,
   agentId: string | undefined,
   platformOrigin: string,
@@ -392,43 +375,25 @@ function getAction(
 }
 
 function toCandidate(params: {
-  type: ConnectorType;
-  config: ConnectorConfig;
-  connector: ConnectedConnector | undefined;
-  configuredTypes: Set<ConnectorType>;
-  availableTypes: Set<ConnectorType>;
+  connector: PublicConnectorCatalogStatusItem;
   authorizedTypes: Set<string> | null;
   agentId: string | undefined;
   platformOrigin: string;
 }): GenerationCandidate {
-  const {
-    type,
-    config,
-    connector,
-    configuredTypes,
-    availableTypes,
-    authorizedTypes,
-    agentId,
-    platformOrigin,
-  } = params;
+  const { connector, authorizedTypes, agentId, platformOrigin } = params;
+  const type = connector.connectorRef;
 
   let status: CandidateStatus;
   let reason: string;
 
-  if (!availableTypes.has(type)) {
-    status = "not-available";
-    reason = "not available for this account";
-  } else if (connector?.connectionStatus === "reconnect-required") {
+  if (connector.connectionStatus === "reconnect-required") {
     status = "needs-reconnect";
     reason = "connected, reconnect required";
-  } else if (!connector) {
-    status = configuredTypes.has(type) ? "not-connected" : "not-available";
-    reason =
-      status === "not-connected"
-        ? agentId
-          ? "not connected or authorized for current agent"
-          : "not connected"
-        : "not available in this environment";
+  } else if (!connector.connected) {
+    status = "not-connected";
+    reason = agentId
+      ? "not connected or authorized for current agent"
+      : "not connected";
   } else if (authorizedTypes && !authorizedTypes.has(type)) {
     status = "not-authorized";
     reason = "connected, not authorized for current agent";
@@ -441,12 +406,12 @@ function toCandidate(params: {
 
   return {
     type,
-    label: config.label,
+    label: connector.label,
     status,
     reason,
-    account: connector ? formatAccount(connector) : undefined,
-    authMethod: connector?.authMethod,
-    ...getAction(status, type, config.label, agentId, platformOrigin),
+    account: connector.connected ? formatAccount(connector) : undefined,
+    authMethod: connector.connection?.authMethod,
+    ...getAction(status, type, connector.label, agentId, platformOrigin),
   };
 }
 
@@ -584,29 +549,17 @@ export async function runLister(
 ): Promise<void> {
   const connectorGenerationType = getConnectorGenerationType(generationType);
   const agentId = process.env.ZERO_AGENT_ID;
-  const [connectorList, availableTypes, enabledTypes, platformOrigin] =
-    await Promise.all([
-      listZeroConnectors(),
-      getFeatureAvailableConnectorTypes(),
-      agentId ? getZeroAgentUserConnectors(agentId) : Promise.resolve(null),
-      getPlatformOrigin(),
-    ]);
-  const connectedMap = new Map(
-    connectorList.connectors.map((connector) => {
-      return [connector.type, connector];
-    }),
-  );
-  const configuredTypes = new Set(connectorList.configuredTypes);
+  const [catalog, enabledTypes, platformOrigin] = await Promise.all([
+    listZeroConnectorCatalogStatus(),
+    agentId ? getZeroAgentUserConnectors(agentId) : Promise.resolve(null),
+    getPlatformOrigin(),
+  ]);
   const authorizedTypes = enabledTypes ? new Set(enabledTypes) : null;
   const candidates = connectorGenerationType
-    ? getGenerationConnectors(connectorGenerationType).map(
-        ([connectorType, config]) => {
+    ? getGenerationConnectors(connectorGenerationType, catalog.connectors).map(
+        (connector) => {
           return toCandidate({
-            type: connectorType,
-            config,
-            connector: connectedMap.get(connectorType),
-            configuredTypes,
-            availableTypes,
+            connector,
             authorizedTypes,
             agentId,
             platformOrigin,

--- a/turbo/apps/cli/src/commands/zero/generate/lister-only.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lister-only.ts
@@ -40,7 +40,7 @@ Notes:
       withErrorHandler(async (options: ListerOnlyOptions) => {
         const provider = options.provider?.trim();
         if (provider && provider !== "built-in") {
-          printConnectorGuidance(config.generationType, provider);
+          await printConnectorGuidance(config.generationType, provider);
           return;
         }
         if (provider === "built-in") {

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -11,6 +11,11 @@ import {
   type ConnectorSearchResponse,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogListResponse,
+  type PublicConnectorCatalogStatusResponse,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
   zeroCustomConnectorByIdContract,
   zeroCustomConnectorsContract,
   type CustomConnectorResponse,
@@ -57,6 +62,32 @@ export async function searchZeroConnectors(
   }
 
   handleError(result, "Failed to search connectors");
+}
+
+export async function listZeroConnectorCatalog(): Promise<PublicConnectorCatalogListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroConnectorCatalogContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list connector catalog");
+}
+
+export async function listZeroConnectorCatalogStatus(): Promise<PublicConnectorCatalogStatusResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroConnectorCatalogContract, config);
+
+  const result = await client.status({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list connector catalog status");
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -146,8 +146,8 @@ export {
 // Domain modules - Zero Connectors
 export {
   listZeroConnectors,
-  getZeroConnector,
-  searchZeroConnectors,
+  listZeroConnectorCatalog,
+  listZeroConnectorCatalogStatus,
   connectZeroConnectorManualGrant,
   listZeroCustomConnectors,
   getZeroCustomConnector,

--- a/turbo/apps/cli/src/lib/domain/schedule-utils.ts
+++ b/turbo/apps/cli/src/lib/domain/schedule-utils.ts
@@ -25,26 +25,3 @@ export function formatRelativeTime(dateStr: string | null): string {
     return isPast ? "just now" : "soon";
   }
 }
-
-/**
- * Format a date string with both absolute and relative time
- * e.g., "2025-01-14 09:00 (in 2h)"
- * Uses local timezone, but doesn't include timezone in output (shown separately)
- */
-export function formatDateTime(dateStr: string | null): string {
-  if (!dateStr) return "-";
-
-  const date = new Date(dateStr);
-
-  // Format: YYYY-MM-DD HH:MM (no seconds, no timezone - shown separately)
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-
-  const formatted = `${year}-${month}-${day} ${hours}:${minutes}`;
-  const relative = formatRelativeTime(dateStr);
-
-  return `${formatted} (${relative})`;
-}

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -2,10 +2,22 @@ import { http, HttpResponse } from "msw";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodConfig,
   connectorAuthMethodIdSchema,
   type ConnectorAuthMethodId,
+  type ConnectorType,
 } from "@vm0/connectors/connectors";
-import { getAvailableConnectorAuthMethodIds } from "@vm0/connectors/connector-utils";
+import type {
+  PublicConnectorCatalogAuthMethodDetail,
+  PublicConnectorCatalogItem,
+  PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
+  getAvailableConnectorAuthMethodIds,
+  getConnectorAuthMethod,
+  getConnectorGenerationTypes,
+  getConnectorTags,
+} from "@vm0/connectors/connector-utils";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -33,6 +45,133 @@ function defaultAvailableConnectors() {
         authMethods,
       };
     });
+}
+
+function defaultPermissionSummary() {
+  return {
+    hasPermissions: false,
+    permissionCount: 0,
+    hasCategories: false,
+    hasDefaultPolicyOverrides: false,
+  };
+}
+
+function defaultManualFieldsForCatalog(
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogAuthMethodDetail["manualFields"] {
+  if (method.grant.kind !== "manual") {
+    return [];
+  }
+  return Object.values(method.grant.fields).map((field) => {
+    return {
+      id: field.publicId,
+      label: field.label,
+      required: field.required,
+      placeholder: field.placeholder ?? null,
+      inputType: field.storage === "variable" ? "text" : "password",
+    };
+  });
+}
+
+function defaultStartOptionsForCatalog(
+  method: ConnectorAuthMethodConfig,
+): PublicConnectorCatalogAuthMethodDetail["startOptions"] {
+  if (method.grant.kind !== "device-auth") {
+    return [];
+  }
+  return Object.values(method.grant.startOptions ?? {}).map((option) => {
+    return {
+      id: option.publicId,
+      kind: option.kind,
+      label: option.label,
+      required: option.required,
+      defaultValue: option.defaultValue ?? null,
+      options: option.options.map((choice) => {
+        return { value: choice.value, label: choice.label };
+      }),
+    };
+  });
+}
+
+function defaultCatalogAuthMethods(
+  type: ConnectorType,
+): PublicConnectorCatalogAuthMethodDetail[] {
+  return getAvailableConnectorAuthMethodIds(type, {}).flatMap((authMethod) => {
+    const method = getConnectorAuthMethod(type, authMethod);
+    if (!method) return [];
+    return [
+      {
+        id: authMethod,
+        label: method.label,
+        description: null,
+        grantKind: method.grant.kind,
+        manualFields: defaultManualFieldsForCatalog(method),
+        startOptions: defaultStartOptionsForCatalog(method),
+      },
+    ];
+  });
+}
+
+function defaultPublicCatalogItem(
+  type: ConnectorType,
+): PublicConnectorCatalogItem | null {
+  const authMethods = defaultCatalogAuthMethods(type);
+  if (authMethods.length === 0) {
+    return null;
+  }
+  const config = CONNECTOR_TYPES[type];
+  return {
+    connectorRef: type,
+    label: config.label,
+    description: config.helpText,
+    category: config.category,
+    generation: [...getConnectorGenerationTypes(type)],
+    tags: [...getConnectorTags(type)],
+    authMethods: authMethods.map((authMethod) => {
+      return {
+        id: authMethod.id,
+        label: authMethod.label,
+        description: authMethod.description,
+        grantKind: authMethod.grantKind,
+      };
+    }),
+    permissionSummary: defaultPermissionSummary(),
+  };
+}
+
+function defaultPublicCatalog() {
+  return CONNECTOR_TYPE_KEYS.flatMap((type) => {
+    const item = defaultPublicCatalogItem(type);
+    return item ? [item] : [];
+  });
+}
+
+function defaultPublicCatalogStatusItem(
+  type: ConnectorType,
+): PublicConnectorCatalogStatusItem | null {
+  const item = defaultPublicCatalogItem(type);
+  if (!item) {
+    return null;
+  }
+  return {
+    ...item,
+    authMethods: defaultCatalogAuthMethods(type),
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: null,
+    connectNotice: null,
+  };
+}
+
+function defaultPublicCatalogStatus() {
+  return CONNECTOR_TYPE_KEYS.flatMap((type) => {
+    const item = defaultPublicCatalogStatusItem(type);
+    return item ? [item] : [];
+  });
 }
 
 function manualGrantAuthMethodFromBody(body: unknown): ConnectorAuthMethodId {
@@ -122,6 +261,46 @@ export const apiHandlers = [
   http.get("https://www.vm0.ai/api/zero/connectors", () => {
     return HttpResponse.json(
       { connectors: [], configuredTypes: [], connectorProvidedBindings: [] },
+      { status: 200 },
+    );
+  }),
+
+  // GET /api/zero/connector-catalog - list public connector catalog
+  http.get("http://localhost:3000/api/zero/connector-catalog", () => {
+    return HttpResponse.json(
+      { connectors: defaultPublicCatalog() },
+      { status: 200 },
+    );
+  }),
+  http.get("https://app.vm0.ai/api/zero/connector-catalog", () => {
+    return HttpResponse.json(
+      { connectors: defaultPublicCatalog() },
+      { status: 200 },
+    );
+  }),
+  http.get("https://www.vm0.ai/api/zero/connector-catalog", () => {
+    return HttpResponse.json(
+      { connectors: defaultPublicCatalog() },
+      { status: 200 },
+    );
+  }),
+
+  // GET /api/zero/connector-catalog/status - public catalog with connection status
+  http.get("http://localhost:3000/api/zero/connector-catalog/status", () => {
+    return HttpResponse.json(
+      { connectors: defaultPublicCatalogStatus() },
+      { status: 200 },
+    );
+  }),
+  http.get("https://app.vm0.ai/api/zero/connector-catalog/status", () => {
+    return HttpResponse.json(
+      { connectors: defaultPublicCatalogStatus() },
+      { status: 200 },
+    );
+  }),
+  http.get("https://www.vm0.ai/api/zero/connector-catalog/status", () => {
+    return HttpResponse.json(
+      { connectors: defaultPublicCatalogStatus() },
       { status: 200 },
     );
   }),


### PR DESCRIPTION
## Summary

Closes #19392.

- Add CLI client helpers for `/api/zero/connector-catalog` and `/api/zero/connector-catalog/status`.
- Move `zero connector list/search/status/connect` to public catalog/status metadata for connector labels, availability, auth methods, manual fields, connection status, and agent authorization display.
- Move generation connector listing and connector guidance to public catalog/status instead of local static connector metadata.
- Rebuild connector search over public fields only and avoid credential-style private identifier matches such as `GH_TOKEN` and `GH_API_KEY`.
- Update CLI MSW handlers and command integration tests to use public catalog/status payloads.

## Notes

- `zero doctor check-connector` intentionally remains on runtime/static diagnostic APIs; doctor migration is out of scope for this issue.
- Existing connector action APIs still accept built-in `ConnectorType` path params and `ConnectorAuthMethodId`, so `zero connector connect` keeps a small action-boundary parse before calling manual grant.
- No persistent data or DB schema changes.

## Verification

- `pnpm -F @vm0/cli exec vitest run src/commands/zero/connector/__tests__/search.test.ts`
- `pnpm knip --workspace @vm0/cli`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli test`
- pre-commit lefthook: `prettier`, `knip --cache`, full `pnpm check-types`
