### PR TITLE
fix: sample voice activity before silent detection

### DIFF
--- a/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-stt.ts
@@ -297,7 +297,7 @@ async function startAudioActivityMonitor(
     monitor.frameId = requestFrame(update);
   };
 
-  monitor.frameId = requestFrame(update);
+  update();
   return monitor;
 }
 


### PR DESCRIPTION
## Summary

Fixes a race in voice-input speech detection that made `chat-lifecycle.test.tsx` intermittently leave the composer empty after STT returned text. The voice activity monitor now takes its first analyser sample immediately, then schedules animation-frame polling, so a recording cannot be marked as covered by silence detection before any audio sample has been evaluated.

## Source Turbo Failure

- Run: https://github.com/vm0-ai/vm0/actions/runs/28595693478
- Failed job/shard: `test-app (7)` running `pnpm vitest run --project=@vm0/app --shard=7/8 --coverage.enabled --coverage.reporter=json`
- Failure: `src/views/zero-page/__tests__/chat-lifecycle.test.tsx > chat lifecycle > transcribes voice input into the composer`
- Assertion: expected the composer textarea to contain `Summarize the standup`, but it was empty.
- Recurrence: the same test/signature also failed in https://github.com/vm0-ai/vm0/actions/runs/28570983737.

## Diagnosis

`startAudioActivityMonitor` previously returned after scheduling the first `requestAnimationFrame` sample. `startRecording$` then marked `internalVoiceActivityAvailable$` and `internalVoiceActivityCoversRecording$`, but `internalVoiceDetectedDuringRecording$` could still be false until the first animation frame ran. If the test stopped recording in that window, `stopAndTranscribe$` treated the recording as silent and skipped STT, leaving the composer empty.

The fix preserves the existing polling loop but calls `update()` once immediately so the first analyser sample is processed before the monitor is considered ready.

## Docs and Patterns Applied

- `docs/testing.md`: avoid waits/manual cleanup; fix the real async synchronization issue.
- `docs/testing/patterns.md`: keep the platform UI test path and existing mocks.
- `turbo/docs/no-floating-promise.md`: no new floating promises, sleeps, or detached cleanup.
- `.claude/skills/ccstate/SKILL.md`: existing DOM callback detach/page-signal pattern remains unchanged.
- `.github/workflows/turbo.yml`: verified the failing CI command and app shard.

## Validation

- `pnpm -C turbo exec vitest run --project=@vm0/app apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "transcribes voice input into the composer"`
- `pnpm -C turbo exec vitest run --project=@vm0/app apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "voice input|recording before the voice activity monitor|billing recovery"`
