### PR TITLE
fix: prevent limited free onboarding downgrades

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -144,6 +144,7 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
 
     const paidOnboardingBilling = await runsApi.readBillingStatus(admin);
     expect(paidOnboardingBilling).toMatchObject({
+      tier: "pro-suspend",
       onboardingPaymentPending: true,
     });
 
@@ -157,22 +158,36 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
     expectApiError(forgedLimitedFree.body);
     expect(forgedLimitedFree.body.error.code).toBe("BAD_REQUEST");
 
-    const completeLimitedFree = await api.completeLimitedFreeOnboarding(admin, {
-      credits: 1000,
-      expiresAt: null,
-    });
+    await runsApi.grantProEntitlement(admin);
+    const paidLimitedFree = await api.completeLimitedFreeOnboarding(admin);
+    if (paidLimitedFree.status !== 409) {
+      throw new Error(
+        `Expected paid limited-free completion to fail, got ${paidLimitedFree.status}`,
+      );
+    }
+    expect(paidLimitedFree.body.error.code).toBe("ORG_TIER_ALREADY_SET");
+    const afterPaidLimitedFree = await runsApi.readBillingStatus(admin);
+    expect(afterPaidLimitedFree.tier).toBe("pro");
+
+    const limitedFreeAdmin = api.user();
+    const completeLimitedFree =
+      await api.completeLimitedFreeOnboarding(limitedFreeAdmin);
     expect(completeLimitedFree.status).toBe(200);
     expect(completeLimitedFree.body).toStrictEqual({
-      agentId: defaultAgentId,
       tier: "limited-free-1",
-      needsOnboarding: false,
+      needsOnboarding: true,
     });
 
-    const afterLimitedFree = await api.readOnboardingStatus(admin);
-    expect(afterLimitedFree.needsOnboarding).toBeFalsy();
-    expect(afterLimitedFree.defaultAgentId).toBe(defaultAgentId);
+    const limitedFreeBeforeSetup =
+      await api.readOnboardingStatus(limitedFreeAdmin);
+    expect(limitedFreeBeforeSetup).toMatchObject({
+      needsOnboarding: true,
+      hasDefaultAgent: false,
+      defaultAgentId: null,
+    });
 
