### PR TITLE
refactor: serve connector category metadata from catalog api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -81,13 +81,24 @@ function assertCategoryMetadataMatchesVisibleConnectors(
       return connector.category;
     }),
   );
-  expect(
-    new Set(
-      metadata.categories.map((category) => {
-        return category.id;
-      }),
-    ),
-  ).toStrictEqual(connectorCategories);
+  const metadataCategoryIds = metadata.categories.map((category) => {
+    return category.id;
+  });
+  expect(metadataCategoryIds).toHaveLength(new Set(metadataCategoryIds).size);
+  expect(new Set(metadataCategoryIds)).toStrictEqual(connectorCategories);
+  const referencedGroupIds = new Set(
+    metadata.categories.flatMap((category) => {
+      return category.groupId ? [category.groupId] : [];
+    }),
+  );
+  const metadataGroupIds = metadata.groups.map((group) => {
+    return group.id;
+  });
+  expect(metadataGroupIds).toHaveLength(new Set(metadataGroupIds).size);
+  expect(new Set(metadataGroupIds)).toStrictEqual(referencedGroupIds);
+  for (const groupId of metadataGroupIds) {
+    expect(connectorCategories.has(groupId)).toBeFalsy();
+  }
 
   const aiCategoryIndex = metadata.categories.findIndex((category) => {
     return category.id === "ai-general-models";

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
-import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogListResponse,
+  type PublicConnectorCatalogStatusResponse,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
 import { afterEach } from "vitest";
@@ -60,6 +64,51 @@ async function deleteFeatureSwitches(
 
 function currentSecond(): number {
   return Math.floor(now() / 1000);
+}
+
+function assertCategoryMetadataMatchesVisibleConnectors(
+  body:
+    | PublicConnectorCatalogListResponse
+    | PublicConnectorCatalogStatusResponse,
+): void {
+  const metadata = body.categoryMetadata;
+  expect(metadata).toBeDefined();
+  if (!metadata) {
+    return;
+  }
+  const connectorCategories = new Set(
+    body.connectors.map((connector) => {
+      return connector.category;
+    }),
+  );
+  expect(
+    new Set(
+      metadata.categories.map((category) => {
+        return category.id;
+      }),
+    ),
+  ).toStrictEqual(connectorCategories);
+
+  const aiCategoryIndex = metadata.categories.findIndex((category) => {
+    return category.id === "ai-general-models";
+  });
+  const engineeringCategoryIndex = metadata.categories.findIndex((category) => {
+    return category.id === "engineering-team-execution";
+  });
+  expect(aiCategoryIndex).toBeGreaterThanOrEqual(0);
+  expect(engineeringCategoryIndex).toBeGreaterThanOrEqual(0);
+  expect(aiCategoryIndex).toBeLessThan(engineeringCategoryIndex);
+  expect(metadata.categories[aiCategoryIndex]).toMatchObject({
+    id: "ai-general-models",
+    label: "General Models and Reasoning",
+    menuLabel: "General Models",
+    groupId: "ai",
+  });
+  expect(metadata.groups).toContainEqual({
+    id: "ai",
+    label: "AI",
+    menuLabel: "AI",
+  });
 }
 
 function stateFromAuthorizationUrl(authorizationUrl: string): string {
@@ -130,6 +179,7 @@ describe("GET /api/zero/connector-catalog", () => {
     );
 
     assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    assertCategoryMetadataMatchesVisibleConnectors(response.body);
     expect(response.body.connectors.length).toBeGreaterThan(0);
   });
 
@@ -297,6 +347,7 @@ describe("GET /api/zero/connector-catalog", () => {
     );
 
     assertPublicConnectorCatalogHasNoPrivateFields(response.body);
+    assertCategoryMetadataMatchesVisibleConnectors(response.body);
     const openai = response.body.connectors.find((connector) => {
       return connector.connectorRef === "openai";
     });

--- a/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-catalog.ts
@@ -46,13 +46,13 @@ const listConnectorCatalogInner$ = command(
     const context = await set(connectorCatalogRequestContext$);
     signal.throwIfAborted();
 
-    const connectors = await listPublicConnectorCatalog({
+    const catalog = await listPublicConnectorCatalog({
       featureStates: context.featureStates,
       apiAuthMethodPolicy: "include",
     });
     signal.throwIfAborted();
 
-    return { status: 200 as const, body: { connectors } };
+    return { status: 200 as const, body: catalog };
   },
 );
 
@@ -71,14 +71,14 @@ const listConnectorCatalogStatusInner$ = command(
     );
     signal.throwIfAborted();
 
-    const connectors = await listPublicConnectorCatalogStatus({
+    const catalog = await listPublicConnectorCatalogStatus({
       featureStates: context.featureStates,
       apiAuthMethodPolicy: "include",
       connectors: connectorState.connectors,
     });
     signal.throwIfAborted();
 
-    return { status: 200 as const, body: { connectors } };
+    return { status: 200 as const, body: catalog };
   },
 );
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -1,24 +1,32 @@
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogAuthMethodSummary,
+  PublicConnectorCatalogCategoryMetadata,
   PublicConnectorCatalogConnection,
   PublicConnectorCatalogConnectionStatus,
   PublicConnectorCatalogDetail,
   PublicConnectorCatalogItem,
+  PublicConnectorCatalogListResponse,
   PublicConnectorCatalogManualField,
   PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogPermissionSummary,
   PublicConnectorCatalogStartOption,
   PublicConnectorCatalogStatusItem,
+  PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
 import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
 import {
+  CONNECTOR_DISPLAY_CATEGORY_GROUPS,
+  CONNECTOR_DISPLAY_CATEGORY_META,
+  CONNECTOR_DISPLAY_CATEGORY_ORDER,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
+  type ConnectorDisplayCategory,
+  type ConnectorDisplayCategoryGroup,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -56,8 +64,86 @@ interface ConnectorCatalogConnectorReadArgs extends ConnectorCatalogReadArgs {
   readonly connectorRef: string;
 }
 
+interface ConnectorCatalogCategorizedItem {
+  readonly category: string;
+}
+
 function isConnectorType(connectorRef: string): connectorRef is ConnectorType {
   return Object.prototype.hasOwnProperty.call(CONNECTOR_TYPES, connectorRef);
+}
+
+function isConnectorDisplayCategory(
+  category: string,
+): category is ConnectorDisplayCategory {
+  return Object.prototype.hasOwnProperty.call(
+    CONNECTOR_DISPLAY_CATEGORY_META,
+    category,
+  );
+}
+
+function fallbackCategoryLabel(category: string): string {
+  const label = category
+    .split(/[-_\s]+/)
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .map((part) => {
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+  return label || "Other";
+}
+
+function categoryMetadataForCatalog(
+  items: readonly ConnectorCatalogCategorizedItem[],
+): PublicConnectorCatalogCategoryMetadata {
+  const visibleCategories = new Set(
+    items.flatMap((item) => {
+      return item.category ? [item.category] : [];
+    }),
+  );
+  const orderedCategories = [
+    ...CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
+      return visibleCategories.has(category);
+    }),
+    ...[...visibleCategories].filter((category) => {
+      return !isConnectorDisplayCategory(category);
+    }),
+  ];
+  const visibleGroups = new Set<ConnectorDisplayCategoryGroup>();
+  const categories = orderedCategories.map((category) => {
+    if (!isConnectorDisplayCategory(category)) {
+      const label = fallbackCategoryLabel(category);
+      return {
+        id: category,
+        label,
+        menuLabel: label,
+        groupId: null,
+      };
+    }
+    const metadata = CONNECTOR_DISPLAY_CATEGORY_META[category];
+    if (metadata.group) {
+      visibleGroups.add(metadata.group);
+    }
+    return {
+      id: category,
+      label: metadata.label,
+      menuLabel: metadata.menuLabel,
+      groupId: metadata.group ?? null,
+    };
+  });
+
+  return {
+    categories,
+    groups: [...visibleGroups].map((group) => {
+      const metadata = CONNECTOR_DISPLAY_CATEGORY_GROUPS[group];
+      return {
+        id: group,
+        label: metadata.label,
+        menuLabel: metadata.menuLabel,
+      };
+    }),
+  };
 }
 
 function availableAuthMethodsForCatalog(
@@ -356,7 +442,7 @@ export function searchConnectorCatalog(
 
 export function listPublicConnectorCatalog(
   args: ConnectorCatalogReadArgs,
-): Promise<PublicConnectorCatalogItem[]> {
+): Promise<PublicConnectorCatalogListResponse> {
   const connectors = CONNECTOR_TYPE_KEYS.flatMap((type) => {
     const authMethods = availableAuthMethodsForCatalog(type, args);
     if (authMethods.length === 0) {
@@ -365,14 +451,17 @@ export function listPublicConnectorCatalog(
     return [connectorCatalogItem(type, authMethods)];
   });
 
-  return Promise.resolve(connectors);
+  return Promise.resolve({
+    connectors,
+    categoryMetadata: categoryMetadataForCatalog(connectors),
+  });
 }
 
 export function listPublicConnectorCatalogStatus(
   args: ConnectorCatalogReadArgs & {
     readonly connectors: readonly ConnectorResponse[];
   },
-): Promise<PublicConnectorCatalogStatusItem[]> {
+): Promise<PublicConnectorCatalogStatusResponse> {
   const connectorsByType = new Map(
     args.connectors.map((connector) => {
       return [connector.type, connector];
@@ -392,7 +481,10 @@ export function listPublicConnectorCatalogStatus(
     ];
   });
 
-  return Promise.resolve(connectors);
+  return Promise.resolve({
+    connectors,
+    categoryMetadata: categoryMetadataForCatalog(connectors),
+  });
 }
 
 export function getPublicConnectorCatalogDetail(

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -1,7 +1,6 @@
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogAuthMethodSummary,
-  PublicConnectorCatalogCategoryMetadata,
   PublicConnectorCatalogConnection,
   PublicConnectorCatalogConnectionStatus,
   PublicConnectorCatalogDetail,
@@ -18,15 +17,11 @@ import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-s
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
 import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
 import {
-  CONNECTOR_DISPLAY_CATEGORY_GROUPS,
-  CONNECTOR_DISPLAY_CATEGORY_META,
-  CONNECTOR_DISPLAY_CATEGORY_ORDER,
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
+  connectorDisplayCategoryMetadataForItems,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
-  type ConnectorDisplayCategory,
-  type ConnectorDisplayCategoryGroup,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
 import {
@@ -64,89 +59,8 @@ interface ConnectorCatalogConnectorReadArgs extends ConnectorCatalogReadArgs {
   readonly connectorRef: string;
 }
 
-interface ConnectorCatalogCategorizedItem {
-  readonly category: string;
-}
-
 function isConnectorType(connectorRef: string): connectorRef is ConnectorType {
   return Object.prototype.hasOwnProperty.call(CONNECTOR_TYPES, connectorRef);
-}
-
-function isConnectorDisplayCategory(
-  category: string,
-): category is ConnectorDisplayCategory {
-  return Object.prototype.hasOwnProperty.call(
-    CONNECTOR_DISPLAY_CATEGORY_META,
-    category,
-  );
-}
-
-function fallbackCategoryLabel(category: string): string {
-  const label = category
-    .split(/[-_\s]+/)
-    .filter((part) => {
-      return part.length > 0;
-    })
-    .map((part) => {
-      return part.charAt(0).toUpperCase() + part.slice(1);
-    })
-    .join(" ");
-  return label || "Other";
-}
-
-function categoryMetadataForCatalog(
-  items: readonly ConnectorCatalogCategorizedItem[],
-): PublicConnectorCatalogCategoryMetadata {
-  const visibleCategories = new Set(
-    items.flatMap((item) => {
-      return item.category ? [item.category] : [];
-    }),
-  );
-  const orderedConnectorDisplayCategories =
-    CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
-      return visibleCategories.has(category);
-    });
-  const orderedCategoryIds = new Set<string>(orderedConnectorDisplayCategories);
-  const orderedCategories = [
-    ...orderedConnectorDisplayCategories,
-    ...[...visibleCategories].filter((category) => {
-      return !orderedCategoryIds.has(category);
-    }),
-  ];
-  const visibleGroups = new Set<ConnectorDisplayCategoryGroup>();
-  const categories = orderedCategories.map((category) => {
-    if (!isConnectorDisplayCategory(category)) {
-      const label = fallbackCategoryLabel(category);
-      return {
-        id: category,
-        label,
-        menuLabel: label,
-        groupId: null,
-      };
-    }
-    const metadata = CONNECTOR_DISPLAY_CATEGORY_META[category];
-    if (metadata.group) {
-      visibleGroups.add(metadata.group);
-    }
-    return {
-      id: category,
-      label: metadata.label,
-      menuLabel: metadata.menuLabel,
-      groupId: metadata.group ?? null,
-    };
-  });
-
-  return {
-    categories,
-    groups: [...visibleGroups].map((group) => {
-      const metadata = CONNECTOR_DISPLAY_CATEGORY_GROUPS[group];
-      return {
-        id: group,
-        label: metadata.label,
-        menuLabel: metadata.menuLabel,
-      };
-    }),
-  };
 }
 
 function availableAuthMethodsForCatalog(
@@ -456,7 +370,7 @@ export function listPublicConnectorCatalog(
 
   return Promise.resolve({
     connectors,
-    categoryMetadata: categoryMetadataForCatalog(connectors),
+    categoryMetadata: connectorDisplayCategoryMetadataForItems(connectors),
   });
 }
 
@@ -486,7 +400,7 @@ export function listPublicConnectorCatalogStatus(
 
   return Promise.resolve({
     connectors,
-    categoryMetadata: categoryMetadataForCatalog(connectors),
+    categoryMetadata: connectorDisplayCategoryMetadataForItems(connectors),
   });
 }
 

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -102,12 +102,15 @@ function categoryMetadataForCatalog(
       return item.category ? [item.category] : [];
     }),
   );
-  const orderedCategories = [
-    ...CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
+  const orderedConnectorDisplayCategories =
+    CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
       return visibleCategories.has(category);
-    }),
+    });
+  const orderedCategoryIds = new Set<string>(orderedConnectorDisplayCategories);
+  const orderedCategories = [
+    ...orderedConnectorDisplayCategories,
     ...[...visibleCategories].filter((category) => {
-      return !isConnectorDisplayCategory(category);
+      return !orderedCategoryIds.has(category);
     }),
   ];
   const visibleGroups = new Set<ConnectorDisplayCategoryGroup>();

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -1,7 +1,12 @@
 import {
+  CONNECTOR_DISPLAY_CATEGORY_GROUPS,
+  CONNECTOR_DISPLAY_CATEGORY_META,
+  CONNECTOR_DISPLAY_CATEGORY_ORDER,
   CONNECTOR_TYPE_KEYS,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
+  type ConnectorDisplayCategory,
+  type ConnectorDisplayCategoryGroup,
   type ConnectorType,
   CONNECTOR_TYPES,
 } from "@vm0/connectors/connectors";
@@ -14,6 +19,7 @@ import type {
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogAuthMethodDetail,
+  type PublicConnectorCatalogCategoryMetadata,
   type PublicConnectorCatalogConnection,
   type PublicConnectorCatalogConnectionStatus,
   type PublicConnectorCatalogPermissionDetail,
@@ -189,6 +195,79 @@ function mockFeatureStates(): ConnectorFeatureStates {
 
 function isMockConnectorType(type: string): type is ConnectorType {
   return MOCK_CONNECTOR_TYPE_SET.has(type);
+}
+
+function isConnectorDisplayCategory(
+  category: string,
+): category is ConnectorDisplayCategory {
+  return Object.prototype.hasOwnProperty.call(
+    CONNECTOR_DISPLAY_CATEGORY_META,
+    category,
+  );
+}
+
+function fallbackCategoryLabel(category: string): string {
+  const label = category
+    .split(/[-_\s]+/)
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .map((part) => {
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+  return label || "Other";
+}
+
+function mockCategoryMetadata(
+  items: readonly { readonly category: string }[],
+): PublicConnectorCatalogCategoryMetadata {
+  const visibleCategories = new Set(
+    items.flatMap((item) => {
+      return item.category ? [item.category] : [];
+    }),
+  );
+  const orderedCategories = [
+    ...CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
+      return visibleCategories.has(category);
+    }),
+    ...[...visibleCategories].filter((category) => {
+      return !isConnectorDisplayCategory(category);
+    }),
+  ];
+  const visibleGroups = new Set<ConnectorDisplayCategoryGroup>();
+  const categories = orderedCategories.map((category) => {
+    if (!isConnectorDisplayCategory(category)) {
+      const label = fallbackCategoryLabel(category);
+      return {
+        id: category,
+        label,
+        menuLabel: label,
+        groupId: null,
+      };
+    }
+    const metadata = CONNECTOR_DISPLAY_CATEGORY_META[category];
+    if (metadata.group) {
+      visibleGroups.add(metadata.group);
+    }
+    return {
+      id: category,
+      label: metadata.label,
+      menuLabel: metadata.menuLabel,
+      groupId: metadata.group ?? null,
+    };
+  });
+  return {
+    categories,
+    groups: [...visibleGroups].map((group) => {
+      const metadata = CONNECTOR_DISPLAY_CATEGORY_GROUPS[group];
+      return {
+        id: group,
+        label: metadata.label,
+        menuLabel: metadata.menuLabel,
+      };
+    }),
+  };
 }
 
 function mockPermissionSummary(
@@ -435,7 +514,11 @@ export const apiConnectorsHandlers = [
   }),
 
   mockApi(zeroConnectorCatalogContract.status, ({ respond }) => {
-    return respond(200, { connectors: mockConnectorCatalogStatus() });
+    const connectors = mockConnectorCatalogStatus();
+    return respond(200, {
+      connectors,
+      categoryMetadata: mockCategoryMetadata(connectors),
+    });
   }),
 
   mockApi(

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -227,12 +227,15 @@ function mockCategoryMetadata(
       return item.category ? [item.category] : [];
     }),
   );
-  const orderedCategories = [
-    ...CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
+  const orderedConnectorDisplayCategories =
+    CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
       return visibleCategories.has(category);
-    }),
+    });
+  const orderedCategoryIds = new Set<string>(orderedConnectorDisplayCategories);
+  const orderedCategories = [
+    ...orderedConnectorDisplayCategories,
     ...[...visibleCategories].filter((category) => {
-      return !isConnectorDisplayCategory(category);
+      return !orderedCategoryIds.has(category);
     }),
   ];
   const visibleGroups = new Set<ConnectorDisplayCategoryGroup>();

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -1,14 +1,10 @@
 import {
-  CONNECTOR_DISPLAY_CATEGORY_GROUPS,
-  CONNECTOR_DISPLAY_CATEGORY_META,
-  CONNECTOR_DISPLAY_CATEGORY_ORDER,
   CONNECTOR_TYPE_KEYS,
   type ConnectorAuthMethodConfig,
   type ConnectorAuthMethodId,
-  type ConnectorDisplayCategory,
-  type ConnectorDisplayCategoryGroup,
   type ConnectorType,
   CONNECTOR_TYPES,
+  connectorDisplayCategoryMetadataForItems,
 } from "@vm0/connectors/connectors";
 import type {
   ConnectorExternalCodeSessionStartResponse,
@@ -19,7 +15,6 @@ import type {
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogAuthMethodDetail,
-  type PublicConnectorCatalogCategoryMetadata,
   type PublicConnectorCatalogConnection,
   type PublicConnectorCatalogConnectionStatus,
   type PublicConnectorCatalogPermissionDetail,
@@ -195,82 +190,6 @@ function mockFeatureStates(): ConnectorFeatureStates {
 
 function isMockConnectorType(type: string): type is ConnectorType {
   return MOCK_CONNECTOR_TYPE_SET.has(type);
-}
-
-function isConnectorDisplayCategory(
-  category: string,
-): category is ConnectorDisplayCategory {
-  return Object.prototype.hasOwnProperty.call(
-    CONNECTOR_DISPLAY_CATEGORY_META,
-    category,
-  );
-}
-
-function fallbackCategoryLabel(category: string): string {
-  const label = category
-    .split(/[-_\s]+/)
-    .filter((part) => {
-      return part.length > 0;
-    })
-    .map((part) => {
-      return part.charAt(0).toUpperCase() + part.slice(1);
-    })
-    .join(" ");
-  return label || "Other";
-}
-
-function mockCategoryMetadata(
-  items: readonly { readonly category: string }[],
-): PublicConnectorCatalogCategoryMetadata {
-  const visibleCategories = new Set(
-    items.flatMap((item) => {
-      return item.category ? [item.category] : [];
-    }),
-  );
-  const orderedConnectorDisplayCategories =
-    CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
-      return visibleCategories.has(category);
-    });
-  const orderedCategoryIds = new Set<string>(orderedConnectorDisplayCategories);
-  const orderedCategories = [
-    ...orderedConnectorDisplayCategories,
-    ...[...visibleCategories].filter((category) => {
-      return !orderedCategoryIds.has(category);
-    }),
-  ];
-  const visibleGroups = new Set<ConnectorDisplayCategoryGroup>();
-  const categories = orderedCategories.map((category) => {
-    if (!isConnectorDisplayCategory(category)) {
-      const label = fallbackCategoryLabel(category);
-      return {
-        id: category,
-        label,
-        menuLabel: label,
-        groupId: null,
-      };
-    }
-    const metadata = CONNECTOR_DISPLAY_CATEGORY_META[category];
-    if (metadata.group) {
-      visibleGroups.add(metadata.group);
-    }
-    return {
-      id: category,
-      label: metadata.label,
-      menuLabel: metadata.menuLabel,
-      groupId: metadata.group ?? null,
-    };
-  });
-  return {
-    categories,
-    groups: [...visibleGroups].map((group) => {
-      const metadata = CONNECTOR_DISPLAY_CATEGORY_GROUPS[group];
-      return {
-        id: group,
-        label: metadata.label,
-        menuLabel: metadata.menuLabel,
-      };
-    }),
-  };
 }
 
 function mockPermissionSummary(
@@ -520,7 +439,7 @@ export const apiConnectorsHandlers = [
     const connectors = mockConnectorCatalogStatus();
     return respond(200, {
       connectors,
-      categoryMetadata: mockCategoryMetadata(connectors),
+      categoryMetadata: connectorDisplayCategoryMetadataForItems(connectors),
     });
   }),
 

--- a/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 const SERVER_FIREWALL_METADATA_SPECIFIER =
   "@vm0/connectors/firewall-metadata/server";
 const ROOT_FIREWALL_METADATA_SPECIFIER = "@vm0/connectors/firewall-metadata";
+const CONNECTORS_SPECIFIER = "@vm0/connectors/connectors";
 const IMPORT_SPECIFIER_PATTERN =
   /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 
@@ -85,6 +86,26 @@ describe("firewall metadata import boundary", () => {
         return (
           isProductionSourcePath(path) &&
           importsExactSpecifier(source, ROOT_FIREWALL_METADATA_SPECIFIER)
+        );
+      });
+
+    expect(
+      offenders.map((offender) => {
+        return offender.path;
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps static connector category metadata out of platform production source", () => {
+    const offenders = Object.entries(productionSourceModules)
+      .map(([path, source]) => {
+        return { path: sourcePathFromGlobKey(path), source };
+      })
+      .filter(({ path, source }) => {
+        return (
+          isProductionSourcePath(path) &&
+          importsExactSpecifier(source, CONNECTORS_SPECIFIER) &&
+          source.includes("CONNECTOR_DISPLAY_CATEGORY_")
         );
       });
 

--- a/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 const SERVER_FIREWALL_METADATA_SPECIFIER =
   "@vm0/connectors/firewall-metadata/server";
 const ROOT_FIREWALL_METADATA_SPECIFIER = "@vm0/connectors/firewall-metadata";
-const CONNECTORS_SPECIFIER = "@vm0/connectors/connectors";
 const IMPORT_SPECIFIER_PATTERN =
   /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 
@@ -97,6 +96,10 @@ describe("firewall metadata import boundary", () => {
   });
 
   it("keeps static connector category metadata out of platform production source", () => {
+    const staticCategorySymbols = [
+      "CONNECTOR_DISPLAY_CATEGORY_",
+      "ConnectorDisplayCategory",
+    ];
     const offenders = Object.entries(productionSourceModules)
       .map(([path, source]) => {
         return { path: sourcePathFromGlobKey(path), source };
@@ -104,8 +107,9 @@ describe("firewall metadata import boundary", () => {
       .filter(({ path, source }) => {
         return (
           isProductionSourcePath(path) &&
-          importsExactSpecifier(source, CONNECTORS_SPECIFIER) &&
-          source.includes("CONNECTOR_DISPLAY_CATEGORY_")
+          staticCategorySymbols.some((symbol) => {
+            return source.includes(symbol);
+          })
         );
       });
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -107,9 +107,14 @@ export function groupConnectorsByCategory<
       return [group.id, group];
     }) ?? [],
   );
+  const categorySectionIds = new Set(
+    categorySections.map((section) => {
+      return section.category;
+    }),
+  );
 
   for (const section of categorySections) {
-    if (!section.groupId) {
+    if (!section.groupId || categorySectionIds.has(section.groupId)) {
       groups.push({
         id: section.category,
         kind: "category",

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -68,6 +68,9 @@ export function groupConnectorsByCategory<
   const groupedCategoryIds = new Set<string>();
   const categorySections: ConnectorCategorySection<T>[] =
     categoryMetadata?.categories.flatMap((category) => {
+      if (groupedCategoryIds.has(category.id)) {
+        return [];
+      }
       const items = grouped.get(category.id);
       if (!items || items.length === 0) {
         return [];

--- a/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connector-categories.ts
@@ -1,35 +1,60 @@
 import { command, computed, state } from "ccstate";
-import {
-  CONNECTOR_DISPLAY_CATEGORY_GROUPS,
-  CONNECTOR_DISPLAY_CATEGORY_META,
-  CONNECTOR_DISPLAY_CATEGORY_ORDER,
-  type ConnectorDisplayCategory,
-  type ConnectorDisplayCategoryGroup,
-} from "@vm0/connectors/connectors";
+import type { PublicConnectorCatalogCategoryMetadata } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 
 export interface ConnectorCategorySection<T> {
-  category: ConnectorDisplayCategory;
+  category: string;
   label: string;
   menuLabel: string;
+  groupId: string | null;
   connectors: T[];
 }
 
 export interface ConnectorCategoryGroup<T> {
-  id: ConnectorDisplayCategory | ConnectorDisplayCategoryGroup;
+  id: string;
   kind: "category" | "group";
   label: string;
   menuLabel: string;
   sections: [ConnectorCategorySection<T>, ...ConnectorCategorySection<T>[]];
 }
 
-export function groupConnectorsByCategory<
+function fallbackCategoryLabel(category: string): string {
+  const label = category
+    .split(/[-_\s]+/)
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .map((part) => {
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+  return label || "Other";
+}
+
+function sortedCategoryConnectors<
   T extends {
-    category: ConnectorDisplayCategory;
     connected: boolean;
     label: string;
   },
->(connectors: readonly T[]): ConnectorCategoryGroup<T>[] {
-  const grouped = new Map<ConnectorDisplayCategory, T[]>();
+>(items: readonly T[]): T[] {
+  return [...items].sort((a, b) => {
+    if (a.connected !== b.connected) {
+      return a.connected ? -1 : 1;
+    }
+    return a.label.localeCompare(b.label);
+  });
+}
+
+export function groupConnectorsByCategory<
+  T extends {
+    category: string;
+    connected: boolean;
+    label: string;
+  },
+>(
+  connectors: readonly T[],
+  categoryMetadata: PublicConnectorCatalogCategoryMetadata | undefined,
+): ConnectorCategoryGroup<T>[] {
+  const grouped = new Map<string, T[]>();
 
   for (const connector of connectors) {
     const items = grouped.get(connector.category);
@@ -40,34 +65,48 @@ export function groupConnectorsByCategory<
     }
   }
 
-  const categorySections = CONNECTOR_DISPLAY_CATEGORY_ORDER.flatMap(
-    (category) => {
-      const items = grouped.get(category);
+  const groupedCategoryIds = new Set<string>();
+  const categorySections: ConnectorCategorySection<T>[] =
+    categoryMetadata?.categories.flatMap((category) => {
+      const items = grouped.get(category.id);
       if (!items || items.length === 0) {
         return [];
       }
-      const sorted = [...items].sort((a, b) => {
-        if (a.connected !== b.connected) {
-          return a.connected ? -1 : 1;
-        }
-        return a.label.localeCompare(b.label);
-      });
+      groupedCategoryIds.add(category.id);
       return [
         {
-          category,
-          label: CONNECTOR_DISPLAY_CATEGORY_META[category].label,
-          menuLabel: CONNECTOR_DISPLAY_CATEGORY_META[category].menuLabel,
-          connectors: sorted,
+          category: category.id,
+          label: category.label,
+          menuLabel: category.menuLabel,
+          groupId: category.groupId,
+          connectors: sortedCategoryConnectors(items),
         },
       ];
-    },
-  );
+    }) ?? [];
+
+  for (const [category, items] of grouped) {
+    if (groupedCategoryIds.has(category)) {
+      continue;
+    }
+    const label = fallbackCategoryLabel(category);
+    categorySections.push({
+      category,
+      label,
+      menuLabel: label,
+      groupId: null,
+      connectors: sortedCategoryConnectors(items),
+    });
+  }
 
   const groups: ConnectorCategoryGroup<T>[] = [];
+  const groupMetadata = new Map(
+    categoryMetadata?.groups.map((group) => {
+      return [group.id, group];
+    }) ?? [],
+  );
 
   for (const section of categorySections) {
-    const meta = CONNECTOR_DISPLAY_CATEGORY_META[section.category];
-    if (!meta.group) {
+    if (!section.groupId) {
       groups.push({
         id: section.category,
         kind: "category",
@@ -79,18 +118,22 @@ export function groupConnectorsByCategory<
     }
 
     const existingGroup = groups.find((group) => {
-      return group.kind === "group" && group.id === meta.group;
+      return group.kind === "group" && group.id === section.groupId;
     });
     if (existingGroup) {
       existingGroup.sections.push(section);
       continue;
     }
 
+    const metadata = groupMetadata.get(section.groupId);
+    const label = metadata?.label ?? fallbackCategoryLabel(section.groupId);
+    const menuLabel =
+      metadata?.menuLabel ?? fallbackCategoryLabel(section.groupId);
     groups.push({
-      id: meta.group,
+      id: section.groupId,
       kind: "group",
-      label: CONNECTOR_DISPLAY_CATEGORY_GROUPS[meta.group].label,
-      menuLabel: CONNECTOR_DISPLAY_CATEGORY_GROUPS[meta.group].menuLabel,
+      label,
+      menuLabel,
       sections: [section],
     });
   }

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -5,13 +5,11 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import {
-  CONNECTOR_DISPLAY_CATEGORY_ORDER,
   connectorAuthMethodIdSchema,
   connectorTypeSchema,
   type ConnectorAuthMethodId,
   type ConnectorDeviceAuthStartOptions,
   type ConnectorType,
-  type ConnectorDisplayCategory,
 } from "@vm0/connectors/connectors";
 import {
   zeroConnectorScopeDiffContract,
@@ -88,7 +86,7 @@ export interface ConnectorTypeWithStatus {
   type: ConnectorType;
   label: string;
   helpText: string;
-  category: ConnectorDisplayCategory;
+  category: string;
   /** Lowercase aliases/keywords used by connector search. */
   tags: readonly string[];
   connected: boolean;
@@ -326,14 +324,6 @@ export function connectorReconnectReasonTooltipText(
   return reason ? reconnectReasonTooltipText[reason] : null;
 }
 
-function isConnectorDisplayCategory(
-  value: string,
-): value is ConnectorDisplayCategory {
-  return CONNECTOR_DISPLAY_CATEGORY_ORDER.some((category) => {
-    return category === value;
-  });
-}
-
 function parseConnectorAuthMethodId(
   value: string | null,
 ): ConnectorAuthMethodId | null {
@@ -348,7 +338,7 @@ function connectorCatalogStatusItemToConnectorType(
   item: PublicConnectorCatalogStatusItem,
 ): ConnectorTypeWithStatus | null {
   const type = connectorTypeSchema.safeParse(item.connectorRef);
-  if (!type.success || !isConnectorDisplayCategory(item.category)) {
+  if (!type.success) {
     return null;
   }
   const availableAuthMethods = item.authMethods.flatMap((authMethod) => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -491,6 +491,63 @@ describe("connectors page", () => {
     ).toHaveTextContent("Partners");
   });
 
+  it("does not render duplicate connector sections for duplicate category metadata", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus(
+      [
+        publicStatusItem({
+          connectorRef: "github",
+          label: "Duplicate GitHub",
+          category: "partner-apps",
+          authMethods: [
+            {
+              id: "oauth",
+              label: "OAuth",
+              description: null,
+              grantKind: "auth-code",
+              manualFields: [],
+              startOptions: [],
+            },
+          ],
+        }),
+      ],
+      {
+        categories: [
+          {
+            id: "partner-apps",
+            label: "Partner Apps",
+            menuLabel: "Partners",
+            groupId: null,
+          },
+          {
+            id: "partner-apps",
+            label: "Duplicate Partner Apps",
+            menuLabel: "Duplicate Partners",
+            groupId: null,
+          },
+        ],
+        groups: [],
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const partnerSection = await screen.findByTestId(
+      "connector-category-partner-apps",
+    );
+    expect(
+      within(partnerSection).getByText("Partner Apps"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Duplicate Partner Apps"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByTestId("connector-card-label").filter((element) => {
+        return element.textContent === "Duplicate GitHub";
+      }),
+    ).toHaveLength(1);
+  });
+
   it("keeps connectors visible when category metadata is missing during rollout", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   zeroConnectorCatalogContract,
+  type PublicConnectorCatalogCategoryMetadata,
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
@@ -270,9 +271,13 @@ function publicStatusItem(args: {
 
 function mockPublicConnectorStatus(
   connectors: readonly PublicConnectorCatalogStatusItem[],
+  categoryMetadata?: PublicConnectorCatalogCategoryMetadata,
 ): void {
   context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
-    return respond(200, { connectors: [...connectors] });
+    return respond(200, {
+      connectors: [...connectors],
+      ...(categoryMetadata ? { categoryMetadata } : {}),
+    });
   });
 }
 
@@ -416,6 +421,105 @@ describe("connectors page", () => {
       aiGroup.compareDocumentPosition(engineeringGroup) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("renders server-authored connector categories unknown to the browser", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus(
+      [
+        publicStatusItem({
+          connectorRef: "github",
+          label: "Public GitHub",
+          category: "partner-apps",
+          authMethods: [
+            {
+              id: "oauth",
+              label: "OAuth",
+              description: null,
+              grantKind: "auth-code",
+              manualFields: [],
+              startOptions: [],
+            },
+          ],
+        }),
+        publicStatusItem({
+          connectorRef: "stripe",
+          label: "Public Stripe",
+          category: "billing-apps",
+          authMethods: [
+            {
+              id: "api-token",
+              label: "API token",
+              description: null,
+              grantKind: "manual",
+              manualFields: [],
+              startOptions: [],
+            },
+          ],
+        }),
+      ],
+      {
+        categories: [
+          {
+            id: "partner-apps",
+            label: "Partner Apps",
+            menuLabel: "Partners",
+            groupId: null,
+          },
+          {
+            id: "billing-apps",
+            label: "Billing Apps",
+            menuLabel: "Billing",
+            groupId: null,
+          },
+        ],
+        groups: [],
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const partnerSection = await screen.findByTestId(
+      "connector-category-partner-apps",
+    );
+    expect(
+      within(partnerSection).getByText("Partner Apps"),
+    ).toBeInTheDocument();
+    expect(queryConnectorCardByLabel("Public GitHub")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("connector-category-menu-partner-apps"),
+    ).toHaveTextContent("Partners");
+  });
+
+  it("keeps connectors visible when category metadata is missing during rollout", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "github",
+        label: "Fallback GitHub",
+        category: "legacy-category",
+        authMethods: [
+          {
+            id: "oauth",
+            label: "OAuth",
+            description: null,
+            grantKind: "auth-code",
+            manualFields: [],
+            startOptions: [],
+          },
+        ],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const fallbackSection = await screen.findByTestId(
+      "connector-category-legacy-category",
+    );
+    expect(
+      within(fallbackSection).getByText("Legacy Category"),
+    ).toBeInTheDocument();
+    expect(queryConnectorCardByLabel("Fallback GitHub")).toBeInTheDocument();
   });
 
   it("does not show reconnect reason help on the connection expired badge", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -548,6 +548,79 @@ describe("connectors page", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps category section ids unique when a metadata group id collides with a category", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus(
+      [
+        publicStatusItem({
+          connectorRef: "github",
+          label: "Partner GitHub",
+          category: "partner-apps",
+          authMethods: [
+            {
+              id: "oauth",
+              label: "OAuth",
+              description: null,
+              grantKind: "auth-code",
+              manualFields: [],
+              startOptions: [],
+            },
+          ],
+        }),
+        publicStatusItem({
+          connectorRef: "stripe",
+          label: "Billing Stripe",
+          category: "billing-apps",
+          authMethods: [
+            {
+              id: "api-token",
+              label: "API token",
+              description: null,
+              grantKind: "manual",
+              manualFields: [],
+              startOptions: [],
+            },
+          ],
+        }),
+      ],
+      {
+        categories: [
+          {
+            id: "partner-apps",
+            label: "Partner Apps",
+            menuLabel: "Partners",
+            groupId: null,
+          },
+          {
+            id: "billing-apps",
+            label: "Billing Apps",
+            menuLabel: "Billing",
+            groupId: "partner-apps",
+          },
+        ],
+        groups: [
+          {
+            id: "partner-apps",
+            label: "Partner Group",
+            menuLabel: "Partner Group",
+          },
+        ],
+      },
+    );
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await screen.findByTestId("connector-category-partner-apps");
+    expect(
+      screen.getAllByTestId("connector-category-partner-apps"),
+    ).toHaveLength(1);
+    expect(
+      screen.getAllByTestId("connector-category-billing-apps"),
+    ).toHaveLength(1);
+    expect(queryConnectorCardByLabel("Partner GitHub")).toBeInTheDocument();
+    expect(queryConnectorCardByLabel("Billing Stripe")).toBeInTheDocument();
+  });
+
   it("keeps connectors visible when category metadata is missing during rollout", async () => {
     mockConnectors([]);
     mockPublicConnectorStatus([

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -25,6 +25,7 @@ import {
   setConnectorsPageTab$,
   openCustomConnectorCreateDialog$,
 } from "../../signals/zero-page/settings/custom-connectors.ts";
+import { connectorCatalogStatus$ } from "../../signals/external/connectors.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { agents$ } from "../../signals/agent.ts";
 import { CustomConnectorsPanel } from "./components/settings/custom-connectors-panel.tsx";
@@ -933,6 +934,7 @@ function connectorLabelForType(
 export function ZeroConnectorsPage() {
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const filteredTypesLoadable = useLastLoadable(filteredConnectorTypes$);
+  const catalogStatusLoadable = useLastLoadable(connectorCatalogStatus$);
   const pollingAuthCodeType = useGet(pollingOAuthAuthCodeConnectorType$);
   const pollingDeviceAuthType = useGet(pollingOAuthDeviceAuthConnectorType$);
   const connect = useSet(connectConnectorOAuthAuthCode$);
@@ -972,6 +974,10 @@ export function ZeroConnectorsPage() {
 
   const filteredConnectors =
     filteredTypesLoadable.state === "hasData" ? filteredTypesLoadable.data : [];
+  const categoryMetadata =
+    catalogStatusLoadable.state === "hasData"
+      ? catalogStatusLoadable.data.categoryMetadata
+      : undefined;
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
   const managedConnectorLabel = connectorLabelForType(
@@ -1067,6 +1073,7 @@ export function ZeroConnectorsPage() {
 
   const grouped = groupConnectorsByCategory(
     filteredConnectors.map(getOptimisticConnector),
+    categoryMetadata,
   );
 
   const builtinList = renderBuiltinList({

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -27,6 +27,24 @@ const publicConnectorCatalogPermissionSummarySchema = z.object({
   hasDefaultPolicyOverrides: z.boolean(),
 });
 
+const publicConnectorCatalogCategoryGroupSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  menuLabel: z.string(),
+});
+
+const publicConnectorCatalogCategorySchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  menuLabel: z.string(),
+  groupId: z.string().nullable(),
+});
+
+const publicConnectorCatalogCategoryMetadataSchema = z.object({
+  categories: z.array(publicConnectorCatalogCategorySchema),
+  groups: z.array(publicConnectorCatalogCategoryGroupSchema),
+});
+
 const publicConnectorCatalogItemSchema = z.object({
   connectorRef: connectorRefSchema,
   label: z.string(),
@@ -73,6 +91,7 @@ const publicConnectorCatalogDetailSchema =
 
 const publicConnectorCatalogListResponseSchema = z.object({
   connectors: z.array(publicConnectorCatalogItemSchema),
+  categoryMetadata: publicConnectorCatalogCategoryMetadataSchema.optional(),
 });
 
 const publicConnectorCatalogDetailResponseSchema = z.object({
@@ -107,6 +126,7 @@ const publicConnectorCatalogStatusItemSchema =
 
 const publicConnectorCatalogStatusResponseSchema = z.object({
   connectors: z.array(publicConnectorCatalogStatusItemSchema),
+  categoryMetadata: publicConnectorCatalogCategoryMetadataSchema.optional(),
 });
 
 const publicFirewallPolicyValueSchema = z.enum(["allow", "deny", "ask"]);
@@ -149,6 +169,15 @@ export type PublicConnectorCatalogAuthMethodSummary = z.infer<
 >;
 export type PublicConnectorCatalogPermissionSummary = z.infer<
   typeof publicConnectorCatalogPermissionSummarySchema
+>;
+export type PublicConnectorCatalogCategoryGroup = z.infer<
+  typeof publicConnectorCatalogCategoryGroupSchema
+>;
+export type PublicConnectorCatalogCategory = z.infer<
+  typeof publicConnectorCatalogCategorySchema
+>;
+export type PublicConnectorCatalogCategoryMetadata = z.infer<
+  typeof publicConnectorCatalogCategoryMetadataSchema
 >;
 export type PublicConnectorCatalogItem = z.infer<
   typeof publicConnectorCatalogItemSchema

--- a/turbo/packages/connectors/src/connector-config.ts
+++ b/turbo/packages/connectors/src/connector-config.ts
@@ -419,6 +419,105 @@ export const CONNECTOR_DISPLAY_CATEGORY_ORDER: readonly ConnectorDisplayCategory
     "data-automation-infrastructure",
   ];
 
+export interface ConnectorDisplayCategorizedItem {
+  readonly category: string;
+}
+
+export interface ConnectorDisplayCategoryMetadataGroup {
+  id: string;
+  label: string;
+  menuLabel: string;
+}
+
+export interface ConnectorDisplayCategoryMetadataCategory {
+  id: string;
+  label: string;
+  menuLabel: string;
+  groupId: string | null;
+}
+
+export interface ConnectorDisplayCategoryMetadata {
+  categories: ConnectorDisplayCategoryMetadataCategory[];
+  groups: ConnectorDisplayCategoryMetadataGroup[];
+}
+
+function isConnectorDisplayCategory(
+  category: string,
+): category is ConnectorDisplayCategory {
+  return Object.prototype.hasOwnProperty.call(
+    CONNECTOR_DISPLAY_CATEGORY_META,
+    category,
+  );
+}
+
+function fallbackCategoryLabel(category: string): string {
+  const label = category
+    .split(/[-_\s]+/)
+    .filter((part) => {
+      return part.length > 0;
+    })
+    .map((part) => {
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+  return label || "Other";
+}
+
+export function connectorDisplayCategoryMetadataForItems(
+  items: readonly ConnectorDisplayCategorizedItem[],
+): ConnectorDisplayCategoryMetadata {
+  const visibleCategories = new Set(
+    items.flatMap((item) => {
+      return item.category ? [item.category] : [];
+    }),
+  );
+  const orderedConnectorDisplayCategories =
+    CONNECTOR_DISPLAY_CATEGORY_ORDER.filter((category) => {
+      return visibleCategories.has(category);
+    });
+  const orderedCategoryIds = new Set<string>(orderedConnectorDisplayCategories);
+  const orderedCategories = [
+    ...orderedConnectorDisplayCategories,
+    ...[...visibleCategories].filter((category) => {
+      return !orderedCategoryIds.has(category);
+    }),
+  ];
+  const visibleGroups = new Set<ConnectorDisplayCategoryGroup>();
+  const categories = orderedCategories.map((category) => {
+    if (!isConnectorDisplayCategory(category)) {
+      const label = fallbackCategoryLabel(category);
+      return {
+        id: category,
+        label,
+        menuLabel: label,
+        groupId: null,
+      };
+    }
+    const metadata = CONNECTOR_DISPLAY_CATEGORY_META[category];
+    if (metadata.group) {
+      visibleGroups.add(metadata.group);
+    }
+    return {
+      id: category,
+      label: metadata.label,
+      menuLabel: metadata.menuLabel,
+      groupId: metadata.group ?? null,
+    };
+  });
+
+  return {
+    categories,
+    groups: [...visibleGroups].map((group) => {
+      const metadata = CONNECTOR_DISPLAY_CATEGORY_GROUPS[group];
+      return {
+        id: group,
+        label: metadata.label,
+        menuLabel: metadata.menuLabel,
+      };
+    }),
+  };
+}
+
 type ConnectorAuthMethods = Partial<
   Record<ConnectorAuthMethodId, ConnectorAuthMethodConfig>
 >;

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -316,6 +316,7 @@ export {
   CONNECTOR_DISPLAY_CATEGORY_META,
   CONNECTOR_DISPLAY_CATEGORY_ORDER,
   CONNECTOR_PLATFORM_SECRET_NAMES,
+  connectorDisplayCategoryMetadataForItems,
   connectorAuthMethodIdSchema,
 } from "./connector-config";
 export type {
@@ -333,7 +334,11 @@ export type {
   ConnectorDeviceAuthStartOptionsConfig,
   ConnectorDeviceAuthStartSelectOptionChoiceConfig,
   ConnectorDeviceAuthStartSelectOptionConfig,
+  ConnectorDisplayCategorizedItem,
   ConnectorDisplayCategory,
+  ConnectorDisplayCategoryMetadata,
+  ConnectorDisplayCategoryMetadataCategory,
+  ConnectorDisplayCategoryMetadataGroup,
   ConnectorDisplayCategoryGroup,
   ConnectorEnvBindingValue,
   ConnectorEnvBindings,


### PR DESCRIPTION
## Summary
- add catalog category metadata to public connector catalog list/status responses
- have the platform group connector sections from API-provided metadata instead of static category constants
- add API/app tests and a production import-boundary test to prevent reintroducing static category metadata in platform source

Closes #20000

## Tests
- pnpm format
- pnpm lint
- pnpm check-types
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts --reporter=dot
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/signals/__tests__/firewall-metadata-import-boundary.test.ts --reporter=dot
