### PR TITLE
fix: default agents page to public tab instead of private

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
@@ -42,7 +42,7 @@ export const setJobsVisibility$ = command(
 
 // -- Active tab -------------------------------------------------------------
 
-const internalActiveTab$ = state<"public" | "private">("private");
+const internalActiveTab$ = state<"public" | "private">("public");
 export const jobsActiveTab$ = computed((get) => {
   return get(internalActiveTab$);
 });


### PR DESCRIPTION
## Problem

On the Agents page, the tab selector defaults to **Private** (the second tab) on load, even though **Public** is the first tab. The default landing tab should be the first one, Public.

## Change

`turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts` — change the initial value of `internalActiveTab$` from `"private"` to `"public"` so the Agents page opens on the Public tab by default.

## User-visible impact

Opening the Agents page now shows the **Public** tab (and its public/shared agents) selected by default, matching the tab order. Users can still switch to Private manually. The create-dialog default visibility is unchanged.

## Verification

Existing `agents-page-tabs.test.tsx` cases explicitly click the tab they assert on, so they remain valid with the new default. Relying on the PR pipeline for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)