### PR TITLE
feat: scope chat thread event sourcing overrides to orgs

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -190,6 +190,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
           switches: {
             [FeatureSwitchKey.DataExport]: true,
             [FeatureSwitchKey.AgentUnreadIndicators]: true,
+            [FeatureSwitchKey.ChatThreadEventSourcing]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
         },
@@ -200,6 +201,14 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       ownerUpdate.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
     ).toBeTruthy();
+    expect(
+      ownerUpdate.body.switches[FeatureSwitchKey.ChatThreadEventSourcing],
+    ).toBeTruthy();
+    expect(
+      ownerUpdate.body.effectiveSwitches[
+        FeatureSwitchKey.ChatThreadEventSourcing
+      ],
+    ).toBeTruthy();
     expect(ownerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
 
     const peerRead = await accept(
@@ -209,6 +218,12 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(peerRead.body.switches[FeatureSwitchKey.DataExport]).toBeTruthy();
     expect(
       peerRead.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeTruthy();
+    expect(
+      peerRead.body.switches[FeatureSwitchKey.ChatThreadEventSourcing],
+    ).toBeTruthy();
+    expect(
+      peerRead.body.effectiveSwitches[FeatureSwitchKey.ChatThreadEventSourcing],
     ).toBeTruthy();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
@@ -222,6 +237,14 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       outsiderRead.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
     ).toBeUndefined();
+    expect(
+      outsiderRead.body.switches[FeatureSwitchKey.ChatThreadEventSourcing],
+    ).toBeUndefined();
+    expect(
+      outsiderRead.body.effectiveSwitches[
+        FeatureSwitchKey.ChatThreadEventSourcing
+      ],
+    ).toBeFalsy();
 
     const peerUpdate = await accept(
       featureSwitchesClient().update({
@@ -230,6 +253,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
           switches: {
             [FeatureSwitchKey.DataExport]: false,
             [FeatureSwitchKey.AgentUnreadIndicators]: false,
+            [FeatureSwitchKey.ChatThreadEventSourcing]: false,
           },
         },
       }),
@@ -238,6 +262,14 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(peerUpdate.body.switches[FeatureSwitchKey.DataExport]).toBeFalsy();
     expect(
       peerUpdate.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeFalsy();
+    expect(
+      peerUpdate.body.switches[FeatureSwitchKey.ChatThreadEventSourcing],
+    ).toBeFalsy();
+    expect(
+      peerUpdate.body.effectiveSwitches[
+        FeatureSwitchKey.ChatThreadEventSourcing
+      ],
     ).toBeFalsy();
     expect(peerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
@@ -251,6 +283,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       ownerReadAfterPeerUpdate.body.switches[
         FeatureSwitchKey.AgentUnreadIndicators
+      ],
+    ).toBeFalsy();
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[
+        FeatureSwitchKey.ChatThreadEventSourcing
       ],
     ).toBeFalsy();
     expect(
@@ -272,6 +309,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeUndefined();
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeUndefined();
+    expect(
+      peerReadAfterDelete.body.switches[
+        FeatureSwitchKey.ChatThreadEventSourcing
+      ],
     ).toBeUndefined();
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.Dummy],

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -9,11 +9,14 @@ import { nowDate } from "../external/time";
 
 const ORG_SENTINEL_USER_ID = "__org__";
 
+const ORG_SCOPED_FEATURE_SWITCH_KEYS: readonly string[] = [
+  FeatureSwitchKey.DataExport,
+  FeatureSwitchKey.AgentUnreadIndicators,
+  FeatureSwitchKey.ChatThreadEventSourcing,
+];
+
 function isOrgScopedFeatureSwitchKey(key: string): boolean {
-  return (
-    key === FeatureSwitchKey.DataExport ||
-    key === FeatureSwitchKey.AgentUnreadIndicators
-  );
+  return ORG_SCOPED_FEATURE_SWITCH_KEYS.includes(key);
 }
 
 function splitFeatureSwitchesByScope(switches: Record<string, boolean>): {
@@ -251,8 +254,9 @@ async function removeOrgScopedFeatureSwitches(
   }
 
   const next = { ...existingRow.switches };
-  delete next[FeatureSwitchKey.DataExport];
-  delete next[FeatureSwitchKey.AgentUnreadIndicators];
+  for (const key of ORG_SCOPED_FEATURE_SWITCH_KEYS) {
+    delete next[key];
+  }
 
   if (Object.keys(next).length === 0) {
     await writeDb


### PR DESCRIPTION
## Summary
- Treat `ChatThreadEventSourcing` as an org-scoped feature switch override, so enabling it through `/api/zero/feature-switches` applies to every user in the active org.
- Centralize the org-scoped feature switch key list and reuse it when clearing org sentinel overrides.
- Extend the OPS-01 feature switch route coverage for owner, same-org peer, outsider, disable, and delete behavior for chat thread event sourcing.

## Verification
- `pnpm exec prettier --check apps/api/src/signals/services/feature-switches.service.ts apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts`
- `git diff --check`
- `pnpm -F api exec oxlint src/signals/services/feature-switches.service.ts src/signals/routes/__tests__/hooks-ops.bdd.test.ts --deny-warnings`
- `pnpm -F api exec eslint src/signals/services/feature-switches.service.ts src/signals/routes/__tests__/hooks-ops.bdd.test.ts --max-warnings 0`
- `pnpm -F api exec oxlint src/signals/services/feature-switches.service.ts src/signals/routes/__tests__/hooks-ops.bdd.test.ts --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings`

## Notes
- Attempted `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts`; local runner has no Postgres server available, so DB-backed tests fail with `ECONNREFUSED` before exercising the assertions.
- Attempted API package type-check with increased heap; the runner killed the process with SIGKILL/OOM before emitting TypeScript diagnostics.
- Did not run full local vitest or start a dev server, per vm0 PR verification preference.