### PR TITLE
feat: signal the workflow trigger pill is clickable

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -118,7 +118,7 @@ function connectorPillClassName({
     "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-white px-2 text-[11px] font-normal leading-none",
     muted ? "text-muted-foreground" : "text-foreground/70",
     interactive &&
-      "transition-colors hover:border-border hover:text-foreground",
+      "cursor-pointer transition-colors hover:border-border hover:bg-gray-50 hover:text-foreground",
   );
 }
 
@@ -246,20 +246,27 @@ function ConnectorCell({
   const remaining = entries.length - 2;
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className={connectorPillClassName({ interactive: true })}
-        >
-          {lead ? (
-            <ConnectorPillMarker dotClassName={triggerDotClass(lead)} />
-          ) : null}
-          <span>{connectorNames(entries)}</span>
-          {remaining > 0 ? (
-            <span className="text-muted-foreground">+{remaining}</span>
-          ) : null}
-        </button>
-      </PopoverTrigger>
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className={connectorPillClassName({ interactive: true })}
+              >
+                {lead ? (
+                  <ConnectorPillMarker dotClassName={triggerDotClass(lead)} />
+                ) : null}
+                <span>{connectorNames(entries)}</span>
+                {remaining > 0 ? (
+                  <span className="text-muted-foreground">+{remaining}</span>
+                ) : null}
+              </button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">View automations</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <PopoverContent align="end" className="w-80 p-1">
         <ConnectorPopoverList
           entries={entries}


### PR DESCRIPTION
## What & why

On the workflows list, the trigger pill (e.g. the "Webhook" pill next to the lock icon and agent avatar) opens a popover listing that workflow's automations, but it didn't *look* interactive: hovering only nudged the border/text color and the cursor stayed as the default arrow, so users couldn't tell it was clickable/selectable.

This adds two affordances to the interactive pill (`ConnectorCell`):

1. **Pointer cursor + stronger hover** — the interactive variant of `connectorPillClassName` now includes `cursor-pointer` and a `hover:bg-gray-50` fill on top of the existing border/text transition, so the pointer cursor "漏出" and the hover state reads clearly.
2. **Tooltip** — the pill is wrapped in the existing `@vm0/ui` Tooltip and shows **"View automations"** on hover (200ms delay), hinting that clicking expands the automations list. Tooltip and popover coexist via nested Radix `asChild` triggers, so the click-to-open behavior is unchanged.

Scope: only the interactive pill (workflows that have automations) gets the cursor/tooltip. The non-interactive **Manual** state is left untouched so it doesn't falsely signal interactivity.

## Verification

- `prettier@3.8.1 --check` (the `lint-format` CI gate) passes on the changed file.
- Remaining lint/type/test gates rely on the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)