### PR TITLE
feat: rename "Without automation" workflow filter pill to "Manual"

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -997,8 +997,8 @@ describe("workflows routes", () => {
     expect(screen.queryByText("Launch Checklist")).not.toBeInTheDocument();
     expect(screen.queryByText("Support Intake")).not.toBeInTheDocument();
 
-    // "Without automation" keeps only the manual workflows.
-    click(tabByName("Without automation"));
+    // "Manual" keeps only the manual workflows.
+    click(tabByName("Manual"));
     await waitFor(() => {
       expect(search()).toBe("?filter=without");
     });

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -769,7 +769,7 @@ function WorkflowFilterBar({
         options={[
           { value: "all", label: "All" },
           { value: "automated", label: "Automated" },
-          { value: "without", label: "Without automation" },
+          { value: "without", label: "Manual" },
           { value: "private", label: "Private" },
           { value: "public", label: "Public" },
         ]}


### PR DESCRIPTION
## Summary

Renames the workflows-page filter pill label from **"Without automation"** to **"Manual"**. The old label was long and wrapped awkwardly next to the other pills (All / Automated / Private / Public); "Manual" is the concise, sentence-case term for workflows with no automation attached.

## Changes

- `workflows-page.tsx`: filter pill label `Without automation` → `Manual`.
- `workflows-page.test.tsx`: updated the tab lookup and comment to match the new label.

The underlying filter value (`without`) and all filtering logic are unchanged, so the `?filter=without` URL and behavior are unaffected — display-copy change only.

## Verification

Prettier (CI version) passes on the changed files. Relying on the PR pipeline for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)