### PR TITLE
feat: resolve presentation runbook templates in zero generate presentation --template

### DIFF
--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -1,11 +1,12 @@
 import {
+  buildPresentationRunbookInstructionLines,
   findColorSystem,
   findDesignSystem,
   findImageStyle,
   findPresentationRunbookPackage,
   findTemplate,
   findVideoTemplate,
-  presentationColorSystemToken,
+  resolvePresentationRunbookColorToken,
   type PresentationRunbookPackage,
 } from "@vm0/core/resource-registry";
 import { findWorkflowTemplateItem } from "@vm0/core/workflow-template-items";
@@ -132,11 +133,7 @@ function buildPresentationGenerationTemplatePrompt(
     generationTemplate.selection.templateId,
   );
   if (runbookPackage) {
-    return buildPresentationRunbookPrompt(
-      generationTemplate,
-      template,
-      runbookPackage,
-    );
+    return buildPresentationRunbookPrompt(generationTemplate, runbookPackage);
   }
 
   const designSystem = findDesignSystem(
@@ -199,38 +196,27 @@ function buildPresentationGenerationTemplatePrompt(
 
 function buildPresentationRunbookPrompt(
   generationTemplate: PresentationGenerationTemplateInput,
-  template: {
-    readonly name: string;
-    readonly id: string;
-    readonly description: string;
-  },
   runbookPackage: PresentationRunbookPackage,
 ): GenerationTemplatePromptResult {
-  const { colorSystemId } = generationTemplate.selection;
-  const colorSystemToken = colorSystemId
-    ? presentationColorSystemToken(colorSystemId)
-    : runbookPackage.defaultColorSystem;
-  if (colorSystemId && !colorSystemToken) {
+  const color = resolvePresentationRunbookColorToken(
+    runbookPackage,
+    generationTemplate.selection.colorSystemId,
+  );
+  if ("error" in color) {
     return {
       status: "invalid",
       message: "Unknown generation template color system",
     };
   }
 
-  const slug = runbookPackage.slug;
   return {
     status: "resolved",
     prompt: [
       ...templateFraming("a presentation"),
-      `Selected presentation template: ${template.name} (${template.id})`,
-      `Color system token: ${colorSystemToken}`,
-      "",
-      "To produce the presentation:",
-      `- Pull the package: zero resource pull ${runbookPackage.resourceId} --dir ./generated/resources`,
-      `- Follow ./generated/resources/${slug}/AGENT_RUNBOOK.md, running its commands from ./generated/resources. Set "colorSystem": "${colorSystemToken}" in the deck JSON.`,
-      "- Use the slide count the user asks for; if unspecified, default to 8 pages.",
-      "- Host the finished deck: zero host <output-dir> --site <slug> --artifact-kind presentation-html",
-      "- Return only the generated HTML deck as the final deliverable.",
+      ...buildPresentationRunbookInstructionLines({
+        runbookPackage,
+        colorSystemToken: color.token,
+      }),
     ].join("\n"),
   };
 }

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/presentation.test.ts
@@ -182,13 +182,13 @@ describe("zero generate presentation command", () => {
     );
   });
 
-  it("should accept the switched picker presentation template from the registry", async () => {
+  it("resolves a picker template to runbook instructions, ignoring --design-system", async () => {
     await generateCommand.parseAsync([
       "node",
       "cli",
       "presentation",
       "--prompt",
-      "product launch",
+      "create a 15-slide launch deck",
       "--design-system",
       "playful-editorial",
       "--template",
@@ -198,25 +198,23 @@ describe("zero generate presentation command", () => {
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(stdout).toContain("# Presentation Generation (runbook)");
     expect(stdout).toContain(
-      "Selected design system: design-system:playful-editorial (Playful Launch)",
+      "Selected presentation template: Playful Launch Presentation (template:html-ppt-playful-launch)",
     );
     expect(stdout).toContain(
-      "Selected template: template:html-ppt-playful-launch (Playful Launch Presentation)",
+      "zero resource pull template:html-ppt-playful-launch-runbook --dir ./generated/resources",
     );
     expect(stdout).toContain(
-      "zero resource pull <resource-id> --dir ./generated/resources",
+      "./generated/resources/playful-launch/AGENT_RUNBOOK.md",
     );
-    expect(stdout).toContain('"tool:presentation-deck-tools"');
-    expect(stdout).toContain('"id": "template:html-ppt-playful-launch"');
-    expect(stdout).toContain('"path": "presentation-template/aplocoto"');
-    expect(stdout).toContain('"archive"');
-    expect(stdout).toContain('"type": "tar.gz"');
-    expect(stdout).toContain('"sha256"');
-    expect(stdout).toContain('"id": "design-system:playful-editorial"');
-    expect(stdout).toContain(
-      '"path": "presentation-design-system/playful-editorial"',
-    );
+    expect(stdout).toContain('"colorSystem": "carnival"');
+    expect(stdout).toContain("User request: create a 15-slide launch deck");
+    // Runbook flow is self-contained: the design system is ignored and no
+    // legacy authoring packet (deck-tools) is emitted.
+    expect(stdout).not.toContain("Selected design system:");
+    expect(stdout).not.toContain("design-system:playful-editorial");
+    expect(stdout).not.toContain("tool:presentation-deck-tools");
   });
 
   it("should reject a template that does not target presentation", async () => {

--- a/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/presentation-generate.ts
@@ -2,10 +2,13 @@ import { Command, InvalidArgumentError } from "commander";
 import { withErrorHandler } from "../../../lib/command";
 import { createHtmlArtifactAuthoringPacket } from "./html-artifact-authoring";
 import {
+  buildPresentationRunbookInstructionLines,
   findDesignSystem,
+  findPresentationRunbookPackage,
   findTemplate,
   listDesignSystems,
   listTemplates,
+  resolvePresentationRunbookColorToken,
 } from "./resource-registry";
 import {
   canonicalizeRegistryId,
@@ -128,6 +131,41 @@ ${formatRegistryListing(templates, "presentation templates")}`;
         });
         if (dispatch.outcome === "handled") return;
         const prompt = dispatch.prompt;
+
+        // Runbook-first: a picker template (`html-ppt-<slug>`) is served by its
+        // self-contained runbook package. Resolve it before the legacy
+        // design-system/template path and emit runbook instructions — the
+        // design system is not part of the runbook flow, so it is ignored here.
+        if (options.template !== undefined) {
+          const canonical = canonicalizeRegistryId(
+            "template",
+            options.template,
+          );
+          const runbookPackage = findPresentationRunbookPackage(canonical);
+          if (runbookPackage) {
+            const color = resolvePresentationRunbookColorToken(
+              runbookPackage,
+              undefined,
+            );
+            const colorSystemToken =
+              "error" in color
+                ? runbookPackage.defaultColorSystem
+                : color.token;
+            console.log(
+              [
+                "# Presentation Generation (runbook)",
+                "",
+                ...buildPresentationRunbookInstructionLines({
+                  runbookPackage,
+                  colorSystemToken,
+                }),
+                "",
+                `User request: ${prompt}`,
+              ].join("\n"),
+            );
+            return;
+          }
+        }
 
         let resolvedDesignSystem;
         if (options.designSystem !== undefined) {

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -4363,6 +4363,11 @@ export interface PresentationRunbookPackage {
   readonly slug: string;
   /** Default color-system token applied when the user selects no color system. */
   readonly defaultColorSystem: string;
+  /** Display name (relocated onto the package so runbook resolution no longer
+   * needs the legacy `template:html-ppt-*` registry entry). */
+  readonly name: string;
+  /** Template description (relocated from the legacy template entry). */
+  readonly description: string;
   readonly source: ResourceSourceRef;
 }
 
@@ -4424,121 +4429,192 @@ const PRESENTATION_RUNBOOK_PACKAGE_DEFS: readonly {
   readonly templateId: string;
   readonly slug: string;
   readonly defaultColorSystem: string;
+  readonly name: string;
+  readonly description: string;
 }[] = [
   {
     templateId: "template:html-ppt-playful-launch",
     slug: "playful-launch",
     defaultColorSystem: "carnival",
+    name: "Playful Launch Presentation",
+    description:
+      "15-slot HTML presentation structure for product and service launches with oversized headlines, color-field rhythm, recurring motifs, and required media slots.",
   },
   {
     templateId: "template:html-ppt-bloom-pitch",
     slug: "bloom",
     defaultColorSystem: "carnival",
+    name: "Bloom Pitch Presentation",
+    description:
+      "15-slot playful investor-pitch presentation structure with oversized headlines, colour-field dividers, organic visuals, stat stacks, quote cards, and pricing cards.",
   },
   {
     templateId: "template:html-ppt-blueprint-academy",
     slug: "blueprint-academy",
     defaultColorSystem: "forest_editorial",
+    name: "Blueprint Academy Presentation",
+    description:
+      "15-slot academic education presentation structure with blueprint grids, wire diagrams, matted photos, goal cards, process spines, stats, testimonials, and contact slides.",
   },
   {
     templateId: "template:html-ppt-botane-organic",
     slug: "botane-organic",
     defaultColorSystem: "mauve_dusk",
+    name: "Botane Organic Presentation",
+    description:
+      "15-slot organic wellness deck with colour-block panels, circular media, side titles, icon cycles, and donut stats.",
   },
   {
     templateId: "template:html-ppt-business-data",
     slug: "business-data",
     defaultColorSystem: "berry_pop",
+    name: "Business Data Presentation",
+    description:
+      "15-slot HTML presentation structure for metric-led business reports with big numbers, stat strips, bars, rings, photo squares, and dark/accent proof slides.",
   },
   {
     templateId: "template:html-ppt-crayon",
     slug: "crayon",
     defaultColorSystem: "prism",
+    name: "Crayon Presentation",
+    description:
+      "Light 15-slot playful education deck with peripheral blobs, multi-colour marker titles, doodle sparks, colour-block cards, burst stats, quote cards, and rounded pricing cards.",
   },
   {
     templateId: "template:html-ppt-creative-agency",
     slug: "creative-agency",
     defaultColorSystem: "coral_studio",
+    name: "Creative Agency Presentation",
+    description:
+      "Minimal modern 15-slot agency deck with generous whitespace, foliage sprigs, B&W photo blocks, sharp rectangles, team grids, icon services, process spine, and a big-stat impact band.",
   },
   {
     templateId: "template:html-ppt-data-report",
     slug: "data-report",
     defaultColorSystem: "prism",
+    name: "Data Report Presentation",
+    description:
+      "Chart-led 15-page data report variant with saturated colour grounds, sharp outlines, frameless numbers, stacked/combo/area/line/doughnut/pie/bar/bubble charts, and data-first summary pages.",
   },
   {
     templateId: "template:html-ppt-editorial-magazine",
     slug: "editorial-magazine",
     defaultColorSystem: "warm_sand",
+    name: "Editorial Magazine Presentation",
+    description:
+      "Restrained 15-slot magazine deck with masthead cover, dotted TOC, colour-block dividers, two-column editorial pages, roman/italic titles, running footer, stat boxes, quote rows, and editorial table.",
   },
   {
     templateId: "template:html-ppt-landing-consulting",
     slug: "landing-consulting",
     defaultColorSystem: "pop_art",
+    name: "Landing Consulting Presentation",
+    description:
+      "Consulting deck dressed like a landing page, with persistent nav chrome, two-tone display titles, dashed circuit wires, marker emphasis, speech-bubble callouts, square photo blocks, frameless stats, and CTA rhythm.",
   },
   {
     templateId: "template:html-ppt-lumina",
     slug: "lumina",
     defaultColorSystem: "prism",
+    name: "Lumina Presentation",
+    description:
+      "Sticker-tag creative studio deck with brush-letter title accents, asterisk punctuation, frame-edge chrome, sharp colour cells, photo blocks, stat bands, and agency-style 15-slot rhythm.",
   },
   {
     templateId: "template:html-ppt-meridian",
     slug: "meridian",
     defaultColorSystem: "slate_corporate",
+    name: "Meridian Presentation",
+    description:
+      "15-slot professional data-agency presentation structure with flat nav chrome, sharp blocks, index numbers, stat matrices, bar charts, service blocks, and executive close.",
   },
   {
     templateId: "template:html-ppt-mosaic-geometric",
     slug: "mosaic-geometric",
     defaultColorSystem: "carnival",
+    name: "Mosaic Geometric Presentation",
+    description:
+      "Bold modular geometric 15-slot pitch deck with Bauhaus mosaic tile clusters, dotted TOC, chapter dividers, framed icon services, process spine, gallery grid, segmented pie, burst stats, quote rows, and price cards.",
   },
   {
     templateId: "template:html-ppt-neo-brutalism",
     slug: "neo-brutalism",
     defaultColorSystem: "mono_ink",
+    name: "Neo Brutalism Presentation",
+    description:
+      "Bold 15-slot brutalist business-plan deck with persistent nav chrome, CTA pairs, numbered circles, arch cards, and heavy framed content blocks.",
   },
   {
     templateId: "template:html-ppt-nocturne",
     slug: "nocturne",
     defaultColorSystem: "midnight_mono",
+    name: "Nocturne Presentation",
+    description:
+      "Dark 15-slot data-keynote deck with rounded chart devices, frameless hero numbers, bento metrics, and clear text/data alternation.",
   },
   {
     templateId: "template:html-ppt-pixel-glitch",
     slug: "pixel-glitch",
     defaultColorSystem: "bauhaus_primary",
+    name: "Pixel Glitch Presentation",
+    description:
+      "15-slot Y2K creative-studio presentation structure with pixel trails, glitch titles, sharp dividers, image blocks, ring charts, process spines, and bold proof pages.",
   },
   {
     templateId: "template:html-ppt-playful-pop",
     slug: "playful-pop",
     defaultColorSystem: "pop_art",
+    name: "Playful Pop Presentation",
+    description:
+      "Loud 15-slot playful brand deck with neon-on-dark Pop Art colour, overlapping offset-shadow cards, organic blobs, corner dot grids, burst rosettes, pill chips, icon quads, process spine, photo gallery, quotes, and pricing.",
   },
   {
     templateId: "template:html-ppt-prospectus",
     slug: "prospectus",
     defaultColorSystem: "slate_corporate",
+    name: "Prospectus Presentation",
+    description:
+      "15-slot corporate landing-page business-plan structure with persistent nav, colour-field stages, diagonal arrows, CTA clusters, flat charts, gantt timelines, and pricing tiers.",
   },
   {
     templateId: "template:html-ppt-schoolhouse",
     slug: "schoolhouse",
     defaultColorSystem: "bauhaus_primary",
+    name: "Schoolhouse Presentation",
+    description:
+      "15-slot retro school-poster presentation structure with paper stages, stamp badges, index cards, ruled rows, stat bands, quote cards, and membership tiers.",
   },
   {
     templateId: "template:html-ppt-sticker-scrapbook",
     slug: "sticker-scrapbook",
     defaultColorSystem: "prism",
+    name: "Sticker Scrapbook Presentation",
+    description:
+      "15-slot vibrant scrapbook presentation structure with sticker seals, spiral pads, agenda cards, doodle dividers, photo grids, stat stickers, quote cards, and pricing cards.",
   },
   {
     templateId: "template:html-ppt-strata",
     slug: "strata",
     defaultColorSystem: "mono_ink",
+    name: "Strata Presentation",
+    description:
+      "15-slot Swiss-minimal agency presentation structure with giant caps, asterisk dividers, tile ramps, mono photo grids, frameless stats, quote cards, and pricing cards.",
   },
   {
     templateId: "template:html-ppt-taped-consulting",
     slug: "taped-consulting",
     defaultColorSystem: "slate_corporate",
+    name: "Taped Consulting Presentation",
+    description:
+      "15-slot consulting presentation structure with taped photo clusters, inset frames, feature rows, process spines, big-number proof, quote cards, and pricing cards.",
   },
   {
     templateId: "template:html-ppt-vantage",
     slug: "vantage",
     defaultColorSystem: "slate_corporate",
+    name: "Vantage Presentation",
+    description:
+      "15-slot business-proposal presentation structure with two-tone headings, corner indexes, square-pair motifs, split panels, frameless numbers, donut charts, and milestone lines.",
   },
 ];
 
@@ -4549,6 +4625,8 @@ const PRESENTATION_RUNBOOK_PACKAGES: readonly PresentationRunbookPackage[] =
       resourceId: `${def.templateId}-runbook`,
       slug: def.slug,
       defaultColorSystem: def.defaultColorSystem,
+      name: def.name,
+      description: def.description,
       source: privateR2ArchiveSource(
         def.slug,
         presentationRunbookArchiveSha256(def.slug),
@@ -4579,17 +4657,14 @@ export function findPresentationRunbookResource(
   if (!pkg) {
     return undefined;
   }
-  // Reuse the legacy template's display name and description — the runbook
-  // package renders the same template, so they describe it accurately and stay
-  // in sync without a second copy. Only id and source diverge.
-  const template = findTemplate(pkg.templateId);
+  // Name/description live on the package itself (relocated from the legacy
+  // `template:html-ppt-*` registry entry) so this no longer depends on that
+  // entry surviving. Only id and source diverge.
   return {
     id: pkg.resourceId,
     kind: "template",
-    name: template?.name ?? pkg.slug,
-    description:
-      template?.description ??
-      "Self-contained presentation runbook package pulled as a single private R2 archive.",
+    name: pkg.name,
+    description: pkg.description,
     source: pkg.source,
     targets: ["presentation"],
   };
@@ -4611,6 +4686,48 @@ export function presentationColorSystemToken(
   return colorSystemId
     .slice(COLOR_SYSTEM_ID_PREFIX.length)
     .replaceAll("-", "_");
+}
+
+/**
+ * Resolve the color-system token for a presentation runbook: an explicit color
+ * system id must resolve to a known token; with none, the package's default
+ * token is used. Returns `{ token }` or `{ error }`.
+ */
+export function resolvePresentationRunbookColorToken(
+  runbookPackage: PresentationRunbookPackage,
+  colorSystemId: string | undefined,
+): { readonly token: string } | { readonly error: "unknown-color-system" } {
+  if (!colorSystemId) {
+    return { token: runbookPackage.defaultColorSystem };
+  }
+  const token = presentationColorSystemToken(colorSystemId);
+  if (!token) {
+    return { error: "unknown-color-system" };
+  }
+  return { token };
+}
+
+/**
+ * Shared runbook authoring instructions for a selected presentation template.
+ * Used by both the chat generation-template prompt (API) and
+ * `zero generate presentation --template` (CLI) so the two never drift.
+ */
+export function buildPresentationRunbookInstructionLines(args: {
+  readonly runbookPackage: PresentationRunbookPackage;
+  readonly colorSystemToken: string;
+}): readonly string[] {
+  const { runbookPackage: pkg, colorSystemToken } = args;
+  return [
+    `Selected presentation template: ${pkg.name} (${pkg.templateId})`,
+    `Color system token: ${colorSystemToken}`,
+    "",
+    "To produce the presentation:",
+    `- Pull the package: zero resource pull ${pkg.resourceId} --dir ./generated/resources`,
+    `- Follow ./generated/resources/${pkg.slug}/AGENT_RUNBOOK.md, running its commands from ./generated/resources. Set "colorSystem": "${colorSystemToken}" in the deck JSON.`,
+    "- Use the slide count the user asks for; if unspecified, default to 8 pages.",
+    "- Host the finished deck: zero host <output-dir> --site <slug> --artifact-kind presentation-html",
+    "- Return only the generated HTML deck as the final deliverable.",
+  ];
 }
 
 function filterByKind(kind: ResourceKind): readonly RegistryEntry[] {


### PR DESCRIPTION
## What (PR ① of the presentation-runbook retirement — additive)

Makes `zero generate presentation --template html-ppt-<slug>` resolve a template's **runbook package** and emit runbook instructions, so a free-text prompt that names a template deterministically routes to runbook.

## Why

Free-text generation (marketing "Try it", any `/gen presentation ... template X` chat) reaches generation through `zero generate presentation` — the agent is told to use the Zero CLI, and there is **no `/gen` parser**. That command only did `findTemplate`, so a picker template resolved to the legacy multi-resource authoring packet, not its runbook. This is the missing piece so the free-text path lands on runbook (the in-app picker path already does, via the structured selection).

## Changes

- **CLI** (`presentation-generate.ts`): before the legacy path, resolve `findPresentationRunbookPackage(--template)`; on a hit, print runbook instructions (pull `template:html-ppt-<slug>-runbook`, follow `AGENT_RUNBOOK.md`, set the color token, `zero host … --artifact-kind presentation-html`) and return. `--design-system` is ignored for runbook templates.
- **Core** (`@vm0/core`): relocate each template's `name`/`description` onto its `PresentationRunbookPackage`; extract the shared `buildPresentationRunbookInstructionLines` + `resolvePresentationRunbookColorToken` so the API chat flow and the CLI share one source of truth and no longer need the legacy `template:html-ppt-*` registry entry.
- **API** (`generation-template-prompt.ts`): `buildPresentationRunbookPrompt` / `findPresentationRunbookResource` now read package metadata via the shared helpers (output unchanged).

## Additivity / safety

Retires nothing — the legacy registry entries still exist (their removal is **PR ②**). So this can ship first with no breakage; picker templates simply route to runbook through the CLI now. This unblocks:
- **PR ②** (retire legacy `template:html-ppt-*` + `design-system:*`), which depends on this so `--template` still resolves post-retirement.
- **PR ③** (marketing prompts carry the template id, drop the retired design system).

## Tests

CLI: `--template html-ppt-playful-launch` → runbook instructions, `--design-system` ignored, no legacy deck-tools packet. API runbook prompt output unchanged.

Relying on the PR pipeline for typecheck/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)