### PR TITLE
style: unify workflow section headers with sidebar label typography

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -443,7 +443,9 @@ function workflowNextRunBucket(
 function WorkflowSectionHeader({ label }: { readonly label: string }) {
   return (
     <div className="px-5 pb-1.5 pt-4">
-      <span className="text-xs font-semibold text-foreground/80">{label}</span>
+      <span className="text-[13px] font-medium leading-4 text-foreground/50">
+        {label}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## What

Make the Workflows page section headers (**Runs today** / **On event** / **Manual**) visually consistent with the sidebar section labels (**Pinned** / **Chats with Zero**).

Ming flagged that the "Pinned" sidebar label and the "Runs today" workflow-list header look different despite being the same kind of section-header element.

## Change

`WorkflowSectionHeader` in `workflows-page.tsx` used a one-off style:

```
text-xs font-semibold text-foreground/80
```

The established sidebar section-label pattern (shared across `zero-sidebar-pinned.tsx`, `sidebar-threads.tsx`, `zero-sidebar.tsx`) is:

```
text-[13px] font-medium leading-4 text-sidebar-foreground/50
```

Aligned the workflow header to that pattern, mapped to the content-area color token (`text-foreground/50` instead of the sidebar-scoped `text-sidebar-foreground/50`). Result: same 13px size, medium weight, and muted 50% color as the sidebar labels.

## Direction

The sidebar style is the canonical one — it's shared by 3 files, whereas the workflow header style was unique to one component — so the workflow header was brought in line rather than the reverse. If the preferred direction is the opposite (make the sidebar labels heavier/darker), it's a one-line flip.

## Verification

- `prettier@3.8.1 --check` passes on the changed file.
- Pure Tailwind class change, no logic touched; relying on the PR pipeline for lint/type/test gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)