### PR TITLE
feat: show build commit shas in settings debug

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-build-info.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-build-info.ts
@@ -1,0 +1,12 @@
+import { buildInfoContract } from "@vm0/api-contracts/contracts/build-info";
+
+import { mockApi } from "../msw-contract.ts";
+
+export const MOCK_BACKEND_COMMIT_SHA =
+  "fedcba9876543210fedcba9876543210fedcba98";
+
+export const apiBuildInfoHandlers = [
+  mockApi(buildInfoContract.get, ({ respond }) => {
+    return respond(200, { commitSha: MOCK_BACKEND_COMMIT_SHA });
+  }),
+];

--- a/turbo/apps/platform/src/mocks/handlers/index.ts
+++ b/turbo/apps/platform/src/mocks/handlers/index.ts
@@ -105,8 +105,10 @@ import {
   resetMockUserPermissionGrants,
 } from "./api-user-permission-grants.ts";
 import { apiVoiceIoHandlers } from "./api-voice-io.ts";
+import { apiBuildInfoHandlers } from "./api-build-info.ts";
 
 export const handlers = [
+  ...apiBuildInfoHandlers,
   ...apiConnectorsHandlers,
   ...apiOrgHandlers,
   ...apiOrgMembersHandlers,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -156,7 +156,7 @@ const chatThreadEventData$ = computed(
   },
 );
 
-export const syncEventDrivenChatThreads$ = command(
+const syncEventDrivenChatThreads$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
     const store = await get(chatThreadEventStores$);
     signal.throwIfAborted();
@@ -211,7 +211,7 @@ export const subscribeEventDrivenChatThreads$ = command(
   },
 );
 
