### PR TITLE
fix: carry clerk session across origins on onboarding redirect

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -164,6 +164,8 @@ export function clearMockedAuth() {
     status: "complete",
     createdSessionId: "test-created-session-id",
   });
+  mockedClerk.buildUrlWithAuth.mockReset();
+  mockedClerk.buildUrlWithAuth.mockImplementation(defaultBuildUrlWithAuthImpl);
 }
 
 const clerkListeners: (() => void)[] = [];
@@ -185,6 +187,9 @@ const clientSignInCreate = vi.fn(
     });
   },
 );
+const defaultBuildUrlWithAuthImpl = (to: string) => {
+  return to;
+};
 
 export const mockedClerk = {
   get user() {
@@ -233,9 +238,7 @@ export const mockedClerk = {
   redirectToSignIn: vi.fn(),
   // Production-instance behavior: the URL passes through unchanged. Dev
   // instances append the __clerk_db_jwt session handoff parameter.
-  buildUrlWithAuth: (to: string) => {
-    return to;
-  },
+  buildUrlWithAuth: vi.fn(defaultBuildUrlWithAuthImpl),
   setActive: vi.fn(
     (params: {
       organization?: string;

--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -231,6 +231,11 @@ export const mockedClerk = {
     };
   },
   redirectToSignIn: vi.fn(),
+  // Production-instance behavior: the URL passes through unchanged. Dev
+  // instances append the __clerk_db_jwt session handoff parameter.
+  buildUrlWithAuth: (to: string) => {
+    return to;
+  },
   setActive: vi.fn(
     (params: {
       organization?: string;

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -115,7 +115,7 @@ export const setupPromptPage$ = command(
     const agentId = await get(defaultAgentId$);
     signal.throwIfAborted();
     if (!agentId) {
-      set(redirectToConfiguredOnboarding$, params);
+      await set(redirectToConfiguredOnboarding$, params, signal);
       return;
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -21,21 +21,37 @@ function onboardingUrl(searchParams: URLSearchParams): string {
 }
 
 const redirectToOnboarding$ = command(
-  ({ get }, searchParams?: URLSearchParams) => {
-    window.location.href = onboardingUrl(searchParams ?? get(searchParams$));
+  async (
+    { get },
+    searchParams: URLSearchParams | undefined,
+    signal: AbortSignal,
+  ) => {
+    const url = onboardingUrl(searchParams ?? get(searchParams$));
+    // buildUrlWithAuth carries the session across origins: on Clerk
+    // development instances the session lives in a per-origin dev browser
+    // JWT, so a bare cross-origin navigation to the www onboarding surface
+    // would land signed-out and bounce back to /sign-in. On production
+    // instances it returns the URL unchanged.
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    window.location.href = clerk.buildUrlWithAuth(url);
   },
 );
 
 export const redirectToConfiguredOnboarding$ = command(
-  ({ set }, searchParams?: URLSearchParams) => {
-    set(redirectToOnboarding$, searchParams);
+  async (
+    { set },
+    searchParams: URLSearchParams | undefined,
+    signal: AbortSignal,
+  ) => {
+    await set(redirectToOnboarding$, searchParams, signal);
   },
 );
 
 export const setupOnboardingRedirectPage$ = command(
-  ({ set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     signal.throwIfAborted();
-    set(redirectToConfiguredOnboarding$);
+    await set(redirectToConfiguredOnboarding$, undefined, signal);
   },
 );
 
@@ -74,7 +90,7 @@ export const onboardGuard$ = command(
       }
     }
 
-    set(redirectToConfiguredOnboarding$);
+    await set(redirectToConfiguredOnboarding$, undefined, signal);
     return true;
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -3,6 +3,7 @@ import { zeroConnectorsMainContract } from "@vm0/api-contracts/contracts/zero-co
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { mockedClerk } from "../../../__tests__/mock-auth.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
@@ -28,6 +29,11 @@ function mockOnboardingNeeded(): void {
 describe("zero onboarding", () => {
   it("redirects admins who need onboarding to paid onboarding with query params", async () => {
     mockOnboardingNeeded();
+    mockedClerk.buildUrlWithAuth.mockImplementation((to) => {
+      const url = new URL(to);
+      url.searchParams.set("__clerk_db_jwt", "dvb_test_handoff");
+      return url.toString();
+    });
     setBrowserUrl("https://app.vm7.ai:8443/");
 
     detachedSetupPage({
@@ -42,6 +48,7 @@ describe("zero onboarding", () => {
       expect(url.searchParams.get("prompt")).toBe("hello world");
       expect(url.searchParams.get("connector")).toBe("github");
       expect(url.searchParams.get("vm0_source")).toBe("presentation");
+      expect(url.searchParams.get("__clerk_db_jwt")).toBe("dvb_test_handoff");
       expect(url.searchParams.has("domain")).toBeFalsy();
     });
   });


### PR DESCRIPTION
## Problem

Fresh sign-ups in the local dev environment get stranded on the sign-in form instead of landing on the onboarding flow:

1. Sign-up on `app.vm7.ai:8443` completes (email OTP), session is created on the app origin
2. `onboardGuard$` redirects the new user to the www onboarding surface with a bare `window.location.href` navigation
3. On Clerk **development instances** the session lives in a per-origin dev browser JWT, and cross-origin handoff requires a `__clerk_db_jwt` URL parameter — which the bare navigation does not carry
4. The www onboarding surface loads signed-out and bounces back to `app/sign-in?redirect_url=...`
5. The Clerk instance runs in multi-session mode (`singleSessionMode: false`), so `<SignIn>` renders the form for the already-signed-in user instead of redirecting — the user appears logged out even though the app-origin session is still active

Production is unaffected: production instances share the session via an eTLD+1 cookie, so the bare navigation works there.

## Fix

Route the onboarding redirect through `clerk.buildUrlWithAuth()`, which appends the `__clerk_db_jwt` handoff parameter on development instances and returns the URL unchanged on production instances. This makes the redirect commands async, so the `signal: AbortSignal` parameter is threaded through per the ccstate lint rules, and the test Clerk mock gains a pass-through `buildUrlWithAuth`.

## Verification

Reproduced the bug with a fresh account before the fix (HAR-recorded redirect chain shows the www navigation without `__clerk_db_jwt`, followed by the bounce to `/sign-in`). After the fix, a fresh sign-up lands directly on `www.vm7.ai:8443/onboarding/2afcf6` signed in — the intermediate navigation carries `__clerk_db_jwt` and clerk-js consumes it:

```
app/sign-up/verify-email-address
app/
www/onboarding/2afcf6?__clerk_db_jwt=dvb_...   <- handoff now present
www/onboarding/2afcf6                          <- signed in, no bounce
```

- [x] lint, check-types, knip pass
- [x] full @vm0/app vitest suite passes (1178 tests)
- [x] end-to-end verified in the dev environment with a fresh Clerk test account

🤖 Generated with [Claude Code](https://claude.com/claude-code)