### PR TITLE
fix: preserve presentation html backgrounds in pptx export

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -80,4 +80,69 @@ describe("buildPresentationHtmlPptxExportHtml", () => {
     expect(scriptText).toContain("preserveBrowserTextLineBreaks(nodes)");
     expect(scriptText).not.toContain("resolveEmbeddableFonts");
   });
+
+  it("prepares staged slides with complex backgrounds before exporting", async () => {
+    const exportHtml = await buildPresentationHtmlPptxExportHtml({
+      baseUrl: "https://presentation.example.test/index.html",
+      html: `
+        <!doctype html>
+        <html>
+          <head>
+            <style>
+              :root { --bg: #f3f6fb; }
+              body { margin: 0; background: #0f172a; }
+              .slide {
+                position: absolute;
+                inset: 0;
+                display: none;
+                background: #0f172a;
+              }
+              .slide.active { display: flex; }
+              .stage {
+                position: relative;
+                width: min(100vw, 177.7778vh);
+                height: min(56.25vw, 100vh);
+                background:
+                  linear-gradient(rgba(21, 35, 58, 0.035) 1px, transparent 1px),
+                  linear-gradient(90deg, rgba(21, 35, 58, 0.035) 1px, transparent 1px),
+                  radial-gradient(circle at 68% 42%, rgba(37, 99, 235, 0.08), transparent 34%),
+                  var(--bg);
+              }
+            </style>
+          </head>
+          <body>
+            <section class="slide active">
+              <div class="stage">
+                <h1>Slide</h1>
+              </div>
+            </section>
+          </body>
+        </html>
+      `,
+      options: {
+        fileName: "deck.pptx",
+        layout: "LAYOUT_WIDE",
+        skipDownload: true,
+        svgAsVector: true,
+      },
+      signal: AbortSignal.any([]),
+    });
+    const doc = new DOMParser().parseFromString(exportHtml, "text/html");
+    const scriptText = Array.from(doc.querySelectorAll("script"))
+      .map((script) => {
+        return script.textContent ?? "";
+      })
+      .join("\n");
+
+    expect(scriptText).toContain("normalizeSlideStages(nodes)");
+    expect(scriptText).toContain(
+      "await materializeComplexSlideBackgrounds(nodes)",
+    );
+    expect(scriptText.indexOf("normalizeSlideStages(nodes)")).toBeLessThan(
+      scriptText.indexOf("window.domToPptx.exportToPptx"),
+    );
+    expect(
+      scriptText.indexOf("await materializeComplexSlideBackgrounds(nodes)"),
+    ).toBeLessThan(scriptText.indexOf("window.domToPptx.exportToPptx"));
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -402,7 +402,11 @@ function createExportSlideScript(): string {
     }
     return ancestors;
   };
+`;
+}
 
+function createExportBackgroundInheritanceScript(): string {
+  return `
   const isTransparentColor = (color) => {
     const normalized = color.trim().toLowerCase();
     return (
@@ -472,7 +476,224 @@ function createExportSlideScript(): string {
       }
     }
   };
+`;
+}
 
+function createExportStageNormalizationScript(): string {
+  return `
+  const stageForSlideNode = (node) => {
+    if (!(node instanceof HTMLElement)) {
+      return null;
+    }
+    if (node.classList.contains("stage")) {
+      return node;
+    }
+    const stage = Array.from(node.children).find((child) => {
+      return child instanceof HTMLElement && child.classList.contains("stage");
+    });
+    return stage instanceof HTMLElement ? stage : null;
+  };
+
+  const backgroundTargetsForSlideNodes = (nodes) => {
+    const targets = [];
+    const seen = new Set();
+    for (const node of nodes) {
+      if (!(node instanceof HTMLElement)) {
+        continue;
+      }
+      const target = stageForSlideNode(node) ?? node;
+      if (seen.has(target)) {
+        continue;
+      }
+      seen.add(target);
+      targets.push(target);
+    }
+    return targets;
+  };
+
+  const normalizeSlideStages = (nodes) => {
+    for (const node of nodes) {
+      if (!(node instanceof HTMLElement)) {
+        continue;
+      }
+      const stage = stageForSlideNode(node);
+      if (!stage) {
+        continue;
+      }
+      if (stage !== node) {
+        if (window.getComputedStyle(node).position === "static") {
+          node.style.setProperty("position", "relative", "important");
+        }
+        node.style.setProperty("overflow", "hidden", "important");
+        stage.style.setProperty("position", "absolute", "important");
+        stage.style.setProperty("inset", "0", "important");
+      }
+      stage.style.setProperty("width", "100%", "important");
+      stage.style.setProperty("height", "100%", "important");
+      stage.style.setProperty("max-width", "none", "important");
+      stage.style.setProperty("max-height", "none", "important");
+      stage.style.setProperty("margin", "0", "important");
+      stage.style.setProperty("border-radius", "0", "important");
+      stage.style.setProperty("box-sizing", "border-box", "important");
+      stage.style.setProperty("overflow", "hidden", "important");
+    }
+  };
+`;
+}
+
+function createExportComplexBackgroundDetectionScript(): string {
+  return `
+  const splitCssBackgroundLayers = (value) => {
+    const layers = [];
+    let current = "";
+    let depth = 0;
+    let quote = "";
+    for (const char of value) {
+      if (quote) {
+        current += char;
+        if (char === quote) {
+          quote = "";
+        }
+        continue;
+      }
+      if (char === '"' || char === "'") {
+        quote = char;
+        current += char;
+        continue;
+      }
+      if (char === "(") {
+        depth += 1;
+      } else if (char === ")" && depth > 0) {
+        depth -= 1;
+      } else if (char === "," && depth === 0) {
+        if (current.trim()) {
+          layers.push(current.trim());
+        }
+        current = "";
+        continue;
+      }
+      current += char;
+    }
+    if (current.trim()) {
+      layers.push(current.trim());
+    }
+    return layers;
+  };
+
+  const isComplexBackgroundImage = (value) => {
+    const normalized = value.trim().toLowerCase();
+    return (
+      normalized !== "" &&
+      normalized !== "none" &&
+      (splitCssBackgroundLayers(value).length > 1 ||
+        /\\b(?:repeating-)?(?:radial|conic)-gradient\\(/.test(normalized))
+    );
+  };
+`;
+}
+
+function createExportBackgroundRasterizerScript(): string {
+  return `
+  const imageFromDataUrl = (src) => {
+    return new Promise((resolve) => {
+      const image = new Image();
+      image.addEventListener("load", () => resolve(image), { once: true });
+      image.addEventListener("error", () => resolve(null), { once: true });
+      image.src = src;
+    });
+  };
+
+  const svgDataUrl = (svg) => {
+    return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svg);
+  };
+
+  const renderElementBackgroundAsImage = async (element) => {
+    const rect = element.getBoundingClientRect();
+    const width = Math.max(1, Math.round(rect.width));
+    const height = Math.max(1, Math.round(rect.height));
+    const style = window.getComputedStyle(element);
+    const background = document.createElement("div");
+    background.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+    background.style.width = width + "px";
+    background.style.height = height + "px";
+    background.style.margin = "0";
+    background.style.backgroundColor = style.backgroundColor;
+    background.style.backgroundImage = style.backgroundImage;
+    background.style.backgroundSize = style.backgroundSize;
+    background.style.backgroundPosition = style.backgroundPosition;
+    background.style.backgroundRepeat = style.backgroundRepeat;
+    background.style.backgroundOrigin = style.backgroundOrigin;
+    background.style.backgroundClip = style.backgroundClip;
+    background.style.borderRadius = style.borderRadius;
+    const serializedBackground = new XMLSerializer().serializeToString(background);
+    const svg = [
+      '<svg xmlns="http://www.w3.org/2000/svg" width="',
+      String(width),
+      '" height="',
+      String(height),
+      '" viewBox="0 0 ',
+      String(width),
+      " ",
+      String(height),
+      '"><foreignObject width="100%" height="100%">',
+      serializedBackground,
+      "</foreignObject></svg>",
+    ].join("");
+    const image = await imageFromDataUrl(svgDataUrl(svg));
+    if (!image) {
+      return null;
+    }
+    const scale = Math.min(window.devicePixelRatio || 1, 2);
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.round(width * scale);
+    canvas.height = Math.round(height * scale);
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return null;
+    }
+    context.scale(scale, scale);
+    context.drawImage(image, 0, 0, width, height);
+    try {
+      return canvas.toDataURL("image/png");
+    } catch {
+      return null;
+    }
+  };
+`;
+}
+
+function createExportComplexBackgroundMaterializationScript(): string {
+  return `
+  const materializeComplexSlideBackgrounds = async (nodes) => {
+    for (const target of backgroundTargetsForSlideNodes(nodes)) {
+      const style = window.getComputedStyle(target);
+      if (!isComplexBackgroundImage(style.backgroundImage)) {
+        continue;
+      }
+      const backgroundColor = style.backgroundColor;
+      const imageDataUrl = await renderElementBackgroundAsImage(target);
+      if (!isTransparentColor(backgroundColor)) {
+        target.style.setProperty("background-color", backgroundColor, "important");
+      }
+      if (imageDataUrl) {
+        target.style.setProperty(
+          "background-image",
+          'url("' + imageDataUrl + '")',
+          "important",
+        );
+        target.style.setProperty("background-size", "100% 100%", "important");
+        target.style.setProperty("background-position", "center center", "important");
+        target.style.setProperty("background-repeat", "no-repeat", "important");
+        continue;
+      }
+      target.style.setProperty("background-image", "none", "important");
+    }
+  };
+`;
+}
+
+function createExportImageWaitScript(): string {
+  return `
   const waitForImages = async (nodes) => {
     const images = nodes.flatMap((node) => {
       const nested = Array.from(node.querySelectorAll("img"));
@@ -701,7 +922,9 @@ function createExportRunnerScript(): string {
       throw new Error("Presentation HTML has no exportable content");
     }
     revealSlideNodes(nodes);
+    normalizeSlideStages(nodes);
     copyInheritedSlideBackgrounds(nodes);
+    await materializeComplexSlideBackgrounds(nodes);
     await waitForExportReadiness(nodes);
     preserveBrowserTextLineBreaks(nodes);
     const blob = await window.domToPptx.exportToPptx(nodes, options);
@@ -720,6 +943,12 @@ function createExportScript(options: DomToPptxOptions): string {
   return [
     createExportBootstrapScript(options),
     createExportSlideScript(),
+    createExportBackgroundInheritanceScript(),
+    createExportStageNormalizationScript(),
+    createExportComplexBackgroundDetectionScript(),
+    createExportBackgroundRasterizerScript(),
+    createExportComplexBackgroundMaterializationScript(),
+    createExportImageWaitScript(),
     createExportReadinessScript(),
     createExportLineBreakScript(),
     createExportRunnerScript(),


### PR DESCRIPTION
## Summary
- normalize nested `.stage` slides to full-slide dimensions before PPTX export
- materialize complex multi-layer/radial backgrounds as PNG data URLs before `dom-to-pptx`
- add regression coverage for staged slides with complex backgrounds

## Tests
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts`
- `git diff --check`

## Notes
- `pnpm vitest` was attempted locally, but API integration suites could not connect to local Postgres (`ECONNREFUSED`). Frontend focused tests and repo lint/type/knip checks passed.