### PR TITLE
fix: validate runner config image artifacts under locks

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -14,8 +14,7 @@ use crate::config;
 use crate::deps::MITMPROXY_VERSION;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor;
-use crate::lock;
-use crate::paths::{HomePaths, RootfsPaths, RunnerPaths};
+use crate::paths::{HomePaths, RunnerPaths};
 use crate::prefetch;
 use crate::proxy;
 use crate::workspace_mount::ensure_workspace_drive_mounted;
@@ -120,18 +119,13 @@ pub async fn run_benchmark(
         RunnerError::Config(format!("profile '{profile_name}' not found in config"))
     })?;
 
-    let rootfs_lock = lock::acquire_shared(home.rootfs_lock(&profile_config.rootfs_hash)).await?;
-    let rootfs_paths = RootfsPaths::new(&home, &profile_config.rootfs_hash);
-    let snapshot_lock =
-        lock::acquire_shared(home.snapshot_lock(&profile_config.snapshot_hash)).await?;
-    config::validate_profile_image_artifacts(profile_name, profile_config, &home).await?;
-    let resource_locks = (rootfs_lock, snapshot_lock);
+    let resource_locks =
+        config::lock_and_validate_profile_image_artifacts(profile_name, profile_config, &home)
+            .await?;
 
     // Block until memory.bin is in page cache so benchmark numbers are stable.
     {
-        let path = rootfs_paths
-            .snapshot(&profile_config.snapshot_hash)
-            .memory_bin();
+        let path = resource_locks.snapshot_paths().memory_bin();
         let _ = tokio::task::spawn_blocking(move || prefetch::prefetch_memory(&path)).await;
     }
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -160,6 +160,7 @@ pub async fn run_benchmark(
     {
         Ok(handle) => handle,
         Err(e) => {
+            drop(resource_locks);
             stop_benchmark_proxy(&mut mitm, "live_runner_publish").await;
             return Err(e);
         }
@@ -218,6 +219,7 @@ pub async fn run_benchmark(
     // Shutdown factory first (releases the COW pool), then runtime-owned pools.
     factory.shutdown().await;
     runtime.shutdown().await;
+    drop(resource_locks);
     if let Err(e) = mitm.stop().await {
         warn!(error = %e, "proxy stop failed");
     }

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -66,6 +66,11 @@ async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResul
             "--profile, --rootfs-hash, and --snapshot-hash must be specified the same number of times".into(),
         ));
     }
+    if args.profile.is_empty() {
+        return Err(RunnerError::Config(
+            "--profile, --rootfs-hash, and --snapshot-hash must be specified at least once".into(),
+        ));
+    }
     for profile_name in &args.profile {
         profile::validate_or_err(profile_name)?;
     }
