### PR TITLE
test: add firewall final decision contract coverage

### DIFF
--- a/crates/runner/mitm-addon/tests/test_firewall_semantics_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_semantics_contract.py
@@ -33,6 +33,7 @@ def _load_cases() -> tuple[
     list[dict[str, object]],
     list[dict[str, object]],
     list[dict[str, object]],
+    list[dict[str, object]],
 ]:
     raw_contract = json.loads(_CONTRACT_PATH.read_text())
     assert isinstance(raw_contract, dict)
@@ -44,6 +45,7 @@ def _load_cases() -> tuple[
         _contract_cases(raw_contract, "hostMatchCases"),
         _contract_cases(raw_contract, "pathPrefixMatchCases"),
         _contract_cases(raw_contract, "baseUrlMatchCases"),
+        _contract_cases(raw_contract, "finalDecisionCases"),
     )
 
 
@@ -99,7 +101,37 @@ def _assert_relative_path_match(
     _HOST_MATCH_CASES,
     _PATH_PREFIX_MATCH_CASES,
     _BASE_URL_MATCH_CASES,
+    _FINAL_DECISION_CASES,
 ) = _load_cases()
+
+
+def _normalize_final_decision(result: object | None) -> dict[str, object]:
+    if result is None:
+        return {"kind": "no_match"}
+    if isinstance(result, matching.FirewallAllow):
+        base = result.api_entry["base"]
+        assert isinstance(base, str)
+        normalized: dict[str, object] = {
+            "kind": "allow",
+            "firewallName": result.name,
+            "base": base,
+            "relativePath": result.rel_path,
+        }
+        if result.permission is not None:
+            normalized["permission"] = result.permission
+        if result.rule is not None:
+            normalized["rule"] = result.rule
+        return normalized
+    if isinstance(result, matching.FirewallBlock):
+        return {
+            "kind": "block",
+            "firewallName": result.name,
+            "base": result.base,
+            "relativePath": result.path,
+            "reason": result.reason,
+            "permissions": list(result.permissions),
+        }
+    raise TypeError(f"unexpected firewall decision result: {result!r}")
 
 
 @pytest.mark.parametrize("case", _SEGMENT_PARSE_CASES, ids=_case_name)
@@ -196,3 +228,26 @@ def test_base_url_matching_matches_shared_contract(case: dict[str, object]):
     result = matching.match_base_url(url, base)
     actual_relative_path = None if result is None else result[0]
     _assert_relative_path_match(actual_relative_path, expected)
+
+
+@pytest.mark.parametrize("case", _FINAL_DECISION_CASES, ids=_case_name)
+def test_final_decision_matches_shared_contract(case: dict[str, object]):
+    firewalls = case["firewalls"]
+    request = case["request"]
+    assert isinstance(request, dict)
+    method = request["method"]
+    assert isinstance(method, str)
+    url = request["url"]
+    assert isinstance(url, str)
+    expected = case["expected"]
+    assert isinstance(expected, dict)
+
+    compiled_firewalls = matching.compile_firewalls(firewalls)
+    result = matching.match_compiled_firewall_request(
+        url,
+        method,
+        compiled_firewalls,
+        case.get("networkPolicies"),
+    )
+
+    assert _normalize_final_decision(result) == expected

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -612,7 +612,42 @@ describe("zero doctor check-connector command", () => {
       expect(output).toContain('"admin" is in the deny list');
     });
 
