### PR TITLE
fix: coalesce runner direct candidate bursts

### DIFF
--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -100,6 +100,8 @@ use orphan_reap::{
 };
 use signals::{EarlySignals, SignalController, handle_stopping_signal, recv_handler_task};
 
+const READY_DIRECT_CANDIDATE_DRAIN_LIMIT: usize = 8;
+
 struct TeardownTimer {
     start: Instant,
 }
@@ -1402,6 +1404,48 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         "session affinity state triggered immediate heartbeat"
                     );
                     send_heartbeat(&hb_ctx, live_mode).await;
+                }
+                let mut drained_ready_candidates = 0;
+                while drained_ready_candidates < READY_DIRECT_CANDIDATE_DRAIN_LIMIT {
+                    let live_mode = *mode_rx.borrow();
+                    if !matches!(live_mode, RunnerMode::Running) {
+                        break;
+                    }
+                    if !capacity
+                        .budget
+                        .can_afford(capacity.min_vcpu, capacity.min_memory_mb)
+                    {
+                        break;
+                    }
+                    let Some(candidate) = provider_state.provider.try_discover_ready().await else {
+                        break;
+                    };
+                    drained_ready_candidates += 1;
+                    let needs_session_affinity_refresh = handle_discovered_job(
+                        DiscoveredJob { candidate },
+                        DiscoveredJobContext {
+                            profiles: &runner.profiles,
+                            factories: &factories,
+                            budget: &capacity.budget,
+                            idle_pool: &shared.idle_pool,
+                            status: &shared.status,
+                            mode_rx: &mode_rx,
+                            cancel_tokens: &provider_state.cancel_tokens,
+                            spawn_ctx: &spawn_ctx,
+                            destroy_tasks: &mut destroy_tasks,
+                            jobs: &mut jobs,
+                        },
+                    ).await;
+                    let live_mode = *mode_rx.borrow();
+                    if needs_session_affinity_refresh
+                        && matches!(live_mode, RunnerMode::Running | RunnerMode::Draining)
+                    {
+                        info!(
+                            source = "ready_direct_candidate_drain",
+                            "session affinity state triggered immediate heartbeat"
+                        );
+                        send_heartbeat(&hb_ctx, live_mode).await;
+                    }
                 }
             }
             // Mode changes (signals)

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -250,6 +250,89 @@ async fn affinity_protected_candidate_without_local_session_defers_before_claim(
 }
 
 #[tokio::test(start_paused = true)]
