### PR TITLE
fix: allow maskdb aggregate queries through firewall

### DIFF
--- a/crates/runner/mitm-addon/src/generated/builtin_firewalls/maskdb_0.py
+++ b/crates/runner/mitm-addon/src/generated/builtin_firewalls/maskdb_0.py
@@ -16,6 +16,7 @@ JSON_PART = r"""{
         {
           "name": "db:query",
           "rules": [
+            "POST /v1/databases/{db}/aggregate",
             "POST /v1/databases/{db}/query"
           ]
         },

--- a/turbo/packages/connectors/src/connectors/maskdb.ts
+++ b/turbo/packages/connectors/src/connectors/maskdb.ts
@@ -5,7 +5,7 @@ export const maskdb = {
     label: "maskdb",
     category: "data-automation-infrastructure",
     helpText:
-      "Connect maskdb to run read-only, structured queries against a masked Postgres database. Sensitive columns are returned masked and can never be used to filter or sort.",
+      "Connect maskdb to run read-only, structured queries against a masked Postgres database. Sensitive columns are returned masked and can never be used to filter, sort, group, or aggregate.",
     authMethods: {
       "api-token": {
         label: "Token",

--- a/turbo/packages/firewalls-generator/src/maskdb.ts
+++ b/turbo/packages/firewalls-generator/src/maskdb.ts
@@ -35,8 +35,12 @@ const DEFAULT_ALLOWED: string[] = ["db:metadata", "db:query", "policy:read"];
 const PERMISSIONS: { name: string; description: string; rules: string[] }[] = [
   {
     name: "db:query",
-    description: "Run read-only structured queries (results masked).",
-    rules: ["POST /v1/databases/{db}/query"],
+    description:
+      "Run read-only structured and aggregate queries (results masked).",
+    rules: [
+      "POST /v1/databases/{db}/aggregate",
+      "POST /v1/databases/{db}/query",
+    ],
   },
   {
     name: "db:metadata",


### PR DESCRIPTION
## Summary
- Add `POST /v1/databases/{db}/aggregate` to the maskdb `db:query` firewall permission.
- Regenerate the runner builtin firewall entry so sandbox request matching allows the aggregate endpoint.
- Update the maskdb connector help text to mention group/aggregate restrictions alongside filter/sort.

## Verification
- `pnpm -F @vm0/firewalls-generator generate:maskdb`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-default-policies.test.ts`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/connectors check-types`
- `git diff --check`
