### PR TITLE
Add connector catalog artifact contract

### DIFF
--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -200,6 +200,21 @@ function fixtureManualAuthMethod(
   return authMethod;
 }
 
+function fixtureDeviceAuthMethod(
+  publicArtifact: ConnectorCatalogPublicArtifact,
+): ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number] {
+  const connector = publicArtifact.connectors.find((item) => {
+    return item.connectorRef === "fixture-device";
+  });
+  const authMethod = connector?.authMethods.find((item) => {
+    return item.id === "device";
+  });
+  if (!authMethod) {
+    throw new Error("Missing fixture device auth method");
+  }
+  return authMethod;
+}
+
 describe("connector catalog artifacts", () => {
   it("loads the fixture artifact set and converts public view models", async () => {
     const artifacts = await loadFixtureConnectorCatalogArtifacts();
@@ -493,6 +508,27 @@ describe("connector catalog artifacts", () => {
     );
   });
 
+  it("rejects duplicate required capabilities", async () => {
+    const records = await fixtureRecords();
+    const manifest = manifestFromRecords(records);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithManifest(records, {
+            ...manifest,
+            requiredCapabilities: [
+              ...manifest.requiredCapabilities,
+              manifest.requiredCapabilities[0] ?? "catalog.public-connectors@1",
+            ],
+          }),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Duplicate connector catalog required capabilities: catalog.public-connectors@1",
+    );
+  });
+
   it("rejects public artifacts that leak private runtime names", async () => {
     const records = await fixtureRecords();
     const publicArtifact = publicArtifactFromRecords(records);
@@ -765,6 +801,85 @@ describe("connector catalog artifacts", () => {
       }),
     ).rejects.toThrow(
       "fixture-oauth/oauth has manual fields for auth-code grant",
+    );
+  });
+
+  it("rejects invalid auth method ids", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    fixtureManualAuthMethod(publicArtifact).id = "api/token";
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, publicArtifact),
+        ),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects invalid device start option choices", async () => {
+    const records = await fixtureRecords();
+    const emptyOptionsArtifact = publicArtifactFromRecords(records);
+    const emptyOptionsAuthMethod =
+      fixtureDeviceAuthMethod(emptyOptionsArtifact);
+    const emptyOptionsStartOption = emptyOptionsAuthMethod.startOptions[0];
+    if (!emptyOptionsStartOption) {
+      throw new Error("Missing fixture device start option");
+    }
+    emptyOptionsStartOption.options = [];
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, emptyOptionsArtifact),
+        ),
+      }),
+    ).rejects.toThrow();
+
+    const duplicateOptionsArtifact = publicArtifactFromRecords(records);
+    const duplicateOptionsAuthMethod = fixtureDeviceAuthMethod(
+      duplicateOptionsArtifact,
+    );
+    const duplicateOptionsStartOption =
+      duplicateOptionsAuthMethod.startOptions[0];
+    const duplicateOption = duplicateOptionsStartOption?.options[0];
+    if (!duplicateOptionsStartOption || !duplicateOption) {
+      throw new Error("Missing fixture device start option choice");
+    }
+    duplicateOptionsStartOption.options.push({
+      ...duplicateOption,
+      label: "Duplicate Test",
+    });
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, duplicateOptionsArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Duplicate connector catalog fixture-device/device/mode start option values: test",
+    );
+
+    const invalidDefaultArtifact = publicArtifactFromRecords(records);
+    const invalidDefaultAuthMethod = fixtureDeviceAuthMethod(
+      invalidDefaultArtifact,
+    );
+    const invalidDefaultStartOption = invalidDefaultAuthMethod.startOptions[0];
+    if (!invalidDefaultStartOption) {
+      throw new Error("Missing fixture device start option");
+    }
+    invalidDefaultStartOption.defaultValue = "missing";
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, invalidDefaultArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Connector catalog auth method fixture-device/device start option mode defaultValue is not an option",
     );
   });
 

--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -328,8 +328,42 @@ describe("connector catalog artifacts", () => {
     const reader = createFixtureConnectorCatalogArtifactReader();
 
     await expect(reader.readArtifact("../manifest.json")).rejects.toThrow(
-      "escapes fixture root",
+      "Artifact keys must be relative object keys",
     );
+  });
+
+  it.each(["../active.json", "./active.json", ".", "private/"])(
+    "rejects invalid active artifact key %s before reading",
+    async (activeKey) => {
+      await expect(
+        loadConnectorCatalogArtifacts({
+          reader: readerFromRecords(new Map()),
+          activeKey,
+        }),
+      ).rejects.toThrow("Artifact keys must be relative object keys");
+    },
+  );
+
+  it("rejects invalid referenced artifact keys", async () => {
+    const records = await fixtureRecords();
+    const manifest = manifestFromRecords(records);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithManifest(records, {
+            ...manifest,
+            artifacts: {
+              ...manifest.artifacts,
+              public: {
+                ...manifest.artifacts.public,
+                key: "./public/catalog.json",
+              },
+            },
+          }),
+        ),
+      }),
+    ).rejects.toThrow("Artifact keys must be relative object keys");
   });
 
   it("verifies artifact digests before parsing JSON", async () => {
@@ -445,9 +479,14 @@ describe("connector catalog artifacts", () => {
           recordsWithPublicArtifact(records, publicArtifact),
         ),
       }),
-    ).rejects.toThrow(
-      "Public connector catalog artifact leaked FIXTURE_MANUAL_API_TOKEN",
-    );
+    ).rejects.toThrow("Public connector catalog artifact leaked private value");
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, publicArtifact),
+        ),
+      }),
+    ).rejects.not.toThrow("FIXTURE_MANUAL_API_TOKEN");
   });
 
   it("rejects public artifacts that leak private runtime artifact keys", async () => {
@@ -481,9 +520,17 @@ describe("connector catalog artifacts", () => {
           ),
         ),
       }),
-    ).rejects.toThrow(
-      "Public connector catalog artifact leaked private/fixture-manual/runtime.json",
-    );
+    ).rejects.toThrow("Public connector catalog artifact leaked private value");
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPrivateArtifact(
+            recordsWithPublicArtifact(records, publicArtifact),
+            privateArtifact,
+          ),
+        ),
+      }),
+    ).rejects.not.toThrow("private/fixture-manual/runtime.json");
   });
 
   it("rejects public permission summary drift", async () => {
@@ -556,6 +603,39 @@ describe("connector catalog artifacts", () => {
       }),
     ).rejects.toThrow(
       "fixture-manual permission category display order mismatch",
+    );
+
+    const emptyCategoryArtifact = publicArtifactFromRecords(records);
+    emptyCategoryArtifact.permissions.push({
+      connectorRef: "fixture-oauth",
+      label: "Fixture OAuth",
+      permissionCount: 0,
+      permissions: [],
+      categories: {
+        categories: {},
+        displayOrder: [],
+      },
+      defaultPolicy: {
+        permissionDefault: "allow",
+        unknownPolicy: "allow",
+      },
+    });
+    const oauthConnector = emptyCategoryArtifact.connectors.find((item) => {
+      return item.connectorRef === "fixture-oauth";
+    });
+    if (!oauthConnector) {
+      throw new Error("Missing fixture OAuth connector");
+    }
+    oauthConnector.permissionSummary.hasCategories = true;
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, emptyCategoryArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "permission categories require permissions for fixture-oauth",
     );
 
     const overrideDriftArtifact = publicArtifactFromRecords(records);

--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -344,6 +344,35 @@ describe("connector catalog artifacts", () => {
     },
   );
 
+  it("allows relative artifact keys with non-traversal dot substrings", async () => {
+    const records = await fixtureRecords();
+    const manifest = manifestFromRecords(records);
+    const publicBytes = requiredBytes(records, PUBLIC_ARTIFACT_KEY);
+    const recordsWithDottedKey = cloneRecords(records);
+    recordsWithDottedKey.set("public/catalog..v1.json", publicBytes);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithManifest(recordsWithDottedKey, {
+            ...manifest,
+            artifacts: {
+              ...manifest.artifacts,
+              public: {
+                ...manifest.artifacts.public,
+                key: "public/catalog..v1.json",
+              },
+            },
+          }),
+        ),
+      }),
+    ).resolves.toMatchObject({
+      publicArtifact: {
+        catalogVersion: "fixture-2026-07-03.1",
+      },
+    });
+  });
+
   it("rejects invalid referenced artifact keys", async () => {
     const records = await fixtureRecords();
     const manifest = manifestFromRecords(records);
@@ -761,6 +790,67 @@ describe("connector catalog artifacts", () => {
       }),
     ).rejects.toThrow(
       "fixture-manual/api-token private manual field public ids mismatch",
+    );
+  });
+
+  it("rejects duplicate private mapping names within an auth method", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    const manualAuthMethod = fixtureManualAuthMethod(publicArtifact);
+    manualAuthMethod.manualFields.push({
+      id: "secondaryApiKey",
+      label: "Secondary API Key",
+      required: true,
+      placeholder: null,
+      inputType: "password",
+    });
+
+    const privateArtifact = privateArtifactFromRecords(records);
+    const privateConnector = privateArtifact.connectors.find((item) => {
+      return item.connectorRef === "fixture-manual";
+    });
+    const privateAuthMethod = privateConnector?.authMethods.find((item) => {
+      return item.id === "api-token";
+    });
+    const privateMapping = privateAuthMethod?.manualFieldMappings[0];
+    if (!privateAuthMethod || !privateMapping) {
+      throw new Error("Missing fixture private manual field mapping");
+    }
+    privateAuthMethod.manualFieldMappings.push({
+      ...privateMapping,
+      publicId: "secondaryApiKey",
+    });
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPrivateArtifact(
+            recordsWithPublicArtifact(records, publicArtifact),
+            privateArtifact,
+          ),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Duplicate connector catalog fixture-manual/api-token private manual field private names",
+    );
+
+    privateAuthMethod.manualFieldMappings[1] = {
+      ...privateMapping,
+      publicId: "secondaryApiKey",
+      privateName: "FIXTURE_MANUAL_SECONDARY_API_TOKEN",
+    };
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPrivateArtifact(
+            recordsWithPublicArtifact(records, publicArtifact),
+            privateArtifact,
+          ),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Duplicate connector catalog fixture-manual/api-token private manual field runtime names",
     );
   });
 });

--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -310,6 +310,18 @@ describe("connector catalog artifacts", () => {
         description: "Write fixture files",
       },
     ]);
+    expect(
+      getPublicConnectorCatalogPermissionDetailFromArtifact(
+        artifacts.publicArtifact,
+        "fixture-manual",
+      )?.categories,
+    ).toStrictEqual({
+      categories: {
+        "files.read": "Files",
+        "files.write": "Files",
+      },
+      displayOrder: ["Files"],
+    });
   });
 
   it("rejects a fixture key that escapes the fixture root", async () => {
@@ -452,6 +464,76 @@ describe("connector catalog artifacts", () => {
       }),
     ).rejects.toThrow(
       "Connector catalog permission summary mismatch for fixture-manual",
+    );
+  });
+
+  it("rejects invalid permission categories and default policy overrides", async () => {
+    const records = await fixtureRecords();
+    const categoryDriftArtifact = publicArtifactFromRecords(records);
+    const categoryDriftPermission = categoryDriftArtifact.permissions[0];
+    if (!categoryDriftPermission?.categories) {
+      throw new Error("Missing fixture permission categories");
+    }
+    categoryDriftPermission.categories.displayOrder = ["Unknown"];
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, categoryDriftArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "fixture-manual permission category display order mismatch",
+    );
+
+    const overrideDriftArtifact = publicArtifactFromRecords(records);
+    const overrideDriftPermission = overrideDriftArtifact.permissions[0];
+    if (!overrideDriftPermission) {
+      throw new Error("Missing fixture permission metadata");
+    }
+    overrideDriftPermission.defaultPolicy.permissionOverrides = {
+      allow: ["files.read", "files.delete"],
+    };
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, overrideDriftArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "default policy override references unknown permission fixture-manual/files.delete",
+    );
+  });
+
+  it("rejects auth method fields that do not match the grant kind", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    const oauthConnector = publicArtifact.connectors.find((item) => {
+      return item.connectorRef === "fixture-oauth";
+    });
+    const oauthAuthMethod = oauthConnector?.authMethods[0];
+    if (!oauthAuthMethod) {
+      throw new Error("Missing fixture OAuth auth method");
+    }
+    oauthAuthMethod.manualFields = [
+      {
+        id: "apiKey",
+        label: "API Key",
+        required: true,
+        placeholder: null,
+        inputType: "password",
+      },
+    ];
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, publicArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "fixture-oauth/oauth has manual fields for auth-code grant",
     );
   });
 

