### PR TITLE
feat: roll out PresentationTemplateRunbook feature switch to 100%

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -302,8 +302,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "bingjie@vm0.ai",
     description:
       "Generate presentations from a selected template via its self-contained runbook package: the agent pulls one R2 archive, follows AGENT_RUNBOOK.md, and selects a color system at runtime. When off, presentation generation uses the legacy multi-resource selection flow.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.PresentationImageUnsplashPreferred]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## What

Rolls the `PresentationTemplateRunbook` feature switch out to **100% of orgs** by setting `enabled: true` and removing the staff-only `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` gate in `turbo/packages/core/src/feature-switch.ts`.

## User-visible impact

Every user's presentation generation now goes through the **self-contained template runbook** flow: the agent pulls a single R2 archive for the selected template, follows its `AGENT_RUNBOOK.md`, and selects a color system at runtime. This replaces the legacy multi-resource selection flow (which the switch's `off` state previously served to non-staff orgs).

## Implementation

- `enabled: false` → `enabled: true`
- Dropped the now-redundant `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` staff gate, matching the convention for fully-rolled-out switches (e.g. `Dummy`). `isFeatureEnabled` short-circuits on `enabled === true`, so this applies globally.

## Verification

Prettier-formatted; relying on the PR pipeline for lint/type/test. No other switch entries touched; `STAFF_ORG_ID_HASHES` remains imported and used by the remaining staff-gated switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)