### PR TITLE
fix: move runner bootstrap payloads out of env

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -1,6 +1,6 @@
 //! Curated environment for CLI children.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use super::CliRuntimeConfig;
 
@@ -27,34 +27,48 @@ const OPTIONAL_BASE_ENV_KEYS: &[&str] = &[
     "CARGO_HTTP_CAINFO",
 ];
 
-pub(super) fn apply_to_tokio_command_for_runtime(
-    cmd: &mut tokio::process::Command,
-    runtime: &CliRuntimeConfig<'_>,
-) {
-    apply_to_tokio_command_with_values(
-        cmd,
+pub(super) fn values_for_runtime(runtime: &CliRuntimeConfig<'_>) -> Vec<(String, String)> {
+    values_with_inputs(
         runtime.home_dir.as_ref(),
         runtime.user_env,
         runtime.api_url.as_ref(),
-    );
+    )
 }
 
-pub(super) fn apply_to_tokio_command_with_values(
-    cmd: &mut tokio::process::Command,
+pub(super) fn values_with_inputs(
     home_dir: &str,
     user_env: &HashMap<String, String>,
     api_url: &str,
-) {
-    cmd.env_clear();
+) -> Vec<(String, String)> {
+    let mut values = Vec::new();
     for (key, value) in base_child_env(home_dir) {
-        cmd.env(key, value);
+        values.push((key.to_string(), value));
     }
     for (key, value) in user_env {
-        cmd.env(key, value);
+        values.push((key.clone(), value.clone()));
     }
     apply_runner_visible_env(api_url, |key, value| {
-        cmd.env(key, value);
+        values.push((key.to_string(), value));
     });
+    normalize_values(values)
+}
+
+pub(super) fn normalize_values(values: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut final_values = BTreeMap::new();
+    for (key, value) in values {
+        final_values.insert(key, value);
+    }
+    final_values.into_iter().collect()
+}
+
+pub(super) fn apply_values_to_tokio_command(
+    cmd: &mut tokio::process::Command,
+    values: &[(String, String)],
+) {
+    cmd.env_clear();
+    for (key, value) in values {
+        cmd.env(key, value);
+    }
 }
 
 fn base_child_env(home_dir: &str) -> Vec<(&'static str, String)> {
@@ -106,5 +120,56 @@ mod tests {
         assert!(keys.contains(&"HOME"));
         assert!(keys.contains(&"PATH"));
         assert!(keys.contains(&"SHELL"));
+    }
+
+    #[test]
+    fn normalize_values_keeps_last_value_for_duplicate_keys() {
+        let values = normalize_values(vec![
+            ("VM0_API_URL".to_string(), "user-value".to_string()),
+            ("VM0_API_URL".to_string(), "runner-value".to_string()),
+        ]);
+
+        assert_eq!(
+            values
+                .iter()
+                .find(|(key, _)| key == "VM0_API_URL")
+                .map(|(_, value)| value.as_str()),
+            Some("runner-value")
+        );
+        assert_eq!(
+            values
+                .iter()
+                .filter(|(key, _)| key == "VM0_API_URL")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn values_with_inputs_counts_final_runner_visible_api_url() {
+        let mut user_env = HashMap::new();
+        let oversized_user_api_url =
+            "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
+        user_env.insert(
+            guest_contracts::env::API_URL_ENV.to_string(),
+            oversized_user_api_url,
+        );
+
+        let values = values_with_inputs("/tmp/home", &user_env, "https://runner.example");
+
+        assert_eq!(
+            values
+                .iter()
+                .find(|(key, _)| key == guest_contracts::env::API_URL_ENV)
+                .map(|(_, value)| value.as_str()),
+            Some("https://runner.example")
+        );
+        assert_eq!(
+            values
+                .iter()
+                .filter(|(key, _)| key == guest_contracts::env::API_URL_ENV)
+                .count(),
+            1
+        );
     }
 }

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -21,7 +21,7 @@ use tokio::task::JoinHandle;
 
 use crate::error::AgentError;
 
-use super::{child_env, diagnostics, process_group::ChildProcessGroup};
+use super::{child_env, diagnostics, exec_boundary, process_group::ChildProcessGroup};
 
 const METHOD_NOT_FOUND: i64 = -32601;
 const NOTIFICATION_QUEUE_CAPACITY: usize = 128;
@@ -203,13 +203,29 @@ impl CodexAppServerClient {
         let child_env_config = config.child_env.as_ref().ok_or_else(|| {
             CodexAppServerError::Protocol("app-server child env config is required".to_string())
         })?;
-        child_env::apply_to_tokio_command_with_values(
-            &mut cmd,
+        let mut child_env_values = child_env::values_with_inputs(
             &child_env_config.home_dir,
             &child_env_config.user_env,
             &child_env_config.api_url,
         );
-        cmd.args(["app-server", "--listen", "stdio://"])
+        child_env_values.extend(config.extra_env.iter().cloned());
+        child_env_values.push((
+            "CODEX_HOME".to_string(),
+            config.codex_home.to_string_lossy().into_owned(),
+        ));
+        child_env_values.retain(|(key, _)| key != "MOCK_CODEX_FIXTURE");
+        let child_env_values = child_env::normalize_values(child_env_values);
+        let args = ["app-server", "--listen", "stdio://"];
+        let binary = config.binary.to_string_lossy();
+        exec_boundary::validate_process_argv_env(
+            "codex app-server argv/env too large",
+            &binary,
+            args,
+            &child_env_values,
+        )
+        .map_err(CodexAppServerError::Protocol)?;
+        child_env::apply_values_to_tokio_command(&mut cmd, &child_env_values);
+        cmd.args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -218,11 +234,7 @@ impl CodexAppServerClient {
         if let Some(current_dir) = config.current_dir {
             cmd.current_dir(current_dir);
         }
-        for (key, value) in config.extra_env {
-            cmd.env(key, value);
-        }
-        cmd.env("CODEX_HOME", &config.codex_home)
-            .env_remove("MOCK_CODEX_FIXTURE");
+        cmd.env_remove("MOCK_CODEX_FIXTURE");
 
         let mut child = cmd.spawn().map_err(CodexAppServerError::Spawn)?;
         let process_id = child.id();

--- a/crates/guest-agent/src/cli/exec_boundary.rs
+++ b/crates/guest-agent/src/cli/exec_boundary.rs
@@ -1,0 +1,22 @@
+//! Process argv/env preflight guards for CLI children.
+
+use guest_contracts::exec_limits::{ExecBoundaryValue, validate_exec_boundary_sizes};
+
+pub(super) fn validate_process_argv_env<'a>(
+    label: &str,
+    bin: &str,
+    args: impl IntoIterator<Item = &'a str>,
+    env_values: &[(String, String)],
+) -> Result<(), String> {
+    let mut values = Vec::with_capacity(env_values.len() + 1);
+    values.push(ExecBoundaryValue::arg("argv[0]", bin));
+    for (index, arg) in args.into_iter().enumerate() {
+        let name = format!("argv[{}]", index + 1);
+        values.push(ExecBoundaryValue::arg(name, arg));
+    }
+    for (key, value) in env_values {
+        values.push(ExecBoundaryValue::env(key.as_str(), value));
+    }
+
+    validate_exec_boundary_sizes(values).map_err(|error| format!("{label}: {error}"))
+}

--- a/crates/guest-agent/src/cli/exec_boundary.rs
+++ b/crates/guest-agent/src/cli/exec_boundary.rs
@@ -8,9 +8,11 @@ pub(super) fn validate_process_argv_env<'a>(
     args: impl IntoIterator<Item = &'a str>,
     env_values: &[(String, String)],
 ) -> Result<(), String> {
-    let mut values = Vec::with_capacity(env_values.len() + 1);
+    let args = args.into_iter();
+    let (lower_args, upper_args) = args.size_hint();
+    let mut values = Vec::with_capacity(env_values.len() + upper_args.unwrap_or(lower_args) + 1);
     values.push(ExecBoundaryValue::arg("argv[0]", bin));
-    for (index, arg) in args.into_iter().enumerate() {
+    for (index, arg) in args.enumerate() {
         let name = format!("argv[{}]", index + 1);
         values.push(ExecBoundaryValue::arg(name, arg));
     }

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -24,6 +24,7 @@ mod codex_setup;
 mod command;
 mod diagnostics;
 mod event_delivery;
+mod exec_boundary;
 mod framework;
 mod process_group;
 mod termination;
@@ -524,11 +525,8 @@ async fn execute_cli_inner(
         // If a future setup step fails after spawn, dropping `Child` must not
         // leave a CLI process running in the VM.
         .kill_on_drop(true);
-    child_env::apply_to_tokio_command_for_runtime(&mut cmd, runtime);
-    // Set the child cwd explicitly at spawn time so the CLI observes the
-    // current canonical workspace mount instead of relying on inherited cwd.
-    set_cli_current_dir(&mut cmd, paths::CANONICAL_WORKING_DIR)?;
 
+    let mut child_env_values = child_env::values_for_runtime(runtime);
     match runtime.framework {
         env::Framework::ClaudeCode => {
             // Suppress Claude CLI features that are unnecessary or harmful in a
@@ -536,34 +534,60 @@ async fn execute_cli_inner(
             // update check, GitHub) add ~2s latency, background tasks can keep
             // a one-shot run alive after its final result, telemetry has no
             // receiver, and the CLI version is baked into the rootfs image.
-            cmd.env("CLAUDE_CODE_DISABLE_BACKGROUND_TASKS", "1");
-            cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
-            cmd.env("CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY", "1");
-            cmd.env("CLAUDE_CODE_DISABLE_TERMINAL_TITLE", "1");
-            cmd.env("DISABLE_AUTOUPDATER", "1");
-            cmd.env("DISABLE_ERROR_REPORTING", "1");
-            cmd.env("DISABLE_INSTALLATION_CHECKS", "1");
-            cmd.env("DISABLE_TELEMETRY", "1");
+            child_env_values.extend([
+                (
+                    "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS".to_string(),
+                    "1".to_string(),
+                ),
+                (
+                    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
+                    "1".to_string(),
+                ),
+                (
+                    "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY".to_string(),
+                    "1".to_string(),
+                ),
+                (
+                    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE".to_string(),
+                    "1".to_string(),
+                ),
+                ("DISABLE_AUTOUPDATER".to_string(), "1".to_string()),
+                ("DISABLE_ERROR_REPORTING".to_string(), "1".to_string()),
+                ("DISABLE_INSTALLATION_CHECKS".to_string(), "1".to_string()),
+                ("DISABLE_TELEMETRY".to_string(), "1".to_string()),
+            ]);
         }
         env::Framework::Codex => {
             // Auth reconciliation and `codex exec` both honor CODEX_HOME;
             // pin it to $HOME/.codex so setup_codex state is visible to exec.
-            cmd.env("CODEX_HOME", runtime.codex_home());
+            child_env_values.push(("CODEX_HOME".to_string(), runtime.codex_home()));
             // Test-only mock fixture selector; keep it explicit instead of
             // reopening inherited env for Codex children.
             if runtime.use_mock_codex
                 && let Ok(fixture) = std::env::var("MOCK_CODEX_FIXTURE")
             {
-                cmd.env("MOCK_CODEX_FIXTURE", fixture);
+                child_env_values.push(("MOCK_CODEX_FIXTURE".to_string(), fixture));
             }
             if runtime.codex_oauth_mode {
-                cmd.env(
-                    "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
-                    crate::codex_auth::REFRESH_TOKEN_NOOP_URL,
-                );
+                child_env_values.push((
+                    "CODEX_REFRESH_TOKEN_URL_OVERRIDE".to_string(),
+                    crate::codex_auth::REFRESH_TOKEN_NOOP_URL.to_string(),
+                ));
             }
         }
     }
+    let child_env_values = child_env::normalize_values(child_env_values);
+    exec_boundary::validate_process_argv_env(
+        "CLI child argv/env too large",
+        bin,
+        args.iter().map(String::as_str),
+        &child_env_values,
+    )
+    .map_err(AgentError::Execution)?;
+    child_env::apply_values_to_tokio_command(&mut cmd, &child_env_values);
+    // Set the child cwd explicitly at spawn time so the CLI observes the
+    // current canonical workspace mount instead of relying on inherited cwd.
+    set_cli_current_dir(&mut cmd, paths::CANONICAL_WORKING_DIR)?;
 
     // Open the run log before spawning the CLI. If the run-id-scoped path is
     // invalid or unavailable, fail without starting a child process.
@@ -1304,15 +1328,127 @@ fn with_carried_failure_reason(
 mod tests {
     use super::termination::{CliTerminationRuntime, PostResultCleanupPolicy};
     use super::{
-        CliExitObservation, CliFailureDiagnostic, claude_initial_prompt_frame,
-        codex_home_for_home_dir, record_cli_exit, select_failure_diagnostic, set_cli_current_dir,
+        CliExitObservation, CliFailureDiagnostic, CliRuntimeConfig, child_env,
+        claude_initial_prompt_frame, codex_home_for_home_dir, command, exec_boundary,
+        record_cli_exit, select_failure_diagnostic, set_cli_current_dir,
         with_carried_failure_reason,
     };
     use crate::active_input::ActiveInputRuntime;
+    use crate::{constants, env};
     use guest_contracts::diagnostics::{FailureDetailSource, FailureReason};
+    use std::borrow::Cow;
+    use std::collections::HashMap;
     #[cfg(unix)]
     use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
+
+    fn runtime_for_exec_boundary_test<'a>(
+        framework: env::Framework,
+        prompt: &'a str,
+        append_system_prompt: &'a str,
+        use_codex_app_server_backend: bool,
+        user_env: &'a HashMap<String, String>,
+    ) -> CliRuntimeConfig<'a> {
+        CliRuntimeConfig {
+            framework,
+            run_id: Cow::Borrowed("run-exec-boundary-test"),
+            prompt: Cow::Borrowed(prompt),
+            resume_session_id: Cow::Borrowed(""),
+            append_system_prompt: Cow::Borrowed(append_system_prompt),
+            disallowed_tools: Cow::Borrowed(""),
+            tools: Cow::Borrowed(""),
+            settings: Cow::Borrowed(""),
+            use_mock_claude: false,
+            mock_claude_path: Cow::Borrowed(""),
+            use_mock_codex: false,
+            use_codex_app_server_backend,
+            mock_codex_path: Cow::Borrowed(""),
+            home_dir: Cow::Borrowed("/tmp/home"),
+            api_url: Cow::Borrowed(""),
+            api_start_time: Cow::Borrowed(""),
+            anthropic_model: Cow::Borrowed(""),
+            openai_model: Cow::Borrowed(""),
+            openai_base_url: Cow::Borrowed(""),
+            codex_oauth_mode: false,
+            codex_fast_mode: false,
+            stuck_tool_timeout_secs: constants::STUCK_TOOL_TIMEOUT_SECS,
+            post_result_cleanup_policy: PostResultCleanupPolicy::new(
+                Duration::from_secs(constants::POST_RESULT_SIGTERM_GRACE_SECS),
+                Duration::from_secs(constants::POST_RESULT_TOTAL_CAP_SECS),
+                Duration::from_secs(constants::POST_RESULT_SIGKILL_GRACE_SECS),
+            ),
+            agent_log_file: Cow::Borrowed("/tmp/agent.log"),
+            session_id_file: Cow::Borrowed("/tmp/session-id"),
+            session_history_path_file: Cow::Borrowed("/tmp/session-history-path"),
+            event_error_flag: Cow::Borrowed("/tmp/event-error"),
+            user_env,
+        }
+    }
+
+    #[test]
+    fn claude_large_prompt_is_not_rejected_by_process_argv_guard() {
+        let user_env = HashMap::new();
+        let prompt = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
+        let runtime = runtime_for_exec_boundary_test(
+            env::Framework::ClaudeCode,
+            &prompt,
+            "",
+            false,
+            &user_env,
+        );
+
+        let cmd = command::build_cli_command_for_runtime(&runtime, false).unwrap();
+        let (bin, args) = cmd.split_first().unwrap();
+        let env_values = child_env::values_for_runtime(&runtime);
+
+        exec_boundary::validate_process_argv_env(
+            "test cli child",
+            bin,
+            args.iter().map(String::as_str),
+            &env_values,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn legacy_codex_large_prompt_is_rejected_by_process_argv_guard() {
+        let user_env = HashMap::new();
+        let prompt = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
+        let runtime =
+            runtime_for_exec_boundary_test(env::Framework::Codex, &prompt, "", false, &user_env);
+
+        let cmd = command::build_cli_command_for_runtime(&runtime, false).unwrap();
+        let (bin, args) = cmd.split_first().unwrap();
+        let env_values = child_env::values_for_runtime(&runtime);
+        let error = exec_boundary::validate_process_argv_env(
+            "test cli child",
+            bin,
+            args.iter().map(String::as_str),
+            &env_values,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("argv value too large"));
+        assert!(!error.contains(&prompt));
+    }
+
+    #[test]
+    fn codex_app_server_large_prompt_is_not_part_of_process_argv_guard() {
+        let user_env = HashMap::new();
+        let prompt = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
+        let runtime =
+            runtime_for_exec_boundary_test(env::Framework::Codex, &prompt, "", true, &user_env);
+        let mut env_values = child_env::values_for_runtime(&runtime);
+        env_values.push(("CODEX_HOME".to_string(), runtime.codex_home()));
+
+        exec_boundary::validate_process_argv_env(
+            "test codex app-server",
+            "codex",
+            ["app-server", "--listen", "stdio://"],
+            &env_values,
+        )
+        .unwrap();
+    }
 
     #[test]
     fn claude_initial_prompt_frame_matches_stream_json_user_shape() {

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -129,11 +129,11 @@ pub struct ArtifactEnv {
     pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
 }
 
-/// Raw startup values used to build an owned guest-agent run config.
+/// Raw runner bootstrap values used to build an owned guest-agent run config.
 ///
-/// Empty strings represent unset runner bootstrap values. Optional override
-/// fields preserve the difference between an unset variable and an explicitly
-/// empty variable.
+/// Empty strings represent unset bootstrap environment values. Variable-length
+/// run payload fields live in [`guest_contracts::env::RunPayload`] and are
+/// loaded through `run_payload_file`.
 #[derive(Clone, Default)]
 pub struct GuestConfigRaw {
     pub run_id: String,
@@ -141,15 +141,9 @@ pub struct GuestConfigRaw {
     pub api_token: String,
     pub sandbox_id: String,
     pub sandbox_reuse_result: String,
-    pub prompt: String,
-    pub append_system_prompt: String,
     pub vercel_bypass: String,
     pub resume_session_id: String,
     pub api_start_time: String,
-    pub secret_values: String,
-    pub disallowed_tools: String,
-    pub tools: String,
-    pub settings: String,
     pub use_mock_claude: String,
     pub mock_claude_path: Option<String>,
     pub cli_agent_type: String,
@@ -161,8 +155,6 @@ pub struct GuestConfigRaw {
     pub home: Option<String>,
     pub runtime_home: Option<PathBuf>,
     pub guest_runtime_dir: Option<PathBuf>,
-    pub artifacts: String,
-    pub feature_flags: String,
     pub stuck_tool_timeout_secs: String,
     pub post_result_sigterm_grace_secs: String,
     pub post_result_total_cap_secs: String,
@@ -183,15 +175,9 @@ impl GuestConfigRaw {
             api_token: env_or_empty(guest_contracts::env::API_TOKEN_ENV),
             sandbox_id: env_or_empty(guest_contracts::env::SANDBOX_ID_ENV),
             sandbox_reuse_result: env_or_empty(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV),
-            prompt: String::new(),
-            append_system_prompt: String::new(),
             vercel_bypass: env_or_empty(guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV),
             resume_session_id: env_or_empty(guest_contracts::env::RESUME_SESSION_ID_ENV),
             api_start_time: env_or_empty(guest_contracts::env::API_START_TIME_ENV),
-            secret_values: String::new(),
-            disallowed_tools: String::new(),
-            tools: String::new(),
-            settings: String::new(),
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
             mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV).ok(),
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
@@ -205,8 +191,6 @@ impl GuestConfigRaw {
             home: std::env::var("HOME").ok(),
             runtime_home: std::env::var_os("HOME").map(PathBuf::from),
             guest_runtime_dir,
-            artifacts: String::new(),
-            feature_flags: String::new(),
             stuck_tool_timeout_secs: env_or_empty(
                 guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
             ),
@@ -273,20 +257,19 @@ impl GuestConfig {
     }
 
     /// Build an owned config from explicit startup values.
-    pub fn from_raw(mut raw: GuestConfigRaw) -> Result<Self, String> {
-        if let Some(payload) = load_run_payload_from_raw(&raw)? {
-            apply_run_payload_to_raw(&mut raw, payload);
-        }
+    pub fn from_raw(raw: GuestConfigRaw) -> Result<Self, String> {
+        let payload = load_run_payload_from_raw(&raw)?;
         let user_env = load_user_env_from_raw(&raw)?;
-        Self::from_raw_with_user_env(raw, user_env)
+        Self::from_raw_with_user_env(raw, payload, user_env)
     }
 
     fn from_raw_with_user_env(
         raw: GuestConfigRaw,
+        payload: guest_contracts::env::RunPayload,
         user_env: HashMap<String, String>,
     ) -> Result<Self, String> {
         let home_dir = resolve_home_dir(&user_env, raw.home.as_deref())?;
-        let artifacts = parse_artifacts_value(&raw.artifacts)
+        let artifacts = parse_artifacts_value(&payload.artifacts)
             .map_err(|e| format!("parse {} JSON: {e}", guest_contracts::env::ARTIFACTS_ENV))?;
 
         Ok(Self {
@@ -295,15 +278,15 @@ impl GuestConfig {
             api_token: raw.api_token,
             sandbox_id: raw.sandbox_id,
             sandbox_reuse_result: raw.sandbox_reuse_result,
-            prompt: raw.prompt,
-            append_system_prompt: raw.append_system_prompt,
+            prompt: payload.prompt,
+            append_system_prompt: payload.append_system_prompt,
             vercel_bypass: raw.vercel_bypass,
             resume_session_id: raw.resume_session_id,
             api_start_time: raw.api_start_time,
-            secret_values: raw.secret_values,
-            disallowed_tools: raw.disallowed_tools,
-            tools: raw.tools,
-            settings: raw.settings,
+            secret_values: payload.secret_values,
+            disallowed_tools: payload.disallowed_tools,
+            tools: payload.tools,
+            settings: payload.settings,
             use_mock_claude: bool_true_value(Some(&raw.use_mock_claude)),
             mock_claude_path: default_mock_path(
                 raw.mock_claude_path.as_deref(),
@@ -322,7 +305,7 @@ impl GuestConfig {
             ),
             home_dir,
             artifacts,
-            feature_flags: raw.feature_flags,
+            feature_flags: payload.feature_flags,
             stuck_tool_timeout_secs: u64_value_or(
                 guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
                 non_empty(&raw.stuck_tool_timeout_secs),
@@ -389,10 +372,8 @@ fn parse_artifacts_value(raw: &str) -> Result<Vec<ArtifactEnv>, serde_json::Erro
 
 fn load_run_payload_from_raw(
     raw: &GuestConfigRaw,
-) -> Result<Option<guest_contracts::env::RunPayload>, String> {
-    if raw.run_payload_file.is_empty() {
-        return Ok(None);
-    }
+) -> Result<guest_contracts::env::RunPayload, String> {
+    raw.require_run_payload_file()?;
 
     let path = Path::new(&raw.run_payload_file);
     let runtime_dir = guest_runtime_dir_for_private_file_values(
@@ -404,7 +385,7 @@ fn load_run_payload_from_raw(
             .or_else(|| raw.home.as_deref().map(Path::new)),
     )?;
     validate_run_payload_file_path_for_runtime(path, &runtime_dir)?;
-    load_run_payload_from_path(path).map(Some)
+    load_run_payload_from_path(path)
 }
 
 fn load_run_payload_from_path(path: &Path) -> Result<guest_contracts::env::RunPayload, String> {
@@ -417,17 +398,6 @@ fn load_run_payload_from_path(path: &Path) -> Result<guest_contracts::env::RunPa
     validate_run_payload(&payload)?;
 
     Ok(payload)
-}
-
-fn apply_run_payload_to_raw(raw: &mut GuestConfigRaw, payload: guest_contracts::env::RunPayload) {
-    raw.prompt = payload.prompt;
-    raw.append_system_prompt = payload.append_system_prompt;
-    raw.secret_values = payload.secret_values;
-    raw.disallowed_tools = payload.disallowed_tools;
-    raw.tools = payload.tools;
-    raw.settings = payload.settings;
-    raw.artifacts = payload.artifacts;
-    raw.feature_flags = payload.feature_flags;
 }
 
 fn remove_run_payload_file(path: &Path) -> Result<(), String> {
@@ -681,6 +651,24 @@ mod tests {
         path
     }
 
+    fn raw_config_fixture_with_run_payload(
+        payload: &guest_contracts::env::RunPayload,
+    ) -> (tempfile::TempDir, GuestConfigRaw) {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let run_payload_file = write_run_payload_fixture(&runtime_dir, payload);
+        let raw = GuestConfigRaw {
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(runtime_dir),
+            ..raw_config_fixture()
+        };
+        (tmp, raw)
+    }
+
+    fn raw_config_fixture_with_default_run_payload() -> (tempfile::TempDir, GuestConfigRaw) {
+        raw_config_fixture_with_run_payload(&guest_contracts::env::RunPayload::default())
+    }
+
     #[test]
     fn bounded_duration_secs_value_defaults_when_unset() {
         assert_eq!(
@@ -757,32 +745,36 @@ mod tests {
 
     #[test]
     fn guest_config_from_raw_builds_owned_config_without_process_env_mutation() {
+        let payload = guest_contracts::env::RunPayload {
+            prompt: "hello".to_string(),
+            append_system_prompt: "extra system".to_string(),
+            secret_values: "encoded-secret".to_string(),
+            disallowed_tools: "WebFetch".to_string(),
+            tools: "Bash".to_string(),
+            settings: "{}".to_string(),
+            artifacts:
+                r#"[{"name":"artifact","mountPath":"/mnt/a","storageId":"storage","versionId":"v1"}]"#
+                    .to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        };
+        let (_tmp, raw) = raw_config_fixture_with_run_payload(&payload);
         let raw = GuestConfigRaw {
             api_url: "https://api.example.test".to_string(),
             api_token: String::new(),
             sandbox_id: "sandbox-1".to_string(),
             sandbox_reuse_result: "reused".to_string(),
-            prompt: "hello".to_string(),
-            append_system_prompt: "extra system".to_string(),
             vercel_bypass: "bypass".to_string(),
             resume_session_id: "session-1".to_string(),
             api_start_time: "123".to_string(),
-            secret_values: "encoded-secret".to_string(),
-            disallowed_tools: "WebFetch".to_string(),
-            tools: "Bash".to_string(),
-            settings: "{}".to_string(),
             use_mock_claude: "true".to_string(),
             cli_agent_type: "codex".to_string(),
             use_mock_codex: "1".to_string(),
             use_codex_app_server_backend: "true".to_string(),
-            artifacts:
-                r#"[{"name":"artifact","mountPath":"/mnt/a","storageId":"storage","versionId":"v1"}]"#
-                    .to_string(),
             stuck_tool_timeout_secs: "7".to_string(),
             post_result_sigterm_grace_secs: "8".to_string(),
             post_result_total_cap_secs: "9".to_string(),
             post_result_sigkill_grace_secs: "10".to_string(),
-            ..raw_config_fixture()
+            ..raw
         };
 
         let config = GuestConfig::from_raw(raw).unwrap();
@@ -832,9 +824,12 @@ mod tests {
             r#"{"HOME":"/home/from-user-env","OPENAI_MODEL":"gpt-test"}"#,
         )
         .unwrap();
+        let run_payload_file =
+            write_run_payload_fixture(&runtime_dir, &guest_contracts::env::RunPayload::default());
 
         let raw = GuestConfigRaw {
             user_env_file: user_env_path.to_string_lossy().into_owned(),
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
             guest_runtime_dir: Some(runtime_dir),
             home: Some("/home/from-process".to_string()),
             ..raw_config_fixture()
@@ -872,13 +867,6 @@ mod tests {
 
         let raw = GuestConfigRaw {
             run_payload_file: path.to_string_lossy().into_owned(),
-            prompt: "legacy prompt".to_string(),
-            append_system_prompt: "legacy system".to_string(),
-            secret_values: "legacy-secret".to_string(),
-            disallowed_tools: "LegacyTool".to_string(),
-            tools: "LegacyAllowedTool".to_string(),
-            settings: r#"{"legacy":true}"#.to_string(),
-            artifacts: String::new(),
             guest_runtime_dir: Some(runtime_dir),
             ..raw_config_fixture()
         };
@@ -970,9 +958,12 @@ mod tests {
             r#"{"HOME":"/home/from-user-env","OPENAI_MODEL":"gpt-runtime-home"}"#,
         )
         .unwrap();
+        let run_payload_file =
+            write_run_payload_fixture(&runtime_dir, &guest_contracts::env::RunPayload::default());
 
         let raw = GuestConfigRaw {
             user_env_file: user_env_path.to_string_lossy().into_owned(),
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
             home: None,
             runtime_home: Some(runtime_home),
             ..raw_config_fixture()
@@ -991,8 +982,14 @@ mod tests {
 
     #[test]
     fn guest_config_from_raw_preserves_empty_process_home() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let run_payload_file =
+            write_run_payload_fixture(&runtime_dir, &guest_contracts::env::RunPayload::default());
         let raw = GuestConfigRaw {
             home: Some(String::new()),
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(runtime_dir),
             ..raw_config_fixture()
         };
 
@@ -1003,10 +1000,11 @@ mod tests {
 
     #[test]
     fn guest_config_from_raw_preserves_explicit_empty_mock_paths() {
+        let (_tmp, raw) = raw_config_fixture_with_default_run_payload();
         let raw = GuestConfigRaw {
             mock_claude_path: Some(String::new()),
             mock_codex_path: Some(String::new()),
-            ..raw_config_fixture()
+            ..raw
         };
 
         let config = GuestConfig::from_raw(raw).unwrap();
@@ -1017,10 +1015,11 @@ mod tests {
 
     #[test]
     fn guest_config_from_raw_reports_invalid_artifacts() {
-        let raw = GuestConfigRaw {
+        let payload = guest_contracts::env::RunPayload {
             artifacts: "{not-json".to_string(),
-            ..raw_config_fixture()
+            ..guest_contracts::env::RunPayload::default()
         };
+        let (_tmp, raw) = raw_config_fixture_with_run_payload(&payload);
 
         let err = GuestConfig::from_raw(raw).err().unwrap();
 
@@ -1032,9 +1031,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let runtime_dir = tmp.path().join("runtime");
         let unexpected = tmp.path().join("other").join("user-env").join("env.json");
+        let run_payload_file =
+            write_run_payload_fixture(&runtime_dir, &guest_contracts::env::RunPayload::default());
 
         let raw = GuestConfigRaw {
             user_env_file: unexpected.to_string_lossy().into_owned(),
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
             guest_runtime_dir: Some(runtime_dir),
             ..raw_config_fixture()
         };

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -15,6 +15,7 @@ use guest_common::log_warn;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const USER_ENV_FILE_ENV_KEY: &str = guest_contracts::env::USER_ENV_FILE_ENV;
+const RUN_PAYLOAD_FILE_ENV_KEY: &str = guest_contracts::env::RUN_PAYLOAD_FILE_ENV;
 const USER_ENV_PRIVATE_DIR_NAME: &str = "user-env";
 const USER_ENV_FILENAME: &str = "env.json";
 const POST_RESULT_CLEANUP_MAX_SECS: u64 = 60 * 60;
@@ -154,6 +155,7 @@ pub struct GuestConfigRaw {
     pub mock_claude_path: Option<String>,
     pub cli_agent_type: String,
     pub user_env_file: String,
+    pub run_payload_file: String,
     pub use_mock_codex: String,
     pub use_codex_app_server_backend: String,
     pub mock_codex_path: Option<String>,
@@ -161,6 +163,7 @@ pub struct GuestConfigRaw {
     pub runtime_home: Option<PathBuf>,
     pub guest_runtime_dir: Option<PathBuf>,
     pub artifacts: String,
+    pub feature_flags: String,
     pub stuck_tool_timeout_secs: String,
     pub post_result_sigterm_grace_secs: String,
     pub post_result_total_cap_secs: String,
@@ -194,6 +197,7 @@ impl GuestConfigRaw {
             mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV).ok(),
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
             user_env_file: env_or_empty(USER_ENV_FILE_ENV_KEY),
+            run_payload_file: env_or_empty(RUN_PAYLOAD_FILE_ENV_KEY),
             use_mock_codex: env_or_empty(guest_contracts::env::USE_MOCK_CODEX_ENV),
             use_codex_app_server_backend: env_or_empty(
                 guest_contracts::env::CODEX_APP_SERVER_BACKEND_ENV,
@@ -203,6 +207,7 @@ impl GuestConfigRaw {
             runtime_home: std::env::var_os("HOME").map(PathBuf::from),
             guest_runtime_dir,
             artifacts: env_or_empty(guest_contracts::env::ARTIFACTS_ENV),
+            feature_flags: env_or_empty(guest_contracts::env::FEATURE_FLAGS_ENV),
             stuck_tool_timeout_secs: env_or_empty(
                 guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
             ),
@@ -246,6 +251,7 @@ pub struct GuestConfig {
     pub mock_codex_path: String,
     pub home_dir: String,
     pub artifacts: Vec<ArtifactEnv>,
+    pub feature_flags: String,
     pub stuck_tool_timeout_secs: u64,
     pub post_result_sigterm_grace: Duration,
     pub post_result_total_cap: Duration,
@@ -259,7 +265,10 @@ impl GuestConfig {
     }
 
     /// Build an owned config from explicit startup values.
-    pub fn from_raw(raw: GuestConfigRaw) -> Result<Self, String> {
+    pub fn from_raw(mut raw: GuestConfigRaw) -> Result<Self, String> {
+        if let Some(payload) = load_run_payload_from_raw(&raw)? {
+            apply_run_payload_to_raw(&mut raw, payload);
+        }
         let user_env = load_user_env_from_raw(&raw)?;
         Self::from_raw_with_user_env(raw, user_env)
     }
@@ -305,6 +314,7 @@ impl GuestConfig {
             ),
             home_dir,
             artifacts,
+            feature_flags: raw.feature_flags,
             stuck_tool_timeout_secs: u64_value_or(
                 guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
                 non_empty(&raw.stuck_tool_timeout_secs),
@@ -369,13 +379,140 @@ fn parse_artifacts_value(raw: &str) -> Result<Vec<ArtifactEnv>, serde_json::Erro
     serde_json::from_str::<Vec<ArtifactEnv>>(raw)
 }
 
+fn load_run_payload_from_raw(
+    raw: &GuestConfigRaw,
+) -> Result<Option<guest_contracts::env::RunPayload>, String> {
+    if raw.run_payload_file.is_empty() {
+        return Ok(None);
+    }
+
+    let path = Path::new(&raw.run_payload_file);
+    let runtime_dir = guest_runtime_dir_for_private_file_values(
+        RUN_PAYLOAD_FILE_ENV_KEY,
+        &raw.run_id,
+        raw.guest_runtime_dir.as_deref(),
+        raw.runtime_home
+            .as_deref()
+            .or_else(|| raw.home.as_deref().map(Path::new)),
+    )?;
+    validate_run_payload_file_path_for_runtime(path, &runtime_dir)?;
+    load_run_payload_from_path(path).map(Some)
+}
+
+fn load_run_payload_from_path(path: &Path) -> Result<guest_contracts::env::RunPayload, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("read {RUN_PAYLOAD_FILE_ENV_KEY} {}: {e}", path.display()))?;
+    remove_run_payload_file(path)?;
+
+    let payload: guest_contracts::env::RunPayload = serde_json::from_str(&raw)
+        .map_err(|e| format!("parse {RUN_PAYLOAD_FILE_ENV_KEY} JSON: {e}"))?;
+    validate_run_payload(&payload)?;
+
+    Ok(payload)
+}
+
+fn apply_run_payload_to_raw(raw: &mut GuestConfigRaw, payload: guest_contracts::env::RunPayload) {
+    raw.prompt = payload.prompt;
+    raw.append_system_prompt = payload.append_system_prompt;
+    raw.secret_values = payload.secret_values;
+    raw.disallowed_tools = payload.disallowed_tools;
+    raw.tools = payload.tools;
+    raw.settings = payload.settings;
+    raw.artifacts = payload.artifacts;
+    raw.feature_flags = payload.feature_flags;
+}
+
+fn remove_run_payload_file(path: &Path) -> Result<(), String> {
+    std::fs::remove_file(path)
+        .map_err(|e| format!("remove {RUN_PAYLOAD_FILE_ENV_KEY} {}: {e}", path.display()))?;
+    if let Some(parent) = path.parent()
+        && is_run_payload_private_dir(parent)
+    {
+        std::fs::remove_dir(parent).map_err(|e| {
+            format!(
+                "remove {RUN_PAYLOAD_FILE_ENV_KEY} parent {}: {e}",
+                parent.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn is_run_payload_private_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME)
+}
+
+fn run_payload_file_path_for_runtime(runtime_dir: &Path) -> PathBuf {
+    runtime_dir
+        .join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME)
+        .join(guest_contracts::env::RUN_PAYLOAD_FILENAME)
+}
+
+fn validate_run_payload_file_path_for_runtime(
+    path: &Path,
+    runtime_dir: &Path,
+) -> Result<(), String> {
+    if path == run_payload_file_path_for_runtime(runtime_dir) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "{RUN_PAYLOAD_FILE_ENV_KEY} must point to guest runtime {}/{}",
+        guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME,
+        guest_contracts::env::RUN_PAYLOAD_FILENAME
+    ))
+}
+
+fn validate_run_payload(payload: &guest_contracts::env::RunPayload) -> Result<(), String> {
+    for (name, value) in [
+        (guest_contracts::env::PROMPT_ENV, payload.prompt.as_str()),
+        (
+            guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
+            payload.append_system_prompt.as_str(),
+        ),
+        (
+            guest_contracts::env::SECRET_VALUES_ENV,
+            payload.secret_values.as_str(),
+        ),
+        (
+            guest_contracts::env::DISALLOWED_TOOLS_ENV,
+            payload.disallowed_tools.as_str(),
+        ),
+        (guest_contracts::env::TOOLS_ENV, payload.tools.as_str()),
+        (
+            guest_contracts::env::SETTINGS_ENV,
+            payload.settings.as_str(),
+        ),
+        (
+            guest_contracts::env::ARTIFACTS_ENV,
+            payload.artifacts.as_str(),
+        ),
+        (
+            guest_contracts::env::FEATURE_FLAGS_ENV,
+            payload.feature_flags.as_str(),
+        ),
+    ] {
+        if value.contains('\0') {
+            return Err(format!(
+                "{RUN_PAYLOAD_FILE_ENV_KEY} contains NUL byte for {name}"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn load_user_env_from_raw(raw: &GuestConfigRaw) -> Result<HashMap<String, String>, String> {
     if raw.user_env_file.is_empty() {
         return Ok(HashMap::new());
     }
 
     let path = Path::new(&raw.user_env_file);
-    let runtime_dir = guest_runtime_dir_for_user_env_values(
+    let runtime_dir = guest_runtime_dir_for_private_file_values(
+        USER_ENV_FILE_ENV_KEY,
         &raw.run_id,
         raw.guest_runtime_dir.as_deref(),
         raw.runtime_home
@@ -421,18 +558,19 @@ fn is_user_env_private_dir(path: &Path) -> bool {
         .is_some_and(|name| name == USER_ENV_PRIVATE_DIR_NAME)
 }
 
-fn guest_runtime_dir_for_user_env_values(
+fn guest_runtime_dir_for_private_file_values(
+    env_key: &str,
     run_id: &str,
     runtime_dir: Option<&Path>,
     home: Option<&Path>,
 ) -> Result<PathBuf, String> {
     guest_contracts::runtime_paths::validate_run_id(run_id)
-        .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))?;
+        .map_err(|e| format!("resolve guest runtime dir for {env_key}: {e}"))?;
 
     if let Some(runtime_dir) = runtime_dir {
         if !runtime_dir.is_absolute() {
             return Err(format!(
-                "resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {}",
+                "resolve guest runtime dir for {env_key}: {}",
                 guest_contracts::runtime_paths::RuntimePathError::InvalidRuntimeDir
             ));
         }
@@ -441,13 +579,13 @@ fn guest_runtime_dir_for_user_env_values(
 
     let Some(home) = home.filter(|value| !value.as_os_str().is_empty()) else {
         return Err(format!(
-            "resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {}",
+            "resolve guest runtime dir for {env_key}: {}",
             guest_contracts::runtime_paths::RuntimePathError::MissingHome
         ));
     };
 
     guest_contracts::runtime_paths::run_dir_for_home(home, run_id)
-        .map_err(|e| format!("resolve guest runtime dir for {USER_ENV_FILE_ENV_KEY}: {e}"))
+        .map_err(|e| format!("resolve guest runtime dir for {env_key}: {e}"))
 }
 
 fn user_env_file_path_for_runtime(runtime_dir: &Path) -> PathBuf {
@@ -522,6 +660,17 @@ mod tests {
         let path = dir.join(USER_ENV_FILENAME);
         std::fs::write(&path, json).unwrap();
         (tmp, path)
+    }
+
+    fn write_run_payload_fixture(
+        runtime_dir: &Path,
+        payload: &guest_contracts::env::RunPayload,
+    ) -> std::path::PathBuf {
+        let dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+        std::fs::write(&path, serde_json::to_vec(payload).unwrap()).unwrap();
+        path
     }
 
     #[test]
@@ -695,6 +844,111 @@ mod tests {
     }
 
     #[test]
+    fn guest_config_from_raw_loads_run_payload_and_removes_private_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let payload = guest_contracts::env::RunPayload {
+            prompt: "payload prompt".to_string(),
+            append_system_prompt: "payload system".to_string(),
+            secret_values: "payload-secret".to_string(),
+            disallowed_tools: "WebFetch".to_string(),
+            tools: "Bash".to_string(),
+            settings: "{}".to_string(),
+            artifacts:
+                r#"[{"name":"artifact","mountPath":"/mnt/a","storageId":"storage","versionId":"v1"}]"#
+                    .to_string(),
+            feature_flags: r#"{"flag":true}"#.to_string(),
+        };
+        let path = write_run_payload_fixture(&runtime_dir, &payload);
+        let parent = path.parent().unwrap().to_path_buf();
+
+        let raw = GuestConfigRaw {
+            run_payload_file: path.to_string_lossy().into_owned(),
+            prompt: "legacy prompt".to_string(),
+            append_system_prompt: "legacy system".to_string(),
+            secret_values: "legacy-secret".to_string(),
+            disallowed_tools: "LegacyTool".to_string(),
+            tools: "LegacyAllowedTool".to_string(),
+            settings: r#"{"legacy":true}"#.to_string(),
+            artifacts: String::new(),
+            guest_runtime_dir: Some(runtime_dir),
+            ..raw_config_fixture()
+        };
+
+        let config = GuestConfig::from_raw(raw).unwrap();
+
+        assert_eq!(config.prompt, "payload prompt");
+        assert_eq!(config.append_system_prompt, "payload system");
+        assert_eq!(config.secret_values, "payload-secret");
+        assert_eq!(config.disallowed_tools, "WebFetch");
+        assert_eq!(config.tools, "Bash");
+        assert_eq!(config.settings, "{}");
+        assert_eq!(config.artifacts.len(), 1);
+        assert_eq!(config.feature_flags, r#"{"flag":true}"#);
+        assert!(!path.exists());
+        assert!(!parent.exists());
+    }
+
+    #[test]
+    fn guest_config_from_raw_rejects_run_payload_outside_runtime_dir_without_path_leak() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let unexpected = tmp
+            .path()
+            .join("other")
+            .join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME)
+            .join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+
+        let raw = GuestConfigRaw {
+            run_payload_file: unexpected.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(runtime_dir),
+            ..raw_config_fixture()
+        };
+
+        let err = GuestConfig::from_raw(raw).err().unwrap();
+
+        assert!(err.contains("run-payload/payload.json"));
+        assert!(!err.contains(unexpected.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn load_run_payload_from_path_rejects_nul_without_value_leak() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let payload = guest_contracts::env::RunPayload {
+            prompt: "secret\0prompt".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        };
+        let path = write_run_payload_fixture(&runtime_dir, &payload);
+        let parent = path.parent().unwrap().to_path_buf();
+
+        let err = load_run_payload_from_path(&path).unwrap_err();
+
+        assert!(err.contains(guest_contracts::env::PROMPT_ENV));
+        assert!(!err.contains("secret"));
+        assert!(!err.contains("prompt"));
+        assert!(!path.exists());
+        assert!(!parent.exists());
+    }
+
+    #[test]
+    fn load_run_payload_from_path_removes_file_before_parse_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let runtime_dir = tmp.path().join("runtime");
+        let dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+        std::fs::write(&path, r#"{"prompt":"secret""#).unwrap();
+
+        let err = load_run_payload_from_path(&path).unwrap_err();
+
+        assert!(err.contains("parse"));
+        assert!(!err.contains("secret"));
+        assert!(!path.exists());
+        assert!(!dir.exists());
+    }
+
+    #[test]
     fn guest_config_from_raw_validates_user_env_with_runtime_home_when_home_string_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let runtime_home = tmp.path().join("home");
@@ -863,8 +1117,13 @@ mod tests {
 
     #[test]
     fn guest_runtime_dir_for_user_env_returns_error_when_run_id_missing() {
-        let err = guest_runtime_dir_for_user_env_values("", None, Some(Path::new("/home/vm0")))
-            .unwrap_err();
+        let err = guest_runtime_dir_for_private_file_values(
+            USER_ENV_FILE_ENV_KEY,
+            "",
+            None,
+            Some(Path::new("/home/vm0")),
+        )
+        .unwrap_err();
 
         assert!(err.contains("VM0_RUN_ID is required"));
     }

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -100,15 +100,15 @@ fn bounded_duration_secs_value_or(
 // ---------------------------------------------------------------------------
 // Artifacts (multi-mount)
 //
-// The runner emits a single `VM0_ARTIFACTS` env var containing a JSON array
-// of `{name, mountPath, storageId, versionId, missingRootPolicy?}` entries —
-// one per artifact mounted at boot. If the env var is unset or empty, there
-// are no artifacts.
+// The runner supplies a JSON array of
+// `{name, mountPath, storageId, versionId, missingRootPolicy?}` entries through
+// the run payload, with legacy `VM0_ARTIFACTS` env fallback. If the value is
+// unset or empty, there are no artifacts.
 // ---------------------------------------------------------------------------
 
-/// One artifact mount described by the runner-provided `VM0_ARTIFACTS` JSON array.
+/// One artifact mount described by the runner-provided artifact JSON array.
 ///
-/// The environment value is encoded as camelCase JSON, so this struct expects
+/// The wire value is encoded as camelCase JSON, so this struct expects
 /// `mountPath`, `storageId`, and `versionId` keys at the guest-agent boundary.
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -221,6 +221,13 @@ impl GuestConfigRaw {
             ),
         }
     }
+
+    pub(crate) fn require_run_payload_file(&self) -> Result<(), String> {
+        if self.run_payload_file.is_empty() {
+            return Err(format!("{RUN_PAYLOAD_FILE_ENV_KEY} is required"));
+        }
+        Ok(())
+    }
 }
 
 /// Immutable guest-agent startup configuration for a single run.
@@ -261,9 +268,7 @@ impl GuestConfig {
     /// Build an owned config from the current process environment.
     pub fn from_process_env() -> Result<Self, String> {
         let raw = GuestConfigRaw::from_process_env();
-        if raw.run_payload_file.is_empty() {
-            return Err(format!("{RUN_PAYLOAD_FILE_ENV_KEY} is required"));
-        }
+        raw.require_run_payload_file()?;
         Self::from_raw(raw)
     }
 

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -102,8 +102,7 @@ fn bounded_duration_secs_value_or(
 //
 // The runner supplies a JSON array of
 // `{name, mountPath, storageId, versionId, missingRootPolicy?}` entries through
-// the run payload, with legacy `VM0_ARTIFACTS` env fallback. If the value is
-// unset or empty, there are no artifacts.
+// the run payload. If the value is unset or empty, there are no artifacts.
 // ---------------------------------------------------------------------------
 
 /// One artifact mount described by the runner-provided artifact JSON array.
@@ -184,15 +183,15 @@ impl GuestConfigRaw {
             api_token: env_or_empty(guest_contracts::env::API_TOKEN_ENV),
             sandbox_id: env_or_empty(guest_contracts::env::SANDBOX_ID_ENV),
             sandbox_reuse_result: env_or_empty(guest_contracts::env::SANDBOX_REUSE_RESULT_ENV),
-            prompt: env_or_empty(guest_contracts::env::PROMPT_ENV),
-            append_system_prompt: env_or_empty(guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV),
+            prompt: String::new(),
+            append_system_prompt: String::new(),
             vercel_bypass: env_or_empty(guest_contracts::env::VERCEL_PROTECTION_BYPASS_ENV),
             resume_session_id: env_or_empty(guest_contracts::env::RESUME_SESSION_ID_ENV),
             api_start_time: env_or_empty(guest_contracts::env::API_START_TIME_ENV),
-            secret_values: env_or_empty(guest_contracts::env::SECRET_VALUES_ENV),
-            disallowed_tools: env_or_empty(guest_contracts::env::DISALLOWED_TOOLS_ENV),
-            tools: env_or_empty(guest_contracts::env::TOOLS_ENV),
-            settings: env_or_empty(guest_contracts::env::SETTINGS_ENV),
+            secret_values: String::new(),
+            disallowed_tools: String::new(),
+            tools: String::new(),
+            settings: String::new(),
             use_mock_claude: env_or_empty(guest_contracts::env::USE_MOCK_CLAUDE_ENV),
             mock_claude_path: std::env::var(guest_contracts::env::MOCK_CLAUDE_PATH_ENV).ok(),
             cli_agent_type: env_or_empty(guest_contracts::env::CLI_AGENT_TYPE_ENV),
@@ -206,8 +205,8 @@ impl GuestConfigRaw {
             home: std::env::var("HOME").ok(),
             runtime_home: std::env::var_os("HOME").map(PathBuf::from),
             guest_runtime_dir,
-            artifacts: env_or_empty(guest_contracts::env::ARTIFACTS_ENV),
-            feature_flags: env_or_empty(guest_contracts::env::FEATURE_FLAGS_ENV),
+            artifacts: String::new(),
+            feature_flags: String::new(),
             stuck_tool_timeout_secs: env_or_empty(
                 guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
             ),
@@ -261,7 +260,11 @@ pub struct GuestConfig {
 impl GuestConfig {
     /// Build an owned config from the current process environment.
     pub fn from_process_env() -> Result<Self, String> {
-        Self::from_raw(GuestConfigRaw::from_process_env())
+        let raw = GuestConfigRaw::from_process_env();
+        if raw.run_payload_file.is_empty() {
+            return Err(format!("{RUN_PAYLOAD_FILE_ENV_KEY} is required"));
+        }
+        Self::from_raw(raw)
     }
 
     /// Build an owned config from explicit startup values.

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1284,8 +1284,10 @@ mod tests {
             run_id: "main-recovery-checkpoint".to_string(),
             api_url: server.base_url(),
             api_token: "test-token".to_string(),
-            prompt: prompt.unwrap_or_default().to_string(),
             home: Some("/home/vm0".to_string()),
+            run_payload_file: write_test_run_payload(prompt)
+                .to_string_lossy()
+                .into_owned(),
             guest_runtime_dir: Some(test_runtime_dir()),
             ..env::GuestConfigRaw::default()
         })
@@ -3101,15 +3103,29 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let explicit_paths = paths::GuestPaths::from_runtime_dir(tmp.path().join("captured-run"));
         let stale_paths = paths::GuestPaths::from_runtime_dir(tmp.path().join("stale-run"));
+        let run_payload_dir = explicit_paths
+            .runtime_dir()
+            .join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+        std::fs::create_dir_all(&run_payload_dir).unwrap();
+        let run_payload_file = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+        std::fs::write(
+            &run_payload_file,
+            serde_json::to_vec(&guest_contracts::env::RunPayload {
+                prompt: "captured prompt".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            })
+            .unwrap(),
+        )
+        .unwrap();
         let config = env::GuestConfig::from_raw(env::GuestConfigRaw {
             run_id: "captured-run".to_string(),
-            prompt: "captured prompt".to_string(),
             home: Some(
                 tmp.path()
                     .join("captured-home")
                     .to_string_lossy()
                     .into_owned(),
             ),
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
             guest_runtime_dir: Some(explicit_paths.runtime_dir().to_path_buf()),
             ..env::GuestConfigRaw::default()
         })

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1304,6 +1304,29 @@ mod tests {
         MAIN_TEST_RUNTIME_ROOT.join("main-recovery-checkpoint")
     }
 
+    fn write_test_run_payload(prompt: Option<&str>) -> std::path::PathBuf {
+        let dir = test_runtime_dir().join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+        if let Err(error) = std::fs::create_dir_all(&dir) {
+            eprintln!("create test run payload dir: {error}");
+        }
+        let path = dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+        let payload = guest_contracts::env::RunPayload {
+            prompt: prompt.unwrap_or_default().to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        };
+        let bytes = match serde_json::to_vec(&payload) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                eprintln!("serialize test run payload: {error}");
+                Vec::new()
+            }
+        };
+        if let Err(error) = std::fs::write(&path, bytes) {
+            eprintln!("write test run payload: {error}");
+        }
+        path
+    }
+
     fn test_guest_paths() -> paths::GuestPaths {
         paths::GuestPaths::from_runtime_dir(test_runtime_dir())
     }
@@ -1389,9 +1412,10 @@ mod tests {
                 guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
                 test_runtime_dir(),
             );
-            if let Some(prompt) = prompt {
-                std::env::set_var("VM0_PROMPT", prompt);
-            }
+            std::env::set_var(
+                guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+                write_test_run_payload(prompt),
+            );
         }
         TestEnvGuard
     }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1414,6 +1414,7 @@ mod tests {
             guest_contracts::env::SETTINGS_ENV,
             guest_contracts::env::CLI_AGENT_TYPE_ENV,
             guest_contracts::env::USER_ENV_FILE_ENV,
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
             guest_contracts::env::ARTIFACTS_ENV,
             guest_contracts::env::FEATURE_FLAGS_ENV,
             guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1306,24 +1306,26 @@ mod tests {
 
     fn write_test_run_payload(prompt: Option<&str>) -> std::path::PathBuf {
         let dir = test_runtime_dir().join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
-        if let Err(error) = std::fs::create_dir_all(&dir) {
-            eprintln!("create test run payload dir: {error}");
-        }
+        let create_result = std::fs::create_dir_all(&dir);
+        assert!(
+            create_result.is_ok(),
+            "create test run payload dir: {create_result:?}"
+        );
         let path = dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
         let payload = guest_contracts::env::RunPayload {
             prompt: prompt.unwrap_or_default().to_string(),
             ..guest_contracts::env::RunPayload::default()
         };
-        let bytes = match serde_json::to_vec(&payload) {
-            Ok(bytes) => bytes,
-            Err(error) => {
-                eprintln!("serialize test run payload: {error}");
-                Vec::new()
-            }
-        };
-        if let Err(error) = std::fs::write(&path, bytes) {
-            eprintln!("write test run payload: {error}");
-        }
+        let bytes_result = serde_json::to_vec(&payload);
+        assert!(
+            bytes_result.is_ok(),
+            "serialize test run payload: {bytes_result:?}"
+        );
+        let write_result = std::fs::write(&path, bytes_result.unwrap_or_default());
+        assert!(
+            write_result.is_ok(),
+            "write test run payload: {write_result:?}"
+        );
         path
     }
 

--- a/crates/guest-agent/src/masker.rs
+++ b/crates/guest-agent/src/masker.rs
@@ -1,8 +1,9 @@
 //! Secret value masking for event payloads and CLI diagnostics.
 //!
-//! Reads `VM0_SECRET_VALUES` (comma-separated base64 values), pre-computes
-//! plain / base64 / URL-encoded variants for normal payload masking, and derives
-//! diagnostic-only multiline variants for bounded CLI stderr tails.
+//! Consumes the guest config's comma-separated base64 secret values,
+//! pre-computes plain / base64 / URL-encoded variants for normal payload
+//! masking, and derives diagnostic-only multiline variants for bounded CLI
+//! stderr tails.
 
 use crate::env;
 use aho_corasick::{AhoCorasick, MatchKind};

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -20,6 +20,7 @@ impl GuestContext {
     /// Build a run context from the current process environment.
     pub fn from_process_env() -> Result<Self, String> {
         let raw = GuestConfigRaw::from_process_env();
+        raw.require_run_payload_file()?;
         let paths = paths_from_raw(&raw)?;
         let config = GuestConfig::from_raw(raw)?;
         Ok(Self::new(config, paths))
@@ -38,6 +39,7 @@ impl GuestRuntime {
     /// Build the production runtime from one raw process environment snapshot.
     pub fn from_process_env() -> Result<Self, String> {
         let raw = GuestConfigRaw::from_process_env();
+        raw.require_run_payload_file()?;
         let paths = paths_from_raw(&raw)?;
         guest_common::log::set_system_log_file(paths.system_log_file());
         guest_common::telemetry::set_sandbox_ops_log_file(paths.sandbox_ops_file());

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -5,7 +5,7 @@ use guest_agent::run_context::GuestRuntime;
 use httpmock::prelude::*;
 use serde_json::json;
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const RUN_ID: &str = "artifact-checkpoint-content-hash";
@@ -58,6 +58,17 @@ impl Drop for SandboxOpsOverrideGuard {
     }
 }
 
+fn write_run_payload(
+    runtime_dir: &Path,
+    payload: &guest_contracts::env::RunPayload,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::write(&path, serde_json::to_vec(payload)?)?;
+    Ok(path)
+}
+
 fn test_runtime(
     temp_dir: &Path,
     mount_path: &Path,
@@ -66,22 +77,29 @@ fn test_runtime(
 ) -> Result<GuestRuntime, Box<dyn std::error::Error>> {
     let runtime_dir = temp_dir.join("runtime");
     let paths = GuestPaths::from_runtime_dir(&runtime_dir);
+    let run_payload_file = write_run_payload(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            artifacts: json!([
+                {
+                    "name": "workspace",
+                    "mountPath": mount_path.to_string_lossy(),
+                    "storageId": STORAGE_ID,
+                    "versionId": version_id,
+                }
+            ])
+            .to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
     let config = GuestConfig::from_raw(GuestConfigRaw {
         run_id: RUN_ID.to_string(),
         api_url: api_url.to_string(),
         api_token: "test-token".to_string(),
         cli_agent_type: "claude-code".to_string(),
         home: Some(temp_dir.join("home").to_string_lossy().into_owned()),
+        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
         guest_runtime_dir: Some(runtime_dir),
-        artifacts: json!([
-            {
-                "name": "workspace",
-                "mountPath": mount_path.to_string_lossy(),
-                "storageId": STORAGE_ID,
-                "versionId": version_id,
-            }
-        ])
-        .to_string(),
         ..GuestConfigRaw::default()
     })?;
     let http = HttpClient::with_api_config(api_url, "test-token", "", Duration::ZERO)?;

--- a/crates/guest-agent/tests/cli_setup_failure.rs
+++ b/crates/guest-agent/tests/cli_setup_failure.rs
@@ -26,7 +26,13 @@ async fn agent_log_open_failure_happens_before_cli_spawn() -> Result<(), Box<dyn
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             runtime_dir.as_os_str(),
         );
-        std::env::set_var("VM0_PROMPT", "@exit-after-result");
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "@exit-after-result".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
         std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("CLI_AGENT_TYPE", "claude-code");

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -99,8 +99,16 @@ unsafe fn setup_codex_env(
             .and_then(Path::file_name)
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| "codex-jsonl-failure-logging-test".to_string());
-        std::env::set_var("VM0_RUN_ID", run_id);
-        std::env::set_var("VM0_PROMPT", "drive the codex error fixture");
+        std::env::set_var("VM0_RUN_ID", &run_id);
+        let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(workdir, &run_id)
+            .map_err(|error| format!("resolve runtime dir: {error}"))?;
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "drive the codex error fixture".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
         std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -69,16 +69,24 @@ fn codex_resume_config(
     api_url: &str,
     api_token: &str,
 ) -> Result<guest_agent::env::GuestConfig, String> {
+    let runtime_dir = codex_resume_runtime_dir();
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "test prompt".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
     guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
         run_id: CODEX_RESUME_RUN_ID.clone(),
         api_url: api_url.to_string(),
         api_token: api_token.to_string(),
         sandbox_id: "00000000-0000-4000-8000-000000000abc".to_string(),
         sandbox_reuse_result: "reused".to_string(),
-        prompt: "test prompt".to_string(),
         cli_agent_type: "codex".to_string(),
         home: Some(CODEX_RESUME_HOME.to_string_lossy().into_owned()),
-        guest_runtime_dir: Some(codex_resume_runtime_dir()),
+        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+        guest_runtime_dir: Some(runtime_dir),
         ..Default::default()
     })
 }

--- a/crates/guest-agent/tests/codex_setup_api_key_reconcile.rs
+++ b/crates/guest-agent/tests/codex_setup_api_key_reconcile.rs
@@ -18,14 +18,21 @@ async fn api_key_setup_writes_auth_without_invoking_codex() -> TestResult {
     let runtime_dir = tmp.path().join("runtime");
     let user_env_dir = runtime_dir.join("user-env");
     let user_env_path = user_env_dir.join("env.json");
+    let run_payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let run_payload_path = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
 
     std::fs::create_dir_all(&bin_dir)?;
     std::fs::create_dir_all(&user_env_dir)?;
+    std::fs::create_dir_all(&run_payload_dir)?;
     std::fs::write(
         &user_env_path,
         serde_json::to_vec(&serde_json::json!({
             "OPENAI_API_KEY": "sk-test-api-key-reconcile",
         }))?,
+    )?;
+    std::fs::write(
+        &run_payload_path,
+        serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
     )?;
     write_fake_codex(&fake_codex, &invoked_marker)?;
 
@@ -40,6 +47,7 @@ async fn api_key_setup_writes_auth_without_invoking_codex() -> TestResult {
         run_id: "codex-setup-api-key".to_string(),
         cli_agent_type: "codex".to_string(),
         user_env_file: user_env_path.to_string_lossy().into_owned(),
+        run_payload_file: run_payload_path.to_string_lossy().into_owned(),
         guest_runtime_dir: Some(runtime_dir),
         home: Some(tmp.path().to_string_lossy().into_owned()),
         ..Default::default()

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -23,6 +23,13 @@ fn codex_auth_setup_failure_exits_before_cli_spawn() -> TestResult {
     let codex_home_path = tmp.path().join(".codex");
     std::fs::write(&codex_home_path, b"not a directory")?;
     write_fake_codex(&fake_codex, &invoked_marker)?;
+    let run_payload_path = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "should not reach codex".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
 
     let guest_agent = env!("CARGO_BIN_EXE_guest-agent");
     let output = Command::new(guest_agent)
@@ -31,7 +38,7 @@ fn codex_auth_setup_failure_exits_before_cli_spawn() -> TestResult {
         .env("USE_MOCK_CODEX", "true")
         .env("VM0_MOCK_CODEX_PATH", &fake_codex)
         .env("VM0_RUN_ID", "codex-auth-setup-fail-closed")
-        .env("VM0_PROMPT", "should not reach codex")
+        .env(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, run_payload_path)
         .env("VM0_API_URL", "http://127.0.0.1:1")
         .env("VM0_API_TOKEN", "")
         .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")

--- a/crates/guest-agent/tests/codex_setup_no_auth_reconcile.rs
+++ b/crates/guest-agent/tests/codex_setup_no_auth_reconcile.rs
@@ -11,11 +11,18 @@ async fn codex_setup_no_auth_removes_stale_auth_json() -> TestResult {
     let runtime_dir = tmp.path().join("runtime");
     let user_env_dir = runtime_dir.join("user-env");
     let user_env_path = user_env_dir.join("env.json");
+    let run_payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let run_payload_path = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
     let codex_home = tmp.path().join(".codex");
     let auth_path = codex_home.join("auth.json");
 
     std::fs::create_dir_all(&user_env_dir)?;
+    std::fs::create_dir_all(&run_payload_dir)?;
     std::fs::write(&user_env_path, "{}")?;
+    std::fs::write(
+        &run_payload_path,
+        serde_json::to_vec(&guest_contracts::env::RunPayload::default())?,
+    )?;
     std::fs::create_dir_all(&codex_home)?;
     std::fs::write(
         &auth_path,
@@ -26,6 +33,7 @@ async fn codex_setup_no_auth_removes_stale_auth_json() -> TestResult {
         run_id: "codex-setup-no-auth".to_string(),
         cli_agent_type: "codex".to_string(),
         user_env_file: user_env_path.to_string_lossy().into_owned(),
+        run_payload_file: run_payload_path.to_string_lossy().into_owned(),
         guest_runtime_dir: Some(runtime_dir),
         home: Some(tmp.path().to_string_lossy().into_owned()),
         ..Default::default()

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -483,6 +483,7 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
         guest_contracts::env::SETTINGS_ENV,
         guest_contracts::env::CLI_AGENT_TYPE_ENV,
         guest_contracts::env::USER_ENV_FILE_ENV,
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
         guest_contracts::env::ARTIFACTS_ENV,
         guest_contracts::env::FEATURE_FLAGS_ENV,
         guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -506,6 +506,34 @@ pub unsafe fn clear_guest_agent_bootstrap_env_for_test() {
     }
 }
 
+pub fn write_run_payload_file_for_test(
+    runtime_dir: &Path,
+    payload: &guest_contracts::env::RunPayload,
+) -> Result<std::path::PathBuf, String> {
+    let dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    std::fs::create_dir_all(&dir).map_err(|error| format!("create run payload dir: {error}"))?;
+    let path = dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    let bytes =
+        serde_json::to_vec(payload).map_err(|error| format!("serialize run payload: {error}"))?;
+    std::fs::write(&path, bytes).map_err(|error| format!("write run payload: {error}"))?;
+    Ok(path)
+}
+
+/// Write the runner-owned run payload file and expose it through process env.
+///
+/// # Safety
+/// Call before any other test thread reads process environment.
+pub unsafe fn set_run_payload_file_env_for_test(
+    runtime_dir: &Path,
+    payload: &guest_contracts::env::RunPayload,
+) -> Result<(), String> {
+    let path = write_run_payload_file_for_test(runtime_dir, payload)?;
+    unsafe {
+        std::env::set_var(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, path);
+    }
+    Ok(())
+}
+
 /// Configure one test binary for the experimental Codex app-server backend.
 ///
 /// Must be called before building a `GuestRuntime` because runtime bootstrap
@@ -531,12 +559,20 @@ pub unsafe fn setup_codex_app_server_env(
             std::env::remove_var("MOCK_CODEX_APP_SERVER_SCENARIO");
         }
         std::env::set_var("VM0_RUN_ID", config.run_id);
-        std::env::set_var("VM0_PROMPT", config.prompt);
         std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
         std::env::set_var("HOME", home);
+        let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(home, config.run_id)
+            .map_err(|error| format!("resolve runtime dir: {error}"))?;
+        set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: config.prompt.to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
         if let Some(resume_session_id) = config.resume_session_id {
             std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
         } else {
@@ -638,8 +674,16 @@ pub unsafe fn setup_env(
             .and_then(Path::file_name)
             .map(|n| n.to_string_lossy().into_owned())
             .unwrap_or_else(|| "post-result-reap-test".to_string());
-        std::env::set_var("VM0_RUN_ID", run_id);
-        std::env::set_var("VM0_PROMPT", prompt);
+        std::env::set_var("VM0_RUN_ID", &run_id);
+        let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(workdir, &run_id)
+            .map_err(|error| format!("resolve runtime dir: {error}"))?;
+        set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: prompt.to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
         // Empty API token → has_api() false → no network calls.
         std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -31,8 +31,16 @@ unsafe fn setup_api_env(
             .and_then(Path::file_name)
             .map(|name| name.to_string_lossy().into_owned())
             .unwrap_or_else(|| "execute-cli-api-mode-test".to_string());
-        std::env::set_var("VM0_RUN_ID", run_id);
-        std::env::set_var("VM0_PROMPT", prompt);
+        std::env::set_var("VM0_RUN_ID", &run_id);
+        let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(workdir, &run_id)
+            .map_err(|error| format!("resolve runtime dir: {error}"))?;
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: prompt.to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
         std::env::set_var("VM0_API_URL", api_url);
         std::env::set_var("VM0_API_TOKEN", "test-token");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");

--- a/crates/guest-agent/tests/guest_config_process_env.rs
+++ b/crates/guest-agent/tests/guest_config_process_env.rs
@@ -26,6 +26,31 @@ fn process_env_config_loads_user_env_once() {
         );
     }
 
+    let missing_payload_error = match guest_agent::env::GuestConfig::from_process_env() {
+        Ok(_) => panic!("missing run payload file should fail fast"),
+        Err(error) => error,
+    };
+    assert!(
+        missing_payload_error.contains(guest_contracts::env::RUN_PAYLOAD_FILE_ENV),
+        "error should identify {}, got: {missing_payload_error}",
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV
+    );
+    assert!(
+        user_env_path.exists(),
+        "missing run payload should fail before consuming user env"
+    );
+
+    unsafe {
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "process env prompt".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )
+        .unwrap();
+    }
+
     let config = guest_agent::env::GuestConfig::from_process_env().unwrap();
 
     assert_eq!(config.user_env["OPENAI_MODEL"], "gpt-process-env");

--- a/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
+++ b/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
@@ -8,6 +8,7 @@ mod common;
 #[test]
 fn runtime_bootstrap_requires_api_url_when_api_token_is_set() {
     let tmp = tempfile::tempdir().unwrap();
+    let runtime_dir = tmp.path().join("runtime");
 
     unsafe {
         common::clear_guest_agent_bootstrap_env_for_test();
@@ -18,8 +19,16 @@ fn runtime_bootstrap_requires_api_url_when_api_token_is_set() {
         std::env::set_var("HOME", tmp.path().join("home"));
         std::env::set_var(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            tmp.path().join("runtime"),
+            &runtime_dir,
         );
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "missing api url prompt".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )
+        .unwrap();
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
         std::env::set_var(guest_contracts::env::API_URL_ENV, "");
         std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -23,6 +23,21 @@ fn runtime_bootstrap_installs_system_log_and_sandbox_ops_paths() {
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         );
+        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
+        std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);
+    }
+
+    let missing_payload_error = match guest_agent::run_context::GuestRuntime::from_process_env() {
+        Ok(_) => panic!("missing run payload file should fail fast"),
+        Err(error) => error,
+    };
+    assert!(
+        missing_payload_error.contains(guest_contracts::env::RUN_PAYLOAD_FILE_ENV),
+        "error should identify {}, got: {missing_payload_error}",
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV
+    );
+
+    unsafe {
         common::set_run_payload_file_env_for_test(
             &runtime_dir,
             &guest_contracts::env::RunPayload {
@@ -31,8 +46,6 @@ fn runtime_bootstrap_installs_system_log_and_sandbox_ops_paths() {
             },
         )
         .unwrap();
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
-        std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);
     }
     guest_common::log::clear_system_log_file();
     guest_common::telemetry::clear_sandbox_ops_log_file();

--- a/crates/guest-agent/tests/guest_runtime_process_env.rs
+++ b/crates/guest-agent/tests/guest_runtime_process_env.rs
@@ -23,6 +23,14 @@ fn runtime_bootstrap_installs_system_log_and_sandbox_ops_paths() {
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
         );
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "runtime process env prompt".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )
+        .unwrap();
         std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "");
         std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);
     }

--- a/crates/guest-agent/tests/http_env_missing_api_url.rs
+++ b/crates/guest-agent/tests/http_env_missing_api_url.rs
@@ -2,10 +2,24 @@ use guest_agent::http::HttpClient;
 
 #[test]
 fn for_config_requires_api_url_when_api_token_is_set() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    let runtime_dir = tmp.path().join("runtime");
+    let run_payload_dir = runtime_dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME);
+    let run_payload_path = run_payload_dir.join(guest_contracts::env::RUN_PAYLOAD_FILENAME);
+    std::fs::create_dir_all(&run_payload_dir).expect("create run payload dir");
+    std::fs::write(
+        &run_payload_path,
+        serde_json::to_vec(&guest_contracts::env::RunPayload::default())
+            .expect("serialize run payload"),
+    )
+    .expect("write run payload");
+
     let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
         run_id: "http-missing-api-url".to_string(),
         api_token: "test-token".to_string(),
-        home: Some(std::env::temp_dir().to_string_lossy().into_owned()),
+        home: Some(tmp.path().to_string_lossy().into_owned()),
+        run_payload_file: run_payload_path.to_string_lossy().into_owned(),
+        guest_runtime_dir: Some(runtime_dir),
         ..Default::default()
     })
     .expect("test config should be valid");

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -384,12 +384,18 @@ async fn success_checkpoint_uses_explicit_runtime_after_process_env_changes() {
     let stale_runtime_dir = tmp.path().join("stale-runtime");
     let home_dir = tmp.path().join("home");
     let paths = guest_agent::paths::GuestPaths::from_runtime_dir(&runtime_dir);
+    let run_payload_file = crate::common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload::default(),
+    )
+    .unwrap();
     let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
         run_id: "captured-run".to_string(),
         api_url: server.base_url(),
         api_token: "test-token-abc123".to_string(),
         cli_agent_type: "claude-code".to_string(),
         home: Some(home_dir.to_string_lossy().into_owned()),
+        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
         guest_runtime_dir: Some(runtime_dir.clone()),
         ..guest_agent::env::GuestConfigRaw::default()
     })

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -142,16 +142,23 @@ pub(crate) fn shared_guest_paths() -> guest_agent::paths::GuestPaths {
 
 pub(crate) fn shared_guest_config() -> Result<guest_agent::env::GuestConfig, String> {
     let server = &*MOCK_SERVER;
+    let run_payload_file = crate::common::write_run_payload_file_for_test(
+        &MOCK_RUNTIME_DIR,
+        &guest_contracts::env::RunPayload {
+            prompt: "test prompt".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
     guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
         run_id: TEST_RUN_ID.to_string(),
         api_url: server.base_url(),
         api_token: "test-token-abc123".to_string(),
         sandbox_id: "00000000-0000-4000-8000-000000000abc".to_string(),
         sandbox_reuse_result: "reused".to_string(),
-        prompt: "test prompt".to_string(),
         vercel_bypass: "test-bypass-value".to_string(),
         cli_agent_type: "claude-code".to_string(),
         home: Some(shared_guest_home_dir().to_string_lossy().into_owned()),
+        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
         guest_runtime_dir: Some(MOCK_RUNTIME_DIR.clone()),
         ..Default::default()
     })

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -31,15 +31,7 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             MOCK_RUNTIME_DIR.as_os_str(),
         );
-        if let Err(error) = crate::common::set_run_payload_file_env_for_test(
-            &MOCK_RUNTIME_DIR,
-            &guest_contracts::env::RunPayload {
-                prompt: "test prompt".to_string(),
-                ..guest_contracts::env::RunPayload::default()
-            },
-        ) {
-            eprintln!("write test run payload: {error}");
-        }
+        write_shared_run_payload_file_or_panic();
         std::env::set_var("VERCEL_PROTECTION_BYPASS", "test-bypass-value");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");
@@ -65,6 +57,7 @@ impl SharedApiMock {
         let server = &*MOCK_SERVER;
         server.reset_async().await;
         cleanup_integration_runtime_root();
+        write_shared_run_payload_file_or_panic();
         Self {
             _guard: guard,
             server,
@@ -88,6 +81,16 @@ impl Drop for SharedApiMock {
     fn drop(&mut self) {
         cleanup_integration_runtime_root();
     }
+}
+
+fn write_shared_run_payload_file_or_panic() {
+    let payload = guest_contracts::env::RunPayload {
+        prompt: "test prompt".to_string(),
+        ..guest_contracts::env::RunPayload::default()
+    };
+    let result =
+        unsafe { crate::common::set_run_payload_file_env_for_test(&MOCK_RUNTIME_DIR, &payload) };
+    assert!(result.is_ok(), "write test run payload: {result:?}");
 }
 
 fn cleanup_integration_runtime_root() {

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -31,7 +31,15 @@ pub(crate) static MOCK_SERVER: LazyLock<MockServer> = LazyLock::new(|| {
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             MOCK_RUNTIME_DIR.as_os_str(),
         );
-        std::env::set_var("VM0_PROMPT", "test prompt");
+        if let Err(error) = crate::common::set_run_payload_file_env_for_test(
+            &MOCK_RUNTIME_DIR,
+            &guest_contracts::env::RunPayload {
+                prompt: "test prompt".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        ) {
+            eprintln!("write test run payload: {error}");
+        }
         std::env::set_var("VERCEL_PROTECTION_BYPASS", "test-bypass-value");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");
         std::env::set_var("VM0_SANDBOX_REUSE_RESULT", "reused");

--- a/crates/guest-agent/tests/process_control_channel.rs
+++ b/crates/guest-agent/tests/process_control_channel.rs
@@ -77,6 +77,15 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
     let prompt = "@active-input-smoke:2";
     let workdir = tmp.path().to_string_lossy().into_owned();
     let mock_path = mock.to_string_lossy().into_owned();
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), &run_id)?;
+    let run_payload_path = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: prompt.to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+    let run_payload_path = run_payload_path.to_string_lossy().into_owned();
     let env = [
         ("CLI_AGENT_TYPE", "claude-code"),
         ("VM0_MOCK_CLAUDE_PATH", mock_path.as_str()),
@@ -84,7 +93,10 @@ async fn process_control_channel_reaches_guest_agent() -> TestResult<()> {
         ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
         ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),
         ("VM0_RUN_ID", run_id.as_str()),
-        ("VM0_PROMPT", prompt),
+        (
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+            run_payload_path.as_str(),
+        ),
         ("VM0_API_URL", "http://127.0.0.1:1"),
         ("VM0_API_TOKEN", ""),
         ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),
@@ -182,6 +194,15 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
     let prompt = "printf no-active-input";
     let workdir = tmp.path().to_string_lossy().into_owned();
     let mock_path = mock.to_string_lossy().into_owned();
+    let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), &run_id)?;
+    let run_payload_path = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: prompt.to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+    let run_payload_path = run_payload_path.to_string_lossy().into_owned();
     let env = [
         ("CLI_AGENT_TYPE", "claude-code"),
         ("VM0_MOCK_CLAUDE_PATH", mock_path.as_str()),
@@ -189,7 +210,10 @@ async fn process_control_enabled_plain_run_does_not_wait_for_stdin_eof() -> Test
         ("VM0_POST_RESULT_SIGTERM_GRACE_SECS", "1"),
         ("VM0_POST_RESULT_SIGKILL_GRACE_SECS", "1"),
         ("VM0_RUN_ID", run_id.as_str()),
-        ("VM0_PROMPT", prompt),
+        (
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+            run_payload_path.as_str(),
+        ),
         ("VM0_API_URL", "http://127.0.0.1:1"),
         ("VM0_API_TOKEN", ""),
         ("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc"),

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -42,13 +42,13 @@ pub const SANDBOX_ID_ENV: &str = "VM0_SANDBOX_ID";
 /// `noSessionId`.
 pub const SANDBOX_REUSE_RESULT_ENV: &str = "VM0_SANDBOX_REUSE_RESULT";
 
-/// User prompt payload sent to the guest-agent.
+/// Legacy env key and logical run-payload field name for the user prompt.
 pub const PROMPT_ENV: &str = "VM0_PROMPT";
 
-/// Optional extra system prompt text.
+/// Legacy env key and logical run-payload field name for optional extra system
+/// prompt text.
 ///
-/// The runner omits this key when the append-system-prompt value is absent or
-/// empty.
+/// Unset or empty means there is no extra system prompt.
 pub const APPEND_SYSTEM_PROMPT_ENV: &str = "VM0_APPEND_SYSTEM_PROMPT";
 
 /// Sensitive Vercel protection bypass secret for guest API calls.
@@ -71,28 +71,31 @@ pub const RESUME_SESSION_ID_ENV: &str = "VM0_RESUME_SESSION_ID";
 /// The runner emits an empty string when the timestamp is unavailable.
 pub const API_START_TIME_ENV: &str = "VM0_API_START_TIME";
 
-/// Sensitive values used by the guest-agent masker.
+/// Legacy env key and logical run-payload field name for sensitive values used
+/// by the guest-agent masker.
 ///
 /// The payload is a comma-separated list of base64-encoded secret values, not
 /// secret names. The runner includes the sandbox token so event payloads and
 /// CLI diagnostics can redact it.
 pub const SECRET_VALUES_ENV: &str = "VM0_SECRET_VALUES";
 
-/// Comma-separated Claude Code tool names that should be disallowed.
+/// Legacy env key and logical run-payload field name for comma-separated Claude
+/// Code tool names that should be disallowed.
 ///
 /// Unset or empty means there is no explicit deny list.
 pub const DISALLOWED_TOOLS_ENV: &str = "VM0_DISALLOWED_TOOLS";
 
-/// Comma-separated Claude Code tool names that should be allowed.
+/// Legacy env key and logical run-payload field name for comma-separated Claude
+/// Code tool names that should be allowed.
 ///
 /// Unset or empty means there is no explicit allow list.
 pub const TOOLS_ENV: &str = "VM0_TOOLS";
 
-/// Raw Claude Code settings payload passed to the guest-agent.
+/// Legacy env key and logical run-payload field name for the raw Claude Code
+/// settings payload passed to the guest-agent.
 ///
-/// The runner treats this as an opaque string and currently emits JSON from
-/// the API execution context. Unset or empty means there is no settings
-/// override.
+/// The runner treats this as an opaque string. Unset or empty means there is no
+/// settings override.
 pub const SETTINGS_ENV: &str = "VM0_SETTINGS";
 
 /// CLI framework selector, for example `claude-code` or `codex`.
@@ -124,16 +127,18 @@ pub const RUN_PAYLOAD_PRIVATE_DIR_NAME: &str = "run-payload";
 /// Private runtime filename used by [`RUN_PAYLOAD_FILE_ENV`].
 pub const RUN_PAYLOAD_FILENAME: &str = "payload.json";
 
-/// JSON array describing artifact mounts prepared by the runner.
+/// Legacy env key and logical run-payload field name for the JSON array
+/// describing artifact mounts prepared by the runner.
 ///
 /// Each entry uses camelCase wire keys: `name`, `mountPath`, `storageId`,
 /// `versionId`, and optional `missingRootPolicy`. Unset or empty means there
 /// are no artifact mounts.
 pub const ARTIFACTS_ENV: &str = "VM0_ARTIFACTS";
 
-/// JSON map of feature flag names to enabled states.
+/// Legacy env key and logical run-payload field name for the JSON map of
+/// feature flag names to enabled states.
 ///
-/// The runner omits this key when there are no feature flags.
+/// Unset or empty means there are no feature flags.
 pub const FEATURE_FLAGS_ENV: &str = "VM0_FEATURE_FLAGS";
 
 /// Runner-owned variable-length run payload sent through

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -110,6 +110,20 @@ pub const CLI_AGENT_TYPE_ENV: &str = "CLI_AGENT_TYPE";
 /// payload.
 pub const USER_ENV_FILE_ENV: &str = "VM0_USER_ENV_FILE";
 
+/// Path to the private runner-owned run payload JSON file.
+///
+/// Large prompt-like and configuration payloads use this file instead of
+/// bootstrap environment values so guest-agent startup does not hit Linux
+/// argv/env limits. Unset or empty means the guest-agent should fall back to
+/// legacy env keys.
+pub const RUN_PAYLOAD_FILE_ENV: &str = "VM0_RUN_PAYLOAD_FILE";
+
+/// Private runtime subdirectory used by [`RUN_PAYLOAD_FILE_ENV`].
+pub const RUN_PAYLOAD_PRIVATE_DIR_NAME: &str = "run-payload";
+
+/// Private runtime filename used by [`RUN_PAYLOAD_FILE_ENV`].
+pub const RUN_PAYLOAD_FILENAME: &str = "payload.json";
+
 /// JSON array describing artifact mounts prepared by the runner.
 ///
 /// Each entry uses camelCase wire keys: `name`, `mountPath`, `storageId`,
@@ -121,6 +135,39 @@ pub const ARTIFACTS_ENV: &str = "VM0_ARTIFACTS";
 ///
 /// The runner omits this key when there are no feature flags.
 pub const FEATURE_FLAGS_ENV: &str = "VM0_FEATURE_FLAGS";
+
+/// Runner-owned variable-length run payload sent through
+/// [`RUN_PAYLOAD_FILE_ENV`].
+///
+/// Empty strings retain the legacy env semantics where an unset or empty
+/// value means "no value" for optional fields.
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunPayload {
+    /// User prompt payload sent to the guest-agent.
+    pub prompt: String,
+    /// Optional extra system prompt text.
+    #[serde(default)]
+    pub append_system_prompt: String,
+    /// Sensitive values used by the guest-agent masker.
+    #[serde(default)]
+    pub secret_values: String,
+    /// Comma-separated Claude Code tool names that should be disallowed.
+    #[serde(default)]
+    pub disallowed_tools: String,
+    /// Comma-separated Claude Code tool names that should be allowed.
+    #[serde(default)]
+    pub tools: String,
+    /// Raw Claude Code settings payload passed to the guest-agent.
+    #[serde(default)]
+    pub settings: String,
+    /// JSON array describing artifact mounts prepared by the runner.
+    #[serde(default)]
+    pub artifacts: String,
+    /// JSON map of feature flag names to enabled states.
+    #[serde(default)]
+    pub feature_flags: String,
+}
 
 /// Guest-agent stuck-tool timeout override in seconds.
 ///
@@ -277,6 +324,29 @@ mod tests {
         assert_eq!(RUN_ID_ENV, "VM0_RUN_ID");
         assert_eq!(CLI_AGENT_TYPE_ENV, "CLI_AGENT_TYPE");
         assert_eq!(USER_ENV_FILE_ENV, "VM0_USER_ENV_FILE");
+        assert_eq!(RUN_PAYLOAD_FILE_ENV, "VM0_RUN_PAYLOAD_FILE");
+    }
+
+    #[test]
+    fn run_payload_uses_camel_case_wire_keys() {
+        let payload = RunPayload {
+            prompt: "hello".to_string(),
+            append_system_prompt: "system".to_string(),
+            secret_values: "secret".to_string(),
+            disallowed_tools: "WebFetch".to_string(),
+            tools: "Bash".to_string(),
+            settings: "{}".to_string(),
+            artifacts: "[]".to_string(),
+            feature_flags: r#"{"flag":true}"#.to_string(),
+        };
+
+        let json = serde_json::to_value(&payload).unwrap();
+
+        assert_eq!(json["prompt"], "hello");
+        assert_eq!(json["appendSystemPrompt"], "system");
+        assert_eq!(json["secretValues"], "secret");
+        assert_eq!(json["disallowedTools"], "WebFetch");
+        assert_eq!(json["featureFlags"], r#"{"flag":true}"#);
     }
 
     #[test]
@@ -322,6 +392,7 @@ mod tests {
         for key in [
             API_URL_ENV,
             WORKING_DIR_ENV,
+            RUN_PAYLOAD_FILE_ENV,
             CLI_AGENT_TYPE_ENV,
             USE_MOCK_CLAUDE_ENV,
             USE_MOCK_CODEX_ENV,

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -42,11 +42,10 @@ pub const SANDBOX_ID_ENV: &str = "VM0_SANDBOX_ID";
 /// `noSessionId`.
 pub const SANDBOX_REUSE_RESULT_ENV: &str = "VM0_SANDBOX_REUSE_RESULT";
 
-/// Legacy env key and logical run-payload field name for the user prompt.
+/// Logical run-payload field name for the user prompt.
 pub const PROMPT_ENV: &str = "VM0_PROMPT";
 
-/// Legacy env key and logical run-payload field name for optional extra system
-/// prompt text.
+/// Logical run-payload field name for optional extra system prompt text.
 ///
 /// Unset or empty means there is no extra system prompt.
 pub const APPEND_SYSTEM_PROMPT_ENV: &str = "VM0_APPEND_SYSTEM_PROMPT";
@@ -71,28 +70,28 @@ pub const RESUME_SESSION_ID_ENV: &str = "VM0_RESUME_SESSION_ID";
 /// The runner emits an empty string when the timestamp is unavailable.
 pub const API_START_TIME_ENV: &str = "VM0_API_START_TIME";
 
-/// Legacy env key and logical run-payload field name for sensitive values used
-/// by the guest-agent masker.
+/// Logical run-payload field name for sensitive values used by the guest-agent
+/// masker.
 ///
 /// The payload is a comma-separated list of base64-encoded secret values, not
 /// secret names. The runner includes the sandbox token so event payloads and
 /// CLI diagnostics can redact it.
 pub const SECRET_VALUES_ENV: &str = "VM0_SECRET_VALUES";
 
-/// Legacy env key and logical run-payload field name for comma-separated Claude
-/// Code tool names that should be disallowed.
+/// Logical run-payload field name for comma-separated Claude Code tool names
+/// that should be disallowed.
 ///
 /// Unset or empty means there is no explicit deny list.
 pub const DISALLOWED_TOOLS_ENV: &str = "VM0_DISALLOWED_TOOLS";
 
-/// Legacy env key and logical run-payload field name for comma-separated Claude
-/// Code tool names that should be allowed.
+/// Logical run-payload field name for comma-separated Claude Code tool names
+/// that should be allowed.
 ///
 /// Unset or empty means there is no explicit allow list.
 pub const TOOLS_ENV: &str = "VM0_TOOLS";
 
-/// Legacy env key and logical run-payload field name for the raw Claude Code
-/// settings payload passed to the guest-agent.
+/// Logical run-payload field name for the raw Claude Code settings payload
+/// passed to the guest-agent.
 ///
 /// The runner treats this as an opaque string. Unset or empty means there is no
 /// settings override.
@@ -117,8 +116,7 @@ pub const USER_ENV_FILE_ENV: &str = "VM0_USER_ENV_FILE";
 ///
 /// Large prompt-like and configuration payloads use this file instead of
 /// bootstrap environment values so guest-agent startup does not hit Linux
-/// argv/env limits. Unset or empty means the guest-agent should fall back to
-/// legacy env keys.
+/// argv/env limits. Production guest-agent startup requires this key.
 pub const RUN_PAYLOAD_FILE_ENV: &str = "VM0_RUN_PAYLOAD_FILE";
 
 /// Private runtime subdirectory used by [`RUN_PAYLOAD_FILE_ENV`].
@@ -127,16 +125,16 @@ pub const RUN_PAYLOAD_PRIVATE_DIR_NAME: &str = "run-payload";
 /// Private runtime filename used by [`RUN_PAYLOAD_FILE_ENV`].
 pub const RUN_PAYLOAD_FILENAME: &str = "payload.json";
 
-/// Legacy env key and logical run-payload field name for the JSON array
-/// describing artifact mounts prepared by the runner.
+/// Logical run-payload field name for the JSON array describing artifact mounts
+/// prepared by the runner.
 ///
 /// Each entry uses camelCase wire keys: `name`, `mountPath`, `storageId`,
 /// `versionId`, and optional `missingRootPolicy`. Unset or empty means there
 /// are no artifact mounts.
 pub const ARTIFACTS_ENV: &str = "VM0_ARTIFACTS";
 
-/// Legacy env key and logical run-payload field name for the JSON map of
-/// feature flag names to enabled states.
+/// Logical run-payload field name for the JSON map of feature flag names to
+/// enabled states.
 ///
 /// Unset or empty means there are no feature flags.
 pub const FEATURE_FLAGS_ENV: &str = "VM0_FEATURE_FLAGS";
@@ -144,8 +142,7 @@ pub const FEATURE_FLAGS_ENV: &str = "VM0_FEATURE_FLAGS";
 /// Runner-owned variable-length run payload sent through
 /// [`RUN_PAYLOAD_FILE_ENV`].
 ///
-/// Empty strings retain the legacy env semantics where an unset or empty
-/// value means "no value" for optional fields.
+/// Empty strings mean "no value" for optional fields.
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunPayload {

--- a/crates/guest-contracts/src/exec_limits.rs
+++ b/crates/guest-contracts/src/exec_limits.rs
@@ -19,6 +19,8 @@ pub const EXECVE_STRING_MAX_BYTES: usize = 128 * 1024 - 1;
 /// guard rather than a product-level payload limit.
 pub const EXECVE_ARG_ENV_MAX_BYTES: usize = 2 * 1024 * 1024;
 
+const EXECVE_POINTER_OVERHEAD_BYTES: usize = std::mem::size_of::<usize>();
+
 /// Process boundary value kind.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExecBoundaryValueKind {
@@ -85,7 +87,8 @@ pub enum ExecBoundarySizeError {
     },
     /// Aggregate argv+env payload exceeds the conservative total budget.
     AggregateTooLarge {
-        /// Actual aggregate byte count including per-string NUL bytes.
+        /// Actual aggregate byte count including per-string NUL bytes and
+        /// argv/env pointer-table overhead.
         bytes: usize,
         /// Maximum allowed aggregate byte count.
         max_bytes: usize,
@@ -119,7 +122,14 @@ impl std::error::Error for ExecBoundarySizeError {}
 pub fn validate_exec_boundary_sizes(
     values: impl IntoIterator<Item = ExecBoundaryValue>,
 ) -> Result<(), ExecBoundarySizeError> {
-    let mut aggregate_bytes = 0usize;
+    validate_exec_boundary_sizes_with_budget(values, EXECVE_ARG_ENV_MAX_BYTES)
+}
+
+fn validate_exec_boundary_sizes_with_budget(
+    values: impl IntoIterator<Item = ExecBoundaryValue>,
+    aggregate_max_bytes: usize,
+) -> Result<(), ExecBoundarySizeError> {
+    let mut aggregate_bytes = EXECVE_POINTER_OVERHEAD_BYTES;
 
     for value in values {
         if value.bytes > EXECVE_STRING_MAX_BYTES {
@@ -130,13 +140,18 @@ pub fn validate_exec_boundary_sizes(
                 max_bytes: EXECVE_STRING_MAX_BYTES,
             });
         }
-        aggregate_bytes = aggregate_bytes.saturating_add(value.bytes.saturating_add(1));
+        aggregate_bytes = aggregate_bytes.saturating_add(
+            value
+                .bytes
+                .saturating_add(1)
+                .saturating_add(EXECVE_POINTER_OVERHEAD_BYTES),
+        );
     }
 
-    if aggregate_bytes > EXECVE_ARG_ENV_MAX_BYTES {
+    if aggregate_bytes > aggregate_max_bytes {
         return Err(ExecBoundarySizeError::AggregateTooLarge {
             bytes: aggregate_bytes,
-            max_bytes: EXECVE_ARG_ENV_MAX_BYTES,
+            max_bytes: aggregate_max_bytes,
         });
     }
 
@@ -208,6 +223,27 @@ mod tests {
         assert!(matches!(
             error,
             ExecBoundarySizeError::AggregateTooLarge { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_aggregate_overflow_from_pointer_overhead() {
+        let string_only_bytes = "/bin/bash".len() + 1 + "A=".len() + 1;
+        let error = validate_exec_boundary_sizes_with_budget(
+            [
+                ExecBoundaryValue::arg("argv[0]", "/bin/bash"),
+                ExecBoundaryValue::env("A", ""),
+            ],
+            string_only_bytes,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExecBoundarySizeError::AggregateTooLarge {
+                bytes,
+                max_bytes
+            } if bytes > string_only_bytes && max_bytes == string_only_bytes
         ));
     }
 }

--- a/crates/guest-contracts/src/exec_limits.rs
+++ b/crates/guest-contracts/src/exec_limits.rs
@@ -20,6 +20,7 @@ pub const EXECVE_STRING_MAX_BYTES: usize = 128 * 1024 - 1;
 pub const EXECVE_ARG_ENV_MAX_BYTES: usize = 2 * 1024 * 1024;
 
 const EXECVE_POINTER_OVERHEAD_BYTES: usize = std::mem::size_of::<usize>();
+const EXECVE_POINTER_TABLE_TERMINATOR_BYTES: usize = EXECVE_POINTER_OVERHEAD_BYTES * 2;
 
 /// Process boundary value kind.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -129,7 +130,7 @@ fn validate_exec_boundary_sizes_with_budget(
     values: impl IntoIterator<Item = ExecBoundaryValue>,
     aggregate_max_bytes: usize,
 ) -> Result<(), ExecBoundarySizeError> {
-    let mut aggregate_bytes = EXECVE_POINTER_OVERHEAD_BYTES;
+    let mut aggregate_bytes = EXECVE_POINTER_TABLE_TERMINATOR_BYTES;
 
     for value in values {
         if value.bytes > EXECVE_STRING_MAX_BYTES {
@@ -244,6 +245,32 @@ mod tests {
                 bytes,
                 max_bytes
             } if bytes > string_only_bytes && max_bytes == string_only_bytes
+        ));
+    }
+
+    #[test]
+    fn aggregate_pointer_overhead_counts_argv_and_envp_null_terminators() {
+        let value_count = 2usize;
+        let string_bytes = "/bin/bash".len() + 1 + "A=".len() + 1;
+        let budget_missing_envp_null =
+            string_bytes + ((value_count + 1) * EXECVE_POINTER_OVERHEAD_BYTES);
+        let expected_bytes = budget_missing_envp_null + EXECVE_POINTER_OVERHEAD_BYTES;
+
+        let error = validate_exec_boundary_sizes_with_budget(
+            [
+                ExecBoundaryValue::arg("argv[0]", "/bin/bash"),
+                ExecBoundaryValue::env("A", ""),
+            ],
+            budget_missing_envp_null,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExecBoundarySizeError::AggregateTooLarge {
+                bytes,
+                max_bytes
+            } if bytes == expected_bytes && max_bytes == budget_missing_envp_null
         ));
     }
 }

--- a/crates/guest-contracts/src/exec_limits.rs
+++ b/crates/guest-contracts/src/exec_limits.rs
@@ -1,0 +1,213 @@
+//! Conservative Linux `execve` argv/environment size guards.
+//!
+//! These helpers let the runner and guest-agent fail before spawning a process
+//! that would otherwise surface as an opaque `E2BIG` or shell-level
+//! "Argument list too long" error.
+
+use std::fmt;
+
+/// Conservative maximum byte length for one argv or env string.
+///
+/// Linux's `MAX_ARG_STRLEN` is commonly 32 pages, or 128 KiB on 4 KiB page
+/// systems. The limit includes the trailing NUL, so callers may pass at most
+/// one byte less of actual string payload.
+pub const EXECVE_STRING_MAX_BYTES: usize = 128 * 1024 - 1;
+
+/// Conservative aggregate byte budget for argv and environment strings.
+///
+/// This matches the common Linux `ARG_MAX` value and is used as a preflight
+/// guard rather than a product-level payload limit.
+pub const EXECVE_ARG_ENV_MAX_BYTES: usize = 2 * 1024 * 1024;
+
+/// Process boundary value kind.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExecBoundaryValueKind {
+    /// An argv entry.
+    Arg,
+    /// An environment entry in `KEY=VALUE` form.
+    Env,
+}
+
+impl ExecBoundaryValueKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Arg => "argv",
+            Self::Env => "env",
+        }
+    }
+}
+
+/// One named value crossing an `execve` argv/env boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExecBoundaryValue {
+    kind: ExecBoundaryValueKind,
+    name: String,
+    bytes: usize,
+}
+
+impl ExecBoundaryValue {
+    /// Construct an argv value from its logical name and string payload.
+    pub fn arg(name: impl Into<String>, value: &str) -> Self {
+        Self {
+            kind: ExecBoundaryValueKind::Arg,
+            name: name.into(),
+            bytes: value.len(),
+        }
+    }
+
+    /// Construct an env value from its key and value.
+    ///
+    /// The measured string is `KEY=VALUE`, matching the string passed through
+    /// `execve`.
+    pub fn env(key: impl Into<String>, value: &str) -> Self {
+        let key = key.into();
+        Self {
+            kind: ExecBoundaryValueKind::Env,
+            bytes: key.len() + 1 + value.len(),
+            name: key,
+        }
+    }
+}
+
+/// Error returned when a process argv/env boundary is too large.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ExecBoundarySizeError {
+    /// One argv or env string exceeds the per-string limit.
+    StringTooLarge {
+        /// Whether the value is argv or env.
+        kind: ExecBoundaryValueKind,
+        /// Logical field name, never the raw value.
+        name: String,
+        /// Actual byte length of the string.
+        bytes: usize,
+        /// Maximum allowed byte length.
+        max_bytes: usize,
+    },
+    /// Aggregate argv+env payload exceeds the conservative total budget.
+    AggregateTooLarge {
+        /// Actual aggregate byte count including per-string NUL bytes.
+        bytes: usize,
+        /// Maximum allowed aggregate byte count.
+        max_bytes: usize,
+    },
+}
+
+impl fmt::Display for ExecBoundarySizeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StringTooLarge {
+                kind,
+                name,
+                bytes,
+                max_bytes,
+            } => write!(
+                formatter,
+                "{} value too large: {name} length={bytes} max={max_bytes}",
+                kind.label()
+            ),
+            Self::AggregateTooLarge { bytes, max_bytes } => write!(
+                formatter,
+                "argv/env aggregate too large: bytes={bytes} max={max_bytes}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ExecBoundarySizeError {}
+
+/// Validate argv/env string and aggregate sizes.
+pub fn validate_exec_boundary_sizes(
+    values: impl IntoIterator<Item = ExecBoundaryValue>,
+) -> Result<(), ExecBoundarySizeError> {
+    let mut aggregate_bytes = 0usize;
+
+    for value in values {
+        if value.bytes > EXECVE_STRING_MAX_BYTES {
+            return Err(ExecBoundarySizeError::StringTooLarge {
+                kind: value.kind,
+                name: value.name,
+                bytes: value.bytes,
+                max_bytes: EXECVE_STRING_MAX_BYTES,
+            });
+        }
+        aggregate_bytes = aggregate_bytes.saturating_add(value.bytes.saturating_add(1));
+    }
+
+    if aggregate_bytes > EXECVE_ARG_ENV_MAX_BYTES {
+        return Err(ExecBoundarySizeError::AggregateTooLarge {
+            bytes: aggregate_bytes,
+            max_bytes: EXECVE_ARG_ENV_MAX_BYTES,
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_values_inside_limits() {
+        validate_exec_boundary_sizes([
+            ExecBoundaryValue::arg("argv[0]", "/bin/bash"),
+            ExecBoundaryValue::env("HOME", "/home/vm0"),
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_oversized_single_arg_without_value_leak() {
+        let secret = "x".repeat(EXECVE_STRING_MAX_BYTES + 1);
+
+        let error =
+            validate_exec_boundary_sizes([ExecBoundaryValue::arg("prompt", &secret)]).unwrap_err();
+
+        assert_eq!(
+            error,
+            ExecBoundarySizeError::StringTooLarge {
+                kind: ExecBoundaryValueKind::Arg,
+                name: "prompt".to_string(),
+                bytes: EXECVE_STRING_MAX_BYTES + 1,
+                max_bytes: EXECVE_STRING_MAX_BYTES,
+            }
+        );
+        assert!(!error.to_string().contains(&secret));
+    }
+
+    #[test]
+    fn rejects_oversized_single_env_with_key_length_included() {
+        let value = "x".repeat(EXECVE_STRING_MAX_BYTES);
+
+        let error =
+            validate_exec_boundary_sizes([ExecBoundaryValue::env("BIG_ENV", &value)]).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExecBoundarySizeError::StringTooLarge {
+                kind: ExecBoundaryValueKind::Env,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_aggregate_overflow() {
+        let first = "x".repeat(EXECVE_STRING_MAX_BYTES);
+        let second = "y".repeat(EXECVE_STRING_MAX_BYTES);
+        let values = (0..20).map(|index| {
+            if index % 2 == 0 {
+                ExecBoundaryValue::arg("chunk", &first)
+            } else {
+                ExecBoundaryValue::arg("chunk", &second)
+            }
+        });
+
+        let error = validate_exec_boundary_sizes(values).unwrap_err();
+
+        assert!(matches!(
+            error,
+            ExecBoundarySizeError::AggregateTooLarge { .. }
+        ));
+    }
+}

--- a/crates/guest-contracts/src/lib.rs
+++ b/crates/guest-contracts/src/lib.rs
@@ -8,5 +8,6 @@
 pub mod codex_thread_id;
 pub mod diagnostics;
 pub mod env;
+pub mod exec_limits;
 pub mod runtime_paths;
 pub mod session_history_identity;

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -327,6 +327,9 @@ fn validate_agent_bootstrap_exec_boundary(
         "/bin/bash",
     ));
     values.push(guest_contracts::exec_limits::ExecBoundaryValue::arg(
+        "argv[1]", "-c",
+    ));
+    values.push(guest_contracts::exec_limits::ExecBoundaryValue::arg(
         "argv[2] bootstrap command",
         agent_cmd,
     ));
@@ -1609,6 +1612,36 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 mod tests {
     use super::*;
 
+    fn exec_arg_aggregate_bytes(value: &str) -> usize {
+        value.len() + 1
+    }
+
+    fn env_pairs_for_aggregate_bytes(target_bytes: usize) -> Vec<(String, String)> {
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        let mut remaining = target_bytes;
+        let mut index = 0;
+
+        while remaining > 0 {
+            let key = format!("VM0_FILL_{index}");
+            let overhead = key.len() + 2;
+            if remaining <= overhead {
+                pairs
+                    .last_mut()
+                    .expect("aggregate target must require at least one env pair")
+                    .1
+                    .push_str(&"x".repeat(remaining));
+                break;
+            }
+
+            let value_len = (64 * 1024).min(remaining - overhead);
+            pairs.push((key, "x".repeat(value_len)));
+            remaining -= overhead + value_len;
+            index += 1;
+        }
+
+        pairs
+    }
+
     #[test]
     fn bootstrap_exec_boundary_rejects_oversized_env_value_without_value_leak() {
         let secret = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
@@ -1635,6 +1668,23 @@ mod tests {
             validate_agent_bootstrap_exec_boundary("exec /usr/local/bin/guest-agent", &env_pairs)
                 .unwrap_err()
                 .to_string();
+
+        assert!(error.contains("argv/env aggregate too large"));
+    }
+
+    #[test]
+    fn bootstrap_exec_boundary_counts_shell_wrapper_dash_c_arg() {
+        let agent_cmd = "exec /usr/local/bin/guest-agent";
+        let shell_arg_bytes = exec_arg_aggregate_bytes("/bin/bash")
+            + exec_arg_aggregate_bytes("-c")
+            + exec_arg_aggregate_bytes(agent_cmd);
+        let env_pairs = env_pairs_for_aggregate_bytes(
+            guest_contracts::exec_limits::EXECVE_ARG_ENV_MAX_BYTES + 1 - shell_arg_bytes,
+        );
+
+        let error = validate_agent_bootstrap_exec_boundary(agent_cmd, &env_pairs)
+            .unwrap_err()
+            .to_string();
 
         assert!(error.contains("argv/env aggregate too large"));
     }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -321,7 +321,7 @@ fn validate_agent_bootstrap_exec_boundary(
     agent_cmd: &str,
     env_pairs: &[(String, String)],
 ) -> RunnerResult<()> {
-    let mut values = Vec::with_capacity(env_pairs.len() + 2);
+    let mut values = Vec::with_capacity(env_pairs.len() + 3);
     values.push(guest_contracts::exec_limits::ExecBoundaryValue::arg(
         "argv[0]",
         "/bin/bash",

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -29,7 +29,10 @@ use super::diagnostics::{
     should_collect_agent_abnormal_exit_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
-use super::env::{build_env_json_for_run, build_user_env_json, write_user_env_file};
+use super::env::{
+    build_env_json_for_run, build_run_payload_for_run, build_user_env_json, write_run_payload_file,
+    write_user_env_file,
+};
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
 use super::session_history_download::{
     SessionHistoryDownloadPhaseTiming, SessionHistoryDownloadTimings,
@@ -41,7 +44,7 @@ use super::telemetry::{RunnerSpawnTiming, record_api_latency};
 use super::{
     EXIT_SIGKILL, EXIT_SIGNAL_KILL, ExecutionFailure, ExecutorConfig, JOB_TIMEOUT,
     JOB_TIMEOUT_EXIT_CODE, PROCESS_CANCEL_TIMEOUTS, ResourceFailureDiagnostics,
-    ResourceFailureKind, RunnerResult, SandboxReuseResult, USER_ENV_FILE_ENV_KEY,
+    ResourceFailureKind, RunnerError, RunnerResult, SandboxReuseResult, USER_ENV_FILE_ENV_KEY,
     agent_exit_failure_message, guest_runtime_dir, guest_runtime_path, job_terminal_wait_timeout,
     normalize_failure_exit_code,
 };
@@ -312,6 +315,31 @@ pub(super) fn build_agent_start_command(run_agent_path: &str) -> String {
         fi; \
         exec {run_agent_path} 2>&1"
     )
+}
+
+fn validate_agent_bootstrap_exec_boundary(
+    agent_cmd: &str,
+    env_pairs: &[(String, String)],
+) -> RunnerResult<()> {
+    let mut values = Vec::with_capacity(env_pairs.len() + 2);
+    values.push(guest_contracts::exec_limits::ExecBoundaryValue::arg(
+        "argv[0]",
+        "/bin/bash",
+    ));
+    values.push(guest_contracts::exec_limits::ExecBoundaryValue::arg(
+        "argv[2] bootstrap command",
+        agent_cmd,
+    ));
+    for (key, value) in env_pairs {
+        values.push(guest_contracts::exec_limits::ExecBoundaryValue::env(
+            key.as_str(),
+            value,
+        ));
+    }
+
+    guest_contracts::exec_limits::validate_exec_boundary_sizes(values).map_err(|error| {
+        RunnerError::Internal(format!("guest-agent bootstrap argv/env too large: {error}"))
+    })
 }
 
 async fn verify_restored_session_identity_for_reuse(
@@ -1055,6 +1083,52 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         }
     };
     let env_build_started = Instant::now();
+    let run_payload = match build_run_payload_for_run(context) {
+        Ok(run_payload) => run_payload,
+        Err(error) => {
+            telemetry.record(
+                "runner_agent_env_build",
+                env_build_started.elapsed(),
+                false,
+                None,
+            );
+            return Err(error);
+        }
+    };
+    info!(
+        run_id = %context.run_id,
+        prompt_bytes = run_payload.prompt.len(),
+        append_system_prompt_bytes = run_payload.append_system_prompt.len(),
+        secret_values_bytes = run_payload.secret_values.len(),
+        disallowed_tools_bytes = run_payload.disallowed_tools.len(),
+        tools_bytes = run_payload.tools.len(),
+        settings_bytes = run_payload.settings.len(),
+        artifacts_bytes = run_payload.artifacts.len(),
+        feature_flags_bytes = run_payload.feature_flags.len(),
+        "guest-agent run payload prepared"
+    );
+    let run_payload_write_started = Instant::now();
+    let run_payload_file = match write_run_payload_file(sandbox, context.run_id, &run_payload).await
+    {
+        Ok(path) => {
+            telemetry.record(
+                "runner_run_payload_write",
+                run_payload_write_started.elapsed(),
+                true,
+                None,
+            );
+            path
+        }
+        Err(error) => {
+            telemetry.record(
+                "runner_run_payload_write",
+                run_payload_write_started.elapsed(),
+                false,
+                None,
+            );
+            return Err(error);
+        }
+    };
     let mut env_map = match build_env_json_for_run(
         context,
         &config.api_url,
@@ -1076,6 +1150,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     if let Some(path) = user_env_file {
         env_map.insert(USER_ENV_FILE_ENV_KEY.into(), path);
     }
+    env_map.insert(
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV.into(),
+        run_payload_file,
+    );
     let env_diagnostics = build_agent_env_diagnostics(&env_map, &user_env_map);
     let env_pairs: Vec<(String, String)> = env_map.into_iter().collect();
     let env_refs: Vec<(&str, &str)> = env_pairs
@@ -1094,6 +1172,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     //    merged into stdout, while a small stderr capture keeps shell/wrapper
     //    startup failures visible when the process exits before guest logging.
     let agent_cmd = build_agent_start_command(guest::RUN_AGENT);
+    validate_agent_bootstrap_exec_boundary(&agent_cmd, &env_pairs)?;
     info!(run_id = %context.run_id, "spawning agent");
 
     // JOB_TIMEOUT remains the guest-side runtime budget. The host waits a
@@ -1524,4 +1603,39 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             .map(|failure| failure.error.as_str()),
     );
     Ok(agent_result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_exec_boundary_rejects_oversized_env_value_without_value_leak() {
+        let secret = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES + 1);
+        let env_pairs = vec![("VM0_OVERSIZED".to_string(), secret.clone())];
+
+        let error =
+            validate_agent_bootstrap_exec_boundary("exec /usr/local/bin/guest-agent", &env_pairs)
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("guest-agent bootstrap argv/env too large"));
+        assert!(error.contains("VM0_OVERSIZED"));
+        assert!(!error.contains(&secret));
+    }
+
+    #[test]
+    fn bootstrap_exec_boundary_rejects_aggregate_overflow() {
+        let value = "x".repeat(guest_contracts::exec_limits::EXECVE_STRING_MAX_BYTES - 16);
+        let env_pairs: Vec<(String, String)> = (0..20)
+            .map(|index| (format!("VM0_CHUNK_{index}"), value.clone()))
+            .collect();
+
+        let error =
+            validate_agent_bootstrap_exec_boundary("exec /usr/local/bin/guest-agent", &env_pairs)
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("argv/env aggregate too large"));
+    }
 }

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1099,7 +1099,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         run_id = %context.run_id,
         prompt_bytes = run_payload.prompt.len(),
         append_system_prompt_bytes = run_payload.append_system_prompt.len(),
-        secret_values_bytes = run_payload.secret_values.len(),
+        secret_values_present = !run_payload.secret_values.is_empty(),
         disallowed_tools_bytes = run_payload.disallowed_tools.len(),
         tools_bytes = run_payload.tools.len(),
         settings_bytes = run_payload.settings.len(),

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -131,6 +131,8 @@ pub(super) fn validate_execution_context_before_sandbox_with_host_env(
         build_env_json_with_host_env(context, api_url, sandbox_id, reuse_result, host_env)
             .map_err(|error| error.to_string())?;
     validate_bootstrap_environment_for_guest(&bootstrap_env)?;
+    let run_payload = build_run_payload_for_run(context).map_err(|error| error.to_string())?;
+    validate_run_payload_for_guest(&run_payload)?;
     Ok(())
 }
 
@@ -244,6 +246,13 @@ pub(super) fn guest_user_env_file_path(run_id: RunId) -> RunnerResult<String> {
     })
 }
 
+pub(super) fn guest_run_payload_file_path(run_id: RunId) -> RunnerResult<String> {
+    guest_runtime_path(run_id, |dir| {
+        dir.join(guest_contracts::env::RUN_PAYLOAD_PRIVATE_DIR_NAME)
+            .join(guest_contracts::env::RUN_PAYLOAD_FILENAME)
+    })
+}
+
 pub(super) async fn write_user_env_file(
     sandbox: &dyn Sandbox,
     run_id: RunId,
@@ -259,6 +268,19 @@ pub(super) async fn write_user_env_file(
     sandbox.write_private_file(&file_path, &payload).await?;
 
     Ok(Some(file_path))
+}
+
+pub(super) async fn write_run_payload_file(
+    sandbox: &dyn Sandbox,
+    run_id: RunId,
+    run_payload: &guest_contracts::env::RunPayload,
+) -> RunnerResult<String> {
+    let file_path = guest_run_payload_file_path(run_id)?;
+    let payload = serde_json::to_vec(run_payload)
+        .map_err(|e| RunnerError::Internal(format!("serialize run payload: {e}")))?;
+    sandbox.write_private_file(&file_path, &payload).await?;
+
+    Ok(file_path)
 }
 
 pub(super) fn build_env_json_with_host_env(
@@ -331,19 +353,7 @@ pub(super) fn build_env_json_with_host_env_for_run(
         guest_contracts::env::SANDBOX_REUSE_RESULT_ENV.into(),
         reuse_result.as_wire().into(),
     );
-    env.insert(
-        guest_contracts::env::PROMPT_ENV.into(),
-        context.prompt.clone(),
-    );
     insert_guest_agent_tuning_env(&mut env, context);
-    if let Some(asp) = &context.append_system_prompt
-        && !asp.is_empty()
-    {
-        env.insert(
-            guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV.into(),
-            asp.clone(),
-        );
-    }
     env.insert(
         guest_contracts::env::API_START_TIME_ENV.into(),
         context
@@ -365,48 +375,6 @@ pub(super) fn build_env_json_with_host_env_for_run(
         );
     }
 
-    // Artifacts config (multi-mount).
-    //
-    // Emit a single `VM0_ARTIFACTS` env var containing a JSON array of
-    // `{name, mountPath, storageId, versionId, missingRootPolicy?}` objects.
-    // Guest-agent parses this on startup and iterates the list when taking
-    // snapshots at run end. The required fields here must stay lockstep with
-    // guest-agent's `ArtifactEnv` — the two ship as one unit via
-    // `include_bytes!`, and required field drops will panic the VM at startup
-    // instead of silently producing empty strings.
-    //
-    // Empty-list case: do not set the env var at all (matches the prior
-    // "unset = no artifact" convention).
-    if let Some(manifest) = &context.storage_manifest
-        && !manifest.artifacts.is_empty()
-    {
-        let payload: Vec<serde_json::Value> = manifest
-            .artifacts
-            .iter()
-            .map(|a| {
-                let mut entry = serde_json::json!({
-                    "name": a.vas_storage_name,
-                    "mountPath": a.mount_path,
-                    "storageId": a.vas_storage_id,
-                    "versionId": a.vas_version_id,
-                });
-                if let Some(policy) = a.missing_root_policy
-                    && let Some(object) = entry.as_object_mut()
-                {
-                    object.insert("missingRootPolicy".to_string(), serde_json::json!(policy));
-                }
-                entry
-            })
-            .collect();
-        // Serialization cannot fail — payload is a Vec of String-only JSON
-        // objects. Use `.expect` to make the invariant explicit; falling
-        // back to an empty string would silently produce a broken env.
-        #[allow(clippy::expect_used)]
-        let serialized = serde_json::to_string(&payload)
-            .expect("VM0_ARTIFACTS payload must serialize (String-only Values)");
-        env.insert(guest_contracts::env::ARTIFACTS_ENV.into(), serialized);
-    }
-
     // Resume session ID
     if let Some(session) = &context.resume_session {
         let session_id =
@@ -425,42 +393,145 @@ pub(super) fn build_env_json_with_host_env_for_run(
     // Note: Connector placeholder env vars (e.g., GITHUB_TOKEN=gho_CoffeeSafeLocal...)
     // are injected by the web API into `context.environment` directly.
 
-    // Plain secret values (base64-encoded, comma-separated) for redaction.
-    // These are values, not names; base64 is only transport encoding.
-    // Always include the sandbox token so it gets redacted in logs.
-    {
-        use base64::Engine as _;
-        let mut encoded: Vec<String> =
-            vec![base64::engine::general_purpose::STANDARD.encode(&context.sandbox_token)];
-        if let Some(secret_values) = &context.secret_values {
-            encoded.extend(
-                secret_values
-                    .iter()
-                    .map(|s| base64::engine::general_purpose::STANDARD.encode(s)),
-            );
-        }
-        env.insert(
-            guest_contracts::env::SECRET_VALUES_ENV.into(),
-            encoded.join(","),
-        );
-    }
-
     match effective_cli_framework(&context.cli_agent_type) {
-        EffectiveCliFramework::ClaudeCode => insert_claude_code_env(&mut env, context, host_env)?,
+        EffectiveCliFramework::ClaudeCode => insert_claude_code_env(&mut env, context, host_env),
         EffectiveCliFramework::Codex => {
             insert_codex_env(&mut env, context, host_env, has_active_input_source);
         }
     }
 
-    // Feature flags (JSON-encoded map of flag name → enabled)
-    if let Some(flags) = &context.feature_flags
-        && !flags.is_empty()
-        && let Ok(json) = serde_json::to_string(flags)
-    {
-        env.insert(guest_contracts::env::FEATURE_FLAGS_ENV.into(), json);
+    Ok(env)
+}
+
+pub(super) fn build_run_payload_for_run(
+    context: &ExecutionContext,
+) -> RunnerResult<guest_contracts::env::RunPayload> {
+    let mut payload = guest_contracts::env::RunPayload {
+        prompt: context.prompt.clone(),
+        append_system_prompt: context.append_system_prompt.clone().unwrap_or_default(),
+        secret_values: serialize_secret_values(context),
+        artifacts: serialize_artifacts_payload(context)?,
+        feature_flags: serialize_feature_flags_payload(context)?,
+        ..guest_contracts::env::RunPayload::default()
+    };
+
+    if effective_cli_framework(&context.cli_agent_type) == EffectiveCliFramework::ClaudeCode {
+        if let Some(tools) = &context.disallowed_tools
+            && let Some(serialized) =
+                serialize_claude_tool_env(guest_contracts::env::DISALLOWED_TOOLS_ENV, tools)?
+        {
+            payload.disallowed_tools = serialized;
+        }
+        if let Some(tools) = &context.tools
+            && let Some(serialized) =
+                serialize_claude_tool_env(guest_contracts::env::TOOLS_ENV, tools)?
+        {
+            payload.tools = serialized;
+        }
+        if let Some(settings) = &context.settings
+            && !settings.is_empty()
+        {
+            payload.settings = settings.clone();
+        }
     }
 
-    Ok(env)
+    validate_run_payload_for_guest(&payload).map_err(RunnerError::Internal)?;
+    Ok(payload)
+}
+
+fn serialize_secret_values(context: &ExecutionContext) -> String {
+    use base64::Engine as _;
+    let mut encoded: Vec<String> =
+        vec![base64::engine::general_purpose::STANDARD.encode(&context.sandbox_token)];
+    if let Some(secret_values) = &context.secret_values {
+        encoded.extend(
+            secret_values
+                .iter()
+                .map(|s| base64::engine::general_purpose::STANDARD.encode(s)),
+        );
+    }
+    encoded.join(",")
+}
+
+fn serialize_artifacts_payload(context: &ExecutionContext) -> RunnerResult<String> {
+    let Some(manifest) = &context.storage_manifest else {
+        return Ok(String::new());
+    };
+    if manifest.artifacts.is_empty() {
+        return Ok(String::new());
+    }
+
+    let payload: Vec<serde_json::Value> = manifest
+        .artifacts
+        .iter()
+        .map(|a| {
+            let mut entry = serde_json::json!({
+                "name": a.vas_storage_name,
+                "mountPath": a.mount_path,
+                "storageId": a.vas_storage_id,
+                "versionId": a.vas_version_id,
+            });
+            if let Some(policy) = a.missing_root_policy
+                && let Some(object) = entry.as_object_mut()
+            {
+                object.insert("missingRootPolicy".to_string(), serde_json::json!(policy));
+            }
+            entry
+        })
+        .collect();
+
+    serde_json::to_string(&payload)
+        .map_err(|e| RunnerError::Internal(format!("serialize artifact payload: {e}")))
+}
+
+fn serialize_feature_flags_payload(context: &ExecutionContext) -> RunnerResult<String> {
+    let Some(flags) = &context.feature_flags else {
+        return Ok(String::new());
+    };
+    if flags.is_empty() {
+        return Ok(String::new());
+    }
+    serde_json::to_string(flags)
+        .map_err(|e| RunnerError::Internal(format!("serialize feature flags payload: {e}")))
+}
+
+fn validate_run_payload_for_guest(
+    payload: &guest_contracts::env::RunPayload,
+) -> Result<(), String> {
+    for (name, value) in [
+        (guest_contracts::env::PROMPT_ENV, payload.prompt.as_str()),
+        (
+            guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
+            payload.append_system_prompt.as_str(),
+        ),
+        (
+            guest_contracts::env::SECRET_VALUES_ENV,
+            payload.secret_values.as_str(),
+        ),
+        (
+            guest_contracts::env::DISALLOWED_TOOLS_ENV,
+            payload.disallowed_tools.as_str(),
+        ),
+        (guest_contracts::env::TOOLS_ENV, payload.tools.as_str()),
+        (
+            guest_contracts::env::SETTINGS_ENV,
+            payload.settings.as_str(),
+        ),
+        (
+            guest_contracts::env::ARTIFACTS_ENV,
+            payload.artifacts.as_str(),
+        ),
+        (
+            guest_contracts::env::FEATURE_FLAGS_ENV,
+            payload.feature_flags.as_str(),
+        ),
+    ] {
+        if value.contains('\0') {
+            return Err(format!("run payload contains NUL byte for {name}"));
+        }
+    }
+
+    Ok(())
 }
 
 pub(super) fn insert_guest_agent_tuning_env(
@@ -508,7 +579,7 @@ pub(super) fn insert_claude_code_env(
     env: &mut HashMap<String, String>,
     context: &ExecutionContext,
     host_env: &HostEnv,
-) -> RunnerResult<()> {
+) {
     // Pass USE_MOCK_CLAUDE from host environment for testing
     // (skip if debugNoMockClaude is set in execution context)
     if let Some(val) = &host_env.use_mock_claude
@@ -519,31 +590,6 @@ pub(super) fn insert_claude_code_env(
             val.clone(),
         );
     }
-
-    if let Some(tools) = &context.disallowed_tools
-        && let Some(serialized) =
-            serialize_claude_tool_env(guest_contracts::env::DISALLOWED_TOOLS_ENV, tools)?
-    {
-        env.insert(
-            guest_contracts::env::DISALLOWED_TOOLS_ENV.into(),
-            serialized,
-        );
-    }
-
-    if let Some(tools) = &context.tools
-        && let Some(serialized) = serialize_claude_tool_env(guest_contracts::env::TOOLS_ENV, tools)?
-    {
-        env.insert(guest_contracts::env::TOOLS_ENV.into(), serialized);
-    }
-
-    // Settings JSON (passed directly as single string)
-    if let Some(settings) = &context.settings
-        && !settings.is_empty()
-    {
-        env.insert(guest_contracts::env::SETTINGS_ENV.into(), settings.clone());
-    }
-
-    Ok(())
 }
 
 pub(super) fn serialize_claude_tool_env(

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -11,9 +11,10 @@ use super::super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
 };
 use super::super::env::{
-    HostEnv, build_env_json_with_host_env, build_user_env_json, guest_user_env_file_path,
-    is_runner_owned_env_key, validate_execution_context_before_sandbox,
-    validate_model_provider_env_placeholders, write_user_env_file,
+    HostEnv, build_env_json_with_host_env, build_run_payload_for_run, build_user_env_json,
+    guest_run_payload_file_path, guest_user_env_file_path, is_runner_owned_env_key,
+    validate_execution_context_before_sandbox, validate_model_provider_env_placeholders,
+    write_run_payload_file, write_user_env_file,
 };
 use super::super::{USER_ENV_FILE_ENV_KEY, guest_runtime_dir};
 use super::support::{
@@ -186,7 +187,7 @@ fn execution_context_validation_rejects_bootstrap_env_nul_before_sandbox() {
 
     let error = validate_context_for_test(&ctx).unwrap_err();
 
-    assert!(error.contains("bootstrap environment"));
+    assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
     assert!(error.contains("VM0_PROMPT"));
     assert!(!error.contains(secret));
@@ -333,7 +334,7 @@ fn build_env_json_required_keys() {
             .unwrap(),
         &guest_runtime_dir(ctx.run_id).unwrap()
     );
-    assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
+    assert!(!env.contains_key("VM0_PROMPT"));
     assert!(!env.contains_key("VM0_WORKING_DIR"));
     // Guest-agent needs these to post /complete with full metadata when
     // checkpoint lands before VM teardown.
@@ -406,12 +407,13 @@ fn build_env_json_claude_code_gets_only_claude_framework_env() {
     );
 
     assert_eq!(env.get("USE_MOCK_CLAUDE").unwrap(), "true");
-    assert_eq!(
-        env.get("VM0_DISALLOWED_TOOLS").unwrap(),
-        "CronCreate,CronDelete"
-    );
-    assert_eq!(env.get("VM0_TOOLS").unwrap(), "Bash,Edit");
-    assert_eq!(env.get("VM0_SETTINGS").unwrap(), r#"{"hooks":{}}"#);
+    assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
+    assert!(!env.contains_key("VM0_TOOLS"));
+    assert!(!env.contains_key("VM0_SETTINGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert_eq!(payload.disallowed_tools, "CronCreate,CronDelete");
+    assert_eq!(payload.tools, "Bash,Edit");
+    assert_eq!(payload.settings, r#"{"hooks":{}}"#);
     assert!(!env.contains_key("USE_MOCK_CODEX"));
 }
 
@@ -498,9 +500,13 @@ fn build_env_json_unknown_framework_preserves_claude_compatible_env() {
 
     assert_eq!(env.get("CLI_AGENT_TYPE").unwrap(), "custom-agent");
     assert_eq!(env.get("USE_MOCK_CLAUDE").unwrap(), "true");
-    assert_eq!(env.get("VM0_DISALLOWED_TOOLS").unwrap(), "CronCreate");
-    assert_eq!(env.get("VM0_TOOLS").unwrap(), "Bash");
-    assert_eq!(env.get("VM0_SETTINGS").unwrap(), r#"{"hooks":{}}"#);
+    assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
+    assert!(!env.contains_key("VM0_TOOLS"));
+    assert!(!env.contains_key("VM0_SETTINGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert_eq!(payload.disallowed_tools, "CronCreate");
+    assert_eq!(payload.tools, "Bash");
+    assert_eq!(payload.settings, r#"{"hooks":{}}"#);
     assert!(!env.contains_key("USE_MOCK_CODEX"));
 }
 
@@ -568,13 +574,21 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
             "/tmp/mock-codex".into(),
         ),
         (USER_ENV_FILE_ENV_KEY.into(), "/tmp/user-env".into()),
+        (
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV.into(),
+            "/tmp/run-payload".into(),
+        ),
     ]));
 
     let bootstrap_env = build_env_for_test(&ctx, "http://localhost");
     let user_env = build_user_env_json(&ctx);
 
     assert!(!bootstrap_env.contains_key("CUSTOM_ENV"));
-    assert_eq!(bootstrap_env.get("VM0_PROMPT").unwrap(), "test prompt");
+    assert!(!bootstrap_env.contains_key("VM0_PROMPT"));
+    assert_eq!(
+        build_run_payload_for_run(&ctx).unwrap().prompt,
+        "test prompt"
+    );
     assert_eq!(bootstrap_env.get("VM0_API_TOKEN").unwrap(), "tok");
     assert_eq!(
         bootstrap_env
@@ -607,6 +621,7 @@ fn build_env_json_scrubs_user_provided_runner_owned_env() {
         guest_contracts::env::MOCK_CLAUDE_PATH_ENV,
         guest_contracts::env::MOCK_CODEX_PATH_ENV,
         USER_ENV_FILE_ENV_KEY,
+        guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
     ] {
         assert!(!user_env.contains_key(key), "{key} should be scrubbed");
     }
@@ -704,11 +719,10 @@ fn build_env_json_codex_keeps_shared_runner_env() {
     ));
 
     let env = build_env_for_test(&ctx, "http://localhost");
+    let payload = build_run_payload_for_run(&ctx).unwrap();
 
-    assert_eq!(
-        env.get("VM0_APPEND_SYSTEM_PROMPT").unwrap(),
-        "Use terse answers."
-    );
+    assert!(!env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
+    assert_eq!(payload.append_system_prompt, "Use terse answers.");
     assert_eq!(
         env.get("VM0_RESUME_SESSION_ID").unwrap(),
         "019e9154-c304-70f0-adde-36efb1be1701"
@@ -754,7 +768,9 @@ fn build_env_json_with_single_artifact() {
     });
 
     let env = build_env_for_test(&ctx, "http://localhost");
-    let raw = env.get("VM0_ARTIFACTS").expect("VM0_ARTIFACTS must be set");
+    assert!(!env.contains_key("VM0_ARTIFACTS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let raw = &payload.artifacts;
     let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).unwrap();
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[0]["name"], "my-vol");
@@ -786,7 +802,9 @@ fn build_env_json_with_artifact_missing_root_policy() {
     });
 
     let env = build_env_for_test(&ctx, "http://localhost");
-    let raw = env.get("VM0_ARTIFACTS").expect("VM0_ARTIFACTS must be set");
+    assert!(!env.contains_key("VM0_ARTIFACTS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let raw = &payload.artifacts;
     let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).unwrap();
 
     assert_eq!(parsed.len(), 1);
@@ -818,7 +836,9 @@ fn build_env_json_with_two_artifacts() {
     });
 
     let env = build_env_for_test(&ctx, "http://localhost");
-    let raw = env.get("VM0_ARTIFACTS").unwrap();
+    assert!(!env.contains_key("VM0_ARTIFACTS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let raw = &payload.artifacts;
     let parsed: Vec<serde_json::Value> = serde_json::from_str(raw).unwrap();
     assert_eq!(parsed.len(), 2);
     assert_eq!(parsed[0]["name"], "art-a");
@@ -839,6 +859,8 @@ fn build_env_json_empty_artifacts_emits_no_env_var() {
 
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_ARTIFACTS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.artifacts.is_empty());
 }
 
 #[test]
@@ -848,7 +870,9 @@ fn build_env_json_with_secrets() {
     ctx.secret_values = Some(vec!["secret1".into(), "secret,with\nnewline".into()]);
 
     let env = build_env_for_test(&ctx, "http://localhost");
-    let val = env.get("VM0_SECRET_VALUES").unwrap();
+    assert!(!env.contains_key("VM0_SECRET_VALUES"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let val = &payload.secret_values;
 
     use base64::Engine as _;
     let parts: Vec<&str> = val.split(',').collect();
@@ -891,9 +915,11 @@ fn build_env_json_user_vars_cannot_override_system() {
     ]));
 
     let env = build_env_for_test(&ctx, "http://localhost");
+    let payload = build_run_payload_for_run(&ctx).unwrap();
     let user_env = build_user_env_json(&ctx);
     // System variables take precedence over user environment
-    assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
+    assert!(!env.contains_key("VM0_PROMPT"));
+    assert_eq!(payload.prompt, "test prompt");
     assert!(!env.contains_key("CUSTOM"));
     assert_eq!(user_env.get("CUSTOM").unwrap(), "value");
     assert!(!user_env.contains_key("VM0_PROMPT"));
@@ -982,6 +1008,53 @@ async fn write_user_env_file_returns_private_write_error() {
     assert_eq!(writes.len(), 1);
 }
 
+#[tokio::test]
+async fn write_run_payload_file_uses_private_write_for_large_payload() {
+    let sandbox = MockSandbox::new("test");
+    let run_id = RunId::nil();
+    let payload = guest_contracts::env::RunPayload {
+        prompt: "x".repeat(vsock_proto::MAX_EXEC_STDIN_BYTES),
+        append_system_prompt: "system".to_string(),
+        secret_values: "secret".to_string(),
+        ..guest_contracts::env::RunPayload::default()
+    };
+
+    let path = write_run_payload_file(&sandbox, run_id, &payload)
+        .await
+        .unwrap();
+
+    assert_eq!(path, guest_run_payload_file_path(run_id).unwrap());
+    assert!(sandbox.exec_calls().is_empty());
+    assert!(sandbox.write_file_calls().is_empty());
+    let writes = sandbox.private_write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(writes[0].path, path);
+    let decoded: guest_contracts::env::RunPayload =
+        serde_json::from_slice(&writes[0].content).unwrap();
+    assert_eq!(decoded, payload);
+}
+
+#[tokio::test]
+async fn write_run_payload_file_returns_private_write_error() {
+    let sandbox = MockSandbox::new("test");
+    sandbox.push_private_write_file_result(Err(sandbox_write_file_error("private write failed")));
+    let run_id = RunId::nil();
+    let payload = guest_contracts::env::RunPayload {
+        prompt: "test prompt".to_string(),
+        ..guest_contracts::env::RunPayload::default()
+    };
+
+    let err = write_run_payload_file(&sandbox, run_id, &payload)
+        .await
+        .unwrap_err();
+    let message = err.to_string();
+
+    assert!(message.contains("private write failed"), "got: {message}");
+    assert!(sandbox.exec_calls().is_empty());
+    assert!(sandbox.write_file_calls().is_empty());
+    assert_eq!(sandbox.private_write_file_calls().len(), 1);
+}
+
 #[test]
 fn build_env_json_with_environment() {
     let mut ctx = minimal_context();
@@ -1013,8 +1086,10 @@ fn build_env_json_empty_secrets_still_has_sandbox_token() {
     ctx.secret_values = Some(vec![]);
 
     let env = build_env_for_test(&ctx, "http://localhost");
-    // VM0_SECRET_VALUES always present because sandbox_token is included
-    let val = env.get("VM0_SECRET_VALUES").unwrap();
+    assert!(!env.contains_key("VM0_SECRET_VALUES"));
+    // VM0_SECRET_VALUES payload always includes the sandbox token for masking.
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let val = &payload.secret_values;
     use base64::Engine as _;
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(val)
@@ -1027,10 +1102,9 @@ fn build_env_json_with_append_system_prompt() {
     let mut ctx = minimal_context();
     ctx.append_system_prompt = Some("Your name is Aria.".into());
     let env = build_env_for_test(&ctx, "http://localhost");
-    assert_eq!(
-        env.get("VM0_APPEND_SYSTEM_PROMPT").unwrap(),
-        "Your name is Aria."
-    );
+    assert!(!env.contains_key("VM0_APPEND_SYSTEM_PROMPT"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert_eq!(payload.append_system_prompt, "Your name is Aria.");
 }
 
 #[test]
@@ -1082,9 +1156,11 @@ fn build_env_json_environment_cannot_override_system() {
     ]));
 
     let env = build_env_for_test(&ctx, "http://localhost");
+    let payload = build_run_payload_for_run(&ctx).unwrap();
     let user_env = build_user_env_json(&ctx);
     // System variables take precedence over user environment
-    assert_eq!(env.get("VM0_PROMPT").unwrap(), "test prompt");
+    assert!(!env.contains_key("VM0_PROMPT"));
+    assert_eq!(payload.prompt, "test prompt");
     assert_eq!(env.get("VM0_API_TOKEN").unwrap(), "tok");
     assert!(!env.contains_key("CUSTOM_ENV"));
     assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
@@ -1242,10 +1318,9 @@ fn build_env_json_with_disallowed_tools() {
     let mut ctx = minimal_context();
     ctx.disallowed_tools = Some(vec!["CronCreate".into(), "CronDelete".into()]);
     let env = build_env_for_test(&ctx, "http://localhost");
-    assert_eq!(
-        env.get("VM0_DISALLOWED_TOOLS").unwrap(),
-        "CronCreate,CronDelete"
-    );
+    assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert_eq!(payload.disallowed_tools, "CronCreate,CronDelete");
 }
 
 #[test]
@@ -1254,6 +1329,8 @@ fn build_env_json_empty_disallowed_tools_omitted() {
     ctx.disallowed_tools = Some(vec![]);
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.disallowed_tools.is_empty());
 }
 
 #[test]
@@ -1261,6 +1338,8 @@ fn build_env_json_no_disallowed_tools() {
     let ctx = minimal_context();
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.disallowed_tools.is_empty());
 }
 
 #[test]
@@ -1268,7 +1347,9 @@ fn build_env_json_with_tools() {
     let mut ctx = minimal_context();
     ctx.tools = Some(vec!["Bash".into(), "Edit".into()]);
     let env = build_env_for_test(&ctx, "http://localhost");
-    assert_eq!(env.get("VM0_TOOLS").unwrap(), "Bash,Edit");
+    assert!(!env.contains_key("VM0_TOOLS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert_eq!(payload.tools, "Bash,Edit");
 }
 
 #[test]
@@ -1277,6 +1358,8 @@ fn build_env_json_empty_tools_omitted() {
     ctx.tools = Some(vec![]);
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_TOOLS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.tools.is_empty());
 }
 
 #[test]
@@ -1284,10 +1367,12 @@ fn build_env_json_no_tools() {
     let ctx = minimal_context();
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_TOOLS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.tools.is_empty());
 }
 
-fn assert_tool_env_error(
-    result: RunnerResult<HashMap<String, String>>,
+fn assert_tool_env_error<T: std::fmt::Debug>(
+    result: RunnerResult<T>,
     env_name: &str,
     expected: &str,
 ) {
@@ -1310,7 +1395,7 @@ fn build_env_json_rejects_invalid_disallowed_tools_entries() {
     ] {
         let mut ctx = minimal_context();
         ctx.disallowed_tools = Some(vec![tool.into()]);
-        let result = build_env_for_test_result(&ctx, "http://localhost");
+        let result = build_run_payload_for_run(&ctx);
         assert_tool_env_error(result, "VM0_DISALLOWED_TOOLS", expected);
     }
 }
@@ -1326,7 +1411,7 @@ fn build_env_json_rejects_invalid_tools_entries() {
     ] {
         let mut ctx = minimal_context();
         ctx.tools = Some(vec![tool.into()]);
-        let result = build_env_for_test_result(&ctx, "http://localhost");
+        let result = build_run_payload_for_run(&ctx);
         assert_tool_env_error(result, "VM0_TOOLS", expected);
     }
 }
@@ -1340,6 +1425,9 @@ fn build_env_json_codex_ignores_claude_tool_lists() {
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_DISALLOWED_TOOLS"));
     assert!(!env.contains_key("VM0_TOOLS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.disallowed_tools.is_empty());
+    assert!(payload.tools.is_empty());
 }
 
 #[test]
@@ -1347,7 +1435,9 @@ fn build_env_json_with_settings() {
     let mut ctx = minimal_context();
     ctx.settings = Some(r#"{"hooks":{}}"#.into());
     let env = build_env_for_test(&ctx, "http://localhost");
-    assert_eq!(env.get("VM0_SETTINGS").unwrap(), r#"{"hooks":{}}"#);
+    assert!(!env.contains_key("VM0_SETTINGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert_eq!(payload.settings, r#"{"hooks":{}}"#);
 }
 
 #[test]
@@ -1356,6 +1446,8 @@ fn build_env_json_empty_settings_omitted() {
     ctx.settings = Some("".into());
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_SETTINGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.settings.is_empty());
 }
 
 #[test]
@@ -1363,6 +1455,8 @@ fn build_env_json_no_settings() {
     let ctx = minimal_context();
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_SETTINGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.settings.is_empty());
 }
 
 #[test]
@@ -1373,9 +1467,9 @@ fn build_env_json_with_feature_flags() {
     flags.insert("audioOutput".into(), false);
     ctx.feature_flags = Some(flags);
     let env = build_env_for_test(&ctx, "http://localhost");
-    let raw = env
-        .get("VM0_FEATURE_FLAGS")
-        .expect("VM0_FEATURE_FLAGS should be set");
+    assert!(!env.contains_key("VM0_FEATURE_FLAGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let raw = &payload.feature_flags;
     let parsed: HashMap<String, bool> = serde_json::from_str(raw).unwrap();
     assert_eq!(parsed.get("computerUse"), Some(&true));
     assert_eq!(parsed.get("audioOutput"), Some(&false));
@@ -1387,6 +1481,8 @@ fn build_env_json_empty_feature_flags_omitted() {
     ctx.feature_flags = Some(HashMap::new());
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_FEATURE_FLAGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.feature_flags.is_empty());
 }
 
 #[test]
@@ -1394,6 +1490,8 @@ fn build_env_json_no_feature_flags() {
     let ctx = minimal_context();
     let env = build_env_for_test(&ctx, "http://localhost");
     assert!(!env.contains_key("VM0_FEATURE_FLAGS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(payload.feature_flags.is_empty());
 }
 
 #[tokio::test]
@@ -1415,7 +1513,9 @@ async fn build_env_json_with_memory_as_artifact() {
     assert!(!env.contains_key("VM0_MEMORY_MOUNT_PATH"));
     assert!(!env.contains_key("VM0_MEMORY_NAME"));
     assert!(!env.contains_key("VM0_MEMORY_VERSION_ID"));
-    let artifacts = env.get("VM0_ARTIFACTS").unwrap();
+    assert!(!env.contains_key("VM0_ARTIFACTS"));
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let artifacts = &payload.artifacts;
     assert!(artifacts.contains("\"memory\""));
     assert!(artifacts.contains("\"/memory\""));
     assert!(artifacts.contains("\"v2\""));

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -221,12 +221,34 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert_eq!(start_calls.len(), 1);
     let start_env: BTreeMap<String, String> = start_calls[0].env.iter().cloned().collect();
     let expected_user_env_file = guest_user_env_file_path(ctx.run_id).unwrap();
+    let expected_run_payload_file = guest_run_payload_file_path(ctx.run_id).unwrap();
     assert_eq!(start_env.get("VM0_API_TOKEN").unwrap(), "tok");
     assert_eq!(start_env.get("VM0_STUCK_TOOL_TIMEOUT_SECS").unwrap(), "3");
     assert_eq!(
         start_env.get(USER_ENV_FILE_ENV_KEY).map(String::as_str),
         Some(expected_user_env_file.as_str())
     );
+    assert_eq!(
+        start_env
+            .get(guest_contracts::env::RUN_PAYLOAD_FILE_ENV)
+            .map(String::as_str),
+        Some(expected_run_payload_file.as_str())
+    );
+    for key in [
+        guest_contracts::env::PROMPT_ENV,
+        guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
+        guest_contracts::env::SECRET_VALUES_ENV,
+        guest_contracts::env::DISALLOWED_TOOLS_ENV,
+        guest_contracts::env::TOOLS_ENV,
+        guest_contracts::env::SETTINGS_ENV,
+        guest_contracts::env::ARTIFACTS_ENV,
+        guest_contracts::env::FEATURE_FLAGS_ENV,
+    ] {
+        assert!(
+            !start_env.contains_key(key),
+            "{key} should be passed through the run payload file"
+        );
+    }
     for key in ["CUSTOM_USER_ENV", "BASH_ENV", "NODE_OPTIONS", "TZ"] {
         assert!(
             !start_env.contains_key(key),
@@ -243,10 +265,17 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
         "user env file should not be written through shell exec"
     );
     let private_writes = overrides.private_write_file_calls();
-    assert_eq!(private_writes.len(), 1);
-    assert_eq!(private_writes[0].path, expected_user_env_file);
+    assert_eq!(private_writes.len(), 2);
+    let user_env_write = private_writes
+        .iter()
+        .find(|write| write.path == expected_user_env_file)
+        .unwrap();
+    let run_payload_write = private_writes
+        .iter()
+        .find(|write| write.path == expected_run_payload_file)
+        .unwrap();
     let user_env: HashMap<String, String> =
-        serde_json::from_slice(&private_writes[0].content).unwrap();
+        serde_json::from_slice(&user_env_write.content).unwrap();
     assert_eq!(user_env.get("CUSTOM_USER_ENV").unwrap(), "visible-to-cli");
     assert_eq!(user_env.get("BASH_ENV").unwrap(), "/tmp/user-bash-env");
     assert_eq!(
@@ -257,6 +286,9 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
     assert!(!user_env.contains_key("VM0_API_TOKEN"));
     assert!(!user_env.contains_key(USER_ENV_FILE_ENV_KEY));
     assert!(!user_env.contains_key("VM0_STUCK_TOOL_TIMEOUT_SECS"));
+    let run_payload: guest_contracts::env::RunPayload =
+        serde_json::from_slice(&run_payload_write.content).unwrap();
+    assert_eq!(run_payload.prompt, ctx.prompt);
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/fresh_sandbox.rs
@@ -292,6 +292,42 @@ async fn execute_inner_writes_user_env_file_and_starts_agent_with_bootstrap_env_
 }
 
 #[tokio::test]
+async fn execute_inner_run_payload_private_write_failure_does_not_start_agent() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_private_write_file_result(Err(sandbox_write_file_error(
+        "payload private write failed",
+    )));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+    let (exit_code, error_msg) =
+        run_new_sandbox_status(&factory, &minimal_context(), &config, &default_params())
+            .await
+            .unwrap();
+
+    assert_eq!(exit_code, 1);
+    let error = error_msg.unwrap();
+    assert!(
+        error.contains("payload private write failed"),
+        "got: {error}"
+    );
+    let private_writes = overrides.private_write_file_calls();
+    assert_eq!(private_writes.len(), 1);
+    assert!(
+        private_writes[0]
+            .path
+            .ends_with("/run-payload/payload.json"),
+        "got: {}",
+        private_writes[0].path
+    );
+    assert!(
+        overrides.start_process_calls().is_empty(),
+        "agent must not start after run payload write failure"
+    );
+}
+
+#[tokio::test]
 async fn execute_inner_passes_device_rate_limits_to_sandbox_create() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -17,7 +17,7 @@ use sandbox::{
 use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
 use super::super::agent_run::{RunControls, RunStart};
-use super::super::env::guest_user_env_file_path;
+use super::super::env::{guest_run_payload_file_path, guest_user_env_file_path};
 use super::super::sandbox_run::{
     NewSandboxHooks, PreparedSandboxRun, execute_new_sandbox,
     execute_new_sandbox_with_prepared_notifier, execute_prepared_sandbox_run,

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -33,6 +33,8 @@ pub(crate) struct FileOverrideState {
     pub(crate) write_files_calls: Mutex<Vec<WriteFilesCall>>,
     /// Recorded write_private_file calls across all sandboxes built from this override set.
     pub(crate) private_write_file_calls: Mutex<Vec<WriteFileCall>>,
+    /// FIFO queue of write_private_file results consumed by factory-created sandboxes.
+    pub(crate) private_write_file_results: Mutex<VecDeque<Result<()>>>,
     /// FIFO queue of read_file results consumed by factory-created sandboxes.
     pub(crate) read_file_results: Mutex<VecDeque<Result<Option<Vec<u8>>>>>,
     /// Recorded copy_file calls across all sandboxes built from this override
@@ -307,6 +309,16 @@ impl MockSandboxOverrides {
             .private_write_file_calls
             .lock_ignoring_poison()
             .clone()
+    }
+
+    /// Queue a write_private_file result applied to the next private write made
+    /// through any sandbox built from these overrides after that sandbox's
+    /// local private-write queue is empty.
+    pub fn push_private_write_file_result(&self, result: Result<()>) {
+        self.file
+            .private_write_file_results
+            .lock_ignoring_poison()
+            .push_back(result);
     }
 
     /// Queue a read_file result applied to the next read made through any

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -543,10 +543,23 @@ impl Sandbox for MockSandbox {
                 .lock_ignoring_poison()
                 .push(call);
         }
-        self.private_write_file_results
+        if let Some(result) = self
+            .private_write_file_results
             .lock_ignoring_poison()
             .pop_front()
-            .unwrap_or(Ok(()))
+        {
+            return result;
+        }
+        if let Some(result) = self.overrides.as_ref().and_then(|overrides| {
+            overrides
+                .file
+                .private_write_file_results
+                .lock_ignoring_poison()
+                .pop_front()
+        }) {
+            return result;
+        }
+        Ok(())
     }
 
     async fn start_process(&self, request: &StartProcessRequest<'_>) -> Result<GuestProcessHandle> {

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -412,6 +412,96 @@ async fn sandbox_write_private_file_queued_error_and_records_calls() {
 }
 
 #[tokio::test]
+async fn overrides_share_private_write_file_results_across_factory_sandboxes() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_private_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "first private write failed".into(),
+    }));
+    overrides.push_private_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "second private write failed".into(),
+    }));
+    let factory = MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+    let first = factory.create(test_sandbox_config()).await.unwrap();
+    let second = factory.create(test_sandbox_config()).await.unwrap();
+
+    let first_error = first
+        .write_private_file("/tmp/private-one.env", b"one")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        first_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "first private write failed",
+    );
+
+    let second_error = second
+        .write_private_file("/tmp/private-two.env", b"two")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        second_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "second private write failed",
+    );
+
+    first
+        .write_private_file("/tmp/private-empty.env", b"empty")
+        .await
+        .unwrap();
+
+    let calls = overrides.private_write_file_calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].path, "/tmp/private-one.env");
+    assert_eq!(calls[1].path, "/tmp/private-two.env");
+    assert_eq!(calls[2].path, "/tmp/private-empty.env");
+}
+
+#[tokio::test]
+async fn sandbox_local_private_write_file_result_takes_precedence_over_shared_overrides() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.push_private_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "shared private write failed".into(),
+    }));
+    let sandbox = MockSandbox::with_overrides("sandbox", Arc::clone(&overrides));
+    sandbox.push_private_write_file_result(Err(SandboxError::Operation {
+        operation: SandboxOperation::WriteFile,
+        reason: SandboxOperationReason::Guest,
+        message: "local private write failed".into(),
+    }));
+
+    let local_error = sandbox
+        .write_private_file("/tmp/local-private.env", b"local")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        local_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "local private write failed",
+    );
+
+    let shared_error = sandbox
+        .write_private_file("/tmp/shared-private.env", b"shared")
+        .await
+        .unwrap_err();
+    assert_operation_error(
+        shared_error,
+        SandboxOperation::WriteFile,
+        SandboxOperationReason::Guest,
+        "shared private write failed",
+    );
+}
+
+#[tokio::test]
 async fn sandbox_write_file_lifecycle_gate_blocks_until_released() {
     let sandbox = Arc::new(MockSandbox::new("test-1"));
     let gate = MockLifecycleGate::new();


### PR DESCRIPTION
## Summary

- Move runner-owned prompt/config payloads from bootstrap env into a private per-run run payload file exposed through VM0_RUN_PAYLOAD_FILE.
- Add shared argv/env size guards for runner bootstrap and guest-agent child process spawns.
- Keep large prompt support for stdin/JSON-RPC-backed paths while failing early with non-secret diagnostics for remaining argv/env boundaries.
- Preserve legacy guest-agent env fallback and add focused coverage for payload loading, removal, path validation, redaction, and final child env normalization.

Fixes #19946

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all -- --check
- cargo test --manifest-path crates/Cargo.toml -p guest-contracts
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo test --manifest-path crates/Cargo.toml -p runner
- pre-commit hook: crates cargo-fmt, cargo-clippy, cargo-doc