### PR TITLE
fix: prioritize route agent during pinned chat switches

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/agent-chat.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/agent-chat.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCurrentChatAgentId } from "../agent-chat.ts";
+
+describe("resolveCurrentChatAgentId", () => {
+  it("lets the agent chat route win over stale internal chat agent state", () => {
+    expect(
+      resolveCurrentChatAgentId({
+        threadAgentId: null,
+        routeAgentId: "route-agent",
+        internalAgentId: "previous-agent",
+        defaultAgentId: "default-agent",
+      }),
+    ).toBe("route-agent");
+  });
+
+  it("keeps thread-owned chat routes ahead of agent chat routes", () => {
+    expect(
+      resolveCurrentChatAgentId({
+        threadAgentId: "thread-agent",
+        routeAgentId: "route-agent",
+        internalAgentId: "previous-agent",
+        defaultAgentId: "default-agent",
+      }),
+    ).toBe("thread-agent");
+  });
+});

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -70,14 +70,28 @@ const currentChatThreadAgentId$ = computed(
 
 export const currentChatAgentId$ = computed(
   async (get): Promise<string | null> => {
-    return (
-      (await get(currentChatThreadAgentId$)) ??
-      get(internalChatAgentId$) ??
-      get(currentAgentId$) ??
-      (await get(defaultAgentId$))
-    );
+    return resolveCurrentChatAgentId({
+      threadAgentId: await get(currentChatThreadAgentId$),
+      routeAgentId: get(currentAgentId$),
+      internalAgentId: get(internalChatAgentId$),
+      defaultAgentId: await get(defaultAgentId$),
+    });
   },
 );
+
+export function resolveCurrentChatAgentId({
+  defaultAgentId,
+  internalAgentId,
+  routeAgentId,
+  threadAgentId,
+}: {
+  readonly defaultAgentId: string | null;
+  readonly internalAgentId: string | null;
+  readonly routeAgentId: string | null;
+  readonly threadAgentId: string | null;
+}): string | null {
+  return threadAgentId ?? routeAgentId ?? internalAgentId ?? defaultAgentId;
+}
 
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -32,7 +32,7 @@ import {
 } from "../../signals/zero-page/zero-nav.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
 import type { RouteKey } from "../../signals/route-paths.ts";
-import { defaultAgentName$ } from "../../signals/agent.ts";
+import { currentAgentId$, defaultAgentName$ } from "../../signals/agent.ts";
 import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import {
   isScrolled$,
@@ -138,8 +138,9 @@ const FOOTER_NAV = [
 // useLastResolved keeps the previously-resolved agent ID during re-loads, preventing unnecessary
 // remounts of ChatThreadsSection that would cause the chat list to flash.
 function ChatThreadsSectionWithKey() {
+  const routeAgentId = useGet(currentAgentId$);
   const currentChatAgentId = useLastResolved(currentChatAgentId$);
-  return <ChatThreadsSection key={currentChatAgentId} />;
+  return <ChatThreadsSection key={routeAgentId ?? currentChatAgentId} />;
 }
 
 // Shared subscription hooks. Each sibling component pulls its own state from


### PR DESCRIPTION
## Summary
- Make `/agents/:agentId/chat` route state win over stale internal chat-agent state when resolving the current chat agent.
- Remount the sidebar chat-thread section with the route agent id immediately, so rapidly clicking pinned agents does not keep showing the previous agent chat list while async chat-agent state catches up.
- Add a small regression test that locks route-agent precedence over previous internal chat-agent state.

## Verification
- pnpm exec prettier --check apps/platform/src/signals/agent-chat.ts apps/platform/src/signals/__tests__/agent-chat.test.ts apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
- pnpm exec vitest run src/signals/__tests__/agent-chat.test.ts --config vitest.config.ts --reporter verbose (from turbo/apps/platform)
- NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app check-types