### PR TITLE
Render event-sourced chat thread lists from cached IndexedDB snapshot before remote sync.

### DIFF
--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -105,6 +105,7 @@ export async function setupPage(options: {
   };
   debugLoggers?: string[];
   featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
+  withoutRender?: boolean;
 }) {
   ensureTestLocalStorage();
   createPushStateMock(options.context.signal);
@@ -170,6 +171,9 @@ export async function setupPage(options: {
     bootstrap$,
     () => {
       setupRouter(options.context.store, (element) => {
+        if (options.withoutRender) {
+          return;
+        }
         const { unmount } = render(element);
         options.context.signal.addEventListener("abort", () => {
           unmount();

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -5,12 +5,7 @@ import {
   type PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  agentById,
-  agents$,
-  currentAgentId$,
-  defaultAgentId$,
-} from "./agent.ts";
+import { agentById, currentAgentId$, defaultAgentId$ } from "./agent.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
@@ -186,22 +181,8 @@ const eventDrivenFilteredChatThreads$ = computed(
 
 const eventDrivenVisibleChatThreads$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
-    const [threads, allAgents, legacyThreads] = await Promise.all([
-      get(eventDrivenFilteredChatThreads$),
-      get(agents$),
-      get(legacyChatThreads$),
-    ]);
+    const threads = await get(eventDrivenFilteredChatThreads$);
     const maxItems = get(chatThreadMaxItem$);
-    const avatarByAgentId = new Map(
-      allAgents.map((agent) => {
-        return [agent.id, agent.avatarUrl ?? null] as const;
-      }),
-    );
-    const runningByThreadId = new Map(
-      legacyThreads.map((thread) => {
-        return [thread.id, thread.running] as const;
-      }),
-    );
     const pendingRunningByThreadId = new Map(
       get(allPendingChatThreads$).map((thread) => {
         return [thread.threadId, thread.running] as const;
@@ -214,14 +195,11 @@ const eventDrivenVisibleChatThreads$ = computed(
         title: thread.title,
         agent: {
           id: thread.agentId,
-          avatarUrl: avatarByAgentId.get(thread.agentId) ?? null,
+          avatarUrl: null,
         },
         createdAt: thread.createdAt,
         updatedAt: thread.updatedAt,
-        running:
-          pendingRunningByThreadId.get(thread.id) ??
-          runningByThreadId.get(thread.id) ??
-          false,
+        running: pendingRunningByThreadId.get(thread.id) ?? false,
         pinnedAt: thread.pinnedAt,
         renamedAt: thread.renamedAt,
       };

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  chatThreadsContract,
+  type ChatThreadEvent,
+  type ChatThreadSnapshotProjection,
+} from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { zeroTeamContract } from "@vm0/api-contracts/contracts/zero-team";
+
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { chatThreads$, setChatAgentId$ } from "../../agent-chat.ts";
+
+const idbThreadEventStoreMock = vi.hoisted(() => {
+  let snapshot: {
+    readonly chatThreads: readonly ChatThreadSnapshotProjection[];
+    readonly latestEventId: string | null;
+  } | null = null;
+  let events: readonly ChatThreadEvent[] = [];
+
+  const readSnapshot = vi.fn(() => {
+    return Promise.resolve(snapshot);
+  });
+  const readLatestEventId = vi.fn(() => {
+    return Promise.resolve(snapshot?.latestEventId ?? null);
+  });
+  const readEvents = vi.fn(() => {
+    return Promise.resolve(events);
+  });
+  const replaceFromSnapshot = vi.fn(() => {
+    return Promise.resolve();
+  });
+  const upsertEvents = vi.fn(() => {
+    return Promise.resolve();
+  });
+
+  return {
+    readSnapshot,
+    readLatestEventId,
+    readEvents,
+    replaceFromSnapshot,
+    upsertEvents,
+    setData(args: {
+      readonly snapshot: {
+        readonly chatThreads: readonly ChatThreadSnapshotProjection[];
+        readonly latestEventId: string | null;
+      } | null;
+      readonly events?: readonly ChatThreadEvent[];
+    }) {
+      snapshot = args.snapshot;
+      events = args.events ?? [];
+    },
+    reset() {
+      snapshot = null;
+      events = [];
+      readSnapshot.mockClear();
+      readLatestEventId.mockClear();
+      readEvents.mockClear();
+      replaceFromSnapshot.mockClear();
+      upsertEvents.mockClear();
+    },
+  };
+});
+
+vi.mock("../../external/idb-chat-thread-event-store.ts", () => {
+  return {
+    createIdbChatThreadEventStores: () => {
+      return {
+        readStore: {
+          readSnapshot: idbThreadEventStoreMock.readSnapshot,
+          readLatestEventId: idbThreadEventStoreMock.readLatestEventId,
+          readEvents: idbThreadEventStoreMock.readEvents,
+        },
+        writeStore: {
+          replaceFromSnapshot: idbThreadEventStoreMock.replaceFromSnapshot,
+          upsertEvents: idbThreadEventStoreMock.upsertEvents,
+        },
+      };
+    },
+  };
+});
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000001";
+const EVENT_ID = "d0000000-0000-4000-a000-000000000001";
+
+function expectCallback(callback: (() => void) | null): () => void {
+  expect(callback).not.toBeNull();
+  if (!callback) {
+    throw new Error("Expected callback to be set");
+  }
+  return callback;
+}
+
+describe("chat thread event sourcing local-first list", () => {
+  afterEach(() => {
+    idbThreadEventStoreMock.reset();
+  });
+
+  it("renders cached thread list data while event sync is blocked", async () => {
+    context.store.set(setChatAgentId$, AGENT_ID);
+
+    idbThreadEventStoreMock.setData({
+      snapshot: {
+        latestEventId: EVENT_ID,
+        chatThreads: [
+          {
+            id: THREAD_ID,
+            agentId: AGENT_ID,
+            title: "Cached old title",
+            sortAt: "2026-07-03T02:00:00.000Z",
+            createdAt: "2026-07-03T01:00:00.000Z",
+            updatedAt: "2026-07-03T02:00:00.000Z",
+            pinnedAt: null,
+            renamedAt: null,
+          },
+        ],
+      },
+      events: [
+        {
+          id: EVENT_ID,
+          kind: "renamed",
+          chatThreadId: THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Cached renamed title",
+          createdAt: "2026-07-03T03:00:00.000Z",
+        },
+      ],
+    });
+
+    let eventsRequests = 0;
+    let listRequests = 0;
+    let teamRequests = 0;
+    let unblockEventsRequest: (() => void) | null = null;
+    context.mocks.api(
+      chatThreadsContract.events,
+      async ({ deferred, respond }) => {
+        eventsRequests += 1;
+        const blocked = deferred<void>();
+        unblockEventsRequest = () => {
+          blocked.resolve(undefined);
+        };
+        await blocked.promise;
+        return respond(200, { events: [], hasMore: false });
+      },
+    );
+    context.mocks.api(chatThreadsContract.list, ({ never }) => {
+      listRequests += 1;
+      return never();
+    });
+    context.mocks.api(zeroTeamContract.list, ({ never }) => {
+      teamRequests += 1;
+      return never();
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      withoutRender: true,
+      user: { id: "user_1", fullName: "Test User" },
+      session: { token: "token" },
+      org: {
+        activeOrg: { id: "org_1", name: "Test Org" },
+        memberships: [{ id: "org_1" }],
+      },
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEventSourcing]: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(eventsRequests).toBe(1);
+    });
+
+    const threads = await context.store.get(chatThreads$);
+
+    expect(threads).toStrictEqual([
+      {
+        id: THREAD_ID,
+        title: "Cached renamed title",
+        agent: { id: AGENT_ID, avatarUrl: null },
+        createdAt: "2026-07-03T01:00:00.000Z",
+        updatedAt: "2026-07-03T03:00:00.000Z",
+        running: false,
+        pinnedAt: null,
+        renamedAt: "2026-07-03T03:00:00.000Z",
+      },
+    ]);
+    expect(eventsRequests).toBe(1);
+    expect(listRequests).toBe(0);
+    expect(teamRequests).toBe(0);
+    expectCallback(unblockEventsRequest)();
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -5,6 +5,7 @@ import {
   type ChatThreadEvent,
   type ChatThreadSnapshotProjection,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type {
   InitClientArgs,
   InitClientReturn,
@@ -15,6 +16,9 @@ import { clerk$ } from "../auth.ts";
 import { createIdbChatThreadEventStores } from "../external/idb-chat-thread-event-store.ts";
 import { logger } from "../log.ts";
 import { reloadChatThreadsCounter$ } from "../chat-thread-list-reload.ts";
+import { setAblyLoop$ } from "../realtime.ts";
+import { featureSwitch$ } from "../external/feature-switch.ts";
+import { settle, withCleanup } from "../utils.ts";
 import { replayChatThreadEvents } from "./chat-thread-event-replay.ts";
 
 const L = logger("ChatThreadEventSourcing");
@@ -30,6 +34,8 @@ interface ChatThreadEventData {
 
 const optimisticChatThreadEventsState$ = state<readonly ChatThreadEvent[]>([]);
 const chatThreadMaxItemState$ = state(CHAT_THREAD_VISIBLE_PAGE_SIZE);
+const chatThreadEventSyncVersionState$ = state(0);
+const chatThreadEventSyncInFlightState$ = state(false);
 
 export const chatThreadMaxItem$ = computed((get) => {
   return get(chatThreadMaxItemState$);
@@ -107,13 +113,17 @@ async function syncChatThreadEvents(
 const chatThreadEventData$ = computed(
   async (get): Promise<ChatThreadEventData> => {
     get(reloadChatThreadsCounter$);
+    get(chatThreadEventSyncVersionState$);
     const store = await get(chatThreadEventStores$);
     if (!store) {
       return { snapshot: [], events: [] };
     }
 
-    const client = get(zeroClient$)(chatThreadsContract);
-    await syncChatThreadEvents(store, client);
+    const cachedSnapshot = await store.readStore.readSnapshot();
+    if (!cachedSnapshot) {
+      const client = get(zeroClient$)(chatThreadsContract);
+      await syncChatThreadEvents(store, client);
+    }
 
     const [snapshot, events] = await Promise.all([
       store.readStore.readSnapshot(),
@@ -123,6 +133,61 @@ const chatThreadEventData$ = computed(
       snapshot: snapshot?.chatThreads ?? [],
       events,
     };
+  },
+);
+
+export const syncEventDrivenChatThreads$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    const store = await get(chatThreadEventStores$);
+    signal.throwIfAborted();
+    if (!store || get(chatThreadEventSyncInFlightState$)) {
+      return;
+    }
+
+    set(chatThreadEventSyncInFlightState$, true);
+    await withCleanup(
+      (async () => {
+        const client = get(zeroClient$)(chatThreadsContract);
+        const synced = await settle(
+          syncChatThreadEvents(store, client, signal),
+          signal,
+        );
+        if (!synced.ok) {
+          L.debug("event sync failed", { error: synced.error });
+          return;
+        }
+        signal.throwIfAborted();
+        set(chatThreadEventSyncVersionState$, (version) => {
+          return version + 1;
+        });
+      })(),
+      () => {
+        set(chatThreadEventSyncInFlightState$, false);
+      },
+    );
+  },
+);
+
+export const subscribeEventDrivenChatThreads$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<void> => {
+    if (!get(featureSwitch$)[FeatureSwitchKey.ChatThreadEventSourcing]) {
+      return;
+    }
+
+    const syncOnThreadListChanged$ = command(
+      async ({ set }, signal: AbortSignal): Promise<boolean> => {
+        await set(syncEventDrivenChatThreads$, signal);
+        return false;
+      },
+    );
+
+    await set(syncEventDrivenChatThreads$, signal);
+    signal.throwIfAborted();
+    await set(
+      setAblyLoop$,
+      { topic: "threadListChanged", loopCommand$: syncOnThreadListChanged$ },
+      signal,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -10,6 +10,7 @@ import {
   subscribeThreadListChanged$,
 } from "../signals/chat-thread-list-reload.ts";
 import { subscribeBackgroundChatThreadRunFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
+import { subscribeEventDrivenChatThreads$ } from "../signals/chat-page/chat-thread-event-sourcing.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import { detach, Reason } from "../signals/utils.ts";
 import { IN_VITEST } from "../env.ts";
@@ -29,6 +30,7 @@ export const setupRouter = (
     store.set(subscribeBackgroundChatThreadRunFinished$, signal),
     Reason.Daemon,
   );
+  detach(store.set(subscribeEventDrivenChatThreads$, signal), Reason.Daemon);
   render(
     <StrictMode>
       <StoreProvider value={store}>

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -1044,7 +1044,6 @@ function ChatThreadsSkeleton() {
 
 function ChatThreadsContent() {
   const chatThreadsLoading = useLastLoadable(chatThreads$).state === "loading";
-
   const collapsed = useGet(sessionListCollapsed$);
 
   return (


### PR DESCRIPTION
## Summary
- Render event-sourced chat thread lists from cached IndexedDB snapshot/events before waiting on remote event sync.
- Move event-driven thread sync into global bootstrap instead of a sidebar render side effect.
- Remove legacy chat thread list and team list dependencies from the event-sourced sidebar critical path, and add a platform Vitest covering blocked API sync with cached local data.

## Verification
- pnpm --filter @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts src/signals/chat-page/__tests__/chat-thread-event-replay.test.ts src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts --reporter verbose
- pnpm --filter @vm0/app check-types
- pnpm --filter @vm0/app lint
- git diff --check