### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.198"
+CLAUDE_CODE_VERSION="2.1.199"
 CODEX_CLI_VERSION="0.142.5"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"


### PR DESCRIPTION
## Summary
- Updated the rootfs template Claude Code standalone binary from 2.1.198 to 2.1.199.
- Checked the other pinned versions and left them unchanged because they already match current stable/latest upstream versions or configured LTS major lines.

## Updated versions
- Claude Code: 2.1.198 -> 2.1.199

## Verification
- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`