### PR TITLE
feat: show artifact download progress

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-actions.ts
@@ -1,9 +1,14 @@
 import { command, computed, state } from "ccstate";
 
 const internalArtifactDownloadMenuOpenKey$ = state<string | null>(null);
+const internalArtifactDownloadPendingKey$ = state<string | null>(null);
 
 export const artifactDownloadMenuOpenKey$ = computed((get) => {
   return get(internalArtifactDownloadMenuOpenKey$);
+});
+
+export const artifactDownloadPendingKey$ = computed((get) => {
+  return get(internalArtifactDownloadPendingKey$);
 });
 
 export const openArtifactDownloadMenu$ = command(
@@ -14,4 +19,14 @@ export const openArtifactDownloadMenu$ = command(
 
 export const closeArtifactDownloadMenu$ = command(({ set }) => {
   set(internalArtifactDownloadMenuOpenKey$, null);
+});
+
+export const startArtifactDownload$ = command(({ set }, key: string) => {
+  set(internalArtifactDownloadPendingKey$, key);
+});
+
+export const finishArtifactDownload$ = command(({ get, set }, key: string) => {
+  if (get(internalArtifactDownloadPendingKey$) === key) {
+    set(internalArtifactDownloadPendingKey$, null);
+  }
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1342,6 +1342,61 @@ describe("zero artifact sidebar", () => {
     });
   });
 
+  it("shows download progress while downloading an HTML artifact", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://launch.sites.vm7.io/launch-plan.html";
+    const downloads = captureDownloads(context.signal);
+    const downloadReady = context.mocks.deferred<Response>();
+    context.mocks.data.connectors([]);
+    context.mocks.http.get(siteUrl, () => {
+      return downloadReady.promise;
+    });
+    setupChatThread({
+      artifactFiles: [
+        artifactFile(siteUrl, {
+          id: "artifact-launch-plan",
+          filename: "launch-plan.html",
+          contentType: "text/html",
+          artifactKind: "hosted-site",
+          size: 1024,
+        }),
+      ],
+      content: `[Launch plan](${siteUrl})`,
+      path: `${THREAD_PATH}?artifact=${encodeURIComponent(siteUrl)}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+      expect(screen.getByLabelText("Download artifact")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Download artifact"));
+    await waitFor(() => {
+      expect(menuItemByText("Download")).toBeInTheDocument();
+    });
+    click(menuItemByText("Download"));
+
+    const downloadButton = screen.getByLabelText("Download artifact");
+    await waitFor(() => {
+      expect(downloadButton).toHaveAttribute("aria-busy", "true");
+      expect(downloadButton).toBeDisabled();
+      expect(downloadButton.querySelector(".animate-spin")).not.toBeNull();
+    });
+
+    downloadReady.resolve(
+      new Response("<!doctype html><html><body>Launch plan</body></html>", {
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(downloads).toContain("launch-plan.html");
+      expect(downloadButton).not.toHaveAttribute("aria-busy");
+      expect(downloadButton).not.toBeDisabled();
+      expect(downloadButton.querySelector(".animate-spin")).toBeNull();
+    });
+  });
+
   it("uploads an artifact to connected Google Drive from the sidebar", async () => {
     const user = userEvent.setup({ delay: null });
     const markdownUrl =
@@ -1467,6 +1522,13 @@ describe("zero artifact sidebar", () => {
       expect(menuItemByText("Download (.pptx)")).toBeInTheDocument();
     });
     click(menuItemByText("Download (.pptx)"));
+    const downloadButton = screen.getByLabelText("Download artifact");
+
+    await waitFor(() => {
+      expect(downloadButton).toHaveAttribute("aria-busy", "true");
+      expect(downloadButton).toBeDisabled();
+      expect(downloadButton.querySelector(".animate-spin")).not.toBeNull();
+    });
 
     const exportFrame = await waitFor(() => {
       const frame = document.querySelector(
@@ -1482,6 +1544,9 @@ describe("zero artifact sidebar", () => {
       expect(
         document.querySelector('iframe[title="Presentation PPTX export"]'),
       ).not.toBeInTheDocument();
+      expect(downloadButton).not.toHaveAttribute("aria-busy");
+      expect(downloadButton).not.toBeDisabled();
+      expect(downloadButton.querySelector(".animate-spin")).toBeNull();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -2,6 +2,7 @@ import type { ComponentPropsWithoutRef, MouseEvent, ReactNode } from "react";
 import {
   IconBrandGoogleDrive,
   IconDownload,
+  IconLoader2,
   IconShare,
 } from "@tabler/icons-react";
 import {
@@ -28,11 +29,14 @@ import {
 } from "../../signals/api-client.ts";
 import { connectors$ } from "../../signals/external/connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { detach, Reason, tapError } from "../../signals/utils.ts";
+import { detach, Reason, tapError, withCleanup } from "../../signals/utils.ts";
 import {
   artifactDownloadMenuOpenKey$,
+  artifactDownloadPendingKey$,
   closeArtifactDownloadMenu$,
+  finishArtifactDownload$,
   openArtifactDownloadMenu$,
+  startArtifactDownload$,
 } from "../../signals/zero-page/zero-artifact-actions.ts";
 import {
   type ArtifactGoogleDriveSyncFile,
@@ -197,20 +201,16 @@ function syncArtifactToGoogleDriveAndRefresh(params: {
   );
 }
 
-function downloadPresentationPptx(params: {
+async function downloadPresentationPptx(params: {
   filename: string;
   signal: AbortSignal;
   url: string;
-}): void {
-  detach(
-    tapError(downloadPresentationHtmlPptx(params), (error) => {
-      if (!(error instanceof DOMException && error.name === "AbortError")) {
-        toast.error("PPTX download failed");
-      }
-    }),
-    Reason.DomCallback,
-    "presentation html pptx download",
-  );
+}): Promise<void> {
+  await tapError(downloadPresentationHtmlPptx(params), (error) => {
+    if (!(error instanceof DOMException && error.name === "AbortError")) {
+      toast.error("PPTX download failed");
+    }
+  });
 }
 
 function iconButtonClassName(className?: string): string {
@@ -419,6 +419,44 @@ type ArtifactDownloadMenuProps = {
   url: string;
 };
 
+function ArtifactDownloadTrigger({
+  ariaLabel,
+  className,
+  downloadPending,
+  iconSize,
+  open,
+  ...props
+}: ComponentPropsWithoutRef<"button"> & {
+  ariaLabel: string;
+  downloadPending: boolean;
+  iconSize: number;
+  open: boolean;
+}) {
+  return (
+    <button
+      {...props}
+      type="button"
+      aria-label={ariaLabel}
+      aria-busy={downloadPending ? "true" : undefined}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      disabled={downloadPending}
+      className={iconButtonClassName(
+        cn(
+          "data-[state=open]:bg-muted/60 data-[state=open]:text-foreground disabled:pointer-events-none disabled:opacity-70",
+          className,
+        ),
+      )}
+    >
+      {downloadPending ? (
+        <IconLoader2 size={iconSize} stroke={1.5} className="animate-spin" />
+      ) : (
+        <IconDownload size={iconSize} stroke={1.5} />
+      )}
+    </button>
+  );
+}
+
 export function ArtifactDownloadMenu({
   align = "end",
   ariaLabel = "Download options",
@@ -431,10 +469,14 @@ export function ArtifactDownloadMenu({
 }: ArtifactDownloadMenuProps) {
   const menuKey = `${url}:${filename}`;
   const openKey = useGet(artifactDownloadMenuOpenKey$);
+  const pendingKey = useGet(artifactDownloadPendingKey$);
   const openMenu = useSet(openArtifactDownloadMenu$);
   const closeMenu = useSet(closeArtifactDownloadMenu$);
+  const startArtifactDownload = useSet(startArtifactDownload$);
+  const finishArtifactDownload = useSet(finishArtifactDownload$);
   const pageSignal = useGet(pageSignal$);
   const open = openKey === menuKey;
+  const downloadPending = pendingKey === menuKey;
   const showPresentationPptxDownload = artifactKind === "presentation-html";
   const downloadFilename = artifactDownloadFilename(
     artifactKind,
@@ -443,6 +485,17 @@ export function ArtifactDownloadMenu({
   );
   const closeNow = () => {
     closeMenu();
+  };
+  const startDownload = (download: Promise<void>, description: string) => {
+    closeNow();
+    startArtifactDownload(menuKey);
+    detach(
+      withCleanup(download, () => {
+        finishArtifactDownload(menuKey);
+      }),
+      Reason.DomCallback,
+      description,
+    );
   };
 
   return (
@@ -459,20 +512,13 @@ export function ArtifactDownloadMenu({
     >
       <ArtifactActionTooltip label={ariaLabel}>
         <PopoverTrigger asChild>
-          <button
-            type="button"
-            aria-label={ariaLabel}
-            aria-haspopup="menu"
-            aria-expanded={open}
-            className={iconButtonClassName(
-              cn(
-                "data-[state=open]:bg-muted/60 data-[state=open]:text-foreground",
-                className,
-              ),
-            )}
-          >
-            <IconDownload size={iconSize} stroke={1.5} />
-          </button>
+          <ArtifactDownloadTrigger
+            ariaLabel={ariaLabel}
+            className={className}
+            downloadPending={downloadPending}
+            iconSize={iconSize}
+            open={open}
+          />
         </PopoverTrigger>
       </ArtifactActionTooltip>
       {open && (
@@ -500,10 +546,8 @@ export function ArtifactDownloadMenu({
       >
         <ArtifactDownloadMenuItem
           onClick={() => {
-            closeNow();
-            detach(
+            startDownload(
               downloadAttachmentUrl(url, pageSignal, downloadFilename),
-              Reason.DomCallback,
               "artifact download",
             );
           }}
@@ -514,12 +558,14 @@ export function ArtifactDownloadMenu({
         {showPresentationPptxDownload && (
           <ArtifactDownloadMenuItem
             onClick={() => {
-              closeNow();
-              downloadPresentationPptx({
-                filename: downloadFilename,
-                signal: pageSignal,
-                url,
-              });
+              startDownload(
+                downloadPresentationPptx({
+                  filename: downloadFilename,
+                  signal: pageSignal,
+                  url,
+                }),
+                "presentation html pptx download",
+              );
             }}
           >
             <IconDownload size={14} stroke={1.5} />


### PR DESCRIPTION
## Summary
- Show a spinning loader on the artifact download button while a download is still in progress.
- Route standard artifact downloads (HTML/images/files) and presentation `.pptx` exports through the same pending-state cleanup.
- Add page-level coverage for HTML download progress and PPTX export progress.

## Verification
- `corepack pnpm prettier --write apps/platform/src/signals/zero-page/zero-artifact-actions.ts apps/platform/src/views/zero-page/zero-artifact-actions.tsx apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- `corepack pnpm -F @vm0/app exec eslint src/views/zero-page/zero-artifact-actions.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx src/signals/zero-page/zero-artifact-actions.ts --max-warnings 0`
- `corepack pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-artifact-actions.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx src/signals/zero-page/zero-artifact-actions.ts`
- `corepack pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "shows download progress while downloading an HTML artifact" --reporter verbose --testTimeout 10000`
- `corepack pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "downloads a presentation artifact as PPTX from the sidebar" --reporter verbose --testTimeout 10000`
- `corepack pnpm -F @vm0/app check-types`

Per vm0 PR preference, I did not start a local dev server or run the full local Vitest suite.
