### PR TITLE
fix: allow Team workspaces to use paid video templates

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts
@@ -491,7 +491,7 @@ describe("POST /api/zero/video-io/generate", () => {
     });
   });
 
-  it("returns 402 with the Pro upgrade message for limited-free-1 orgs", async () => {
+  it("returns 402 with the paid-plan upgrade message for limited-free-1 orgs", async () => {
     const fixture = await track(
       seedVideoFixture({
         credits: 10_000,
@@ -519,11 +519,44 @@ describe("POST /api/zero/video-io/generate", () => {
     await expect(response.json()).resolves.toStrictEqual({
       error: {
         message:
-          "Built-in video generation requires Pro. Return `pro_required` as the assistant error marker so the app can show the Pro upgrade card. Do not retry video generation until the workspace upgrades.",
+          "Built-in video generation requires Pro or Team. Return `pro_required` as the assistant error marker so the app can show the paid plan upgrade card. Do not retry video generation until the workspace upgrades.",
         code: "PRO_REQUIRED",
       },
     });
     expect(calledBytePlus).toBeFalsy();
+  });
+
+  it("allows Team orgs to submit paid video generation", async () => {
+    const fixture = await track(
+      seedVideoFixture({
+        credits: 10_000,
+        tier: "team",
+        withPricing: true,
+      }),
+    );
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    let calledBytePlus = false;
+    server.use(
+      http.post(BYTEPLUS_VIDEO_TASKS_URL, async ({ request }) => {
+        calledBytePlus = true;
+        await request.json();
+        return HttpResponse.json({
+          id: "team-video-task",
+          status: "queued",
+        });
+      }),
+    );
+
+    const app = createVideoIoTestApp();
+    const response = await app.request("/api/zero/video-io/generate", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ prompt: "a city" }),
+    });
+
+    expect(response.status).toBe(202);
+    readAcceptedGenerationId(await response.json(), "video", fixture.userId);
+    expect(calledBytePlus).toBeTruthy();
   });
 
   it("returns 503 when video pricing is not configured", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-video-io-generate.ts
+++ b/turbo/apps/api/src/signals/routes/zero-video-io-generate.ts
@@ -29,7 +29,7 @@ import {
   videoPricing$,
   videoPricingCategoryForOptions,
   videoPricingKey,
-  videoRequiresPro,
+  videoRequiresPaidPlan,
   videoServiceUnavailable,
 } from "../services/zero-video-io-generate.service";
 import {
@@ -225,7 +225,7 @@ const postVideoInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .limit(1);
   signal.throwIfAborted();
   if (org?.tier === "limited-free-1") {
-    return videoRequiresPro();
+    return videoRequiresPaidPlan();
   }
 
   const bodyResult = await get(videoBody$);

--- a/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-video-io-generate.service.ts
@@ -530,11 +530,11 @@ export function videoInsufficientCredits() {
   };
 }
 
-export function videoRequiresPro() {
+export function videoRequiresPaidPlan() {
   return {
     status: 402 as const,
     body: errorBody(
-      "Built-in video generation requires Pro. Return `pro_required` as the assistant error marker so the app can show the Pro upgrade card. Do not retry video generation until the workspace upgrades.",
+      "Built-in video generation requires Pro or Team. Return `pro_required` as the assistant error marker so the app can show the paid plan upgrade card. Do not retry video generation until the workspace upgrades.",
       "PRO_REQUIRED",
     ),
   };


### PR DESCRIPTION
## Summary
- Treat built-in video/template generation gating as a paid-plan requirement instead of Pro-only copy.
- Keep the existing `PRO_REQUIRED` marker for client compatibility while updating the server guidance to say Pro or Team.
- Add route coverage that Team orgs can submit paid video generation and limited-free orgs still receive the paid-plan upgrade response.

## Verification
- `pnpm --dir turbo exec prettier --write apps/api/src/signals/routes/zero-video-io-generate.ts apps/api/src/signals/services/zero-video-io-generate.service.ts apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo --filter api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir turbo --filter api lint`
- `pnpm --dir turbo exec vitest run apps/api/src/signals/routes/__tests__/zero-video-io-generate.test.ts` *(fails locally because the test Postgres is not running: seed fixture inserts hit ECONNREFUSED)*