### PR TITLE
feat: add codex reset controls

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -131,6 +131,7 @@ import { zeroRunsRoutes } from "./routes/zero-runs";
 import { zeroRunsCancelRoutes } from "./routes/zero-runs-cancel";
 import { zeroMeModelProvidersDeleteRoutes } from "./routes/zero-me-model-providers-delete";
 import { zeroMeModelProvidersListRoutes } from "./routes/zero-me-model-providers-list";
+import { zeroMeModelProvidersResetSubscriptionRoutes } from "./routes/zero-me-model-providers-reset-subscription";
 import { zeroMeModelProvidersUpsertRoutes } from "./routes/zero-me-model-providers-upsert";
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroWorkflowsRoutes } from "./routes/zero-workflows";
@@ -323,6 +324,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroModelProvidersRoutes,
   ...zeroMeModelProvidersDeleteRoutes,
   ...zeroMeModelProvidersListRoutes,
+  ...zeroMeModelProvidersResetSubscriptionRoutes,
   ...zeroMeModelProvidersUpsertRoutes,
   ...zeroVoiceIoQuotaRoutes,
   ...zeroVoiceIoSpeechRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
@@ -362,7 +362,7 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
           expect(request.headers.get("chatgpt-account-id")).toBe(
             "ws_acct_from_id_token_personal",
           );
-          expect(await request.json()).toEqual({
+          await expect(request.json()).resolves.toStrictEqual({
             redeem_request_id: idempotencyKey,
           });
           return HttpResponse.json({
@@ -400,7 +400,7 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
       [200],
     );
 
-    expect(response.body).toEqual({ outcome: "reset" });
+    expect(response.body).toStrictEqual({ outcome: "reset" });
   });
 
   it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID on malformed JSON", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
@@ -2,7 +2,10 @@ import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { HttpResponse, http } from "msw";
 
-import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import {
+  zeroPersonalModelProvidersByTypeContract,
+  zeroPersonalModelProvidersMainContract,
+} from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -46,6 +49,7 @@ function makeJwt(payload: Record<string, unknown>): string {
 function makeIdToken(opts: {
   accountId: string;
   planType: string;
+  email?: string;
   workspaceName?: string;
 }): string {
   const auth: Record<string, unknown> = {
@@ -56,6 +60,7 @@ function makeIdToken(opts: {
     auth.organization = { title: opts.workspaceName };
   }
   return makeJwt({
+    email: opts.email ?? "codex.user@example.com",
     "https://api.openai.com/auth": auth,
     exp: Math.floor(now() / 1000) + 3600,
   });
@@ -277,6 +282,9 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
               used_percent: 40,
             },
           },
+          rate_limit_reset_credits: {
+            available_count: 3,
+          },
         });
       }),
     );
@@ -316,6 +324,8 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
     expect(listed.body.modelProviders).toHaveLength(1);
     expect(listed.body.modelProviders[0]).toMatchObject({
       type: "codex-oauth-token",
+      accountEmail: "codex.user@example.com",
+      subscriptionResetCredits: 3,
       subscriptionUsage: {
         fiveHour: {
           usedPercent: 25,
@@ -331,6 +341,66 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
         },
       },
     });
