### PR TITLE
Fix image preview navigation across grouped generated messages

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-image-navigation.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-image-navigation.test.ts
@@ -1,0 +1,89 @@
+import type {
+  ChatThreadArtifactFile,
+  ChatThreadArtifactRun,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { describe, expect, it } from "vitest";
+import { parseBodyRenderBlocks } from "../../../signals/chat-page/parse-body-blocks.ts";
+import { currentMessageImageArtifactNavigation } from "../zero-artifact-image-navigation.ts";
+
+type MessageFixture = Parameters<
+  typeof currentMessageImageArtifactNavigation
+>[1][number];
+
+function artifactFile(
+  url: string,
+  overrides: Partial<ChatThreadArtifactFile> = {},
+): ChatThreadArtifactFile {
+  return {
+    id: "artifact-image",
+    filename: "image.png",
+    contentType: "image/png",
+    size: 1024,
+    url,
+    createdAt: "2026-03-10T00:00:01Z",
+    googleDriveSync: { status: "not_synced" },
+    ...overrides,
+  };
+}
+
+function assistantMessage({
+  content,
+  runId,
+}: {
+  content: string;
+  runId: string;
+}): MessageFixture {
+  return {
+    role: "assistant",
+    runId,
+    blocks: parseBodyRenderBlocks(content, { previews: true }).blocks,
+  };
+}
+
+describe("currentMessageImageArtifactNavigation", () => {
+  it("navigates assistant images split across messages in the same run", () => {
+    const firstImageUrl =
+      "https://cdn.vm7.io/artifacts/test/body-image-split-navigation/first.png";
+    const secondImageUrl =
+      "https://cdn.vm7.io/artifacts/test/body-image-split-navigation/second.png";
+    const runId = "run-body-image-split-navigation";
+    const runs: ChatThreadArtifactRun[] = [
+      {
+        runId,
+        files: [
+          artifactFile(firstImageUrl, {
+            id: "artifact-body-split-first-image",
+            filename: "first.png",
+          }),
+          artifactFile(secondImageUrl, {
+            id: "artifact-body-split-second-image",
+            filename: "second.png",
+          }),
+        ],
+      },
+    ];
+    const messages: MessageFixture[] = [
+      assistantMessage({ content: "Generated images:", runId }),
+      assistantMessage({
+        content: `1. ![first.png](${firstImageUrl})`,
+        runId,
+      }),
+      assistantMessage({
+        content: `2. ![second.png](${secondImageUrl})`,
+        runId,
+      }),
+    ];
+
+    const navigation = currentMessageImageArtifactNavigation(
+      runs,
+      messages,
+      firstImageUrl,
+    );
+
+    expect(navigation.previous).toBeUndefined();
+    expect(navigation.next).toMatchObject({
+      url: secondImageUrl,
+      filename: "second.png",
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-image-navigation.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-image-navigation.test.ts
@@ -8,7 +8,7 @@ import { currentMessageImageArtifactNavigation } from "../zero-artifact-image-na
 
 type MessageFixture = Parameters<
   typeof currentMessageImageArtifactNavigation
->[1][number];
+>[1][number]["messages"][number];
 
 function artifactFile(
   url: string,
@@ -26,22 +26,14 @@ function artifactFile(
   };
 }
 
-function assistantMessage({
-  content,
-  runId,
-}: {
-  content: string;
-  runId: string;
-}): MessageFixture {
+function assistantMessage({ content }: { content: string }): MessageFixture {
   return {
-    role: "assistant",
-    runId,
     blocks: parseBodyRenderBlocks(content, { previews: true }).blocks,
   };
 }
 
 describe("currentMessageImageArtifactNavigation", () => {
-  it("navigates assistant images split across messages in the same run", () => {
+  it("navigates assistant images split across messages in the same group", () => {
     const firstImageUrl =
       "https://cdn.vm7.io/artifacts/test/body-image-split-navigation/first.png";
     const secondImageUrl =
@@ -62,21 +54,23 @@ describe("currentMessageImageArtifactNavigation", () => {
         ],
       },
     ];
-    const messages: MessageFixture[] = [
-      assistantMessage({ content: "Generated images:", runId }),
-      assistantMessage({
-        content: `1. ![first.png](${firstImageUrl})`,
-        runId,
-      }),
-      assistantMessage({
-        content: `2. ![second.png](${secondImageUrl})`,
-        runId,
-      }),
+    const groups = [
+      {
+        messages: [
+          assistantMessage({ content: "Generated images:" }),
+          assistantMessage({
+            content: `1. ![first.png](${firstImageUrl})`,
+          }),
+          assistantMessage({
+            content: `2. ![second.png](${secondImageUrl})`,
+          }),
+        ],
+      },
     ];
 
     const navigation = currentMessageImageArtifactNavigation(
       runs,
-      messages,
+      groups,
       firstImageUrl,
     );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1297,6 +1297,86 @@ describe("zero attachment chips", () => {
     });
   });
 
+  it("navigates markdown images generated in an ordered assistant list", async () => {
+    const user = userEvent.setup({ delay: null });
+    const firstImageUrl =
+      "https://cdn.vm7.io/artifacts/test/body-image-ordered-navigation/first.png";
+    const secondImageUrl =
+      "https://cdn.vm7.io/artifacts/test/body-image-ordered-navigation/second.png";
+    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
+      return respond(200, {
+        runs: [
+          {
+            runId: "run-body-image-ordered-navigation",
+            files: [
+              artifactFile(firstImageUrl, {
+                id: "artifact-body-ordered-first-image",
+                filename: "first.png",
+                contentType: "image/png",
+                size: 128,
+              }),
+              artifactFile(secondImageUrl, {
+                id: "artifact-body-ordered-second-image",
+                filename: "second.png",
+                contentType: "image/png",
+                size: 256,
+              }),
+            ],
+          },
+        ],
+      });
+    });
+    mockChatLifecycle(context, {
+      threadId: THREAD_ID,
+      chatMessages: [
+        {
+          id: "msg-body-image-ordered-navigation",
+          role: "assistant",
+          content: [
+            "Generated images:",
+            "",
+            `1. ![first.png](${firstImageUrl})`,
+            `2. ![second.png](${secondImageUrl})`,
+          ].join("\n"),
+          runId: "run-body-image-ordered-navigation",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
+      },
+    });
+
+    const bodyImage = await screen.findByAltText("first.png");
+    const previewButton = bodyImage.closest("button");
+    if (!previewButton) {
+      throw new Error("Markdown image preview button not found");
+    }
+    fireEvent.load(bodyImage);
+    click(previewButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "alt",
+        "first.png",
+      );
+    });
+    expect(screen.getByLabelText("Next image artifact")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Next image artifact"));
+    await waitFor(() => {
+      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+        "alt",
+        "second.png",
+      );
+    });
+  });
+
   it("navigates human-uploaded images that are not run artifacts", async () => {
     const user = userEvent.setup({ delay: null });
     const firstImageUrl =

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-image-navigation.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-image-navigation.ts
@@ -6,6 +6,7 @@ import {
   type BodyRenderBlock,
   classifyChatAttachment,
 } from "../../signals/chat-page/parse-body-blocks.ts";
+import { artifactPreviewUrlsMatch } from "./zero-attachment-url.ts";
 
 export type ImageArtifactNavigationItem = {
   readonly url: string;
@@ -34,6 +35,8 @@ type ImageArtifactNavigation = {
  * agent-generated images). Structurally satisfied by `EnrichedChatMessage`.
  */
 type MessageImageSource = {
+  readonly role?: "user" | "assistant";
+  readonly runId?: string;
   readonly attachFiles?: readonly {
     readonly url: string;
     readonly filename: string;
@@ -59,6 +62,11 @@ function isImageDescriptor(descriptor: {
 type MessageImage = {
   readonly url: string;
   readonly filename: string;
+};
+
+type ArtifactImageMetadata = {
+  readonly file: ChatThreadArtifactFile;
+  readonly runId: string;
 };
 
 // Matches a markdown image `![alt](url)`, capturing the alt (filename) and url
@@ -110,14 +118,65 @@ function messageImages(message: MessageImageSource): MessageImage[] {
   return images;
 }
 
+function messageHasImageUrl(
+  message: MessageImageSource,
+  currentUrl: string,
+): boolean {
+  return messageImages(message).some((image) => {
+    return artifactPreviewUrlsMatch(image.url, currentUrl);
+  });
+}
+
+function navigationScopeMessages(
+  messages: readonly MessageImageSource[],
+  currentMessage: MessageImageSource,
+): readonly MessageImageSource[] {
+  if (currentMessage.role !== "assistant" || !currentMessage.runId) {
+    return [currentMessage];
+  }
+  return messages.filter((candidate) => {
+    return (
+      candidate.role === "assistant" && candidate.runId === currentMessage.runId
+    );
+  });
+}
+
+function scopedMessageImages(
+  messages: readonly MessageImageSource[],
+): MessageImage[] {
+  const images: MessageImage[] = [];
+  for (const message of messages) {
+    for (const image of messageImages(message)) {
+      if (
+        images.some((candidate) => {
+          return artifactPreviewUrlsMatch(candidate.url, image.url);
+        })
+      ) {
+        continue;
+      }
+      images.push(image);
+    }
+  }
+  return images;
+}
+
+function artifactMetadataForUrl(
+  artifacts: readonly ArtifactImageMetadata[],
+  url: string,
+): ArtifactImageMetadata | undefined {
+  return artifacts.find((artifact) => {
+    return artifactPreviewUrlsMatch(artifact.file.url, url);
+  });
+}
+
 /**
- * Navigate image previews strictly within the images shown in the same chat
- * message as `currentUrl`. The message is the source of truth (both attached
- * files and body-rendered images), so both human-uploaded and agent-generated
- * images navigate. Run artifacts only enrich metadata when available; images
- * that are not run artifacts (human uploads) still navigate with url + filename.
- * Generated/hosted artifacts that live in the run but are not shown in the
- * message are excluded.
+ * Navigate image previews within the displayed image scope for `currentUrl`.
+ * User images stay scoped to their single message. Assistant images with a
+ * runId navigate across that run's rendered assistant messages, because a
+ * single generated result can be persisted as multiple assistant message rows
+ * while still rendering as one visual assistant group. Run artifacts only
+ * enrich metadata when available; generated/hosted artifacts that live in the
+ * run but are not shown in rendered messages are excluded.
  */
 export function currentMessageImageArtifactNavigation(
   runs: readonly ChatThreadArtifactRun[],
@@ -125,42 +184,35 @@ export function currentMessageImageArtifactNavigation(
   currentUrl: string,
 ): ImageArtifactNavigation {
   const message = messages.find((candidate) => {
-    return messageImages(candidate).some((image) => {
-      return image.url === currentUrl;
-    });
+    return messageHasImageUrl(candidate, currentUrl);
   });
 
   if (!message) {
     return {};
   }
 
-  const artifactByUrl = new Map<
-    string,
-    { file: ChatThreadArtifactFile; runId: string }
-  >();
+  const artifacts: ArtifactImageMetadata[] = [];
   for (const run of runs) {
     for (const file of run.files) {
-      if (!artifactByUrl.has(file.url)) {
-        artifactByUrl.set(file.url, { file, runId: run.runId });
-      }
+      artifacts.push({ file, runId: run.runId });
     }
   }
 
-  const images: ImageArtifactNavigationItem[] = messageImages(message).map(
-    (image) => {
-      const artifact = artifactByUrl.get(image.url);
-      if (artifact) {
-        return {
-          url: image.url,
-          filename: artifact.file.filename,
-          artifact,
-        };
-      }
-      return { url: image.url, filename: image.filename };
-    },
-  );
+  const images: ImageArtifactNavigationItem[] = scopedMessageImages(
+    navigationScopeMessages(messages, message),
+  ).map((image) => {
+    const artifact = artifactMetadataForUrl(artifacts, image.url);
+    if (artifact) {
+      return {
+        url: image.url,
+        filename: artifact.file.filename,
+        artifact,
+      };
+    }
+    return { url: image.url, filename: image.filename };
+  });
   const currentIndex = images.findIndex((item) => {
-    return item.url === currentUrl;
+    return artifactPreviewUrlsMatch(item.url, currentUrl);
   });
 
   if (currentIndex === -1) {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-image-navigation.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-image-navigation.ts
@@ -35,14 +35,16 @@ type ImageArtifactNavigation = {
  * agent-generated images). Structurally satisfied by `EnrichedChatMessage`.
  */
 type MessageImageSource = {
-  readonly role?: "user" | "assistant";
-  readonly runId?: string;
   readonly attachFiles?: readonly {
     readonly url: string;
     readonly filename: string;
     readonly contentType: string;
   }[];
   readonly blocks?: readonly BodyRenderBlock[];
+};
+
+type MessageImageGroup = {
+  readonly messages: readonly MessageImageSource[];
 };
 
 function isImageDescriptor(descriptor: {
@@ -127,20 +129,6 @@ function messageHasImageUrl(
   });
 }
 
-function navigationScopeMessages(
-  messages: readonly MessageImageSource[],
-  currentMessage: MessageImageSource,
-): readonly MessageImageSource[] {
-  if (currentMessage.role !== "assistant" || !currentMessage.runId) {
-    return [currentMessage];
-  }
-  return messages.filter((candidate) => {
-    return (
-      candidate.role === "assistant" && candidate.runId === currentMessage.runId
-    );
-  });
-}
-
 function scopedMessageImages(
   messages: readonly MessageImageSource[],
 ): MessageImage[] {
@@ -171,23 +159,24 @@ function artifactMetadataForUrl(
 
 /**
  * Navigate image previews within the displayed image scope for `currentUrl`.
- * User images stay scoped to their single message. Assistant images with a
- * runId navigate across that run's rendered assistant messages, because a
- * single generated result can be persisted as multiple assistant message rows
- * while still rendering as one visual assistant group. Run artifacts only
- * enrich metadata when available; generated/hosted artifacts that live in the
- * run but are not shown in rendered messages are excluded.
+ * The rendered chat message group is the scope boundary, so agent and human
+ * messages use the same rule: extract the images visible in the group that
+ * contains the current image. Run artifacts only enrich metadata when
+ * available; generated/hosted artifacts that live in the run but are not shown
+ * in rendered messages are excluded.
  */
 export function currentMessageImageArtifactNavigation(
   runs: readonly ChatThreadArtifactRun[],
-  messages: readonly MessageImageSource[],
+  groups: readonly MessageImageGroup[],
   currentUrl: string,
 ): ImageArtifactNavigation {
-  const message = messages.find((candidate) => {
-    return messageHasImageUrl(candidate, currentUrl);
+  const group = groups.find((candidateGroup) => {
+    return candidateGroup.messages.some((message) => {
+      return messageHasImageUrl(message, currentUrl);
+    });
   });
 
-  if (!message) {
+  if (!group) {
     return {};
   }
 
@@ -199,7 +188,7 @@ export function currentMessageImageArtifactNavigation(
   }
 
   const images: ImageArtifactNavigationItem[] = scopedMessageImages(
-    navigationScopeMessages(messages, message),
+    group.messages,
   ).map((image) => {
     const artifact = artifactMetadataForUrl(artifacts, image.url);
     if (artifact) {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -210,9 +210,7 @@ function ArtifactSidebarWithThreadData({
     loadable.state === "hasData"
       ? currentMessageImageArtifactNavigation(
           loadable.data,
-          (messageGroups ?? []).flatMap((group) => {
-            return group.messages;
-          }),
+          messageGroups ?? [],
           artifactRef.url,
         )
       : {};

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -968,9 +968,7 @@ function ArtifactPreviewDialogThreadResolver({
     loadable.state === "hasData"
       ? currentMessageImageArtifactNavigation(
           loadable.data,
-          (messageGroups ?? []).flatMap((group) => {
-            return group.messages;
-          }),
+          messageGroups ?? [],
           preview.url,
         )
       : {};


### PR DESCRIPTION
## Summary
- Fixes image lightbox navigation for generated image results that render as one chat message group but may be persisted across multiple message rows.
- Uses the rendered agent/human message group as the navigation boundary: find the group containing the current image, then extract images from messages in that group.
- Keeps artifacts as metadata enrichment only and reuses artifact preview URL matching so equivalent preview URLs do not miss navigation.

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-image-navigation.test.ts src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "navigates assistant images split|navigates modal images generated|ordered assistant list|human-uploaded images|keeps the modal fullscreen"`
- `pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-artifact-image-navigation.ts src/views/zero-page/zero-artifact-sidebar.tsx src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/__tests__/zero-artifact-image-navigation.test.ts src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `pnpm -F @vm0/app exec tsc -p tsconfig.tests.json --noEmit --pretty false`