### PR TITLE
feat: bootstrap clerk orgs into limited-free workspaces

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -200,9 +200,11 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
       }),
     ).toBeTruthy();
 
-    const selected = await api.requestSetDefaultAgent(admin, created.agentId, [
-      409,
-    ]);
+    const selected = await api.requestSetDefaultAgent(
+      admin,
+      created.agentId,
+      [409],
+    );
     expectApiError(selected.body);
     expect(selected.body.error.code).toBe("CONFLICT");
     const selectedStatus = await api.readOnboardingStatus(admin);
@@ -250,9 +252,11 @@ describe("AUTH-02 and AUTH-03", () => {
     expect(metadata.name).toBe("BDD CLI token");
     expect("token" in metadata).toBeFalsy();
 
-    const tokenMe = await api.requestReadMeWithBearer(created.token, admin, [
-      200,
-    ]);
+    const tokenMe = await api.requestReadMeWithBearer(
+      created.token,
+      admin,
+      [200],
+    );
     expect(tokenMe.body).toStrictEqual({
       userId: admin.userId,
       email: admin.email,
@@ -266,9 +270,11 @@ describe("AUTH-02 and AUTH-03", () => {
       }),
     ).toBeFalsy();
 
-    const revoked = await api.requestReadMeWithBearer(created.token, admin, [
-      401,
-    ]);
+    const revoked = await api.requestReadMeWithBearer(
+      created.token,
+      admin,
+      [401],
+    );
     expectApiError(revoked.body);
     expect(revoked.body.error.code).toBe("UNAUTHORIZED");
   });
@@ -985,9 +991,11 @@ describe("COMPOSE-01", () => {
     expect(crossOrg.body.error.code).toBe("NOT_FOUND");
 
     await api.deleteAgent(admin, created.composeId);
-    const deleted = await api.requestReadComposeById(admin, created.composeId, [
-      404,
-    ]);
+    const deleted = await api.requestReadComposeById(
+      admin,
+      created.composeId,
+      [404],
+    );
     expectApiError(deleted.body);
     expect(deleted.body.error.code).toBe("NOT_FOUND");
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -104,15 +104,6 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
     expectApiError(noOrgAgent.body);
     expect(noOrgAgent.body.error.code).toBe("UNAUTHORIZED");
 
-    const before = await api.readOnboardingStatus(admin);
-    expect(before).toMatchObject({
-      needsOnboarding: true,
-      isAdmin: true,
-      hasOrg: true,
-      hasDefaultAgent: false,
-      defaultAgentId: null,
-    });
-
     const defaultAgentId = await onboardAdmin(admin, {
       displayName: "BDD Default Agent",
       workspaceName: "BDD Chain Org",
@@ -209,11 +200,9 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
       }),
     ).toBeTruthy();
 
-    const selected = await api.requestSetDefaultAgent(
-      admin,
-      created.agentId,
-      [409],
-    );
+    const selected = await api.requestSetDefaultAgent(admin, created.agentId, [
+      409,
+    ]);
     expectApiError(selected.body);
     expect(selected.body.error.code).toBe("CONFLICT");
     const selectedStatus = await api.readOnboardingStatus(admin);
@@ -261,11 +250,9 @@ describe("AUTH-02 and AUTH-03", () => {
     expect(metadata.name).toBe("BDD CLI token");
     expect("token" in metadata).toBeFalsy();
 
-    const tokenMe = await api.requestReadMeWithBearer(
-      created.token,
-      admin,
-      [200],
-    );
+    const tokenMe = await api.requestReadMeWithBearer(created.token, admin, [
+      200,
+    ]);
     expect(tokenMe.body).toStrictEqual({
       userId: admin.userId,
       email: admin.email,
@@ -279,11 +266,9 @@ describe("AUTH-02 and AUTH-03", () => {
       }),
     ).toBeFalsy();
 
-    const revoked = await api.requestReadMeWithBearer(
-      created.token,
-      admin,
-      [401],
-    );
+    const revoked = await api.requestReadMeWithBearer(created.token, admin, [
+      401,
+    ]);
     expectApiError(revoked.body);
     expect(revoked.body.error.code).toBe("UNAUTHORIZED");
   });
@@ -615,17 +600,33 @@ describe("ORG-03 onboarding status mapping", () => {
       defaultAgentMetadata: null,
     });
 
+    api.acceptAgentStorageWrites();
     const adminBeforeSetup = await api.readOnboardingStatus(admin);
-    expect(adminBeforeSetup).toStrictEqual({
-      needsOnboarding: true,
+    expect(adminBeforeSetup).toMatchObject({
+      needsOnboarding: false,
       isAdmin: true,
       hasOrg: true,
-      hasDefaultAgent: false,
-      defaultAgentId: null,
-      defaultAgentMetadata: null,
+      hasDefaultAgent: true,
+      defaultAgentMetadata: {
+        displayName: "Zero",
+        sound: "professional",
+      },
+    });
+    expect(adminBeforeSetup.defaultAgentId).toBeTruthy();
+    if (!adminBeforeSetup.defaultAgentId) {
+      throw new Error(
+        "Expected lazy onboarding status bootstrap to create an agent",
+      );
+    }
+    const bootstrappedAgentId = adminBeforeSetup.defaultAgentId;
+
+    const bootstrappedBilling = await runsApi.readBillingStatus(admin);
+    expect(bootstrappedBilling).toMatchObject({
+      credits: 1000,
+      tier: "limited-free-1",
+      onboardingPaymentPending: false,
     });
 
-    api.acceptAgentStorageWrites();
     const setup = await api.setupOnboarding(admin, {
       displayName: "BDD Status Agent",
       sound: "friendly",
@@ -636,17 +637,18 @@ describe("ORG-03 onboarding status mapping", () => {
       );
     }
     const agentId = setup.body.agentId;
+    expect(agentId).toBe(bootstrappedAgentId);
 
     const paymentPending = await api.readOnboardingStatus(admin);
     expect(paymentPending).toStrictEqual({
-      needsOnboarding: true,
+      needsOnboarding: false,
       isAdmin: true,
       hasOrg: true,
       hasDefaultAgent: true,
       defaultAgentId: agentId,
       defaultAgentMetadata: {
-        displayName: "BDD Status Agent",
-        sound: "friendly",
+        displayName: "Zero",
+        sound: "professional",
       },
     });
 
@@ -659,20 +661,28 @@ describe("ORG-03 onboarding status mapping", () => {
       hasDefaultAgent: true,
       defaultAgentId: agentId,
       defaultAgentMetadata: {
-        displayName: "BDD Status Agent",
-        sound: "friendly",
+        displayName: "Zero",
+        sound: "professional",
       },
     });
 
     await api.deleteAgent(admin, agentId);
     const orphaned = await api.readOnboardingStatus(admin);
-    expect(orphaned).toStrictEqual({
-      needsOnboarding: true,
+    expect(orphaned).toMatchObject({
+      needsOnboarding: false,
       isAdmin: true,
       hasOrg: true,
-      hasDefaultAgent: false,
-      defaultAgentId: null,
-      defaultAgentMetadata: null,
+      hasDefaultAgent: true,
+      defaultAgentMetadata: {
+        displayName: "Zero",
+        sound: "professional",
+      },
+    });
+    expect(orphaned.defaultAgentId).toBeTruthy();
+    expect(orphaned.defaultAgentId).not.toBe(agentId);
+    const preservedPaidBilling = await runsApi.readBillingStatus(admin);
+    expect(preservedPaidBilling).toMatchObject({
+      tier: "pro",
     });
   });
 });
@@ -975,11 +985,9 @@ describe("COMPOSE-01", () => {
     expect(crossOrg.body.error.code).toBe("NOT_FOUND");
 
     await api.deleteAgent(admin, created.composeId);
-    const deleted = await api.requestReadComposeById(
-      admin,
-      created.composeId,
-      [404],
-    );
+    const deleted = await api.requestReadComposeById(admin, created.composeId, [
+      404,
+    ]);
     expectApiError(deleted.body);
     expect(deleted.body.error.code).toBe("NOT_FOUND");
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -181,9 +181,11 @@ describe("ORG-01: org logo lifecycle through the Clerk boundary", () => {
       hasImage: true,
     });
     const file = pngLogoFile();
-    const uploaded = await api.requestUploadOrgLogo(admin, logoForm(file), [
-      200,
-    ]);
+    const uploaded = await api.requestUploadOrgLogo(
+      admin,
+      logoForm(file),
+      [200],
+    );
     expect(uploaded.body).toStrictEqual({
       logoUrl: "https://img.clerk.test/new-logo.png",
       hasImage: true,
@@ -238,17 +240,21 @@ describe("ORG-01: org logo lifecycle through the Clerk boundary", () => {
     });
 
     // POST file validation arms.
-    const emptyForm = await api.requestUploadOrgLogo(admin, new FormData(), [
-      400,
-    ]);
+    const emptyForm = await api.requestUploadOrgLogo(
+      admin,
+      new FormData(),
+      [400],
+    );
     expect(emptyForm.body).toStrictEqual({
       error: { message: "No file provided", code: "BAD_REQUEST" },
     });
     const stringForm = new FormData();
     stringForm.append("file", "not-a-file");
-    const stringField = await api.requestUploadOrgLogo(admin, stringForm, [
-      400,
-    ]);
+    const stringField = await api.requestUploadOrgLogo(
+      admin,
+      stringForm,
+      [400],
+    );
     expect(stringField.body).toStrictEqual({
       error: { message: "No file provided", code: "BAD_REQUEST" },
     });
@@ -365,9 +371,11 @@ describe("ORG-01: org logo lifecycle through the Clerk boundary", () => {
 describe("ORG-01: org update and delete error matrix", () => {
   it("maps no-org, slug-force, reserved, conflict, admin-leave, and delete failure arms [ORG-UPDATE-B]", async () => {
     const noOrg = api.user({ orgId: null });
-    const noOrgUpdate = await api.requestUpdateOrg(noOrg, { force: false }, [
-      400,
-    ]);
+    const noOrgUpdate = await api.requestUpdateOrg(
+      noOrg,
+      { force: false },
+      [400],
+    );
     expectApiError(noOrgUpdate.body);
     expect(noOrgUpdate.body.error.message).toBe(
       "No org configured. Set your org with: zero org set <slug>",
@@ -446,17 +454,21 @@ describe("ORG-01: org update and delete error matrix", () => {
       orgId: admin.orgId,
       orgRole: "org:member",
     });
-    const memberDelete = await api.requestDeleteOrg(memberCaller, baseSlug, [
-      403,
-    ]);
+    const memberDelete = await api.requestDeleteOrg(
+      memberCaller,
+      baseSlug,
+      [403],
+    );
     expectApiError(memberDelete.body);
     expect(memberDelete.body.error.message).toBe(
       "Only admins can delete the organization",
     );
 
-    const wrongSlug = await api.requestDeleteOrg(admin, slug("bdd-r5-wrong"), [
-      400,
-    ]);
+    const wrongSlug = await api.requestDeleteOrg(
+      admin,
+      slug("bdd-r5-wrong"),
+      [400],
+    );
     expectApiError(wrongSlug.body);
     expect(wrongSlug.body.error.message).toBe(
       "Organization name does not match",
@@ -847,9 +859,10 @@ describe("ORG-02: member cleanup detaches Slack connections", () => {
       workspaceId: install.teamId,
       slackUserId: `U_LEAVE_${shortId().toUpperCase()}`,
     });
-    const connected = await integrations.requestSlackConnectStatus(member, [
-      200,
-    ]);
+    const connected = await integrations.requestSlackConnectStatus(
+      member,
+      [200],
+    );
     expect(connected.body).toMatchObject({ isConnected: true });
 
     api.mockClerkOrg(member, {
@@ -861,9 +874,10 @@ describe("ORG-02: member cleanup detaches Slack connections", () => {
     await expect(api.leaveOrg(member)).resolves.toStrictEqual({
       message: "Left org",
     });
-    const afterLeave = await integrations.requestSlackConnectStatus(member, [
-      200,
-    ]);
+    const afterLeave = await integrations.requestSlackConnectStatus(
+      member,
+      [200],
+    );
     expect(afterLeave.body).toMatchObject({ isConnected: false });
 
     await integrations.connectSlackUser(secondMember, {
@@ -1235,9 +1249,10 @@ describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
       role: "admin",
     });
 
-    const membersRead = await api.requestListMembersWithBearer(zeroToken, [
-      200,
-    ]);
+    const membersRead = await api.requestListMembersWithBearer(
+      zeroToken,
+      [200],
+    );
     expect(membersRead.body.role).toBe("admin");
     expect(
       membersRead.body.members.some((candidate) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts
@@ -181,11 +181,9 @@ describe("ORG-01: org logo lifecycle through the Clerk boundary", () => {
       hasImage: true,
     });
     const file = pngLogoFile();
-    const uploaded = await api.requestUploadOrgLogo(
-      admin,
-      logoForm(file),
-      [200],
-    );
+    const uploaded = await api.requestUploadOrgLogo(admin, logoForm(file), [
+      200,
+    ]);
     expect(uploaded.body).toStrictEqual({
       logoUrl: "https://img.clerk.test/new-logo.png",
       hasImage: true,
@@ -240,21 +238,17 @@ describe("ORG-01: org logo lifecycle through the Clerk boundary", () => {
     });
 
     // POST file validation arms.
-    const emptyForm = await api.requestUploadOrgLogo(
-      admin,
-      new FormData(),
-      [400],
-    );
+    const emptyForm = await api.requestUploadOrgLogo(admin, new FormData(), [
+      400,
+    ]);
     expect(emptyForm.body).toStrictEqual({
       error: { message: "No file provided", code: "BAD_REQUEST" },
     });
     const stringForm = new FormData();
     stringForm.append("file", "not-a-file");
-    const stringField = await api.requestUploadOrgLogo(
-      admin,
-      stringForm,
-      [400],
-    );
+    const stringField = await api.requestUploadOrgLogo(admin, stringForm, [
+      400,
+    ]);
     expect(stringField.body).toStrictEqual({
       error: { message: "No file provided", code: "BAD_REQUEST" },
     });
@@ -371,11 +365,9 @@ describe("ORG-01: org logo lifecycle through the Clerk boundary", () => {
 describe("ORG-01: org update and delete error matrix", () => {
   it("maps no-org, slug-force, reserved, conflict, admin-leave, and delete failure arms [ORG-UPDATE-B]", async () => {
     const noOrg = api.user({ orgId: null });
-    const noOrgUpdate = await api.requestUpdateOrg(
-      noOrg,
-      { force: false },
-      [400],
-    );
+    const noOrgUpdate = await api.requestUpdateOrg(noOrg, { force: false }, [
+      400,
+    ]);
     expectApiError(noOrgUpdate.body);
     expect(noOrgUpdate.body.error.message).toBe(
       "No org configured. Set your org with: zero org set <slug>",
@@ -454,21 +446,17 @@ describe("ORG-01: org update and delete error matrix", () => {
       orgId: admin.orgId,
       orgRole: "org:member",
     });
-    const memberDelete = await api.requestDeleteOrg(
-      memberCaller,
-      baseSlug,
-      [403],
-    );
+    const memberDelete = await api.requestDeleteOrg(memberCaller, baseSlug, [
+      403,
+    ]);
     expectApiError(memberDelete.body);
     expect(memberDelete.body.error.message).toBe(
       "Only admins can delete the organization",
     );
 
-    const wrongSlug = await api.requestDeleteOrg(
-      admin,
-      slug("bdd-r5-wrong"),
-      [400],
-    );
+    const wrongSlug = await api.requestDeleteOrg(admin, slug("bdd-r5-wrong"), [
+      400,
+    ]);
     expectApiError(wrongSlug.body);
     expect(wrongSlug.body.error.message).toBe(
       "Organization name does not match",
@@ -859,10 +847,9 @@ describe("ORG-02: member cleanup detaches Slack connections", () => {
       workspaceId: install.teamId,
       slackUserId: `U_LEAVE_${shortId().toUpperCase()}`,
     });
-    const connected = await integrations.requestSlackConnectStatus(
-      member,
-      [200],
-    );
+    const connected = await integrations.requestSlackConnectStatus(member, [
+      200,
+    ]);
     expect(connected.body).toMatchObject({ isConnected: true });
 
     api.mockClerkOrg(member, {
@@ -874,10 +861,9 @@ describe("ORG-02: member cleanup detaches Slack connections", () => {
     await expect(api.leaveOrg(member)).resolves.toStrictEqual({
       message: "Left org",
     });
-    const afterLeave = await integrations.requestSlackConnectStatus(
-      member,
-      [200],
-    );
+    const afterLeave = await integrations.requestSlackConnectStatus(member, [
+      200,
+    ]);
     expect(afterLeave.body).toMatchObject({ isConnected: false });
 
     await integrations.connectSlackUser(secondMember, {
@@ -1024,19 +1010,12 @@ describe("ORG-01/AGENT-02: team listing and default-agent recovery", () => {
     expect(peerTeamIds).not.toContain(ownPrivate.agentId);
     await expect(api.listTeam(crossOrgAdmin)).resolves.toStrictEqual([]);
 
-    // Deleting the default agent clears the selection (FK set-null) and a
-    // new default can then be configured.
+    // Deleting the default agent clears the FK, then onboarding status lazily
+    // restores a usable org default for admins.
     await api.deleteAgent(admin, defaultAgentId);
-    const orphaned = await api.readOnboardingStatus(admin);
-    expect(orphaned.defaultAgentId).toBeNull();
-    const replacement = await api.createAgent(admin, {
-      displayName: "BDD Replacement Default",
-      visibility: "public",
-    });
-    const selected = await api.setDefaultAgent(admin, replacement.agentId);
-    expect(selected).toStrictEqual({ agentId: replacement.agentId });
     const restored = await api.readOnboardingStatus(admin);
-    expect(restored.defaultAgentId).toBe(replacement.agentId);
+    expect(restored.defaultAgentId).toBeTruthy();
+    expect(restored.defaultAgentId).not.toBe(defaultAgentId);
 
     const missingAgent = await api.requestSetDefaultAgent(
       crossOrgAdmin,
@@ -1256,10 +1235,9 @@ describe("AUTH-02/ORG-01: run-scoped zero tokens on org routes", () => {
       role: "admin",
     });
 
-    const membersRead = await api.requestListMembersWithBearer(
-      zeroToken,
-      [200],
-    );
+    const membersRead = await api.requestListMembersWithBearer(zeroToken, [
+      200,
+    ]);
     expect(membersRead.body.role).toBe("admin");
     expect(
       membersRead.body.members.some((candidate) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -429,6 +429,72 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
     expect(membershipDeleted.body).toBe("OK");
   });
 
+  it("bootstraps limited-free orgs after verified Clerk org creation events", async () => {
+    const bdd = createBddApi(context);
+    const runs = createRunsAutomationsApi(context);
+    api.configureClerkWebhookSecret();
+    bdd.acceptAgentStorageWrites();
+
+    const admin = bdd.user();
+    api.verifyNextClerkWebhook({
+      type: "organization.created",
+      data: {
+        id: orgOf(admin),
+        created_by: admin.userId,
+      },
+    });
+    const created = await api.requestClerkWebhook("{}", {}, [200]);
+    expect(created.body).toBe("OK");
+    await flushWaitUntilForTest();
+
+    const billing = await runs.readBillingStatus(admin);
+    expect(billing).toMatchObject({
+      credits: 1000,
+      tier: "limited-free-1",
+      onboardingPaymentPending: false,
+    });
+
+    api.verifyNextClerkWebhook({
+      type: "organizationMembership.created",
+      data: {
+        id: "mem_bdd_created",
+        organization: { id: orgOf(admin) },
+        publicUserData: { userId: admin.userId },
+        role: "org:admin",
+      },
+    });
+    const duplicate = await api.requestClerkWebhook("{}", {}, [200]);
+    expect(duplicate.body).toBe("OK");
+    await flushWaitUntilForTest();
+
+    const repeatedBilling = await runs.readBillingStatus(admin);
+    expect(repeatedBilling).toMatchObject({
+      credits: 1000,
+      tier: "limited-free-1",
+      onboardingPaymentPending: false,
+    });
+
+    const status = await bdd.readOnboardingStatus(admin);
+    expect(status).toMatchObject({
+      needsOnboarding: false,
+      isAdmin: true,
+      hasOrg: true,
+      hasDefaultAgent: true,
+      defaultAgentMetadata: {
+        displayName: "Zero",
+        sound: "professional",
+      },
+    });
+    expect(status.defaultAgentId).toBeTruthy();
+
+    const agents = await bdd.listAgents(admin);
+    expect(
+      agents.filter((agent) => {
+        return agent.displayName === "Zero";
+      }),
+    ).toHaveLength(1);
+  });
+
   it("suspends org-member automations after a verified organizationMembership.deleted event", async () => {
     const bdd = createBddApi(context);
     const runs = createRunsAutomationsApi(context);

--- a/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-clerk.ts
@@ -8,6 +8,7 @@ import { request$ } from "../context/hono";
 import { waitUntil } from "../context/wait-until";
 import type { RouteEntry } from "../route-entry";
 import { settle, tapError } from "../utils";
+import { ensureOrgLimitedFreeBootstrap$ } from "../services/org-limited-free-bootstrap.service";
 import {
   cleanupClerkBannedUser$,
   cleanupClerkDeletedOrgMembership$,
@@ -49,6 +50,7 @@ function organizationMembershipIdentity(data: unknown):
   | {
       readonly orgId: string;
       readonly userId: string;
+      readonly role?: string;
     }
   | undefined {
   const organization = propertyOf(data, "organization");
@@ -61,8 +63,46 @@ function organizationMembershipIdentity(data: unknown):
     stringPropertyOf(publicUserData, "userId") ??
     stringPropertyOf(publicUserData, "user_id") ??
     stringPropertyOf(data, "user_id");
+  const role = stringPropertyOf(data, "role");
+
+  return orgId && userId ? { orgId, userId, role } : undefined;
+}
+
+function organizationCreatedIdentity(data: unknown):
+  | {
+      readonly orgId: string;
+      readonly userId: string;
+    }
+  | undefined {
+  const orgId = eventDataId(data);
+  const userId =
+    stringPropertyOf(data, "createdBy") ??
+    stringPropertyOf(data, "created_by") ??
+    stringPropertyOf(data, "createdByUserId") ??
+    stringPropertyOf(data, "created_by_user_id");
 
   return orgId && userId ? { orgId, userId } : undefined;
+}
+
+function isAdminMembershipRole(role: string | undefined): boolean {
+  return role === "org:admin" || role === "admin";
+}
+
+function enqueueOrgBootstrap(args: {
+  readonly eventType: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly task: Promise<unknown>;
+}): void {
+  waitUntil(
+    tapError(args.task, (error) => {
+      L.error(`${args.eventType} bootstrap failed`, {
+        orgId: args.orgId,
+        userId: args.userId,
+        error,
+      });
+    }),
+  );
 }
 
 const postClerkWebhook$ = command(
@@ -80,6 +120,59 @@ const postClerkWebhook$ = command(
 
     const event = eventResult.value;
     L.debug("clerk webhook received", { type: event.type });
+
+    if ((event.type as string) === "organization.created") {
+      const identity = organizationCreatedIdentity(event.data);
+      if (!identity) {
+        L.error("organization.created event missing org/creator user ID", {
+          data: event.data,
+        });
+        return new Response("OK", { status: 200 });
+      }
+
+      enqueueOrgBootstrap({
+        eventType: "organization.created",
+        orgId: identity.orgId,
+        userId: identity.userId,
+        task: set(
+          ensureOrgLimitedFreeBootstrap$,
+          { orgId: identity.orgId, ownerUserId: identity.userId },
+          signal,
+        ),
+      });
+      return new Response("OK", { status: 200 });
+    }
+
+    if ((event.type as string) === "organizationMembership.created") {
+      const identity = organizationMembershipIdentity(event.data);
+      if (!identity) {
+        L.error("organizationMembership.created event missing org/user ID", {
+          data: event.data,
+        });
+        return new Response("OK", { status: 200 });
+      }
+
+      if (!isAdminMembershipRole(identity.role)) {
+        L.debug("ignoring non-admin organizationMembership.created event", {
+          orgId: identity.orgId,
+          userId: identity.userId,
+          role: identity.role,
+        });
+        return new Response("OK", { status: 200 });
+      }
+
+      enqueueOrgBootstrap({
+        eventType: "organizationMembership.created",
+        orgId: identity.orgId,
+        userId: identity.userId,
+        task: set(
+          ensureOrgLimitedFreeBootstrap$,
+          { orgId: identity.orgId, ownerUserId: identity.userId },
+          signal,
+        ),
+      });
+      return new Response("OK", { status: 200 });
+    }
 
     if (event.type === "organization.deleted") {
       const orgId = eventDataId(event.data);

--- a/turbo/apps/api/src/signals/routes/zero-onboarding-status.ts
+++ b/turbo/apps/api/src/signals/routes/zero-onboarding-status.ts
@@ -1,19 +1,53 @@
-import { computed } from "ccstate";
 import { onboardingStatusContract } from "@vm0/api-contracts/contracts/onboarding";
+import { command } from "ccstate";
 
+import { logger } from "../../lib/log";
 import { authContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
 import type { RouteEntry } from "../route-entry";
+import { ensureOrgLimitedFreeBootstrap$ } from "../services/org-limited-free-bootstrap.service";
 import { onboardingStatus } from "../services/onboarding.service";
+import { settle } from "../utils";
 
-const getOnboardingStatusInner$ = computed(async (get): Promise<unknown> => {
-  const auth = get(authContext$);
-  const body = await get(onboardingStatus(auth));
-  return {
-    status: 200 as const,
-    body,
-  };
-});
+const L = logger("zero-onboarding-status.route");
+
+const getOnboardingStatusInner$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<unknown> => {
+    const auth = get(authContext$);
+    const body = await get(onboardingStatus(auth));
+    signal.throwIfAborted();
+
+    if (auth.orgId && body.isAdmin && !body.hasDefaultAgent) {
+      const bootstrapResult = await settle(
+        set(
+          ensureOrgLimitedFreeBootstrap$,
+          { orgId: auth.orgId, ownerUserId: auth.userId },
+          signal,
+        ),
+      );
+      signal.throwIfAborted();
+
+      if (bootstrapResult.ok) {
+        const repairedBody = await get(onboardingStatus(auth));
+        signal.throwIfAborted();
+        return {
+          status: 200 as const,
+          body: repairedBody,
+        };
+      }
+
+      L.warn("Lazy onboarding status bootstrap failed", {
+        orgId: auth.orgId,
+        error: bootstrapResult.error,
+      });
+    }
+
+    return {
+      status: 200 as const,
+      body,
+    };
+  },
+);
 
 export const zeroOnboardingStatusRoutes: readonly RouteEntry[] = [
   {

--- a/turbo/apps/api/src/signals/services/onboarding-credit-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding-credit-grants.service.ts
@@ -1,0 +1,55 @@
+import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
+import { sql } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import type { Db } from "../external/db";
+
+const L = logger("onboarding-credit-grants.service");
+
+export const ONBOARDING_CREDITS_NEVER_EXPIRE_AT = "2999-12-31T00:00:00Z";
+export const LIMITED_FREE_ONBOARDING_CREDITS = 1000;
+
+const ONBOARDING_CREDIT_SOURCE = "onboarding";
+const ONBOARDING_CREDIT_IDEMPOTENCY_KEY = "limited-free-onboarding";
+
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+async function grantOrgCredits(
+  tx: DbTransaction,
+  orgId: string,
+  amount: number,
+): Promise<void> {
+  await tx.execute(
+    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
+        VALUES (${orgId}, ${amount}, now(), now())
+        ON CONFLICT (org_id)
+        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
+  );
+}
+
+export async function grantOnboardingCredits(
+  tx: DbTransaction,
+  orgId: string,
+  amount: number,
+  expiresAt: Date,
+): Promise<void> {
+  const rows = await tx
+    .insert(creditExpiresRecord)
+    .values({
+      orgId,
+      source: ONBOARDING_CREDIT_SOURCE,
+      stripeInvoiceId: ONBOARDING_CREDIT_IDEMPOTENCY_KEY,
+      amount,
+      remaining: amount,
+      expiresAt,
+    })
+    .onConflictDoNothing()
+    .returning({ id: creditExpiresRecord.id });
+
+  if (rows.length === 0) {
+    L.debug("Onboarding credits already granted", { orgId });
+    return;
+  }
+
+  await grantOrgCredits(tx, orgId, amount);
+}

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -5,13 +5,12 @@ import type { OnboardingStatusResponse } from "@vm0/api-contracts/contracts/onbo
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { SEED_INSTRUCTIONS } from "@vm0/core/zero-seed-instructions";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
-import { creditExpiresRecord } from "@vm0/db/schema/credit-expires-record";
 import { orgCache } from "@vm0/db/schema/org-cache";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import type { AuthContext } from "../../types/auth";
 import { logger } from "../../lib/log";
@@ -24,13 +23,14 @@ import {
   unavailableUserConnectorTypes,
   userConnectorAvailability,
 } from "./connector-availability.service";
+import {
+  grantOnboardingCredits,
+  ONBOARDING_CREDITS_NEVER_EXPIRE_AT,
+} from "./onboarding-credit-grants.service";
 import { updateUserConnectors } from "./user-connectors.service";
 import { upsertOrgNoSecretModelProvider$ } from "./zero-model-provider.service";
 
 const L = logger("onboarding.service");
-const ONBOARDING_CREDIT_SOURCE = "onboarding";
-const ONBOARDING_CREDIT_IDEMPOTENCY_KEY = "limited-free-onboarding";
-const ONBOARDING_CREDITS_NEVER_EXPIRE_AT = "2999-12-31T00:00:00Z";
 
 interface DefaultAgentInfo {
   readonly composeId: string;
@@ -97,46 +97,6 @@ interface CompleteLimitedFreeOnboardingArgs {
   readonly orgId: string;
   readonly credits: number;
   readonly expiresAt: string | null;
-}
-
-async function grantOrgCredits(
-  tx: Parameters<Parameters<Db["transaction"]>[0]>[0],
-  orgId: string,
-  amount: number,
-): Promise<void> {
-  await tx.execute(
-    sql`INSERT INTO org_metadata (org_id, credits, created_at, updated_at)
-        VALUES (${orgId}, ${amount}, now(), now())
-        ON CONFLICT (org_id)
-        DO UPDATE SET credits = org_metadata.credits + ${amount}, updated_at = now()`,
-  );
-}
-
-async function grantOnboardingCredits(
-  tx: Parameters<Parameters<Db["transaction"]>[0]>[0],
-  orgId: string,
-  amount: number,
-  expiresAt: Date,
-): Promise<void> {
-  const rows = await tx
-    .insert(creditExpiresRecord)
-    .values({
-      orgId,
-      source: ONBOARDING_CREDIT_SOURCE,
-      stripeInvoiceId: ONBOARDING_CREDIT_IDEMPOTENCY_KEY,
-      amount,
-      remaining: amount,
-      expiresAt,
-    })
-    .onConflictDoNothing()
-    .returning({ id: creditExpiresRecord.id });
-
-  if (rows.length === 0) {
-    L.debug("Onboarding credits already granted", { orgId });
-    return;
-  }
-
-  await grantOrgCredits(tx, orgId, amount);
 }
 
 function unavailableSelectedConnectorsError(

--- a/turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts
+++ b/turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts
@@ -1,0 +1,294 @@
+import { command } from "ccstate";
+import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
+import { SEED_INSTRUCTIONS } from "@vm0/core/zero-seed-instructions";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { orgMetadata } from "@vm0/db/schema/org-metadata";
+import { zeroAgents } from "@vm0/db/schema/zero-agent";
+import { and, eq, sql } from "drizzle-orm";
+
+import { logger } from "../../lib/log";
+import { writeDb$, type Db } from "../external/db";
+import { nowDate } from "../external/time";
+import { serverSideZeroAgentCompose$ } from "./agent-compose.service";
+import {
+  grantOnboardingCredits,
+  LIMITED_FREE_ONBOARDING_CREDITS,
+  ONBOARDING_CREDITS_NEVER_EXPIRE_AT,
+} from "./onboarding-credit-grants.service";
+import { upsertOrgNoSecretModelProvider$ } from "./zero-model-provider.service";
+
+const L = logger("org-limited-free-bootstrap.service");
+const DEFAULT_AGENT_NAME = "default-agent";
+const DEFAULT_AGENT_DISPLAY_NAME = "Zero";
+const DEFAULT_AGENT_SOUND = "professional";
+
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
+
+interface EnsureOrgLimitedFreeBootstrapArgs {
+  readonly orgId: string;
+  readonly ownerUserId: string;
+}
+
+type BootstrapReservation =
+  | {
+      readonly status: "skipped";
+      readonly agentId: string;
+    }
+  | {
+      readonly status: "reserved";
+      readonly composeId: string;
+    };
+
+export interface EnsureOrgLimitedFreeBootstrapResult {
+  readonly bootstrapped: boolean;
+  readonly agentId: string | null;
+}
+
+async function lockOrgBootstrap(
+  tx: DbTransaction,
+  orgId: string,
+): Promise<void> {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext('org_bootstrap:' || ${orgId}))`,
+  );
+}
+
+async function existingDefaultAgentId(
+  tx: DbTransaction,
+  orgId: string,
+): Promise<string | null> {
+  const [orgRow] = await tx
+    .select({ defaultAgentId: orgMetadata.defaultAgentId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  if (!orgRow?.defaultAgentId) {
+    return null;
+  }
+
+  const [existing] = await tx
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.id, orgRow.defaultAgentId),
+        eq(zeroAgents.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  return existing?.id ?? null;
+}
+
+async function ensureBootstrapComposeRow(
+  tx: DbTransaction,
+  args: EnsureOrgLimitedFreeBootstrapArgs,
+): Promise<string> {
+  const [created] = await tx
+    .insert(agentComposes)
+    .values({
+      userId: args.ownerUserId,
+      orgId: args.orgId,
+      name: DEFAULT_AGENT_NAME,
+    })
+    .onConflictDoNothing()
+    .returning({ id: agentComposes.id });
+
+  if (created) {
+    return created.id;
+  }
+
+  const [existing] = await tx
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(
+      and(
+        eq(agentComposes.orgId, args.orgId),
+        eq(agentComposes.name, DEFAULT_AGENT_NAME),
+      ),
+    )
+    .limit(1);
+
+  if (!existing) {
+    throw new Error("Expected default bootstrap compose after insert conflict");
+  }
+
+  return existing.id;
+}
+
+function isPaidTier(tier: string): boolean {
+  return tier === "pro" || tier === "team";
+}
+
+async function reserveBootstrapCompose(
+  tx: DbTransaction,
+  args: EnsureOrgLimitedFreeBootstrapArgs,
+): Promise<BootstrapReservation> {
+  await lockOrgBootstrap(tx, args.orgId);
+
+  const existingAgentId = await existingDefaultAgentId(tx, args.orgId);
+  if (existingAgentId) {
+    return { status: "skipped", agentId: existingAgentId };
+  }
+
+  const composeId = await ensureBootstrapComposeRow(tx, args);
+  return { status: "reserved", composeId };
+}
+
+async function finalizeBootstrap(
+  tx: DbTransaction,
+  args: {
+    readonly orgId: string;
+    readonly ownerUserId: string;
+    readonly agentId: string;
+    readonly agentName: string;
+  },
+): Promise<EnsureOrgLimitedFreeBootstrapResult> {
+  await lockOrgBootstrap(tx, args.orgId);
+
+  const existingAgentId = await existingDefaultAgentId(tx, args.orgId);
+  if (existingAgentId) {
+    return { bootstrapped: false, agentId: existingAgentId };
+  }
+
+  await tx
+    .insert(zeroAgents)
+    .values({
+      id: args.agentId,
+      orgId: args.orgId,
+      name: args.agentName,
+      owner: args.ownerUserId,
+      displayName: DEFAULT_AGENT_DISPLAY_NAME,
+      description: null,
+      sound: DEFAULT_AGENT_SOUND,
+      avatarUrl: null,
+    })
+    .onConflictDoUpdate({
+      target: [zeroAgents.orgId, zeroAgents.name],
+      set: {
+        displayName: DEFAULT_AGENT_DISPLAY_NAME,
+        sound: DEFAULT_AGENT_SOUND,
+        avatarUrl: null,
+        updatedAt: nowDate(),
+      },
+    });
+
+  const [agentRow] = await tx
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, args.orgId),
+        eq(zeroAgents.name, args.agentName),
+      ),
+    )
+    .limit(1);
+  if (!agentRow) {
+    throw new Error("Expected zero agent after bootstrap upsert");
+  }
+
+  const [orgRow] = await tx
+    .select({ tier: orgMetadata.tier })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, args.orgId))
+    .limit(1);
+  const tier = orgRow?.tier ?? "pro-suspend";
+
+  if (isPaidTier(tier)) {
+    await tx
+      .update(orgMetadata)
+      .set({ defaultAgentId: agentRow.id, updatedAt: nowDate() })
+      .where(eq(orgMetadata.orgId, args.orgId));
+    return { bootstrapped: true, agentId: agentRow.id };
+  }
+
+  await tx
+    .insert(orgMetadata)
+    .values({
+      orgId: args.orgId,
+      defaultAgentId: agentRow.id,
+      tier: "limited-free-1",
+      onboardingPaymentPending: false,
+      updatedAt: nowDate(),
+    })
+    .onConflictDoUpdate({
+      target: orgMetadata.orgId,
+      set: {
+        defaultAgentId: agentRow.id,
+        tier: "limited-free-1",
+        onboardingPaymentPending: false,
+        updatedAt: nowDate(),
+      },
+    });
+
+  await grantOnboardingCredits(
+    tx,
+    args.orgId,
+    LIMITED_FREE_ONBOARDING_CREDITS,
+    new Date(ONBOARDING_CREDITS_NEVER_EXPIRE_AT),
+  );
+
+  return { bootstrapped: true, agentId: agentRow.id };
+}
+
+export const ensureOrgLimitedFreeBootstrap$ = command(
+  async (
+    { set },
+    args: EnsureOrgLimitedFreeBootstrapArgs,
+    signal: AbortSignal,
+  ): Promise<EnsureOrgLimitedFreeBootstrapResult> => {
+    const writeDb = set(writeDb$);
+    const reservation = await writeDb.transaction(async (tx) => {
+      return await reserveBootstrapCompose(tx, args);
+    });
+    signal.throwIfAborted();
+
+    if (reservation.status === "skipped") {
+      return { bootstrapped: false, agentId: reservation.agentId };
+    }
+
+    await set(
+      upsertOrgNoSecretModelProvider$,
+      {
+        orgId: args.orgId,
+        type: "vm0",
+        selectedModel: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const composeResult = await set(
+      serverSideZeroAgentCompose$,
+      {
+        userId: args.ownerUserId,
+        orgId: args.orgId,
+        agentComposeId: reservation.composeId,
+        agentName: DEFAULT_AGENT_NAME,
+        instructions: SEED_INSTRUCTIONS,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    const result = await writeDb.transaction(async (tx) => {
+      return await finalizeBootstrap(tx, {
+        orgId: args.orgId,
+        ownerUserId: args.ownerUserId,
+        agentId: composeResult.composeId,
+        agentName: composeResult.composeName,
+      });
+    });
+    signal.throwIfAborted();
+
+    if (result.bootstrapped) {
+      L.debug("Org limited-free bootstrap completed", {
+        orgId: args.orgId,
+        agentId: result.agentId,
+      });
+    }
+
+    return result;
+  },
+);

--- a/turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts
+++ b/turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts
@@ -39,7 +39,7 @@ type BootstrapReservation =
       readonly composeId: string;
     };
 
-export interface EnsureOrgLimitedFreeBootstrapResult {
+interface EnsureOrgLimitedFreeBootstrapResult {
   readonly bootstrapped: boolean;
   readonly agentId: string | null;
 }


### PR DESCRIPTION
## Summary

- Add a shared idempotent org bootstrap service that creates a default Zero agent, moves eligible orgs to `limited-free-1`, clears onboarding payment pending state, and grants onboarding credits behind org-level advisory locks.
- Wire Clerk `organization.created` and admin `organizationMembership.created` webhook events into the same bootstrap path.
- Add an admin-only lazy fallback in `GET /api/zero/onboarding/status` that only runs for orgs without a valid default agent, while preserving existing paid tiers.
- Share onboarding credit grant idempotency between onboarding completion and org bootstrap.

Closes #20021

## Verification

- `git diff --check`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api lint`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts --testNamePattern "Clerk"`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/org-team.bdd.test.ts`
