### PR TITLE
ci: enforce conventional pull request titles

### DIFF
--- a/.github/scripts/check-pr-title.sh
+++ b/.github/scripts/check-pr-title.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly MAX_HEADER_LENGTH=100
+readonly ALLOWED_TYPES="feat, fix, docs, style, refactor, test, chore, ci, perf, build, revert"
+readonly TITLE_PATTERN='^(feat|fix|docs|style|refactor|test|chore|ci|perf|build|revert)(\([^()[:space:]]+\))?!?: .+$'
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <pull-request-title>" >&2
+  exit 2
+fi
+
+title="$1"
+failed=0
+
+report_error() {
+  local message="$1"
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::error::$message"
+  else
+    echo "ERROR: $message" >&2
+  fi
+  failed=1
+}
+
+if [ -z "$title" ]; then
+  report_error "Pull request title must not be empty"
+else
+  if [ "${#title}" -gt "$MAX_HEADER_LENGTH" ]; then
+    report_error "Pull request title must be at most ${MAX_HEADER_LENGTH} characters"
+  fi
+
+  if [[ ! "$title" =~ $TITLE_PATTERN ]]; then
+    report_error "Pull request title must use conventional format: type(optional-scope): lower-case summary"
+  else
+    subject="${title#*: }"
+    lower_subject="$(printf '%s' "$subject" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+
+    if [ "$subject" != "$lower_subject" ]; then
+      report_error "Pull request title subject must be lower-case"
+    fi
+
+    if [[ "$subject" == *. ]]; then
+      report_error "Pull request title subject must not end with a period"
+    fi
+  fi
+fi
+
+if [ "$failed" -ne 0 ]; then
+  cat >&2 <<EOF
+
+Expected examples:
+  feat(api): compact chat thread snapshots hourly
+  fix: remove stale runner cleanup
+
+Allowed types:
+  $ALLOWED_TYPES
+EOF
+  exit 1
+fi
+
+echo "Pull request title is conventional: $title"

--- a/.github/scripts/tests/check-pr-title-test.sh
+++ b/.github/scripts/tests/check-pr-title-test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_PR_TITLE="$SCRIPT_DIR/../check-pr-title.sh"
+
+expect_pass() {
+  local title="$1"
+  bash "$CHECK_PR_TITLE" "$title" >/dev/null
+}
+
+expect_fail() {
+  local title="$1"
+  if bash "$CHECK_PR_TITLE" "$title" >/dev/null 2>&1; then
+    echo "Expected title to fail: $title" >&2
+    exit 1
+  fi
+}
+
+expect_pass "feat(api): compact chat thread snapshots hourly"
+expect_pass "fix: remove stale runner cleanup"
+expect_pass "feat(api)!: change runner contract"
+expect_pass "revert: remove stale runner cleanup"
+
+expect_fail "Compact chat thread snapshots hourly"
+expect_fail "feat(api): Compact chat thread snapshots hourly"
+expect_fail "feat(api): compact chat thread snapshots hourly."
+expect_fail "feature: compact chat thread snapshots hourly"
+expect_fail "fix: "
+expect_fail "fix: $(printf 'a%.0s' {1..100})"
+
+echo "check-pr-title tests passed"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,6 +54,45 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "Not a release-please context"
 
+  pr-title:
+    needs: [detect-release]
+    name: Pull Request Title
+    if: needs.detect-release.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Validate pull request title
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          MQ_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          case "$EVENT_NAME" in
+            pull_request)
+              title="$PR_TITLE"
+              ;;
+            merge_group)
+              pr_number="$(printf '%s\n' "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//' || true)"
+              if [ -z "$pr_number" ]; then
+                echo "::error::Could not resolve pull request number from merge queue ref: $MQ_HEAD_REF"
+                exit 1
+              fi
+              title="$(gh pr view "$pr_number" --repo "$REPO" --json title --jq .title)"
+              ;;
+            *)
+              echo "No pull request title to validate for $EVENT_NAME"
+              exit 0
+              ;;
+          esac
+
+          .github/scripts/check-pr-title.sh "$title"
+
   semgrep:
     needs: [detect-release]
     name: Semgrep SAST
@@ -240,6 +279,7 @@ jobs:
     timeout-minutes: 5
     needs:
       - detect-release
+      - pr-title
       - semgrep
       - codeql
       - pnpm-audit
@@ -270,6 +310,7 @@ jobs:
             fi
           }
 
+          check_result "pr-title" "${{ needs.pr-title.result }}"
           check_result "semgrep" "${{ needs.semgrep.result }}"
           check_result "codeql" "${{ needs.codeql.result }}"
           check_result "pnpm-audit" "${{ needs.pnpm-audit.result }}"


### PR DESCRIPTION
## Summary
- Add a reusable PR title checker that enforces the repo's conventional title shape, allowed types, lower-case subject, no trailing period, and 100-character limit.
- Run the title check inside the existing Security Scanning workflow for pull_request and merge_group events.
- Include the title check in ci-gate-security so invalid PR titles fail an already-required gate without needing a separate ruleset change.

## Verification
- .github/scripts/tests/check-pr-title-test.sh
- .github/scripts/check-pr-title.sh 'ci: enforce conventional pull request titles'
- bash -n .github/scripts/check-pr-title.sh .github/scripts/tests/check-pr-title-test.sh
- actionlint .github/workflows/security.yml