@@ -77,6 +82,11 @@ async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResul
     // Build profiles map.
     let mut profiles = BTreeMap::new();
     for (i, profile_name) in args.profile.iter().enumerate() {
+        if profiles.contains_key(profile_name) {
+            return Err(RunnerError::Config(format!(
+                "--profile {profile_name} must not be specified more than once"
+            )));
+        }
         let def = profile::get(profile_name)?;
         // Length equality is validated above, so these indices are safe.
         let rootfs_hash = args
@@ -308,6 +318,34 @@ mod tests {
                 "{field} mismatch returned unexpected error: {msg}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn run_config_rejects_empty_profile_args() {
+        let mut args = args_with_dirname("runner-01");
+        args.profile.clear();
+        args.rootfs_hash.clear();
+        args.snapshot_hash.clear();
+
+        let err = run_config(args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("at least once"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn run_config_rejects_duplicate_profile_args() {
+        let mut args = args_with_valid_image_hashes();
+        args.profile.push("vm0/default".into());
+        args.rootfs_hash.push(args.rootfs_hash[0].clone());
+        args.snapshot_hash.push(args.snapshot_hash[0].clone());
+
+        let err = run_config(args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("more than once"), "got: {msg}");
+        assert!(
+            !msg.contains("rootfs not found"),
+            "duplicate profile validation should happen before image artifact checks: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -8,7 +8,7 @@ use crate::config::{
 };
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
-use crate::paths::HomePaths;
+use crate::paths::{HomePaths, touch_mtime};
 use crate::profile;
 
 #[derive(Args)]
@@ -50,6 +50,11 @@ pub struct ConfigArgs {
 }
 
 pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
+    let paths = HomePaths::new()?;
+    run_config_with_home(args, paths).await
+}
+
+async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResult<()> {
     // Pure-CPU validation first — fail fast before any filesystem I/O.
     crate::group::validate_or_err(&args.group)?;
     crate::runner_dirname::validate_or_err(&args.runner_dirname)?;
@@ -69,8 +74,6 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
     }
     let api_url = config::normalize_api_base_url(&args.api_url)?;
 
-    let paths = HomePaths::new()?;
-
     // Build profiles map.
     let mut profiles = BTreeMap::new();
     for (i, profile_name) in args.profile.iter().enumerate() {
@@ -84,17 +87,6 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
             .snapshot_hash
             .get(i)
             .ok_or_else(|| RunnerError::Internal(format!("missing snapshot_hash at index {i}")))?;
-
-        // Verify rootfs directory exists on disk.
-        let rootfs_dir = paths.images_dir().join(rootfs_hash);
-        if !tokio::fs::try_exists(&rootfs_dir)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("check rootfs dir: {e}")))?
-        {
-            return Err(RunnerError::Config(format!(
-                "rootfs not found for hash {rootfs_hash}; run `build --profile {profile_name}` first"
-            )));
-        }
 
         profiles.insert(
             profile_name.clone(),
@@ -110,7 +102,6 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
     }
 
     let runner_dir = paths.runners_dir().join(&args.runner_dirname);
-
     let runner_config = RunnerConfig {
         name: args.name,
         group: args.group,
@@ -132,7 +123,19 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
         }),
     };
 
+    let mut image_artifact_guards = Vec::new();
+    for (profile_name, profile) in &runner_config.profiles {
+        image_artifact_guards.push(
+            config::lock_and_validate_profile_image_artifacts(profile_name, profile, &paths)
+                .await?,
+        );
+    }
+
     config::generate(&runner_config).await?;
+    for guard in &image_artifact_guards {
+        touch_mtime(guard.rootfs_paths().dir());
+        touch_mtime(guard.snapshot_paths().dir());
+    }
     let config_path = runner_dir.join("runner.yaml");
     tracing::info!("config written to {}", config_path.display());
 
@@ -165,6 +168,40 @@ mod tests {
         args.snapshot_hash =
             vec!["fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210".into()];
         args
+    }
+
+    async fn write_rootfs(home: &HomePaths, rootfs_hash: &str) -> crate::paths::RootfsPaths {
+        let rootfs = crate::paths::RootfsPaths::new(home, rootfs_hash);
+        tokio::fs::create_dir_all(rootfs.dir()).await.unwrap();
+        tokio::fs::write(rootfs.rootfs(), b"rootfs").await.unwrap();
+        rootfs
+    }
+
+    async fn write_snapshot_without_complete_marker(
+        rootfs: &crate::paths::RootfsPaths,
+        snapshot_hash: &str,
+    ) {
+        let snapshot = rootfs.snapshot(snapshot_hash);
+        tokio::fs::create_dir_all(snapshot.dir()).await.unwrap();
+        for path in [
+            snapshot.snapshot_bin(),
+            snapshot.memory_bin(),
+            snapshot.cow_img(),
+            snapshot.cow_bitmap(),
+        ] {
+            tokio::fs::write(path, b"snapshot").await.unwrap();
+        }
+    }
+
+    async fn write_complete_snapshot(rootfs: &crate::paths::RootfsPaths, snapshot_hash: &str) {
+        let snapshot = rootfs.snapshot(snapshot_hash);
+        write_snapshot_without_complete_marker(rootfs, snapshot_hash).await;
+        tokio::fs::write(
+            snapshot.complete_marker(),
+            sandbox_fc::SNAPSHOT_COMPLETE_MARKER_CONTENT,
+        )
+        .await
+        .unwrap();
     }
 
     /// Asserts that `--runner-dirname` validation is wired into `run_config`.
@@ -276,6 +313,53 @@ mod tests {
                 "{field} mismatch returned unexpected error: {msg}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn run_config_rejects_incomplete_snapshot_without_writing_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let args = args_with_valid_image_hashes();
+        let config_path = home
+            .runners_dir()
+            .join(&args.runner_dirname)
+            .join("runner.yaml");
+        let rootfs_hash = args.rootfs_hash[0].clone();
+        let snapshot_hash = args.snapshot_hash[0].clone();
+        let rootfs = write_rootfs(&home, &rootfs_hash).await;
+        write_snapshot_without_complete_marker(&rootfs, &snapshot_hash).await;
+
+        let err = run_config_with_home(args, home).await.unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains(".snapshot-complete"), "got: {msg}");
+        assert!(
+            !config_path.exists(),
+            "runner config should not be written when snapshot validation fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_config_writes_config_for_complete_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+        let args = args_with_valid_image_hashes();
+        let config_path = home
+            .runners_dir()
+            .join(&args.runner_dirname)
+            .join("runner.yaml");
+        let rootfs_hash = args.rootfs_hash[0].clone();
+        let snapshot_hash = args.snapshot_hash[0].clone();
+        let rootfs = write_rootfs(&home, &rootfs_hash).await;
+        write_complete_snapshot(&rootfs, &snapshot_hash).await;
+
+        run_config_with_home(args, home).await.unwrap();
+
+        let config_content = tokio::fs::read_to_string(config_path).await.unwrap();
+        let runner_config: RunnerConfig = serde_yaml_ng::from_str(&config_content).unwrap();
+        let profile = runner_config.profiles.get("vm0/default").unwrap();
+        assert_eq!(profile.rootfs_hash, rootfs_hash);
+        assert_eq!(profile.snapshot_hash, snapshot_hash);
     }
 
     fn args_with_concurrency_factor(factor: f64) -> ConfigArgs {

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -123,18 +123,13 @@ async fn run_config_with_home(args: ConfigArgs, paths: HomePaths) -> RunnerResul
         }),
     };
 
