### PR TITLE
fix: show shortcut help across sidebar pages

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
@@ -171,5 +171,24 @@ describe("agents page", () => {
     expect(
       within(agentCard("Private Ops")).queryByLabelText("Unread"),
     ).not.toBeInTheDocument();
+  });
+
+  it("opens shortcut help from the sidebar layout", async () => {
+    context.mocks.data.team(agents);
+    context.mocks.data.orgMembers({ members: [] });
+
+    detachedSetupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(agentCard("Research Agent")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document.body, { key: "?", shiftKey: true });
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Keyboard Shortcuts",
+    });
+    expect(within(dialog).getByText("Toggle sidebar")).toBeInTheDocument();
+    expect(within(dialog).queryByText("Rename chat")).not.toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1388,6 +1388,26 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("opens shortcut help from the agent chat page when composer is not focused", async () => {
+    prepareAgentTeam();
+    context.mocks.api(chatThreadsContract.list, ({ respond }) => {
+      return respond(200, splitChatThreadListResponse([]));
+    });
+
+    detachedSetupPage({ context, path: `/agents/${AGENT_ID}/chat` });
+
+    await waitFor(() => {
+      expect(sidebar()).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document.body, { key: "?", shiftKey: true });
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Keyboard Shortcuts",
+    });
+    expect(within(dialog).getByText("Show shortcuts")).toBeInTheDocument();
+  });
+
   it("ignores global shortcuts while a dialog is open", async () => {
     prepareAgentTeam();
     context.mocks.api(chatThreadsContract.list, ({ respond }) => {

--- a/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
@@ -1,0 +1,125 @@
+import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { activeRoute$ } from "../../signals/active-route.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import type { RouteKey } from "../../signals/route-paths.ts";
+import {
+  chatShortcutHelpOpen$,
+  setChatShortcutHelpOpen$,
+} from "../../signals/chat-page/chat-shortcut-help.ts";
+import { ShortcutHelpDialog } from "../components/shortcut-help-dialog.tsx";
+
+const CHAT_THREAD_SHORTCUT_SECTIONS = [
+  {
+    title: "Global",
+    shortcuts: [
+      { key: "shift+/", label: "Show shortcuts" },
+      { key: "mod+b", label: "Toggle sidebar" },
+      { key: "mod+shift+o", label: "New chat" },
+      { key: "mod+shift+a", label: "Open agent list" },
+      { key: "f2", label: "Rename chat" },
+      { key: "shift+f2", label: "Change icon" },
+      { key: "ctrl+shift+1", label: "Set icon (Ctrl+Shift+1-9)" },
+      { key: "ctrl+shift+0", label: "Clear icon" },
+    ],
+  },
+  {
+    title: "Messages",
+    shortcuts: [
+      { key: "mod+arrowup", label: "Scroll to top" },
+      { key: "mod+arrowdown", label: "Scroll to bottom" },
+      { key: "mod+shift+arrowup", label: "Previous thread" },
+      { key: "mod+shift+arrowdown", label: "Next thread" },
+    ],
+  },
+  {
+    title: "Composer",
+    shortcuts: [
+      { key: "enter", label: "Send message" },
+      { key: "escape", label: "Blur composer" },
+    ],
+  },
+] as const;
+
+const AGENT_CHAT_SHORTCUT_SECTIONS = [
+  {
+    title: "Global",
+    shortcuts: [
+      { key: "shift+/", label: "Show shortcuts" },
+      { key: "mod+b", label: "Toggle sidebar" },
+      { key: "mod+shift+o", label: "New chat" },
+      { key: "mod+shift+a", label: "Open agent list" },
+      { key: "mod+shift+arrowdown", label: "Open first thread" },
+    ],
+  },
+  {
+    title: "Composer",
+    shortcuts: [
+      { key: "enter", label: "Send message" },
+      { key: "escape", label: "Blur composer" },
+    ],
+  },
+] as const;
+
+const SIDEBAR_SHORTCUT_SECTIONS = [
+  {
+    title: "Global",
+    shortcuts: [
+      { key: "shift+/", label: "Show shortcuts" },
+      { key: "mod+b", label: "Toggle sidebar" },
+      { key: "mod+shift+o", label: "New chat" },
+      { key: "mod+shift+a", label: "Open agent list" },
+    ],
+  },
+] as const;
+
+function isChatThreadEmojiShortcutKey(key: string): boolean {
+  return key === "shift+f2" || key === "ctrl+shift+1" || key === "ctrl+shift+0";
+}
+
+function shortcutSectionsForRoute(
+  route: RouteKey | null,
+  chatThreadEmojiEnabled: boolean,
+) {
+  if (route === "chat") {
+    return chatThreadEmojiEnabled
+      ? CHAT_THREAD_SHORTCUT_SECTIONS
+      : CHAT_THREAD_SHORTCUT_SECTIONS.map((section) => {
+          if (section.title !== "Global") {
+            return section;
+          }
+          return {
+            ...section,
+            shortcuts: section.shortcuts.filter((shortcut) => {
+              return !isChatThreadEmojiShortcutKey(shortcut.key);
+            }),
+          };
+        });
+  }
+  if (route === "agentChat" || route === "home") {
+    return AGENT_CHAT_SHORTCUT_SECTIONS;
+  }
+  return SIDEBAR_SHORTCUT_SECTIONS;
+}
+
+export function ChatShortcutHelpDialog() {
+  const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
+  const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
+  const activeRoute = useGet(activeRoute$);
+  const features = useLastResolved(featureSwitch$);
+  const chatThreadEmojiEnabled =
+    features?.[FeatureSwitchKey.ChatThreadEmoji] ?? false;
+  const shortcutSections = shortcutSectionsForRoute(
+    activeRoute,
+    chatThreadEmojiEnabled,
+  );
+
+  return (
+    <ShortcutHelpDialog
+      open={shortcutHelpOpen}
+      onOpenChange={setShortcutHelpOpen}
+      description="Available shortcuts on this page"
+      sections={shortcutSections}
+    />
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -51,6 +51,7 @@ import {
   currentArtifactInboxThreadId$,
   openArtifactInbox$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
+import { ChatShortcutHelpDialog } from "./chat-shortcut-help-dialog.tsx";
 
 function AgentAvatarInTopBar() {
   const agent = useLastResolved(currentChatAgent$);
@@ -255,6 +256,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
     <div className="zero-app zero-viewport-shell flex w-full bg-background">
       <OrgManageDialogMount />
       <SettingsDialogMount />
+      <ChatShortcutHelpDialog />
       <QueueDrawer />
       <ZeroSidebar />
       <div

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -201,10 +201,6 @@ import {
 import type { ChatClipboardAttachment } from "../../signals/zero-page/clipboard.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
-  chatShortcutHelpOpen$,
-  setChatShortcutHelpOpen$,
-} from "../../signals/chat-page/chat-shortcut-help.ts";
-import {
   agentGithubPrTrackingAvailable$,
   githubPrTrackingOpenThreadId$,
   chatThreadGithubPrs$,
@@ -235,7 +231,6 @@ import {
   toggleOrgAutomationEnabled$,
 } from "../../signals/zero-page/zero-automations.ts";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
-import { ShortcutHelpDialog } from "../components/shortcut-help-dialog.tsx";
 import {
   closeChatThreadEmojiMenu$,
   emojiMenuThreadId$,
@@ -349,42 +344,6 @@ import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-devic
 type RecommendedFollowup = NonNullable<
   Extract<PagedChatMessage, { role: "assistant" }>["recommendedFollowups"]
 >[number];
-
-const CHAT_SHORTCUT_SECTIONS = [
-  {
-    title: "Global",
-    shortcuts: [
-      { key: "shift+/", label: "Show shortcuts" },
-      { key: "mod+b", label: "Toggle sidebar" },
-      { key: "mod+shift+o", label: "New chat" },
-      { key: "mod+shift+a", label: "Open agent list" },
-      { key: "f2", label: "Rename chat" },
-      { key: "shift+f2", label: "Change icon" },
-      { key: "ctrl+shift+1", label: "Set icon (Ctrl+Shift+1-9)" },
-      { key: "ctrl+shift+0", label: "Clear icon" },
-    ],
-  },
-  {
-    title: "Messages",
-    shortcuts: [
-      { key: "mod+arrowup", label: "Scroll to top" },
-      { key: "mod+arrowdown", label: "Scroll to bottom" },
-      { key: "mod+shift+arrowup", label: "Previous thread" },
-      { key: "mod+shift+arrowdown", label: "Next thread" },
-    ],
-  },
-  {
-    title: "Composer",
-    shortcuts: [
-      { key: "enter", label: "Send message" },
-      { key: "escape", label: "Blur composer" },
-    ],
-  },
-] as const;
-
-function isChatThreadEmojiShortcutKey(key: string): boolean {
-  return key === "shift+f2" || key === "ctrl+shift+1" || key === "ctrl+shift+0";
-}
 
 function ArtifactsButton({ thread }: { thread: ChatThreadSignals }) {
   return <ArtifactsButtonInner thread={thread} />;
@@ -3198,11 +3157,6 @@ function ChatThreadArea({
 }
 
 export function ZeroChatThreadPage() {
-  const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
-  const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
-  const features = useLastResolved(featureSwitch$);
-  const chatThreadEmojiEnabled =
-    features?.[FeatureSwitchKey.ChatThreadEmoji] ?? false;
   const leftThread = useGet(currentLeftThread$);
   const rightThread = useGet(currentRightThread$);
   const lightboxUrl = useGet(attachmentLightboxUrl$);
@@ -3238,19 +3192,6 @@ export function ZeroChatThreadPage() {
       />
     </div>
   ) : null;
-  const shortcutSections = chatThreadEmojiEnabled
-    ? CHAT_SHORTCUT_SECTIONS
-    : CHAT_SHORTCUT_SECTIONS.map((section) => {
-        if (section.title !== "Global") {
-          return section;
-        }
-        return {
-          ...section,
-          shortcuts: section.shortcuts.filter((shortcut) => {
-            return !isChatThreadEmojiShortcutKey(shortcut.key);
-          }),
-        };
-      });
 
   return (
     <>
@@ -3308,12 +3249,6 @@ export function ZeroChatThreadPage() {
         typeof document !== "undefined" &&
         presentationEditor &&
         createPortal(presentationEditor, document.body)}
-      <ShortcutHelpDialog
-        open={shortcutHelpOpen}
-        onOpenChange={setShortcutHelpOpen}
-        description="Available shortcuts on this page"
-        sections={shortcutSections}
-      />
       <ChatConnectorActionConnectModal />
     </>
   );


### PR DESCRIPTION
## Summary
- Mount the keyboard shortcut help dialog once from the shared sidebar layout so every `layout === "sidebar"` page can display it.
- Move chat/thread shortcut definitions into a shared dialog mount that selects thread, agent chat, or generic sidebar shortcuts from the active route.
- Add regression coverage for `shift+/` on `/agents/:id/chat` and a non-chat sidebar page.

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/agents-page/__tests__/agents-page.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --testNamePattern "keyboard shortcuts|shifted slash|chat emoji shortcut"`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
