### PR TITLE
Make generation template context strictly one-shot

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2590,7 +2590,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     await cancelChatRun(actor, video.runId);
   }, 90_000);
 
-  it("is one-shot: a follow-up without re-attaching the style relies on the replayed marker, not a live block", async () => {
+  it("is one-shot: a follow-up without re-attaching the style gets no template context", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const style = ILLUSTRATION_TEMPLATE_ITEMS[0];
@@ -2626,10 +2626,8 @@ describe("CHAT-02: generation templates and attachments", () => {
       });
     });
 
-    // Turn 2: a follow-up without re-attaching the style gets no live block —
-    // there is no thread-sticky DB default (see resolveThreadGenerationTemplatePrompt).
-    // It only sees the selection via the marker replayed inside "# Web Chat Run
-    // Context" for turn 1's message.
+    // Turn 2: a follow-up without re-attaching the style gets no template
+    // context.
     const second = await sendChatRun(actor, {
       agentId,
       threadId: first.threadId,
@@ -2639,12 +2637,12 @@ describe("CHAT-02: generation templates and attachments", () => {
       .appendSystemPrompt;
     expect(secondPrompt).not.toContain("# Artifact Template Context");
     expect(secondPrompt).toContain("# Web Chat Run Context");
-    expect(secondPrompt).toContain("Selected a template");
-    expect(secondPrompt).toContain(style.illustrationStyleId);
+    expect(secondPrompt).not.toContain("Selected a template");
+    expect(secondPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, second.runId);
 
     // Turn 3: attaching a video preset now only resolves the video template live
-    // — templates no longer merge across types via thread-sticky DB state.
+    // — templates no longer merge across turns or types.
     const videoTemplate = VIDEO_TEMPLATE_ITEMS.find((item) => {
       return item.id === "video-template:epic-grandeur";
     });
@@ -2668,21 +2666,16 @@ describe("CHAT-02: generation templates and attachments", () => {
     expect(thirdPrompt).toContain(
       `zero generate video --provider built-in --template ${videoTemplate.id}`,
     );
-    // The illustration style is gone entirely for this turn: it's not live
-    // (explicit selection this turn is video, not illustration), and turn 2's
-    // cancellation put an incomplete round in the thread, which suppresses the
-    // general "# Web Chat Run Context" replay (turn 1's marker included) in
-    // favor of resuming the existing session. An explicit selection this turn
-    // means there's nothing to fall back to either — see the "no explicit
-    // selection" case covered by the workflow test below.
+    // The illustration style is gone entirely for this turn: it's not attached
+    // to this message, and prior/incomplete context no longer repeats template
+    // selections.
     expect(thirdPrompt).not.toContain(
       `zero generate image --provider built-in --style ${style.illustrationStyleId}`,
     );
     expect(thirdPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, third.runId);
 
-    // A brand-new thread starts clean: neither template carries over — there is
-    // no DB-backed cross-thread state and no prior turns to replay a marker from.
+    // A brand-new thread starts clean: neither template carries over.
     const fresh = await sendChatRun(actor, { agentId, prompt: "draw a cat" });
     const freshPrompt = (await api.readRun(actor, fresh.runId))
       .appendSystemPrompt;
@@ -2696,7 +2689,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     await cancelChatRun(actor, fresh.runId);
   }, 120_000);
 
-  it("injects workflow templates as one-shot context, independent of illustration template markers", async () => {
+  it("injects workflow templates as one-shot context without prior template selections", async () => {
     const { actor, agentId } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const style = ILLUSTRATION_TEMPLATE_ITEMS[0];
@@ -2708,7 +2701,7 @@ describe("CHAT-02: generation templates and attachments", () => {
       throw new Error("Expected a registered workflow template");
     }
 
-    const sticky = await sendChatRun(actor, {
+    const illustration = await sendChatRun(actor, {
       agentId,
       prompt: "draw a labeled inbox",
       generationTemplate: {
@@ -2716,15 +2709,15 @@ describe("CHAT-02: generation templates and attachments", () => {
         selection: { illustrationStyleId: style.illustrationStyleId },
       },
     });
-    const stickyPrompt = (await api.readRun(actor, sticky.runId))
+    const illustrationPrompt = (await api.readRun(actor, illustration.runId))
       .appendSystemPrompt;
-    expect(stickyPrompt).toContain("# Artifact Template Context");
-    expect(stickyPrompt).toContain(style.illustrationStyleId);
-    await cancelChatRun(actor, sticky.runId);
+    expect(illustrationPrompt).toContain("# Artifact Template Context");
+    expect(illustrationPrompt).toContain(style.illustrationStyleId);
+    await cancelChatRun(actor, illustration.runId);
 
     const workflow = await sendChatRun(actor, {
       agentId,
-      threadId: sticky.threadId,
+      threadId: illustration.threadId,
       prompt: "create the workflow version",
       generationTemplate: {
         type: "workflow",
@@ -2740,36 +2733,30 @@ describe("CHAT-02: generation templates and attachments", () => {
     expect(workflowPrompt).toContain("Use the workflow-setup skill");
     expect(workflowPrompt).toContain("Gmail label-applied automation");
     expect(workflowPrompt).not.toContain("# Artifact Template Context");
-    // The "sticky" run was cancelled, so it's now an incomplete round replayed
-    // via "# Incomplete Rounds Context" — its illustration marker legitimately
-    // shows up there. That's independent of (and doesn't contaminate) the live
-    // workflow block asserted above: workflow selections never get their own
-    // replay marker (checked below), so nothing here merges the two types.
+    // The illustration run was cancelled, so only its message text is replayed
+    // via "# Incomplete Rounds Context"; the template id is not.
     expect(workflowPrompt).toContain("# Incomplete Rounds Context");
-    expect(workflowPrompt).toContain(style.illustrationStyleId);
+    expect(workflowPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, workflow.runId);
 
     const followUp = await sendChatRun(actor, {
       agentId,
-      threadId: sticky.threadId,
+      threadId: illustration.threadId,
       prompt: "continue the thread",
     });
     const followUpPrompt = (await api.readRun(actor, followUp.runId))
       .appendSystemPrompt;
     // No explicit selection this turn, so there is no live block for either
-    // type. Both "sticky" and "workflow" were cancelled, so the general
-    // "# Web Chat Run Context" replay is suppressed in favor of resuming the
-    // existing session (see prepareRecentChatContext) — the illustration
-    // selection surfaces instead via the incomplete round replay's own
-    // marker. Workflow selections never get a marker at all (one-shot by
-    // design), so nothing carries the workflow template forward.
+    // type. Both earlier runs were cancelled, so the general "# Web Chat Run
+    // Context" replay is suppressed in favor of resuming the existing session
+    // (see prepareRecentChatContext).
     expect(followUpPrompt).not.toContain("# Workflow Template Context");
     expect(followUpPrompt).not.toContain(workflowTemplate.id);
     expect(followUpPrompt).not.toContain("# Artifact Template Context");
     expect(followUpPrompt).not.toContain("# Web Chat Run Context");
     expect(followUpPrompt).toContain("# Incomplete Rounds Context");
-    expect(followUpPrompt).toContain("Selected a template");
-    expect(followUpPrompt).toContain(style.illustrationStyleId);
+    expect(followUpPrompt).not.toContain("Selected a template");
+    expect(followUpPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, followUp.runId);
   }, 120_000);
 

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -91,20 +91,17 @@ export function buildGenerationTemplatePrompt(
 // three builders cannot drift. It balances two jobs that pull in opposite
 // directions:
 //   1. The user *deliberately* selected this template — a strong signal, so it is
-//      the default style for that artifact, and the agent must not re-ask for an
-//      already-selected style (vm0-ai/vm0#17525).
-//   2. The selection must not hijack unrelated turns. This block is injected on
-//      every run while the template is thread-sticky (see resolveThread-
-//      GenerationTemplatePrompt), including messages that have nothing to do with
-//      generation, so the "does not force you to generate" boundary is load-
-//      bearing, not decorative.
+//      the default style for that artifact in this run, and the agent must not
+//      re-ask for an already-selected style (vm0-ai/vm0#17525).
+//   2. The selection must not hijack unrelated work in this run, so the "does
+//      not force you to generate" boundary is load-bearing, not decorative.
 // State the facts and hand back the decision, rather than naming a step ("resolve
 // from the registry") without the facts needed to act on it.
 function templateFraming(artifactNoun: string): readonly string[] {
   return [
     "# Artifact Template Context",
     "",
-    `- The user deliberately selected this artifact template for the chat — treat it as the default style for any ${artifactNoun} you produce here, including in follow-up messages.`,
+    `- The user deliberately selected this artifact template for this run — treat it as the default style for any ${artifactNoun} you produce here.`,
     `- It does not force you to generate: the user's prompt decides the task, content, output format, and whether to produce an artifact at all. If a request isn't about producing ${artifactNoun}, just answer it normally.`,
     "- Other artifact templates, files, or attachments may also be present.",
     "",
@@ -303,48 +300,4 @@ function buildIllustrationGenerationTemplatePrompt(
       "- If a flag above no longer applies, run `zero generate image -h` to discover the current flags, models, providers, and styles.",
     ].join("\n"),
   };
-}
-
-/**
- * Short, non-instructional label for a generation template selection, meant to be
- * embedded into replayed prior-turn text (see buildWebChatPriorRunsContext) so a
- * later turn can see *when* the selection changed without repeating the full
- * "# Artifact Template Context" instructions for every past turn. There is no
- * thread-sticky persistence for these templates, so this replayed marker is the
- * only way a future turn learns a selection happened here.
- */
-export function describeGenerationTemplateSelection(
-  generationTemplate: GenerationTemplateInput | null | undefined,
-): string | null {
-  if (!generationTemplate) {
-    return null;
-  }
-  if (generationTemplate.type === "illustration") {
-    const style = findImageStyle(
-      generationTemplate.selection.illustrationStyleId,
-    );
-    return style
-      ? `using illustration style "${style.name}" (${style.id})`
-      : null;
-  }
-  if (generationTemplate.type === "video") {
-    const template = findVideoTemplate(
-      generationTemplate.selection.stylePresetId,
-    );
-    return template
-      ? `using video template "${template.name}" (${template.id})`
-      : null;
-  }
-  if (generationTemplate.type === "presentation") {
-    const template = findTemplate(generationTemplate.selection.templateId);
-    return template
-      ? `using presentation template "${template.name}" (${template.id})`
-      : null;
-  }
-  const template = findWorkflowTemplateItem(
-    generationTemplate.selection.workflowTemplateId,
-  );
-  return template
-    ? `using workflow template "${template.title}" (${template.id})`
-    : null;
 }

--- a/turbo/apps/api/src/signals/routes/thread-generation-template.ts
+++ b/turbo/apps/api/src/signals/routes/thread-generation-template.ts
@@ -5,13 +5,8 @@ import { buildGenerationTemplatePrompt } from "./generation-template-prompt";
  * Resolve the generation-template system prompt for a chat run.
  *
  * One-shot only: the prompt is built from the selection attached to *this*
- * message and nothing else. There is no thread-sticky persistence — a
- * follow-up message that doesn't reattach a template resolves to "", and the
- * agent must rely on the marker embedded in the replayed prior-run text (see
- * buildWebChatPriorRunsContext) to keep using the same template across turns.
- * This trades a DB-backed "never expires" default for one signal that lives
- * entirely in-context: no separate store to fall out of sync with what the
- * agent actually sees.
+ * message and nothing else. There is no thread-level default: a follow-up
+ * message that doesn't reattach a template resolves to "".
  */
 export function resolveThreadGenerationTemplatePrompt(args: {
   readonly explicit: GenerationTemplateRequest | null | undefined;

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -85,10 +85,7 @@ import { bestEffort } from "../utils";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import type { RouteEntry } from "../route-entry";
-import {
-  buildGenerationTemplatePrompt,
-  describeGenerationTemplateSelection,
-} from "./generation-template-prompt";
+import { buildGenerationTemplatePrompt } from "./generation-template-prompt";
 import { resolveThreadGenerationTemplatePrompt } from "./thread-generation-template";
 
 type SendBody = z.infer<typeof chatMessagesContract.send.body>;
@@ -577,31 +574,10 @@ function formatAttachFileIds(
     .join("\n");
 }
 
-// Generation templates are one-shot (see resolveThreadGenerationTemplatePrompt) —
-// there is no thread-sticky DB default, so a later turn only learns a selection
-// happened here by seeing this marker in the replayed text.
-function generationTemplateReplayMarker(
-  role: "user" | "assistant",
-  generationTemplate: ChatMessageGenerationTemplate | null,
-): string {
-  // Workflow templates are one-shot by design (never sticky, see
-  // resolveThreadGenerationTemplatePrompt) — a "stays in effect" marker would
-  // misrepresent that, so only illustration/video/presentation get one.
-  if (role !== "user" || generationTemplate?.type === "workflow") {
-    return "";
-  }
-  const description = describeGenerationTemplateSelection(generationTemplate);
-  return description ? `[Selected a template — ${description}.]\n` : "";
-}
-
 function formatPriorRunMessage(message: WebChatPriorRunMessage): string {
   const roleLabel = message.role === "user" ? "User" : "Assistant";
-  const marker = generationTemplateReplayMarker(
-    message.role,
-    message.generationTemplate,
-  );
   const attach = formatAttachFileIds(message.attachFiles);
-  const body = `${marker}${roleLabel}: ${truncatePrior(message.content) || "[empty message]"}`;
+  const body = `${roleLabel}: ${truncatePrior(message.content) || "[empty message]"}`;
   return attach ? `${body}\n${attach}` : body;
 }
 
@@ -661,17 +637,11 @@ function formatIncompleteMessage(
 ): string {
   const attach = formatAttachFileIds(message.attachFiles);
   if (message.role === "user") {
-    const marker = generationTemplateReplayMarker(
-      message.role,
-      message.generationTemplate,
-    );
     const body =
       message.content !== null && message.content !== ""
         ? truncateIncomplete(message.content)
         : "[empty message]";
-    return attach
-      ? `${marker}User: ${body}\n${attach}`
-      : `${marker}User: ${body}`;
+    return attach ? `User: ${body}\n${attach}` : `User: ${body}`;
   }
   if (message.content !== null && message.content !== "") {
     return `Assistant (partial): ${truncateIncomplete(message.content)}`;

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -75,7 +75,6 @@ import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
-import { describeGenerationTemplateSelection } from "../routes/generation-template-prompt";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
@@ -1331,30 +1330,9 @@ function truncateIncomplete(value: string): string {
   return `${value.slice(0, INCOMPLETE_MESSAGE_CHAR_CAP)}...[truncated]`;
 }
 
-// Generation templates are one-shot (see resolveThreadGenerationTemplatePrompt) —
-// there is no thread-sticky DB default, so a later turn only learns a selection
-// happened here by seeing this marker in the replayed text.
-function generationTemplateReplayMarker(
-  role: "user" | "assistant",
-  generationTemplate: ChatMessageGenerationTemplate | null,
-): string {
-  // Workflow templates are one-shot by design (never sticky, see
-  // resolveThreadGenerationTemplatePrompt) — a "stays in effect" marker would
-  // misrepresent that, so only illustration/video/presentation get one.
-  if (role !== "user" || generationTemplate?.type === "workflow") {
-    return "";
-  }
-  const description = describeGenerationTemplateSelection(generationTemplate);
-  return description ? `[Selected a template — ${description}.]\n` : "";
-}
-
 function formatPriorRunMessage(message: PriorRunMessage): string {
   const roleLabel = message.role === "user" ? "User" : "Assistant";
-  const marker = generationTemplateReplayMarker(
-    message.role,
-    message.generationTemplate,
-  );
-  const body = `${marker}${roleLabel}: ${truncatePrior(message.content) || "[empty message]"}`;
+  const body = `${roleLabel}: ${truncatePrior(message.content) || "[empty message]"}`;
   const attach = formatAttachFileIds(message.attachFiles);
   return attach ? `${body}\n${attach}` : body;
 }
@@ -1395,17 +1373,11 @@ function buildWebChatPriorRunsContext(runs: readonly PriorRun[]): string {
 function formatIncompleteMessage(message: IncompleteRoundMessage): string {
   const attach = formatAttachFileIds(message.attachFiles);
   if (message.role === "user") {
-    const marker = generationTemplateReplayMarker(
-      message.role,
-      message.generationTemplate,
-    );
     const body =
       message.content !== null && message.content !== ""
         ? truncateIncomplete(message.content)
         : "[empty message]";
-    return attach
-      ? `${marker}User: ${body}\n${attach}`
-      : `${marker}User: ${body}`;
+    return attach ? `User: ${body}\n${attach}` : `User: ${body}`;
   }
   if (message.content !== null && message.content !== "") {
     return `Assistant (partial): ${truncateIncomplete(message.content)}`;

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -1214,20 +1214,22 @@ export type GenerationTemplateRequest = z.infer<
   typeof generationTemplateRequestSchema
 >;
 export type GenerationTemplateType = GenerationTemplateRequest["type"];
-export type StickyGenerationTemplateType = Exclude<
+export type LegacyThreadGenerationTemplateType = Exclude<
   GenerationTemplateType,
   "workflow"
 >;
 /**
- * Per-thread sticky generation templates, keyed by template type so a single
- * thread can keep an illustration style, a video preset, and a presentation
- * design active at the same time. Workflow templates are intentionally omitted
- * because they are one-shot context for the current run.
+ * Legacy generation template shape retained for older thread-level storage.
+ * Current prompt injection uses the generation template attached to the current
+ * message only.
  */
 export type ThreadGenerationTemplates = Partial<
   Record<
-    StickyGenerationTemplateType,
-    Extract<GenerationTemplateRequest, { type: StickyGenerationTemplateType }>
+    LegacyThreadGenerationTemplateType,
+    Extract<
+      GenerationTemplateRequest,
+      { type: LegacyThreadGenerationTemplateType }
+    >
   >
 >;
 export type PresentationGenerationTemplateRequest = z.infer<

--- a/turbo/packages/db/src/schema/chat-thread.ts
+++ b/turbo/packages/db/src/schema/chat-thread.ts
@@ -78,14 +78,9 @@ export const chatThreads = pgTable(
     /** Per-thread selected model pin. Provider routing is resolved per run. */
     selectedModel: varchar("selected_model", { length: 255 }),
     /**
-     * Per-thread sticky generation templates, keyed by template type
-     * (illustration style / video preset / presentation design) so a thread can
-     * keep several active at once. Persisted so follow-up messages inherit the
-     * selections the user attached earlier without restating them. Workflow
-     * templates are not stored here; they are one-shot context for a single run.
-     * NULL means none are attached. Thread-scoped on purpose: a new thread
-     * starts clean (no cross-session carry-over) and there is intentionally no
-     * org/global default.
+     * Legacy generation template column retained for schema compatibility.
+     * Current prompt injection reads the generation template attached to the
+     * current chat message only.
      */
     generationTemplate: jsonb(
       "generation_template",


### PR DESCRIPTION
## Summary
- Remove generation template replay markers from prior-run and incomplete-round context so template selections only affect the run where they are attached.
- Update artifact template framing to say the template applies to "this run" and remove the follow-up carryover language.
- Clean up legacy sticky wording in generation template comments/types and update chat-message BDD expectations for the one-shot behavior.

## Verification
- `pnpm exec prettier --check apps/api/src/signals/routes/generation-template-prompt.ts apps/api/src/signals/routes/thread-generation-template.ts apps/api/src/signals/routes/zero-chat-messages.ts apps/api/src/signals/services/internal-chat-run-callback.service.ts apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts packages/api-contracts/src/contracts/chat-threads.ts packages/db/src/schema/chat-thread.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`

## Notes
- Targeted Vitest attempts were not usable in this local environment because the API test runner collected DB-backed BDD suites and failed with local Postgres `ECONNREFUSED`; CI should run the PR pipeline checks.
