### PR TITLE
feat: expose build commit sha

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -203,11 +203,12 @@ runs:
             add_env VM0_MACHINE_SECRET_KEY "$machine_secret_key"
           fi
         fi
-        # Inject the workflow head commit explicitly so OTel / Sentry can tag
-        # service.version and release on every deploy. Vercel CLI prebuilt
+        # Inject the checked-out build commit explicitly so OTel / Sentry can
+        # tag service.version and release on every deploy. Vercel CLI prebuilt
         # deploys do not reliably populate Vercel's own VERCEL_GIT_* system
         # vars, and we don't want runtime to depend on Vercel auto-injection.
-        add_env GIT_COMMIT_SHA "${GITHUB_SHA:-}"
+        build_commit_sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+        add_env GIT_COMMIT_SHA "$build_commit_sha"
         add_env BLOG_BASE_URL "$web_url"
         add_env STRAPI_URL "$strapi_url"
         add_var CLERK_PUBLISHABLE_KEY CLERK_PUBLISHABLE_KEY

--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -37,10 +37,6 @@ inputs:
     description: "Backend API URL used by web proxy routes"
     required: false
     default: ""
-  build-commit-sha:
-    description: "Full commit SHA for the build; defaults to the checked-out HEAD"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -57,7 +53,6 @@ runs:
         INPUT_APP_URL: ${{ inputs.app-url }}
         INPUT_API_URL: ${{ inputs.api-url }}
         INPUT_API_BACKEND_URL: ${{ inputs.api-backend-url }}
-        INPUT_BUILD_COMMIT_SHA: ${{ inputs.build-commit-sha }}
       run: |
         set -euo pipefail
 
@@ -212,14 +207,7 @@ runs:
         # tag service.version and release on every deploy. Vercel CLI prebuilt
         # deploys do not reliably populate Vercel's own VERCEL_GIT_* system
         # vars, and we don't want runtime to depend on Vercel auto-injection.