-    it("should report unmatched permission falling through to unknown policy", async () => {
+    it("should report permission in ask list", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json(runContextResponse);
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--env-name",
+        "GH_TOKEN",
+        "--check-permission",
+        "actions:write",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("ask list:   [actions:write]");
+      expect(output).toContain('"actions:write" is in the ask list');
+      expect(output).toContain("blocked until approval");
+    });
+
+    it("should report unmatched permission as allowed by permission policy", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
       vi.stubEnv("VM0_TOKEN", "test-token");
       vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
@@ -643,9 +678,11 @@ describe("zero doctor check-connector command", () => {
 
       const output = getOutput();
       expect(output).toContain(
-        '"some-unknown-perm" is not in any permission list',
+        '"some-unknown-perm" is not in the deny or ask list',
       );
-      expect(output).toContain("unknown endpoint policy: allow");
+      expect(output).toContain(
+        "the unknown endpoint policy only applies when no named permission matches a request",
+      );
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -1454,6 +1454,75 @@ describe("zero doctor check-connector command", () => {
       expect(output).not.toContain("unknown endpoint policy applies: deny");
     });
 
+    it("should not describe unsafe paths as unknown endpoints", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        stubAvailableConnectors(["test-oauth"]),
+        http.get("https://app.vm0.ai/api/zero/connectors/test-oauth", () => {
+          return HttpResponse.json({
+            ...connectedResponse,
+            type: "test-oauth",
+          });
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["test-oauth"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              {
+                name: "test-oauth",
+                apis: [
+                  {
+                    base: "https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
+                    permissions: [
+                      {
+                        name: "full",
+                        rules: ["ANY /{path+}"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            networkPolicies: {
+              "test-oauth": {
+                allow: ["full"],
+                deny: [],
+                ask: [],
+                unknownPolicy: "allow" as const,
+              },
+            },
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/users/%2e%2e/admin",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain(
+        "Permission matching could not complete because the request path contains unsafe path syntax.",
+      );
+      expect(output).toContain(
+        "Result: The request path contains unsafe path syntax, so the request is blocked.",
+      );
+      expect(output).not.toContain(
+        "falls through to the unknown-endpoint policy",
+      );
+    });
+
     it("should fail for unrecognized URL", async () => {
       await expect(async () => {
         await checkConnectorCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -1119,7 +1119,7 @@ describe("zero doctor check-connector command", () => {
         "node",
         "cli",
         "--url",
-        "https://API.XERO.COM.:443/api.xro/2.0/Accounts?where=Name#ignored",
+        "https://API.XERO.COM.:443/api.xro/2.0/Accounts?token=secret-token#ignored",
       ]);
 
       const output = getOutput();
@@ -1132,6 +1132,9 @@ describe("zero doctor check-connector command", () => {
         "Matched permissions: [accounting.settings.read]",
       );
       expect(output).not.toContain("Matched permissions: [connections");
+      expect(output).not.toContain("secret-token");
+      expect(output).not.toContain("token=");
+      expect(output).not.toContain("#ignored");
     });
 
     it("should not resolve connector base paths without a segment boundary", async () => {
@@ -1145,7 +1148,7 @@ describe("zero doctor check-connector command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("No connector found for URL"),
+        expect.stringContaining("No connector found for provided URL"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -1591,7 +1594,7 @@ describe("zero doctor check-connector command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("No connector found for URL"),
+        expect.stringContaining("No connector found for provided URL"),
       );
     });
 
@@ -1636,7 +1639,7 @@ describe("zero doctor check-connector command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("No connector found for URL"),
+        expect.stringContaining("No connector found for provided URL"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -790,7 +790,7 @@ describe("zero doctor check-connector command", () => {
 
       const output = getOutput();
       expect(output).toContain(
-        "zero doctor check-connector --env-name GH_TOKEN",
+        "zero doctor check-connector --env-name 'GH_TOKEN'",
       );
     });
 
@@ -825,7 +825,7 @@ describe("zero doctor check-connector command", () => {
 
       const output = getOutput();
       expect(output).toContain(
-        "zero doctor check-connector --env-name GH_TOKEN --check-permission contents:read",
+        "zero doctor check-connector --env-name 'GH_TOKEN' --check-permission 'contents:read'",
       );
     });
   });
@@ -868,7 +868,7 @@ describe("zero doctor check-connector command", () => {
         "Step 3: Permission policy check (auto-detected from URL)",
       );
       expect(output).toContain(
-        "zero doctor check-connector --url https://api.github.com/repos/owner/repo",
+        "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo'",
       );
     });
 
@@ -1132,6 +1132,42 @@ describe("zero doctor check-connector command", () => {
         "Matched permissions: [accounting.settings.read]",
       );
       expect(output).not.toContain("Matched permissions: [connections");
+      expect(output).not.toContain("secret-token");
+      expect(output).not.toContain("token=");
+      expect(output).not.toContain("#ignored");
+    });
+
+    it("should shell-quote sanitized URL in re-diagnose hint", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json(runContextResponse);
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.github.com/repos/owner/repo'$(touch-pwn)?token=secret-token#ignored",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain(
+        "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo'\\''$(touch-pwn)'",
+      );
       expect(output).not.toContain("secret-token");
       expect(output).not.toContain("token=");
       expect(output).not.toContain("#ignored");
@@ -1675,7 +1711,7 @@ describe("zero doctor check-connector command", () => {
 
       const output = getOutput();
       expect(output).toContain(
-        "zero doctor check-connector --url https://api.github.com/repos/owner/repo --method POST",
+        "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo' --method 'POST'",
       );
     });
   });

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -969,6 +969,69 @@ describe("zero doctor check-connector command", () => {
       expect(output).toContain("  - https://acme.zendesk.com");
     });
 
+    it("should keep resolved run context bases for connectors without permission routes", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        stubAvailableConnectors(["altium-365"]),
+        http.get("https://app.vm0.ai/api/zero/connectors/altium-365", () => {
+          return HttpResponse.json({
+            ...connectedResponse,
+            type: "altium-365",
+            authMethod: "api-token",
+          });
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["altium-365"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              {
+                kind: "builtin",
+                name: "altium-365",
+                baseUrlVars: {
+                  ALTIUM365_WORKSPACE_URL: "https://acme.365.altium.com",
+                },
+              },
+            ],
+            networkPolicies: {
+              "altium-365": {
+                allow: [],
+                deny: [],
+                ask: [],
+                unknownPolicy: "deny" as const,
+              },
+            },
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://acme.365.altium.com/api/v1/projects",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("matches the Altium 365 connector");
+      expect(output).toContain("Matched base URL: https://acme.365.altium.com");
+      expect(output).toContain("Relative path:    /api/v1/projects");
+      expect(output).toContain(
+        "No named permission matches GET /api/v1/projects. This request falls through to the unknown-endpoint policy.",
+      );
+      expect(output).toContain(
+        "Result: No permission matched. The unknown endpoint policy applies: deny.",
+      );
+    });
+
     it("should reject compact built-in run context base URL vars outside host policy", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
       vi.stubEnv("VM0_TOKEN", "test-token");
@@ -1036,14 +1099,8 @@ describe("zero doctor check-connector command", () => {
             ...runContextResponse,
             firewalls: [
               {
+                kind: "builtin",
                 name: "xero",
-                apis: [
-                  { base: "https://api.xero.com", permissions: [] },
-                  {
-                    base: "https://api.xero.com/api.xro/2.0",
-                    permissions: [],
-                  },
-                ],
               },
             ],
             networkPolicies: {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -1350,6 +1350,73 @@ describe("zero doctor check-connector command", () => {
       );
     });
 
+    it("should allow matched permissions that are not denied or asked", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        stubAvailableConnectors(["test-oauth"]),
+        http.get("https://app.vm0.ai/api/zero/connectors/test-oauth", () => {
+          return HttpResponse.json({
+            ...connectedResponse,
+            type: "test-oauth",
+          });
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["test-oauth"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              {
+                name: "test-oauth",
+                apis: [
+                  {
+                    base: "https://tenant-123.{pr}.vm6.ai/api/test/oauth-provider",
+                    permissions: [
+                      {
+                        name: "echo",
+                        description:
+                          "Test echo endpoint used to verify token injection",
+                        rules: ["GET /echo"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            networkPolicies: {
+              "test-oauth": {
+                allow: [],
+                deny: [],
+                ask: [],
+                unknownPolicy: "deny" as const,
+              },
+            },
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/echo",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("Matched permissions: [echo]");
+      expect(output).toContain(
+        'Result: "echo" is not blocked by the deny or ask list',
+      );
+      expect(output).not.toContain("unknown endpoint policy applies: deny");
+    });
+
     it("should fail for unrecognized URL", async () => {
       await expect(async () => {
         await checkConnectorCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -114,12 +114,6 @@ function connectorEnvName(type: ConnectorType): string | null {
   return getConnectorEnvBindingEntries(type)[0]?.envName ?? null;
 }
 
-function hasRoutingPermissionRules(config: DiagnosticRoutingConfig): boolean {
-  return config.apis.some((api) => {
-    return api.routes.length > 0;
-  });
-}
-
 function routesToDecisionPermissions(
   routes: readonly FirewallRoutingPermissionRoute[],
 ): DiagnosticDecisionPermission[] {
@@ -328,9 +322,7 @@ async function resolveConnectorFromRunContext(
     envName,
     matchedBase: bestMatch.match.displayBase,
     relativePath: bestMatch.match.relativePath,
-    ...(hasRoutingPermissionRules(bestMatch.routingConfig)
-      ? { routingConfig: bestMatch.routingConfig }
-      : {}),
+    routingConfig: bestMatch.routingConfig,
   };
 }
 

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -9,9 +9,11 @@ import {
 } from "@vm0/connectors/connector-utils";
 import {
   type FirewallBaseUrlMatch,
-  findMatchingRoutingPermissions,
+  type FirewallRequestDecision,
   matchFirewallBaseUrl,
+  matchFirewallRequestDecision,
   type FirewallRoutingPermissionApi,
+  type FirewallRoutingPermissionRoute,
 } from "@vm0/connectors/firewall-rule-matcher";
 import {
   type FirewallBaseHostPolicy,
@@ -64,6 +66,22 @@ interface DiagnosticRoutingConfig {
   apis: readonly FirewallRoutingPermissionApi[];
 }
 
+interface DiagnosticDecisionPermission {
+  readonly name: string;
+  readonly rules: readonly string[];
+}
+
+interface DiagnosticDecisionApi {
+  readonly base: string;
+  readonly auth: Record<string, never>;
+  readonly permissions: readonly DiagnosticDecisionPermission[];
+}
+
+interface DiagnosticDecisionFirewall {
+  readonly name: ConnectorType;
+  readonly apis: readonly DiagnosticDecisionApi[];
+}
+
 interface UrlLookupResult {
   connectorType: ConnectorType;
   envName: string;
@@ -100,6 +118,41 @@ function hasRoutingPermissionRules(config: DiagnosticRoutingConfig): boolean {
   return config.apis.some((api) => {
     return api.routes.length > 0;
   });
+}
+
+function routesToDecisionPermissions(
+  routes: readonly FirewallRoutingPermissionRoute[],
+): DiagnosticDecisionPermission[] {
+  const rulesByPermission = new Map<string, string[]>();
+  for (const route of routes) {
+    const rules = rulesByPermission.get(route.permissionName);
+    if (rules) {
+      rules.push(route.rule);
+    } else {
+      rulesByPermission.set(route.permissionName, [route.rule]);
+    }
+  }
+
+  return [...rulesByPermission.entries()].map(([name, rules]) => {
+    return { name, rules };
+  });
+}
+
+function routingConfigToDecisionFirewalls(
+  config: DiagnosticRoutingConfig,
+): readonly DiagnosticDecisionFirewall[] {
+  return [
+    {
+      name: config.type,
+      apis: config.apis.map((api) => {
+        return {
+          base: api.base,
+          auth: {},
+          permissions: routesToDecisionPermissions(api.routes),
+        };
+      }),
+    },
+  ];
 }
 
 interface RoutingBaseExecutionTemplate {
@@ -582,6 +635,99 @@ function unknownPermissionChangeCommand(connectorRef: string): string {
   return `zero doctor permission-change ${connectorRef} --permission ${UNKNOWN_PERMISSION_GRANT} --enable --duration 1h`;
 }
 
+function matchedPermissionsFromDecision(
+  decision: FirewallRequestDecision,
+): string[] {
+  if (decision.kind === "allow") {
+    return decision.permission === undefined ? [] : [decision.permission];
+  }
+  if (decision.kind === "block" && decision.reason === "permission_denied") {
+    return [...decision.permissions];
+  }
+  return [];
+}
+
+function printAllowedPermissionResult(
+  permission: string,
+  connectorPolicies: NetworkPolicies[string],
+): void {
+  if (connectorPolicies.allow.includes(permission)) {
+    console.log(`Result: "${permission}" is in the allow list — allowed.`);
+    return;
+  }
+  console.log(
+    `Result: "${permission}" is not blocked by the deny or ask list — allowed.`,
+  );
+}
+
+function printDeniedPermissionResult(
+  permission: string,
+  connectorPolicies: NetworkPolicies[string],
+): void {
+  if (connectorPolicies.deny.includes(permission)) {
+    console.log(`Result: "${permission}" is in the deny list — denied.`);
+    return;
+  }
+  if (connectorPolicies.ask.includes(permission)) {
+    console.log(`Result: "${permission}" is in the ask list — blocked.`);
+    return;
+  }
+  console.log(`Result: "${permission}" is blocked by permission policy.`);
+}
+
+function printFirewallDecisionResult(
+  connectorType: ConnectorType,
+  decision: FirewallRequestDecision,
+  connectorPolicies: NetworkPolicies[string],
+): void {
+  if (decision.kind === "allow") {
+    if (decision.permission === undefined) {
+      console.log(
+        "Result: No permission matched. The unknown endpoint policy applies: allow.",
+      );
+      return;
+    }
+    printAllowedPermissionResult(decision.permission, connectorPolicies);
+    return;
+  }
+
+  if (decision.kind === "no_match") {
+    console.log("Result: No connector firewall base matched this request.");
+    return;
+  }
+
+  switch (decision.reason) {
+    case "permission_denied":
+      for (const permission of decision.permissions) {
+        printDeniedPermissionResult(permission, connectorPolicies);
+      }
+      return;
+    case "unknown_endpoint":
+      console.log(
+        `Result: No permission matched. The unknown endpoint policy applies: ${connectorPolicies.unknownPolicy}.`,
+      );
+      console.log(
+        `To allow unknown endpoints, run: ${unknownPermissionChangeCommand(connectorType)}`,
+      );
+      return;
+    case "malformed_firewall_config":
+      console.log(
+        "Result: The matched firewall config is malformed, so the request is blocked.",
+      );
+      return;
+    case "malformed_network_policy":
+      console.log(
+        "Result: The matched network policy is malformed, so the request is blocked.",
+      );
+      return;
+    case "unsafe_path":
+      console.log(
+        "Result: The request path contains unsafe path syntax, so the request is blocked.",
+      );
+      return;
+  }
+}
+
 /**
  * When --url is provided, auto-detect the matching permission by running
  * the URL's relative path against the connector's firewall rules.
@@ -590,6 +736,7 @@ async function resolvePermissionFromUrl(
   connectorType: ConnectorType,
   label: string,
   method: string,
+  url: string,
   relativePath: string,
   matchedBase: string,
   routingConfig: DiagnosticRoutingConfig | undefined,
@@ -618,12 +765,13 @@ async function resolvePermissionFromUrl(
     return;
   }
 
-  const matchedPermissions = findMatchingRoutingPermissions(
+  const decision = matchFirewallRequestDecision(
+    routingConfigToDecisionFirewalls(config),
     method,
-    relativePath,
-    config.apis,
-    { apiBase: matchedBase },
+    url,
+    networkPolicies,
   );
+  const matchedPermissions = matchedPermissionsFromDecision(decision);
 
   if (matchedPermissions.length === 0) {
     console.log(
@@ -665,33 +813,11 @@ async function resolvePermissionFromUrl(
   console.log(`Permission policies for the ${label} connector:`);
   console.log(`  allow list: [${connectorPolicies.allow.join(", ")}]`);
   console.log(`  deny list:  [${connectorPolicies.deny.join(", ")}]`);
+  console.log(`  ask list:   [${connectorPolicies.ask.join(", ")}]`);
   console.log(`  unknown endpoint policy: ${connectorPolicies.unknownPolicy}`);
   console.log("");
 
-  if (matchedPermissions.length === 0) {
-    console.log(
-      `Result: No permission matched. The unknown endpoint policy applies: ${connectorPolicies.unknownPolicy}.`,
-    );
-    if (connectorPolicies.unknownPolicy !== "allow") {
-      console.log(
-        `To allow unknown endpoints, run: ${unknownPermissionChangeCommand(connectorType)}`,
-      );
-    }
-  } else {
-    for (const perm of matchedPermissions) {
-      const isInAllow = connectorPolicies.allow.includes(perm);
-      const isInDeny = connectorPolicies.deny.includes(perm);
-      if (isInAllow) {
-        console.log(`Result: "${perm}" is in the allow list — allowed.`);
-      } else if (isInDeny) {
-        console.log(`Result: "${perm}" is in the deny list — denied.`);
-      } else {
-        console.log(
-          `Result: "${perm}" is not in any list — falls through to unknown endpoint policy: ${connectorPolicies.unknownPolicy}.`,
-        );
-      }
-    }
-  }
+  printFirewallDecisionResult(connectorType, decision, connectorPolicies);
   console.log("");
 }
 
@@ -831,12 +957,14 @@ How connectors work:
       console.log("");
 
       // Step 3: Permission policy check
-      if (urlLookup) {
+      const diagnosedUrl = opts.url;
+      if (urlLookup && diagnosedUrl) {
         // --url mode: auto-detect permission from URL path
         await resolvePermissionFromUrl(
           connectorType,
           label,
           opts.method,
+          diagnosedUrl,
           urlLookup.relativePath,
           urlLookup.matchedBase,
           urlLookup.routingConfig,

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -653,6 +653,53 @@ function matchedPermissionsFromDecision(
   return [];
 }
 
+function printMatchedPermissionsSummary(
+  method: string,
+  relativePath: string,
+  decision: FirewallRequestDecision,
+): void {
+  const matchedPermissions = matchedPermissionsFromDecision(decision);
+  if (matchedPermissions.length > 0) {
+    console.log(`Matched permissions: [${matchedPermissions.join(", ")}]`);
+    return;
+  }
+
+  if (
+    decision.kind === "allow" ||
+    (decision.kind === "block" && decision.reason === "unknown_endpoint")
+  ) {
+    console.log(
+      `No named permission matches ${method} ${relativePath}. This request falls through to the unknown-endpoint policy.`,
+    );
+    return;
+  }
+
+  if (decision.kind === "no_match") {
+    console.log(
+      "No connector firewall base matched this request during final permission evaluation.",
+    );
+    return;
+  }
+
+  if (decision.reason === "malformed_firewall_config") {
+    console.log(
+      "Permission matching could not complete because the matched firewall config is malformed.",
+    );
+    return;
+  }
+
+  if (decision.reason === "malformed_network_policy") {
+    console.log(
+      "Permission matching could not complete because the matched network policy is malformed.",
+    );
+    return;
+  }
+
+  console.log(
+    "Permission matching could not complete because the request path contains unsafe path syntax.",
+  );
+}
+
 function printAllowedPermissionResult(
   permission: string,
   connectorPolicies: NetworkPolicies[string],
@@ -777,15 +824,7 @@ async function resolvePermissionFromUrl(
     url,
     networkPolicies,
   );
-  const matchedPermissions = matchedPermissionsFromDecision(decision);
-
-  if (matchedPermissions.length === 0) {
-    console.log(
-      `No named permission matches ${method} ${relativePath}. This request falls through to the unknown-endpoint policy.`,
-    );
-  } else {
-    console.log(`Matched permissions: [${matchedPermissions.join(", ")}]`);
-  }
+  printMatchedPermissionsSummary(method, relativePath, decision);
   console.log("");
 
   if (!networkPolicies) {

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -609,23 +609,29 @@ function checkPermissionPolicy(
   console.log(`Permission policies for the ${label} connector:`);
   console.log(`  allow list: [${connectorPolicies.allow.join(", ")}]`);
   console.log(`  deny list:  [${connectorPolicies.deny.join(", ")}]`);
+  console.log(`  ask list:   [${connectorPolicies.ask.join(", ")}]`);
   console.log(`  unknown endpoint policy: ${connectorPolicies.unknownPolicy}`);
   console.log("");
 
   const isInAllow = connectorPolicies.allow.includes(permissionName);
   const isInDeny = connectorPolicies.deny.includes(permissionName);
+  const isInAsk = connectorPolicies.ask.includes(permissionName);
 
-  if (isInAllow) {
-    console.log(
-      `Result: "${permissionName}" is in the allow list. Requests matching this permission are allowed.`,
-    );
-  } else if (isInDeny) {
+  if (isInDeny) {
     console.log(
       `Result: "${permissionName}" is in the deny list. Requests matching this permission are denied.`,
     );
+  } else if (isInAsk) {
+    console.log(
+      `Result: "${permissionName}" is in the ask list. Requests matching this permission are blocked until approval.`,
+    );
+  } else if (isInAllow) {
+    console.log(
+      `Result: "${permissionName}" is in the allow list. Requests matching this permission are allowed.`,
+    );
   } else {
     console.log(
-      `Result: "${permissionName}" is not in any permission list. It will be handled by the unknown endpoint policy: ${connectorPolicies.unknownPolicy}.`,
+      `Result: "${permissionName}" is not in the deny or ask list. Requests matching this permission are allowed; the unknown endpoint policy only applies when no named permission matches a request.`,
     );
   }
   console.log("");

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -114,6 +114,15 @@ function connectorEnvName(type: ConnectorType): string | null {
   return getConnectorEnvBindingEntries(type)[0]?.envName ?? null;
 }
 
+function stripUrlQueryAndFragment(url: string): string {
+  const queryIndex = url.indexOf("?");
+  const fragmentIndex = url.indexOf("#");
+  let end = url.length;
+  if (queryIndex !== -1) end = Math.min(end, queryIndex);
+  if (fragmentIndex !== -1) end = Math.min(end, fragmentIndex);
+  return url.slice(0, end);
+}
+
 function routesToDecisionPermissions(
   routes: readonly FirewallRoutingPermissionRoute[],
 ): DiagnosticDecisionPermission[] {
@@ -930,13 +939,14 @@ How connectors work:
         }
         if (!urlLookup) {
           throw new Error(
-            `No connector found for URL: ${opts.url} — no registered base URL matches this URL`,
+            "No connector found for provided URL — no registered base URL matches this URL",
           );
         }
+        const displayUrl = stripUrlQueryAndFragment(opts.url);
         connectorType = urlLookup.connectorType;
         envName = opts.envName ?? urlLookup.envName;
         console.log(
-          `URL ${opts.url} matches the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
+          `URL ${displayUrl} matches the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
         );
         console.log(`  Matched base URL: ${urlLookup.matchedBase}`);
         console.log(`  Relative path:    ${urlLookup.relativePath}`);
@@ -1022,7 +1032,7 @@ How connectors work:
       // Re-diagnose hint
       const args: string[] = [];
       if (opts.url) {
-        args.push(`--url ${opts.url}`);
+        args.push(`--url ${stripUrlQueryAndFragment(opts.url)}`);
         if (opts.method !== "GET") {
           args.push(`--method ${opts.method}`);
         }

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -123,6 +123,10 @@ function stripUrlQueryAndFragment(url: string): string {
   return url.slice(0, end);
 }
 
+function shellQuoteArg(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 function routesToDecisionPermissions(
   routes: readonly FirewallRoutingPermissionRoute[],
 ): DiagnosticDecisionPermission[] {
@@ -1032,15 +1036,15 @@ How connectors work:
       // Re-diagnose hint
       const args: string[] = [];
       if (opts.url) {
-        args.push(`--url ${stripUrlQueryAndFragment(opts.url)}`);
+        args.push(`--url ${shellQuoteArg(stripUrlQueryAndFragment(opts.url))}`);
         if (opts.method !== "GET") {
-          args.push(`--method ${opts.method}`);
+          args.push(`--method ${shellQuoteArg(opts.method)}`);
         }
       } else {
-        args.push(`--env-name ${envName}`);
+        args.push(`--env-name ${shellQuoteArg(envName)}`);
       }
       if (opts.checkPermission) {
-        args.push(`--check-permission ${opts.checkPermission}`);
+        args.push(`--check-permission ${shellQuoteArg(opts.checkPermission)}`);
       }
       console.log(
         `To re-diagnose after changes, run: zero doctor check-connector ${args.join(" ")}`,

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
@@ -226,6 +226,10 @@ function stripUrlQueryAndFragment(url: string): string {
   return url.slice(0, end);
 }
 
+function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
 function rawPathFromDeniedUrl(url: string): string {
   const urlWithoutQuery = stripUrlQueryAndFragment(url);
   const schemeEnd = urlWithoutQuery.indexOf("://");
@@ -316,9 +320,10 @@ function routesForMatchedBase(
   }[],
   apiBase: string,
 ): readonly FirewallRoutingPermissionRoute[] {
+  const normalizedApiBase = stripTrailingSlash(apiBase);
   const routes: FirewallRoutingPermissionRoute[] = [];
   for (const api of apis) {
-    if (api.base === apiBase) {
+    if (stripTrailingSlash(api.base) === normalizedApiBase) {
       routes.push(...api.routes);
     }
   }

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-deny.ts
@@ -1,12 +1,14 @@
 import { Command, Option } from "commander";
 import {
-  findMatchingRoutingPermissions,
   matchFirewallBaseUrl,
+  matchFirewallRequestDecision,
+  type FirewallRoutingPermissionRoute,
 } from "@vm0/connectors/firewall-rule-matcher";
 import { getFirewallPermissionSummary } from "@vm0/connectors/firewall-metadata";
 import { loadFirewallRoutingMetadata } from "@vm0/connectors/firewall-metadata/routing";
 import {
   hasUnsafeFirewallPath,
+  type NetworkPolicies,
   UNKNOWN_PERMISSION_GRANT,
 } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
@@ -27,9 +29,26 @@ interface PermissionDenyOptions {
 
 interface PermissionDenyBaseMatch {
   readonly apiBase: string;
+  readonly decisionBase: string;
   readonly displayBase: string;
   readonly relativePath: string;
   readonly score: number;
+}
+
+interface PermissionDenyDecisionPermission {
+  readonly name: string;
+  readonly rules: readonly string[];
+}
+
+interface PermissionDenyDecisionApi {
+  readonly base: string;
+  readonly auth: Record<string, never>;
+  readonly permissions: readonly PermissionDenyDecisionPermission[];
+}
+
+interface PermissionDenyDecisionFirewall {
+  readonly name: string;
+  readonly apis: readonly PermissionDenyDecisionApi[];
 }
 
 const BASE_URL_VAR_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
@@ -223,6 +242,7 @@ function matchApiBaseUrl(
   if (directMatch) {
     return {
       apiBase,
+      decisionBase: apiBase,
       displayBase: directMatch.displayBase,
       relativePath: directMatch.relativePath,
       score: directMatch.score,
@@ -235,6 +255,7 @@ function matchApiBaseUrl(
     if (resolvedMatch) {
       return {
         apiBase,
+        decisionBase: resolvedBase,
         displayBase: resolvedMatch.displayBase,
         relativePath: resolvedMatch.relativePath,
         score: resolvedMatch.score,
@@ -249,6 +270,7 @@ function matchApiBaseUrl(
   if (!patternMatch) return null;
   return {
     apiBase,
+    decisionBase: patternBase,
     displayBase: apiBase,
     relativePath: patternMatch.relativePath,
     score: patternMatch.score,
@@ -280,10 +302,104 @@ function findBestBaseMatch(
   const api = unresolvedWholeBaseApis[0]!;
   return {
     apiBase: api.base,
+    decisionBase: deniedUrl.origin,
     displayBase: api.base,
     relativePath: rawPathFromDeniedUrl(url),
     score: 0,
   };
+}
+
+function routesForMatchedBase(
+  apis: readonly {
+    readonly base: string;
+    readonly routes: readonly FirewallRoutingPermissionRoute[];
+  }[],
+  apiBase: string,
+): readonly FirewallRoutingPermissionRoute[] {
+  const routes: FirewallRoutingPermissionRoute[] = [];
+  for (const api of apis) {
+    if (api.base === apiBase) {
+      routes.push(...api.routes);
+    }
+  }
+  return routes;
+}
+
+function routesToDecisionPermissions(
+  routes: readonly FirewallRoutingPermissionRoute[],
+): PermissionDenyDecisionPermission[] {
+  const rulesByPermission = new Map<string, string[]>();
+  for (const route of routes) {
+    const rules = rulesByPermission.get(route.permissionName);
+    if (rules) {
+      rules.push(route.rule);
+    } else {
+      rulesByPermission.set(route.permissionName, [route.rule]);
+    }
+  }
+
+  return [...rulesByPermission.entries()].map(([name, rules]) => {
+    return { name, rules };
+  });
+}
+
+function buildDecisionFirewall(
+  connectorRef: string,
+  base: string,
+  permissions: readonly PermissionDenyDecisionPermission[],
+): readonly PermissionDenyDecisionFirewall[] {
+  return [
+    {
+      name: connectorRef,
+      apis: [
+        {
+          base,
+          auth: {},
+          permissions,
+        },
+      ],
+    },
+  ];
+}
+
+function buildAllDeniedNetworkPolicies(
+  connectorRef: string,
+  permissions: readonly PermissionDenyDecisionPermission[],
+): NetworkPolicies {
+  return {
+    [connectorRef]: {
+      allow: [],
+      deny: permissions.map((permission) => {
+        return permission.name;
+      }),
+      ask: [],
+      unknownPolicy: "deny",
+    },
+  };
+}
+
+function findDeniedDecisionPermissions(
+  connectorRef: string,
+  method: string,
+  url: string,
+  match: PermissionDenyBaseMatch,
+  apis: readonly {
+    readonly base: string;
+    readonly routes: readonly FirewallRoutingPermissionRoute[];
+  }[],
+): string[] {
+  const routes = routesForMatchedBase(apis, match.apiBase);
+  const permissions = routesToDecisionPermissions(routes);
+  const decision = matchFirewallRequestDecision(
+    buildDecisionFirewall(connectorRef, match.decisionBase, permissions),
+    method,
+    url,
+    buildAllDeniedNetworkPolicies(connectorRef, permissions),
+  );
+  if (decision.kind !== "block" || decision.reason !== "permission_denied") {
+    return [];
+  }
+  return [...decision.permissions];
 }
 
 function printPermissionChangeGuidance(
@@ -390,11 +506,12 @@ Notes:
           );
         }
 
-        const permissions = findMatchingRoutingPermissions(
+        const permissions = findDeniedDecisionPermissions(
+          connectorRef,
           method,
-          match.relativePath,
+          opts.url,
+          match,
           metadata.apis,
-          { apiBase: match.apiBase, serviceName: connectorRef },
         );
 
         console.log(

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-matcher.test.ts
@@ -5,7 +5,6 @@ import {
   matchFirewallPathPrefix,
   matchFirewallBaseUrl,
   findMatchingPermissions,
-  findMatchingRoutingPermissions,
 } from "../firewall-rule-matcher";
 import type { FirewallConfig } from "../firewall-types";
 
@@ -1846,118 +1845,5 @@ describe("findMatchingPermissions", () => {
     expect(findMatchingPermissions("GET", "/data", multiApi)).toEqual([
       "shared-perm",
     ]);
-  });
-});
-
-describe("findMatchingRoutingPermissions", () => {
-  it("matches routing rules without requiring full firewall config auth", () => {
-    expect(
-      findMatchingRoutingPermissions("get", "/repos/acme/demo/issues", [
-        {
-          base: "https://api.example.com",
-          routes: [
-            {
-              permissionName: "repos.read",
-              rule: "GET /repos/{owner}/{repo}/issues",
-            },
-          ],
-        },
-      ]),
-    ).toEqual(["repos.read"]);
-  });
-
-  it("matches ANY rules and keeps the most-specific route per API", () => {
-    expect(
-      findMatchingRoutingPermissions("POST", "/api/users", [
-        {
-          base: "https://api.example.com",
-          routes: [
-            { permissionName: "catchall", rule: "ANY /{path*}" },
-            { permissionName: "users.write", rule: "POST /api/users" },
-          ],
-        },
-      ]),
-    ).toEqual(["users.write"]);
-  });
-
-  it("can restrict matching to one routing API base", () => {
-    const apis = [
-      {
-        base: "https://api1.example.com",
-        routes: [{ permissionName: "api1.read", rule: "GET /data" }],
-      },
-      {
-        base: "https://api2.example.com/",
-        routes: [{ permissionName: "api2.read", rule: "GET /data" }],
-      },
-    ];
-
-    expect(
-      findMatchingRoutingPermissions("GET", "/data", apis, {
-        apiBase: "https://api1.example.com",
-      }),
-    ).toEqual(["api1.read"]);
-    expect(
-      findMatchingRoutingPermissions("GET", "/data", apis, {
-        apiBase: "https://api2.example.com",
-      }),
-    ).toEqual(["api2.read"]);
-  });
-
-  it("deduplicates duplicate routing permission names inside and across APIs", () => {
-    expect(
-      findMatchingRoutingPermissions("GET", "/data", [
-        {
-          base: "https://api1.example.com",
-          routes: [
-            { permissionName: "shared", rule: "GET /data" },
-            { permissionName: "shared", rule: "ANY /data" },
-          ],
-        },
-        {
-          base: "https://api2.example.com",
-          routes: [{ permissionName: "shared", rule: "GET /data" }],
-        },
-      ]),
-    ).toEqual(["shared"]);
-  });
-
-  it("ignores malformed routing APIs and routes while keeping valid routes", () => {
-    const apis = [
-      "not-an-api",
-      { base: "https://bad.example.com?token=1", routes: [] },
-      { base: "https://missing-routes.example.com" },
-      {
-        base: "https://api.example.com",
-        routes: [
-          { permissionName: "", rule: "GET /empty" },
-          { permissionName: "all", rule: "GET /all" },
-          { permissionName: "lowercase-method", rule: "get /data" },
-          { permissionName: "query-path", rule: "GET /data?debug=1" },
-          { permissionName: "non-string-rule", rule: 123 },
-          { permissionName: 123, rule: "GET /data" },
-          { permissionName: "valid", rule: "GET /data" },
-        ],
-      },
-    ] as unknown as Parameters<typeof findMatchingRoutingPermissions>[2];
-
-    expect(findMatchingRoutingPermissions("GET", "/data", apis)).toEqual([
-      "valid",
-    ]);
-  });
-
-  it("returns multiple routing permissions when best-specificity routes tie", () => {
-    expect(
-      findMatchingRoutingPermissions("GET", "/api/users", [
-        {
-          base: "https://api.example.com",
-          routes: [
-            { permissionName: "users.read", rule: "GET /api/users" },
-            { permissionName: "users.audit", rule: "ANY /api/users" },
-            { permissionName: "catchall", rule: "ANY /{path*}" },
-          ],
-        },
-      ]),
-    ).toEqual(["users.read", "users.audit"]);
   });
 });

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -824,6 +824,46 @@
       }
     },
     {
+      "name": "asked permission blocks like denied permission",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.write",
+                  "rules": ["POST /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": [],
+          "ask": ["items.write"],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "reason": "permission_denied",
+        "permissions": ["items.write"]
+      }
+    },
+    {
       "name": "unknown endpoint follows deny policy",
       "firewalls": [
         {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -706,5 +706,370 @@
         "kind": "no-match"
       }
     }
+  ],
+  "finalDecisionCases": [
+    {
+      "name": "no base match returns no_match",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://other.example.com/items/123"
+      },
+      "expected": {
+        "kind": "no_match"
+      }
+    },
+    {
+      "name": "known permission is allowed when not blocked",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "permission": "items.read",
+        "rule": "GET /items/{id}"
+      }
+    },
+    {
+      "name": "denied permission blocks before unknown policy",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": ["items.read"],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "reason": "permission_denied",
+        "permissions": ["items.read"]
+      }
+    },
+    {
+      "name": "unknown endpoint follows deny policy",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "reason": "unknown_endpoint",
+        "permissions": []
+      }
+    },
+    {
+      "name": "missing network policy entry is permissive",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "other": {
+          "allow": [],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "POST",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123"
+      }
+    },
+    {
+      "name": "most specific base wins before policy evaluation",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "all.read",
+                  "rules": ["GET /admin/{rest+}"]
+                }
+              ]
+            },
+            {
+              "base": "https://api.example.com/admin",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "admin.read",
+                  "rules": ["GET /users/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": ["admin.read"],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/admin/users/42"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com/admin",
+        "relativePath": "/users/42",
+        "reason": "permission_denied",
+        "permissions": ["admin.read"]
+      }
+    },
+    {
+      "name": "matched malformed firewall config blocks",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com/admin?token=1",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "admin.read",
+                  "rules": ["GET /delete"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["admin.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/admin/delete"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com/admin?token=1",
+        "relativePath": "/delete",
+        "reason": "malformed_firewall_config",
+        "permissions": []
+      }
+    },
+    {
+      "name": "matched malformed network policy blocks",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": "items.read",
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "reason": "malformed_network_policy",
+        "permissions": []
+      }
+    },
+    {
+      "name": "unsafe path blocks after base match",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "full",
+                  "rules": ["ANY /{path+}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["full"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/users/%2e%2e/admin"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/users/%2e%2e/admin",
+        "reason": "unsafe_path",
+        "permissions": []
+      }
+    }
   ]
 }

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1160,6 +1160,121 @@
       }
     },
     {
+      "name": "matched malformed base port blocks",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com:abc",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com:abc",
+        "relativePath": "/items/123",
+        "reason": "malformed_firewall_config",
+        "permissions": []
+      }
+    },
+    {
+      "name": "base backslash does not match",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com\\evil",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /evil/items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/evil/items/123"
+      },
+      "expected": {
+        "kind": "no_match"
+      }
+    },
+    {
+      "name": "matched malformed base query backslash blocks",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com/v1?x=\\",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/v1/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com/v1?x=\\",
+        "relativePath": "/items/123",
+        "reason": "malformed_firewall_config",
+        "permissions": []
+      }
+    },
+    {
       "name": "matched malformed network policy blocks",
       "firewalls": [
         {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -864,6 +864,94 @@
       }
     },
     {
+      "name": "same-specificity allowed permission wins over blocked permission",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.blocked",
+                  "rules": ["GET /items/{id}"]
+                },
+                {
+                  "name": "items.allowed",
+                  "rules": ["GET /items/{itemId}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": ["items.blocked"],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "permission": "items.allowed",
+        "rule": "GET /items/{itemId}"
+      }
+    },
+    {
+      "name": "more-specific blocked permission wins over broader allowed permission",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.broad",
+                  "rules": ["GET /items/{path+}"]
+                },
+                {
+                  "name": "items.specific",
+                  "rules": ["GET /items/admin"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": [],
+          "deny": ["items.specific"],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/admin"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/admin",
+        "reason": "permission_denied",
+        "permissions": ["items.specific"]
+      }
+    },
+    {
       "name": "unknown endpoint follows deny policy",
       "firewalls": [
         {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1120,6 +1120,46 @@
       }
     },
     {
+      "name": "matched malformed base userinfo blocks",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://user@api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://user@api.example.com",
+        "relativePath": "/items/123",
+        "reason": "malformed_firewall_config",
+        "permissions": []
+      }
+    },
+    {
       "name": "matched malformed network policy blocks",
       "firewalls": [
         {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1275,6 +1275,46 @@
       }
     },
     {
+      "name": "matched malformed base host invalid greedy blocks",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.{env+}.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.prod.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.{env+}.example.com",
+        "relativePath": "/items/123",
+        "reason": "malformed_firewall_config",
+        "permissions": []
+      }
+    },
+    {
       "name": "matched malformed network policy blocks",
       "firewalls": [
         {
@@ -1312,6 +1352,81 @@
         "relativePath": "/items/123",
         "reason": "malformed_network_policy",
         "permissions": []
+      }
+    },
+    {
+      "name": "runtime backslash path preserves relative path in unsafe block",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "full",
+                  "rules": ["ANY /{path+}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["full"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items\\123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items\\123",
+        "reason": "unsafe_path",
+        "permissions": []
+      }
+    },
+    {
+      "name": "runtime backslash does not cross static base path boundary",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com/v1",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "full",
+                  "rules": ["ANY /{path+}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["full"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "allow"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/v1\\items/123"
+      },
+      "expected": {
+        "kind": "no_match"
       }
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json
@@ -1160,6 +1160,86 @@
       }
     },
     {
+      "name": "terminal slash base is preserved in allow decision output",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com/",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "example",
+        "base": "https://api.example.com/",
+        "relativePath": "/items/123",
+        "permission": "items.read",
+        "rule": "GET /items/{id}"
+      }
+    },
+    {
+      "name": "terminal slash base is normalized in block decision output",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.example.com/",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "items.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["items.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "PATCH",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.example.com",
+        "relativePath": "/items/123",
+        "reason": "unknown_endpoint",
+        "permissions": []
+      }
+    },
+    {
       "name": "matched malformed base port blocks",
       "firewalls": [
         {
@@ -1309,6 +1389,156 @@
         "kind": "block",
         "firewallName": "example",
         "base": "https://api.{env+}.example.com",
+        "relativePath": "/items/123",
+        "reason": "malformed_firewall_config",
+        "permissions": []
+      }
+    },
+    {
+      "name": "normalized unicode dot base can override prior malformed same-specificity base",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://user@api.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "malformed.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            },
+            {
+              "base": "https://api。example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "unicode.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["malformed.read", "unicode.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "allow",
+        "firewallName": "example",
+        "base": "https://api。example.com",
+        "relativePath": "/items/123",
+        "permission": "unicode.read",
+        "rule": "GET /items/{id}"
+      }
+    },
+    {
+      "name": "malformed percent-encoded dot base outranks host parameter base",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api%2eexample.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "percent.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            },
+            {
+              "base": "https://{tenant}.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "tenant.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["percent.read", "tenant.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api%2eexample.com",
+        "relativePath": "/items/123",
+        "reason": "malformed_firewall_config",
+        "permissions": []
+      }
+    },
+    {
+      "name": "malformed host parameter score preserves config order on tie",
+      "firewalls": [
+        {
+          "name": "example",
+          "apis": [
+            {
+              "base": "https://api.{a}{b}.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "double.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            },
+            {
+              "base": "https://api.{env+}.example.com",
+              "auth": {},
+              "permissions": [
+                {
+                  "name": "greedy.read",
+                  "rules": ["GET /items/{id}"]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "networkPolicies": {
+        "example": {
+          "allow": ["double.read", "greedy.read"],
+          "deny": [],
+          "ask": [],
+          "unknownPolicy": "deny"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "url": "https://api.prod.example.com/items/123"
+      },
+      "expected": {
+        "kind": "block",
+        "firewallName": "example",
+        "base": "https://api.{a}{b}.example.com",
         "relativePath": "/items/123",
         "reason": "malformed_firewall_config",
         "permissions": []

--- a/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-semantics-contract.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
+  type FirewallRequestDecision,
   matchFirewallBaseUrl,
   matchFirewallHost,
   matchFirewallPath,
   matchFirewallPathPrefix,
+  matchFirewallRequestDecision,
 } from "../firewall-rule-matcher";
 import { parseSegment, splitPathSegments } from "../segment-parser";
 
@@ -46,6 +48,34 @@ const relativePathMatchExpectedSchema = z.discriminatedUnion("kind", [
   }),
   z.object({
     kind: z.literal("no-match"),
+  }),
+]);
+
+const firewallDecisionExpectedSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("no_match"),
+  }),
+  z.object({
+    kind: z.literal("allow"),
+    firewallName: z.string(),
+    base: z.string(),
+    relativePath: z.string(),
+    permission: z.string().optional(),
+    rule: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("block"),
+    firewallName: z.string(),
+    base: z.string(),
+    relativePath: z.string(),
+    reason: z.union([
+      z.literal("permission_denied"),
+      z.literal("unknown_endpoint"),
+      z.literal("malformed_firewall_config"),
+      z.literal("malformed_network_policy"),
+      z.literal("unsafe_path"),
+    ]),
+    permissions: z.array(z.string()),
   }),
 ]);
 
@@ -96,6 +126,18 @@ const contractSchema = z.object({
       expected: relativePathMatchExpectedSchema,
     }),
   ),
+  finalDecisionCases: z.array(
+    z.object({
+      name: z.string(),
+      firewalls: z.unknown(),
+      networkPolicies: z.unknown().optional(),
+      request: z.object({
+        method: z.string(),
+        url: z.string(),
+      }),
+      expected: firewallDecisionExpectedSchema,
+    }),
+  ),
 });
 
 type SegmentExpected = z.infer<typeof segmentExpectedSchema>;
@@ -103,6 +145,7 @@ type ParamsMatchExpected = z.infer<typeof paramsMatchExpectedSchema>;
 type RelativePathMatchExpected = z.infer<
   typeof relativePathMatchExpectedSchema
 >;
+type FirewallDecisionExpected = z.infer<typeof firewallDecisionExpectedSchema>;
 
 function loadContract(): z.infer<typeof contractSchema> {
   const rawContract: unknown = JSON.parse(
@@ -151,6 +194,13 @@ function assertRelativePathMatch(
   }
 
   expect(actual).toBe(expected.relativePath);
+}
+
+function assertFirewallDecision(
+  actual: FirewallRequestDecision,
+  expected: FirewallDecisionExpected,
+): void {
+  expect(actual).toEqual(expected);
 }
 
 const contract = loadContract();
@@ -211,6 +261,22 @@ describe("firewall semantics contract", () => {
         assertRelativePathMatch(
           matchFirewallBaseUrl(testCase.url, testCase.base)?.relativePath ??
             null,
+          testCase.expected,
+        );
+      });
+    }
+  });
+
+  describe("final request decisions", () => {
+    for (const testCase of contract.finalDecisionCases) {
+      it(testCase.name, () => {
+        assertFirewallDecision(
+          matchFirewallRequestDecision(
+            testCase.firewalls,
+            testCase.request.method,
+            testCase.request.url,
+            testCase.networkPolicies,
+          ),
           testCase.expected,
         );
       });

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -8,6 +8,14 @@ import {
 import { hasRawWhitespace, hasUnsafeUrlCodepoint } from "./firewall-url-utils";
 import { parseSegment, splitPathSegments } from "./segment-parser";
 
+type SegmentParseResult = ReturnType<typeof parseSegment>;
+type MatchableSegment = Exclude<SegmentParseResult, { kind: "error" }>;
+type SegmentMatchParser = (
+  segment: string,
+  patternIndex: number,
+  lastPatternIndex: number,
+) => MatchableSegment | null;
+
 type PathSpecificity = readonly [
   literalSegments: number,
   mixedParamSegments: number,
@@ -222,6 +230,28 @@ function isInvalidGreedyParam(
   suffix: string,
 ): boolean {
   return patternIndex !== lastPatternIndex || prefix !== "" || suffix !== "";
+}
+
+function parseStrictMatchSegment(
+  segment: string,
+  patternIndex: number,
+  lastPatternIndex: number,
+): MatchableSegment | null {
+  const parsed = parseSegment(segment);
+  if (parsed.kind === "error") return null;
+  if (
+    parsed.kind === "param" &&
+    parsed.greedy !== "" &&
+    isInvalidGreedyParam(
+      patternIndex,
+      lastPatternIndex,
+      parsed.prefix,
+      parsed.suffix,
+    )
+  ) {
+    return null;
+  }
+  return parsed;
 }
 
 function pathSpecificity(pattern: string): PathSpecificity | null {
@@ -1042,6 +1072,9 @@ function normalizedUrlAuthority(
 function matchStaticFirewallBaseUrl(
   url: string,
   rawBase: string,
+  options: {
+    readonly tolerateMalformedBaseParams?: boolean;
+  } = {},
 ): FirewallBaseUrlMatch | null {
   const parsedUrl = new URL(url);
   const parsedBase = new URL(rawBase);
@@ -1057,14 +1090,23 @@ function matchStaticFirewallBaseUrl(
   });
   if (urlAuthority === null || baseAuthority === null) return null;
   if (baseHasParams) {
-    if (matchFirewallHost(urlAuthority, baseAuthority) === null) return null;
+    const hostParams =
+      options.tolerateMalformedBaseParams === true
+        ? matchFirewallHostForMalformedBaseDecision(urlAuthority, baseAuthority)
+        : matchFirewallHost(urlAuthority, baseAuthority);
+    if (hostParams === null) return null;
   } else if (urlAuthority !== baseAuthority) {
     return null;
   }
 
   const basePath = rawBasePathFromUrl(baseForMatch);
   const relativePath = baseHasParams
-    ? matchFirewallPathPrefix(rawPathFromUrl(url), basePath)
+    ? options.tolerateMalformedBaseParams === true
+      ? matchFirewallPathPrefixForMalformedBaseDecision(
+          rawPathFromUrl(url),
+          basePath,
+        )
+      : matchFirewallPathPrefix(rawPathFromUrl(url), basePath)
     : matchStaticBasePathPrefix(rawPathFromUrl(url), basePath);
   if (relativePath === null) return null;
 
@@ -1097,10 +1139,6 @@ function runtimeUrlCanMatchFirewallBase(url: string): boolean {
   }
 }
 
-function runtimeUrlForBaseMatch(url: string): string {
-  return url.includes("\\") ? url.replaceAll("\\", "/") : url;
-}
-
 function matchFirewallBaseUrlForDecision(
   url: string,
   rawBase: string,
@@ -1110,10 +1148,9 @@ function matchFirewallBaseUrlForDecision(
   if (baseForMatch === null) return null;
 
   try {
-    return matchStaticFirewallBaseUrl(
-      runtimeUrlForBaseMatch(url),
-      baseForMatch,
-    );
+    return matchStaticFirewallBaseUrl(url, baseForMatch, {
+      tolerateMalformedBaseParams: true,
+    });
   } catch {
     return null;
   }
@@ -1507,16 +1544,10 @@ export function matchFirewallRequestDecision(
   return resolveFirewallDecision(state, compiledNetworkPolicies);
 }
 
-/**
- * Match a runtime host/authority against a firewall base host pattern.
- *
- * Host comparison is case-insensitive and mirrors the runner's right-to-left
- * host matcher. Non-default ports are part of the normalized authority and
- * therefore participate in the final host segment comparison.
- */
-export function matchFirewallHost(
+function matchFirewallHostWithParser(
   host: string,
   pattern: string,
+  parsePatternSegment: SegmentMatchParser,
 ): Record<string, string> | null {
   const hostSegsOrig = host.split(".");
   const hostSegsLower = hostSegsOrig.map((segment) => {
@@ -1537,8 +1568,8 @@ export function matchFirewallHost(
     patternIndex++
   ) {
     const seg = patternSegs[patternIndex]!;
-    const parsed = parseSegment(seg);
-    if (parsed.kind === "error") return null;
+    const parsed = parsePatternSegment(seg, patternIndex, lastPatternIndex);
+    if (parsed === null) return null;
     if (parsed.kind === "literal") {
       if (
         hi >= hostSegsLower.length ||
@@ -1552,15 +1583,11 @@ export function matchFirewallHost(
 
     const { name, prefix, suffix, greedy } = parsed;
     if (greedy === "+") {
-      if (isInvalidGreedyParam(patternIndex, lastPatternIndex, prefix, suffix))
-        return null;
       if (hi >= hostSegsOrig.length) return null;
       params[name] = hostSegsOrig.slice(hi).reverse().join(".");
       return params;
     }
     if (greedy === "*") {
-      if (isInvalidGreedyParam(patternIndex, lastPatternIndex, prefix, suffix))
-        return null;
       params[name] = hostSegsOrig.slice(hi).reverse().join(".");
       return params;
     }
@@ -1583,14 +1610,64 @@ export function matchFirewallHost(
 }
 
 /**
- * Match a runtime path against the beginning of a firewall base path pattern.
+ * Match a runtime host/authority against a firewall base host pattern.
  *
- * Unlike matchFirewallPath(), this intentionally allows extra runtime path
- * segments and returns the remaining relative path after the base prefix.
+ * Host comparison is case-insensitive and mirrors the runner's right-to-left
+ * host matcher. Non-default ports are part of the normalized authority and
+ * therefore participate in the final host segment comparison.
  */
-export function matchFirewallPathPrefix(
+export function matchFirewallHost(
+  host: string,
+  pattern: string,
+): Record<string, string> | null {
+  return matchFirewallHostWithParser(host, pattern, parseStrictMatchSegment);
+}
+
+function parseMalformedTolerantBaseSegment(
+  segment: string,
+  patternIndex: number,
+  lastPatternIndex: number,
+): MatchableSegment {
+  const parsed = parseSegment(segment);
+  if (parsed.kind === "error") {
+    return {
+      kind: "param",
+      prefix: "",
+      name: `__malformed_base_segment_${patternIndex}`,
+      suffix: "",
+      greedy: "",
+    };
+  }
+  if (
+    parsed.kind === "param" &&
+    parsed.greedy !== "" &&
+    isInvalidGreedyParam(
+      patternIndex,
+      lastPatternIndex,
+      parsed.prefix,
+      parsed.suffix,
+    )
+  ) {
+    return { ...parsed, greedy: "" };
+  }
+  return parsed;
+}
+
+function matchFirewallHostForMalformedBaseDecision(
+  host: string,
+  pattern: string,
+): Record<string, string> | null {
+  return matchFirewallHostWithParser(
+    host,
+    pattern,
+    parseMalformedTolerantBaseSegment,
+  );
+}
+
+function matchFirewallPathPrefixWithParser(
   path: string,
   pattern: string,
+  parsePatternSegment: SegmentMatchParser,
 ): string | null {
   const pathSegs = splitPathSegments(path);
   const patternSegs = splitPathSegments(pattern);
@@ -1603,8 +1680,8 @@ export function matchFirewallPathPrefix(
     patternIndex++
   ) {
     const seg = patternSegs[patternIndex]!;
-    const parsed = parseSegment(seg);
-    if (parsed.kind === "error") return null;
+    const parsed = parsePatternSegment(seg, patternIndex, lastPatternIndex);
+    if (parsed === null) return null;
     if (parsed.kind === "literal") {
       if (pi >= pathSegs.length || pathSegs[pi] !== parsed.value) return null;
       pi += 1;
@@ -1613,16 +1690,12 @@ export function matchFirewallPathPrefix(
 
     const { prefix, suffix, greedy } = parsed;
     if (greedy === "+") {
-      if (isInvalidGreedyParam(patternIndex, lastPatternIndex, prefix, suffix))
-        return null;
       if (pi >= pathSegs.length || !hasNonEmptySegment(pathSegs, pi)) {
         return null;
       }
       return "/";
     }
     if (greedy === "*") {
-      if (isInvalidGreedyParam(patternIndex, lastPatternIndex, prefix, suffix))
-        return null;
       return "/";
     }
     if (pi >= pathSegs.length) return null;
@@ -1637,6 +1710,34 @@ export function matchFirewallPathPrefix(
   }
 
   return relativePathFromSegments(pathSegs, pi);
+}
+
+/**
+ * Match a runtime path against the beginning of a firewall base path pattern.
+ *
+ * Unlike matchFirewallPath(), this intentionally allows extra runtime path
+ * segments and returns the remaining relative path after the base prefix.
+ */
+export function matchFirewallPathPrefix(
+  path: string,
+  pattern: string,
+): string | null {
+  return matchFirewallPathPrefixWithParser(
+    path,
+    pattern,
+    parseStrictMatchSegment,
+  );
+}
+
+function matchFirewallPathPrefixForMalformedBaseDecision(
+  path: string,
+  pattern: string,
+): string | null {
+  return matchFirewallPathPrefixWithParser(
+    path,
+    pattern,
+    parseMalformedTolerantBaseSegment,
+  );
 }
 
 /**

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -696,6 +696,25 @@ function stripUrlQueryAndFragment(url: string): string {
   return url.slice(0, end);
 }
 
+function stripRawUrlUserinfo(url: string): string {
+  const schemeEnd = url.indexOf("://");
+  if (schemeEnd === -1) return url;
+
+  const authorityStart = schemeEnd + 3;
+  let authorityEnd = url.length;
+  for (const delimiter of ["/", "?", "#"]) {
+    const delimiterIndex = url.indexOf(delimiter, authorityStart);
+    if (delimiterIndex !== -1)
+      authorityEnd = Math.min(authorityEnd, delimiterIndex);
+  }
+
+  const authority = url.slice(authorityStart, authorityEnd);
+  const userinfoEnd = authority.lastIndexOf("@");
+  if (userinfoEnd === -1) return url;
+
+  return `${url.slice(0, authorityStart)}${authority.slice(userinfoEnd + 1)}${url.slice(authorityEnd)}`;
+}
+
 function rawPathFromUrl(url: string): string {
   const urlWithoutQuery = stripUrlQueryAndFragment(url);
   const schemeEnd = urlWithoutQuery.indexOf("://");
@@ -1027,7 +1046,10 @@ function matchFirewallBaseUrlForDecision(
   if (!runtimeUrlCanMatchFirewallBase(url)) return null;
 
   try {
-    return matchStaticFirewallBaseUrl(runtimeUrlForBaseMatch(url), rawBase);
+    return matchStaticFirewallBaseUrl(
+      runtimeUrlForBaseMatch(url),
+      stripRawUrlUserinfo(rawBase),
+    );
   } catch {
     return null;
   }

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -1,5 +1,6 @@
 import {
   type FirewallConfig,
+  hasUnsafeFirewallPath,
   hasBaseUrlParams,
   validateAuthBaseUrl,
   validateBaseUrl,
@@ -41,6 +42,34 @@ export interface FirewallRoutingPermissionApi {
   readonly routes: readonly FirewallRoutingPermissionRoute[];
 }
 
+export type FirewallRequestBlockReason =
+  | "permission_denied"
+  | "unknown_endpoint"
+  | "malformed_firewall_config"
+  | "malformed_network_policy"
+  | "unsafe_path";
+
+export type FirewallRequestDecision =
+  | {
+      readonly kind: "no_match";
+    }
+  | {
+      readonly kind: "allow";
+      readonly firewallName: string;
+      readonly base: string;
+      readonly relativePath: string;
+      readonly permission?: string;
+      readonly rule?: string;
+    }
+  | {
+      readonly kind: "block";
+      readonly firewallName: string;
+      readonly base: string;
+      readonly relativePath: string;
+      readonly reason: FirewallRequestBlockReason;
+      readonly permissions: readonly string[];
+    };
+
 interface ApiMatchState {
   bestSpecificity: PathSpecificity | null;
   matched: string[];
@@ -53,6 +82,66 @@ interface PermissionRuleSet {
 
 interface PermissionMatchApi {
   readonly permissionRuleSets: readonly PermissionRuleSet[];
+}
+
+type UnknownPolicy = "allow" | "deny" | "ask";
+
+interface CompiledNetworkPolicy {
+  readonly blockedPermissions: ReadonlySet<string>;
+  readonly unknownPolicy: UnknownPolicy;
+  readonly permissionMalformed: boolean;
+  readonly unknownPolicyMalformed: boolean;
+}
+
+interface CompiledNetworkPolicies {
+  readonly policies: ReadonlyMap<string, CompiledNetworkPolicy>;
+  readonly topLevelMalformed: boolean;
+}
+
+interface DecisionRule {
+  readonly permission: string;
+  readonly raw: string;
+  readonly method: string;
+  readonly path: string;
+  readonly specificity: PathSpecificity;
+}
+
+interface DecisionApi {
+  readonly rawBase: string;
+  readonly baseMalformed: boolean;
+  readonly authMalformed: boolean;
+  readonly hasMalformedRules: boolean;
+  readonly rules: readonly DecisionRule[];
+}
+
+interface DecisionFirewall {
+  readonly name: string;
+  readonly nameMalformed: boolean;
+  readonly apis: readonly DecisionApi[];
+}
+
+interface DecisionBaseMatch {
+  readonly firewallName: string;
+  readonly base: string;
+  readonly relativePath: string;
+}
+
+interface DecisionAllowedRuleMatch extends DecisionBaseMatch {
+  readonly permission: string;
+  readonly rule: string;
+}
+
+type DecisionBlockMatch = DecisionBaseMatch;
+
+interface FirewallDecisionState {
+  bestBaseScore: number | null;
+  bestRuleSpecificity: PathSpecificity | null;
+  baseMatch: DecisionBaseMatch | null;
+  allowedMatch: DecisionAllowedRuleMatch | null;
+  deniedMatch: DecisionBlockMatch | null;
+  deniedPermissionNames: string[];
+  malformedConfigMatch: DecisionBlockMatch | null;
+  malformedPolicyMatch: DecisionBlockMatch | null;
 }
 
 const VALID_RULE_METHODS = new Set([
@@ -228,6 +317,20 @@ function matchingRulePath(rule: string, upperMethod: string): string | null {
   return rule.slice(spaceIdx + 1);
 }
 
+function compileDecisionRule(
+  permission: string,
+  rule: string,
+): DecisionRule | null {
+  const spaceIdx = rule.indexOf(" ");
+  if (spaceIdx === -1) return null;
+  const method = rule.slice(0, spaceIdx);
+  if (!VALID_RULE_METHODS.has(method)) return null;
+  const path = rule.slice(spaceIdx + 1);
+  const specificity = pathSpecificity(path);
+  if (specificity === null) return null;
+  return { permission, raw: rule, method, path, specificity };
+}
+
 function isValidPermissionName(permissionName: string): boolean {
   return permissionName !== "" && permissionName !== "all";
 }
@@ -338,6 +441,201 @@ function getPermissionRules(permission: unknown): string[] {
     return typeof rule === "string";
   });
   return rules;
+}
+
+function rawObjectHasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function isValidAuthConfigForDecision(
+  auth: unknown,
+  serviceName: string,
+): boolean {
+  try {
+    return isValidAuthConfig(auth, serviceName);
+  } catch {
+    return false;
+  }
+}
+
+function compileDecisionApi(
+  api: Record<string, unknown>,
+  serviceName: string,
+  nameMalformed: boolean,
+): DecisionApi | null {
+  if (typeof api.base !== "string") return null;
+
+  let baseMalformed = false;
+  try {
+    validateBaseUrl(api.base, serviceName);
+  } catch {
+    baseMalformed = true;
+  }
+  const authMalformed = !isValidAuthConfigForDecision(api.auth, serviceName);
+  const rules: DecisionRule[] = [];
+  const seenPermissionNames = new Set<string>();
+  let hasMalformedRules = nameMalformed;
+  const rawPermissions = api.permissions;
+
+  if (Array.isArray(rawPermissions)) {
+    for (const rawPermission of rawPermissions) {
+      if (!isObjectRecord(rawPermission)) {
+        hasMalformedRules = true;
+        continue;
+      }
+      const permissionName = rawPermission.name;
+      if (
+        typeof permissionName !== "string" ||
+        !isValidPermissionName(permissionName)
+      ) {
+        hasMalformedRules = true;
+        continue;
+      }
+      if (seenPermissionNames.has(permissionName)) {
+        hasMalformedRules = true;
+        continue;
+      }
+      seenPermissionNames.add(permissionName);
+
+      const rawRules = rawPermission.rules;
+      if (!Array.isArray(rawRules)) {
+        hasMalformedRules = true;
+        continue;
+      }
+      if (rawRules.length === 0) {
+        hasMalformedRules = true;
+      }
+
+      for (const rawRule of rawRules) {
+        if (typeof rawRule !== "string") {
+          hasMalformedRules = true;
+          continue;
+        }
+        const compiledRule = compileDecisionRule(permissionName, rawRule);
+        if (compiledRule === null) {
+          hasMalformedRules = true;
+          continue;
+        }
+        rules.push(compiledRule);
+      }
+    }
+  } else if (rawObjectHasOwn(api, "permissions")) {
+    hasMalformedRules = true;
+  }
+
+  return {
+    rawBase: api.base,
+    baseMalformed,
+    authMalformed,
+    hasMalformedRules,
+    rules,
+  };
+}
+
+function compileDecisionFirewall(
+  rawFirewall: unknown,
+): DecisionFirewall | null {
+  if (!isObjectRecord(rawFirewall)) return null;
+
+  const rawName = rawFirewall.name;
+  const nameMalformed = typeof rawName !== "string" || rawName === "";
+  const name = typeof rawName === "string" ? rawName : "";
+  const rawApis = rawFirewall.apis;
+  if (!Array.isArray(rawApis)) return null;
+
+  const apis: DecisionApi[] = [];
+  for (const rawApi of rawApis) {
+    if (!isObjectRecord(rawApi)) continue;
+    const api = compileDecisionApi(rawApi, name, nameMalformed);
+    if (api !== null) {
+      apis.push(api);
+    }
+  }
+
+  if (apis.length === 0) return null;
+  return { name, nameMalformed, apis };
+}
+
+function compileDecisionFirewalls(rawFirewalls: unknown): DecisionFirewall[] {
+  if (!Array.isArray(rawFirewalls) || rawFirewalls.length === 0) return [];
+
+  const firewalls: DecisionFirewall[] = [];
+  for (const rawFirewall of rawFirewalls) {
+    const firewall = compileDecisionFirewall(rawFirewall);
+    if (firewall !== null) {
+      firewalls.push(firewall);
+    }
+  }
+  return firewalls;
+}
+
+function compilePermissionSet(rawValue: unknown): {
+  readonly values: ReadonlySet<string>;
+  readonly malformed: boolean;
+} {
+  if (rawValue === undefined || rawValue === null) {
+    return { values: new Set<string>(), malformed: false };
+  }
+  if (
+    !Array.isArray(rawValue) ||
+    rawValue.some((item) => {
+      return typeof item !== "string";
+    })
+  ) {
+    return { values: new Set<string>(), malformed: true };
+  }
+  return { values: new Set(rawValue), malformed: false };
+}
+
+function compileNetworkPolicies(
+  rawNetworkPolicies: unknown,
+): CompiledNetworkPolicies {
+  if (rawNetworkPolicies === undefined || rawNetworkPolicies === null) {
+    return { policies: new Map(), topLevelMalformed: false };
+  }
+  if (!isObjectRecord(rawNetworkPolicies)) {
+    return { policies: new Map(), topLevelMalformed: true };
+  }
+
+  const policies = new Map<string, CompiledNetworkPolicy>();
+  for (const [firewallName, grant] of Object.entries(rawNetworkPolicies)) {
+    if (!isObjectRecord(grant)) {
+      policies.set(firewallName, {
+        blockedPermissions: new Set<string>(),
+        unknownPolicy: "allow",
+        permissionMalformed: true,
+        unknownPolicyMalformed: false,
+      });
+      continue;
+    }
+
+    const allow = compilePermissionSet(grant.allow);
+    const deny = compilePermissionSet(grant.deny);
+    const ask = compilePermissionSet(grant.ask);
+    const blockedPermissions = new Set<string>([...deny.values, ...ask.values]);
+
+    let unknownPolicy: UnknownPolicy = "allow";
+    let unknownPolicyMalformed = false;
+    const rawUnknownPolicy = grant.unknownPolicy;
+    if (
+      rawUnknownPolicy === "allow" ||
+      rawUnknownPolicy === "deny" ||
+      rawUnknownPolicy === "ask"
+    ) {
+      unknownPolicy = rawUnknownPolicy;
+    } else if (rawUnknownPolicy !== undefined && rawUnknownPolicy !== null) {
+      unknownPolicyMalformed = true;
+    }
+
+    policies.set(firewallName, {
+      blockedPermissions,
+      unknownPolicy,
+      permissionMalformed: allow.malformed || deny.malformed || ask.malformed,
+      unknownPolicyMalformed,
+    });
+  }
+
+  return { policies, topLevelMalformed: false };
 }
 
 function getApiPermissionRuleSetsForMatch(
@@ -736,6 +1034,373 @@ function matchStaticFirewallBaseUrl(
   };
 }
 
+function runtimeUrlCanMatchFirewallBase(url: string): boolean {
+  if (
+    hasUnsafeUrlCodepoint(url) ||
+    hasRawWhitespace(url) ||
+    !url.includes("://") ||
+    hasMalformedRuntimeAuthoritySyntax(url)
+  ) {
+    return false;
+  }
+
+  const runtimeAuthorityOrigin = runtimeAuthorityOriginForHostValidation(url);
+  if (runtimeAuthorityOrigin === null) return true;
+
+  try {
+    validateBaseUrl(runtimeAuthorityOrigin, "runtime");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runtimeUrlForBaseMatch(url: string): string {
+  return url.includes("\\") ? url.replaceAll("\\", "/") : url;
+}
+
+function matchFirewallBaseUrlForDecision(
+  url: string,
+  rawBase: string,
+): FirewallBaseUrlMatch | null {
+  if (!runtimeUrlCanMatchFirewallBase(url)) return null;
+
+  try {
+    return matchStaticFirewallBaseUrl(runtimeUrlForBaseMatch(url), rawBase);
+  } catch {
+    return null;
+  }
+}
+
+function createDecisionState(): FirewallDecisionState {
+  return {
+    bestBaseScore: null,
+    bestRuleSpecificity: null,
+    baseMatch: null,
+    allowedMatch: null,
+    deniedMatch: null,
+    deniedPermissionNames: [],
+    malformedConfigMatch: null,
+    malformedPolicyMatch: null,
+  };
+}
+
+function acceptDecisionBaseMatch(
+  state: FirewallDecisionState,
+  match: DecisionBaseMatch,
+  score: number,
+): boolean {
+  if (state.bestBaseScore === null || score > state.bestBaseScore) {
+    state.bestBaseScore = score;
+    state.bestRuleSpecificity = null;
+    state.baseMatch = null;
+    state.allowedMatch = null;
+    state.deniedMatch = null;
+    state.deniedPermissionNames = [];
+    state.malformedConfigMatch = null;
+    state.malformedPolicyMatch = null;
+  } else if (score < state.bestBaseScore) {
+    return false;
+  }
+
+  state.baseMatch ??= match;
+  return true;
+}
+
+function canRuleSpecificityAffectDecision(
+  state: FirewallDecisionState,
+  specificity: PathSpecificity,
+): boolean {
+  if (state.bestRuleSpecificity === null) return true;
+  const comparison = comparePathSpecificity(
+    specificity,
+    state.bestRuleSpecificity,
+  );
+  if (comparison > 0) return true;
+  if (comparison < 0) return false;
+  return state.allowedMatch === null;
+}
+
+function acceptRuleSpecificity(
+  state: FirewallDecisionState,
+  specificity: PathSpecificity,
+): boolean {
+  if (state.bestRuleSpecificity === null) {
+    state.bestRuleSpecificity = specificity;
+    return true;
+  }
+
+  const comparison = comparePathSpecificity(
+    specificity,
+    state.bestRuleSpecificity,
+  );
+  if (comparison > 0) {
+    state.bestRuleSpecificity = specificity;
+    state.allowedMatch = null;
+    state.deniedMatch = null;
+    state.deniedPermissionNames = [];
+    return true;
+  }
+  return comparison === 0;
+}
+
+function recordDeniedRule(
+  state: FirewallDecisionState,
+  match: DecisionBlockMatch,
+  permission: string,
+): void {
+  if (!state.deniedPermissionNames.includes(permission)) {
+    state.deniedPermissionNames.push(permission);
+  }
+  state.deniedMatch ??= match;
+}
+
+function resolveFirewallDecision(
+  state: FirewallDecisionState,
+  networkPolicies: CompiledNetworkPolicies,
+): FirewallRequestDecision {
+  const baseMatch = state.baseMatch;
+  if (baseMatch === null) {
+    return { kind: "no_match" };
+  }
+
+  if (state.allowedMatch !== null) {
+    return {
+      kind: "allow",
+      firewallName: state.allowedMatch.firewallName,
+      base: state.allowedMatch.base,
+      relativePath: state.allowedMatch.relativePath,
+      permission: state.allowedMatch.permission,
+      rule: state.allowedMatch.rule,
+    };
+  }
+
+  if (state.deniedMatch !== null) {
+    return {
+      kind: "block",
+      firewallName: state.deniedMatch.firewallName,
+      base: state.deniedMatch.base,
+      relativePath: state.deniedMatch.relativePath,
+      reason: "permission_denied",
+      permissions: state.deniedPermissionNames,
+    };
+  }
+
+  if (state.malformedPolicyMatch !== null) {
+    return {
+      kind: "block",
+      firewallName: state.malformedPolicyMatch.firewallName,
+      base: state.malformedPolicyMatch.base,
+      relativePath: state.malformedPolicyMatch.relativePath,
+      reason: "malformed_network_policy",
+      permissions: [],
+    };
+  }
+
+  if (state.malformedConfigMatch !== null) {
+    return {
+      kind: "block",
+      firewallName: state.malformedConfigMatch.firewallName,
+      base: state.malformedConfigMatch.base,
+      relativePath: state.malformedConfigMatch.relativePath,
+      reason: "malformed_firewall_config",
+      permissions: [],
+    };
+  }
+
+  const policy = networkPolicies.policies.get(baseMatch.firewallName);
+  if (policy === undefined) {
+    return {
+      kind: "allow",
+      firewallName: baseMatch.firewallName,
+      base: baseMatch.base,
+      relativePath: baseMatch.relativePath,
+    };
+  }
+  if (policy.unknownPolicyMalformed) {
+    return {
+      kind: "block",
+      firewallName: baseMatch.firewallName,
+      base: baseMatch.base,
+      relativePath: baseMatch.relativePath,
+      reason: "malformed_network_policy",
+      permissions: [],
+    };
+  }
+  if (policy.unknownPolicy === "allow") {
+    return {
+      kind: "allow",
+      firewallName: baseMatch.firewallName,
+      base: baseMatch.base,
+      relativePath: baseMatch.relativePath,
+    };
+  }
+
+  return {
+    kind: "block",
+    firewallName: baseMatch.firewallName,
+    base: baseMatch.base,
+    relativePath: baseMatch.relativePath,
+    reason: "unknown_endpoint",
+    permissions: [],
+  };
+}
+
+function unsafePathBlockDecision(
+  firewall: DecisionFirewall,
+  api: DecisionApi,
+  baseMatch: FirewallBaseUrlMatch,
+): FirewallRequestDecision {
+  return {
+    kind: "block",
+    firewallName: firewall.name,
+    base: api.rawBase,
+    relativePath: baseMatch.relativePath,
+    reason: "unsafe_path",
+    permissions: [],
+  };
+}
+
+function recordMalformedDecisionState(
+  state: FirewallDecisionState,
+  api: DecisionApi,
+  blockMatch: DecisionBlockMatch,
+): void {
+  if (api.baseMalformed || api.authMalformed || api.hasMalformedRules) {
+    state.malformedConfigMatch ??= blockMatch;
+  }
+}
+
+function apiCannotEvaluateRules(
+  firewall: DecisionFirewall,
+  api: DecisionApi,
+): boolean {
+  return firewall.nameMalformed || api.baseMalformed || api.authMalformed;
+}
+
+function policyCannotEvaluateRules(
+  networkPolicies: CompiledNetworkPolicies,
+  policy: CompiledNetworkPolicy | undefined,
+): boolean {
+  return (
+    networkPolicies.topLevelMalformed ||
+    (policy !== undefined && policy.permissionMalformed)
+  );
+}
+
+function evaluateDecisionRule({
+  state,
+  rule,
+  policy,
+  blockMatch,
+  baseMatch,
+  upperMethod,
+}: {
+  readonly state: FirewallDecisionState;
+  readonly rule: DecisionRule;
+  readonly policy: CompiledNetworkPolicy | undefined;
+  readonly blockMatch: DecisionBlockMatch;
+  readonly baseMatch: FirewallBaseUrlMatch;
+  readonly upperMethod: string;
+}): void {
+  if (rule.method !== "ANY" && rule.method !== upperMethod) return;
+  if (!canRuleSpecificityAffectDecision(state, rule.specificity)) return;
+
+  const permissionBlocked =
+    policy !== undefined && policy.blockedPermissions.has(rule.permission);
+  if (matchFirewallPath(baseMatch.relativePath, rule.path) === null) return;
+  if (!acceptRuleSpecificity(state, rule.specificity)) return;
+
+  if (permissionBlocked) {
+    recordDeniedRule(state, blockMatch, rule.permission);
+    return;
+  }
+
+  state.allowedMatch ??= {
+    firewallName: blockMatch.firewallName,
+    base: blockMatch.base,
+    relativePath: blockMatch.relativePath,
+    permission: rule.permission,
+    rule: rule.raw,
+  };
+}
+
+function evaluateDecisionRules({
+  state,
+  api,
+  policy,
+  blockMatch,
+  baseMatch,
+  upperMethod,
+}: {
+  readonly state: FirewallDecisionState;
+  readonly api: DecisionApi;
+  readonly policy: CompiledNetworkPolicy | undefined;
+  readonly blockMatch: DecisionBlockMatch;
+  readonly baseMatch: FirewallBaseUrlMatch;
+  readonly upperMethod: string;
+}): void {
+  for (const rule of api.rules) {
+    evaluateDecisionRule({
+      state,
+      rule,
+      policy,
+      blockMatch,
+      baseMatch,
+      upperMethod,
+    });
+  }
+}
+
+function evaluateDecisionApi({
+  state,
+  firewall,
+  api,
+  url,
+  unsafePath,
+  networkPolicies,
+  upperMethod,
+}: {
+  readonly state: FirewallDecisionState;
+  readonly firewall: DecisionFirewall;
+  readonly api: DecisionApi;
+  readonly url: string;
+  readonly unsafePath: boolean;
+  readonly networkPolicies: CompiledNetworkPolicies;
+  readonly upperMethod: string;
+}): FirewallRequestDecision | null {
+  const policy = networkPolicies.policies.get(firewall.name);
+  const baseMatch = matchFirewallBaseUrlForDecision(url, api.rawBase);
+  if (baseMatch === null) return null;
+  if (unsafePath) return unsafePathBlockDecision(firewall, api, baseMatch);
+
+  const blockMatch: DecisionBlockMatch = {
+    firewallName: firewall.name,
+    base: api.rawBase,
+    relativePath: baseMatch.relativePath,
+  };
+  if (!acceptDecisionBaseMatch(state, blockMatch, baseMatch.score)) {
+    return null;
+  }
+
+  recordMalformedDecisionState(state, api, blockMatch);
+  if (apiCannotEvaluateRules(firewall, api)) return null;
+  if (policyCannotEvaluateRules(networkPolicies, policy)) {
+    state.malformedPolicyMatch ??= blockMatch;
+    return null;
+  }
+
+  evaluateDecisionRules({
+    state,
+    api,
+    policy,
+    blockMatch,
+    baseMatch,
+    upperMethod,
+  });
+  return null;
+}
+
 export function matchFirewallBaseUrl(
   url: string,
   rawBase: string,
@@ -758,6 +1423,41 @@ export function matchFirewallBaseUrl(
   } catch {
     return null;
   }
+}
+
+export function matchFirewallRequestDecision(
+  firewalls: unknown,
+  method: string,
+  url: string,
+  networkPolicies: unknown = undefined,
+): FirewallRequestDecision {
+  const decisionFirewalls = compileDecisionFirewalls(firewalls);
+  if (decisionFirewalls.length === 0) return { kind: "no_match" };
+
+  const compiledNetworkPolicies = compileNetworkPolicies(networkPolicies);
+  const upperMethod = method.toUpperCase();
+  const state = createDecisionState();
+  const unsafePath =
+    url.includes("\\") || hasUnsafeFirewallPath(rawPathFromUrl(url));
+
+  for (const firewall of decisionFirewalls) {
+    for (const api of firewall.apis) {
+      const immediateDecision = evaluateDecisionApi({
+        state,
+        firewall,
+        api,
+        url,
+        unsafePath,
+        networkPolicies: compiledNetworkPolicies,
+        upperMethod,
+      });
+      if (immediateDecision !== null) {
+        return immediateDecision;
+      }
+    }
+  }
+
+  return resolveFirewallDecision(state, compiledNetworkPolicies);
 }
 
 /**

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -22,10 +22,6 @@ export interface FindMatchingPermissionsOptions {
   apiBase?: string;
 }
 
-export interface FindMatchingRoutingPermissionsOptions extends FindMatchingPermissionsOptions {
-  serviceName?: string;
-}
-
 export interface FirewallBaseUrlMatch {
   displayBase: string;
   relativePath: string;
@@ -661,41 +657,6 @@ function getApiPermissionRuleSetsForMatch(
     });
   }
   return permissionRuleSets;
-}
-
-function getRoutingApiPermissionRuleSetsForMatch(
-  api: FirewallRoutingPermissionApi,
-  serviceName: string,
-  apiBase: string | null,
-): PermissionRuleSet[] | null {
-  if (!isObjectRecord(api)) return null;
-  if (typeof api.base !== "string") return null;
-  try {
-    validateBaseUrl(api.base, serviceName);
-  } catch {
-    return null;
-  }
-  if (apiBase !== null && stripTrailingSlash(api.base) !== apiBase) return null;
-  if (!Array.isArray(api.routes)) return null;
-
-  const rulesByPermission = new Map<string, string[]>();
-  for (const route of api.routes) {
-    if (!isObjectRecord(route)) continue;
-    if (typeof route.permissionName !== "string") continue;
-    if (!isValidPermissionName(route.permissionName)) continue;
-    if (typeof route.rule !== "string") continue;
-
-    const rules = rulesByPermission.get(route.permissionName);
-    if (rules) {
-      rules.push(route.rule);
-    } else {
-      rulesByPermission.set(route.permissionName, [route.rule]);
-    }
-  }
-
-  return [...rulesByPermission.entries()].map(([name, rules]) => {
-    return { name, rules };
-  });
 }
 
 function recordPermissionMatch(
@@ -1694,33 +1655,6 @@ export function findMatchingPermissions(
     const permissionRuleSets = getApiPermissionRuleSetsForMatch(
       api,
       config.name,
-      apiBase,
-    );
-    if (permissionRuleSets !== null) {
-      matchApis.push({ permissionRuleSets });
-    }
-  }
-
-  return findMatchingPermissionRuleSets(method, path, matchApis);
-}
-
-export function findMatchingRoutingPermissions(
-  method: string,
-  path: string,
-  apis: readonly FirewallRoutingPermissionApi[],
-  options: FindMatchingRoutingPermissionsOptions = {},
-): string[] {
-  if (!Array.isArray(apis)) return [];
-
-  const serviceName = options.serviceName ?? "routing";
-  const apiBase =
-    options.apiBase === undefined ? null : stripTrailingSlash(options.apiBase);
-  const matchApis: PermissionMatchApi[] = [];
-
-  for (const api of apis) {
-    const permissionRuleSets = getRoutingApiPermissionRuleSetsForMatch(
-      api,
-      serviceName,
       apiBase,
     );
     if (permissionRuleSets !== null) {

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -696,9 +696,12 @@ function stripUrlQueryAndFragment(url: string): string {
   return url.slice(0, end);
 }
 
-function stripRawUrlUserinfo(url: string): string {
+function rawUrlAuthorityBounds(url: string): {
+  readonly authorityStart: number;
+  readonly authorityEnd: number;
+} | null {
   const schemeEnd = url.indexOf("://");
-  if (schemeEnd === -1) return url;
+  if (schemeEnd === -1) return null;
 
   const authorityStart = schemeEnd + 3;
   let authorityEnd = url.length;
@@ -708,11 +711,70 @@ function stripRawUrlUserinfo(url: string): string {
       authorityEnd = Math.min(authorityEnd, delimiterIndex);
   }
 
-  const authority = url.slice(authorityStart, authorityEnd);
+  return { authorityStart, authorityEnd };
+}
+
+function replaceRawUrlAuthority(
+  url: string,
+  bounds: { readonly authorityStart: number; readonly authorityEnd: number },
+  authority: string,
+): string {
+  return `${url.slice(0, bounds.authorityStart)}${authority}${url.slice(bounds.authorityEnd)}`;
+}
+
+function stripRawUrlUserinfo(url: string): string {
+  const bounds = rawUrlAuthorityBounds(url);
+  if (bounds === null) return url;
+
+  const authority = url.slice(bounds.authorityStart, bounds.authorityEnd);
   const userinfoEnd = authority.lastIndexOf("@");
   if (userinfoEnd === -1) return url;
 
-  return `${url.slice(0, authorityStart)}${authority.slice(userinfoEnd + 1)}${url.slice(authorityEnd)}`;
+  return replaceRawUrlAuthority(url, bounds, authority.slice(userinfoEnd + 1));
+}
+
+function rawAuthorityPortIsMalformed(port: string): boolean {
+  if (port === "") return true;
+  if (
+    ![...port].every((char) => {
+      return char >= "0" && char <= "9";
+    })
+  ) {
+    return true;
+  }
+  return Number(port) > 65535;
+}
+
+function stripRawUrlMalformedPort(url: string): string {
+  const bounds = rawUrlAuthorityBounds(url);
+  if (bounds === null) return url;
+
+  const authority = url.slice(bounds.authorityStart, bounds.authorityEnd);
+  if (authority.startsWith("[")) {
+    const closeBracketIndex = authority.indexOf("]");
+    if (closeBracketIndex === -1) return url;
+    const portPrefix = authority.slice(closeBracketIndex + 1);
+    if (!portPrefix.startsWith(":")) return url;
+    if (!rawAuthorityPortIsMalformed(portPrefix.slice(1))) return url;
+    return replaceRawUrlAuthority(
+      url,
+      bounds,
+      authority.slice(0, closeBracketIndex + 1),
+    );
+  }
+
+  const portSeparator = authority.lastIndexOf(":");
+  if (portSeparator === -1) return url;
+  if (authority.indexOf(":") !== portSeparator) return url;
+  if (!rawAuthorityPortIsMalformed(authority.slice(portSeparator + 1))) {
+    return url;
+  }
+  return replaceRawUrlAuthority(url, bounds, authority.slice(0, portSeparator));
+}
+
+function rawBaseForDecisionMatch(rawBase: string): string | null {
+  if (stripUrlQueryAndFragment(rawBase).includes("\\")) return null;
+  return stripRawUrlMalformedPort(stripRawUrlUserinfo(rawBase));
 }
 
 function rawPathFromUrl(url: string): string {
@@ -1044,11 +1106,13 @@ function matchFirewallBaseUrlForDecision(
   rawBase: string,
 ): FirewallBaseUrlMatch | null {
   if (!runtimeUrlCanMatchFirewallBase(url)) return null;
+  const baseForMatch = rawBaseForDecisionMatch(rawBase);
+  if (baseForMatch === null) return null;
 
   try {
     return matchStaticFirewallBaseUrl(
       runtimeUrlForBaseMatch(url),
-      stripRawUrlUserinfo(rawBase),
+      baseForMatch,
     );
   } catch {
     return null;

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -127,15 +127,23 @@ interface DecisionFirewall {
 interface DecisionBaseMatch {
   readonly firewallName: string;
   readonly base: string;
+  readonly allowBase: string;
   readonly relativePath: string;
 }
 
-interface DecisionAllowedRuleMatch extends DecisionBaseMatch {
+interface DecisionAllowedRuleMatch {
+  readonly firewallName: string;
+  readonly base: string;
+  readonly relativePath: string;
   readonly permission: string;
   readonly rule: string;
 }
 
-type DecisionBlockMatch = DecisionBaseMatch;
+interface DecisionBlockMatch {
+  readonly firewallName: string;
+  readonly base: string;
+  readonly relativePath: string;
+}
 
 interface FirewallDecisionState {
   bestBaseScore: number | null;
@@ -942,11 +950,7 @@ function scoreLiteralSegment(segment: string): number {
   return LITERAL_SEGMENT_SCORE + codePointLength(segment);
 }
 
-function scorePatternSegment(segment: string, allowParams: boolean): number {
-  if (!allowParams) return scoreLiteralSegment(segment);
-
-  const parsed = parseSegment(segment);
-  if (parsed.kind === "error") return 0;
+function scoreParsedPatternSegment(parsed: MatchableSegment): number {
   if (parsed.kind === "literal") {
     return scoreLiteralSegment(parsed.value);
   }
@@ -961,19 +965,38 @@ function scorePatternSegment(segment: string, allowParams: boolean): number {
   return PLAIN_PARAM_SEGMENT_SCORE;
 }
 
-function scorePatternSegments(
-  segments: string[],
-  allowParams: boolean,
-): number {
+function scoreStaticSegments(segments: string[]): number {
   return segments.reduce((score, segment) => {
-    return score + scorePatternSegment(segment, allowParams);
+    return score + scoreLiteralSegment(segment);
   }, 0);
 }
 
-function scorePathPattern(path: string, allowParams: boolean): number {
+function scorePatternSegmentsWithParser(
+  segments: string[],
+  parsePatternSegment: SegmentMatchParser,
+): number {
+  const lastPatternIndex = segments.length - 1;
+  let score = 0;
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index]!;
+    const parsed = parsePatternSegment(segment, index, lastPatternIndex);
+    if (parsed !== null) {
+      score += scoreParsedPatternSegment(parsed);
+    }
+  }
+  return score;
+}
+
+function scorePathPattern(
+  path: string,
+  parsePatternSegment: SegmentMatchParser | null,
+): number {
   if (path === "") return 0;
   if (path === "/") return ROOT_PATH_SCORE;
-  return scorePatternSegments(splitPathSegments(path), allowParams);
+  const segments = splitPathSegments(path);
+  return parsePatternSegment === null
+    ? scoreStaticSegments(segments)
+    : scorePatternSegmentsWithParser(segments, parsePatternSegment);
 }
 
 function splitAuthoritySegments(authority: string): string[] {
@@ -984,16 +1007,31 @@ function splitAuthoritySegments(authority: string): string[] {
   return normalized === "" ? [] : normalized.split(".");
 }
 
-function baseUrlSpecificityScore(rawBase: string, hasParams: boolean): number {
-  const baseForMatch = stripTrailingSlash(rawBase);
-  const authorityScore = scorePatternSegments(
-    splitAuthoritySegments(rawAuthorityFromUrl(baseForMatch) ?? ""),
-    hasParams,
-  );
-  const pathScore = scorePathPattern(
-    rawBasePathFromUrl(baseForMatch),
-    hasParams,
-  );
+function baseUrlSpecificityScore({
+  authority,
+  path,
+  hasParams,
+  tolerateMalformedBaseParams = false,
+}: {
+  readonly authority: string;
+  readonly path: string;
+  readonly hasParams: boolean;
+  readonly tolerateMalformedBaseParams?: boolean;
+}): number {
+  const patternParser = hasParams
+    ? tolerateMalformedBaseParams
+      ? parseMalformedTolerantBaseSegment
+      : parseStrictMatchSegment
+    : null;
+  const authoritySegments = splitAuthoritySegments(authority);
+  const authorityScore =
+    patternParser === null
+      ? scoreStaticSegments(authoritySegments)
+      : scorePatternSegmentsWithParser(
+          [...authoritySegments].reverse(),
+          patternParser,
+        );
+  const pathScore = scorePathPattern(path, patternParser);
   return (
     pathScore * PATH_SCORE_MULTIPLIER +
     authorityScore * AUTHORITY_SCORE_MULTIPLIER +
@@ -1114,7 +1152,12 @@ function matchStaticFirewallBaseUrl(
   return {
     displayBase,
     relativePath,
-    score: baseUrlSpecificityScore(rawBase, baseHasParams),
+    score: baseUrlSpecificityScore({
+      authority: baseAuthority,
+      path: basePath,
+      hasParams: baseHasParams,
+      tolerateMalformedBaseParams: options.tolerateMalformedBaseParams === true,
+    }),
   };
 }
 
@@ -1148,9 +1191,11 @@ function matchFirewallBaseUrlForDecision(
   if (baseForMatch === null) return null;
 
   try {
-    return matchStaticFirewallBaseUrl(url, baseForMatch, {
+    const match = matchStaticFirewallBaseUrl(url, baseForMatch, {
       tolerateMalformedBaseParams: true,
     });
+    if (match === null) return null;
+    return { ...match, displayBase: stripTrailingSlash(rawBase) };
   } catch {
     return null;
   }
@@ -1297,7 +1342,7 @@ function resolveFirewallDecision(
     return {
       kind: "allow",
       firewallName: baseMatch.firewallName,
-      base: baseMatch.base,
+      base: baseMatch.allowBase,
       relativePath: baseMatch.relativePath,
     };
   }
@@ -1315,7 +1360,7 @@ function resolveFirewallDecision(
     return {
       kind: "allow",
       firewallName: baseMatch.firewallName,
-      base: baseMatch.base,
+      base: baseMatch.allowBase,
       relativePath: baseMatch.relativePath,
     };
   }
@@ -1332,13 +1377,12 @@ function resolveFirewallDecision(
 
 function unsafePathBlockDecision(
   firewall: DecisionFirewall,
-  api: DecisionApi,
   baseMatch: FirewallBaseUrlMatch,
 ): FirewallRequestDecision {
   return {
     kind: "block",
     firewallName: firewall.name,
-    base: api.rawBase,
+    base: baseMatch.displayBase,
     relativePath: baseMatch.relativePath,
     reason: "unsafe_path",
     permissions: [],
@@ -1384,7 +1428,7 @@ function evaluateDecisionRule({
   readonly rule: DecisionRule;
   readonly policy: CompiledNetworkPolicy | undefined;
   readonly blockMatch: DecisionBlockMatch;
-  readonly baseMatch: FirewallBaseUrlMatch;
+  readonly baseMatch: DecisionBaseMatch;
   readonly upperMethod: string;
 }): void {
   if (rule.method !== "ANY" && rule.method !== upperMethod) return;
@@ -1401,9 +1445,9 @@ function evaluateDecisionRule({
   }
 
   state.allowedMatch ??= {
-    firewallName: blockMatch.firewallName,
-    base: blockMatch.base,
-    relativePath: blockMatch.relativePath,
+    firewallName: baseMatch.firewallName,
+    base: baseMatch.allowBase,
+    relativePath: baseMatch.relativePath,
     permission: rule.permission,
     rule: rule.raw,
   };
@@ -1421,7 +1465,7 @@ function evaluateDecisionRules({
   readonly api: DecisionApi;
   readonly policy: CompiledNetworkPolicy | undefined;
   readonly blockMatch: DecisionBlockMatch;
-  readonly baseMatch: FirewallBaseUrlMatch;
+  readonly baseMatch: DecisionBaseMatch;
   readonly upperMethod: string;
 }): void {
   for (const rule of api.rules) {
@@ -1456,14 +1500,20 @@ function evaluateDecisionApi({
   const policy = networkPolicies.policies.get(firewall.name);
   const baseMatch = matchFirewallBaseUrlForDecision(url, api.rawBase);
   if (baseMatch === null) return null;
-  if (unsafePath) return unsafePathBlockDecision(firewall, api, baseMatch);
+  if (unsafePath) return unsafePathBlockDecision(firewall, baseMatch);
 
-  const blockMatch: DecisionBlockMatch = {
+  const decisionBaseMatch: DecisionBaseMatch = {
     firewallName: firewall.name,
-    base: api.rawBase,
+    base: baseMatch.displayBase,
+    allowBase: api.rawBase,
     relativePath: baseMatch.relativePath,
   };
-  if (!acceptDecisionBaseMatch(state, blockMatch, baseMatch.score)) {
+  const blockMatch: DecisionBlockMatch = {
+    firewallName: decisionBaseMatch.firewallName,
+    base: decisionBaseMatch.base,
+    relativePath: decisionBaseMatch.relativePath,
+  };
+  if (!acceptDecisionBaseMatch(state, decisionBaseMatch, baseMatch.score)) {
     return null;
   }
 
@@ -1479,7 +1529,7 @@ function evaluateDecisionApi({
     api,
     policy,
     blockMatch,
-    baseMatch,
+    baseMatch: decisionBaseMatch,
     upperMethod,
   });
   return null;


### PR DESCRIPTION
## Summary
- add a shared TypeScript firewall final-decision helper aligned with the runner matcher output
- extend the shared firewall semantics contract with final allow/block/no-match decision cases
- update zero doctor check-connector URL diagnostics to use the final decision helper instead of re-inferring policy semantics

Closes #19902

## Tests
- pnpm -F @vm0/connectors lint && pnpm -F @vm0/connectors check-types && pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-semantics-contract.test.ts
- pnpm -F @vm0/cli lint && pnpm -F @vm0/cli check-types && pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/check-connector.test.ts
- PYTHONPATH=/tmp/vm0-pytest-target:src python3 -m pytest tests/test_firewall_semantics_contract.py -v