### PR TITLE
feat: color private workflow visibility icon violet

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -181,10 +181,7 @@ function VisibilityIcon({
     <Icon
       size={15}
       stroke={1.7}
-      className={cn(
-        "shrink-0",
-        isPublic ? "text-blue-500" : "text-muted-foreground/70",
-      )}
+      className={cn("shrink-0", isPublic ? "text-blue-500" : "text-violet-500")}
       aria-label={isPublic ? "Public" : "Private"}
     />
   );


### PR DESCRIPTION
## What
On the Workflows list, the per-row visibility icon marks each workflow as **Public** (blue globe `IconWorld`) or **Private** (lock `IconLock`). The private lock was rendered in a low-contrast gray (`text-muted-foreground/70`), so it read like a disabled/placeholder state and did not pair visually with the colorful public globe.

This colors the private lock **violet** (`text-violet-500`), keeping the existing line/outline lock glyph. Public/private are now a clear color pair — blue globe vs. violet lock — and the private marker no longer looks inactive.

## Change
- `turbo/apps/platform/src/views/workflows-page/workflows-page.tsx` — `VisibilityIcon`: private icon color class `text-muted-foreground/70` → `text-violet-500`. Glyph, size, stroke, and `aria-label` unchanged.

## User-visible impact
Private workflows in the list now show a violet lock instead of a faint gray one. No behavior, layout, or accessibility-label changes.

## Verification
- Prettier (`prettier@3.8.1 --check`) and platform `oxlint` clean on the changed file.
- Existing `workflows-page` tests match the icon by `aria-label`/text, not color class, so they are unaffected. Relying on the PR pipeline for full lint/test.