### PR TITLE
fix(proxy): route marketing to local dev server

### DIFF
--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -14,14 +14,12 @@ vm7.ai:8443 {
 	redir https://www.vm7.ai:8443{uri} permanent
 }
 
-# Marketing/onboarding surface proxied to the shared staging web deployment.
+# Marketing/onboarding surface proxied to local vm0-marketing.
 www.vm7.ai:8443 {
 	tls {
 		dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
 	}
-	reverse_proxy https://staging-www.vm6.ai {
-		header_up Host staging-www.vm6.ai
-	}
+	reverse_proxy localhost:3042
 }
 
 # App application

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -20,9 +20,9 @@ This package provides a Caddy-based reverse proxy that enables HTTPS for local d
 Browser
   ↓
 Caddy Proxy (HTTPS: 8443, HTTP: 8080)
-  ↓              ↓              ↓              ↓
-Web App        App            API            SO staging
-(port 3000)    (port 3002)    (port 3001)    (staging-www.vm6.ai)
+  ↓              ↓              ↓
+Marketing      App            API
+(port 3042)    (port 3002)    (port 3001)
 ```
 
 ## Quick Start
@@ -61,6 +61,7 @@ On first start, Caddy will automatically obtain a Let's Encrypt certificate (~30
 
 Direct access (HTTP only):
 
+- Marketing: http://localhost:3042
 - App: http://localhost:3002
 - API: http://localhost:3001
 
@@ -79,7 +80,7 @@ The `Caddyfile` defines:
 
 | Domain          | Port | Backend                     |
 | --------------- | ---- | --------------------------- |
-| www.vm7.ai:8443 | 8443 | staging-www.vm6.ai          |
+| www.vm7.ai:8443 | 8443 | localhost:3042 (Marketing)  |
 | app.vm7.ai:8443 | 8443 | localhost:3002 (Vite app)   |
 | api.vm7.ai:8443 | 8443 | localhost:3001 (Hono API)   |
 | vm7.ai:8443     | 8443 | Redirect to www.vm7.ai:8443 |

--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -75,9 +75,9 @@ setTimeout(() => {
   console.log("   App:       https://app.vm7.ai:8443");
   console.log("   API:       https://api.vm7.ai:8443");
   console.log("\n💡 Make sure your applications are running:");
+  console.log("   Marketing: pnpm dev (port 3042)");
   console.log("   App:       pnpm --filter @vm0/app dev (port 3002)");
   console.log("   API:       pnpm --filter api dev (port 3001)");
-  console.log("   Marketing is proxied to staging-www.vm6.ai");
   console.log(
     "\n🔐 Certificates are provisioned automatically via Let's Encrypt.",
   );


### PR DESCRIPTION
## Summary
- route `www.vm7.ai:8443` to local `vm0-marketing` on `localhost:3042`
- update proxy README architecture/backend docs for the local marketing service
- update the Caddy startup hint to include the marketing dev server port

## Verification
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm -F @vm0/db db:migrate`
- `pnpm knip`
- `pnpm knip --cache`
- `caddy adapt --config turbo/packages/proxy/Caddyfile --pretty`
- `node --check turbo/packages/proxy/scripts/start-caddy.js`
- `git diff --check`

## Test Notes
- `pnpm test` initially failed because local DB schema was missing `chat_messages.goal_snapshot`; fixed locally by running migrations and reran.
- After migration, `pnpm test` still failed in unrelated tests:
  - `@vm0/connectors` `firewall-metadata.test.ts` expected tracked missing Sentry/Xero descriptions but generated zero gaps.
  - `@vm0/connectors` `firewall-rule-validation.test.ts` Xero connection permission now includes a description field.
  - `api` `chat-threads.bdd.test.ts` timed out in snapshot compaction.
  - `api` `run-lifecycle.bdd.test.ts` expected `creditsCharged: 14`, got `12`.
  - `api` `zero-workflow-trigger-scheduler.test.ts` did not create the expected runner job.

These failures do not touch `packages/proxy` or this PR's changed files.