--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -450,6 +450,42 @@ describe("connector catalog artifacts", () => {
     );
   });
 
+  it("rejects public artifacts that leak private runtime artifact keys", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    fixtureManualConnector(publicArtifact).description =
+      "Runtime schema: private/fixture-manual/runtime.json";
+
+    const privateArtifact = privateArtifactFromRecords(records);
+    const privateConnector = privateArtifact.connectors.find((item) => {
+      return item.connectorRef === "fixture-manual";
+    });
+    if (!privateConnector) {
+      throw new Error("Missing fixture private connector");
+    }
+    privateConnector.runtimeArtifactRefs = [
+      {
+        kind: "runtime-schema",
+        key: "private/fixture-manual/runtime.json",
+        digest:
+          "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      },
+    ];
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPrivateArtifact(
+            recordsWithPublicArtifact(records, publicArtifact),
+            privateArtifact,
+          ),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Public connector catalog artifact leaked private/fixture-manual/runtime.json",
+    );
+  });
+
   it("rejects public permission summary drift", async () => {
     const records = await fixtureRecords();
     const publicArtifact = publicArtifactFromRecords(records);
@@ -465,6 +501,42 @@ describe("connector catalog artifacts", () => {
     ).rejects.toThrow(
       "Connector catalog permission summary mismatch for fixture-manual",
     );
+  });
+
+  it("allows permission detail entries with zero permissions", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    publicArtifact.permissions.push({
+      connectorRef: "fixture-oauth",
+      label: "Fixture OAuth",
+      permissionCount: 0,
+      permissions: [],
+      categories: null,
+      defaultPolicy: {
+        permissionDefault: "allow",
+        unknownPolicy: "allow",
+      },
+    });
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, publicArtifact),
+        ),
+      }),
+    ).resolves.toMatchObject({
+      publicArtifact: {
+        permissions: [
+          {
+            connectorRef: "fixture-manual",
+          },
+          {
+            connectorRef: "fixture-oauth",
+            permissionCount: 0,
+          },
+        ],
+      },
+    });
   });
 
   it("rejects invalid permission categories and default policy overrides", async () => {

--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -586,6 +586,56 @@ describe("connector catalog artifacts", () => {
     });
   });
 
+  it("allows forbidden-looking permission names inside category maps", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    const permission = publicArtifact.permissions[0];
+    if (!permission?.categories) {
+      throw new Error("Missing fixture permission categories");
+    }
+    const readPermission = permission.permissions.find((item) => {
+      return item.name === "files.read";
+    });
+    if (!readPermission) {
+      throw new Error("Missing fixture read permission");
+    }
+
+    readPermission.name = "storage";
+    readPermission.description = "Read storage fixtures";
+    permission.categories.categories = {
+      storage: "Storage",
+      "files.write": "Files",
+    };
+    permission.categories.displayOrder = ["Files", "Storage"];
+    permission.defaultPolicy.permissionOverrides = {
+      allow: ["storage"],
+    };
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, publicArtifact),
+        ),
+      }),
+    ).resolves.toMatchObject({
+      publicArtifact: {
+        permissions: [
+          {
+            permissions: [
+              {
+                name: "storage",
+                description: "Read storage fixtures",
+              },
+              {
+                name: "files.write",
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
   it("rejects invalid permission categories and default policy overrides", async () => {
     const records = await fixtureRecords();
     const categoryDriftArtifact = publicArtifactFromRecords(records);

--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -136,7 +136,7 @@ function recordsWithActive(
 
 function recordsWithPublicArtifact(
   records: ReadonlyMap<string, Uint8Array>,
-  publicArtifact: ConnectorCatalogPublicArtifact,
+  publicArtifact: unknown,
 ): Map<string, Uint8Array> {
   const nextRecords = cloneRecords(records);
   const publicBytes = jsonBytes(publicArtifact);
@@ -207,7 +207,7 @@ function fixtureDeviceAuthMethod(
     return item.connectorRef === "fixture-device";
   });
   const authMethod = connector?.authMethods.find((item) => {
-    return item.id === "device";
+    return item.id === "api";
   });
   if (!authMethod) {
     throw new Error("Missing fixture device auth method");
@@ -281,7 +281,7 @@ describe("connector catalog artifacts", () => {
         tags: ["fixture", "device"],
         authMethods: [
           {
-            id: "device",
+            id: "api",
             label: "Device Code",
             description: "Connect with a device code.",
             grantKind: "device-auth",
@@ -528,6 +528,36 @@ describe("connector catalog artifacts", () => {
       "Duplicate connector catalog required capabilities: catalog.public-connectors@1",
     );
   });
+
+  it.each([
+    "catalog.public-connectors@1",
+    "catalog.private-field-mapping@1",
+    "grant.device-auth@1",
+    "firewall.permission-metadata@1",
+  ])(
+    "rejects manifests that omit artifact capability %s",
+    async (capability) => {
+      const records = await fixtureRecords();
+      const manifest = manifestFromRecords(records);
+
+      await expect(
+        loadConnectorCatalogArtifacts({
+          reader: readerFromRecords(
+            recordsWithManifest(records, {
+              ...manifest,
+              requiredCapabilities: manifest.requiredCapabilities.filter(
+                (item) => {
+                  return item !== capability;
+                },
+              ),
+            }),
+          ),
+        }),
+      ).rejects.toThrow(
+        `Connector catalog manifest requiredCapabilities missing artifact capabilities: ${capability}`,
+      );
+    },
+  );
 
   it("rejects public artifacts that leak private runtime names", async () => {
     const records = await fixtureRecords();
@@ -806,8 +836,22 @@ describe("connector catalog artifacts", () => {
 
   it("rejects invalid auth method ids", async () => {
     const records = await fixtureRecords();
-    const publicArtifact = publicArtifactFromRecords(records);
-    fixtureManualAuthMethod(publicArtifact).id = "api/token";
+    const publicArtifact = parseJson(
+      requiredBytes(records, PUBLIC_ARTIFACT_KEY),
+    ) as {
+      connectors: {
+        connectorRef: string;
+        authMethods: { id: string }[];
+      }[];
+    };
+    const connector = publicArtifact.connectors.find((item) => {
+      return item.connectorRef === "fixture-manual";
+    });
+    const authMethod = connector?.authMethods[0];
+    if (!authMethod) {
+      throw new Error("Missing fixture manual auth method");
+    }
+    authMethod.id = "api/token";
 
     await expect(
       loadConnectorCatalogArtifacts({
@@ -859,7 +903,7 @@ describe("connector catalog artifacts", () => {
         ),
       }),
     ).rejects.toThrow(
-      "Duplicate connector catalog fixture-device/device/mode start option values: test",
+      "Duplicate connector catalog fixture-device/api/mode start option values: test",
     );
 
     const invalidDefaultArtifact = publicArtifactFromRecords(records);
@@ -879,7 +923,7 @@ describe("connector catalog artifacts", () => {
         ),
       }),
     ).rejects.toThrow(
-      "Connector catalog auth method fixture-device/device start option mode defaultValue is not an option",
+      "Connector catalog auth method fixture-device/api start option mode defaultValue is not an option",
     );
   });
 

--- a/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
+++ b/turbo/apps/api/src/signals/services/__tests__/connector-catalog-artifacts.test.ts
@@ -1,0 +1,482 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CONNECTOR_CATALOG_FIXTURE_KEYS,
+  connectorCatalogArtifactDigest,
+  createFixtureConnectorCatalogArtifactReader,
+  getPublicConnectorCatalogDetailFromArtifact,
+  getPublicConnectorCatalogPermissionDetailFromArtifact,
+  listPublicConnectorCatalogFromArtifact,
+  loadConnectorCatalogArtifacts,
+  loadFixtureConnectorCatalogArtifacts,
+  type ConnectorCatalogArtifactReader,
+} from "../connector-catalog-artifacts";
+import {
+  connectorCatalogActivePointerSchema,
+  connectorCatalogManifestSchema,
+  connectorCatalogPrivateArtifactSchema,
+  connectorCatalogPublicArtifactSchema,
+  type ConnectorCatalogActivePointer,
+  type ConnectorCatalogManifest,
+  type ConnectorCatalogPrivateArtifact,
+  type ConnectorCatalogPublicArtifact,
+} from "../connector-catalog-artifacts/schemas";
+
+const ACTIVE_KEY = "active.json";
+const MANIFEST_KEY = "manifest.json";
+const PUBLIC_ARTIFACT_KEY = "public/catalog.json";
+const PRIVATE_ARTIFACT_KEY = "private/runtime.json";
+
+function jsonBytes(value: unknown): Buffer {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function requiredBytes(
+  records: ReadonlyMap<string, Uint8Array>,
+  key: string,
+): Uint8Array {
+  const bytes = records.get(key);
+  if (!bytes) {
+    throw new Error(`Missing fixture record ${key}`);
+  }
+  return bytes;
+}
+
+function parseJson(bytes: Uint8Array): unknown {
+  return JSON.parse(Buffer.from(bytes).toString("utf8")) as unknown;
+}
+
+function activeFromRecords(
+  records: ReadonlyMap<string, Uint8Array>,
+): ConnectorCatalogActivePointer {
+  return connectorCatalogActivePointerSchema.parse(
+    parseJson(requiredBytes(records, ACTIVE_KEY)),
+  );
+}
+
+function manifestFromRecords(
+  records: ReadonlyMap<string, Uint8Array>,
+): ConnectorCatalogManifest {
+  return connectorCatalogManifestSchema.parse(
+    parseJson(requiredBytes(records, MANIFEST_KEY)),
+  );
+}
+
+function publicArtifactFromRecords(
+  records: ReadonlyMap<string, Uint8Array>,
+): ConnectorCatalogPublicArtifact {
+  return connectorCatalogPublicArtifactSchema.parse(
+    parseJson(requiredBytes(records, PUBLIC_ARTIFACT_KEY)),
+  );
+}
+
+function privateArtifactFromRecords(
+  records: ReadonlyMap<string, Uint8Array>,
+): ConnectorCatalogPrivateArtifact {
+  return connectorCatalogPrivateArtifactSchema.parse(
+    parseJson(requiredBytes(records, PRIVATE_ARTIFACT_KEY)),
+  );
+}
+
+function cloneRecords(
+  records: ReadonlyMap<string, Uint8Array>,
+): Map<string, Uint8Array> {
+  return new Map(
+    [...records].map(([key, bytes]) => {
+      return [key, Buffer.from(bytes)] as const;
+    }),
+  );
+}
+
+function readerFromRecords(
+  records: ReadonlyMap<string, Uint8Array>,
+): ConnectorCatalogArtifactReader {
+  return {
+    readArtifact(key: string): Promise<Uint8Array> {
+      return Promise.resolve(Buffer.from(requiredBytes(records, key)));
+    },
+  };
+}
+
+async function fixtureRecords(): Promise<Map<string, Uint8Array>> {
+  const reader = createFixtureConnectorCatalogArtifactReader();
+  const records = new Map<string, Uint8Array>();
+  for (const key of CONNECTOR_CATALOG_FIXTURE_KEYS) {
+    records.set(key, await reader.readArtifact(key));
+  }
+  return records;
+}
+
+function recordsWithManifest(
+  records: ReadonlyMap<string, Uint8Array>,
+  manifest: ConnectorCatalogManifest,
+): Map<string, Uint8Array> {
+  const nextRecords = cloneRecords(records);
+  const manifestBytes = jsonBytes(manifest);
+  const active = activeFromRecords(nextRecords);
+  nextRecords.set(MANIFEST_KEY, manifestBytes);
+  nextRecords.set(
+    ACTIVE_KEY,
+    jsonBytes({
+      ...active,
+      manifestDigest: connectorCatalogArtifactDigest(manifestBytes),
+    }),
+  );
+  return nextRecords;
+}
+
+function recordsWithActive(
+  records: ReadonlyMap<string, Uint8Array>,
+  active: ConnectorCatalogActivePointer,
+): Map<string, Uint8Array> {
+  const nextRecords = cloneRecords(records);
+  nextRecords.set(ACTIVE_KEY, jsonBytes(active));
+  return nextRecords;
+}
+
+function recordsWithPublicArtifact(
+  records: ReadonlyMap<string, Uint8Array>,
+  publicArtifact: ConnectorCatalogPublicArtifact,
+): Map<string, Uint8Array> {
+  const nextRecords = cloneRecords(records);
+  const publicBytes = jsonBytes(publicArtifact);
+  const manifest = manifestFromRecords(nextRecords);
+  nextRecords.set(PUBLIC_ARTIFACT_KEY, publicBytes);
+  return recordsWithManifest(nextRecords, {
+    ...manifest,
+    artifacts: {
+      ...manifest.artifacts,
+      public: {
+        ...manifest.artifacts.public,
+        digest: connectorCatalogArtifactDigest(publicBytes),
+      },
+    },
+  });
+}
+
+function recordsWithPrivateArtifact(
+  records: ReadonlyMap<string, Uint8Array>,
+  privateArtifact: ConnectorCatalogPrivateArtifact,
+): Map<string, Uint8Array> {
+  const nextRecords = cloneRecords(records);
+  const privateBytes = jsonBytes(privateArtifact);
+  const manifest = manifestFromRecords(nextRecords);
+  nextRecords.set(PRIVATE_ARTIFACT_KEY, privateBytes);
+  return recordsWithManifest(nextRecords, {
+    ...manifest,
+    artifacts: {
+      ...manifest.artifacts,
+      private: {
+        ...manifest.artifacts.private,
+        digest: connectorCatalogArtifactDigest(privateBytes),
+      },
+    },
+  });
+}
+
+function fixtureManualConnector(
+  publicArtifact: ConnectorCatalogPublicArtifact,
+): ConnectorCatalogPublicArtifact["connectors"][number] {
+  const connector = publicArtifact.connectors.find((item) => {
+    return item.connectorRef === "fixture-manual";
+  });
+  if (!connector) {
+    throw new Error("Missing fixture manual connector");
+  }
+  return connector;
+}
+
+function fixtureManualAuthMethod(
+  publicArtifact: ConnectorCatalogPublicArtifact,
+): ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number] {
+  const authMethod = fixtureManualConnector(publicArtifact).authMethods.find(
+    (item) => {
+      return item.id === "api-token";
+    },
+  );
+  if (!authMethod) {
+    throw new Error("Missing fixture manual auth method");
+  }
+  return authMethod;
+}
+
+describe("connector catalog artifacts", () => {
+  it("loads the fixture artifact set and converts public view models", async () => {
+    const artifacts = await loadFixtureConnectorCatalogArtifacts();
+
+    expect(artifacts.active.catalogVersion).toBe("fixture-2026-07-03.1");
+    expect(artifacts.manifest.requiredCapabilities).toContain(
+      "catalog.public-connectors@1",
+    );
+
+    const list = listPublicConnectorCatalogFromArtifact(
+      artifacts.publicArtifact,
+    );
+    expect(list).toStrictEqual([
+      {
+        connectorRef: "fixture-manual",
+        label: "Fixture Manual",
+        description: "Manual fixture connector",
+        category: "Development",
+        generation: ["text"],
+        tags: ["fixture", "manual"],
+        authMethods: [
+          {
+            id: "api-token",
+            label: "API Token",
+            description: "Connect with an API token.",
+            grantKind: "manual",
+          },
+        ],
+        permissionSummary: {
+          hasPermissions: true,
+          permissionCount: 2,
+          hasCategories: true,
+          hasDefaultPolicyOverrides: true,
+        },
+      },
+      {
+        connectorRef: "fixture-oauth",
+        label: "Fixture OAuth",
+        description: "OAuth fixture connector",
+        category: "Development",
+        generation: ["text"],
+        tags: ["fixture", "oauth"],
+        authMethods: [
+          {
+            id: "oauth",
+            label: "OAuth",
+            description: "Connect with OAuth.",
+            grantKind: "auth-code",
+          },
+        ],
+        permissionSummary: {
+          hasPermissions: false,
+          permissionCount: 0,
+          hasCategories: false,
+          hasDefaultPolicyOverrides: false,
+        },
+      },
+      {
+        connectorRef: "fixture-device",
+        label: "Fixture Device",
+        description: "Device-auth fixture connector",
+        category: "Development",
+        generation: ["text"],
+        tags: ["fixture", "device"],
+        authMethods: [
+          {
+            id: "device",
+            label: "Device Code",
+            description: "Connect with a device code.",
+            grantKind: "device-auth",
+          },
+        ],
+        permissionSummary: {
+          hasPermissions: false,
+          permissionCount: 0,
+          hasCategories: false,
+          hasDefaultPolicyOverrides: false,
+        },
+      },
+    ]);
+
+    expect(
+      getPublicConnectorCatalogDetailFromArtifact(
+        artifacts.publicArtifact,
+        "fixture-manual",
+      )?.authMethods[0]?.manualFields,
+    ).toStrictEqual([
+      {
+        id: "apiKey",
+        label: "API Key",
+        required: true,
+        placeholder: "key-...",
+        inputType: "password",
+      },
+    ]);
+    expect(
+      getPublicConnectorCatalogPermissionDetailFromArtifact(
+        artifacts.publicArtifact,
+        "fixture-manual",
+      )?.permissions,
+    ).toStrictEqual([
+      {
+        name: "files.read",
+        description: "Read fixture files",
+      },
+      {
+        name: "files.write",
+        description: "Write fixture files",
+      },
+    ]);
+  });
+
+  it("rejects a fixture key that escapes the fixture root", async () => {
+    const reader = createFixtureConnectorCatalogArtifactReader();
+
+    await expect(reader.readArtifact("../manifest.json")).rejects.toThrow(
+      "escapes fixture root",
+    );
+  });
+
+  it("verifies artifact digests before parsing JSON", async () => {
+    const records = await fixtureRecords();
+    const tamperedPublicBytes = Buffer.from(
+      requiredBytes(records, PUBLIC_ARTIFACT_KEY),
+    );
+    tamperedPublicBytes[0] = "{".charCodeAt(0) + 1;
+    const tamperedRecords = cloneRecords(records);
+    tamperedRecords.set(PUBLIC_ARTIFACT_KEY, tamperedPublicBytes);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(tamperedRecords),
+      }),
+    ).rejects.toThrow("public/catalog.json digest mismatch");
+  });
+
+  it("rejects manifest and private artifact digest mismatches", async () => {
+    const records = await fixtureRecords();
+    const manifest = manifestFromRecords(records);
+    const manifestBytes = jsonBytes({
+      ...manifest,
+      requiredCapabilities: [],
+    });
+    const privateBytes = Buffer.from(
+      requiredBytes(records, PRIVATE_ARTIFACT_KEY),
+    );
+    privateBytes[0] = "{".charCodeAt(0) + 1;
+
+    const manifestDigestMismatchRecords = cloneRecords(records);
+    manifestDigestMismatchRecords.set(MANIFEST_KEY, manifestBytes);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(manifestDigestMismatchRecords),
+      }),
+    ).rejects.toThrow("manifest.json digest mismatch");
+
+    const privateDigestMismatchRecords = cloneRecords(records);
+    privateDigestMismatchRecords.set(PRIVATE_ARTIFACT_KEY, privateBytes);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(privateDigestMismatchRecords),
+      }),
+    ).rejects.toThrow("private/runtime.json digest mismatch");
+  });
+
+  it("rejects unsupported active and artifact schema versions", async () => {
+    const records = await fixtureRecords();
+    const active = activeFromRecords(records);
+    const manifest = manifestFromRecords(records);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithActive(records, {
+            ...active,
+            schemaVersion: 2,
+          }),
+        ),
+      }),
+    ).rejects.toThrow("Unsupported connector catalog active schema version: 2");
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithManifest(records, {
+            ...manifest,
+            artifactSchemaVersion: 2,
+          }),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Unsupported connector catalog artifact schema version: 2",
+    );
+  });
+
+  it("rejects unsupported required capabilities", async () => {
+    const records = await fixtureRecords();
+    const manifest = manifestFromRecords(records);
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithManifest(records, {
+            ...manifest,
+            requiredCapabilities: [
+              ...manifest.requiredCapabilities,
+              "catalog.future@99",
+            ],
+          }),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Unsupported connector catalog capabilities: catalog.future@99",
+    );
+  });
+
+  it("rejects public artifacts that leak private runtime names", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    const field = fixtureManualAuthMethod(publicArtifact).manualFields[0];
+    if (!field) {
+      throw new Error("Missing fixture manual field");
+    }
+    field.placeholder = "FIXTURE_MANUAL_API_TOKEN";
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, publicArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Public connector catalog artifact leaked FIXTURE_MANUAL_API_TOKEN",
+    );
+  });
+
+  it("rejects public permission summary drift", async () => {
+    const records = await fixtureRecords();
+    const publicArtifact = publicArtifactFromRecords(records);
+    fixtureManualConnector(publicArtifact).permissionSummary.permissionCount =
+      1;
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPublicArtifact(records, publicArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "Connector catalog permission summary mismatch for fixture-manual",
+    );
+  });
+
+  it("rejects private field mapping drift from public manual fields", async () => {
+    const records = await fixtureRecords();
+    const privateArtifact = privateArtifactFromRecords(records);
+    const connector = privateArtifact.connectors.find((item) => {
+      return item.connectorRef === "fixture-manual";
+    });
+    const authMethod = connector?.authMethods.find((item) => {
+      return item.id === "api-token";
+    });
+    if (!authMethod) {
+      throw new Error("Missing fixture private auth method");
+    }
+    authMethod.manualFieldMappings = [];
+
+    await expect(
+      loadConnectorCatalogArtifacts({
+        reader: readerFromRecords(
+          recordsWithPrivateArtifact(records, privateArtifact),
+        ),
+      }),
+    ).rejects.toThrow(
+      "fixture-manual/api-token private manual field public ids mismatch",
+    );
+  });
+});

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/active.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/active.json
@@ -2,6 +2,6 @@
   "schemaVersion": 1,
   "catalogVersion": "fixture-2026-07-03.1",
   "manifestKey": "manifest.json",
