### PR TITLE
refactor: centralize firewall base url malformed checks

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -73,6 +73,11 @@ class _CompiledBase(NamedTuple):
     path_segments: tuple[ParsedSegment, ...]
 
 
+class _CompiledFirewallConfigBase(NamedTuple):
+    base: _CompiledBase
+    malformed: bool
+
+
 class _RawAuthorityHost(NamedTuple):
     hostname: str
     bracketed: bool
@@ -389,20 +394,26 @@ def _compiled_base_params_are_valid(base: _CompiledBase) -> bool:
     return True
 
 
-def firewall_base_config_is_valid(raw_base: str) -> bool:
-    """Return whether a firewall base URL is valid for runtime matching."""
+def _compile_firewall_config_base(raw_base: str) -> _CompiledFirewallConfigBase | None:
     base = _compile_base(raw_base)
     if base is None:
-        return False
-    return not (
+        return None
+    return _CompiledFirewallConfigBase(
+        base,
         base.has_query_or_fragment
         or base.raw_syntax_malformed
         or base.param_parse_malformed
         or base.parts.host_malformed
         or base.parts.has_userinfo
         or base.parts.port_malformed
-        or not _compiled_base_params_are_valid(base)
+        or not _compiled_base_params_are_valid(base),
     )
+
+
+def firewall_base_config_is_valid(raw_base: str) -> bool:
+    """Return whether a firewall base URL is valid for runtime matching."""
+    compiled_config_base = _compile_firewall_config_base(raw_base)
+    return compiled_config_base is not None and not compiled_config_base.malformed
 
 
 def static_firewall_base_config_key(raw_base: str) -> str | None:
@@ -441,6 +452,8 @@ def match_url_authority_key(url: str) -> str | None:
 
 
 def _compiled_base_is_invalid_for_match_base_url(base: _CompiledBase) -> bool:
+    # Direct base matching intentionally has narrower semantics than firewall
+    # config validation, where malformed-but-compilable bases fail closed.
     return (
         base.has_query_or_fragment
         or has_unsafe_runtime_url_syntax(base.raw)

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -21,8 +21,7 @@ from firewall_matching import base_url as _firewall_base_url
 from firewall_matching import patterns as _firewall_patterns
 from firewall_matching.base_url import (
     _BaseUrlParts,
-    _compile_base,
-    _compiled_base_params_are_valid,
+    _compile_firewall_config_base,
     _CompiledBase,
     _match_compiled_base_authority,
     _match_compiled_base_url_parts,
@@ -754,18 +753,11 @@ def compile_firewall_core(fw_entry: object) -> CompiledFirewallCore | None:
         raw_base = api_entry.get("base", "")
         if not isinstance(raw_base, str):
             continue
-        base = _compile_base(raw_base)
-        if base is None:
+        compiled_config_base = _compile_firewall_config_base(raw_base)
+        if compiled_config_base is None:
             continue
-        base_malformed = (
-            base.has_query_or_fragment
-            or base.raw_syntax_malformed
-            or base.param_parse_malformed
-            or base.parts.host_malformed
-            or base.parts.has_userinfo
-            or base.parts.port_malformed
-            or not _compiled_base_params_are_valid(base)
-        )
+        base = compiled_config_base.base
+        base_malformed = compiled_config_base.malformed
         auth_malformed = not _auth_config_is_valid(api_entry)
 
         compiled_permissions: list[_CompiledPermission] = []


### PR DESCRIPTION
## Summary

- Add a config-specific compiled base result in the mitm addon base URL matcher.
- Route `firewall_base_config_is_valid()` and `compile_firewall_core()` through the same firewall config base classification.
- Keep direct `match_base_url()` invalidity and static index eligibility separate from firewall config validation.

Closes #20005.

## Tests

```bash
cd crates/runner/mitm-addon
.venv/bin/python -m pytest tests/test_compiled_firewall_malformed_base.py tests/test_matching_base_url_static.py tests/test_matching_base_url_parameterized.py tests/test_firewall_semantics_contract.py
.venv/bin/ruff check . && .venv/bin/ruff format --check . && .venv/bin/basedpyright -p .
.venv/bin/python -m pytest tests/test_firewall_request_base_matching.py tests/test_firewall_request_matching.py
```