+  });
+
+  it("consumes a Codex subscription reset credit", async () => {
+    const fixture = uniqueOrgUser("zmmp-codex-reset");
+    mocks.clerk.session(fixture.userId, fixture.orgId);
+    const idempotencyKey = randomUUID();
+    server.use(
+      http.get("https://chatgpt.com/backend-api/wham/usage", () => {
+        return HttpResponse.json({
+          plan_type: "pro",
+          rate_limit_reset_credits: {
+            available_count: 2,
+          },
+        });
+      }),
+      http.post(
+        "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume",
+        async ({ request }) => {
+          expect(request.headers.get("chatgpt-account-id")).toBe(
+            "ws_acct_from_id_token_personal",
+          );
+          expect(await request.json()).toEqual({
+            redeem_request_id: idempotencyKey,
+          });
+          return HttpResponse.json({
+            code: "reset",
+            windows_reset: 2,
+          });
+        },
+      ),
+    );
+
+    const mainClient = setupApp({ context })(
+      zeroPersonalModelProvidersMainContract,
+    );
+    await accept(
+      mainClient.upsert({
+        body: {
+          type: "codex-oauth-token",
+          authMethod: "auth_json",
+          secrets: { CODEX_AUTH_JSON: makeAuthJson() },
+        },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [201],
+    );
+
+    const byTypeClient = setupApp({ context })(
+      zeroPersonalModelProvidersByTypeContract,
+    );
+    const response = await accept(
+      byTypeClient.resetSubscriptionUsage({
+        params: { type: "codex-oauth-token" },
+        body: { idempotencyKey },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    expect(response.body).toEqual({ outcome: "reset" });
   });
 
   it("returns 400 CODEX_AUTH_JSON_SHAPE_INVALID on malformed JSON", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-me-model-providers-reset-subscription.ts
+++ b/turbo/apps/api/src/signals/routes/zero-me-model-providers-reset-subscription.ts
@@ -1,0 +1,62 @@
+import { command } from "ccstate";
+import { zeroPersonalModelProvidersByTypeContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import { isNotFoundResponse, notFound } from "../../lib/error";
+import { consumePersonalCodexRateLimitResetCredit$ } from "../services/model-provider-subscription-usage.service";
+import type { RouteEntry } from "../route-entry";
+
+const resetSubscriptionUsageInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(
+      pathParamsOf(
+        zeroPersonalModelProvidersByTypeContract.resetSubscriptionUsage,
+      ),
+    );
+    signal.throwIfAborted();
+
+    if (params.type !== "codex-oauth-token") {
+      return notFound(`Provider "${params.type}" not found`);
+    }
+
+    const bodyResult = await get(
+      bodyResultOf(
+        zeroPersonalModelProvidersByTypeContract.resetSubscriptionUsage,
+      ),
+    );
+    signal.throwIfAborted();
+    if (!bodyResult.ok) {
+      return bodyResult.response;
+    }
+
+    const result = await set(
+      consumePersonalCodexRateLimitResetCredit$,
+      {
+        orgId: auth.orgId,
+        userId: auth.userId,
+        idempotencyKey: bodyResult.data.idempotencyKey,
+      },
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (isNotFoundResponse(result)) {
+      return result;
+    }
+    return { status: 200 as const, body: result };
+  },
+);
+
+export const zeroMeModelProvidersResetSubscriptionRoutes: readonly RouteEntry[] =
+  [
+    {
+      route: zeroPersonalModelProvidersByTypeContract.resetSubscriptionUsage,
+      handler: authRoute(
+        { requireOrganization: true, missingOrganizationStatus: 401 },
+        resetSubscriptionUsageInner$,
+      ),
+    },
+  ];

--- a/turbo/apps/api/src/signals/services/codex-auth-json-parser.ts
+++ b/turbo/apps/api/src/signals/services/codex-auth-json-parser.ts
@@ -65,6 +65,8 @@ const chatgptAuthClaimsSchema = z
 const chatgptIdTokenClaimsSchema = z
   .object({
     exp: z.number().optional(),
+    email: z.string().nullable().optional(),
+    "https://api.openai.com/profile.email": z.string().nullable().optional(),
     "https://api.openai.com/auth": chatgptAuthClaimsSchema.optional(),
   })
   .passthrough();
@@ -102,6 +104,25 @@ function extractWorkspaceName(authClaims: ChatgptAuthClaims): string | null {
     nonEmptyString(authClaims.workspace_name) ??
     extractNamedClaim(authClaims.account) ??
     nonEmptyString(authClaims.chatgpt_account_name) ??
+    null
+  );
+}
+
+export function extractCodexAccountEmailFromIdToken(
+  idToken: string | null | undefined,
+): string | null {
+  if (!idToken) {
+    return null;
+  }
+  const decoded = safeSync(() => {
+    return chatgptIdTokenClaimsSchema.parse(decodeJwtPayload(idToken));
+  });
+  if ("error" in decoded) {
+    return null;
+  }
+  return (
+    nonEmptyString(decoded.ok.email) ??
+    nonEmptyString(decoded.ok["https://api.openai.com/profile.email"]) ??
     null
   );
 }

--- a/turbo/apps/api/src/signals/services/codex-auth-json-paste-handler.ts
+++ b/turbo/apps/api/src/signals/services/codex-auth-json-paste-handler.ts
@@ -145,6 +145,7 @@ export async function handleCodexAuthJsonPaste(args: CodexAuthJsonPasteArgs) {
         fetchCodexUsageMetadata({
           accessToken: parsed.accessToken,
           accountId: parsed.accountId,
+          idToken: parsed.idToken,
           signal: args.signal,
         }),
       );

--- a/turbo/apps/api/src/signals/services/codex-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-usage.service.ts
@@ -5,8 +5,11 @@ import type {
   SubscriptionUsageMetadata,
   SubscriptionUsageWindowMetadata,
 } from "./model-provider-subscription-usage.types";
+import { extractCodexAccountEmailFromIdToken } from "./codex-auth-json-parser";
 
 const CHATGPT_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const CHATGPT_RESET_CREDITS_CONSUME_URL =
+  "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume";
 const CODEX_ORIGINATOR = "codex_cli_rs";
 const CODEX_USER_AGENT = "codex_cli_rs/0.0.0";
 const WEEK_SECONDS = 7 * 24 * 60 * 60;
@@ -28,6 +31,12 @@ const rateLimitDetailsSchema = z
   .object({
     primary_window: rateLimitWindowSchema.nullable().optional(),
     secondary_window: rateLimitWindowSchema.nullable().optional(),
+  })
+  .passthrough();
+
+const rateLimitResetCreditsSchema = z
+  .object({
+    available_count: z.number().int().nonnegative().nullable().optional(),
   })
   .passthrough();
 
@@ -53,8 +62,21 @@ const codexUsageResponseSchema = z
     organization: namedMetadataSchema.nullable().optional(),
     organization_name: z.string().nullable().optional(),
     rate_limit: rateLimitDetailsSchema.nullable().optional(),
+    rate_limit_reset_credits: rateLimitResetCreditsSchema.nullable().optional(),
     workspace: namedMetadataSchema.nullable().optional(),
     workspace_name: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+const codexRateLimitResetCreditConsumeResponseSchema = z
+  .object({
+    code: z.enum([
+      "reset",
+      "nothing_to_reset",
+      "no_credit",
+      "already_redeemed",
+    ]),
+    windows_reset: z.number().nullable().optional(),
   })
   .passthrough();
 
@@ -63,12 +85,20 @@ type CodexNamedMetadata = z.infer<typeof namedMetadataSchema>;
 type CodexUsageResponse = z.infer<typeof codexUsageResponseSchema>;
 
 interface CodexUsageMetadata {
+  readonly accountEmail: string | null;
   readonly planType: string | null;
   readonly workspaceName: string | null;
   readonly subscriptionResetPeriod: string | null;
   readonly subscriptionNextResetAt: Date | null;
   readonly subscriptionUsage: SubscriptionUsageMetadata | null;
+  readonly subscriptionResetCredits: number | null;
 }
+
+export type CodexRateLimitResetCreditOutcome =
+  | "reset"
+  | "nothingToReset"
+  | "noCredit"
+  | "alreadyRedeemed";
 
 interface UsageResetWindow {
   readonly period: string | null;
@@ -271,6 +301,7 @@ function subscriptionUsageFromRateLimit(
 export async function fetchCodexUsageMetadata(args: {
   readonly accessToken: string;
   readonly accountId: string;
+  readonly idToken?: string | null;
   readonly signal: AbortSignal;
 }): Promise<CodexUsageMetadata | null> {
   const response = await fetch(CHATGPT_USAGE_URL, {
@@ -297,10 +328,69 @@ export async function fetchCodexUsageMetadata(args: {
 
   const resetWindow = chooseSubscriptionResetWindow(parsed.data.rate_limit);
   return {
+    accountEmail: extractCodexAccountEmailFromIdToken(args.idToken),
     planType: nonEmptyString(parsed.data.plan_type),
     workspaceName: workspaceNameFromUsage(parsed.data),
     subscriptionResetPeriod: resetWindow?.period ?? null,
     subscriptionNextResetAt: resetWindow?.nextResetAt ?? null,
     subscriptionUsage: subscriptionUsageFromRateLimit(parsed.data.rate_limit),
+    subscriptionResetCredits:
+      parsed.data.rate_limit_reset_credits?.available_count ?? null,
+  };
+}
+
+function codexResetCreditOutcome(
+  code: z.infer<typeof codexRateLimitResetCreditConsumeResponseSchema>["code"],
+): CodexRateLimitResetCreditOutcome {
+  switch (code) {
+    case "reset":
+      return "reset";
+    case "nothing_to_reset":
+      return "nothingToReset";
+    case "no_credit":
+      return "noCredit";
+    case "already_redeemed":
+      return "alreadyRedeemed";
+  }
+}
+
+export async function consumeCodexRateLimitResetCredit(args: {
+  readonly accessToken: string;
+  readonly accountId: string;
+  readonly idempotencyKey: string;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly outcome: CodexRateLimitResetCreditOutcome;
+}> {
+  const response = await fetch(CHATGPT_RESET_CREDITS_CONSUME_URL, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${args.accessToken}`,
+      "chatgpt-account-id": args.accountId,
+      "content-type": "application/json",
+      originator: CODEX_ORIGINATOR,
+      "user-agent": CODEX_USER_AGENT,
+    },
+    body: JSON.stringify({
+      redeem_request_id: args.idempotencyKey,
+    }),
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Codex reset credit consume request failed with status ${response.status}`,
+    );
+  }
+
+  const parsed = codexRateLimitResetCreditConsumeResponseSchema.safeParse(
+    await response.json(),
+  );
+  if (!parsed.success) {
+    throw new Error("Codex reset credit consume response shape unrecognized");
+  }
+
+  return {
+    outcome: codexResetCreditOutcome(parsed.data.code),
   };
 }

--- a/turbo/apps/api/src/signals/services/codex-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/codex-usage.service.ts
@@ -343,14 +343,18 @@ function codexResetCreditOutcome(
   code: z.infer<typeof codexRateLimitResetCreditConsumeResponseSchema>["code"],
 ): CodexRateLimitResetCreditOutcome {
   switch (code) {
-    case "reset":
+    case "reset": {
       return "reset";
-    case "nothing_to_reset":
+    }
+    case "nothing_to_reset": {
       return "nothingToReset";
-    case "no_credit":
+    }
+    case "no_credit": {
       return "noCredit";
-    case "already_redeemed":
+    }
+    case "already_redeemed": {
       return "alreadyRedeemed";
+    }
   }
 }
 

--- a/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/model-provider-subscription-usage.service.ts
@@ -9,9 +9,14 @@ import { and, eq, inArray } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
 import { db$, type ReadonlyDb } from "../external/db";
+import { notFound } from "../../lib/error";
 import { settle } from "../utils";
 import { fetchClaudeCodeSubscriptionMetadata } from "./claude-code-usage.service";
-import { fetchCodexUsageMetadata } from "./codex-usage.service";
+import {
+  consumeCodexRateLimitResetCredit,
+  fetchCodexUsageMetadata,
+  type CodexRateLimitResetCreditOutcome,
+} from "./codex-usage.service";
 import { decryptStoredSecretValue } from "./crypto.utils";
 import { userFeatureSwitchContext } from "./feature-switches.service";
 import type {
@@ -24,15 +29,18 @@ const L = logger("model-provider-subscription-usage.service");
 const CODEX_USAGE_SECRET_NAMES = [
   "CHATGPT_ACCESS_TOKEN",
   "CHATGPT_ACCOUNT_ID",
+  "CHATGPT_ID_TOKEN",
 ] as const;
 const CLAUDE_CODE_OAUTH_TOKEN_SECRET_NAME = "CLAUDE_CODE_OAUTH_TOKEN";
 
 interface SubscriptionMetadata {
+  readonly accountEmail?: string | null;
   readonly workspaceName?: string | null;
   readonly planType?: string | null;
   readonly subscriptionResetPeriod?: string | null;
   readonly subscriptionNextResetAt?: Date | null;
   readonly subscriptionUsage?: SubscriptionUsageMetadata | null;
+  readonly subscriptionResetCredits?: number | null;
 }
 
 type SerializedSubscriptionUsage = NonNullable<
@@ -120,6 +128,7 @@ function withSubscriptionMetadata(
 
   return {
     ...provider,
+    accountEmail: metadata.accountEmail ?? provider.accountEmail,
     workspaceName: metadata.workspaceName ?? provider.workspaceName,
     planType: metadata.planType ?? provider.planType,
     subscriptionResetPeriod:
@@ -128,6 +137,8 @@ function withSubscriptionMetadata(
       metadata.subscriptionNextResetAt?.toISOString() ??
       provider.subscriptionNextResetAt,
     subscriptionUsage: serializeSubscriptionUsage(metadata.subscriptionUsage),
+    subscriptionResetCredits:
+      metadata.subscriptionResetCredits ?? provider.subscriptionResetCredits,
   };
 }
 
@@ -149,6 +160,7 @@ async function refreshCodexProvider(args: {
   });
   const accessToken = secretValues.get("CHATGPT_ACCESS_TOKEN");
   const accountId = secretValues.get("CHATGPT_ACCOUNT_ID");
+  const idToken = secretValues.get("CHATGPT_ID_TOKEN");
   if (!accessToken || !accountId) {
     return args.provider;
   }
@@ -156,6 +168,7 @@ async function refreshCodexProvider(args: {
   const metadata = await fetchCodexUsageMetadata({
     accessToken,
     accountId,
+    idToken,
     signal: args.signal,
   });
 
@@ -262,5 +275,51 @@ export const refreshPersonalModelProviderSubscriptionUsage$ = command(
     return {
       modelProviders: refreshed,
     };
+  },
+);
+
+type NotFoundResponse = ReturnType<typeof notFound>;
+
+export const consumePersonalCodexRateLimitResetCredit$ = command(
+  async (
+    { get },
+    args: {
+      readonly orgId: string;
+      readonly userId: string;
+      readonly idempotencyKey: string;
+    },
+    signal: AbortSignal,
+  ): Promise<
+    | {
+        readonly outcome: CodexRateLimitResetCreditOutcome;
+      }
+    | NotFoundResponse
+  > => {
+    const database = get(db$);
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+
+    const secretValues = await modelProviderSecretValues({
+      db: database,
+      orgId: args.orgId,
+      userId: args.userId,
+      names: CODEX_USAGE_SECRET_NAMES,
+      featureSwitchContext,
+      signal,
+    });
+    const accessToken = secretValues.get("CHATGPT_ACCESS_TOKEN");
+    const accountId = secretValues.get("CHATGPT_ACCOUNT_ID");
+    if (!accessToken || !accountId) {
+      return notFound("Resource not found");
+    }
+
+    return await consumeCodexRateLimitResetCredit({
+      accessToken,
+      accountId,
+      idempotencyKey: args.idempotencyKey,
+      signal,
+    });
   },
 );

--- a/turbo/apps/platform/src/mocks/handlers/api-personal-model-providers.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-personal-model-providers.ts
@@ -88,4 +88,36 @@ export const apiPersonalModelProvidersHandlers = [
       return respond(204);
     },
   ),
+
+  // POST /api/zero/me/model-providers/:type/subscription-reset - Reset Codex usage
+  mockApi(
+    zeroPersonalModelProvidersByTypeContract.resetSubscriptionUsage,
+    ({ params, respond }) => {
+      const existing = mockPersonalModelProviders.find((p) => {
+        return p.type === params.type;
+      });
+
+      if (!existing || params.type !== "codex-oauth-token") {
+        return respond(404, {
+          error: { message: "Model provider not found", code: "NOT_FOUND" },
+        });
+      }
+
+      const resetCredits = existing.subscriptionResetCredits ?? 0;
+      if (resetCredits <= 0) {
+        return respond(200, { outcome: "noCredit" });
+      }
+
+      mockPersonalModelProviders = mockPersonalModelProviders.map((p) => {
+        return p.type === params.type
+          ? {
+              ...p,
+              subscriptionResetCredits: resetCredits - 1,
+            }
+          : p;
+      });
+
+      return respond(200, { outcome: "reset" });
+    },
+  ),
 ];

--- a/turbo/apps/platform/src/signals/external/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/personal-model-providers.ts
@@ -51,8 +51,8 @@ export const resetPersonalCodexSubscriptionUsage$ = command(
     { get, set },
     args: {
       readonly idempotencyKey: string;
-      readonly signal: AbortSignal;
     },
+    signal: AbortSignal,
   ): Promise<ResetPersonalModelProviderSubscriptionUsageResponse> => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroPersonalModelProvidersByTypeContract);
@@ -60,10 +60,11 @@ export const resetPersonalCodexSubscriptionUsage$ = command(
       client.resetSubscriptionUsage({
         params: { type: "codex-oauth-token" },
         body: { idempotencyKey: args.idempotencyKey },
-        fetchOptions: { signal: args.signal },
+        fetchOptions: { signal },
       }),
       [200],
     );
+    signal.throwIfAborted();
 
     set(internalReloadPersonalModelProviders$, (x) => {
       return x + 1;

--- a/turbo/apps/platform/src/signals/external/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/external/personal-model-providers.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import {
   zeroPersonalModelProvidersMainContract,
   zeroPersonalModelProvidersByTypeContract,
+  type ResetPersonalModelProviderSubscriptionUsageResponse,
 } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import type { ModelProviderType } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroClient$ } from "../api-client.ts";
@@ -42,6 +43,33 @@ export const deletePersonalModelProvider$ = command(
     set(internalReloadPersonalModelProviders$, (x) => {
       return x + 1;
     });
+  },
+);
+
+export const resetPersonalCodexSubscriptionUsage$ = command(
+  async (
+    { get, set },
+    args: {
+      readonly idempotencyKey: string;
+      readonly signal: AbortSignal;
+    },
+  ): Promise<ResetPersonalModelProviderSubscriptionUsageResponse> => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroPersonalModelProvidersByTypeContract);
+    const result = await accept(
+      client.resetSubscriptionUsage({
+        params: { type: "codex-oauth-token" },
+        body: { idempotencyKey: args.idempotencyKey },
+        fetchOptions: { signal: args.signal },
+      }),
+      [200],
+    );
+
+    set(internalReloadPersonalModelProviders$, (x) => {
+      return x + 1;
+    });
+
+    return result.body;
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/account-menu-subscriptions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/account-menu-subscriptions.ts
@@ -17,6 +17,7 @@ export interface AccountMenuSubscriptionUsageRow {
   readonly type: ModelProviderType;
   readonly label: string;
   readonly usage: AccountMenuSubscriptionUsage;
+  readonly resetCredits?: number | null;
 }
 
 export type AccountMenuSubscriptionUsageRowsCacheKey = string | null;
@@ -97,7 +98,16 @@ function accountMenuSubscriptionUsageRows(
     if (!usage || accountMenuSubscriptionUsageWindows(usage).length === 0) {
       return [];
     }
-    return [{ ...definition, usage }];
+    return [
+      {
+        ...definition,
+        usage,
+        resetCredits:
+          provider.type === "codex-oauth-token"
+            ? (provider.subscriptionResetCredits ?? null)
+            : undefined,
+      },
+    ];
   });
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -7,6 +7,7 @@ import {
 import {
   deletePersonalModelProvider$,
   personalModelProviders$,
+  resetPersonalCodexSubscriptionUsage$ as resetPersonalCodexSubscriptionUsageRequest$,
 } from "../../external/personal-model-providers.ts";
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,41 @@ export const disconnectPersonalOAuthCredential$ = command(
       await set(deletePersonalModelProvider$, providerType, signal);
       signal.throwIfAborted();
       toast.success(`${providerLabel} disconnected`);
+    })();
+
+    set(internalPersonalActionPromise$, promise);
+    signal.addEventListener("abort", () => {
+      set(internalPersonalActionPromise$, null);
+    });
+
+    await promise;
+    signal.throwIfAborted();
+  },
+);
+
+export const resetPersonalCodexSubscriptionUsage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    const promise = (async () => {
+      const result = await set(resetPersonalCodexSubscriptionUsageRequest$, {
+        idempotencyKey: crypto.randomUUID(),
+        signal,
+      });
+      signal.throwIfAborted();
+
+      switch (result.outcome) {
+        case "reset":
+          toast.success("Codex usage reset");
+          break;
+        case "nothingToReset":
+          toast.info("Codex usage does not need a reset right now");
+          break;
+        case "noCredit":
+          toast.error("No Codex usage resets available");
+          break;
+        case "alreadyRedeemed":
+          toast.success("Codex usage reset");
+          break;
+      }
     })();
 
     set(internalPersonalActionPromise$, promise);

--- a/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/personal-model-providers.ts
@@ -15,10 +15,38 @@ import {
 // ---------------------------------------------------------------------------
 
 const internalPersonalActionPromise$ = state<Promise<unknown> | null>(null);
+const internalSettingsCodexResetDialog$ = state({
+  open: false,
+  resetCredits: null as number | null,
+});
+const internalAccountMenuCodexResetDialog$ = state({
+  open: false,
+  resetCredits: null as number | null,
+});
 
 export const personalActionPromise$ = computed((get) => {
   return get(internalPersonalActionPromise$);
 });
+
+export const settingsCodexResetDialog$ = computed((get) => {
+  return get(internalSettingsCodexResetDialog$);
+});
+
+export const accountMenuCodexResetDialog$ = computed((get) => {
+  return get(internalAccountMenuCodexResetDialog$);
+});
+
+export const setSettingsCodexResetDialog$ = command(
+  ({ set }, dialog: { open: boolean; resetCredits: number | null }) => {
+    set(internalSettingsCodexResetDialog$, dialog);
+  },
+);
+
+export const setAccountMenuCodexResetDialog$ = command(
+  ({ set }, dialog: { open: boolean; resetCredits: number | null }) => {
+    set(internalAccountMenuCodexResetDialog$, dialog);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Derived state
@@ -55,25 +83,32 @@ export const disconnectPersonalOAuthCredential$ = command(
 export const resetPersonalCodexSubscriptionUsage$ = command(
   async ({ set }, signal: AbortSignal) => {
     const promise = (async () => {
-      const result = await set(resetPersonalCodexSubscriptionUsageRequest$, {
-        idempotencyKey: crypto.randomUUID(),
+      const result = await set(
+        resetPersonalCodexSubscriptionUsageRequest$,
+        {
+          idempotencyKey: crypto.randomUUID(),
+        },
         signal,
-      });
+      );
       signal.throwIfAborted();
 
       switch (result.outcome) {
-        case "reset":
+        case "reset": {
           toast.success("Codex usage reset");
           break;
-        case "nothingToReset":
+        }
+        case "nothingToReset": {
           toast.info("Codex usage does not need a reset right now");
           break;
-        case "noCredit":
+        }
+        case "noCredit": {
           toast.error("No Codex usage resets available");
           break;
-        case "alreadyRedeemed":
+        }
+        case "alreadyRedeemed": {
           toast.success("Codex usage reset");
           break;
+        }
       }
     })();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -28,6 +28,7 @@ function stalePersonalCodexProvider(): ModelProviderResponse {
     planType: "pro",
     subscriptionResetPeriod: "Weekly",
     subscriptionNextResetAt: "2030-01-01T00:00:00.000Z",
+    accountEmail: "codex.user@example.com",
     needsReconnect: true,
     lastRefreshErrorCode: "refresh_token_expired",
     createdAt: "2026-03-01T00:00:00Z",
@@ -52,6 +53,7 @@ function connectedPersonalCodexProvider(): ModelProviderResponse {
         windowSeconds: 604_800,
       },
     },
+    subscriptionResetCredits: 2,
     needsReconnect: false,
     lastRefreshErrorCode: null,
   };
@@ -343,11 +345,54 @@ describe("personal model providers settings", () => {
     expect(
       within(codexRow).queryByText(/Personal ChatGPT/),
     ).not.toBeInTheDocument();
+    expect(
+      within(codexRow).queryByText(/codex\.user@example\.com/),
+    ).not.toBeInTheDocument();
     expect(within(codexRow).getByText("82% left")).toBeInTheDocument();
     expect(within(codexRow).getByText("55% left")).toBeInTheDocument();
     expect(
       within(codexRow).queryByText(/Account:|Plan:|Reset:|Connected .*resets/),
     ).not.toBeInTheDocument();
+  });
+
+  it("resets connected personal Codex usage from the row menu", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "test-org",
+      name: "Test Org",
+      role: "member",
+    });
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+    ]);
+
+    await openModelSettings();
+
+    const codexRow = await screen.findByTestId("oauth-card-codex-oauth-token");
+    expect(
+      within(codexRow).queryByText(/codex\.user@example\.com/),
+    ).not.toBeInTheDocument();
+
+    click(within(codexRow).getByLabelText("More options"));
+    expect(await screen.findByText("2 resets left")).toBeInTheDocument();
+    click(screen.getByText("Reset usage"));
+
+    const confirmDialog = await screen.findByRole("dialog", {
+      name: "Reset Codex usage?",
+    });
+    expect(
+      within(confirmDialog).getByText(/2 resets left/),
+    ).toBeInTheDocument();
+    click(within(confirmDialog).getByRole("button", { name: "Reset usage" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Reset Codex usage?" }),
+      ).not.toBeInTheDocument();
+    });
+
+    click(within(codexRow).getByLabelText("More options"));
+    expect(await screen.findByText("1 reset left")).toBeInTheDocument();
   });
 
   it("falls back to stored Claude Code reset metadata when usage is unavailable", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -374,7 +374,9 @@ describe("personal model providers settings", () => {
     ).not.toBeInTheDocument();
 
     click(within(codexRow).getByLabelText("More options"));
-    expect(await screen.findByText("2 resets left")).toBeInTheDocument();
+    await expect(
+      screen.findByText("2 resets left"),
+    ).resolves.toBeInTheDocument();
     click(screen.getByText("Reset usage"));
 
     const confirmDialog = await screen.findByRole("dialog", {
@@ -383,7 +385,15 @@ describe("personal model providers settings", () => {
     expect(
       within(confirmDialog).getByText(/2 resets left/),
     ).toBeInTheDocument();
-    click(within(confirmDialog).getByRole("button", { name: "Reset usage" }));
+    const resetButton = queryAllByRoleFast("button", confirmDialog).find(
+      (button) => {
+        return button.textContent === "Reset usage";
+      },
+    );
+    if (!resetButton) {
+      throw new Error("Reset usage button not found");
+    }
+    click(resetButton);
 
     await waitFor(() => {
       expect(
@@ -392,7 +402,9 @@ describe("personal model providers settings", () => {
     });
 
     click(within(codexRow).getByLabelText("More options"));
-    expect(await screen.findByText("1 reset left")).toBeInTheDocument();
+    await expect(
+      screen.findByText("1 reset left"),
+    ).resolves.toBeInTheDocument();
   });
 
   it("falls back to stored Claude Code reset metadata when usage is unavailable", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -354,7 +354,15 @@ describe("zero sidebar account menu", () => {
     expect(
       within(confirmDialog).getByText(/2 resets left/),
     ).toBeInTheDocument();
-    click(within(confirmDialog).getByRole("button", { name: "Reset usage" }));
+    const resetButton = queryAllByRoleFast("button", confirmDialog).find(
+      (button) => {
+        return button.textContent === "Reset usage";
+      },
+    );
+    if (!resetButton) {
+      throw new Error("Reset usage button not found");
+    }
+    click(resetButton);
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -4,7 +4,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
-import { zeroPersonalModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import {
+  zeroPersonalModelProvidersByTypeContract,
+  zeroPersonalModelProvidersMainContract,
+} from "@vm0/api-contracts/contracts/zero-personal-model-providers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import {
@@ -39,6 +42,7 @@ function connectedPersonalCodexProvider(
     selectedModel: null,
     workspaceName: "Personal ChatGPT",
     planType: "pro",
+    accountEmail: "codex.user@example.com",
     subscriptionResetPeriod: "Weekly",
     subscriptionNextResetAt: "2030-01-07T00:00:00.000Z",
     subscriptionUsage: {
@@ -55,6 +59,7 @@ function connectedPersonalCodexProvider(
         windowSeconds: 604_800,
       },
     },
+    subscriptionResetCredits: 2,
     needsReconnect: false,
     lastRefreshErrorCode: null,
     createdAt: "2026-03-01T00:00:00Z",
@@ -294,6 +299,10 @@ describe("zero sidebar account menu", () => {
     expect(within(panel).getByText("55%")).toBeInTheDocument();
     expect(within(panel).getByText("88%")).toBeInTheDocument();
     expect(within(panel).getByText("76%")).toBeInTheDocument();
+    expect(within(panel).getByText("2 resets left")).toBeInTheDocument();
+    expect(
+      within(panel).queryByText(/codex\.user@example\.com/),
+    ).not.toBeInTheDocument();
 
     const codexFiveHour = within(panel).getByRole("progressbar", {
       name: "Codex 5h remaining",
@@ -305,6 +314,57 @@ describe("zero sidebar account menu", () => {
     expect(
       credits.compareDocumentPosition(codex) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("resets Codex usage from the account menu", async () => {
+    mockAdminAccountSidebar();
+    context.mocks.data.personalModelProviders([
+      connectedPersonalCodexProvider(),
+    ]);
+    context.mocks.api(
+      zeroPersonalModelProvidersByTypeContract.resetSubscriptionUsage,
+      ({ respond }) => {
+        const provider = connectedPersonalCodexProvider({
+          subscriptionResetCredits: 1,
+        });
+        context.mocks.data.personalModelProviders([provider]);
+        return respond(200, { outcome: "reset" });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+      featureSwitches: { [FeatureSwitchKey.SidebarSubscriptionUsage]: true },
+    });
+
+    let menu = await openAccountMenu();
+    let panel = await within(menu).findByTestId("account-menu-subscriptions");
+    expect(within(panel).getByText("2 resets left")).toBeInTheDocument();
+    click(within(panel).getByText("Reset"));
+
+    const confirmDialog = await screen.findByRole("dialog", {
+      name: "Reset Codex usage?",
+    });
+    expect(
+      within(confirmDialog).getByText(/2 resets left/),
+    ).toBeInTheDocument();
+    click(within(confirmDialog).getByRole("button", { name: "Reset usage" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Reset Codex usage?" }),
+      ).not.toBeInTheDocument();
+    });
+
+    menu = await openAccountMenu();
+    panel = await within(menu).findByTestId("account-menu-subscriptions");
+    expect(within(panel).getByText("1 reset left")).toBeInTheDocument();
   });
 
   it("refreshes account menu subscriptions when the menu opens", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/codex-reset-usage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/codex-reset-usage-dialog.tsx
@@ -1,0 +1,72 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui";
+
+export function formatCodexResetCredits(
+  value: number | null | undefined,
+): string {
+  if (value === null || value === undefined) {
+    return "Resets left unavailable";
+  }
+  return `${value} ${value === 1 ? "reset" : "resets"} left`;
+}
+
+export function CodexResetUsageDialog({
+  open,
+  resetCredits,
+  resetting,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  resetCredits: number | null;
+  resetting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!resetting) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reset Codex usage?</DialogTitle>
+          <DialogDescription>
+            Use one Codex reset to reset your current usage windows. You have{" "}
+            {formatCodexResetCredits(resetCredits)}.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={resetting}
+            onClick={() => {
+              onOpenChange(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={resetting || resetCredits === 0}
+            onClick={onConfirm}
+          >
+            {resetting ? "Resetting..." : "Reset usage"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { IconDotsVertical } from "@tabler/icons-react";
 import {
@@ -18,6 +17,8 @@ import {
   personalActionPromise$,
   personalConfiguredProviders$,
   resetPersonalCodexSubscriptionUsage$,
+  setSettingsCodexResetDialog$,
+  settingsCodexResetDialog$,
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
 import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
@@ -60,9 +61,10 @@ function OAuthCredentialsSection() {
   const resetCodexSubscriptionUsage = useSet(
     resetPersonalCodexSubscriptionUsage$,
   );
+  const resetDialog = useGet(settingsCodexResetDialog$);
+  const setResetDialog = useSet(setSettingsCodexResetDialog$);
   const actionLoadable = useLoadable(personalActionPromise$);
   const pageSignal = useGet(pageSignal$);
-  const [resetCodexConfirmOpen, setResetCodexConfirmOpen] = useState(false);
 
   const isLoading = providersLoadable.state === "loading";
   const providers =
@@ -92,10 +94,17 @@ function OAuthCredentialsSection() {
     detach(
       (async () => {
         await resetCodexSubscriptionUsage(pageSignal);
-        setResetCodexConfirmOpen(false);
+        setResetDialog({ open: false, resetCredits: null });
       })(),
       Reason.DomCallback,
     );
+  };
+
+  const setCodexResetOpen = (open: boolean) => {
+    setResetDialog({
+      open,
+      resetCredits: open ? resetDialog.resetCredits : null,
+    });
   };
 
   return (
@@ -115,96 +124,144 @@ function OAuthCredentialsSection() {
           </>
         ) : (
           <>
-            <OAuthCredentialRow
-              type="claude-code-oauth-token"
-              title="Claude Code OAuth"
-              description="Connect with Claude Code login for Claude-backed model routes."
+            <ClaudeOAuthCredentialRow
+              actionPending={actionPending}
               provider={claudeCode}
               status={getOpenAIStatus(claudeCode)}
-              menuItems={
-                claudeCode
-                  ? [
-                      {
-                        label: "Replace",
-                        onSelect: connectClaudeCode,
-                      },
-                      {
-                        label: "Disconnect",
-                        disabled: actionPending,
-                        onSelect: () => {
-                          detach(
-                            disconnectCredential(
-                              "claude-code-oauth-token",
-                              pageSignal,
-                            ),
-                            Reason.DomCallback,
-                          );
-                        },
-                      },
-                    ]
-                  : []
-              }
               onAction={connectClaudeCode}
-              testId="oauth-card-claude-code-oauth-token"
+              onDisconnect={() => {
+                detach(
+                  disconnectCredential("claude-code-oauth-token", pageSignal),
+                  Reason.DomCallback,
+                );
+              }}
             />
-            <OAuthCredentialRow
-              type="codex-oauth-token"
-              title="ChatGPT (Codex)"
-              description="Connect with Codex device login for Codex-backed model routes."
+            <CodexOAuthCredentialRow
+              actionPending={actionPending}
               provider={openAI}
+              resetCredits={codexResetCredits}
               status={openAIStatus}
-              menuItems={
-                openAI
-                  ? [
-                      {
-                        kind: "status",
-                        label: formatCodexResetCredits(codexResetCredits),
-                      },
-                      {
-                        kind: "separator",
-                        label: "codex-reset-separator",
-                      },
-                      {
-                        label: "Reset usage",
-                        disabled: actionPending || codexResetCredits === 0,
-                        onSelect: () => {
-                          setResetCodexConfirmOpen(true);
-                        },
-                      },
-                      {
-                        label: "Replace",
-                        onSelect: connectOpenAI,
-                      },
-                      {
-                        label: "Disconnect",
-                        disabled: actionPending,
-                        onSelect: () => {
-                          detach(
-                            disconnectCredential(
-                              "codex-oauth-token",
-                              pageSignal,
-                            ),
-                            Reason.DomCallback,
-                          );
-                        },
-                      },
-                    ]
-                  : []
-              }
               onAction={connectOpenAI}
-              testId="oauth-card-codex-oauth-token"
+              onDisconnect={() => {
+                detach(
+                  disconnectCredential("codex-oauth-token", pageSignal),
+                  Reason.DomCallback,
+                );
+              }}
+              onOpenReset={() => {
+                setResetDialog({ open: true, resetCredits: codexResetCredits });
+              }}
             />
             <CodexResetUsageDialog
-              open={resetCodexConfirmOpen}
-              resetCredits={codexResetCredits}
+              open={resetDialog.open}
+              resetCredits={resetDialog.resetCredits}
               resetting={actionPending}
-              onOpenChange={setResetCodexConfirmOpen}
+              onOpenChange={setCodexResetOpen}
               onConfirm={confirmCodexReset}
             />
           </>
         )}
       </div>
     </section>
+  );
+}
+
+function ClaudeOAuthCredentialRow({
+  actionPending,
+  provider,
+  status,
+  onAction,
+  onDisconnect,
+}: {
+  actionPending: boolean;
+  provider: ModelProviderResponse | undefined;
+  status: OAuthStatus;
+  onAction: () => void;
+  onDisconnect: () => void;
+}) {
+  return (
+    <OAuthCredentialRow
+      type="claude-code-oauth-token"
+      title="Claude Code OAuth"
+      description="Connect with Claude Code login for Claude-backed model routes."
+      provider={provider}
+      status={status}
+      menuItems={
+        provider
+          ? [
+              {
+                label: "Replace",
+                onSelect: onAction,
+              },
+              {
+                label: "Disconnect",
+                disabled: actionPending,
+                onSelect: onDisconnect,
+              },
+            ]
+          : []
+      }
+      onAction={onAction}
+      testId="oauth-card-claude-code-oauth-token"
+    />
+  );
+}
+
+function CodexOAuthCredentialRow({
+  actionPending,
+  provider,
+  resetCredits,
+  status,
+  onAction,
+  onDisconnect,
+  onOpenReset,
+}: {
+  actionPending: boolean;
+  provider: ModelProviderResponse | undefined;
+  resetCredits: number | null;
+  status: OAuthStatus;
+  onAction: () => void;
+  onDisconnect: () => void;
+  onOpenReset: () => void;
+}) {
+  return (
+    <OAuthCredentialRow
+      type="codex-oauth-token"
+      title="ChatGPT (Codex)"
+      description="Connect with Codex device login for Codex-backed model routes."
+      provider={provider}
+      status={status}
+      menuItems={
+        provider
+          ? [
+              {
+                kind: "status",
+                label: formatCodexResetCredits(resetCredits),
+              },
+              {
+                kind: "separator",
+                label: "codex-reset-separator",
+              },
+              {
+                label: "Reset usage",
+                disabled: actionPending || resetCredits === 0,
+                onSelect: onOpenReset,
+              },
+              {
+                label: "Replace",
+                onSelect: onAction,
+              },
+              {
+                label: "Disconnect",
+                disabled: actionPending,
+                onSelect: onDisconnect,
+              },
+            ]
+          : []
+      }
+      onAction={onAction}
+      testId="oauth-card-codex-oauth-token"
+    />
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
 import { IconDotsVertical } from "@tabler/icons-react";
 import {
@@ -5,6 +6,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@vm0/ui";
 import type {
@@ -15,6 +17,7 @@ import {
   disconnectPersonalOAuthCredential$,
   personalActionPromise$,
   personalConfiguredProviders$,
+  resetPersonalCodexSubscriptionUsage$,
 } from "../../../../signals/zero-page/settings/personal-model-providers.ts";
 import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogStatePersonal$ } from "../../../../signals/zero-page/settings/codex-device-auth.ts";
@@ -24,6 +27,10 @@ import { ProviderIcon } from "../settings/provider-icons.tsx";
 import { PersonalClaudeCodeDeviceAuthDialog } from "../settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "../settings/codex-device-auth-dialog.tsx";
 import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
+import {
+  CodexResetUsageDialog,
+  formatCodexResetCredits,
+} from "./codex-reset-usage-dialog.tsx";
 
 type OAuthStatus = "connected" | "stale" | "missing";
 type SubscriptionUsage = NonNullable<
@@ -50,8 +57,12 @@ function OAuthCredentialsSection() {
     setCodexDeviceAuthDialogStatePersonal$,
   );
   const disconnectCredential = useSet(disconnectPersonalOAuthCredential$);
+  const resetCodexSubscriptionUsage = useSet(
+    resetPersonalCodexSubscriptionUsage$,
+  );
   const actionLoadable = useLoadable(personalActionPromise$);
   const pageSignal = useGet(pageSignal$);
+  const [resetCodexConfirmOpen, setResetCodexConfirmOpen] = useState(false);
 
   const isLoading = providersLoadable.state === "loading";
   const providers =
@@ -59,7 +70,8 @@ function OAuthCredentialsSection() {
   const claudeCode = findProvider(providers, "claude-code-oauth-token");
   const openAI = findProvider(providers, "codex-oauth-token");
   const openAIStatus = getOpenAIStatus(openAI);
-  const disconnecting = actionLoadable.state === "loading";
+  const actionPending = actionLoadable.state === "loading";
+  const codexResetCredits = openAI?.subscriptionResetCredits ?? null;
 
   const connectClaudeCode = () => {
     const next = {
@@ -74,6 +86,16 @@ function OAuthCredentialsSection() {
       mode: openAI?.needsReconnect ? "reconnect" : "connect",
     } as const;
     openCodexDeviceAuthDialog(next);
+  };
+
+  const confirmCodexReset = () => {
+    detach(
+      (async () => {
+        await resetCodexSubscriptionUsage(pageSignal);
+        setResetCodexConfirmOpen(false);
+      })(),
+      Reason.DomCallback,
+    );
   };
 
   return (
@@ -108,7 +130,7 @@ function OAuthCredentialsSection() {
                       },
                       {
                         label: "Disconnect",
-                        disabled: disconnecting,
+                        disabled: actionPending,
                         onSelect: () => {
                           detach(
                             disconnectCredential(
@@ -135,12 +157,27 @@ function OAuthCredentialsSection() {
                 openAI
                   ? [
                       {
+                        kind: "status",
+                        label: formatCodexResetCredits(codexResetCredits),
+                      },
+                      {
+                        kind: "separator",
+                        label: "codex-reset-separator",
+                      },
+                      {
+                        label: "Reset usage",
+                        disabled: actionPending || codexResetCredits === 0,
+                        onSelect: () => {
+                          setResetCodexConfirmOpen(true);
+                        },
+                      },
+                      {
                         label: "Replace",
                         onSelect: connectOpenAI,
                       },
                       {
                         label: "Disconnect",
-                        disabled: disconnecting,
+                        disabled: actionPending,
                         onSelect: () => {
                           detach(
                             disconnectCredential(
@@ -156,6 +193,13 @@ function OAuthCredentialsSection() {
               }
               onAction={connectOpenAI}
               testId="oauth-card-codex-oauth-token"
+            />
+            <CodexResetUsageDialog
+              open={resetCodexConfirmOpen}
+              resetCredits={codexResetCredits}
+              resetting={actionPending}
+              onOpenChange={setResetCodexConfirmOpen}
+              onConfirm={confirmCodexReset}
             />
           </>
         )}
@@ -374,8 +418,9 @@ function SubscriptionUsageMeter({
 
 interface OAuthMenuItem {
   label: string;
+  kind?: "item" | "status" | "separator";
   disabled?: boolean;
-  onSelect: () => void;
+  onSelect?: () => void;
 }
 
 function OAuthCredentialRow({
@@ -458,6 +503,20 @@ function OAuthCredentialRow({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-44">
                   {menuItems.map((item) => {
+                    if (item.kind === "separator") {
+                      return <DropdownMenuSeparator key={item.label} />;
+                    }
+                    if (item.kind === "status") {
+                      return (
+                        <DropdownMenuItem
+                          key={item.label}
+                          disabled
+                          className="text-xs text-muted-foreground data-[disabled]:opacity-100"
+                        >
+                          {item.label}
+                        </DropdownMenuItem>
+                      );
+                    }
                     return (
                       <DropdownMenuItem
                         key={item.label}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -1,5 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
+import { useState } from "react";
 import {
   useGet,
   useLoadable,
@@ -50,6 +51,11 @@ import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
+import {
+  personalActionPromise$,
+  resetPersonalCodexSubscriptionUsage$,
+} from "../../signals/zero-page/settings/personal-model-providers.ts";
+import { CodexResetUsageDialog } from "./components/preferences/codex-reset-usage-dialog.tsx";
 import {
   AccountMenuSubscriptionsPanel,
   useSubscriptionUsageRows,
@@ -222,10 +228,14 @@ function CurrentAccountHeader({
 
 function AccountUsageGroup({
   onOpenCreditBalance,
+  onResetCodexUsage,
+  resetPending,
   subscriptionRowsCacheKey,
   subscriptionsEnabled,
 }: {
   onOpenCreditBalance: () => void;
+  onResetCodexUsage: (resetCredits: number | null) => void;
+  resetPending: boolean;
   subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
   subscriptionsEnabled: boolean;
 }) {
@@ -237,10 +247,14 @@ function AccountUsageGroup({
     return isAdmin ? (
       <AccountUsageGroupWithCredit
         onOpenCreditBalance={onOpenCreditBalance}
+        onResetCodexUsage={onResetCodexUsage}
+        resetPending={resetPending}
         subscriptionRowsCacheKey={subscriptionRowsCacheKey}
       />
     ) : (
       <AccountSubscriptionsGroup
+        onResetCodexUsage={onResetCodexUsage}
+        resetPending={resetPending}
         subscriptionRowsCacheKey={subscriptionRowsCacheKey}
       />
     );
@@ -284,9 +298,13 @@ function AccountCreditBalanceGroup({
 
 function AccountUsageGroupWithCredit({
   onOpenCreditBalance,
+  onResetCodexUsage,
+  resetPending,
   subscriptionRowsCacheKey,
 }: {
   onOpenCreditBalance: () => void;
+  onResetCodexUsage: (resetCredits: number | null) => void;
+  resetPending: boolean;
   subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
 }) {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
@@ -320,6 +338,8 @@ function AccountUsageGroupWithCredit({
       {showSubscriptions && (
         <AccountMenuSubscriptionsPanel
           loading={subscriptionsLoading}
+          onResetCodexUsage={onResetCodexUsage}
+          resetPending={resetPending}
           rows={rows}
         />
       )}
@@ -329,8 +349,12 @@ function AccountUsageGroupWithCredit({
 }
 
 function AccountSubscriptionsGroup({
+  onResetCodexUsage,
+  resetPending,
   subscriptionRowsCacheKey,
 }: {
+  onResetCodexUsage: (resetCredits: number | null) => void;
+  resetPending: boolean;
   subscriptionRowsCacheKey: AccountMenuSubscriptionUsageRowsCacheKey;
 }) {
   const { loading, rows } = useSubscriptionUsageRows({
@@ -344,7 +368,12 @@ function AccountSubscriptionsGroup({
 
   return (
     <>
-      <AccountMenuSubscriptionsPanel loading={loading} rows={rows} />
+      <AccountMenuSubscriptionsPanel
+        loading={loading}
+        onResetCodexUsage={onResetCodexUsage}
+        resetPending={resetPending}
+        rows={rows}
+      />
       <DropdownMenuSeparator />
     </>
   );
@@ -558,11 +587,19 @@ export function AccountDropdown({
   const selectNav = useSet(handleZeroNavSelect$);
   const openSettings = useSet(openSettingsDialogAt$);
   const reloadSubscriptions = useSet(reloadAccountMenuSubscriptionUsageRows$);
+  const resetCodexSubscriptionUsage = useSet(
+    resetPersonalCodexSubscriptionUsage$,
+  );
+  const actionLoadable = useLoadable(personalActionPromise$);
   const setSidebarExpanded = useSet(setSidebarExpanded$);
   const suppressUnauthorizedRedirectForAuthTransition = useSet(
     suppressUnauthorizedRedirectForAuthTransition$,
   );
   const pageSignal = useGet(pageSignal$);
+  const [resetCodexConfirmOpen, setResetCodexConfirmOpen] = useState(false);
+  const [resetCodexCredits, setResetCodexCredits] = useState<number | null>(
+    null,
+  );
 
   const current = accounts.find((a) => {
     return a.isActive;
@@ -576,6 +613,7 @@ export function AccountDropdown({
   const others = accounts.filter((a) => {
     return !a.isActive;
   });
+  const actionPending = actionLoadable.state === "loading";
 
   const handleAccountAction = (action: ZeroAccountAction) => {
     if (action === "signout") {
@@ -633,6 +671,22 @@ export function AccountDropdown({
     detach(openSettings("usage", pageSignal), Reason.DomCallback);
   };
 
+  const handleOpenCodexReset = (resetCredits: number | null) => {
+    setResetCodexCredits(resetCredits);
+    setResetCodexConfirmOpen(true);
+  };
+
+  const handleConfirmCodexReset = () => {
+    detach(
+      (async () => {
+        await resetCodexSubscriptionUsage(pageSignal);
+        await reloadSubscriptions(subscriptionRowsCacheKey, pageSignal);
+        setResetCodexConfirmOpen(false);
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
   const handleMenuOpenChange = (open: boolean) => {
     if (!open || hidePreferences || !subscriptionsEnabled) {
       return;
@@ -646,46 +700,57 @@ export function AccountDropdown({
   };
 
   return (
-    <DropdownMenu onOpenChange={handleMenuOpenChange}>
-      <DropdownMenuTrigger asChild>
-        {renderAccountTrigger(accountDisplay, collapsed)}
-      </DropdownMenuTrigger>
+    <>
+      <DropdownMenu onOpenChange={handleMenuOpenChange}>
+        <DropdownMenuTrigger asChild>
+          {renderAccountTrigger(accountDisplay, collapsed)}
+        </DropdownMenuTrigger>
 
-      <DropdownMenuContent
-        side="top"
-        align="start"
-        sideOffset={8}
-        className="w-[240px]"
-      >
-        <CurrentAccountHeader
-          display={accountDisplay}
-          visible={current !== undefined || user !== undefined}
-        />
-        {!hidePreferences && (
-          <AccountUsageGroup
-            onOpenCreditBalance={handleOpenCreditBalance}
-            subscriptionRowsCacheKey={subscriptionRowsCacheKey}
-            subscriptionsEnabled={subscriptionsEnabled}
+        <DropdownMenuContent
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-[240px]"
+        >
+          <CurrentAccountHeader
+            display={accountDisplay}
+            visible={current !== undefined || user !== undefined}
           />
-        )}
-        {!hidePreferences && (
-          <UnifiedSettingsGroup
-            memoryEnabled={memoryEnabled}
-            labEnabled={labEnabled}
-            onOpenMemory={handleOpenMemory}
-            onAccountAction={handleAccountAction}
-            onOpenSettings={handleOpenSettings}
+          {!hidePreferences && (
+            <AccountUsageGroup
+              onOpenCreditBalance={handleOpenCreditBalance}
+              onResetCodexUsage={handleOpenCodexReset}
+              resetPending={actionPending}
+              subscriptionRowsCacheKey={subscriptionRowsCacheKey}
+              subscriptionsEnabled={subscriptionsEnabled}
+            />
+          )}
+          {!hidePreferences && (
+            <UnifiedSettingsGroup
+              memoryEnabled={memoryEnabled}
+              labEnabled={labEnabled}
+              onOpenMemory={handleOpenMemory}
+              onAccountAction={handleAccountAction}
+              onOpenSettings={handleOpenSettings}
+            />
+          )}
+          <AccountManagementGroup
+            others={others}
+            onSwitchSession={handleSwitchSession}
+            onAddAccount={handleAddAccount}
           />
-        )}
-        <AccountManagementGroup
-          others={others}
-          onSwitchSession={handleSwitchSession}
-          onAddAccount={handleAddAccount}
-        />
-        <ExtraAccountActions />
-        <DropdownMenuSeparator />
-        <SignOutItem onAccountAction={handleAccountAction} />
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <ExtraAccountActions />
+          <DropdownMenuSeparator />
+          <SignOutItem onAccountAction={handleAccountAction} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CodexResetUsageDialog
+        open={resetCodexConfirmOpen}
+        resetCredits={resetCodexCredits}
+        resetting={actionPending}
+        onOpenChange={setResetCodexConfirmOpen}
+        onConfirm={handleConfirmCodexReset}
+      />
+    </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -1,6 +1,5 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import { useState } from "react";
 import {
   useGet,
   useLoadable,
@@ -52,8 +51,10 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
 import {
+  accountMenuCodexResetDialog$,
   personalActionPromise$,
   resetPersonalCodexSubscriptionUsage$,
+  setAccountMenuCodexResetDialog$,
 } from "../../signals/zero-page/settings/personal-model-providers.ts";
 import { CodexResetUsageDialog } from "./components/preferences/codex-reset-usage-dialog.tsx";
 import {
@@ -590,16 +591,14 @@ export function AccountDropdown({
   const resetCodexSubscriptionUsage = useSet(
     resetPersonalCodexSubscriptionUsage$,
   );
+  const resetDialog = useGet(accountMenuCodexResetDialog$);
+  const setResetDialog = useSet(setAccountMenuCodexResetDialog$);
   const actionLoadable = useLoadable(personalActionPromise$);
   const setSidebarExpanded = useSet(setSidebarExpanded$);
   const suppressUnauthorizedRedirectForAuthTransition = useSet(
     suppressUnauthorizedRedirectForAuthTransition$,
   );
   const pageSignal = useGet(pageSignal$);
-  const [resetCodexConfirmOpen, setResetCodexConfirmOpen] = useState(false);
-  const [resetCodexCredits, setResetCodexCredits] = useState<number | null>(
-    null,
-  );
 
   const current = accounts.find((a) => {
     return a.isActive;
@@ -672,8 +671,7 @@ export function AccountDropdown({
   };
 
   const handleOpenCodexReset = (resetCredits: number | null) => {
-    setResetCodexCredits(resetCredits);
-    setResetCodexConfirmOpen(true);
+    setResetDialog({ open: true, resetCredits });
   };
 
   const handleConfirmCodexReset = () => {
@@ -681,10 +679,17 @@ export function AccountDropdown({
       (async () => {
         await resetCodexSubscriptionUsage(pageSignal);
         await reloadSubscriptions(subscriptionRowsCacheKey, pageSignal);
-        setResetCodexConfirmOpen(false);
+        setResetDialog({ open: false, resetCredits: null });
       })(),
       Reason.DomCallback,
     );
+  };
+
+  const handleCodexResetOpenChange = (open: boolean) => {
+    setResetDialog({
+      open,
+      resetCredits: open ? resetDialog.resetCredits : null,
+    });
   };
 
   const handleMenuOpenChange = (open: boolean) => {
@@ -745,10 +750,10 @@ export function AccountDropdown({
         </DropdownMenuContent>
       </DropdownMenu>
       <CodexResetUsageDialog
-        open={resetCodexConfirmOpen}
-        resetCredits={resetCodexCredits}
+        open={resetDialog.open}
+        resetCredits={resetDialog.resetCredits}
         resetting={actionPending}
-        onOpenChange={setResetCodexConfirmOpen}
+        onOpenChange={handleCodexResetOpenChange}
         onConfirm={handleConfirmCodexReset}
       />
     </>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
@@ -1,5 +1,6 @@
 import { useGet, useLoadable } from "ccstate-react";
 import {
+  DropdownMenuItem,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -16,6 +17,7 @@ import {
   type AccountMenuSubscriptionUsageWindow,
   type AccountMenuSubscriptionUsageRowsCacheKey,
 } from "../../signals/zero-page/account-menu-subscriptions.ts";
+import { formatCodexResetCredits } from "./components/preferences/codex-reset-usage-dialog.tsx";
 
 type SubscriptionUsage = AccountMenuSubscriptionUsage;
 type SubscriptionUsageWindow = AccountMenuSubscriptionUsageWindow;
@@ -41,9 +43,13 @@ export function useSubscriptionUsageRows({
 export function AccountMenuSubscriptionsPanel({
   loading,
   rows,
+  onResetCodexUsage,
+  resetPending = false,
 }: {
   readonly loading: boolean;
   readonly rows: readonly AccountMenuSubscriptionUsageRow[];
+  readonly onResetCodexUsage?: (resetCredits: number | null) => void;
+  readonly resetPending?: boolean;
 }) {
   return (
     <div data-testid="account-menu-subscriptions" className="px-3 py-2.5">
@@ -57,8 +63,12 @@ export function AccountMenuSubscriptionsPanel({
                 <AccountMenuSubscriptionProviderSection
                   key={row.type}
                   divided={index > 0}
+                  type={row.type}
                   label={row.label}
                   usage={row.usage}
+                  resetCredits={row.resetCredits}
+                  resetPending={resetPending}
+                  onResetCodexUsage={onResetCodexUsage}
                 />
               );
             })}
@@ -98,14 +108,28 @@ function AccountMenuSubscriptionsSkeleton() {
 
 function AccountMenuSubscriptionProviderSection({
   divided,
+  type,
   label,
   usage,
+  resetCredits,
+  resetPending,
+  onResetCodexUsage,
 }: {
   readonly divided: boolean;
+  readonly type: AccountMenuSubscriptionUsageRow["type"];
   readonly label: string;
   readonly usage: SubscriptionUsage;
+  readonly resetCredits?: number | null;
+  readonly resetPending: boolean;
+  readonly onResetCodexUsage?: (resetCredits: number | null) => void;
 }) {
   const windows = accountMenuSubscriptionUsageWindows(usage);
+  const canResetCodex =
+    type === "codex-oauth-token" &&
+    onResetCodexUsage !== undefined &&
+    resetCredits !== null &&
+    resetCredits !== undefined &&
+    resetCredits > 0;
 
   return (
     <section className="flex flex-col gap-1.5" aria-label={`${label} usage`}>
@@ -125,6 +149,20 @@ function AccountMenuSubscriptionProviderSection({
           );
         })}
       </div>
+      {type === "codex-oauth-token" ? (
+        <DropdownMenuItem
+          disabled={!canResetCodex || resetPending}
+          onClick={() => {
+            onResetCodexUsage?.(resetCredits ?? null);
+          }}
+          className="mt-1 flex h-7 items-center justify-between gap-2 rounded-md px-2 py-1 text-xs"
+        >
+          <span className="min-w-0 flex-1 truncate text-muted-foreground">
+            {formatCodexResetCredits(resetCredits)}
+          </span>
+          <span className="shrink-0 font-medium text-foreground">Reset</span>
+        </DropdownMenuItem>
+      ) : null}
     </section>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -1352,6 +1352,7 @@ export const modelProviderResponseSchema = z.object({
   updatedAt: z.string(),
   // OAuth account metadata populated by provider-specific connect flows. Other
   // provider types omit these.
+  accountEmail: z.string().nullable().optional(),
   workspaceName: z.string().nullable().optional(),
   planType: z.string().nullable().optional(),
   // Subscription quota metadata. Providers omit these until an upstream source
@@ -1359,6 +1360,12 @@ export const modelProviderResponseSchema = z.object({
   subscriptionResetPeriod: z.string().nullable().optional(),
   subscriptionNextResetAt: z.string().nullable().optional(),
   subscriptionUsage: modelProviderSubscriptionUsageSchema.nullable().optional(),
+  subscriptionResetCredits: z
+    .number()
+    .int()
+    .nonnegative()
+    .nullable()
+    .optional(),
   // OAuth refresh state. `needsReconnect` flips to true when the firewall's
   // refresh attempt fails (#11921 writes this on the model_providers row).
   // `lastRefreshErrorCode` carries the typed code from `ChatgptRefreshError`

--- a/turbo/packages/api-contracts/src/contracts/zero-personal-model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-personal-model-providers.ts
@@ -10,6 +10,20 @@ import {
 
 const c = initContract();
 
+export const resetPersonalModelProviderSubscriptionUsageRequestSchema =
+  z.object({
+    idempotencyKey: z.uuid(),
+  });
+
+export const resetPersonalModelProviderSubscriptionUsageResponseSchema =
+  z.object({
+    outcome: z.enum(["reset", "nothingToReset", "noCredit", "alreadyRedeemed"]),
+  });
+
+export type ResetPersonalModelProviderSubscriptionUsageResponse = z.infer<
+  typeof resetPersonalModelProviderSubscriptionUsageResponseSchema
+>;
+
 /**
  * Zero personal (user-level) model providers main contract for /api/zero/me/model-providers
  *
@@ -74,6 +88,23 @@ export const zeroPersonalModelProvidersByTypeContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Delete a personal model provider for the requesting user",
+  },
+  resetSubscriptionUsage: {
+    method: "POST",
+    path: "/api/zero/me/model-providers/:type/subscription-reset",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      type: modelProviderTypeSchema,
+    }),
+    body: resetPersonalModelProviderSubscriptionUsageRequestSchema,
+    responses: {
+      200: resetPersonalModelProviderSubscriptionUsageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Reset a personal model provider subscription usage window",
   },
 });
 


### PR DESCRIPTION
## Summary
- expose Codex account email and reset-credit count through personal model provider responses
- add a personal Codex subscription reset API that posts a UUID idempotency key to the ChatGPT reset-credit consume endpoint
- show Codex reset count and reset actions in Settings > Models and the sidebar account menu, both gated by a confirmation dialog

## Verification
- pnpm -F @vm0/app test src/views/zero-page/__tests__/personal-providers-tab.test.tsx
- pnpm -F @vm0/app test src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types

## Not run
- pnpm -F api test src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts: local Postgres was unavailable in this runtime (ECONNREFUSED); route coverage was added and API type-check passes.