### PR TITLE
refactor: remove Computer Use delegated authorization switch

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -60,22 +60,6 @@ function requireOrg(actor: ApiTestUser): string {
   return actor.orgId;
 }
 
-async function enableComputerUseDelegatedAuthorization(
-  actor: ApiTestUser,
-): Promise<void> {
-  await updateFeatureSwitchesForUser(
-    context,
-    {
-      userId: actor.userId,
-      orgId: requireOrg(actor),
-      orgRole: actor.orgRole,
-    },
-    {
-      [FeatureSwitchKey.ComputerUseDelegatedAuthorization]: true,
-    },
-  );
-}
-
 async function enableComputerUseDesktopPlugins(
   actor: ApiTestUser,
 ): Promise<void> {
@@ -193,33 +177,9 @@ describe("FILE-03 desktop computer-use runtime", () => {
     expect(response.status).toBe(404);
   });
 
-  it("keeps delegated computer-use authorization requests behind the feature switch", async () => {
-    const orgId = `org_${randomUUID()}`;
-    const actor = bdd.user({ orgId });
-    const run = await seedZeroRun({ actor, triggerSource: "web" });
-    mockClerkMembership(context, actor, "org:admin");
-
-    const token = zeroComputerUseToken({
-      userId: actor.userId,
-      orgId,
-      runId: run.runId,
-      capabilities: ["connector:read"],
-    }).token;
-
-    const response = await api.requestCreateComputerUseAuthorizationRequest(
-      { bearer: token },
-      [403],
-    );
-    expectApiError(response.body);
-    expect(response.body.error.message).toBe(
-      "Computer Use delegated authorization is not enabled",
-    );
-  });
-
   it("creates a delegated authorization link and applies the selected host to the chat thread", async () => {
     const orgId = `org_${randomUUID()}`;
     const actor = bdd.user({ orgId });
-    await enableComputerUseDelegatedAuthorization(actor);
     const run = await seedZeroRun({ actor, triggerSource: "web" });
     if (!run.threadId) {
       throw new Error("Expected web run fixture to create a chat thread");
@@ -283,7 +243,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
   it("only exposes online hosts for delegated authorization requests", async () => {
     const orgId = `org_${randomUUID()}`;
     const actor = bdd.user({ orgId });
-    await enableComputerUseDelegatedAuthorization(actor);
     const run = await seedZeroRun({ actor, triggerSource: "web" });
     if (!run.threadId) {
       throw new Error("Expected web run fixture to create a chat thread");
@@ -364,7 +323,6 @@ describe("FILE-03 desktop computer-use runtime", () => {
   it("creates a delegated authorization link and applies the selected host to the Slack thread", async () => {
     const orgId = `org_${randomUUID()}`;
     const actor = bdd.user({ orgId });
-    await enableComputerUseDelegatedAuthorization(actor);
     const run = await seedZeroRun({ actor, triggerSource: "slack" });
 
     const host = await api.startComputerUseHost(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -10,7 +10,6 @@ import type {
   TestSlackStatePostResponse,
   TestSlackStateResponse,
 } from "@vm0/api-contracts/contracts/test-slack-state";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
@@ -24,7 +23,6 @@ import { testSlackStateRoutes } from "../test-slack-state";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
-import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -186,23 +184,6 @@ function actorForFixture(fixture: SlackProbeFixture): ApiTestUser {
     orgRole: "org:admin",
     email: `${fixture.userId}@example.test`,
   };
-}
-
-async function enableComputerUseDelegatedAuthorization(
-  fixture: SlackProbeFixture,
-): Promise<void> {
-  await updateFeatureSwitchesForUser(
-    context,
-    {
-      userId: fixture.userId,
-      orgId: fixture.orgId,
-      orgRole: "org:admin",
-    },
-    {
-      [FeatureSwitchKey.ComputerUseDelegatedAuthorization]: true,
-    },
-  );
-  mockTestUserMembership(fixture.userId, fixture.orgId);
 }
 
 async function heartbeatRunner() {
@@ -500,7 +481,7 @@ describe("POST /api/test/slack-dispatch-probe", () => {
     const channelId = "C-test";
     const threadTs = "1710000004.000000";
     const actor = actorForFixture(fixture);
-    await enableComputerUseDelegatedAuthorization(fixture);
+    mockTestUserMembership(fixture.userId, fixture.orgId);
     const host = await computerUseApi.startComputerUseHost(actor, {
       hostName: "Slack authorized host",
     });

--- a/turbo/apps/api/src/signals/routes/zero-computer-use-authorization.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use-authorization.ts
@@ -1,12 +1,9 @@
 import { command } from "ccstate";
 import { zeroComputerUseAuthorizationRequestsContract } from "@vm0/api-contracts/contracts/zero-computer-use";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import { bodyResultOf, pathParamsOf } from "../context/request";
-import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
 import {
   applyComputerUseAuthorizationRequest$,
   createComputerUseAuthorizationRequest$,
@@ -14,18 +11,6 @@ import {
 } from "../services/zero-computer-use-authorization.service";
 import { badRequestMessage, conflict, notFound } from "../../lib/error";
 import type { RouteEntry } from "../route-entry";
-
-function featureDisabled() {
-  return {
-    status: 403 as const,
-    body: {
-      error: {
-        message: "Computer Use delegated authorization is not enabled",
-        code: "FORBIDDEN",
-      },
-    },
-  };
-}
 
 function expired() {
   return {
@@ -67,18 +52,6 @@ const computerUseAuthorizationCreateAuthOptions = {
   accept: ["zero", "sandbox"],
 } as const;
 
-function featureEnabled(args: {
-  readonly orgId: string;
-  readonly userId: string;
-  readonly overrides: Record<string, boolean>;
-}): boolean {
-  return isFeatureEnabled(FeatureSwitchKey.ComputerUseDelegatedAuthorization, {
-    orgId: args.orgId,
-    userId: args.userId,
-    overrides: args.overrides,
-  });
-}
-
 const createAuthorizationRequestInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -86,20 +59,6 @@ const createAuthorizationRequestInner$ = command(
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
-    }
-
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !featureEnabled({
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return featureDisabled();
     }
 
     if (auth.tokenType !== "zero" && auth.tokenType !== "sandbox") {
@@ -137,20 +96,6 @@ const getAuthorizationRequestInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
     const params = get(getParams$);
-
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !featureEnabled({
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return featureDisabled();
-    }
 
     const result = await set(
       readComputerUseAuthorizationRequest$,
@@ -191,20 +136,6 @@ const applyAuthorizationRequestInner$ = command(
     signal.throwIfAborted();
     if (!body.ok) {
       return body.response;
-    }
-
-    const overrides = await get(
-      userFeatureSwitchOverrides(auth.orgId, auth.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !featureEnabled({
-        orgId: auth.orgId,
-        userId: auth.userId,
-        overrides,
-      })
-    ) {
-      return featureDisabled();
     }
 
     const result = await set(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -4,7 +4,6 @@ import {
   zeroUserPermissionGrantsContract,
   type UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -410,9 +409,6 @@ describe("chat message action cards", () => {
 
     detachedSetupPage({
       context,
-      featureSwitches: {
-        [FeatureSwitchKey.ComputerUseDelegatedAuthorization]: true,
-      },
       path: `/chats/${THREAD_ID}-computer-use-authorization`,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5738,14 +5738,6 @@ function ComputerUseAuthorizationCard({
 }: {
   block: ComputerUseAuthorizationBlock;
 }) {
-  const features = useLastResolved(featureSwitch$);
-  const enabled =
-    features?.[FeatureSwitchKey.ComputerUseDelegatedAuthorization] ?? false;
-
-  if (!enabled) {
-    return null;
-  }
-
   return (
     <div
       data-testid="computer-use-authorization-card"

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -49,7 +49,6 @@ export enum FeatureSwitchKey {
   ChatThreadEmoji = "chatThreadEmoji",
   MemoryViewer = "memoryViewer",
   HtmlArtifactCommentEditing = "htmlArtifactCommentEditing",
-  ComputerUseDelegatedAuthorization = "computerUseDelegatedAuthorization",
   ComputerUseDesktopPlugins = "computerUseDesktopPlugins",
   DesktopX64Download = "desktopX64Download",
   PresentationTemplateRunbook = "presentationTemplateRunbook",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -277,13 +277,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the HTML artifact comment-editing workflow for collecting DOM comments and preparing instrumented working-copy edits.",
     enabled: false,
   },
-  [FeatureSwitchKey.ComputerUseDelegatedAuthorization]: {
-    maintainer: "lancy@vm0.ai",
-    description:
-      "Enable short-lived Computer Use authorization links for agent runs that need a user to bind a Desktop host to the current chat or Slack thread.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ComputerUseDesktopPlugins]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the `computerUseDelegatedAuthorization` feature switch from the enum and registry
- make delegated Computer Use authorization API routes and chat action cards always use the shipped behavior
- remove feature-switch setup and disabled-state coverage from the related API, Slack probe, and chat card tests

## Verification
- `pnpm exec prettier --write apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts apps/api/src/signals/routes/zero-computer-use-authorization.ts apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx apps/platform/src/views/zero-page/zero-chat-thread-page.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm exec vitest run src/signals/routes/__tests__/computer-use.bdd.test.ts src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts`
- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`