### PR TITLE
fix: stop sidebar thread list flashing a skeleton on chat thread switch

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -1,4 +1,10 @@
-import { useGet, useSet, useLastResolved, useLoadable } from "ccstate-react";
+import {
+  useGet,
+  useSet,
+  useLastResolved,
+  useLoadable,
+  useLastLoadable,
+} from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconPlus,
@@ -1065,7 +1071,10 @@ function ChatThreadsSkeleton() {
 }
 
 function ChatThreadsContent() {
-  const chatThreadsLoadable = useLoadable(sidebarChatThreads$);
+  // useLastLoadable keeps the previous resolved list rendered while
+  // sidebarChatThreads$ recomputes on a pane/thread switch; useLoadable would
+  // flash the skeleton on every switch.
+  const chatThreadsLoadable = useLastLoadable(sidebarChatThreads$);
   const chatThreads =
     chatThreadsLoadable.state === "hasData" ? chatThreadsLoadable.data : [];
   const chatThreadsLoading = chatThreadsLoadable.state === "loading";


### PR DESCRIPTION
## Summary

Switching chat threads in the sidebar makes the whole thread list blink: it briefly swaps to the 3-bar `ChatThreadsSkeleton` and back on every switch.

**Root cause:** `sidebarChatThreads$` is an async computed that depends on `currentLeftThread$`/`currentRightThread$`. Clicking a thread synchronously writes a fresh `ChatThreadSignals` into the pane signal (`chat-thread-panes.ts` `setupPaneThread$`), which forces `sidebarChatThreads$` to recompute and return a new pending promise. `ChatThreadsContent` read it via `useLoadable`, which reports `loading` the moment a new pending promise appears, so the list is replaced by the skeleton for at least a frame — and much longer when the selected thread is outside the persisted 25-thread list and the recompute awaits the uncached `threadData$`.

**Fix:** read the list via `useLastLoadable`, which keeps the previous resolved list rendered while the recompute is in flight. This matches the pattern already used in the same file for `draftThreadIds` / `unreadThreadIds` / `activeRunThreadIds` (`useLastResolved`). The skeleton still shows on true first load, since there is no previous resolved value then.

## User-visible impact

Thread switching no longer flashes the sidebar list; the list stays stable and only the selection highlight moves.

## Verification

Behavior change is a one-hook swap verified by code inspection against the existing `useLastResolved` pattern in the same file; relying on the PR pipeline for lint/type/test checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)