### PR TITLE
fix(core): update schoolhouse and sticker scrapbook runbook archives

### DIFF
--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -215,9 +215,9 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "template:html-ppt-prospectus-runbook":
     "69e3c21d3ff27ebdd5ee6079e2809e9f7e7a0a1d6ba673349d957a961798f36b",
   "template:html-ppt-schoolhouse-runbook":
-    "ce36ff2a8290306c809e067622543e1c77334ca8958bc8a984d6b195ae1269d0",
+    "a34ed3483769cc2825656849385b86f23c50e5500d8ab20e7a705019949e49a5",
   "template:html-ppt-sticker-scrapbook-runbook":
-    "1d774755a5eb66e81e58e2f47a47793640c34ecb74a4254316c5f5e5538c1594",
+    "3b8eae68d6ff1dbb90396b0e929e9adc88dcb8c1850a6e7dbf13b650beb279bc",
   "template:html-ppt-strata-runbook":
     "480717095fda024858014262a77e95344cf2f2f319603eb3f295662bc3ec43cc",
   "template:html-ppt-taped-consulting-runbook":

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -4399,9 +4399,9 @@ const PRESENTATION_RUNBOOK_ARCHIVE_SHA256: Record<string, string> = {
   prospectus:
     "8e9595845cc76df222e822bcde82ed665024a533c641882efd6d0de3ed63dd54",
   schoolhouse:
-    "64eb8efe553f51e42c9e0ce944486f7c354e528b0ee3fec48dd7e6589a3d7578",
+    "9bd19af256dfb6f17073ec9af52ed0163a5f432a3d143eb82f1fa67aaf8b015e",
   "sticker-scrapbook":
-    "ddf9441bbdb2fef740a75668316d32e190be502bf13c050361d407c86d6196a2",
+    "d02ce61703c4b0000e0e03f568356a7d2e0ed43a7f2e37430a4afebb4280baa6",
   strata: "72c73b34abe7da4230048d6d532e5e1ee5dfb7f9d4895ed90ec412b7ff50ceeb",
   "taped-consulting":
     "21801079a05d1e47bbf3342e8dbfa2245f00abaf31de29484efbdecd3eba4e99",

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -4365,7 +4365,8 @@ export interface PresentationRunbookPackage {
   readonly source: ResourceSourceRef;
 }
 
-// Archive digests for uploaded private R2 presentation runbook packages.
+// Archive digests for uploaded private R2 presentation runbook packages. Keep
+// these in sync with the private R2 version ids served by the API download route.
 const PRESENTATION_RUNBOOK_ARCHIVE_SHA256: Record<string, string> = {
   "playful-launch":
     "c0d5ee9d37a45550865517aff796dae245cce4a63dfc5e1068423a1c918bb43c",


### PR DESCRIPTION
## Summary
- Uploaded refreshed `schoolhouse` and `sticker-scrapbook` presentation runbook packages from the provided Google Drive folder to the private registry-resource volumes in R2.
- Updated the private runbook archive version IDs used by `registry-resources/download`.
- Updated the `presentationTemplateRunbook` archive sha256 values so `zero resource pull` verifies the new archive bytes.
- Kept the PR title and a follow-up `fix(core)` commit releasable so release-please creates a core release; the existing workspace dependency release flow then bumps/publishes the CLI package with the refreshed bundled registry metadata.

## Uploaded archives
- `template:html-ppt-schoolhouse-runbook`: version `a34ed3483769cc2825656849385b86f23c50e5500d8ab20e7a705019949e49a5`, sha256 `9bd19af256dfb6f17073ec9af52ed0163a5f432a3d143eb82f1fa67aaf8b015e`
- `template:html-ppt-sticker-scrapbook-runbook`: version `3b8eae68d6ff1dbb90396b0e929e9adc88dcb8c1850a6e7dbf13b650beb279bc`, sha256 `d02ce61703c4b0000e0e03f568356a7d2e0ed43a7f2e37430a4afebb4280baa6`

## Verification
- Downloaded both new R2 archives through `/api/storages/download` and verified their sha256 digests match the source constants.
- `tar -tzf` confirmed both archives extract under the expected top-level slug and contain 35 files each.
- `git diff --check`
- `npx -p prettier@3.8.1 prettier --check turbo/apps/api/src/signals/routes/registry-resources-download.ts turbo/packages/core/src/resource-registry.ts`