-        build_commit_sha="$INPUT_BUILD_COMMIT_SHA"
-        if [[ -z "$build_commit_sha" ]]; then
-          build_commit_sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
-        fi
-        if [[ ! "$build_commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
-          echo "::error::build commit SHA is not a full SHA-1: $build_commit_sha" >&2
-          exit 1
-        fi
+        build_commit_sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
         add_env GIT_COMMIT_SHA "$build_commit_sha"
         add_env BLOG_BASE_URL "$web_url"
         add_env STRAPI_URL "$strapi_url"

--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: "Backend API URL used by web proxy routes"
     required: false
     default: ""
+  build-commit-sha:
+    description: "Full commit SHA for the build; defaults to the checked-out HEAD"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -53,6 +57,7 @@ runs:
         INPUT_APP_URL: ${{ inputs.app-url }}
         INPUT_API_URL: ${{ inputs.api-url }}
         INPUT_API_BACKEND_URL: ${{ inputs.api-backend-url }}
+        INPUT_BUILD_COMMIT_SHA: ${{ inputs.build-commit-sha }}
       run: |
         set -euo pipefail
 
@@ -207,7 +212,14 @@ runs:
         # tag service.version and release on every deploy. Vercel CLI prebuilt
         # deploys do not reliably populate Vercel's own VERCEL_GIT_* system
         # vars, and we don't want runtime to depend on Vercel auto-injection.
-        build_commit_sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+        build_commit_sha="$INPUT_BUILD_COMMIT_SHA"
+        if [[ -z "$build_commit_sha" ]]; then
+          build_commit_sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+        fi
+        if [[ ! "$build_commit_sha" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::build commit SHA is not a full SHA-1: $build_commit_sha" >&2
+          exit 1
+        fi
         add_env GIT_COMMIT_SHA "$build_commit_sha"
         add_env BLOG_BASE_URL "$web_url"
         add_env STRAPI_URL "$strapi_url"

--- a/.github/scripts/resolve-build-commit-sha.sh
+++ b/.github/scripts/resolve-build-commit-sha.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ref="${1:-HEAD}"
-sha="$(git rev-parse --verify "${ref}^{commit}")"
+sha="$(git rev-parse --verify HEAD)"
 
 if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
   echo "::error::resolved build commit SHA is not a full SHA-1: $sha" >&2

--- a/.github/scripts/resolve-build-commit-sha.sh
+++ b/.github/scripts/resolve-build-commit-sha.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sha="$(git rev-parse --verify HEAD)"
+
+if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "::error::resolved build commit SHA is not a full SHA-1: $sha" >&2
+  exit 1
+fi
+
+printf '%s\n' "$sha"

--- a/.github/scripts/resolve-build-commit-sha.sh
+++ b/.github/scripts/resolve-build-commit-sha.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sha="$(git rev-parse --verify HEAD)"
+ref="${1:-HEAD}"
+sha="$(git rev-parse --verify "${ref}^{commit}")"
 
 if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
   echo "::error::resolved build commit SHA is not a full SHA-1: $sha" >&2

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 ACTION="${REPO_ROOT}/.github/actions/web-api-env/action.yml"
+EXPECTED_BUILD_COMMIT_SHA="$(git -C "$REPO_ROOT" rev-parse --verify HEAD)"
 TEMP_DIRS=()
 
 cleanup() {
@@ -166,6 +167,7 @@ assert_env_value "$success_env_file" ATOM_URL "https://tunnel-yuma-atom-api.vm7.
 assert_env_value "$success_env_file" VM0_MACHINE_SECRET_KEY "github-atom-machine-secret"
 assert_env_value "$success_env_file" VM0_PREVIEW_JOB_REF "pr-123"
 assert_env_value "$success_env_file" VM0_WEB_URL "https://pr-123-www.vm0.test"
+assert_env_value "$success_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_value "$success_env_file" ONBOARDING_URL "https://staging-www.vm6.ai"
 assert_env_value "$success_env_file" ZERO_PRICE_PRO "price_test_pro"
 assert_env_value "$success_env_file" ZERO_PRICE_TEAM "price_test_team"
@@ -186,6 +188,7 @@ production_web_env_file="$(awk -F= '$1 == "file" { sub(/^[^=]*=/, ""); print }' 
 assert_contains "$production_web_output" "Rendered"
 assert_env_value "$production_web_env_file" POSTHOG_KEY "github-posthog-key"
 assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github.test"
+assert_env_value "$production_web_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_absent_value "$production_web_env_file" "ATOM_URL="
 assert_env_absent_value "$production_web_env_file" "VM0_MACHINE_SECRET_KEY="
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -785,6 +785,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Build Runtime API Schema
@@ -983,6 +985,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Notify Slack - Starting

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,8 +41,6 @@ jobs:
       app_version: ${{ steps.release.outputs['turbo/apps/platform--version'] }}
       desktop_version: ${{ steps.release.outputs['turbo/apps/desktop--version'] }}
       cli_version: ${{ steps.release.outputs['turbo/apps/cli--version'] }}
-      api_build_sha: ${{ steps.release.outputs['turbo/apps/api--sha'] || steps.release.outputs['turbo/packages/core--sha'] || steps.release.outputs['turbo/packages/api-contracts--sha'] || steps.release.outputs['turbo/packages/connectors--sha'] }}
-      app_build_sha: ${{ steps.release.outputs['turbo/apps/platform--sha'] }}
     steps:
       - uses: vm0-ai/release-please-action@vm0
         id: release
@@ -851,7 +849,6 @@ jobs:
           web-url: https://www.vm0.ai
           app-url: https://app.vm0.ai
           api-url: ${{ vars.VM0_API_URL }}
-          build-commit-sha: ${{ needs.release-please.outputs.api_build_sha }}
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
@@ -1345,14 +1342,11 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      - name: Validate App Build Commit SHA
-        env:
-          APP_BUILD_SHA: ${{ needs.release-please.outputs.app_build_sha }}
+      - name: Resolve App Build Commit SHA
+        id: build-commit
         run: |
-          if [[ ! "$APP_BUILD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error::app build commit SHA is not a full SHA-1: $APP_BUILD_SHA" >&2
-            exit 1
-          fi
+          sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Build App Staged Production Deployment
         id: deploy
@@ -1371,7 +1365,7 @@ jobs:
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
             VITE_VERCEL_ENV=production
             VITE_API_URL=https://www.vm0.ai
-            VITE_GIT_COMMIT_SHA=${{ needs.release-please.outputs.app_build_sha }}
+            VITE_GIT_COMMIT_SHA=${{ steps.build-commit.outputs.sha }}
             VITE_ONBOARDING_URL=${{ vars.ONBOARDING_URL || 'https://www.vm0.ai' }}
             PUBLIC_ARTIFACTS_BASE_URL=${{ vars.PUBLIC_ARTIFACTS_BASE_URL }}
             VITE_STATIC_ASSETS_BASE_URL=${{ vars.STATIC_ASSETS_BASE_URL_PROD || vars.STATIC_ASSETS_BASE_URL || 'https://static.vm0.io' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1344,8 +1344,11 @@ jobs:
 
       - name: Resolve App Build Commit SHA
         id: build-commit
+        env:
+          RELEASE_TAG: app-v${{ needs.release-please.outputs.app_version }}
         run: |
-          sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+          git fetch --force --depth=1 origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          sha="$(bash .github/scripts/resolve-build-commit-sha.sh "$RELEASE_TAG")"
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Build App Staged Production Deployment

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,6 +41,8 @@ jobs:
       app_version: ${{ steps.release.outputs['turbo/apps/platform--version'] }}
       desktop_version: ${{ steps.release.outputs['turbo/apps/desktop--version'] }}
       cli_version: ${{ steps.release.outputs['turbo/apps/cli--version'] }}
+      api_build_sha: ${{ steps.release.outputs['turbo/apps/api--sha'] || steps.release.outputs['turbo/packages/core--sha'] || steps.release.outputs['turbo/packages/api-contracts--sha'] || steps.release.outputs['turbo/packages/connectors--sha'] }}
+      app_build_sha: ${{ steps.release.outputs['turbo/apps/platform--sha'] }}
     steps:
       - uses: vm0-ai/release-please-action@vm0
         id: release
@@ -849,6 +851,7 @@ jobs:
           web-url: https://www.vm0.ai
           app-url: https://app.vm0.ai
           api-url: ${{ vars.VM0_API_URL }}
+          build-commit-sha: ${{ needs.release-please.outputs.api_build_sha }}
         env:
           REPO_VARS_JSON: ${{ toJSON(vars) }}
           REPO_SECRETS_JSON: ${{ toJSON(secrets) }}
@@ -1342,14 +1345,14 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve App Build Commit SHA
-        id: build-commit
+      - name: Validate App Build Commit SHA
         env:
-          RELEASE_TAG: app-v${{ needs.release-please.outputs.app_version }}
+          APP_BUILD_SHA: ${{ needs.release-please.outputs.app_build_sha }}
         run: |
-          git fetch --force --depth=1 origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-          sha="$(bash .github/scripts/resolve-build-commit-sha.sh "$RELEASE_TAG")"
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          if [[ ! "$APP_BUILD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::app build commit SHA is not a full SHA-1: $APP_BUILD_SHA" >&2
+            exit 1
+          fi
 
       - name: Build App Staged Production Deployment
         id: deploy
@@ -1368,7 +1371,7 @@ jobs:
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
             VITE_VERCEL_ENV=production
             VITE_API_URL=https://www.vm0.ai
-            VITE_GIT_COMMIT_SHA=${{ steps.build-commit.outputs.sha }}
+            VITE_GIT_COMMIT_SHA=${{ needs.release-please.outputs.app_build_sha }}
             VITE_ONBOARDING_URL=${{ vars.ONBOARDING_URL || 'https://www.vm0.ai' }}
             PUBLIC_ARTIFACTS_BASE_URL=${{ vars.PUBLIC_ARTIFACTS_BASE_URL }}
             VITE_STATIC_ASSETS_BASE_URL=${{ vars.STATIC_ASSETS_BASE_URL_PROD || vars.STATIC_ASSETS_BASE_URL || 'https://static.vm0.io' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -785,8 +785,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Build Runtime API Schema
@@ -985,8 +983,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: ./.github/actions/toolchain-init
 
       - name: Notify Slack - Starting

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1342,6 +1342,12 @@ jobs:
         id: timer
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve App Build Commit SHA
+        id: build-commit
+        run: |
+          sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
       - name: Build App Staged Production Deployment
         id: deploy
         uses: ./.github/actions/vercel-deploy
@@ -1359,6 +1365,7 @@ jobs:
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
             VITE_VERCEL_ENV=production
             VITE_API_URL=https://www.vm0.ai
+            VITE_GIT_COMMIT_SHA=${{ steps.build-commit.outputs.sha }}
             VITE_ONBOARDING_URL=${{ vars.ONBOARDING_URL || 'https://www.vm0.ai' }}
             PUBLIC_ARTIFACTS_BASE_URL=${{ vars.PUBLIC_ARTIFACTS_BASE_URL }}
             VITE_STATIC_ASSETS_BASE_URL=${{ vars.STATIC_ASSETS_BASE_URL_PROD || vars.STATIC_ASSETS_BASE_URL || 'https://static.vm0.io' }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1038,6 +1038,12 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/toolchain-init
 
+      - name: Resolve App Build Commit SHA
+        id: build-commit
+        run: |
+          sha="$(bash .github/scripts/resolve-build-commit-sha.sh)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
       - name: Deploy App to Vercel
         id: deploy
         uses: ./.github/actions/vercel-deploy
@@ -1052,6 +1058,7 @@ jobs:
             VITE_CLERK_PUBLISHABLE_KEY=${{ vars.CLERK_PUBLISHABLE_KEY }}
             VITE_VERCEL_ENV=preview
             VITE_API_URL=${{ needs.prepare.outputs.api-preview-url }}
+            VITE_GIT_COMMIT_SHA=${{ steps.build-commit.outputs.sha }}
             VITE_ONBOARDING_URL=${{ vars.ONBOARDING_URL_STAGING || 'https://staging-www.vm6.ai' }}
             VITE_ONBOARDING_DOMAIN=${{ startsWith(needs.prepare.outputs.job-ref, 'pr-') && format('{0}-api.{1}', needs.prepare.outputs.job-ref, vars.PREVIEW_DOMAIN || 'vm6.ai') || '' }}
             PUBLIC_ARTIFACTS_BASE_URL=${{ vars.PUBLIC_ARTIFACTS_BASE_URL_DEV || vars.PUBLIC_ARTIFACTS_BASE_URL }}

--- a/turbo/apps/api/src/lib/build-info.ts
+++ b/turbo/apps/api/src/lib/build-info.ts
@@ -1,0 +1,10 @@
+const GIT_COMMIT_SHA_REGEX = /^[0-9a-f]{40}$/u;
+
+export function normalizeBuildCommitSha(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const commitSha = value.trim().toLowerCase();
+  return GIT_COMMIT_SHA_REGEX.test(commitSha) ? commitSha : null;
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -1,3 +1,4 @@
+import { buildInfoContract } from "@vm0/api-contracts/contracts/build-info";
 import { healthContract } from "@vm0/api-contracts/contracts/health";
 
 import { agentCheckpointsRoutes } from "./routes/agent-checkpoints-id";
@@ -37,6 +38,7 @@ import { desktopAuthRoutes } from "./routes/desktop-auth";
 import { desktopUpdateRoutes } from "./routes/desktop-updates";
 import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { apiHealth$ } from "./routes/health";
+import { apiBuildInfo$ } from "./routes/build-info";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { legacyFileRoutes } from "./routes/legacy-file";
@@ -205,6 +207,10 @@ export const ROUTES: readonly RouteEntry[] = [
   {
     route: healthContract.check,
     handler: apiHealth$,
+  },
+  {
+    route: buildInfoContract.get,
+    handler: apiBuildInfo$,
   },
   ...authMeRoutes,
   // The unified Automation resource: one automation, N schedule triggers.

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { buildInfoContract } from "@vm0/api-contracts/contracts/build-info";
 import { healthContract } from "@vm0/api-contracts/contracts/health";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroReportErrorContract } from "@vm0/api-contracts/contracts/zero-report-error";
@@ -7,6 +8,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { mockEnv } from "../../../lib/env";
 import { healthAuthProbeContract } from "../health-auth-probe";
 import {
   createBddApi,
@@ -28,6 +30,10 @@ const routeMocks = createZeroRouteMocks(context);
 
 function healthClient() {
   return setupApp({ context })(healthContract);
+}
+
+function buildInfoClient() {
+  return setupApp({ context })(buildInfoContract);
 }
 
 function healthAuthClient() {
@@ -65,6 +71,25 @@ function expectRecord(
 }
 
 describe("OPS-02: API health and auth boundary", () => {
+  it("returns public build info with a configured commit SHA", async () => {
+    const commitSha = "0123456789abcdef0123456789abcdef01234567";
+    mockEnv("GIT_COMMIT_SHA", commitSha);
+
+    const response = await accept(buildInfoClient().get(), [200]);
+
+    expect(response.body).toStrictEqual({ commitSha });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("returns null build info for local commit placeholders", async () => {
+    mockEnv("GIT_COMMIT_SHA", "local-dev");
+
+    const response = await accept(buildInfoClient().get(), [200]);
+
+    expect(response.body).toStrictEqual({ commitSha: null });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
   it("checks public health and authenticated health probe through HTTP routes", async () => {
     const admin = api.user();
 

--- a/turbo/apps/api/src/signals/routes/build-info.ts
+++ b/turbo/apps/api/src/signals/routes/build-info.ts
@@ -1,0 +1,19 @@
+import { command } from "ccstate";
+import type { BuildInfoRouteResponse } from "@vm0/api-contracts/contracts";
+
+import { normalizeBuildCommitSha } from "../../lib/build-info";
+import { env } from "../../lib/env";
+import { setResHeader$ } from "../context/hono";
+
+export const apiBuildInfo$ = command(
+  ({ set }, _signal: AbortSignal): BuildInfoRouteResponse => {
+    set(setResHeader$, "Cache-Control", "no-store");
+
+    return {
+      status: 200,
+      body: {
+        commitSha: normalizeBuildCommitSha(env("GIT_COMMIT_SHA")),
+      },
+    };
+  },
+);

--- a/turbo/apps/platform/.env.local.tpl
+++ b/turbo/apps/platform/.env.local.tpl
@@ -2,7 +2,6 @@
 # Use 1Password CLI to inject secrets: ./scripts/sync-env.sh
 VITE_CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VITE_API_URL=http://localhost:3000
-VITE_GIT_COMMIT_SHA=local-dev
 PUBLIC_ARTIFACTS_BASE_URL=https://cdn.vm7.io
 VITE_STATIC_ASSETS_BASE_URL=https://static.vm7.io
 VITE_ZERO_HOST_DOMAIN=sites.vm7.io

--- a/turbo/apps/platform/.env.local.tpl
+++ b/turbo/apps/platform/.env.local.tpl
@@ -2,6 +2,7 @@
 # Use 1Password CLI to inject secrets: ./scripts/sync-env.sh
 VITE_CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VITE_API_URL=http://localhost:3000
+VITE_GIT_COMMIT_SHA=local-dev
 PUBLIC_ARTIFACTS_BASE_URL=https://cdn.vm7.io
 VITE_STATIC_ASSETS_BASE_URL=https://static.vm7.io
 VITE_ZERO_HOST_DOMAIN=sites.vm7.io

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -3,6 +3,7 @@ import type { DebugLoggers } from "./types/global-method";
 interface VM0Global {
   loggers: DebugLoggers;
   inspectLogs: () => void;
+  getBuildCommitSha: () => string | null;
 }
 
 declare global {

--- a/turbo/apps/platform/src/lib/build-info.ts
+++ b/turbo/apps/platform/src/lib/build-info.ts
@@ -1,0 +1,14 @@
+const GIT_COMMIT_SHA_REGEX = /^[0-9a-f]{40}$/u;
+
+function normalizeBuildCommitSha(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const commitSha = value.trim().toLowerCase();
+  return GIT_COMMIT_SHA_REGEX.test(commitSha) ? commitSha : null;
+}
+
+export function getBuildCommitSha(): string | null {
+  return normalizeBuildCommitSha(import.meta.env.VITE_GIT_COMMIT_SHA);
+}

--- a/turbo/apps/platform/src/signals/bootstrap/global-method.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/global-method.ts
@@ -1,6 +1,7 @@
 import { command } from "ccstate";
 import { getLoggers, Level, logger } from "../log";
 import type { DebugLoggers } from "../../types/global-method";
+import { getBuildCommitSha } from "../../lib/build-info";
 import { inspectLogInput$ } from "./inspect-log-input";
 import { extendDebugLoggerLocalStorage } from "./loggers";
 
@@ -43,6 +44,7 @@ export const setupGlobalMethod$ = command(({ get }, signal: AbortSignal) => {
     inspectLogs() {
       get(inspectLogInput$)?.click();
     },
+    getBuildCommitSha,
   };
 
   signal.addEventListener("abort", () => {

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -30,6 +30,7 @@ vi.hoisted(() => {
   vi.stubEnv("VITE_CLERK_PUBLISHABLE_KEY", "test_key");
   vi.stubEnv("VITE_API_URL", "http://localhost:3000");
   vi.stubEnv("VITE_ZERO_HOST_DOMAIN", "sites.vm7.io");
+  vi.stubEnv("VITE_GIT_COMMIT_SHA", "0123456789abcdef0123456789abcdef01234567");
 });
 
 globalThis.indexedDB = indexedDB;

--- a/turbo/apps/platform/src/views/router/__tests__/global-method.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/global-method.test.tsx
@@ -1,0 +1,18 @@
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+const TEST_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+describe("global method", () => {
+  it("exposes the app build commit SHA after bootstrap", async () => {
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(window._vm0?.getBuildCommitSha()).toBe(TEST_SHA);
+    });
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/__tests__/build-info.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/build-info.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCommitShaSchema,
+  buildInfoContract,
+  buildInfoResponseSchema,
+} from "../build-info";
+
+const TEST_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+describe("build info contract", () => {
+  it("defines the build info endpoint", () => {
+    expect(buildInfoContract.get.method).toBe("GET");
+    expect(buildInfoContract.get.path).toBe("/api/build-info");
+  });
+
+  it("accepts a valid build info response body", () => {
+    expect(buildInfoResponseSchema.parse({ commitSha: TEST_SHA })).toEqual({
+      commitSha: TEST_SHA,
+    });
+    expect(buildInfoResponseSchema.parse({ commitSha: null })).toEqual({
+      commitSha: null,
+    });
+  });
+
+  it("rejects malformed commit SHAs", () => {
+    expect(buildCommitShaSchema.safeParse("local-dev").success).toBe(false);
+    expect(buildCommitShaSchema.safeParse("abc123").success).toBe(false);
+    expect(buildCommitShaSchema.safeParse(TEST_SHA.toUpperCase()).success).toBe(
+      false,
+    );
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/build-info.ts
+++ b/turbo/packages/api-contracts/src/contracts/build-info.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const buildCommitShaSchema = z
+  .string()
+  .regex(/^[0-9a-f]{40}$/u)
+  .nullable();
+
+export const buildInfoResponseSchema = z.object({
+  commitSha: buildCommitShaSchema,
+});
+
+export const buildInfoContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/build-info",
+    responses: {
+      200: buildInfoResponseSchema,
+    },
+    summary: "Get API build information",
+  },
+});
+
+export type BuildInfoContract = typeof buildInfoContract;
+export type BuildInfoResponse = z.infer<typeof buildInfoResponseSchema>;
+export type BuildInfoRouteResponse = {
+  readonly status: 200;
+  readonly body: BuildInfoResponse;
+};

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -6,6 +6,14 @@
  */
 export { initContract } from "./base";
 export {
+  buildCommitShaSchema,
+  buildInfoContract,
+  buildInfoResponseSchema,
+  type BuildInfoContract,
+  type BuildInfoResponse,
+  type BuildInfoRouteResponse,
+} from "./build-info";
+export {
   healthAuthContract,
   healthContract,
   healthResponseSchema,

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -268,6 +268,29 @@
         ".source/**"
       ]
     },
+    "@vm0/app#build": {
+      "dependsOn": ["^build"],
+      "env": ["VITE_GIT_COMMIT_SHA"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        ".env*",
+        "!**/__tests__/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.spec.ts",
+        "!**/*.spec.tsx",
+        "!**/vitest.config.ts",
+        "!**/src/test/**"
+      ],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        ".vercel/output/**",
+        "dist/**",
+        "src/dist/**",
+        ".source/**"
+      ]
+    },
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
## Summary
- add GET /api/build-info returning the API artifact commit SHA or null
- expose window._vm0.getBuildCommitSha() for the platform bundle commit SHA
- inject checked-out build commit SHA into API/app deploy env and scope the Vite cache input to @vm0/app#build

## Tests
- pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/build-info.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts
- pnpm -F @vm0/app exec vitest run src/views/router/__tests__/global-method.test.tsx
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/desktop check-types
- pnpm knip
- pnpm turbo run build --filter=@vm0/app --dry=json

Closes #19912