### PR TITLE
refactor(runner): centralize job candidate defaults

### DIFF
--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -82,17 +82,8 @@ impl JobCandidate {
 
     pub(crate) fn local(run_id: RunId, profile_name: String, job_path: PathBuf) -> Self {
         Self {
-            run_id,
-            profile_name,
             local_job_path: Some(job_path),
-            discovered_at: Instant::now(),
-            local_admission_started_at: None,
-            discovery_source: None,
-            poll_reason: None,
-            poll_due_to_job_discovered_elapsed: None,
-            poll_http_request_elapsed: None,
-            cli_agent_session_id: None,
-            affinity_protected_until: None,
+            ..Self::new(run_id, profile_name)
         }
     }
 
@@ -196,17 +187,8 @@ impl JobCandidate {
         local_admission_started_at: Option<Instant>,
     ) -> Self {
         Self {
-            run_id,
-            profile_name,
-            local_job_path: None,
-            discovered_at,
             local_admission_started_at,
-            discovery_source: None,
-            poll_reason: None,
-            poll_due_to_job_discovered_elapsed: None,
-            poll_http_request_elapsed: None,
-            cli_agent_session_id: None,
-            affinity_protected_until: None,
+            ..Self::new_with_discovered_at(run_id, profile_name, discovered_at)
         }
     }
 }


### PR DESCRIPTION
## Summary

- centralize `JobCandidate` default initialization through the existing base initializer
- make `local` and `new_with_timing_for_test` specify only their differing fields
- keep provider behavior, telemetry semantics, and API contracts unchanged

Closes #19986

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests::claim_request_body`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests::discover_returns_ably_direct_candidate_without_polling`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::local::tests::claim`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit: `cargo-fmt`, `cargo-clippy`, `cargo-doc`, `commitlint`
