### PR TITLE
fix: make workflow trigger pill solid white so it stands out on card hover

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -118,10 +118,10 @@ function connectorPillClassName({
   readonly muted?: boolean;
 }) {
   return cn(
-    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-background px-2 text-[11px] font-normal leading-none",
+    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-white px-2 text-[11px] font-normal leading-none",
     muted ? "text-muted-foreground" : "text-foreground/70",
     interactive &&
-      "transition-colors hover:border-border hover:bg-gray-50 hover:text-foreground",
+      "transition-colors hover:border-border hover:text-foreground",
   );
 }
 


### PR DESCRIPTION
## What

On the workflows list (`WorkflowRow`), the trigger pill (e.g. the blue-dot **Schedule** pill) shared a `hover:bg-gray-50` interactive style with its card row. When the pill was hovered it turned the same gray as the row's `hover:bg-gray-50`, so the pill blended into the card instead of popping.

## Change

In `connectorPillClassName` (`turbo/apps/platform/src/views/workflows-page/workflows-page.tsx`):
- Fill changed from `bg-background` to explicit **`bg-white`**.
- Removed the pill's own `hover:bg-gray-50`; hover feedback is now border/text only (`hover:border-border hover:text-foreground`).

## User-visible impact

- Default: white pill on the white card, delineated by its border.
- On card hover: the card goes `bg-gray-50` and the solid-white pill now clearly stands out.

## Dark mode note

This surface is drawn with hardcoded light fills (the card hover `bg-gray-50`, avatars `bg-gray-50`/`bg-gray-100`) and has no `dark:` overrides, so a hardcoded `bg-white` pill is the consistent, matched pair — the theme-flipping `bg-background` would actually mismatch the hardcoded-gray hover. Border/text keep their theme tokens.

## Verification

Visual/CSS-only change. Prettier (CI version) run on the changed file; relying on the PR pipeline for lint/type/test gates.