-    const limitedFreeBilling = await runsApi.readBillingStatus(admin);
+    const limitedFreeBilling =
+      await runsApi.readBillingStatus(limitedFreeAdmin);
     expect(limitedFreeBilling).toMatchObject({
       credits: 1000,
       tier: "limited-free-1",
@@ -188,6 +203,18 @@ describe("AUTH-01, ORG-03, AGENT-02, CHAIN-AGENT", () => {
       amount: 1000,
       remaining: 1000,
       expiresAt: "2999-12-31T00:00:00.000Z",
+    });
+
+    const limitedFreeAgentId = await onboardAdmin(limitedFreeAdmin, {
+      displayName: "BDD Limited Free Agent",
+      workspaceName: "BDD Limited Free Org",
+    });
+    const afterLimitedFreeSetup =
+      await api.readOnboardingStatus(limitedFreeAdmin);
+    expect(afterLimitedFreeSetup).toMatchObject({
+      needsOnboarding: false,
+      hasDefaultAgent: true,
+      defaultAgentId: limitedFreeAgentId,
     });
 
     const afterRepeatedSetup = await api.listAgents(admin);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd.ts
@@ -71,10 +71,7 @@ export interface OnboardingSetupBody {
   readonly role?: string;
 }
 
-interface OnboardingCompleteLimitedFreeBody {
-  readonly credits?: number;
-  readonly expiresAt?: string | null;
-}
+type OnboardingCompleteLimitedFreeBody = Record<string, never>;
 
 function authHeaders(user: ApiTestUser | null): AuthHeaders {
   return user ? { authorization: "Bearer clerk-session" } : {};

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-gmail.test.ts
@@ -452,12 +452,14 @@ async function setupFixture(): Promise<GmailTestFixture> {
   }
 
   bdd.acceptAgentStorageWrites();
+  const completed = await bdd.completeLimitedFreeOnboarding(actor);
+  if (completed.status !== 200) {
+    throw new Error(
+      `Expected limited-free onboarding to succeed, got ${completed.status}`,
+    );
+  }
   await bdd.setupOnboarding(actor, {
     displayName: "BDD Gmail Webhook Owner",
-  });
-  await bdd.completeLimitedFreeOnboarding(actor, {
-    credits: 1000,
-    expiresAt: null,
   });
   await grantVisibleCredits({ ...actor, orgId: actor.orgId });
   const agent = await bdd.createAgent(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-agents-create.test.ts
@@ -72,21 +72,18 @@ async function completeLimitedFreeWorkspace(
   fixture: AgentsFixture,
 ): Promise<void> {
   authOrgApi.acceptAgentStorageWrites();
+  const completed = await authOrgApi.completeLimitedFreeOnboarding(fixture);
+  if (completed.status !== 200) {
+    throw new Error(
+      `Expected limited-free onboarding to succeed, got ${completed.status}`,
+    );
+  }
   const setup = await authOrgApi.setupOnboarding(fixture, {
     displayName: "BDD Agent Create Workspace",
   });
   if (setup.status !== 200 && setup.status !== 409) {
     throw new Error(
       `Expected onboarding setup to succeed, got ${setup.status}`,
-    );
-  }
-  const completed = await authOrgApi.completeLimitedFreeOnboarding(fixture, {
-    credits: 1000,
-    expiresAt: null,
-  });
-  if (completed.status !== 200) {
-    throw new Error(
-      `Expected limited-free onboarding to succeed, got ${completed.status}`,
     );
   }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -115,21 +115,18 @@ async function makeLimitedFreeWorkspace(
   fixture: ModelPolicyFixture,
 ): Promise<void> {
   authOrgApi.acceptAgentStorageWrites();
+  const completed = await authOrgApi.completeLimitedFreeOnboarding(fixture);
+  if (completed.status !== 200) {
+    throw new Error(
+      `Expected limited-free onboarding to succeed, got ${completed.status}`,
+    );
+  }
   const setup = await authOrgApi.setupOnboarding(fixture, {
     displayName: "BDD Model Policy Agent",
   });
   if (setup.status !== 200 && setup.status !== 409) {
     throw new Error(
       `Expected onboarding setup to succeed, got ${setup.status}`,
-    );
-  }
-  const completed = await authOrgApi.completeLimitedFreeOnboarding(fixture, {
-    credits: 1000,
-    expiresAt: null,
-  });
-  if (completed.status !== 200) {
-    throw new Error(
-      `Expected limited-free onboarding to succeed, got ${completed.status}`,
     );
   }
 }

--- a/turbo/apps/api/src/signals/routes/zero-onboarding-complete-limited-free.ts
+++ b/turbo/apps/api/src/signals/routes/zero-onboarding-complete-limited-free.ts
@@ -38,8 +38,6 @@ const completeInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     completeLimitedFreeOnboarding$,
     {
       orgId: auth.orgId,
-      credits: body.data.credits,
-      expiresAt: body.data.expiresAt,
     },
     signal,
   );

--- a/turbo/apps/api/src/signals/services/onboarding.service.ts
+++ b/turbo/apps/api/src/signals/services/onboarding.service.ts
@@ -31,6 +31,7 @@ const L = logger("onboarding.service");
 const ONBOARDING_CREDIT_SOURCE = "onboarding";
 const ONBOARDING_CREDIT_IDEMPOTENCY_KEY = "limited-free-onboarding";
 const ONBOARDING_CREDITS_NEVER_EXPIRE_AT = "2999-12-31T00:00:00Z";
+const LIMITED_FREE_ONBOARDING_CREDITS = 1000;
 
 interface DefaultAgentInfo {
   readonly composeId: string;
@@ -78,9 +79,8 @@ type CompleteLimitedFreeOnboardingResponse =
   | {
       readonly status: 200;
       readonly body: {
-        readonly agentId: string;
         readonly tier: "limited-free-1";
-        readonly needsOnboarding: false;
+        readonly needsOnboarding: true;
       };
     }
   | {
@@ -88,15 +88,13 @@ type CompleteLimitedFreeOnboardingResponse =
       readonly body: {
         readonly error: {
           readonly message: string;
-          readonly code: "DEFAULT_AGENT_REQUIRED";
+          readonly code: "ORG_TIER_ALREADY_SET";
         };
       };
     };
 
 interface CompleteLimitedFreeOnboardingArgs {
   readonly orgId: string;
-  readonly credits: number;
-  readonly expiresAt: string | null;
 }
 
 async function grantOrgCredits(
@@ -768,56 +766,51 @@ export const completeLimitedFreeOnboarding$ = command(
     signal: AbortSignal,
   ): Promise<CompleteLimitedFreeOnboardingResponse> => {
     const writeDb = set(writeDb$);
-    const agentId = await existingDefaultAgentId(writeDb, args.orgId);
+    const inserted = await writeDb.transaction(async (tx) => {
+      const rows = await tx
+        .insert(orgMetadata)
+        .values({
+          orgId: args.orgId,
+          tier: "limited-free-1",
+          onboardingPaymentPending: false,
+          updatedAt: nowDate(),
+        })
+        .onConflictDoNothing({ target: orgMetadata.orgId })
+        .returning({ orgId: orgMetadata.orgId });
+
+      if (rows.length === 0) {
+        return false;
+      }
+
+      await grantOnboardingCredits(
+        tx,
+        args.orgId,
+        LIMITED_FREE_ONBOARDING_CREDITS,
+        new Date(ONBOARDING_CREDITS_NEVER_EXPIRE_AT),
+      );
+
+      return true;
+    });
     signal.throwIfAborted();
 
-    if (!agentId) {
+    if (!inserted) {
       return {
         status: 409,
         body: {
           error: {
-            message: "A default agent is required before completing onboarding",
-            code: "DEFAULT_AGENT_REQUIRED",
+            message:
+              "Limited free onboarding can only start before an org tier is set",
+            code: "ORG_TIER_ALREADY_SET",
           },
         },
       };
     }
 
-    await writeDb.transaction(async (tx) => {
-      await tx
-        .insert(orgMetadata)
-        .values({
-          orgId: args.orgId,
-          defaultAgentId: agentId,
-          tier: "limited-free-1",
-          onboardingPaymentPending: false,
-          updatedAt: nowDate(),
-        })
-        .onConflictDoUpdate({
-          target: orgMetadata.orgId,
-          set: {
-            defaultAgentId: agentId,
-            tier: "limited-free-1",
-            onboardingPaymentPending: false,
-            updatedAt: nowDate(),
-          },
-        });
-
-      await grantOnboardingCredits(
-        tx,
-        args.orgId,
-        args.credits,
-        new Date(args.expiresAt ?? ONBOARDING_CREDITS_NEVER_EXPIRE_AT),
-      );
-    });
-    signal.throwIfAborted();
-
     return {
       status: 200,
       body: {
-        agentId,
         tier: "limited-free-1",
-        needsOnboarding: false,
+        needsOnboarding: true,
       },
     };
   },

--- a/turbo/packages/api-contracts/src/contracts/onboarding.ts
+++ b/turbo/packages/api-contracts/src/contracts/onboarding.ts
@@ -73,24 +73,18 @@ export const onboardingCompleteLimitedFreeContract = c.router({
     method: "POST",
     path: "/api/zero/onboarding/complete-limited-free",
     headers: authHeadersSchema,
-    body: z
-      .object({
-        credits: z.number().int().positive().max(1000).default(1000),
-        expiresAt: z.string().datetime().nullable().default(null),
-      })
-      .strict(),
+    body: z.object({}).strict(),
     responses: {
       200: z.object({
-        agentId: z.string(),
         tier: z.literal("limited-free-1"),
-        needsOnboarding: z.literal(false),
+        needsOnboarding: z.literal(true),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       409: apiErrorSchema,
     },
-    summary: "Complete onboarding and enter the limited free tier",
+    summary: "Initialize a new organization in the limited free tier",
   },
 });
 


### PR DESCRIPTION
## Summary
- make limited-free onboarding accept only an empty request body and grant the fixed 1000-credit ($1) onboarding grant server-side
- create `org_metadata` only for orgs without an existing metadata row, returning `ORG_TIER_ALREADY_SET` instead of downgrading existing Pro/Team tiers
- update onboarding fixtures so limited-free initialization happens before setup creates the default agent

## Tests
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/auth-org-agents.bdd.test.ts src/signals/routes/__tests__/zero-agents-create.test.ts src/signals/routes/__tests__/zero-model-policies.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-gmail.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`

## Notes
- Full `pnpm vitest` was attempted after syncing DB migrations. API schema failures were fixed by migration, app UI timeout failures passed when rerun by file, and the remaining deterministic failures are unrelated connector firewall metadata drift for Sentry/Xero cached specs.
