### PR TITLE
style: remove outer border on automation list row icons

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -310,7 +310,7 @@ function WorkflowRowIcon({
     return <TriggerListIcon trigger={lead.trigger} size="sm" />;
   }
   return (
-    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-gray-100 text-muted-foreground">
+    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-muted-foreground">
       <IconRoute size={16} stroke={1.7} />
     </span>
   );

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -283,7 +283,7 @@ export function TriggerListIcon({
   return (
     <span
       className={cn(
-        "flex shrink-0 items-center justify-center border border-border/60",
+        "flex shrink-0 items-center justify-center",
         compact ? "h-8 w-8 rounded-lg" : "h-11 w-11 rounded-xl",
         tone,
       )}


### PR DESCRIPTION
## What

Removes the thin outer rectangle border (`border border-border/60`) around the small icon badges in the automations/workflows list rows, keeping the colored rounded-square fill.

Requested by Ming: remove the border around these small icons.

## Changes

- `TriggerListIcon` (shared badge for schedule/event triggers — blue calendar/repeat, amber link, emerald mail): drop `border border-border/60`.
- `WorkflowRowIcon` manual fallback (gray route icon): drop `border border-border/60`, keep `bg-gray-100`.

## User-visible impact

The colored icon chips in the automations list ("Runs today" / "On event" / "Manual" groups) now render as a clean filled rounded square with no surrounding hairline border.

## Verification

- Prettier (3.8.1) `--check`: clean
- package-local `oxlint` on both files: no diagnostics