-export const chatThreadsSnapshot$ = computed(async (get) => {
+const chatThreadsSnapshot$ = computed(async (get) => {
   return (await get(chatThreadEventData$)).snapshot;
 });
 
@@ -241,7 +241,7 @@ export const eventDrivenChatThreads$ = computed(async (get) => {
   );
 });
 
-export const eventDrivenChatThreadMetaMap$ = computed(async (get) => {
+const eventDrivenChatThreadMetaMap$ = computed(async (get) => {
   return new Map<string, ThreadMeta>(
     (await get(eventDrivenChatThreads$)).map((thread) => {
       return [

--- a/turbo/apps/platform/src/signals/zero-page/settings/build-info.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/build-info.ts
@@ -1,0 +1,21 @@
+import { computed } from "ccstate";
+import { buildInfoContract } from "@vm0/api-contracts/contracts/build-info";
+
+import { accept } from "../../../lib/accept.ts";
+import { zeroClient$ } from "../../api-client.ts";
+
+interface BackendBuildInfo {
+  readonly backendCommitSha: string | null;
+}
+
+export const backendBuildInfo$ = computed(
+  async (get): Promise<BackendBuildInfo> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(buildInfoContract);
+    const result = await accept(client.get(), [200], { toast: false });
+
+    return {
+      backendCommitSha: result.body.commitSha,
+    };
+  },
+);

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -6,6 +6,7 @@ import {
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
+import { MOCK_BACKEND_COMMIT_SHA } from "../../../mocks/handlers/api-build-info.ts";
 import {
   click,
   detachedSetupPage,
@@ -14,6 +15,7 @@ import {
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+const TEST_FRONTEND_COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567";
 
 function createMockPreferences(
   overrides?: Partial<UserPreferencesResponse>,
@@ -139,6 +141,11 @@ describe("preferences page", () => {
     });
 
     await waitFor(() => {
+      expect(screen.getByText("Build commit SHA")).toBeInTheDocument();
+      expect(screen.getByText("Frontend")).toBeInTheDocument();
+      expect(screen.getByText(TEST_FRONTEND_COMMIT_SHA)).toBeInTheDocument();
+      expect(screen.getByText("Backend")).toBeInTheDocument();
+      expect(screen.getByText(MOCK_BACKEND_COMMIT_SHA)).toBeInTheDocument();
       expect(screen.getByText("Capture network bodies")).toBeInTheDocument();
       expect(screen.getByText("Disabled")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
@@ -1,0 +1,64 @@
+import { useLoadable } from "ccstate-react";
+import { IconGitCommit } from "@tabler/icons-react";
+
+import { getBuildCommitSha } from "../../../../lib/build-info.ts";
+import { backendBuildInfo$ } from "../../../../signals/zero-page/settings/build-info.ts";
+
+const UNAVAILABLE_VALUE = "Unavailable";
+
+function formatCommitSha(value: string | null | undefined): string {
+  return value ?? UNAVAILABLE_VALUE;
+}
+
+function BuildInfoRow({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      <div className="text-sm text-muted-foreground">{label}</div>
+      <code className="break-all text-xs text-foreground sm:text-right">
+        {value}
+      </code>
+    </div>
+  );
+}
+
+export function BuildInfoBlock() {
+  const backendBuildInfoLoadable = useLoadable(backendBuildInfo$);
+  const loading = backendBuildInfoLoadable.state === "loading";
+  const backendBuildInfo =
+    backendBuildInfoLoadable.state === "hasData"
+      ? backendBuildInfoLoadable.data
+      : null;
+  const frontendCommitSha = formatCommitSha(getBuildCommitSha());
+  const backendCommitSha = loading
+    ? "Loading"
+    : formatCommitSha(backendBuildInfo?.backendCommitSha);
+
+  return (
+    <div className="flex items-start gap-4 bg-card p-4 rounded-xl zero-border">
+      <div className="shrink-0">
+        <div className="flex h-7 w-7 items-center justify-center">
+          <IconGitCommit
+            size={22}
+            stroke={1.5}
+            className="text-muted-foreground"
+          />
+        </div>
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-3">
+        <div className="text-sm font-medium text-foreground">
+          Build commit SHA
+        </div>
+        <div className="flex flex-col gap-2">
+          <BuildInfoRow label="Frontend" value={frontendCommitSha} />
+          <BuildInfoRow label="Backend" value={backendCommitSha} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/sections/debug-section.tsx
@@ -9,6 +9,7 @@ import {
   captureNetworkBodiesRemaining$,
   updateCaptureNetworkBodies$,
 } from "../../../../../signals/zero-page/settings/preferences-page.ts";
+import { BuildInfoBlock } from "../build-info-block.tsx";
 
 const CAPTURE_RUN_COUNT = 3;
 
@@ -61,6 +62,7 @@ function CaptureNetworkBodiesBlock() {
 export function DebugSection() {
   return (
     <div className="flex flex-col gap-6">
+      <BuildInfoBlock />
       <CaptureNetworkBodiesBlock />
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -34,6 +34,7 @@ import {
   captureNetworkBodiesRemaining$,
   updateCaptureNetworkBodies$,
 } from "../../signals/zero-page/settings/preferences-page.ts";
+import { BuildInfoBlock } from "./components/settings/build-info-block.tsx";
 
 function AppearanceSettings() {
   const THEME_OPTIONS = [
@@ -318,6 +319,7 @@ export function ZeroPreferencesPage() {
                 showModelConfiguration && <PersonalProvidersTab />}
               {activeTab === "debug" && showDebug && (
                 <div className="flex flex-col gap-6">
+                  <BuildInfoBlock />
                   <CaptureNetworkBodiesSettings />
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Show frontend and backend build commit SHA values on the settings Debug tab
- Reuse the existing API build-info endpoint for backend commit data
- Add a platform MSW handler and coverage for the debug preferences page
- Remove unused chat thread event exports so knip stays clean on this branch

## Tests
- pnpm -F @vm0/app exec vitest run src/views/preferences-page/__tests__/preferences-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --cache
- pre-commit hook: prettier, knip, check-types