### PR TITLE
refactor: share runner status file reader

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -11,9 +11,9 @@ use crate::error::RunnerResult;
 use crate::live_runner_instances::LiveRunnerInstance;
 use crate::paths::HomePaths;
 use crate::process;
+use crate::status_file::{self, StatusForDoctor};
 use chrono::{DateTime, Utc};
 use clap::Args;
-use serde::Deserialize;
 
 // ---------------------------------------------------------------------------
 // CLI args
@@ -833,26 +833,6 @@ fn find_stopped_services(
 // Status reading
 // ---------------------------------------------------------------------------
 
-#[derive(Deserialize)]
-struct StatusFile {
-    mode: String,
-    /// `#[serde(default)]` defends against transient schema skew during
-    /// rolling deploys: if a reader binary meets a status.json still
-    /// written by an older runner (or a newer one that renamed fields
-    /// again), we surface an empty active_runs rather than failing to
-    /// parse and losing the whole report.
-    #[serde(default)]
-    active_runs: Vec<ActiveRun>,
-    started_at: String,
-    #[serde(default)]
-    idle_vms: Vec<IdleVm>,
-    #[serde(default)]
-    proxy_port: Option<u16>,
-    #[serde(default)]
-    dns_port: Option<u16>,
-}
-
-#[derive(Deserialize)]
 struct ActiveRun {
     run_id: String,
     sandbox_id: String,
@@ -876,7 +856,6 @@ impl ActiveRun {
     }
 }
 
-#[derive(Deserialize)]
 struct IdleVm {
     session_id: String,
     sandbox_id: String,
@@ -888,20 +867,33 @@ fn is_inactive_mode(mode: &str) -> bool {
 }
 
 async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
-    let path = base_dir.join("status.json");
-    let content = crate::private_fs::read_private_file_to_string_with_max(
-        &path,
-        crate::private_fs::PRIVATE_STATUS_FILE_READ_MAX_BYTES,
-    )
-    .await
-    .ok()
-    .flatten()?;
-    let file: StatusFile = serde_json::from_str(&content).ok()?;
+    let file = status_file::read_as::<StatusForDoctor>(base_dir)
+        .await
+        .ok()
+        .flatten()?;
+    let active_runs = file
+        .active_runs
+        .into_iter()
+        .map(|run| ActiveRun {
+            run_id: run.run_id,
+            sandbox_id: run.sandbox_id,
+            phase: run.phase,
+            phase_started_at: run.phase_started_at,
+        })
+        .collect();
+    let idle_vms = file
+        .idle_vms
+        .into_iter()
+        .map(|vm| IdleVm {
+            session_id: vm.session_id,
+            sandbox_id: vm.sandbox_id,
+        })
+        .collect();
     Some(StatusInfo {
         mode: file.mode,
         started_at: file.started_at,
-        active_runs: file.active_runs,
-        idle_vms: file.idle_vms,
+        active_runs,
+        idle_vms,
         proxy_port: file.proxy_port,
         dns_port: file.dns_port,
     })
@@ -1436,6 +1428,49 @@ mod tests {
         assert_eq!(parse_netns_list_line("vm0-ns-00-0A"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-40-00"), None);
         assert_eq!(parse_netns_list_line("vm0-ns-ff-00"), None);
+    }
+
+    #[tokio::test]
+    async fn read_status_defaults_missing_collections_to_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("status.json"),
+            r#"{"mode":"running","started_at":"2026-01-01T00:00:00.000Z"}"#,
+        )
+        .unwrap();
+
+        let status = read_status(dir.path()).await.unwrap();
+
+        assert!(status.active_runs.is_empty());
+        assert!(status.idle_vms.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_status_missing_active_run_identifier_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("status.json"),
+            r#"{
+                "mode":"running",
+                "started_at":"2026-01-01T00:00:00.000Z",
+                "active_runs":[{"run_id":"R1"}]
+            }"#,
+        )
+        .unwrap();
+
+        assert!(read_status(dir.path()).await.is_none());
+    }
+
+    #[test]
+    fn active_run_unknown_phase_defaults_running() {
+        let active = ActiveRun {
+            run_id: "R1".into(),
+            sandbox_id: "S1".into(),
+            phase: Some("future-phase".into()),
+            phase_started_at: None,
+        };
+
+        assert_eq!(active.phase(), ActiveRunPhase::Running);
     }
 
     fn legacy_active_run(run_id: &str, sandbox_id: &str) -> ActiveRun {

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1461,6 +1461,22 @@ mod tests {
         assert!(read_status(dir.path()).await.is_none());
     }
 
+    #[tokio::test]
+    async fn read_status_missing_idle_vm_identifier_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("status.json"),
+            r#"{
+                "mode":"running",
+                "started_at":"2026-01-01T00:00:00.000Z",
+                "idle_vms":[{"session_id":"session-a"}]
+            }"#,
+        )
+        .unwrap();
+
+        assert!(read_status(dir.path()).await.is_none());
+    }
+
     #[test]
     fn active_run_unknown_phase_defaults_running() {
         let active = ActiveRun {

--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::error::{ActiveJobsError, RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::paths::HomePaths;
+use crate::status_file::{self, StatusFileReadError, StatusForGate};
 use tracing::{info, warn};
 
 use super::diagnostic::status_field_preview;
@@ -102,51 +103,31 @@ fn decide_gate(status: &RunnerStatusSnapshot) -> GateDecision {
     }
 }
 
-/// Read status.json at `base_dir`.
-///
-/// Returns an error on any I/O or parse failure — the caller should log the
-/// reason and fall through to forceful stop (status unknown → cannot protect
-/// jobs).
-async fn read_private_status_json(path: &Path) -> std::io::Result<String> {
-    match crate::private_fs::read_private_file_to_string_with_max(
-        path,
-        crate::private_fs::PRIVATE_STATUS_FILE_READ_MAX_BYTES,
-    )
-    .await
-    {
-        Ok(Some(content)) => Ok(content),
-        Ok(None) => Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("{} not found", path.display()),
-        )),
-        Err(error) => Err(std::io::Error::other(error.to_string())),
-    }
-}
-
 pub(super) async fn read_runner_status(
     base_dir: &Path,
 ) -> Result<RunnerStatusSnapshot, RunnerStatusReadError> {
-    #[derive(serde::Deserialize)]
-    struct StatusFile {
-        mode: String,
-        active_runs: Vec<ActiveRunEntry>,
-        started_at: String,
-    }
-    #[derive(serde::Deserialize)]
-    struct ActiveRunEntry {
-        run_id: RunId,
-        // `sandbox_id` is present in the file but unused by the gate.
-    }
-    let path = base_dir.join("status.json");
-    let content =
-        read_private_status_json(&path)
-            .await
-            .map_err(|error| RunnerStatusReadError::Read {
+    let path = status_file::path(base_dir);
+    let file = match status_file::read_as::<StatusForGate>(base_dir).await {
+        Ok(Some(file)) => file,
+        Ok(None) => {
+            return Err(RunnerStatusReadError::Read {
                 path: path.clone(),
-                error,
-            })?;
-    let file: StatusFile = serde_json::from_str(&content)
-        .map_err(|error| RunnerStatusReadError::ParseJson { path, error })?;
+                error: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("{} not found", path.display()),
+                ),
+            });
+        }
+        Err(StatusFileReadError::Read { path, error }) => {
+            return Err(RunnerStatusReadError::Read {
+                path,
+                error: std::io::Error::other(error.to_string()),
+            });
+        }
+        Err(StatusFileReadError::ParseJson { path, error }) => {
+            return Err(RunnerStatusReadError::ParseJson { path, error });
+        }
+    };
     let started = chrono::DateTime::parse_from_rfc3339(&file.started_at).map_err(|error| {
         RunnerStatusReadError::ParseStartedAt {
             started_at: file.started_at.clone(),
@@ -159,7 +140,7 @@ pub(super) async fn read_runner_status(
         .unwrap_or_default();
     Ok(RunnerStatusSnapshot {
         mode: file.mode,
-        run_ids: file.active_runs.into_iter().map(|r| r.run_id).collect(),
+        run_ids: file.active_runs.into_iter().map(|run| run.run_id).collect(),
         uptime,
     })
 }
@@ -282,7 +263,18 @@ mod tests {
         tokio::fs::write(dir.path().join("status.json"), "{}")
             .await
             .unwrap();
-        // Missing required fields -> parse error.
+        // Missing required fields -> error.
+        assert!(read_runner_status(dir.path()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn read_runner_status_missing_active_runs_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = r#"{"mode":"running","started_at":"2026-04-13T00:00:00.000Z"}"#;
+        tokio::fs::write(dir.path().join("status.json"), s)
+            .await
+            .unwrap();
+
         assert!(read_runner_status(dir.path()).await.is_err());
     }
 

--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -279,6 +279,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn read_runner_status_invalid_run_id_is_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = r#"{
+            "mode":"running",
+            "active_runs":[{"run_id":"not-a-uuid"}],
+            "started_at":"2026-04-13T00:00:00.000Z"
+        }"#;
+        tokio::fs::write(dir.path().join("status.json"), s)
+            .await
+            .unwrap();
+
+        assert!(read_runner_status(dir.path()).await.is_err());
+    }
+
+    #[tokio::test]
     async fn read_runner_status_malformed_started_at() {
         let dir = tempfile::tempdir().unwrap();
         let s = r#"{"mode":"running","active_runs":[],"started_at":"not-a-date"}"#;

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -44,6 +44,7 @@ mod runner_dirname;
 mod runtime_overrides;
 mod state_file;
 mod status;
+mod status_file;
 mod storage_cache;
 mod storage_fingerprints;
 mod telemetry;

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -5,50 +5,33 @@ use std::path::Path;
 use crate::error::{RunnerError, RunnerResult};
 use crate::live_runner_instances::LiveRunnerInstance;
 use crate::paths::HomePaths;
+use crate::status_file::{self, StatusActiveRunsOnly, StatusFileReadError};
 
 /// Read `{base_dir}/status.json` and extract `(run_id, sandbox_id)` for
 /// every active run. Returns `None` if the file is missing or unparseable
 /// (logs at `warn` level so the operator sees the miss immediately).
 async fn read_active_runs(base_dir: &Path) -> Option<Vec<(String, String)>> {
-    #[derive(serde::Deserialize)]
-    struct StatusShape {
-        #[serde(default)]
-        active_runs: Vec<ActiveRunShape>,
-    }
-    #[derive(serde::Deserialize)]
-    struct ActiveRunShape {
-        run_id: String,
-        sandbox_id: String,
-    }
-    let path = base_dir.join("status.json");
-    let content = match crate::private_fs::read_private_file_to_string_with_max(
-        &path,
-        crate::private_fs::PRIVATE_STATUS_FILE_READ_MAX_BYTES,
-    )
-    .await
-    {
-        Ok(Some(c)) => c,
+    let status = match status_file::read_as::<StatusActiveRunsOnly>(base_dir).await {
+        Ok(Some(status)) => status,
         Ok(None) => {
+            let path = status_file::path(base_dir);
             tracing::warn!(path = %path.display(), "skipping runner: status.json is missing");
             return None;
         }
-        Err(e) => {
-            tracing::warn!(path = %path.display(), error = %e, "skipping runner: cannot read status.json");
+        Err(StatusFileReadError::Read { path, error }) => {
+            tracing::warn!(path = %path.display(), error = %error, "skipping runner: cannot read status.json");
             return None;
         }
-    };
-    let shape: StatusShape = match serde_json::from_str(&content) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(path = %path.display(), error = %e, "skipping runner: cannot parse status.json");
+        Err(StatusFileReadError::ParseJson { path, error }) => {
+            tracing::warn!(path = %path.display(), error = %error, "skipping runner: cannot parse status.json");
             return None;
         }
     };
     Some(
-        shape
+        status
             .active_runs
             .into_iter()
-            .map(|r| (r.run_id, r.sandbox_id))
+            .map(|run| (run.run_id, run.sandbox_id))
             .collect(),
     )
 }
@@ -232,8 +215,8 @@ mod tests {
                 {
                     "run_id": "R1",
                     "sandbox_id": "S1",
-                    "phase": "preparing",
-                    "phase_started_at": "2026-01-01T00:00:00.000Z"
+                    "phase": 42,
+                    "phase_started_at": {"unexpected": true}
                 },
                 {
                     "run_id": "R2",
@@ -261,6 +244,18 @@ mod tests {
         std::fs::write(dir.path().join("status.json"), r#"{"mode":"running"}"#).unwrap();
         let runs = read_active_runs(dir.path()).await.unwrap();
         assert!(runs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_active_runs_missing_entry_identifier_is_unparseable() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("status.json"),
+            r#"{"active_runs":[{"run_id":"run-a"}]}"#,
+        )
+        .unwrap();
+
+        assert!(read_active_runs(dir.path()).await.is_none());
     }
 
     #[tokio::test]

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -33,6 +33,10 @@ pub(crate) fn path(base_dir: &Path) -> PathBuf {
     base_dir.join(STATUS_FILE_NAME)
 }
 
+/// Read and deserialize `status.json` into the caller-selected wire shape.
+///
+/// Callers intentionally use different shapes below so fields irrelevant to one
+/// command cannot make that command reject an otherwise usable status file.
 pub(crate) async fn read_as<T>(base_dir: &Path) -> Result<Option<T>, StatusFileReadError>
 where
     T: DeserializeOwned,
@@ -58,6 +62,8 @@ where
 #[derive(Debug, Deserialize)]
 pub(crate) struct StatusForGate {
     pub(crate) mode: String,
+    // Gate intentionally requires this field so malformed active-job status
+    // never looks like an empty runner.
     pub(crate) active_runs: Vec<StatusGateActiveRun>,
     pub(crate) started_at: String,
 }
@@ -70,6 +76,8 @@ pub(crate) struct StatusGateActiveRun {
 #[derive(Debug, Deserialize)]
 pub(crate) struct StatusForDoctor {
     pub(crate) mode: String,
+    // Defaulting collections preserves doctor reports across rolling schema
+    // skew while keeping required per-entry identifiers strict.
     #[serde(default)]
     pub(crate) active_runs: Vec<StatusActiveRun>,
     pub(crate) started_at: String,
@@ -83,6 +91,8 @@ pub(crate) struct StatusForDoctor {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct StatusActiveRunsOnly {
+    // Run resolution only needs mappings. Missing active_runs has historically
+    // meant "no active runs", but malformed entries still invalidate the file.
     #[serde(default)]
     pub(crate) active_runs: Vec<StatusActiveRunMapping>,
 }

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -230,6 +230,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn active_runs_only_ignores_unneeded_malformed_top_level_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{
+                "mode": {},
+                "active_runs": [
+                    {"run_id":"run-a","sandbox_id":"sandbox-a"}
+                ],
+                "started_at": [],
+                "idle_vms": null
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        let status = read_as::<StatusActiveRunsOnly>(dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(status.active_runs.len(), 1);
+        assert_eq!(status.active_runs[0].run_id, "run-a");
+        assert_eq!(status.active_runs[0].sandbox_id, "sandbox-a");
+    }
+
+    #[tokio::test]
     async fn active_runs_only_rejects_null_active_runs() {
         let dir = tempfile::tempdir().unwrap();
         tokio::fs::write(

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -1,0 +1,294 @@
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+
+use crate::error::RunnerError;
+use crate::ids::RunId;
+
+const STATUS_FILE_NAME: &str = "status.json";
+
+#[derive(Debug)]
+pub(crate) enum StatusFileReadError {
+    Read {
+        path: PathBuf,
+        error: RunnerError,
+    },
+    ParseJson {
+        path: PathBuf,
+        error: serde_json::Error,
+    },
+}
+
+impl std::fmt::Display for StatusFileReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Read { path, error } => write!(f, "read {}: {error}", path.display()),
+            Self::ParseJson { path, error } => write!(f, "parse {}: {error}", path.display()),
+        }
+    }
+}
+
+pub(crate) fn path(base_dir: &Path) -> PathBuf {
+    base_dir.join(STATUS_FILE_NAME)
+}
+
+pub(crate) async fn read_as<T>(base_dir: &Path) -> Result<Option<T>, StatusFileReadError>
+where
+    T: DeserializeOwned,
+{
+    let path = path(base_dir);
+    let content = match crate::private_fs::read_private_file_to_string_with_max(
+        &path,
+        crate::private_fs::PRIVATE_STATUS_FILE_READ_MAX_BYTES,
+    )
+    .await
+    {
+        Ok(Some(content)) => content,
+        Ok(None) => return Ok(None),
+        Err(error) => {
+            return Err(StatusFileReadError::Read { path, error });
+        }
+    };
+    serde_json::from_str(&content)
+        .map(Some)
+        .map_err(|error| StatusFileReadError::ParseJson { path, error })
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusForGate {
+    pub(crate) mode: String,
+    pub(crate) active_runs: Vec<StatusGateActiveRun>,
+    pub(crate) started_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusGateActiveRun {
+    pub(crate) run_id: RunId,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusForDoctor {
+    pub(crate) mode: String,
+    #[serde(default)]
+    pub(crate) active_runs: Vec<StatusActiveRun>,
+    pub(crate) started_at: String,
+    #[serde(default)]
+    pub(crate) idle_vms: Vec<StatusIdleVm>,
+    #[serde(default)]
+    pub(crate) proxy_port: Option<u16>,
+    #[serde(default)]
+    pub(crate) dns_port: Option<u16>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusActiveRunsOnly {
+    #[serde(default)]
+    pub(crate) active_runs: Vec<StatusActiveRunMapping>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusActiveRunMapping {
+    pub(crate) run_id: String,
+    pub(crate) sandbox_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusActiveRun {
+    pub(crate) run_id: String,
+    pub(crate) sandbox_id: String,
+    pub(crate) phase: Option<String>,
+    pub(crate) phase_started_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct StatusIdleVm {
+    pub(crate) session_id: String,
+    pub(crate) sandbox_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let status = read_as::<StatusForGate>(dir.path()).await.unwrap();
+
+        assert!(status.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_malformed_json_returns_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(dir.path().join("status.json"), "not json")
+            .await
+            .unwrap();
+
+        let error = read_as::<StatusForGate>(dir.path()).await.unwrap_err();
+
+        assert!(matches!(error, StatusFileReadError::ParseJson { .. }));
+    }
+
+    #[tokio::test]
+    async fn read_full_writer_payload_preserves_doctor_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = r#"{
+            "mode": "running",
+            "max_concurrent": 4,
+            "active_runs": [
+                {
+                    "run_id":"0191c4e0-0000-7000-8000-000000000001",
+                    "sandbox_id":"aaaaaaaa-0000-7000-8000-000000000001",
+                    "phase":"preparing",
+                    "phase_started_at":"2026-04-13T00:00:01.000Z"
+                }
+            ],
+            "idle_vms": [
+                {"session_id":"sess-1","sandbox_id":"bbbbbbbb-0000-7000-8000-000000000001"}
+            ],
+            "proxy_port": 8080,
+            "dns_port": 5300,
+            "started_at": "2026-04-13T00:00:00.000Z",
+            "updated_at": "2026-04-13T00:05:00.000Z"
+        }"#;
+        tokio::fs::write(dir.path().join("status.json"), content)
+            .await
+            .unwrap();
+
+        let status = read_as::<StatusForDoctor>(dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(status.mode, "running");
+        assert_eq!(status.started_at, "2026-04-13T00:00:00.000Z");
+        assert_eq!(status.proxy_port, Some(8080));
+        assert_eq!(status.dns_port, Some(5300));
+        assert_eq!(status.active_runs.len(), 1);
+        assert_eq!(
+            status.active_runs[0].run_id,
+            "0191c4e0-0000-7000-8000-000000000001"
+        );
+        assert_eq!(status.active_runs[0].phase.as_deref(), Some("preparing"));
+        assert_eq!(
+            status.active_runs[0].phase_started_at.as_deref(),
+            Some("2026-04-13T00:00:01.000Z")
+        );
+        assert_eq!(status.idle_vms.len(), 1);
+        assert_eq!(status.idle_vms[0].session_id, "sess-1");
+    }
+
+    #[tokio::test]
+    async fn active_runs_only_defaults_missing_active_runs_to_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{"mode":"running","started_at":"2026-04-13T00:00:00.000Z"}"#,
+        )
+        .await
+        .unwrap();
+
+        let status = read_as::<StatusActiveRunsOnly>(dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(status.active_runs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn gate_shape_ignores_unneeded_malformed_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{
+                "mode":"running",
+                "active_runs":[],
+                "started_at":"2026-04-13T00:00:00.000Z",
+                "idle_vms":null
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        let status = read_as::<StatusForGate>(dir.path()).await.unwrap().unwrap();
+
+        assert_eq!(status.mode, "running");
+    }
+
+    #[tokio::test]
+    async fn active_runs_only_rejects_null_active_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{"mode":"running","active_runs":null}"#,
+        )
+        .await
+        .unwrap();
+
+        let error = read_as::<StatusActiveRunsOnly>(dir.path())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, StatusFileReadError::ParseJson { .. }));
+    }
+
+    #[tokio::test]
+    async fn active_runs_only_ignores_unneeded_malformed_phase_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            dir.path().join("status.json"),
+            r#"{
+                "active_runs": [
+                    {
+                        "run_id":"run-a",
+                        "sandbox_id":"sandbox-a",
+                        "phase":42,
+                        "phase_started_at":{}
+                    }
+                ]
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        let status = read_as::<StatusActiveRunsOnly>(dir.path())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(status.active_runs.len(), 1);
+        assert_eq!(status.active_runs[0].run_id, "run-a");
+        assert_eq!(status.active_runs[0].sandbox_id, "sandbox-a");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn read_rejects_fifo_without_blocking() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            read_as::<StatusForGate>(dir.path()),
+        )
+        .await;
+
+        assert!(result.is_ok(), "FIFO read should not block");
+        assert!(result.unwrap().is_err(), "FIFO status should be rejected");
+    }
+}


### PR DESCRIPTION
## Summary

- Add a runner-internal `status_file` module for secure `status.json` path construction, bounded private-file reads, and JSON parse error reporting.
- Move the production readers in service gate, doctor, and run resolution onto shared wire shapes while keeping their caller-specific behavior.
- Preserve the existing writer-side `status.json` format; this PR does not change `crates/runner/src/status.rs` serialization.

## Behavior notes

- Gate remains strict for `mode`, `active_runs`, `started_at`, and active-run `run_id`; unknown mode strings still flow into the existing gate decision logic.
- Doctor still treats missing/read/parse failures as unavailable status, defaults missing active/idle collections to empty, and maps missing or unknown phases to running.
- Run resolution still reads only `run_id` and `sandbox_id` mappings, defaults missing `active_runs` to empty, and ignores unrelated/malformed phase fields.

Closes #19987

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner status_file`
- `cargo test --manifest-path crates/Cargo.toml -p runner read_runner_status`
- `cargo test --manifest-path crates/Cargo.toml -p runner read_active_runs`
- `cargo test --manifest-path crates/Cargo.toml -p runner doctor`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --tests -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
