### PR TITLE
fix: unify typography and simplify trigger icon in workflow automations list

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -4191,6 +4191,8 @@ function TriggerRow({
   const editing = editingTriggerId === trigger.id;
   const title = workflowScheduleTitle(trigger, displayTimezone);
   const subtitle = workflowTriggerSubtitle(trigger);
+  const hasLastRun = hasValidRunTimestamp(trigger.lastRunAt);
+  const hasNextRun = hasValidRunTimestamp(trigger.nextRunAt);
 
   return (
     <>
@@ -4203,13 +4205,13 @@ function TriggerRow({
       >
         <div className="flex min-w-0 items-center gap-3">
           <span
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-gray-50 text-muted-foreground group-hover:bg-background"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-50 text-muted-foreground group-hover:bg-background"
             aria-hidden="true"
           >
             <IconRepeat size={15} stroke={1.5} />
           </span>
           <div className="min-w-0">
-            <div className="truncate text-sm font-semibold text-foreground">
+            <div className="truncate text-sm font-medium text-foreground">
               {title}
             </div>
             {subtitle ? (
@@ -4232,7 +4234,14 @@ function TriggerRow({
             className="shrink-0 text-muted-foreground"
           />
           <span className="shrink-0 text-sm text-muted-foreground">Last</span>
-          <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          <span
+            className={cn(
+              "min-w-0 truncate text-sm",
+              hasLastRun
+                ? "font-medium text-foreground"
+                : "text-muted-foreground",
+            )}
+          >
             {formatWorkflowTriggerRun(trigger.lastRunAt, displayTimezone)}
           </span>
         </div>
@@ -4249,7 +4258,14 @@ function TriggerRow({
             className="shrink-0 text-muted-foreground"
           />
           <span className="shrink-0 text-sm text-muted-foreground">Next</span>
-          <span className="min-w-0 truncate text-sm font-medium text-foreground">
+          <span
+            className={cn(
+              "min-w-0 truncate text-sm",
+              hasNextRun
+                ? "font-medium text-foreground"
+                : "text-muted-foreground",
+            )}
+          >
             {formatWorkflowTriggerNextRun(trigger.nextRunAt, displayTimezone)}
           </span>
         </div>
@@ -4294,6 +4310,14 @@ function workflowTriggerSubtitle(
     return trigger.webhookUrl;
   }
   return triggerKindLabel(trigger);
+}
+
+function hasValidRunTimestamp(value: string | null): boolean {
+  if (!value) {
+    return false;
+  }
+
+  return !Number.isNaN(new Date(value).getTime());
 }
 
 function formatWorkflowTriggerRun(


### PR DESCRIPTION
## What & why

The automations list on the workflow detail page (`TriggerRow`) mixed too many font-weight × color combinations within a single row, so empty states looked as prominent as real data. This flattens it into a clear two-tier hierarchy.

### User-visible changes
- **Trigger title**: `font-semibold` (600) → `font-medium` (500), so the title shares the same weight as the run-timestamp values instead of adding a third weight to the row.
- **Empty states**: `No runs yet` / `No upcoming run` now render in `muted-foreground` at normal weight instead of `font-medium text-foreground`. Previously they were as dark/heavy as a real timestamp and read like actual data; now they clearly read as "no data".
- **Real timestamps** keep the emphasis treatment (`font-medium text-foreground`).
- **Trigger icon chip**: removed the `border border-border/60` from the repeat-icon square for a cleaner row (keeps the rounded gray fill and hover background).

### Implementation
- Added a small `hasValidRunTimestamp(value)` helper; the Last/Next value styling is now conditional on whether the trigger actually has a valid `lastRunAt` / `nextRunAt`.

Net result: each row collapses from three foreground weights (600 / 500 / normal) to a two-level system — **emphasis** (medium + foreground) for title and real values, **muted** (normal + muted-foreground) for labels, subtitle and empty states.

## Verification
- Prettier 3.8.1 (CI version): clean
- oxlint (platform package-local config, pinned 1.57.0): 0 warnings / 0 errors
- Visual-only change; relying on the PR pipeline for lint/type/test gates.