### PR TITLE
refactor: retire PresentationTemplateRunbook feature switch, make runbook flow the default

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -52,7 +52,7 @@ describe("buildGenerationTemplatePrompt", () => {
     );
   });
 
-  it("builds presentation template guidance for the switched picker catalog", () => {
+  it("builds runbook presentation guidance for a template that ships a runbook package", () => {
     const item = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
 
     const result = buildGenerationTemplatePrompt({
@@ -63,39 +63,6 @@ describe("buildGenerationTemplatePrompt", () => {
         templateId: item.templateId,
       },
     });
-
-    expect(result.status).toBe("resolved");
-    if (result.status !== "resolved") {
-      return;
-    }
-    expect(result.prompt).toContain("Playful Launch Presentation");
-    expect(result.prompt).toContain(`(${item.designSystemId})`);
-    expect(result.prompt).toContain(`(${item.templateId})`);
-    expect(result.prompt).toContain("Color system: Carnival");
-    expect(result.prompt).toContain("color-system:carnival");
-    expect(result.prompt).toContain(
-      "Apply the selected color system (color-system:carnival)",
-    );
-    expect(result.prompt).toContain("media seed names");
-    expect(result.prompt).toContain(
-      `zero generate presentation --design-system ${item.designSystemId} --template ${item.templateId}`,
-    );
-  });
-
-  it("builds runbook presentation guidance when the switch is on", () => {
-    const item = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
-
-    const result = buildGenerationTemplatePrompt(
-      {
-        type: "presentation",
-        selection: {
-          colorSystemId: item.colorSystemId,
-          designSystemId: item.designSystemId,
-          templateId: item.templateId,
-        },
-      },
-      { presentationRunbookEnabled: true },
-    );
 
     expect(result.status).toBe("resolved");
     if (result.status !== "resolved") {
@@ -119,19 +86,16 @@ describe("buildGenerationTemplatePrompt", () => {
     expect(result.prompt).not.toContain("zero generate presentation");
   });
 
-  it("falls back to the default color token when none is selected (runbook on)", () => {
+  it("falls back to the default color token when none is selected", () => {
     const item = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
 
-    const result = buildGenerationTemplatePrompt(
-      {
-        type: "presentation",
-        selection: {
-          designSystemId: item.designSystemId,
-          templateId: item.templateId,
-        },
+    const result = buildGenerationTemplatePrompt({
+      type: "presentation",
+      selection: {
+        designSystemId: item.designSystemId,
+        templateId: item.templateId,
       },
-      { presentationRunbookEnabled: true },
-    );
+    });
 
     expect(result.status).toBe("resolved");
     if (result.status !== "resolved") {
@@ -141,13 +105,14 @@ describe("buildGenerationTemplatePrompt", () => {
     expect(result.prompt).toContain('"colorSystem": "carnival"');
   });
 
-  it("uses the legacy presentation flow when the switch is off", () => {
-    const item = PRESENTATION_TEMPLATE_PICKER_ITEMS[0]!;
+  it("uses the legacy multi-resource flow for a template without a runbook package", () => {
+    // PRESENTATION_TEMPLATE_ITEMS[0] ships no runbook package, so it resolves
+    // through the legacy design-system + `zero generate presentation` flow.
+    const item = PRESENTATION_TEMPLATE_ITEMS[0]!;
 
     const result = buildGenerationTemplatePrompt({
       type: "presentation",
       selection: {
-        colorSystemId: item.colorSystemId,
         designSystemId: item.designSystemId,
         templateId: item.templateId,
       },

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -57,18 +57,8 @@ type GenerationTemplatePromptResult =
       readonly message: string;
     };
 
-interface BuildGenerationTemplatePromptOptions {
-  /**
-   * When true, presentation templates that ship a self-contained runbook package
-   * use the runbook flow (pull one resource, follow AGENT_RUNBOOK.md, pick the
-   * color system at runtime). When false, the legacy multi-resource flow is used.
-   */
-  readonly presentationRunbookEnabled?: boolean;
-}
-
 export function buildGenerationTemplatePrompt(
   generationTemplate: GenerationTemplateInput | null | undefined,
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   if (!generationTemplate) {
     return { status: "resolved", prompt: "" };
@@ -84,7 +74,7 @@ export function buildGenerationTemplatePrompt(
     return buildWorkflowGenerationTemplatePrompt(generationTemplate);
   }
 
-  return buildPresentationGenerationTemplatePrompt(generationTemplate, options);
+  return buildPresentationGenerationTemplatePrompt(generationTemplate);
 }
 
 // Shared framing for every artifact-template block, kept in one place so the
@@ -125,7 +115,6 @@ function buildWorkflowGenerationTemplatePrompt(
 
 function buildPresentationGenerationTemplatePrompt(
   generationTemplate: PresentationGenerationTemplateInput,
-  options?: BuildGenerationTemplatePromptOptions,
 ): GenerationTemplatePromptResult {
   const template = findTemplate(generationTemplate.selection.templateId);
   if (!template) {
@@ -138,9 +127,13 @@ function buildPresentationGenerationTemplatePrompt(
     };
   }
 
-  const runbookPackage = options?.presentationRunbookEnabled
-    ? findPresentationRunbookPackage(generationTemplate.selection.templateId)
-    : undefined;
+  // Presentation templates that ship a self-contained runbook package use the
+  // runbook flow (pull one resource, follow AGENT_RUNBOOK.md, pick the color
+  // system at runtime). Templates without a package fall back to the legacy
+  // multi-resource flow below.
+  const runbookPackage = findPresentationRunbookPackage(
+    generationTemplate.selection.templateId,
+  );
   if (runbookPackage) {
     return buildPresentationRunbookPrompt(
       generationTemplate,

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -177,7 +177,7 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
     "b4639811099781c662a9671126762c67c1cc726e7a545b7bfbed18032faace9b",
   "template:html-ppt-vantage":
     "93e9a05f8c9c7f5ad99b51b1b9dae87a16d026782458edcfa629a514242de3f6",
-  // Presentation runbook packages (feature: presentationTemplateRunbook).
+  // Presentation runbook packages (self-contained per-template archives).
   "template:html-ppt-playful-launch-runbook":
     "1c46e7d953de0ea47924b9e9936433d7ede1d21ac595f62cbcdee160bded6c26",
   "template:html-ppt-bloom-pitch-runbook":

--- a/turbo/apps/api/src/signals/routes/thread-generation-template.ts
+++ b/turbo/apps/api/src/signals/routes/thread-generation-template.ts
@@ -15,13 +15,10 @@ import { buildGenerationTemplatePrompt } from "./generation-template-prompt";
  */
 export function resolveThreadGenerationTemplatePrompt(args: {
   readonly explicit: GenerationTemplateRequest | null | undefined;
-  readonly presentationRunbookEnabled?: boolean;
 }): string {
   if (!args.explicit) {
     return "";
   }
-  const built = buildGenerationTemplatePrompt(args.explicit, {
-    presentationRunbookEnabled: args.presentationRunbookEnabled,
-  });
+  const built = buildGenerationTemplatePrompt(args.explicit);
   return built.status === "resolved" ? built.prompt : "";
 }

--- a/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-messages.ts
@@ -217,7 +217,6 @@ interface PreparedNormalSend {
 
 interface NormalSendFeatureSwitches {
   readonly codexFastModeEnabled: boolean;
-  readonly presentationRunbookEnabled: boolean;
   readonly initialThinkingEnabled: boolean;
 }
 
@@ -1368,10 +1367,6 @@ async function resolveNormalSendFeatureSwitches(
       FeatureSwitchKey.CodexFastMode,
       context,
     ),
-    presentationRunbookEnabled: isFeatureEnabled(
-      FeatureSwitchKey.PresentationTemplateRunbook,
-      context,
-    ),
     initialThinkingEnabled:
       isFeatureEnabled(
         FeatureSwitchKey.ChatInitialThinkingIndicator,
@@ -2291,7 +2286,6 @@ const prepareNormalSend$ = command(
     signal.throwIfAborted();
     const generationTemplatePrompt = resolveThreadGenerationTemplatePrompt({
       explicit: args.body.generationTemplate,
-      presentationRunbookEnabled: featureSwitches.presentationRunbookEnabled,
     });
     const persistedExplicitSelection =
       await maybePersistExplicitModelFirstSelection({

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -73,12 +73,9 @@ import {
 } from "./zero-chat-title.service";
 import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
-import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { describeGenerationTemplateSelection } from "../routes/generation-template-prompt";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
-import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
 const log = logger("callback:chat");
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
@@ -2000,22 +1997,6 @@ async function buildCreateQueuedChatRunInput(args: {
       });
     },
   );
-  const featureSwitchContext = await measureChatCallbackPreCreateTiming(
-    args.timing,
-    "api_dispatch_pre_create_zero_chat_callback_auto_send_load_feature_switch_context",
-    "nested",
-    () => {
-      return loadUserFeatureSwitchContext(
-        args.db,
-        args.agent.orgId,
-        args.userId,
-      );
-    },
-  );
-  const presentationRunbookEnabled = isFeatureEnabled(
-    FeatureSwitchKey.PresentationTemplateRunbook,
-    featureSwitchContext,
-  );
   const generationTemplatePrompt = await measureChatCallbackPreCreateTiming(
     args.timing,
     "api_dispatch_pre_create_zero_chat_callback_auto_send_resolve_generation_template",
@@ -2023,7 +2004,6 @@ async function buildCreateQueuedChatRunInput(args: {
     () => {
       return resolveThreadGenerationTemplatePrompt({
         explicit: resolvedQueuedMessage.generationTemplate,
-        presentationRunbookEnabled,
       });
     },
   );

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -52,7 +52,6 @@ export enum FeatureSwitchKey {
   ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   DesktopX64Download = "desktopX64Download",
-  PresentationTemplateRunbook = "presentationTemplateRunbook",
   PresentationImageUnsplashPreferred = "presentationImageUnsplashPreferred",
   AgentUnreadIndicators = "agentUnreadIndicators",
   ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -298,13 +298,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.PresentationTemplateRunbook]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Generate presentations from a selected template via its self-contained runbook package: the agent pulls one R2 archive, follows AGENT_RUNBOOK.md, and selects a color system at runtime. When off, presentation generation uses the legacy multi-resource selection flow.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.PresentationImageUnsplashPreferred]: {
     maintainer: "bingjie@vm0.ai",
     description:

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -4346,12 +4346,13 @@ const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
 
 // ── Presentation runbook packages ────────────────────────────────────────────
 // Self-contained per-template presentation packages (agent runbook + renderer)
-// uploaded to private R2 as one archive each. Gated behind the
-// `presentationTemplateRunbook` feature switch: when on, the agent pulls exactly
-// one of these by template, then selects a color system at runtime — no separate
-// design system or color archive to resolve. These are intentionally NOT part of
-// RESOURCE_REGISTRY so they never leak into the legacy multi-resource candidate
-// slice (selectResourceCandidates) or listTemplates.
+// uploaded to private R2 as one archive each. When a selected template ships one
+// of these, the agent pulls exactly that archive by template, then selects a
+// color system at runtime — no separate design system or color archive to
+// resolve. Templates without a package fall back to the legacy multi-resource
+// flow. These are intentionally NOT part of RESOURCE_REGISTRY so they never leak
+// into the legacy multi-resource candidate slice (selectResourceCandidates) or
+// listTemplates.
 
 export interface PresentationRunbookPackage {
   /** Picker template id (the legacy `template:html-ppt-*` id the user selects). */


### PR DESCRIPTION
## What

The `PresentationTemplateRunbook` flow is ready to go 100%, so instead of just flipping the switch to `enabled: true`, this **removes the switch entirely** and makes the runbook package the permanent, unconditional behavior — retiring the flag and its dead branching in one step.

Supersedes #19963 (the interim `enabled: true` rollout), which I'll close in favor of this.

## User-visible impact

No behavior change versus the switch being on for everyone:
- Presentation templates that **ship a runbook package** (the 24 `template:html-ppt-*` picker templates) resolve via the self-contained runbook flow: pull one R2 archive, follow `AGENT_RUNBOOK.md`, select a color system at runtime.
- Templates **without** a runbook package continue to use the legacy multi-resource flow (design system + `zero generate presentation`) — this fallback is preserved, not deleted.

## Implementation

- Delete the switch's registry entry (`feature-switch.ts`) and its `FeatureSwitchKey` enum member (`feature-switch-key.ts`).
- `buildGenerationTemplatePrompt` now always calls `findPresentationRunbookPackage(...)`; the `presentationRunbookEnabled` option and `BuildGenerationTemplatePromptOptions` are gone.
- Drop the option from `resolveThreadGenerationTemplatePrompt` and both call sites — the normal-send route (`zero-chat-messages.ts`) and the auto-send callback (`internal-chat-run-callback.service.ts`). The callback no longer loads a feature-switch context solely for this flag, so the now-unused `loadUserFeatureSwitchContext` / `isFeatureEnabled` / `FeatureSwitchKey` imports are removed.
- Refresh the runbook-package registry comments that referenced the switch.

## Tests

`generation-template-prompt.test.ts` updated: runbook output is now the default for a packaged template (`playful-launch`), and an explicit legacy-fallback case is kept using `PRESENTATION_TEMPLATE_ITEMS[0]` (`pitch-deck`), which ships no runbook package. The switch-on/switch-off test pairs are collapsed accordingly. The registry test iterates `Object.values(FeatureSwitchKey)` dynamically, so dropping the key needs no snapshot update.

## Verification

Prettier-formatted with the repo-pinned major (`^3.6.2`) style; relying on the PR pipeline for lint/type/test per team preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)