### PR TITLE
perf(mitm-addon): negotiate safe response encodings

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -161,6 +161,7 @@ _AUTH_SCHEMES_REQUIRING_CREDENTIAL = frozenset(
     )
 )
 _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
+_HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 # Network log size fields are consumed as JavaScript numbers downstream.
 _MAX_SAFE_NETWORK_LOG_SIZE = 9_007_199_254_740_991
 _MAX_SAFE_NETWORK_LOG_SIZE_DIGITS = len(str(_MAX_SAFE_NETWORK_LOG_SIZE))
@@ -2937,6 +2938,8 @@ def _expects_http_response_body_usage_inspection(
     allow: matching.FirewallAllow,
     vm_info: dict,
 ) -> bool:
+    if flow.request.method.upper() in _HTTP_RESPONSE_BODYLESS_METHODS:
+        return False
     if _is_websocket_upgrade_request(flow):
         return False
     if _is_model_provider_usage_observable(allow.name, vm_info):

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -2952,7 +2952,7 @@ def _is_websocket_upgrade_request(flow: http.HTTPFlow) -> bool:
 
     connection_values = flow.request.headers.get_all("Connection")
     if not connection_values:
-        return True
+        return False
 
     return any(
         token.strip(_HTTP_OWS_CHARS).lower() == "upgrade"

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -33,8 +33,8 @@ from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
 #
-# auth_base_forwarder/body_capture/matching/registry/response_streaming/usage
-# are imported by module
+# auth_base_forwarder/body_capture/matching/registry/response_encoding_negotiation/
+# response_streaming/usage are imported by module
 # (not selective `from X import ...`)
 # so that:
 #   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
@@ -54,6 +54,7 @@ import network_log_sanitization
 import public_destination
 import registry
 import request_streaming
+import response_encoding_negotiation
 import response_streaming
 import upstream_destination_binding
 import usage
@@ -2653,6 +2654,7 @@ async def _try_firewall_request_stream_capture_from_headers(
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
         return
 
+    _maybe_normalize_accept_encoding_for_body_inspection(flow, allow, vm_info)
     _start_request_timing(flow)
     try:
         result = await try_apply_stream_safe_firewall_auth_for_requestheaders(flow, allow, vm_info)
@@ -2869,6 +2871,7 @@ async def request(flow: http.HTTPFlow) -> None:
                     error=host_policy_error,
                 )
                 return
+            _maybe_normalize_accept_encoding_for_body_inspection(flow, allow, vm_info)
             _maybe_track_usage_flow(
                 flow,
                 is_billable_firewall(allow.name, vm_info),
@@ -2914,6 +2917,46 @@ def _is_model_provider_usage_observable(firewall_name: str, vm_info: dict) -> bo
         firewall_name.startswith("model-provider:")
         and isinstance(model_usage_provider, str)
         and bool(model_usage_provider)
+    )
+
+
+def _maybe_normalize_accept_encoding_for_body_inspection(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+) -> None:
+    if _expects_http_response_body_usage_inspection(flow, allow, vm_info):
+        response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(
+            flow.request.headers
+        )
+
+
+def _expects_http_response_body_usage_inspection(
+    flow: http.HTTPFlow,
+    allow: matching.FirewallAllow,
+    vm_info: dict,
+) -> bool:
+    if _is_websocket_upgrade_request(flow):
+        return False
+    if _is_model_provider_usage_observable(allow.name, vm_info):
+        return True
+    return is_billable_firewall(allow.name, vm_info) and usage.has_connector_response_parser(
+        allow.name
+    )
+
+
+def _is_websocket_upgrade_request(flow: http.HTTPFlow) -> bool:
+    if flow.request.headers.get("Upgrade", "").strip().lower() != "websocket":
+        return False
+
+    connection_values = flow.request.headers.get_all("Connection")
+    if not connection_values:
+        return True
+
+    return any(
+        token.strip().lower() == "upgrade"
+        for value in connection_values
+        for token in value.split(",")
     )
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -94,6 +94,7 @@ _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _ADDRESS_PAIR_LENGTH = 2
 _HTTP_DEFAULT_PORT = 80
 _HTTPS_DEFAULT_PORT = 443
+_HTTP_OWS_CHARS = " \t"
 _BROWSER_USER_AGENT_MARKERS = (
     " chrome/",
     " chromium/",
@@ -2946,7 +2947,7 @@ def _expects_http_response_body_usage_inspection(
 
 
 def _is_websocket_upgrade_request(flow: http.HTTPFlow) -> bool:
-    if flow.request.headers.get("Upgrade", "").strip().lower() != "websocket":
+    if flow.request.headers.get("Upgrade", "").strip(_HTTP_OWS_CHARS).lower() != "websocket":
         return False
 
     connection_values = flow.request.headers.get_all("Connection")
@@ -2954,7 +2955,7 @@ def _is_websocket_upgrade_request(flow: http.HTTPFlow) -> bool:
         return True
 
     return any(
-        token.strip().lower() == "upgrade"
+        token.strip(_HTTP_OWS_CHARS).lower() == "upgrade"
         for value in connection_values
         for token in value.split(",")
     )

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -34,6 +34,9 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
     identity_accepted = False
     identity_disallowed = False
     wildcard_disallows_identity = False
+    wildcard_accepted = False
+    wildcard_q_text: str | None = None
+    wildcard_rejected = False
 
     for raw_value in values:
         for raw_coding in raw_value.split(","):
@@ -49,8 +52,15 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
                     identity_accepted = True
                 elif q_value == _MIN_Q_VALUE:
                     identity_disallowed = True
-            elif name == _WILDCARD and q_value == _MIN_Q_VALUE:
-                wildcard_disallows_identity = True
+            elif name == _WILDCARD:
+                if q_value == _MIN_Q_VALUE:
+                    wildcard_disallows_identity = True
+                    wildcard_rejected = True
+                    wildcard_accepted = False
+                    wildcard_q_text = None
+                elif accepted and not wildcard_rejected and not wildcard_accepted:
+                    wildcard_accepted = True
+                    wildcard_q_text = q_text
 
             if name in _SAFE_ENCODINGS:
                 if q_value == _MIN_Q_VALUE:
@@ -73,6 +83,18 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
         return _set_if_changed(headers, values, rewritten)
 
     if identity_rejected:
+        _add_wildcard_safe_compression_encodings(
+            accepted_safe,
+            rejected_safe,
+            wildcard_accepted,
+            wildcard_q_text,
+        )
+        if accepted_safe:
+            accepted_safe[_IDENTITY] = "0"
+            rewritten = ", ".join(
+                _format_coding(name, q_text) for name, q_text in accepted_safe.items()
+            )
+            return _set_if_changed(headers, values, rewritten)
         return False
 
     return _set_if_changed(headers, values, _IDENTITY)
@@ -123,6 +145,19 @@ def _format_coding(name: str, q_text: str | None) -> str:
     if q_text is None:
         return name
     return f"{name};q={q_text}"
+
+
+def _add_wildcard_safe_compression_encodings(
+    accepted_safe: dict[str, str | None],
+    rejected_safe: set[str],
+    wildcard_accepted: bool,
+    wildcard_q_text: str | None,
+) -> None:
+    if not wildcard_accepted:
+        return
+    for name in ("gzip", "deflate"):
+        if name not in rejected_safe:
+            accepted_safe[name] = wildcard_q_text
 
 
 def _set_if_changed(headers: http.Headers, original_values: list[str], value: str) -> bool:

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -29,6 +29,7 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
         return True
 
     accepted_safe: dict[str, str | None] = {}
+    rejected_safe: set[str] = set()
     identity_accepted = False
     identity_disallowed = False
     wildcard_disallows_identity = False
@@ -50,8 +51,12 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
             elif name == _WILDCARD and q_value == _MIN_Q_VALUE:
                 wildcard_disallows_identity = True
 
-            if name in _SAFE_ENCODINGS and accepted and name not in accepted_safe:
-                accepted_safe[name] = q_text
+            if name in _SAFE_ENCODINGS:
+                if q_value == _MIN_Q_VALUE:
+                    rejected_safe.add(name)
+                    accepted_safe.pop(name, None)
+                elif accepted and name not in accepted_safe and name not in rejected_safe:
+                    accepted_safe[name] = q_text
 
     identity_rejected = identity_disallowed or (
         wildcard_disallows_identity and not identity_accepted
@@ -80,9 +85,14 @@ def _parse_coding(raw_coding: str) -> tuple[str, Decimal | None]:
 
 
 def _parse_q_value(parameters: list[str]) -> Decimal | None:
+    saw_q_value = False
+    parsed_q_value: Decimal | None = None
     for parameter in parameters:
         key, separator, value = parameter.strip().partition("=")
         if separator and key.strip().lower() == "q":
+            if saw_q_value:
+                return _INVALID_Q_VALUE
+            saw_q_value = True
             q_text = value.strip()
             if not _Q_VALUE_PATTERN.fullmatch(q_text):
                 return _INVALID_Q_VALUE
@@ -92,8 +102,8 @@ def _parse_q_value(parameters: list[str]) -> Decimal | None:
                 return _INVALID_Q_VALUE
             if not q_value.is_finite() or q_value < _MIN_Q_VALUE or q_value > _MAX_Q_VALUE:
                 return _INVALID_Q_VALUE
-            return q_value
-    return None
+            parsed_q_value = q_value
+    return parsed_q_value
 
 
 def _q_text(raw_coding: str) -> str | None:

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -13,6 +13,7 @@ _INVALID_Q_VALUE = Decimal(-1)
 _MIN_Q_VALUE = Decimal(0)
 _MAX_Q_VALUE = Decimal(1)
 _Q_VALUE_PATTERN = re.compile(r"(?:0(?:\.[0-9]{1,3})?|1(?:\.0{1,3})?)")
+_HTTP_OWS_CHARS = " \t"
 
 
 def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool:
@@ -79,7 +80,7 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
 
 def _parse_coding(raw_coding: str) -> tuple[str, Decimal | None]:
     parts = raw_coding.split(";")
-    name = parts[0].strip().lower()
+    name = parts[0].strip(_HTTP_OWS_CHARS).lower()
     q_value = _parse_q_value(parts[1:])
     return name, q_value
 
@@ -88,16 +89,16 @@ def _parse_q_value(parameters: list[str]) -> Decimal | None:
     saw_q_value = False
     parsed_q_value: Decimal | None = None
     for parameter in parameters:
-        parameter = parameter.strip()
+        parameter = parameter.strip(_HTTP_OWS_CHARS)
         if not parameter:
             return _INVALID_Q_VALUE
         key, separator, value = parameter.partition("=")
-        if not separator or key.strip().lower() != "q":
+        if not separator or key.strip(_HTTP_OWS_CHARS).lower() != "q":
             return _INVALID_Q_VALUE
         if saw_q_value:
             return _INVALID_Q_VALUE
         saw_q_value = True
-        q_text = value.strip()
+        q_text = value.strip(_HTTP_OWS_CHARS)
         if not _Q_VALUE_PATTERN.fullmatch(q_text):
             return _INVALID_Q_VALUE
         try:
@@ -112,9 +113,9 @@ def _parse_q_value(parameters: list[str]) -> Decimal | None:
 
 def _q_text(raw_coding: str) -> str | None:
     for parameter in raw_coding.split(";")[1:]:
-        key, separator, value = parameter.strip().partition("=")
-        if separator and key.strip().lower() == "q":
-            return value.strip()
+        key, separator, value = parameter.strip(_HTTP_OWS_CHARS).partition("=")
+        if separator and key.strip(_HTTP_OWS_CHARS).lower() == "q":
+            return value.strip(_HTTP_OWS_CHARS)
     return None
 
 

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -88,21 +88,25 @@ def _parse_q_value(parameters: list[str]) -> Decimal | None:
     saw_q_value = False
     parsed_q_value: Decimal | None = None
     for parameter in parameters:
-        key, separator, value = parameter.strip().partition("=")
-        if separator and key.strip().lower() == "q":
-            if saw_q_value:
-                return _INVALID_Q_VALUE
-            saw_q_value = True
-            q_text = value.strip()
-            if not _Q_VALUE_PATTERN.fullmatch(q_text):
-                return _INVALID_Q_VALUE
-            try:
-                q_value = Decimal(q_text)
-            except InvalidOperation:
-                return _INVALID_Q_VALUE
-            if not q_value.is_finite() or q_value < _MIN_Q_VALUE or q_value > _MAX_Q_VALUE:
-                return _INVALID_Q_VALUE
-            parsed_q_value = q_value
+        parameter = parameter.strip()
+        if not parameter:
+            return _INVALID_Q_VALUE
+        key, separator, value = parameter.partition("=")
+        if not separator or key.strip().lower() != "q":
+            return _INVALID_Q_VALUE
+        if saw_q_value:
+            return _INVALID_Q_VALUE
+        saw_q_value = True
+        q_text = value.strip()
+        if not _Q_VALUE_PATTERN.fullmatch(q_text):
+            return _INVALID_Q_VALUE
+        try:
+            q_value = Decimal(q_text)
+        except InvalidOperation:
+            return _INVALID_Q_VALUE
+        if not q_value.is_finite() or q_value < _MIN_Q_VALUE or q_value > _MAX_Q_VALUE:
+            return _INVALID_Q_VALUE
+        parsed_q_value = q_value
     return parsed_q_value
 
 

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -73,6 +73,14 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
         wildcard_disallows_identity and not identity_accepted
     )
 
+    if identity_rejected:
+        _add_wildcard_safe_compression_encodings(
+            accepted_safe,
+            rejected_safe,
+            wildcard_accepted,
+            wildcard_q_text,
+        )
+
     if accepted_safe:
         if identity_rejected and _IDENTITY not in accepted_safe:
             # Removing "*" would otherwise make identity implicitly acceptable again.
@@ -83,18 +91,6 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
         return _set_if_changed(headers, values, rewritten)
 
     if identity_rejected:
-        _add_wildcard_safe_compression_encodings(
-            accepted_safe,
-            rejected_safe,
-            wildcard_accepted,
-            wildcard_q_text,
-        )
-        if accepted_safe:
-            accepted_safe[_IDENTITY] = "0"
-            rewritten = ", ".join(
-                _format_coding(name, q_text) for name, q_text in accepted_safe.items()
-            )
-            return _set_if_changed(headers, values, rewritten)
         return False
 
     return _set_if_changed(headers, values, _IDENTITY)
@@ -156,7 +152,7 @@ def _add_wildcard_safe_compression_encodings(
     if not wildcard_accepted:
         return
     for name in ("gzip", "deflate"):
-        if name not in rejected_safe:
+        if name not in accepted_safe and name not in rejected_safe:
             accepted_safe[name] = wildcard_q_text
 
 

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -1,5 +1,6 @@
 """Request-side response encoding negotiation for body-inspected flows."""
 
+import re
 from decimal import Decimal, InvalidOperation
 
 from mitmproxy import http
@@ -11,6 +12,7 @@ _SAFE_ENCODINGS = frozenset(("gzip", "deflate", _IDENTITY))
 _INVALID_Q_VALUE = Decimal(-1)
 _MIN_Q_VALUE = Decimal(0)
 _MAX_Q_VALUE = Decimal(1)
+_Q_VALUE_PATTERN = re.compile(r"(?:0(?:\.[0-9]{1,3})?|1(?:\.0{1,3})?)")
 
 
 def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool:
@@ -81,8 +83,11 @@ def _parse_q_value(parameters: list[str]) -> Decimal | None:
     for parameter in parameters:
         key, separator, value = parameter.strip().partition("=")
         if separator and key.strip().lower() == "q":
+            q_text = value.strip()
+            if not _Q_VALUE_PATTERN.fullmatch(q_text):
+                return _INVALID_Q_VALUE
             try:
-                q_value = Decimal(value.strip())
+                q_value = Decimal(q_text)
             except InvalidOperation:
                 return _INVALID_Q_VALUE
             if not q_value.is_finite() or q_value < _MIN_Q_VALUE or q_value > _MAX_Q_VALUE:

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -1,0 +1,104 @@
+"""Request-side response encoding negotiation for body-inspected flows."""
+
+from decimal import Decimal, InvalidOperation
+
+from mitmproxy import http
+
+_ACCEPT_ENCODING = "Accept-Encoding"
+_IDENTITY = "identity"
+_WILDCARD = "*"
+_SAFE_ENCODINGS = frozenset(("gzip", "deflate", _IDENTITY))
+_MIN_Q_VALUE = Decimal(0)
+_MAX_Q_VALUE = Decimal(1)
+
+
+def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool:
+    """Restrict Accept-Encoding to safe values for response-body inspection.
+
+    The proxy inspects selected upstream responses for usage/billing.  For those
+    requests, avoid negotiating encodings whose Python streaming decoders cannot
+    provide the needed bounded-output behavior.  The helper still respects an
+    explicit requester rejection of ``identity``.
+    """
+    values = headers.get_all(_ACCEPT_ENCODING)
+    if not values:
+        headers[_ACCEPT_ENCODING] = _IDENTITY
+        return True
+
+    accepted_safe: dict[str, str | None] = {}
+    identity_accepted = False
+    identity_disallowed = False
+    wildcard_disallows_identity = False
+
+    for raw_value in values:
+        for raw_coding in raw_value.split(","):
+            name, q_value = _parse_coding(raw_coding)
+            if not name:
+                continue
+
+            accepted = q_value is None or q_value > _MIN_Q_VALUE
+            q_text = _q_text(raw_coding)
+
+            if name == _IDENTITY:
+                if accepted:
+                    identity_accepted = True
+                elif q_value == _MIN_Q_VALUE:
+                    identity_disallowed = True
+            elif name == _WILDCARD and q_value == _MIN_Q_VALUE:
+                wildcard_disallows_identity = True
+
+            if name in _SAFE_ENCODINGS and accepted and name not in accepted_safe:
+                accepted_safe[name] = q_text
+
+    if accepted_safe:
+        rewritten = ", ".join(
+            _format_coding(name, q_text) for name, q_text in accepted_safe.items()
+        )
+        return _set_if_changed(headers, values, rewritten)
+
+    if identity_disallowed or (wildcard_disallows_identity and not identity_accepted):
+        return False
+
+    return _set_if_changed(headers, values, _IDENTITY)
+
+
+def _parse_coding(raw_coding: str) -> tuple[str, Decimal | None]:
+    parts = raw_coding.split(";")
+    name = parts[0].strip().lower()
+    q_value = _parse_q_value(parts[1:])
+    return name, q_value
+
+
+def _parse_q_value(parameters: list[str]) -> Decimal | None:
+    for parameter in parameters:
+        key, separator, value = parameter.strip().partition("=")
+        if separator and key.strip().lower() == "q":
+            try:
+                q_value = Decimal(value.strip())
+            except InvalidOperation:
+                return _MIN_Q_VALUE
+            if not q_value.is_finite() or q_value < _MIN_Q_VALUE or q_value > _MAX_Q_VALUE:
+                return _MIN_Q_VALUE
+            return q_value
+    return None
+
+
+def _q_text(raw_coding: str) -> str | None:
+    for parameter in raw_coding.split(";")[1:]:
+        key, separator, value = parameter.strip().partition("=")
+        if separator and key.strip().lower() == "q":
+            return value.strip()
+    return None
+
+
+def _format_coding(name: str, q_text: str | None) -> str:
+    if q_text is None:
+        return name
+    return f"{name};q={q_text}"
+
+
+def _set_if_changed(headers: http.Headers, original_values: list[str], value: str) -> bool:
+    if len(original_values) == 1 and original_values[0] == value:
+        return False
+    headers[_ACCEPT_ENCODING] = value
+    return True

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -8,6 +8,7 @@ _ACCEPT_ENCODING = "Accept-Encoding"
 _IDENTITY = "identity"
 _WILDCARD = "*"
 _SAFE_ENCODINGS = frozenset(("gzip", "deflate", _IDENTITY))
+_INVALID_Q_VALUE = Decimal(-1)
 _MIN_Q_VALUE = Decimal(0)
 _MAX_Q_VALUE = Decimal(1)
 
@@ -50,13 +51,20 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
             if name in _SAFE_ENCODINGS and accepted and name not in accepted_safe:
                 accepted_safe[name] = q_text
 
+    identity_rejected = identity_disallowed or (
+        wildcard_disallows_identity and not identity_accepted
+    )
+
     if accepted_safe:
+        if identity_rejected and _IDENTITY not in accepted_safe:
+            # Removing "*" would otherwise make identity implicitly acceptable again.
+            accepted_safe[_IDENTITY] = "0"
         rewritten = ", ".join(
             _format_coding(name, q_text) for name, q_text in accepted_safe.items()
         )
         return _set_if_changed(headers, values, rewritten)
 
-    if identity_disallowed or (wildcard_disallows_identity and not identity_accepted):
+    if identity_rejected:
         return False
 
     return _set_if_changed(headers, values, _IDENTITY)
@@ -76,9 +84,9 @@ def _parse_q_value(parameters: list[str]) -> Decimal | None:
             try:
                 q_value = Decimal(value.strip())
             except InvalidOperation:
-                return _MIN_Q_VALUE
+                return _INVALID_Q_VALUE
             if not q_value.is_finite() or q_value < _MIN_Q_VALUE or q_value > _MAX_Q_VALUE:
-                return _MIN_Q_VALUE
+                return _INVALID_Q_VALUE
             return q_value
     return None
 

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -51,7 +51,11 @@ from .openai_responses import (
     extract_openai_responses_usage_with_error_from_json,
     merge_openai_responses_usage_result,
 )
-from .providers.connectors import create_connector_response_parser, report_connector_usage
+from .providers.connectors import (
+    create_connector_response_parser,
+    has_connector_response_parser,
+    report_connector_usage,
+)
 from .providers.model_provider import (
     has_positive_model_provider_usage,
     is_model_provider_usage_observable,
@@ -80,6 +84,7 @@ __all__ = [
     "extract_openai_responses_usage_from_json",
     "extract_openai_responses_usage_with_error_from_json",
     "flush_usage_events",
+    "has_connector_response_parser",
     "has_positive_model_provider_usage",
     "increment_in_flight_flows",
     "is_model_provider_usage_observable",

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -103,6 +103,11 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     handler(flow, run_id, original_url)
 
 
+def has_connector_response_parser(firewall_name: str) -> bool:
+    """Return whether a connector has response-body parser capability."""
+    return firewall_name in _RESPONSE_PARSER_FACTORIES
+
+
 def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponseParser | None:
     """Create the connector-specific response parser for this flow, if registered.
 

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -89,6 +89,18 @@ _BROWSER_USER_AGENT = (
             id="wildcard-safe-compression-respects-explicit-safe-rejection",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip;q=0.2, zstd, *;q=0.8, identity;q=0")],
+            True,
+            ["gzip;q=0.2, deflate;q=0.8, identity;q=0"],
+            id="wildcard-adds-missing-safe-compression-after-explicit-safe-coding",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "deflate, br"), ("Accept-Encoding", "*;q=0.5, identity;q=0")],
+            True,
+            ["deflate, gzip;q=0.5, identity;q=0"],
+            id="wildcard-adds-missing-safe-compression-across-header-fields",
+        ),
+        pytest.param(
             [
                 (
                     "Accept-Encoding",

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -520,6 +520,10 @@ async def test_model_provider_websocket_upgrade_keeps_accept_encoding(
             (("Connection", "keep-alive, \u2028Upgrade"), ("Upgrade", "websocket")),
             id="invalid-connection-token-whitespace",
         ),
+        pytest.param(
+            (("Upgrade", "websocket"),),
+            id="missing-connection-upgrade-token",
+        ),
     ],
 )
 async def test_invalid_websocket_upgrade_whitespace_normalizes_accept_encoding(

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -41,6 +41,18 @@ _BROWSER_USER_AGENT = (
             id="drops-safe-q-zero",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip, identity;q=0, zstd")],
+            True,
+            ["gzip, identity;q=0"],
+            id="preserves-explicit-identity-rejection-with-safe-coding",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip, *;q=0, zstd")],
+            True,
+            ["gzip, identity;q=0"],
+            id="preserves-wildcard-identity-rejection-with-safe-coding",
+        ),
+        pytest.param(
             [("Accept-Encoding", "zstd, br, *")],
             True,
             ["identity"],
@@ -75,6 +87,12 @@ _BROWSER_USER_AGENT = (
             True,
             ["identity"],
             id="invalid-q-value-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "identity;q=bogus, zstd")],
+            True,
+            ["identity"],
+            id="malformed-identity-q-is-not-explicit-rejection",
         ),
     ],
 )
@@ -211,6 +229,32 @@ async def test_observable_model_provider_request_normalizes_accept_encoding_befo
     auth_fetch.assert_awaited_once()
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
     assert flow.request.headers["Authorization"] == "Bearer x"
+
+
+async def test_observable_model_provider_without_accept_encoding_sets_identity(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _model_provider_registry(tmp_path)
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_MODEL_PROVIDER_HOST,
+        path=_MODEL_PROVIDER_PATH,
+        method="POST",
+        accept_encoding=None,
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.request.headers[_ACCEPT_ENCODING] == "identity"
 
 
 async def test_billable_connector_with_response_parser_normalizes_accept_encoding(

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -1,0 +1,403 @@
+"""Safe response encoding negotiation for usage-inspected requests."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from mitmproxy import http
+
+import mitm_addon
+import response_encoding_negotiation
+from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.requestheaders_helpers import await_requestheaders_result
+
+_MODEL_PROVIDER_FIREWALL_NAME = "model-provider:anthropic-api-key"
+_MODEL_PROVIDER_HOST = "api.anthropic.com"
+_MODEL_PROVIDER_PATH = "/v1/messages"
+_X_FIREWALL_NAME = "x"
+_X_HOST = "api.x.com"
+_X_PATH = "/2/users/by"
+_ACCEPT_ENCODING = "Accept-Encoding"
+_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
+)
+
+
+@pytest.mark.parametrize(
+    ("header_pairs", "changed", "values"),
+    [
+        pytest.param([], True, ["identity"], id="absent"),
+        pytest.param(
+            [("Accept-Encoding", "gzip, zstd, br")],
+            True,
+            ["gzip"],
+            id="drops-unsafe-keeps-gzip",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=0, deflate;q=0.5, identity;q=1")],
+            True,
+            ["deflate;q=0.5, identity;q=1"],
+            id="drops-safe-q-zero",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "zstd, br, *")],
+            True,
+            ["identity"],
+            id="unsafe-only-falls-back-to-identity",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "identity;q=0, zstd")],
+            False,
+            ["identity;q=0, zstd"],
+            id="respects-explicit-identity-rejection",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "*;q=0, zstd")],
+            False,
+            ["*;q=0, zstd"],
+            id="wildcard-zero-rejects-implicit-identity",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "GZip;q=1, zstd"), ("Accept-Encoding", "deflate;q=0.5, br")],
+            True,
+            ["gzip;q=1, deflate;q=0.5"],
+            id="case-insensitive-and-multiple-fields",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip, gzip;q=0.5, deflate")],
+            True,
+            ["gzip, deflate"],
+            id="collapses-duplicate-safe-codings",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=2, zstd")],
+            True,
+            ["identity"],
+            id="invalid-q-value-not-readvertised",
+        ),
+    ],
+)
+def test_normalize_accept_encoding_for_body_inspection(
+    headers,
+    header_pairs: list[tuple[str, str]],
+    changed: bool,
+    values: list[str],
+) -> None:
+    request_headers = headers(*header_pairs)
+
+    assert (
+        response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(request_headers)
+        is changed
+    )
+    assert request_headers.get_all(_ACCEPT_ENCODING) == values
+
+
+def _model_provider_registry(
+    tmp_path: Path,
+    *,
+    model_usage_provider: object = "claude-sonnet-4-6",
+    capture_network_bodies: bool = False,
+) -> Path:
+    vm_fields: dict[str, object] = {}
+    if model_usage_provider is not None:
+        vm_fields["modelUsageProvider"] = model_usage_provider
+    if capture_network_bodies:
+        vm_fields["captureNetworkBodies"] = True
+
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name=_MODEL_PROVIDER_FIREWALL_NAME,
+            api_entry={
+                "base": f"https://{_MODEL_PROVIDER_HOST}",
+                "auth": {"headers": {"x-api-key": "test-key"}},
+                "permissions": [{"name": "messages", "rules": [f"POST {_MODEL_PROVIDER_PATH}"]}],
+            },
+            network_policy={
+                "allow": ["messages"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            vm_fields=vm_fields,
+        ),
+    )
+
+
+def _connector_registry(
+    tmp_path: Path,
+    *,
+    firewall_name: str,
+    host: str,
+    path: str,
+    billable: bool,
+    capture_network_bodies: bool = False,
+) -> Path:
+    vm_fields: dict[str, object] = {}
+    if capture_network_bodies:
+        vm_fields["captureNetworkBodies"] = True
+
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name=firewall_name,
+            api_entry={
+                "base": f"https://{host}",
+                "auth": {"headers": {"Authorization": "Bearer token"}},
+                "permissions": [{"name": "read", "rules": [f"GET {path}"]}],
+            },
+            network_policy={
+                "allow": ["read"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "deny",
+            },
+            billable_firewalls=[firewall_name] if billable else None,
+            vm_fields=vm_fields,
+        ),
+    )
+
+
+def _request_flow(
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    *,
+    host: str,
+    path: str,
+    method: str,
+    accept_encoding: str | None,
+    extra_headers: tuple[tuple[str, str], ...] = (),
+) -> http.HTTPFlow:
+    header_pairs = [("Host", host)]
+    if accept_encoding is not None:
+        header_pairs.append((_ACCEPT_ENCODING, accept_encoding))
+    header_pairs.extend(extra_headers)
+    return real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host=host,
+        path=path,
+        method=method,
+        request_headers=headers(*header_pairs),
+    )
+
+
+async def test_observable_model_provider_request_normalizes_accept_encoding_before_auth(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _model_provider_registry(tmp_path)
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_MODEL_PROVIDER_HOST,
+        path=_MODEL_PROVIDER_PATH,
+        method="POST",
+        accept_encoding="gzip, zstd, br",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+    assert flow.request.headers["Authorization"] == "Bearer x"
+
+
+async def test_billable_connector_with_response_parser_normalizes_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _connector_registry(
+        tmp_path,
+        firewall_name=_X_FIREWALL_NAME,
+        host=_X_HOST,
+        path=_X_PATH,
+        billable=True,
+    )
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_X_HOST,
+        path=_X_PATH,
+        method="GET",
+        accept_encoding="deflate, zstd",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.request.headers[_ACCEPT_ENCODING] == "deflate"
+
+
+async def test_billable_connector_without_response_parser_keeps_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _connector_registry(
+        tmp_path,
+        firewall_name="stripe",
+        host="api.stripe.com",
+        path="/v1/charges",
+        billable=True,
+    )
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host="api.stripe.com",
+        path="/v1/charges",
+        method="GET",
+        accept_encoding="gzip, zstd, br",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+
+
+async def test_non_observable_model_provider_keeps_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _model_provider_registry(tmp_path, model_usage_provider=None)
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_MODEL_PROVIDER_HOST,
+        path=_MODEL_PROVIDER_PATH,
+        method="POST",
+        accept_encoding="gzip, zstd, br",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+
+
+async def test_header_phase_stream_safe_auth_normalizes_accept_encoding_before_auth(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _connector_registry(
+        tmp_path,
+        firewall_name=_X_FIREWALL_NAME,
+        host=_X_HOST,
+        path=_X_PATH,
+        billable=True,
+        capture_network_bodies=True,
+    )
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_X_HOST,
+        path=_X_PATH,
+        method="GET",
+        accept_encoding="gzip, zstd, br",
+        extra_headers=(("Content-Length", str(mitm_addon.STREAM_BUFFER_LIMIT + 1)),),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+        assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+        assert flow.request.headers["Authorization"] == "Bearer x"
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+
+
+async def test_model_provider_websocket_upgrade_keeps_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _model_provider_registry(tmp_path)
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_MODEL_PROVIDER_HOST,
+        path=_MODEL_PROVIDER_PATH,
+        method="POST",
+        accept_encoding="gzip, zstd, br",
+        extra_headers=(("Connection", "keep-alive, Upgrade"), ("Upgrade", "websocket")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+
+
+async def test_browser_passthrough_keeps_accept_encoding_for_parser_connector(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+) -> None:
+    reg_path = _connector_registry(
+        tmp_path,
+        firewall_name=_X_FIREWALL_NAME,
+        host=_X_HOST,
+        path=_X_PATH,
+        billable=True,
+    )
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_X_HOST,
+        path=_X_PATH,
+        method="GET",
+        accept_encoding="gzip, zstd, br",
+        extra_headers=(("User-Agent", _BROWSER_USER_AGENT),),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -89,10 +89,34 @@ _BROWSER_USER_AGENT = (
             id="invalid-q-value-not-readvertised",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip;q=1.0000, zstd")],
+            True,
+            ["identity"],
+            id="q-value-with-too-many-digits-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=.5, zstd")],
+            True,
+            ["identity"],
+            id="q-value-without-leading-zero-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=1e-1, zstd")],
+            True,
+            ["identity"],
+            id="exponent-q-value-not-readvertised",
+        ),
+        pytest.param(
             [("Accept-Encoding", "identity;q=bogus, zstd")],
             True,
             ["identity"],
             id="malformed-identity-q-is-not-explicit-rejection",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "identity;q=0.0000, zstd")],
