### PR TITLE
refactor: centralize mitm idna dot separators

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -16,19 +16,15 @@ from firewall_auth_config import (
     auth_config_injects_credentials,
     auth_config_injects_ordinary_upstream_credentials,
 )
-from host_normalization import normalize_idna_hostname
+from host_normalization import (
+    normalize_idna_hostname,
+    translate_idna_dot_separators,
+)
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 BUILTIN_HOST_POLICY_RUNTIME_MARKER = "_builtinHostPolicyRuntime"
 _DEFAULT_HTTPS_PORT = 443
 _MIN_FIXED_HOST_OWNERSHIP_LABELS = 2
-_HOST_DOT_EQUIVALENT_TRANSLATION = str.maketrans(
-    {
-        "\u3002": ".",
-        "\uff0e": ".",
-        "\uff61": ".",
-    }
-)
 _HOST_POLICY_HOST_FORBIDDEN_CHARS = frozenset("%*[]/?#@\\:{}")
 _IPV4_LITERAL_COMPONENT_PATTERN = re.compile(r"(?:0[xX][0-9a-fA-F]+|[0-9]+)")
 _IPV4_LITERAL_MAX_COMPONENTS = 4
@@ -181,7 +177,7 @@ def _parsed_port(
 
 
 def _normalize_host_policy_hostname(hostname: str) -> str:
-    normalized = hostname.translate(_HOST_DOT_EQUIVALENT_TRANSLATION).lower()
+    normalized = translate_idna_dot_separators(hostname).lower()
     if normalized.endswith("."):
         return normalized[:-1]
     return normalized

--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -21,7 +21,11 @@ from firewall_matching.patterns import (
     _parse_segment,
     _split_path_segments,
 )
-from host_normalization import normalize_idna_hostname
+from host_normalization import (
+    normalize_hostname_separators,
+    normalize_idna_hostname,
+    translate_idna_dot_separators,
+)
 from url_syntax import (
     has_raw_whitespace,
     has_unsafe_runtime_url_syntax,
@@ -31,13 +35,6 @@ from url_syntax import (
 
 _MIN_HOST_SEGMENTS = 2
 _ASCII_MAX = 0x7F
-_IDNA_DOT_TRANSLATION = str.maketrans(
-    {
-        "\u3002": ".",
-        "\uff0e": ".",
-        "\uff61": ".",
-    }
-)
 _FORBIDDEN_AUTHORITY_HOST_CHARS = frozenset("#%/<>?@[\\]^|[]")
 _FORBIDDEN_RUNTIME_AUTHORITY_HOST_CHARS = _FORBIDDEN_AUTHORITY_HOST_CHARS | frozenset("{}")
 _PERCENT_DECODED_AUTHORITY_SYNTAX_CHARS = frozenset("{}*.\u3002\uff0e\uff61")
@@ -99,7 +96,7 @@ def _percent_decode_authority_host(host: str) -> tuple[str, bool]:
     if decoded.invalid_encoding:
         return decoded.value, True
     if decoded.decoded_syntax:
-        return decoded.value.translate(_IDNA_DOT_TRANSLATION), True
+        return translate_idna_dot_separators(decoded.value), True
     if ":" in decoded.value:
         return decoded.value, True
     return decoded.value, False
@@ -129,21 +126,12 @@ def _extract_raw_hostname(netloc: str) -> _RawAuthorityHost | None:
     return _RawAuthorityHost(authority, bracketed=False)
 
 
-def _normalize_host_pattern_dots(host: str) -> str:
-    normalized = host.translate(_IDNA_DOT_TRANSLATION)
-    if normalized.endswith("."):
-        normalized = normalized[:-1]
-        if not normalized or normalized.endswith("."):
-            raise UnicodeError("empty IDNA label")
-    return normalized
-
-
 def _format_param_segment(parsed: SegmentParam) -> str:
     return f"{parsed.prefix.lower()}{{{parsed.name}{parsed.greedy}}}{parsed.suffix.lower()}"
 
 
 def _normalize_parameterized_authority_host(host: str) -> tuple[str, bool]:
-    normalized = _normalize_host_pattern_dots(host)
+    normalized = normalize_hostname_separators(host)
     labels: list[str] = []
     malformed = False
 

--- a/crates/runner/mitm-addon/src/host_normalization.py
+++ b/crates/runner/mitm-addon/src/host_normalization.py
@@ -165,8 +165,19 @@ def _has_unicode_control_chars(value: str) -> bool:
     return any(category(char).startswith(_UNICODE_CONTROL_CATEGORY_PREFIX) for char in value)
 
 
-def _normalize_hostname_dots(host: str) -> str:
-    normalized = host.translate(_IDNA_DOT_TRANSLATION)
+def translate_idna_dot_separators(host: str) -> str:
+    """Translate IDNA dot separators to ASCII dots without validating the host."""
+    return host.translate(_IDNA_DOT_TRANSLATION)
+
+
+def normalize_hostname_separators(host: str) -> str:
+    """Normalize hostname separators without normalizing individual IDNA labels.
+
+    This helper only translates IDNA dot separators and removes one optional
+    trailing dot. It is not a hostname validator; callers that need host identity
+    checks must still use ``normalize_idna_hostname()``.
+    """
+    normalized = translate_idna_dot_separators(host)
     if normalized.endswith("."):
         normalized = normalized[:-1]
         if not normalized or normalized.endswith("."):
@@ -429,7 +440,7 @@ def normalize_idna_hostname(host: str) -> str:
     that would obscure host identity, including folds to plain ASCII labels such
     as fullwidth Latin text.
     """
-    normalized = _normalize_hostname_dots(host)
+    normalized = normalize_hostname_separators(host)
     if not normalized:
         raise ValueError("empty hostname")
     if _is_ipv4_literal_like(normalized):

--- a/crates/runner/mitm-addon/src/public_destination.py
+++ b/crates/runner/mitm-addon/src/public_destination.py
@@ -4,7 +4,10 @@ import ipaddress
 from dataclasses import dataclass
 from typing import Literal
 
-from host_normalization import normalize_idna_hostname
+from host_normalization import (
+    normalize_idna_hostname,
+    translate_idna_dot_separators,
+)
 
 _IPV4_NON_PUBLIC_RANGES = (
     (0x00000000, 0x00FFFFFF),
@@ -22,13 +25,6 @@ _IPV4_NON_PUBLIC_RANGES = (
     (0xC6336400, 0xC63364FF),
     (0xCB007100, 0xCB0071FF),
     (0xE0000000, 0xFFFFFFFF),
-)
-_HOST_DOT_EQUIVALENT_TRANSLATION = str.maketrans(
-    {
-        "\u3002": ".",
-        "\uff0e": ".",
-        "\uff61": ".",
-    }
 )
 _IPV4_HEX_PREFIX = "0x"
 _IPV4_LITERAL_MAX_COMPONENTS = 4
@@ -193,7 +189,7 @@ def _looks_like_ipv4_number_component(value: str) -> bool:
 
 
 def _looks_like_legacy_ipv4_literal(hostname: str) -> bool:
-    normalized = hostname.translate(_HOST_DOT_EQUIVALENT_TRANSLATION)
+    normalized = translate_idna_dot_separators(hostname)
     if normalized.endswith("."):
         normalized = normalized[:-1]
     parts = normalized.split(".")

--- a/crates/runner/mitm-addon/tests/test_matching_base_url_parameterized.py
+++ b/crates/runner/mitm-addon/tests/test_matching_base_url_parameterized.py
@@ -208,6 +208,9 @@ class TestMatchBaseUrl:
         [
             ("https://acme.zendesk.com/api", "https://{sub}.zendesk.com."),
             ("https://acme.zendesk.com./api", "https://{sub}.zendesk.com"),
+            ("https://acme.example.com/api", "https://{sub}.example。com"),
+            ("https://acme.example.com/api", "https://{sub}.example\uff0ecom"),
+            ("https://acme.example.com/api", "https://{sub}.example\uff61com"),
             ("https://acme.zendesk.com:8443/api", "https://{sub}.zendesk.com.:08443"),
             ("https://acme.zendesk.com.:8443/api", "https://{sub}.zendesk.com:8443"),
         ],
@@ -258,6 +261,7 @@ class TestMatchBaseUrl:
             "https://user:pass@{sub}.zendesk.com",
             "https://.{sub}.zendesk.com",
             "https://{sub}..zendesk.com",
+            "https://{sub}.zendesk.com。。",
             "https://{sub}.zendesk.com:bad",
             "https://{sub}.zendesk.com:99999",
         ],

--- a/crates/runner/mitm-addon/tests/test_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_public_destination.py
@@ -35,6 +35,8 @@ import public_destination
         ("127.0.0.1.", False),
         ("0x7f.0.0.1", False),
         ("127\u30020\u30020\u30021\u3002", False),
+        ("127\uff0e0\uff0e0\uff0e1\uff0e", False),
+        ("127\uff610\uff610\uff611\uff61", False),
         ("2130706433", False),
         ("2130706433.", False),
         ("127.1", False),

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -174,20 +174,22 @@ class TestRegistryBuiltinBaseUrlVars:
         assert api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] is True
 
     def test_builtin_provider_owned_accepts_idna_dot_equivalent_host(self, tmp_path):
-        path = tmp_path / "registry.json"
-        write_builtin_firewall_registry(
-            path,
-            run_id="run-jira",
-            name="jira",
-            base_url_vars={"JIRA_DOMAIN": "acme。atlassian。net"},
-        )
+        for index, dot in enumerate(("\u3002", "\uff0e", "\uff61")):
+            path = tmp_path / f"registry-{index}.json"
+            host = f"acme{dot}atlassian{dot}net"
+            write_builtin_firewall_registry(
+                path,
+                run_id=f"run-jira-{index}",
+                name="jira",
+                base_url_vars={"JIRA_DOMAIN": host},
+            )
 
-        context = registry.get_vm_context("10.200.0.1", str(path))
+            context = registry.get_vm_context("10.200.0.1", str(path))
 
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme。atlassian。net"
+            assert context is not None
+            vm_info, compiled_firewalls, _ = context
+            assert compiled_firewalls is not None
+            assert vm_info["firewalls"][0]["apis"][0]["base"] == f"https://{host}"
 
     def test_builtin_provider_owned_rejects_unsafe_idna_compatibility_host(
         self, tmp_path, monkeypatch


### PR DESCRIPTION
## Summary

- Add shared IDNA dot separator helpers in the mitm addon hostname normalization module.
- Replace duplicate separator tables in firewall base matching, builtin host policy, and public destination classification.
- Preserve caller-specific behavior for malformed authorities, parameterized host parsing, host-policy matching, and legacy IPv4-like classification.

Closes #20007

## Tests

- `cd crates/runner/mitm-addon && ruff check src/host_normalization.py src/firewall_matching/base_url.py src/builtin_host_policy.py src/public_destination.py tests/test_matching_base_url_parameterized.py tests/test_public_destination.py tests/test_registry_builtin_base_url_vars.py`
- `cd crates/runner/mitm-addon && PYTHONPATH=src pytest tests/test_matching_base_url_parameterized.py tests/test_matching_base_url_static.py tests/test_registry_builtin_base_url_vars.py tests/test_public_destination.py tests/test_compiled_firewall_authority_normalization.py`