### PR TITLE
feat: add build versions to debug build info

### DIFF
--- a/turbo/apps/api/src/lib/build-info.ts
+++ b/turbo/apps/api/src/lib/build-info.ts
@@ -1,3 +1,5 @@
+import apiPackage from "../../package.json";
+
 const GIT_COMMIT_SHA_REGEX = /^[0-9a-f]{40}$/u;
 
 export function normalizeBuildCommitSha(value: unknown): string | null {
@@ -7,4 +9,8 @@ export function normalizeBuildCommitSha(value: unknown): string | null {
 
   const commitSha = value.trim().toLowerCase();
   return GIT_COMMIT_SHA_REGEX.test(commitSha) ? commitSha : null;
+}
+
+export function getBuildVersion(): string {
+  return apiPackage.version;
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -7,6 +7,7 @@ import { zeroReportErrorContract } from "@vm0/api-contracts/contracts/zero-repor
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
+import apiPackage from "../../../../package.json";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { mockEnv } from "../../../lib/env";
 import { healthAuthProbeContract } from "../health-auth-probe";
@@ -77,7 +78,10 @@ describe("OPS-02: API health and auth boundary", () => {
 
     const response = await accept(buildInfoClient().get(), [200]);
 
-    expect(response.body).toStrictEqual({ commitSha });
+    expect(response.body).toStrictEqual({
+      commitSha,
+      version: apiPackage.version,
+    });
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
@@ -86,7 +90,10 @@ describe("OPS-02: API health and auth boundary", () => {
 
     const response = await accept(buildInfoClient().get(), [200]);
 
-    expect(response.body).toStrictEqual({ commitSha: null });
+    expect(response.body).toStrictEqual({
+      commitSha: null,
+      version: apiPackage.version,
+    });
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 

--- a/turbo/apps/api/src/signals/routes/build-info.ts
+++ b/turbo/apps/api/src/signals/routes/build-info.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import type { BuildInfoRouteResponse } from "@vm0/api-contracts/contracts";
 
-import { normalizeBuildCommitSha } from "../../lib/build-info";
+import { getBuildVersion, normalizeBuildCommitSha } from "../../lib/build-info";
 import { env } from "../../lib/env";
 import { setResHeader$ } from "../context/hono";
 
@@ -13,6 +13,7 @@ export const apiBuildInfo$ = command(
       status: 200,
       body: {
         commitSha: normalizeBuildCommitSha(env("GIT_COMMIT_SHA")),
+        version: getBuildVersion(),
       },
     };
   },

--- a/turbo/apps/platform/src/global.d.ts
+++ b/turbo/apps/platform/src/global.d.ts
@@ -4,6 +4,7 @@ interface VM0Global {
   loggers: DebugLoggers;
   inspectLogs: () => void;
   getBuildCommitSha: () => string | null;
+  getBuildVersion: () => string | null;
 }
 
 declare global {

--- a/turbo/apps/platform/src/lib/build-info.ts
+++ b/turbo/apps/platform/src/lib/build-info.ts
@@ -9,6 +9,19 @@ function normalizeBuildCommitSha(value: unknown): string | null {
   return GIT_COMMIT_SHA_REGEX.test(commitSha) ? commitSha : null;
 }
 
+function normalizeBuildVersion(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const version = value.trim();
+  return version.length > 0 ? version : null;
+}
+
 export function getBuildCommitSha(): string | null {
   return normalizeBuildCommitSha(import.meta.env.VITE_GIT_COMMIT_SHA);
+}
+
+export function getBuildVersion(): string | null {
+  return normalizeBuildVersion(import.meta.env.VITE_APP_VERSION);
 }

--- a/turbo/apps/platform/src/mocks/handlers/api-build-info.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-build-info.ts
@@ -4,9 +4,13 @@ import { mockApi } from "../msw-contract.ts";
 
 export const MOCK_BACKEND_COMMIT_SHA =
   "fedcba9876543210fedcba9876543210fedcba98";
+export const MOCK_BACKEND_VERSION = "1.212.2";
 
 export const apiBuildInfoHandlers = [
   mockApi(buildInfoContract.get, ({ respond }) => {
-    return respond(200, { commitSha: MOCK_BACKEND_COMMIT_SHA });
+    return respond(200, {
+      commitSha: MOCK_BACKEND_COMMIT_SHA,
+      version: MOCK_BACKEND_VERSION,
+    });
   }),
 ];

--- a/turbo/apps/platform/src/signals/bootstrap/global-method.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/global-method.ts
@@ -1,7 +1,7 @@
 import { command } from "ccstate";
 import { getLoggers, Level, logger } from "../log";
 import type { DebugLoggers } from "../../types/global-method";
-import { getBuildCommitSha } from "../../lib/build-info";
+import { getBuildCommitSha, getBuildVersion } from "../../lib/build-info";
 import { inspectLogInput$ } from "./inspect-log-input";
 import { extendDebugLoggerLocalStorage } from "./loggers";
 
@@ -45,6 +45,7 @@ export const setupGlobalMethod$ = command(({ get }, signal: AbortSignal) => {
       get(inspectLogInput$)?.click();
     },
     getBuildCommitSha,
+    getBuildVersion,
   };
 
   signal.addEventListener("abort", () => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/build-info.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/build-info.ts
@@ -6,6 +6,7 @@ import { zeroClient$ } from "../../api-client.ts";
 
 interface BackendBuildInfo {
   readonly backendCommitSha: string | null;
+  readonly backendVersion: string | null;
 }
 
 export const backendBuildInfo$ = computed(
@@ -16,6 +17,7 @@ export const backendBuildInfo$ = computed(
 
     return {
       backendCommitSha: result.body.commitSha,
+      backendVersion: result.body.version ?? null,
     };
   },
 );

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -31,6 +31,7 @@ vi.hoisted(() => {
   vi.stubEnv("VITE_API_URL", "http://localhost:3000");
   vi.stubEnv("VITE_ZERO_HOST_DOMAIN", "sites.vm7.io");
   vi.stubEnv("VITE_GIT_COMMIT_SHA", "0123456789abcdef0123456789abcdef01234567");
+  vi.stubEnv("VITE_APP_VERSION", "0.540.0");
 });
 
 globalThis.indexedDB = indexedDB;

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -6,7 +6,10 @@ import {
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
-import { MOCK_BACKEND_COMMIT_SHA } from "../../../mocks/handlers/api-build-info.ts";
+import {
+  MOCK_BACKEND_COMMIT_SHA,
+  MOCK_BACKEND_VERSION,
+} from "../../../mocks/handlers/api-build-info.ts";
 import {
   click,
   detachedSetupPage,
@@ -16,6 +19,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 const TEST_FRONTEND_COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567";
+const TEST_FRONTEND_VERSION = "0.540.0";
 
 function createMockPreferences(
   overrides?: Partial<UserPreferencesResponse>,
@@ -141,10 +145,14 @@ describe("preferences page", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Build commit SHA")).toBeInTheDocument();
-      expect(screen.getByText("Frontend")).toBeInTheDocument();
+      expect(screen.getByText("Build information")).toBeInTheDocument();
+      expect(screen.getByText("Frontend version")).toBeInTheDocument();
+      expect(screen.getByText(TEST_FRONTEND_VERSION)).toBeInTheDocument();
+      expect(screen.getByText("Frontend commit SHA")).toBeInTheDocument();
       expect(screen.getByText(TEST_FRONTEND_COMMIT_SHA)).toBeInTheDocument();
-      expect(screen.getByText("Backend")).toBeInTheDocument();
+      expect(screen.getByText("Backend version")).toBeInTheDocument();
+      expect(screen.getByText(MOCK_BACKEND_VERSION)).toBeInTheDocument();
+      expect(screen.getByText("Backend commit SHA")).toBeInTheDocument();
       expect(screen.getByText(MOCK_BACKEND_COMMIT_SHA)).toBeInTheDocument();
       expect(screen.getByText("Capture network bodies")).toBeInTheDocument();
       expect(screen.getByText("Disabled")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -146,14 +146,13 @@ describe("preferences page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Build information")).toBeInTheDocument();
-      expect(screen.getByText("Frontend version")).toBeInTheDocument();
+      expect(screen.getByText("Frontend")).toBeInTheDocument();
       expect(screen.getByText(TEST_FRONTEND_VERSION)).toBeInTheDocument();
-      expect(screen.getByText("Frontend commit SHA")).toBeInTheDocument();
       expect(screen.getByText(TEST_FRONTEND_COMMIT_SHA)).toBeInTheDocument();
-      expect(screen.getByText("Backend version")).toBeInTheDocument();
+      expect(screen.getByText("Backend")).toBeInTheDocument();
       expect(screen.getByText(MOCK_BACKEND_VERSION)).toBeInTheDocument();
-      expect(screen.getByText("Backend commit SHA")).toBeInTheDocument();
       expect(screen.getByText(MOCK_BACKEND_COMMIT_SHA)).toBeInTheDocument();
+      expect(screen.getAllByText("Commit SHA")).toHaveLength(2);
       expect(screen.getByText("Capture network bodies")).toBeInTheDocument();
       expect(screen.getByText("Disabled")).toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/router/__tests__/global-method.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/global-method.test.tsx
@@ -6,6 +6,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
 const TEST_SHA = "0123456789abcdef0123456789abcdef01234567";
+const TEST_VERSION = "0.540.0";
 
 describe("global method", () => {
   it("exposes the app build commit SHA after bootstrap", async () => {
@@ -13,6 +14,7 @@ describe("global method", () => {
 
     await waitFor(() => {
       expect(window._vm0?.getBuildCommitSha()).toBe(TEST_SHA);
+      expect(window._vm0?.getBuildVersion()).toBe(TEST_VERSION);
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
@@ -13,7 +13,7 @@ import { backendBuildInfo$ } from "../../../../signals/zero-page/settings/build-
 
 const UNAVAILABLE_VALUE = "Unavailable";
 
-function formatCommitSha(value: string | null | undefined): string {
+function formatBuildInfoValue(value: string | null | undefined): string {
   return value ?? UNAVAILABLE_VALUE;
 }
 
@@ -39,7 +39,7 @@ function BuildInfoTarget({
             {title}
           </div>
         </div>
-        <code className="zero-badge inline-flex max-w-[11rem] shrink-0 truncate rounded-md px-2 py-0.5 text-xs font-medium text-foreground">
+        <code className="zero-badge min-w-0 rounded-md px-2 py-0.5 text-right text-xs font-medium text-foreground break-all">
           {version}
         </code>
       </div>
@@ -60,14 +60,14 @@ export function BuildInfoBlock() {
     backendBuildInfoLoadable.state === "hasData"
       ? backendBuildInfoLoadable.data
       : null;
-  const frontendCommitSha = formatCommitSha(getBuildCommitSha());
-  const frontendVersion = formatCommitSha(getBuildVersion());
+  const frontendCommitSha = formatBuildInfoValue(getBuildCommitSha());
+  const frontendVersion = formatBuildInfoValue(getBuildVersion());
   const backendCommitSha = loading
     ? "Loading"
-    : formatCommitSha(backendBuildInfo?.backendCommitSha);
+    : formatBuildInfoValue(backendBuildInfo?.backendCommitSha);
   const backendVersion = loading
     ? "Loading"
-    : formatCommitSha(backendBuildInfo?.backendVersion);
+    : formatBuildInfoValue(backendBuildInfo?.backendVersion);
 
   return (
     <div className="flex items-start gap-4 rounded-xl bg-card p-4 zero-border">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
@@ -1,5 +1,9 @@
 import { useLoadable } from "ccstate-react";
-import { IconGitCommit } from "@tabler/icons-react";
+import {
+  IconDeviceDesktop,
+  IconGitCommit,
+  IconPackage,
+} from "@tabler/icons-react";
 
 import {
   getBuildCommitSha,
@@ -13,19 +17,38 @@ function formatCommitSha(value: string | null | undefined): string {
   return value ?? UNAVAILABLE_VALUE;
 }
 
-function BuildInfoRow({
-  label,
-  value,
+function BuildInfoTarget({
+  title,
+  version,
+  commitSha,
+  icon: Icon,
 }: {
-  readonly label: string;
-  readonly value: string;
+  readonly title: string;
+  readonly version: string;
+  readonly commitSha: string;
+  readonly icon: typeof IconGitCommit;
 }) {
   return (
-    <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-      <div className="text-sm text-muted-foreground">{label}</div>
-      <code className="break-all text-xs text-foreground sm:text-right">
-        {value}
-      </code>
+    <div className="flex min-w-0 flex-col gap-3">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
+            <Icon size={15} stroke={1.5} />
+          </span>
+          <div className="truncate text-sm font-medium text-foreground">
+            {title}
+          </div>
+        </div>
+        <code className="zero-badge inline-flex max-w-[11rem] shrink-0 truncate rounded-md px-2 py-0.5 text-xs font-medium text-foreground">
+          {version}
+        </code>
+      </div>
+      <div className="flex min-w-0 flex-col gap-1">
+        <div className="text-xs text-muted-foreground">Commit SHA</div>
+        <code className="block min-h-7 break-all rounded-md bg-muted/40 px-2 py-1.5 text-[11px] leading-4 text-foreground">
+          {commitSha}
+        </code>
+      </div>
     </div>
   );
 }
@@ -47,7 +70,7 @@ export function BuildInfoBlock() {
     : formatCommitSha(backendBuildInfo?.backendVersion);
 
   return (
-    <div className="flex items-start gap-4 bg-card p-4 rounded-xl zero-border">
+    <div className="flex items-start gap-4 rounded-xl bg-card p-4 zero-border">
       <div className="shrink-0">
         <div className="flex h-7 w-7 items-center justify-center">
           <IconGitCommit
@@ -61,11 +84,23 @@ export function BuildInfoBlock() {
         <div className="text-sm font-medium text-foreground">
           Build information
         </div>
-        <div className="flex flex-col gap-2">
-          <BuildInfoRow label="Frontend version" value={frontendVersion} />
-          <BuildInfoRow label="Frontend commit SHA" value={frontendCommitSha} />
-          <BuildInfoRow label="Backend version" value={backendVersion} />
-          <BuildInfoRow label="Backend commit SHA" value={backendCommitSha} />
+        <div className="grid gap-4 sm:grid-cols-2 sm:gap-0">
+          <div className="min-w-0 sm:pr-5">
+            <BuildInfoTarget
+              title="Frontend"
+              version={frontendVersion}
+              commitSha={frontendCommitSha}
+              icon={IconDeviceDesktop}
+            />
+          </div>
+          <div className="min-w-0 border-t border-border/60 pt-4 sm:border-l sm:border-t-0 sm:pl-5 sm:pt-0">
+            <BuildInfoTarget
+              title="Backend"
+              version={backendVersion}
+              commitSha={backendCommitSha}
+              icon={IconPackage}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/build-info-block.tsx
@@ -1,7 +1,10 @@
 import { useLoadable } from "ccstate-react";
 import { IconGitCommit } from "@tabler/icons-react";
 
-import { getBuildCommitSha } from "../../../../lib/build-info.ts";
+import {
+  getBuildCommitSha,
+  getBuildVersion,
+} from "../../../../lib/build-info.ts";
 import { backendBuildInfo$ } from "../../../../signals/zero-page/settings/build-info.ts";
 
 const UNAVAILABLE_VALUE = "Unavailable";
@@ -35,9 +38,13 @@ export function BuildInfoBlock() {
       ? backendBuildInfoLoadable.data
       : null;
   const frontendCommitSha = formatCommitSha(getBuildCommitSha());
+  const frontendVersion = formatCommitSha(getBuildVersion());
   const backendCommitSha = loading
     ? "Loading"
     : formatCommitSha(backendBuildInfo?.backendCommitSha);
+  const backendVersion = loading
+    ? "Loading"
+    : formatCommitSha(backendBuildInfo?.backendVersion);
 
   return (
     <div className="flex items-start gap-4 bg-card p-4 rounded-xl zero-border">
@@ -52,11 +59,13 @@ export function BuildInfoBlock() {
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-3">
         <div className="text-sm font-medium text-foreground">
-          Build commit SHA
+          Build information
         </div>
         <div className="flex flex-col gap-2">
-          <BuildInfoRow label="Frontend" value={frontendCommitSha} />
-          <BuildInfoRow label="Backend" value={backendCommitSha} />
+          <BuildInfoRow label="Frontend version" value={frontendVersion} />
+          <BuildInfoRow label="Frontend commit SHA" value={frontendCommitSha} />
+          <BuildInfoRow label="Backend version" value={backendVersion} />
+          <BuildInfoRow label="Backend commit SHA" value={backendCommitSha} />
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -5,6 +5,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { get as httpsGet } from "node:https";
 import { defineConfig, type PluginOption } from "vite";
 
+import platformPackage from "./package.json";
+
 const DEV_ARTIFACT_FETCH_PROXY_PATH = "/__vm0-dev-artifact-fetch";
 const DEV_ARTIFACT_FETCH_PROXY_HEADERS = [
   "cache-control",
@@ -28,6 +30,7 @@ const FIREWALL_PERMISSION_DETAIL_METADATA_MODULE_ID_RE =
 const FIREWALL_PERMISSION_DETAIL_METADATA_CHUNK_NAME_RE =
   /^vm0-firewall-permission-detail-metadata-([a-z0-9][a-z0-9-]*)\.generated$/;
 
+process.env.VITE_APP_VERSION = platformPackage.version;
 process.env.VITE_STATIC_ASSETS_BASE_URL = STATIC_ASSETS_BASE_URL;
 
 function normalizedModuleId(id: string): string {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/build-info.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/build-info.test.ts
@@ -4,6 +4,7 @@ import {
   buildCommitShaSchema,
   buildInfoContract,
   buildInfoResponseSchema,
+  buildVersionSchema,
 } from "../build-info";
 
 const TEST_SHA = "0123456789abcdef0123456789abcdef01234567";
@@ -15,11 +16,17 @@ describe("build info contract", () => {
   });
 
   it("accepts a valid build info response body", () => {
+    expect(
+      buildInfoResponseSchema.parse({ commitSha: TEST_SHA, version: "1.2.3" }),
+    ).toEqual({
+      commitSha: TEST_SHA,
+      version: "1.2.3",
+    });
+    expect(
+      buildInfoResponseSchema.parse({ commitSha: null, version: null }),
+    ).toEqual({ commitSha: null, version: null });
     expect(buildInfoResponseSchema.parse({ commitSha: TEST_SHA })).toEqual({
       commitSha: TEST_SHA,
-    });
-    expect(buildInfoResponseSchema.parse({ commitSha: null })).toEqual({
-      commitSha: null,
     });
   });
 
@@ -29,5 +36,9 @@ describe("build info contract", () => {
     expect(buildCommitShaSchema.safeParse(TEST_SHA.toUpperCase()).success).toBe(
       false,
     );
+  });
+
+  it("rejects malformed build versions", () => {
+    expect(buildVersionSchema.safeParse("").success).toBe(false);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/build-info.ts
+++ b/turbo/packages/api-contracts/src/contracts/build-info.ts
@@ -8,8 +8,11 @@ export const buildCommitShaSchema = z
   .regex(/^[0-9a-f]{40}$/u)
   .nullable();
 
+export const buildVersionSchema = z.string().min(1).nullable().optional();
+
 export const buildInfoResponseSchema = z.object({
   commitSha: buildCommitShaSchema,
+  version: buildVersionSchema,
 });
 
 export const buildInfoContract = c.router({


### PR DESCRIPTION
## Summary
- Extend the build-info contract and API response with backend package version metadata
- Expose the platform package version through the existing frontend build-info helper and window debug global
- Show frontend/backend versions alongside commit SHAs in Settings > Debug

## Tests
- pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/build-info.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts
- pnpm -F @vm0/app exec vitest run src/views/router/__tests__/global-method.test.tsx src/views/preferences-page/__tests__/preferences-page.test.tsx
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F api build
- pnpm -F @vm0/app build
- pnpm knip --cache
- pre-commit hook: prettier, knip, check-types