### PR TITLE
docs(platform): clarify workflows page subtitle as a reusable SOP

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -809,7 +809,8 @@ export function WorkflowsPage() {
               Workflows
             </h1>
             <p className="mt-0.5 text-sm text-muted-foreground">
-              Reusable instructions your team can run, edit, or automate.
+              A reusable SOP for a task. Write one from scratch or distill it
+              from your daily work, then run, edit, or automate it.
             </p>
           </div>
           <Button


### PR DESCRIPTION
## What & why

The Workflows page header subtitle read *"Reusable instructions your team can run, edit, or automate."* Users didn't grasp what a workflow actually **is** — that it's a Standard Operating Procedure / best-practice playbook for a task, and that they can either author one from scratch or distill one out of the work they already do every day.

## Change

Reword the subtitle in `turbo/apps/platform/src/views/workflows-page/workflows-page.tsx` (desktop header):

> **Before:** Reusable instructions your team can run, edit, or automate.
> **After:** A reusable SOP for a task. Write one from scratch or distill it from your daily work, then run, edit, or automate it.

This leads with the concept (a reusable SOP), adds the "create yourself or abstract from daily tasks" origin, and keeps the run / edit / automate framing that matches the filter tabs below it. Copy-only, no behavior change.

## Verification

- `prettier@3.8.1 --check` on the changed file: unchanged (already formatted)
- `oxlint@1.57.0` (platform-local) on the changed file: 0 warnings, 0 errors