### PR TITLE
style: remove border and background from automation row agent avatar

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -142,7 +142,7 @@ function AgentAvatar({ workflow }: { readonly workflow: ZeroWorkflowSummary }) {
     <AgentAvatarImg
       name={workflow.agentId}
       alt={`Runs as ${label}`}
-      className="h-6 w-6 shrink-0 rounded-md border border-border/60 bg-gray-50"
+      className="h-6 w-6 shrink-0 rounded-md"
       size={24}
     />
   );


### PR DESCRIPTION
## What

Removes the border ring and gray background from the agent avatar shown at the right of each row on the automations (workflows) page. The avatar image now renders directly with just its rounded-square shape.

## Why

The bordered, gray-filled backdrop around each avatar added visual noise to the row. Ming requested dropping both the outer border and the background color.

## Change

`turbo/apps/platform/src/views/workflows-page/workflows-page.tsx` — in the `AgentAvatar` component:

- Before: `className="h-6 w-6 shrink-0 rounded-md border border-border/60 bg-gray-50"`
- After: `className="h-6 w-6 shrink-0 rounded-md"`

Dropped `border border-border/60` and `bg-gray-50`; kept the `h-6 w-6` size and `rounded-md` shape.

## Verification

Formatting checked with `prettier@3.8.1`. Remaining checks rely on the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)