### PR TITLE
fix: align automation row title underline with standard tooltip style

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -338,7 +338,7 @@ function WorkflowRow({
               className="flex min-w-0 flex-1 items-center gap-3 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
             >
               <WorkflowRowIcon entries={entries} />
-              <span className="min-w-0 truncate text-sm font-medium underline decoration-muted-foreground/40 decoration-dashed underline-offset-4">
+              <span className="min-w-0 truncate text-sm font-medium underline decoration-dotted decoration-foreground/40 decoration-[1px] underline-offset-2">
                 {title}
               </span>
             </Link>


### PR DESCRIPTION
## Problem

The automation row title on the workflows/automations page (e.g. "Course Inbound Poller" under **Runs today**) rendered its hover-tooltip underline with a **dashed** style, which was visually inconsistent with every other tooltip-title underline in the platform (agents page, network insights, usage insight tables, etc.). Those all use a **dotted** underline.

## Fix

Updated the single title `<span>` in `workflows-page.tsx` to match the shared standard pattern used everywhere else:

`underline decoration-dotted decoration-foreground/40 decoration-[1px] underline-offset-2`

Concrete changes on that one line:
- `decoration-dashed` → `decoration-dotted`
- `decoration-muted-foreground/40` → `decoration-foreground/40` (color)
- added `decoration-[1px]` (line thickness)
- `underline-offset-4` → `underline-offset-2` (offset)

`min-w-0 truncate text-sm font-medium` are unchanged (layout-critical).

## User-visible impact

The automation row title underline now matches all other hover-tooltip titles across the app — no more one-off dashed underline.

## Verification

- Confirmed the target pattern against the sibling components (`agents-page-tabs.tsx`, `network-insights-page.tsx`, `usage-insight-*-table.tsx`).
- Ran `prettier@3.8.1 --check` on the changed file — passes.
- Relying on the PR pipeline for lint/type/test gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)