### PR TITLE
fix: prefill workflow chat with refine prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -311,6 +311,9 @@ describe("zero workflows", () => {
       [200],
     );
     expect(preparedSource.body.chatThreadId).toBe(sourceThread.id);
+    expect(preparedSource.body.prompt).toBe(
+      `help me refine the workflow /${sourceWorkflow.body.name}`,
+    );
 
     const targetWorkflow = await createWorkflow(actor, {
       agentId: targetAgent.agentId,

--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -897,6 +897,10 @@ function workflowSlashPrompt(workflow: Pick<WorkflowRow, "name">): string {
   return `/${workflow.name}`;
 }
 
+function workflowRefinePrompt(workflow: Pick<WorkflowRow, "name">): string {
+  return `help me refine the workflow ${workflowSlashPrompt(workflow)}`;
+}
+
 const prepareWorkflowChatThreadInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -936,7 +940,7 @@ const prepareWorkflowChatThreadInner$ = command(
       status: 200 as const,
       body: {
         chatThreadId,
-        prompt: workflowSlashPrompt(workflow),
+        prompt: workflowRefinePrompt(workflow),
       },
     };
   },

--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -255,7 +255,7 @@ export const apiWorkflowsHandlers = [
     }
     return respond(200, {
       chatThreadId: "00000000-0000-4000-a000-000000000fff",
-      prompt: `/${workflow.name}`,
+      prompt: `help me refine the workflow /${workflow.name}`,
     });
   }),
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -855,7 +855,7 @@ function mockOpenWorkflowChat(onOpen: (workflowId: string) => void): void {
       onOpen(params.workflowId);
       return respond(200, {
         chatThreadId: WORKFLOW_CHAT_THREAD_ID,
-        prompt: "/sales-research",
+        prompt: "help me refine the workflow /sales-research",
       });
     },
   );
@@ -1286,7 +1286,7 @@ describe("workflow detail page", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens the shared workflow chat thread with the workflow slash command", async () => {
+  it("opens the shared workflow chat thread with the workflow refinement prompt", async () => {
     const openedWorkflowIds: string[] = [];
     mockChatLifecycle(context, { threadId: WORKFLOW_CHAT_THREAD_ID });
     mockWorkflowApis([salesResearch()]);
@@ -1309,7 +1309,7 @@ describe("workflow detail page", () => {
     });
     expect(pathname()).toBe(`/chats/${WORKFLOW_CHAT_THREAD_ID}`);
     expect(search()).toBe("");
-    await expectComposerText("/sales-research");
+    await expectComposerText("help me refine the workflow /sales-research");
   });
 
   it("orders workflow info sections without audit metadata", async () => {


### PR DESCRIPTION
## Summary
- Prefill the shared workflow chat draft with `help me refine the workflow /<workflow-slug>` when users click `Refine with ...` from workflow detail.
- Keep the prompt source in the workflow chat-thread API so platform UI and mocks stay aligned.
- Update workflow page and API coverage for the new refinement prompt.

## Verification
- `pnpm exec prettier --check apps/api/src/signals/routes/zero-workflows.ts apps/api/src/signals/routes/__tests__/zero-workflows.test.ts apps/platform/src/mocks/handlers/api-workflows.ts apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app test src/views/workflows-page/__tests__/workflows-page.test.tsx`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm -F api test src/signals/routes/__tests__/zero-workflows.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- Targeted API/platform oxlint + ESLint for changed files

## Notes
- Full `pnpm -F api lint` was blocked locally by `oxlint-tsgolint` receiving `SIGKILL`; targeted lint for the changed API files passed.
- Browser walkthrough was blocked locally because the platform dev server needs `VITE_API_URL`.
