### PR TITLE
Move chat emoji digit shortcuts to Ctrl+Shift

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -281,8 +281,9 @@ function createEmojiShortcutBindings({
     ...(Object.fromEntries(
       CHAT_THREAD_EMOJI_OPTIONS.map((option, index) => {
         return [
-          `shift+${index + 1}`,
+          `ctrl+shift+${index + 1}`,
           {
+            allowInEditableTarget: true,
             run: async () => {
               await setEmoji(option.emoji);
             },
@@ -290,7 +291,8 @@ function createEmojiShortcutBindings({
         ];
       }),
     ) as GlobalShortcutBindings),
-    "shift+0": {
+    "ctrl+shift+0": {
+      allowInEditableTarget: true,
       run: clearEmoji,
     },
   };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3761,7 +3761,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("adds an emoji to the focused side chat directly with Shift+1", async () => {
+  it("adds an emoji to the focused side chat directly with Ctrl+Shift+1", async () => {
     const renameRequest = vi.fn();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
@@ -3796,6 +3796,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(sideThreadRegion, {
       key: "!",
       code: "Digit1",
+      ctrlKey: true,
       shiftKey: true,
     });
 
@@ -3842,10 +3843,11 @@ describe("chat lifecycle", () => {
     expect(queryAllByRoleFast("menuitem", menu)).toHaveLength(10);
     expect(within(menu).queryByText("Done")).not.toBeInTheDocument();
     expect(within(menu).getByText("Clear icon")).toBeInTheDocument();
+    expect(within(menu).getAllByText("Ctrl").length).toBeGreaterThan(0);
     expect(within(menu).getAllByText("Shift").length).toBeGreaterThan(0);
     expect(within(menu).getByText("1")).toBeInTheDocument();
     expect(within(menu).getByText("0")).toBeInTheDocument();
-    click(menuItemByLabel("Done icon Shift 1", menu));
+    click(menuItemByLabel("Done icon Ctrl Shift 1", menu));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -3855,7 +3857,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("adds an emoji to the current chat directly with Shift+1", async () => {
+  it("adds an emoji to the current chat directly with Ctrl+Shift+1", async () => {
     const renameRequest = vi.fn();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
@@ -3884,6 +3886,49 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(threadRegion, {
       key: "!",
       code: "Digit1",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        "keyboard-current-thread",
+        "✅ Current keyboard thread",
+      );
+    });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("adds an emoji to the current chat directly from the composer with Ctrl+Shift+1", async () => {
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads({ currentDetailTitle: null });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/keyboard-current-thread",
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+    });
+
+    const composer = chatComposerTextarea();
+    composer.focus();
+    fireEvent.keyDown(composer, {
+      key: "!",
+      code: "Digit1",
+      ctrlKey: true,
       shiftKey: true,
     });
 
@@ -4022,7 +4067,7 @@ describe("chat lifecycle", () => {
       }),
     ).toBeFalsy();
     const doneItem = queryAllByRoleFast("menuitem", menu).find((item) => {
-      return item.getAttribute("aria-label") === "Done icon Shift 1";
+      return item.getAttribute("aria-label") === "Done icon Ctrl Shift 1";
     });
     if (!doneItem) {
       throw new Error("Done icon menu item not found");
@@ -4037,7 +4082,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("clears the current chat emoji directly with Shift+0", async () => {
+  it("clears the current chat emoji directly with Ctrl+Shift+0", async () => {
     const renameRequest = vi.fn();
     mockResizeObserver();
     mockKeyboardNavigationThreads({
@@ -4066,6 +4111,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(threadRegion, {
       key: ")",
       code: "Digit0",
+      ctrlKey: true,
       shiftKey: true,
     });
 
@@ -4104,6 +4150,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(threadRegion, {
       key: ")",
       code: "Digit0",
+      ctrlKey: true,
       shiftKey: true,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -356,8 +356,8 @@ const CHAT_SHORTCUT_SECTIONS = [
       { key: "mod+shift+a", label: "Open agent list" },
       { key: "f2", label: "Rename chat" },
       { key: "shift+f2", label: "Change icon" },
-      { key: "shift+1", label: "Set icon (shift+1-9)" },
-      { key: "shift+0", label: "Clear icon" },
+      { key: "ctrl+shift+1", label: "Set icon (Ctrl+Shift+1-9)" },
+      { key: "ctrl+shift+0", label: "Clear icon" },
     ],
   },
   {
@@ -379,7 +379,7 @@ const CHAT_SHORTCUT_SECTIONS = [
 ] as const;
 
 function isChatThreadEmojiShortcutKey(key: string): boolean {
-  return key === "shift+f2" || key === "shift+1" || key === "shift+0";
+  return key === "shift+f2" || key === "ctrl+shift+1" || key === "ctrl+shift+0";
 }
 
 function ArtifactsButton({ thread }: { thread: ChatThreadSignals }) {
@@ -1275,11 +1275,11 @@ function ChatThreadEmojiMenuButton({
           }}
         >
           {CHAT_THREAD_EMOJI_OPTIONS.map((option, index) => {
-            const shortcut = `shift+${index + 1}`;
+            const shortcut = `ctrl+shift+${index + 1}`;
             return (
               <UiDropdownMenuItem
                 key={option.emoji}
-                aria-label={`${option.label} icon Shift ${index + 1}`}
+                aria-label={`${option.label} icon Ctrl Shift ${index + 1}`}
                 className="justify-between gap-4"
                 onSelect={() => {
                   selectEmoji(option.emoji);
@@ -1294,14 +1294,14 @@ function ChatThreadEmojiMenuButton({
           })}
           <UiDropdownMenuSeparator />
           <UiDropdownMenuItem
-            aria-label="Clear icon Shift 0"
+            aria-label="Clear icon Ctrl Shift 0"
             className="justify-between gap-4"
             onSelect={() => {
               clearEmoji();
             }}
           >
             <span className="whitespace-nowrap">Clear icon</span>
-            <ChatThreadIconShortcutHint shortcut="shift+0" />
+            <ChatThreadIconShortcutHint shortcut="ctrl+shift+0" />
           </UiDropdownMenuItem>
         </UiDropdownMenuContent>
       </UiDropdownMenu>

--- a/turbo/packages/ui/src/lib/__tests__/keyboard-shortcuts.test.ts
+++ b/turbo/packages/ui/src/lib/__tests__/keyboard-shortcuts.test.ts
@@ -79,6 +79,29 @@ describe("matchShortcut", () => {
     ).toBe(false);
   });
 
+  it("should match ctrl+shift+digit with the physical digit code", () => {
+    expect(
+      matchShortcut(
+        "ctrl+shift+1",
+        createEvent({
+          key: "!",
+          code: "Digit1",
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("should not match ctrl+shift+digit without ctrl", () => {
+    expect(
+      matchShortcut(
+        "ctrl+shift+1",
+        createEvent({ key: "!", code: "Digit1", shiftKey: true }),
+      ),
+    ).toBe(false);
+  });
+
   it("should match space key", () => {
     expect(matchShortcut(" ", createEvent({ key: " " }))).toBe(true);
   });

--- a/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
+++ b/turbo/packages/ui/src/lib/keyboard-shortcuts.ts
@@ -3,10 +3,11 @@
  *
  * Shortcut strings use `+` as separator with these modifiers:
  * - `mod` — Command on Mac, Ctrl on Windows/Linux
+ * - `ctrl` — Control key on every platform
  * - `shift` — Shift key
  * - `alt` — Option on Mac, Alt on Windows/Linux
  *
- * Examples: `"mod+b"`, `"mod+shift+enter"`, `"j"`, `"escape"`
+ * Examples: `"mod+b"`, `"ctrl+shift+1"`, `"j"`, `"escape"`
  */
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,7 @@ export interface KeyboardEventLike {
 
 interface ParsedShortcut {
   mod: boolean;
+  ctrl: boolean;
   shift: boolean;
   alt: boolean;
   key: string;
@@ -51,6 +53,7 @@ const isMac =
 function parseShortcut(shortcut: string): ParsedShortcut {
   const parts = shortcut.toLowerCase().split("+");
   let mod = false;
+  let ctrl = false;
   let shift = false;
   let alt = false;
   let key = "";
@@ -59,6 +62,10 @@ function parseShortcut(shortcut: string): ParsedShortcut {
     switch (part) {
       case "mod": {
         mod = true;
+        break;
+      }
+      case "ctrl": {
+        ctrl = true;
         break;
       }
       case "shift": {
@@ -82,7 +89,7 @@ function parseShortcut(shortcut: string): ParsedShortcut {
     key = "?";
   }
 
-  return { mod, shift, alt, key };
+  return { mod, ctrl, shift, alt, key };
 }
 
 const SHIFTED_DIGIT_KEYS: Record<string, string> = {
@@ -128,14 +135,14 @@ function matchesShortcutKey(parsed: ParsedShortcut, e: KeyboardEventLike) {
 
 export function matchShortcut(shortcut: string, e: KeyboardEventLike): boolean {
   const parsed = parseShortcut(shortcut);
-  const modPressed = isMac ? e.metaKey : e.ctrlKey;
-  const extraMod = isMac ? e.ctrlKey : e.metaKey;
+  const expectedMetaKey = parsed.mod && isMac;
+  const expectedCtrlKey = parsed.ctrl || (parsed.mod && !isMac);
 
   return (
-    modPressed === parsed.mod &&
+    e.metaKey === expectedMetaKey &&
+    e.ctrlKey === expectedCtrlKey &&
     e.shiftKey === parsed.shift &&
     e.altKey === parsed.alt &&
-    !extraMod &&
     matchesShortcutKey(parsed, e)
   );
 }
@@ -215,6 +222,9 @@ export function getShortcutLabel(shortcut: string): string {
     if (parsed.mod) {
       parts.push("⌘");
     }
+    if (parsed.ctrl) {
+      parts.push("⌃");
+    }
     if (parsed.shift) {
       parts.push("⇧");
     }
@@ -227,6 +237,9 @@ export function getShortcutLabel(shortcut: string): string {
 
   const parts: string[] = [];
   if (parsed.mod) {
+    parts.push("Ctrl");
+  }
+  if (parsed.ctrl) {
     parts.push("Ctrl");
   }
   if (parsed.shift) {


### PR DESCRIPTION
## Summary
- Change chat thread emoji digit shortcuts from Shift+1-9/0 to Ctrl+Shift+1-9/0.
- Allow the new Ctrl+Shift digit shortcuts to fire while the composer or another editable target is focused.
- Add explicit ctrl shortcut matching support and update shortcut help/menu hints.

## Verification
- pnpm exec prettier --write --ignore-unknown apps/platform/src/signals/chat-page/chat-keyboard.ts apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx packages/ui/src/lib/keyboard-shortcuts.ts packages/ui/src/lib/__tests__/keyboard-shortcuts.test.ts
- pnpm exec vitest run packages/ui/src/lib/__tests__/keyboard-shortcuts.test.ts
- pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "emoji|shifted digit"
- pnpm turbo run lint --filter=@vm0/ui --filter=@vm0/app --log-order grouped
- pnpm turbo run check-types --filter=@vm0/ui --filter=@vm0/app --log-order grouped

Dev server was not started per vm0 PR verification preference.
