### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,7 +111,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.4"
-CLAUDE_CODE_VERSION="2.1.199"
+CLAUDE_CODE_VERSION="2.1.201"
 CODEX_CLI_VERSION="0.142.5"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"


### PR DESCRIPTION
## Summary
- Update Claude Code CLI from `2.1.199` to `2.1.201` in `crates/runner/scripts/build-template.sh`.

## Version checks
- Go: `1.26.4` is current stable from go.dev.
- Node.js: `24.x` remains the current LTS major.
- PostgreSQL: `18` remains the newest supported major.
- Codex CLI, Google Workspace CLI, xurl, agent-browser, and pnpm already match npm `latest`.
- Debian Bookworm Chromium already matches the current Chromium version available from Debian security; no distro pin change was needed.

## Verification
- `bash -n crates/runner/scripts/build-template.sh`