### PR TITLE
fix: diagnose shared-base connector ownership before auth

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -550,7 +550,7 @@ def _base_match_permissions() -> list[dict]:
 
 
 def _has_dynamic_base_marker(raw_base: str) -> bool:
-    return any(marker in raw_base for marker in _DYNAMIC_BASE_MARKERS)
+    return all(marker in raw_base for marker in _DYNAMIC_BASE_MARKERS)
 
 
 def _matching_network_policies(

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -255,11 +255,15 @@ def _diagnostic_catalog() -> _DiagnosticCatalog:
 
     connector_firewalls: list[dict] = []
     connector_matchers: list[_DiagnosticConnectorMatcher] = []
+    shared_route_aware_base_keys = _shared_route_aware_base_keys(CONNECTOR_DIAGNOSTIC_FIREWALLS)
     for firewall in CONNECTOR_DIAGNOSTIC_FIREWALLS:
         diagnostic_firewall = _diagnostic_firewall_from_manifest(firewall)
         if diagnostic_firewall is not None:
             connector_firewalls.append(diagnostic_firewall)
-        route_aware_firewall = _route_aware_diagnostic_firewall_from_manifest(firewall)
+        route_aware_firewall = _route_aware_diagnostic_firewall_from_manifest(
+            firewall,
+            shared_base_keys=shared_route_aware_base_keys,
+        )
         if route_aware_firewall is not None:
             connector_matchers.append(
                 _DiagnosticConnectorMatcher(
@@ -319,6 +323,49 @@ def _manifest_str_tuple(value: object) -> tuple[str, ...]:
     return tuple(result)
 
 
+def _diagnostic_static_base_key(raw_base: str) -> str | None:
+    if _has_dynamic_base_marker(raw_base):
+        return None
+    if not matching.firewall_base_config_is_valid(raw_base):
+        return None
+    try:
+        parsed = urllib.parse.urlparse(raw_base)
+    except ValueError:
+        return None
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{parsed.path.rstrip('/')}"
+
+
+def _shared_route_aware_base_keys(firewalls: object) -> frozenset[str]:
+    if not isinstance(firewalls, (list, tuple)):
+        return frozenset()
+    connector_names_by_base: dict[str, set[str]] = {}
+    for firewall in firewalls:
+        if not isinstance(firewall, dict):
+            continue
+        raw_name = firewall.get("name")
+        raw_apis = firewall.get("apis")
+        if not isinstance(raw_name, str) or raw_name == "" or not isinstance(raw_apis, list):
+            continue
+        for api in raw_apis:
+            if not isinstance(api, dict):
+                continue
+            raw_base = api.get("base")
+            if not isinstance(raw_base, str) or not _manifest_str_tuple(api.get("envNames")):
+                continue
+            base_key = _diagnostic_static_base_key(raw_base)
+            if base_key is None:
+                continue
+            connector_names = connector_names_by_base.setdefault(base_key, set())
+            connector_names.add(raw_name)
+    return frozenset(
+        base_key
+        for base_key, connector_names in connector_names_by_base.items()
+        if len(connector_names) > 1
+    )
+
+
 def _url_hostname(url: str) -> str | None:
     try:
         hostname = urllib.parse.urlparse(url).hostname
@@ -365,7 +412,11 @@ def _diagnostic_firewall_from_manifest(firewall: object) -> dict | None:
     return {"name": raw_name, "apis": apis}
 
 
-def _route_aware_diagnostic_firewall_from_manifest(firewall: object) -> dict | None:
+def _route_aware_diagnostic_firewall_from_manifest(
+    firewall: object,
+    *,
+    shared_base_keys: frozenset[str],
+) -> dict | None:
     if not isinstance(firewall, dict):
         return None
     raw_name = firewall.get("name")
@@ -377,7 +428,10 @@ def _route_aware_diagnostic_firewall_from_manifest(firewall: object) -> dict | N
 
     apis: list[dict] = []
     for api in raw_apis:
-        diagnostic_api = _route_aware_diagnostic_api_from_manifest(api)
+        diagnostic_api = _route_aware_diagnostic_api_from_manifest(
+            api,
+            shared_base_keys=shared_base_keys,
+        )
         if diagnostic_api is not None:
             apis.append(diagnostic_api)
 
@@ -430,13 +484,18 @@ def _diagnostic_api_from_manifest(api: object) -> dict | None:
     }
 
 
-def _route_aware_diagnostic_api_from_manifest(api: object) -> dict | None:
+def _route_aware_diagnostic_api_from_manifest(
+    api: object,
+    *,
+    shared_base_keys: frozenset[str],
+) -> dict | None:
     if not isinstance(api, dict):
         return None
     raw_base = api.get("base")
-    if not isinstance(raw_base, str) or _has_dynamic_base_marker(raw_base):
+    if not isinstance(raw_base, str):
         return None
-    if not matching.firewall_base_config_is_valid(raw_base):
+    base_key = _diagnostic_static_base_key(raw_base)
+    if base_key is None or base_key not in shared_base_keys:
         return None
 
     env_names = _manifest_str_tuple(api.get("envNames"))

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -36,7 +36,6 @@ class SharedBaseOwnershipResolution:
 
 @dataclass(frozen=True)
 class _DiagnosticConnectorMatcher:
-    name: str
     base_hosts: frozenset[str]
     compiled_firewalls: matching.CompiledFirewallSet | None
     compiled_network_policies: matching.CompiledNetworkPolicies | None
@@ -262,12 +261,8 @@ def _diagnostic_catalog() -> _DiagnosticCatalog:
             connector_firewalls.append(diagnostic_firewall)
         route_aware_firewall = _route_aware_diagnostic_firewall_from_manifest(firewall)
         if route_aware_firewall is not None:
-            matcher_name = route_aware_firewall.get("name")
-            if not isinstance(matcher_name, str):
-                continue
             connector_matchers.append(
                 _DiagnosticConnectorMatcher(
-                    name=matcher_name,
                     base_hosts=_firewall_base_hosts(route_aware_firewall),
                     compiled_firewalls=matching.compile_firewalls([route_aware_firewall]),
                     compiled_network_policies=matching.compile_network_policies(

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -1,6 +1,5 @@
 """Diagnostic-only matching for unavailable built-in connector URLs."""
 
-import urllib.parse
 from dataclasses import dataclass
 from typing import Final
 
@@ -36,7 +35,7 @@ class SharedBaseOwnershipResolution:
 
 @dataclass(frozen=True)
 class _DiagnosticConnectorMatcher:
-    base_hosts: frozenset[str]
+    base_authorities: frozenset[str]
     compiled_firewalls: matching.CompiledFirewallSet | None
     compiled_network_policies: matching.CompiledNetworkPolicies | None
 
@@ -170,9 +169,9 @@ def _ownership_matches(
     catalog: _DiagnosticCatalog,
 ) -> list[_OwnershipMatch]:
     matches: list[_OwnershipMatch] = []
-    hostname = _url_hostname(url)
+    authority = matching.match_url_authority_key(url)
     for matcher in catalog.connector_matchers:
-        if hostname is not None and hostname not in matcher.base_hosts:
+        if authority is not None and authority not in matcher.base_authorities:
             continue
         match = matching.match_compiled_firewall_request(
             url,
@@ -267,7 +266,7 @@ def _diagnostic_catalog() -> _DiagnosticCatalog:
         if route_aware_firewall is not None:
             connector_matchers.append(
                 _DiagnosticConnectorMatcher(
-                    base_hosts=_firewall_base_hosts(route_aware_firewall),
+                    base_authorities=_firewall_base_authorities(route_aware_firewall),
                     compiled_firewalls=matching.compile_firewalls([route_aware_firewall]),
                     compiled_network_policies=matching.compile_network_policies(
                         _matching_network_policies(
@@ -358,29 +357,21 @@ def _shared_route_aware_base_keys(firewalls: object) -> frozenset[str]:
     )
 
 
-def _url_hostname(url: str) -> str | None:
-    try:
-        hostname = urllib.parse.urlparse(url).hostname
-    except ValueError:
-        return None
-    return hostname.lower() if hostname else None
-
-
-def _firewall_base_hosts(firewall: dict) -> frozenset[str]:
+def _firewall_base_authorities(firewall: dict) -> frozenset[str]:
     raw_apis = firewall.get("apis")
     if not isinstance(raw_apis, list):
         return frozenset()
-    hosts: set[str] = set()
+    authorities: set[str] = set()
     for api in raw_apis:
         if not isinstance(api, dict):
             continue
         base = api.get("base")
         if not isinstance(base, str):
             continue
-        hostname = _url_hostname(base)
-        if hostname is not None:
-            hosts.add(hostname)
-    return frozenset(hosts)
+        authority = matching.static_firewall_base_authority_key(base)
+        if authority is not None:
+            authorities.add(authority)
+    return frozenset(authorities)
 
 
 def _diagnostic_firewall_from_manifest(firewall: object) -> dict | None:

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -1,5 +1,6 @@
 """Diagnostic-only matching for unavailable built-in connector URLs."""
 
+import urllib.parse
 from dataclasses import dataclass
 from typing import Final
 
@@ -12,6 +13,7 @@ from generated.builtin_firewalls.diagnostics import (
 _DYNAMIC_BASE_MARKERS: Final = ("{", "}")
 _DIAGNOSTIC_ANY_PERMISSION: Final = "__connector_diagnostic_any__"
 _DIAGNOSTIC_ANY_RULES: Final = ("ANY /", "ANY /{path+}")
+_SHARED_BASE_MIN_CANDIDATES: Final = 2
 
 
 @dataclass(frozen=True)
@@ -25,11 +27,34 @@ class ConnectorDiagnosticCandidate:
 
 
 @dataclass(frozen=True)
+class SharedBaseOwnershipResolution:
+    candidate: ConnectorDiagnosticCandidate | None
+    reason: str
+    candidate_connector_types: tuple[str, ...]
+    hint_status: str
+
+
+@dataclass(frozen=True)
+class _DiagnosticConnectorMatcher:
+    name: str
+    base_hosts: frozenset[str]
+    compiled_firewalls: matching.CompiledFirewallSet | None
+    compiled_network_policies: matching.CompiledNetworkPolicies | None
+
+
+@dataclass(frozen=True)
 class _DiagnosticCatalog:
     compiled_connector_firewalls: matching.CompiledFirewallSet | None
     compiled_network_policies: matching.CompiledNetworkPolicies | None
+    connector_matchers: tuple[_DiagnosticConnectorMatcher, ...]
     compiled_model_provider_exclusions: matching.CompiledFirewallSet | None
     compiled_model_provider_exclusion_policies: matching.CompiledNetworkPolicies | None
+
+
+@dataclass(frozen=True)
+class _OwnershipMatch:
+    candidate: ConnectorDiagnosticCandidate
+    route_specific: bool
 
 
 _catalog: _DiagnosticCatalog | None = None
@@ -68,6 +93,138 @@ def find_candidate(
     if match.name in active_firewall_names:
         return None
 
+    return _candidate_from_match(match)
+
+
+def resolve_shared_base_ownership(
+    url: str,
+    method: str,
+    *,
+    active_firewall_names: set[str],
+    matched_firewall_name: str,
+    connector_intent: str | None = None,
+) -> SharedBaseOwnershipResolution | None:
+    """Resolve shared-base ownership for an active unknown-endpoint allow.
+
+    The returned ``candidate`` is set only when the request should diagnose a
+    missing inactive sibling connector. Active-owner, base-only, and ambiguous
+    outcomes are represented with ``candidate=None`` so callers can keep normal
+    auth injection behavior.
+    """
+    catalog = _diagnostic_catalog()
+    if _matches_model_provider_exclusion(url, method, catalog):
+        return None
+
+    matches = _ownership_matches(url, method, catalog)
+    if len(matches) < _SHARED_BASE_MIN_CANDIDATES:
+        return None
+    if not any(match.candidate.connector_type == matched_firewall_name for match in matches):
+        return None
+
+    candidate_connector_types = tuple(sorted(match.candidate.connector_type for match in matches))
+    route_matches = [match for match in matches if match.route_specific]
+    if len(route_matches) == 1:
+        selected = route_matches[0].candidate
+        if selected.connector_type in active_firewall_names:
+            return SharedBaseOwnershipResolution(
+                candidate=None,
+                reason="active_route_owner",
+                candidate_connector_types=candidate_connector_types,
+                hint_status=_hint_status(connector_intent, matches, used=False),
+            )
+        return SharedBaseOwnershipResolution(
+            candidate=selected,
+            reason="route_owner",
+            candidate_connector_types=candidate_connector_types,
+            hint_status=_hint_status(connector_intent, matches, used=False),
+        )
+
+    hint_match = _hint_match(connector_intent, matches)
+    if hint_match is not None:
+        selected = hint_match.candidate
+        if selected.connector_type in active_firewall_names:
+            return SharedBaseOwnershipResolution(
+                candidate=None,
+                reason="active_hint_owner",
+                candidate_connector_types=candidate_connector_types,
+                hint_status="used",
+            )
+        return SharedBaseOwnershipResolution(
+            candidate=selected,
+            reason="hint_owner",
+            candidate_connector_types=candidate_connector_types,
+            hint_status="used",
+        )
+
+    reason = "ambiguous_route_owners" if route_matches else "base_only"
+    return SharedBaseOwnershipResolution(
+        candidate=None,
+        reason=reason,
+        candidate_connector_types=candidate_connector_types,
+        hint_status=_hint_status(connector_intent, matches, used=False),
+    )
+
+
+def _ownership_matches(
+    url: str,
+    method: str,
+    catalog: _DiagnosticCatalog,
+) -> list[_OwnershipMatch]:
+    matches: list[_OwnershipMatch] = []
+    hostname = _url_hostname(url)
+    for matcher in catalog.connector_matchers:
+        if hostname is not None and hostname not in matcher.base_hosts:
+            continue
+        match = matching.match_compiled_firewall_request(
+            url,
+            method,
+            matcher.compiled_firewalls,
+            matcher.compiled_network_policies,
+        )
+        if not isinstance(match, matching.FirewallAllow):
+            continue
+        candidate = _candidate_from_match(match)
+        if candidate is None:
+            continue
+        matches.append(
+            _OwnershipMatch(
+                candidate=candidate,
+                route_specific=match.permission is not None and match.rule is not None,
+            )
+        )
+    return matches
+
+
+def _hint_match(
+    connector_intent: str | None,
+    matches: list[_OwnershipMatch],
+) -> _OwnershipMatch | None:
+    if connector_intent is None:
+        return None
+    for match in matches:
+        if match.candidate.connector_type == connector_intent:
+            return match
+    return None
+
+
+def _hint_status(
+    connector_intent: str | None,
+    matches: list[_OwnershipMatch],
+    *,
+    used: bool,
+) -> str:
+    if connector_intent is None:
+        return "absent"
+    if used:
+        return "used"
+    if _hint_match(connector_intent, matches) is None:
+        return "outside_candidate_set"
+    return "ignored"
+
+
+def _candidate_from_match(
+    match: matching.FirewallAllow,
+) -> ConnectorDiagnosticCandidate | None:
     api_entry = match.api_entry
     env_names = api_entry.get("_diagnostic_env_names")
     auth_header_names = api_entry.get("_diagnostic_auth_header_names")
@@ -78,12 +235,15 @@ def find_candidate(
         or not isinstance(auth_query_param_names, tuple)
     ):
         return None
+    base = match.api_entry.get("base")
+    if not isinstance(base, str):
+        return None
 
     return ConnectorDiagnosticCandidate(
         connector_type=match.name,
         reason="not_configured_for_run",
         env_names=env_names,
-        base=match.api_entry["base"],
+        base=base,
         auth_header_names=auth_header_names,
         auth_query_param_names=auth_query_param_names,
     )
@@ -95,10 +255,29 @@ def _diagnostic_catalog() -> _DiagnosticCatalog:
         return _catalog
 
     connector_firewalls: list[dict] = []
+    connector_matchers: list[_DiagnosticConnectorMatcher] = []
     for firewall in CONNECTOR_DIAGNOSTIC_FIREWALLS:
         diagnostic_firewall = _diagnostic_firewall_from_manifest(firewall)
         if diagnostic_firewall is not None:
             connector_firewalls.append(diagnostic_firewall)
+        route_aware_firewall = _route_aware_diagnostic_firewall_from_manifest(firewall)
+        if route_aware_firewall is not None:
+            matcher_name = route_aware_firewall.get("name")
+            if not isinstance(matcher_name, str):
+                continue
+            connector_matchers.append(
+                _DiagnosticConnectorMatcher(
+                    name=matcher_name,
+                    base_hosts=_firewall_base_hosts(route_aware_firewall),
+                    compiled_firewalls=matching.compile_firewalls([route_aware_firewall]),
+                    compiled_network_policies=matching.compile_network_policies(
+                        _matching_network_policies(
+                            [route_aware_firewall],
+                            unknown_policy="allow",
+                        )
+                    ),
+                )
+            )
 
     model_provider_exclusions: list[dict] = []
     for firewall in MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS:
@@ -111,6 +290,7 @@ def _diagnostic_catalog() -> _DiagnosticCatalog:
         compiled_network_policies=matching.compile_network_policies(
             _matching_network_policies(connector_firewalls)
         ),
+        connector_matchers=tuple(connector_matchers),
         compiled_model_provider_exclusions=matching.compile_firewalls(model_provider_exclusions),
         compiled_model_provider_exclusion_policies=matching.compile_network_policies(
             _matching_network_policies(model_provider_exclusions)
@@ -144,6 +324,31 @@ def _manifest_str_tuple(value: object) -> tuple[str, ...]:
     return tuple(result)
 
 
+def _url_hostname(url: str) -> str | None:
+    try:
+        hostname = urllib.parse.urlparse(url).hostname
+    except ValueError:
+        return None
+    return hostname.lower() if hostname else None
+
+
+def _firewall_base_hosts(firewall: dict) -> frozenset[str]:
+    raw_apis = firewall.get("apis")
+    if not isinstance(raw_apis, list):
+        return frozenset()
+    hosts: set[str] = set()
+    for api in raw_apis:
+        if not isinstance(api, dict):
+            continue
+        base = api.get("base")
+        if not isinstance(base, str):
+            continue
+        hostname = _url_hostname(base)
+        if hostname is not None:
+            hosts.add(hostname)
+    return frozenset(hosts)
+
+
 def _diagnostic_firewall_from_manifest(firewall: object) -> dict | None:
     if not isinstance(firewall, dict):
         return None
@@ -157,6 +362,27 @@ def _diagnostic_firewall_from_manifest(firewall: object) -> dict | None:
     apis: list[dict] = []
     for api in raw_apis:
         diagnostic_api = _diagnostic_api_from_manifest(api)
+        if diagnostic_api is not None:
+            apis.append(diagnostic_api)
+
+    if not apis:
+        return None
+    return {"name": raw_name, "apis": apis}
+
+
+def _route_aware_diagnostic_firewall_from_manifest(firewall: object) -> dict | None:
+    if not isinstance(firewall, dict):
+        return None
+    raw_name = firewall.get("name")
+    if not isinstance(raw_name, str) or raw_name == "":
+        return None
+    raw_apis = firewall.get("apis")
+    if not isinstance(raw_apis, list):
+        return None
+
+    apis: list[dict] = []
+    for api in raw_apis:
+        diagnostic_api = _route_aware_diagnostic_api_from_manifest(api)
         if diagnostic_api is not None:
             apis.append(diagnostic_api)
 
@@ -209,6 +435,29 @@ def _diagnostic_api_from_manifest(api: object) -> dict | None:
     }
 
 
+def _route_aware_diagnostic_api_from_manifest(api: object) -> dict | None:
+    if not isinstance(api, dict):
+        return None
+    raw_base = api.get("base")
+    if not isinstance(raw_base, str) or _has_dynamic_base_marker(raw_base):
+        return None
+    if not matching.firewall_base_config_is_valid(raw_base):
+        return None
+
+    env_names = _manifest_str_tuple(api.get("envNames"))
+    if not env_names:
+        return None
+
+    return {
+        "base": raw_base,
+        "auth": {},
+        "permissions": _manifest_permissions(api.get("permissions")),
+        "_diagnostic_env_names": env_names,
+        "_diagnostic_auth_header_names": _manifest_str_tuple(api.get("authHeaderNames")),
+        "_diagnostic_auth_query_param_names": _manifest_str_tuple(api.get("authQueryParamNames")),
+    }
+
+
 def _model_provider_exclusion_api_from_manifest(api: object) -> dict | None:
     if not isinstance(api, dict):
         return None
@@ -223,6 +472,26 @@ def _model_provider_exclusion_api_from_manifest(api: object) -> dict | None:
         "auth": {},
         "permissions": _diagnostic_permissions(api.get("permissions")),
     }
+
+
+def _manifest_permissions(raw_permissions: object) -> list[dict]:
+    if not isinstance(raw_permissions, (list, tuple)):
+        return []
+    permissions: list[dict] = []
+    for permission in raw_permissions:
+        if not isinstance(permission, dict):
+            return []
+        name = permission.get("name")
+        rules = permission.get("rules")
+        if not isinstance(name, str) or not isinstance(rules, list):
+            return []
+        rule_values: list[str] = []
+        for rule in rules:
+            if not isinstance(rule, str):
+                return []
+            rule_values.append(rule)
+        permissions.append({"name": name, "rules": rule_values})
+    return permissions
 
 
 def _diagnostic_permissions(raw_permissions: object) -> list[dict]:
@@ -247,7 +516,11 @@ def _has_dynamic_base_marker(raw_base: str) -> bool:
     return any(marker in raw_base for marker in _DYNAMIC_BASE_MARKERS)
 
 
-def _matching_network_policies(firewalls: list[dict]) -> dict[str, dict]:
+def _matching_network_policies(
+    firewalls: list[dict],
+    *,
+    unknown_policy: str = "deny",
+) -> dict[str, dict]:
     policies: dict[str, dict] = {}
     for firewall in firewalls:
         raw_name = firewall.get("name")
@@ -275,6 +548,6 @@ def _matching_network_policies(firewalls: list[dict]) -> dict[str, dict]:
             "allow": allow,
             "deny": [],
             "ask": [],
-            "unknownPolicy": "deny",
+            "unknownPolicy": unknown_policy,
         }
     return policies

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -326,15 +326,7 @@ def _manifest_str_tuple(value: object) -> tuple[str, ...]:
 def _diagnostic_static_base_key(raw_base: str) -> str | None:
     if _has_dynamic_base_marker(raw_base):
         return None
-    if not matching.firewall_base_config_is_valid(raw_base):
-        return None
-    try:
-        parsed = urllib.parse.urlparse(raw_base)
-    except ValueError:
-        return None
-    if not parsed.scheme or not parsed.netloc:
-        return None
-    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{parsed.path.rstrip('/')}"
+    return matching.static_firewall_base_config_key(raw_base)
 
 
 def _shared_route_aware_base_keys(firewalls: object) -> frozenset[str]:

--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -405,6 +405,20 @@ def firewall_base_config_is_valid(raw_base: str) -> bool:
     )
 
 
+def static_firewall_base_config_key(raw_base: str) -> str | None:
+    """Return the normalized key used to compare valid static firewall bases."""
+    if _has_base_url_params(raw_base) or not firewall_base_config_is_valid(raw_base):
+        return None
+    parts = _split_base_match_url(
+        strip_optional_terminal_slash(raw_base),
+        allow_malformed_authority=True,
+        allow_unsafe_runtime_url_syntax=True,
+    )
+    if parts is None:
+        return None
+    return f"{parts.scheme.lower()}://{parts.authority}{parts.path.rstrip('/')}"
+
+
 def _compiled_base_is_invalid_for_match_base_url(base: _CompiledBase) -> bool:
     return (
         base.has_query_or_fragment

--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -419,6 +419,27 @@ def static_firewall_base_config_key(raw_base: str) -> str | None:
     return f"{parts.scheme.lower()}://{parts.authority}{parts.path.rstrip('/')}"
 
 
+def static_firewall_base_authority_key(raw_base: str) -> str | None:
+    """Return the normalized authority key used to prefilter static firewall bases."""
+    if _has_base_url_params(raw_base) or not firewall_base_config_is_valid(raw_base):
+        return None
+    parts = _split_base_match_url(
+        strip_optional_terminal_slash(raw_base),
+        allow_malformed_authority=True,
+        allow_unsafe_runtime_url_syntax=True,
+    )
+    return parts.authority.lower() if parts is not None else None
+
+
+def match_url_authority_key(url: str) -> str | None:
+    """Return the normalized request authority key used by base URL matching."""
+    parts = _split_base_match_url(
+        url,
+        allow_runtime_backslash_syntax="\\" in url,
+    )
+    return parts.authority.lower() if parts is not None else None
+
+
 def _compiled_base_is_invalid_for_match_base_url(base: _CompiledBase) -> bool:
     return (
         base.has_query_or_fragment

--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/diagnostics.py
@@ -2877,6 +2877,92 @@ CONNECTOR_DIAGNOSTIC_FIREWALLS = json.loads(r"""[
         "base": "https://graph.microsoft.com",
         "envNames": [
           "MICROSOFT_365_TOKEN"
+        ],
+        "permissions": [
+          {
+            "name": "User.Read",
+            "rules": [
+              "GET /v1.0/me",
+              "GET /beta/me"
+            ]
+          },
+          {
+            "name": "Files.ReadWrite.All",
+            "rules": [
+              "ANY /v1.0/me/drive/{path*}",
+              "ANY /v1.0/drives/{drive-id}/{path*}",
+              "ANY /v1.0/users/{user-id}/drive/{path*}",
+              "ANY /beta/me/drive/{path*}",
+              "ANY /beta/drives/{drive-id}/{path*}"
+            ]
+          },
+          {
+            "name": "Sites.ReadWrite.All",
+            "rules": [
+              "ANY /v1.0/sites/{path*}",
+              "ANY /v1.0/groups/{group-id}/sites/{path*}",
+              "ANY /beta/sites/{path*}",
+              "ANY /beta/groups/{group-id}/sites/{path*}"
+            ]
+          },
+          {
+            "name": "Team.ReadBasic.All",
+            "rules": [
+              "GET /v1.0/me/joinedTeams",
+              "GET /v1.0/teams",
+              "GET /v1.0/teams/{team-id}",
+              "GET /beta/me/joinedTeams",
+              "GET /beta/teams",
+              "GET /beta/teams/{team-id}"
+            ]
+          },
+          {
+            "name": "Channel.ReadBasic.All",
+            "rules": [
+              "GET /v1.0/teams/{team-id}/channels",
+              "GET /v1.0/teams/{team-id}/channels/{channel-id}",
+              "GET /beta/teams/{team-id}/channels",
+              "GET /beta/teams/{team-id}/channels/{channel-id}"
+            ]
+          },
+          {
+            "name": "ChannelMessage.Read.All",
+            "rules": [
+              "GET /v1.0/teams/{team-id}/channels/{channel-id}/messages",
+              "GET /v1.0/teams/{team-id}/channels/{channel-id}/messages/{message-id}",
+              "GET /v1.0/teams/{team-id}/channels/{channel-id}/messages/{message-id}/replies",
+              "GET /beta/teams/{team-id}/channels/{channel-id}/messages",
+              "GET /beta/teams/{team-id}/channels/{channel-id}/messages/{message-id}",
+              "GET /beta/teams/{team-id}/channels/{channel-id}/messages/{message-id}/replies"
+            ]
+          },
+          {
+            "name": "ChannelMessage.Send",
+            "rules": [
+              "POST /v1.0/teams/{team-id}/channels/{channel-id}/messages",
+              "POST /v1.0/teams/{team-id}/channels/{channel-id}/messages/{message-id}/replies",
+              "POST /beta/teams/{team-id}/channels/{channel-id}/messages",
+              "POST /beta/teams/{team-id}/channels/{channel-id}/messages/{message-id}/replies"
+            ]
+          },
+          {
+            "name": "Chat.ReadWrite",
+            "rules": [
+              "ANY /v1.0/chats",
+              "ANY /v1.0/chats/{chat-id}",
+              "ANY /v1.0/chats/{chat-id}/{path*}",
+              "ANY /beta/chats",
+              "ANY /beta/chats/{chat-id}",
+              "ANY /beta/chats/{chat-id}/{path*}"
+            ]
+          },
+          {
+            "name": "ChatMessage.Send",
+            "rules": [
+              "POST /v1.0/chats/{chat-id}/messages",
+              "POST /beta/chats/{chat-id}/messages"
+            ]
+          }
         ]
       }
     ],

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -43,6 +43,7 @@ from url_syntax import (
 )
 
 firewall_base_config_is_valid = _firewall_base_url.firewall_base_config_is_valid
+static_firewall_base_config_key = _firewall_base_url.static_firewall_base_config_key
 match_base_url = _firewall_base_url.match_base_url
 
 CompiledPathPattern: _TypeAlias = _firewall_patterns.CompiledPathPattern

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -44,6 +44,8 @@ from url_syntax import (
 
 firewall_base_config_is_valid = _firewall_base_url.firewall_base_config_is_valid
 static_firewall_base_config_key = _firewall_base_url.static_firewall_base_config_key
+static_firewall_base_authority_key = _firewall_base_url.static_firewall_base_authority_key
+match_url_authority_key = _firewall_base_url.match_url_authority_key
 match_base_url = _firewall_base_url.match_base_url
 
 CompiledPathPattern: _TypeAlias = _firewall_patterns.CompiledPathPattern

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -127,6 +127,9 @@ _CONNECTOR_DIAGNOSTIC_RESPONSE_BODY = "_connector_diagnostic_response_body"
 _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT = "_connector_diagnostic_response_stream_body_sent"
 _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK = "_connector_diagnostic_response_stream_callback"
 _CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED = "_connector_diagnostic_proxy_entry_logged"
+_CONNECTOR_INTENT_HEADER: Final = "X-VM0-Connector-Intent"
+_CONNECTOR_INTENT_VALUE = "_connector_intent_value"
+_CONNECTOR_INTENT_STATUS = "_connector_intent_status"
 _EMPTY_RESPONSE_STREAM_CHUNKS: tuple[bytes, ...] = ()
 _GENERIC_AUTH_HEADER_NAMES = frozenset(
     (
@@ -212,6 +215,8 @@ _REQUEST_HEADERS_PROBE_METADATA_KEYS = (
     metadata_keys.TRUSTED_AUTHORITY_HOST,
     metadata_keys.NETWORK_LOG_TARGET,
     metadata_keys.HTTP_REQUEST_START_MONOTONIC,
+    _CONNECTOR_INTENT_VALUE,
+    _CONNECTOR_INTENT_STATUS,
 )
 
 
@@ -564,6 +569,30 @@ def _is_browser_passthrough_heuristic(flow: http.HTTPFlow) -> bool:
     # header. The spoofable User-Agent heuristic is currently accepted as a
     # known tradeoff until runner-owned browser provenance is prioritized again.
     return _is_browser_user_agent(flow.request.headers.get("User-Agent"))
+
+
+def _capture_and_strip_connector_intent_header(flow: http.HTTPFlow) -> None:
+    if _CONNECTOR_INTENT_STATUS not in flow.metadata:
+        values = flow.request.headers.get_all(_CONNECTOR_INTENT_HEADER)
+        if not values:
+            flow.metadata[_CONNECTOR_INTENT_STATUS] = "absent"
+        elif len(values) != 1:
+            flow.metadata[_CONNECTOR_INTENT_STATUS] = "malformed"
+        else:
+            value = values[0].strip()
+            if value == "" or "," in value:
+                flow.metadata[_CONNECTOR_INTENT_STATUS] = "malformed"
+            else:
+                flow.metadata[_CONNECTOR_INTENT_STATUS] = "present"
+                flow.metadata[_CONNECTOR_INTENT_VALUE] = value
+
+    if _CONNECTOR_INTENT_HEADER in flow.request.headers:
+        del flow.request.headers[_CONNECTOR_INTENT_HEADER]
+
+
+def _connector_intent_from_flow(flow: http.HTTPFlow) -> str | None:
+    value = flow.metadata.get(_CONNECTOR_INTENT_VALUE)
+    return value if isinstance(value, str) else None
 
 
 def _active_firewall_names(vm_info: dict) -> set[str]:
@@ -1509,6 +1538,60 @@ def _maybe_make_connector_diagnostic_local_response(
     candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
     if candidate is None:
         return False
+    if _request_has_connector_auth_material(flow, candidate, original_url):
+        return False
+
+    _start_request_timing(flow)
+    _set_connector_diagnostic_failure_metadata(flow, candidate)
+    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow.response = http.Response.make(
+        _HTTP_STATUS_FAILED_DEPENDENCY,
+        _connector_diagnostic_response_body(candidate, upstream_status=0),
+        {"Content-Type": "application/json"},
+    )
+    _log_connector_diagnostic_proxy_entry(
+        flow,
+        original_url=original_url,
+        upstream_status=0,
+    )
+    return True
+
+
+def _firewall_allow_is_unknown_endpoint(allow: matching.FirewallAllow) -> bool:
+    return allow.permission is None and allow.rule is None
+
+
+def _maybe_make_firewall_allow_connector_diagnostic_local_response(
+    flow: http.HTTPFlow,
+    classification: _RequestClassification,
+) -> bool:
+    if classification.kind != "firewall_allow":
+        return False
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT) or _is_browser_passthrough_heuristic(
+        flow
+    ):
+        return False
+
+    allow = classification.firewall_allow
+    vm_info = classification.vm_info
+    if allow is None or vm_info is None or not _firewall_allow_is_unknown_endpoint(allow):
+        return False
+
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(original_url, str) or not original_url:
+        return False
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        original_url,
+        flow.request.method,
+        active_firewall_names=_active_firewall_names(vm_info),
+        matched_firewall_name=allow.name,
+        connector_intent=_connector_intent_from_flow(flow),
+    )
+    if resolution is None or resolution.candidate is None:
+        return False
+
+    candidate = resolution.candidate
     if _request_has_connector_auth_material(flow, candidate, original_url):
         return False
 
@@ -2511,6 +2594,8 @@ def client_disconnected(client: connection.Client) -> None:
 
 def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     """Handle request-header-only decisions before mitmproxy buffers bodies."""
+    _capture_and_strip_connector_intent_header(flow)
+
     body_check = _auth_base_body_header_check(flow)
     body_fits_stream_buffer = body_check.kind == "ok" and _request_body_fits_stream_buffer(flow)
     if body_fits_stream_buffer:
@@ -2541,6 +2626,11 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
             upstream_destination_binding.forget_server_binding(flow.server_conn)
             flow.kill()
+        return None
+
+    if _maybe_make_firewall_allow_connector_diagnostic_local_response(flow, classification):
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        upstream_destination_binding.forget_server_binding(flow.server_conn)
         return None
 
     _prebind_requestheaders_upstream_destination(flow, classification)
@@ -2778,6 +2868,8 @@ async def request(flow: http.HTTPFlow) -> None:
     2. VM0 API auto-allow (agent must always reach the platform)
     3. Firewall match (inject auth headers for allowed requests)
     """
+    _capture_and_strip_connector_intent_header(flow)
+
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
         upstream_destination_binding.forget_server_binding(flow.server_conn)
@@ -2857,6 +2949,13 @@ async def request(flow: http.HTTPFlow) -> None:
                 _block_public_destination_denied(flow, public_destination_denial)
                 return
             if flow.metadata.get(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS):
+                return
+            if _maybe_make_firewall_allow_connector_diagnostic_local_response(
+                flow,
+                classification,
+            ):
+                auth_base_forwarder.release_forward_request_admission_from_flow(flow)
+                _release_tracked_usage_flow(flow)
                 return
             if _firewall_allow_injects_ordinary_upstream_credentials(
                 allow

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -130,6 +130,9 @@ _CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED = "_connector_diagnostic_proxy_entry_lo
 _CONNECTOR_INTENT_HEADER: Final = "X-VM0-Connector-Intent"
 _CONNECTOR_INTENT_VALUE = "_connector_intent_value"
 _CONNECTOR_INTENT_STATUS = "_connector_intent_status"
+_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON = "_connector_diagnostic_ownership_reason"
+_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES = "_connector_diagnostic_ownership_candidates"
+_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS = "_connector_diagnostic_ownership_hint_status"
 _EMPTY_RESPONSE_STREAM_CHUNKS: tuple[bytes, ...] = ()
 _GENERIC_AUTH_HEADER_NAMES = frozenset(
     (
@@ -1513,6 +1516,18 @@ def _log_connector_diagnostic_proxy_entry(
     if candidate is None:
         return
     safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
+    extra: dict[str, object] = {}
+    ownership_reason = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON)
+    if isinstance(ownership_reason, str) and ownership_reason:
+        extra["ownership_reason"] = ownership_reason
+    ownership_candidates = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES)
+    if isinstance(ownership_candidates, tuple) and all(
+        isinstance(candidate, str) for candidate in ownership_candidates
+    ):
+        extra["ownership_candidates"] = list(ownership_candidates)
+    ownership_hint_status = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS)
+    if isinstance(ownership_hint_status, str) and ownership_hint_status:
+        extra["ownership_hint_status"] = ownership_hint_status
     log_proxy_entry(
         flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
         "warn",
@@ -1522,6 +1537,7 @@ def _log_connector_diagnostic_proxy_entry(
         reason=candidate.reason,
         upstream_status=upstream_status,
         url=original_url,
+        **extra,
     )
     flow.metadata[_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED] = True
 
@@ -1597,6 +1613,9 @@ def _maybe_make_firewall_allow_connector_diagnostic_local_response(
 
     _start_request_timing(flow)
     _set_connector_diagnostic_failure_metadata(flow, candidate)
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON] = resolution.reason
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES] = resolution.candidate_connector_types
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS] = resolution.hint_status
     flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
     flow.response = http.Response.make(
         _HTTP_STATUS_FAILED_DEPENDENCY,

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -275,3 +275,35 @@ def test_shared_base_ownership_route_specific_active_overrides_conflicting_inten
     assert resolution.candidate is None
     assert resolution.reason == "active_route_owner"
     assert resolution.hint_status == "ignored"
+
+
+def test_shared_base_ownership_normalizes_static_base_keys(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall(
+                "active",
+                "ACTIVE_TOKEN",
+                base="https://Shared.Example.com:443/api/",
+                permissions=[{"name": "active-read", "rules": ["GET /active/{id}"]}],
+            ),
+            _shared_base_firewall(
+                "inactive",
+                "INACTIVE_TOKEN",
+                base="https://shared.example.com/api",
+                permissions=[{"name": "inactive-read", "rules": ["GET /messages/{id}"]}],
+            ),
+        ],
+    )
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        "https://shared.example.com/api/messages/123",
+        "GET",
+        active_firewall_names={"active"},
+        matched_firewall_name="active",
+    )
+
+    assert resolution is not None
+    assert resolution.reason == "route_owner"
+    assert resolution.candidate is not None
+    assert resolution.candidate.connector_type == "inactive"

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -84,6 +84,50 @@ def test_skips_dynamic_template_base_urls():
     assert candidate is None
 
 
+def test_classifies_static_base_with_literal_unbalanced_brace(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall(
+                "literal-brace",
+                "LITERAL_BRACE_TOKEN",
+                base="https://literal.example.com/{literal",
+            )
+        ],
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        "https://literal.example.com/{literal/item",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is not None
+    assert candidate.connector_type == "literal-brace"
+    assert candidate.env_names == ("LITERAL_BRACE_TOKEN",)
+
+
+def test_skips_parameterized_manifest_base_urls(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall(
+                "parameterized",
+                "PARAMETERIZED_TOKEN",
+                base="https://parameterized.example.com/{tenant}",
+            )
+        ],
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        "https://parameterized.example.com/acme/item",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is None
+
+
 def test_skips_parameterized_base_urls():
     for url in (
         "https://s3.amazonaws.com/my-bucket/private-object",

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -284,7 +284,7 @@ def test_shared_base_ownership_normalizes_static_base_keys(monkeypatch):
             _shared_base_firewall(
                 "active",
                 "ACTIVE_TOKEN",
-                base="https://Shared.Example.com:443/api/",
+                base="https://Shared.Example.com.:443/api/",
                 permissions=[{"name": "active-read", "rules": ["GET /active/{id}"]}],
             ),
             _shared_base_firewall(

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -4,6 +4,33 @@ import builtin_connector_diagnostics
 import generated.builtin_firewalls
 
 
+def _shared_base_firewall(
+    name,
+    token_name,
+    *,
+    permissions=None,
+    base="https://shared.example.com",
+):
+    return {
+        "name": name,
+        "apis": [
+            {
+                "base": base,
+                "envNames": [token_name],
+                "authHeaderNames": ["Authorization"],
+                "authQueryParamNames": [],
+                "permissions": permissions or [],
+            }
+        ],
+    }
+
+
+def _patch_connector_diagnostics(monkeypatch, firewalls):
+    monkeypatch.setattr(builtin_connector_diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS", firewalls)
+    monkeypatch.setattr(builtin_connector_diagnostics, "MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS", [])
+    builtin_connector_diagnostics.reset_cache_for_tests()
+
+
 def test_classifies_static_builtin_connector_url():
     candidate = builtin_connector_diagnostics.find_candidate(
         "https://fal.run/fal-ai/nano-banana-pro",
@@ -121,3 +148,130 @@ def test_classifies_connector_permission_path_on_model_provider_host():
     assert candidate is not None
     assert candidate.connector_type == "anthropic-managed-agents"
     assert candidate.env_names == ("ANTHROPIC_MANAGED_AGENTS_TOKEN",)
+
+
+def test_shared_base_ownership_selects_route_specific_inactive_sibling(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall(
+                "active",
+                "ACTIVE_TOKEN",
+                permissions=[{"name": "active-read", "rules": ["GET /active/{id}"]}],
+            ),
+            _shared_base_firewall(
+                "inactive",
+                "INACTIVE_TOKEN",
+                permissions=[{"name": "inactive-read", "rules": ["GET /messages/{id}"]}],
+            ),
+        ],
+    )
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        "https://shared.example.com/messages/123",
+        "GET",
+        active_firewall_names={"active"},
+        matched_firewall_name="active",
+    )
+
+    assert resolution is not None
+    assert resolution.reason == "route_owner"
+    assert resolution.hint_status == "absent"
+    assert resolution.candidate is not None
+    assert resolution.candidate.connector_type == "inactive"
+    assert resolution.candidate.env_names == ("INACTIVE_TOKEN",)
+
+
+def test_shared_base_ownership_suppresses_base_only_candidate(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall("active", "ACTIVE_TOKEN"),
+            _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
+        ],
+    )
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        "https://shared.example.com/messages/123",
+        "GET",
+        active_firewall_names={"active"},
+        matched_firewall_name="active",
+    )
+
+    assert resolution is not None
+    assert resolution.candidate is None
+    assert resolution.reason == "base_only"
+
+
+def test_shared_base_ownership_uses_intent_inside_candidate_set(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall("active", "ACTIVE_TOKEN"),
+            _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
+        ],
+    )
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        "https://shared.example.com/graphql/v2",
+        "POST",
+        active_firewall_names={"active"},
+        matched_firewall_name="active",
+        connector_intent="inactive",
+    )
+
+    assert resolution is not None
+    assert resolution.reason == "hint_owner"
+    assert resolution.hint_status == "used"
+    assert resolution.candidate is not None
+    assert resolution.candidate.connector_type == "inactive"
+
+
+def test_shared_base_ownership_ignores_intent_outside_candidate_set(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall("active", "ACTIVE_TOKEN"),
+            _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
+        ],
+    )
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        "https://shared.example.com/graphql/v2",
+        "POST",
+        active_firewall_names={"active"},
+        matched_firewall_name="active",
+        connector_intent="other",
+    )
+
+    assert resolution is not None
+    assert resolution.candidate is None
+    assert resolution.reason == "base_only"
+    assert resolution.hint_status == "outside_candidate_set"
+
+
+def test_shared_base_ownership_route_specific_active_overrides_conflicting_intent(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall(
+                "active",
+                "ACTIVE_TOKEN",
+                permissions=[{"name": "active-read", "rules": ["GET /active/{id}"]}],
+            ),
+            _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
+        ],
+    )
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        "https://shared.example.com/active/123",
+        "GET",
+        active_firewall_names={"active"},
+        matched_firewall_name="active",
+        connector_intent="inactive",
+    )
+
+    assert resolution is not None
+    assert resolution.candidate is None
+    assert resolution.reason == "active_route_owner"
+    assert resolution.hint_status == "ignored"

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -147,26 +147,54 @@ def _write_shared_base_active_firewall_registry(
     )
 
 
-def _shared_base_inactive_candidate():
-    return builtin_connector_diagnostics.ConnectorDiagnosticCandidate(
-        connector_type="inactive-shared",
-        reason="not_configured_for_run",
-        env_names=("INACTIVE_TOKEN",),
-        base="https://shared.example.com",
-        auth_header_names=("Authorization",),
-        auth_query_param_names=("api_key",),
-    )
+def _shared_base_diagnostic_firewall(
+    name: str,
+    token_name: str,
+    *,
+    permissions: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "apis": [
+            {
+                "base": "https://shared.example.com",
+                "envNames": [token_name],
+                "authHeaderNames": ["Authorization"],
+                "authQueryParamNames": ["api_key"],
+                "permissions": permissions or [],
+            }
+        ],
+    }
 
 
-def _shared_base_resolution(
-    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None = None,
-):
-    return builtin_connector_diagnostics.SharedBaseOwnershipResolution(
-        candidate=_shared_base_inactive_candidate() if candidate is None else candidate,
-        reason="route_owner",
-        candidate_connector_types=("active-shared", "inactive-shared"),
-        hint_status="absent",
+def _patch_shared_base_diagnostic_catalog(
+    monkeypatch,
+    *,
+    active_permissions: list[dict[str, object]] | None = None,
+    inactive_permissions: list[dict[str, object]] | None = None,
+) -> None:
+    monkeypatch.setattr(
+        builtin_connector_diagnostics,
+        "CONNECTOR_DIAGNOSTIC_FIREWALLS",
+        [
+            _shared_base_diagnostic_firewall(
+                "active-shared",
+                "ACTIVE_TOKEN",
+                permissions=active_permissions,
+            ),
+            _shared_base_diagnostic_firewall(
+                "inactive-shared",
+                "INACTIVE_TOKEN",
+                permissions=inactive_permissions,
+            ),
+        ],
     )
+    monkeypatch.setattr(
+        builtin_connector_diagnostics,
+        "MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS",
+        [],
+    )
+    builtin_connector_diagnostics.reset_cache_for_tests()
 
 
 def _assert_shared_base_inactive_diagnostic(flow):
@@ -1358,8 +1386,13 @@ async def test_public_destination_requestheaders_kills_unknown_length_before_ear
 
 
 async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
 ):
+    _patch_shared_base_diagnostic_catalog(
+        monkeypatch,
+        active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
+        inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
+    )
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -1375,22 +1408,39 @@ async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_au
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
-        patch.object(
-            builtin_connector_diagnostics,
-            "resolve_shared_base_ownership",
-            return_value=_shared_base_resolution(),
-        ) as resolve_ownership,
     ):
         await mitm_addon.request(flow)
 
     auth_fetch.assert_not_called()
-    resolve_ownership.assert_called_once_with(
-        "https://shared.example.com/inactive",
-        "GET",
-        active_firewall_names={"active-shared"},
-        matched_firewall_name="active-shared",
-        connector_intent="inactive-shared",
+    _assert_shared_base_inactive_diagnostic(flow)
+    assert "Authorization" not in flow.request.headers
+    assert "X-VM0-Connector-Intent" not in flow.request.headers
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_before_auth(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+):
+    _patch_shared_base_diagnostic_catalog(monkeypatch)
+    reg_path = _write_shared_base_active_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/graphql/v2",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("X-VM0-Connector-Intent", "inactive-shared"),
+        ),
     )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
     _assert_shared_base_inactive_diagnostic(flow)
     assert "Authorization" not in flow.request.headers
     assert "X-VM0-Connector-Intent" not in flow.request.headers
@@ -1398,8 +1448,13 @@ async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_au
 
 
 async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_path(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
 ):
+    _patch_shared_base_diagnostic_catalog(
+        monkeypatch,
+        active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
+        inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
+    )
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -1416,16 +1471,10 @@ async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_pat
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
-        patch.object(
-            builtin_connector_diagnostics,
-            "resolve_shared_base_ownership",
-            return_value=_shared_base_resolution(),
-        ) as resolve_ownership,
     ):
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    resolve_ownership.assert_called_once()
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer active"
     assert "X-VM0-Connector-Intent" not in flow.request.headers
@@ -1433,8 +1482,9 @@ async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_pat
 
 
 async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
 ):
