### PR TITLE
refactor: serve platform permission metadata from catalog api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -595,6 +595,32 @@ describe("GET /api/zero/connector-catalog", () => {
     );
   });
 
+  it("rejects connector catalog refs outside the public connector-ref bounds", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const connectorRef = "x".repeat(65);
+    const detailResponse = await accept(
+      client.get({
+        params: { connectorRef },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+    const permissionResponse = await accept(
+      client.permissions({
+        params: { connectorRef },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [400],
+    );
+
+    expect(detailResponse.body.error.code).toBe("BAD_REQUEST");
+    expect(permissionResponse.body.error.code).toBe("BAD_REQUEST");
+  });
+
   it("returns semantic public ids for device-auth start options", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -16,6 +16,7 @@ import {
   type PublicConnectorCatalogAuthMethodDetail,
   type PublicConnectorCatalogConnection,
   type PublicConnectorCatalogConnectionStatus,
+  type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogPermissionSummary,
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
@@ -37,11 +38,15 @@ import {
   hasRequiredConnectorAuthMethodScopes,
   type ConnectorFeatureStates,
 } from "@vm0/connectors/connector-utils";
-import { getFirewallPermissionSummary } from "@vm0/connectors/firewall-metadata";
+import {
+  getFirewallPermissionSummary,
+  loadFirewallPermissionMetadata,
+} from "@vm0/connectors/firewall-metadata";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { mockApi } from "../msw-contract.ts";
 
 const FEATURE_SWITCH_CACHE_KEY = "vm0:feature-switch-cache:v1";
+const MOCK_CONNECTOR_TYPE_SET = new Set<string>(CONNECTOR_TYPE_KEYS);
 
 let mockConnectors: ConnectorResponse[] = [];
 type MockOauthDeviceAuthSessionStartResponse = Omit<
@@ -182,6 +187,10 @@ function mockFeatureStates(): ConnectorFeatureStates {
     : getAllFeatureStates({});
 }
 
+function isMockConnectorType(type: string): type is ConnectorType {
+  return MOCK_CONNECTOR_TYPE_SET.has(type);
+}
+
 function mockPermissionSummary(
   type: ConnectorType,
 ): PublicConnectorCatalogPermissionSummary {
@@ -191,6 +200,63 @@ function mockPermissionSummary(
     permissionCount: summary?.permissionCount ?? 0,
     hasCategories: summary?.hasCategories ?? false,
     hasDefaultPolicyOverrides: summary?.hasDefaultPolicyOverrides ?? false,
+  };
+}
+
+async function mockPermissionDetail(
+  connectorRef: string,
+): Promise<PublicConnectorCatalogPermissionDetail | null> {
+  if (!isMockConnectorType(connectorRef)) {
+    return null;
+  }
+
+  const authMethods = getAvailableConnectorAuthMethodIds(
+    connectorRef,
+    mockFeatureStates(),
+    { apiAuthMethodPolicy: "include" },
+  );
+  if (authMethods.length === 0) {
+    return null;
+  }
+
+  const metadata = await loadFirewallPermissionMetadata(connectorRef);
+  if (!metadata) {
+    return null;
+  }
+
+  return {
+    connectorRef,
+    label: metadata.label,
+    permissionCount: metadata.permissionCount,
+    permissions: metadata.permissions.map((permission) => {
+      return {
+        name: permission.name,
+        ...(permission.description
+          ? { description: permission.description }
+          : {}),
+      };
+    }),
+    categories: metadata.categories
+      ? {
+          categories: { ...metadata.categories.categories },
+          displayOrder: [...metadata.categories.displayOrder],
+        }
+      : null,
+    defaultPolicy: {
+      permissionDefault: metadata.defaultPolicy.permissionDefault,
+      ...(metadata.defaultPolicy.permissionOverrides
+        ? {
+            permissionOverrides: Object.fromEntries(
+              Object.entries(metadata.defaultPolicy.permissionOverrides).map(
+                ([policy, permissions]) => {
+                  return [policy, [...permissions]];
+                },
+              ),
+            ),
+          }
+        : {}),
+      unknownPolicy: metadata.defaultPolicy.unknownPolicy,
+    },
   };
 }
 
@@ -371,6 +437,19 @@ export const apiConnectorsHandlers = [
   mockApi(zeroConnectorCatalogContract.status, ({ respond }) => {
     return respond(200, { connectors: mockConnectorCatalogStatus() });
   }),
+
+  mockApi(
+    zeroConnectorCatalogContract.permissions,
+    async ({ params, respond }) => {
+      const permissions = await mockPermissionDetail(params.connectorRef);
+      if (!permissions) {
+        return respond(404, {
+          error: { message: "Connector not found", code: "NOT_FOUND" },
+        });
+      }
+      return respond(200, { permissions });
+    },
+  ),
 
   mockApi(zeroConnectorsByTypeContract.delete, ({ params, respond }) => {
     const type = params.type as string;

--- a/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 const SERVER_FIREWALL_METADATA_SPECIFIER =
   "@vm0/connectors/firewall-metadata/server";
+const ROOT_FIREWALL_METADATA_SPECIFIER = "@vm0/connectors/firewall-metadata";
 const IMPORT_SPECIFIER_PATTERN =
   /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 
@@ -49,6 +50,12 @@ function importsSpecifier(source: string, specifier: string): boolean {
   });
 }
 
+function importsExactSpecifier(source: string, specifier: string): boolean {
+  return importSpecifiers(source).some((importedSpecifier) => {
+    return importedSpecifier === specifier;
+  });
+}
+
 describe("firewall metadata import boundary", () => {
   it("keeps server-only firewall metadata out of platform production source", () => {
     const offenders = Object.entries(productionSourceModules)
@@ -59,6 +66,25 @@ describe("firewall metadata import boundary", () => {
         return (
           isProductionSourcePath(path) &&
           importsSpecifier(source, SERVER_FIREWALL_METADATA_SPECIFIER)
+        );
+      });
+
+    expect(
+      offenders.map((offender) => {
+        return offender.path;
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps generated firewall metadata root imports out of platform production source", () => {
+    const offenders = Object.entries(productionSourceModules)
+      .map(([path, source]) => {
+        return { path: sourcePathFromGlobKey(path), source };
+      })
+      .filter(({ path, source }) => {
+        return (
+          isProductionSourcePath(path) &&
+          importsExactSpecifier(source, ROOT_FIREWALL_METADATA_SPECIFIER)
         );
       });
 

--- a/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/permission-action-block.ts
@@ -1,7 +1,3 @@
-import {
-  isFirewallMetadataConnectorType,
-  type FirewallMetadataConnectorType,
-} from "@vm0/connectors/firewall-metadata";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { parseUserPermissionGrantExpiresIn } from "../permission-allow/permission-grant-expiration.ts";
 
@@ -11,7 +7,7 @@ type PlatformHostTarget = "api" | "www" | "app" | "platform";
 export interface PermissionActionDescriptor {
   scope: "agent";
   agentId: string;
-  connectorRef: FirewallMetadataConnectorType;
+  connectorRef: string;
   permission: string;
   action: PermissionAction;
   method: string | null;
@@ -190,7 +186,6 @@ export function parsePermissionActionUrl(
   if (
     !path.agentId ||
     !connectorRef ||
-    !isFirewallMetadataConnectorType(connectorRef) ||
     !permission ||
     !isPermissionAction(action)
   ) {

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -19,11 +19,15 @@ import { featureSwitch$ } from "./feature-switch.ts";
  */
 const internalReloadConnectors$ = state(0);
 
+export const connectorsReloadVersion$ = computed((get) => {
+  return get(internalReloadConnectors$);
+});
+
 /**
  * Current user's connectors.
  */
 export const connectors$ = computed(async (get) => {
-  get(internalReloadConnectors$);
+  get(connectorsReloadVersion$);
   get(featureSwitch$);
 
   const createClient = get(zeroClient$);
@@ -36,7 +40,7 @@ export const connectors$ = computed(async (get) => {
  * Public connector catalog metadata joined with the current user's connector status.
  */
 export const connectorCatalogStatus$ = computed(async (get) => {
-  get(internalReloadConnectors$);
+  get(connectorsReloadVersion$);
   get(featureSwitch$);
 
   const createClient = get(zeroClient$);

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -3,6 +3,7 @@ import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogPermissionDetail,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { CONNECTOR_REF_MAX_LENGTH } from "@vm0/api-contracts/contracts/connector-ref";
 import { accept } from "../lib/accept.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { connectorsReloadVersion$ } from "./external/connectors.ts";
@@ -13,6 +14,11 @@ interface FirewallPermissionMetadataParams {
 }
 
 const FIREWALL_PERMISSION_METADATA_CACHE_LIMIT = 256;
+const MISSING_FIREWALL_PERMISSION_METADATA$ = computed(
+  (): Promise<PublicConnectorCatalogPermissionDetail | null> => {
+    return Promise.resolve(null);
+  },
+);
 
 function evictOldestCacheEntry<K, V>(cache: Map<K, V>): void {
   const oldest = cache.keys().next();
@@ -30,6 +36,9 @@ function createFirewallPermissionMetadataFactory(): (
   >();
   return (params) => {
     const key = params.connectorRef;
+    if (key.length === 0 || key.length > CONNECTOR_REF_MAX_LENGTH) {
+      return MISSING_FIREWALL_PERMISSION_METADATA$;
+    }
     const existing = cache.get(key);
     if (existing) {
       return existing;

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -50,7 +50,13 @@ function createFirewallPermissionMetadataFactory(): (
       if (result.status === 404) {
         return null;
       }
-      return result.body.permissions;
+      const { permissions } = result.body;
+      if (permissions.connectorRef !== key) {
+        throw new Error(
+          `Permission metadata connectorRef mismatch: expected ${key}, got ${permissions.connectorRef}`,
+        );
+      }
+      return permissions;
     });
     if (cache.size >= FIREWALL_PERMISSION_METADATA_CACHE_LIMIT) {
       evictOldestCacheEntry(cache);

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -42,7 +42,7 @@ function createFirewallPermissionMetadataFactory(): (
       const client = createClient(zeroConnectorCatalogContract);
       const result = await accept(
         client.permissions({
-          params: { connectorRef: params.connectorRef },
+          params: { connectorRef: key },
         }),
         [200, 404],
         { toast: false },

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -1,32 +1,47 @@
 import { computed, type Computed } from "ccstate";
 import {
-  isFirewallMetadataConnectorType,
-  loadFirewallPermissionMetadata,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogPermissionDetail,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { accept } from "../lib/accept.ts";
+import { zeroClient$ } from "./api-client.ts";
+import { connectorsReloadVersion$ } from "./external/connectors.ts";
+import { featureSwitch$ } from "./external/feature-switch.ts";
 
 interface FirewallPermissionMetadataParams {
-  readonly connectorType: string;
+  readonly connectorRef: string;
 }
 
 function createFirewallPermissionMetadataFactory(): (
   params: FirewallPermissionMetadataParams,
-) => Computed<Promise<FirewallPermissionDetailMetadata | null>> {
+) => Computed<Promise<PublicConnectorCatalogPermissionDetail | null>> {
   const cache = new Map<
     string,
-    Computed<Promise<FirewallPermissionDetailMetadata | null>>
+    Computed<Promise<PublicConnectorCatalogPermissionDetail | null>>
   >();
   return (params) => {
-    const key = params.connectorType;
+    const key = params.connectorRef;
     const existing = cache.get(key);
     if (existing) {
       return existing;
     }
-    const atom$ = computed(async () => {
-      if (!isFirewallMetadataConnectorType(params.connectorType)) {
+    const atom$ = computed(async (get) => {
+      get(connectorsReloadVersion$);
+      get(featureSwitch$);
+
+      const createClient = get(zeroClient$);
+      const client = createClient(zeroConnectorCatalogContract);
+      const result = await accept(
+        client.permissions({
+          params: { connectorRef: params.connectorRef },
+        }),
+        [200, 404],
+        { toast: false },
+      );
+      if (result.status === 404) {
         return null;
       }
-      return await loadFirewallPermissionMetadata(params.connectorType);
+      return result.body.permissions;
     });
     cache.set(key, atom$);
     return atom$;

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -12,6 +12,15 @@ interface FirewallPermissionMetadataParams {
   readonly connectorRef: string;
 }
 
+const FIREWALL_PERMISSION_METADATA_CACHE_LIMIT = 256;
+
+function evictOldestCacheEntry<K, V>(cache: Map<K, V>): void {
+  const oldest = cache.keys().next();
+  if (!oldest.done) {
+    cache.delete(oldest.value);
+  }
+}
+
 function createFirewallPermissionMetadataFactory(): (
   params: FirewallPermissionMetadataParams,
 ) => Computed<Promise<PublicConnectorCatalogPermissionDetail | null>> {
@@ -43,6 +52,9 @@ function createFirewallPermissionMetadataFactory(): (
       }
       return result.body.permissions;
     });
+    if (cache.size >= FIREWALL_PERMISSION_METADATA_CACHE_LIMIT) {
+      evictOldestCacheEntry(cache);
+    }
     cache.set(key, atom$);
     return atom$;
   };

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -7,6 +7,7 @@ import {
   type UserPermissionGrantResponse,
   zeroUserPermissionGrantsContract,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicyValue,
@@ -14,8 +15,7 @@ import {
 import {
   permissionGrantsToFirewallPolicies,
   resolveFirewallMetadataPolicies,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+} from "@vm0/connectors/firewall-metadata/policy";
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
@@ -79,7 +79,7 @@ export interface Permission {
 }
 
 export function findPermissionInMetadata(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: PublicConnectorCatalogPermissionDetail,
   name: string,
 ): Permission | null {
   if (name === UNKNOWN_PERMISSION_GRANT) {
@@ -103,13 +103,13 @@ const internalUserPermissionGrantsReload$ = state(0);
 
 export function resolveUserPermissionGrantPolicy(
   grants: readonly UserPermissionGrantResponse[],
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: PublicConnectorCatalogPermissionDetail,
   permission: string,
 ): FirewallPolicyValue | undefined {
   const policies = resolveFirewallMetadataPolicies(
     permissionGrantsToFirewallPolicies(grants),
     [metadata],
-  )?.[metadata.type];
+  )?.[metadata.connectorRef];
   return permission === UNKNOWN_PERMISSION_GRANT
     ? policies?.unknownPolicy
     : policies?.policies[permission];

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -34,6 +34,7 @@ import type {
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogConnection,
+  PublicConnectorCatalogPermissionSummary,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
@@ -110,6 +111,8 @@ export interface ConnectorTypeWithStatus {
   tokenExpiresAt: string | null;
   /** True when the selected auth method can refresh runtime access. */
   authMethodSupportsRefresh: boolean;
+  /** Public permission summary returned by the catalog status API. */
+  permissionSummary: PublicConnectorCatalogPermissionSummary;
 }
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -371,6 +374,7 @@ function connectorCatalogStatusItemToConnectorType(
     connectionStatus: item.connectionStatus,
     tokenExpiresAt: item.tokenExpiresAt,
     authMethodSupportsRefresh: item.authMethodSupportsRefresh,
+    permissionSummary: item.permissionSummary,
   };
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
@@ -1,5 +1,5 @@
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import type { FirewallPermissionDetailMetadata } from "@vm0/connectors/firewall-metadata";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicies,
@@ -34,24 +34,26 @@ const READ_PERMISSIONS = [
   { name: "channels:history" },
 ] as const;
 
-const METADATA = {
-  type: "slack",
-  label: "Slack",
-  permissionCount: READ_PERMISSIONS.length,
-  permissions: READ_PERMISSIONS,
-  categories: {
+function createMetadata(): PublicConnectorCatalogPermissionDetail {
+  return {
+    connectorRef: "slack",
+    label: "Slack",
+    permissionCount: READ_PERMISSIONS.length,
+    permissions: [...READ_PERMISSIONS],
     categories: {
-      "bookmarks:read": "Read",
-      "channels:read": "Read",
-      "channels:history": "Read",
+      categories: {
+        "bookmarks:read": "Read",
+        "channels:read": "Read",
+        "channels:history": "Read",
+      },
+      displayOrder: ["Read"],
     },
-    displayOrder: ["Read"],
-  },
-  defaultPolicy: {
-    permissionDefault: "allow",
-    unknownPolicy: "allow",
-  },
-} satisfies FirewallPermissionDetailMetadata;
+    defaultPolicy: {
+      permissionDefault: "allow",
+      unknownPolicy: "allow",
+    },
+  };
+}
 
 const INITIAL_POLICIES = {} satisfies FirewallPolicies;
 
@@ -73,7 +75,7 @@ function createGrant(
 
 function createContext() {
   return createPermissionDraftContext({
-    metadata: METADATA,
+    metadata: createMetadata(),
     initialPolicies: INITIAL_POLICIES,
   });
 }
@@ -81,11 +83,11 @@ function createContext() {
 describe("permission draft intent keys", () => {
   it("fingerprints resolved initial permission policies", () => {
     const initialAllowContext = createPermissionDraftContext({
-      metadata: METADATA,
+      metadata: createMetadata(),
       initialPolicies: INITIAL_POLICIES,
     });
     const initialDenyContext = createPermissionDraftContext({
-      metadata: METADATA,
+      metadata: createMetadata(),
       initialPolicies: {
         slack: {
           policies: {
@@ -583,7 +585,7 @@ describe("permission draft intent reset persistence", () => {
       ["bookmarks:read", createGrant("bookmarks:read", "deny")],
     ]);
     const context = createPermissionDraftContext({
-      metadata: METADATA,
+      metadata: createMetadata(),
       initialPolicies: {
         slack: {
           policies: {
@@ -625,7 +627,7 @@ describe("permission draft intent reset persistence", () => {
       [UNKNOWN_PERMISSION_GRANT, createGrant(UNKNOWN_PERMISSION_GRANT, "deny")],
     ]);
     const context = createPermissionDraftContext({
-      metadata: METADATA,
+      metadata: createMetadata(),
       initialPolicies: {
         slack: {
           policies: {},

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.ts
@@ -2,12 +2,12 @@ import type {
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
   createFirewallMetadataPolicyResolver,
   type FirewallMetadataPolicyOverlay,
   type FirewallMetadataPolicyResolver,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+} from "@vm0/connectors/firewall-metadata/policy";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicy,
@@ -34,7 +34,7 @@ export interface PermissionDraftIntent {
 }
 
 export interface PermissionDraftContext {
-  readonly metadata: FirewallPermissionDetailMetadata;
+  readonly metadata: PublicConnectorCatalogPermissionDetail;
   readonly defaultResolver: FirewallMetadataPolicyResolver;
   readonly initialResolver: FirewallMetadataPolicyResolver;
 }
@@ -100,7 +100,7 @@ function omitKeys<T>(
 }
 
 function permissionCategory(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: PublicConnectorCatalogPermissionDetail,
   permissionName: string,
 ): string | undefined {
   return metadata.categories?.categories[permissionName];
@@ -252,7 +252,7 @@ export function createPermissionDraftContext({
   metadata,
   initialPolicies,
 }: {
-  readonly metadata: FirewallPermissionDetailMetadata;
+  readonly metadata: PublicConnectorCatalogPermissionDetail;
   readonly initialPolicies: FirewallPolicies;
 }): PermissionDraftContext {
   return {
@@ -260,16 +260,16 @@ export function createPermissionDraftContext({
     defaultResolver: createFirewallMetadataPolicyResolver(metadata),
     initialResolver: createFirewallMetadataPolicyResolver(
       metadata,
-      firewallPolicyToOverlay(initialPolicies[metadata.type]),
+      firewallPolicyToOverlay(initialPolicies[metadata.connectorRef]),
     ),
   };
 }
 
 export function permissionDraftMetadataKey(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: PublicConnectorCatalogPermissionDetail,
 ): string {
   return JSON.stringify({
-    type: metadata.type,
+    connectorRef: metadata.connectorRef,
     permissions: metadata.permissions.map((permission) => {
       return permission.name;
     }),
@@ -1027,7 +1027,7 @@ export function materializePermissionDraftForLegacySave({
 
   return {
     policies: {
-      [context.metadata.type]: {
+      [context.metadata.connectorRef]: {
         policies: connectorPolicies,
         unknownPolicy,
       },

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-grant-save.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-grant-save.ts
@@ -1,4 +1,4 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicies,
@@ -7,8 +7,7 @@ import {
 import {
   expandFirewallMetadataDefaultPolicy,
   resolveFirewallMetadataPolicies,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+} from "@vm0/connectors/firewall-metadata/policy";
 import type {
   ApplyUserPermissionGrant,
   UserPermissionGrantAction,
@@ -81,8 +80,8 @@ function addNamedPolicyChanges({
   expiresInByPermission,
 }: {
   changes: Map<string, ChangedUserGrantPolicy>;
-  initial: FirewallPolicies[ConnectorType] | undefined;
-  current: FirewallPolicies[ConnectorType] | undefined;
+  initial: FirewallPolicies[string] | undefined;
+  current: FirewallPolicies[string] | undefined;
   expiresInByPermission: GrantExpirationSelections;
 }): void {
   for (const [permission, action] of Object.entries(current?.policies ?? {})) {
@@ -105,8 +104,8 @@ function addUnknownPolicyChange({
   expiresInByPermission,
 }: {
   changes: Map<string, ChangedUserGrantPolicy>;
-  initial: FirewallPolicies[ConnectorType] | undefined;
-  current: FirewallPolicies[ConnectorType] | undefined;
+  initial: FirewallPolicies[string] | undefined;
+  current: FirewallPolicies[string] | undefined;
   expiresInByPermission: GrantExpirationSelections;
 }): void {
   const unknownPolicy = current?.unknownPolicy;
@@ -128,19 +127,19 @@ function addUnknownPolicyChange({
 
 function addExpirationOnlyChanges({
   changes,
-  connectorType,
+  connectorRef,
   initialGrants,
   current,
   expiresInByPermission,
 }: {
   changes: Map<string, ChangedUserGrantPolicy>;
-  connectorType: ConnectorType;
+  connectorRef: string;
   initialGrants: readonly UserPermissionGrantResponse[];
-  current: FirewallPolicies[ConnectorType] | undefined;
+  current: FirewallPolicies[string] | undefined;
   expiresInByPermission: GrantExpirationSelections;
 }): void {
   for (const grant of initialGrants) {
-    if (grant.connectorRef !== connectorType || changes.has(grant.permission)) {
+    if (grant.connectorRef !== connectorRef || changes.has(grant.permission)) {
       continue;
     }
     const expiresIn = expiresInByPermission[grant.permission];
@@ -168,21 +167,21 @@ function addExpirationOnlyChanges({
 
 function addDefaultAllowExpirationChanges({
   changes,
-  connectorType,
+  connectorRef,
   initialGrants,
   current,
   expiresInByPermission,
 }: {
   changes: Map<string, ChangedUserGrantPolicy>;
-  connectorType: ConnectorType;
+  connectorRef: string;
   initialGrants: readonly UserPermissionGrantResponse[];
-  current: FirewallPolicies[ConnectorType] | undefined;
+  current: FirewallPolicies[string] | undefined;
   expiresInByPermission: GrantExpirationSelections;
 }): void {
   const initialGrantPermissions = new Set(
     initialGrants
       .filter((grant) => {
-        return grant.connectorRef === connectorType;
+        return grant.connectorRef === connectorRef;
       })
       .map((grant) => {
         return grant.permission;
@@ -216,15 +215,15 @@ function addDefaultAllowExpirationChanges({
 }
 
 function changedUserGrantPolicies({
-  connectorType,
+  connectorRef,
   metadata,
   initialPolicies,
   initialGrants,
   policies,
   expiresInByPermission,
 }: {
-  connectorType: ConnectorType;
-  metadata: FirewallPermissionDetailMetadata;
+  connectorRef: string;
+  metadata: PublicConnectorCatalogPermissionDetail;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
@@ -232,8 +231,8 @@ function changedUserGrantPolicies({
 }): ChangedUserGrantPolicy[] {
   const initial = resolveFirewallMetadataPolicies(initialPolicies, [
     metadata,
-  ])?.[connectorType];
-  const current = policies[connectorType];
+  ])?.[connectorRef];
+  const current = policies[connectorRef];
   const changes = new Map<string, ChangedUserGrantPolicy>();
 
   addNamedPolicyChanges({
@@ -251,14 +250,14 @@ function changedUserGrantPolicies({
 
   addExpirationOnlyChanges({
     changes,
-    connectorType,
+    connectorRef,
     initialGrants,
     current,
     expiresInByPermission,
   });
   addDefaultAllowExpirationChanges({
     changes,
-    connectorType,
+    connectorRef,
     initialGrants,
     current,
     expiresInByPermission,
@@ -268,10 +267,10 @@ function changedUserGrantPolicies({
 }
 
 function defaultFirewallPoliciesForConnector(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: PublicConnectorCatalogPermissionDetail,
 ): FirewallPolicies {
   return {
-    [metadata.type]: expandFirewallMetadataDefaultPolicy(metadata),
+    [metadata.connectorRef]: expandFirewallMetadataDefaultPolicy(metadata),
   };
 }
 
@@ -288,7 +287,7 @@ function applyGrantFromChangedPolicy(
 }
 
 function buildAppliedUserGrantPolicies({
-  connectorType,
+  connectorRef,
   metadata,
   initialPolicies,
   initialGrants,
@@ -296,8 +295,8 @@ function buildAppliedUserGrantPolicies({
   expiresInByPermission,
   resetPending,
 }: {
-  connectorType: ConnectorType;
-  metadata: FirewallPermissionDetailMetadata;
+  connectorRef: string;
+  metadata: PublicConnectorCatalogPermissionDetail;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
@@ -309,7 +308,7 @@ function buildAppliedUserGrantPolicies({
     : initialPolicies;
   const baseGrants = resetPending ? [] : initialGrants;
   return changedUserGrantPolicies({
-    connectorType,
+    connectorRef,
     metadata,
     initialPolicies: basePolicies,
     initialGrants: baseGrants,
@@ -320,7 +319,7 @@ function buildAppliedUserGrantPolicies({
 
 async function saveUserGrantPolicies({
   scope,
-  connectorType,
+  connectorRef,
   metadata,
   initialPolicies,
   initialGrants,
@@ -331,8 +330,8 @@ async function saveUserGrantPolicies({
   applyGrantPolicies,
 }: {
   scope: { agentId: string };
-  connectorType: ConnectorType;
-  metadata: FirewallPermissionDetailMetadata;
+  connectorRef: string;
+  metadata: PublicConnectorCatalogPermissionDetail;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   policies: FirewallPolicies;
@@ -344,10 +343,10 @@ async function saveUserGrantPolicies({
   await applyGrantPolicies(
     {
       ...scope,
-      connectorRef: connectorType,
+      connectorRef,
       mode: resetPending ? "replace" : "patch",
       grants: buildAppliedUserGrantPolicies({
-        connectorType,
+        connectorRef,
         metadata,
         initialPolicies,
         initialGrants,
@@ -362,7 +361,7 @@ async function saveUserGrantPolicies({
 
 export async function savePermissionDraftPolicies({
   scope,
-  connectorType,
+  connectorRef,
   metadata,
   initialPolicies,
   initialGrants,
@@ -371,8 +370,8 @@ export async function savePermissionDraftPolicies({
   applyGrantPolicies,
 }: {
   scope: { agentId: string };
-  connectorType: ConnectorType;
-  metadata: FirewallPermissionDetailMetadata;
+  connectorRef: string;
+  metadata: PublicConnectorCatalogPermissionDetail;
   initialPolicies: FirewallPolicies;
   initialGrants: readonly UserPermissionGrantResponse[];
   intent: PermissionDraftIntent;
@@ -387,7 +386,7 @@ export async function savePermissionDraftPolicies({
     });
   await saveUserGrantPolicies({
     scope,
-    connectorType,
+    connectorRef,
     metadata,
     initialPolicies,
     initialGrants,

--- a/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permissions-dialog.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import type { FirewallPermissionDetailMetadata } from "@vm0/connectors/firewall-metadata";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 
 import {
   createEmptyPermissionDraftIntent,
@@ -21,7 +21,7 @@ interface InitialPermissionDrawerUiState {
 }
 
 interface PermissionDrawerApplyOptions {
-  readonly metadata: FirewallPermissionDetailMetadata;
+  readonly metadata: PublicConnectorCatalogPermissionDetail;
 }
 
 type PermissionDrawerApply = (
@@ -31,7 +31,7 @@ type PermissionDrawerApply = (
 
 interface ApplyPermissionDrawerParams {
   readonly intent: PermissionDraftIntent;
-  readonly metadata: FirewallPermissionDetailMetadata;
+  readonly metadata: PublicConnectorCatalogPermissionDetail;
   readonly onApply: PermissionDrawerApply;
   readonly onClose: () => void;
 }

--- a/turbo/apps/platform/src/signals/zero-page/settings/permissions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permissions.ts
@@ -1,11 +1,4 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
-import { hasFirewallMetadataPermissions } from "@vm0/connectors/firewall-metadata";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
-
-/** Check if a connector has any permissions defined. */
-export function hasConnectorPermissions(type: ConnectorType): boolean {
-  return hasFirewallMetadataPermissions(type);
-}
 
 // ---------------------------------------------------------------------------
 // Permission policy: allow | deny | ask

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -2,6 +2,10 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents";
 import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogPermissionDetail,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
   zeroUserPermissionGrantsContract,
   type UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
@@ -14,6 +18,28 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 const user = userEvent.setup();
+
+function catalogPermissionDetail(
+  overrides: Partial<PublicConnectorCatalogPermissionDetail> &
+    Pick<
+      PublicConnectorCatalogPermissionDetail,
+      "connectorRef" | "label" | "permissions"
+    >,
+): PublicConnectorCatalogPermissionDetail {
+  const { connectorRef, label, permissions, ...rest } = overrides;
+  return {
+    connectorRef,
+    label,
+    permissionCount: permissions.length,
+    permissions,
+    categories: null,
+    defaultPolicy: {
+      permissionDefault: "ask",
+      unknownPolicy: "ask",
+    },
+    ...rest,
+  };
+}
 
 describe("permission allow page", () => {
   it("rejects unsupported permission actions instead of defaulting to allow", async () => {
@@ -38,7 +64,9 @@ describe("permission allow page", () => {
   });
 
   it("lets a user grant an expiring connector permission to an agent", async () => {
+    mockNow();
     const agentId = "c0000000-0000-4000-a000-000000000001";
+    let capturedBody: unknown = null;
 
     context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
       return respond(200, {
@@ -53,10 +81,49 @@ describe("permission allow page", () => {
         preferPersonalProvider: false,
       });
     });
+    context.mocks.api(
+      zeroConnectorCatalogContract.permissions,
+      ({ params, respond }) => {
+        expect(params.connectorRef).toBe("slack");
+        return respond(200, {
+          permissions: catalogPermissionDetail({
+            connectorRef: "slack",
+            label: "Catalog Slack",
+            permissions: [
+              {
+                name: "catalog.analytics:read",
+                description: "Catalog analytics access",
+              },
+            ],
+          }),
+        });
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.apply,
+      ({ body, respond }) => {
+        capturedBody = body;
+        const appliedGrant = body.grants[0];
+        if (!appliedGrant) {
+          throw new Error("Expected a permission grant");
+        }
+        return respond(200, [
+          {
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: appliedGrant.permission,
+            action: appliedGrant.action,
+            expiresAt: isoFromNowMs(24 * 60 * 60 * 1000),
+            createdAt: "2026-03-10T00:00:00.000Z",
+            updatedAt: "2026-03-10T00:01:00.000Z",
+          },
+        ]);
+      },
+    );
 
     detachedSetupPage({
       context,
-      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=catalog.analytics%3Aread&action=allow&expiresIn=24h`,
       user: {
         id: "test-user-123",
         fullName: "Dana Analyst",
@@ -72,11 +139,9 @@ describe("permission allow page", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText("Research Bot")).toBeInTheDocument();
-    expect(screen.getByText("Slack")).toBeInTheDocument();
-    expect(
-      screen.getByText("Access workspace analytics data"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("admin.analytics:read")).toBeInTheDocument();
+    expect(screen.getByText("Catalog Slack")).toBeInTheDocument();
+    expect(screen.getByText("Catalog analytics access")).toBeInTheDocument();
+    expect(screen.getByText("catalog.analytics:read")).toBeInTheDocument();
     expect(screen.getByText("Duration")).toBeInTheDocument();
     expect(screen.getByText("24 hours")).toBeInTheDocument();
 
@@ -89,6 +154,61 @@ describe("permission allow page", () => {
       screen.getByText("Your connector permission grant has been updated"),
     ).toBeInTheDocument();
     expect(screen.getByText(/Expires in (1 day|24 hours)/)).toBeInTheDocument();
+    expect(capturedBody).toMatchObject({
+      agentId,
+      connectorRef: "slack",
+      mode: "patch",
+      grants: [
+        {
+          permission: "catalog.analytics:read",
+          action: "allow",
+          expiresIn: "24h",
+        },
+      ],
+    });
+  });
+
+  it("fails closed when catalog permissions returns not found", async () => {
+    const agentId = "c0000000-0000-4000-a000-000000000009";
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Hidden Connector Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(
+      zeroConnectorCatalogContract.permissions,
+      ({ respond }) => {
+        return respond(404, {
+          error: { message: "Connector not found", code: "NOT_FOUND" },
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/permissions?ref=hidden-connector&permission=hidden.permission&action=allow`,
+      user: {
+        id: "test-user-123",
+        fullName: "Dana Analyst",
+        firstName: "Dana",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Unknown connector: hidden-connector"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
   });
 
   it("lets a user deny a connector permission without an expiry choice", async () => {

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -12,11 +12,7 @@ import type {
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
-import {
-  isFirewallMetadataConnectorType,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
@@ -43,7 +39,10 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
-import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
+import {
+  ConnectorIcon,
+  isConnectorIconType,
+} from "../zero-page/components/settings/connector-icons.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 
 function TargetPill({
@@ -97,24 +96,20 @@ function resolvePermissionGrantTarget({
 
 function ConnectorPermissionCard({
   connectorRef,
+  connectorLabel,
   permission,
   action,
 }: {
   connectorRef: string;
+  connectorLabel: string;
   permission: Permission;
   action: "allow" | "deny";
 }) {
-  const connectorConfig = isFirewallMetadataConnectorType(connectorRef)
-    ? CONNECTOR_TYPES[connectorRef]
-    : undefined;
-  const connectorLabel = connectorConfig?.label ?? connectorRef;
-  const connectorHelpText = connectorConfig?.helpText ?? "";
-
   return (
     <div className="w-full rounded-lg border border-border px-4 py-3">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2 border-b border-border/70 pb-4 pt-1">
-          {isFirewallMetadataConnectorType(connectorRef) && (
+          {isConnectorIconType(connectorRef) && (
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-muted/40">
               <ConnectorIcon type={connectorRef} size={20} />
             </span>
@@ -123,11 +118,6 @@ function ConnectorPermissionCard({
             <p className="text-sm font-medium text-foreground">
               {connectorLabel}
             </p>
-            {connectorHelpText && (
-              <p className="text-xs text-muted-foreground line-clamp-1">
-                {connectorHelpText}
-              </p>
-            )}
           </div>
         </div>
         <div className="flex items-center gap-2 py-2">
@@ -292,7 +282,7 @@ function resolveExistingPermissionGrantResult({
   connectorRef: string;
   focusedPermission: Permission;
   grants: readonly UserPermissionGrantResponse[];
-  metadata: FirewallPermissionDetailMetadata;
+  metadata: PublicConnectorCatalogPermissionDetail;
 }): { expiresAt?: string | null } | null {
   const effectivePolicy = resolveUserPermissionGrantPolicy(
     grants,
@@ -316,6 +306,7 @@ function resolveExistingPermissionGrantResult({
 function ConfirmGrantCard({
   target,
   connectorRef,
+  connectorLabel,
   permission,
   action,
   initialExpiresIn,
@@ -325,6 +316,7 @@ function ConfirmGrantCard({
 }: {
   target: PermissionGrantTarget;
   connectorRef: string;
+  connectorLabel: string;
   permission: Permission;
   action: "allow" | "deny";
   initialExpiresIn: UserPermissionGrantExpiresIn | null;
@@ -388,6 +380,7 @@ function ConfirmGrantCard({
             <p className="text-sm font-medium text-foreground">Would like to</p>
             <ConnectorPermissionCard
               connectorRef={connectorRef}
+              connectorLabel={connectorLabel}
               permission={permission}
               action={action}
             />
@@ -447,7 +440,7 @@ function PermissionAllowDoctorPage({
   const userLoadable = useLastLoadable(user$);
   const grantsLoadable = useLastLoadable(permissionAllowUserPermissionGrants$);
   const metadataLoadable = useLoadable(
-    firewallPermissionMetadataByConnector({ connectorType: ref }),
+    firewallPermissionMetadataByConnector({ connectorRef: ref }),
   );
   const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
 
@@ -526,6 +519,7 @@ function PermissionAllowDoctorPage({
     <ConfirmGrantCard
       target={targetResult.target}
       connectorRef={ref}
+      connectorLabel={metadata.label}
       permission={focusedPermission}
       action={action}
       initialExpiresIn={initialExpiresIn}
@@ -550,10 +544,6 @@ export function PermissionAllowPage() {
 
   if (!ref || !permission) {
     return <ErrorMessage message="Missing permission in URL parameters" />;
-  }
-
-  if (!isFirewallMetadataConnectorType(ref)) {
-    return <ErrorMessage message={`Unknown connector: ${ref}`} />;
   }
 
   if (actionParam !== null && action === null) {

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -3,6 +3,11 @@ import type { ConnectorType } from "@vm0/connectors/connectors";
 import { loadFirewallPermissionMetadata } from "@vm0/connectors/firewall-metadata";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogPermissionSummary,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
   chatThreadByIdContract,
   chatThreadMessagesContract,
   chatThreadsContract,
@@ -111,6 +116,43 @@ function createConnector(
     tokenExpiresAt: null,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function axiomCatalogStatusItem(
+  permissionSummary: PublicConnectorCatalogPermissionSummary,
+): PublicConnectorCatalogStatusItem {
+  return {
+    connectorRef: "axiom",
+    label: "Axiom",
+    description: "Observability and log analytics",
+    category: "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: [
+      {
+        id: "api-token",
+        label: "API Token",
+        description: null,
+        grantKind: "manual",
+        manualFields: [],
+        startOptions: [],
+      },
+    ],
+    permissionSummary,
+    connection: {
+      authMethod: "api-token",
+      externalUsername: "workspace",
+      externalEmail: null,
+      reconnectReason: null,
+    },
+    connected: true,
+    connectionStatus: "connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: null,
+    connectNotice: null,
   };
 }
 
@@ -955,6 +997,34 @@ describe("team page navigation", () => {
       within(reopenedPermissionRow).queryByText("24h"),
     ).not.toBeInTheDocument();
     expect(buttonByText("Apply", reopenedPermissionsDialog)).toBeDisabled();
+  });
+
+  it("hides connector permission management when catalog status has no permissions", async () => {
+    mockTeamAPIs();
+    context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+      return respond(200, {
+        connectors: [
+          axiomCatalogStatusItem({
+            hasPermissions: false,
+            permissionCount: 0,
+            hasCategories: false,
+            hasDefaultPolicyOverrides: false,
+          }),
+        ],
+      });
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("@workspace")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByLabelText("Manage Axiom permissions"),
+    ).not.toBeInTheDocument();
   });
 
   it("applies and restores connector permission policies from an agent page", async () => {

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -93,7 +93,6 @@ import type { PermissionDraftIntent } from "../../signals/zero-page/settings/per
 import { savePermissionDraftPolicies } from "../../signals/zero-page/settings/permission-grant-save.ts";
 import { noConnectorImg } from "../zero-page/platform-assets.ts";
 import { JobCustomConnectorsSection } from "./job-custom-connectors-section.tsx";
-import { hasConnectorPermissions } from "../../signals/zero-page/settings/permissions.ts";
 import {
   applyUserPermissionGrants$,
   userPermissionGrantsByAgent,
@@ -115,10 +114,8 @@ import {
   setPermSavingType$,
 } from "../../signals/zero-page/zero-job-detail-page.ts";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
-import {
-  permissionGrantsToFirewallPolicies,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import { agentVisibleWorkflows$ } from "../../signals/workflows-page/workflows-signals.ts";
 import { WorkflowListPanel } from "../workflows-page/workflows-page.tsx";
@@ -604,7 +601,7 @@ export function ConnectedConnectorPermissions({
                 })}
                 loading={savingType === c.type}
                 showManage={
-                  canManagePermissions && hasConnectorPermissions(c.type)
+                  canManagePermissions && c.permissionSummary.hasPermissions
                 }
                 onManage={() => {
                   return onManage(c.type);
@@ -656,7 +653,7 @@ export function AgentPermissionsDrawer({
   onApply: (
     intent: PermissionDraftIntent,
     options: {
-      readonly metadata: FirewallPermissionDetailMetadata;
+      readonly metadata: PublicConnectorCatalogPermissionDetail;
     },
   ) => Promise<void>;
   onClose: () => void;
@@ -811,7 +808,7 @@ function JobPermissionsTab({
               }
               await savePermissionDraftPolicies({
                 scope: { agentId },
-                connectorType,
+                connectorRef: connectorType,
                 metadata,
                 initialPolicies: drawerInitialPolicies,
                 initialGrants: userGrants,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -1,4 +1,8 @@
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogPermissionDetail,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import {
   zeroUserPermissionGrantsContract,
@@ -21,6 +25,28 @@ const context = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "thread-action-cards";
+
+function catalogPermissionDetail(
+  overrides: Partial<PublicConnectorCatalogPermissionDetail> &
+    Pick<
+      PublicConnectorCatalogPermissionDetail,
+      "connectorRef" | "label" | "permissions"
+    >,
+): PublicConnectorCatalogPermissionDetail {
+  const { connectorRef, label, permissions, ...rest } = overrides;
+  return {
+    connectorRef,
+    label,
+    permissionCount: permissions.length,
+    permissions,
+    categories: null,
+    defaultPolicy: {
+      permissionDefault: "ask",
+      unknownPolicy: "ask",
+    },
+    ...rest,
+  };
+}
 
 function applyUserConnectorUpdate(
   current: readonly string[],
@@ -124,7 +150,8 @@ describe("chat message action cards", () => {
   it("lets users authorize connectors and confirm permissions from assistant messages", async () => {
     const user = userEvent.setup({ delay: null });
     const connectorAuthorizeUrl = `https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID}`;
-    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`;
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=catalog.analytics%3Aread&action=allow&expiresIn=24h`;
+    let capturedPermissionGrantBody: unknown = null;
 
     context.mocks.data.connectors([
       connectedConnector({
@@ -134,6 +161,45 @@ describe("chat message action cards", () => {
       }),
     ]);
     mockAgentConnectorAuthorizations([]);
+    context.mocks.api(
+      zeroConnectorCatalogContract.permissions,
+      ({ params, respond }) => {
+        expect(params.connectorRef).toBe("slack");
+        return respond(200, {
+          permissions: catalogPermissionDetail({
+            connectorRef: "slack",
+            label: "Catalog Slack",
+            permissions: [
+              {
+                name: "catalog.analytics:read",
+                description: "Catalog analytics access",
+              },
+            ],
+          }),
+        });
+      },
+    );
+    context.mocks.api(
+      zeroUserPermissionGrantsContract.apply,
+      ({ body, respond }) => {
+        capturedPermissionGrantBody = body;
+        const grant = body.grants[0];
+        if (!grant) {
+          throw new Error("Expected a permission grant");
+        }
+        return respond(200, [
+          {
+            agentId: body.agentId,
+            connectorRef: body.connectorRef,
+            permission: grant.permission,
+            action: grant.action,
+            expiresAt: isoFromNowMs(24 * 60 * 60 * 1000),
+            createdAt: "2026-06-09T11:00:00Z",
+            updatedAt: "2026-06-09T11:01:00Z",
+          },
+        ]);
+      },
+    );
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
       threadTitle: "Action cards",
@@ -169,12 +235,14 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
-    expect(
-      within(permissionCard).getByText("Slack permissions"),
-    ).toBeInTheDocument();
-    expect(
-      within(permissionCard).getByText("Allow admin.analytics:read"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Catalog Slack permissions"),
+      ).toBeInTheDocument();
+      expect(
+        within(permissionCard).getByText("Allow catalog.analytics:read"),
+      ).toBeInTheDocument();
+    });
     expect(within(permissionCard).getByText("24 hours")).toBeInTheDocument();
 
     await confirmPermissionAction(user, permissionCard);
@@ -183,7 +251,67 @@ describe("chat message action cards", () => {
       expect(
         within(permissionCard).getByText("Permissions updated"),
       ).toBeInTheDocument();
+      expect(capturedPermissionGrantBody).toMatchObject({
+        agentId: AGENT_ID,
+        connectorRef: "slack",
+        mode: "patch",
+        grants: [
+          {
+            permission: "catalog.analytics:read",
+            action: "allow",
+            expiresIn: "24h",
+          },
+        ],
+      });
     });
+  });
+
+  it("fails closed when permission action metadata is hidden", async () => {
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=hidden-connector&permission=hidden.permission&action=allow&expiresIn=1h`;
+    context.mocks.api(
+      zeroConnectorCatalogContract.permissions,
+      ({ respond }) => {
+        return respond(404, {
+          error: { message: "Connector not found", code: "NOT_FOUND" },
+        });
+      },
+    );
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-hidden-permission-metadata`,
+      threadTitle: "Hidden permission metadata",
+      chatMessages: [
+        {
+          id: "msg-user-hidden-permission",
+          role: "user",
+          content: "Allow a hidden connector permission",
+          runId: "run-hidden-permission",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-assistant-hidden-permission-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-hidden-permission",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-hidden-permission-metadata`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("hidden-connector permissions"),
+      ).toBeInTheDocument();
+      expect(
+        within(permissionCard).getByText("Unknown permission"),
+      ).toBeInTheDocument();
+    });
+    expect(queryButtonByText("Confirm", permissionCard)).toBeNull();
   });
 
   it("shows already allowed permission action cards as read-only after refresh", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -19,11 +19,8 @@ import {
   cn,
 } from "@vm0/ui";
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import {
-  hasFirewallMetadataPermissions,
-  permissionGrantsToFirewallPolicies,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { firewallPermissionMetadataByConnector } from "../../../../signals/firewall-permission-metadata.ts";
@@ -114,7 +111,6 @@ function ConnectorAccessSearch({
 
 function AgentAccessRow({
   row,
-  connectorType,
   connectorLabel,
   metadata,
   saving,
@@ -122,9 +118,8 @@ function AgentAccessRow({
   onManage,
 }: {
   readonly row: ConnectorAgentAccessRow;
-  readonly connectorType: ConnectorType;
   readonly connectorLabel: string;
-  readonly metadata: FirewallPermissionDetailMetadata | null;
+  readonly metadata: PublicConnectorCatalogPermissionDetail | null;
   readonly saving: boolean;
   readonly onToggle: (
     row: ConnectorAgentAccessRow,
@@ -133,10 +128,7 @@ function AgentAccessRow({
   readonly onManage: (row: ConnectorAgentAccessRow) => void;
 }) {
   const name = agentName(row.agent);
-  const canManage =
-    row.authorized &&
-    metadata !== null &&
-    hasFirewallMetadataPermissions(connectorType);
+  const canManage = row.authorized && (metadata?.permissionCount ?? 0) > 0;
 
   return (
     <div className="flex items-center gap-2 px-1 py-4">
@@ -181,7 +173,6 @@ function AgentAccessRow({
 
 function AgentAccessList({
   rows,
-  connectorType,
   connectorLabel,
   metadata,
   savingAgentId,
@@ -190,9 +181,8 @@ function AgentAccessList({
   onManage,
 }: {
   readonly rows: readonly ConnectorAgentAccessRow[];
-  readonly connectorType: ConnectorType;
   readonly connectorLabel: string;
-  readonly metadata: FirewallPermissionDetailMetadata | null;
+  readonly metadata: PublicConnectorCatalogPermissionDetail | null;
   readonly savingAgentId: string | null;
   readonly search: string;
   readonly onToggle: (
@@ -218,7 +208,6 @@ function AgentAccessList({
           <AgentAccessRow
             key={row.agent.id}
             row={row}
-            connectorType={connectorType}
             connectorLabel={connectorLabel}
             metadata={metadata}
             saving={savingAgentId === row.agent.id}
@@ -258,7 +247,7 @@ function ConnectorAccessDialog({
   readonly connectorLabel: string;
   readonly rows: readonly ConnectorAgentAccessRow[];
   readonly rowsLoaded: boolean;
-  readonly metadata: FirewallPermissionDetailMetadata | null;
+  readonly metadata: PublicConnectorCatalogPermissionDetail | null;
   readonly savingAgentId: string | null;
   readonly search: string;
   readonly onSearchChange: (value: string) => void;
@@ -306,7 +295,6 @@ function ConnectorAccessDialog({
           {rowsLoaded ? (
             <AgentAccessList
               rows={rows}
-              connectorType={connectorType}
               connectorLabel={connectorLabel}
               metadata={metadata}
               savingAgentId={savingAgentId}
@@ -333,7 +321,7 @@ function AgentPermissionDialog({
   onClose,
 }: {
   readonly row: ConnectorAgentAccessRow | undefined;
-  readonly metadata: FirewallPermissionDetailMetadata | null;
+  readonly metadata: PublicConnectorCatalogPermissionDetail | null;
   readonly connectorType: ConnectorType;
   readonly connectorLabel: string;
   readonly pageSignal: AbortSignal;
@@ -358,7 +346,7 @@ function AgentPermissionDialog({
       onApply={async (intent, { metadata: appliedMetadata }) => {
         await savePermissionDraftPolicies({
           scope: { agentId: row.agent.id },
-          connectorType,
+          connectorRef: connectorType,
           metadata: appliedMetadata,
           initialPolicies,
           initialGrants: row.grants,
@@ -382,7 +370,7 @@ export function ConnectorAccessManagementDialog({
     connectorAgentAccessRows({ connectorType }),
   );
   const metadataLoadable = useLastLoadable(
-    firewallPermissionMetadataByConnector({ connectorType }),
+    firewallPermissionMetadataByConnector({ connectorRef: connectorType }),
   );
   const pageSignal = useGet(pageSignal$);
   const search = useGet(connectorAccessManagementSearch$);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -295,6 +295,10 @@ function connectorIconSkipsDarkInvert(type: ConnectorType): boolean {
   return type in CONNECTOR_ICON_COLORFUL;
 }
 
+export function isConnectorIconType(type: string): type is ConnectorType {
+  return Object.prototype.hasOwnProperty.call(CONNECTOR_ICONS, type);
+}
+
 /**
  * Connector mark in a square slot. The asset scales with `object-contain` so the
  * drawable uses the full `size×size` box (e.g. a 20×28 logo fills height in a 28×28 slot).

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -23,10 +23,8 @@ import {
   DropdownMenuItem,
 } from "@vm0/ui";
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import {
-  groupFirewallMetadataPermissionsByCategory,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { groupFirewallMetadataPermissionsByCategory } from "@vm0/connectors/firewall-metadata/policy";
 import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicies,
@@ -121,7 +119,7 @@ interface PermissionsDrawerProps {
 }
 
 interface PermissionDrawerApplyOptions {
-  readonly metadata: FirewallPermissionDetailMetadata;
+  readonly metadata: PublicConnectorCatalogPermissionDetail;
 }
 
 type PermissionsSurface = "sheet" | "dialog";
@@ -157,7 +155,7 @@ type LoadedPermissionsDrawerContentProps = Pick<
   | "onClose"
 > & {
   readonly surface: PermissionsSurface;
-  readonly metadata: FirewallPermissionDetailMetadata;
+  readonly metadata: PublicConnectorCatalogPermissionDetail;
   readonly initialState: InitialPermissionDrawerState;
 };
 
@@ -171,7 +169,7 @@ function buildInitialPermissionDrawerState({
   PermissionsDrawerProps,
   "agentId" | "connectorType" | "initialPolicies" | "initialGrants"
 > & {
-  readonly metadata: FirewallPermissionDetailMetadata;
+  readonly metadata: PublicConnectorCatalogPermissionDetail;
 }): InitialPermissionDrawerState {
   const explicitGrants = buildExplicitGrantMap(connectorType, initialGrants);
   const grantStateKey = explicitGrantStateKey(explicitGrants);
@@ -332,7 +330,7 @@ function PolicyPill({
 }
 
 function buildSortedGroups(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: PublicConnectorCatalogPermissionDetail,
 ): { category: string; permissions: ConnectorPermission[] }[] | null {
   return (
     groupFirewallMetadataPermissionsByCategory(
@@ -345,7 +343,7 @@ function buildSortedGroups(
 }
 
 function sortedPermissionsForMetadata(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: PublicConnectorCatalogPermissionDetail,
 ): ConnectorPermission[] {
   return sortPermissions(metadata.permissions);
 }
@@ -410,7 +408,7 @@ function canApplyPermissionPolicies({
   saving,
   hasChanges,
 }: {
-  metadata: FirewallPermissionDetailMetadata;
+  metadata: PublicConnectorCatalogPermissionDetail;
   saving: boolean;
   hasChanges: boolean;
 }): boolean {
@@ -1523,7 +1521,7 @@ function PermissionsContent({
 }) {
   const metadataLoadable = useLoadable(
     firewallPermissionMetadataByConnector({
-      connectorType: props.connectorType,
+      connectorRef: props.connectorType,
     }),
   );
   const loadedMetadata =

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -107,6 +107,7 @@ import type {
   UserPermissionGrantExpiresIn,
   UserPermissionGrantResponse,
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { emptyArtifactImg, emptyChatImg } from "./platform-assets.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
@@ -156,7 +157,10 @@ import type { PermissionActionBlock } from "../../signals/chat-page/permission-a
 import type { ComputerUseAuthorizationBlock } from "../../signals/chat-page/computer-use-authorization-block.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
-import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import {
+  ConnectorIcon,
+  isConnectorIconType,
+} from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
@@ -318,7 +322,6 @@ import {
   resolveUserPermissionGrantPolicy,
   userPermissionGrantsByAgent,
 } from "../../signals/permission-allow/permission-allow-signals.ts";
-import type { FirewallPermissionDetailMetadata } from "@vm0/connectors/firewall-metadata";
 import { firewallPermissionMetadataByConnector } from "../../signals/firewall-permission-metadata.ts";
 import {
   billingStatusAsync$,
@@ -5990,7 +5993,7 @@ function isPermissionActionAlreadyApplied(params: {
 
 function findPermissionActionPermission(
   block: PermissionActionBlock,
-  metadata: FirewallPermissionDetailMetadata | undefined,
+  metadata: PublicConnectorCatalogPermissionDetail | undefined,
 ) {
   return metadata
     ? (findPermissionInMetadata(metadata, block.permission) ?? undefined)
@@ -6000,7 +6003,7 @@ function findPermissionActionPermission(
 function permissionActionUserGrantPolicy(
   loadable: LoadableLike<readonly PermissionActionUserGrant[]>,
   block: PermissionActionBlock,
-  metadata: FirewallPermissionDetailMetadata | undefined,
+  metadata: PublicConnectorCatalogPermissionDetail | undefined,
 ): FirewallPolicyValue | undefined {
   const grants = loadableData(loadable);
   if (!grants || !metadata) {
@@ -6067,7 +6070,7 @@ function createPermissionActionCardViewState(params: {
   block: PermissionActionBlock;
   hasAgent: boolean;
   agentLoadableState: string;
-  permissionMetadataLoadable: LoadableLike<FirewallPermissionDetailMetadata | null>;
+  permissionMetadataLoadable: LoadableLike<PublicConnectorCatalogPermissionDetail | null>;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
   grantLoadableState: string;
 }) {
@@ -6193,6 +6196,11 @@ function PermissionActionCardContent({
   expiresAt: string | null;
   onClick: () => void;
 }) {
+  const connectorIcon = isConnectorIconType(block.connectorRef) ? (
+    <ConnectorIcon type={block.connectorRef} size={22} />
+  ) : (
+    <IconPackage size={22} />
+  );
   const expiryText = expirationAvailable
     ? permissionGrantExpiryText(expiresAt)
     : null;
@@ -6208,7 +6216,7 @@ function PermissionActionCardContent({
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          <ConnectorIcon type={block.connectorRef} size={22} />
+          {connectorIcon}
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
@@ -6253,7 +6261,6 @@ function PermissionActionCardForTarget({
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const config = CONNECTOR_TYPES[block.connectorRef];
   const expirationAvailable = block.action === "allow";
   const durationScope = `${block.id}\u0000${block.expiresIn ?? ""}`;
   const expiresInByScope = useGet(permissionGrantExpiresInByScope$);
@@ -6264,7 +6271,7 @@ function PermissionActionCardForTarget({
     DEFAULT_USER_PERMISSION_GRANT_EXPIRES_IN;
   const permissionMetadataLoadable = useLoadable(
     firewallPermissionMetadataByConnector({
-      connectorType: block.connectorRef,
+      connectorRef: block.connectorRef,
     }),
   );
   const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
@@ -6277,6 +6284,10 @@ function PermissionActionCardForTarget({
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
   });
+  const permissionMetadata =
+    permissionMetadataLoadable.state === "hasData"
+      ? permissionMetadataLoadable.data
+      : null;
   const grantExpiresAt =
     grantLoadable.state === "hasData"
       ? grantLoadable.data.expiresAt
@@ -6285,7 +6296,7 @@ function PermissionActionCardForTarget({
   return (
     <PermissionActionCardContent
       block={block}
-      connectorLabel={config.label}
+      connectorLabel={permissionMetadata?.label ?? block.connectorRef}
       actionLabel={actionState.actionLabel}
       permissionName={actionState.focusedPermission?.name ?? block.permission}
       status={actionState.status}

--- a/turbo/packages/api-contracts/src/contracts/connector-ref.ts
+++ b/turbo/packages/api-contracts/src/contracts/connector-ref.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const CONNECTOR_REF_MAX_LENGTH = 64;
+
+export const connectorRefSchema = z
+  .string()
+  .min(1)
+  .max(CONNECTOR_REF_MAX_LENGTH);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1181,6 +1181,7 @@ export {
   type PublicConnectorCatalogStatusResponse,
   type ZeroConnectorCatalogContract,
 } from "./zero-connector-catalog";
+export { CONNECTOR_REF_MAX_LENGTH, connectorRefSchema } from "./connector-ref";
 export {
   codexDeviceAuthScopeSchema,
   zeroCodexDeviceAuthContract,

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { authHeadersSchema, initContract } from "./base";
 import { connectorReconnectReasonSchema } from "./connector-schemas";
+import { connectorRefSchema } from "./connector-ref";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
@@ -27,7 +28,7 @@ const publicConnectorCatalogPermissionSummarySchema = z.object({
 });
 
 const publicConnectorCatalogItemSchema = z.object({
-  connectorRef: z.string(),
+  connectorRef: connectorRefSchema,
   label: z.string(),
   description: z.string(),
   category: z.string(),
@@ -127,7 +128,7 @@ const publicConnectorCatalogDefaultPolicySchema = z.object({
 });
 
 const publicConnectorCatalogPermissionDetailSchema = z.object({
-  connectorRef: z.string(),
+  connectorRef: connectorRefSchema,
   label: z.string(),
   permissionCount: z.number().int().nonnegative(),
   permissions: z.array(publicConnectorCatalogPermissionSchema),
@@ -140,7 +141,7 @@ const publicConnectorCatalogPermissionDetailResponseSchema = z.object({
 });
 
 const connectorCatalogPathParamsSchema = z.object({
-  connectorRef: z.string().min(1),
+  connectorRef: connectorRefSchema,
 });
 
 export type PublicConnectorCatalogAuthMethodSummary = z.infer<
@@ -219,6 +220,7 @@ export const zeroConnectorCatalogContract = c.router({
     pathParams: connectorCatalogPathParamsSchema,
     responses: {
       200: publicConnectorCatalogDetailResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
@@ -232,6 +234,7 @@ export const zeroConnectorCatalogContract = c.router({
     pathParams: connectorCatalogPathParamsSchema,
     responses: {
       200: publicConnectorCatalogPermissionDetailResponseSchema,
+      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,

--- a/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-user-permission-grants.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
+import { connectorRefSchema } from "./connector-ref";
 import { apiErrorSchema } from "./errors";
 
 const c = initContract();
 
 const agentIdSchema = z.string().uuid();
-const connectorRefSchema = z.string().min(1).max(64);
 const permissionSchema = z.string().min(1).max(128);
 
 export const userPermissionGrantActionSchema = z.enum(["allow", "deny"]);

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -44,6 +44,10 @@
       "import": "./src/firewall-metadata/index.ts",
       "types": "./src/firewall-metadata/index.ts"
     },
+    "./firewall-metadata/policy": {
+      "import": "./src/firewall-metadata/policy.ts",
+      "types": "./src/firewall-metadata/policy.ts"
+    },
     "./firewall-metadata/server": {
       "import": "./src/firewall-metadata/server.ts",
       "types": "./src/firewall-metadata/server.ts"

--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -383,15 +383,31 @@ describe("firewall metadata", () => {
     const source = fs.readFileSync(entrypoint, "utf-8");
 
     expect(staticImportSpecifiers(source).sort(compareStrings)).toStrictEqual([
-      "../firewall-types",
       "./permission-detail-loader.generated",
       "./permission-summaries.generated",
-      "./policy-resolver",
       "./types",
     ]);
     expect(exportFromSpecifiers(source).sort(compareStrings)).toStrictEqual([
-      "./policy-resolver",
+      "./policy",
+      "./policy",
       "./types",
+    ]);
+    expect(dynamicImportSpecifiers(source)).toStrictEqual([]);
+  });
+
+  it("keeps the policy helper entrypoint generated-data-free", () => {
+    const entrypoint = path.resolve(
+      import.meta.dirname,
+      "../firewall-metadata/policy.ts",
+    );
+    const source = fs.readFileSync(entrypoint, "utf-8");
+
+    expect(staticImportSpecifiers(source).sort(compareStrings)).toStrictEqual([
+      "../firewall-types",
+      "./policy-resolver",
+    ]);
+    expect(exportFromSpecifiers(source).sort(compareStrings)).toStrictEqual([
+      "./policy-resolver",
     ]);
     expect(dynamicImportSpecifiers(source)).toStrictEqual([]);
   });

--- a/turbo/packages/connectors/src/firewall-metadata/index.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/index.ts
@@ -1,11 +1,4 @@
-import {
-  UNKNOWN_PERMISSION_GRANT,
-  type FirewallPolicies,
-  type FirewallPolicy,
-  type FirewallPolicyValue,
-} from "../firewall-types";
 import { loadGeneratedFirewallPermissionMetadata } from "./permission-detail-loader.generated";
-import { createFirewallMetadataPolicyResolver } from "./policy-resolver";
 import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./permission-summaries.generated";
 import type {
   FirewallPermissionDetailMetadata,
@@ -13,12 +6,27 @@ import type {
 } from "./types";
 
 export { FIREWALL_PERMISSION_METADATA_SUMMARIES };
-export { createFirewallMetadataPolicyResolver };
 export type {
+  FirewallMetadataPermissionGroup,
   FirewallMetadataPolicyListState,
   FirewallMetadataPolicyOverlay,
   FirewallMetadataPolicyResolver,
-} from "./policy-resolver";
+  FirewallPermissionGrant,
+  FirewallPermissionGrantAction,
+  FirewallPermissionPolicyCategoryMetadata,
+  FirewallPermissionPolicyDefaultMetadata,
+  FirewallPermissionPolicyDefaultOverrides,
+  FirewallPermissionPolicyMetadata,
+  FirewallPermissionPolicyMetadataPermission,
+} from "./policy";
+export {
+  createFirewallMetadataPolicyResolver,
+  expandFirewallMetadataDefaultPolicy,
+  findFirewallMetadataPermission,
+  groupFirewallMetadataPermissionsByCategory,
+  permissionGrantsToFirewallPolicies,
+  resolveFirewallMetadataPolicies,
+} from "./policy";
 export type {
   FirewallPermissionCategoryMetadata,
   FirewallPermissionDefaultPolicyMetadata,
@@ -30,22 +38,6 @@ export type {
 
 export type FirewallMetadataConnectorType =
   keyof typeof FIREWALL_PERMISSION_METADATA_SUMMARIES;
-
-export interface FirewallMetadataPermissionGroup<T extends { name: string }> {
-  readonly category: string;
-  readonly permissions: T[];
-}
-
-export type FirewallPermissionGrantAction = Extract<
-  FirewallPolicyValue,
-  "allow" | "deny"
->;
-
-export interface FirewallPermissionGrant {
-  readonly connectorRef: string;
-  readonly permission: string;
-  readonly action: FirewallPermissionGrantAction;
-}
 
 export function isFirewallMetadataConnectorType(
   type: string,
@@ -76,103 +68,4 @@ export async function loadFirewallPermissionMetadata(
     return null;
   }
   return await loadGeneratedFirewallPermissionMetadata(type);
-}
-
-export function expandFirewallMetadataDefaultPolicy(
-  metadata: FirewallPermissionDetailMetadata,
-): FirewallPolicy {
-  const resolver = createFirewallMetadataPolicyResolver(metadata);
-  const policies: Record<string, FirewallPolicyValue> = {};
-
-  for (const permission of metadata.permissions) {
-    policies[permission.name] = resolver.permission(permission.name);
-  }
-
-  return {
-    policies,
-    unknownPolicy: resolver.unknown(),
-  };
-}
-
-export function findFirewallMetadataPermission(
-  metadata: FirewallPermissionDetailMetadata,
-  name: string,
-): FirewallPermissionDetailMetadata["permissions"][number] | null {
-  return (
-    metadata.permissions.find((permission) => {
-      return permission.name === name;
-    }) ?? null
-  );
-}
-
-export function groupFirewallMetadataPermissionsByCategory<
-  T extends { name: string },
->(
-  permissions: readonly T[],
-  metadata: FirewallPermissionDetailMetadata,
-): FirewallMetadataPermissionGroup<T>[] | null {
-  if (!metadata.categories) {
-    return null;
-  }
-
-  const grouped = new Map<string, T[]>();
-  for (const category of metadata.categories.displayOrder) {
-    grouped.set(category, []);
-  }
-
-  for (const permission of permissions) {
-    const category = metadata.categories.categories[permission.name];
-    if (!category) {
-      continue;
-    }
-    grouped.get(category)?.push(permission);
-  }
-
-  return [...grouped.entries()]
-    .filter(([, groupPermissions]) => {
-      return groupPermissions.length > 0;
-    })
-    .map(([category, groupPermissions]) => {
-      return { category, permissions: groupPermissions };
-    });
-}
-
-export function resolveFirewallMetadataPolicies(
-  stored: FirewallPolicies | null,
-  metadata: readonly FirewallPermissionDetailMetadata[],
-): FirewallPolicies | null {
-  let resolved: FirewallPolicies | null = stored;
-  for (const detail of metadata) {
-    const defaults = expandFirewallMetadataDefaultPolicy(detail);
-    const existing = resolved?.[detail.type];
-    resolved = {
-      ...resolved,
-      [detail.type]: {
-        policies: { ...defaults.policies, ...existing?.policies },
-        ...(existing?.unknownPolicy !== undefined
-          ? { unknownPolicy: existing.unknownPolicy }
-          : { unknownPolicy: defaults.unknownPolicy }),
-      },
-    };
-  }
-  return resolved;
-}
-
-export function permissionGrantsToFirewallPolicies(
-  grants: readonly FirewallPermissionGrant[],
-): FirewallPolicies | null {
-  const policies: FirewallPolicies = {};
-  for (const grant of grants) {
-    const current = policies[grant.connectorRef] ?? { policies: {} };
-    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
-      policies[grant.connectorRef] = {
-        ...current,
-        unknownPolicy: grant.action,
-      };
-      continue;
-    }
-    current.policies[grant.permission] = grant.action;
-    policies[grant.connectorRef] = current;
-  }
-  return Object.keys(policies).length > 0 ? policies : null;
 }

--- a/turbo/packages/connectors/src/firewall-metadata/policy-resolver.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/policy-resolver.ts
@@ -1,5 +1,14 @@
 import type { FirewallPolicyValue } from "../firewall-types";
-import type { FirewallPermissionDetailMetadata } from "./types";
+
+interface FirewallMetadataPolicyResolverMetadata {
+  readonly defaultPolicy: {
+    readonly permissionDefault: FirewallPolicyValue;
+    readonly permissionOverrides?: Readonly<
+      Partial<Record<FirewallPolicyValue, readonly string[]>>
+    >;
+    readonly unknownPolicy: FirewallPolicyValue;
+  };
+}
 
 export interface FirewallMetadataPolicyOverlay {
   readonly permissionDefault?: FirewallPolicyValue;
@@ -22,7 +31,7 @@ export interface FirewallMetadataPolicyResolver {
 }
 
 function buildMetadataOverrideLookup(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: FirewallMetadataPolicyResolverMetadata,
 ): ReadonlyMap<string, FirewallPolicyValue> {
   const overrides = metadata.defaultPolicy.permissionOverrides;
   const lookup = new Map<string, FirewallPolicyValue>();
@@ -54,7 +63,7 @@ function getOwnPermissionOverride(
 }
 
 export function createFirewallMetadataPolicyResolver(
-  metadata: FirewallPermissionDetailMetadata,
+  metadata: FirewallMetadataPolicyResolverMetadata,
   overlay?: FirewallMetadataPolicyOverlay,
 ): FirewallMetadataPolicyResolver {
   const metadataOverrides = buildMetadataOverrideLookup(metadata);

--- a/turbo/packages/connectors/src/firewall-metadata/policy.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/policy.ts
@@ -1,0 +1,172 @@
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicies,
+  type FirewallPolicy,
+  type FirewallPolicyValue,
+} from "../firewall-types";
+import { createFirewallMetadataPolicyResolver } from "./policy-resolver";
+
+export type {
+  FirewallMetadataPolicyListState,
+  FirewallMetadataPolicyOverlay,
+  FirewallMetadataPolicyResolver,
+} from "./policy-resolver";
+
+export interface FirewallPermissionPolicyMetadataPermission {
+  readonly name: string;
+  readonly description?: string;
+}
+
+export interface FirewallPermissionPolicyCategoryMetadata {
+  readonly categories: Readonly<Record<string, string>>;
+  readonly displayOrder: readonly string[];
+}
+
+export type FirewallPermissionPolicyDefaultOverrides = Readonly<
+  Partial<Record<FirewallPolicyValue, readonly string[]>>
+>;
+
+export interface FirewallPermissionPolicyDefaultMetadata {
+  readonly permissionDefault: FirewallPolicyValue;
+  readonly permissionOverrides?: FirewallPermissionPolicyDefaultOverrides;
+  readonly unknownPolicy: FirewallPolicyValue;
+}
+
+interface FirewallPermissionPolicyMetadataBase {
+  readonly label: string;
+  readonly permissionCount: number;
+  readonly permissions: readonly FirewallPermissionPolicyMetadataPermission[];
+  readonly categories?: FirewallPermissionPolicyCategoryMetadata | null;
+  readonly defaultPolicy: FirewallPermissionPolicyDefaultMetadata;
+}
+
+export type FirewallPermissionPolicyMetadata =
+  FirewallPermissionPolicyMetadataBase &
+    (
+      | { readonly connectorRef: string; readonly type?: string }
+      | { readonly connectorRef?: undefined; readonly type: string }
+    );
+
+export interface FirewallMetadataPermissionGroup<T extends { name: string }> {
+  readonly category: string;
+  readonly permissions: T[];
+}
+
+export type FirewallPermissionGrantAction = Extract<
+  FirewallPolicyValue,
+  "allow" | "deny"
+>;
+
+export interface FirewallPermissionGrant {
+  readonly connectorRef: string;
+  readonly permission: string;
+  readonly action: FirewallPermissionGrantAction;
+}
+
+function metadataConnectorRef(
+  metadata: FirewallPermissionPolicyMetadata,
+): string {
+  return metadata.connectorRef ?? metadata.type;
+}
+
+export { createFirewallMetadataPolicyResolver };
+
+export function expandFirewallMetadataDefaultPolicy(
+  metadata: FirewallPermissionPolicyMetadata,
+): FirewallPolicy {
+  const resolver = createFirewallMetadataPolicyResolver(metadata);
+  const policies: Record<string, FirewallPolicyValue> = {};
+
+  for (const permission of metadata.permissions) {
+    policies[permission.name] = resolver.permission(permission.name);
+  }
+
+  return {
+    policies,
+    unknownPolicy: resolver.unknown(),
+  };
+}
+
+export function findFirewallMetadataPermission(
+  metadata: FirewallPermissionPolicyMetadata,
+  name: string,
+): FirewallPermissionPolicyMetadata["permissions"][number] | null {
+  return (
+    metadata.permissions.find((permission) => {
+      return permission.name === name;
+    }) ?? null
+  );
+}
+
+export function groupFirewallMetadataPermissionsByCategory<
+  T extends { name: string },
+>(
+  permissions: readonly T[],
+  metadata: FirewallPermissionPolicyMetadata,
+): FirewallMetadataPermissionGroup<T>[] | null {
+  if (!metadata.categories) {
+    return null;
+  }
+
+  const grouped = new Map<string, T[]>();
+  for (const category of metadata.categories.displayOrder) {
+    grouped.set(category, []);
+  }
+
+  for (const permission of permissions) {
+    const category = metadata.categories.categories[permission.name];
+    if (!category) {
+      continue;
+    }
+    grouped.get(category)?.push(permission);
+  }
+
+  return [...grouped.entries()]
+    .filter(([, groupPermissions]) => {
+      return groupPermissions.length > 0;
+    })
+    .map(([category, groupPermissions]) => {
+      return { category, permissions: groupPermissions };
+    });
+}
+
+export function resolveFirewallMetadataPolicies(
+  stored: FirewallPolicies | null,
+  metadata: readonly FirewallPermissionPolicyMetadata[],
+): FirewallPolicies | null {
+  let resolved: FirewallPolicies | null = stored;
+  for (const detail of metadata) {
+    const connectorRef = metadataConnectorRef(detail);
+    const defaults = expandFirewallMetadataDefaultPolicy(detail);
+    const existing = resolved?.[connectorRef];
+    resolved = {
+      ...resolved,
+      [connectorRef]: {
+        policies: { ...defaults.policies, ...existing?.policies },
+        ...(existing?.unknownPolicy !== undefined
+          ? { unknownPolicy: existing.unknownPolicy }
+          : { unknownPolicy: defaults.unknownPolicy }),
+      },
+    };
+  }
+  return resolved;
+}
+
+export function permissionGrantsToFirewallPolicies(
+  grants: readonly FirewallPermissionGrant[],
+): FirewallPolicies | null {
+  const policies: FirewallPolicies = {};
+  for (const grant of grants) {
+    const current = policies[grant.connectorRef] ?? { policies: {} };
+    if (grant.permission === UNKNOWN_PERMISSION_GRANT) {
+      policies[grant.connectorRef] = {
+        ...current,
+        unknownPolicy: grant.action,
+      };
+      continue;
+    }
+    current.policies[grant.permission] = grant.action;
+    policies[grant.connectorRef] = current;
+  }
+  return Object.keys(policies).length > 0 ? policies : null;
+}


### PR DESCRIPTION
Closes #19999

## Summary
- Move platform permission metadata reads to `zeroConnectorCatalogContract.permissions` and use catalog status `permissionSummary` for manage-button visibility.
- Add a generated-data-free `@vm0/connectors/firewall-metadata/policy` helper subpath for shared policy/default/grouping logic.
- Convert permission allow pages, chat permission action cards, permission drawers, and access management flows to public `connectorRef` permission detail data.
- Add MSW permissions endpoint coverage and boundary tests to prevent platform runtime root firewall metadata imports.

## Verification
- `pnpm -F @vm0/app exec vitest src/signals/__tests__/firewall-metadata-import-boundary.test.ts src/signals/zero-page/settings/permission-draft-intent.test.ts src/views/permission-allow/__tests__/permission-allow-page.test.tsx src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-metadata.test.ts -t "entrypoint"`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors check-types`
- `pnpm knip`
- pre-commit hook: prettier, knip, repo check-types

Note: full `pnpm -F @vm0/connectors test` still reports existing generated firewall metadata drift for google-meet/sentry/xero/xero connections. The focused entrypoint/helper tests added for this PR pass.
