### PR TITLE
fix: make workflow list filters one mutually-exclusive pill group

### DIFF
--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -39,8 +39,12 @@ import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 
 type WorkflowDetailActionDialog = "copy" | "delete" | null;
 export type WorkflowDetailTab = "automations" | "instructions" | "info";
-export type WorkflowAutomationFilter = "all" | "automated" | "without";
-export type WorkflowVisibilityFilter = "all" | "private" | "public";
+export type WorkflowFilter =
+  | "all"
+  | "automated"
+  | "without"
+  | "private"
+  | "public";
 export type WorkflowSortMode = "next-run" | "alphabetical" | "created";
 export type WorkflowCopyDialogAgent = {
   readonly id: string;
@@ -204,8 +208,7 @@ export const workflowCopyDialogState$ = computed((get) => {
   return get(internalWorkflowCopyDialogState$);
 });
 
-const AUTOMATION_FILTER_PARAM = "automation";
-const VISIBILITY_FILTER_PARAM = "visibility";
+const FILTER_PARAM = "filter";
 const SORT_MODE_PARAM = "sort";
 
 function readSearchParam<T extends string>(
@@ -220,27 +223,14 @@ function readSearchParam<T extends string>(
     : fallback;
 }
 
-export const workflowAutomationFilter$ = computed(
-  (get): WorkflowAutomationFilter => {
-    return readSearchParam(
-      get(searchParams$),
-      AUTOMATION_FILTER_PARAM,
-      ["all", "automated", "without"],
-      "all",
-    );
-  },
-);
-
-export const workflowVisibilityFilter$ = computed(
-  (get): WorkflowVisibilityFilter => {
-    return readSearchParam(
-      get(searchParams$),
-      VISIBILITY_FILTER_PARAM,
-      ["all", "private", "public"],
-      "all",
-    );
-  },
-);
+export const workflowFilter$ = computed((get): WorkflowFilter => {
+  return readSearchParam(
+    get(searchParams$),
+    FILTER_PARAM,
+    ["all", "automated", "without", "private", "public"],
+    "all",
+  );
+});
 
 export const workflowSortMode$ = computed((get): WorkflowSortMode => {
   return readSearchParam(
@@ -266,30 +256,11 @@ function nextSearchParams(
   return params;
 }
 
-export const setWorkflowAutomationFilter$ = command(
-  ({ get, set }, value: WorkflowAutomationFilter) => {
+export const setWorkflowFilter$ = command(
+  ({ get, set }, value: WorkflowFilter) => {
     set(
       replaceSearchParams$,
-      nextSearchParams(
-        get(searchParams$),
-        AUTOMATION_FILTER_PARAM,
-        value,
-        "all",
-      ),
-    );
-  },
-);
-
-export const setWorkflowVisibilityFilter$ = command(
-  ({ get, set }, value: WorkflowVisibilityFilter) => {
-    set(
-      replaceSearchParams$,
-      nextSearchParams(
-        get(searchParams$),
-        VISIBILITY_FILTER_PARAM,
-        value,
-        "all",
-      ),
+      nextSearchParams(get(searchParams$), FILTER_PARAM, value, "all"),
     );
   },
 );

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -909,7 +909,7 @@ describe("workflows routes", () => {
     expect(screen.queryByText("Workflow not found.")).not.toBeInTheDocument();
   });
 
-  it("filters the workspace workflows by automation", async () => {
+  it("filters the workspace workflows by automation and visibility", async () => {
     context.mocks.data.userPreferences({ timezone: "UTC" });
     mockAgentPageApis();
     mockChatLifecycle(context);
@@ -949,7 +949,7 @@ describe("workflows routes", () => {
     // "Automated" keeps only workflows that have at least one automation.
     click(tabByName("Automated"));
     await waitFor(() => {
-      expect(search()).toBe("?automation=automated");
+      expect(search()).toBe("?filter=automated");
     });
     expect(linkByAriaLabel("Open Sales Research")).toBeInTheDocument();
     expect(screen.queryByText("Ops Playbook")).not.toBeInTheDocument();
@@ -959,11 +959,32 @@ describe("workflows routes", () => {
     // "Without automation" keeps only the manual workflows.
     click(tabByName("Without automation"));
     await waitFor(() => {
-      expect(search()).toBe("?automation=without");
+      expect(search()).toBe("?filter=without");
     });
     expect(screen.queryByText("Sales Research")).not.toBeInTheDocument();
     expect(linkByAriaLabel("Open Ops Playbook")).toBeInTheDocument();
     expect(linkByAriaLabel("Open Launch Checklist")).toBeInTheDocument();
+
+    // The pills are a single mutually-exclusive group: selecting "Private"
+    // replaces the automation selection rather than combining with it.
+    click(tabByName("Private"));
+    await waitFor(() => {
+      expect(search()).toBe("?filter=private");
+    });
+    expect(linkByAriaLabel("Open Ops Playbook")).toBeInTheDocument();
+    expect(linkByAriaLabel("Open Launch Checklist")).toBeInTheDocument();
+    expect(screen.queryByText("Sales Research")).not.toBeInTheDocument();
+    expect(screen.queryByText("Support Intake")).not.toBeInTheDocument();
+
+    // "Public" keeps only the public workflows.
+    click(tabByName("Public"));
+    await waitFor(() => {
+      expect(search()).toBe("?filter=public");
+    });
+    expect(linkByAriaLabel("Open Sales Research")).toBeInTheDocument();
+    expect(linkByAriaLabel("Open Support Intake")).toBeInTheDocument();
+    expect(screen.queryByText("Ops Playbook")).not.toBeInTheDocument();
+    expect(screen.queryByText("Launch Checklist")).not.toBeInTheDocument();
 
     // Clearing the filter returns to the full list.
     click(tabByName("All"));

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -37,16 +37,13 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import {
   allVisibleWorkflows$,
   allWorkflowTriggerEntries$,
-  setWorkflowAutomationFilter$,
+  setWorkflowFilter$,
   setWorkflowSortMode$,
-  setWorkflowVisibilityFilter$,
-  workflowAutomationFilter$,
+  workflowFilter$,
   workflowSortMode$,
-  workflowVisibilityFilter$,
-  type WorkflowAutomationFilter,
+  type WorkflowFilter,
   type WorkflowSortMode,
   type WorkflowTriggerAutomationEntry,
-  type WorkflowVisibilityFilter,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { AgentAvatarImg } from "../zero-page/zero-sidebar-shared.tsx";
@@ -368,22 +365,48 @@ function hasTriggers(
 function applyWorkflowFilters(
   workflows: readonly ZeroWorkflowSummary[],
   entriesByWorkflowId: WorkflowTriggerEntryMap,
-  automation: WorkflowAutomationFilter,
-  visibility: WorkflowVisibilityFilter,
+  filter: WorkflowFilter,
 ): readonly ZeroWorkflowSummary[] {
   return workflows.filter((workflow) => {
     const automated = hasTriggers(workflow.id, entriesByWorkflowId);
-    if (automation === "automated" && !automated) {
-      return false;
+    switch (filter) {
+      case "automated": {
+        return automated;
+      }
+      case "without": {
+        return !automated;
+      }
+      case "private": {
+        return workflow.visibility === "private";
+      }
+      case "public": {
+        return workflow.visibility === "public";
+      }
+      default: {
+        return true;
+      }
     }
-    if (automation === "without" && automated) {
-      return false;
-    }
-    if (visibility !== "all" && workflow.visibility !== visibility) {
-      return false;
-    }
-    return true;
   });
+}
+
+function emptyDescriptionForFilter(filter: WorkflowFilter): string {
+  switch (filter) {
+    case "without": {
+      return "Every workflow here runs on a schedule or event.";
+    }
+    case "automated": {
+      return "Add a schedule or trigger to a workflow and it shows up here.";
+    }
+    case "private": {
+      return "No private workflows yet.";
+    }
+    case "public": {
+      return "No public workflows yet.";
+    }
+    default: {
+      return "Create a workflow from chat or save one from a useful run.";
+    }
+  }
 }
 
 type NextRunBucket = "today" | "week" | "later" | "event" | "manual";
@@ -585,7 +608,6 @@ function FilterPills<T extends string>({
   value,
   options,
   onChange,
-  deselectValue,
 }: {
   readonly value: T;
   readonly options: readonly {
@@ -593,8 +615,6 @@ function FilterPills<T extends string>({
     readonly label: ReactNode;
   }[];
   readonly onChange: (value: T) => void;
-  /** When set, clicking the active pill toggles back to this value. */
-  readonly deselectValue?: T;
 }) {
   return (
     <>
@@ -605,11 +625,7 @@ function FilterPills<T extends string>({
             key={option.value}
             type="button"
             onClick={() => {
-              onChange(
-                active && deselectValue !== undefined
-                  ? deselectValue
-                  : option.value,
-              );
+              onChange(option.value);
             }}
             className={cn(
               "inline-flex h-7 shrink-0 cursor-pointer items-center rounded-md border border-border px-2.5 text-sm font-medium leading-none transition-colors",
@@ -699,34 +715,24 @@ function sortWorkflows(
 }
 
 function WorkflowFilterBar({
-  automation,
-  visibility,
+  filter,
   sortMode,
 }: {
-  readonly automation: WorkflowAutomationFilter;
-  readonly visibility: WorkflowVisibilityFilter;
+  readonly filter: WorkflowFilter;
   readonly sortMode: WorkflowSortMode;
 }) {
-  const setAutomation = useSet(setWorkflowAutomationFilter$);
-  const setVisibility = useSet(setWorkflowVisibilityFilter$);
+  const setFilter = useSet(setWorkflowFilter$);
   const setSortMode = useSet(setWorkflowSortMode$);
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <FilterPills
-        value={automation}
-        onChange={setAutomation}
+        value={filter}
+        onChange={setFilter}
         options={[
           { value: "all", label: "All" },
           { value: "automated", label: "Automated" },
           { value: "without", label: "Without automation" },
-        ]}
-      />
-      <FilterPills
-        value={visibility}
-        onChange={setVisibility}
-        deselectValue="all"
-        options={[
           { value: "private", label: "Private" },
           { value: "public", label: "Public" },
         ]}
@@ -739,8 +745,7 @@ function WorkflowFilterBar({
 }
 
 export function WorkflowsPage() {
-  const automation = useGet(workflowAutomationFilter$);
-  const visibility = useGet(workflowVisibilityFilter$);
+  const filter = useGet(workflowFilter$);
   const sortMode = useGet(workflowSortMode$);
   const workflowsLoadable = useLastLoadable(allVisibleWorkflows$);
   const triggerEntriesLoadable = useLastLoadable(allWorkflowTriggerEntries$);
@@ -761,12 +766,7 @@ export function WorkflowsPage() {
     new Intl.DateTimeFormat().resolvedOptions().timeZone;
   const filteredWorkflows = workflows
     ? sortWorkflows(
-        applyWorkflowFilters(
-          workflows,
-          triggerEntriesByWorkflowId,
-          automation,
-          visibility,
-        ),
+        applyWorkflowFilters(workflows, triggerEntriesByWorkflowId, filter),
         sortMode,
       )
     : null;
@@ -800,22 +800,12 @@ export function WorkflowsPage() {
 
       <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
         <div className="mx-auto flex max-w-[900px] flex-col gap-4">
-          <WorkflowFilterBar
-            automation={automation}
-            visibility={visibility}
-            sortMode={sortMode}
-          />
+          <WorkflowFilterBar filter={filter} sortMode={sortMode} />
           <WorkflowListPanel
             workflows={filteredWorkflows}
             loading={loading}
             sortMode={sortMode}
-            emptyDescription={
-              automation === "without"
-                ? "Every workflow here runs on a schedule or event."
-                : automation === "automated"
-                  ? "Add a schedule or trigger to a workflow and it shows up here."
-                  : "Create a workflow from chat or save one from a useful run."
-            }
+            emptyDescription={emptyDescriptionForFilter(filter)}
             triggerEntriesByWorkflowId={triggerEntriesByWorkflowId}
             displayTimezone={displayTimezone}
           />


### PR DESCRIPTION
## Problem

On the Workflows list, the filter pills (**All / Automated / Without automation / Private / Public**) look like one row but were implemented as **two independent filter axes**:

- **Automation** — `All / Automated / Without automation`, URL param `automation`
- **Visibility** — `Private / Public`, URL param `visibility`

Each axis had its own signal and search param, so contradictory combinations such as `?automation=automated&visibility=private` were allowed and could highlight two pills at once. There was no reason for a user to ever have "All" and "Private" active together — the pills are conceptually one single-select group.

## Change

Collapse the two axes into a single mutually-exclusive filter:

- Replace `WorkflowAutomationFilter` + `WorkflowVisibilityFilter` with one `WorkflowFilter = "all" | "automated" | "without" | "private" | "public"`.
- Merge the two URL params (`automation` + `visibility`) into a single `filter` param (`?filter=private`) — only one value can ever be set, so mutual exclusivity is structural and the two-param contradiction is gone.
- Render all five pills as one `FilterPills` group: selecting any pill replaces the current selection; `All` clears it.
- Update `applyWorkflowFilters` filtering logic and the empty-state copy to switch on the single filter.

## User-visible impact

Clicking a filter pill now always deselects the others. You can no longer end up with an automation filter and a visibility filter applied simultaneously (whether via clicks or a hand-crafted URL). Behavior of each individual filter is unchanged.

## Verification

- `check-types` ✅
- `oxlint` (platform package) — 0 errors ✅
- `prettier@3.8.1 --check` ✅
- `knip` — no new unused exports ✅
- `workflows-page.test.tsx` — 32 passed ✅, including a new assertion that selecting **Private** after **Without automation** produces `?filter=private` (replace, not combine) and lists only private workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)