### PR TITLE
docs: clarify auth base forwarder test helpers

### DIFF
--- a/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
@@ -1,4 +1,4 @@
-"""Shared fake upstream helpers for auth.base forwarder tests."""
+"""Shared fake upstream helpers for auth.base forwarding tests."""
 
 import contextlib
 import http.client as http_client
@@ -7,6 +7,8 @@ from collections.abc import Callable, Iterator
 from unittest.mock import patch
 
 import auth_base_forwarder as forwarder
+
+__all__ = ["FakeSocket", "fake_forwarder_upstream", "http_response"]
 
 
 def _addrinfo(address: str, port: int):
@@ -33,6 +35,7 @@ def http_response(
     body: bytes = b"ok",
     headers: list[tuple[str, str]] | None = None,
 ) -> bytes:
+    """Build raw HTTP/1.1 response bytes for a fake upstream socket."""
     reason = http_client.responses.get(status, "OK")
     header_bytes = b"".join(f"{name}: {value}\r\n".encode() for name, value in (headers or []))
     return f"HTTP/1.1 {status} {reason}\r\n".encode("ascii") + header_bytes + b"\r\n" + body
@@ -66,6 +69,17 @@ class _FakeResponseFile(io.BytesIO):
 
 
 class FakeSocket:
+    """Socket-like test double that records forwarded auth.base requests.
+
+    The forwarder writes to ``sent``, calls ``setsockopt``/``makefile``/``close``,
+    and reads the provided response bytes from the file object returned by
+    ``makefile``. Side-effect arguments raise at the matching boundary so tests
+    can exercise send, read, response setup, and TCP option failures.
+
+    Use ``request_text``, ``request_lines``, and ``request_header_values`` for
+    assertions about the HTTP request that the real forwarder serialized.
+    """
+
     def __init__(
         self,
         response: bytes,
@@ -137,6 +151,9 @@ class FakeSocket:
         return values
 
 
+_CreateConnection = Callable[[tuple[str, int], object, object], FakeSocket]
+
+
 class _FakeTLSContext:
     def __init__(
         self,
@@ -163,6 +180,14 @@ class _FakeTLSContext:
 
 
 class _FakeForwarderUpstream:
+    """Assertion handle yielded by ``fake_forwarder_upstream``.
+
+    Tests normally obtain this from the context manager because direct
+    construction does not patch ``auth_base_forwarder``. Stable assertion state
+    includes DNS calls, connection calls, created sockets, TLS contexts, and the
+    most recent socket via ``socket``.
+    """
+
     def __init__(
         self,
         *,
@@ -176,7 +201,7 @@ class _FakeForwarderUpstream:
         setsockopt_side_effect: Exception | None = None,
         wrap_side_effect: Exception | None = None,
         on_action: Callable[[], None] | None = None,
-        create_connection: Callable[[tuple[str, int], object, object], FakeSocket] | None = None,
+        create_connection: _CreateConnection | None = None,
     ) -> None:
         self._addresses = addresses
         self._response = http_response(status=status, body=body, headers=headers)
@@ -230,8 +255,45 @@ class _FakeForwarderUpstream:
 
 
 @contextlib.contextmanager
-def fake_forwarder_upstream(**kwargs) -> Iterator[_FakeForwarderUpstream]:
-    upstream = _FakeForwarderUpstream(**kwargs)
+def fake_forwarder_upstream(
+    *,
+    status: int = 200,
+    body: bytes = b"ok",
+    headers: list[tuple[str, str]] | None = None,
+    addresses: tuple[str, ...] = ("93.184.216.34",),
+    read_side_effect: Exception | None = None,
+    send_side_effect: Exception | None = None,
+    makefile_side_effect: Exception | None = None,
+    setsockopt_side_effect: Exception | None = None,
+    wrap_side_effect: Exception | None = None,
+    on_action: Callable[[], None] | None = None,
+    create_connection: _CreateConnection | None = None,
+) -> Iterator[_FakeForwarderUpstream]:
+    """Patch auth.base DNS/connect/TLS boundaries and yield an upstream handle.
+
+    The context manager patches only ``auth_base_forwarder.socket.getaddrinfo``,
+    ``auth_base_forwarder.socket.create_connection``, and
+    ``auth_base_forwarder.ssl.create_default_context``. ``addresses`` controls
+    the DNS answers returned to the real forwarder before any socket is opened.
+    Socket and TLS side effects raise at their matching fake boundary.
+
+    The yielded handle exposes stable assertion state: ``getaddrinfo_calls``,
+    ``create_connection_calls``, ``sockets``, ``contexts``, and ``socket`` for
+    the most recent connection.
+    """
+    upstream = _FakeForwarderUpstream(
+        status=status,
+        body=body,
+        headers=headers,
+        addresses=addresses,
+        read_side_effect=read_side_effect,
+        send_side_effect=send_side_effect,
+        makefile_side_effect=makefile_side_effect,
+        setsockopt_side_effect=setsockopt_side_effect,
+        wrap_side_effect=wrap_side_effect,
+        on_action=on_action,
+        create_connection=create_connection,
+    )
     with (
         patch.object(forwarder.socket, "getaddrinfo", side_effect=upstream.getaddrinfo),
         patch.object(

--- a/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import auth_base_forwarder as forwarder
 
-__all__ = ["FakeSocket", "fake_forwarder_upstream", "http_response"]
+__all__ = ["FakeForwarderUpstream", "FakeSocket", "fake_forwarder_upstream", "http_response"]
 
 
 def _addrinfo(address: str, port: int):
@@ -35,7 +35,12 @@ def http_response(
     body: bytes = b"ok",
     headers: list[tuple[str, str]] | None = None,
 ) -> bytes:
-    """Build raw HTTP/1.1 response bytes for a fake upstream socket."""
+    """Build raw HTTP/1.1 response bytes for a fake upstream socket.
+
+    The status line uses the standard reason phrase when Python knows the
+    status code, repeated headers are preserved in order, and ``body`` is
+    appended verbatim after the header terminator.
+    """
     reason = http_client.responses.get(status, "OK")
     header_bytes = b"".join(f"{name}: {value}\r\n".encode() for name, value in (headers or []))
     return f"HTTP/1.1 {status} {reason}\r\n".encode("ascii") + header_bytes + b"\r\n" + body
@@ -73,8 +78,12 @@ class FakeSocket:
 
     The forwarder writes to ``sent``, calls ``setsockopt``/``makefile``/``close``,
     and reads the provided response bytes from the file object returned by
-    ``makefile``. Side-effect arguments raise at the matching boundary so tests
-    can exercise send, read, response setup, and TCP option failures.
+    ``makefile``. ``closed``, ``close_count``, ``setsockopt_calls``, and
+    ``response_file`` are stable assertion state for tests that need to verify
+    cleanup and TCP option behavior.
+
+    Side-effect arguments raise at the matching boundary so tests can exercise
+    send, read, response setup, and TCP option failures.
 
     Use ``request_text``, ``request_lines``, and ``request_header_values`` for
     assertions about the HTTP request that the real forwarder serialized.
@@ -179,13 +188,16 @@ class _FakeTLSContext:
         return raw_sock
 
 
-class _FakeForwarderUpstream:
+class FakeForwarderUpstream:
     """Assertion handle yielded by ``fake_forwarder_upstream``.
 
-    Tests normally obtain this from the context manager because direct
-    construction does not patch ``auth_base_forwarder``. Stable assertion state
-    includes DNS calls, connection calls, created sockets, TLS contexts, and the
-    most recent socket via ``socket``.
+    The class is public so the context manager's return value and stable fields
+    are explicit. Tests should still obtain instances from
+    ``fake_forwarder_upstream`` because direct construction does not patch
+    ``auth_base_forwarder``.
+
+    Stable assertion state includes DNS calls, connection calls, created
+    sockets, TLS contexts, and the most recent socket via ``socket``.
     """
 
     def __init__(
@@ -268,7 +280,7 @@ def fake_forwarder_upstream(
     wrap_side_effect: Exception | None = None,
     on_action: Callable[[], None] | None = None,
     create_connection: _CreateConnection | None = None,
-) -> Iterator[_FakeForwarderUpstream]:
+) -> Iterator[FakeForwarderUpstream]:
     """Patch auth.base DNS/connect/TLS boundaries and yield an upstream handle.
 
     The context manager patches only ``auth_base_forwarder.socket.getaddrinfo``,
@@ -281,7 +293,7 @@ def fake_forwarder_upstream(
     ``create_connection_calls``, ``sockets``, ``contexts``, and ``socket`` for
     the most recent connection.
     """
-    upstream = _FakeForwarderUpstream(
+    upstream = FakeForwarderUpstream(
         status=status,
         body=body,
         headers=headers,

--- a/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_base_forwarder_helpers.py
@@ -8,7 +8,14 @@ from unittest.mock import patch
 
 import auth_base_forwarder as forwarder
 
-__all__ = ["FakeForwarderUpstream", "FakeSocket", "fake_forwarder_upstream", "http_response"]
+__all__ = [
+    "FakeForwarderUpstream",
+    "FakeResponseFile",
+    "FakeSocket",
+    "FakeTLSContext",
+    "fake_forwarder_upstream",
+    "http_response",
+]
 
 
 def _addrinfo(address: str, port: int):
@@ -46,7 +53,14 @@ def http_response(
     return f"HTTP/1.1 {status} {reason}\r\n".encode("ascii") + header_bytes + b"\r\n" + body
 
 
-class _FakeResponseFile(io.BytesIO):
+class FakeResponseFile(io.BytesIO):
+    """Readable response handle exposed through ``FakeSocket.response_file``.
+
+    Tests use this object to assert how the real forwarder read and closed the
+    upstream response. ``read_sizes`` and ``close_count`` are stable assertion
+    state.
+    """
+
     def __init__(
         self,
         payload: bytes,
@@ -106,7 +120,7 @@ class FakeSocket:
         self._setsockopt_side_effect = setsockopt_side_effect
         self._on_action = on_action
         self.sent = bytearray()
-        self.response_file: _FakeResponseFile | None = None
+        self.response_file: FakeResponseFile | None = None
         self.closed = False
         self.close_count = 0
         self.setsockopt_calls: list[tuple[int, int, int]] = []
@@ -127,11 +141,11 @@ class FakeSocket:
             raise self._send_side_effect
         self.sent.extend(data)
 
-    def makefile(self, *_args, **_kwargs) -> _FakeResponseFile:
+    def makefile(self, *_args, **_kwargs) -> FakeResponseFile:
         self._record_action()
         if self._makefile_side_effect is not None:
             raise self._makefile_side_effect
-        self.response_file = _FakeResponseFile(
+        self.response_file = FakeResponseFile(
             self._response,
             read_side_effect=self._read_side_effect,
             on_action=self._on_action,
@@ -163,7 +177,14 @@ class FakeSocket:
 _CreateConnection = Callable[[tuple[str, int], object, object], FakeSocket]
 
 
-class _FakeTLSContext:
+class FakeTLSContext:
+    """TLS context test double created by ``fake_forwarder_upstream``.
+
+    Tests use ``server_hostnames`` to assert SNI behavior. ``alpn_protocols`` and
+    ``post_handshake_auth`` reflect how the real forwarder configures the TLS
+    context before wrapping sockets.
+    """
+
     def __init__(
         self,
         *,
@@ -225,7 +246,7 @@ class FakeForwarderUpstream:
         self._on_action = on_action
         self._create_connection = create_connection
         self.sockets: list[FakeSocket] = []
-        self.contexts: list[_FakeTLSContext] = []
+        self.contexts: list[FakeTLSContext] = []
         self.getaddrinfo_calls: list[tuple[str, int]] = []
         self.create_connection_calls: list[tuple[tuple[str, int], object, object]] = []
 
@@ -252,8 +273,8 @@ class FakeForwarderUpstream:
             on_action=self._on_action,
         )
 
-    def create_default_context(self) -> _FakeTLSContext:
-        context = _FakeTLSContext(
+    def create_default_context(self) -> FakeTLSContext:
+        context = FakeTLSContext(
             wrap_side_effect=self._wrap_side_effect,
             on_action=self._on_action,
         )


### PR DESCRIPTION
## Summary

- make `fake_forwarder_upstream` expose its supported keyword-only configuration surface directly
- expose the yielded `FakeForwarderUpstream` assertion handle instead of returning a private type
- expose `FakeResponseFile` and `FakeTLSContext` for nested stable assertion state
- document the fake upstream patch boundary and assertion-handle contract
- document `FakeSocket` and `http_response` for tests that import them directly

Closes #20004

## Tests

- `PATH=/tmp/vm2-mitm-addon-venv/bin:$PATH git commit -m "docs: clarify auth base forwarder test helpers"` (pre-commit ran crates ruff format/check)
- `/tmp/vm2-mitm-addon-venv/bin/ruff check tests/auth_base_forwarder_helpers.py`
- `/tmp/vm2-mitm-addon-venv/bin/ruff format --check tests/auth_base_forwarder_helpers.py`
- `/tmp/vm2-mitm-addon-venv/bin/basedpyright tests/auth_base_forwarder_helpers.py`
- `/tmp/vm2-mitm-addon-venv/bin/python -m pytest tests/test_auth_base_forwarder.py tests/test_firewall_rewrite_forwarding.py tests/test_firewall_rewrite_success.py tests/test_firewall_rewrite_safety.py tests/test_request_handler_firewall_dispatch.py tests/test_request_handler_usage_tracking.py`
