### PR TITLE
feat: rename templates picker modal title to "Create with template"

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -4750,7 +4750,7 @@ function TemplatePickerDialog({
         ) : (
           <>
             <DialogHeader className="shrink-0 border-b border-border px-5 py-4">
-              <DialogTitle>Templates</DialogTitle>
+              <DialogTitle>Create with template</DialogTitle>
             </DialogHeader>
             <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 pt-3 sm:flex-row sm:items-start sm:justify-between">
               <TemplatePickerTabs


### PR DESCRIPTION
## What

Renames the title of the chat-composer template picker modal from **Templates** to **Create with template**.

## Why

"Templates" alone reads as a passive label; "Create with template" makes the modal's purpose explicit — the user is starting a new creation (Presentation / Illustration / Video / Workflow) from a template.

## User-visible impact

The modal header shown when opening the template picker in the Zero chat composer now reads "Create with template".

## Implementation

- `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx` — `<DialogTitle>` copy change only. No behavior, layout, or logic changes.
- Copy uses sentence case to match the platform's copy convention.

## Verification

- Prettier (`prettier@3.8.1 --check`) passes on the changed file.
- No test asserts on the old dialog title, so nothing breaks; relying on the PR pipeline for full CI.