### PR TITLE
style: refine workflow trigger pills with hairline border, shadow and medium label

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -90,11 +90,11 @@ function initials(label: string): string {
 function triggerDotClass(entry: WorkflowTriggerAutomationEntry): string {
   const trigger = entry.trigger;
   if (trigger.kind === "schedule") {
-    return "bg-[radial-gradient(circle_at_40%_35%,#93c5fd,#2563eb)] ring-2 ring-blue-400/20";
+    return "bg-blue-500";
   }
   return trigger.eventType === "webhook-received"
-    ? "bg-[radial-gradient(circle_at_40%_35%,#fcd34d,#d97706)] ring-2 ring-amber-400/25"
-    : "bg-[radial-gradient(circle_at_40%_35%,#6ee7b7,#059669)] ring-2 ring-emerald-400/20";
+    ? "bg-amber-500"
+    : "bg-emerald-500";
 }
 
 function connectorNames(

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -116,7 +116,7 @@ function connectorPillClassName({
   readonly muted?: boolean;
 }) {
   return cn(
-    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-white px-2 text-[11px] font-normal leading-none shadow-sm",
+    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border-[0.7px] border-border/80 bg-white px-2 text-[11px] font-normal leading-none shadow-sm",
     muted ? "text-muted-foreground" : "text-foreground/70",
     interactive &&
       "cursor-pointer transition-colors hover:border-border hover:bg-gray-50 hover:text-foreground",

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -90,11 +90,11 @@ function initials(label: string): string {
 function triggerDotClass(entry: WorkflowTriggerAutomationEntry): string {
   const trigger = entry.trigger;
   if (trigger.kind === "schedule") {
-    return "bg-blue-500";
+    return "bg-[radial-gradient(circle_at_40%_35%,#93c5fd,#2563eb)] ring-2 ring-blue-400/20";
   }
   return trigger.eventType === "webhook-received"
-    ? "bg-amber-500"
-    : "bg-emerald-500";
+    ? "bg-[radial-gradient(circle_at_40%_35%,#fcd34d,#d97706)] ring-2 ring-amber-400/25"
+    : "bg-[radial-gradient(circle_at_40%_35%,#6ee7b7,#059669)] ring-2 ring-emerald-400/20";
 }
 
 function connectorNames(
@@ -116,7 +116,7 @@ function connectorPillClassName({
   readonly muted?: boolean;
 }) {
   return cn(
-    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border-[0.7px] border-border/80 bg-white px-2 text-[11px] font-normal leading-none shadow-sm",
+    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border-[0.7px] border-border/80 bg-white px-2 text-[11px] font-medium leading-none shadow-sm",
     muted ? "text-muted-foreground" : "text-foreground/70",
     interactive &&
       "cursor-pointer transition-colors hover:border-border hover:bg-gray-50 hover:text-foreground",

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -116,7 +116,7 @@ function connectorPillClassName({
   readonly muted?: boolean;
 }) {
   return cn(
-    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-white px-2 text-[11px] font-normal leading-none",
+    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-white px-2 text-[11px] font-normal leading-none shadow-sm",
     muted ? "text-muted-foreground" : "text-foreground/70",
     interactive &&
       "cursor-pointer transition-colors hover:border-border hover:bg-gray-50 hover:text-foreground",


### PR DESCRIPTION
## What

Visual refinement of the trigger-type pills (Schedule / Webhook / Email / Manual) in the workflows/automations list — the small colored-dot chips shown on each row. Driven by iterative design review with Ming.

## Changes (all in `connectorPillClassName` / `triggerDotClass`, `workflows-page.tsx`)

- **Subtle shadow** — added `shadow-sm` so the pill reads as gently raised instead of flat.
- **Hairline border** — border thinned from `1px border-border/60` to `0.7px border-border/80` (finer, but a touch deeper in tone to keep presence).
- **Medium label** — pill text weight `font-normal` → `font-medium` for a slightly crisper label.
- **Dot** — kept the flat solid fill (`bg-blue-500` / `bg-amber-500` / `bg-emerald-500`, Manual `bg-muted-foreground/40`). A gradient-core + halo-ring treatment was explored and reverted per final review.

Single source of truth: all pill variants (interactive, muted/Manual, popover list) inherit these via `connectorPillClassName`, so the treatment stays consistent everywhere.

## Visual impact

- User-visible on the workflows list rows only. No layout, spacing, or copy changes — purely the pill's border, shadow, label weight, and dot.

## Verification

- `prettier@3.8.1 --check` passes on the changed file.
- Platform `oxlint@1.57.0` — 0 warnings / 0 errors.
- Remaining lint/type/test left to the PR pipeline.