+async fn ready_direct_drain_continues_after_affinity_defer() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let trigger_run_id = RunId::new_v4();
+    let protected_run_id = RunId::new_v4();
+    let followup_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        protected_run_id,
+        Some(context_with_session(
+            protected_run_id,
+            "sess-owned-elsewhere",
+        )),
+    );
+    env.provider
+        .set_claim_result(followup_run_id, Some(minimal_context(followup_run_id)));
+    env.handle
+        .push_ready_candidate(affinity_protected_candidate(
+            protected_run_id,
+            "sess-owned-elsewhere",
+        ));
+    env.handle
+        .push_ready_candidate(crate::provider::JobCandidate::new(
+            followup_run_id,
+            "vm0/default".into(),
+        ));
+
+    push_job(
+        &env,
+        trigger_run_id,
+        "vm0/default",
+        Some(minimal_context(trigger_run_id)),
+    );
+
+    let trigger_completion = env
+        .handle
+        .wait_completion(trigger_run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        trigger_completion.is_some(),
+        "trigger job should complete before ready-candidate drain assertions"
+    );
+    let followup_completion = env
+        .handle
+        .wait_completion(followup_run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        followup_completion.is_some(),
+        "ready drain should continue to a later candidate after deferring a protected one"
+    );
+    wait_cancel_token_removed(&env.cancel_tokens, protected_run_id, Duration::from_secs(5)).await;
+
+    let claim_candidates = env.handle.claim_candidates();
+    assert!(
+        claim_candidates
+            .iter()
+            .any(|candidate| candidate.run_id() == trigger_run_id),
+        "trigger candidate should be claimed"
+    );
+    assert!(
+        claim_candidates
+            .iter()
+            .any(|candidate| candidate.run_id() == followup_run_id),
+        "follow-up ready candidate should be claimed"
+    );
+    assert!(
+        !claim_candidates
+            .iter()
+            .any(|candidate| candidate.run_id() == protected_run_id),
+        "protected ready candidate should be deferred before claim"
+    );
+    assert_eq!(
+        env.handle.deferred_poll_delays().len(),
+        1,
+        "protected ready candidate should schedule one follow-up poll"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn affinity_protected_candidate_with_local_session_claims() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -333,6 +333,69 @@ async fn ready_direct_drain_continues_after_affinity_defer() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn ready_direct_drain_continues_after_claim_conflict() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let trigger_run_id = RunId::new_v4();
+    let conflict_run_id = RunId::new_v4();
+    let followup_run_id = RunId::new_v4();
+    env.provider.set_claim_result(conflict_run_id, None);
+    env.provider
+        .set_claim_result(followup_run_id, Some(minimal_context(followup_run_id)));
+    env.handle
+        .push_ready_candidate(crate::provider::JobCandidate::new(
+            conflict_run_id,
+            "vm0/default".into(),
+        ));
+    env.handle
+        .push_ready_candidate(crate::provider::JobCandidate::new(
+            followup_run_id,
+            "vm0/default".into(),
+        ));
+
+    push_job(
+        &env,
+        trigger_run_id,
+        "vm0/default",
+        Some(minimal_context(trigger_run_id)),
+    );
+
+    let trigger_completion = env
+        .handle
+        .wait_completion(trigger_run_id, Duration::from_secs(5))
+        .await;
+    assert!(trigger_completion.is_some(), "trigger job should complete");
+    let followup_completion = env
+        .handle
+        .wait_completion(followup_run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        followup_completion.is_some(),
+        "ready drain should continue to a later candidate after a claim conflict"
+    );
+    wait_cancel_token_removed(&env.cancel_tokens, conflict_run_id, Duration::from_secs(5)).await;
+
+    let claim_candidates = env.handle.claim_candidates();
+    assert!(
+        claim_candidates
+            .iter()
+            .any(|candidate| candidate.run_id() == conflict_run_id),
+        "claim conflict candidate should reach claim"
+    );
+    assert!(
+        claim_candidates
+            .iter()
+            .any(|candidate| candidate.run_id() == followup_run_id),
+        "follow-up ready candidate should still be claimed"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn affinity_protected_candidate_with_local_session_claims() {
     let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
     let budget = Arc::clone(&config.capacity.budget);

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -12,9 +11,9 @@ use reqwest::{RequestBuilder, Response, StatusCode};
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::api_ably_supervisor::{
-    AblySupervisor, AblySupervisorConfig, DirectCandidateSenders, DirectJobCandidate, PollDue,
-    PollOutcome, PollReason, PollWakeups,
+    AblySupervisor, AblySupervisorConfig, PollDue, PollOutcome, PollReason, PollWakeups,
 };
+use super::api_direct_candidates::{DirectCandidateInbox, DirectJobCandidate};
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
 };
@@ -68,7 +67,7 @@ const POLL_SLOW: Duration = Duration::from_secs(30);
 const POLL_FAST: Duration = Duration::from_secs(5);
 /// Retry delay after a job-notification wakeup reaches poll but poll fails.
 const POLL_WAKEUP_RETRY: Duration = POLL_FAST;
-const DIRECT_CANDIDATE_QUEUE_CAPACITY: usize = 128;
+const DIRECT_CANDIDATE_INBOX_CAPACITY: usize = 128;
 
 enum DiscoveryWakeup {
     Direct(DirectJobCandidate),
@@ -96,8 +95,7 @@ pub struct ApiProvider {
     /// Coalesced poll wakeup state updated by the Ably supervisor.
     poll_wakeups: Arc<PollWakeups>,
     /// Supported direct job candidates delivered by Ably notifications.
-    _direct_candidate_tx: mpsc::Sender<DirectJobCandidate>,
-    direct_candidate_rx: tokio::sync::Mutex<mpsc::Receiver<DirectJobCandidate>>,
+    direct_candidates: Arc<DirectCandidateInbox>,
     /// Background Ably control-plane task.
     ably_supervisor: AblySupervisor,
     /// Shutdown signal.
@@ -116,14 +114,13 @@ impl ApiProvider {
     ) -> Arc<Self> {
         let api = ApiClient::new(http, token);
         let poll_wakeups = Arc::new(PollWakeups::new(false));
-        let (direct_candidate_tx, direct_candidate_rx) =
-            mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
+        let direct_candidates = DirectCandidateInbox::new(DIRECT_CANDIDATE_INBOX_CAPACITY);
         let ably_supervisor = AblySupervisor::spawn(AblySupervisorConfig {
             api: api.clone(),
             group: group.clone(),
             profiles: profiles.clone(),
             poll_wakeups: Arc::clone(&poll_wakeups),
-            direct_candidate_senders: DirectCandidateSenders::new(direct_candidate_tx.clone()),
+            direct_candidates: Arc::clone(&direct_candidates),
             cancel_tokens,
             provider_cancel: cancel.clone(),
         });
@@ -133,42 +130,18 @@ impl ApiProvider {
             group,
             profiles,
             poll_wakeups,
-            _direct_candidate_tx: direct_candidate_tx,
-            direct_candidate_rx: tokio::sync::Mutex::new(direct_candidate_rx),
+            direct_candidates,
             ably_supervisor,
             cancel,
         })
     }
 
     async fn try_recv_direct_candidate(&self) -> Option<DirectJobCandidate> {
-        let mut direct_candidate_rx = self.direct_candidate_rx.lock().await;
-        match direct_candidate_rx.try_recv() {
-            Ok(candidate) => Some(candidate),
-            Err(mpsc::error::TryRecvError::Empty) => None,
-            Err(mpsc::error::TryRecvError::Disconnected) => None,
-        }
+        self.direct_candidates.try_pop().await
     }
 
     async fn wait_for_direct_candidate(&self) -> Option<DirectJobCandidate> {
-        loop {
-            if let Some(candidate) = self.try_recv_direct_candidate().await {
-                return Some(candidate);
-            }
-
-            let mut direct_candidate_rx = self.direct_candidate_rx.lock().await;
-
-            tokio::select! {
-                biased;
-                () = self.cancel.cancelled() => {
-                    return None;
-                }
-                candidate = direct_candidate_rx.recv() => {
-                    if let Some(candidate) = candidate {
-                        return Some(candidate);
-                    }
-                }
-            }
-        }
+        self.direct_candidates.wait_pop(&self.cancel).await
     }
 
     async fn wait_for_discovery_wakeup(&self) -> Option<DiscoveryWakeup> {
@@ -289,6 +262,18 @@ impl JobProvider for ApiProvider {
                 }
             }
         }
+    }
+
+    async fn try_discover_ready(&self) -> Option<JobCandidate> {
+        let direct = self.try_recv_direct_candidate().await?;
+        let run_id = direct.run_id();
+        let profile = direct.profile_name().to_owned();
+        info!(
+            run_id = %run_id,
+            profile = %profile,
+            "ably: ready direct job candidate drained"
+        );
+        Some(direct.into_job_candidate())
     }
 
     async fn claim(&self, candidate: JobCandidate) -> Option<ClaimedJob> {
@@ -876,8 +861,6 @@ mod tests {
         cancel: CancellationToken,
         poll_wakeups: Arc<PollWakeups>,
     ) -> Arc<ApiProvider> {
-        let (direct_candidate_tx, direct_candidate_rx) =
-            mpsc::channel(DIRECT_CANDIDATE_QUEUE_CAPACITY);
         Arc::new(ApiProvider {
             api: ApiClient::new(
                 HttpClient::new(HttpClientConfig {
@@ -890,11 +873,14 @@ mod tests {
             group: "default".to_string(),
             profiles: Vec::new(),
             poll_wakeups,
-            _direct_candidate_tx: direct_candidate_tx,
-            direct_candidate_rx: tokio::sync::Mutex::new(direct_candidate_rx),
+            direct_candidates: DirectCandidateInbox::new(DIRECT_CANDIDATE_INBOX_CAPACITY),
             ably_supervisor: AblySupervisor::disabled(),
             cancel,
         })
+    }
+
+    async fn push_direct_candidate_for_test(provider: &ApiProvider, candidate: DirectJobCandidate) {
+        provider.direct_candidates.push(candidate).await;
     }
 
     async fn read_http_request(socket: &mut tokio::net::TcpStream) {
@@ -1211,14 +1197,15 @@ mod tests {
         let discovered_at = Instant::now()
             .checked_sub(Duration::from_millis(25))
             .unwrap();
-        provider
-            ._direct_candidate_tx
-            .try_send(DirectJobCandidate::new_with_discovered_at(
+        push_direct_candidate_for_test(
+            &provider,
+            DirectJobCandidate::new_with_discovered_at(
                 run_id,
                 crate::profile::DEFAULT_PROFILE.to_string(),
                 discovered_at,
-            ))
-            .unwrap();
+            ),
+        )
+        .await;
 
         let discovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
@@ -1234,6 +1221,43 @@ mod tests {
         assert!(discovered.job_discovered_elapsed() >= Duration::from_millis(25));
         assert!(discovered.poll_due_to_job_discovered_elapsed().is_none());
         assert!(discovered.poll_http_request_elapsed().is_none());
+        poll_mock.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn try_discover_ready_returns_buffered_direct_candidate_without_polling() {
+        let server = MockServer::start_async().await;
+        let run_id: RunId = "00000000-0000-0000-0000-000000000016".parse().unwrap();
+        let poll_mock = server
+            .mock_async(|when, then| {
+                when.method(POST).path(routes::runners::poll::POLL.path);
+                then.status(200)
+                    .json_body(serde_json::json!({ "job": null }));
+            })
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+        push_direct_candidate_for_test(
+            &provider,
+            DirectJobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string()),
+        )
+        .await;
+
+        let discovered = provider
+            .try_discover_ready()
+            .await
+            .expect("ready candidate should be available");
+
+        assert_eq!(discovered.run_id(), run_id);
+        assert_eq!(discovered.profile_name(), crate::profile::DEFAULT_PROFILE);
+        assert_eq!(
+            discovered.discovery_source(),
+            Some(JobDiscoverySource::Ably)
+        );
+        assert!(provider.try_discover_ready().await.is_none());
         poll_mock.assert_calls_async(0).await;
     }
 
@@ -1280,13 +1304,11 @@ mod tests {
             CancellationToken::new(),
             Arc::clone(&wakeups),
         );
-        provider
-            ._direct_candidate_tx
-            .try_send(DirectJobCandidate::new(
-                run_id,
-                crate::profile::DEFAULT_PROFILE.to_string(),
-            ))
-            .unwrap();
+        push_direct_candidate_for_test(
+            &provider,
+            DirectJobCandidate::new(run_id, crate::profile::DEFAULT_PROFILE.to_string()),
+        )
+        .await;
 
         let direct = tokio::time::timeout(Duration::from_secs(1), provider.discover())
             .await
@@ -1339,13 +1361,11 @@ mod tests {
             .await
             .expect("poll should reach the server")
             .unwrap();
-        provider
-            ._direct_candidate_tx
-            .try_send(DirectJobCandidate::new(
-                direct_run_id,
-                crate::profile::DEFAULT_PROFILE.to_string(),
-            ))
-            .unwrap();
+        push_direct_candidate_for_test(
+            &provider,
+            DirectJobCandidate::new(direct_run_id, crate::profile::DEFAULT_PROFILE.to_string()),
+        )
+        .await;
 
         let discovered = tokio::time::timeout(Duration::from_secs(1), discover_task)
             .await

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -3,14 +3,14 @@
 //! `ApiProvider` uses this module as the low-latency side of discovery while
 //! keeping HTTP polling as the correctness fallback. Job notifications become
 //! direct candidates when they include a supported profile; incomplete
-//! notifications or direct-queue fallback request immediate poll wakeups so the
+//! notifications or direct-inbox fallback request immediate poll wakeups so the
 //! server remains the source of truth for job selection. Ably cancel
 //! notifications bypass discovery and only signal local cancellation handles.
 //! Invalid job notifications are ignored. Unsupported profiles are ignored
 //! without mutating discovery wakeup state.
 //!
-//! The direct candidate queue is an optimization, not the only delivery path:
-//! incomplete notifications, full or closed direct queues, backlog draining, and
+//! The direct candidate inbox is an optimization, not the only delivery path:
+//! incomplete notifications, inbox overflow, backlog draining, and
 //! Ably connection state all route through `PollWakeups` so a runner can still
 //! discover work through HTTP polling.
 
@@ -18,12 +18,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
-use tokio::sync::{Mutex, Notify, mpsc};
+use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use super::api::ApiClient;
-use super::{JobCandidate, JobDiscoverySource};
+use super::api_direct_candidates::{
+    DirectCandidateInbox, DirectCandidateInsertOutcome, DirectJobCandidate,
+};
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
@@ -34,87 +36,6 @@ const ABLY_DISCONNECT_ERROR_AFTER: Duration = Duration::from_secs(60);
 const DEFERRED_POLL_MAX: Duration = Duration::from_secs(10);
 type AblyConnectHandle =
     tokio::task::JoinHandle<Result<ably_subscriber::Subscription, ably_subscriber::Error>>;
-
-#[derive(Debug)]
-pub(super) struct DirectJobCandidate {
-    run_id: RunId,
-    profile_name: String,
-    discovered_at: StdInstant,
-    cli_agent_session_id: Option<String>,
-    affinity_protected_until: Option<String>,
-}
-
-impl DirectJobCandidate {
-    #[cfg(test)]
-    pub(super) fn new(run_id: RunId, profile_name: String) -> Self {
-        Self::new_with_discovered_at(run_id, profile_name, StdInstant::now())
-    }
-
-    pub(super) fn new_with_affinity(
-        run_id: RunId,
-        profile_name: String,
-        cli_agent_session_id: Option<String>,
-        affinity_protected_until: Option<String>,
-    ) -> Self {
-        Self::new_with_affinity_metadata(
-            run_id,
-            profile_name,
-            StdInstant::now(),
-            cli_agent_session_id,
-            affinity_protected_until,
-        )
-    }
-
-    #[cfg(test)]
-    pub(super) fn new_with_discovered_at(
-        run_id: RunId,
-        profile_name: String,
-        discovered_at: StdInstant,
-    ) -> Self {
-        Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None)
-    }
-
-    pub(super) fn new_with_affinity_metadata(
-        run_id: RunId,
-        profile_name: String,
-        discovered_at: StdInstant,
-        cli_agent_session_id: Option<String>,
-        affinity_protected_until: Option<String>,
-    ) -> Self {
-        Self {
-            run_id,
-            profile_name,
-            discovered_at,
-            cli_agent_session_id,
-            affinity_protected_until,
-        }
-    }
-
-    pub(super) fn run_id(&self) -> RunId {
-        self.run_id
-    }
-
-    pub(super) fn profile_name(&self) -> &str {
-        &self.profile_name
-    }
-
-    pub(super) fn into_job_candidate(self) -> JobCandidate {
-        JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
-            .with_affinity_metadata(self.cli_agent_session_id, self.affinity_protected_until)
-            .with_discovery_source(JobDiscoverySource::Ably)
-    }
-}
-
-#[derive(Clone)]
-pub(super) struct DirectCandidateSenders {
-    direct: mpsc::Sender<DirectJobCandidate>,
-}
-
-impl DirectCandidateSenders {
-    pub(super) fn new(direct: mpsc::Sender<DirectJobCandidate>) -> Self {
-        Self { direct }
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PollReason {
@@ -501,7 +422,7 @@ pub(super) struct AblySupervisorConfig {
     pub(super) group: String,
     pub(super) profiles: Vec<String>,
     pub(super) poll_wakeups: Arc<PollWakeups>,
-    pub(super) direct_candidate_senders: DirectCandidateSenders,
+    pub(super) direct_candidates: Arc<DirectCandidateInbox>,
     pub(super) cancel_tokens: SharedRunCancellationMap,
     pub(super) provider_cancel: CancellationToken,
 }
@@ -511,7 +432,7 @@ struct SupervisorTaskConfig {
     group: String,
     profiles: Vec<String>,
     poll_wakeups: Arc<PollWakeups>,
-    direct_candidate_senders: DirectCandidateSenders,
+    direct_candidates: Arc<DirectCandidateInbox>,
     cancel_tokens: SharedRunCancellationMap,
     provider_cancel: CancellationToken,
     shutdown: CancellationToken,
@@ -526,7 +447,7 @@ impl AblySupervisor {
             group: config.group,
             profiles: config.profiles,
             poll_wakeups: config.poll_wakeups,
-            direct_candidate_senders: config.direct_candidate_senders,
+            direct_candidates: config.direct_candidates,
             cancel_tokens: config.cancel_tokens,
             provider_cancel: config.provider_cancel,
             shutdown: task_shutdown,
@@ -597,7 +518,7 @@ async fn run_supervisor(config: SupervisorTaskConfig) {
                             &msg,
                             &config.profiles,
                             &config.poll_wakeups,
-                            &config.direct_candidate_senders,
+                            &config.direct_candidates,
                             &config.cancel_tokens,
                         )
                         .await;
@@ -668,7 +589,7 @@ async fn handle_ably_message(
     msg: &ably_subscriber::Message,
     profiles: &[String],
     poll_wakeups: &PollWakeups,
-    direct_candidate_senders: &DirectCandidateSenders,
+    direct_candidates: &DirectCandidateInbox,
     cancel_tokens: &Mutex<HashMap<RunId, RunCancellationHandle>>,
 ) {
     if let Some(run_id) = parse_cancel_notification(msg) {
@@ -720,7 +641,7 @@ async fn handle_ably_message(
             poll_wakeups.request_immediate_poll().await;
         }
         JobNotificationAction::Direct(candidate) => {
-            enqueue_direct_candidate(candidate, direct_candidate_senders, poll_wakeups).await;
+            enqueue_direct_candidate(candidate, direct_candidates, poll_wakeups).await;
         }
         JobNotificationAction::Ignore => {}
     }
@@ -745,26 +666,29 @@ fn supports_profile(profiles: &[String], profile: &str) -> bool {
 
 async fn enqueue_direct_candidate(
     candidate: DirectJobCandidate,
-    direct_candidate_senders: &DirectCandidateSenders,
+    direct_candidates: &DirectCandidateInbox,
     poll_wakeups: &PollWakeups,
 ) {
-    // Direct candidates are a latency optimization. If the bounded queue cannot
-    // accept one, HTTP polling preserves discovery correctness.
-    match direct_candidate_senders.direct.try_send(candidate) {
-        Ok(()) => {}
-        Err(mpsc::error::TrySendError::Full(candidate)) => {
+    let run_id = candidate.run_id();
+    let profile = candidate.profile_name().to_owned();
+    match direct_candidates.push(candidate).await {
+        DirectCandidateInsertOutcome::Inserted(_) | DirectCandidateInsertOutcome::Updated(_) => {}
+        DirectCandidateInsertOutcome::Overflow {
+            snapshot,
+            coalesced_count,
+            should_wake_poll,
+        } => {
+            if !should_wake_poll {
+                return;
+            }
             warn!(
-                run_id = %candidate.run_id(),
-                profile = %candidate.profile_name(),
-                "ably: direct candidate queue full, waking poll"
-            );
-            poll_wakeups.request_immediate_poll().await;
-        }
-        Err(mpsc::error::TrySendError::Closed(candidate)) => {
-            warn!(
-                run_id = %candidate.run_id(),
-                profile = %candidate.profile_name(),
-                "ably: direct candidate queue closed, waking poll"
+                run_id = %run_id,
+                profile = %profile,
+                depth = snapshot.depth,
+                capacity = snapshot.capacity,
+                coalesced_overflow_count = coalesced_count,
+                fallback_poll_requested = true,
+                "ably: direct candidate inbox full, waking poll"
             );
             poll_wakeups.request_immediate_poll().await;
         }
@@ -985,22 +909,20 @@ mod tests {
         due.map(PollDue::reason)
     }
 
-    struct DirectCandidateReceivers {
-        direct: mpsc::Receiver<DirectJobCandidate>,
+    fn direct_candidate_inbox() -> Arc<DirectCandidateInbox> {
+        direct_candidate_inbox_with_capacity(4)
     }
 
-    fn direct_candidate_channels() -> (DirectCandidateSenders, DirectCandidateReceivers) {
-        direct_candidate_channels_with_capacity(4)
+    fn direct_candidate_inbox_with_capacity(capacity: usize) -> Arc<DirectCandidateInbox> {
+        DirectCandidateInbox::new(capacity)
     }
 
-    fn direct_candidate_channels_with_capacity(
-        capacity: usize,
-    ) -> (DirectCandidateSenders, DirectCandidateReceivers) {
-        let (direct_tx, direct_rx) = mpsc::channel(capacity);
-        (
-            DirectCandidateSenders::new(direct_tx),
-            DirectCandidateReceivers { direct: direct_rx },
-        )
+    async fn pop_direct_candidate(inbox: &DirectCandidateInbox) -> DirectJobCandidate {
+        inbox.try_pop().await.expect("direct candidate")
+    }
+
+    async fn assert_no_direct_candidate(inbox: &DirectCandidateInbox) {
+        assert!(inbox.try_pop().await.is_none());
     }
 
     fn default_profiles() -> Vec<String> {
@@ -1593,21 +1515,21 @@ mod tests {
         let token = handle.token();
         let tokens = Mutex::new(HashMap::from([(run_id, handle)]));
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let msg = make_message(Some("cancel"), serde_json::json!({ "runId": run_id }));
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         assert!(token.is_cancelled());
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
     }
 
     #[tokio::test]
     async fn broadcast_supported_job_notification_enqueues_direct_candidate() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1626,9 +1548,9 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
-        let candidate = direct_rx.direct.try_recv().expect("direct candidate");
+        let candidate = pop_direct_candidate(&direct_candidates).await;
         assert_eq!(
             candidate.run_id().to_string(),
             "00000000-0000-0000-0000-000000000001"
@@ -1637,7 +1559,7 @@ mod tests {
         let candidate = candidate.into_job_candidate();
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
         assert!(candidate.is_affinity_protected());
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
     }
 
@@ -1645,7 +1567,7 @@ mod tests {
     async fn legacy_target_runner_id_is_ignored_for_direct_candidate() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1663,11 +1585,11 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
-        let candidate = direct_rx.direct.try_recv().expect("direct candidate");
+        let candidate = pop_direct_candidate(&direct_candidates).await;
         assert_eq!(candidate.profile_name(), "vm0/default");
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
     }
 
@@ -1675,7 +1597,7 @@ mod tests {
     async fn unsupported_profile_job_notification_is_ignored() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1692,9 +1614,9 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
         let snapshot = wakeups.snapshot().await;
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
@@ -1721,7 +1643,7 @@ mod tests {
         ] {
             let tokens = Mutex::new(HashMap::new());
             let wakeups = PollWakeups::new(true);
-            let (direct_senders, mut direct_rx) = direct_candidate_channels();
+            let direct_candidates = direct_candidate_inbox();
             let profiles = default_profiles();
             let _ = wakeups
                 .wait_for_poll_due(
@@ -1732,10 +1654,10 @@ mod tests {
                 .await;
             let msg = make_message(Some("job"), data);
 
-            handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+            handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
             let snapshot = wakeups.snapshot().await;
-            assert!(direct_rx.direct.try_recv().is_err());
+            assert_no_direct_candidate(&direct_candidates).await;
             assert_eq!(snapshot.poll_now, should_wake_poll);
             assert!(snapshot.deferred_poll_at.is_none());
         }
@@ -1745,7 +1667,7 @@ mod tests {
     async fn missing_profile_job_notification_wakes_poll() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1761,9 +1683,9 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
         assert!(wakeups.snapshot().await.poll_now);
     }
 
@@ -1771,7 +1693,7 @@ mod tests {
     async fn empty_profile_job_notification_wakes_poll() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1788,9 +1710,9 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
         assert!(wakeups.snapshot().await.poll_now);
     }
 
@@ -1798,7 +1720,7 @@ mod tests {
     async fn full_direct_candidate_queue_wakes_poll_fallback() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels_with_capacity(1);
+        let direct_candidates = direct_candidate_inbox_with_capacity(1);
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1814,11 +1736,25 @@ mod tests {
                 "profile": "vm0/default"
             }),
         );
+        let overflowing_msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000002",
+                "profile": "vm0/default"
+            }),
+        );
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+        handle_ably_message(
+            &overflowing_msg,
+            &profiles,
+            &wakeups,
+            &direct_candidates,
+            &tokens,
+        )
+        .await;
 
-        let candidate = direct_rx.direct.try_recv().expect("first direct candidate");
+        let candidate = pop_direct_candidate(&direct_candidates).await;
         assert_eq!(candidate.profile_name(), "vm0/default");
         assert!(wakeups.snapshot().await.poll_now);
     }
@@ -1827,7 +1763,7 @@ mod tests {
     async fn legacy_target_runner_id_does_not_defer_poll() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1845,12 +1781,12 @@ mod tests {
             }),
         );
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
-        let candidate = direct_rx.direct.try_recv().expect("direct candidate");
+        let candidate = pop_direct_candidate(&direct_candidates).await;
         assert_eq!(candidate.profile_name(), "vm0/default");
         let snapshot = wakeups.snapshot().await;
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
     }
@@ -1876,7 +1812,7 @@ mod tests {
         ] {
             let tokens = Mutex::new(HashMap::new());
             let wakeups = PollWakeups::new(true);
-            let (direct_senders, mut direct_rx) = direct_candidate_channels();
+            let direct_candidates = direct_candidate_inbox();
             let profiles = default_profiles();
             let _ = wakeups
                 .wait_for_poll_due(
@@ -1887,10 +1823,10 @@ mod tests {
                 .await;
             let msg = make_message(Some("job"), data);
 
-            handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+            handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
             let snapshot = wakeups.snapshot().await;
-            assert!(direct_rx.direct.try_recv().is_err());
+            assert_no_direct_candidate(&direct_candidates).await;
             assert_eq!(snapshot.poll_now, should_wake_poll);
             assert!(snapshot.deferred_poll_at.is_none());
         }
@@ -1900,7 +1836,7 @@ mod tests {
     async fn invalid_job_notification_does_not_mutate_wakeup_state() {
         let tokens = Mutex::new(HashMap::new());
         let wakeups = PollWakeups::new(true);
-        let (direct_senders, mut direct_rx) = direct_candidate_channels();
+        let direct_candidates = direct_candidate_inbox();
         let profiles = default_profiles();
         let _ = wakeups
             .wait_for_poll_due(
@@ -1911,11 +1847,10 @@ mod tests {
             .await;
         let msg = make_message(Some("job"), serde_json::json!({ "runId": "not-a-uuid" }));
 
-        handle_ably_message(&msg, &profiles, &wakeups, &direct_senders, &tokens).await;
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
 
         let snapshot = wakeups.snapshot().await;
-        assert!(direct_rx.direct.try_recv().is_err());
-        assert!(direct_rx.direct.try_recv().is_err());
+        assert_no_direct_candidate(&direct_candidates).await;
         assert!(!snapshot.poll_now);
         assert!(snapshot.deferred_poll_at.is_none());
     }

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -1,0 +1,368 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::Instant as StdInstant;
+
+use tokio::sync::{Mutex, Notify};
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+use super::{JobCandidate, JobDiscoverySource};
+use crate::ids::RunId;
+
+#[derive(Debug)]
+pub(super) struct DirectJobCandidate {
+    run_id: RunId,
+    profile_name: String,
+    discovered_at: StdInstant,
+    cli_agent_session_id: Option<String>,
+    affinity_protected_until: Option<String>,
+}
+
+impl DirectJobCandidate {
+    #[cfg(test)]
+    pub(super) fn new(run_id: RunId, profile_name: String) -> Self {
+        Self::new_with_discovered_at(run_id, profile_name, StdInstant::now())
+    }
+
+    pub(super) fn new_with_affinity(
+        run_id: RunId,
+        profile_name: String,
+        cli_agent_session_id: Option<String>,
+        affinity_protected_until: Option<String>,
+    ) -> Self {
+        Self::new_with_affinity_metadata(
+            run_id,
+            profile_name,
+            StdInstant::now(),
+            cli_agent_session_id,
+            affinity_protected_until,
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn new_with_discovered_at(
+        run_id: RunId,
+        profile_name: String,
+        discovered_at: StdInstant,
+    ) -> Self {
+        Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None)
+    }
+
+    pub(super) fn new_with_affinity_metadata(
+        run_id: RunId,
+        profile_name: String,
+        discovered_at: StdInstant,
+        cli_agent_session_id: Option<String>,
+        affinity_protected_until: Option<String>,
+    ) -> Self {
+        Self {
+            run_id,
+            profile_name,
+            discovered_at,
+            cli_agent_session_id,
+            affinity_protected_until,
+        }
+    }
+
+    pub(super) fn run_id(&self) -> RunId {
+        self.run_id
+    }
+
+    pub(super) fn profile_name(&self) -> &str {
+        &self.profile_name
+    }
+
+    #[cfg(test)]
+    pub(super) fn discovered_at(&self) -> StdInstant {
+        self.discovered_at
+    }
+
+    pub(super) fn into_job_candidate(self) -> JobCandidate {
+        JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
+            .with_affinity_metadata(self.cli_agent_session_id, self.affinity_protected_until)
+            .with_discovery_source(JobDiscoverySource::Ably)
+    }
+
+    fn merge_metadata_from(&mut self, candidate: Self) {
+        if self.profile_name != candidate.profile_name {
+            warn!(
+                run_id = %self.run_id,
+                existing_profile = %self.profile_name,
+                candidate_profile = %candidate.profile_name,
+                "ably: duplicate direct candidate profile mismatch, keeping first profile"
+            );
+            return;
+        }
+        if candidate.cli_agent_session_id.is_some() {
+            self.cli_agent_session_id = candidate.cli_agent_session_id;
+        }
+        if candidate.affinity_protected_until.is_some() {
+            self.affinity_protected_until = candidate.affinity_protected_until;
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DirectCandidateInsertOutcome {
+    Inserted(DirectCandidateInboxSnapshot),
+    Updated(DirectCandidateInboxSnapshot),
+    Overflow {
+        snapshot: DirectCandidateInboxSnapshot,
+        coalesced_count: u64,
+        should_wake_poll: bool,
+    },
+}
+
+impl DirectCandidateInsertOutcome {
+    #[cfg(test)]
+    pub(super) fn snapshot(self) -> DirectCandidateInboxSnapshot {
+        match self {
+            Self::Inserted(snapshot) | Self::Updated(snapshot) => snapshot,
+            Self::Overflow { snapshot, .. } => snapshot,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DirectCandidateInboxSnapshot {
+    pub(super) depth: usize,
+    pub(super) capacity: usize,
+}
+
+#[derive(Debug)]
+struct DirectCandidateInboxInner {
+    order: VecDeque<RunId>,
+    candidates: HashMap<RunId, DirectJobCandidate>,
+    overflow_active: bool,
+    overflow_count: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct DirectCandidateInbox {
+    capacity: usize,
+    inner: Mutex<DirectCandidateInboxInner>,
+    notify: Notify,
+}
+
+impl DirectCandidateInbox {
+    pub(super) fn new(capacity: usize) -> Arc<Self> {
+        Arc::new(Self {
+            capacity,
+            inner: Mutex::new(DirectCandidateInboxInner {
+                order: VecDeque::new(),
+                candidates: HashMap::new(),
+                overflow_active: false,
+                overflow_count: 0,
+            }),
+            notify: Notify::new(),
+        })
+    }
+
+    pub(super) async fn push(&self, candidate: DirectJobCandidate) -> DirectCandidateInsertOutcome {
+        let mut inner = self.inner.lock().await;
+        let run_id = candidate.run_id();
+        if let Some(existing) = inner.candidates.get_mut(&run_id) {
+            existing.merge_metadata_from(candidate);
+            return DirectCandidateInsertOutcome::Updated(snapshot(
+                inner.order.len(),
+                self.capacity,
+            ));
+        }
+
+        if inner.order.len() >= self.capacity {
+            inner.overflow_count = inner.overflow_count.saturating_add(1);
+            let should_wake_poll = !inner.overflow_active;
+            inner.overflow_active = true;
+            return DirectCandidateInsertOutcome::Overflow {
+                snapshot: snapshot(inner.order.len(), self.capacity),
+                coalesced_count: inner.overflow_count,
+                should_wake_poll,
+            };
+        }
+
+        inner.order.push_back(run_id);
+        inner.candidates.insert(run_id, candidate);
+        let snapshot = snapshot(inner.order.len(), self.capacity);
+        drop(inner);
+        self.notify.notify_one();
+        DirectCandidateInsertOutcome::Inserted(snapshot)
+    }
+
+    pub(super) async fn try_pop(&self) -> Option<DirectJobCandidate> {
+        let mut inner = self.inner.lock().await;
+        let candidate = pop_candidate(&mut inner);
+        if candidate.is_some() && inner.order.len() < self.capacity {
+            inner.overflow_active = false;
+            inner.overflow_count = 0;
+        }
+        candidate
+    }
+
+    pub(super) async fn wait_pop(&self, cancel: &CancellationToken) -> Option<DirectJobCandidate> {
+        loop {
+            if let Some(candidate) = self.try_pop().await {
+                return Some(candidate);
+            }
+
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => return None,
+                () = self.notify.notified() => {}
+            }
+        }
+    }
+}
+
+fn pop_candidate(inner: &mut DirectCandidateInboxInner) -> Option<DirectJobCandidate> {
+    while let Some(run_id) = inner.order.pop_front() {
+        if let Some(candidate) = inner.candidates.remove(&run_id) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn snapshot(depth: usize, capacity: usize) -> DirectCandidateInboxSnapshot {
+    DirectCandidateInboxSnapshot { depth, capacity }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn run_id(value: u128) -> RunId {
+        RunId::from(uuid::Uuid::from_u128(value))
+    }
+
+    #[tokio::test]
+    async fn duplicate_run_id_occupies_one_slot_and_preserves_first_discovery_time() {
+        let inbox = DirectCandidateInbox::new(4);
+        let first_discovered_at = StdInstant::now() - Duration::from_secs(5);
+        let second_discovered_at = StdInstant::now();
+        let run_id = run_id(1);
+
+        let inserted = inbox
+            .push(DirectJobCandidate::new_with_affinity_metadata(
+                run_id,
+                "vm0/default".to_string(),
+                first_discovered_at,
+                Some("sess-1".to_string()),
+                None,
+            ))
+            .await;
+        assert_eq!(
+            inserted.snapshot(),
+            DirectCandidateInboxSnapshot {
+                depth: 1,
+                capacity: 4,
+            }
+        );
+
+        let updated = inbox
+            .push(DirectJobCandidate::new_with_affinity_metadata(
+                run_id,
+                "vm0/default".to_string(),
+                second_discovered_at,
+                None,
+                Some("2999-01-01T00:00:00.000Z".to_string()),
+            ))
+            .await;
+        assert!(matches!(
+            updated,
+            DirectCandidateInsertOutcome::Updated(DirectCandidateInboxSnapshot {
+                depth: 1,
+                capacity: 4,
+            })
+        ));
+
+        let candidate = inbox.try_pop().await.expect("direct candidate");
+        assert_eq!(candidate.discovered_at(), first_discovered_at);
+        let candidate = candidate.into_job_candidate();
+        assert_eq!(candidate.cli_agent_session_id(), Some("sess-1"));
+        assert!(candidate.is_affinity_protected());
+        assert!(inbox.try_pop().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn overflow_is_coalesced_until_capacity_makes_progress() {
+        let inbox = DirectCandidateInbox::new(1);
+        let _ = inbox
+            .push(DirectJobCandidate::new(
+                run_id(1),
+                "vm0/default".to_string(),
+            ))
+            .await;
+
+        let first_overflow = inbox
+            .push(DirectJobCandidate::new(
+                run_id(2),
+                "vm0/default".to_string(),
+            ))
+            .await;
+        assert!(matches!(
+            first_overflow,
+            DirectCandidateInsertOutcome::Overflow {
+                snapshot: DirectCandidateInboxSnapshot {
+                    depth: 1,
+                    capacity: 1,
+                },
+                coalesced_count: 1,
+                should_wake_poll: true,
+            }
+        ));
+
+        let second_overflow = inbox
+            .push(DirectJobCandidate::new(
+                run_id(3),
+                "vm0/default".to_string(),
+            ))
+            .await;
+        assert!(matches!(
+            second_overflow,
+            DirectCandidateInsertOutcome::Overflow {
+                snapshot: DirectCandidateInboxSnapshot {
+                    depth: 1,
+                    capacity: 1,
+                },
+                coalesced_count: 2,
+                should_wake_poll: false,
+            }
+        ));
+
+        assert_eq!(
+            inbox.try_pop().await.expect("first candidate").run_id(),
+            run_id(1)
+        );
+        let _ = inbox
+            .push(DirectJobCandidate::new(
+                run_id(4),
+                "vm0/default".to_string(),
+            ))
+            .await;
+        let reset_overflow = inbox
+            .push(DirectJobCandidate::new(
+                run_id(5),
+                "vm0/default".to_string(),
+            ))
+            .await;
+        assert!(matches!(
+            reset_overflow,
+            DirectCandidateInsertOutcome::Overflow {
+                coalesced_count: 1,
+                should_wake_poll: true,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn wait_pop_exits_on_cancel() {
+        let inbox = DirectCandidateInbox::new(1);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        assert!(inbox.wait_pop(&cancel).await.is_none());
+    }
+}

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -14,7 +14,7 @@
 //! - **#8898**: `shutdown()` deadlocking because `discover_fut` still holds
 //!   the Mutex when `provider.shutdown()` is called.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
@@ -53,6 +53,7 @@ pub struct MockJobProvider {
     /// pinned), this delay restarts from scratch — jobs pushed during the
     /// delay won't be discovered until it completes.
     poll_delay: Option<Duration>,
+    ready_discovery: Arc<StdMutex<VecDeque<JobCandidate>>>,
     claim_results: StdMutex<HashMap<RunId, Option<ExecutionContext>>>,
     claim_candidates: Arc<StdMutex<Vec<JobCandidate>>>,
     completions: Arc<StdMutex<Vec<Completion>>>,
@@ -87,6 +88,7 @@ pub struct MockJobProvider {
 /// Test-side handle for driving the mock provider.
 pub struct MockProviderHandle {
     pub discover_tx: mpsc::UnboundedSender<JobCandidate>,
+    ready_discovery: Arc<StdMutex<VecDeque<JobCandidate>>>,
     claim_candidates: Arc<StdMutex<Vec<JobCandidate>>>,
     pub completions: Arc<StdMutex<Vec<Completion>>>,
     pub heartbeats: Arc<StdMutex<Vec<HeartbeatState>>>,
@@ -121,6 +123,7 @@ impl MockJobProvider {
         poll_delay: Option<Duration>,
     ) -> (Arc<Self>, MockProviderHandle) {
         let (tx, rx) = mpsc::unbounded_channel();
+        let ready_discovery = Arc::new(StdMutex::new(VecDeque::new()));
         let claim_candidates = Arc::new(StdMutex::new(Vec::new()));
         let completions = Arc::new(StdMutex::new(Vec::new()));
         let heartbeats = Arc::new(StdMutex::new(Vec::new()));
@@ -132,6 +135,7 @@ impl MockJobProvider {
         let provider = Arc::new(Self {
             discovery: Mutex::new(rx),
             poll_delay,
+            ready_discovery: Arc::clone(&ready_discovery),
             claim_results: StdMutex::new(HashMap::new()),
             claim_candidates: Arc::clone(&claim_candidates),
             completions: Arc::clone(&completions),
@@ -145,6 +149,7 @@ impl MockJobProvider {
         });
         let handle = MockProviderHandle {
             discover_tx: tx,
+            ready_discovery,
             claim_candidates,
             completions,
             heartbeats,
@@ -236,6 +241,13 @@ impl MockProviderHandle {
             .clone()
     }
 
+    pub fn push_ready_candidate(&self, candidate: JobCandidate) {
+        self.ready_discovery
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push_back(candidate);
+    }
+
     /// Wait until `heartbeat_count()` exceeds `baseline`, or return false on
     /// timeout. Uses the same subscribe-then-check pattern as
     /// [`wait_completion`](Self::wait_completion) — a heartbeat that lands
@@ -316,6 +328,13 @@ impl JobProvider for MockJobProvider {
                 None
             }
         }
+    }
+
+    async fn try_discover_ready(&self) -> Option<JobCandidate> {
+        self.ready_discovery
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .pop_front()
     }
 
     async fn complete(

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -6,6 +6,7 @@
 
 mod api;
 mod api_ably_supervisor;
+mod api_direct_candidates;
 mod local;
 #[cfg(test)]
 pub mod mock;
@@ -371,6 +372,15 @@ pub trait JobProvider: Send + Sync {
     /// This method has **no server-side side effects** and can be safely
     /// dropped (cancelled) at any `.await` point.
     async fn discover(&self) -> Option<JobCandidate>;
+
+    /// Return one already-buffered job candidate without waiting or polling.
+    ///
+    /// Default no-op for providers that do not have a local push-delivery
+    /// inbox. Implementations must not perform network I/O here; the runner
+    /// main loop uses this only for bounded catch-up after a normal discovery.
+    async fn try_discover_ready(&self) -> Option<JobCandidate> {
+        None
+    }
 
     /// Claim a discovered job. Returns `None` if the job was already claimed
     /// by another runner or an error occurred. A returned claim must carry an

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -1053,21 +1053,13 @@ export function createRunsAutomationsApi(context: TestContext) {
       );
     },
 
-    async pollRunner(
-      group?: string,
-      args: {
-        readonly heldSessionStates?: RunnerPollBody["heldSessionStates"];
-      } = {},
-    ) {
+    async pollRunner(group?: string) {
       return await accept(
         runsAutomationApp(context)(runnersPollContract).poll({
           headers: runnerHeaders(true),
           body: {
             group: group ?? "vm0/test",
             profiles: ["vm0/default"],
-            ...(args.heldSessionStates === undefined
-              ? {}
-              : { heldSessionStates: args.heldSessionStates }),
           },
         }),
         [200],

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -392,18 +392,6 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
       );
     }
     expect(emptyWithoutProfiles.body.job).toBeNull();
-
-    const emptyHeldSessionPoll = await api.requestPollRunner(
-      true,
-      { group: runnerGroup, heldSessionStates },
-      [200],
-    );
-    if (emptyHeldSessionPoll.status !== 200) {
-      throw new Error(
-        `Expected held-session poll to succeed, got ${emptyHeldSessionPoll.status}`,
-      );
-    }
-    expect(emptyHeldSessionPoll.body.job).toBeNull();
   });
 
   it("keeps missing run detail and context hidden for another organization", async () => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -215,7 +215,7 @@ export const chatThreadsSnapshot$ = computed(async (get) => {
   return (await get(chatThreadEventData$)).snapshot;
 });
 
-export const allChatThreadsEvents$ = computed(async (get) => {
+const allChatThreadsEvents$ = computed(async (get) => {
   const persisted = (await get(chatThreadEventData$)).events;
   const optimistic = get(optimisticChatThreadEventsState$);
   const byId = new Map<string, ChatThreadEvent>();
@@ -277,26 +277,8 @@ export const registerOptimisticChatThreadEvent$ = command(
   },
 );
 
-export const clearOptimisticChatThreadEvents$ = command(
-  ({ set }, eventIds: readonly string[]) => {
-    if (eventIds.length === 0) {
-      return;
-    }
-    const confirmed = new Set(eventIds);
-    set(optimisticChatThreadEventsState$, (events) => {
-      return events.filter((event) => {
-        return !confirmed.has(event.id);
-      });
-    });
-  },
-);
-
 export const loadMoreEventDrivenChatThreads$ = command(({ set }) => {
   set(chatThreadMaxItemState$, (count) => {
     return count + CHAT_THREAD_VISIBLE_PAGE_SIZE;
   });
-});
-
-export const resetEventDrivenChatThreadLimit$ = command(({ set }) => {
-  set(chatThreadMaxItemState$, CHAT_THREAD_VISIBLE_PAGE_SIZE);
 });

--- a/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
@@ -15,7 +15,7 @@ import { openChatIdb } from "./chat-idb-store.ts";
 
 const SINGLETON_ID = "current";
 
-export interface ChatThreadSnapshotRecord {
+interface ChatThreadSnapshotRecord {
   readonly chatThreads: readonly ChatThreadSnapshotProjection[];
   readonly latestEventId: string | null;
 }

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -125,7 +125,6 @@ export const runnersPollContract = c.router({
     body: z.object({
       group: runnerGroupSchema,
       profiles: z.array(z.string()).optional(),
-      heldSessionStates: z.array(heldSessionStateSchema).max(1024).optional(),
       telemetry: runnerPollTelemetrySchema.optional(),
     }),
     responses: {


### PR DESCRIPTION
## Summary

Closes #19933.

- Replace the runner's raw Ably direct-candidate channel with a bounded, run-id deduplicating inbox that preserves first-discovery timing and affinity metadata.
- Coalesce direct-candidate overflow warnings and fallback poll wakeups so bursts request one fallback poll per overflow period instead of logging once per dropped candidate.
- Add bounded ready direct-candidate draining after normal discovery while preserving the existing sequential `handle_discovered_job` admission/claim path.
- Remove `heldSessionStates` from the runner poll contract; heartbeat remains the only held-session state reporting path.
- Clean up pre-existing unused platform exports so `lint-knip` stays green in this PR.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api_direct_candidates`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/runs-schedules.bdd.test.ts`
- `cd turbo && pnpm -F @vm0/db db:migrate` before rerunning the route test locally
- `cd turbo && pnpm -F @vm0/app check-types`
- `cd turbo && pnpm knip --cache`
- pre-commit hook: prettier, cargo fmt/doc/clippy, knip, full `pnpm check-types`
