### PR TITLE
fix: embed deck fonts in presentation PPTX export to prevent layout reflow

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -78,4 +78,52 @@ describe("buildPresentationHtmlPptxExportHtml", () => {
     expect(scriptText).not.toContain("var MONO");
     expect(scriptText).toContain("vm0-presentation-pptx-export");
   });
+
+  it("injects live-render font resolution and merges embedded fonts into the export options", async () => {
+    const exportHtml = await buildPresentationHtmlPptxExportHtml({
+      baseUrl: "https://presentation.example.test/index.html",
+      html: `
+        <!doctype html>
+        <html>
+          <head>
+            <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" rel="stylesheet">
+          </head>
+          <body>
+            <div class="slide" data-slide-id="slide-1">
+              <div class="stage" data-vm0-slide>
+                <h1 style="font-family:'Poppins',sans-serif">Slide</h1>
+              </div>
+            </div>
+          </body>
+        </html>
+      `,
+      options: {
+        fileName: "deck.pptx",
+        layout: "LAYOUT_WIDE",
+        skipDownload: true,
+        svgAsVector: true,
+      },
+      signal: AbortSignal.any([]),
+    });
+    const doc = new DOMParser().parseFromString(exportHtml, "text/html");
+    const scriptText = Array.from(doc.querySelectorAll("script"))
+      .map((script) => {
+        return script.textContent ?? "";
+      })
+      .join("\n");
+
+    // Fonts are detected from the live render (computed style), so the resolver
+    // is injected and its result is spread into the dom-to-pptx options.
+    expect(scriptText).toContain("resolveEmbeddableFonts");
+    expect(scriptText).toContain("collectUsedFontFamilies");
+    expect(scriptText).toContain(
+      "https://cdn.jsdelivr.net/fontsource/fonts/{slug}@latest/latin-{weight}-normal.woff",
+    );
+    expect(scriptText).toContain(
+      "const exportOptions = fonts.length > 0 ? { ...options, fonts } : options;",
+    );
+    expect(scriptText).toContain(
+      "window.domToPptx.exportToPptx(nodes, exportOptions)",
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -116,9 +116,10 @@ describe("buildPresentationHtmlPptxExportHtml", () => {
     // is injected and its result is spread into the dom-to-pptx options.
     expect(scriptText).toContain("resolveEmbeddableFonts");
     expect(scriptText).toContain("collectUsedFontFamilies");
-    expect(scriptText).toContain(
-      "https://cdn.jsdelivr.net/fontsource/fonts/{slug}@latest/latin-{weight}-normal.woff",
-    );
+    // Universal URL resolution goes through the Fontsource metadata API so the
+    // family's real weights/styles/subsets are used instead of a guessed path.
+    expect(scriptText).toContain("https://api.fontsource.org/v1/fonts/");
+    expect(scriptText).toContain("https://cdn.jsdelivr.net/fontsource/fonts/");
     expect(scriptText).toContain(
       "const exportOptions = fonts.length > 0 ? { ...options, fonts } : options;",
     );

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -757,18 +757,17 @@ function createExportFontScript(): string {
 
   const resolveEmbeddableFonts = async (nodes) => {
     const localIndex = indexLocalFontFaces();
-    const fonts = [];
-    for (const family of collectUsedFontFamilies(nodes)) {
-      const local = localIndex.get(family.name.toLowerCase());
-      const url =
-        local && local.length > 0
-          ? nearestByWeight(local, family.weight).url
-          : await fontsourceUrl(family.name, family.weight, family.style);
-      if (url) {
-        fonts.push({ name: family.name, url });
-      }
-    }
-    return fonts;
+    const resolved = await Promise.all(
+      collectUsedFontFamilies(nodes).map(async (family) => {
+        const local = localIndex.get(family.name.toLowerCase());
+        const url =
+          local && local.length > 0
+            ? nearestByWeight(local, family.weight).url
+            : await fontsourceUrl(family.name, family.weight, family.style);
+        return url ? { name: family.name, url } : null;
+      }),
+    );
+    return resolved.filter((font) => font !== null);
   };
 `;
 }

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -13,6 +13,11 @@ import {
 import { materializePresentationThemeSwitcherDefaults } from "./presentation-html-edit-protocol.ts";
 
 const EXPORT_FONT_READY_TIMEOUT_MS = 800;
+// dom-to-pptx embeds fonts from a fetchable ttf/otf/woff URL (never woff2). Deck
+// families are resolved from the live render and mapped to a Fontsource woff on
+// jsDelivr when the page itself only ships woff2 (e.g. Google Fonts <link>).
+const FONT_EMBED_CDN_TEMPLATE =
+  "https://cdn.jsdelivr.net/fontsource/fonts/{slug}@latest/latin-{weight}-normal.woff";
 const METADATA_SCRIPT_ID = "vm0-deck-metadata";
 const CONTENT_TYPES_PATH = "[Content_Types].xml";
 const PRESENTATION_PATH = "ppt/presentation.xml";
@@ -579,6 +584,155 @@ function createExportReadinessScript(): string {
 `;
 }
 
+function createExportFontScript(): string {
+  return `
+  const fontEmbedCdnTemplate = ${JSON.stringify(FONT_EMBED_CDN_TEMPLATE)};
+  const genericFontFamilies = new Set([
+    "serif", "sans-serif", "monospace", "cursive", "fantasy", "system-ui",
+    "ui-sans-serif", "ui-serif", "ui-monospace", "ui-rounded", "math", "emoji",
+    "fangsong", "-apple-system", "blinkmacsystemfont",
+  ]);
+
+  const fontFamilySlug = (family) => {
+    return family
+      .trim()
+      .toLowerCase()
+      .replace(/['"]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  };
+
+  const normalizeFontWeight = (weight) => {
+    if (weight === "normal") return 400;
+    if (weight === "bold") return 700;
+    const numeric = Number.parseInt(weight, 10);
+    if (!Number.isFinite(numeric)) return 400;
+    return Math.min(900, Math.max(100, Math.round(numeric / 100) * 100));
+  };
+
+  // Ground truth for "which fonts are used" is the live render's computed style,
+  // not the deck's theme script — so this stays correct across any template. Keep
+  // the weight of the largest text per family (the reflow-sensitive headline).
+  const collectUsedFontFamilies = (nodes) => {
+    const byFamily = new Map();
+    const visit = (node) => {
+      if (node.nodeType === 1) {
+        const style = window.getComputedStyle(node);
+        const primary = (style.fontFamily.split(",")[0] || "")
+          .trim()
+          .replace(/['"]/g, "");
+        const key = primary.toLowerCase();
+        if (primary && !genericFontFamilies.has(key)) {
+          const size = Number.parseFloat(style.fontSize) || 0;
+          const weight = normalizeFontWeight(style.fontWeight);
+          const current = byFamily.get(key);
+          if (!current || size > current.size) {
+            byFamily.set(key, { name: primary, weight, size });
+          }
+        }
+      }
+      for (const child of node.childNodes) {
+        visit(child);
+      }
+    };
+    for (const node of nodes) {
+      visit(node);
+    }
+    return Array.from(byFamily.values());
+  };
+
+  const localFontUrlFromSrc = (src) => {
+    const matches = src.match(/url\\((['"]?)([^'")]+)\\1\\)/gi) || [];
+    for (const match of matches) {
+      const parsed = /url\\((['"]?)([^'")]+)\\1\\)/i.exec(match);
+      if (!parsed) continue;
+      const rawUrl = parsed[2].trim();
+      const extension = rawUrl.split(/[?#]/)[0].split(".").pop().toLowerCase();
+      if (extension === "ttf" || extension === "otf" || extension === "woff") {
+        try {
+          return new URL(rawUrl, document.baseURI).href;
+        } catch {
+          return rawUrl;
+        }
+      }
+    }
+    return null;
+  };
+
+  // Same-origin / inline @font-face only; cross-origin sheets (Google Fonts)
+  // throw on cssRules access and are skipped, falling back to the CDN template.
+  const indexLocalFontFaces = () => {
+    const index = new Map();
+    for (const sheet of Array.from(document.styleSheets)) {
+      let rules;
+      try {
+        rules = sheet.cssRules;
+      } catch {
+        continue;
+      }
+      if (!rules) continue;
+      for (const rule of Array.from(rules)) {
+        if (
+          typeof CSSFontFaceRule === "undefined" ||
+          !(rule instanceof CSSFontFaceRule)
+        ) {
+          continue;
+        }
+        const family = (rule.style.getPropertyValue("font-family") || "")
+          .trim()
+          .replace(/['"]/g, "")
+          .toLowerCase();
+        const url = localFontUrlFromSrc(
+          rule.style.getPropertyValue("src") || "",
+        );
+        if (!family || !url) continue;
+        const weight = normalizeFontWeight(
+          (rule.style.getPropertyValue("font-weight") || "400")
+            .trim()
+            .split(/\\s+/)[0],
+        );
+        const list = index.get(family) || [];
+        list.push({ weight, url });
+        index.set(family, list);
+      }
+    }
+    return index;
+  };
+
+  const nearestByWeight = (candidates, target) => {
+    return candidates.reduce((best, candidate) => {
+      return Math.abs(candidate.weight - target) <
+        Math.abs(best.weight - target)
+        ? candidate
+        : best;
+    }, candidates[0]);
+  };
+
+  const resolveEmbeddableFonts = (nodes) => {
+    const localIndex = indexLocalFontFaces();
+    const fonts = [];
+    for (const family of collectUsedFontFamilies(nodes)) {
+      const local = localIndex.get(family.name.toLowerCase());
+      let url = null;
+      if (local && local.length > 0) {
+        url = nearestByWeight(local, family.weight).url;
+      } else {
+        const slug = fontFamilySlug(family.name);
+        if (slug) {
+          url = fontEmbedCdnTemplate
+            .replace("{slug}", slug)
+            .replace("{weight}", String(family.weight));
+        }
+      }
+      if (url) {
+        fonts.push({ name: family.name, url });
+      }
+    }
+    return fonts;
+  };
+`;
+}
+
 function createExportRunnerScript(): string {
   return `
   void (async () => {
@@ -593,7 +747,9 @@ function createExportRunnerScript(): string {
     revealSlideNodes(nodes);
     copyInheritedSlideBackgrounds(nodes);
     await waitForExportReadiness(nodes);
-    const blob = await window.domToPptx.exportToPptx(nodes, options);
+    const fonts = resolveEmbeddableFonts(nodes);
+    const exportOptions = fonts.length > 0 ? { ...options, fonts } : options;
+    const blob = await window.domToPptx.exportToPptx(nodes, exportOptions);
     post({ status: "success", blob });
   })().catch((error) => {
     post({
@@ -610,6 +766,7 @@ function createExportScript(options: DomToPptxOptions): string {
     createExportBootstrapScript(options),
     createExportSlideScript(),
     createExportReadinessScript(),
+    createExportFontScript(),
     createExportRunnerScript(),
   ].join("");
 }

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -14,10 +14,11 @@ import { materializePresentationThemeSwitcherDefaults } from "./presentation-htm
 
 const EXPORT_FONT_READY_TIMEOUT_MS = 800;
 // dom-to-pptx embeds fonts from a fetchable ttf/otf/woff URL (never woff2). Deck
-// families are resolved from the live render and mapped to a Fontsource woff on
-// jsDelivr when the page itself only ships woff2 (e.g. Google Fonts <link>).
-const FONT_EMBED_CDN_TEMPLATE =
-  "https://cdn.jsdelivr.net/fontsource/fonts/{slug}@latest/latin-{weight}-normal.woff";
+// families are resolved from the live render; when the page itself only ships
+// woff2 (e.g. Google Fonts <link>), the Fontsource metadata API is queried for
+// the family's real weights/styles/subsets so the woff URL always exists.
+const FONT_METADATA_API_BASE = "https://api.fontsource.org/v1/fonts/";
+const FONT_FILE_CDN_BASE = "https://cdn.jsdelivr.net/fontsource/fonts/";
 const METADATA_SCRIPT_ID = "vm0-deck-metadata";
 const CONTENT_TYPES_PATH = "[Content_Types].xml";
 const PRESENTATION_PATH = "ppt/presentation.xml";
@@ -586,7 +587,8 @@ function createExportReadinessScript(): string {
 
 function createExportFontScript(): string {
   return `
-  const fontEmbedCdnTemplate = ${JSON.stringify(FONT_EMBED_CDN_TEMPLATE)};
+  const fontMetadataApiBase = ${JSON.stringify(FONT_METADATA_API_BASE)};
+  const fontFileCdnBase = ${JSON.stringify(FONT_FILE_CDN_BASE)};
   const genericFontFamilies = new Set([
     "serif", "sans-serif", "monospace", "cursive", "fantasy", "system-ui",
     "ui-sans-serif", "ui-serif", "ui-monospace", "ui-rounded", "math", "emoji",
@@ -625,9 +627,10 @@ function createExportFontScript(): string {
         if (primary && !genericFontFamilies.has(key)) {
           const size = Number.parseFloat(style.fontSize) || 0;
           const weight = normalizeFontWeight(style.fontWeight);
+          const fontStyle = style.fontStyle === "italic" ? "italic" : "normal";
           const current = byFamily.get(key);
           if (!current || size > current.size) {
-            byFamily.set(key, { name: primary, weight, size });
+            byFamily.set(key, { name: primary, weight, size, style: fontStyle });
           }
         }
       }
@@ -699,6 +702,14 @@ function createExportFontScript(): string {
     return index;
   };
 
+  const nearestNumber = (candidates, target) => {
+    return candidates.reduce((best, candidate) => {
+      return Math.abs(candidate - target) < Math.abs(best - target)
+        ? candidate
+        : best;
+    }, candidates[0]);
+  };
+
   const nearestByWeight = (candidates, target) => {
     return candidates.reduce((best, candidate) => {
       return Math.abs(candidate.weight - target) <
@@ -708,22 +719,51 @@ function createExportFontScript(): string {
     }, candidates[0]);
   };
 
-  const resolveEmbeddableFonts = (nodes) => {
+  // True-universal URL resolution: ask the Fontsource metadata API for the
+  // family's real weights/styles/subsets, so we never guess a 404 (missing
+  // weight, italic-only, or a non-latin subset like chinese-simplified). Any
+  // family not on Fontsource returns null and is left to the page @font-face
+  // path or skipped — no crash, no regression.
+  const fontsourceUrl = async (family, weight, style) => {
+    const slug = fontFamilySlug(family);
+    if (!slug) return null;
+    let meta;
+    try {
+      const response = await fetch(fontMetadataApiBase + slug);
+      if (!response.ok) return null;
+      meta = await response.json();
+    } catch {
+      return null;
+    }
+    const weights = Array.isArray(meta.weights) ? meta.weights : [];
+    const subsets = Array.isArray(meta.subsets) ? meta.subsets : [];
+    const styles = Array.isArray(meta.styles) ? meta.styles : [];
+    if (weights.length === 0 || subsets.length === 0) return null;
+    const resolvedWeight = nearestNumber(weights, weight);
+    const resolvedStyle = styles.includes(style) ? style : "normal";
+    const resolvedSubset = subsets.includes("latin") ? "latin" : subsets[0];
+    return (
+      fontFileCdnBase +
+      slug +
+      "@latest/" +
+      resolvedSubset +
+      "-" +
+      resolvedWeight +
+      "-" +
+      resolvedStyle +
+      ".woff"
+    );
+  };
+
+  const resolveEmbeddableFonts = async (nodes) => {
     const localIndex = indexLocalFontFaces();
     const fonts = [];
     for (const family of collectUsedFontFamilies(nodes)) {
       const local = localIndex.get(family.name.toLowerCase());
-      let url = null;
-      if (local && local.length > 0) {
-        url = nearestByWeight(local, family.weight).url;
-      } else {
-        const slug = fontFamilySlug(family.name);
-        if (slug) {
-          url = fontEmbedCdnTemplate
-            .replace("{slug}", slug)
-            .replace("{weight}", String(family.weight));
-        }
-      }
+      const url =
+        local && local.length > 0
+          ? nearestByWeight(local, family.weight).url
+          : await fontsourceUrl(family.name, family.weight, family.style);
       if (url) {
         fonts.push({ name: family.name, url });
       }
@@ -747,7 +787,7 @@ function createExportRunnerScript(): string {
     revealSlideNodes(nodes);
     copyInheritedSlideBackgrounds(nodes);
     await waitForExportReadiness(nodes);
-    const fonts = resolveEmbeddableFonts(nodes);
+    const fonts = await resolveEmbeddableFonts(nodes);
     const exportOptions = fonts.length > 0 ? { ...options, fonts } : options;
     const blob = await window.domToPptx.exportToPptx(nodes, exportOptions);
     post({ status: "success", blob });


### PR DESCRIPTION
## Problem

Downloading a `presentation-html` deck as PPTX produced a file that PowerPoint/Keynote opened with a **"missing font"** warning (e.g. *Poppins*, *Figtree*, *Archivo*, *Manrope*). With the design font absent, the app substitutes a narrower font and **re-flows the text**: the cover headline dropped from 4 lines to 3, the last line overflowed right and collided with decorative elements. Users read this as the layout "shifting" — but the shape coordinates were correct; only the text inside the boxes re-wrapped.

Root cause: `downloadPresentationHtmlStringPptx` called `dom-to-pptx` **without a `fonts` option**, so no fonts were embedded. `dom-to-pptx`'s auto-detect deliberately skips `woff2`, and decks load fonts via a Google Fonts `<link>` that only serves `woff2`, so nothing got embedded (no `ppt/fonts/*.fntdata`).

## Fix

Resolve the fonts to embed at export time and hand them to `dom-to-pptx`:

- **Detect used families from the live render** (`getComputedStyle(...).fontFamily`) inside the export iframe — ground truth and **template-agnostic**. This matters: a deck's `<link>` may declare 17 families, its `:root` may default to one pair, and the theme switcher may select yet another at runtime (e.g. the dog deck renders **Archivo/Manrope**, not the `:root` Poppins/Figtree). Only computed style gives the truly-used pair. Keep the weight of the largest text per family (the reflow-sensitive headline).
- **Map each family to a fetchable non-woff2 URL**:
  1. Prefer a `ttf/otf/woff` `src` already declared in the page's own `@font-face` (covers self-hosted / non-Google templates).
  2. Otherwise query the **Fontsource metadata API** (`api.fontsource.org/v1/fonts/{slug}`) for the family's real `weights`/`styles`/`subsets`, then build a jsDelivr `woff` URL from an **existing** nearest weight, an existing style, and a valid subset. This avoids guessed-404s: single-weight families (DM Serif Display → 400), italic-only families, and non-latin subsets are all handled.
  3. Families not on Fontsource (commercial/brand fonts) resolve to null and are skipped — no crash, no regression.
- Merge the resolved list into the `exportToPptx` options; `dom-to-pptx` then writes `ppt/fonts/*.fntdata` + `embeddedFontLst` so the deck's fonts travel with the file.

Scope is limited to the export path (`presentation-html-pptx-download.ts`); no template or generator changes.

## Notes / follow-ups

- `dom-to-pptx` fills only the `<p:regular>` slot per typeface, so exactly one weight per family is embedded; heavier weights are synthesized by the viewer. Enough to stabilize the reported reflow.
- Subset selection prefers `latin`; a deck whose **primary** text is CJK would need content-driven subset selection (and a much larger embed). Current decks use CJK only as fallbacks, so this is out of scope here.
- Residual browser-vs-PowerPoint line-break differences (even with the right font) are a separate optional hardening step (bake soft-wraps into hard breaks + disable autofit).

## Verification

- Injected export script syntax-checked (`node --check`); resolver exercised against the **live** Fontsource API: Archivo 600 → `latin-600`, Manrope 400 → `latin-400`, DM Serif Display 600 → clamped to `latin-400` (200), Helvetica Neue → null (skipped).
- Confirmed Fontsource file + metadata endpoints return `200` with `access-control-allow-origin: *` (fetchable from the sandboxed null-origin export iframe).
- Integration test asserts the resolver is injected and its result is spread into the `dom-to-pptx` options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)