### PR TITLE
fix(desktop): bundle filesystem mcp sdk dependency

### DIFF
--- a/turbo/apps/desktop/scripts/packaged-app-paths.js
+++ b/turbo/apps/desktop/scripts/packaged-app-paths.js
@@ -39,6 +39,13 @@ function packagedAppPaths(platformUrl) {
       "dist",
       "main.js",
     ),
+    mcpBundlePath: path.join(
+      appBundlePath,
+      "Contents",
+      "Resources",
+      "mcp",
+      "index.mjs",
+    ),
   };
 }
 

--- a/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
+++ b/turbo/apps/desktop/scripts/smoke-test-packaged-app.js
@@ -10,7 +10,7 @@ if (process.platform !== "darwin") {
   throw new Error("Packaged desktop smoke tests are only supported on macOS.");
 }
 
-const { executablePath, mainBundlePath } = packagedAppPaths(
+const { executablePath, mainBundlePath, mcpBundlePath } = packagedAppPaths(
   process.env.VM0_DESKTOP_PLATFORM_URL,
 );
 
@@ -18,20 +18,72 @@ if (!fs.existsSync(executablePath)) {
   throw new Error(`Packaged app executable was not found at ${executablePath}`);
 }
 
-const UNBUNDLED_REQUIRE_PREFIXES = ["@vm0/", "@modelcontextprotocol/sdk/"];
+if (!fs.existsSync(mcpBundlePath)) {
+  throw new Error(
+    `Packaged filesystem MCP bundle was not found at ${mcpBundlePath}`,
+  );
+}
 
-const mainBundle = fs.readFileSync(mainBundlePath, "utf8");
-for (const prefix of UNBUNDLED_REQUIRE_PREFIXES) {
-  for (const unbundledRequire of [`require("${prefix}`, `require('${prefix}`]) {
-    if (mainBundle.includes(unbundledRequire)) {
-      throw new Error(
-        `Packaged main bundle contains an unbundled require (${unbundledRequire}...). ` +
-          "These packages must be bundled via tsup noExternal; see tsup.electron.config.js.",
-      );
+function assertNoUnbundledRequires(bundlePath, bundle, prefixes, guidance) {
+  for (const prefix of prefixes) {
+    for (const unbundledRequire of [
+      `require("${prefix}`,
+      `require('${prefix}`,
+    ]) {
+      if (bundle.includes(unbundledRequire)) {
+        throw new Error(
+          `Packaged bundle contains an unbundled require (${unbundledRequire}...) in ${bundlePath}. ${guidance}`,
+        );
+      }
     }
   }
 }
+
+function assertNoUnbundledEsmImports(bundlePath, bundle, prefixes, guidance) {
+  const lines = bundle.split(/\r?\n/);
+  for (const prefix of prefixes) {
+    for (const importSpecifier of [`"${prefix}`, `'${prefix}`]) {
+      const lineIndex = lines.findIndex((line) => {
+        const trimmed = line.trimStart();
+        return (
+          trimmed.startsWith("import ") && trimmed.includes(importSpecifier)
+        );
+      });
+      if (lineIndex !== -1) {
+        throw new Error(
+          `Packaged bundle contains an unbundled import (${importSpecifier}...) in ${bundlePath}:${lineIndex + 1}. ${guidance}`,
+        );
+      }
+    }
+  }
+}
+
+const mainBundle = fs.readFileSync(mainBundlePath, "utf8");
+assertNoUnbundledRequires(
+  mainBundlePath,
+  mainBundle,
+  ["@vm0/", "@modelcontextprotocol/sdk/"],
+  "These packages must be bundled via tsup noExternal; see tsup.electron.config.js.",
+);
 console.log(`Main bundle has no unbundled requires: ${mainBundlePath}`);
+
+const mcpBundle = fs.readFileSync(mcpBundlePath, "utf8");
+const unbundledMcpPrefixes = ["@modelcontextprotocol/sdk"];
+assertNoUnbundledRequires(
+  mcpBundlePath,
+  mcpBundle,
+  unbundledMcpPrefixes,
+  "These packages must be bundled via tsup noExternal; see tsup.mcp-filesystem.config.js.",
+);
+assertNoUnbundledEsmImports(
+  mcpBundlePath,
+  mcpBundle,
+  unbundledMcpPrefixes,
+  "These packages must be bundled via tsup noExternal; see tsup.mcp-filesystem.config.js.",
+);
+console.log(
+  `Filesystem MCP bundle has no unbundled SDK imports: ${mcpBundlePath}`,
+);
 
 const child = spawn(executablePath, [], {
   env: { ...process.env, VM0_DESKTOP_SMOKE_TEST: "1" },

--- a/turbo/apps/desktop/tsup.mcp-filesystem.config.js
+++ b/turbo/apps/desktop/tsup.mcp-filesystem.config.js
@@ -8,6 +8,7 @@ module.exports = defineConfig({
   outDir: "dist/mcp",
   sourcemap: true,
   clean: false,
+  noExternal: [/^@modelcontextprotocol\/sdk(\/.*)?$/],
   outExtension() {
     return { js: ".mjs" };
   },


### PR DESCRIPTION
## Summary

- Bundle `@modelcontextprotocol/sdk` into the packaged Desktop filesystem MCP server.
- Extend the packaged app smoke test to verify `Contents/Resources/mcp/index.mjs` exists and has no unbundled SDK imports.
- Share the packaged MCP bundle path through the existing packaged app path helper.

## Verification

- `corepack pnpm format`
- `corepack pnpm -F @vm0/desktop build`
- `corepack pnpm -F @vm0/desktop lint`
- `corepack pnpm -F @vm0/desktop check-types`
- `corepack pnpm -F @vm0/desktop test`
- `node --check turbo/apps/desktop/scripts/smoke-test-packaged-app.js`
- `node --check turbo/apps/desktop/scripts/packaged-app-paths.js`
- Packaged filesystem MCP server starts with the packaged Electron binary and prints `Secure MCP Filesystem Server running on stdio`.
- `VM0_DESKTOP_PLATFORM_URL=http://localhost:3000 node scripts/smoke-test-packaged-app.js`

## Notes

- `corepack pnpm knip --workspace @vm0/desktop` still reports the existing unused `@sentry/cli` devDependency in `apps/desktop/package.json`; this PR does not touch that dependency.
