### PR TITLE
feat: virtualize zero sidebar chat threads behind switch

### DIFF
--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -5,6 +5,7 @@ import {
   type CodexServiceTier,
   type PersistedAttachment,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { agentById, currentAgentId$, defaultAgentId$ } from "./agent.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
@@ -24,6 +25,7 @@ import {
   eventDrivenChatThreads$,
 } from "./chat-page/chat-thread-event-sourcing.ts";
 import type { EventDrivenChatThread } from "./chat-page/chat-thread-event-replay.ts";
+import { featureSwitch$ } from "./external/feature-switch.ts";
 
 export { reloadChatThreads$ } from "./chat-thread-list-reload.ts";
 
@@ -170,13 +172,21 @@ const eventDrivenFilteredChatThreads$ = computed(
   },
 );
 
+export const chatThreadSidebarVirtualListEnabled$ = computed((get) => {
+  return (
+    get(featureSwitch$)[FeatureSwitchKey.ChatThreadSidebarVirtualList] ?? false
+  );
+});
+
 const eventDrivenVisibleChatThreads$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
     const threads = await get(eventDrivenFilteredChatThreads$);
-    const maxItems = get(chatThreadMaxItem$);
+    const visibleThreads = get(chatThreadSidebarVirtualListEnabled$)
+      ? threads
+      : threads.slice(0, get(chatThreadMaxItem$));
     const activeRunThreadIds = get(eventDrivenActiveRunChatThreadIds$);
 
