### PR TITLE
fix: pin memory page date header to en-US locale

### DIFF
--- a/turbo/apps/platform/src/views/memory-page/memory-page.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-page.tsx
@@ -512,7 +512,9 @@ function formatActivityDate(date: string): string {
   if (Number.isNaN(parsed.getTime())) {
     return date;
   }
-  return parsed.toLocaleDateString(undefined, {
+  // Pin the locale to en-US so the date header matches the English memory
+  // content instead of following the viewer's browser locale (e.g. zh-CN).
+  return parsed.toLocaleDateString("en-US", {
     weekday: "long",
     year: "numeric",
     month: "long",


### PR DESCRIPTION
## Problem

On the **Memory** page (`Updates` tab), the daily date header renders in the viewer's browser locale. For anyone browsing with a Chinese system locale it shows up as `2026年7月2日星期四`, while the memory summary text right below it is always English — so the card reads as a jarring "Chinese date + English body" mix.

## Cause

`formatActivityDate` in `turbo/apps/platform/src/views/memory-page/memory-page.tsx` called `toLocaleDateString(undefined, …)`. The `undefined` locale means "follow the browser/system default", which is why the day/weekday came out localized.

## Fix

Pin the formatter to `"en-US"` so the date header stays consistent with the English memory content regardless of the viewer's browser language. The `YYYY-MM-DD` label is still parsed as a local date, so the displayed day is unchanged — only the language of the weekday/month text is fixed to English.

## Verification

- Local Prettier (CI version 3.8.1) clean on the changed file.
- No snapshot/test asserts on the formatted date string, so no test changes needed.
- Relying on the PR pipeline for lint/type/test gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)