### PR TITLE
fix: prune chat thread events and apply unread filtering

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -587,11 +587,16 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
     chat.mockObjectStorageObjectsExist();
     await authOrg.deleteAgent(actor, deletedAgent.agentId);
 
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    mockNow(now() + 8 * 24 * 60 * 60 * 1000);
     const incrementalCompact = await compactChatThreadSnapshots();
     expect(incrementalCompact.eventsApplied).toBeGreaterThanOrEqual(1);
     expect(
       incrementalCompact.removedDeletedAgentThreads,
     ).toBeGreaterThanOrEqual(1);
+    expect(incrementalCompact.eventsPruned).toBeGreaterThanOrEqual(1);
 
     const compactedSnapshot = await chat.getThreadSnapshot(actor);
     expect(compactedSnapshot.latestEventId).toBe(renameEventId);
@@ -603,6 +608,31 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
         renamedAt: expect.any(String),
       }),
     ]);
+
+    const prunedCursor = await chat.requestThreadEvents(
+      actor,
+      { sinceEventId: liveCreateEventId },
+      [410],
+    );
+    expect(prunedCursor.body).toStrictEqual({
+      error: {
+        message: "Chat thread events cursor has expired",
+        code: "CHAT_THREAD_EVENTS_EXPIRED",
+      },
+    });
+
+    const retainedAnchorCursor = await chat.requestThreadEvents(
+      actor,
+      { sinceEventId: renameEventId },
+      [200],
+    );
+    expect(retainedAnchorCursor.status).toBe(200);
+    if (retainedAnchorCursor.status !== 200) {
+      throw new Error(
+        "Expected retained snapshot anchor event to be queryable",
+      );
+    }
+    expect(retainedAnchorCursor.body.events).toStrictEqual([]);
   });
 
   it("falls back to the first run model on detail after the explicit pin is cleared", async () => {

--- a/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { and, asc, eq, gt, or, sql } from "drizzle-orm";
+import { and, asc, eq, sql, type SQL } from "drizzle-orm";
 import type {
   ChatThreadEvent,
   ChatThreadSnapshotProjection,
@@ -16,19 +16,16 @@ interface SnapshotScope extends Record<string, unknown> {
   readonly orgId: string;
 }
 
-interface EventCursor {
-  readonly id: string;
-  readonly createdAt: Date;
-}
-
 interface SnapshotCompactionStats {
   readonly scopes: number;
   readonly eventsApplied: number;
   readonly removedDeletedAgentThreads: number;
+  readonly eventsPruned: number;
 }
 
 type SnapshotReadWriteDb = Pick<Db, "select" | "insert" | "execute">;
 type SnapshotRootDb = SnapshotReadWriteDb & Pick<Db, "transaction">;
+const CHAT_THREAD_EVENT_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 function toApiEvent(row: {
   readonly id: string;
@@ -205,9 +202,9 @@ async function loadEventCursor(
   db: SnapshotReadWriteDb,
   scope: SnapshotScope,
   eventId: string | null,
-): Promise<EventCursor | null> {
+): Promise<boolean> {
   if (!eventId) {
-    return null;
+    return false;
   }
 
   const [row] = await db
@@ -225,7 +222,7 @@ async function loadEventCursor(
     )
     .limit(1);
 
-  return row ?? null;
+  return row !== undefined;
 }
 
 async function loadEventsAfterMarker(
@@ -233,20 +230,21 @@ async function loadEventsAfterMarker(
   scope: SnapshotScope,
   eventId: string | null,
 ): Promise<readonly ChatThreadEvent[]> {
-  const cursor = await loadEventCursor(db, scope, eventId);
-  const filters = [
+  const hasCursor = await loadEventCursor(db, scope, eventId);
+  const filters: SQL[] = [
     eq(chatThreadEvents.userId, scope.userId),
     eq(chatThreadEvents.orgId, scope.orgId),
   ];
-  if (cursor) {
+  if (hasCursor && eventId !== null) {
     filters.push(
-      or(
-        gt(chatThreadEvents.createdAt, cursor.createdAt),
-        and(
-          eq(chatThreadEvents.createdAt, cursor.createdAt),
-          gt(chatThreadEvents.id, cursor.id),
-        ),
-      )!,
+      sql`(${chatThreadEvents.createdAt}, ${chatThreadEvents.id}) > (
+        SELECT marker.created_at, marker.id
+        FROM ${chatThreadEvents} AS marker
+        WHERE marker.user_id = ${scope.userId}
+          AND marker.org_id = ${scope.orgId}
+          AND marker.id = ${eventId}
+        LIMIT 1
+      )`,
     );
   }
 
@@ -352,10 +350,28 @@ async function compactChatThreadSnapshotsForAllScopes(
     removedDeletedAgentThreads += result.removedDeletedAgentThreads;
   }
 
+  signal?.throwIfAborted();
+  const cutoff = new Date(nowDate().getTime() - CHAT_THREAD_EVENT_RETENTION_MS);
+  const pruned = await db.execute<{ readonly count: number }>(sql`
+    WITH pruned AS (
+      DELETE FROM ${chatThreadEvents}
+      WHERE ${chatThreadEvents.createdAt} < ${cutoff}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM ${chatThreadSnapshots}
+          WHERE ${chatThreadSnapshots.latestEventId} = ${chatThreadEvents.id}
+        )
+      RETURNING 1
+    )
+    SELECT COUNT(*)::int AS "count"
+    FROM pruned
+  `);
+
   return {
     scopes: scopes.length,
     eventsApplied,
     removedDeletedAgentThreads,
+    eventsPruned: pruned.rows[0]?.count ?? 0,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread-event.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread-event.service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, or } from "drizzle-orm";
+import { and, asc, eq, sql, type SQL } from "drizzle-orm";
 import type {
   ChatThreadEvent,
   ChatThreadSnapshotProjection,
@@ -120,18 +120,12 @@ export async function getChatThreadEventsSince(
     }
   | { readonly kind: "expired" }
 > {
-  let cursor:
-    | {
-        readonly id: string;
-        readonly createdAt: Date;
-      }
-    | undefined;
+  let hasCursor = false;
 
   if (args.sinceEventId !== undefined) {
     const [row] = await db
       .select({
         id: chatThreadEvents.id,
-        createdAt: chatThreadEvents.createdAt,
       })
       .from(chatThreadEvents)
       .where(
@@ -145,22 +139,23 @@ export async function getChatThreadEventsSince(
     if (!row) {
       return { kind: "expired" };
     }
-    cursor = row;
+    hasCursor = true;
   }
 
-  const filters = [
+  const filters: SQL[] = [
     eq(chatThreadEvents.userId, args.userId),
     eq(chatThreadEvents.orgId, args.orgId),
   ];
-  if (cursor) {
+  if (hasCursor && args.sinceEventId !== undefined) {
     filters.push(
-      or(
-        gt(chatThreadEvents.createdAt, cursor.createdAt),
-        and(
-          eq(chatThreadEvents.createdAt, cursor.createdAt),
-          gt(chatThreadEvents.id, cursor.id),
-        ),
-      )!,
+      sql`(${chatThreadEvents.createdAt}, ${chatThreadEvents.id}) > (
+        SELECT marker.created_at, marker.id
+        FROM ${chatThreadEvents} AS marker
+        WHERE marker.user_id = ${args.userId}
+          AND marker.org_id = ${args.orgId}
+          AND marker.id = ${args.sinceEventId}
+        LIMIT 1
+      )`,
     );
   }
 

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -11,7 +11,10 @@ import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
 import { activeRoute$ } from "./active-route.ts";
-import { reloadChatThreadsCounter$ } from "./chat-thread-list-reload.ts";
+import {
+  reloadChatThreadsCounter$,
+  reloadChatUnreadStateCounter$,
+} from "./chat-thread-list-reload.ts";
 import { clerk$ } from "./auth.ts";
 import { readThreadMeta$ } from "./external/idb-thread-meta-store.ts";
 import { chatThreadOnlyUnread$ } from "./chat-page/chat-thread-only-unread.ts";
@@ -169,14 +172,40 @@ const legacyChatThreads$ = computed(
   },
 );
 
+const filteredThreadIds$ = computed(
+  async (get): Promise<ReadonlySet<string> | null> => {
+    if (!get(chatThreadEventSourcingEnabled$) || !get(chatThreadOnlyUnread$)) {
+      return null;
+    }
+    get(reloadChatUnreadStateCounter$);
+
+    const agentId = await get(currentChatAgentId$);
+    if (!agentId) {
+      return new Set();
+    }
+
+    const client = get(zeroClient$)(chatThreadsContract);
+    const result = await accept(client.unreads({ query: { agentId } }), [200]);
+    return new Set(
+      result.body.unreads.map((unread) => {
+        return unread.threadId;
+      }),
+    );
+  },
+);
+
 const eventDrivenFilteredChatThreads$ = computed(
   async (get): Promise<EventDrivenChatThread[]> => {
     const agentId = await get(currentChatAgentId$);
     if (!agentId) {
       return [];
     }
+    const filteredThreadIds = await get(filteredThreadIds$);
     return (await get(eventDrivenChatThreads$)).filter((thread) => {
-      return thread.agentId === agentId;
+      return (
+        thread.agentId === agentId &&
+        (filteredThreadIds === null || filteredThreadIds.has(thread.id))
+      );
     });
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -12,6 +12,7 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { chatThreads$, setChatAgentId$ } from "../../agent-chat.ts";
 import { renameDialogInput$ } from "../../zero-page/zero-sidebar-state.ts";
+import { setChatThreadOnlyUnread$ } from "../chat-thread-only-unread.ts";
 import { openRenameChatThreadDialogFromThreadData$ } from "../chat-thread-rename.ts";
 
 const idbThreadEventStoreMock = vi.hoisted(() => {
@@ -87,6 +88,7 @@ const context = testContext();
 
 const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 const THREAD_ID = "b0000000-0000-4000-a000-000000000001";
+const OTHER_THREAD_ID = "b0000000-0000-4000-a000-000000000002";
 const EVENT_ID = "d0000000-0000-4000-a000-000000000001";
 
 function expectCallback(callback: (() => void) | null): () => void {
@@ -99,6 +101,7 @@ function expectCallback(callback: (() => void) | null): () => void {
 
 describe("chat thread event sourcing local-first list", () => {
   afterEach(() => {
+    context.store.set(setChatThreadOnlyUnread$, false);
     idbThreadEventStoreMock.reset();
   });
 
@@ -259,6 +262,90 @@ describe("chat thread event sourcing local-first list", () => {
       },
     ]);
     expect(activeIdsRequests).toBe(1);
+    expect(listRequests).toBe(0);
+  });
+
+  it("filters event-sourced visible threads through unread thread ids", async () => {
+    context.store.set(setChatAgentId$, AGENT_ID);
+    context.store.set(setChatThreadOnlyUnread$, true);
+
+    idbThreadEventStoreMock.setData({
+      snapshot: {
+        latestEventId: EVENT_ID,
+        chatThreads: [
+          {
+            id: THREAD_ID,
+            agentId: AGENT_ID,
+            title: "Unread cached thread",
+            sortAt: "2026-07-03T03:00:00.000Z",
+            createdAt: "2026-07-03T01:00:00.000Z",
+            updatedAt: "2026-07-03T03:00:00.000Z",
+            pinnedAt: null,
+            renamedAt: null,
+          },
+          {
+            id: OTHER_THREAD_ID,
+            agentId: AGENT_ID,
+            title: "Read cached thread",
+            sortAt: "2026-07-03T02:00:00.000Z",
+            createdAt: "2026-07-03T01:00:00.000Z",
+            updatedAt: "2026-07-03T02:00:00.000Z",
+            pinnedAt: null,
+            renamedAt: null,
+          },
+        ],
+      },
+      events: [],
+    });
+
+    let unreadsRequests = 0;
+    let listRequests = 0;
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      return respond(200, { events: [], hasMore: false });
+    });
+    context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
+      return respond(200, { threadIds: [] });
+    });
+    context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
+      unreadsRequests += 1;
+      return respond(200, {
+        unreads: [
+          {
+            threadId: THREAD_ID,
+            unreadAt: "2026-07-03T04:00:00.000Z",
+          },
+        ],
+      });
+    });
+    context.mocks.api(chatThreadsContract.list, ({ never }) => {
+      listRequests += 1;
+      return never();
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      withoutRender: true,
+      user: { id: "user_1", fullName: "Test User" },
+      session: { token: "token" },
+      org: {
+        activeOrg: { id: "org_1", name: "Test Org" },
+        memberships: [{ id: "org_1" }],
+      },
+      featureSwitches: {
+        [FeatureSwitchKey.AgentUnreadIndicators]: true,
+        [FeatureSwitchKey.ChatThreadEventSourcing]: true,
+      },
+    });
+
+    const threads = await context.store.get(chatThreads$);
+
+    expect(
+      threads.map((thread) => {
+        return thread.id;
+      }),
+    ).toStrictEqual([THREAD_ID]);
+    expect(unreadsRequests).toBe(1);
     expect(listRequests).toBe(0);
   });
 

--- a/turbo/packages/api-contracts/src/contracts/cron.ts
+++ b/turbo/packages/api-contracts/src/contracts/cron.ts
@@ -64,6 +64,7 @@ const cronCompactChatThreadSnapshotsResponseSchema = z.object({
   scopes: z.number(),
   eventsApplied: z.number(),
   removedDeletedAgentThreads: z.number(),
+  eventsPruned: z.number(),
 });
 
 const cronReconcileBillingEntitlementsResponseSchema = z.object({


### PR DESCRIPTION
## Summary

- Prune `chat_thread_events` older than 7 days after chat thread snapshot compaction, while retaining any event that is still used as a snapshot `latestEventId` anchor.
- Return `eventsPruned` from the compaction cron contract and extend the compaction route test to cover pruned cursors, retained anchors, and deleted-agent projection cleanup.
- Apply unread-only filtering to event-sourced visible chat threads via the `unreads` thread id set, guarded by `ChatThreadEventSourcing`; the legacy switch-off path continues to use the existing list endpoint behavior.
- Compare event cursors with DB-side `(created_at, id)` tuple comparisons so timestamp precision does not replay the marker event.

## Verification

- `git diff --check`
- `pnpm exec prettier --write apps/api/src/signals/services/cron-compact-chat-thread-snapshots.service.ts apps/api/src/signals/services/zero-chat-thread-event.service.ts apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts apps/platform/src/signals/agent-chat.ts apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts packages/api-contracts/src/contracts/cron.ts`
- `pnpm -F api exec oxlint src/signals/services/cron-compact-chat-thread-snapshots.service.ts src/signals/services/zero-chat-thread-event.service.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts --deny-warnings`
- `pnpm -F api exec oxlint src/signals/services/cron-compact-chat-thread-snapshots.service.ts src/signals/services/zero-chat-thread-event.service.ts --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings`
- `pnpm -F @vm0/app exec oxlint src/signals/agent-chat.ts src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts --deny-warnings`
- `pnpm -F @vm0/app exec oxlint src/signals/agent-chat.ts src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts --type-aware -c ../../.oxlintrc.typeaware.json --deny-warnings`
- `pnpm -F @vm0/api-contracts exec oxlint src/contracts/cron.ts --deny-warnings`
- `pnpm -F @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts --reporter=verbose`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t "compacts chat thread snapshots from event markers and prunes deleted agent threads" --reporter=verbose`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t "returns chat thread snapshot and lifecycle events with cursor expiry" --reporter=verbose`
