### PR TITLE
style: shrink workflow trigger pill shadow and make it even on all sides

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -116,7 +116,7 @@ function connectorPillClassName({
   readonly muted?: boolean;
 }) {
   return cn(
-    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border-[0.7px] border-border/80 bg-white px-2 text-[11px] font-medium leading-none shadow-sm",
+    "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-full border-[0.7px] border-border/80 bg-white px-2 text-[11px] font-medium leading-none shadow-[0_0_2px_rgba(0,0,0,0.06)]",
     muted ? "text-muted-foreground" : "text-foreground/70",
     interactive &&
       "cursor-pointer transition-colors hover:border-border hover:bg-gray-50 hover:text-foreground",


### PR DESCRIPTION
## What

Follow-up on #19992. The trigger pills in the workflows/automations list (Schedule / Webhook / Email / Manual) currently use Tailwind's \`shadow-sm\` (\`0 1px 2px rgba(0,0,0,0.05)\`), which is a downward, bottom-weighted drop shadow.

Per feedback the shadow reads as too large and lopsided. This changes it to a smaller, symmetric shadow with **zero offset on both axes** so it looks the same horizontally and vertically:

\`shadow-sm\` → \`shadow-[0_0_2px_rgba(0,0,0,0.06)]\`

- Smaller overall footprint (removes the extra 1px downward reach)
- Even glow around the whole pill instead of a bottom drop shadow

## Impact

Pure style change to \`connectorPillClassName\` in \`workflows-page.tsx\`. All four trigger states inherit it; no layout or copy changes.

## Verification

- \`prettier@3.8.1 --check\`: pass
- No behavioral change; visual-only