### PR TITLE
test: add shared firewall matcher contract cases

### DIFF
--- a/crates/runner/mitm-addon/tests/test_firewall_semantics_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_semantics_contract.py
@@ -19,19 +19,32 @@ _CONTRACT_PATH = (
 )
 
 
-def _load_cases() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+def _contract_cases(raw_contract: dict[str, object], key: str) -> list[dict[str, object]]:
+    cases = raw_contract[key]
+    assert isinstance(cases, list)
+    assert all(isinstance(case, dict) for case in cases)
+    return cases
+
+
+def _load_cases() -> tuple[
+    list[dict[str, object]],
+    list[dict[str, object]],
+    list[dict[str, object]],
+    list[dict[str, object]],
+    list[dict[str, object]],
+    list[dict[str, object]],
+]:
     raw_contract = json.loads(_CONTRACT_PATH.read_text())
     assert isinstance(raw_contract, dict)
 
-    segment_parse_cases = raw_contract["segmentParseCases"]
-    assert isinstance(segment_parse_cases, list)
-    assert all(isinstance(case, dict) for case in segment_parse_cases)
-
-    path_split_cases = raw_contract["pathSplitCases"]
-    assert isinstance(path_split_cases, list)
-    assert all(isinstance(case, dict) for case in path_split_cases)
-
-    return segment_parse_cases, path_split_cases
+    return (
+        _contract_cases(raw_contract, "segmentParseCases"),
+        _contract_cases(raw_contract, "pathSplitCases"),
+        _contract_cases(raw_contract, "pathMatchCases"),
+        _contract_cases(raw_contract, "hostMatchCases"),
+        _contract_cases(raw_contract, "pathPrefixMatchCases"),
+        _contract_cases(raw_contract, "baseUrlMatchCases"),
+    )
 
 
 def _case_name(case: dict[str, object]) -> str:
@@ -40,7 +53,53 @@ def _case_name(case: dict[str, object]) -> str:
     return name
 
 
-_SEGMENT_PARSE_CASES, _PATH_SPLIT_CASES = _load_cases()
+def _expected_kind(expected: dict[str, object]) -> str:
+    kind = expected["kind"]
+    assert isinstance(kind, str)
+    return kind
+
+
+def _relative_path_from_segments(segments: list[str], consumed: int) -> str:
+    rest = "/".join(segments[consumed:])
+    return "/" if rest == "" else f"/{rest}"
+
+
+def _assert_params_match(
+    actual: dict[str, str] | None,
+    expected: dict[str, object],
+) -> None:
+    if _expected_kind(expected) == "no-match":
+        assert actual is None
+        return
+
+    params = expected["params"]
+    assert isinstance(params, dict)
+    assert all(isinstance(key, str) for key in params)
+    assert all(isinstance(value, str) for value in params.values())
+    assert actual == params
+
+
+def _assert_relative_path_match(
+    actual: str | None,
+    expected: dict[str, object],
+) -> None:
+    if _expected_kind(expected) == "no-match":
+        assert actual is None
+        return
+
+    relative_path = expected["relativePath"]
+    assert isinstance(relative_path, str)
+    assert actual == relative_path
+
+
+(
+    _SEGMENT_PARSE_CASES,
+    _PATH_SPLIT_CASES,
+    _PATH_MATCH_CASES,
+    _HOST_MATCH_CASES,
+    _PATH_PREFIX_MATCH_CASES,
+    _BASE_URL_MATCH_CASES,
+) = _load_cases()
 
 
 @pytest.mark.parametrize("case", _SEGMENT_PARSE_CASES, ids=_case_name)
@@ -77,3 +136,63 @@ def test_path_splitting_matches_shared_contract(case: dict[str, object]):
     assert all(isinstance(segment, str) for segment in expected)
 
     assert _split_path_segments(path) == expected
