### PR TITLE
refactor: retire presentation-deck-tools server-side (phase 2)

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -76,11 +76,6 @@ const deleteStorageFixtures$ = command(
 
 const PRIVATE_ARCHIVE_FIXTURES = [
   {
-    id: "tool:presentation-deck-tools",
-    versionId:
-      "3c4f3323dcf5d8a03a9780c3a46906706efbdc9f845d50c0d882e05d5ff1828f",
-  },
-  {
     id: "color-system:bauhaus-primary",
     versionId:
       "26c34a2a33a5c7b751b6741da5e4013020d5dbe138e60f5b3a444f4a5d3a351b",

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -45,8 +45,6 @@ function storageServiceNotConfigured() {
 }
 
 const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
-  "tool:presentation-deck-tools":
-    "3c4f3323dcf5d8a03a9780c3a46906706efbdc9f845d50c0d882e05d5ff1828f",
   "color-system:bauhaus-primary":
     "26c34a2a33a5c7b751b6741da5e4013020d5dbe138e60f5b3a444f4a5d3a351b",
   "color-system:berry-pop":

--- a/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
@@ -3,22 +3,22 @@ import { describe, expect, it } from "vitest";
 import { findRegistryResourceForPull } from "../index";
 
 describe("zero resource pull registry resolver", () => {
-  it("resolves presentation runtime tools", () => {
-    expect(findRegistryResourceForPull("tool:presentation-deck-tools")).toEqual(
+  it("resolves a presentation color system archive", () => {
+    expect(findRegistryResourceForPull("color-system:carnival")).toEqual(
       expect.objectContaining({
-        id: "tool:presentation-deck-tools",
-        kind: "tool",
+        id: "color-system:carnival",
+        kind: "color-system",
         source: expect.objectContaining({
-          path: "presentation-runtime/html-ppt-deck-tools",
+          path: "presentation-color-system/carnival",
           archive: expect.objectContaining({ type: "tar.gz" }),
         }),
       }),
     );
   });
 
-  it("canonicalizes unprefixed presentation runtime tool ids", () => {
-    expect(findRegistryResourceForPull("presentation-deck-tools")?.id).toBe(
-      "tool:presentation-deck-tools",
+  it("canonicalizes unprefixed presentation color system ids", () => {
+    expect(findRegistryResourceForPull("carnival")?.id).toBe(
+      "color-system:carnival",
     );
   });
 });

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -123,8 +123,6 @@ function privateR2ArchiveSource(
 }
 
 const PRESENTATION_RESOURCE_ARCHIVE_SHA256 = {
-  presentationDeckTools:
-    "00897f9278c014d2d7fcb95f3d03ee954c3d9c281cdef280fb92597be6609b38",
   colorSystemBauhausPrimary:
     "f42a1d62462f24b1a411889f8011b07bd3f1bb1db82a339cc59cf5ab5be2f475",
   colorSystemBerryPop:
@@ -258,17 +256,6 @@ const VIDEO_TEMPLATE_REGISTRY: readonly VideoTemplateRegistryEntry[] = [
 ];
 
 const RESOURCE_REGISTRY: readonly RegistryEntry[] = [
-  {
-    id: "tool:presentation-deck-tools",
-    kind: "tool",
-    name: "Presentation Deck Tools",
-    description:
-      "Shared HTML presentation deck shell, device primitives, render scripts, and QA gate required for vm0 presentation generation.",
-    source: privateR2ArchiveSource(
-      "presentation-runtime/html-ppt-deck-tools",
-      PRESENTATION_RESOURCE_ARCHIVE_SHA256.presentationDeckTools,
-    ),
-  },
   {
     id: "skill:article-magazine",
     kind: "skill",


### PR DESCRIPTION
## What (PR ④ — phase 2)

Removes the **server side** of `tool:presentation-deck-tools`, split out from the legacy html-ppt retirement for deploy-ordering safety:
- the `RESOURCE_REGISTRY` entry
- its `presentationDeckTools` archive SHA
- the download-route version-id
- deck-tools download fixture; resolver test repointed to a kept color-system

## Why split / merge order

PR ② (#20064) removed every **producer** of deck-tools (`PRESENTATION_REQUIRED_RESOURCE_IDS` + the `requiredResources` machinery), so no new CLI injects it. This PR removes the API/Core server-side resource after #20064 merged and `@vm0/cli@9.222.5` was published, avoiding a window where older CLI runs could request `tool:presentation-deck-tools` and receive a 404.

## Status

- Base: `main`
- Ready for review: yes
- Verification: branch rebased onto latest `main`; Prettier 3.8.1 check passed for all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)