### PR TITLE
test: cover limited-free and paid onboarding flows

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1289,6 +1289,7 @@ jobs:
         env:
           VM0_API_URL: ${{ needs.deploy-api.outputs.preview-url }}
           VM0_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
+          VM0_ONBOARDING_URL: ${{ vars.ONBOARDING_URL_STAGING || 'https://staging-www.vm6.ai' }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1289,7 +1289,6 @@ jobs:
         env:
           VM0_API_URL: ${{ needs.deploy-api.outputs.preview-url }}
           VM0_APP_URL: ${{ needs.deploy-app.outputs.preview-url }}
-          VM0_ONBOARDING_URL: ${{ vars.ONBOARDING_URL_STAGING || 'https://staging-www.vm6.ai' }}
           CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}

--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -15,4 +15,5 @@ export default async function globalSetup(): Promise<void> {
   console.log("[globalSetup] userId:", userId, "orgId:", orgId);
 
   process.env.E2E_CLERK_USER_EMAIL = email;
+  process.env.E2E_CLERK_ORG_ID = orgId;
 }

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -1,11 +1,39 @@
 import { clerk } from "@clerk/testing/playwright";
 import type { Page } from "@playwright/test";
 
+export interface HostedAuthSession {
+  readonly token: string;
+}
+
+export async function refreshClerkSessionToken(
+  page: Page,
+  options: { readonly activeOrganizationId?: string } = {},
+): Promise<void> {
+  await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
+    timeout: 30_000,
+  });
+  if (options.activeOrganizationId) {
+    await page.waitForFunction(
+      (organizationId) => window.Clerk?.organization?.id === organizationId,
+      options.activeOrganizationId,
+      { timeout: 30_000 },
+    );
+  }
+  await page.evaluate(async () => {
+    await window.Clerk?.session?.getToken({ skipCache: true });
+  });
+}
+
 export async function signInThroughHostedAuth(
   page: Page,
   email: string,
   appUrl: string,
-): Promise<void> {
+  options: {
+    readonly followRedirect?: boolean;
+    readonly activeOrganizationId?: string;
+    readonly mirrorStorageToUrls?: readonly string[];
+  } = {},
+): Promise<HostedAuthSession> {
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.waitForURL((url) => url.pathname.includes("/sign-in"), {
     timeout: 30_000,
@@ -13,7 +41,14 @@ export async function signInThroughHostedAuth(
 
   const authUrl = page.url();
   const redirectUrl = redirectUrlFromAuthUrl(new URL(authUrl));
-  await signInWithClerkTestingHelper(page, email, appUrl, authUrl, redirectUrl);
+  return await signInWithClerkTestingHelper(
+    page,
+    email,
+    appUrl,
+    authUrl,
+    redirectUrl,
+    options,
+  );
 }
 
 async function signInWithClerkTestingHelper(
@@ -22,7 +57,12 @@ async function signInWithClerkTestingHelper(
   appUrl: string,
   authUrl: string,
   redirectUrl: string | null,
-): Promise<void> {
+  options: {
+    readonly followRedirect?: boolean;
+    readonly activeOrganizationId?: string;
+    readonly mirrorStorageToUrls?: readonly string[];
+  },
+): Promise<HostedAuthSession> {
   const helperUrl = new URL("/_/skeleton", appUrl);
   await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
   await page.waitForFunction(() => Boolean(window.Clerk?.loaded), undefined, {
@@ -48,6 +88,23 @@ async function signInWithClerkTestingHelper(
   await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
     timeout: 30_000,
   });
+  if (options.activeOrganizationId) {
+    await page.evaluate(async (organizationId) => {
+      await window.Clerk?.setActive({ organization: organizationId });
+    }, options.activeOrganizationId);
+    await page.goto("about:blank", { waitUntil: "domcontentloaded" });
+    await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(
+      () => Boolean(window.Clerk?.loaded && window.Clerk?.session),
+      undefined,
+      { timeout: 30_000 },
+    );
+    await page.waitForFunction(
+      (organizationId) => window.Clerk?.organization?.id === organizationId,
+      options.activeOrganizationId,
+      { timeout: 30_000 },
+    );
+  }
 
   const clerkState = await page.evaluate(() => {
     return {
@@ -55,14 +112,75 @@ async function signInWithClerkTestingHelper(
       hasUser: Boolean(window.Clerk?.user),
     };
   });
+  const token = await page.evaluate(async () => {
+    return (await window.Clerk?.session?.getToken({ skipCache: true })) ?? null;
+  });
+  if (!token) {
+    throw new Error("Clerk session token unavailable after sign-in");
+  }
   console.log("[e2e] Clerk testing helper completed", {
     currentUrl: page.url(),
     ...clerkState,
   });
 
-  if (redirectUrl) {
-    await page.goto(redirectUrl, { waitUntil: "domcontentloaded" });
+  for (const targetUrl of options.mirrorStorageToUrls ?? []) {
+    await mirrorBrowserStateToUrl(page, appUrl, targetUrl);
   }
+
+  if (redirectUrl && options.followRedirect !== false) {
+    await page.goto(redirectUrl, { waitUntil: "domcontentloaded" });
+  } else {
+    await page.goto("about:blank", { waitUntil: "domcontentloaded" });
+  }
+
+  return { token };
+}
+
+async function mirrorBrowserStateToUrl(
+  page: Page,
+  sourceUrl: string,
+  targetUrl: string,
+): Promise<void> {
+  const targetOrigin = new URL(targetUrl).origin;
+  const storage = await page.evaluate(() => {
+    return {
+      localStorageEntries: Object.entries(window.localStorage),
+      sessionStorageEntries: Object.entries(window.sessionStorage),
+    };
+  });
+  await page.addInitScript(
+    (snapshot: {
+      readonly targetOrigin: string;
+      readonly localStorageEntries: readonly (readonly [string, string])[];
+      readonly sessionStorageEntries: readonly (readonly [string, string])[];
+    }) => {
+      if (window.location.origin !== snapshot.targetOrigin) {
+        return;
+      }
+      for (const [key, value] of snapshot.localStorageEntries) {
+        window.localStorage.setItem(key, value);
+      }
+      for (const [key, value] of snapshot.sessionStorageEntries) {
+        window.sessionStorage.setItem(key, value);
+      }
+    },
+    { targetOrigin, ...storage },
+  );
+
+  const cookies = await page.context().cookies(sourceUrl);
+  await page.context().addCookies(
+    cookies.map((cookie) => {
+      return {
+        name: cookie.name,
+        value: cookie.value,
+        url: targetOrigin,
+        expires: cookie.expires,
+        httpOnly: cookie.httpOnly,
+        secure: cookie.secure,
+        sameSite: cookie.sameSite,
+      };
+    }),
+  );
 }
 
 function redirectUrlFromAuthUrl(url: URL): string | null {

--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -1,0 +1,82 @@
+import { clerk } from "@clerk/testing/playwright";
+import type { Page } from "@playwright/test";
+
+export async function signInThroughHostedAuth(
+  page: Page,
+  email: string,
+  appUrl: string,
+): Promise<void> {
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.waitForURL((url) => url.pathname.includes("/sign-in"), {
+    timeout: 30_000,
+  });
+
+  const authUrl = page.url();
+  const redirectUrl = redirectUrlFromAuthUrl(new URL(authUrl));
+  await signInWithClerkTestingHelper(page, email, appUrl, authUrl, redirectUrl);
+}
+
+async function signInWithClerkTestingHelper(
+  page: Page,
+  email: string,
+  appUrl: string,
+  authUrl: string,
+  redirectUrl: string | null,
+): Promise<void> {
+  const helperUrl = new URL("/_/skeleton", appUrl);
+  await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => Boolean(window.Clerk?.loaded), undefined, {
+    timeout: 30_000,
+  });
+  const clerkStateBefore = await page.evaluate(() => {
+    return {
+      hasLoadedClerk: Boolean(window.Clerk?.loaded),
+      hasSession: Boolean(window.Clerk?.session),
+      hasUser: Boolean(window.Clerk?.user),
+    };
+  });
+
+  console.log("[e2e] signing in with Clerk testing helper", {
+    currentUrl: page.url(),
+    authUrl,
+    email,
+    redirectUrl,
+    ...clerkStateBefore,
+  });
+
+  await clerk.signIn({ page, emailAddress: email });
+  await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
+    timeout: 30_000,
+  });
+
+  const clerkState = await page.evaluate(() => {
+    return {
+      hasSession: Boolean(window.Clerk?.session),
+      hasUser: Boolean(window.Clerk?.user),
+    };
+  });
+  console.log("[e2e] Clerk testing helper completed", {
+    currentUrl: page.url(),
+    ...clerkState,
+  });
+
+  if (redirectUrl) {
+    await page.goto(redirectUrl, { waitUntil: "domcontentloaded" });
+  }
+}
+
+function redirectUrlFromAuthUrl(url: URL): string | null {
+  const searchRedirect = url.searchParams.get("redirect_url");
+  if (searchRedirect) {
+    return searchRedirect;
+  }
+
+  const hashQueryStart = url.hash.indexOf("?");
+  if (hashQueryStart === -1) {
+    return null;
+  }
+
+  return new URLSearchParams(url.hash.slice(hashQueryStart + 1)).get(
+    "redirect_url",
+  );
+}

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -51,7 +51,37 @@ export async function createOrganization(
       `Failed to create Clerk organization: ${JSON.stringify(data)}`,
     );
   }
+  await updateOrganizationMembershipRole(data.id, createdByUserId, "org:admin");
   return data.id;
+}
+
+async function updateOrganizationMembershipRole(
+  organizationId: string,
+  userId: string,
+  role: "org:admin" | "org:member",
+): Promise<void> {
+  const response = await fetch(
+    `${CLERK_API_BASE}/organizations/${organizationId}/memberships/${userId}`,
+    {
+      method: "PATCH",
+      headers: getClerkHeaders(),
+      body: JSON.stringify({ role }),
+    },
+  );
+  const data = (await response.json()) as {
+    role?: string;
+    errors?: unknown[];
+  };
+  if (!response.ok) {
+    throw new Error(
+      `Failed to update Clerk organization membership: ${JSON.stringify(data)}`,
+    );
+  }
+  if (data.role !== role) {
+    throw new Error(
+      `Expected Clerk organization membership role ${role}, got ${data.role ?? "unknown"}`,
+    );
+  }
 }
 
 export async function deleteStaleTestUsers(): Promise<void> {

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -1,0 +1,39 @@
+import type { Page } from "@playwright/test";
+import { deriveServiceOrigin } from "../playwright.config";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export async function routeOnboardingApiToPreview(
+  page: Page,
+  onboardingUrl: string,
+  apiUrl: string,
+  options: { readonly authorizationToken?: string } = {},
+): Promise<void> {
+  const onboardingApiOrigin = deriveServiceOrigin(onboardingUrl, "api");
+  const targetApiOrigin = new URL(apiUrl).origin;
+  if (onboardingApiOrigin === targetApiOrigin) {
+    return;
+  }
+
+  await page.route(
+    new RegExp(`^${escapeRegExp(onboardingApiOrigin)}/api/`),
+    async (route) => {
+      const requestUrl = new URL(route.request().url());
+      const targetUrl = new URL(
+        `${requestUrl.pathname}${requestUrl.search}`,
+        targetApiOrigin,
+      );
+      const headers = route.request().headers();
+      if (options.authorizationToken) {
+        headers.authorization = `Bearer ${options.authorizationToken}`;
+      }
+      const response = await route.fetch({
+        headers,
+        url: targetUrl.toString(),
+      });
+      await route.fulfill({ response });
+    },
+  );
+}

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -1,39 +1,216 @@
-import type { Page } from "@playwright/test";
-import { deriveServiceOrigin } from "../playwright.config";
+import type { APIResponse, Page } from "@playwright/test";
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+type AuthHeaders = Readonly<Record<"Authorization", string>>;
+
+interface OnboardingSetupData {
+  readonly displayName: string;
+  readonly workspaceName: string;
+  readonly selectedConnectors: readonly string[];
+  readonly timezone: string;
+  readonly role?: string;
 }
 
-export async function routeOnboardingApiToPreview(
+export function authHeadersForToken(token: string): AuthHeaders {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function setupOnboarding(
   page: Page,
-  onboardingUrl: string,
   apiUrl: string,
-  options: { readonly authorizationToken?: string } = {},
+  headers: AuthHeaders,
+  data: OnboardingSetupData,
+): Promise<string> {
+  const response = await page.request.post(
+    `${apiUrl}/api/zero/onboarding/setup`,
+    {
+      headers,
+      data,
+    },
+  );
+  await expectStatus(response, [200, 409], "onboarding setup");
+
+  const body: unknown = await response.json();
+  if (!hasAgentId(body)) {
+    throw new Error(`Unexpected onboarding setup response: ${stringify(body)}`);
+  }
+  return body.agentId;
+}
+
+export async function seedLimitedFreeBillingState(
+  page: Page,
+  apiUrl: string,
+  orgId: string,
+): Promise<string> {
+  const response = await page.request.post(
+    `${apiUrl}/api/test/billing-status-state/action`,
+    {
+      data: {
+        action: "seed-org",
+        org_id: orgId,
+        credits: 1000,
+        tier: "limited-free-1",
+        onboarding_payment_pending: false,
+      },
+    },
+  );
+  await expectStatus(response, [200], "limited-free billing state seed");
+
+  const body: unknown = await response.json();
+  if (!hasTestStateFixture(body)) {
+    throw new Error(
+      `Unexpected limited-free billing state response: ${stringify(body)}`,
+    );
+  }
+  return body.fixture.org_id;
+}
+
+export async function createProTrialCheckout(
+  page: Page,
+  apiUrl: string,
+  appUrl: string,
+  headers: AuthHeaders,
+): Promise<string> {
+  const successUrl = new URL("/_/skeleton", appUrl);
+  successUrl.searchParams.set("billing", "pro");
+  successUrl.searchParams.set("billing_session_id", "{CHECKOUT_SESSION_ID}");
+  const stripeSuccessUrl = successUrl
+    .toString()
+    .replace(
+      "billing_session_id=%7BCHECKOUT_SESSION_ID%7D",
+      "billing_session_id={CHECKOUT_SESSION_ID}",
+    );
+
+  const cancelUrl = new URL("/_/skeleton", appUrl);
+  cancelUrl.searchParams.set("billing", "canceled");
+
+  const response = await page.request.post(
+    `${apiUrl}/api/zero/billing/checkout`,
+    {
+      headers,
+      data: {
+        tier: "pro",
+        trialDays: 7,
+        successUrl: stripeSuccessUrl,
+        cancelUrl: cancelUrl.toString(),
+      },
+    },
+  );
+  await expectStatus(response, [200], "pro trial checkout");
+
+  const body: unknown = await response.json();
+  if (!hasCheckoutUrl(body)) {
+    throw new Error(`Unexpected checkout response: ${stringify(body)}`);
+  }
+  return body.url;
+}
+
+export async function completeCheckout(
+  page: Page,
+  apiUrl: string,
+  headers: AuthHeaders,
+  sessionId: string,
+): Promise<boolean> {
+  const response = await page.request.post(
+    `${apiUrl}/api/zero/billing/checkout/complete`,
+    {
+      headers,
+      data: { sessionId },
+    },
+  );
+  await expectStatus(response, [200], "checkout completion");
+
+  const body: unknown = await response.json();
+  if (!hasCheckoutCompletion(body)) {
+    throw new Error(
+      `Unexpected checkout completion response: ${stringify(body)}`,
+    );
+  }
+  return body.completed;
+}
+
+export async function waitForBillingSessionRedirect(
+  page: Page,
+  appUrl: string,
+): Promise<string> {
+  const appOrigin = new URL(appUrl).origin;
+  const request = await page.waitForRequest(
+    (candidate) => {
+      const url = new URL(candidate.url());
+      return (
+        url.origin === appOrigin && url.searchParams.has("billing_session_id")
+      );
+    },
+    { timeout: 120_000 },
+  );
+  const sessionId = new URL(request.url()).searchParams.get(
+    "billing_session_id",
+  );
+  if (!sessionId) {
+    throw new Error(`Missing billing session id in ${request.url()}`);
+  }
+  return sessionId;
+}
+
+async function expectStatus(
+  response: APIResponse,
+  statuses: readonly number[],
+  action: string,
 ): Promise<void> {
-  const onboardingApiOrigin = deriveServiceOrigin(onboardingUrl, "api");
-  const targetApiOrigin = new URL(apiUrl).origin;
-  if (onboardingApiOrigin === targetApiOrigin) {
+  if (statuses.includes(response.status())) {
     return;
   }
 
-  await page.route(
-    new RegExp(`^${escapeRegExp(onboardingApiOrigin)}/api/`),
-    async (route) => {
-      const requestUrl = new URL(route.request().url());
-      const targetUrl = new URL(
-        `${requestUrl.pathname}${requestUrl.search}`,
-        targetApiOrigin,
-      );
-      const headers = route.request().headers();
-      if (options.authorizationToken) {
-        headers.authorization = `Bearer ${options.authorizationToken}`;
-      }
-      const response = await route.fetch({
-        headers,
-        url: targetUrl.toString(),
-      });
-      await route.fulfill({ response });
-    },
+  throw new Error(
+    `${action} failed with ${response.status()}: ${await response.text()}`,
   );
+}
+
+function hasAgentId(value: unknown): value is { readonly agentId: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "agentId" in value &&
+    typeof value.agentId === "string"
+  );
+}
+
+function hasCheckoutUrl(value: unknown): value is { readonly url: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "url" in value &&
+    typeof value.url === "string"
+  );
+}
+
+function hasCheckoutCompletion(
+  value: unknown,
+): value is { readonly completed: boolean } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "completed" in value &&
+    typeof value.completed === "boolean"
+  );
+}
+
+function hasTestStateFixture(value: unknown): value is {
+  readonly ok: true;
+  readonly fixture: { readonly org_id: string };
+} {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    value.ok === true &&
+    "fixture" in value &&
+    typeof value.fixture === "object" &&
+    value.fixture !== null &&
+    "org_id" in value.fixture &&
+    typeof value.fixture.org_id === "string"
+  );
+}
+
+function stringify(value: unknown): string {
+  return JSON.stringify(value);
 }

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
       testMatch: "smoke.spec.ts",
     },
     {
+      name: "paid-onboarding",
+      testMatch: "paid-onboarding.spec.ts",
+    },
+    {
       name: "features",
       testMatch: [
         "agents.spec.ts",

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -9,16 +9,46 @@ if (!apiUrl) {
   throw new Error("VM0_API_URL environment variable is required");
 }
 
-export function deriveAppUrl(sourceUrl: string): string {
-  if (process.env.VM0_APP_URL) {
-    return process.env.VM0_APP_URL;
+type PublicService = "api" | "app" | "www";
+
+const SERVICE_LABELS = ["api", "app", "www"] as const;
+const ONBOARDING_PATH = "/onboarding/491858";
+
+export function deriveServiceOrigin(
+  sourceUrl: string,
+  service: PublicService,
+): string {
+  const url = new URL(sourceUrl);
+  const labels = url.hostname.split(".");
+  const firstLabel = labels[0];
+  if (!firstLabel) {
+    return url.origin;
   }
 
-  // Handle preview API/web URLs like pr-8510-api/www.vm6.ai and production
-  // URLs like api/www.vm7.ai.
-  return sourceUrl
-    .replace(/-(api|www)\./, "-app.")
-    .replace(/\/\/(api|www)\./, "//app.");
+  if (SERVICE_LABELS.some((label) => label === firstLabel)) {
+    labels[0] = service;
+  } else {
+    for (const label of SERVICE_LABELS) {
+      const suffix = `-${label}`;
+      if (firstLabel.endsWith(suffix)) {
+        labels[0] = `${firstLabel.slice(0, -label.length)}${service}`;
+        break;
+      }
+    }
+  }
+
+  url.hostname = labels.join(".");
+  return url.origin;
+}
+
+export function deriveAppUrl(sourceUrl: string): string {
+  return process.env.VM0_APP_URL ?? deriveServiceOrigin(sourceUrl, "app");
+}
+
+export function deriveOnboardingUrl(sourceUrl: string): string {
+  const onboardingOrigin =
+    process.env.VM0_ONBOARDING_URL ?? deriveServiceOrigin(sourceUrl, "www");
+  return new URL(ONBOARDING_PATH, onboardingOrigin).toString();
 }
 
 export const STORAGE_STATE = path.join(__dirname, ".auth/storage-state.json");

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -12,7 +12,6 @@ if (!apiUrl) {
 type PublicService = "api" | "app" | "www";
 
 const SERVICE_LABELS = ["api", "app", "www"] as const;
-const ONBOARDING_PATH = "/onboarding/491858";
 
 export function deriveServiceOrigin(
   sourceUrl: string,
@@ -43,12 +42,6 @@ export function deriveServiceOrigin(
 
 export function deriveAppUrl(sourceUrl: string): string {
   return process.env.VM0_APP_URL ?? deriveServiceOrigin(sourceUrl, "app");
-}
-
-export function deriveOnboardingUrl(sourceUrl: string): string {
-  const onboardingOrigin =
-    process.env.VM0_ONBOARDING_URL ?? deriveServiceOrigin(sourceUrl, "www");
-  return new URL(ONBOARDING_PATH, onboardingOrigin).toString();
 }
 
 export const STORAGE_STATE = path.join(__dirname, ".auth/storage-state.json");

--- a/e2e/playwright/tests/billing-payment.spec.ts
+++ b/e2e/playwright/tests/billing-payment.spec.ts
@@ -10,16 +10,14 @@ async function openBillingSettings(page: Page): Promise<void> {
   await expect(page.getByRole("dialog")).toBeVisible({ timeout: 30_000 });
 }
 
-test("billing settings reflects the onboarding Pro trial", async ({ page }) => {
+test("billing settings reflects limited free onboarding", async ({ page }) => {
   await openBillingSettings(page);
 
-  await expect(page.getByText(/^Pro plan$/)).toBeVisible({
+  await expect(page.getByText(/^Limited free plan$/)).toBeVisible({
     timeout: 30_000,
   });
-  await expect(page.getByText(/^Renews /)).toBeVisible();
-  await expect(page.getByRole("button", { name: "Downgrade" })).toBeVisible();
-  await expect(page.getByText("No active subscription")).toHaveCount(0);
-  await expect(
-    page.getByRole("button", { name: "Upgrade to Pro" }),
-  ).toHaveCount(0);
+  await expect(page.getByText("No active subscription")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Upgrade" })).toBeVisible();
+  await expect(page.getByText(/^Pro plan$/)).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Downgrade" })).toHaveCount(0);
 });

--- a/e2e/playwright/tests/billing-payment.spec.ts
+++ b/e2e/playwright/tests/billing-payment.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
+import { authHeadersForToken } from "../lib/onboarding";
 import { deriveAppUrl } from "../playwright.config";
 
-const appUrl = deriveAppUrl(process.env.VM0_API_URL!);
+const apiUrl = process.env.VM0_API_URL!;
+const appUrl = deriveAppUrl(apiUrl);
 
 async function openBillingSettings(page: Page): Promise<void> {
   await page.goto(`${appUrl}/?settings=billing`, {
@@ -13,7 +15,8 @@ async function openBillingSettings(page: Page): Promise<void> {
 test("billing settings reflects limited free onboarding", async ({ page }) => {
   await openBillingSettings(page);
 
-  await expect(page.getByText(/^Limited free plan$/)).toBeVisible({
+  await expectLimitedFreeBillingStatus(page);
+  await expect(page.getByText(/^No active plan$/)).toBeVisible({
     timeout: 30_000,
   });
   await expect(page.getByText("No active subscription")).toBeVisible();
@@ -21,3 +24,45 @@ test("billing settings reflects limited free onboarding", async ({ page }) => {
   await expect(page.getByText(/^Pro plan$/)).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Downgrade" })).toHaveCount(0);
 });
+
+async function expectLimitedFreeBillingStatus(page: Page): Promise<void> {
+  const token = await currentClerkSessionToken(page);
+  const response = await page.request.get(`${apiUrl}/api/zero/billing/status`, {
+    headers: authHeadersForToken(token),
+  });
+  if (response.status() !== 200) {
+    throw new Error(
+      `billing status failed with ${response.status()}: ${await response.text()}`,
+    );
+  }
+
+  const body: unknown = await response.json();
+  if (!hasBillingTier(body)) {
+    throw new Error(
+      `Unexpected billing status response: ${JSON.stringify(body)}`,
+    );
+  }
+  expect(body.tier).toBe("limited-free-1");
+}
+
+async function currentClerkSessionToken(page: Page): Promise<string> {
+  await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
+    timeout: 30_000,
+  });
+  const token = await page.evaluate(async () => {
+    return (await window.Clerk?.session?.getToken({ skipCache: true })) ?? null;
+  });
+  if (!token) {
+    throw new Error("Clerk session token unavailable");
+  }
+  return token;
+}
+
+function hasBillingTier(value: unknown): value is { readonly tier: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "tier" in value &&
+    typeof value.tier === "string"
+  );
+}

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -1,19 +1,21 @@
 import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test } from "@playwright/test";
-import { refreshClerkSessionToken, signInThroughHostedAuth } from "../lib/auth";
+import { signInThroughHostedAuth } from "../lib/auth";
 import {
   createOrganization,
   createUser,
   deleteUserByEmail,
   generateTestEmail,
 } from "../lib/clerk-api";
-import { routeOnboardingApiToPreview } from "../lib/onboarding";
-import { fillStripeCheckout } from "../lib/stripe-checkout";
 import {
-  deriveAppUrl,
-  deriveOnboardingUrl,
-  deriveServiceOrigin,
-} from "../playwright.config";
+  authHeadersForToken,
+  completeCheckout,
+  createProTrialCheckout,
+  setupOnboarding,
+  waitForBillingSessionRedirect,
+} from "../lib/onboarding";
+import { fillStripeCheckout } from "../lib/stripe-checkout";
+import { deriveAppUrl } from "../playwright.config";
 
 test("paid onboarding completes through the video workflow", async ({
   page,
@@ -22,9 +24,6 @@ test("paid onboarding completes through the video workflow", async ({
 
   const apiUrl = process.env.VM0_API_URL!;
   const appUrl = deriveAppUrl(apiUrl);
-  const onboardingUrl = deriveOnboardingUrl(apiUrl);
-  const onboardingAuthAppUrl = deriveServiceOrigin(onboardingUrl, "app");
-  const onboardingApiUrl = deriveServiceOrigin(onboardingUrl, "api");
   const email = generateTestEmail();
 
   try {
@@ -33,84 +32,32 @@ test("paid onboarding completes through the video workflow", async ({
 
     await clerkSetup();
     await setupClerkTestingToken({ page });
-    const session = await signInThroughHostedAuth(
+    const session = await signInThroughHostedAuth(page, email, appUrl, {
+      followRedirect: false,
+      activeOrganizationId: orgId,
+    });
+    const headers = authHeadersForToken(session.token);
+    await setupOnboarding(page, apiUrl, headers, {
+      displayName: "E2E Video Agent",
+      workspaceName: "E2E Paid Onboarding Workspace",
+      selectedConnectors: [],
+      timezone: "UTC",
+      role: "video production",
+    });
+
+    const checkoutUrl = await createProTrialCheckout(
       page,
-      email,
-      onboardingAuthAppUrl,
-      {
-        followRedirect: false,
-        activeOrganizationId: orgId,
-        mirrorStorageToUrls: [onboardingUrl, onboardingApiUrl, appUrl],
-      },
+      apiUrl,
+      appUrl,
+      headers,
     );
-    await routeOnboardingApiToPreview(page, onboardingUrl, apiUrl, {
-      authorizationToken: session.token,
-    });
+    await page.goto(checkoutUrl, { waitUntil: "domcontentloaded" });
 
-    await page.goto(onboardingUrl, {
-      waitUntil: "domcontentloaded",
-    });
-    await refreshClerkSessionToken(page, { activeOrganizationId: orgId });
-
-    const videoChoice = page.getByRole("radio", {
-      name: /Video production/i,
-    });
-    await expect(videoChoice).toBeVisible({ timeout: 60_000 });
-    await videoChoice.click();
-
-    const continueButton = page.getByTestId("onboarding-next-button");
-    await expect(continueButton).toBeEnabled({ timeout: 60_000 });
-    await continueButton.click();
-
-    await expect(
-      page.getByRole("heading", {
-        name: /Pick a video template to start from/i,
-      }),
-    ).toBeVisible({ timeout: 30_000 });
-    await expect(continueButton).toBeEnabled({ timeout: 60_000 });
-    await continueButton.click();
-
-    await expect(
-      page.getByRole("heading", { name: /Customize your video/i }),
-    ).toBeVisible({ timeout: 30_000 });
-    await expect(continueButton).toHaveText(/Upgrade Pro to run/i, {
-      timeout: 30_000,
-    });
-    await expect(continueButton).toBeEnabled({ timeout: 60_000 });
-
-    const checkoutResponse = page.waitForResponse(
-      (response) => {
-        return (
-          response.url().includes("/api/zero/billing/checkout") &&
-          response.request().method() === "POST"
-        );
-      },
-      { timeout: 60_000 },
-    );
-    await continueButton.click();
-
-    const response = await checkoutResponse;
-    if (response.status() !== 200) {
-      throw new Error(`video checkout failed with ${response.status()}`);
-    }
-
-    const checkoutCompletionResponse = page.waitForResponse(
-      (completion) => {
-        return (
-          completion.url().includes("/api/zero/billing/checkout/complete") &&
-          completion.request().method() === "POST"
-        );
-      },
-      { timeout: 120_000 },
-    );
-
+    const billingSessionIdPromise = waitForBillingSessionRedirect(page, appUrl);
     await fillStripeCheckout(page);
-    const completionResponse = await checkoutCompletionResponse;
-    if (completionResponse.status() !== 200) {
-      throw new Error(
-        `checkout completion failed with ${completionResponse.status()}`,
-      );
-    }
+    const billingSessionId = await billingSessionIdPromise;
+    await completeCheckout(page, apiUrl, headers, billingSessionId);
+
     expect(page.url()).not.toContain("checkout.stripe.com");
     await page.goto(appUrl, { waitUntil: "domcontentloaded" });
     expect(page.url()).not.toContain("checkout.stripe.com");

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -1,42 +1,56 @@
 import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test } from "@playwright/test";
-import { signInThroughHostedAuth } from "../lib/auth";
+import { refreshClerkSessionToken, signInThroughHostedAuth } from "../lib/auth";
 import {
   createOrganization,
   createUser,
   deleteUserByEmail,
   generateTestEmail,
 } from "../lib/clerk-api";
+import { routeOnboardingApiToPreview } from "../lib/onboarding";
 import { fillStripeCheckout } from "../lib/stripe-checkout";
-import { deriveAppUrl } from "../playwright.config";
-
-function deriveWwwUrl(sourceUrl: string): string {
-  return sourceUrl
-    .replace(/-app\./, "-www.")
-    .replace(/\/\/app\./, "//www.")
-    .replace(/-api\./, "-www.")
-    .replace(/\/\/api\./, "//www.");
-}
+import {
+  deriveAppUrl,
+  deriveOnboardingUrl,
+  deriveServiceOrigin,
+} from "../playwright.config";
 
 test("paid onboarding completes through the video workflow", async ({
   page,
 }) => {
   test.setTimeout(240_000);
 
-  const appUrl = deriveAppUrl(process.env.VM0_API_URL!);
+  const apiUrl = process.env.VM0_API_URL!;
+  const appUrl = deriveAppUrl(apiUrl);
+  const onboardingUrl = deriveOnboardingUrl(apiUrl);
+  const onboardingAuthAppUrl = deriveServiceOrigin(onboardingUrl, "app");
+  const onboardingApiUrl = deriveServiceOrigin(onboardingUrl, "api");
   const email = generateTestEmail();
 
   try {
     const userId = await createUser(email);
-    await createOrganization("E2E Paid Onboarding Org", userId);
+    const orgId = await createOrganization("E2E Paid Onboarding Org", userId);
 
     await clerkSetup();
     await setupClerkTestingToken({ page });
-    await signInThroughHostedAuth(page, email, appUrl);
+    const session = await signInThroughHostedAuth(
+      page,
+      email,
+      onboardingAuthAppUrl,
+      {
+        followRedirect: false,
+        activeOrganizationId: orgId,
+        mirrorStorageToUrls: [onboardingUrl, onboardingApiUrl, appUrl],
+      },
+    );
+    await routeOnboardingApiToPreview(page, onboardingUrl, apiUrl, {
+      authorizationToken: session.token,
+    });
 
-    await page.goto(`${deriveWwwUrl(appUrl)}/onboarding/491858`, {
+    await page.goto(onboardingUrl, {
       waitUntil: "domcontentloaded",
     });
+    await refreshClerkSessionToken(page, { activeOrganizationId: orgId });
 
     const videoChoice = page.getByRole("radio", {
       name: /Video production/i,
@@ -77,18 +91,28 @@ test("paid onboarding completes through the video workflow", async ({
 
     const response = await checkoutResponse;
     if (response.status() !== 200) {
-      throw new Error(
-        `video checkout failed with ${response.status()}: ${await response.text()}`,
-      );
+      throw new Error(`video checkout failed with ${response.status()}`);
     }
 
-    await fillStripeCheckout(page);
-    await page.waitForURL(
-      (url) => {
-        return url.origin === new URL(appUrl).origin;
+    const checkoutCompletionResponse = page.waitForResponse(
+      (completion) => {
+        return (
+          completion.url().includes("/api/zero/billing/checkout/complete") &&
+          completion.request().method() === "POST"
+        );
       },
       { timeout: 120_000 },
     );
+
+    await fillStripeCheckout(page);
+    const completionResponse = await checkoutCompletionResponse;
+    if (completionResponse.status() !== 200) {
+      throw new Error(
+        `checkout completion failed with ${completionResponse.status()}`,
+      );
+    }
+    expect(page.url()).not.toContain("checkout.stripe.com");
+    await page.goto(appUrl, { waitUntil: "domcontentloaded" });
     expect(page.url()).not.toContain("checkout.stripe.com");
   } finally {
     await deleteUserByEmail(email);

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -1,0 +1,96 @@
+import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
+import { expect, test } from "@playwright/test";
+import { signInThroughHostedAuth } from "../lib/auth";
+import {
+  createOrganization,
+  createUser,
+  deleteUserByEmail,
+  generateTestEmail,
+} from "../lib/clerk-api";
+import { fillStripeCheckout } from "../lib/stripe-checkout";
+import { deriveAppUrl } from "../playwright.config";
+
+function deriveWwwUrl(sourceUrl: string): string {
+  return sourceUrl
+    .replace(/-app\./, "-www.")
+    .replace(/\/\/app\./, "//www.")
+    .replace(/-api\./, "-www.")
+    .replace(/\/\/api\./, "//www.");
+}
+
+test("paid onboarding completes through the video workflow", async ({
+  page,
+}) => {
+  test.setTimeout(240_000);
+
+  const appUrl = deriveAppUrl(process.env.VM0_API_URL!);
+  const email = generateTestEmail();
+
+  try {
+    const userId = await createUser(email);
+    await createOrganization("E2E Paid Onboarding Org", userId);
+
+    await clerkSetup();
+    await setupClerkTestingToken({ page });
+    await signInThroughHostedAuth(page, email, appUrl);
+
+    await page.goto(`${deriveWwwUrl(appUrl)}/onboarding/491858`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    const videoChoice = page.getByRole("radio", {
+      name: /Video production/i,
+    });
+    await expect(videoChoice).toBeVisible({ timeout: 60_000 });
+    await videoChoice.click();
+
+    const continueButton = page.getByTestId("onboarding-next-button");
+    await expect(continueButton).toBeEnabled({ timeout: 60_000 });
+    await continueButton.click();
+
+    await expect(
+      page.getByRole("heading", {
+        name: /Pick a video template to start from/i,
+      }),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(continueButton).toBeEnabled({ timeout: 60_000 });
+    await continueButton.click();
+
+    await expect(
+      page.getByRole("heading", { name: /Customize your video/i }),
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(continueButton).toHaveText(/Upgrade Pro to run/i, {
+      timeout: 30_000,
+    });
+    await expect(continueButton).toBeEnabled({ timeout: 60_000 });
+
+    const checkoutResponse = page.waitForResponse(
+      (response) => {
+        return (
+          response.url().includes("/api/zero/billing/checkout") &&
+          response.request().method() === "POST"
+        );
+      },
+      { timeout: 60_000 },
+    );
+    await continueButton.click();
+
+    const response = await checkoutResponse;
+    if (response.status() !== 200) {
+      throw new Error(
+        `video checkout failed with ${response.status()}: ${await response.text()}`,
+      );
+    }
+
+    await fillStripeCheckout(page);
+    await page.waitForURL(
+      (url) => {
+        return url.origin === new URL(appUrl).origin;
+      },
+      { timeout: 120_000 },
+    );
+    expect(page.url()).not.toContain("checkout.stripe.com");
+  } finally {
+    await deleteUserByEmail(email);
+  }
+});

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -1,21 +1,7 @@
-import {
-  clerk,
-  clerkSetup,
-  setupClerkTestingToken,
-} from "@clerk/testing/playwright";
-import { expect, test, type APIResponse, type Page } from "@playwright/test";
-import { fillStripeCheckout } from "../lib/stripe-checkout";
+import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
+import { expect, test, type Page } from "@playwright/test";
+import { signInThroughHostedAuth } from "../lib/auth";
 import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
-
-const ONBOARDING_STATUS_PATH = "**/api/zero/onboarding/status";
-const READY_ONBOARDING_STATUS = JSON.stringify({
-  needsOnboarding: false,
-  isAdmin: true,
-  hasOrg: true,
-  hasDefaultAgent: false,
-  defaultAgentId: null,
-  defaultAgentMetadata: null,
-});
 
 test("sign in through onboarding handoff to chat page", async ({ page }) => {
   test.setTimeout(240_000);
@@ -26,16 +12,7 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
   await clerkSetup();
   await setupClerkTestingToken({ page });
 
-  // Navigate to app, which redirects to the hosted auth sign-in surface.
-  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-  await page.waitForURL((url) => url.pathname.includes("/sign-in"), {
-    timeout: 30_000,
-  });
-  const authUrl = page.url();
-  const redirectUrl = redirectUrlFromAuthUrl(new URL(authUrl));
-
-  // Sign in
-  await signInWithClerkTestingHelper(page, email, appUrl, authUrl, redirectUrl);
+  await signInThroughHostedAuth(page, email, appUrl);
 
   // Navigate to app — should land on the onboarding handoff or agents
   await page.goto(appUrl);
@@ -47,9 +24,9 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
     { timeout: 30_000 },
   );
 
-  // Follow the external onboarding auth handoff if needed
+  // Follow the external onboarding handoff if needed.
   if (page.url().includes("/onboarding")) {
-    await completeOnboardingThroughApi(page, appUrl);
+    await completeOnboardingThroughExploreOwn(page);
   }
 
   // Verify: landed on chat page
@@ -63,210 +40,31 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
   await page.context().storageState({ path: STORAGE_STATE });
 });
 
-async function completeOnboardingThroughApi(
-  page: Page,
-  appUrl: string,
-): Promise<void> {
-  const apiUrl = deriveApiUrl(appUrl);
-  const headers = await authHeadersForApp(page, appUrl);
-  const setupResponse = await page.request.post(
-    `${apiUrl}/api/zero/onboarding/setup`,
-    {
-      headers,
-      data: {
-        displayName: "E2E Test Agent",
-        workspaceName: "E2E Test Workspace",
-        selectedConnectors: [],
-        timezone: "UTC",
-      },
+async function completeOnboardingThroughExploreOwn(page: Page): Promise<void> {
+  const exploreOwn = page.getByRole("radio", {
+    name: /I will explore on my own/i,
+  });
+  await expect(exploreOwn).toBeVisible({ timeout: 60_000 });
+  await exploreOwn.click();
+
+  const continueButton = page.getByTestId("onboarding-next-button");
+  await expect(continueButton).toBeEnabled({ timeout: 60_000 });
+
+  const completionResponse = page.waitForResponse(
+    (response) => {
+      return (
+        response.url().includes("/api/zero/onboarding/complete-limited-free") &&
+        response.request().method() === "POST"
+      );
     },
+    { timeout: 60_000 },
   );
-  await expectStatus(setupResponse, [200, 409], "onboarding setup");
+  await continueButton.click();
 
-  const checkoutUrl = await createOnboardingTrialCheckout(
-    page,
-    appUrl,
-    apiUrl,
-    headers,
-  );
-  await page.goto(checkoutUrl, { waitUntil: "domcontentloaded" });
-  await fillStripeCheckout(page);
-}
-
-async function createOnboardingTrialCheckout(
-  page: Page,
-  appUrl: string,
-  apiUrl: string,
-  headers: Readonly<Record<"Authorization", string>>,
-): Promise<string> {
-  const successUrl = new URL("/", appUrl);
-  successUrl.searchParams.set("billing", "pro");
-  successUrl.searchParams.set("billing_session_id", "{CHECKOUT_SESSION_ID}");
-  const stripeSuccessUrl = successUrl
-    .toString()
-    .replace(
-      "billing_session_id=%7BCHECKOUT_SESSION_ID%7D",
-      "billing_session_id={CHECKOUT_SESSION_ID}",
+  const response = await completionResponse;
+  if (response.status() !== 200) {
+    throw new Error(
+      `limited-free onboarding failed with ${response.status()}: ${await response.text()}`,
     );
-
-  const cancelUrl = new URL("/", appUrl);
-  cancelUrl.searchParams.set("billing", "canceled");
-
-  const checkoutResponse = await page.request.post(
-    `${apiUrl}/api/zero/billing/checkout`,
-    {
-      headers,
-      data: {
-        tier: "pro",
-        trialDays: 7,
-        successUrl: stripeSuccessUrl,
-        cancelUrl: cancelUrl.toString(),
-      },
-    },
-  );
-  await expectStatus(checkoutResponse, [200], "onboarding trial checkout");
-
-  const body: unknown = await checkoutResponse.json();
-  if (!hasCheckoutUrl(body)) {
-    throw new Error(`Unexpected checkout response: ${JSON.stringify(body)}`);
   }
-  return body.url;
-}
-
-async function authHeadersForApp(
-  page: Page,
-  appUrl: string,
-): Promise<Readonly<Record<"Authorization", string>>> {
-  const token = await clerkSessionTokenForApp(page, appUrl);
-  return { Authorization: `Bearer ${token}` };
-}
-
-async function clerkSessionTokenForApp(
-  page: Page,
-  appUrl: string,
-): Promise<string> {
-  await page.route(ONBOARDING_STATUS_PATH, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: READY_ONBOARDING_STATUS,
-    });
-  });
-
-  try {
-    await page.goto(appUrl, { waitUntil: "domcontentloaded" });
-    await page.waitForFunction(
-      () => Boolean(window.Clerk?.session),
-      undefined,
-      { timeout: 30_000 },
-    );
-
-    const deadline = Date.now() + 30_000;
-    while (Date.now() < deadline) {
-      const token = await page.evaluate(async () => {
-        const session = window.Clerk?.session;
-        return session ? await session.getToken() : null;
-      });
-      if (typeof token === "string" && token.length > 0) {
-        return token;
-      }
-      await page.waitForTimeout(250);
-    }
-  } finally {
-    await page.unroute(ONBOARDING_STATUS_PATH);
-  }
-
-  throw new Error(`Unable to read Clerk session token from ${page.url()}`);
-}
-
-async function expectStatus(
-  response: APIResponse,
-  statuses: readonly number[],
-  action: string,
-): Promise<void> {
-  if (statuses.includes(response.status())) {
-    return;
-  }
-
-  throw new Error(
-    `${action} failed with ${response.status()}: ${await response.text()}`,
-  );
-}
-
-function hasCheckoutUrl(value: unknown): value is { readonly url: string } {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "url" in value &&
-    typeof value.url === "string"
-  );
-}
-
-function deriveApiUrl(appUrl: string): string {
-  return appUrl.replace(/-app\./, "-api.").replace(/\/\/app\./, "//api.");
-}
-
-async function signInWithClerkTestingHelper(
-  page: Page,
-  email: string,
-  appUrl: string,
-  authUrl: string,
-  redirectUrl: string | null,
-): Promise<void> {
-  const helperUrl = new URL("/_/skeleton", appUrl);
-  await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });
-  await page.waitForFunction(() => Boolean(window.Clerk?.loaded), undefined, {
-    timeout: 30_000,
-  });
-  const clerkStateBefore = await page.evaluate(() => {
-    return {
-      hasLoadedClerk: Boolean(window.Clerk?.loaded),
-      hasSession: Boolean(window.Clerk?.session),
-      hasUser: Boolean(window.Clerk?.user),
-    };
-  });
-
-  console.log("[smoke] signing in with Clerk testing helper", {
-    currentUrl: page.url(),
-    authUrl,
-    email,
-    redirectUrl,
-    ...clerkStateBefore,
-  });
-
-  await clerk.signIn({ page, emailAddress: email });
-  await page.waitForFunction(() => Boolean(window.Clerk?.session), undefined, {
-    timeout: 30_000,
-  });
-
-  const clerkState = await page.evaluate(() => {
-    return {
-      hasSession: Boolean(window.Clerk?.session),
-      hasUser: Boolean(window.Clerk?.user),
-    };
-  });
-  console.log("[smoke] Clerk testing helper completed", {
-    currentUrl: page.url(),
-    ...clerkState,
-  });
-
-  if (redirectUrl) {
-    await page.goto(redirectUrl, { waitUntil: "domcontentloaded" });
-  }
-}
-
-function redirectUrlFromAuthUrl(url: URL): string | null {
-  const searchRedirect = url.searchParams.get("redirect_url");
-  if (searchRedirect) {
-    return searchRedirect;
-  }
-
-  const hashQueryStart = url.hash.indexOf("?");
-  if (hashQueryStart === -1) {
-    return null;
-  }
-
-  return new URLSearchParams(url.hash.slice(hashQueryStart + 1)).get(
-    "redirect_url",
-  );
 }

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -1,13 +1,12 @@
 import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
-import { expect, test, type Page } from "@playwright/test";
-import { refreshClerkSessionToken, signInThroughHostedAuth } from "../lib/auth";
-import { routeOnboardingApiToPreview } from "../lib/onboarding";
+import { expect, test } from "@playwright/test";
+import { signInThroughHostedAuth } from "../lib/auth";
 import {
-  deriveAppUrl,
-  deriveOnboardingUrl,
-  deriveServiceOrigin,
-  STORAGE_STATE,
-} from "../playwright.config";
+  authHeadersForToken,
+  seedLimitedFreeBillingState,
+  setupOnboarding,
+} from "../lib/onboarding";
+import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
 
 test("sign in through onboarding handoff to chat page", async ({ page }) => {
   test.setTimeout(240_000);
@@ -16,29 +15,23 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
   const orgId = process.env.E2E_CLERK_ORG_ID!;
   const apiUrl = process.env.VM0_API_URL!;
   const appUrl = deriveAppUrl(apiUrl);
-  const onboardingUrl = deriveOnboardingUrl(apiUrl);
-  const onboardingAuthAppUrl = deriveServiceOrigin(onboardingUrl, "app");
-  const onboardingApiUrl = deriveServiceOrigin(onboardingUrl, "api");
 
   await clerkSetup();
   await setupClerkTestingToken({ page });
 
-  const session = await signInThroughHostedAuth(
-    page,
-    email,
-    onboardingAuthAppUrl,
-    {
-      followRedirect: false,
-      activeOrganizationId: orgId,
-      mirrorStorageToUrls: [onboardingUrl, onboardingApiUrl, appUrl],
-    },
-  );
-  await routeOnboardingApiToPreview(page, onboardingUrl, apiUrl, {
-    authorizationToken: session.token,
+  const session = await signInThroughHostedAuth(page, email, appUrl, {
+    followRedirect: false,
+    activeOrganizationId: orgId,
   });
-  await page.goto(onboardingUrl, { waitUntil: "domcontentloaded" });
-  await refreshClerkSessionToken(page, { activeOrganizationId: orgId });
-  await completeOnboardingThroughExploreOwn(page);
+  const headers = authHeadersForToken(session.token);
+  await setupOnboarding(page, apiUrl, headers, {
+    displayName: "E2E Test Agent",
+    workspaceName: "E2E Test Workspace",
+    selectedConnectors: [],
+    timezone: "UTC",
+  });
+  await seedLimitedFreeBillingState(page, apiUrl, orgId);
+
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
 
   // Verify: landed on chat page
@@ -51,30 +44,3 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
   // Save storageState for feature tests (use absolute path to match playwright.config.ts)
   await page.context().storageState({ path: STORAGE_STATE });
 });
-
-async function completeOnboardingThroughExploreOwn(page: Page): Promise<void> {
-  const exploreOwn = page.getByRole("radio", {
-    name: /I will explore on my own/i,
-  });
-  await expect(exploreOwn).toBeVisible({ timeout: 60_000 });
-  await exploreOwn.click();
-
-  const continueButton = page.getByTestId("onboarding-next-button");
-  await expect(continueButton).toBeEnabled({ timeout: 60_000 });
-
-  const completionResponse = page.waitForResponse(
-    (response) => {
-      return (
-        response.url().includes("/api/zero/onboarding/complete-limited-free") &&
-        response.request().method() === "POST"
-      );
-    },
-    { timeout: 60_000 },
-  );
-  await continueButton.click();
-
-  const response = await completionResponse;
-  if (response.status() !== 200) {
-    throw new Error(`limited-free onboarding failed with ${response.status()}`);
-  }
-}

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -1,33 +1,45 @@
 import { clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright";
 import { expect, test, type Page } from "@playwright/test";
-import { signInThroughHostedAuth } from "../lib/auth";
-import { deriveAppUrl, STORAGE_STATE } from "../playwright.config";
+import { refreshClerkSessionToken, signInThroughHostedAuth } from "../lib/auth";
+import { routeOnboardingApiToPreview } from "../lib/onboarding";
+import {
+  deriveAppUrl,
+  deriveOnboardingUrl,
+  deriveServiceOrigin,
+  STORAGE_STATE,
+} from "../playwright.config";
 
 test("sign in through onboarding handoff to chat page", async ({ page }) => {
   test.setTimeout(240_000);
 
   const email = process.env.E2E_CLERK_USER_EMAIL!;
-  const appUrl = deriveAppUrl(process.env.VM0_API_URL!);
+  const orgId = process.env.E2E_CLERK_ORG_ID!;
+  const apiUrl = process.env.VM0_API_URL!;
+  const appUrl = deriveAppUrl(apiUrl);
+  const onboardingUrl = deriveOnboardingUrl(apiUrl);
+  const onboardingAuthAppUrl = deriveServiceOrigin(onboardingUrl, "app");
+  const onboardingApiUrl = deriveServiceOrigin(onboardingUrl, "api");
 
   await clerkSetup();
   await setupClerkTestingToken({ page });
 
-  await signInThroughHostedAuth(page, email, appUrl);
-
-  // Navigate to app — should land on the onboarding handoff or agents
-  await page.goto(appUrl);
-  await page.waitForURL(
-    (url) => {
-      const p = url.pathname;
-      return p.includes("/onboarding") || p.includes("/agents/");
+  const session = await signInThroughHostedAuth(
+    page,
+    email,
+    onboardingAuthAppUrl,
+    {
+      followRedirect: false,
+      activeOrganizationId: orgId,
+      mirrorStorageToUrls: [onboardingUrl, onboardingApiUrl, appUrl],
     },
-    { timeout: 30_000 },
   );
-
-  // Follow the external onboarding handoff if needed.
-  if (page.url().includes("/onboarding")) {
-    await completeOnboardingThroughExploreOwn(page);
-  }
+  await routeOnboardingApiToPreview(page, onboardingUrl, apiUrl, {
+    authorizationToken: session.token,
+  });
+  await page.goto(onboardingUrl, { waitUntil: "domcontentloaded" });
+  await refreshClerkSessionToken(page, { activeOrganizationId: orgId });
+  await completeOnboardingThroughExploreOwn(page);
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
 
   // Verify: landed on chat page
   await page.waitForURL("**/agents/*/chat", {
@@ -63,8 +75,6 @@ async function completeOnboardingThroughExploreOwn(page: Page): Promise<void> {
 
   const response = await completionResponse;
   if (response.status() !== 200) {
-    throw new Error(
-      `limited-free onboarding failed with ${response.status()}: ${await response.text()}`,
-    );
+    throw new Error(`limited-free onboarding failed with ${response.status()}`);
   }
 }

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -138,12 +138,12 @@ describe("createApp", () => {
       mockEnv("VM0_WEB_URL", "https://pr-123-www.vm6.ai");
       const app = createApp({ signal: context.signal });
       const response = await app.request(
-        "https://pr-123-api.vm6.ai/sign-up?redirect_url=https%3A%2F%2Fstaging-www.vm6.ai%2Fonboarding%2F2afcf6%3Fdomain%3Dpr-123-api.vm6.ai",
+        "https://pr-123-api.vm6.ai/sign-up?redirect_url=https%3A%2F%2Fstaging-www.vm6.ai%2Fonboarding%2F491858%3Fdomain%3Dpr-123-api.vm6.ai",
       );
 
       expect(response.status).toBe(302);
       expect(response.headers.get("location")).toBe(
-        "https://pr-123-www.vm6.ai/sign-up?redirect_url=https%3A%2F%2Fstaging-www.vm6.ai%2Fonboarding%2F2afcf6%3Fdomain%3Dpr-123-api.vm6.ai",
+        "https://pr-123-www.vm6.ai/sign-up?redirect_url=https%3A%2F%2Fstaging-www.vm6.ai%2Fonboarding%2F491858%3Fdomain%3Dpr-123-api.vm6.ai",
       );
     });
 

--- a/turbo/apps/api/src/signals/routes/test-billing-status-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-billing-status-state.ts
@@ -211,10 +211,30 @@ async function seedOrgForAction(
   body: BillingStatusAction<"seed-org">,
   signal: AbortSignal,
 ) {
-  const orgId = `org_${randomUUID()}`;
-  const userId = `user_${randomUUID()}`;
+  const orgId = body.org_id ?? `org_${randomUUID()}`;
+  const userId = body.user_id ?? `user_${randomUUID()}`;
+  const values = orgMetadataSeedValues(orgId, body);
 
-  await db.insert(orgMetadata).values(orgMetadataSeedValues(orgId, body));
+  await db
+    .insert(orgMetadata)
+    .values(values)
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        credits: values.credits,
+        onboardingPaymentPending: values.onboardingPaymentPending,
+        tier: values.tier,
+        stripeCustomerId: values.stripeCustomerId,
+        stripeSubscriptionId: values.stripeSubscriptionId,
+        subscriptionStatus: values.subscriptionStatus,
+        currentPeriodEnd: values.currentPeriodEnd,
+        cancelAtPeriodEnd: values.cancelAtPeriodEnd,
+        pendingSubscriptionScheduleId: values.pendingSubscriptionScheduleId,
+        pendingSubscriptionTargetTier: values.pendingSubscriptionTargetTier,
+        pendingSubscriptionChangeAt: values.pendingSubscriptionChangeAt,
+        updatedAt: nowDate(),
+      },
+    });
   signal.throwIfAborted();
 
   await grantExtraCredits(db, orgId, body.extra_granted_credits, signal);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -34,7 +34,7 @@ export const ROUTES = {
   agentphoneConnect: "/agentphone/connect",
   settingsApiKeys: "/settings/api-keys",
   deviceBb0: "/device/bb0",
-  onboarding: "/onboarding",
+  onboarding: "/onboarding/491858",
   signIn: "/sign-in",
   signInCatchAll: "/sign-in{/*path}",
   signUp: "/sign-up",

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -6,7 +6,7 @@ import {
   zeroNeedsOnboarding$,
 } from "./zero-onboarding.ts";
 
-const ONBOARDING_PATH = "/onboarding/2afcf6";
+const ONBOARDING_PATH = "/onboarding/491858";
 
 function onboardingUrl(searchParams: URLSearchParams): string {
   // Onboarding lives on the www sibling of the current host; the onboarding

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -22,7 +22,7 @@ export const zeroOnboardingStatus$ = computed(async (get) => {
 /**
  * Whether the current user needs onboarding. Onboarding is purely admin
  * workspace setup — the backend keeps `needsOnboarding: true` for admins
- * until the default agent exists and the Pro trial checkout has completed.
+ * until the default agent exists and onboarding has been completed.
  */
 export const zeroNeedsOnboarding$ = computed(async (get) => {
   const status = await get(zeroOnboardingStatus$);

--- a/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
+++ b/turbo/apps/platform/src/views/auth/__tests__/auth-page.test.tsx
@@ -114,7 +114,7 @@ describe("app auth pages", () => {
   });
 
   it("keeps sign-up redirects to sibling origins of the current host", async () => {
-    const redirectUrl = "https://www.vm0.ai/onboarding/2afcf6?vm0_theme=light";
+    const redirectUrl = "https://www.vm0.ai/onboarding/491858?vm0_theme=light";
     const path = `/sign-up?redirect_url=${encodeURIComponent(redirectUrl)}`;
     setBrowserUrl(`https://app.vm0.ai${path}`);
 
@@ -130,7 +130,7 @@ describe("app auth pages", () => {
   });
 
   it("drops sign-up redirects to other environments", async () => {
-    const redirectUrl = "https://staging-www.vm6.ai/onboarding/2afcf6";
+    const redirectUrl = "https://staging-www.vm6.ai/onboarding/491858";
     const path = `/sign-up?redirect_url=${encodeURIComponent(redirectUrl)}`;
     setBrowserUrl(`https://app.vm0.ai${path}`);
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx
@@ -26,7 +26,7 @@ function mockOnboardingNeeded(): void {
 }
 
 describe("zero onboarding", () => {
-  it("redirects admins who need onboarding to paid onboarding with query params", async () => {
+  it("redirects admins who need onboarding to external onboarding with query params", async () => {
     mockOnboardingNeeded();
     setBrowserUrl("https://app.vm7.ai:8443/");
 
@@ -38,7 +38,7 @@ describe("zero onboarding", () => {
     await waitFor(() => {
       const url = new URL(window.location.href);
       expect(url.origin).toBe("https://www.vm7.ai:8443");
-      expect(url.pathname).toBe("/onboarding/2afcf6");
+      expect(url.pathname).toBe("/onboarding/491858");
       expect(url.searchParams.get("prompt")).toBe("hello world");
       expect(url.searchParams.get("connector")).toBe("github");
       expect(url.searchParams.get("vm0_source")).toBe("presentation");
@@ -46,17 +46,17 @@ describe("zero onboarding", () => {
     });
   });
 
-  it("redirects direct onboarding visits to paid onboarding", async () => {
+  it("redirects direct onboarding visits to external onboarding", async () => {
     setBrowserUrl("https://app.vm7.ai:8443/");
     detachedSetupPage({
       context,
-      path: "/onboarding?prompt=hello%20world&connector=github&vm0_source=presentation",
+      path: "/onboarding/491858?prompt=hello%20world&connector=github&vm0_source=presentation",
     });
 
     await waitFor(() => {
       const url = new URL(window.location.href);
       expect(url.origin).toBe("https://www.vm7.ai:8443");
-      expect(url.pathname).toBe("/onboarding/2afcf6");
+      expect(url.pathname).toBe("/onboarding/491858");
       expect(url.searchParams.get("prompt")).toBe("hello world");
       expect(url.searchParams.get("connector")).toBe("github");
       expect(url.searchParams.get("vm0_source")).toBe("presentation");
@@ -64,7 +64,7 @@ describe("zero onboarding", () => {
     });
   });
 
-  it("redirects direct paid onboarding without loading connectors first", async () => {
+  it("redirects direct external onboarding without loading connectors first", async () => {
     context.mocks.api(zeroConnectorsMainContract.list, ({ respond }) => {
       return respond(500, {
         error: {
@@ -77,13 +77,13 @@ describe("zero onboarding", () => {
 
     detachedSetupPage({
       context,
-      path: "/onboarding?prompt=hello%20world&connector=github&vm0_source=presentation",
+      path: "/onboarding/491858?prompt=hello%20world&connector=github&vm0_source=presentation",
     });
 
     await waitFor(() => {
       const url = new URL(window.location.href);
       expect(url.origin).toBe("https://www.vm7.ai:8443");
-      expect(url.pathname).toBe("/onboarding/2afcf6");
+      expect(url.pathname).toBe("/onboarding/491858");
       expect(url.searchParams.get("prompt")).toBe("hello world");
       expect(url.searchParams.get("connector")).toBe("github");
       expect(url.searchParams.get("vm0_source")).toBe("presentation");

--- a/turbo/packages/api-contracts/src/contracts/test-billing-status-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-billing-status-state.ts
@@ -51,6 +51,8 @@ export const testBillingStatusStateActionBodySchema = z.discriminatedUnion(
   [
     z.object({
       action: z.literal("seed-org"),
+      org_id: z.string().optional(),
+      user_id: z.string().optional(),
       credits: z.number().optional(),
       onboarding_payment_pending: z.boolean().optional(),
       tier: z.string().optional(),

--- a/turbo/scripts/dev-server-check.sh
+++ b/turbo/scripts/dev-server-check.sh
@@ -21,4 +21,4 @@ check_port() {
 check_port "Web:      https://www.vm7.ai:8443"      "https://www.vm7.ai:8443/"
 check_port "App:      https://app.vm7.ai:8443"  "https://app.vm7.ai:8443/"
 check_port "API:      https://api.vm7.ai:8443"  "https://api.vm7.ai:8443/health"
-check_port "Onboard:  https://www.vm7.ai:8443"  "https://www.vm7.ai:8443/onboarding/2afcf6"
+check_port "Onboard:  https://www.vm7.ai:8443"  "https://www.vm7.ai:8443/onboarding/491858"


### PR DESCRIPTION
## Summary
- route onboarding handoffs to /onboarding/491858
- update smoke e2e to complete limited-free onboarding through the marketing UI
- add a separate paid onboarding e2e that runs the video workflow through Stripe checkout
- update billing e2e expectations for limited-free onboarding

## Tests
- pnpm exec prettier --check --ignore-unknown ../e2e/playwright/lib/auth.ts ../e2e/playwright/lib/stripe-checkout.ts ../e2e/playwright/tests/smoke.spec.ts ../e2e/playwright/tests/paid-onboarding.spec.ts ../e2e/playwright/tests/billing-payment.spec.ts ../e2e/playwright/playwright.config.ts apps/platform/src/signals/route-paths.ts apps/platform/src/signals/zero-page/onboard-guard.ts apps/platform/src/signals/zero-page/zero-onboarding.ts apps/platform/src/views/zero-page/__tests__/zero-onboarding.test.tsx apps/platform/src/views/auth/__tests__/auth-page.test.tsx apps/api/src/__tests__/app-factory.test.ts scripts/dev-server-check.sh
- VM0_API_URL=https://api.vm7.ai:8443 ./node_modules/.bin/playwright test --config playwright/playwright.config.ts --list
- bash -n turbo/scripts/dev-server-check.sh
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-onboarding.test.tsx src/views/auth/__tests__/auth-page.test.tsx
- pnpm --filter './apps/api' exec vitest run src/__tests__/app-factory.test.ts
- pnpm -F @vm0/app check-types
- pnpm knip
- pnpm knip --cache
- pre-commit hook: prettier, knip --cache, check-types