### PR TITLE
fix: remove invalid goal deny rules

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -4465,6 +4465,40 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
+  it("injects the workflow goal skill without denying invalid goal tool names", async () => {
+    const api = createRunsAutomationsApi(context);
+    const connectors = createConnectorBddApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    await connectors.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.WorkflowAutomation]: true,
+    });
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "continue the goal",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.featureFlags).toMatchObject({
+      [FeatureSwitchKey.WorkflowAutomation]: true,
+    });
+    expect(claim.disallowedTools).toStrictEqual([
+      "CronCreate",
+      "CronList",
+      "CronDelete",
+      "ScheduleWakeup",
+      "AskUserQuestion",
+      "Skill(loop)",
+      "Skill(loop *)",
+    ]);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
   it("promotes queued runs with feature flags and a fresh api start time", async () => {
     const api = createRunsAutomationsApi(context);
     const computerUse = createComputerUseBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -75,6 +75,15 @@ const MODEL_FIRST_SELECTION_PROVIDER_ID =
 const API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_insert_runner_job_queue",
 ] as const;
+const EXPECTED_ZERO_RUN_DISALLOWED_TOOLS = [
+  "CronCreate",
+  "CronList",
+  "CronDelete",
+  "ScheduleWakeup",
+  "AskUserQuestion",
+  "Skill(loop)",
+  "Skill(loop *)",
+] as const;
 const CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES = [
   "claim_route_request_prepare",
   "claim_route_lookup_authorization",
@@ -4443,15 +4452,9 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(appendSystemPrompt).toContain(`Email: ${actor.email}`);
     expect(appendSystemPrompt).toContain("Timezone: America/Los_Angeles");
 
-    expect(claim.disallowedTools).toStrictEqual([
-      "CronCreate",
-      "CronList",
-      "CronDelete",
-      "ScheduleWakeup",
-      "AskUserQuestion",
-      "Skill(loop)",
-      "Skill(loop *)",
-    ]);
+    expect(claim.disallowedTools).toStrictEqual(
+      EXPECTED_ZERO_RUN_DISALLOWED_TOOLS,
+    );
     expect(claim.environment?.ZERO_AGENT_ID).toBe(agent.agentId);
     const zeroToken = claim.environment?.ZERO_TOKEN;
     expect(zeroToken).toMatch(/^vm0_sandbox_/);
@@ -4465,7 +4468,7 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("injects the workflow goal skill without denying invalid goal tool names", async () => {
+  it("keeps workflow automation from denying invalid goal tool names", async () => {
     const api = createRunsAutomationsApi(context);
     const connectors = createConnectorBddApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -4484,15 +4487,11 @@ describe("RUN-01: zero runner context, queue promotion, and skills", () => {
     expect(claim.featureFlags).toMatchObject({
       [FeatureSwitchKey.WorkflowAutomation]: true,
     });
-    expect(claim.disallowedTools).toStrictEqual([
-      "CronCreate",
-      "CronList",
-      "CronDelete",
-      "ScheduleWakeup",
-      "AskUserQuestion",
-      "Skill(loop)",
-      "Skill(loop *)",
-    ]);
+    expect(claim.disallowedTools).toStrictEqual(
+      EXPECTED_ZERO_RUN_DISALLOWED_TOOLS,
+    );
+    expect(claim.disallowedTools).not.toContain("goal");
+    expect(claim.disallowedTools).not.toContain("update_goal");
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -643,25 +643,6 @@ function skillMountPath(
 // declared in the compose — a run can execute on a provider whose framework
 // differs from the compose, and skills mounted at the wrong path are invisible
 // to the agent.
-// The harness ships a built-in `/goal` (Claude Code & Codex). When the vm0
-// `goal` seed skill is injected it must take over, so these built-in goal tool
-// identifiers are added to the run's disallowed-tools list to suppress the
-// native command. Disallowing a name the active harness does not expose is a
-// harmless no-op, so both harnesses' identifiers are listed.
-const BUILTIN_GOAL_DISALLOWED_TOOLS = ["goal", "update_goal"] as const;
-
-function withBuiltinGoalDisabled(
-  disallowedTools: string[] | undefined,
-  goalSeedEnabled: boolean,
-): string[] | undefined {
-  if (!goalSeedEnabled) {
-    return disallowedTools;
-  }
-  return [
-    ...new Set([...(disallowedTools ?? []), ...BUILTIN_GOAL_DISALLOWED_TOOLS]),
-  ];
-}
-
 function buildSystemSkillVolumes(
   connectorTypes: readonly ConnectorType[],
   framework: SupportedFramework,
@@ -4732,13 +4713,7 @@ async function buildStoredExecutionContext(args: {
       userTimezone: args.userTimezone,
       firewalls: permissions?.firewalls,
       networkPolicies: permissions?.networkPolicies,
-      disallowedTools: withBuiltinGoalDisabled(
-        args.body.disallowedTools,
-        isFeatureEnabled(
-          FeatureSwitchKey.WorkflowAutomation,
-          args.featureSwitchContext,
-        ),
-      ),
+      disallowedTools: args.body.disallowedTools,
       tools: args.body.tools,
       settings: args.body.settings,
       experimentalProfile: runnerProfile(args.resolved.content),


### PR DESCRIPTION
## Summary

- Remove the API-side injection of `goal` and `update_goal` into `disallowedTools` when WorkflowAutomation is enabled.
- Keep user-provided `disallowedTools` unchanged and leave goal seed skill injection behind WorkflowAutomation intact.
- Add regression coverage for WorkflowAutomation runner claims so valid deny entries remain and invalid goal names are not emitted.

Fixes #19937

## Testing

- `pnpm format`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "keeps workflow automation from denying invalid goal tool names"`
- `pnpm -F api lint`
- `pnpm -F api check-types`