### PR TITLE
fix: keep event-sourced chat header synced from thread meta

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -263,9 +263,9 @@ const openFocusedThreadEmojiMenu$ = command(
     if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
       return;
     }
-    const threadData = await get(args.thread.threadData$);
+    const threadMeta = await get(args.thread.threadMeta$);
     signal.throwIfAborted();
-    const title = args.title !== undefined ? args.title : threadData?.title;
+    const title = args.title !== undefined ? args.title : threadMeta?.title;
     set(openChatThreadEmojiMenu$, { threadId: args.thread.threadId, title });
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -28,6 +28,17 @@ interface ChatThreadEventData {
   readonly events: readonly ChatThreadEvent[];
 }
 
+interface ChatThreadSnapshotData {
+  readonly chatThreads: readonly ChatThreadSnapshotProjection[];
+  readonly latestEventId: string | null;
+}
+
+export interface ThreadMeta {
+  readonly threadId: string;
+  readonly agentId: string;
+  readonly title: string | null;
+}
+
 const optimisticChatThreadEventsState$ = state<readonly ChatThreadEvent[]>([]);
 const chatThreadMaxItemState$ = state(CHAT_THREAD_VISIBLE_PAGE_SIZE);
 
@@ -50,7 +61,7 @@ async function replaceFromRemoteSnapshot(
   store: Stores["writeStore"],
   client: ChatThreadsClient,
   signal?: AbortSignal,
-): Promise<string | null> {
+): Promise<ChatThreadSnapshotData> {
   const result = await accept(
     client.snapshot({ fetchOptions: { signal } }),
     [200],
@@ -58,18 +69,24 @@ async function replaceFromRemoteSnapshot(
   );
   signal?.throwIfAborted();
   await store.replaceFromSnapshot(result.body, signal);
-  return result.body.latestEventId;
+  return result.body;
 }
 
 async function syncChatThreadEvents(
   store: Stores,
   client: ChatThreadsClient,
   signal?: AbortSignal,
-): Promise<void> {
+): Promise<ChatThreadSnapshotData | null> {
   const existingSnapshot = await store.readStore.readSnapshot(signal);
+  let activeSnapshot = existingSnapshot;
   let cursor = await store.readStore.readLatestEventId(signal);
-  if (!existingSnapshot) {
-    cursor = await replaceFromRemoteSnapshot(store.writeStore, client, signal);
+  if (!activeSnapshot) {
+    activeSnapshot = await replaceFromRemoteSnapshot(
+      store.writeStore,
+      client,
+      signal,
+    );
+    cursor = activeSnapshot.latestEventId;
   }
 
   for (let page = 0; page < 20; page++) {
@@ -85,11 +102,12 @@ async function syncChatThreadEvents(
 
     if (result.status === 410) {
       L.debug("events cursor expired, reloading snapshot");
-      cursor = await replaceFromRemoteSnapshot(
+      activeSnapshot = await replaceFromRemoteSnapshot(
         store.writeStore,
         client,
         signal,
       );
+      cursor = activeSnapshot.latestEventId;
       continue;
     }
 
@@ -99,9 +117,10 @@ async function syncChatThreadEvents(
     }
 
     if (!result.body.hasMore || result.body.events.length === 0) {
-      return;
+      return activeSnapshot;
     }
   }
+  return activeSnapshot;
 }
 
 const chatThreadEventData$ = computed(
@@ -113,14 +132,14 @@ const chatThreadEventData$ = computed(
     }
 
     const client = get(zeroClient$)(chatThreadsContract);
-    await syncChatThreadEvents(store, client);
+    const syncedSnapshot = await syncChatThreadEvents(store, client);
 
     const [snapshot, events] = await Promise.all([
       store.readStore.readSnapshot(),
       store.readStore.readEvents(),
     ]);
     return {
-      snapshot: snapshot?.chatThreads ?? [],
+      snapshot: (snapshot ?? syncedSnapshot)?.chatThreads ?? [],
       events,
     };
   },
@@ -155,6 +174,27 @@ export const eventDrivenChatThreads$ = computed(async (get) => {
     await get(allChatThreadsEvents$),
   );
 });
+
+export const eventDrivenChatThreadMetaMap$ = computed(async (get) => {
+  return new Map<string, ThreadMeta>(
+    (await get(eventDrivenChatThreads$)).map((thread) => {
+      return [
+        thread.id,
+        {
+          threadId: thread.id,
+          agentId: thread.agentId,
+          title: thread.title,
+        },
+      ];
+    }),
+  );
+});
+
+export function eventDrivenChatThreadMeta(threadId: string) {
+  return computed(async (get): Promise<ThreadMeta | null> => {
+    return (await get(eventDrivenChatThreadMetaMap$)).get(threadId) ?? null;
+  });
+}
 
 export const registerOptimisticChatThreadEvent$ = command(
   ({ set }, event: ChatThreadEvent) => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
@@ -32,11 +32,11 @@ export const openRenameChatThreadDialogFromThreadData$ = command(
       get(currentLeftThread$),
       get(currentRightThread$),
     );
-    const threadData = thread ? await get(thread.threadData$) : null;
+    const threadMeta = thread ? await get(thread.threadMeta$) : null;
     signal.throwIfAborted();
     set(openRenameChatThreadDialog$, {
       threadId,
-      title: threadData?.title,
+      title: threadMeta?.title,
     });
   },
 );
@@ -69,9 +69,9 @@ export const setChatThreadEmojiFromThreadData$ = command(
       get(currentLeftThread$),
       get(currentRightThread$),
     );
-    const threadData = thread ? await get(thread.threadData$) : null;
+    const threadMeta = thread ? await get(thread.threadMeta$) : null;
     signal.throwIfAborted();
-    const currentTitle = title !== undefined ? title : threadData?.title;
+    const currentTitle = title !== undefined ? title : threadMeta?.title;
     await set(
       renameChatThread$,
       { threadId, title: applyChatThreadEmoji(currentTitle, emoji) },
@@ -92,9 +92,9 @@ export const clearChatThreadEmojiFromThreadData$ = command(
       get(currentLeftThread$),
       get(currentRightThread$),
     );
-    const threadData = thread ? await get(thread.threadData$) : null;
+    const threadMeta = thread ? await get(thread.threadMeta$) : null;
     signal.throwIfAborted();
-    const currentTitle = title !== undefined ? title : threadData?.title;
+    const currentTitle = title !== undefined ? title : threadMeta?.title;
     const nextTitle = removeChatThreadEmoji(currentTitle);
     if (!nextTitle) {
       return;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -9,6 +9,7 @@ import type {
   EnrichedChatMessage,
   GroupedChatMessageGroup,
 } from "./chat-message.ts";
+import type { ThreadMeta } from "./chat-thread-event-sourcing.ts";
 
 export interface LoadHistoryResult {
   hasMore: boolean;
@@ -29,6 +30,7 @@ export interface ChatThreadSignals {
   threadId: string;
   // -- Data signals ----------------------------------------------------------
   threadData$: Computed<Promise<ChatThread | null>>;
+  threadMeta$: Computed<Promise<ThreadMeta | null>>;
   reloadThread$: Command<void, []>;
   threadTitleEmoji$: Computed<Promise<string | null>>;
   threadTitleText$: Computed<Promise<string>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -89,6 +89,10 @@ import {
 } from "./parse-body-blocks.ts";
 import { getChatThreadTitleParts } from "./chat-thread-title.ts";
 import {
+  eventDrivenChatThreadMeta,
+  type ThreadMeta,
+} from "./chat-thread-event-sourcing.ts";
+import {
   previousRunGroupVisualWindowStartIndex,
   runGroupVisualWindowStartIndex,
 } from "./run-group-folding.ts";
@@ -491,12 +495,38 @@ function createThreadData(dataSource: ChatThreadDataSource) {
   };
 }
 
-function createThreadTitleParts(
+function threadMetaFromThreadData(threadData: ChatThread): ThreadMeta {
+  return {
+    threadId: threadData.id,
+    agentId: threadData.agentId,
+    title: threadData.title,
+  };
+}
+
+function createThreadMeta(
+  threadId: string,
   threadData$: Computed<Promise<ChatThread | null>>,
 ) {
-  const threadTitleParts$ = computed(async (get) => {
+  const eventDrivenThreadMeta$ = eventDrivenChatThreadMeta(threadId);
+  return computed(async (get): Promise<ThreadMeta | null> => {
+    if (
+      get(featureSwitch$)[FeatureSwitchKey.ChatThreadEventSourcing] ??
+      false
+    ) {
+      return await get(eventDrivenThreadMeta$);
+    }
+
     const threadData = await get(threadData$);
-    return getChatThreadTitleParts(threadData?.title);
+    return threadData ? threadMetaFromThreadData(threadData) : null;
+  });
+}
+
+function createThreadTitleParts(
+  threadMeta$: Computed<Promise<ThreadMeta | null>>,
+) {
+  const threadTitleParts$ = computed(async (get) => {
+    const threadMeta = await get(threadMeta$);
+    return getChatThreadTitleParts(threadMeta?.title);
   });
   const threadTitleEmoji$ = computed(async (get) => {
     return (await get(threadTitleParts$)).emoji;
@@ -3441,8 +3471,9 @@ export function createChatThreadSignals(
   dataSource: ChatThreadDataSource = createRemoteChatThreadDataSource(threadId),
 ): ChatThreadSignals {
   const { threadData$, reloadThread$ } = createThreadData(dataSource);
+  const threadMeta$ = createThreadMeta(threadId, threadData$);
   const { threadTitleEmoji$, threadTitleText$ } =
-    createThreadTitleParts(threadData$);
+    createThreadTitleParts(threadMeta$);
   const { modelSelection$, setModelSelection$ } = createModelSelection(
     threadId,
     threadData$,
@@ -3519,6 +3550,7 @@ export function createChatThreadSignals(
   return {
     threadId,
     threadData$,
+    threadMeta$,
     reloadThread$,
     threadTitleEmoji$,
     threadTitleText$,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -67,6 +67,7 @@ const AUTOMATION_THREAD_ID = "b0000000-0000-4000-a000-000000000701";
 const GITHUB_PR_THREAD_ID = "b0000000-0000-4000-a000-000000000702";
 const FOLLOWUP_THREAD_ID = "b0000000-0000-4000-a000-000000000704";
 const HISTORY_THREAD_ID = "b0000000-0000-4000-a000-000000000705";
+const EVENT_SOURCED_RENAME_THREAD_ID = "b0000000-0000-4000-a000-000000000706";
 const AGENT_CHAT_PATH = `/agents/${AGENT_ID}/chat`;
 
 function replaceNavigatorProperty(property: string, value: unknown): void {
@@ -3666,6 +3667,91 @@ describe("chat lifecycle", () => {
     expect(
       within(reopenedDialog).getByPlaceholderText("Chat title"),
     ).toHaveValue("Current keyboard thread");
+  });
+
+  it("renames the event-sourced current chat while thread detail is pending", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockResizeObserver();
+    const originalTitle = "Original event-sourced thread";
+    const renamedTitle = "Renamed event-sourced thread";
+    const thread = {
+      id: EVENT_SOURCED_RENAME_THREAD_ID,
+      title: originalTitle,
+      agent: { id: AGENT_ID, avatarUrl: null },
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+      running: false,
+      pinnedAt: null,
+    };
+    const lifecycle = mockChatLifecycle(context, {
+      threadId: EVENT_SOURCED_RENAME_THREAD_ID,
+      threadTitle: "Thread detail should stay pending",
+    });
+    lifecycle.setThreadList([thread]);
+    const renameRequest = vi.fn();
+
+    context.mocks.api(chatThreadByIdContract.get, ({ never }) => {
+      return never();
+    });
+    context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+      return respond(200, {
+        chatThreads: [
+          {
+            id: EVENT_SOURCED_RENAME_THREAD_ID,
+            agentId: AGENT_ID,
+            title: originalTitle,
+            sortAt: "2026-06-01T00:00:00.000Z",
+            createdAt: "2026-06-01T00:00:00.000Z",
+            updatedAt: "2026-06-01T00:00:00.000Z",
+            pinnedAt: null,
+            renamedAt: null,
+          },
+        ],
+        latestEventId: null,
+      });
+    });
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, { events: [], hasMore: false });
+    });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${EVENT_SOURCED_RENAME_THREAD_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEventSourcing]: true },
+    });
+
+    const threadRegion = await screen.findByLabelText("Chat thread");
+    await waitFor(() => {
+      expect(within(threadRegion).getByText(originalTitle)).toBeInTheDocument();
+    });
+    expect(
+      within(threadRegion).queryByText("Thread detail should stay pending"),
+    ).not.toBeInTheDocument();
+
+    threadRegion.focus();
+    await user.keyboard("{F2}");
+
+    const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
+      originalTitle,
+    );
+    await fill(within(dialog).getByPlaceholderText("Chat title"), renamedTitle);
+    click(buttonByText("Rename", dialog));
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        EVENT_SOURCED_RENAME_THREAD_ID,
+        renamedTitle,
+      );
+      expect(within(threadRegion).getByText(renamedTitle)).toBeInTheDocument();
+    });
   });
 
   it("keeps F2 rename available after creating a chat from the agent composer", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1101,7 +1101,7 @@ function GithubPrTrackingDock({ thread }: { thread: ChatThreadSignals }) {
 }
 
 function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
-  const threadDataLoadable = useLastLoadable(thread.threadData$);
+  const threadMetaLoadable = useLastLoadable(thread.threadMeta$);
   const threadTitleEmoji = useLastResolved(thread.threadTitleEmoji$);
   const threadTitleText = useLastResolved(thread.threadTitleText$) ?? "";
   const features = useLastResolved(featureSwitch$);
@@ -1110,19 +1110,19 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const chatThreadEmojiEnabled =
     features?.[FeatureSwitchKey.ChatThreadEmoji] ?? false;
   const agentId =
-    threadDataLoadable.state === "hasData"
-      ? (threadDataLoadable.data?.agentId ?? null)
+    threadMetaLoadable.state === "hasData"
+      ? (threadMetaLoadable.data?.agentId ?? null)
       : null;
   const threadTitle =
-    threadDataLoadable.state === "hasData"
-      ? (threadDataLoadable.data?.title?.trim() ?? "")
+    threadMetaLoadable.state === "hasData"
+      ? (threadMetaLoadable.data?.title?.trim() ?? "")
       : "";
   const displayTitle = chatThreadEmojiEnabled ? threadTitleText : threadTitle;
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
       <div className="flex min-w-0 items-center gap-2">
-        {threadDataLoadable.state === "loading" ? (
+        {threadMetaLoadable.state === "loading" ? (
           <Skeleton className="h-5 w-48 rounded" />
         ) : (
           <>
@@ -3367,17 +3367,15 @@ function githubPrTrackingLayoutStyle(
   };
 }
 
-function useGithubPrTrackingOpen(
-  thread: ChatThreadSignals,
-  threadDataLoadable: LoadableValue<ChatThread | null>,
-): boolean {
+function useGithubPrTrackingOpen(thread: ChatThreadSignals): boolean {
   const openGithubPrTrackingThreadId = useGet(githubPrTrackingOpenThreadId$);
+  const threadMetaLoadable = useLastLoadable(thread.threadMeta$);
   const features = useLastResolved(featureSwitch$);
   const githubPrTrackingEnabled =
     features?.[FeatureSwitchKey.ChatGithubPrTracking] ?? false;
   const agentId =
-    threadDataLoadable.state === "hasData"
-      ? (threadDataLoadable.data?.agentId ?? null)
+    threadMetaLoadable.state === "hasData"
+      ? (threadMetaLoadable.data?.agentId ?? null)
       : null;
 
   return (
@@ -4220,10 +4218,7 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const loadMoreRenderedChatGroups = useSet(thread.loadMoreRenderedChatGroups$);
   const pageSignal = useGet(pageSignal$);
   const skeletonVisible = useGet(thread.skeletonVisible$);
-  const githubPrTrackingOpen = useGithubPrTrackingOpen(
-    thread,
-    threadDataLoadable,
-  );
+  const githubPrTrackingOpen = useGithubPrTrackingOpen(thread);
 
   const handleScroll = (event: ReactUIEvent<HTMLDivElement>) => {
     if (


### PR DESCRIPTION
## Summary
- Adds an event-driven `ThreadMeta` map derived from replayed chat thread snapshots/events, including optimistic rename events.
- Gives each chat thread a `threadMeta$` signal that uses event-sourced metadata when `ChatThreadEventSourcing` is enabled and falls back to `threadData$` otherwise.
- Moves the chat thread header, current-thread rename prefill, and emoji title actions onto `threadMeta$` so a stalled thread detail request no longer blocks rename/header title updates.
- Keeps the freshly fetched remote snapshot available for the current event-data computation even when the best-effort IDB write/read path is unavailable.

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "renames the event-sourced current chat while thread detail is pending"`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`

Did not run full Vitest or start a dev server per vm0 PR verification preference.