### PR TITLE
feat: use optimized bb0 onboarding icon assets

### DIFF
--- a/turbo/apps/platform/src/lib/static-assets.ts
+++ b/turbo/apps/platform/src/lib/static-assets.ts
@@ -1,4 +1,4 @@
-const DEFAULT_STATIC_ASSETS_BASE_URL = "https://static.vm7.io";
+const DEFAULT_STATIC_ASSETS_BASE_URL = "https://static.vm0.io";
 
 function staticAssetsBaseUrl() {
   return (

--- a/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
+++ b/turbo/apps/platform/src/views/device-bb0/bb0-device-page.tsx
@@ -148,7 +148,7 @@ function BleConnectStep() {
     <div className="px-6 py-5">
       <div className="flex items-center gap-4">
         <StepIcon
-          src={platformStaticAssetUrl("onboarding-step1-connect-v3.png")}
+          src={platformStaticAssetUrl("onboarding-step1-connect-v3_96x96.png")}
         />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-foreground">Connect BB0</p>
@@ -217,7 +217,7 @@ function WifiStep() {
     <div className="px-6 py-5">
       <div className="flex items-center gap-4">
         <StepIcon
-          src={platformStaticAssetUrl("onboarding-step2-wifi-v2.png")}
+          src={platformStaticAssetUrl("onboarding-step2-wifi-v2_96x96.png")}
         />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-foreground">Share Wi-Fi</p>
@@ -306,7 +306,7 @@ function DeviceCodeStep() {
     <div className="px-6 pt-5 pb-8">
       <div className="flex items-center gap-4">
         <StepIcon
-          src={platformStaticAssetUrl("onboarding-step3-code-v2.png")}
+          src={platformStaticAssetUrl("onboarding-step3-code-v2_96x96.png")}
         />
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-foreground">


### PR DESCRIPTION
## Summary
- switch the BB0 setup step icons from 1024px PNGs to new 96x96 static asset variants
- use static.vm0.io as the default platform static asset host so previews can resolve the new append-only paths

## Dependency
- Depends on vm0-ai/static-files#9 being merged and mirrored before this ships, because the new BB0 icon paths are added there.

## Verification
- Not run locally per vm0 PR preference; change is limited to static asset URL references and relies on PR CI.