### PR TITLE
test: cover sidebar shortcut from chat composer

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1364,6 +1364,30 @@ describe("zero sidebar", () => {
     expect(within(dialog).getByText("Support Agent")).toBeInTheDocument();
   });
 
+  it("toggles the sidebar with mod+b while the chat composer is focused", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([createThread(EXISTING_THREAD_ID, "Release plan")]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+    });
+
+    const composer = await screen.findByPlaceholderText(PLACEHOLDER);
+    await waitFor(() => {
+      expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Expand sidebar")).not.toBeInTheDocument();
+    });
+
+    composer.focus();
+    expect(composer).toHaveFocus();
+    fireEvent.keyDown(composer, { key: "b", ctrlKey: true });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Expand sidebar")).toBeInTheDocument();
+    });
+  });
+
   it("ignores global shortcuts while a dialog is open", async () => {
     prepareAgentTeam();
     context.mocks.api(chatThreadsContract.list, ({ respond }) => {


### PR DESCRIPTION
## Summary
- Adds a regression test for the global `mod+b` sidebar shortcut on `/chats/:threadId`.
- Verifies the shortcut still toggles the sidebar while the chat composer textarea is focused.

## Verification
- `pnpm prettier --check apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "while the chat composer is focused"`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
