### PR TITLE
chore(rust): update num-bigint and rustc-hash

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2584,9 +2584,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"


### PR DESCRIPTION
## Summary
- Ran `cargo update --verbose` for the Rust workspace in `crates/`.
- Updated `num-bigint` from `0.4.6` to `0.4.7`.
- Updated `rustc-hash` from `2.1.2` to `2.1.3`.

## Dependencies not updated
- `generic-array` remains at `0.14.7` although `0.14.9` is available. `cargo update -p generic-array --verbose` left it unchanged because the resolved transitive dependency `crypto-common 0.1.7` requires `generic-array =0.14.7` exactly via the `digest 0.10.7` dependency chain. This is not pinned by a vm0 `Cargo.toml` entry, so there was no safe local manifest bump to make.

## Manual version bumps
- None. No safe minor/patch `Cargo.toml` version specifier bumps were needed or available.

## Test status
- Passed: `umask 077 && CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target-nodebug RUSTFLAGS='-C debuginfo=0' cargo test --workspace -j 1`
- Passed: `cargo fmt --check`

Notes on local retries:
- A default `cargo test --workspace` first failed because `/tmp`/root filled while Cargo wrote build artifacts under `/tmp/vm0-rust-deps/crates/target`.
- Retrying with `CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target` avoided the disk issue, but the `runner` test binary link was killed by the local runtime memory limit.
- The final passing run used a workspace-backed target directory, `-j 1`, reduced debug info, and `umask 077`; the restrictive umask is required in this environment so runner tests create private temp directories accepted by the lock/queue path safety checks.