### PR TITLE
fix: add tooltips and visible hover to workflow automation row actions

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -65,6 +65,10 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from "@vm0/ui";
 
 import { agents$ } from "../../signals/agent.ts";
@@ -4371,102 +4375,139 @@ function TriggerControls({
   const navigate = useSet(detachedNavigateTo$);
   const setEditingTriggerId = useSet(setEditingWorkflowTriggerId$);
   const setEditingScheduleCronFields = useSet(setEditingScheduleCronFields$);
-  const [deleteLoadable, deleteTrigger] = useLoadableSet(
-    deleteWorkflowTrigger$,
-  );
   const [runNowLoadable, runNow] = useLoadableSet(runWorkflowTriggerNow$);
-  const busy =
-    deleteLoadable.state === "loading" || runNowLoadable.state === "loading";
-  const running = runNowLoadable.state === "loading";
+  const busy = runNowLoadable.state === "loading";
+  const running = busy;
   const canEdit = canEditWorkflowTrigger(trigger);
 
   return (
-    <div className="flex min-w-0 items-center justify-end">
-      <div className="flex items-center justify-end gap-1 opacity-100 transition-opacity pointer-events-auto [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:pointer-events-auto [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-focus-within:pointer-events-auto [@media(hover:hover)]:group-focus-within:opacity-100">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          disabled={busy}
-          aria-label="Run now"
-          className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-50 hover:text-foreground"
-          onClick={() => {
-            detach(
-              (async () => {
-                const result = await runNow(trigger.id, pageSignal);
-                navigate(ROUTES.chat, {
-                  pathParams: { threadId: result.chatThreadId },
-                });
-              })(),
-              Reason.DomCallback,
-              "run workflow trigger now",
-            );
-          }}
-        >
-          {running ? (
-            <IconLoader2 size={14} className="animate-spin" />
-          ) : (
-            <IconPlayerPlay size={14} stroke={1.5} />
-          )}
-        </Button>
-        {canEdit ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            disabled={busy}
-            aria-label="Edit automation"
-            className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-50 hover:text-foreground"
-            onClick={() => {
-              if (
-                trigger.kind === "schedule" &&
-                trigger.schedule.type === "cron"
-              ) {
-                setEditingScheduleCronFields(
-                  parseWorkflowCronFields(trigger.schedule, displayTimezone),
-                );
-              }
-              setEditingTriggerId(trigger.id);
-            }}
-          >
-            <IconPencil size={14} stroke={1.5} />
-          </Button>
-        ) : null}
-        <DropdownMenu>
+    <div className="flex min-w-0 items-center justify-end pr-1.5">
+      <TooltipProvider delayDuration={200}>
+        <div className="flex items-center justify-end gap-1 opacity-100 transition-opacity pointer-events-auto [@media(hover:hover)]:pointer-events-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:pointer-events-auto [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-focus-within:pointer-events-auto [@media(hover:hover)]:group-focus-within:opacity-100">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={busy}
+                aria-label="Run now"
+                className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-200 hover:text-foreground"
+                onClick={() => {
+                  detach(
+                    (async () => {
+                      const result = await runNow(trigger.id, pageSignal);
+                      navigate(ROUTES.chat, {
+                        pathParams: { threadId: result.chatThreadId },
+                      });
+                    })(),
+                    Reason.DomCallback,
+                    "run workflow trigger now",
+                  );
+                }}
+              >
+                {running ? (
+                  <IconLoader2 size={14} className="animate-spin" />
+                ) : (
+                  <IconPlayerPlay size={14} stroke={1.5} />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="text-xs">Run now</p>
+            </TooltipContent>
+          </Tooltip>
+          {canEdit ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  disabled={busy}
+                  aria-label="Edit automation"
+                  className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-200 hover:text-foreground"
+                  onClick={() => {
+                    if (
+                      trigger.kind === "schedule" &&
+                      trigger.schedule.type === "cron"
+                    ) {
+                      setEditingScheduleCronFields(
+                        parseWorkflowCronFields(
+                          trigger.schedule,
+                          displayTimezone,
+                        ),
+                      );
+                    }
+                    setEditingTriggerId(trigger.id);
+                  }}
+                >
+                  <IconPencil size={14} stroke={1.5} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="text-xs">Edit automation</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+          <TriggerMoreActionsMenu trigger={trigger} disabled={busy} />
+        </div>
+      </TooltipProvider>
+    </div>
+  );
+}
+
+function TriggerMoreActionsMenu({
+  trigger,
+  disabled,
+}: {
+  readonly trigger: ZeroWorkflowTriggerSummary;
+  readonly disabled: boolean;
+}) {
+  const pageSignal = useGet(pageSignal$);
+  const [deleteLoadable, deleteTrigger] = useLoadableSet(
+    deleteWorkflowTrigger$,
+  );
+  const deleting = deleteLoadable.state === "loading";
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              disabled={busy}
+              disabled={disabled || deleting}
               aria-label="More actions"
-              className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-50 hover:text-foreground data-[state=open]:bg-gray-50 data-[state=open]:text-foreground"
+              className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:bg-gray-200 hover:text-foreground data-[state=open]:bg-gray-200 data-[state=open]:text-foreground"
             >
               <IconDotsVertical size={14} stroke={1.5} />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-44">
-            <DropdownMenuItem
-              disabled={deleteLoadable.state === "loading"}
-              className="gap-2 text-destructive focus:text-destructive"
-              onClick={() => {
-                detach(
-                  deleteTrigger(trigger.id, pageSignal),
-                  Reason.DomCallback,
-                );
-              }}
-            >
-              {deleteLoadable.state === "loading" ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : (
-                <IconTrash size={14} stroke={1.5} />
-              )}
-              Delete automation
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="text-xs">More actions</p>
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem
+          disabled={deleting}
+          className="gap-2 text-destructive focus:text-destructive"
+          onClick={() => {
+            detach(deleteTrigger(trigger.id, pageSignal), Reason.DomCallback);
+          }}
+        >
+          {deleting ? (
+            <IconLoader2 size={14} className="animate-spin" />
+          ) : (
+            <IconTrash size={14} stroke={1.5} />
+          )}
+          Delete automation
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 


### PR DESCRIPTION
## What & why

On the workflow detail page (`WorkflowTriggerAutomationsPage`), the per-automation action buttons (▶ Run now / ✏️ Edit / ⋮ More) had two UX problems flagged in review:

1. **Flush to the edge (怼到头)** — the button cluster butted right up against the card's right edge with no breathing room.
2. **No visible hover state** — each button's hover used `hover:bg-gray-50`, which is *the same color* the row itself turns on hover (`hover:bg-gray-50`). Once the row was hovered, the individual button hover was invisible.
3. **No tooltips** — buttons only carried `aria-label`, so their purpose wasn't discoverable on hover.

## Changes

All in `turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx`:

- **Spacing:** added `pr-1.5` to the action-button cluster so it's no longer flush to the card edge.
- **Hover contrast:** bumped button hover to `hover:bg-gray-200` (and `data-[state=open]:bg-gray-200` on the ⋮ trigger) so a hovered button stands out clearly against the row's `gray-50` hover background.
- **Tooltips:** wrapped **Run now**, **Edit automation**, and **More actions** in `Tooltip` from `@vm0/ui`, matching the sidebar idiom (`TooltipProvider delayDuration={200}`).
- **Refactor:** extracted the ⋮ delete menu into a small `TriggerMoreActionsMenu` component. The added tooltip markup pushed `TriggerControls` past the platform's `max-lines-per-function: 128` lint gate; the split keeps it clean and scopes the delete state to the menu.

## User-visible impact

Hovering an automation row now shows clearly-highlighted action buttons with descriptive tooltips, and the cluster sits inset from the card edge instead of crammed against it.

## Behavior note

The Run/Edit buttons no longer disable *while a delete is in flight* (delete state now lives in the extracted menu, which still disables its own trigger during delete). This is a negligible edge since the row is being removed on delete anyway.

## Verification

- `prettier@3.8.1 --check` ✅
- package-local `oxlint@1.57.0` ✅ (0 warnings, 0 errors)

Relying on the PR pipeline for full lint/type/test per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)