### PR TITLE
feat: show Create workflow button in home page chat composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -37,7 +37,16 @@ import {
   setBillingSubPage$,
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
+import type { ModelProviderSelection } from "./components/model-provider-picker.tsx";
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
+import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx";
+import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "./workflow-chat-prompts.ts";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import {
+  replaceWorkflowPromptDraftTarget$,
+  setReplaceWorkflowPromptDraftTarget$,
+} from "../../signals/chat-page/workflow-prompt-action.ts";
 import { AttachmentLightbox } from "./zero-attachment-chips.tsx";
 import {
   chatPageDefaultModelSelection$,
@@ -462,34 +471,26 @@ function useAgentChatDraftSync(pageSignal: AbortSignal) {
   };
 }
 
-export function AgentChatPage() {
-  const currentChatAgentId = useLastResolved(currentChatAgentId$);
-  const currentChatAgentDisplayName = useLastResolved(
-    currentChatAgentDisplayName$,
-  );
-
+function useAgentChatSendMessage({
+  currentChatAgentId,
+  modelSelection,
+  selectedComputerUseHostId,
+  clearComputerUseHostId,
+  setGenerationTemplate,
+}: {
+  currentChatAgentId: string | null | undefined;
+  modelSelection: ModelProviderSelection | null;
+  selectedComputerUseHostId: string | null | undefined;
+  clearComputerUseHostId: () => void;
+  setGenerationTemplate: (value: GenerationTemplateRequest | undefined) => void;
+}): (
+  message: string,
+  selectedGenerationTemplate: GenerationTemplateRequest | undefined,
+) => void {
   const sendNewThread = useSet(sendNewThreadOptimistically$);
-  const generationTemplate = useGet(newThreadGenerationTemplate$);
-  const setGenerationTemplate = useSet(setNewThreadGenerationTemplate$);
-  const { selectedComputerUseHostId, clearComputerUseHostId, computerUse } =
-    useNewThreadComputerUse();
   const rootSignal = useGet(rootSignal$);
-  const pageSignal = useGet(pageSignal$);
-  const subscribeComputerUseHostsChangedRef = useSet(
-    subscribeComputerUseHostsChangedRef$,
-  );
-  const {
-    modelSelection,
-    modelPicker,
-    modelPickerLoading,
-    submitBlockerProps,
-  } = useAgentChatComposerModel(pageSignal);
-  const resetModelSelection = useSet(resetChatPageModelSelection$);
 
-  const handleSendMessage = (
-    message: string,
-    selectedGenerationTemplate: GenerationTemplateRequest | undefined,
-  ) => {
+  return (message, selectedGenerationTemplate) => {
     if (!currentChatAgentId) {
       return;
     }
@@ -514,12 +515,102 @@ export function AgentChatPage() {
       Reason.DomCallback,
     );
   };
+}
+
+function useAgentChatComposerWorkflowPrompt({
+  input,
+  setInput,
+  queueDraftSync,
+}: {
+  input: string;
+  setInput: (value: string) => void;
+  queueDraftSync: () => void;
+}): {
+  onCreateWorkflowPrompt: (() => void) | undefined;
+  replaceDraftDialogOpen: boolean;
+  onConfirmReplaceDraft: () => void;
+  onReplaceDialogOpenChange: (open: boolean) => void;
+} {
+  const features = useGet(featureSwitch$);
+  const replaceDraftTarget = useGet(replaceWorkflowPromptDraftTarget$);
+  const setReplaceDraftTarget = useSet(setReplaceWorkflowPromptDraftTarget$);
+  const workflowAutomationEnabled =
+    features[FeatureSwitchKey.WorkflowAutomation] ?? false;
+  const workflowPromptDraftTarget = "composer:new-thread";
+  const replaceDraftDialogOpen =
+    replaceDraftTarget === workflowPromptDraftTarget;
+
+  const applyWorkflowPrompt = () => {
+    setInput(CREATE_WORKFLOW_WITH_CHAT_PROMPT);
+    queueDraftSync();
+  };
+
+  const handleCreateWorkflowPrompt = () => {
+    if (input.trim().length > 0) {
+      setReplaceDraftTarget(workflowPromptDraftTarget);
+      return;
+    }
+    applyWorkflowPrompt();
+  };
+
+  const handleConfirmReplaceDraft = () => {
+    setReplaceDraftTarget(null);
+    applyWorkflowPrompt();
+  };
+
+  const handleReplaceDialogOpenChange = (open: boolean) => {
+    setReplaceDraftTarget(open ? workflowPromptDraftTarget : null);
+  };
+
+  return {
+    onCreateWorkflowPrompt: workflowAutomationEnabled
+      ? handleCreateWorkflowPrompt
+      : undefined,
+    replaceDraftDialogOpen,
+    onConfirmReplaceDraft: handleConfirmReplaceDraft,
+    onReplaceDialogOpenChange: handleReplaceDialogOpenChange,
+  };
+}
+
+export function AgentChatPage() {
+  const currentChatAgentId = useLastResolved(currentChatAgentId$);
+  const currentChatAgentDisplayName = useLastResolved(
+    currentChatAgentDisplayName$,
+  );
+
+  const generationTemplate = useGet(newThreadGenerationTemplate$);
+  const setGenerationTemplate = useSet(setNewThreadGenerationTemplate$);
+  const { selectedComputerUseHostId, clearComputerUseHostId, computerUse } =
+    useNewThreadComputerUse();
+  const pageSignal = useGet(pageSignal$);
+  const subscribeComputerUseHostsChangedRef = useSet(
+    subscribeComputerUseHostsChangedRef$,
+  );
+  const {
+    modelSelection,
+    modelPicker,
+    modelPickerLoading,
+    submitBlockerProps,
+  } = useAgentChatComposerModel(pageSignal);
+  const resetModelSelection = useSet(resetChatPageModelSelection$);
+  const handleSendMessage = useAgentChatSendMessage({
+    currentChatAgentId,
+    modelSelection,
+    selectedComputerUseHostId,
+    clearComputerUseHostId,
+    setGenerationTemplate,
+  });
 
   const userFirstName = useLastResolved(user$)?.firstName ?? null;
 
   const input = useGet(chatPageInput$);
   const setInput = useSet(setChatPageInput$);
   const queueAgentDraftSync = useAgentChatDraftSync(pageSignal);
+  const workflowPrompt = useAgentChatComposerWorkflowPrompt({
+    input,
+    setInput,
+    queueDraftSync: queueAgentDraftSync,
+  });
   const startTiming = useSet(startChatNavigationTiming$);
   const taglineIndex = useGet(chatPageTaglineIndex$);
   const tagline =
@@ -589,9 +680,15 @@ export function AgentChatPage() {
               value: generationTemplate,
               onChange: setGenerationTemplate,
             }}
+            onCreateWorkflowPrompt={workflowPrompt.onCreateWorkflowPrompt}
             computerUse={computerUse}
             modelPickerLoading={modelPickerLoading}
             submitBlocker={submitBlockerProps}
+          />
+          <ReplaceComposerDraftDialog
+            open={workflowPrompt.replaceDraftDialogOpen}
+            onOpenChange={workflowPrompt.onReplaceDialogOpenChange}
+            onConfirm={workflowPrompt.onConfirmReplaceDraft}
           />
 
           <SuggestedPromptsGrid onSelectPrompt={handleInputChange} />

--- a/turbo/apps/platform/src/views/zero-page/replace-composer-draft-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/replace-composer-draft-dialog.tsx
@@ -1,0 +1,47 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui";
+
+export function ReplaceComposerDraftDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="zero-app sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Replace composer draft?</DialogTitle>
+          <DialogDescription>
+            Continuing will clear your current composer draft and start a
+            workflow prompt.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              onOpenChange(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={onConfirm}>
+            Continue
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -260,6 +260,7 @@ import {
   type WorkflowTriggerCardRow,
 } from "../workflows-page/workflow-trigger-card.tsx";
 import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "./workflow-chat-prompts.ts";
+import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx";
 
 import {
   renameChatThread$,
@@ -7758,44 +7759,6 @@ function PagedGroupPrimaryActions({
       )}
       {usage && firstRunId && <RunUsageChip runId={firstRunId} usage={usage} />}
     </div>
-  );
-}
-
-function ReplaceComposerDraftDialog({
-  open,
-  onOpenChange,
-  onConfirm,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onConfirm: () => void;
-}) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="zero-app sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Replace composer draft?</DialogTitle>
-          <DialogDescription>
-            Continuing will clear your current composer draft and start a
-            workflow prompt.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              onOpenChange(false);
-            }}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={onConfirm}>
-            Continue
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 


### PR DESCRIPTION
## Problem

On the home page (`agent-chat-page.tsx`, the "Molly has entered the chat" screen), the chat composer's bottom toolbar shows attach / illustration / connectors / model picker / mic / send — but **no "Create workflow" button**, even when the `WorkflowAutomation` feature switch is on.

The button itself already exists (`CreateWorkflowPromptButton` → `ComposerWorkflowPromptSlot` in `zero-chat-composer.tsx`), and it renders correctly in the **in-thread** composer. The slot only renders when both the `WorkflowAutomation` switch is on **and** the `onCreateWorkflowPrompt` prop is passed. The home page never passed `onCreateWorkflowPrompt`, so the slot was always `null` there — regardless of the feature switch. As a result, users can't start the chat-driven workflow creation flow from the landing composer.

## Change

Wire the home composer to the same flow the thread composer already uses:

- **`useAgentChatComposerWorkflowPrompt`** (new hook in `agent-chat-page.tsx`) — pre-fills the composer with `CREATE_WORKFLOW_WITH_CHAT_PROMPT`, gated on the `WorkflowAutomation` feature switch (so `onCreateWorkflowPrompt` is `undefined` when off, exactly like the thread page). If the composer already has a typed draft, it defers to a replace-draft confirmation dialog instead of clobbering it.
- **`ReplaceComposerDraftDialog`** — extracted from `zero-chat-thread-page.tsx` into its own module (`replace-composer-draft-dialog.tsx`) and reused by both the home and thread pages (no behavior change on the thread page; pure move).
- **`useAgentChatSendMessage`** — extracted the existing inline `handleSendMessage` into a hook so `AgentChatPage` stays within the platform `max-lines-per-function: 128` lint budget. No behavior change.

## User-visible impact

With the `WorkflowAutomation` feature switch enabled, the home page composer now shows the "Create workflow" button (the `IconRoute` icon, `aria-label="Create workflow"`). Clicking it pre-fills the composer with the workflow-setup prompt — matching the existing in-thread behavior. When the switch is off, nothing changes.

## Verification

- `prettier@3.8.1 --check` — clean on changed files.
- Package-local `oxlint` (`turbo/apps/platform`) — 0 warnings / 0 errors (including `max-lines-per-function`).
- Existing "Create workflow" button tests in `chat-lifecycle.test.tsx` exercise the thread-page path; this change reuses the identical component/prop wiring, and the thread-page edit is a pure extraction. Type-check / full test suite left to the PR pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)