-    return threads.slice(0, maxItems).map((thread) => {
+    return visibleThreads.map((thread) => {
       return eventDrivenThreadToListItem(thread, activeRunThreadIds);
     });
   },
@@ -222,11 +232,17 @@ export const allChatThreadListItems$ = computed(
  * Drives the "Load more" button rendered at the bottom of the sidebar list.
  */
 export const chatThreadsHasMore$ = computed(async (get) => {
+  if (get(chatThreadSidebarVirtualListEnabled$)) {
+    return false;
+  }
   const threads = await get(eventDrivenFilteredChatThreads$);
   return threads.length > get(chatThreadMaxItem$);
 });
 
 export const chatThreadsNextCursor$ = computed(async (get) => {
+  if (get(chatThreadSidebarVirtualListEnabled$)) {
+    return null;
+  }
   const threads = await get(eventDrivenFilteredChatThreads$);
   return threads.length > get(chatThreadMaxItem$) ? "event-driven" : null;
 });

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -4,6 +4,8 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   currentLeftThread$,
   currentRightThread$,
+  loadLeftThread$,
+  loadRightThread$,
 } from "./chat-thread-panes.ts";
 import {
   clickAdjacentSidebarThread,
@@ -24,6 +26,7 @@ import { onRef } from "../utils.ts";
 import { openChatThreadEmojiMenu$ } from "../zero-page/zero-sidebar-state.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { currentChatThreadId$ } from "../agent-chat.ts";
+import { sidebarChatThreadIds$ } from "./sidebar-chat-thread-ids.ts";
 import {
   setupGlobalShortcut,
   type GlobalShortcutBindings,
@@ -196,7 +199,7 @@ interface ChatPageShortcutActions {
 interface ChatPageShortcutSetup {
   doc: Document;
   focusedThread: () => ChatThreadSignals | null;
-  navigateFocusedThread: (direction: "prev" | "next") => void;
+  navigateFocusedThread: (direction: "prev" | "next") => void | Promise<void>;
   root: HTMLElement;
   sidebarTitleForThread: (
     thread: ChatThreadSignals,
@@ -299,10 +302,10 @@ const setupChatPageShortcutActions$ = command(
           }
         },
         navigateNext: () => {
-          navigateFocusedThread("next");
+          return navigateFocusedThread("next");
         },
         navigatePrev: () => {
-          navigateFocusedThread("prev");
+          return navigateFocusedThread("prev");
         },
         scrollBottom: () => {
           const thread = focusedThread();
@@ -534,9 +537,50 @@ export const setChatKeyboardScrollRoot$ = onRef(
         get(currentRightThread$),
         focusedThread(),
       );
-      if (pane) {
-        clickAdjacentSidebarThread(el, pane, direction);
+      if (!pane) {
+        return;
       }
+      if (
+        get(featureSwitch$)[FeatureSwitchKey.ChatThreadSidebarVirtualList] ??
+        false
+      ) {
+        return navigateAdjacentSidebarThreadFromSignals(pane, direction);
+      }
+      clickAdjacentSidebarThread(el, pane, direction);
+      return;
+    };
+
+    const navigateAdjacentSidebarThreadFromSignals = async (
+      pane: SidebarThreadPane,
+      direction: "prev" | "next",
+    ) => {
+      const leftThread = get(currentLeftThread$);
+      const rightThread = get(currentRightThread$);
+      const currentId =
+        pane === "main" ? leftThread?.threadId : rightThread?.threadId;
+      if (!currentId) {
+        return;
+      }
+      const otherPaneThreadId =
+        pane === "main" ? rightThread?.threadId : leftThread?.threadId;
+      const ids = (await get(sidebarChatThreadIds$)).filter((id) => {
+        return id !== otherPaneThreadId;
+      });
+      const currentIndex = ids.indexOf(currentId);
+      if (currentIndex === -1) {
+        return;
+      }
+      const targetIndex =
+        direction === "prev" ? currentIndex - 1 : currentIndex + 1;
+      const targetId = ids[targetIndex];
+      if (!targetId) {
+        return;
+      }
+      const promise =
+        pane === "main"
+          ? set(loadLeftThread$, targetId, signal)
+          : set(loadRightThread$, targetId, signal);
+      await promise;
     };
 
     el.addEventListener("focusin", markActiveThread, { signal });

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -212,6 +212,68 @@ export const setHovering$ = command(({ set }, hovering: boolean) => {
 });
 
 // ---------------------------------------------------------------------------
+// Overlay scroll viewport (OverlayScrollArea)
+// ---------------------------------------------------------------------------
+const internalOverlayScrollViewport$ = state<HTMLElement | null>(null);
+interface OverlayScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+const internalOverlayScrollMetrics$ = state<OverlayScrollMetrics>(
+  emptyOverlayScrollMetrics(),
+);
+
+function emptyOverlayScrollMetrics(): OverlayScrollMetrics {
+  return {
+    scrollTop: 0,
+    scrollHeight: 0,
+    clientHeight: 0,
+  };
+}
+
+export const overlayScrollViewport$ = computed((get) => {
+  return get(internalOverlayScrollViewport$);
+});
+export const overlayScrollMetrics$ = computed((get) => {
+  return get(internalOverlayScrollMetrics$);
+});
+export const setOverlayScrollViewport$ = command(
+  ({ set }, viewport: HTMLElement | null) => {
+    set(internalOverlayScrollViewport$, viewport);
+    set(
+      internalOverlayScrollMetrics$,
+      viewport
+        ? {
+            scrollTop: viewport.scrollTop,
+            scrollHeight: viewport.scrollHeight,
+            clientHeight: viewport.clientHeight,
+          }
+        : emptyOverlayScrollMetrics(),
+    );
+  },
+);
+export const setOverlayScrollMetrics$ = command(
+  ({ set }, metrics: OverlayScrollMetrics) => {
+    set(internalOverlayScrollMetrics$, metrics);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Chat thread virtual list DOM state (RecentChatSection)
+// ---------------------------------------------------------------------------
+const internalChatThreadVirtualListElement$ = state<HTMLElement | null>(null);
+export const chatThreadVirtualListElement$ = computed((get) => {
+  return get(internalChatThreadVirtualListElement$);
+});
+export const setChatThreadVirtualListElement$ = command(
+  ({ set }, element: HTMLElement | null) => {
+    set(internalChatThreadVirtualListElement$, element);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Main sidebar scroll tracking (ZeroSidebar)
 // ---------------------------------------------------------------------------
 const internalIsScrolled$ = state(false);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1115,6 +1115,73 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("virtualizes sidebar chats behind the feature switch", async () => {
+    prepareDefaultAgent();
+    const overflowThreads = Array.from({ length: 23 }, (_, index) => {
+      return createThread(
+        `b2000000-0000-4000-a000-${String(index).padStart(12, "0")}`,
+        `Virtual overflow ${index + 1}`,
+      );
+    });
+    mockSidebarThreadStory(
+      [
+        createThread(EXISTING_THREAD_ID, "Release plan"),
+        createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+      ],
+      [
+        ...overflowThreads,
+        createThread(ARCHIVED_THREAD_ID, "Archived context"),
+      ],
+    );
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.ChatThreadSidebarVirtualList]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("sidebar-chat-threads-load-more")).toBeNull();
+      expect(
+        screen.getByTestId("sidebar-chat-threads-virtual-list"),
+      ).toBeInTheDocument();
+    });
+
+    const scrollArea = screen.getByTestId("sidebar-scroll-area");
+    Object.defineProperty(scrollArea, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scrollArea, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(scrollArea, "scrollTop", {
+      configurable: true,
+      value: 0,
+    });
+    fireEvent.scroll(scrollArea);
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+    });
+    expect(within(sidebar()).queryByText("Archived context")).toBeNull();
+
+    Object.defineProperty(scrollArea, "scrollTop", {
+      configurable: true,
+      value: 780,
+    });
+    fireEvent.scroll(scrollArea);
+
+    await waitFor(() => {
+      expect(
+        within(sidebar()).getByText("Archived context"),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("cancels and confirms deleting a regular chat from the sidebar", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import {
   useGet,
   useSet,
@@ -100,11 +101,19 @@ import {
   setRenameDialogInput$,
   sessionListCollapsed$,
   setSessionListCollapsed$,
+  overlayScrollMetrics$,
+  overlayScrollViewport$,
+  chatThreadVirtualListElement$,
+  setChatThreadVirtualListElement$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { Link } from "../router/link.tsx";
 
 type IndicatorState = "running" | "unread" | "draft";
 type ChatThreadPaneIndicator = "main" | "sidebar";
+const CHAT_THREAD_VIRTUAL_ROW_HEIGHT = 36;
+const CHAT_THREAD_VIRTUAL_OVERSCAN = 8;
+const CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT =
+  CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 12;
 
 function SessionStateIndicator({ state }: { state: IndicatorState }) {
   if (state === "running") {
@@ -182,7 +191,7 @@ function isChatThreadRunning(
 }
 
 function handleChatThreadClick(
-  e: React.MouseEvent<HTMLAnchorElement>,
+  e: MouseEvent<HTMLAnchorElement>,
   {
     closeSidebarOnSelect,
     currentLeftId,
@@ -296,7 +305,7 @@ function ChatThreadMenu({
     }
   }
 
-  function handleMenuTriggerClick(e: React.MouseEvent) {
+  function handleMenuTriggerClick(e: MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
   }
@@ -768,6 +777,93 @@ function DeleteChatThreadDialog() {
   );
 }
 
+function getFixedVirtualRange({
+  itemCount,
+  scrollMargin,
+  scrollTop,
+  viewportHeight,
+}: {
+  itemCount: number;
+  scrollMargin: number;
+  scrollTop: number;
+  viewportHeight: number;
+}) {
+  const localScrollTop = Math.max(0, scrollTop - scrollMargin);
+  const firstVisibleIndex = Math.floor(
+    localScrollTop / CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+  );
+  const visibleCount = Math.max(
+    1,
+    Math.ceil(viewportHeight / CHAT_THREAD_VIRTUAL_ROW_HEIGHT),
+  );
+  const startIndex = Math.max(
+    0,
+    firstVisibleIndex - CHAT_THREAD_VIRTUAL_OVERSCAN,
+  );
+  const endIndex = Math.min(
+    itemCount,
+    firstVisibleIndex + visibleCount + CHAT_THREAD_VIRTUAL_OVERSCAN,
+  );
+
+  return {
+    endIndex,
+    startIndex,
+    totalHeight: itemCount * CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+  };
+}
+
+function VirtualizedChatThreads({
+  chatThreads,
+}: {
+  chatThreads: readonly ChatThreadListItem[];
+}) {
+  const scrollViewport = useGet(overlayScrollViewport$);
+  const scrollMetrics = useGet(overlayScrollMetrics$);
+  const virtualListElement = useGet(chatThreadVirtualListElement$);
+  const setVirtualListElement = useSet(setChatThreadVirtualListElement$);
+  const scrollMargin = virtualListElement?.offsetTop ?? 0;
+  const viewportHeight =
+    scrollMetrics.clientHeight ||
+    scrollViewport?.clientHeight ||
+    CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT;
+  const scrollTop = scrollMetrics.scrollTop || scrollViewport?.scrollTop || 0;
+  const { startIndex, endIndex, totalHeight } = getFixedVirtualRange({
+    itemCount: chatThreads.length,
+    scrollMargin,
+    scrollTop,
+    viewportHeight,
+  });
+  const visibleChatThreads = chatThreads.slice(startIndex, endIndex);
+
+  return (
+    <div
+      ref={setVirtualListElement}
+      className="relative w-full"
+      data-testid="sidebar-chat-threads-virtual-list"
+      style={{ height: totalHeight }}
+    >
+      {visibleChatThreads.map((session, visibleOffset) => {
+        const index = startIndex + visibleOffset;
+        return (
+          <div
+            key={session.id}
+            data-index={index}
+            data-testid="sidebar-chat-thread-virtual-row"
+            className="absolute left-0 top-0 w-full pb-1"
+            style={{
+              transform: `translateY(${
+                index * CHAT_THREAD_VIRTUAL_ROW_HEIGHT
+              }px)`,
+            }}
+          >
+            <ChatThreadItem session={session} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function ChatThreads({
   chatThreads,
 }: {
@@ -776,6 +872,9 @@ function ChatThreads({
   const pageSignal = useGet(pageSignal$);
 
   const unreadOnly = useGet(chatThreadOnlyUnread$);
+  const features = useGet(featureSwitch$);
+  const virtualListEnabled =
+    features[FeatureSwitchKey.ChatThreadSidebarVirtualList] ?? false;
   const firstPageHasMoreLoadable = useLastLoadable(chatThreadsHasMore$);
   const firstPageNextCursorLoadable = useLastLoadable(chatThreadsNextCursor$);
   const firstPageHasMore =
@@ -815,6 +914,9 @@ function ChatThreads({
           : "Start a conversation and it'll show up here"}
       </p>
     );
+  }
+  if (virtualListEnabled) {
+    return <VirtualizedChatThreads chatThreads={chatThreads} />;
   }
   return (
     <>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-scroll.tsx
@@ -1,10 +1,12 @@
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode, UIEvent } from "react";
 import { useGet, useSet } from "ccstate-react";
 import {
   thumbStyle$,
   setThumbStyle$,
   hovering$,
   setHovering$,
+  setOverlayScrollMetrics$,
+  setOverlayScrollViewport$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 
 /** Overlay scroll area: hides native scrollbar, renders a custom thin indicator. */
@@ -17,19 +19,22 @@ export function OverlayScrollArea({
 }: {
   className?: string;
   children: ReactNode;
-  onScroll?: (e: React.UIEvent<HTMLDivElement>) => void;
-  style?: React.CSSProperties;
+  onScroll?: (e: UIEvent<HTMLDivElement>) => void;
+  style?: CSSProperties;
   "data-testid"?: string;
 }) {
   const thumbStyleValue = useGet(thumbStyle$);
   const setThumbStyleFn = useSet(setThumbStyle$);
   const hovering = useGet(hovering$);
   const setHoveringFn = useSet(setHovering$);
+  const setOverlayScrollMetricsFn = useSet(setOverlayScrollMetrics$);
+  const setViewportRef = useSet(setOverlayScrollViewport$);
 
-  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+  const handleScroll = (e: UIEvent<HTMLDivElement>) => {
     onScroll?.(e);
     const el = e.currentTarget;
     const { scrollTop, scrollHeight, clientHeight } = el;
+    setOverlayScrollMetricsFn({ scrollTop, scrollHeight, clientHeight });
     if (scrollHeight <= clientHeight) {
       setThumbStyleFn({
         top: thumbStyleValue.top,
@@ -58,6 +63,7 @@ export function OverlayScrollArea({
       }}
     >
       <div
+        ref={setViewportRef}
         className="h-full overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={style}
         onScroll={handleScroll}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -59,6 +59,7 @@ export enum FeatureSwitchKey {
   AgentsPageRedesign = "agentsPageRedesign",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   ChatThreadLatestUserMessageScrollAnchor = "chatThreadLatestUserMessageScrollAnchor",
+  ChatThreadSidebarVirtualList = "chatThreadSidebarVirtualList",
   TeamsIntegration = "teamsIntegration",
   BytePlusVoiceInputStt = "bytePlusVoiceInputStt",
   ImageEditing = "imageEditing",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -345,6 +345,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "After chat sends, keep auto-scroll moving only until the latest rendered user message reaches the top of the thread viewport instead of always pinning to the absolute bottom.",
     enabled: false,
   },
+  [FeatureSwitchKey.ChatThreadSidebarVirtualList]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Render the Zero sidebar chat thread list with a fixed-row virtual list backed by the local event-driven thread cache.",
+    enabled: false,
+  },
   [FeatureSwitchKey.TeamsIntegration]: {
     maintainer: "linghan@vm0.ai",
     description:

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -1592,7 +1592,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true


### PR DESCRIPTION
## Summary
- add the `chatThreadSidebarVirtualList` feature switch, defaulted off, so the legacy sidebar load-more path remains unchanged
- render the sidebar chat list with a local fixed-row virtualizer when enabled, using the existing overlay scroll viewport and a 36px row pitch
- return the full event-driven thread list only behind the switch and move keyboard next/previous navigation to signal-backed thread ids for the virtualized path

## Verification
- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app check-types`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`