### PR TITLE
perf: attribute storage manifest presign sources

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1040,6 +1040,20 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         storage_manifest_dropped_compose_count_bucket: "1",
         storage_manifest_planned_presign_count_bucket: "2_4",
         storage_manifest_duplicate_presign_candidate_count_bucket: "0",
+        storage_manifest_source_compose_volume_resolved_count_bucket: "1",
+        storage_manifest_source_compose_volume_planned_presign_count_bucket:
+          "0",
+        storage_manifest_source_compose_volume_non_system_presign_count_bucket:
+          "0",
+        storage_manifest_source_request_additional_volume_resolved_count_bucket:
+          "1",
+        storage_manifest_source_request_additional_volume_planned_presign_count_bucket:
+          "1",
+        storage_manifest_source_request_additional_volume_non_system_presign_count_bucket:
+          "1",
+        storage_manifest_source_artifact_resolved_count_bucket: "1",
+        storage_manifest_source_artifact_planned_presign_count_bucket: "1",
+        storage_manifest_source_artifact_non_system_presign_count_bucket: "1",
         storage_manifest_artifact_ensure_already_initialized_count_bucket: "0",
         storage_manifest_artifact_ensure_missing_storage_count_bucket: "1",
         storage_manifest_artifact_ensure_created_storage_count_bucket: "1",
@@ -1077,6 +1091,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         storage_manifest_resolved_artifact_count_bucket: "1",
         storage_manifest_planned_presign_count_bucket: "2_4",
         storage_manifest_duplicate_presign_candidate_count_bucket: "0",
