### PR TITLE
refactor: use catalog metadata for connector display

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
@@ -8,6 +8,8 @@ const IMPORT_SPECIFIER_PATTERN =
   /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
 const CONNECTORS_IMPORT_STATEMENT_PATTERN =
   /\bimport\s+(?!type\b)(?<clause>[^;]*?)\s+from\s*["']@vm0\/connectors\/connectors["']/g;
+const CONNECTORS_NAMESPACE_IMPORT_PATTERN =
+  /\bimport\s+\*\s+as\s+(?<namespace>[A-Za-z_$][\w$]*)\s+from\s*["']@vm0\/connectors\/connectors["']/g;
 
 const PLATFORM_SRC_PREFIX = "../../";
 const productionSourceModules = import.meta.glob<string>(
@@ -59,19 +61,39 @@ function importsExactSpecifier(source: string, specifier: string): boolean {
   });
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, String.raw`\$&`);
+}
+
 function importsConnectorTypesValue(source: string): boolean {
-  return [...source.matchAll(CONNECTORS_IMPORT_STATEMENT_PATTERN)].some(
+  const namedImport = [
+    ...source.matchAll(CONNECTORS_IMPORT_STATEMENT_PATTERN),
+  ].some((match) => {
+    const namedImports =
+      match.groups?.clause.match(/\{(?<imports>[\s\S]*?)\}/u)?.groups
+        ?.imports ?? "";
+    return namedImports.split(",").some((specifier) => {
+      const trimmed = specifier.trim();
+      if (trimmed.startsWith("type ")) {
+        return false;
+      }
+      return trimmed.split(/\s+as\s+/u)[0]?.trim() === "CONNECTOR_TYPES";
+    });
+  });
+  if (namedImport) {
+    return true;
+  }
+
+  return [...source.matchAll(CONNECTORS_NAMESPACE_IMPORT_PATTERN)].some(
     (match) => {
-      const namedImports =
-        match.groups?.clause.match(/\{(?<imports>[\s\S]*?)\}/u)?.groups
-          ?.imports ?? "";
-      return namedImports.split(",").some((specifier) => {
-        const trimmed = specifier.trim();
-        if (trimmed.startsWith("type ")) {
-          return false;
-        }
-        return trimmed.split(/\s+as\s+/u)[0]?.trim() === "CONNECTOR_TYPES";
-      });
+      const namespace = match.groups?.namespace;
+      if (!namespace) {
+        return false;
+      }
+      return new RegExp(
+        `\\b${escapeRegExp(namespace)}\\.CONNECTOR_TYPES\\b`,
+        "u",
+      ).test(source);
     },
   );
 }

--- a/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest";
 const SERVER_FIREWALL_METADATA_SPECIFIER =
   "@vm0/connectors/firewall-metadata/server";
 const ROOT_FIREWALL_METADATA_SPECIFIER = "@vm0/connectors/firewall-metadata";
+const CONNECTORS_SPECIFIER = "@vm0/connectors/connectors";
 const IMPORT_SPECIFIER_PATTERN =
   /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
+const CONNECTORS_IMPORT_STATEMENT_PATTERN =
+  /\bimport\s+(?!type\b)(?<clause>[^;]*?)\s+from\s*["']@vm0\/connectors\/connectors["']/g;
 
 const PLATFORM_SRC_PREFIX = "../../";
 const productionSourceModules = import.meta.glob<string>(
@@ -54,6 +57,23 @@ function importsExactSpecifier(source: string, specifier: string): boolean {
   return importSpecifiers(source).some((importedSpecifier) => {
     return importedSpecifier === specifier;
   });
+}
+
+function importsConnectorTypesValue(source: string): boolean {
+  return [...source.matchAll(CONNECTORS_IMPORT_STATEMENT_PATTERN)].some(
+    (match) => {
+      const namedImports =
+        match.groups?.clause.match(/\{(?<imports>[\s\S]*?)\}/u)?.groups
+          ?.imports ?? "";
+      return namedImports.split(",").some((specifier) => {
+        const trimmed = specifier.trim();
+        if (trimmed.startsWith("type ")) {
+          return false;
+        }
+        return trimmed.split(/\s+as\s+/u)[0]?.trim() === "CONNECTOR_TYPES";
+      });
+    },
+  );
 }
 
 describe("firewall metadata import boundary", () => {
@@ -120,14 +140,16 @@ describe("firewall metadata import boundary", () => {
     ).toStrictEqual([]);
   });
 
-  it("keeps static connector registry values out of platform production source", () => {
+  it("keeps static connector registry value imports out of platform production source", () => {
     const offenders = Object.entries(productionSourceModules)
       .map(([path, source]) => {
         return { path: sourcePathFromGlobKey(path), source };
       })
       .filter(({ path, source }) => {
         return (
-          isProductionSourcePath(path) && source.includes("CONNECTOR_TYPES")
+          isProductionSourcePath(path) &&
+          importsExactSpecifier(source, CONNECTORS_SPECIFIER) &&
+          importsConnectorTypesValue(source)
         );
       });
 

--- a/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/firewall-metadata-import-boundary.test.ts
@@ -119,4 +119,22 @@ describe("firewall metadata import boundary", () => {
       }),
     ).toStrictEqual([]);
   });
+
+  it("keeps static connector registry values out of platform production source", () => {
+    const offenders = Object.entries(productionSourceModules)
+      .map(([path, source]) => {
+        return { path: sourcePathFromGlobKey(path), source };
+      })
+      .filter(({ path, source }) => {
+        return (
+          isProductionSourcePath(path) && source.includes("CONNECTOR_TYPES")
+        );
+      });
+
+    expect(
+      offenders.map((offender) => {
+        return offender.path;
+      }),
+    ).toStrictEqual([]);
+  });
 });

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -1,12 +1,17 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
 import {
-  CONNECTOR_TYPES,
+  connectorTypeSchema,
   type ConnectorType,
 } from "@vm0/connectors/connectors";
+import { connectorRefSchema } from "@vm0/api-contracts/contracts/connector-ref";
 import { customConnectorProposalSchema } from "@vm0/api-contracts/contracts/zero-custom-connectors";
-import { connectors$ } from "../external/connectors.ts";
 import {
-  allConnectorTypes$,
+  connectorCatalogDisplayMetadataByRef$,
+  connectorCatalogStatusByRef$,
+  connectors$,
+  type ConnectorCatalogDisplayMetadata,
+} from "../external/connectors.ts";
+import {
   justConnectedTypes$,
   setSelectedConnectorType$,
 } from "../zero-page/settings/connectors.ts";
@@ -15,12 +20,14 @@ import { isAgentConnectorAuthorized } from "../zero-page/agent-connector-authori
 import { jsonParseBase64UrlOr } from "../utils.ts";
 
 export interface ConnectorActionDescriptor {
-  connectorType: ConnectorType;
+  connectorRef: string;
+  connectorType: ConnectorType | null;
   agentId: string;
   originalUrl: string;
 }
 
 export interface ConnectorActionSignals {
+  displayMetadata$: Computed<Promise<ConnectorCatalogDisplayMetadata | null>>;
   available$: Computed<Promise<boolean>>;
   connected$: Computed<Promise<boolean>>;
   authorized$: Computed<Promise<boolean>>;
@@ -46,6 +53,7 @@ export type CustomConnectorActionBlock = CustomConnectorActionDescriptor & {
 };
 
 type ActiveChatConnectorAction = ConnectorActionDescriptor & {
+  connectorType: ConnectorType;
   markComplete$: Command<void, []>;
 };
 
@@ -80,8 +88,9 @@ export const completeChatConnectorActionConnect$ = command(
   },
 );
 
-function isConnectorType(value: string): value is ConnectorType {
-  return value in CONNECTOR_TYPES;
+function parseConnectorType(value: string): ConnectorType | null {
+  const parsed = connectorTypeSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
 }
 
 const CONNECTOR_AUTHORIZE_BASE_URL = "https://app.vm0.ai";
@@ -100,14 +109,19 @@ export function parseConnectorAuthorizeUrl(
   const match = url.pathname.match(
     /^\/connectors\/([^/]+)\/(?:authorize|connect)$/,
   );
-  const connectorType = match?.[1]?.toLowerCase();
+  const connectorRef = match?.[1]?.toLowerCase();
   const agentId = url.searchParams.get("agentId");
-  if (!connectorType || !agentId || !isConnectorType(connectorType)) {
+  if (
+    !connectorRef ||
+    !agentId ||
+    !connectorRefSchema.safeParse(connectorRef).success
+  ) {
     return null;
   }
 
   return {
-    connectorType,
+    connectorRef,
+    connectorType: parseConnectorType(connectorRef),
     agentId,
     originalUrl: value,
   };
@@ -165,34 +179,43 @@ export function createConnectorActionBlock(
     set(authorizedOverride$, true);
   });
 
+  const displayMetadata$ = computed(async (get) => {
+    const metadataByRef = await get(connectorCatalogDisplayMetadataByRef$);
+    return metadataByRef.get(descriptor.connectorRef) ?? null;
+  });
+
   const available$ = computed(async (get): Promise<boolean> => {
-    const allConnectors = await get(allConnectorTypes$);
-    return allConnectors.some((connector) => {
-      return connector.type === descriptor.connectorType;
-    });
+    const displayMetadata = await get(displayMetadata$);
+    return displayMetadata !== null && descriptor.connectorType !== null;
   });
 
   const connected$ = computed(async (get): Promise<boolean> => {
+    const connectorType = descriptor.connectorType;
+    if (connectorType === null) {
+      return false;
+    }
     if (
       get(connectedOverride$) ||
-      get(justConnectedTypes$).has(descriptor.connectorType)
+      get(justConnectedTypes$).has(connectorType)
     ) {
       return true;
     }
-    const allConnectors = await get(allConnectorTypes$);
-    return allConnectors.some((connector) => {
-      return connector.type === descriptor.connectorType && connector.connected;
-    });
+    const statusByRef = await get(connectorCatalogStatusByRef$);
+    return statusByRef.get(descriptor.connectorRef)?.connected ?? false;
   });
 
   const authorized$ = computed(async (get): Promise<boolean> => {
+    const connectorType = descriptor.connectorType;
+    if (connectorType === null) {
+      return false;
+    }
     if (get(authorizedOverride$)) {
       return true;
     }
     return await get(
       isAgentConnectorAuthorized({
         agentId: descriptor.agentId,
-        connectorType: descriptor.connectorType,
+        connectorType,
       }),
     );
   });
@@ -211,6 +234,10 @@ export function createConnectorActionBlock(
   });
 
   const activate$ = command(async ({ get, set }, signal: AbortSignal) => {
+    const connectorType = descriptor.connectorType;
+    if (connectorType === null) {
+      return;
+    }
     const available = await get(available$);
     signal.throwIfAborted();
     if (!available) {
@@ -222,7 +249,7 @@ export function createConnectorActionBlock(
     if (connected) {
       await set(
         authorizeDirectedConnector$,
-        descriptor.connectorType,
+        connectorType,
         descriptor.agentId,
         signal,
       );
@@ -233,14 +260,19 @@ export function createConnectorActionBlock(
 
     await get(connectors$);
     signal.throwIfAborted();
-    set(activeChatConnectorActionState$, { ...descriptor, markComplete$ });
-    set(setSelectedConnectorType$, descriptor.connectorType);
+    set(activeChatConnectorActionState$, {
+      ...descriptor,
+      connectorType,
+      markComplete$,
+    });
+    set(setSelectedConnectorType$, connectorType);
   });
 
   return {
     type: "connector-action",
     id,
     ...descriptor,
+    displayMetadata$,
     available$,
     connected$,
     authorized$,

--- a/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
+++ b/turbo/apps/platform/src/signals/chat-page/connector-action-block.ts
@@ -186,7 +186,7 @@ export function createConnectorActionBlock(
 
   const available$ = computed(async (get): Promise<boolean> => {
     const displayMetadata = await get(displayMetadata$);
-    return displayMetadata !== null && descriptor.connectorType !== null;
+    return displayMetadata !== null;
   });
 
   const connected$ = computed(async (get): Promise<boolean> => {

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -5,6 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorType } from "@vm0/connectors/connectors";
@@ -12,6 +13,12 @@ import type { ConnectorListResponse } from "@vm0/api-contracts/contracts/connect
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept.ts";
 import { featureSwitch$ } from "./feature-switch.ts";
+
+export interface ConnectorCatalogDisplayMetadata {
+  readonly connectorRef: string;
+  readonly label: string;
+  readonly helpText: string;
+}
 
 /**
  * Reload trigger for connector signals.
@@ -47,6 +54,37 @@ export const connectorCatalogStatus$ = computed(async (get) => {
   const client = createClient(zeroConnectorCatalogContract);
   const result = await accept(client.status(), [200]);
   return result.body as PublicConnectorCatalogStatusResponse;
+});
+
+export const connectorCatalogStatusByRef$ = computed(async (get) => {
+  const { connectors } = await get(connectorCatalogStatus$);
+  return new Map(
+    connectors.map((connector) => {
+      return [connector.connectorRef, connector];
+    }),
+  );
+});
+
+function connectorCatalogDisplayMetadata(
+  connector: PublicConnectorCatalogStatusItem,
+): ConnectorCatalogDisplayMetadata {
+  return {
+    connectorRef: connector.connectorRef,
+    label: connector.label,
+    helpText: connector.description,
+  };
+}
+
+export const connectorCatalogDisplayMetadataByRef$ = computed(async (get) => {
+  const connectorsByRef = await get(connectorCatalogStatusByRef$);
+  return new Map(
+    [...connectorsByRef.values()].map((connector) => {
+      return [
+        connector.connectorRef,
+        connectorCatalogDisplayMetadata(connector),
+      ];
+    }),
+  );
 });
 
 /**

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
@@ -4,6 +4,10 @@ import {
   zeroInsightsContract,
   type InsightsResponse,
 } from "@vm0/api-contracts/contracts/zero-insights";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -21,6 +25,45 @@ const user = userEvent.setup();
 beforeEach(() => {
   mockNow();
 });
+
+function publicConnectorStatusItem(
+  overrides: Partial<PublicConnectorCatalogStatusItem> &
+    Pick<PublicConnectorCatalogStatusItem, "connectorRef" | "label">,
+): PublicConnectorCatalogStatusItem {
+  const { connectorRef, label, ...rest } = overrides;
+  return {
+    connectorRef,
+    label,
+    description: `${label} public help text`,
+    category: "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: [],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: null,
+    connectNotice: null,
+    ...rest,
+  };
+}
+
+function mockConnectorCatalogStatus(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+): void {
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: [...connectors] });
+  });
+}
 
 function localDateDaysAgo(daysAgo: number): string {
   const date = nowDate();
@@ -482,6 +525,78 @@ describe("network insights page", () => {
     expect(screen.queryByText("Hidden chat")).not.toBeInTheDocument();
     await user.click(screen.getByText("+1 more chat"));
     expect(screen.getByText("Hidden chat")).toBeInTheDocument();
+  });
+
+  it("uses connector labels from public catalog metadata", async () => {
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({
+        connectorRef: "slack",
+        label: "Catalog Slack",
+      }),
+      publicConnectorStatusItem({
+        connectorRef: "github",
+        label: "Catalog GitHub",
+      }),
+      publicConnectorStatusItem({
+        connectorRef: "google-calendar",
+        label: "Catalog Calendar",
+      }),
+    ]);
+    context.mocks.api(zeroInsightsContract.get, ({ respond }) => {
+      return respond(200, insightsResponse());
+    });
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Insights" }),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("Catalog Slack").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Catalog GitHub").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("uses fallback connector labels when catalog metadata omits a ref", async () => {
+    const data = insightsResponse();
+    const day = data.days[0]!;
+    mockConnectorCatalogStatus([]);
+    context.mocks.api(zeroInsightsContract.get, ({ respond }) => {
+      return respond(200, {
+        ...data,
+        days: [
+          {
+            ...day,
+            services: [
+              {
+                domain: "github",
+                calls: 2,
+                agentNames: ["Research Bot"],
+              },
+            ],
+            permissions: [
+              {
+                label: "repo-read",
+                connectorType: "github",
+                allowed: 1,
+                denied: 0,
+                agentNames: ["Research Bot"],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    detachedSetupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Insights" }),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("Github").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
   it("shows a no-activity message when the selected range excludes older data", async () => {

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -48,12 +48,17 @@ import {
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
+import {
+  connectorCatalogDisplayMetadataByRef$,
+  type ConnectorCatalogDisplayMetadata,
+} from "../../signals/external/connectors.ts";
 import { formatCredits } from "../../lib/format-credits.ts";
 import { getCardPalette } from "../../lib/card-palette.ts";
-import {
-  CONNECTOR_TYPES,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+
+type ConnectorDisplayMetadataByRef = ReadonlyMap<
+  string,
+  ConnectorCatalogDisplayMetadata
+>;
 
 // ---------------------------------------------------------------------------
 // Date range filter
@@ -726,29 +731,52 @@ function YourCreditUsageCard({
 // Card: Services accessed
 // ---------------------------------------------------------------------------
 
-function connectorLabel(type: string): string {
-  const config = CONNECTOR_TYPES[type as ConnectorType];
-  if (config) {
-    return config.label;
+function fallbackConnectorLabel(ref: string): string {
+  const words = ref
+    .split(/[-_\s]+/u)
+    .map((word) => {
+      return word.trim();
+    })
+    .filter((word) => {
+      return word.length > 0;
+    });
+  if (words.length === 0) {
+    return ref;
   }
-  return type.charAt(0).toUpperCase() + type.slice(1);
+  return words
+    .map((word) => {
+      return `${word.charAt(0).toUpperCase()}${word.slice(1)}`;
+    })
+    .join(" ");
 }
 
-function permissionLabel(p: { label: string; connectorType?: string }): string {
+function connectorLabel(
+  type: string,
+  metadataByRef: ConnectorDisplayMetadataByRef | null,
+): string {
+  return metadataByRef?.get(type)?.label ?? fallbackConnectorLabel(type);
+}
+
+function permissionLabel(
+  p: { label: string; connectorType?: string },
+  metadataByRef: ConnectorDisplayMetadataByRef | null,
+): string {
   if (!p.connectorType || p.label === p.connectorType) {
-    return connectorLabel(p.label);
+    return connectorLabel(p.label, metadataByRef);
   }
-  return `${connectorLabel(p.connectorType)}(${p.label})`;
+  return `${connectorLabel(p.connectorType, metadataByRef)}(${p.label})`;
 }
 
 function ServicesCard({
   day,
   colorIndex,
   hoveredAgent,
+  metadataByRef,
 }: {
   day: DayInsight;
   colorIndex: number;
   hoveredAgent: string | null;
+  metadataByRef: ConnectorDisplayMetadataByRef | null;
 }) {
   const maxCalls = Math.max(
     1,
@@ -790,7 +818,7 @@ function ServicesCard({
               className={`flex items-center gap-3 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
               <span className="text-sm font-medium w-20 truncate shrink-0">
-                {connectorLabel(s.domain)}
+                {connectorLabel(s.domain, metadataByRef)}
               </span>
               <div className="flex-1 h-1.5 rounded-full bg-current/10 overflow-hidden">
                 <div
@@ -819,10 +847,12 @@ function PermissionsAllowedCard({
   day,
   colorIndex,
   hoveredAgent,
+  metadataByRef,
 }: {
   day: DayInsight;
   colorIndex: number;
   hoveredAgent: string | null;
+  metadataByRef: ConnectorDisplayMetadataByRef | null;
 }) {
   const expandedDays = useGet(expandedAllowedDays$);
   const toggleExpanded = useSet(toggleExpandedAllowed$);
@@ -870,7 +900,7 @@ function PermissionsAllowedCard({
             >
               <div className="flex items-center justify-between gap-2">
                 <span className="text-sm font-medium">
-                  {connectorLabel(p.connectorType ?? p.label)}
+                  {connectorLabel(p.connectorType ?? p.label, metadataByRef)}
                 </span>
                 <span className="text-xs opacity-60 tabular-nums shrink-0">
                   {p.allowed} {p.allowed === 1 ? "call" : "calls"}
@@ -904,9 +934,11 @@ function PermissionsAllowedCard({
 function PermissionsBlockedCard({
   day,
   hoveredAgent,
+  metadataByRef,
 }: {
   day: DayInsight;
   hoveredAgent: string | null;
+  metadataByRef: ConnectorDisplayMetadataByRef | null;
 }) {
   const blocked = day.permissions.filter((p) => {
     return p.denied > 0;
@@ -947,7 +979,9 @@ function PermissionsBlockedCard({
               key={`${p.connectorType ?? ""}:${p.label}`}
               className={`flex items-center justify-between gap-2 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
-              <span className="text-sm font-medium">{permissionLabel(p)}</span>
+              <span className="text-sm font-medium">
+                {permissionLabel(p, metadataByRef)}
+              </span>
               <span className="text-xs tabular-nums shrink-0 opacity-70">
                 {fullyBlocked
                   ? `${p.denied} rejected`
@@ -1235,10 +1269,12 @@ function DaySection({
   day,
   isAdmin,
   userId,
+  metadataByRef,
 }: {
   day: DayInsight;
   isAdmin: boolean;
   userId: string | null;
+  metadataByRef: ConnectorDisplayMetadataByRef | null;
 }) {
   const hoveredAgent = useGet(insightsHoveredAgent$);
   const setHoveredAgent = useSet(setInsightsHoveredAgent$);
@@ -1273,15 +1309,25 @@ function DaySection({
           hoveredAgent={hoveredAgent}
           onHoverAgent={handleHoverAgent}
         />
-        <ServicesCard day={day} colorIndex={2} hoveredAgent={hoveredAgent} />
+        <ServicesCard
+          day={day}
+          colorIndex={2}
+          hoveredAgent={hoveredAgent}
+          metadataByRef={metadataByRef}
+        />
         <DayAutomationsCard dayDate={day.date} automations={day.automations} />
         <DayChatsCard dayDate={day.date} chats={day.chats} />
         <PermissionsAllowedCard
           day={day}
           colorIndex={5}
           hoveredAgent={hoveredAgent}
+          metadataByRef={metadataByRef}
         />
-        <PermissionsBlockedCard day={day} hoveredAgent={hoveredAgent} />
+        <PermissionsBlockedCard
+          day={day}
+          hoveredAgent={hoveredAgent}
+          metadataByRef={metadataByRef}
+        />
       </div>
     </section>
   );
@@ -1311,6 +1357,9 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
   const prefsLoadable = useLastLoadable(userPreferences$);
   const adminLoadable = useLastLoadable(isOrgAdmin$);
   const userLoadable = useLastLoadable(user$);
+  const connectorMetadataLoadable = useLastLoadable(
+    connectorCatalogDisplayMetadataByRef$,
+  );
   const timezone =
     prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
       ? prefsLoadable.data.timezone
@@ -1321,6 +1370,10 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
     adminLoadable.state === "hasData" ? adminLoadable.data : false;
   const userId =
     userLoadable.state === "hasData" ? (userLoadable.data?.id ?? null) : null;
+  const connectorMetadataByRef =
+    connectorMetadataLoadable.state === "hasData"
+      ? connectorMetadataLoadable.data
+      : null;
 
   return (
     <div className="h-full overflow-auto">
@@ -1377,6 +1430,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
                 day={day}
                 isAdmin={isAdmin}
                 userId={userId}
+                metadataByRef={connectorMetadataByRef}
               />
             );
           })

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -326,9 +326,16 @@ describe("chat message action cards", () => {
     });
   });
 
-  it("does not render connector action cards when catalog metadata is hidden", async () => {
-    const connectorAuthorizeUrl = `https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID}`;
-    mockConnectorCatalogStatus([]);
+  it("omits connector action cards when catalog metadata is hidden", async () => {
+    const hiddenConnectorAuthorizeUrl = `https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID}`;
+    const visibleConnectorAuthorizeUrl = `https://app.vm0.ai/connectors/slack/authorize?agentId=${AGENT_ID}`;
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({
+        connectorRef: "slack",
+        label: "Catalog Slack",
+        description: "Catalog Slack server help text",
+      }),
+    ]);
     mockChatLifecycle(context, {
       threadId: `${THREAD_ID}-hidden-connector-metadata`,
       threadTitle: "Hidden connector metadata",
@@ -343,7 +350,7 @@ describe("chat message action cards", () => {
         {
           id: "msg-assistant-hidden-connector-card",
           role: "assistant",
-          content: connectorAuthorizeUrl,
+          content: `${hiddenConnectorAuthorizeUrl}\n\n${visibleConnectorAuthorizeUrl}`,
           runId: "run-hidden-connector",
           createdAt: "2026-06-09T10:01:00Z",
         },
@@ -359,11 +366,16 @@ describe("chat message action cards", () => {
       "Connect hidden catalog connector",
     );
     expect(userMessage).toBeInTheDocument();
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("connector-action-card"),
-      ).not.toBeInTheDocument();
-    });
+    const connectorCards = await screen.findAllByTestId(
+      "connector-action-card",
+    );
+    expect(connectorCards).toHaveLength(1);
+    expect(
+      within(connectorCards[0]!).getByText("Catalog Slack"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectorCards[0]!).getByText("Catalog Slack server help text"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -367,6 +367,51 @@ describe("chat message action cards", () => {
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
+  it("renders catalog-visible unsupported connector action cards as disabled", async () => {
+    const connectorAuthorizeUrl = `https://app.vm0.ai/connectors/future-connector/authorize?agentId=${AGENT_ID}`;
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({
+        connectorRef: "future-connector",
+        label: "Catalog Future Connector",
+        description: "Catalog future connector help text",
+      }),
+    ]);
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-future-connector`,
+      threadTitle: "Future connector",
+      chatMessages: [
+        {
+          id: "msg-user-future-connector",
+          role: "user",
+          content: "Connect future connector",
+          runId: "run-future-connector",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-assistant-future-connector-card",
+          role: "assistant",
+          content: connectorAuthorizeUrl,
+          runId: "run-future-connector",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-future-connector`,
+    });
+
+    const connectorCard = await screen.findByTestId("connector-action-card");
+    expect(
+      within(connectorCard).getByText("Catalog Future Connector"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectorCard).getByText("Catalog future connector help text"),
+    ).toBeInTheDocument();
+    expect(buttonByText("Unavailable", connectorCard)).toBeDisabled();
+  });
+
   it("fails closed when permission action metadata is hidden", async () => {
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=hidden-connector&permission=hidden.permission&action=allow&expiresIn=1h`;
     context.mocks.api(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -2,6 +2,7 @@ import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-s
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogPermissionDetail,
+  type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import {
@@ -85,6 +86,45 @@ function connectedConnector(
   };
 }
 
+function publicConnectorStatusItem(
+  overrides: Partial<PublicConnectorCatalogStatusItem> &
+    Pick<PublicConnectorCatalogStatusItem, "connectorRef" | "label">,
+): PublicConnectorCatalogStatusItem {
+  const { connectorRef, label, ...rest } = overrides;
+  return {
+    connectorRef,
+    label,
+    description: `${label} public help text`,
+    category: "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: [],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: null,
+    connectNotice: null,
+    ...rest,
+  };
+}
+
+function mockConnectorCatalogStatus(
+  connectors: readonly PublicConnectorCatalogStatusItem[],
+): void {
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, { connectors: [...connectors] });
+  });
+}
+
 function mockAgentConnectorAuthorizations(
   initialTypes: readonly string[],
 ): void {
@@ -160,6 +200,21 @@ describe("chat message action cards", () => {
         externalUsername: "octocat",
       }),
     ]);
+    mockConnectorCatalogStatus([
+      publicConnectorStatusItem({
+        connectorRef: "github",
+        label: "Catalog GitHub",
+        description: "Catalog GitHub server help text",
+        connected: true,
+        connectionStatus: "connected",
+        connection: {
+          authMethod: "oauth",
+          externalUsername: "octocat",
+          externalEmail: null,
+          reconnectReason: null,
+        },
+      }),
+    ]);
     mockAgentConnectorAuthorizations([]);
     context.mocks.api(
       zeroConnectorCatalogContract.permissions,
@@ -227,7 +282,12 @@ describe("chat message action cards", () => {
     });
 
     const connectorCard = await screen.findByTestId("connector-action-card");
-    expect(within(connectorCard).getByText("GitHub")).toBeInTheDocument();
+    expect(
+      within(connectorCard).getByText("Catalog GitHub"),
+    ).toBeInTheDocument();
+    expect(
+      within(connectorCard).getByText("Catalog GitHub server help text"),
+    ).toBeInTheDocument();
     await user.click(within(connectorCard).getByText("Connect"));
 
     await waitFor(() => {
@@ -264,6 +324,47 @@ describe("chat message action cards", () => {
         ],
       });
     });
+  });
+
+  it("does not render connector action cards when catalog metadata is hidden", async () => {
+    const connectorAuthorizeUrl = `https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID}`;
+    mockConnectorCatalogStatus([]);
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-hidden-connector-metadata`,
+      threadTitle: "Hidden connector metadata",
+      chatMessages: [
+        {
+          id: "msg-user-hidden-connector",
+          role: "user",
+          content: "Connect hidden catalog connector",
+          runId: "run-hidden-connector",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-assistant-hidden-connector-card",
+          role: "assistant",
+          content: connectorAuthorizeUrl,
+          runId: "run-hidden-connector",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-hidden-connector-metadata`,
+    });
+
+    const userMessage = await screen.findByText(
+      "Connect hidden catalog connector",
+    );
+    expect(userMessage).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("connector-action-card"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
   it("fails closed when permission action metadata is hidden", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -110,7 +110,6 @@ import type {
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { emptyArtifactImg, emptyChatImg } from "./platform-assets.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { CONNECTOR_TYPES } from "@vm0/connectors/connectors";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { Markdown } from "../components/markdown.tsx";
@@ -5610,11 +5609,12 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
   const pageSignal = useGet(pageSignal$);
   const available = useLastResolved(block.available$) ?? false;
   const complete = useLastResolved(block.complete$) ?? false;
+  const displayMetadata = useLastResolved(block.displayMetadata$);
   const [activateLoadable, activate] = useLoadableSet(block.activate$);
   const activating = activateLoadable.state === "loading";
-  const config = CONNECTOR_TYPES[block.connectorType];
+  const connectorType = block.connectorType;
 
-  if (!available) {
+  if (!available || !displayMetadata || connectorType === null) {
     return null;
   }
 
@@ -5625,14 +5625,14 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          <ConnectorIcon type={block.connectorType} size={22} />
+          <ConnectorIcon type={connectorType} size={22} />
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
-            {config.label}
+            {displayMetadata.label}
           </div>
           <div className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
-            {config.helpText}
+            {displayMetadata.helpText}
           </div>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5614,9 +5614,11 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
   const activating = activateLoadable.state === "loading";
   const connectorType = block.connectorType;
 
-  if (!available || !displayMetadata || connectorType === null) {
+  if (!available || !displayMetadata) {
     return null;
   }
+
+  const canActivate = connectorType !== null;
 
   return (
     <div
@@ -5625,7 +5627,11 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          <ConnectorIcon type={connectorType} size={22} />
+          {connectorType ? (
+            <ConnectorIcon type={connectorType} size={22} />
+          ) : (
+            <IconPackage size={22} />
+          )}
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
@@ -5638,14 +5644,14 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
       </div>
       <button
         type="button"
-        disabled={complete || activating}
+        disabled={complete || activating || !canActivate}
         onClick={() => {
           detach(activate(pageSignal), Reason.DomCallback);
         }}
         className="inline-flex h-9 w-full shrink-0 items-center justify-center gap-2 rounded-lg border border-border bg-background px-3 text-[0.9375rem] font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
       >
         {activating && <IconLoader2 size={15} className="animate-spin" />}
-        {complete ? "Connected" : "Connect"}
+        {!canActivate ? "Unavailable" : complete ? "Connected" : "Connect"}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- derive raw connector display/status lookup from the public catalog status response
- move network insights and chat connector action cards off static `CONNECTOR_TYPES` display lookups
- keep enum narrowing only at existing connector action execution boundaries and add a platform import-boundary guard

Closes #20001

## Tests
- `pnpm format`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/firewall-metadata-import-boundary.test.ts --reporter=dot`
- `pnpm -F @vm0/app exec vitest run src/views/network-insights/__tests__/network-insights-page.test.tsx --reporter=dot`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx --reporter=dot`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