+
+
+@pytest.mark.parametrize("case", _PATH_MATCH_CASES, ids=_case_name)
+def test_path_matching_matches_shared_contract(case: dict[str, object]):
+    path = case["path"]
+    assert isinstance(path, str)
+    pattern = case["pattern"]
+    assert isinstance(pattern, str)
+
+    expected = case["expected"]
+    assert isinstance(expected, dict)
+
+    _assert_params_match(matching.match_path(path, pattern), expected)
+
+
+@pytest.mark.parametrize("case", _HOST_MATCH_CASES, ids=_case_name)
+def test_host_matching_matches_shared_contract(case: dict[str, object]):
+    host = case["host"]
+    assert isinstance(host, str)
+    pattern = case["pattern"]
+    assert isinstance(pattern, str)
+
+    expected = case["expected"]
+    assert isinstance(expected, dict)
+
+    _assert_params_match(matching.match_host(host, pattern), expected)
+
+
+@pytest.mark.parametrize("case", _PATH_PREFIX_MATCH_CASES, ids=_case_name)
+def test_path_prefix_matching_matches_shared_contract(case: dict[str, object]):
+    path = case["path"]
+    assert isinstance(path, str)
+    pattern = case["pattern"]
+    assert isinstance(pattern, str)
+
+    expected = case["expected"]
+    assert isinstance(expected, dict)
+
+    path_segments = _split_path_segments(path)
+    pattern_segments = _split_path_segments(pattern)
+    result = matching.match_path_prefix(path_segments, pattern_segments)
+    actual_relative_path = (
+        None if result is None else _relative_path_from_segments(path_segments, result[1])
+    )
+    _assert_relative_path_match(actual_relative_path, expected)
+
+
+@pytest.mark.parametrize("case", _BASE_URL_MATCH_CASES, ids=_case_name)
+def test_base_url_matching_matches_shared_contract(case: dict[str, object]):
+    url = case["url"]
+    assert isinstance(url, str)
+    base = case["base"]
+    assert isinstance(base, str)
+
+    expected = case["expected"]
+    assert isinstance(expected, dict)
+
+    result = matching.match_base_url(url, base)
+    actual_relative_path = None if result is None else result[0]
+    _assert_relative_path_match(actual_relative_path, expected)

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -254,6 +254,15 @@
       }
     },
     {
+      "name": "root literal path",
+      "path": "/",
+      "pattern": "/",
+      "expected": {
+        "kind": "match",
+        "params": {}
+      }
+    },
+    {
       "name": "plain path parameters",
       "path": "/repos/myorg/myrepo/pulls",
       "pattern": "/repos/{owner}/{repo}/pulls",
@@ -269,6 +278,14 @@
       "name": "plain path parameter rejects empty segment",
       "path": "/repos//pulls",
       "pattern": "/repos/{owner}/pulls",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "path matcher requires full path consumption",
+      "path": "/repos/myorg/myrepo/pulls/123",
+      "pattern": "/repos/{owner}/{repo}/pulls",
       "expected": {
         "kind": "no-match"
       }
@@ -564,6 +581,15 @@
       }
     },
     {
+      "name": "static base normalizes trailing dot and default port",
+      "url": "HTTPS://API.GitHub.com.:443/repos",
+      "base": "https://api.github.com.",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/repos"
+      }
+    },
+    {
       "name": "scheme mismatch fails closed",
       "url": "http://api.github.com/repos",
       "base": "https://api.github.com",
@@ -638,6 +664,14 @@
       "expected": {
         "kind": "match",
         "relativePath": "/users"
+      }
+    },
+    {
+      "name": "runtime URL with userinfo fails closed",
+      "url": "https://user:pass@api.github.com/repos",
+      "base": "https://api.github.com",
+      "expected": {
+        "kind": "no-match"
       }
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -348,6 +348,14 @@
       }
     },
     {
+      "name": "literal host rejects extra leading segment",
+      "host": "evil.api.github.com",
+      "pattern": "api.github.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
       "name": "plain host parameter captures lowercase segment",
       "host": "ACME.zendesk.com",
       "pattern": "{subdomain}.zendesk.com",
@@ -563,6 +571,14 @@
       "name": "runtime URL with backslash fails closed",
       "url": "https://api.github.com/re\\pos",
       "base": "https://api.github.com/repos",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "malformed runtime URL fails closed",
+      "url": "https://[::1",
+      "base": "https://api.github.com",
       "expected": {
         "kind": "no-match"
       }

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -266,6 +266,14 @@
       }
     },
     {
+      "name": "plain path parameter rejects empty segment",
+      "path": "/repos//pulls",
+      "pattern": "/repos/{owner}/pulls",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
       "name": "mixed path segment captures suffix middle",
       "path": "/repos/octocat/hello.git",
       "pattern": "/repos/{owner}/{repo}.git",
@@ -367,6 +375,14 @@
       }
     },
     {
+      "name": "plain host parameter rejects multiple leading segments",
+      "host": "a.b.zendesk.com",
+      "pattern": "{subdomain}.zendesk.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
       "name": "mixed host parameter captures lowercase middle",
       "host": "API-US.example.com",
       "pattern": "api-{region}.example.com",
@@ -397,6 +413,14 @@
       }
     },
     {
+      "name": "leading greedy plus host rejects empty prefix",
+      "host": "example.com",
+      "pattern": "{sub+}.example.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
       "name": "leading greedy star host can capture empty prefix",
       "host": "example.com",
       "pattern": "{sub*}.example.com",
@@ -419,6 +443,14 @@
       "name": "mixed greedy host parameter fails closed",
       "host": "api-us.example.com",
       "pattern": "api-{region+}.example.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "non-default port participates in literal host matching",
+      "host": "api.example.com:9443",
+      "pattern": "api.example.com:8443",
       "expected": {
         "kind": "no-match"
       }
@@ -471,6 +503,22 @@
       }
     },
     {
+      "name": "parameterized prefix rejects empty segment",
+      "path": "/owner//main",
+      "pattern": "/{owner}/{repo}",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "mixed parameterized prefix rejects empty capture",
+      "path": "/owner/.git/info/refs",
+      "pattern": "/{owner}/{repo}.git",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
       "name": "prefix keeps segment boundary strict",
       "path": "/apiary/users",
       "pattern": "/api",
@@ -482,6 +530,15 @@
       "name": "greedy plus prefix consumes remaining path",
       "path": "/api/users/123",
       "pattern": "/api/{rest+}",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/"
+      }
+    },
+    {
+      "name": "greedy star prefix consumes zero remaining segments",
+      "path": "/api",
+      "pattern": "/api/{rest*}",
       "expected": {
         "kind": "match",
         "relativePath": "/"
@@ -504,6 +561,22 @@
       "expected": {
         "kind": "match",
         "relativePath": "/repos"
+      }
+    },
+    {
+      "name": "scheme mismatch fails closed",
+      "url": "http://api.github.com/repos",
+      "base": "https://api.github.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "non-default runtime port without base port fails closed",
+      "url": "https://api.github.com:8443/repos",
+      "base": "https://api.github.com",
+      "expected": {
+        "kind": "no-match"
       }
     },
     {
@@ -579,6 +652,14 @@
       "name": "malformed runtime URL fails closed",
       "url": "https://[::1",
       "base": "https://api.github.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "base URL with query fails closed",
+      "url": "https://api.github.com/repos",
+      "base": "https://api.github.com?token=1",
       "expected": {
         "kind": "no-match"
       }

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -242,5 +242,338 @@
       "path": "///",
       "expected": ["", "", ""]
     }
+  ],
+  "pathMatchCases": [
+    {
+      "name": "exact literal path",
+      "path": "/api/v1/users",
+      "pattern": "/api/v1/users",
+      "expected": {
+        "kind": "match",
+        "params": {}
+      }
+    },
+    {
+      "name": "plain path parameters",
+      "path": "/repos/myorg/myrepo/pulls",
+      "pattern": "/repos/{owner}/{repo}/pulls",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "owner": "myorg",
+          "repo": "myrepo"
+        }
+      }
+    },
+    {
+      "name": "mixed path segment captures suffix middle",
+      "path": "/repos/octocat/hello.git",
+      "pattern": "/repos/{owner}/{repo}.git",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "owner": "octocat",
+          "repo": "hello"
+        }
+      }
+    },
+    {
+      "name": "mixed path segment rejects empty capture",
+      "path": "/repos/octocat/.git",
+      "pattern": "/repos/{owner}/{repo}.git",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "greedy plus path preserves repeated slash before non-empty rest",
+      "path": "/repos/a/b/git//heads/main",
+      "pattern": "/repos/{owner}/{repo}/git/{rest+}",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "owner": "a",
+          "repo": "b",
+          "rest": "/heads/main"
+        }
+      }
+    },
+    {
+      "name": "greedy plus path rejects only empty remaining segment",
+      "path": "/repos/a/b/git/",
+      "pattern": "/repos/{owner}/{repo}/git/{rest+}",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "greedy star path matches zero segments",
+      "path": "/",
+      "pattern": "/{path*}",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "path": ""
+        }
+      }
+    },
+    {
+      "name": "explicit empty path segment can match literal empty segment",
+      "path": "/repos//octocat",
+      "pattern": "/repos//{owner}",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "owner": "octocat"
+        }
+      }
+    },
+    {
+      "name": "non-terminal greedy path parameter fails closed",
+      "path": "/api/a/b/tail",
+      "pattern": "/api/{rest+}/tail",
+      "expected": {
+        "kind": "no-match"
+      }
+    }
+  ],
+  "hostMatchCases": [
+    {
+      "name": "literal host matches case-insensitively",
+      "host": "API.GitHub.COM",
+      "pattern": "api.github.com",
+      "expected": {
+        "kind": "match",
+        "params": {}
+      }
+    },
+    {
+      "name": "plain host parameter captures lowercase segment",
+      "host": "ACME.zendesk.com",
+      "pattern": "{subdomain}.zendesk.com",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "subdomain": "acme"
+        }
+      }
+    },
+    {
+      "name": "mixed host parameter captures lowercase middle",
+      "host": "API-US.example.com",
+      "pattern": "api-{region}.example.com",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "region": "us"
+        }
+      }
+    },
+    {
+      "name": "mixed host parameter rejects empty capture",
+      "host": "api-.example.com",
+      "pattern": "api-{region}.example.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "leading greedy plus host preserves input case",
+      "host": "Foo.Bar.example.com",
+      "pattern": "{sub+}.example.com",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "sub": "Foo.Bar"
+        }
+      }
+    },
+    {
+      "name": "leading greedy star host can capture empty prefix",
+      "host": "example.com",
+      "pattern": "{sub*}.example.com",
+      "expected": {
+        "kind": "match",
+        "params": {
+          "sub": ""
+        }
+      }
+    },
+    {
+      "name": "non-leading greedy host parameter fails closed",
+      "host": "foo.bar.example.com",
+      "pattern": "foo.{sub+}.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "mixed greedy host parameter fails closed",
+      "host": "api-us.example.com",
+      "pattern": "api-{region+}.example.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    }
+  ],
+  "pathPrefixMatchCases": [
+    {
+      "name": "root prefix returns full path",
+      "path": "/v2/demo",
+      "pattern": "/",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/v2/demo"
+      }
+    },
+    {
+      "name": "exact prefix returns slash",
+      "path": "/api/v1",
+      "pattern": "/api/v1",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/"
+      }
+    },
+    {
+      "name": "literal prefix preserves repeated slash after base",
+      "path": "/api/v1//users",
+      "pattern": "/api/v1",
+      "expected": {
+        "kind": "match",
+        "relativePath": "//users"
+      }
+    },
+    {
+      "name": "trailing empty prefix segment is significant",
+      "path": "/api/v1//users",
+      "pattern": "/api/v1/",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/users"
+      }
+    },
+    {
+      "name": "parameterized prefix returns remaining path",
+      "path": "/owner/repo/main/README.md",
+      "pattern": "/{owner}/{repo}",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/main/README.md"
+      }
+    },
+    {
+      "name": "prefix keeps segment boundary strict",
+      "path": "/apiary/users",
+      "pattern": "/api",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "greedy plus prefix consumes remaining path",
+      "path": "/api/users/123",
+      "pattern": "/api/{rest+}",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/"
+      }
+    },
+    {
+      "name": "greedy plus prefix rejects only empty remaining segment",
+      "path": "/api/",
+      "pattern": "/api/{rest+}",
+      "expected": {
+        "kind": "no-match"
+      }
+    }
+  ],
+  "baseUrlMatchCases": [
+    {
+      "name": "static base strips query and fragment from relative path",
+      "url": "https://API.GitHub.com/repos?tab=code#readme",
+      "base": "https://api.github.com",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/repos"
+      }
+    },
+    {
+      "name": "exact static base returns slash",
+      "url": "https://api.github.com?per_page=1#ignored",
+      "base": "https://api.github.com",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/"
+      }
+    },
+    {
+      "name": "static base rejects evil domain suffix",
+      "url": "https://api.github.com.evil.com/steal",
+      "base": "https://api.github.com",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "static base path keeps segment boundary strict",
+      "url": "https://example.com/apiary/users",
+      "base": "https://example.com/api",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "parameterized host base matches case-insensitively",
+      "url": "https://ETH.G.ALCHEMY.COM/v2/demo",
+      "base": "https://{network}.g.alchemy.com",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/v2/demo"
+      }
+    },
+    {
+      "name": "parameterized path base returns remaining path",
+      "url": "https://raw.githubusercontent.com/owner/repo/main/README.md",
+      "base": "https://raw.githubusercontent.com/{owner}/{repo}",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/main/README.md"
+      }
+    },
+    {
+      "name": "parameterized path treats encoded slash as segment content",
+      "url": "https://api.example.com/v1/acme%2Fteam/projects/123",
+      "base": "https://api.example.com/v1/{org}",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/projects/123"
+      }
+    },
+    {
+      "name": "repeated root slash base preserves path boundary",
+      "url": "https://api.example.com//users",
+      "base": "https://api.example.com//",
+      "expected": {
+        "kind": "match",
+        "relativePath": "/users"
+      }
+    },
+    {
+      "name": "runtime URL with backslash fails closed",
+      "url": "https://api.github.com/re\\pos",
+      "base": "https://api.github.com/repos",
+      "expected": {
+        "kind": "no-match"
+      }
+    },
+    {
+      "name": "malformed base URL fails closed",
+      "url": "https://api.github.com/repos",
+      "base": "https://[::1",
+      "expected": {
+        "kind": "no-match"
+      }
+    }
   ]
 }

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.test.ts
@@ -3,6 +3,12 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import {
+  matchFirewallBaseUrl,
+  matchFirewallHost,
+  matchFirewallPath,
+  matchFirewallPathPrefix,
+} from "../firewall-rule-matcher";
 import { parseSegment, splitPathSegments } from "../segment-parser";
 
 const segmentExpectedSchema = z.discriminatedUnion("kind", [
@@ -23,6 +29,26 @@ const segmentExpectedSchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
+const paramsMatchExpectedSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("match"),
+    params: z.record(z.string(), z.string()),
+  }),
+  z.object({
+    kind: z.literal("no-match"),
+  }),
+]);
+
+const relativePathMatchExpectedSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("match"),
+    relativePath: z.string(),
+  }),
+  z.object({
+    kind: z.literal("no-match"),
+  }),
+]);
+
 const contractSchema = z.object({
   segmentParseCases: z.array(
     z.object({
@@ -38,9 +64,45 @@ const contractSchema = z.object({
       expected: z.array(z.string()),
     }),
   ),
+  pathMatchCases: z.array(
+    z.object({
+      name: z.string(),
+      path: z.string(),
+      pattern: z.string(),
+      expected: paramsMatchExpectedSchema,
+    }),
+  ),
+  hostMatchCases: z.array(
+    z.object({
+      name: z.string(),
+      host: z.string(),
+      pattern: z.string(),
+      expected: paramsMatchExpectedSchema,
+    }),
+  ),
+  pathPrefixMatchCases: z.array(
+    z.object({
+      name: z.string(),
+      path: z.string(),
+      pattern: z.string(),
+      expected: relativePathMatchExpectedSchema,
+    }),
+  ),
+  baseUrlMatchCases: z.array(
+    z.object({
+      name: z.string(),
+      url: z.string(),
+      base: z.string(),
+      expected: relativePathMatchExpectedSchema,
+    }),
+  ),
 });
 
 type SegmentExpected = z.infer<typeof segmentExpectedSchema>;
+type ParamsMatchExpected = z.infer<typeof paramsMatchExpectedSchema>;
+type RelativePathMatchExpected = z.infer<
+  typeof relativePathMatchExpectedSchema
+>;
 
 function loadContract(): z.infer<typeof contractSchema> {
   const rawContract: unknown = JSON.parse(
@@ -67,6 +129,30 @@ function assertSegmentResult(segment: string, expected: SegmentExpected): void {
   expect(actual).toEqual(expected);
 }
 
+function assertParamsMatch(
+  actual: Record<string, string> | null,
+  expected: ParamsMatchExpected,
+): void {
+  if (expected.kind === "no-match") {
+    expect(actual).toBeNull();
+    return;
+  }
+
+  expect(actual).toEqual(expected.params);
+}
+
+function assertRelativePathMatch(
+  actual: string | null,
+  expected: RelativePathMatchExpected,
+): void {
+  if (expected.kind === "no-match") {
+    expect(actual).toBeNull();
+    return;
+  }
+
+  expect(actual).toBe(expected.relativePath);
+}
+
 const contract = loadContract();
 
 describe("firewall semantics contract", () => {
@@ -82,6 +168,51 @@ describe("firewall semantics contract", () => {
     for (const testCase of contract.pathSplitCases) {
       it(testCase.name, () => {
         expect(splitPathSegments(testCase.path)).toEqual(testCase.expected);
+      });
+    }
+  });
+
+  describe("path matching", () => {
+    for (const testCase of contract.pathMatchCases) {
+      it(testCase.name, () => {
+        assertParamsMatch(
+          matchFirewallPath(testCase.path, testCase.pattern),
+          testCase.expected,
+        );
+      });
+    }
+  });
+
+  describe("host matching", () => {
+    for (const testCase of contract.hostMatchCases) {
+      it(testCase.name, () => {
+        assertParamsMatch(
+          matchFirewallHost(testCase.host, testCase.pattern),
+          testCase.expected,
+        );
+      });
+    }
+  });
+
+  describe("path prefix matching", () => {
+    for (const testCase of contract.pathPrefixMatchCases) {
+      it(testCase.name, () => {
+        assertRelativePathMatch(
+          matchFirewallPathPrefix(testCase.path, testCase.pattern),
+          testCase.expected,
+        );
+      });
+    }
+  });
+
+  describe("base URL matching", () => {
+    for (const testCase of contract.baseUrlMatchCases) {
+      it(testCase.name, () => {
+        assertRelativePathMatch(
+          matchFirewallBaseUrl(testCase.url, testCase.base)?.relativePath ??
+            null,
+          testCase.expected,
+        );
       });
     }
   });


### PR DESCRIPTION
## Summary
- Extend the shared firewall semantics fixture with path, host, path-prefix, and base URL matcher cases.
- Update TypeScript and Python contract tests to consume the new matcher sections independently.
- Keep full firewall decision parity out of scope; #19902 tracks that follow-up.

Closes #19829.

## Tests
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-semantics-contract.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm exec prettier --check packages/connectors/src/__tests__/firewall-semantics-contract.json packages/connectors/src/__tests__/firewall-semantics-contract.test.ts`
- `/tmp/vm0-mitm-addon-venv/bin/python -m pytest tests/test_firewall_semantics_contract.py -v`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff check .`
- `/tmp/vm0-mitm-addon-venv/bin/python -m ruff format --check .`
- `/tmp/vm0-mitm-addon-venv/bin/basedpyright -p .`
- pre-commit hook: `turbo check-types`, `knip`, formatting, and Python ruff checks