-    let mut image_artifact_guards = Vec::new();
-    for (profile_name, profile) in &runner_config.profiles {
-        image_artifact_guards.push(
-            config::lock_and_validate_profile_image_artifacts(profile_name, profile, &paths)
-                .await?,
-        );
-    }
+    let image_artifact_guards =
+        config::lock_and_validate_runner_image_artifacts(&runner_config.profiles, &paths).await?;
 
     config::generate(&runner_config).await?;
-    for guard in &image_artifact_guards {
-        touch_mtime(guard.rootfs_paths().dir());
-        touch_mtime(guard.snapshot_paths().dir());
+    for (_, profile_paths) in image_artifact_guards.profile_paths() {
+        touch_mtime(profile_paths.rootfs_paths().dir());
+        touch_mtime(profile_paths.snapshot_paths().dir());
     }
     let config_path = runner_dir.join("runner.yaml");
     tracing::info!("config written to {}", config_path.display());

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -344,13 +344,12 @@ async fn run_start_with_home(
     info!(runner_id = %runner_id, runner_name = %runner_config.name, "runner identity");
 
     // Shared locks on rootfs + snapshot per profile — allows `runner gc` to detect in-use resources.
-    let image_artifact_locks =
+    let resource_locks =
         config::lock_and_validate_runner_image_artifacts(&runner_config.profiles, &home).await?;
-    for (_, profile_paths) in image_artifact_locks.profile_paths() {
+    for (_, profile_paths) in resource_locks.profile_paths() {
         touch_mtime(profile_paths.rootfs_paths().dir());
         touch_mtime(profile_paths.snapshot_paths().dir());
     }
-    let resource_locks = image_artifact_locks;
 
     let log_paths = LogPaths::new(home.logs_dir());
     crate::log_file::ensure_log_dir(log_paths.dir()).map_err(|e| {
@@ -387,12 +386,11 @@ async fn run_start_with_home(
     };
 
     // Start background prefetch of snapshot memory for all profiles.
-    let mut memory_prefetch =
-        prefetch::MemoryPrefetchTasks::spawn(runner_config.profiles.values().map(|profile| {
-            crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash)
-                .snapshot(&profile.snapshot_hash)
-                .memory_bin()
-        }));
+    let mut memory_prefetch = prefetch::MemoryPrefetchTasks::spawn(
+        resource_locks
+            .profile_paths()
+            .map(|(_, profile_paths)| profile_paths.snapshot_paths().memory_bin()),
+    );
 
     // Compute the smallest profile resources for budget pre-check.
     // When budget is exhausted for all profiles, we wait instead of polling.

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -346,19 +346,11 @@ async fn run_start_with_home(
     // Shared locks on rootfs + snapshot per profile — allows `runner gc` to detect in-use resources.
     let mut _resource_locks = Vec::new();
     for (profile_name, profile) in &runner_config.profiles {
-        let rootfs_lock = lock::acquire_shared(home.rootfs_lock(&profile.rootfs_hash)).await?;
-        let rootfs_paths = crate::paths::RootfsPaths::new(&home, &profile.rootfs_hash);
-        _resource_locks.push(rootfs_lock);
-        let snapshot_lock =
-            lock::acquire_shared(home.snapshot_lock(&profile.snapshot_hash)).await?;
-        let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
-        _resource_locks.push(snapshot_lock);
-
-        // Validate image artifacts only after both shared locks are held.
-        // Reading them before lock acquisition can race with builders or GC.
-        config::validate_profile_image_artifacts(profile_name, profile, &home).await?;
-        touch_mtime(rootfs_paths.dir());
-        touch_mtime(snapshot_paths.dir());
+        let image_artifact_guard =
+            config::lock_and_validate_profile_image_artifacts(profile_name, profile, &home).await?;
+        touch_mtime(image_artifact_guard.rootfs_paths().dir());
+        touch_mtime(image_artifact_guard.snapshot_paths().dir());
+        _resource_locks.push(image_artifact_guard);
     }
 
     let log_paths = LogPaths::new(home.logs_dir());

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -344,14 +344,13 @@ async fn run_start_with_home(
     info!(runner_id = %runner_id, runner_name = %runner_config.name, "runner identity");
 
     // Shared locks on rootfs + snapshot per profile — allows `runner gc` to detect in-use resources.
-    let mut _resource_locks = Vec::new();
-    for (profile_name, profile) in &runner_config.profiles {
-        let image_artifact_guard =
-            config::lock_and_validate_profile_image_artifacts(profile_name, profile, &home).await?;
-        touch_mtime(image_artifact_guard.rootfs_paths().dir());
-        touch_mtime(image_artifact_guard.snapshot_paths().dir());
-        _resource_locks.push(image_artifact_guard);
+    let image_artifact_locks =
+        config::lock_and_validate_runner_image_artifacts(&runner_config.profiles, &home).await?;
+    for (_, profile_paths) in image_artifact_locks.profile_paths() {
+        touch_mtime(profile_paths.rootfs_paths().dir());
+        touch_mtime(profile_paths.snapshot_paths().dir());
     }
+    let _resource_locks = image_artifact_locks;
 
     let log_paths = LogPaths::new(home.logs_dir());
     crate::log_file::ensure_log_dir(log_paths.dir()).map_err(|e| {

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -350,7 +350,7 @@ async fn run_start_with_home(
         touch_mtime(profile_paths.rootfs_paths().dir());
         touch_mtime(profile_paths.snapshot_paths().dir());
     }
-    let _resource_locks = image_artifact_locks;
+    let resource_locks = image_artifact_locks;
 
     let log_paths = LogPaths::new(home.logs_dir());
     crate::log_file::ensure_log_dir(log_paths.dir()).map_err(|e| {
@@ -703,6 +703,7 @@ async fn run_start_with_home(
     };
 
     let run_result = run(config).await;
+    drop(resource_locks);
     if let Err(e) = live_runner_instance_handle.remove_if_current().await {
         tracing::warn!(error = %e, "failed to remove live runner instance record");
     }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -10,8 +10,9 @@
 //!    resolves any relative paths against the config file's parent directory.
 //! 2. `validate` checks group name, profile names, image hashes, static host
 //!    paths, resource ceilings, and the concurrency factor.
-//! 3. Callers that consume image artifacts hold the relevant rootfs/snapshot
-//!    locks and call [`validate_profile_image_artifacts`].
+//! 3. Callers that consume image artifacts call
+//!    [`lock_and_validate_profile_image_artifacts`] to hold the relevant
+//!    rootfs/snapshot locks while validating artifact completeness.
 //! 4. Callers derive runtime objects (e.g. [`sandbox::FactoryConfig`]) from
 //!    the loaded config.
 //!
@@ -39,13 +40,15 @@
 //! sensible default; rename fields only with a migration plan.
 
 use std::collections::BTreeMap;
+use std::fs::File;
 use std::path::{Path, PathBuf};
 
+use nix::fcntl::Flock;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
-use crate::paths::{HomePaths, RootfsPaths};
+use crate::paths::{HomePaths, RootfsPaths, SnapshotPaths};
 use crate::profile;
 
 /// 0 means auto-detect from host CPU and memory at startup.
@@ -366,6 +369,44 @@ pub(crate) async fn validate_profile_image_artifacts(
     )
     .await?;
     Ok(())
+}
+
+pub(crate) struct LockedProfileImageArtifacts {
+    _rootfs_lock: Flock<File>,
+    _snapshot_lock: Flock<File>,
+    rootfs_paths: RootfsPaths,
+    snapshot_paths: SnapshotPaths,
+}
+
+impl LockedProfileImageArtifacts {
+    pub(crate) fn rootfs_paths(&self) -> &RootfsPaths {
+        &self.rootfs_paths
+    }
+
+    pub(crate) fn snapshot_paths(&self) -> &SnapshotPaths {
+        &self.snapshot_paths
+    }
+}
+
+pub(crate) async fn lock_and_validate_profile_image_artifacts(
+    name: &str,
+    profile: &ProfileConfig,
+    home: &HomePaths,
+) -> RunnerResult<LockedProfileImageArtifacts> {
+    let rootfs_lock = crate::lock::acquire_shared(home.rootfs_lock(&profile.rootfs_hash)).await?;
+    let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
+    let snapshot_lock =
+        crate::lock::acquire_shared(home.snapshot_lock(&profile.snapshot_hash)).await?;
+    let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
+
+    validate_profile_image_artifacts(name, profile, home).await?;
+
+    Ok(LockedProfileImageArtifacts {
+        _rootfs_lock: rootfs_lock,
+        _snapshot_lock: snapshot_lock,
+        rootfs_paths,
+        snapshot_paths,
+    })
 }
 
 async fn validate(

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -349,7 +349,9 @@ async fn check_snapshot_complete_marker(path: &Path, label: &str) -> RunnerResul
     Ok(())
 }
 
-pub(crate) async fn validate_profile_image_artifacts(
+// This intentionally does not acquire resource locks. Runtime callers that
+// consume image files must use `lock_and_validate_*_image_artifacts` instead.
+async fn validate_profile_image_artifacts(
     name: &str,
     profile: &ProfileConfig,
     home: &HomePaths,

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -11,7 +11,8 @@
 //! 2. `validate` checks group name, profile names, image hashes, static host
 //!    paths, resource ceilings, and the concurrency factor.
 //! 3. Callers that consume image artifacts call
-//!    [`lock_and_validate_profile_image_artifacts`] to hold the relevant
+//!    [`lock_and_validate_runner_image_artifacts`] (or the single-profile
+//!    [`lock_and_validate_profile_image_artifacts`]) to hold the relevant
 //!    rootfs/snapshot locks while validating artifact completeness.
 //! 4. Callers derive runtime objects (e.g. [`sandbox::FactoryConfig`]) from
 //!    the loaded config.
@@ -39,7 +40,7 @@
 //! contract operators write. Add fields behind `#[serde(default)]` with a
 //! sensible default; rename fields only with a migration plan.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
@@ -353,12 +354,28 @@ pub(crate) async fn validate_profile_image_artifacts(
     profile: &ProfileConfig,
     home: &HomePaths,
 ) -> RunnerResult<()> {
-    // Validate rootfs files exist on disk.
+    let rootfs_paths = validate_profile_rootfs_artifacts(name, profile, home).await?;
+    validate_profile_snapshot_artifacts(name, profile, &rootfs_paths).await?;
+    Ok(())
+}
+
+async fn validate_profile_rootfs_artifacts(
+    name: &str,
+    profile: &ProfileConfig,
+    home: &HomePaths,
+) -> RunnerResult<RootfsPaths> {
     let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
     for path in rootfs_paths.expected_files() {
         check_path_exists(&path, &format!("profile {name} rootfs")).await?;
     }
-    // Validate snapshot files exist on disk.
+    Ok(rootfs_paths)
+}
+
+async fn validate_profile_snapshot_artifacts(
+    name: &str,
+    profile: &ProfileConfig,
+    rootfs_paths: &RootfsPaths,
+) -> RunnerResult<SnapshotPaths> {
     let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
     for path in snapshot_paths.expected_files() {
         check_path_exists(&path, &format!("profile {name} snapshot")).await?;
@@ -368,17 +385,27 @@ pub(crate) async fn validate_profile_image_artifacts(
         &format!("profile {name} snapshot complete marker"),
     )
     .await?;
-    Ok(())
+    Ok(snapshot_paths)
 }
 
 pub(crate) struct LockedProfileImageArtifacts {
-    _rootfs_lock: Flock<File>,
-    _snapshot_lock: Flock<File>,
-    rootfs_paths: RootfsPaths,
+    _rootfs_locks: Vec<Flock<File>>,
+    _snapshot_locks: Vec<Flock<File>>,
     snapshot_paths: SnapshotPaths,
 }
 
 impl LockedProfileImageArtifacts {
+    pub(crate) fn snapshot_paths(&self) -> &SnapshotPaths {
+        &self.snapshot_paths
+    }
+}
+
+pub(crate) struct LockedProfileImageArtifactPaths {
+    rootfs_paths: RootfsPaths,
+    snapshot_paths: SnapshotPaths,
+}
+
+impl LockedProfileImageArtifactPaths {
     pub(crate) fn rootfs_paths(&self) -> &RootfsPaths {
         &self.rootfs_paths
     }
@@ -388,24 +415,98 @@ impl LockedProfileImageArtifacts {
     }
 }
 
+pub(crate) struct LockedRunnerImageArtifacts {
+    _rootfs_locks: Vec<Flock<File>>,
+    _snapshot_locks: Vec<Flock<File>>,
+    profile_paths: BTreeMap<String, LockedProfileImageArtifactPaths>,
+}
+
+impl LockedRunnerImageArtifacts {
+    pub(crate) fn profile_paths(
+        &self,
+    ) -> impl Iterator<Item = (&str, &LockedProfileImageArtifactPaths)> {
+        self.profile_paths
+            .iter()
+            .map(|(name, paths)| (name.as_str(), paths))
+    }
+}
+
 pub(crate) async fn lock_and_validate_profile_image_artifacts(
     name: &str,
     profile: &ProfileConfig,
     home: &HomePaths,
 ) -> RunnerResult<LockedProfileImageArtifacts> {
-    let rootfs_lock = crate::lock::acquire_shared(home.rootfs_lock(&profile.rootfs_hash)).await?;
-    let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
-    let snapshot_lock =
-        crate::lock::acquire_shared(home.snapshot_lock(&profile.snapshot_hash)).await?;
-    let snapshot_paths = rootfs_paths.snapshot(&profile.snapshot_hash);
-
-    validate_profile_image_artifacts(name, profile, home).await?;
+    let mut profiles = BTreeMap::new();
+    profiles.insert(name.to_string(), profile.clone());
+    let mut locked = lock_and_validate_runner_image_artifacts(&profiles, home).await?;
+    let paths = locked.profile_paths.remove(name).ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "missing locked image artifact paths for profile {name}"
+        ))
+    })?;
 
     Ok(LockedProfileImageArtifacts {
-        _rootfs_lock: rootfs_lock,
-        _snapshot_lock: snapshot_lock,
-        rootfs_paths,
-        snapshot_paths,
+        _rootfs_locks: locked._rootfs_locks,
+        _snapshot_locks: locked._snapshot_locks,
+        snapshot_paths: paths.snapshot_paths,
+    })
+}
+
+pub(crate) async fn lock_and_validate_runner_image_artifacts(
+    profiles: &BTreeMap<String, ProfileConfig>,
+    home: &HomePaths,
+) -> RunnerResult<LockedRunnerImageArtifacts> {
+    // Acquire all rootfs locks before any snapshot lock. A runner can use
+    // multiple profiles, while builders and GC operate on one rootfs plus its
+    // snapshots. Keeping a global rootfs-then-snapshot order prevents a runner
+    // from holding one snapshot while waiting on another rootfs.
+    let rootfs_hashes: BTreeSet<&str> = profiles
+        .values()
+        .map(|profile| profile.rootfs_hash.as_str())
+        .collect();
+    let snapshot_hashes: BTreeSet<&str> = profiles
+        .values()
+        .map(|profile| profile.snapshot_hash.as_str())
+        .collect();
+
+    let mut rootfs_locks = Vec::with_capacity(rootfs_hashes.len());
+    for hash in rootfs_hashes {
+        rootfs_locks.push(crate::lock::acquire_shared(home.rootfs_lock(hash)).await?);
+    }
+
+    let mut rootfs_paths = BTreeMap::new();
+    for (name, profile) in profiles {
+        rootfs_paths.insert(
+            name.clone(),
+            validate_profile_rootfs_artifacts(name, profile, home).await?,
+        );
+    }
+
+    let mut snapshot_locks = Vec::with_capacity(snapshot_hashes.len());
+    for hash in snapshot_hashes {
+        snapshot_locks.push(crate::lock::acquire_shared(home.snapshot_lock(hash)).await?);
+    }
+
+    let mut profile_paths = BTreeMap::new();
+    for (name, profile) in profiles {
+        let rootfs_paths = rootfs_paths.remove(name).ok_or_else(|| {
+            RunnerError::Internal(format!("missing locked rootfs paths for profile {name}"))
+        })?;
+        let snapshot_paths =
+            validate_profile_snapshot_artifacts(name, profile, &rootfs_paths).await?;
+        profile_paths.insert(
+            name.clone(),
+            LockedProfileImageArtifactPaths {
+                rootfs_paths,
+                snapshot_paths,
+            },
+        );
+    }
+
+    Ok(LockedRunnerImageArtifacts {
+        _rootfs_locks: rootfs_locks,
+        _snapshot_locks: snapshot_locks,
+        profile_paths,
     })
 }
 

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -456,6 +456,10 @@ pub(crate) async fn lock_and_validate_runner_image_artifacts(
     profiles: &BTreeMap<String, ProfileConfig>,
     home: &HomePaths,
 ) -> RunnerResult<LockedRunnerImageArtifacts> {
+    if profiles.is_empty() {
+        return Err(RunnerError::Config("profiles must not be empty".into()));
+    }
+
     // Acquire all rootfs locks before any snapshot lock. A runner can use
     // multiple profiles, while builders and GC operate on one rootfs plus its
     // snapshots. Keeping a global rootfs-then-snapshot order prevents a runner

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -797,6 +797,34 @@ async fn lock_and_validate_profile_image_artifacts_holds_resource_locks() {
 }
 
 #[tokio::test]
+async fn lock_and_validate_runner_image_artifacts_releases_locks_on_validation_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let home =
+        test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
+    let snapshot = RootfsPaths::new(&home, TEST_ROOTFS_HASH).snapshot(TEST_SNAPSHOT_HASH);
+    tokio::fs::remove_file(snapshot.cow_bitmap()).await.unwrap();
+    let profiles = make_profiles();
+
+    let err = match lock_and_validate_runner_image_artifacts(&profiles, &home).await {
+        Ok(_) => panic!("expected missing cow bitmap error"),
+        Err(err) => err,
+    };
+    assert!(
+        err.to_string().contains("cow.img.bitmap"),
+        "expected missing cow bitmap error, got: {err}"
+    );
+
+    let rootfs_lock = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
+        .await
+        .unwrap();
+    drop(rootfs_lock);
+    let snapshot_lock = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
+        .await
+        .unwrap();
+    drop(snapshot_lock);
+}
+
+#[tokio::test]
 async fn lock_and_validate_runner_image_artifacts_holds_all_resource_locks() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home_with_artifacts(

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -756,7 +756,7 @@ async fn validate_profile_image_artifacts_rejects_missing_cow_bitmap() {
 }
 
 #[tokio::test]
-async fn lock_and_validate_profile_image_artifacts_holds_snapshot_lock() {
+async fn lock_and_validate_profile_image_artifacts_holds_resource_locks() {
     let dir = tempfile::tempdir().unwrap();
     let home =
         test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
@@ -766,15 +766,27 @@ async fn lock_and_validate_profile_image_artifacts_holds_snapshot_lock() {
         .await
         .unwrap();
 
-    let err = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
+    let rootfs_err = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
         .await
         .unwrap_err();
     assert!(
-        err.to_string().contains("lock is already held"),
-        "got: {err}"
+        rootfs_err.to_string().contains("lock is already held"),
+        "got: {rootfs_err}"
+    );
+
+    let snapshot_err = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
+        .await
+        .unwrap_err();
+    assert!(
+        snapshot_err.to_string().contains("lock is already held"),
+        "got: {snapshot_err}"
     );
 
     drop(guard);
+    let released_lock = crate::lock::try_acquire(home.rootfs_lock(TEST_ROOTFS_HASH))
+        .await
+        .unwrap();
+    drop(released_lock);
     let released_lock = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
         .await
         .unwrap();

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -756,6 +756,32 @@ async fn validate_profile_image_artifacts_rejects_missing_cow_bitmap() {
 }
 
 #[tokio::test]
+async fn lock_and_validate_profile_image_artifacts_holds_snapshot_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let home =
+        test_home_with_artifacts(dir.path(), &[(TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH)]).await;
+    let profile = default_profile_config();
+
+    let guard = lock_and_validate_profile_image_artifacts("vm0/default", &profile, &home)
+        .await
+        .unwrap();
+
+    let err = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("lock is already held"),
+        "got: {err}"
+    );
+
+    drop(guard);
+    let released_lock = crate::lock::try_acquire(home.snapshot_lock(TEST_SNAPSHOT_HASH))
+        .await
+        .unwrap();
+    drop(released_lock);
+}
+
+#[tokio::test]
 async fn load_rejects_snapshot_without_complete_marker() {
     let fixture = ConfigFixture::without_image_artifacts().await;
 

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -3,6 +3,9 @@ use super::*;
 /// 64 lowercase hex chars — matches `Sha256::digest(...).hex_encode()`.
 const TEST_ROOTFS_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const TEST_SNAPSHOT_HASH: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+const OTHER_ROOTFS_HASH: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const OTHER_SNAPSHOT_HASH: &str =
+    "2222222222222222222222222222222222222222222222222222222222222222";
 
 struct ConfigFixture {
     dir: tempfile::TempDir,
@@ -791,6 +794,64 @@ async fn lock_and_validate_profile_image_artifacts_holds_resource_locks() {
         .await
         .unwrap();
     drop(released_lock);
+}
+
+#[tokio::test]
+async fn lock_and_validate_runner_image_artifacts_holds_all_resource_locks() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = test_home_with_artifacts(
+        dir.path(),
+        &[
+            (TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH),
+            (OTHER_ROOTFS_HASH, OTHER_SNAPSHOT_HASH),
+        ],
+    )
+    .await;
+    let mut other_profile = default_profile_config();
+    other_profile.rootfs_hash = OTHER_ROOTFS_HASH.into();
+    other_profile.snapshot_hash = OTHER_SNAPSHOT_HASH.into();
+    let mut profiles = BTreeMap::new();
+    profiles.insert("vm0/default".to_string(), default_profile_config());
+    profiles.insert("vm0/other".to_string(), other_profile);
+
+    let guard = lock_and_validate_runner_image_artifacts(&profiles, &home)
+        .await
+        .unwrap();
+
+    for (rootfs_hash, snapshot_hash) in [
+        (TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH),
+        (OTHER_ROOTFS_HASH, OTHER_SNAPSHOT_HASH),
+    ] {
+        let rootfs_err = crate::lock::try_acquire(home.rootfs_lock(rootfs_hash))
+            .await
+            .unwrap_err();
+        assert!(
+            rootfs_err.to_string().contains("lock is already held"),
+            "got: {rootfs_err}"
+        );
+        let snapshot_err = crate::lock::try_acquire(home.snapshot_lock(snapshot_hash))
+            .await
+            .unwrap_err();
+        assert!(
+            snapshot_err.to_string().contains("lock is already held"),
+            "got: {snapshot_err}"
+        );
+    }
+
+    drop(guard);
+    for (rootfs_hash, snapshot_hash) in [
+        (TEST_ROOTFS_HASH, TEST_SNAPSHOT_HASH),
+        (OTHER_ROOTFS_HASH, OTHER_SNAPSHOT_HASH),
+    ] {
+        let released_lock = crate::lock::try_acquire(home.rootfs_lock(rootfs_hash))
+            .await
+            .unwrap();
+        drop(released_lock);
+        let released_lock = crate::lock::try_acquire(home.snapshot_lock(snapshot_hash))
+            .await
+            .unwrap();
+        drop(released_lock);
+    }
 }
 
 #[tokio::test]

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -825,6 +825,23 @@ async fn lock_and_validate_runner_image_artifacts_releases_locks_on_validation_e
 }
 
 #[tokio::test]
+async fn lock_and_validate_runner_image_artifacts_rejects_empty_profiles() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = HomePaths::with_root(dir.path().join("vm0-runner"));
+    let profiles = BTreeMap::new();
+
+    let err = match lock_and_validate_runner_image_artifacts(&profiles, &home).await {
+        Ok(_) => panic!("expected empty profiles error"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.to_string().contains("profiles must not be empty"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
 async fn lock_and_validate_runner_image_artifacts_holds_all_resource_locks() {
     let dir = tempfile::tempdir().unwrap();
     let home = test_home_with_artifacts(


### PR DESCRIPTION
## Summary
- validate runner config image artifacts under rootfs/snapshot shared locks before writing runner.yaml
- reuse the locked artifact validation helper from start and benchmark so runtime paths keep the same race-safe contract
- add regression coverage for incomplete snapshots, complete snapshots, and held snapshot locks

Fixes #19990

## Tests
- cargo fmt --manifest-path crates/runner/Cargo.toml --check
- cargo test --manifest-path crates/Cargo.toml -p runner
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings