### PR TITLE
test: stabilize generation template incomplete context coverage

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -356,6 +356,19 @@ async function waitForThreadMessages(
   return page;
 }
 
+async function waitForRunUserMessage(
+  actor: ApiTestUser,
+  threadId: string,
+  runId: string,
+  content: string,
+): Promise<void> {
+  await waitForThreadMessages(actor, threadId, (items) => {
+    return userMessages(items).some((message) => {
+      return message.runId === runId && message.content === content;
+    });
+  });
+}
+
 async function waitForRunStatus(
   actor: ApiTestUser,
   runId: string,
@@ -2639,6 +2652,12 @@ describe("CHAT-02: generation templates and attachments", () => {
     expect(secondPrompt).toContain("# Web Chat Run Context");
     expect(secondPrompt).not.toContain("Selected a template");
     expect(secondPrompt).not.toContain(style.illustrationStyleId);
+    await waitForRunUserMessage(
+      actor,
+      first.threadId,
+      second.runId,
+      "another one",
+    );
     await cancelChatRun(actor, second.runId);
 
     // Turn 3: attaching a video preset now only resolves the video template live
@@ -2666,6 +2685,8 @@ describe("CHAT-02: generation templates and attachments", () => {
     expect(thirdPrompt).toContain(
       `zero generate video --provider built-in --template ${videoTemplate.id}`,
     );
+    expect(thirdPrompt).toContain("# Incomplete Rounds Context");
+    expect(thirdPrompt).not.toContain("# Web Chat Run Context");
     // The illustration style is gone entirely for this turn: it's not attached
     // to this message, and prior/incomplete context no longer repeats template
     // selections.


### PR DESCRIPTION
## Summary
- wait for the second chat run user message to be visible and associated with its run before cancelling it
- assert the follow-up template test enters `# Incomplete Rounds Context` instead of falling back to `# Web Chat Run Context`
- keep the test API-only and avoid direct database inspection

## Verification
- `pnpm exec prettier --check apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- attempted targeted Vitest: `pnpm vitest run --project=api apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "is one-shot: a follow-up without re-attaching the style gets no template context"` blocked locally because this runtime has no Postgres/Docker and `localhost:5432/vm0_test` refused the DB connection