### PR TITLE
Hide Desktop filesystem plugin behind developer tools

### DIFF
--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   type ComputerUseHostRuntimeStatus,
   type ComputerUsePermissionState,
+  type DesktopComputerUsePluginsState,
   type DesktopComputerUseState,
   type DesktopKeepAwakeState,
 } from "../computer-use-types";
@@ -49,15 +50,31 @@ const defaultDeveloperToolsState: DesktopDeveloperToolsState = {
   enabled: false,
 };
 
+function createComputerUsePluginsState(): DesktopComputerUsePluginsState {
+  return {
+    filesystem: {
+      featureEnabled: true,
+      enabled: false,
+      allowedDirectories: [],
+      status: "disabled",
+      lastError: null,
+      version: "2026.1.14",
+      capabilities: [],
+    },
+  };
+}
+
 function createComputerUseState({
   deviceName = "lisa",
   keepAwake = { active: false, enabled: false },
   permissions = { accessibility: true, screenRecording: true },
+  plugins,
   status = "offline",
 }: {
   readonly deviceName?: string | null;
   readonly keepAwake?: DesktopKeepAwakeState;
   readonly permissions?: ComputerUsePermissionState;
+  readonly plugins?: DesktopComputerUsePluginsState;
   readonly status?: ComputerUseHostRuntimeStatus;
 } = {}): DesktopComputerUseState {
   return {
@@ -76,6 +93,7 @@ function createComputerUseState({
       localCommandLog: [],
     },
     keepAwake,
+    plugins,
   };
 }
 
@@ -514,16 +532,21 @@ describe("Desktop renderer bridge integration", () => {
 
   it("shows runtime details only after developer tools are enabled", async () => {
     const { developerTools } = installDesktopBridges({
-      computerUseState: createComputerUseState({ status: "online" }),
+      computerUseState: createComputerUseState({
+        plugins: createComputerUsePluginsState(),
+        status: "online",
+      }),
     });
     renderDesktopApp();
 
     expect(await screen.findByText("Online")).toBeTruthy();
+    expect(screen.queryByText("Filesystem plugin")).toBeNull();
     expect(screen.queryByText("Runtime")).toBeNull();
     expect(screen.queryByText("Command Log")).toBeNull();
 
     developerTools.emitState({ available: true, enabled: true });
 
+    expect(await screen.findByText("Filesystem plugin")).toBeTruthy();
     expect(await screen.findByText("Runtime")).toBeTruthy();
     expect(await screen.findByText("Command Log")).toBeTruthy();
     expect(developerTools.subscribe).toHaveBeenCalled();

--- a/turbo/apps/desktop/src/renderer/hero/index.tsx
+++ b/turbo/apps/desktop/src/renderer/hero/index.tsx
@@ -433,9 +433,9 @@ export function ReadyExperience({
         <OfflineHero authState={authState} state={state} />
       )}
       {!running && <PermissionAutoRefresh />}
-      <FilesystemPluginPanel state={state} />
       {developerToolsEnabled && (
         <>
+          <FilesystemPluginPanel state={state} />
           <RuntimePanel state={state} />
           <CommandLogPanel state={state} />
         </>


### PR DESCRIPTION
## Summary
- Gate the Desktop Computer Use filesystem plugin panel behind the existing developer tools enabled state
- Keep the filesystem feature switch check inside the panel so the panel still only appears when the filesystem plugin feature is available
- Extend renderer bridge coverage to assert the filesystem panel stays hidden until developer tools are enabled

## Verification
- `pnpm exec prettier --check apps/desktop/src/renderer/App.test.tsx apps/desktop/src/renderer/hero/index.tsx`
- `pnpm -F @vm0/desktop exec vitest run src/renderer/App.test.tsx`
- `pnpm -F @vm0/desktop check-types`
- `pnpm -F @vm0/desktop lint`
- Browser DOM check via Desktop renderer Vite server with mocked bridges: hidden when developer tools disabled, visible after enabling developer tools