-  "manifestDigest": "sha256:6972af2cf5b85430a171d41527f18b48b4fb9adb323e66680371ace4343378cb",
+  "manifestDigest": "sha256:c32ecb6bb0c7c5c24d760dec6b42d2626689329bfad3534fb9e3f9f347b1509f",
   "publishedAt": "2026-07-03T00:00:00.000Z"
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/active.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/active.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "catalogVersion": "fixture-2026-07-03.1",
+  "manifestKey": "manifest.json",
+  "manifestDigest": "sha256:6972af2cf5b85430a171d41527f18b48b4fb9adb323e66680371ace4343378cb",
+  "publishedAt": "2026-07-03T00:00:00.000Z"
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/active.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/active.json
@@ -2,6 +2,6 @@
   "schemaVersion": 1,
   "catalogVersion": "fixture-2026-07-03.1",
   "manifestKey": "manifest.json",
-  "manifestDigest": "sha256:c32ecb6bb0c7c5c24d760dec6b42d2626689329bfad3534fb9e3f9f347b1509f",
+  "manifestDigest": "sha256:ed0f7b5a8e004ec878579b69331acc6219410bb955cb47b00e77395eae5f16a2",
   "publishedAt": "2026-07-03T00:00:00.000Z"
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/manifest.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/manifest.json
@@ -12,11 +12,11 @@
   "artifacts": {
     "public": {
       "key": "public/catalog.json",
-      "digest": "sha256:ff578d3c42af1bc8b4708f18611e6ad91d8848b7f2e1767e7762cf553c500a27"
+      "digest": "sha256:1f14f81e4f62679dd5d2c6a86c702a4e86a9deeb8169e92a4e542d1719ccfd35"
     },
     "private": {
       "key": "private/runtime.json",
-      "digest": "sha256:bedc6e4dea50cb5af3f1b44e05bcc2f73f9d0c2d1f18013ac0fdec05caeb4070"
+      "digest": "sha256:8d4667590c114faa835e516aa6e37ebf26033c4eff3638145e6dd65371295524"
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/manifest.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/manifest.json
@@ -1,0 +1,22 @@
+{
+  "catalogVersion": "fixture-2026-07-03.1",
+  "artifactSchemaVersion": 1,
+  "requiredCapabilities": [
+    "catalog.public-connectors@1",
+    "catalog.private-field-mapping@1",
+    "grant.manual@1",
+    "grant.auth-code@1",
+    "grant.device-auth@1",
+    "firewall.permission-metadata@1"
+  ],
+  "artifacts": {
+    "public": {
+      "key": "public/catalog.json",
+      "digest": "sha256:25bbd36af13a9c628e7d67aad75832322fe749ab9eeab0fae05b63bdf8fdf647"
+    },
+    "private": {
+      "key": "private/runtime.json",
+      "digest": "sha256:bedc6e4dea50cb5af3f1b44e05bcc2f73f9d0c2d1f18013ac0fdec05caeb4070"
+    }
+  }
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/manifest.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/manifest.json
@@ -12,7 +12,7 @@
   "artifacts": {
     "public": {
       "key": "public/catalog.json",
-      "digest": "sha256:25bbd36af13a9c628e7d67aad75832322fe749ab9eeab0fae05b63bdf8fdf647"
+      "digest": "sha256:ff578d3c42af1bc8b4708f18611e6ad91d8848b7f2e1767e7762cf553c500a27"
     },
     "private": {
       "key": "private/runtime.json",

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/private/runtime.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/private/runtime.json
@@ -1,0 +1,52 @@
+{
+  "artifactSchemaVersion": 1,
+  "catalogVersion": "fixture-2026-07-03.1",
+  "connectors": [
+    {
+      "connectorRef": "fixture-manual",
+      "authMethods": [
+        {
+          "id": "api-token",
+          "manualFieldMappings": [
+            {
+              "publicId": "apiKey",
+              "privateName": "FIXTURE_MANUAL_API_TOKEN",
+              "storage": "secret",
+              "runtimeName": "FIXTURE_MANUAL_API_TOKEN"
+            }
+          ],
+          "startOptionMappings": []
+        }
+      ],
+      "runtimeArtifactRefs": []
+    },
+    {
+      "connectorRef": "fixture-oauth",
+      "authMethods": [
+        {
+          "id": "oauth",
+          "manualFieldMappings": [],
+          "startOptionMappings": []
+        }
+      ],
+      "runtimeArtifactRefs": []
+    },
+    {
+      "connectorRef": "fixture-device",
+      "authMethods": [
+        {
+          "id": "device",
+          "manualFieldMappings": [],
+          "startOptionMappings": [
+            {
+              "publicId": "mode",
+              "privateName": "FIXTURE_DEVICE_MODE",
+              "runtimeName": "FIXTURE_DEVICE_MODE"
+            }
+          ]
+        }
+      ],
+      "runtimeArtifactRefs": []
+    }
+  ]
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/private/runtime.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/private/runtime.json
@@ -35,7 +35,7 @@
       "connectorRef": "fixture-device",
       "authMethods": [
         {
-          "id": "device",
+          "id": "api",
           "manualFieldMappings": [],
           "startOptionMappings": [
             {

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/public/catalog.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/public/catalog.json
@@ -118,9 +118,10 @@
       ],
       "categories": {
         "categories": {
-          "files": "Files"
+          "files.read": "Files",
+          "files.write": "Files"
         },
-        "displayOrder": ["files"]
+        "displayOrder": ["Files"]
       },
       "defaultPolicy": {
         "permissionDefault": "ask",

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/public/catalog.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/public/catalog.json
@@ -67,7 +67,7 @@
       "tags": ["fixture", "device"],
       "authMethods": [
         {
-          "id": "device",
+          "id": "api",
           "label": "Device Code",
           "description": "Connect with a device code.",
           "grantKind": "device-auth",

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/public/catalog.json
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/__fixtures__/catalog-v1/public/catalog.json
@@ -1,0 +1,134 @@
+{
+  "artifactSchemaVersion": 1,
+  "catalogVersion": "fixture-2026-07-03.1",
+  "connectors": [
+    {
+      "connectorRef": "fixture-manual",
+      "label": "Fixture Manual",
+      "description": "Manual fixture connector",
+      "category": "Development",
+      "generation": ["text"],
+      "tags": ["fixture", "manual"],
+      "authMethods": [
+        {
+          "id": "api-token",
+          "label": "API Token",
+          "description": "Connect with an API token.",
+          "grantKind": "manual",
+          "manualFields": [
+            {
+              "id": "apiKey",
+              "label": "API Key",
+              "required": true,
+              "placeholder": "key-...",
+              "inputType": "password"
+            }
+          ],
+          "startOptions": []
+        }
+      ],
+      "permissionSummary": {
+        "hasPermissions": true,
+        "permissionCount": 2,
+        "hasCategories": true,
+        "hasDefaultPolicyOverrides": true
+      }
+    },
+    {
+      "connectorRef": "fixture-oauth",
+      "label": "Fixture OAuth",
+      "description": "OAuth fixture connector",
+      "category": "Development",
+      "generation": ["text"],
+      "tags": ["fixture", "oauth"],
+      "authMethods": [
+        {
+          "id": "oauth",
+          "label": "OAuth",
+          "description": "Connect with OAuth.",
+          "grantKind": "auth-code",
+          "manualFields": [],
+          "startOptions": []
+        }
+      ],
+      "permissionSummary": {
+        "hasPermissions": false,
+        "permissionCount": 0,
+        "hasCategories": false,
+        "hasDefaultPolicyOverrides": false
+      }
+    },
+    {
+      "connectorRef": "fixture-device",
+      "label": "Fixture Device",
+      "description": "Device-auth fixture connector",
+      "category": "Development",
+      "generation": ["text"],
+      "tags": ["fixture", "device"],
+      "authMethods": [
+        {
+          "id": "device",
+          "label": "Device Code",
+          "description": "Connect with a device code.",
+          "grantKind": "device-auth",
+          "manualFields": [],
+          "startOptions": [
+            {
+              "id": "mode",
+              "kind": "select",
+              "label": "Mode",
+              "required": true,
+              "defaultValue": "test",
+              "options": [
+                {
+                  "value": "test",
+                  "label": "Test"
+                },
+                {
+                  "value": "live",
+                  "label": "Live"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "permissionSummary": {
+        "hasPermissions": false,
+        "permissionCount": 0,
+        "hasCategories": false,
+        "hasDefaultPolicyOverrides": false
+      }
+    }
+  ],
+  "permissions": [
+    {
+      "connectorRef": "fixture-manual",
+      "label": "Fixture Manual",
+      "permissionCount": 2,
+      "permissions": [
+        {
+          "name": "files.read",
+          "description": "Read fixture files"
+        },
+        {
+          "name": "files.write",
+          "description": "Write fixture files"
+        }
+      ],
+      "categories": {
+        "categories": {
+          "files": "Files"
+        },
+        "displayOrder": ["files"]
+      },
+      "defaultPolicy": {
+        "permissionDefault": "ask",
+        "permissionOverrides": {
+          "allow": ["files.read"]
+        },
+        "unknownPolicy": "deny"
+      }
+    }
+  ]
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/fixture-backend.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/fixture-backend.ts
@@ -8,6 +8,7 @@ import {
   type ConnectorCatalogArtifactReader,
   type ValidatedConnectorCatalogArtifacts,
 } from "./loader";
+import { parseConnectorCatalogArtifactKey } from "./schemas";
 
 const CONNECTOR_CATALOG_FIXTURE_ACTIVE_KEY =
   DEFAULT_CONNECTOR_CATALOG_ACTIVE_KEY;
@@ -24,7 +25,8 @@ const CONNECTOR_CATALOG_FIXTURE_ROOT = fileURLToPath(
 
 function fixtureArtifactPath(root: string, key: string): string {
   const rootPath = resolve(root);
-  const path = resolve(rootPath, key);
+  const artifactKey = parseConnectorCatalogArtifactKey(key);
+  const path = resolve(rootPath, artifactKey);
   if (path !== rootPath && !path.startsWith(`${rootPath}${sep}`)) {
     throw new Error(
       `Connector catalog fixture key escapes fixture root: ${key}`,

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/fixture-backend.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/fixture-backend.ts
@@ -1,0 +1,51 @@
+import { readFile } from "node:fs/promises";
+import { resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DEFAULT_CONNECTOR_CATALOG_ACTIVE_KEY,
+  loadConnectorCatalogArtifacts,
+  type ConnectorCatalogArtifactReader,
+  type ValidatedConnectorCatalogArtifacts,
+} from "./loader";
+
+const CONNECTOR_CATALOG_FIXTURE_ACTIVE_KEY =
+  DEFAULT_CONNECTOR_CATALOG_ACTIVE_KEY;
+export const CONNECTOR_CATALOG_FIXTURE_KEYS = [
+  "active.json",
+  "manifest.json",
+  "public/catalog.json",
+  "private/runtime.json",
+] as const;
+
+const CONNECTOR_CATALOG_FIXTURE_ROOT = fileURLToPath(
+  new URL("./__fixtures__/catalog-v1/", import.meta.url),
+);
+
+function fixtureArtifactPath(root: string, key: string): string {
+  const rootPath = resolve(root);
+  const path = resolve(rootPath, key);
+  if (path !== rootPath && !path.startsWith(`${rootPath}${sep}`)) {
+    throw new Error(
+      `Connector catalog fixture key escapes fixture root: ${key}`,
+    );
+  }
+  return path;
+}
+
+export function createFixtureConnectorCatalogArtifactReader(
+  root = CONNECTOR_CATALOG_FIXTURE_ROOT,
+): ConnectorCatalogArtifactReader {
+  return {
+    async readArtifact(key: string): Promise<Uint8Array> {
+      return await readFile(fixtureArtifactPath(root, key));
+    },
+  };
+}
+
+export function loadFixtureConnectorCatalogArtifacts(): Promise<ValidatedConnectorCatalogArtifacts> {
+  return loadConnectorCatalogArtifacts({
+    reader: createFixtureConnectorCatalogArtifactReader(),
+    activeKey: CONNECTOR_CATALOG_FIXTURE_ACTIVE_KEY,
+  });
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/index.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/index.ts
@@ -1,0 +1,15 @@
+export {
+  connectorCatalogArtifactDigest,
+  loadConnectorCatalogArtifacts,
+  type ConnectorCatalogArtifactReader,
+} from "./loader";
+export {
+  CONNECTOR_CATALOG_FIXTURE_KEYS,
+  createFixtureConnectorCatalogArtifactReader,
+  loadFixtureConnectorCatalogArtifacts,
+} from "./fixture-backend";
+export {
+  getPublicConnectorCatalogDetailFromArtifact,
+  getPublicConnectorCatalogPermissionDetailFromArtifact,
+  listPublicConnectorCatalogFromArtifact,
+} from "./public-view-model";

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -1,0 +1,495 @@
+import { createHash } from "node:crypto";
+
+import {
+  connectorCatalogActivePointerSchema,
+  connectorCatalogManifestSchema,
+  connectorCatalogPrivateArtifactSchema,
+  connectorCatalogPublicArtifactSchema,
+  isSupportedConnectorCatalogCapability,
+  SUPPORTED_CONNECTOR_CATALOG_ACTIVE_SCHEMA_VERSION,
+  SUPPORTED_CONNECTOR_CATALOG_ARTIFACT_SCHEMA_VERSION,
+  type ConnectorCatalogActivePointer,
+  type ConnectorCatalogManifest,
+  type ConnectorCatalogPrivateArtifact,
+  type ConnectorCatalogPublicArtifact,
+  type ConnectorCatalogPublicArtifactPermission,
+} from "./schemas";
+import { safeJsonParse } from "../../utils";
+import {
+  assertPublicCatalogArtifactHasNoPrivateFields,
+  privateCatalogArtifactSensitiveValues,
+} from "./public-leak";
+
+export const DEFAULT_CONNECTOR_CATALOG_ACTIVE_KEY = "active.json";
+
+export interface ConnectorCatalogArtifactReader {
+  readArtifact(key: string): Promise<Uint8Array>;
+}
+
+export interface ValidatedConnectorCatalogArtifacts {
+  readonly active: ConnectorCatalogActivePointer;
+  readonly manifest: ConnectorCatalogManifest;
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+}
+
+export function connectorCatalogArtifactDigest(bytes: Uint8Array): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function artifactBuffer(bytes: Uint8Array): Buffer {
+  return Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes);
+}
+
+async function readArtifactBytes(
+  reader: ConnectorCatalogArtifactReader,
+  key: string,
+): Promise<Buffer> {
+  return artifactBuffer(await reader.readArtifact(key));
+}
+
+function parseJsonArtifact(key: string, bytes: Uint8Array): unknown {
+  const parsed = safeJsonParse(artifactBuffer(bytes).toString("utf8"));
+  if (parsed === undefined) {
+    throw new Error(`Connector catalog artifact ${key} is not valid JSON`, {
+      cause: new SyntaxError("Invalid JSON"),
+    });
+  }
+  return parsed;
+}
+
+function assertDigest(args: {
+  readonly key: string;
+  readonly expectedDigest: string;
+  readonly bytes: Uint8Array;
+}): void {
+  const actualDigest = connectorCatalogArtifactDigest(args.bytes);
+  if (actualDigest !== args.expectedDigest) {
+    throw new Error(
+      `Connector catalog artifact ${args.key} digest mismatch: expected ${args.expectedDigest}, got ${actualDigest}`,
+    );
+  }
+}
+
+function assertActiveSchemaVersion(
+  active: ConnectorCatalogActivePointer,
+): void {
+  if (
+    active.schemaVersion !== SUPPORTED_CONNECTOR_CATALOG_ACTIVE_SCHEMA_VERSION
+  ) {
+    throw new Error(
+      `Unsupported connector catalog active schema version: ${active.schemaVersion}`,
+    );
+  }
+}
+
+function assertArtifactSchemaVersion(version: number): void {
+  if (version !== SUPPORTED_CONNECTOR_CATALOG_ARTIFACT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported connector catalog artifact schema version: ${version}`,
+    );
+  }
+}
+
+function assertRequiredCapabilities(
+  requiredCapabilities: readonly string[],
+): void {
+  const unsupported = requiredCapabilities.filter((capability) => {
+    return !isSupportedConnectorCatalogCapability(capability);
+  });
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Unsupported connector catalog capabilities: ${unsupported
+        .sort()
+        .join(", ")}`,
+    );
+  }
+}
+
+function assertCatalogVersionMatches(args: {
+  readonly source: string;
+  readonly expected: string;
+  readonly actual: string;
+}): void {
+  if (args.actual !== args.expected) {
+    throw new Error(
+      `Connector catalog ${args.source} catalogVersion mismatch: expected ${args.expected}, got ${args.actual}`,
+    );
+  }
+}
+
+function assertUniqueValues(args: {
+  readonly values: readonly string[];
+  readonly label: string;
+}): void {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of args.values) {
+    if (seen.has(value)) {
+      duplicates.add(value);
+    }
+    seen.add(value);
+  }
+  if (duplicates.size > 0) {
+    throw new Error(
+      `Duplicate connector catalog ${args.label}: ${[...duplicates]
+        .sort()
+        .join(", ")}`,
+    );
+  }
+}
+
+function sorted(values: Iterable<string>): string {
+  return [...values].sort().join(", ");
+}
+
+function assertSameValues(args: {
+  readonly expected: ReadonlySet<string>;
+  readonly actual: ReadonlySet<string>;
+  readonly label: string;
+}): void {
+  const missing = [...args.expected].filter((value) => {
+    return !args.actual.has(value);
+  });
+  const unexpected = [...args.actual].filter((value) => {
+    return !args.expected.has(value);
+  });
+
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new Error(
+      `Connector catalog ${args.label} mismatch: missing [${sorted(
+        missing,
+      )}], unexpected [${sorted(unexpected)}]`,
+    );
+  }
+}
+
+function hasPermissionOverrides(
+  permission: ConnectorCatalogPublicArtifactPermission,
+): boolean {
+  return (
+    permission.defaultPolicy.permissionOverrides !== undefined &&
+    Object.values(permission.defaultPolicy.permissionOverrides).some(
+      (permissions) => {
+        return permissions.length > 0;
+      },
+    )
+  );
+}
+
+function assertPermissionSummaryConsistency(
+  publicArtifact: ConnectorCatalogPublicArtifact,
+): void {
+  const permissionByConnectorRef = new Map(
+    publicArtifact.permissions.map((permission) => {
+      return [permission.connectorRef, permission];
+    }),
+  );
+
+  for (const connector of publicArtifact.connectors) {
+    const permission = permissionByConnectorRef.get(connector.connectorRef);
+    const expectedSummary = permission
+      ? {
+          hasPermissions: true,
+          permissionCount: permission.permissionCount,
+          hasCategories: permission.categories !== null,
+          hasDefaultPolicyOverrides: hasPermissionOverrides(permission),
+        }
+      : {
+          hasPermissions: false,
+          permissionCount: 0,
+          hasCategories: false,
+          hasDefaultPolicyOverrides: false,
+        };
+
+    if (
+      connector.permissionSummary.hasPermissions !==
+        expectedSummary.hasPermissions ||
+      connector.permissionSummary.permissionCount !==
+        expectedSummary.permissionCount ||
+      connector.permissionSummary.hasCategories !==
+        expectedSummary.hasCategories ||
+      connector.permissionSummary.hasDefaultPolicyOverrides !==
+        expectedSummary.hasDefaultPolicyOverrides
+    ) {
+      throw new Error(
+        `Connector catalog permission summary mismatch for ${connector.connectorRef}`,
+      );
+    }
+  }
+
+  for (const permission of publicArtifact.permissions) {
+    if (permission.permissionCount !== permission.permissions.length) {
+      throw new Error(
+        `Connector catalog permission count mismatch for ${permission.connectorRef}`,
+      );
+    }
+    if (permission.categories) {
+      const categoryKeys = new Set(
+        Object.keys(permission.categories.categories),
+      );
+      assertSameValues({
+        expected: categoryKeys,
+        actual: new Set(permission.categories.displayOrder),
+        label: `${permission.connectorRef} permission category display order`,
+      });
+    }
+  }
+}
+
+function assertPublicArtifactConsistency(
+  publicArtifact: ConnectorCatalogPublicArtifact,
+): void {
+  assertUniqueValues({
+    values: publicArtifact.connectors.map((connector) => {
+      return connector.connectorRef;
+    }),
+    label: "public connector refs",
+  });
+  assertUniqueValues({
+    values: publicArtifact.permissions.map((permission) => {
+      return permission.connectorRef;
+    }),
+    label: "permission connector refs",
+  });
+
+  const connectorRefs = new Set(
+    publicArtifact.connectors.map((connector) => {
+      return connector.connectorRef;
+    }),
+  );
+  for (const permission of publicArtifact.permissions) {
+    if (!connectorRefs.has(permission.connectorRef)) {
+      throw new Error(
+        `Permission metadata references unknown connector ${permission.connectorRef}`,
+      );
+    }
+  }
+  assertPermissionSummaryConsistency(publicArtifact);
+
+  for (const connector of publicArtifact.connectors) {
+    assertUniqueValues({
+      values: connector.authMethods.map((authMethod) => {
+        return authMethod.id;
+      }),
+      label: `${connector.connectorRef} auth method ids`,
+    });
+    for (const authMethod of connector.authMethods) {
+      assertUniqueValues({
+        values: authMethod.manualFields.map((field) => {
+          return field.id;
+        }),
+        label: `${connector.connectorRef}/${authMethod.id} manual field ids`,
+      });
+      assertUniqueValues({
+        values: authMethod.startOptions.map((option) => {
+          return option.id;
+        }),
+        label: `${connector.connectorRef}/${authMethod.id} start option ids`,
+      });
+    }
+  }
+}
+
+function assertPrivateArtifactConsistency(args: {
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+  readonly privateArtifact: ConnectorCatalogPrivateArtifact;
+}): void {
+  const publicConnectorByRef = new Map(
+    args.publicArtifact.connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+
+  assertUniqueValues({
+    values: args.privateArtifact.connectors.map((connector) => {
+      return connector.connectorRef;
+    }),
+    label: "private connector refs",
+  });
+  assertSameValues({
+    expected: new Set(publicConnectorByRef.keys()),
+    actual: new Set(
+      args.privateArtifact.connectors.map((connector) => {
+        return connector.connectorRef;
+      }),
+    ),
+    label: "private connector refs",
+  });
+
+  for (const privateConnector of args.privateArtifact.connectors) {
+    const publicConnector = publicConnectorByRef.get(
+      privateConnector.connectorRef,
+    );
+    if (!publicConnector) {
+      throw new Error(
+        `Private artifact references unknown connector ${privateConnector.connectorRef}`,
+      );
+    }
+
+    const publicAuthMethodById = new Map(
+      publicConnector.authMethods.map((authMethod) => {
+        return [authMethod.id, authMethod];
+      }),
+    );
+    assertUniqueValues({
+      values: privateConnector.authMethods.map((authMethod) => {
+        return authMethod.id;
+      }),
+      label: `${privateConnector.connectorRef} private auth method ids`,
+    });
+    assertSameValues({
+      expected: new Set(publicAuthMethodById.keys()),
+      actual: new Set(
+        privateConnector.authMethods.map((authMethod) => {
+          return authMethod.id;
+        }),
+      ),
+      label: `${privateConnector.connectorRef} private auth method ids`,
+    });
+
+    for (const privateAuthMethod of privateConnector.authMethods) {
+      const publicAuthMethod = publicAuthMethodById.get(privateAuthMethod.id);
+      if (!publicAuthMethod) {
+        throw new Error(
+          `Private artifact references unknown auth method ${privateConnector.connectorRef}/${privateAuthMethod.id}`,
+        );
+      }
+
+      const publicManualFieldIds = new Set(
+        publicAuthMethod.manualFields.map((field) => {
+          return field.id;
+        }),
+      );
+      const publicStartOptionIds = new Set(
+        publicAuthMethod.startOptions.map((option) => {
+          return option.id;
+        }),
+      );
+      assertUniqueValues({
+        values: privateAuthMethod.manualFieldMappings.map((mapping) => {
+          return mapping.publicId;
+        }),
+        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private manual field public ids`,
+      });
+      assertUniqueValues({
+        values: privateAuthMethod.startOptionMappings.map((mapping) => {
+          return mapping.publicId;
+        }),
+        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private start option public ids`,
+      });
+      assertSameValues({
+        expected: publicManualFieldIds,
+        actual: new Set(
+          privateAuthMethod.manualFieldMappings.map((mapping) => {
+            return mapping.publicId;
+          }),
+        ),
+        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private manual field public ids`,
+      });
+      assertSameValues({
+        expected: publicStartOptionIds,
+        actual: new Set(
+          privateAuthMethod.startOptionMappings.map((mapping) => {
+            return mapping.publicId;
+          }),
+        ),
+        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private start option public ids`,
+      });
+
+      for (const mapping of privateAuthMethod.manualFieldMappings) {
+        if (!publicManualFieldIds.has(mapping.publicId)) {
+          throw new Error(
+            `Private manual field mapping references unknown public id ${privateConnector.connectorRef}/${privateAuthMethod.id}/${mapping.publicId}`,
+          );
+        }
+      }
+      for (const mapping of privateAuthMethod.startOptionMappings) {
+        if (!publicStartOptionIds.has(mapping.publicId)) {
+          throw new Error(
+            `Private start option mapping references unknown public id ${privateConnector.connectorRef}/${privateAuthMethod.id}/${mapping.publicId}`,
+          );
+        }
+      }
+    }
+  }
+}
+
+export async function loadConnectorCatalogArtifacts(args: {
+  readonly reader: ConnectorCatalogArtifactReader;
+  readonly activeKey?: string;
+}): Promise<ValidatedConnectorCatalogArtifacts> {
+  const activeKey = args.activeKey ?? DEFAULT_CONNECTOR_CATALOG_ACTIVE_KEY;
+  const activeBytes = await readArtifactBytes(args.reader, activeKey);
+  const active = connectorCatalogActivePointerSchema.parse(
+    parseJsonArtifact(activeKey, activeBytes),
+  );
+  assertActiveSchemaVersion(active);
+
+  const manifestBytes = await readArtifactBytes(
+    args.reader,
+    active.manifestKey,
+  );
+  assertDigest({
+    key: active.manifestKey,
+    expectedDigest: active.manifestDigest,
+    bytes: manifestBytes,
+  });
+  const manifest = connectorCatalogManifestSchema.parse(
+    parseJsonArtifact(active.manifestKey, manifestBytes),
+  );
+  assertCatalogVersionMatches({
+    source: "manifest",
+    expected: active.catalogVersion,
+    actual: manifest.catalogVersion,
+  });
+  assertArtifactSchemaVersion(manifest.artifactSchemaVersion);
+  assertRequiredCapabilities(manifest.requiredCapabilities);
+
+  const [publicBytes, privateBytes] = await Promise.all([
+    readArtifactBytes(args.reader, manifest.artifacts.public.key),
+    readArtifactBytes(args.reader, manifest.artifacts.private.key),
+  ]);
+  assertDigest({
+    key: manifest.artifacts.public.key,
+    expectedDigest: manifest.artifacts.public.digest,
+    bytes: publicBytes,
+  });
+  assertDigest({
+    key: manifest.artifacts.private.key,
+    expectedDigest: manifest.artifacts.private.digest,
+    bytes: privateBytes,
+  });
+
+  const publicArtifact = connectorCatalogPublicArtifactSchema.parse(
+    parseJsonArtifact(manifest.artifacts.public.key, publicBytes),
+  );
+  const privateArtifact = connectorCatalogPrivateArtifactSchema.parse(
+    parseJsonArtifact(manifest.artifacts.private.key, privateBytes),
+  );
+  assertArtifactSchemaVersion(publicArtifact.artifactSchemaVersion);
+  assertArtifactSchemaVersion(privateArtifact.artifactSchemaVersion);
+  assertCatalogVersionMatches({
+    source: "public artifact",
+    expected: manifest.catalogVersion,
+    actual: publicArtifact.catalogVersion,
+  });
+  assertCatalogVersionMatches({
+    source: "private artifact",
+    expected: manifest.catalogVersion,
+    actual: privateArtifact.catalogVersion,
+  });
+  assertPublicArtifactConsistency(publicArtifact);
+  assertPrivateArtifactConsistency({ publicArtifact, privateArtifact });
+  assertPublicCatalogArtifactHasNoPrivateFields(
+    publicArtifact,
+    privateCatalogArtifactSensitiveValues(privateArtifact),
+  );
+
+  return {
+    active,
+    manifest,
+    publicArtifact,
+    privateArtifact,
+  };
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -218,7 +218,7 @@ function assertPermissionSummaryConsistency(
     const permission = permissionByConnectorRef.get(connector.connectorRef);
     const expectedSummary = permission
       ? {
-          hasPermissions: true,
+          hasPermissions: permission.permissionCount > 0,
           permissionCount: permission.permissionCount,
           hasCategories: permission.categories !== null,
           hasDefaultPolicyOverrides: hasPermissionOverrides(permission),

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -177,6 +177,34 @@ function hasPermissionOverrides(
   );
 }
 
+function assertPermissionOverridesConsistency(
+  permission: ConnectorCatalogPublicArtifactPermission,
+  permissionNames: ReadonlySet<string>,
+): void {
+  const overrides = permission.defaultPolicy.permissionOverrides;
+  if (!overrides) {
+    return;
+  }
+
+  const overridePermissionNames = Object.values(overrides).flatMap(
+    (permissions) => {
+      return permissions ?? [];
+    },
+  );
+  assertUniqueValues({
+    values: overridePermissionNames,
+    label: `${permission.connectorRef} default policy override permission names`,
+  });
+
+  for (const permissionName of overridePermissionNames) {
+    if (!permissionNames.has(permissionName)) {
+      throw new Error(
+        `Connector catalog default policy override references unknown permission ${permission.connectorRef}/${permissionName}`,
+      );
+    }
+  }
+}
+
 function assertPermissionSummaryConsistency(
   publicArtifact: ConnectorCatalogPublicArtifact,
 ): void {
@@ -224,16 +252,60 @@ function assertPermissionSummaryConsistency(
         `Connector catalog permission count mismatch for ${permission.connectorRef}`,
       );
     }
+    assertUniqueValues({
+      values: permission.permissions.map((item) => {
+        return item.name;
+      }),
+      label: `${permission.connectorRef} permission names`,
+    });
+    const permissionNames = new Set(
+      permission.permissions.map((item) => {
+        return item.name;
+      }),
+    );
+    assertPermissionOverridesConsistency(permission, permissionNames);
+
     if (permission.categories) {
-      const categoryKeys = new Set(
-        Object.keys(permission.categories.categories),
+      assertSameValues({
+        expected: permissionNames,
+        actual: new Set(Object.keys(permission.categories.categories)),
+        label: `${permission.connectorRef} permission category permission names`,
+      });
+      assertUniqueValues({
+        values: permission.categories.displayOrder,
+        label: `${permission.connectorRef} permission category display order`,
+      });
+      const categoryValues = new Set(
+        Object.values(permission.categories.categories),
       );
       assertSameValues({
-        expected: categoryKeys,
+        expected: categoryValues,
         actual: new Set(permission.categories.displayOrder),
         label: `${permission.connectorRef} permission category display order`,
       });
     }
+  }
+}
+
+function assertAuthMethodShape(args: {
+  readonly connectorRef: string;
+  readonly authMethod: ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number];
+}): void {
+  if (
+    args.authMethod.grantKind !== "manual" &&
+    args.authMethod.manualFields.length > 0
+  ) {
+    throw new Error(
+      `Connector catalog auth method ${args.connectorRef}/${args.authMethod.id} has manual fields for ${args.authMethod.grantKind} grant`,
+    );
+  }
+  if (
+    args.authMethod.grantKind !== "device-auth" &&
+    args.authMethod.startOptions.length > 0
+  ) {
+    throw new Error(
+      `Connector catalog auth method ${args.connectorRef}/${args.authMethod.id} has start options for ${args.authMethod.grantKind} grant`,
+    );
   }
 }
 
@@ -275,6 +347,10 @@ function assertPublicArtifactConsistency(
       label: `${connector.connectorRef} auth method ids`,
     });
     for (const authMethod of connector.authMethods) {
+      assertAuthMethodShape({
+        connectorRef: connector.connectorRef,
+        authMethod,
+      });
       assertUniqueValues({
         values: authMethod.manualFields.map((field) => {
           return field.id;

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -373,6 +373,92 @@ function assertPublicArtifactConsistency(
   }
 }
 
+function assertPrivateAuthMethodMappingConsistency(args: {
+  readonly connectorRef: string;
+  readonly privateAuthMethod: ConnectorCatalogPrivateArtifact["connectors"][number]["authMethods"][number];
+  readonly publicAuthMethod: ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number];
+}): void {
+  const publicManualFieldIds = new Set(
+    args.publicAuthMethod.manualFields.map((field) => {
+      return field.id;
+    }),
+  );
+  const publicStartOptionIds = new Set(
+    args.publicAuthMethod.startOptions.map((option) => {
+      return option.id;
+    }),
+  );
+  assertUniqueValues({
+    values: args.privateAuthMethod.manualFieldMappings.map((mapping) => {
+      return mapping.publicId;
+    }),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private manual field public ids`,
+  });
+  assertUniqueValues({
+    values: args.privateAuthMethod.manualFieldMappings.map((mapping) => {
+      return mapping.privateName;
+    }),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private manual field private names`,
+  });
+  assertUniqueValues({
+    values: args.privateAuthMethod.manualFieldMappings.map((mapping) => {
+      return mapping.runtimeName;
+    }),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private manual field runtime names`,
+  });
+  assertUniqueValues({
+    values: args.privateAuthMethod.startOptionMappings.map((mapping) => {
+      return mapping.publicId;
+    }),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private start option public ids`,
+  });
+  assertUniqueValues({
+    values: args.privateAuthMethod.startOptionMappings.map((mapping) => {
+      return mapping.privateName;
+    }),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private start option private names`,
+  });
+  assertUniqueValues({
+    values: args.privateAuthMethod.startOptionMappings.map((mapping) => {
+      return mapping.runtimeName;
+    }),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private start option runtime names`,
+  });
+  assertSameValues({
+    expected: publicManualFieldIds,
+    actual: new Set(
+      args.privateAuthMethod.manualFieldMappings.map((mapping) => {
+        return mapping.publicId;
+      }),
+    ),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private manual field public ids`,
+  });
+  assertSameValues({
+    expected: publicStartOptionIds,
+    actual: new Set(
+      args.privateAuthMethod.startOptionMappings.map((mapping) => {
+        return mapping.publicId;
+      }),
+    ),
+    label: `${args.connectorRef}/${args.privateAuthMethod.id} private start option public ids`,
+  });
+
+  for (const mapping of args.privateAuthMethod.manualFieldMappings) {
+    if (!publicManualFieldIds.has(mapping.publicId)) {
+      throw new Error(
+        `Private manual field mapping references unknown public id ${args.connectorRef}/${args.privateAuthMethod.id}/${mapping.publicId}`,
+      );
+    }
+  }
+  for (const mapping of args.privateAuthMethod.startOptionMappings) {
+    if (!publicStartOptionIds.has(mapping.publicId)) {
+      throw new Error(
+        `Private start option mapping references unknown public id ${args.connectorRef}/${args.privateAuthMethod.id}/${mapping.publicId}`,
+      );
+    }
+  }
+}
+
 function assertPrivateArtifactConsistency(args: {
   readonly publicArtifact: ConnectorCatalogPublicArtifact;
   readonly privateArtifact: ConnectorCatalogPrivateArtifact;
@@ -437,62 +523,11 @@ function assertPrivateArtifactConsistency(args: {
           `Private artifact references unknown auth method ${privateConnector.connectorRef}/${privateAuthMethod.id}`,
         );
       }
-
-      const publicManualFieldIds = new Set(
-        publicAuthMethod.manualFields.map((field) => {
-          return field.id;
-        }),
-      );
-      const publicStartOptionIds = new Set(
-        publicAuthMethod.startOptions.map((option) => {
-          return option.id;
-        }),
-      );
-      assertUniqueValues({
-        values: privateAuthMethod.manualFieldMappings.map((mapping) => {
-          return mapping.publicId;
-        }),
-        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private manual field public ids`,
+      assertPrivateAuthMethodMappingConsistency({
+        connectorRef: privateConnector.connectorRef,
+        privateAuthMethod,
+        publicAuthMethod,
       });
-      assertUniqueValues({
-        values: privateAuthMethod.startOptionMappings.map((mapping) => {
-          return mapping.publicId;
-        }),
-        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private start option public ids`,
-      });
-      assertSameValues({
-        expected: publicManualFieldIds,
-        actual: new Set(
-          privateAuthMethod.manualFieldMappings.map((mapping) => {
-            return mapping.publicId;
-          }),
-        ),
-        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private manual field public ids`,
-      });
-      assertSameValues({
-        expected: publicStartOptionIds,
-        actual: new Set(
-          privateAuthMethod.startOptionMappings.map((mapping) => {
-            return mapping.publicId;
-          }),
-        ),
-        label: `${privateConnector.connectorRef}/${privateAuthMethod.id} private start option public ids`,
-      });
-
-      for (const mapping of privateAuthMethod.manualFieldMappings) {
-        if (!publicManualFieldIds.has(mapping.publicId)) {
-          throw new Error(
-            `Private manual field mapping references unknown public id ${privateConnector.connectorRef}/${privateAuthMethod.id}/${mapping.publicId}`,
-          );
-        }
-      }
-      for (const mapping of privateAuthMethod.startOptionMappings) {
-        if (!publicStartOptionIds.has(mapping.publicId)) {
-          throw new Error(
-            `Private start option mapping references unknown public id ${privateConnector.connectorRef}/${privateAuthMethod.id}/${mapping.publicId}`,
-          );
-        }
-      }
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -95,6 +95,10 @@ function assertArtifactSchemaVersion(version: number): void {
 function assertRequiredCapabilities(
   requiredCapabilities: readonly string[],
 ): void {
+  assertUniqueValues({
+    values: requiredCapabilities,
+    label: "required capabilities",
+  });
   const unsupported = requiredCapabilities.filter((capability) => {
     return !isSupportedConnectorCatalogCapability(capability);
   });
@@ -312,6 +316,23 @@ function assertAuthMethodShape(args: {
     throw new Error(
       `Connector catalog auth method ${args.connectorRef}/${args.authMethod.id} has start options for ${args.authMethod.grantKind} grant`,
     );
+  }
+  for (const startOption of args.authMethod.startOptions) {
+    const optionValues = startOption.options.map((option) => {
+      return option.value;
+    });
+    assertUniqueValues({
+      values: optionValues,
+      label: `${args.connectorRef}/${args.authMethod.id}/${startOption.id} start option values`,
+    });
+    if (
+      startOption.defaultValue !== null &&
+      !optionValues.includes(startOption.defaultValue)
+    ) {
+      throw new Error(
+        `Connector catalog auth method ${args.connectorRef}/${args.authMethod.id} start option ${startOption.id} defaultValue is not an option`,
+      );
+    }
   }
 }
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -6,6 +6,7 @@ import {
   connectorCatalogPrivateArtifactSchema,
   connectorCatalogPublicArtifactSchema,
   isSupportedConnectorCatalogCapability,
+  parseConnectorCatalogArtifactKey,
   SUPPORTED_CONNECTOR_CATALOG_ACTIVE_SCHEMA_VERSION,
   SUPPORTED_CONNECTOR_CATALOG_ARTIFACT_SCHEMA_VERSION,
   type ConnectorCatalogActivePointer,
@@ -266,6 +267,11 @@ function assertPermissionSummaryConsistency(
     assertPermissionOverridesConsistency(permission, permissionNames);
 
     if (permission.categories) {
+      if (permissionNames.size === 0) {
+        throw new Error(
+          `Connector catalog permission categories require permissions for ${permission.connectorRef}`,
+        );
+      }
       assertSameValues({
         expected: permissionNames,
         actual: new Set(Object.keys(permission.categories.categories)),
@@ -495,7 +501,9 @@ export async function loadConnectorCatalogArtifacts(args: {
   readonly reader: ConnectorCatalogArtifactReader;
   readonly activeKey?: string;
 }): Promise<ValidatedConnectorCatalogArtifacts> {
-  const activeKey = args.activeKey ?? DEFAULT_CONNECTOR_CATALOG_ACTIVE_KEY;
+  const activeKey = parseConnectorCatalogArtifactKey(
+    args.activeKey ?? DEFAULT_CONNECTOR_CATALOG_ACTIVE_KEY,
+  );
   const activeBytes = await readArtifactBytes(args.reader, activeKey);
   const active = connectorCatalogActivePointerSchema.parse(
     parseJsonArtifact(activeKey, activeBytes),

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/loader.ts
@@ -111,6 +111,44 @@ function assertRequiredCapabilities(
   }
 }
 
+function authMethodGrantCapability(
+  authMethod: ConnectorCatalogPublicArtifact["connectors"][number]["authMethods"][number],
+): string {
+  return `grant.${authMethod.grantKind}@1`;
+}
+
+function assertRequiredCapabilitiesCoverArtifacts(args: {
+  readonly manifest: ConnectorCatalogManifest;
+  readonly publicArtifact: ConnectorCatalogPublicArtifact;
+}): void {
+  const declaredCapabilities = new Set(args.manifest.requiredCapabilities);
+  const artifactCapabilities = new Set<string>([
+    "catalog.public-connectors@1",
+    "catalog.private-field-mapping@1",
+  ]);
+
+  for (const connector of args.publicArtifact.connectors) {
+    for (const authMethod of connector.authMethods) {
+      artifactCapabilities.add(authMethodGrantCapability(authMethod));
+    }
+  }
+
+  if (args.publicArtifact.permissions.length > 0) {
+    artifactCapabilities.add("firewall.permission-metadata@1");
+  }
+
+  const missingCapabilities = [...artifactCapabilities].filter((capability) => {
+    return !declaredCapabilities.has(capability);
+  });
+  if (missingCapabilities.length > 0) {
+    throw new Error(
+      `Connector catalog manifest requiredCapabilities missing artifact capabilities: ${sorted(
+        missingCapabilities,
+      )}`,
+    );
+  }
+}
+
 function assertCatalogVersionMatches(args: {
   readonly source: string;
   readonly expected: string;
@@ -619,6 +657,7 @@ export async function loadConnectorCatalogArtifacts(args: {
     expected: manifest.catalogVersion,
     actual: privateArtifact.catalogVersion,
   });
+  assertRequiredCapabilitiesCoverArtifacts({ manifest, publicArtifact });
   assertPublicArtifactConsistency(publicArtifact);
   assertPrivateArtifactConsistency({ publicArtifact, privateArtifact });
   assertPublicCatalogArtifactHasNoPrivateFields(

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
@@ -58,7 +58,7 @@ function assertNoSensitiveString(args: {
     }
     if (args.value.includes(sensitiveValue)) {
       throw new Error(
-        `Public connector catalog artifact leaked ${sensitiveValue} at ${args.path}`,
+        `Public connector catalog artifact leaked private value at ${args.path}`,
       );
     }
     const normalizedSensitiveValue = normalizeSensitiveString(sensitiveValue);
@@ -69,7 +69,7 @@ function assertNoSensitiveString(args: {
       normalizedValue.includes(normalizedSensitiveValue)
     ) {
       throw new Error(
-        `Public connector catalog artifact leaked ${sensitiveValue} at ${args.path}`,
+        `Public connector catalog artifact leaked private value at ${args.path}`,
       );
     }
   }

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
@@ -22,6 +22,10 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function hasPublicDataKeys(path: string): boolean {
+  return /^\$\.permissions\[\d+\]\.categories\.categories$/.test(path);
+}
+
 export function privateCatalogArtifactSensitiveValues(
   privateArtifact: ConnectorCatalogPrivateArtifact,
 ): ReadonlySet<string> {
@@ -100,8 +104,9 @@ export function assertPublicCatalogArtifactHasNoPrivateFields(
     return;
   }
 
+  const checkPropertyNames = !hasPublicDataKeys(path);
   for (const [key, child] of Object.entries(value)) {
-    if (isForbiddenPublicPropertyName(key)) {
+    if (checkPropertyNames && isForbiddenPublicPropertyName(key)) {
       throw new Error(
         `Public connector catalog artifact leaked private property ${key} at ${path}`,
       );

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
@@ -1,0 +1,112 @@
+import type { ConnectorCatalogPrivateArtifact } from "./schemas";
+
+function isForbiddenPublicPropertyName(key: string): boolean {
+  return /^(storage|secrets|variables|envBindings|valueRef|source|target|platformSecrets|client|clientIdEnv|clientSecretEnv|clientSecret|scopes|outputs|inputs|refreshableSecrets|revoke|access|featureFlag|showExperimentalLabel|placeholderValues|baseUrlTemplates|secretPlaceholderNames|manifestKey|bucket|objectKey|signedUrl|runtimeArtifactRefs|runtimeName|privateName|authInjection|matcher|routing)$/.test(
+    key,
+  );
+}
+
+function normalizeSensitiveString(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+}
+
+function shouldCheckDerivedSensitiveValue(path: string): boolean {
+  return (
+    path.endsWith(".placeholder") ||
+    path.endsWith(".defaultValue") ||
+    path.endsWith(".value")
+  );
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function privateCatalogArtifactSensitiveValues(
+  privateArtifact: ConnectorCatalogPrivateArtifact,
+): ReadonlySet<string> {
+  const values = new Set<string>();
+
+  for (const connector of privateArtifact.connectors) {
+    for (const authMethod of connector.authMethods) {
+      for (const mapping of authMethod.manualFieldMappings) {
+        values.add(mapping.privateName);
+        values.add(mapping.runtimeName);
+      }
+      for (const mapping of authMethod.startOptionMappings) {
+        values.add(mapping.privateName);
+        values.add(mapping.runtimeName);
+      }
+    }
+  }
+
+  return values;
+}
+
+function assertNoSensitiveString(args: {
+  readonly value: string;
+  readonly path: string;
+  readonly sensitiveValues: ReadonlySet<string>;
+}): void {
+  const normalizedValue = normalizeSensitiveString(args.value);
+  for (const sensitiveValue of args.sensitiveValues) {
+    if (sensitiveValue.length === 0) {
+      continue;
+    }
+    if (args.value.includes(sensitiveValue)) {
+      throw new Error(
+        `Public connector catalog artifact leaked ${sensitiveValue} at ${args.path}`,
+      );
+    }
+    const normalizedSensitiveValue = normalizeSensitiveString(sensitiveValue);
+    if (
+      shouldCheckDerivedSensitiveValue(args.path) &&
+      sensitiveValue.includes("_") &&
+      normalizedSensitiveValue.length >= 8 &&
+      normalizedValue.includes(normalizedSensitiveValue)
+    ) {
+      throw new Error(
+        `Public connector catalog artifact leaked ${sensitiveValue} at ${args.path}`,
+      );
+    }
+  }
+}
+
+export function assertPublicCatalogArtifactHasNoPrivateFields(
+  value: unknown,
+  sensitiveValues: ReadonlySet<string>,
+  path = "$",
+): void {
+  if (typeof value === "string") {
+    assertNoSensitiveString({ value, path, sensitiveValues });
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const [index, child] of value.entries()) {
+      assertPublicCatalogArtifactHasNoPrivateFields(
+        child,
+        sensitiveValues,
+        `${path}[${index}]`,
+      );
+    }
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    if (isForbiddenPublicPropertyName(key)) {
+      throw new Error(
+        `Public connector catalog artifact leaked private property ${key} at ${path}`,
+      );
+    }
+    assertPublicCatalogArtifactHasNoPrivateFields(
+      child,
+      sensitiveValues,
+      `${path}.${key}`,
+    );
+  }
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-leak.ts
@@ -28,6 +28,9 @@ export function privateCatalogArtifactSensitiveValues(
   const values = new Set<string>();
 
   for (const connector of privateArtifact.connectors) {
+    for (const artifactRef of connector.runtimeArtifactRefs) {
+      values.add(artifactRef.key);
+    }
     for (const authMethod of connector.authMethods) {
       for (const mapping of authMethod.manualFieldMappings) {
         values.add(mapping.privateName);

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-view-model.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/public-view-model.ts
@@ -1,0 +1,124 @@
+import type {
+  PublicConnectorCatalogAuthMethodSummary,
+  PublicConnectorCatalogDetail,
+  PublicConnectorCatalogItem,
+  PublicConnectorCatalogPermissionDetail,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+
+import type {
+  ConnectorCatalogPublicArtifact,
+  ConnectorCatalogPublicArtifactConnector,
+  ConnectorCatalogPublicArtifactPermission,
+} from "./schemas";
+
+function authMethodSummary(
+  authMethod: ConnectorCatalogPublicArtifactConnector["authMethods"][number],
+): PublicConnectorCatalogAuthMethodSummary {
+  return {
+    id: authMethod.id,
+    label: authMethod.label,
+    description: authMethod.description,
+    grantKind: authMethod.grantKind,
+  };
+}
+
+function connectorCatalogArtifactToPublicItem(
+  connector: ConnectorCatalogPublicArtifactConnector,
+): PublicConnectorCatalogItem {
+  return {
+    connectorRef: connector.connectorRef,
+    label: connector.label,
+    description: connector.description,
+    category: connector.category,
+    generation: [...connector.generation],
+    tags: [...connector.tags],
+    authMethods: connector.authMethods.map(authMethodSummary),
+    permissionSummary: { ...connector.permissionSummary },
+  };
+}
+
+function connectorCatalogArtifactToPublicDetail(
+  connector: ConnectorCatalogPublicArtifactConnector,
+): PublicConnectorCatalogDetail {
+  return {
+    ...connectorCatalogArtifactToPublicItem(connector),
+    authMethods: connector.authMethods.map((authMethod) => {
+      return {
+        ...authMethodSummary(authMethod),
+        manualFields: authMethod.manualFields.map((field) => {
+          return { ...field };
+        }),
+        startOptions: authMethod.startOptions.map((option) => {
+          return {
+            ...option,
+            options: option.options.map((choice) => {
+              return { ...choice };
+            }),
+          };
+        }),
+      };
+    }),
+  };
+}
+
+function connectorCatalogArtifactToPublicPermissionDetail(
+  permission: ConnectorCatalogPublicArtifactPermission,
+): PublicConnectorCatalogPermissionDetail {
+  return {
+    connectorRef: permission.connectorRef,
+    label: permission.label,
+    permissionCount: permission.permissionCount,
+    permissions: permission.permissions.map((item) => {
+      return { ...item };
+    }),
+    categories: permission.categories
+      ? {
+          categories: { ...permission.categories.categories },
+          displayOrder: [...permission.categories.displayOrder],
+        }
+      : null,
+    defaultPolicy: {
+      permissionDefault: permission.defaultPolicy.permissionDefault,
+      ...(permission.defaultPolicy.permissionOverrides
+        ? {
+            permissionOverrides: Object.fromEntries(
+              Object.entries(permission.defaultPolicy.permissionOverrides).map(
+                ([policy, permissions]) => {
+                  return [policy, [...permissions]];
+                },
+              ),
+            ),
+          }
+        : {}),
+      unknownPolicy: permission.defaultPolicy.unknownPolicy,
+    },
+  };
+}
+
+export function listPublicConnectorCatalogFromArtifact(
+  artifact: ConnectorCatalogPublicArtifact,
+): PublicConnectorCatalogItem[] {
+  return artifact.connectors.map(connectorCatalogArtifactToPublicItem);
+}
+
+export function getPublicConnectorCatalogDetailFromArtifact(
+  artifact: ConnectorCatalogPublicArtifact,
+  connectorRef: string,
+): PublicConnectorCatalogDetail | null {
+  const connector = artifact.connectors.find((item) => {
+    return item.connectorRef === connectorRef;
+  });
+  return connector ? connectorCatalogArtifactToPublicDetail(connector) : null;
+}
+
+export function getPublicConnectorCatalogPermissionDetailFromArtifact(
+  artifact: ConnectorCatalogPublicArtifact,
+  connectorRef: string,
+): PublicConnectorCatalogPermissionDetail | null {
+  const permission = artifact.permissions.find((item) => {
+    return item.connectorRef === connectorRef;
+  });
+  return permission
+    ? connectorCatalogArtifactToPublicPermissionDetail(permission)
+    : null;
+}

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 
 const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
-const connectorRefSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/);
-const authMethodIdSchema = z.string().min(1);
+const connectorCatalogSlugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/);
+const connectorRefSchema = connectorCatalogSlugSchema;
+const authMethodIdSchema = connectorCatalogSlugSchema;
 const publicFieldIdSchema = z.string().regex(/^[a-z][a-zA-Z0-9]*$/);
 const artifactKeySchema = z
   .string()
@@ -114,7 +115,7 @@ const publicConnectorCatalogStartOptionSchema = z
     label: z.string().min(1),
     required: z.boolean(),
     defaultValue: z.string().nullable(),
-    options: z.array(publicConnectorCatalogStartOptionChoiceSchema),
+    options: z.array(publicConnectorCatalogStartOptionChoiceSchema).min(1),
   })
   .strict();
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
@@ -1,0 +1,243 @@
+import { z } from "zod";
+
+const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const connectorRefSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/);
+const authMethodIdSchema = z.string().min(1);
+const publicFieldIdSchema = z.string().regex(/^[a-z][a-zA-Z0-9]*$/);
+const artifactKeySchema = z
+  .string()
+  .min(1)
+  .refine((key) => {
+    return (
+      !key.startsWith("/") &&
+      !key.includes("..") &&
+      !key.includes("\\") &&
+      !key.includes("//")
+    );
+  }, "Artifact keys must be relative object keys");
+
+export const SUPPORTED_CONNECTOR_CATALOG_ACTIVE_SCHEMA_VERSION = 1;
+export const SUPPORTED_CONNECTOR_CATALOG_ARTIFACT_SCHEMA_VERSION = 1;
+
+export function isSupportedConnectorCatalogCapability(
+  capability: string,
+): boolean {
+  return /^(catalog\.public-connectors@1|catalog\.private-field-mapping@1|grant\.manual@1|grant\.auth-code@1|grant\.device-auth@1|firewall\.permission-metadata@1)$/.test(
+    capability,
+  );
+}
+
+const connectorCatalogArtifactReferenceSchema = z
+  .object({
+    key: artifactKeySchema,
+    digest: digestSchema,
+  })
+  .strict();
+
+export const connectorCatalogActivePointerSchema = z
+  .object({
+    schemaVersion: z.number().int().positive(),
+    catalogVersion: z.string().min(1),
+    manifestKey: artifactKeySchema,
+    manifestDigest: digestSchema,
+    publishedAt: z.string().datetime(),
+  })
+  .strict();
+
+export const connectorCatalogManifestSchema = z
+  .object({
+    catalogVersion: z.string().min(1),
+    artifactSchemaVersion: z.number().int().positive(),
+    requiredCapabilities: z.array(z.string().min(1)),
+    artifacts: z
+      .object({
+        public: connectorCatalogArtifactReferenceSchema,
+        private: connectorCatalogArtifactReferenceSchema,
+      })
+      .strict(),
+  })
+  .strict();
+
+const publicFirewallPolicyValueSchema = z.enum(["allow", "deny", "ask"]);
+
+const publicConnectorCatalogPermissionSummarySchema = z
+  .object({
+    hasPermissions: z.boolean(),
+    permissionCount: z.number().int().nonnegative(),
+    hasCategories: z.boolean(),
+    hasDefaultPolicyOverrides: z.boolean(),
+  })
+  .strict();
+
+const publicConnectorCatalogAuthMethodSummarySchema = z
+  .object({
+    id: authMethodIdSchema,
+    label: z.string().min(1),
+    description: z.string().nullable(),
+    grantKind: z.enum([
+      "manual",
+      "auth-code",
+      "external-code",
+      "device-auth",
+      "managed",
+    ]),
+  })
+  .strict();
+
+const publicConnectorCatalogManualFieldSchema = z
+  .object({
+    id: publicFieldIdSchema,
+    label: z.string().min(1),
+    required: z.boolean(),
+    placeholder: z.string().nullable(),
+    inputType: z.enum(["password", "text"]),
+  })
+  .strict();
+
+const publicConnectorCatalogStartOptionChoiceSchema = z
+  .object({
+    value: z.string().min(1),
+    label: z.string().min(1),
+  })
+  .strict();
+
+const publicConnectorCatalogStartOptionSchema = z
+  .object({
+    id: publicFieldIdSchema,
+    kind: z.literal("select"),
+    label: z.string().min(1),
+    required: z.boolean(),
+    defaultValue: z.string().nullable(),
+    options: z.array(publicConnectorCatalogStartOptionChoiceSchema),
+  })
+  .strict();
+
+const publicConnectorCatalogAuthMethodDetailSchema =
+  publicConnectorCatalogAuthMethodSummarySchema
+    .extend({
+      manualFields: z.array(publicConnectorCatalogManualFieldSchema),
+      startOptions: z.array(publicConnectorCatalogStartOptionSchema),
+    })
+    .strict();
+
+export const publicConnectorCatalogArtifactConnectorSchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    label: z.string().min(1),
+    description: z.string(),
+    category: z.string().min(1),
+    generation: z.array(z.string().min(1)),
+    tags: z.array(z.string().min(1)),
+    authMethods: z.array(publicConnectorCatalogAuthMethodDetailSchema).min(1),
+    permissionSummary: publicConnectorCatalogPermissionSummarySchema,
+  })
+  .strict();
+
+const publicConnectorCatalogPermissionSchema = z
+  .object({
+    name: z.string().min(1),
+    description: z.string().optional(),
+  })
+  .strict();
+
+const publicConnectorCatalogPermissionCategoriesSchema = z
+  .object({
+    categories: z.record(z.string(), z.string()),
+    displayOrder: z.array(z.string()),
+  })
+  .strict();
+
+const publicConnectorCatalogDefaultPolicySchema = z
+  .object({
+    permissionDefault: publicFirewallPolicyValueSchema,
+    permissionOverrides: z.record(z.string(), z.array(z.string())).optional(),
+    unknownPolicy: publicFirewallPolicyValueSchema,
+  })
+  .strict();
+
+export const publicConnectorCatalogArtifactPermissionSchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    label: z.string().min(1),
+    permissionCount: z.number().int().nonnegative(),
+    permissions: z.array(publicConnectorCatalogPermissionSchema),
+    categories: publicConnectorCatalogPermissionCategoriesSchema.nullable(),
+    defaultPolicy: publicConnectorCatalogDefaultPolicySchema,
+  })
+  .strict();
+
+export const connectorCatalogPublicArtifactSchema = z
+  .object({
+    artifactSchemaVersion: z.number().int().positive(),
+    catalogVersion: z.string().min(1),
+    connectors: z.array(publicConnectorCatalogArtifactConnectorSchema),
+    permissions: z.array(publicConnectorCatalogArtifactPermissionSchema),
+  })
+  .strict();
+
+const privateManualFieldMappingSchema = z
+  .object({
+    publicId: publicFieldIdSchema,
+    privateName: z.string().min(1),
+    storage: z.enum(["secret", "variable"]),
+    runtimeName: z.string().min(1),
+  })
+  .strict();
+
+const privateStartOptionMappingSchema = z
+  .object({
+    publicId: publicFieldIdSchema,
+    privateName: z.string().min(1),
+    runtimeName: z.string().min(1),
+  })
+  .strict();
+
+const privateRuntimeArtifactReferenceSchema =
+  connectorCatalogArtifactReferenceSchema
+    .extend({
+      kind: z.string().min(1),
+    })
+    .strict();
+
+const privateAuthMethodMappingSchema = z
+  .object({
+    id: authMethodIdSchema,
+    manualFieldMappings: z.array(privateManualFieldMappingSchema),
+    startOptionMappings: z.array(privateStartOptionMappingSchema),
+  })
+  .strict();
+
+const privateConnectorMappingSchema = z
+  .object({
+    connectorRef: connectorRefSchema,
+    authMethods: z.array(privateAuthMethodMappingSchema),
+    runtimeArtifactRefs: z.array(privateRuntimeArtifactReferenceSchema),
+  })
+  .strict();
+
+export const connectorCatalogPrivateArtifactSchema = z
+  .object({
+    artifactSchemaVersion: z.number().int().positive(),
+    catalogVersion: z.string().min(1),
+    connectors: z.array(privateConnectorMappingSchema),
+  })
+  .strict();
+
+export type ConnectorCatalogActivePointer = z.infer<
+  typeof connectorCatalogActivePointerSchema
+>;
+export type ConnectorCatalogManifest = z.infer<
+  typeof connectorCatalogManifestSchema
+>;
+export type ConnectorCatalogPublicArtifact = z.infer<
+  typeof connectorCatalogPublicArtifactSchema
+>;
+export type ConnectorCatalogPublicArtifactConnector = z.infer<
+  typeof publicConnectorCatalogArtifactConnectorSchema
+>;
+export type ConnectorCatalogPublicArtifactPermission = z.infer<
+  typeof publicConnectorCatalogArtifactPermissionSchema
+>;
+export type ConnectorCatalogPrivateArtifact = z.infer<
+  typeof connectorCatalogPrivateArtifactSchema
+>;

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
@@ -142,8 +142,8 @@ const publicConnectorCatalogPermissionSchema = z
 
 const publicConnectorCatalogPermissionCategoriesSchema = z
   .object({
-    categories: z.record(z.string(), z.string()),
-    displayOrder: z.array(z.string()),
+    categories: z.record(z.string().min(1), z.string().min(1)),
+    displayOrder: z.array(z.string().min(1)),
   })
   .strict();
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
@@ -8,11 +8,14 @@ const artifactKeySchema = z
   .string()
   .min(1)
   .refine((key) => {
+    const segments = key.split("/");
     return (
       !key.startsWith("/") &&
       !key.includes("..") &&
       !key.includes("\\") &&
-      !key.includes("//")
+      segments.every((segment) => {
+        return segment.length > 0 && segment !== ".";
+      })
     );
   }, "Artifact keys must be relative object keys");
 
@@ -33,6 +36,10 @@ const connectorCatalogArtifactReferenceSchema = z
     digest: digestSchema,
   })
   .strict();
+
+export function parseConnectorCatalogArtifactKey(key: string): string {
+  return artifactKeySchema.parse(key);
+}
 
 export const connectorCatalogActivePointerSchema = z
   .object({

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
@@ -150,7 +150,14 @@ const publicConnectorCatalogPermissionCategoriesSchema = z
 const publicConnectorCatalogDefaultPolicySchema = z
   .object({
     permissionDefault: publicFirewallPolicyValueSchema,
-    permissionOverrides: z.record(z.string(), z.array(z.string())).optional(),
+    permissionOverrides: z
+      .object({
+        allow: z.array(z.string()).optional(),
+        deny: z.array(z.string()).optional(),
+        ask: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
     unknownPolicy: publicFirewallPolicyValueSchema,
   })
   .strict();

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
@@ -1,9 +1,9 @@
+import { connectorAuthMethodIdSchema } from "@vm0/connectors/connectors";
 import { z } from "zod";
 
 const digestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const connectorCatalogSlugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*$/);
 const connectorRefSchema = connectorCatalogSlugSchema;
-const authMethodIdSchema = connectorCatalogSlugSchema;
 const publicFieldIdSchema = z.string().regex(/^[a-z][a-zA-Z0-9]*$/);
 const artifactKeySchema = z
   .string()
@@ -25,7 +25,7 @@ export const SUPPORTED_CONNECTOR_CATALOG_ARTIFACT_SCHEMA_VERSION = 1;
 export function isSupportedConnectorCatalogCapability(
   capability: string,
 ): boolean {
-  return /^(catalog\.public-connectors@1|catalog\.private-field-mapping@1|grant\.manual@1|grant\.auth-code@1|grant\.device-auth@1|firewall\.permission-metadata@1)$/.test(
+  return /^(catalog\.public-connectors@1|catalog\.private-field-mapping@1|grant\.manual@1|grant\.auth-code@1|grant\.external-code@1|grant\.device-auth@1|grant\.managed@1|firewall\.permission-metadata@1)$/.test(
     capability,
   );
 }
@@ -78,7 +78,7 @@ const publicConnectorCatalogPermissionSummarySchema = z
 
 const publicConnectorCatalogAuthMethodSummarySchema = z
   .object({
-    id: authMethodIdSchema,
+    id: connectorAuthMethodIdSchema,
     label: z.string().min(1),
     description: z.string().nullable(),
     grantKind: z.enum([
@@ -215,7 +215,7 @@ const privateRuntimeArtifactReferenceSchema =
 
 const privateAuthMethodMappingSchema = z
   .object({
-    id: authMethodIdSchema,
+    id: connectorAuthMethodIdSchema,
     manualFieldMappings: z.array(privateManualFieldMappingSchema),
     startOptionMappings: z.array(privateStartOptionMappingSchema),
   })

--- a/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-artifacts/schemas.ts
@@ -11,10 +11,9 @@ const artifactKeySchema = z
     const segments = key.split("/");
     return (
       !key.startsWith("/") &&
-      !key.includes("..") &&
       !key.includes("\\") &&
       segments.every((segment) => {
-        return segment.length > 0 && segment !== ".";
+        return segment.length > 0 && segment !== "." && segment !== "..";
       })
     );
   }, "Artifact keys must be relative object keys");


### PR DESCRIPTION
## Summary
- Add server-only connector catalog artifact schemas and a raw-byte loader with SHA-256 digest, schema version, capability, public/private consistency, and leak validation.
- Add a committed fixture artifact catalog plus a filesystem fixture reader for local/test validation.
- Convert validated public artifacts into the existing public connector catalog view models without changing production route selection.

Fixes #19393

## Tests
- pnpm -F api exec vitest run src/signals/services/__tests__/connector-catalog-artifacts.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm knip --cache
- pre-commit: prettier, knip, turbo run check-types --concurrency=1