### PR TITLE
refactor: reduce fallback slop in test support contracts

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -8,6 +8,7 @@ import type {
   TestMemoryStateFixture,
   TestMemoryStateSummaryRow,
 } from "@vm0/api-contracts/contracts/test-memory-state";
+import type { MemoryActivityResponse } from "@vm0/api-contracts/contracts/zero-memory-activity";
 
 import type { TestContext } from "../../../../__tests__/test-context";
 import { createAppWithRoutes } from "../../../../app-factory-core";
@@ -15,7 +16,8 @@ import { testMemoryStateRoutes } from "../../test-memory-state";
 
 const MEMORY_STATE_ROUTE = "/api/test/memory-state";
 
-type MemoryChangeDiff = unknown;
+type MemoryChangeDiff =
+  MemoryActivityResponse["entries"][number]["items"][number]["diff"];
 
 export interface MemoryFixture {
   readonly orgId: string;

--- a/turbo/apps/api/src/signals/routes/test-telegram-dispatch-probe.ts
+++ b/turbo/apps/api/src/signals/routes/test-telegram-dispatch-probe.ts
@@ -1,5 +1,8 @@
 import { command } from "ccstate";
-import { testTelegramDispatchProbeContract } from "@vm0/api-contracts/contracts/test-telegram-dispatch-probe";
+import {
+  testTelegramDispatchProbeContract,
+  type TestTelegramDispatchProbeBody,
+} from "@vm0/api-contracts/contracts/test-telegram-dispatch-probe";
 
 import { now } from "../external/time";
 import { request$ } from "../context/hono";
@@ -14,16 +17,6 @@ import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
 } from "./test-oauth-provider-helpers";
-
-interface ProbeBody {
-  readonly bot_id: string;
-  readonly chat_id: string;
-  readonly telegram_user_id: string;
-  readonly message_text: string;
-  readonly message_id?: number;
-  readonly chat_type?: "private" | "group" | "supergroup";
-  readonly bot_username?: string;
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -47,7 +40,7 @@ function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function parseProbeBody(value: unknown): ProbeBody | null {
+function parseProbeBody(value: unknown): TestTelegramDispatchProbeBody | null {
   if (!isRecord(value)) {
     return null;
   }
@@ -69,7 +62,9 @@ function parseProbeBody(value: unknown): ProbeBody | null {
   };
 }
 
-function buildMessage(body: ProbeBody): TelegramDispatchMessage {
+function buildMessage(
+  body: TestTelegramDispatchProbeBody,
+): TelegramDispatchMessage {
   const text = body.message_text;
   const chatType = body.chat_type ?? "private";
   const message: TelegramDispatchMessage = {

--- a/turbo/packages/api-contracts/src/contracts/test-memory-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-memory-state.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { initContract } from "./base";
+import { memoryActivityDiffSchema } from "./zero-memory-activity";
 
 const c = initContract();
 
@@ -15,7 +16,7 @@ export const testMemoryStateFixtureSchema = z.object({
 
 const memoryActivityItemSeedSchema = z.object({
   file_path: z.string(),
-  diff: z.unknown().optional(),
+  diff: memoryActivityDiffSchema.optional(),
 });
 
 const memorySummaryRowSchema = z.object({

--- a/turbo/packages/api-contracts/src/contracts/test-telegram-dispatch-probe.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-telegram-dispatch-probe.ts
@@ -4,7 +4,15 @@ import { initContract } from "./base";
 
 const c = initContract();
 
-export const testTelegramDispatchProbeBodySchema = z.unknown().optional();
+export const testTelegramDispatchProbeBodySchema = z.object({
+  bot_id: z.string(),
+  chat_id: z.string(),
+  telegram_user_id: z.string(),
+  message_text: z.string(),
+  message_id: z.number().optional(),
+  chat_type: z.enum(["private", "group", "supergroup"]).optional(),
+  bot_username: z.string().optional(),
+});
 
 export const testTelegramDispatchProbeSuccessSchema = z.object({
   ok: z.literal(true),
@@ -44,3 +52,6 @@ export const testTelegramDispatchProbeContract = c.router({
 
 export type TestTelegramDispatchProbeContract =
   typeof testTelegramDispatchProbeContract;
+export type TestTelegramDispatchProbeBody = z.infer<
+  typeof testTelegramDispatchProbeBodySchema
+>;

--- a/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts
@@ -20,7 +20,7 @@ const memoryActivityDiffHunkSchema = z.object({
   lines: z.array(memoryActivityDiffLineSchema),
 });
 
-const memoryActivityDiffSchema = z.object({
+export const memoryActivityDiffSchema = z.object({
   format: z.literal("line"),
   beforeExists: z.boolean(),
   afterExists: z.boolean(),


### PR DESCRIPTION
## Summary

This daily cleanup tightens two high-confidence `z.unknown().optional()` contract fallbacks in test-support APIs:

- Replaces the Telegram dispatch probe's unknown optional request body with the explicit probe fields already required by the route parser.
- Reuses the existing memory activity diff schema for the memory test-state fixture `diff` field, and aligns the downstream test helper type with the same contract.

## Scan

- Scan timestamp: `2026-07-02T20:01:54.822Z`
- Base commit: `4640b5493550d4e6f4586d74e787d44a91b37533`
- Files scanned: `3827`
- Actionable total: `217` high-confidence production-actionable candidates from the scanner
- Edit budget: `11`
- Candidates changed: `2`

Total matches by category:

- `nullish`: 5205
- `nullish-chain`: 121
- `field-fallback-chain`: 94
- `optional-prop`: 5506
- `zod-optional`: 2033
- `zod-loose-optional`: 8
- `loose-record`: 1177
- `loose-index-signature`: 5
- `as-any`: 0
- `as-unknown-as`: 37
- `empty-fallback`: 581
- `string-fallback`: 658
- `null-undefined-fallback`: 1458
- `empty-catch`: 3
- `promise-catch-swallow`: 14
- `rust-unwrap-or`: 568
- `rust-ok-discard`: 142

## Files Changed

- `turbo/packages/api-contracts/src/contracts/test-telegram-dispatch-probe.ts`: replaces `z.unknown().optional()` with the explicit Telegram dispatch probe body shape already enforced by `parseProbeBody`.
- `turbo/apps/api/src/signals/routes/test-telegram-dispatch-probe.ts`: reuses the inferred contract body type so route parsing and the API contract stay aligned.
- `turbo/packages/api-contracts/src/contracts/zero-memory-activity.ts`: exports the existing memory activity diff schema for reuse.
- `turbo/packages/api-contracts/src/contracts/test-memory-state.ts`: uses the memory activity diff schema for seeded memory activity fixture items instead of accepting unknown data.
- `turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts`: aligns the helper's fixture diff type with the memory activity response contract after the schema tightening.

These changes are safe because they do not alter route behavior; they replace unknown contract surfaces with shapes already required by local parsers or existing response schemas.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm exec prettier --check apps/api/src/signals/routes/test-telegram-dispatch-probe.ts apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts packages/api-contracts/src/contracts/test-memory-state.ts packages/api-contracts/src/contracts/test-telegram-dispatch-probe.ts packages/api-contracts/src/contracts/zero-memory-activity.ts`
- `git diff --check`

Targeted route tests were attempted with:

`pnpm -F api exec vitest run src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts src/signals/routes/__tests__/zero-memory-activity.test.ts`

They failed because the local test Postgres database was unavailable (`ECONNREFUSED`) while seeding test state. The PR pipeline should run the full checks in the correct environment.

This workflow intentionally leaves the remaining candidates for later daily runs.