+        storage_manifest_source_compose_volume_resolved_count_bucket: "1",
+        storage_manifest_source_request_additional_volume_resolved_count_bucket:
+          "1",
+        storage_manifest_source_artifact_resolved_count_bucket: "1",
+        storage_manifest_source_request_additional_volume_planned_presign_count_bucket:
+          "1",
+        storage_manifest_source_request_additional_volume_non_system_presign_count_bucket:
+          "1",
+        storage_manifest_source_artifact_planned_presign_count_bucket: "1",
+        storage_manifest_source_artifact_non_system_presign_count_bucket: "1",
       }),
     );
     expect(
@@ -1087,6 +1111,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ).toStrictEqual(
       expect.objectContaining({
         storage_manifest_compose_planned_presign_count_bucket: "0",
+        storage_manifest_source_compose_volume_planned_presign_count_bucket:
+          "0",
+        storage_manifest_source_compose_volume_non_system_presign_count_bucket:
+          "0",
       }),
     );
     expect(
@@ -1097,6 +1125,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ).toStrictEqual(
       expect.objectContaining({
         storage_manifest_additional_planned_presign_count_bucket: "1",
+        storage_manifest_source_request_additional_volume_planned_presign_count_bucket:
+          "1",
+        storage_manifest_source_request_additional_volume_non_system_presign_count_bucket:
+          "1",
+        storage_manifest_source_artifact_planned_presign_count_bucket: "0",
       }),
     );
     expect(
@@ -1107,6 +1140,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     ).toStrictEqual(
       expect.objectContaining({
         storage_manifest_artifact_planned_presign_count_bucket: "1",
+        storage_manifest_source_artifact_planned_presign_count_bucket: "1",
+        storage_manifest_source_artifact_non_system_presign_count_bucket: "1",
+        storage_manifest_source_request_additional_volume_planned_presign_count_bucket:
+          "0",
       }),
     );
     expect(
@@ -2691,6 +2728,40 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     if (sent.status !== 201 || sent.body.runId === null) {
       throw new Error("Expected the pinned chat send to create a run");
     }
+
+    const timingEvents = apiDispatchTimingEventsForRun(sent.body.runId);
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_storage_manifest_build_entries",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        storage_manifest_source_workflow_skill_resolved_count_bucket: "1",
+        storage_manifest_source_workflow_skill_planned_presign_count_bucket:
+          "1",
+        storage_manifest_source_workflow_skill_non_system_presign_count_bucket:
+          "1",
+      }),
+    );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_prepare_storage_manifest_generate_additional_urls",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        storage_manifest_source_workflow_skill_planned_presign_count_bucket:
+          "1",
+        storage_manifest_source_workflow_skill_non_system_presign_count_bucket:
+          "1",
+      }),
+    );
+    expectApiDispatchTimingEventsNotToLeak(timingEvents, [
+      workflowName,
+      agent.agentId,
+      thread.id,
+    ]);
 
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(sent.body.runId);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -150,6 +150,7 @@ import { activePendingRunPredicate } from "./agent-run-activity.service";
 import {
   prepareAgentRunStorageManifest,
   StorageManifestBuildStats,
+  type StorageManifestSource,
 } from "./agent-run-storage.service";
 import {
   encryptQueuedRunnerJobPayload,
@@ -271,6 +272,18 @@ interface AdditionalVolume {
   readonly version?: string;
   readonly mountPath: string;
   readonly system?: boolean;
+}
+
+type AdditionalVolumeSources = readonly StorageManifestSource[] | undefined;
+
+interface PreparedAdditionalVolume {
+  readonly volume: AdditionalVolume;
+  readonly source: StorageManifestSource;
+}
+
+interface PreparedAdditionalVolumes {
+  readonly volumes: readonly AdditionalVolume[] | undefined;
+  readonly sources: AdditionalVolumeSources;
 }
 
 interface ZeroRunMetadata {
@@ -618,12 +631,30 @@ function concurrentRunLimit(): ApiErrorResponse<429, "CONCURRENT_RUN_LIMIT"> {
 }
 
 function mergeAdditionalVolumes(args: {
-  readonly prepend: readonly AdditionalVolume[] | undefined;
-  readonly base: readonly AdditionalVolume[] | undefined;
-}): readonly AdditionalVolume[] | undefined {
-  return args.prepend || args.base
-    ? [...(args.prepend ?? []), ...(args.base ?? [])]
-    : undefined;
+  readonly prepend: readonly PreparedAdditionalVolume[] | undefined;
+  readonly base: readonly PreparedAdditionalVolume[] | undefined;
+}): PreparedAdditionalVolumes {
+  const prepared =
+    args.prepend || args.base
+      ? [...(args.prepend ?? []), ...(args.base ?? [])]
+      : undefined;
+  return {
+    volumes: prepared?.map((item) => {
+      return item.volume;
+    }),
+    sources: prepared?.map((item) => {
+      return item.source;
+    }),
+  };
+}
+
+function prepareAdditionalVolumesWithSource(
+  volumes: readonly AdditionalVolume[] | undefined,
+  source: StorageManifestSource,
+): readonly PreparedAdditionalVolume[] | undefined {
+  return volumes?.map((volume) => {
+    return { volume, source };
+  });
 }
 
 function frameworkSkillsMountPath(framework: SupportedFramework): string {
@@ -695,17 +726,23 @@ function buildInjectedSkillVolumes(
   },
   framework: SupportedFramework,
   goalSeedEnabled: boolean,
-): readonly AdditionalVolume[] | undefined {
+): readonly PreparedAdditionalVolume[] | undefined {
   if (!args.injectSkillVolumes) {
     return undefined;
   }
   return [
-    ...buildSystemSkillVolumes(
-      args.allowedConnectorTypes ?? [],
-      framework,
-      goalSeedEnabled,
-    ),
-    ...buildWorkflowSkillVolumes(args.injectSkillVolumes.workflows, framework),
+    ...(prepareAdditionalVolumesWithSource(
+      buildSystemSkillVolumes(
+        args.allowedConnectorTypes ?? [],
+        framework,
+        goalSeedEnabled,
+      ),
+      "system_skill",
+    ) ?? []),
+    ...(prepareAdditionalVolumesWithSource(
+      buildWorkflowSkillVolumes(args.injectSkillVolumes.workflows, framework),
+      "workflow_skill",
+    ) ?? []),
   ];
 }
 
@@ -5082,6 +5119,7 @@ function buildRunnerJobPayload(
     readonly modelUsageProvider: string | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+    readonly additionalVolumeSources: AdditionalVolumeSources;
     readonly includeZeroTokenSecret: boolean | undefined;
     readonly zeroTokenComputerUseHostId: string | undefined;
     readonly chatThreadId: string | undefined;
@@ -5143,6 +5181,7 @@ function buildRunnerJobPayload(
             artifacts: args.artifacts,
             volumeVersionOverrides: body.volumeVersions,
             additionalVolumes: args.additionalVolumes,
+            additionalVolumeSources: args.additionalVolumeSources,
             framework: args.framework,
             timing: args.timing,
             stats: storageManifestStats,
@@ -5189,6 +5228,12 @@ function buildRunnerJobPayload(
   });
 }
 
+type BuildRunnerJobPayloadArgs = Parameters<typeof buildRunnerJobPayload>[1];
+type DispatchRunArgs = BuildRunnerJobPayloadArgs & {
+  readonly timing: ApiDispatchTimingCollector;
+  readonly timingDimensions: ApiDispatchTimingDimensions | undefined;
+};
+
 async function lockRunForDerivedPersistence(
   tx: DbTransaction,
   runId: string,
@@ -5211,31 +5256,7 @@ async function lockRunForDerivedPersistence(
 
 function dispatchRun(
   db: Db,
-  args: {
-    readonly run: RunRecord;
-    readonly userId: string;
-    readonly orgId: string;
-    readonly resolved: ResolvedCompose;
-    readonly body: CreateRunBody;
-    readonly artifacts: readonly ContextArtifact[];
-    readonly framework: SupportedFramework;
-    readonly modelProvider: ResolvedModelProviderEnvironment | null;
-    readonly connectorContext: ConnectorRuntimeContext;
-    readonly customConnectorContext: CustomConnectorRuntimeContext;
-    readonly permissionManifest: PermissionManifest | undefined;
-    readonly billableFirewalls: readonly string[];
-    readonly modelUsageProvider: string | undefined;
-    readonly apiStartTime: number;
-    readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
-    readonly includeZeroTokenSecret: boolean | undefined;
-    readonly zeroTokenComputerUseHostId: string | undefined;
-    readonly chatThreadId: string | undefined;
-    readonly extraEnvironment: Record<string, string> | undefined;
-    readonly userTimezone: string | undefined;
-    readonly featureSwitchContext: FeatureSwitchContext;
-    readonly timing: ApiDispatchTimingCollector;
-    readonly timingDimensions: ApiDispatchTimingDimensions | undefined;
-  },
+  args: DispatchRunArgs,
 ): Computed<Promise<DerivedPersistenceResult>> {
   return computed(async (get): Promise<DerivedPersistenceResult> => {
     await measureApiDispatchTiming(
@@ -5363,6 +5384,7 @@ function enqueueRunForConcurrency(
     readonly modelUsageProvider: string | undefined;
     readonly apiStartTime: number;
     readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+    readonly additionalVolumeSources: AdditionalVolumeSources;
     readonly includeZeroTokenSecret: boolean | undefined;
     readonly zeroTokenComputerUseHostId: string | undefined;
     readonly chatThreadId: string | undefined;
@@ -5686,6 +5708,7 @@ function buildAtomicLaunchPayload(
     modelUsageProvider: args.context.modelUsageProvider,
     apiStartTime: args.createArgs.apiStartTime,
     additionalVolumes: args.context.additionalVolumes,
+    additionalVolumeSources: args.context.additionalVolumeSources,
     includeZeroTokenSecret: args.createArgs.includeZeroTokenSecret,
     zeroTokenComputerUseHostId: args.createArgs.zeroTokenComputerUseHostId,
     chatThreadId: args.createArgs.chatThreadId,
@@ -5796,6 +5819,7 @@ interface PreparedRunContext {
   readonly modelUsageProvider: string | undefined;
   readonly artifacts: readonly ContextArtifact[];
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly additionalVolumeSources: AdditionalVolumeSources;
   readonly userTimezone: string | undefined;
   readonly featureSwitchContext: FeatureSwitchContext;
 }
@@ -6052,7 +6076,8 @@ function preparedRunAdditionalVolumes(args: {
   readonly featureSwitchContext: FeatureSwitchContext;
   readonly body: CreateRunBody;
   readonly resolved: ResolvedCompose;
-}): readonly AdditionalVolume[] | undefined {
+}): PreparedAdditionalVolumes {
+  const bodyAdditionalVolumes = args.body.additionalVolumes;
   return mergeAdditionalVolumes({
     prepend: buildInjectedSkillVolumes(
       {
@@ -6065,7 +6090,10 @@ function preparedRunAdditionalVolumes(args: {
         args.featureSwitchContext,
       ),
     ),
-    base: args.body.additionalVolumes ?? args.resolved.additionalVolumes,
+    base: prepareAdditionalVolumesWithSource(
+      bodyAdditionalVolumes ?? args.resolved.additionalVolumes,
+      bodyAdditionalVolumes ? "request_additional_volume" : "unknown",
+    ),
   });
 }
 
@@ -6402,6 +6430,7 @@ function prepareRunOutputMetadata(args: {
 }): {
   readonly artifacts: readonly ContextArtifact[];
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly additionalVolumeSources: AdditionalVolumeSources;
 } {
   const additionalVolumes = preparedRunAdditionalVolumes({
     createArgs: args.createArgs,
@@ -6416,7 +6445,11 @@ function prepareRunOutputMetadata(args: {
     framework: args.framework,
     bodyArtifacts: args.body.artifacts,
   }).artifacts;
-  return { additionalVolumes, artifacts };
+  return {
+    additionalVolumes: additionalVolumes.volumes,
+    additionalVolumeSources: additionalVolumes.sources,
+    artifacts,
+  };
 }
 
 function prepareRunContext(
@@ -6521,6 +6554,7 @@ function prepareRunContext(
         modelUsageProvider: runtimeContext.modelUsageProvider,
         artifacts: outputMetadata.artifacts,
         additionalVolumes: outputMetadata.additionalVolumes,
+        additionalVolumeSources: outputMetadata.additionalVolumeSources,
         userTimezone,
         featureSwitchContext: bodyContext.featureSwitchContext,
       };
@@ -6620,6 +6654,7 @@ function completeQueuedRun(input: {
             modelUsageProvider: input.context.modelUsageProvider,
             apiStartTime: input.args.apiStartTime,
             additionalVolumes: input.context.additionalVolumes,
+            additionalVolumeSources: input.context.additionalVolumeSources,
             includeZeroTokenSecret: input.args.includeZeroTokenSecret,
             zeroTokenComputerUseHostId: input.args.zeroTokenComputerUseHostId,
             chatThreadId: input.args.chatThreadId,
@@ -6676,6 +6711,7 @@ function completePendingRun(input: {
             modelUsageProvider: input.context.modelUsageProvider,
             apiStartTime: input.args.apiStartTime,
             additionalVolumes: input.context.additionalVolumes,
+            additionalVolumeSources: input.context.additionalVolumeSources,
             includeZeroTokenSecret: input.args.includeZeroTokenSecret,
             zeroTokenComputerUseHostId: input.args.zeroTokenComputerUseHostId,
             chatThreadId: input.args.chatThreadId,

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -42,6 +42,14 @@ type ManifestStorage = StorageManifest["storages"][number];
 type ManifestArtifact = StorageManifest["artifacts"][number];
 type ComputedGetter = <T>(computedValue: Computed<T>) => T;
 type StorageManifestEntryKind = "compose" | "additional" | "artifact";
+export type StorageManifestSource =
+  | "system_skill"
+  | "workflow_skill"
+  | "request_additional_volume"
+  | "compose_additional_volume"
+  | "compose_volume"
+  | "artifact"
+  | "unknown";
 type StorageManifestCountBucket =
   (typeof STORAGE_MANIFEST_COUNT_BUCKET_DIMENSIONS)[number];
 
@@ -96,6 +104,9 @@ interface PrepareAgentRunStorageManifestArgs {
   readonly artifacts: readonly ContextArtifact[];
   readonly volumeVersionOverrides: Record<string, string> | undefined;
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly additionalVolumeSources:
+    | readonly StorageManifestSource[]
+    | undefined;
   readonly framework: SupportedFramework;
   readonly timing?: ApiDispatchTimingCollector;
   readonly stats?: StorageManifestBuildStats;
@@ -159,6 +170,9 @@ interface BuildStorageManifestEntriesArgs {
   readonly userId: string;
   readonly composeVolumes: readonly ResolvedVolume[];
   readonly additionalVolumes: readonly AdditionalVolume[] | undefined;
+  readonly additionalVolumeSources:
+    | readonly StorageManifestSource[]
+    | undefined;
   readonly artifacts: readonly ContextArtifact[];
   readonly timing?: ApiDispatchTimingCollector;
   readonly stats?: StorageManifestBuildStats;
@@ -187,6 +201,7 @@ interface ResolvedManifestStorageInput {
 interface ResolvedManifestArtifactInput {
   readonly artifact: ContextArtifact;
   readonly resolved: StorageResolution;
+  readonly source: StorageManifestSource;
 }
 
 interface ResolvedManifestStoragePlan extends ResolvedManifestStorageInput {
@@ -194,6 +209,7 @@ interface ResolvedManifestStoragePlan extends ResolvedManifestStorageInput {
     StorageManifestEntryKind,
     "compose" | "additional"
   >;
+  readonly source: StorageManifestSource;
 }
 
 interface StorageManifestPhaseTimingWindow {
@@ -219,6 +235,15 @@ const STORAGE_MANIFEST_COUNT_BUCKET_DIMENSIONS = [
   "9_16",
   "17_plus",
 ] as const;
+const STORAGE_MANIFEST_SOURCES = [
+  "system_skill",
+  "workflow_skill",
+  "request_additional_volume",
+  "compose_additional_volume",
+  "compose_volume",
+  "artifact",
+  "unknown",
+] as const satisfies readonly StorageManifestSource[];
 const STORAGE_MANIFEST_ARTIFACT_ENSURE_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_ensure_artifact_lookup_storage",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_storage",
@@ -230,6 +255,11 @@ const STORAGE_MANIFEST_ARTIFACT_ENSURE_ACTION_TYPES = [
 
 type StorageManifestArtifactEnsureActionType =
   (typeof STORAGE_MANIFEST_ARTIFACT_ENSURE_ACTION_TYPES)[number];
+type StorageManifestSourceCounts = Record<StorageManifestSource, number>;
+type StorageManifestSourceCountsByKind = Record<
+  StorageManifestEntryKind,
+  StorageManifestSourceCounts
+>;
 
 function storageManifestCountBucket(count: number): StorageManifestCountBucket {
   if (count <= 0) {
@@ -248,6 +278,26 @@ function storageManifestCountBucket(count: number): StorageManifestCountBucket {
     return "9_16";
   }
   return "17_plus";
+}
+
+function emptyStorageManifestSourceCounts(): StorageManifestSourceCounts {
+  return {
+    system_skill: 0,
+    workflow_skill: 0,
+    request_additional_volume: 0,
+    compose_additional_volume: 0,
+    compose_volume: 0,
+    artifact: 0,
+    unknown: 0,
+  };
+}
+
+function emptyStorageManifestSourceCountsByKind(): StorageManifestSourceCountsByKind {
+  return {
+    compose: emptyStorageManifestSourceCounts(),
+    additional: emptyStorageManifestSourceCounts(),
+    artifact: emptyStorageManifestSourceCounts(),
+  };
 }
 
 export class StorageManifestBuildStats {
@@ -270,6 +320,15 @@ export class StorageManifestBuildStats {
   private systemPresignCacheStaleReuseCount = 0;
   private systemPresignCacheSyncRefreshCount = 0;
   private nonSystemPresignCount = 0;
+  private readonly resolvedSourceCounts = emptyStorageManifestSourceCounts();
+  private readonly plannedPresignSourceCounts =
+    emptyStorageManifestSourceCounts();
+  private readonly plannedPresignSourceCountsByKind =
+    emptyStorageManifestSourceCountsByKind();
+  private readonly nonSystemPresignSourceCounts =
+    emptyStorageManifestSourceCounts();
+  private readonly nonSystemPresignSourceCountsByKind =
+    emptyStorageManifestSourceCountsByKind();
   private artifactEnsureAlreadyInitializedCount = 0;
   private artifactEnsureMissingStorageCount = 0;
   private artifactEnsureCreatedStorageCount = 0;
@@ -290,25 +349,31 @@ export class StorageManifestBuildStats {
     this.dedupedArtifactCount = args.dedupedArtifactCount;
   }
 
-  recordResolvedEntry(kind: StorageManifestEntryKind, count = 1): void {
+  recordResolvedEntry(
+    kind: StorageManifestEntryKind,
+    source: StorageManifestSource,
+    count = 1,
+  ): void {
     switch (kind) {
       case "compose": {
         this.resolvedComposeCount += count;
-        return;
+        break;
       }
       case "additional": {
         this.resolvedAdditionalCount += count;
-        return;
+        break;
       }
       case "artifact": {
         this.resolvedArtifactCount += count;
-        return;
+        break;
       }
     }
+    this.resolvedSourceCounts[source] += count;
   }
 
   recordPresignCandidate(
     kind: StorageManifestEntryKind,
+    source: StorageManifestSource,
     input: PresignCandidateInput,
   ): void {
     switch (kind) {
@@ -325,6 +390,8 @@ export class StorageManifestBuildStats {
         break;
       }
     }
+    this.plannedPresignSourceCounts[source] += 1;
+    this.plannedPresignSourceCountsByKind[kind][source] += 1;
 
     const key = JSON.stringify([
       input.bucket,
@@ -366,8 +433,13 @@ export class StorageManifestBuildStats {
     }
   }
 
-  recordNonSystemPresign(): void {
+  recordNonSystemPresign(
+    kind: StorageManifestEntryKind,
+    source: StorageManifestSource,
+  ): void {
     this.nonSystemPresignCount += 1;
+    this.nonSystemPresignSourceCounts[source] += 1;
+    this.nonSystemPresignSourceCountsByKind[kind][source] += 1;
   }
 
   recordArtifactEnsureAlreadyInitialized(): void {
@@ -440,6 +512,11 @@ export class StorageManifestBuildStats {
       ),
       storage_manifest_duplicate_presign_candidate_count_bucket:
         storageManifestCountBucket(this.duplicatePresignCandidateCount()),
+      ...this.sourceDimensions({
+        resolved: this.resolvedSourceCounts,
+        plannedPresign: this.plannedPresignSourceCounts,
+        nonSystemPresign: this.nonSystemPresignSourceCounts,
+      }),
       ...this.systemPresignCacheDimensions(),
       ...this.artifactEnsureDimensions(),
     };
@@ -477,6 +554,11 @@ export class StorageManifestBuildStats {
       ),
       storage_manifest_duplicate_presign_candidate_count_bucket:
         storageManifestCountBucket(this.duplicatePresignCandidateCount()),
+      ...this.sourceDimensions({
+        resolved: this.resolvedSourceCounts,
+        plannedPresign: this.plannedPresignSourceCounts,
+        nonSystemPresign: this.nonSystemPresignSourceCounts,
+      }),
       ...this.systemPresignCacheDimensions(),
     };
   }
@@ -489,18 +571,31 @@ export class StorageManifestBuildStats {
         return {
           storage_manifest_compose_planned_presign_count_bucket:
             storageManifestCountBucket(this.plannedComposePresignCount),
+          ...this.sourceDimensions({
+            plannedPresign: this.plannedPresignSourceCountsByKind.compose,
+            nonSystemPresign: this.nonSystemPresignSourceCountsByKind.compose,
+          }),
         };
       }
       case "additional": {
         return {
           storage_manifest_additional_planned_presign_count_bucket:
             storageManifestCountBucket(this.plannedAdditionalPresignCount),
+          ...this.sourceDimensions({
+            plannedPresign: this.plannedPresignSourceCountsByKind.additional,
+            nonSystemPresign:
+              this.nonSystemPresignSourceCountsByKind.additional,
+          }),
         };
       }
       case "artifact": {
         return {
           storage_manifest_artifact_planned_presign_count_bucket:
             storageManifestCountBucket(this.plannedArtifactPresignCount),
+          ...this.sourceDimensions({
+            plannedPresign: this.plannedPresignSourceCountsByKind.artifact,
+            nonSystemPresign: this.nonSystemPresignSourceCountsByKind.artifact,
+          }),
         };
       }
     }
@@ -534,6 +629,31 @@ export class StorageManifestBuildStats {
       count += Math.max(0, candidateCount - 1);
     }
     return count;
+  }
+
+  private sourceDimensions(args: {
+    readonly resolved?: StorageManifestSourceCounts;
+    readonly plannedPresign?: StorageManifestSourceCounts;
+    readonly nonSystemPresign?: StorageManifestSourceCounts;
+  }): ApiDispatchTimingDimensions {
+    const dimensions: Record<string, string> = {};
+    for (const source of STORAGE_MANIFEST_SOURCES) {
+      if (args.resolved) {
+        dimensions[`storage_manifest_source_${source}_resolved_count_bucket`] =
+          storageManifestCountBucket(args.resolved[source]);
+      }
+      if (args.plannedPresign) {
+        dimensions[
+          `storage_manifest_source_${source}_planned_presign_count_bucket`
+        ] = storageManifestCountBucket(args.plannedPresign[source]);
+      }
+      if (args.nonSystemPresign) {
+        dimensions[
+          `storage_manifest_source_${source}_non_system_presign_count_bucket`
+        ] = storageManifestCountBucket(args.nonSystemPresign[source]);
+      }
+    }
+    return dimensions;
   }
 
   private systemPresignCacheDimensions(): ApiDispatchTimingDimensions {
@@ -1355,6 +1475,7 @@ async function resolveArtifactStorageInput(args: {
   readonly runtimeOrgId: string;
   readonly userId: string;
   readonly artifact: ContextArtifact;
+  readonly source: StorageManifestSource;
 }): Promise<ResolvedManifestArtifactInput> {
   const resolved = await resolveStorageVersion(
     args.db,
@@ -1367,7 +1488,7 @@ async function resolveArtifactStorageInput(args: {
     },
     args.artifact.version,
   );
-  return { artifact: args.artifact, resolved };
+  return { artifact: args.artifact, resolved, source: args.source };
 }
 
 function storageArchiveKey(resolved: StorageResolution): string {
@@ -1397,16 +1518,17 @@ async function generateDirectStorageArchiveUrl(
     readonly archiveKey: string;
     readonly stats?: StorageManifestBuildStats;
     readonly entryKind: StorageManifestEntryKind;
+    readonly source: StorageManifestSource;
   },
 ): Promise<string> {
-  args.stats?.recordPresignCandidate(args.entryKind, {
+  args.stats?.recordPresignCandidate(args.entryKind, args.source, {
     bucket: args.bucket,
     key: args.archiveKey,
     expiresIn: DOWNLOAD_URL_TTL_SECONDS,
     filename: undefined,
     usePublicEndpoint: true,
   });
-  args.stats?.recordNonSystemPresign();
+  args.stats?.recordNonSystemPresign(args.entryKind, args.source);
   return await get(
     generatePresignedGetUrl(
       args.bucket,
@@ -1466,6 +1588,7 @@ async function buildStorageEntriesFromPlans(
             archiveKey,
             stats: args.stats,
             entryKind: plan.entryKind,
+            source: plan.source,
           }),
         });
       }
@@ -1482,7 +1605,7 @@ async function buildStorageEntriesFromPlans(
       }
       args.stats?.recordSystemPresignCacheResult(result.status);
       if (result.status === "miss" || result.status === "sync_refresh") {
-        args.stats?.recordPresignCandidate(plan.entryKind, {
+        args.stats?.recordPresignCandidate(plan.entryKind, plan.source, {
           bucket: args.bucket,
           key: archiveKey,
           expiresIn: SYSTEM_STORAGE_PRESIGNED_URL_TTL_SECONDS,
@@ -1505,14 +1628,14 @@ async function buildArtifactEntryFromInput(
 ): Promise<ManifestArtifact> {
   const { artifact, resolved } = args.input;
   const archiveKey = `${resolved.s3Key}/archive.tar.gz`;
-  args.stats?.recordPresignCandidate("artifact", {
+  args.stats?.recordPresignCandidate("artifact", args.input.source, {
     bucket: args.bucket,
     key: archiveKey,
     expiresIn: DOWNLOAD_URL_TTL_SECONDS,
     filename: undefined,
     usePublicEndpoint: true,
   });
-  args.stats?.recordNonSystemPresign();
+  args.stats?.recordNonSystemPresign("artifact", args.input.source);
   const archiveUrl = await get(
     generatePresignedGetUrl(
       args.bucket,
@@ -1552,9 +1675,11 @@ async function buildComposeStorageEntry(args: {
     });
   });
   if (input) {
-    args.stats?.recordResolvedEntry("compose");
+    args.stats?.recordResolvedEntry("compose", "compose_volume");
   }
-  return input ? { ...input, entryKind: "compose" } : null;
+  return input
+    ? { ...input, entryKind: "compose", source: "compose_volume" }
+    : null;
 }
 
 async function buildAdditionalStorageEntry(args: {
@@ -1562,6 +1687,7 @@ async function buildAdditionalStorageEntry(args: {
   readonly index: StorageIndex;
   readonly runtimeOrgId: string;
   readonly volume: AdditionalVolume;
+  readonly source: StorageManifestSource;
   readonly phaseTiming: StorageManifestEntryPhaseTiming;
   readonly stats?: StorageManifestBuildStats;
 }): Promise<ResolvedManifestStoragePlan | null> {
@@ -1574,9 +1700,11 @@ async function buildAdditionalStorageEntry(args: {
     });
   });
   if (input) {
-    args.stats?.recordResolvedEntry("additional");
+    args.stats?.recordResolvedEntry("additional", args.source);
   }
-  return input ? { ...input, entryKind: "additional" } : null;
+  return input
+    ? { ...input, entryKind: "additional", source: args.source }
+    : null;
 }
 
 function mergeStorageEntries<
@@ -1596,6 +1724,13 @@ function mergeStorageEntries<
     }),
     ...args.additionalEntries,
   ];
+}
+
+function additionalVolumeSourceAt(
+  sources: readonly StorageManifestSource[] | undefined,
+  index: number,
+): StorageManifestSource {
+  return sources?.[index] ?? "unknown";
 }
 
 async function resolveStorageManifestInputs(
@@ -1758,12 +1893,16 @@ async function resolveStorageManifestEntryPlans(args: {
       "nested",
       async () => {
         return await Promise.all(
-          (input.additionalVolumes ?? []).map((volume) => {
+          (input.additionalVolumes ?? []).map((volume, index) => {
             return buildAdditionalStorageEntry({
               db: input.db,
               index: input.storageIndex,
               runtimeOrgId: input.runtimeOrgId,
               volume,
+              source: additionalVolumeSourceAt(
+                input.additionalVolumeSources,
+                index,
+              ),
               phaseTiming: args.phaseTimings.additional,
               stats: input.stats,
             });
@@ -1785,6 +1924,7 @@ async function resolveStorageManifestEntryPlans(args: {
                 runtimeOrgId: input.runtimeOrgId,
                 userId: input.userId,
                 artifact,
+                source: "artifact",
               });
             });
           }),
@@ -1793,7 +1933,11 @@ async function resolveStorageManifestEntryPlans(args: {
     ),
   ]);
 
-  input.stats?.recordResolvedEntry("artifact", artifactInputs.length);
+  input.stats?.recordResolvedEntry(
+    "artifact",
+    "artifact",
+    artifactInputs.length,
+  );
 
   return {
     composePlans: composePlans.filter(isResolvedManifestStoragePlan),
@@ -1973,6 +2117,7 @@ export function prepareAgentRunStorageManifest(
       userId: args.userId,
       composeVolumes,
       additionalVolumes: args.additionalVolumes,
+      additionalVolumeSources: args.additionalVolumeSources,
       artifacts,
       timing: args.timing,
       stats: args.stats,

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1733,6 +1733,18 @@ function additionalVolumeSourceAt(
   return sources?.[index] ?? "unknown";
 }
 
+function normalizeAdditionalVolumeSources(args: {
+  readonly volumes: readonly AdditionalVolume[] | undefined;
+  readonly sources: readonly StorageManifestSource[] | undefined;
+}): readonly StorageManifestSource[] | undefined {
+  if (!args.sources) {
+    return undefined;
+  }
+  return args.sources.length === (args.volumes?.length ?? 0)
+    ? args.sources
+    : undefined;
+}
+
 async function resolveStorageManifestInputs(
   args: PrepareAgentRunStorageManifestArgs,
 ): Promise<StorageManifestInputs> {
@@ -1867,6 +1879,10 @@ async function resolveStorageManifestEntryPlans(args: {
   readonly phaseTimings: StorageManifestEntryPhaseTimings;
 }): Promise<ResolvedStorageManifestEntryPlans> {
   const input = args.input;
+  const additionalVolumeSources = normalizeAdditionalVolumeSources({
+    volumes: input.additionalVolumes,
+    sources: input.additionalVolumeSources,
+  });
   const [composePlans, additionalPlans, artifactInputs] = await Promise.all([
     measureApiDispatchTiming(
       input.timing,
@@ -1899,10 +1915,7 @@ async function resolveStorageManifestEntryPlans(args: {
               index: input.storageIndex,
               runtimeOrgId: input.runtimeOrgId,
               volume,
-              source: additionalVolumeSourceAt(
-                input.additionalVolumeSources,
-                index,
-              ),
+              source: additionalVolumeSourceAt(additionalVolumeSources, index),
               phaseTiming: args.phaseTimings.additional,
               stats: input.stats,
             });


### PR DESCRIPTION
## Summary
- add internal additional-volume source provenance for storage manifest timing
- emit low-cardinality source buckets for resolved entries, planned presigns, and non-system presigns
- cover request additional volumes, compose volumes, artifacts, and workflow skill sources in API integration tests

## Behavior
- no API contract, DB schema, runner payload, storage manifest, URL TTL, or storage cache behavior changes
- provenance stays server-internal and is stripped before persisted/run payload shapes

## Tests
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pre-commit: prettier, knip, turbo check-types

Closes #20074