### PR TITLE
docs: clarify guest logging sinks

### DIFF
--- a/crates/guest-common/src/lib.rs
+++ b/crates/guest-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! Shared logging and telemetry utilities for guest-side VM tools.
 //!
 //! This crate provides:
-//! - Structured stderr logging macros
+//! - Structured guest logging macros
 //! - Sandbox operation telemetry helpers
 
 pub mod log;

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -105,10 +105,10 @@ pub fn timestamp() -> String {
 /// Updating this path drops any cached file handle, including same-path
 /// updates. This lets callers force the next write to reopen the path.
 ///
-/// The file is still opened lazily by the next log line. System log writes are
-/// synchronous and complete before the logging macro returns. This matters for
-/// guest-agent's final telemetry upload, which reads the same file immediately
-/// after some fatal-path log lines are emitted.
+/// The file is still opened lazily by the next log line. System log append
+/// attempts are synchronous and finish before the logging macro returns. This
+/// matters for guest-agent's final telemetry upload, which reads the same file
+/// immediately after some fatal-path log lines are emitted.
 pub fn set_system_log_file(path: impl AsRef<Path>) {
     let mut guard = SYSTEM_LOG.lock().unwrap_or_else(|e| e.into_inner());
     guard.set_path(path.as_ref().to_path_buf());
@@ -133,8 +133,8 @@ fn write_stderr_line(line: &str) {
     let _ = stderr.flush();
 }
 
-/// Emit one formatted log line to stderr and, when enabled, the guest-side
-/// system log file.
+/// Emit one formatted log line to stderr and attempt to append it to the
+/// configured guest-side system log.
 pub fn emit(level: &str, tag: &str, args: std::fmt::Arguments<'_>) {
     let line = format!("[{}] [{level}] [{tag}] {args}", timestamp());
     if let Err(e) = append_system_log_line(&line) {

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -1,9 +1,11 @@
 //! Structured guest logging utilities for VM scripts.
 //!
 //! Logging macros always emit one structured line to stderr. When an embedding
-//! runtime has installed a guest system log with [`set_system_log_file`], the
-//! same line is synchronously appended to that file before the macro returns.
+//! runtime has installed a guest system log with [`set_system_log_file`], they
+//! synchronously attempt to append the same line before returning.
 //! Without a configured system log, logging falls back to stderr-only behavior.
+//! System log append failures are reported to stderr and do not suppress the
+//! original stderr line.
 //!
 //! Embedding runtimes may persist or upload the configured system log; this
 //! module only owns the local logging sinks.
@@ -144,7 +146,8 @@ pub fn emit(level: &str, tag: &str, args: std::fmt::Arguments<'_>) {
     write_stderr_line(&line);
 }
 
-/// Log an info message to stderr and, when configured, the guest system log.
+/// Log an info message to stderr and attempt to append it to the configured
+/// guest system log.
 ///
 /// If no guest system log has been installed with
 /// [`crate::log::set_system_log_file`], the message is emitted to stderr only.
@@ -155,7 +158,8 @@ macro_rules! log_info {
     };
 }
 
-/// Log a warning message to stderr and, when configured, the guest system log.
+/// Log a warning message to stderr and attempt to append it to the configured
+/// guest system log.
 ///
 /// If no guest system log has been installed with
 /// [`crate::log::set_system_log_file`], the message is emitted to stderr only.
@@ -166,7 +170,8 @@ macro_rules! log_warn {
     };
 }
 
-/// Log an error message to stderr and, when configured, the guest system log.
+/// Log an error message to stderr and attempt to append it to the configured
+/// guest system log.
 ///
 /// If no guest system log has been installed with
 /// [`crate::log::set_system_log_file`], the message is emitted to stderr only.

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -1,4 +1,12 @@
-//! Logging utilities for VM scripts.
+//! Structured guest logging utilities for VM scripts.
+//!
+//! Logging macros always emit one structured line to stderr. When an embedding
+//! runtime has installed a guest system log with [`set_system_log_file`], the
+//! same line is synchronously appended to that file before the macro returns.
+//! Without a configured system log, logging falls back to stderr-only behavior.
+//!
+//! Embedding runtimes may persist or upload the configured system log; this
+//! module only owns the local logging sinks.
 
 use std::fs::File;
 use std::io::{self, IoSlice, Write};
@@ -136,7 +144,10 @@ pub fn emit(level: &str, tag: &str, args: std::fmt::Arguments<'_>) {
     write_stderr_line(&line);
 }
 
-/// Log an info message to stderr.
+/// Log an info message to stderr and, when configured, the guest system log.
+///
+/// If no guest system log has been installed with
+/// [`crate::log::set_system_log_file`], the message is emitted to stderr only.
 #[macro_export]
 macro_rules! log_info {
     ($tag:expr, $($arg:tt)*) => {
@@ -144,7 +155,10 @@ macro_rules! log_info {
     };
 }
 
-/// Log a warning message to stderr.
+/// Log a warning message to stderr and, when configured, the guest system log.
+///
+/// If no guest system log has been installed with
+/// [`crate::log::set_system_log_file`], the message is emitted to stderr only.
 #[macro_export]
 macro_rules! log_warn {
     ($tag:expr, $($arg:tt)*) => {
@@ -152,7 +166,10 @@ macro_rules! log_warn {
     };
 }
 
-/// Log an error message to stderr.
+/// Log an error message to stderr and, when configured, the guest system log.
+///
+/// If no guest system log has been installed with
+/// [`crate::log::set_system_log_file`], the message is emitted to stderr only.
 #[macro_export]
 macro_rules! log_error {
     ($tag:expr, $($arg:tt)*) => {


### PR DESCRIPTION
## Summary
- Clarify that guest-common logging macros are structured guest logging, not stderr-only helpers
- Document stderr plus configured guest system log behavior and fallback semantics
- Preserve the boundary that guest-common owns local sinks while embedding runtimes may persist or upload system logs

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo test --manifest-path crates/Cargo.toml -p guest-common
- RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-common --no-deps
- pre-commit cargo-fmt/cargo-doc/cargo-clippy via git commit

Closes #19984