### PR TITLE
fix(platform): match workflow header icon size to agent detail avatar

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -415,8 +415,8 @@ function WorkflowHeaderIcon({
     return <TriggerListIcon trigger={trigger} size="md" />;
   }
   return (
-    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-muted-foreground">
-      <IconRoute size={20} stroke={1.7} />
+    <span className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gray-100 text-muted-foreground sm:h-16 sm:w-16">
+      <IconRoute size={28} stroke={1.7} />
     </span>
   );
 }
@@ -437,7 +437,7 @@ function DetailHeader({
           <div className="flex items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-3">
               <WorkflowHeaderIcon trigger={detail.triggers[0]} />
-              <div className="flex h-11 min-w-0 flex-col justify-center">
+              <div className="flex min-w-0 flex-col justify-center">
                 <TooltipProvider delayDuration={200}>
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -460,7 +460,7 @@ function DetailHeader({
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
-                <p className="mt-0.5 max-w-full truncate text-sm text-muted-foreground">
+                <p className="mt-1.5 max-w-full truncate text-sm text-muted-foreground">
                   /{detail.name}
                 </p>
               </div>

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -294,12 +294,14 @@ export function TriggerListIcon({
     <span
       className={cn(
         "flex shrink-0 items-center justify-center",
-        compact ? "h-8 w-8 rounded-lg" : "h-11 w-11 rounded-xl",
+        compact
+          ? "h-8 w-8 rounded-lg"
+          : "h-14 w-14 rounded-2xl sm:h-16 sm:w-16",
         tone,
       )}
       aria-hidden="true"
     >
-      <Icon size={compact ? 16 : 20} stroke={1.6} />
+      <Icon size={compact ? 16 : 28} stroke={1.6} />
     </span>
   );
 }


### PR DESCRIPTION
## What

The icon next to the title on the workflow detail page (the rounded tile showing the trigger/route glyph) was noticeably smaller than the avatar on the agent detail page. This aligns its size to the agent detail avatar so the two detail headers feel consistent.

## Changes

- **Header icon size**: `h-11 w-11` (44px) → `h-14 w-14 sm:h-16 sm:w-16` (56/64px), matching the agent detail avatar in `zero-job-detail-page.tsx`.
- Covers both header states: the trigger icon (`TriggerListIcon size="md"`, used only in the header) and the no-trigger fallback (`IconRoute`).
- Scaled the inner glyph `20 → 28` and corner radius `rounded-xl → rounded-2xl` so the larger tile stays visually balanced.
- Dropped the fixed `h-11` on the title column so the title vertically centers naturally next to the taller icon, mirroring the agent detail header structure.

The tile keeps its rounded-square shape and tone (the agent avatar is a `rounded-full` image — different form), only the size is aligned per the request.

## Verification

- Prettier (CI version 3.8.1) format check passes on both changed files.
- Pure className / glyph-size JSX change — no logic or type changes. Relying on the PR pipeline for lint/type/test gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)