+            True,
+            ["identity"],
+            id="malformed-identity-zero-is-not-explicit-rejection",
         ),
     ],
 )

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -101,6 +101,24 @@ _BROWSER_USER_AGENT = (
             id="duplicate-q-parameter-is-not-readvertised",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip;foo=bar, zstd")],
+            True,
+            ["identity"],
+            id="non-q-parameter-is-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=0.5;foo=bar, zstd")],
+            True,
+            ["identity"],
+            id="q-with-extra-parameter-is-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;, zstd")],
+            True,
+            ["identity"],
+            id="empty-parameter-is-not-readvertised",
+        ),
+        pytest.param(
             [("Accept-Encoding", "gzip, identity;q=1, identity;q=0, zstd")],
             True,
             ["gzip, identity;q=0"],

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -509,6 +509,47 @@ async def test_model_provider_websocket_upgrade_keeps_accept_encoding(
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
 
 
+@pytest.mark.parametrize(
+    "extra_headers",
+    [
+        pytest.param(
+            (("Connection", "keep-alive, Upgrade"), ("Upgrade", "websocket\u2028")),
+            id="invalid-upgrade-value-whitespace",
+        ),
+        pytest.param(
+            (("Connection", "keep-alive, \u2028Upgrade"), ("Upgrade", "websocket")),
+            id="invalid-connection-token-whitespace",
+        ),
+    ],
+)
+async def test_invalid_websocket_upgrade_whitespace_normalizes_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+    extra_headers: tuple[tuple[str, str], ...],
+) -> None:
+    reg_path = _model_provider_registry(tmp_path)
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_MODEL_PROVIDER_HOST,
+        path=_MODEL_PROVIDER_PATH,
+        method="POST",
+        accept_encoding="gzip, zstd, br",
+        extra_headers=extra_headers,
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip"
+
+
 async def test_browser_passthrough_keeps_accept_encoding_for_parser_connector(
     tmp_path: Path,
     real_flow: Callable[..., http.HTTPFlow],

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -71,6 +71,41 @@ _BROWSER_USER_AGENT = (
             id="wildcard-zero-rejects-implicit-identity",
         ),
         pytest.param(
+            [("Accept-Encoding", "zstd, br, *;q=0.5, identity;q=0")],
+            True,
+            ["gzip;q=0.5, deflate;q=0.5, identity;q=0"],
+            id="wildcard-allows-safe-compression-when-identity-rejected",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "zstd, br, *, identity;q=0")],
+            True,
+            ["gzip, deflate, identity;q=0"],
+            id="wildcard-default-q-allows-safe-compression-when-identity-rejected",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=0, zstd, *;q=0.5, identity;q=0")],
+            True,
+            ["deflate;q=0.5, identity;q=0"],
+            id="wildcard-safe-compression-respects-explicit-safe-rejection",
+        ),
+        pytest.param(
+            [
+                (
+                    "Accept-Encoding",
+                    "gzip;q=0, deflate;q=0, zstd, *;q=0.5, identity;q=0",
+                )
+            ],
+            False,
+            ["gzip;q=0, deflate;q=0, zstd, *;q=0.5, identity;q=0"],
+            id="wildcard-keeps-original-when-all-safe-codings-rejected",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "*;q=0.5, *;q=0, identity;q=0, zstd")],
+            False,
+            ["*;q=0.5, *;q=0, identity;q=0, zstd"],
+            id="duplicate-wildcard-rejection-wins",
+        ),
+        pytest.param(
             [("Accept-Encoding", "GZip;q=1, zstd"), ("Accept-Encoding", "deflate;q=0.5, br")],
             True,
             ["gzip;q=1, deflate;q=0.5"],

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -83,6 +83,30 @@ _BROWSER_USER_AGENT = (
             id="collapses-duplicate-safe-codings",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip;q=1, gzip;q=0, zstd")],
+            True,
+            ["identity"],
+            id="duplicate-safe-coding-rejection-wins-after-acceptance",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=0, gzip;q=1, zstd")],
+            True,
+            ["identity"],
+            id="duplicate-safe-coding-rejection-wins-before-acceptance",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=1;q=0, zstd")],
+            True,
+            ["identity"],
+            id="duplicate-q-parameter-is-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip, identity;q=1, identity;q=0, zstd")],
+            True,
+            ["gzip, identity;q=0"],
+            id="duplicate-identity-rejection-is-preserved-with-safe-coding",
+        ),
+        pytest.param(
             [("Accept-Encoding", "gzip;q=2, zstd")],
             True,
             ["identity"],

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -212,6 +212,7 @@ def _model_provider_registry(
     *,
     model_usage_provider: object = "claude-sonnet-4-6",
     capture_network_bodies: bool = False,
+    rule_method: str = "POST",
 ) -> Path:
     vm_fields: dict[str, object] = {}
     if model_usage_provider is not None:
@@ -227,7 +228,9 @@ def _model_provider_registry(
             api_entry={
                 "base": f"https://{_MODEL_PROVIDER_HOST}",
                 "auth": {"headers": {"x-api-key": "test-key"}},
-                "permissions": [{"name": "messages", "rules": [f"POST {_MODEL_PROVIDER_PATH}"]}],
+                "permissions": [
+                    {"name": "messages", "rules": [f"{rule_method} {_MODEL_PROVIDER_PATH}"]}
+                ],
             },
             network_policy={
                 "allow": ["messages"],
@@ -507,6 +510,42 @@ async def test_model_provider_websocket_upgrade_keeps_accept_encoding(
         await mitm_addon.request(flow)
 
     assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+
+
+@pytest.mark.parametrize(
+    ("method", "rule_method"),
+    [
+        pytest.param("HEAD", "HEAD", id="head"),
+        pytest.param("CONNECT", "ANY", id="connect"),
+    ],
+)
+async def test_response_bodyless_usage_inspected_methods_keep_accept_encoding(
+    tmp_path: Path,
+    real_flow: Callable[..., http.HTTPFlow],
+    headers: Callable[..., http.Headers],
+    mitm_ctx,
+    fake_firewall_headers,
+    method: str,
+    rule_method: str,
+) -> None:
+    reg_path = _model_provider_registry(tmp_path, rule_method=rule_method)
+    flow = _request_flow(
+        real_flow,
+        headers,
+        host=_MODEL_PROVIDER_HOST,
+        path=_MODEL_PROVIDER_PATH,
+        method=method,
+        accept_encoding="gzip, zstd, br",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(),
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.request.headers[_ACCEPT_ENCODING] == "gzip, zstd, br"
+    assert flow.request.headers["Authorization"] == "Bearer x"
 
 
 @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -119,6 +119,36 @@ _BROWSER_USER_AGENT = (
             id="empty-parameter-is-not-readvertised",
         ),
         pytest.param(
+            [("Accept-Encoding", "gzip\u2028, zstd")],
+            True,
+            ["identity"],
+            id="unicode-whitespace-suffix-is-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "\u2028gzip, zstd")],
+            True,
+            ["identity"],
+            id="unicode-whitespace-prefix-is-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip\v, zstd")],
+            True,
+            ["identity"],
+            id="vertical-tab-suffix-is-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip\n, zstd")],
+            True,
+            ["identity"],
+            id="newline-suffix-is-not-readvertised",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip;q=0.5\u2028, zstd")],
+            True,
+            ["identity"],
+            id="unicode-whitespace-q-value-is-not-readvertised",
+        ),
+        pytest.param(
             [("Accept-Encoding", "gzip, identity;q=1, identity;q=0, zstd")],
             True,
             ["gzip, identity;q=0"],


### PR DESCRIPTION
## Summary
- add request-side Accept-Encoding negotiation for usage-inspected HTTP response flows
- scope the rewrite to observable model-provider HTTP traffic and billable connectors with registered response parsers
- keep WebSocket upgrades, browser passthrough, and billable connectors without body parsers unchanged

## Tests
- cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_response_encoding_negotiation.py -v
- cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_request_handler_usage_tracking.py tests/test_request_handler_firewall_dispatch.py tests/test_model_provider_websocket_usage.py tests/test_model_provider_json_streaming.py tests/test_body_decoding.py tests/test_response_streaming.py tests/test_connector_usage.py -q
- cd crates/runner/mitm-addon && .venv/bin/ruff check .
- cd crates/runner/mitm-addon && .venv/bin/ruff format --check .
- cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .

Closes #19904