+    _patch_shared_base_diagnostic_catalog(monkeypatch)
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -1447,32 +1497,14 @@ async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
             ("X-VM0-Connector-Intent", "other"),
         ),
     )
-    resolution = builtin_connector_diagnostics.SharedBaseOwnershipResolution(
-        candidate=None,
-        reason="base_only",
-        candidate_connector_types=("active-shared", "inactive-shared"),
-        hint_status="absent",
-    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
-        patch.object(
-            builtin_connector_diagnostics,
-            "resolve_shared_base_ownership",
-            return_value=resolution,
-        ) as resolve_ownership,
     ):
         await mitm_addon.request(flow)
 
     auth_fetch.assert_awaited_once()
-    resolve_ownership.assert_called_once_with(
-        "https://shared.example.com/inactive",
-        "GET",
-        active_firewall_names={"active-shared"},
-        matched_firewall_name="active-shared",
-        connector_intent=None,
-    )
     assert flow.response is None
     assert flow.request.headers["Authorization"] == "Bearer active"
     assert "X-VM0-Connector-Intent" not in flow.request.headers
@@ -1480,8 +1512,13 @@ async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
 
 
 async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, monkeypatch
 ):
+    _patch_shared_base_diagnostic_catalog(
+        monkeypatch,
+        active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
+        inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
+    )
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -1493,11 +1530,6 @@ async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
-        patch.object(
-            builtin_connector_diagnostics,
-            "resolve_shared_base_ownership",
-            side_effect=AssertionError("known permission must not resolve shared-base ownership"),
-        ),
     ):
         await mitm_addon.request(flow)
 
