### PR TITLE
fix: preserve presentation pptx layout

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts
@@ -121,6 +121,68 @@ describe("previewPresentationHtml", () => {
     expect(injectedCss).toContain("--fb:'Manrope'");
   });
 
+  it("ignores generated object-backed switcher defaults that cannot run", () => {
+    const previewHtml = previewPresentationHtml({
+      activeSlideId: "slide-1",
+      html: `
+        <!doctype html>
+        <html>
+          <head>
+            <style>
+              :root {
+                --bg:#FFFFFF;
+                --accent:#7257E6;
+                --s1:#FF6B4A;
+                --s2:#AEE63E;
+                --s3:#3FA9F5;
+              }
+            </style>
+          </head>
+          <body>
+            <div class="slide" data-slide-id="slide-1">
+              <div class="stage">
+                <h1 style="color:var(--accent)">Slide</h1>
+              </div>
+            </div>
+            <script>
+              var MONO={
+                "Bauhaus Primary":["#F7F3EA","#FFFDF8","#1C1A17","#665F55","#E6DDD0",["#D1493F","#235789","#F2B134","#1C1A17"]]
+              };
+              var VIB={
+                "Prism":["#FFFFFF","#F7F7FA","#1A1726","#5C5870","#ECECF2",["#7257E6","#FF6B4A","#AEE63E","#3FA9F5"]]
+              };
+              var FONTS={
+                "Poppins / Figtree":["Poppins","Figtree"]
+              };
+              var sp={value:''},sf={value:''};
+              var gV=document.createElement('optgroup');gV.label='Vibrant - multi-colour';
+              Object.keys(VIB).forEach(function(k){var o=document.createElement('option');o.value='V:'+k;o.textContent=k;gV.appendChild(o);});sp.appendChild(gV);
+              var gM=document.createElement('optgroup');gM.label='Single-accent';
+              Object.keys(MONO).forEach(function(k){var o=document.createElement('option');o.value='M:'+k;o.textContent=k;gM.appendChild(o);});sp.appendChild(gM);
+              Object.keys(FONTS).forEach(function(k){var o=document.createElement('option');o.value=o.textContent=k;sf.appendChild(o);});
+              sp.onchange=function(){};
+              sf.onchange=function(){};
+              sp.value='M:Bauhaus Primary';sf.value='Poppins / Figtree';sp.onchange();sf.onchange();
+            </script>
+          </body>
+        </html>
+      `,
+    });
+    const doc = new DOMParser().parseFromString(previewHtml, "text/html");
+    const injectedCss = Array.from(doc.querySelectorAll("style"))
+      .map((style) => {
+        return style.textContent ?? "";
+      })
+      .join("\n");
+
+    expect(doc.querySelector("script")).toBeNull();
+    expect(
+      doc.querySelector('[data-vm0-materialized-theme="true"]'),
+    ).toBeNull();
+    expect(injectedCss).toContain("--bg:#FFFFFF");
+    expect(injectedCss).toContain("--accent:#7257E6");
+  });
+
   it("normalizes nested slide stages to fill the preview frame", () => {
     const previewHtml = previewPresentationHtml({
       activeSlideId: "slide-1",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -77,5 +77,7 @@ describe("buildPresentationHtmlPptxExportHtml", () => {
     expect(styleText).toContain("--fb:'Quicksand'");
     expect(scriptText).not.toContain("var MONO");
     expect(scriptText).toContain("vm0-presentation-pptx-export");
+    expect(scriptText).toContain("preserveBrowserTextLineBreaks(nodes)");
+    expect(scriptText).not.toContain("resolveEmbeddableFonts");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -579,6 +579,116 @@ function createExportReadinessScript(): string {
 `;
 }
 
+function createExportLineBreakScript(): string {
+  return `
+  const lineBreakSkipTags = new Set([
+    "SCRIPT", "STYLE", "NOSCRIPT", "TEXTAREA", "SVG",
+  ]);
+
+  const shouldPreserveLineBreaksForTextNode = (node) => {
+    const parent = node.parentElement;
+    if (!parent || lineBreakSkipTags.has(parent.tagName)) return false;
+    if (!node.nodeValue || node.nodeValue.trim().length === 0) return false;
+    const style = window.getComputedStyle(parent);
+    if (
+      style.display === "none" ||
+      style.visibility === "hidden" ||
+      style.fontSize === "0px" ||
+      style.whiteSpace === "nowrap" ||
+      style.whiteSpace === "pre"
+    ) {
+      return false;
+    }
+    return true;
+  };
+
+  const textNodesForLineBreakPreservation = (nodes) => {
+    const textNodes = [];
+    for (const node of nodes) {
+      const walker = document.createTreeWalker(
+        node,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode: (textNode) => {
+            return shouldPreserveLineBreaksForTextNode(textNode)
+              ? NodeFilter.FILTER_ACCEPT
+              : NodeFilter.FILTER_REJECT;
+          },
+        },
+      );
+      let current = walker.nextNode();
+      while (current) {
+        textNodes.push(current);
+        current = walker.nextNode();
+      }
+    }
+    return textNodes;
+  };
+
+  const textOffsetTop = (node, offset) => {
+    const range = document.createRange();
+    range.setStart(node, offset);
+    range.setEnd(node, Math.min(offset + 1, node.nodeValue.length));
+    const rect = Array.from(range.getClientRects()).find((candidate) => {
+      return candidate.width > 0 && candidate.height > 0;
+    });
+    range.detach();
+    return rect ? rect.top : null;
+  };
+
+  const tokenRanges = (text) => {
+    const ranges = [];
+    const matcher = /\\S+\\s*/g;
+    let match = matcher.exec(text);
+    while (match) {
+      ranges.push({
+        start: match.index,
+        visibleStart: match.index,
+      });
+      match = matcher.exec(text);
+    }
+    return ranges;
+  };
+
+  const visualLineBreakOffsets = (node) => {
+    let previousTop = null;
+    const offsets = [];
+    for (const token of tokenRanges(node.nodeValue)) {
+      const top = textOffsetTop(node, token.visibleStart);
+      if (top === null) continue;
+      if (previousTop !== null && Math.abs(top - previousTop) > 1) {
+        offsets.push(token.start);
+      }
+      previousTop = top;
+    }
+    return offsets.filter((offset, index) => {
+      return offset > 0 && offset < node.nodeValue.length && offsets.indexOf(offset) === index;
+    });
+  };
+
+  const applyVisualLineBreakOffsets = (node, offsets) => {
+    const parent = node.parentNode;
+    if (!parent || offsets.length === 0) return;
+    const text = node.nodeValue;
+    const fragment = document.createDocumentFragment();
+    let start = 0;
+    for (const offset of offsets) {
+      fragment.append(document.createTextNode(text.slice(start, offset)));
+      fragment.append(document.createElement("br"));
+      start = offset;
+    }
+    fragment.append(document.createTextNode(text.slice(start)));
+    parent.replaceChild(fragment, node);
+  };
+
+  const preserveBrowserTextLineBreaks = (nodes) => {
+    for (const textNode of textNodesForLineBreakPreservation(nodes)) {
+      applyVisualLineBreakOffsets(textNode, visualLineBreakOffsets(textNode));
+    }
+  };
+`;
+}
+
 function createExportRunnerScript(): string {
   return `
   void (async () => {
@@ -593,6 +703,7 @@ function createExportRunnerScript(): string {
     revealSlideNodes(nodes);
     copyInheritedSlideBackgrounds(nodes);
     await waitForExportReadiness(nodes);
+    preserveBrowserTextLineBreaks(nodes);
     const blob = await window.domToPptx.exportToPptx(nodes, options);
     post({ status: "success", blob });
   })().catch((error) => {
@@ -610,6 +721,7 @@ function createExportScript(options: DomToPptxOptions): string {
     createExportBootstrapScript(options),
     createExportSlideScript(),
     createExportReadinessScript(),
+    createExportLineBreakScript(),
     createExportRunnerScript(),
   ].join("");
 }


### PR DESCRIPTION
## Summary
- preserve browser-rendered text line breaks before `dom-to-pptx` export so downloaded slides keep the same wrapping as the HTML preview
- keep generated switcher defaults from overriding authored theme colors when the generated script cannot run
- leave the previous font embedding changes out of this PR

## Testing
- `pnpm format`
- `pnpm lint` (passes; emits an unrelated existing oxlint warning in `apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts`)
- `pnpm check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/presentation-html-edit-protocol.test.ts src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts`
- `pnpm knip` (passes; reports existing configuration hints)

## Local environment note
- `pnpm test` is blocked locally by the dev database: `DATABASE_URL` is unset and PostgreSQL on `localhost:5432` refuses connections. `scripts/prepare.sh` was run and failed at the same migration/seed step with `invalid DATABASE_URL` / `ECONNREFUSED`.
