### PR TITLE
fix: restyle automation workflow hover card as light card with shadow

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -346,7 +346,17 @@ function WorkflowRow({
               </span>
             </Link>
           </TooltipTrigger>
-          <TooltipContent side="bottom" align="start" className="p-3">
+          <TooltipContent
+            side="bottom"
+            align="start"
+            className="rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] p-3"
+            style={{
+              backgroundColor: "hsl(var(--card))",
+              color: "hsl(var(--card-foreground))",
+              boxShadow:
+                "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)",
+            }}
+          >
             <WorkflowHoverContent workflow={workflow} />
           </TooltipContent>
         </Tooltip>


### PR DESCRIPTION
## Problem

The automation/workflow list row shows a hover card with the workflow title, description, **Created by**, and **Runs as**. It renders that rich content through `TooltipContent`, but that primitive hard-codes a dark `#1a1a1a` background and has **no shadow**. The card's inner text uses `text-foreground` / `text-muted-foreground` (dark colors intended for a light surface), so the actual result is near-invisible **dark-on-dark text**, floating flat against the page with no elevation.

Ming reported the popover looks wrong and has no shadow (screenshot showed the unreadable dark card).

## Fix

Override this single `TooltipContent` instance in `workflows-page.tsx` to match the design system's `PopoverContent` card treatment:

- `bg-card` surface (readable in light and dark themes)
- `--gray-400` hairline border (`border-[0.7px]`)
- the shared popover `box-shadow`

**Scope kept deliberately narrow:**
- Hover-to-reveal is preserved — the row title is a navigating `Link`, so a click-triggered `Popover` would fight navigation.
- The global `TooltipContent` dark default is **not** touched; it is still used as a normal dark tooltip in ~140 other places.

## Verification

- `npx prettier@3.8.1 --check` — clean
- package-local `oxlint@1.57.0` in `apps/platform` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)