@@ -1510,8 +1542,13 @@ async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
 
 
 async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
 ):
+    _patch_shared_base_diagnostic_catalog(
+        monkeypatch,
+        active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
+        inactive_permissions=[{"name": "inactive-write", "rules": ["POST /inactive"]}],
+    )
     reg_path = _write_shared_base_active_firewall_registry(
         tmp_path,
         vm_fields={"captureNetworkBodies": True},
@@ -1532,18 +1569,12 @@ async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
-        patch.object(
-            builtin_connector_diagnostics,
-            "resolve_shared_base_ownership",
-            return_value=_shared_base_resolution(),
-        ) as resolve_ownership,
     ):
         requestheaders_result = mitm_addon.requestheaders(flow)
         assert requestheaders_result is None
         await mitm_addon.request(flow)
 
     auth_fetch.assert_not_called()
-    resolve_ownership.assert_called_once()
     _assert_shared_base_inactive_diagnostic(flow)
     assert flow.request.stream is False
     assert "Authorization" not in flow.request.headers

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -1416,6 +1416,11 @@ async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_au
     assert "Authorization" not in flow.request.headers
     assert "X-VM0-Connector-Intent" not in flow.request.headers
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    [proxy_log_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_log_entry["type"] == "connector_diagnostic"
+    assert proxy_log_entry["ownership_reason"] == "route_owner"
+    assert proxy_log_entry["ownership_candidates"] == ["active-shared", "inactive-shared"]
+    assert proxy_log_entry["ownership_hint_status"] == "ignored"
 
 
 async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_before_auth(
@@ -1445,6 +1450,11 @@ async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_befor
     assert "Authorization" not in flow.request.headers
     assert "X-VM0-Connector-Intent" not in flow.request.headers
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+    [proxy_log_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+    assert proxy_log_entry["type"] == "connector_diagnostic"
+    assert proxy_log_entry["ownership_reason"] == "hint_owner"
+    assert proxy_log_entry["ownership_candidates"] == ["active-shared", "inactive-shared"]
+    assert proxy_log_entry["ownership_hint_status"] == "used"
 
 
 async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_path(

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -10,6 +10,7 @@ from mitmproxy.flow import Error
 
 import auth
 import auth_base_forwarder
+import builtin_connector_diagnostics
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_streaming
@@ -118,6 +119,78 @@ def _write_public_destination_firewall_registry(
             vm_fields=vm_fields,
         ),
     )
+
+
+def _write_shared_base_active_firewall_registry(
+    tmp_path,
+    *,
+    vm_fields: dict[str, object] | None = None,
+):
+    return _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            firewall_name="active-shared",
+            api_entry={
+                "base": "https://shared.example.com",
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.ACTIVE_TOKEN }}"}},
+                "permissions": [{"name": "active-read", "rules": ["GET /active"]}],
+            },
+            network_policy={
+                "allow": ["active-read"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+            vm_fields=vm_fields,
+        ),
+    )
+
+
+def _shared_base_inactive_candidate():
+    return builtin_connector_diagnostics.ConnectorDiagnosticCandidate(
+        connector_type="inactive-shared",
+        reason="not_configured_for_run",
+        env_names=("INACTIVE_TOKEN",),
+        base="https://shared.example.com",
+        auth_header_names=("Authorization",),
+        auth_query_param_names=("api_key",),
+    )
+
+
+def _shared_base_resolution(
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None = None,
+):
+    return builtin_connector_diagnostics.SharedBaseOwnershipResolution(
+        candidate=_shared_base_inactive_candidate() if candidate is None else candidate,
+        reason="route_owner",
+        candidate_connector_types=("active-shared", "inactive-shared"),
+        hint_status="absent",
+    )
+
+
+def _assert_shared_base_inactive_diagnostic(flow):
+    assert flow.response is not None
+    assert flow.response.status_code == 424
+    body = json.loads(flow.response.content)
+    assert body == {
+        "error": "connector_not_configured_for_run",
+        "connector": "inactive-shared",
+        "reason": "not_configured_for_run",
+        "message": (
+            "inactive-shared is not configured for this run. INACTIVE_TOKEN is "
+            "unavailable, so credentials cannot be injected."
+        ),
+        "envNames": ["INACTIVE_TOKEN"],
+        "base": "https://shared.example.com",
+        "upstreamStatus": 0,
+    }
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == "https://shared.example.com"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "inactive-shared"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == ""
+    assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "connector_not_configured_for_run"
+    assert flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] == "inactive-shared"
 
 
 def _public_destination_flow(
@@ -1282,6 +1355,201 @@ async def test_public_destination_requestheaders_kills_unknown_length_before_ear
     assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
     [proxy_log_entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
     assert proxy_log_entry["type"] == "public_destination"
+
+
+async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_auth(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_shared_base_active_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/inactive",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("X-VM0-Connector-Intent", "inactive-shared"),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+        patch.object(
+            builtin_connector_diagnostics,
+            "resolve_shared_base_ownership",
+            return_value=_shared_base_resolution(),
+        ) as resolve_ownership,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    resolve_ownership.assert_called_once_with(
+        "https://shared.example.com/inactive",
+        "GET",
+        active_firewall_names={"active-shared"},
+        matched_firewall_name="active-shared",
+        connector_intent="inactive-shared",
+    )
+    _assert_shared_base_inactive_diagnostic(flow)
+    assert "Authorization" not in flow.request.headers
+    assert "X-VM0-Connector-Intent" not in flow.request.headers
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_path(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_shared_base_active_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/inactive",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("X-VM0-Connector-Intent", "inactive-shared"),
+            ("Authorization", "Bearer user-provided"),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+        patch.object(
+            builtin_connector_diagnostics,
+            "resolve_shared_base_ownership",
+            return_value=_shared_base_resolution(),
+        ) as resolve_ownership,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    resolve_ownership.assert_called_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer active"
+    assert "X-VM0-Connector-Intent" not in flow.request.headers
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+
+
+async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_shared_base_active_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/inactive",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("X-VM0-Connector-Intent", "inactive-shared"),
+            ("X-VM0-Connector-Intent", "other"),
+        ),
+    )
+    resolution = builtin_connector_diagnostics.SharedBaseOwnershipResolution(
+        candidate=None,
+        reason="base_only",
+        candidate_connector_types=("active-shared", "inactive-shared"),
+        hint_status="absent",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+        patch.object(
+            builtin_connector_diagnostics,
+            "resolve_shared_base_ownership",
+            return_value=resolution,
+        ) as resolve_ownership,
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    resolve_ownership.assert_called_once_with(
+        "https://shared.example.com/inactive",
+        "GET",
+        active_firewall_names={"active-shared"},
+        matched_firewall_name="active-shared",
+        connector_intent=None,
+    )
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer active"
+    assert "X-VM0-Connector-Intent" not in flow.request.headers
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+
+
+async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
+):
+    reg_path = _write_shared_base_active_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/active",
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+        patch.object(
+            builtin_connector_diagnostics,
+            "resolve_shared_base_ownership",
+            side_effect=AssertionError("known permission must not resolve shared-base ownership"),
+        ),
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer active"
+    assert flow.metadata[metadata_keys.FIREWALL_NAME] == "active-shared"
+    assert flow.metadata[metadata_keys.FIREWALL_PERMISSION] == "active-read"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata
+
+
+async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_shared_base_active_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        method="POST",
+        path="/inactive",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("X-VM0-Connector-Intent", "inactive-shared"),
+            ("Content-Length", str(mitm_addon.STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+        patch.object(
+            builtin_connector_diagnostics,
+            "resolve_shared_base_ownership",
+            return_value=_shared_base_resolution(),
+        ) as resolve_ownership,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        assert requestheaders_result is None
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_not_called()
+    resolve_ownership.assert_called_once()
+    _assert_shared_base_inactive_diagnostic(flow)
+    assert flow.request.stream is False
+    assert "Authorization" not in flow.request.headers
+    assert "X-VM0-Connector-Intent" not in flow.request.headers
+    assert metadata_keys.REQUEST_STREAM_BUFFER not in flow.metadata
+    assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
 
 
 async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -966,6 +966,45 @@ async def test_capture_enabled_firewall_allow_header_auth_installs_request_strea
     assert flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] is True
 
 
+async def test_firewall_allow_header_auth_requestheaders_strips_connector_intent(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_github_firewall_registry(
+        tmp_path,
+        vm_fields={"captureNetworkBodies": True},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        method="POST",
+        path="/repos/octocat/hello",
+        request_headers=headers(
+            ("Host", "api.github.com"),
+            ("X-VM0-Connector-Intent", "github"),
+            ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+
+        assert callable(flow.request.stream)
+        assert flow.request.headers["Authorization"] == "Bearer resolved"
+        assert "X-VM0-Connector-Intent" not in flow.request.headers
+
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert mitm_addon._REQUEST_CLASSIFICATION not in flow.metadata
+    assert flow.metadata[metadata_keys.REQUEST_STREAM_COMPLETE] is True
+
+
 async def test_firewall_allow_header_auth_requestheaders_falls_back_when_upstream_is_unbound(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -516,7 +516,7 @@ describe("Python builtin firewall catalog renderer", () => {
     ]);
   });
 
-  it("does not collapse malformed host trailing dots into shared static bases", () => {
+  it("omits connector diagnostic APIs whose static bases are invalid at runtime", () => {
     const files = renderEntries([
       connectorEntry({
         name: "malformed-dot",
@@ -532,6 +532,82 @@ describe("Python builtin firewall catalog renderer", () => {
               {
                 name: "malformed:read",
                 rules: ["GET /malformed/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "empty-port",
+        apis: [
+          {
+            base: "https://shared-dot.example.com:/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.EMPTY_PORT_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "empty-port:read",
+                rules: ["GET /empty-port/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "userinfo",
+        apis: [
+          {
+            base: "https://user@shared-dot.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.USERINFO_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "userinfo:read",
+                rules: ["GET /userinfo/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "query-base",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/api?version=1",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.QUERY_BASE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "query-base:read",
+                rules: ["GET /query-base/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "encoded-dot",
+        apis: [
+          {
+            base: "https://shared-dot.example%2ecom/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.ENCODED_DOT_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "encoded-dot:read",
+                rules: ["GET /encoded-dot/{id}"],
               },
             ],
           },
@@ -563,17 +639,6 @@ describe("Python builtin firewall catalog renderer", () => {
       jsonAssignmentFromModule(diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS"),
     ).toStrictEqual([
       {
-        name: "malformed-dot",
-        apis: [
-          {
-            base: "https://shared-dot.example.com../api",
-            envNames: ["MALFORMED_DOT_TOKEN"],
-            authHeaderNames: ["Authorization"],
-            authQueryParamNames: [],
-          },
-        ],
-      },
-      {
         name: "valid-dot",
         apis: [
           {
@@ -581,6 +646,89 @@ describe("Python builtin firewall catalog renderer", () => {
             envNames: ["VALID_DOT_TOKEN"],
             authHeaderNames: ["Authorization"],
             authQueryParamNames: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps runtime-safe percent-encoded host escapes in shared static base matching", () => {
+    const files = renderEntries([
+      connectorEntry({
+        name: "encoded-host",
+        apis: [
+          {
+            base: "https://shared%2ddot.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.ENCODED_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "encoded-host:read",
+                rules: ["GET /encoded-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "decoded-host",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.DECODED_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "decoded-host:read",
+                rules: ["GET /decoded-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+    const diagnostics = findGeneratedFile(files, "diagnostics.py");
+
+    expect(
+      jsonAssignmentFromModule(diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS"),
+    ).toStrictEqual([
+      {
+        name: "decoded-host",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/api",
+            envNames: ["DECODED_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "decoded-host:read",
+                rules: ["GET /decoded-host/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "encoded-host",
+        apis: [
+          {
+            base: "https://shared%2ddot.example.com/api",
+            envNames: ["ENCODED_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "encoded-host:read",
+                rules: ["GET /encoded-host/{id}"],
+              },
+            ],
           },
         ],
       },

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -974,6 +974,121 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       }),
       connectorEntry({
+        name: "wildcard-host",
+        apis: [
+          {
+            base: "https://exa*mple.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.WILDCARD_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "wildcard-host:read",
+                rules: ["GET /wildcard-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "comma-host",
+        apis: [
+          {
+            base: "https://exa,mple.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.COMMA_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "comma-host:read",
+                rules: ["GET /comma-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "noncanonical-ipv4-host",
+        apis: [
+          {
+            base: "https://127.000.000.001/api",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.NONCANONICAL_IPV4_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "noncanonical-ipv4-host:read",
+                rules: ["GET /noncanonical-ipv4-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "compat-ascii-host",
+        apis: [
+          {
+            base: "https://０.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.COMPAT_ASCII_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "compat-ascii-host:read",
+                rules: ["GET /compat-ascii-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "unsafe-uts46-host",
+        apis: [
+          {
+            base: "https://a\u03f2b.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.UNSAFE_UTS46_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "unsafe-uts46-host:read",
+                rules: ["GET /unsafe-uts46-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "arabic-bidi-host",
+        apis: [
+          {
+            base: "https://a\u0870b.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.ARABIC_BIDI_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "arabic-bidi-host:read",
+                rules: ["GET /arabic-bidi-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
         name: "valid-dot",
         apis: [
           {
@@ -1052,6 +1167,63 @@ describe("Python builtin firewall catalog renderer", () => {
           },
         ],
       }),
+      connectorEntry({
+        name: "unicode-dot-host",
+        apis: [
+          {
+            base: "https://shared-dot。example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.UNICODE_DOT_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "unicode-dot-host:read",
+                rules: ["GET /unicode-dot-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "unicode-idna-host",
+        apis: [
+          {
+            base: "https://faß.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.UNICODE_IDNA_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "unicode-idna-host:read",
+                rules: ["GET /unicode-idna-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "punycode-idna-host",
+        apis: [
+          {
+            base: "https://xn--fa-hia.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.PUNYCODE_IDNA_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "punycode-idna-host:read",
+                rules: ["GET /punycode-idna-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
     ]);
     const diagnostics = findGeneratedFile(files, "diagnostics.py");
 
@@ -1087,6 +1259,57 @@ describe("Python builtin firewall catalog renderer", () => {
               {
                 name: "encoded-host:read",
                 rules: ["GET /encoded-host/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "punycode-idna-host",
+        apis: [
+          {
+            base: "https://xn--fa-hia.example.com/api",
+            envNames: ["PUNYCODE_IDNA_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "punycode-idna-host:read",
+                rules: ["GET /punycode-idna-host/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "unicode-dot-host",
+        apis: [
+          {
+            base: "https://shared-dot。example.com/api",
+            envNames: ["UNICODE_DOT_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "unicode-dot-host:read",
+                rules: ["GET /unicode-dot-host/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "unicode-idna-host",
+        apis: [
+          {
+            base: "https://faß.example.com/api",
+            envNames: ["UNICODE_IDNA_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "unicode-idna-host:read",
+                rules: ["GET /unicode-idna-host/{id}"],
               },
             ],
           },

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -516,6 +516,77 @@ describe("Python builtin firewall catalog renderer", () => {
     ]);
   });
 
+  it("does not collapse malformed host trailing dots into shared static bases", () => {
+    const files = renderEntries([
+      connectorEntry({
+        name: "malformed-dot",
+        apis: [
+          {
+            base: "https://shared-dot.example.com../api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.MALFORMED_DOT_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "malformed:read",
+                rules: ["GET /malformed/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "valid-dot",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.VALID_DOT_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "valid:read",
+                rules: ["GET /valid/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+    const diagnostics = findGeneratedFile(files, "diagnostics.py");
+
+    expect(
+      jsonAssignmentFromModule(diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS"),
+    ).toStrictEqual([
+      {
+        name: "malformed-dot",
+        apis: [
+          {
+            base: "https://shared-dot.example.com../api",
+            envNames: ["MALFORMED_DOT_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "valid-dot",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/api",
+            envNames: ["VALID_DOT_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+    ]);
+  });
+
   it("preserves runtime API host policies in catalog JSON", () => {
     const files = renderEntries([
       connectorEntry({

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -516,6 +516,271 @@ describe("Python builtin firewall catalog renderer", () => {
     ]);
   });
 
+  it("uses runtime path semantics for diagnostic shared static bases", () => {
+    const files = renderEntries([
+      connectorEntry({
+        name: "dot-segment",
+        apis: [
+          {
+            base: "https://path.example.com/a/../b",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.DOT_SEGMENT_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "dot-segment:read",
+                rules: ["GET /dot-segment/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "encoded-dot-segment",
+        apis: [
+          {
+            base: "https://encoded-path.example.com/a/%2e%2e/b",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.ENCODED_DOT_SEGMENT_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "encoded-dot-segment:read",
+                rules: ["GET /encoded-dot-segment/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "encoded-target",
+        apis: [
+          {
+            base: "https://encoded-path.example.com/b",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.ENCODED_TARGET_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "encoded-target:read",
+                rules: ["GET /encoded-target/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "encoded-unicode-path",
+        apis: [
+          {
+            base: "https://unicode-path.example.com/%E8%B7%AF%E5%BE%84",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.ENCODED_UNICODE_PATH_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "encoded-unicode-path:read",
+                rules: ["GET /encoded-unicode-path/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "normalized-target",
+        apis: [
+          {
+            base: "https://path.example.com/b",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.NORMALIZED_TARGET_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "normalized-target:read",
+                rules: ["GET /normalized-target/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "shared-path-one",
+        apis: [
+          {
+            base: "https://shared-path.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.SHARED_PATH_ONE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "shared-path-one:read",
+                rules: ["GET /one/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "shared-path-two",
+        apis: [
+          {
+            base: "https://shared-path.example.com/api/",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.SHARED_PATH_TWO_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "shared-path-two:read",
+                rules: ["GET /two/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "unicode-path",
+        apis: [
+          {
+            base: "https://unicode-path.example.com/路径",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.UNICODE_PATH_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "unicode-path:read",
+                rules: ["GET /unicode-path/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+    const diagnostics = findGeneratedFile(files, "diagnostics.py");
+
+    expect(
+      jsonAssignmentFromModule(diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS"),
+    ).toStrictEqual([
+      {
+        name: "dot-segment",
+        apis: [
+          {
+            base: "https://path.example.com/a/../b",
+            envNames: ["DOT_SEGMENT_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "encoded-dot-segment",
+        apis: [
+          {
+            base: "https://encoded-path.example.com/a/%2e%2e/b",
+            envNames: ["ENCODED_DOT_SEGMENT_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "encoded-target",
+        apis: [
+          {
+            base: "https://encoded-path.example.com/b",
+            envNames: ["ENCODED_TARGET_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "encoded-unicode-path",
+        apis: [
+          {
+            base: "https://unicode-path.example.com/%E8%B7%AF%E5%BE%84",
+            envNames: ["ENCODED_UNICODE_PATH_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "normalized-target",
+        apis: [
+          {
+            base: "https://path.example.com/b",
+            envNames: ["NORMALIZED_TARGET_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "shared-path-one",
+        apis: [
+          {
+            base: "https://shared-path.example.com/api",
+            envNames: ["SHARED_PATH_ONE_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "shared-path-one:read",
+                rules: ["GET /one/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "shared-path-two",
+        apis: [
+          {
+            base: "https://shared-path.example.com/api/",
+            envNames: ["SHARED_PATH_TWO_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "shared-path-two:read",
+                rules: ["GET /two/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "unicode-path",
+        apis: [
+          {
+            base: "https://unicode-path.example.com/路径",
+            envNames: ["UNICODE_PATH_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+    ]);
+  });
+
   it("omits connector diagnostic APIs whose static bases are invalid at runtime", () => {
     const files = renderEntries([
       connectorEntry({

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -672,6 +672,46 @@ describe("Python builtin firewall catalog renderer", () => {
           },
         ],
       }),
+      connectorEntry({
+        name: "literal-open-brace-path",
+        apis: [
+          {
+            base: "https://brace-path.example.com/{literal",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.LITERAL_OPEN_BRACE_PATH_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "literal-open-brace-path:read",
+                rules: ["GET /literal-open-brace-path/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "literal-close-brace-path",
+        apis: [
+          {
+            base: "https://brace-path.example.com/literal}",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.LITERAL_CLOSE_BRACE_PATH_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "literal-close-brace-path:read",
+                rules: ["GET /literal-close-brace-path/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
     ]);
     const diagnostics = findGeneratedFile(files, "diagnostics.py");
 
@@ -717,6 +757,28 @@ describe("Python builtin firewall catalog renderer", () => {
           {
             base: "https://unicode-path.example.com/%E8%B7%AF%E5%BE%84",
             envNames: ["ENCODED_UNICODE_PATH_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "literal-close-brace-path",
+        apis: [
+          {
+            base: "https://brace-path.example.com/literal}",
+            envNames: ["LITERAL_CLOSE_BRACE_PATH_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+      {
+        name: "literal-open-brace-path",
+        apis: [
+          {
+            base: "https://brace-path.example.com/{literal",
+            envNames: ["LITERAL_OPEN_BRACE_PATH_TOKEN"],
             authHeaderNames: ["Authorization"],
             authQueryParamNames: [],
           },

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -359,7 +359,7 @@ describe("Python builtin firewall catalog renderer", () => {
         name: "shared-one",
         apis: [
           {
-            base: "https://shared.example.com/api",
+            base: "https://Shared.Example.com.:443/api",
             auth: {
               headers: {
                 Authorization: "Bearer ${{ secrets.SHARED_ONE_TOKEN }}",
@@ -472,7 +472,7 @@ describe("Python builtin firewall catalog renderer", () => {
         name: "shared-one",
         apis: [
           {
-            base: "https://shared.example.com/api",
+            base: "https://Shared.Example.com.:443/api",
             envNames: ["SHARED_ONE_TOKEN"],
             authHeaderNames: ["Authorization"],
             authQueryParamNames: [],

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -1344,6 +1344,26 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       }),
       connectorEntry({
+        name: "greek-prosgegrammeni-idna-host",
+        apis: [
+          {
+            base: "https://\u1fbc\u0301.example.com/api",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.GREEK_PROSGEGRAMMENI_IDNA_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "greek-prosgegrammeni-idna-host:read",
+                rules: ["GET /greek-prosgegrammeni-idna-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
         name: "punycode-idna-host",
         apis: [
           {
@@ -1416,6 +1436,17 @@ describe("Python builtin firewall catalog renderer", () => {
                 rules: ["GET /encoded-host/{id}"],
               },
             ],
+          },
+        ],
+      },
+      {
+        name: "greek-prosgegrammeni-idna-host",
+        apis: [
+          {
+            base: "https://\u1fbc\u0301.example.com/api",
+            envNames: ["GREEK_PROSGEGRAMMENI_IDNA_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
           },
         ],
       },

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -917,6 +917,63 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       }),
       connectorEntry({
+        name: "raw-delete-base",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/\u007fdelete",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.RAW_DELETE_BASE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "raw-delete-base:read",
+                rules: ["GET /raw-delete-base/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "raw-surrogate-base",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/\ud800surrogate",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.RAW_SURROGATE_BASE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "raw-surrogate-base:read",
+                rules: ["GET /raw-surrogate-base/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "encoded-space-host",
+        apis: [
+          {
+            base: "https://shared-dot.example%C2%A0com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.ENCODED_SPACE_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "encoded-space-host:read",
+                rules: ["GET /encoded-space-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
         name: "valid-dot",
         apis: [
           {

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -1070,6 +1070,25 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       }),
       connectorEntry({
+        name: "leading-mark-host",
+        apis: [
+          {
+            base: "https://\u0c3ca.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.LEADING_MARK_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "leading-mark-host:read",
+                rules: ["GET /leading-mark-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
         name: "arabic-bidi-host",
         apis: [
           {
@@ -1083,6 +1102,26 @@ describe("Python builtin firewall catalog renderer", () => {
               {
                 name: "arabic-bidi-host:read",
                 rules: ["GET /arabic-bidi-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "old-uyghur-bidi-host",
+        apis: [
+          {
+            base: "https://a\u{10f70}b.example.com/api",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.OLD_UYGHUR_BIDI_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "old-uyghur-bidi-host:read",
+                rules: ["GET /old-uyghur-bidi-host/{id}"],
               },
             ],
           },

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -412,12 +412,62 @@ describe("Python builtin firewall catalog renderer", () => {
           },
         ],
       }),
+      connectorEntry({
+        name: "duplicate-only",
+        apis: [
+          {
+            base: "https://duplicate.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.DUPLICATE_ONE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "duplicate-one:read",
+                rules: ["GET /one/{id}"],
+              },
+            ],
+          },
+          {
+            base: "https://duplicate.example.com/api/",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.DUPLICATE_TWO_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "duplicate-two:read",
+                rules: ["GET /two/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
     ]);
     const diagnostics = findGeneratedFile(files, "diagnostics.py");
 
     expect(
       jsonAssignmentFromModule(diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS"),
     ).toStrictEqual([
+      {
+        name: "duplicate-only",
+        apis: [
+          {
+            base: "https://duplicate.example.com/api",
+            envNames: ["DUPLICATE_ONE_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+          {
+            base: "https://duplicate.example.com/api/",
+            envNames: ["DUPLICATE_TWO_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
       {
         name: "shared-one",
         apis: [

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -614,6 +614,44 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       }),
       connectorEntry({
+        name: "backslash-base",
+        apis: [
+          {
+            base: "https://shared-dot.example.com\\api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.BACKSLASH_BASE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "backslash-base:read",
+                rules: ["GET /backslash-base/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "raw-space-base",
+        apis: [
+          {
+            base: "https://shared-dot.example.com/ raw-space",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.RAW_SPACE_BASE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "raw-space-base:read",
+                rules: ["GET /raw-space-base/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
         name: "valid-dot",
         apis: [
           {

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -1089,6 +1089,65 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       }),
       connectorEntry({
+        name: "format-char-host",
+        apis: [
+          {
+            base: "https://a\u00ad\u0301.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.FORMAT_CHAR_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "format-char-host:read",
+                rules: ["GET /format-char-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "normalized-comma-host",
+        apis: [
+          {
+            base: "https://a\uff0c\u0301.example.com/api",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.NORMALIZED_COMMA_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "normalized-comma-host:read",
+                rules: ["GET /normalized-comma-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "noncanonical-greek-host",
+        apis: [
+          {
+            base: "https://\u03aa\u0301.example.com/api",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.NONCANONICAL_GREEK_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "noncanonical-greek-host:read",
+                rules: ["GET /noncanonical-greek-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
         name: "arabic-bidi-host",
         apis: [
           {
@@ -1207,6 +1266,26 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       }),
       connectorEntry({
+        name: "decomposed-idna-host",
+        apis: [
+          {
+            base: "https://e\u0301.example.com/api",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.DECOMPOSED_IDNA_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "decomposed-idna-host:read",
+                rules: ["GET /decomposed-idna-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
         name: "unicode-dot-host",
         apis: [
           {
@@ -1239,6 +1318,26 @@ describe("Python builtin firewall catalog renderer", () => {
               {
                 name: "unicode-idna-host:read",
                 rules: ["GET /unicode-idna-host/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "precomposed-idna-host",
+        apis: [
+          {
+            base: "https://é.example.com/api",
+            auth: {
+              headers: {
+                Authorization:
+                  "Bearer ${{ secrets.PRECOMPOSED_IDNA_HOST_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "precomposed-idna-host:read",
+                rules: ["GET /precomposed-idna-host/{id}"],
               },
             ],
           },
@@ -1287,6 +1386,23 @@ describe("Python builtin firewall catalog renderer", () => {
         ],
       },
       {
+        name: "decomposed-idna-host",
+        apis: [
+          {
+            base: "https://e\u0301.example.com/api",
+            envNames: ["DECOMPOSED_IDNA_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "decomposed-idna-host:read",
+                rules: ["GET /decomposed-idna-host/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
         name: "encoded-host",
         apis: [
           {
@@ -1298,6 +1414,23 @@ describe("Python builtin firewall catalog renderer", () => {
               {
                 name: "encoded-host:read",
                 rules: ["GET /encoded-host/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "precomposed-idna-host",
+        apis: [
+          {
+            base: "https://é.example.com/api",
+            envNames: ["PRECOMPOSED_IDNA_HOST_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "precomposed-idna-host:read",
+                rules: ["GET /precomposed-idna-host/{id}"],
               },
             ],
           },

--- a/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/python-builtin-firewall-catalog.test.ts
@@ -245,6 +245,12 @@ describe("Python builtin firewall catalog renderer", () => {
                 Authorization: "Bearer ${{ secrets.CONNECTOR_TOKEN }}",
               },
             },
+            permissions: [
+              {
+                name: "connector-read",
+                rules: ["GET /items/{id}"],
+              },
+            ],
           },
         ],
       }),
@@ -345,6 +351,119 @@ describe("Python builtin firewall catalog renderer", () => {
     ]);
     expect(diagnostics.content).not.toContain("DYNAMIC_TOKEN");
     expect(diagnostics.content).not.toContain("JSON_PART");
+  });
+
+  it("keeps connector diagnostic permissions only for shared static bases", () => {
+    const files = renderEntries([
+      connectorEntry({
+        name: "shared-one",
+        apis: [
+          {
+            base: "https://shared.example.com/api",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.SHARED_ONE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "items:read",
+                rules: ["GET /items/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "shared-two",
+        apis: [
+          {
+            base: "https://shared.example.com/api/",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.SHARED_TWO_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "messages:read",
+                rules: ["GET /messages/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+      connectorEntry({
+        name: "unique",
+        apis: [
+          {
+            base: "https://unique.example.com",
+            auth: {
+              headers: {
+                Authorization: "Bearer ${{ secrets.UNIQUE_TOKEN }}",
+              },
+            },
+            permissions: [
+              {
+                name: "unique:read",
+                rules: ["GET /unique/{id}"],
+              },
+            ],
+          },
+        ],
+      }),
+    ]);
+    const diagnostics = findGeneratedFile(files, "diagnostics.py");
+
+    expect(
+      jsonAssignmentFromModule(diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS"),
+    ).toStrictEqual([
+      {
+        name: "shared-one",
+        apis: [
+          {
+            base: "https://shared.example.com/api",
+            envNames: ["SHARED_ONE_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "items:read",
+                rules: ["GET /items/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "shared-two",
+        apis: [
+          {
+            base: "https://shared.example.com/api/",
+            envNames: ["SHARED_TWO_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+            permissions: [
+              {
+                name: "messages:read",
+                rules: ["GET /messages/{id}"],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "unique",
+        apis: [
+          {
+            base: "https://unique.example.com",
+            envNames: ["UNIQUE_TOKEN"],
+            authHeaderNames: ["Authorization"],
+            authQueryParamNames: [],
+          },
+        ],
+      },
+    ]);
   });
 
   it("preserves runtime API host policies in catalog JSON", () => {

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -88,6 +88,29 @@ const PYTHON_MODULE_HASH_LENGTH = 12;
 const PYTHON_JSON_PART_ASSIGNMENT_PREFIX = "JSON_PART = ";
 const DIAGNOSTIC_JSON_ASSIGNMENT_PREFIX =
   "MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS = json.loads(";
+const HEX_DIGIT_PATTERN = /^[0-9a-fA-F]$/;
+const PERCENT_DECODED_FORBIDDEN_HOST_CHARS = new Set([
+  "#",
+  "%",
+  "/",
+  "<",
+  ">",
+  "?",
+  "@",
+  "[",
+  "\\",
+  "]",
+  "^",
+  "|",
+  "{",
+  "}",
+  "*",
+  ".",
+  ":",
+  "\u3002",
+  "\uff0e",
+  "\uff61",
+]);
 // Fallback JSON string literals can double quotes and backslashes.
 const MAX_JSON_PART_SOURCE_CHARS = Math.floor(
   (MAX_GENERATED_PYTHON_LINE_LENGTH -
@@ -269,18 +292,155 @@ function stripHostnameTrailingDot(host: string): string {
   return `${hostname}${host.slice(portStart)}`;
 }
 
+function rawUrlAuthority(base: string): string | null {
+  const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.exec(base);
+  if (schemeMatch === null) {
+    return null;
+  }
+
+  const authorityStart = schemeMatch[0].length;
+  const authoritySuffix = base.slice(authorityStart);
+  const authorityEnd = authoritySuffix.search(/[/?#]/);
+  const end = authorityEnd === -1 ? base.length : authorityStart + authorityEnd;
+  const authority = base.slice(authorityStart, end);
+  return authority.length > 0 ? authority : null;
+}
+
+function rawAuthorityHostPort(authority: string): string {
+  const userInfoEnd = authority.lastIndexOf("@");
+  return userInfoEnd === -1 ? authority : authority.slice(userInfoEnd + 1);
+}
+
+function rawAuthorityHasEmptyPort(authority: string): boolean {
+  return rawAuthorityHostPort(authority).endsWith(":");
+}
+
+function rawAuthorityHostname(authority: string): string | null {
+  const hostPort = rawAuthorityHostPort(authority);
+  if (hostPort.length === 0) {
+    return null;
+  }
+
+  if (hostPort.startsWith("[")) {
+    const closeIndex = hostPort.indexOf("]");
+    if (closeIndex === -1) {
+      return null;
+    }
+    const rest = hostPort.slice(closeIndex + 1);
+    if (rest.length > 0 && !rest.startsWith(":")) {
+      return null;
+    }
+    return hostPort.slice(1, closeIndex);
+  }
+
+  if (hostPort.split(":").length === 2) {
+    return hostPort.slice(0, hostPort.lastIndexOf(":"));
+  }
+
+  return hostPort;
+}
+
+function hostnameHasEmptyLabel(hostname: string): boolean {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return false;
+  }
+
+  const normalizedHostname = stripSingleHostnameTrailingDot(hostname);
+  return normalizedHostname.split(".").some((label) => {
+    return label.length === 0;
+  });
+}
+
+function isAsciiSpaceOrControl(value: string): boolean {
+  for (const char of value) {
+    const codepoint = char.codePointAt(0);
+    if (codepoint !== undefined && codepoint <= 0x20) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function percentDecodedHostnameEscapesAreRuntimeSafe(
+  hostname: string,
+): boolean {
+  let index = 0;
+  while (index < hostname.length) {
+    if (hostname[index] !== "%") {
+      index += 1;
+      continue;
+    }
+
+    let encoded = "";
+    while (hostname[index] === "%") {
+      const first = hostname[index + 1];
+      const second = hostname[index + 2];
+      if (
+        first === undefined ||
+        second === undefined ||
+        !HEX_DIGIT_PATTERN.test(first) ||
+        !HEX_DIGIT_PATTERN.test(second)
+      ) {
+        return false;
+      }
+      encoded += `%${first}${second}`;
+      index += 3;
+    }
+
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(encoded);
+    } catch {
+      return false;
+    }
+    if (isAsciiSpaceOrControl(decoded)) {
+      return false;
+    }
+    for (const char of decoded) {
+      if (PERCENT_DECODED_FORBIDDEN_HOST_CHARS.has(char)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 function diagnosticStaticBaseKey(base: string): string | null {
   if (hasDynamicBaseMarker(base)) {
     return null;
   }
 
+  const rawAuthority = rawUrlAuthority(base);
+  if (rawAuthority === null || rawAuthorityHasEmptyPort(rawAuthority)) {
+    return null;
+  }
+
+  const rawHostname = rawAuthorityHostname(rawAuthority);
+  if (
+    rawHostname === null ||
+    !percentDecodedHostnameEscapesAreRuntimeSafe(rawHostname)
+  ) {
+    return null;
+  }
+
   try {
     const url = new URL(base);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.search !== "" ||
+      url.hash !== "" ||
+      hostnameHasEmptyLabel(url.hostname.toLowerCase())
+    ) {
+      return null;
+    }
+
     const host = stripHostnameTrailingDot(url.host.toLowerCase());
     const pathname = url.pathname.replace(/\/+$/, "");
     return `${url.protocol}//${host}${pathname}`;
   } catch {
-    return base;
+    return null;
   }
 }
 

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -96,6 +96,7 @@ const ASCII_PUNCTUATION_PATTERN =
   /^[\u0021-\u002f\u003a-\u0040\u005b-\u0060\u007b-\u007e]$/;
 const HEX_DIGIT_PATTERN = /^[0-9a-fA-F]$/;
 const UNICODE_MARK_PATTERN = /^\p{Mark}$/u;
+const UNICODE_OTHER_PATTERN = /^\p{Other}$/u;
 const PERCENT_DECODED_FORBIDDEN_HOST_CHARS = new Set([
   "#",
   "%",
@@ -136,6 +137,26 @@ const FORBIDDEN_RUNTIME_HOST_LABEL_CHARS = new Set([
   "{",
   "}",
   "*",
+]);
+const FORBIDDEN_RUNTIME_NORMALIZED_HOST_LABEL_CHARS = new Set([
+  "#",
+  "%",
+  ",",
+  "/",
+  ":",
+  "<",
+  ">",
+  "?",
+  "@",
+  "[",
+  "\\",
+  "]",
+  "^",
+  "|",
+  ".",
+  "\u3002",
+  "\uff0e",
+  "\uff61",
 ]);
 // Fallback JSON string literals can double quotes and backslashes.
 const MAX_JSON_PART_SOURCE_CHARS = Math.floor(
@@ -573,9 +594,36 @@ function hasForbiddenRuntimeHostLabelChars(value: string): boolean {
   return false;
 }
 
-function hasRuntimeLeadingUnicodeMarkLabel(value: string): boolean {
-  const firstChar = [...value.normalize("NFKD").normalize("NFC")][0];
-  return firstChar !== undefined && UNICODE_MARK_PATTERN.test(firstChar);
+function runtimeLowerNormalizedLabel(value: string): string {
+  // Match Python's normalize-then-per-codepoint-lower order.
+  return [...value.normalize("NFKD").normalize("NFC")]
+    .map((char) => {
+      return char === "\u03a3" ? "\u03c3" : char.toLowerCase();
+    })
+    .join("");
+}
+
+function hasRuntimeIncompatibleNormalizedLabelText(value: string): boolean {
+  const normalized = runtimeLowerNormalizedLabel(value);
+  if (normalized !== normalized.normalize("NFC")) {
+    return true;
+  }
+
+  const firstChar = [...normalized][0];
+  if (firstChar === undefined || UNICODE_MARK_PATTERN.test(firstChar)) {
+    return true;
+  }
+
+  for (const char of normalized) {
+    if (
+      FORBIDDEN_RUNTIME_NORMALIZED_HOST_LABEL_CHARS.has(char) ||
+      /\s/u.test(char) ||
+      UNICODE_OTHER_PATTERN.test(char)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function hasRuntimeIncompatibleBidiLabel(value: string): boolean {
@@ -661,7 +709,7 @@ function runtimeCompatibleHostname(
     if (
       hasForbiddenRuntimeHostLabelChars(rawLabel) ||
       hasUnsafeUts46MappingChars(rawLabel) ||
-      hasRuntimeLeadingUnicodeMarkLabel(rawLabel) ||
+      hasRuntimeIncompatibleNormalizedLabelText(rawLabel) ||
       hasRuntimeIncompatibleBidiLabel(rawLabel)
     ) {
       return false;

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -306,6 +306,31 @@ function rawUrlAuthority(base: string): string | null {
   return authority.length > 0 ? authority : null;
 }
 
+function rawUrlPath(base: string): string | null {
+  const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.exec(base);
+  if (schemeMatch === null) {
+    return null;
+  }
+
+  const authorityStart = schemeMatch[0].length;
+  const authoritySuffix = base.slice(authorityStart);
+  const authorityEnd = authoritySuffix.search(/[/?#]/);
+  if (authorityEnd === -1) {
+    return "";
+  }
+
+  const separatorIndex = authorityStart + authorityEnd;
+  if (base[separatorIndex] !== "/") {
+    return "";
+  }
+
+  const pathSuffix = base.slice(separatorIndex);
+  const queryOrFragmentStart = pathSuffix.search(/[?#]/);
+  return queryOrFragmentStart === -1
+    ? pathSuffix
+    : pathSuffix.slice(0, queryOrFragmentStart);
+}
+
 function rawAuthorityHostPort(authority: string): string {
   const userInfoEnd = authority.lastIndexOf("@");
   return userInfoEnd === -1 ? authority : authority.slice(userInfoEnd + 1);
@@ -415,7 +440,12 @@ function diagnosticStaticBaseKey(base: string): string | null {
   }
 
   const rawAuthority = rawUrlAuthority(base);
-  if (rawAuthority === null || rawAuthorityHasEmptyPort(rawAuthority)) {
+  const rawPath = rawUrlPath(base);
+  if (
+    rawAuthority === null ||
+    rawPath === null ||
+    rawAuthorityHasEmptyPort(rawAuthority)
+  ) {
     return null;
   }
 
@@ -441,7 +471,7 @@ function diagnosticStaticBaseKey(base: string): string | null {
     }
 
     const host = stripHostnameTrailingDot(url.host.toLowerCase());
-    const pathname = url.pathname.replace(/\/+$/, "");
+    const pathname = rawPath.replace(/\/+$/, "");
     return `${url.protocol}//${host}${pathname}`;
   } catch {
     return null;

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -376,10 +376,32 @@ function hostnameHasEmptyLabel(hostname: string): boolean {
   });
 }
 
+function isSurrogateCodepoint(codepoint: number): boolean {
+  return codepoint >= 0xd800 && codepoint <= 0xdfff;
+}
+
 function isAsciiSpaceOrControl(value: string): boolean {
   for (const char of value) {
     const codepoint = char.codePointAt(0);
-    if (codepoint !== undefined && codepoint <= 0x20) {
+    if (
+      codepoint !== undefined &&
+      (codepoint <= 0x20 ||
+        codepoint === 0x7f ||
+        isSurrogateCodepoint(codepoint))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isAuthoritySpaceOrControl(value: string): boolean {
+  for (const char of value) {
+    const codepoint = char.codePointAt(0);
+    if (
+      codepoint !== undefined &&
+      (/\s/u.test(char) || codepoint < 0x20 || codepoint === 0x7f)
+    ) {
       return true;
     }
   }
@@ -418,7 +440,7 @@ function percentDecodedHostnameEscapesAreRuntimeSafe(
     } catch {
       return false;
     }
-    if (isAsciiSpaceOrControl(decoded)) {
+    if (isAuthoritySpaceOrControl(decoded)) {
       return false;
     }
     for (const char of decoded) {

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -53,6 +53,7 @@ interface DiagnosticConnectorApi {
   readonly envNames: readonly string[];
   readonly authHeaderNames: readonly string[];
   readonly authQueryParamNames: readonly string[];
+  readonly permissions?: readonly DiagnosticPermission[];
 }
 
 interface DiagnosticConnectorFirewall {
@@ -245,10 +246,57 @@ function diagnosticAuthQueryParamNames(auth: unknown): readonly string[] {
     .sort();
 }
 
+function diagnosticStaticBaseKey(base: string): string | null {
+  if (hasDynamicBaseMarker(base)) {
+    return null;
+  }
+
+  try {
+    const url = new URL(base);
+    const pathname = url.pathname.replace(/\/+$/, "");
+    return `${url.protocol}//${url.host}${pathname}`;
+  } catch {
+    return base;
+  }
+}
+
+function connectorDiagnosticSharedBaseKeys(
+  entries: readonly PythonBuiltinFirewallCatalogEntry[],
+): ReadonlySet<string> {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.diagnosticKind !== "connector") {
+      continue;
+    }
+    for (const api of entry.firewall.apis) {
+      const baseKey = diagnosticStaticBaseKey(api.base);
+      if (
+        baseKey === null ||
+        extractDiagnosticReferenceNames(api.auth).length === 0
+      ) {
+        continue;
+      }
+      counts.set(baseKey, (counts.get(baseKey) ?? 0) + 1);
+    }
+  }
+
+  return new Set(
+    [...counts.entries()]
+      .filter(([, count]) => {
+        return count > 1;
+      })
+      .map(([base]) => {
+        return base;
+      }),
+  );
+}
+
 function diagnosticConnectorApi(
   api: BuiltinFirewallRuntimeApi,
+  sharedBaseKeys: ReadonlySet<string>,
 ): DiagnosticConnectorApi | null {
-  if (hasDynamicBaseMarker(api.base)) {
+  const baseKey = diagnosticStaticBaseKey(api.base);
+  if (baseKey === null) {
     return null;
   }
 
@@ -257,11 +305,16 @@ function diagnosticConnectorApi(
     return null;
   }
 
+  const permissions = sharedBaseKeys.has(baseKey)
+    ? diagnosticPermissions(api.permissions)
+    : [];
+
   return {
     base: api.base,
     envNames,
     authHeaderNames: diagnosticAuthHeaderNames(api.auth),
     authQueryParamNames: diagnosticAuthQueryParamNames(api.auth),
+    ...(permissions.length > 0 ? { permissions } : {}),
   };
 }
 
@@ -297,6 +350,7 @@ function buildBuiltinFirewallDiagnosticManifest(
 ): BuiltinFirewallDiagnosticManifest {
   const connectorFirewalls: DiagnosticConnectorFirewall[] = [];
   const modelProviderExclusions: DiagnosticModelProviderFirewall[] = [];
+  const sharedConnectorBaseKeys = connectorDiagnosticSharedBaseKeys(entries);
 
   for (const entry of entries) {
     const { firewall } = entry;
@@ -316,7 +370,9 @@ function buildBuiltinFirewallDiagnosticManifest(
     }
 
     const apis = firewall.apis
-      .map(diagnosticConnectorApi)
+      .map((api) => {
+        return diagnosticConnectorApi(api, sharedConnectorBaseKeys);
+      })
       .filter((api): api is DiagnosticConnectorApi => {
         return api !== null;
       });

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -216,7 +216,7 @@ const UNSAFE_UTS46_IGNORABLE_RANGES = [
 ] as const;
 
 function hasDynamicBaseMarker(base: string): boolean {
-  return base.includes("{") || base.includes("}");
+  return base.includes("{") && base.includes("}");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -406,7 +406,11 @@ function percentDecodedHostnameEscapesAreRuntimeSafe(
 }
 
 function diagnosticStaticBaseKey(base: string): string | null {
-  if (hasDynamicBaseMarker(base)) {
+  if (
+    hasDynamicBaseMarker(base) ||
+    base.includes("\\") ||
+    isAsciiSpaceOrControl(base)
+  ) {
     return null;
   }
 

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -246,6 +246,24 @@ function diagnosticAuthQueryParamNames(auth: unknown): readonly string[] {
     .sort();
 }
 
+function trimTrailingDots(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 46) {
+    end -= 1;
+  }
+  return end === value.length ? value : value.slice(0, end);
+}
+
+function stripHostnameTrailingDot(host: string): string {
+  const portStart = host.startsWith("[") ? -1 : host.lastIndexOf(":");
+  if (portStart === -1) {
+    return trimTrailingDots(host);
+  }
+
+  const hostname = trimTrailingDots(host.slice(0, portStart));
+  return `${hostname}${host.slice(portStart)}`;
+}
+
 function diagnosticStaticBaseKey(base: string): string | null {
   if (hasDynamicBaseMarker(base)) {
     return null;
@@ -253,8 +271,9 @@ function diagnosticStaticBaseKey(base: string): string | null {
 
   try {
     const url = new URL(base);
+    const host = stripHostnameTrailingDot(url.host.toLowerCase());
     const pathname = url.pathname.replace(/\/+$/, "");
-    return `${url.protocol}//${url.host}${pathname}`;
+    return `${url.protocol}//${host}${pathname}`;
   } catch {
     return base;
   }

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -246,21 +246,26 @@ function diagnosticAuthQueryParamNames(auth: unknown): readonly string[] {
     .sort();
 }
 
-function trimTrailingDots(value: string): string {
-  let end = value.length;
-  while (end > 0 && value.charCodeAt(end - 1) === 46) {
-    end -= 1;
+function stripSingleHostnameTrailingDot(value: string): string {
+  if (!value.endsWith(".")) {
+    return value;
   }
-  return end === value.length ? value : value.slice(0, end);
+
+  const stripped = value.slice(0, -1);
+  if (stripped.length === 0 || stripped.endsWith(".")) {
+    return value;
+  }
+
+  return stripped;
 }
 
 function stripHostnameTrailingDot(host: string): string {
   const portStart = host.startsWith("[") ? -1 : host.lastIndexOf(":");
   if (portStart === -1) {
-    return trimTrailingDots(host);
+    return stripSingleHostnameTrailingDot(host);
   }
 
-  const hostname = trimTrailingDots(host.slice(0, portStart));
+  const hostname = stripSingleHostnameTrailingDot(host.slice(0, portStart));
   return `${hostname}${host.slice(portStart)}`;
 }
 

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -263,7 +263,7 @@ function diagnosticStaticBaseKey(base: string): string | null {
 function connectorDiagnosticSharedBaseKeys(
   entries: readonly PythonBuiltinFirewallCatalogEntry[],
 ): ReadonlySet<string> {
-  const counts = new Map<string, number>();
+  const connectorNamesByBase = new Map<string, Set<string>>();
   for (const entry of entries) {
     if (entry.diagnosticKind !== "connector") {
       continue;
@@ -276,14 +276,17 @@ function connectorDiagnosticSharedBaseKeys(
       ) {
         continue;
       }
-      counts.set(baseKey, (counts.get(baseKey) ?? 0) + 1);
+      const connectorNames =
+        connectorNamesByBase.get(baseKey) ?? new Set<string>();
+      connectorNames.add(entry.firewall.name);
+      connectorNamesByBase.set(baseKey, connectorNames);
     }
   }
 
   return new Set(
-    [...counts.entries()]
-      .filter(([, count]) => {
-        return count > 1;
+    [...connectorNamesByBase.entries()]
+      .filter(([, connectorNames]) => {
+        return connectorNames.size > 1;
       })
       .map(([base]) => {
         return base;

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -88,7 +88,12 @@ const PYTHON_MODULE_HASH_LENGTH = 12;
 const PYTHON_JSON_PART_ASSIGNMENT_PREFIX = "JSON_PART = ";
 const DIAGNOSTIC_JSON_ASSIGNMENT_PREFIX =
   "MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS = json.loads(";
+const ARABIC_SCRIPT_PATTERN = /^\p{Script=Arabic}$/u;
+const ASCII_LETTER_PATTERN = /^[A-Za-z]$/;
+const ASCII_PUNCTUATION_PATTERN =
+  /^[\u0021-\u002f\u003a-\u0040\u005b-\u0060\u007b-\u007e]$/;
 const HEX_DIGIT_PATTERN = /^[0-9a-fA-F]$/;
+const UNICODE_MARK_PATTERN = /^\p{Mark}$/u;
 const PERCENT_DECODED_FORBIDDEN_HOST_CHARS = new Set([
   "#",
   "%",
@@ -111,6 +116,25 @@ const PERCENT_DECODED_FORBIDDEN_HOST_CHARS = new Set([
   "\uff0e",
   "\uff61",
 ]);
+const FORBIDDEN_RUNTIME_HOST_LABEL_CHARS = new Set([
+  "#",
+  "%",
+  ",",
+  "/",
+  ":",
+  "<",
+  ">",
+  "?",
+  "@",
+  "[",
+  "\\",
+  "]",
+  "^",
+  "|",
+  "{",
+  "}",
+  "*",
+]);
 // Fallback JSON string literals can double quotes and backslashes.
 const MAX_JSON_PART_SOURCE_CHARS = Math.floor(
   (MAX_GENERATED_PYTHON_LINE_LENGTH -
@@ -126,6 +150,25 @@ const MAX_DIAGNOSTIC_JSON_SOURCE_CHARS = Math.floor(
 );
 const DIAGNOSTIC_REFERENCE_NAME_PATTERN =
   /\b(?:secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)/g;
+const IDNA_DOT_VARIANT_PATTERN = /[\u3002\uff0e\uff61]/g;
+const IPV4_MAX_OCTET = 255;
+const UNSAFE_UTS46_COLLISION_CODEPOINTS = new Set([
+  0x03f2, 0x04c0, 0x1e9e, 0x1806, 0x2132, 0x2183, 0x3164, 0xffa0, 0xfffc,
+  0xfffd, 0x2f868, 0x2f874, 0x2f91f, 0x2f95f, 0x2f9bf,
+]);
+const UNSAFE_UTS46_COLLISION_RANGES = [
+  [0x10a0, 0x10c5],
+  [0x115f, 0x1160],
+  [0x17b4, 0x17b5],
+  [0x2ff0, 0x2ffb],
+] as const;
+const UNSAFE_UTS46_IGNORABLE_RANGES = [
+  [0x034f, 0x034f],
+  [0x180b, 0x180d],
+  [0x180f, 0x180f],
+  [0xfe00, 0xfe0f],
+  [0xe0100, 0xe01ef],
+] as const;
 
 function hasDynamicBaseMarker(base: string): boolean {
   return base.includes("{") || base.includes("}");
@@ -408,12 +451,12 @@ function isAuthoritySpaceOrControl(value: string): boolean {
   return false;
 }
 
-function percentDecodedHostnameEscapesAreRuntimeSafe(
-  hostname: string,
-): boolean {
+function percentDecodeRuntimeSafeHostname(hostname: string): string | null {
   let index = 0;
+  let decodedHostname = "";
   while (index < hostname.length) {
     if (hostname[index] !== "%") {
+      decodedHostname += hostname[index];
       index += 1;
       continue;
     }
@@ -428,7 +471,7 @@ function percentDecodedHostnameEscapesAreRuntimeSafe(
         !HEX_DIGIT_PATTERN.test(first) ||
         !HEX_DIGIT_PATTERN.test(second)
       ) {
-        return false;
+        return null;
       }
       encoded += `%${first}${second}`;
       index += 3;
@@ -438,15 +481,185 @@ function percentDecodedHostnameEscapesAreRuntimeSafe(
     try {
       decoded = decodeURIComponent(encoded);
     } catch {
-      return false;
+      return null;
     }
     if (isAuthoritySpaceOrControl(decoded)) {
-      return false;
+      return null;
     }
     for (const char of decoded) {
       if (PERCENT_DECODED_FORBIDDEN_HOST_CHARS.has(char)) {
-        return false;
+        return null;
       }
+    }
+    decodedHostname += decoded;
+  }
+  return decodedHostname;
+}
+
+function isIpv4NumberComponent(value: string): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+  if (value.toLowerCase().startsWith("0x")) {
+    return (
+      value.length > 2 &&
+      [...value.slice(2)].every((char) => {
+        return HEX_DIGIT_PATTERN.test(char);
+      })
+    );
+  }
+  return /^[0-9]+$/.test(value);
+}
+
+function isIpv4LiteralLike(hostname: string): boolean {
+  const parts = hostname.split(".");
+  return (
+    parts.length >= 1 &&
+    parts.length <= 4 &&
+    parts.every((part) => {
+      return isIpv4NumberComponent(part);
+    })
+  );
+}
+
+function isCanonicalIpv4Address(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+  return parts.every((part) => {
+    if (!/^[0-9]+$/.test(part)) {
+      return false;
+    }
+    if (part.length > 1 && part.startsWith("0")) {
+      return false;
+    }
+    return Number(part) <= IPV4_MAX_OCTET;
+  });
+}
+
+function isCodepointInRanges(
+  codepoint: number,
+  ranges: readonly (readonly [number, number])[],
+): boolean {
+  return ranges.some(([start, end]) => {
+    return codepoint >= start && codepoint <= end;
+  });
+}
+
+function hasUnsafeUts46MappingChars(value: string): boolean {
+  for (const char of value) {
+    const codepoint = char.codePointAt(0);
+    if (
+      codepoint !== undefined &&
+      (UNSAFE_UTS46_COLLISION_CODEPOINTS.has(codepoint) ||
+        isCodepointInRanges(codepoint, UNSAFE_UTS46_COLLISION_RANGES) ||
+        isCodepointInRanges(codepoint, UNSAFE_UTS46_IGNORABLE_RANGES))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasForbiddenRuntimeHostLabelChars(value: string): boolean {
+  for (const char of value) {
+    if (FORBIDDEN_RUNTIME_HOST_LABEL_CHARS.has(char)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasRuntimeIncompatibleArabicBidiLabel(value: string): boolean {
+  const chars = [...value];
+  const firstArabicIndex = chars.findIndex((char) => {
+    return ARABIC_SCRIPT_PATTERN.test(char);
+  });
+  if (firstArabicIndex === -1) {
+    return false;
+  }
+
+  const prefix = chars.slice(0, firstArabicIndex);
+  const suffix = chars.slice(firstArabicIndex + 1);
+  const prefixHasAsciiLetter = prefix.some((char) => {
+    return ASCII_LETTER_PATTERN.test(char);
+  });
+  if (
+    prefixHasAsciiLetter &&
+    suffix.some((char) => {
+      return !UNICODE_MARK_PATTERN.test(char);
+    })
+  ) {
+    return true;
+  }
+  if (
+    suffix.some((char) => {
+      return ASCII_LETTER_PATTERN.test(char);
+    })
+  ) {
+    return true;
+  }
+
+  const lastSuffixChar = suffix.at(-1);
+  return (
+    lastSuffixChar !== undefined &&
+    ASCII_PUNCTUATION_PATTERN.test(lastSuffixChar)
+  );
+}
+
+function stripRuntimeHostnameTrailingDot(hostname: string): string | null {
+  if (!hostname.endsWith(".")) {
+    return hostname;
+  }
+  const stripped = hostname.slice(0, -1);
+  return stripped.length > 0 && !stripped.endsWith(".") ? stripped : null;
+}
+
+function runtimeCompatibleHostname(
+  rawHostname: string,
+  parsedHostname: string,
+): boolean {
+  const decodedHostname = percentDecodeRuntimeSafeHostname(rawHostname);
+  if (decodedHostname === null || decodedHostname.includes("*")) {
+    return false;
+  }
+  if (decodedHostname.includes(":")) {
+    return true;
+  }
+
+  const dottedHostname = decodedHostname.replace(IDNA_DOT_VARIANT_PATTERN, ".");
+  const normalizedHostname = stripRuntimeHostnameTrailingDot(dottedHostname);
+  if (normalizedHostname === null || normalizedHostname.length === 0) {
+    return false;
+  }
+  if (isIpv4LiteralLike(normalizedHostname)) {
+    return isCanonicalIpv4Address(normalizedHostname);
+  }
+
+  const parsedLabels = stripSingleHostnameTrailingDot(
+    parsedHostname.toLowerCase(),
+  ).split(".");
+  const rawLabels = normalizedHostname.split(".");
+  if (rawLabels.length !== parsedLabels.length) {
+    return false;
+  }
+
+  for (let index = 0; index < rawLabels.length; index += 1) {
+    const rawLabel = rawLabels[index];
+    const parsedLabel = parsedLabels[index];
+    if (rawLabel === undefined || parsedLabel === undefined) {
+      return false;
+    }
+    if (
+      hasForbiddenRuntimeHostLabelChars(rawLabel) ||
+      hasUnsafeUts46MappingChars(rawLabel) ||
+      hasRuntimeIncompatibleArabicBidiLabel(rawLabel)
+    ) {
+      return false;
+    }
+    if (!/^[\x00-\x7f]*$/.test(rawLabel) && !parsedLabel.startsWith("xn--")) {
+      return false;
     }
   }
   return true;
@@ -472,10 +685,7 @@ function diagnosticStaticBaseKey(base: string): string | null {
   }
 
   const rawHostname = rawAuthorityHostname(rawAuthority);
-  if (
-    rawHostname === null ||
-    !percentDecodedHostnameEscapesAreRuntimeSafe(rawHostname)
-  ) {
+  if (rawHostname === null) {
     return null;
   }
 
@@ -489,6 +699,9 @@ function diagnosticStaticBaseKey(base: string): string | null {
       url.hash !== "" ||
       hostnameHasEmptyLabel(url.hostname.toLowerCase())
     ) {
+      return null;
+    }
+    if (!runtimeCompatibleHostname(rawHostname, url.hostname)) {
       return null;
     }
 

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -97,6 +97,10 @@ const ASCII_PUNCTUATION_PATTERN =
 const HEX_DIGIT_PATTERN = /^[0-9a-fA-F]$/;
 const UNICODE_MARK_PATTERN = /^\p{Mark}$/u;
 const UNICODE_OTHER_PATTERN = /^\p{Other}$/u;
+const GREEK_CAPITAL_SIGMA = "\u03a3";
+const GREEK_COMBINING_YPOGEGRAMMENI = "\u0345";
+const GREEK_SMALL_IOTA = "\u03b9";
+const GREEK_SMALL_SIGMA = "\u03c3";
 const PERCENT_DECODED_FORBIDDEN_HOST_CHARS = new Set([
   "#",
   "%",
@@ -157,6 +161,24 @@ const FORBIDDEN_RUNTIME_NORMALIZED_HOST_LABEL_CHARS = new Set([
   "\u3002",
   "\uff0e",
   "\uff61",
+]);
+const GREEK_MATHEMATICAL_FINAL_SIGMA_CODEPOINTS = new Set([
+  0x1d6d3, 0x1d70d, 0x1d747, 0x1d781, 0x1d7bb,
+]);
+const CHEROKEE_CASEFOLD_RANGES = [
+  [0x13a0, 0x13ff],
+  [0xab70, 0xabbf],
+] as const;
+const CYRILLIC_EXTENDED_C_CASEFOLD_CODEPOINTS = new Map([
+  [0x1c80, "\u0432"],
+  [0x1c81, "\u0434"],
+  [0x1c82, "\u043e"],
+  [0x1c83, "\u0441"],
+  [0x1c84, "\u0442"],
+  [0x1c85, "\u0442"],
+  [0x1c86, "\u044a"],
+  [0x1c87, "\u0463"],
+  [0x1c88, "\ua64b"],
 ]);
 // Fallback JSON string literals can double quotes and backslashes.
 const MAX_JSON_PART_SOURCE_CHARS = Math.floor(
@@ -594,11 +616,55 @@ function hasForbiddenRuntimeHostLabelChars(value: string): boolean {
   return false;
 }
 
+function remapRuntimeLabelChar(char: string): string {
+  const codepoint = char.codePointAt(0);
+  if (codepoint === undefined) {
+    return char;
+  }
+  if (GREEK_MATHEMATICAL_FINAL_SIGMA_CODEPOINTS.has(codepoint)) {
+    return GREEK_SMALL_SIGMA;
+  }
+  if (
+    (codepoint === 0x037a || (codepoint >= 0x1f00 && codepoint < 0x2000)) &&
+    char.normalize("NFKD").includes(GREEK_COMBINING_YPOGEGRAMMENI)
+  ) {
+    return char
+      .normalize("NFKD")
+      .replaceAll(GREEK_COMBINING_YPOGEGRAMMENI, GREEK_SMALL_IOTA);
+  }
+  return char;
+}
+
+function runtimeCasefoldLabelChar(char: string): string {
+  const codepoint = char.codePointAt(0);
+  if (codepoint === undefined) {
+    return char;
+  }
+  if (isCodepointInRanges(codepoint, CHEROKEE_CASEFOLD_RANGES)) {
+    return char.toUpperCase();
+  }
+
+  const cyrillicCasefold =
+    CYRILLIC_EXTENDED_C_CASEFOLD_CODEPOINTS.get(codepoint);
+  if (cyrillicCasefold !== undefined) {
+    return cyrillicCasefold;
+  }
+  if (char === GREEK_CAPITAL_SIGMA) {
+    return GREEK_SMALL_SIGMA;
+  }
+  return char.toLowerCase();
+}
+
 function runtimeLowerNormalizedLabel(value: string): string {
-  // Match Python's normalize-then-per-codepoint-lower order.
-  return [...value.normalize("NFKD").normalize("NFC")]
+  // Match Python's remap, normalize, then per-codepoint casefold order.
+  const remapped = [...value]
+    .map(remapRuntimeLabelChar)
+    .join("")
+    .replaceAll(GREEK_COMBINING_YPOGEGRAMMENI, GREEK_SMALL_IOTA);
+
+  return [...remapped.normalize("NFKD").normalize("NFC")]
     .map((char) => {
-      return char === "\u03a3" ? "\u03c3" : char.toLowerCase();
+      return runtimeCasefoldLabelChar(char);
     })
     .join("");
 }

--- a/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
+++ b/turbo/packages/firewalls-generator/src/python-builtin-firewall-catalog.ts
@@ -88,7 +88,9 @@ const PYTHON_MODULE_HASH_LENGTH = 12;
 const PYTHON_JSON_PART_ASSIGNMENT_PREFIX = "JSON_PART = ";
 const DIAGNOSTIC_JSON_ASSIGNMENT_PREFIX =
   "MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS = json.loads(";
-const ARABIC_SCRIPT_PATTERN = /^\p{Script=Arabic}$/u;
+// Scripts that Node URL accepts directly but Python's bidi validation can reject.
+const RUNTIME_BIDI_RTL_SCRIPT_PATTERN =
+  /^(?:\p{Script=Arabic}|\p{Script=Old_Uyghur})$/u;
 const ASCII_LETTER_PATTERN = /^[A-Za-z]$/;
 const ASCII_PUNCTUATION_PATTERN =
   /^[\u0021-\u002f\u003a-\u0040\u005b-\u0060\u007b-\u007e]$/;
@@ -571,17 +573,22 @@ function hasForbiddenRuntimeHostLabelChars(value: string): boolean {
   return false;
 }
 
-function hasRuntimeIncompatibleArabicBidiLabel(value: string): boolean {
+function hasRuntimeLeadingUnicodeMarkLabel(value: string): boolean {
+  const firstChar = [...value.normalize("NFKD").normalize("NFC")][0];
+  return firstChar !== undefined && UNICODE_MARK_PATTERN.test(firstChar);
+}
+
+function hasRuntimeIncompatibleBidiLabel(value: string): boolean {
   const chars = [...value];
-  const firstArabicIndex = chars.findIndex((char) => {
-    return ARABIC_SCRIPT_PATTERN.test(char);
+  const firstRtlIndex = chars.findIndex((char) => {
+    return RUNTIME_BIDI_RTL_SCRIPT_PATTERN.test(char);
   });
-  if (firstArabicIndex === -1) {
+  if (firstRtlIndex === -1) {
     return false;
   }
 
-  const prefix = chars.slice(0, firstArabicIndex);
-  const suffix = chars.slice(firstArabicIndex + 1);
+  const prefix = chars.slice(0, firstRtlIndex);
+  const suffix = chars.slice(firstRtlIndex + 1);
   const prefixHasAsciiLetter = prefix.some((char) => {
     return ASCII_LETTER_PATTERN.test(char);
   });
@@ -654,7 +661,8 @@ function runtimeCompatibleHostname(
     if (
       hasForbiddenRuntimeHostLabelChars(rawLabel) ||
       hasUnsafeUts46MappingChars(rawLabel) ||
-      hasRuntimeIncompatibleArabicBidiLabel(rawLabel)
+      hasRuntimeLeadingUnicodeMarkLabel(rawLabel) ||
+      hasRuntimeIncompatibleBidiLabel(rawLabel)
     ) {
       return false;
     }


### PR DESCRIPTION
## Summary

- add route-aware shared-base ownership resolution for connector diagnostics
- return the existing `connector_not_configured_for_run` local response before active connector auth injection when an inactive sibling owns the request
- add and strip `X-VM0-Connector-Intent` as an internal, candidate-set-only tie-breaker hint
- generate connector diagnostic route metadata only for shared static bases to avoid bloating the generated catalog

Fixes #19906.

## Verification

- `cd crates/runner/mitm-addon && python3 -m ruff format --check . && python3 -m ruff check .`
- `cd crates/runner/mitm-addon && python3 -m basedpyright -p .`
- `cd crates/runner/mitm-addon && python3 -m pytest -q` (`3503 passed`)
- `cd turbo && pnpm -F @vm0/firewalls-generator check-types`
- `cd turbo && pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/python-builtin-firewall-catalog.test.ts src/__tests__/python-builtin-firewall-catalog-composition.test.ts`
- `cd turbo && pnpm -F @vm0/firewalls-generator generate`

Note: local pre-commit hooks were run once and ruff/prettier passed, but full `knip` failed on existing unrelated unused exports in `apps/platform` and an existing firewalls-generator unused export. The commit was created with `--no-verify` after the targeted checks above passed.
