### PR TITLE
refactor: simplify new chat thread metadata flow

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/realtime.test.ts
@@ -120,7 +120,7 @@ function createFailingSubscribeDataSource(
   };
 
   return {
-    getThread$: computed(() => {
+    remoteThreadDetail$: computed(() => {
       return Promise.resolve(thread);
     }),
     reloadThread$: command(() => {}),

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -20,8 +20,11 @@ import {
 import { renameDialogInput$ } from "../../zero-page/zero-sidebar-state.ts";
 import { sidebarChatThreadIds$ } from "../sidebar-chat-thread-ids.ts";
 import { setChatThreadOnlyUnread$ } from "../chat-thread-only-unread.ts";
-import { openRenameChatThreadDialogFromThreadData$ } from "../chat-thread-rename.ts";
-import { registerOptimisticChatThreadEvent$ } from "../chat-thread-event-sourcing.ts";
+import { openRenameChatThreadDialogFromThreadMeta$ } from "../chat-thread-rename.ts";
+import {
+  eventDrivenChatThreadMeta,
+  registerOptimisticChatThreadEvent$,
+} from "../chat-thread-event-sourcing.ts";
 import { createIdbCachedDataSource } from "../idb-cached-chat-thread-data-source.ts";
 
 const idbThreadEventStoreMock = vi.hoisted(() => {
@@ -438,25 +441,14 @@ describe("chat thread event sourcing local-first list", () => {
 
     const dataSource = createIdbCachedDataSource(OPTIMISTIC_THREAD_ID);
     await expect(
-      context.store.get(dataSource.getThread$),
+      context.store.get(dataSource.remoteThreadDetail$),
+    ).resolves.toBeNull();
+    await expect(
+      context.store.get(eventDrivenChatThreadMeta(OPTIMISTIC_THREAD_ID)),
     ).resolves.toStrictEqual({
-      id: OPTIMISTIC_THREAD_ID,
-      title: null,
+      threadId: OPTIMISTIC_THREAD_ID,
       agentId: AGENT_ID,
-      createdAt: "2026-07-03T05:00:00.000Z",
-      updatedAt: "2026-07-03T05:00:00.000Z",
-      lastReadMessageId: null,
-      lastReadAt: null,
-      lastMessageAt: "2026-07-03T05:00:00.000Z",
-      pinnedAt: null,
-      activeRunIds: [],
-      isLegacySession: false,
-      draftContent: null,
-      draftAttachments: null,
-      modelProviderId: null,
-      selectedModel: null,
-      codexServiceTier: null,
-      computerUseHostId: null,
+      title: null,
     });
   });
 
@@ -578,7 +570,7 @@ describe("chat thread event sourcing local-first list", () => {
 
     detailRequests = 0;
     await context.store.set(
-      openRenameChatThreadDialogFromThreadData$,
+      openRenameChatThreadDialogFromThreadMeta$,
       {
         threadId: THREAD_ID,
         title: "Cached renamed title",

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -9,9 +9,9 @@ import {
 } from "./chat-thread-panes.ts";
 import type { ChatThreadSignals } from "./chat-thread-signals.ts";
 import {
-  clearChatThreadEmojiFromThreadData$,
-  openRenameChatThreadDialogFromThreadData$,
-  setChatThreadEmojiFromThreadData$,
+  clearChatThreadEmojiFromThreadMeta$,
+  openRenameChatThreadDialogFromThreadMeta$,
+  setChatThreadEmojiFromThreadMeta$,
   type RenameChatThreadDialogRequest,
 } from "./chat-thread-rename.ts";
 import { eventDrivenChatThreadMeta } from "./chat-thread-event-sourcing.ts";
@@ -235,7 +235,7 @@ const setFocusedThreadEmoji$ = command(
       return;
     }
     await set(
-      setChatThreadEmojiFromThreadData$,
+      setChatThreadEmojiFromThreadMeta$,
       {
         threadId: args.thread.threadId,
         emoji: args.emoji,
@@ -276,7 +276,7 @@ const setupChatPageShortcutActions$ = command(
               signal,
             );
             await set(
-              openRenameChatThreadDialogFromThreadData$,
+              openRenameChatThreadDialogFromThreadMeta$,
               request,
               signal,
             );
@@ -324,7 +324,7 @@ const clearFocusedThreadEmoji$ = command(
       return;
     }
     await set(
-      clearChatThreadEmojiFromThreadData$,
+      clearChatThreadEmojiFromThreadMeta$,
       {
         threadId: args.thread.threadId,
       },

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-data-source.ts
@@ -102,7 +102,7 @@ export interface SubscribeRealtimeArgs {
 }
 
 export interface ChatThreadDataSource {
-  getThread$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   reloadThread$: Command<void, []>;
   initialPage$: Computed<Promise<InitialPage>>;
   patchDraft$: Command<Promise<void>, [PatchDraftArgs, AbortSignal]>;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -68,15 +68,15 @@ const loadDraft$ = command(
     isNew: boolean,
     signal: AbortSignal,
   ) => {
-    const threadData = await get(thread.threadData$);
+    const remoteThreadDetail = await get(thread.remoteThreadDetail$);
     signal.throwIfAborted();
 
-    if (!threadData) {
-      throw new Error("Thread data missing");
+    if (!remoteThreadDetail) {
+      return;
     }
 
-    const hasDraftContent = threadData.draftContent !== null;
-    const draftAttachments = threadData.draftAttachments;
+    const hasDraftContent = remoteThreadDetail.draftContent !== null;
+    const draftAttachments = remoteThreadDetail.draftAttachments;
     const hasDraftAttachments =
       draftAttachments !== null && draftAttachments.length > 0;
     if (isNew && (hasDraftContent || hasDraftAttachments)) {
@@ -85,7 +85,7 @@ const loadDraft$ = command(
       );
       set(
         thread.draft.seed$,
-        threadData.draftContent ?? "",
+        remoteThreadDetail.draftContent ?? "",
         restoredAttachments,
       );
     }

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
@@ -13,7 +13,7 @@ export interface RenameChatThreadDialogRequest {
   readonly agentId?: string | null;
 }
 
-export const openRenameChatThreadDialogFromThreadData$ = command(
+export const openRenameChatThreadDialogFromThreadMeta$ = command(
   ({ set }, request: RenameChatThreadDialogRequest, _signal: AbortSignal) => {
     set(openRenameChatThreadDialog$, {
       threadId: request.threadId,
@@ -28,7 +28,7 @@ export const openRenameChatThreadDialogForThreadId$ = command(
     const threadMeta = await get(eventDrivenChatThreadMeta(threadId));
     signal.throwIfAborted();
     set(
-      openRenameChatThreadDialogFromThreadData$,
+      openRenameChatThreadDialogFromThreadMeta$,
       {
         threadId,
         title: threadMeta?.title,
@@ -39,13 +39,7 @@ export const openRenameChatThreadDialogForThreadId$ = command(
   },
 );
 
-export const reloadChatThreadDataForId$ = command(
-  (_context, _threadId: string) => {
-    return undefined;
-  },
-);
-
-export const setChatThreadEmojiFromThreadData$ = command(
+export const setChatThreadEmojiFromThreadMeta$ = command(
   async (
     { get, set },
     {
@@ -67,11 +61,10 @@ export const setChatThreadEmojiFromThreadData$ = command(
       },
       signal,
     );
-    set(reloadChatThreadDataForId$, threadId);
   },
 );
 
-export const clearChatThreadEmojiFromThreadData$ = command(
+export const clearChatThreadEmojiFromThreadMeta$ = command(
   async (
     { get, set },
     { threadId, title }: { threadId: string; title?: string | null },
@@ -89,6 +82,5 @@ export const clearChatThreadEmojiFromThreadData$ = command(
       { threadId, title: nextTitle, agentId: threadMeta?.agentId },
       signal,
     );
-    set(reloadChatThreadDataForId$, threadId);
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -29,14 +29,14 @@ export interface SendMessageOptions {
 export interface ChatThreadSignals {
   threadId: string;
   // -- Data signals ----------------------------------------------------------
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   threadMeta$: Computed<Promise<ThreadMeta | null>>;
   reloadThread$: Command<void, []>;
   threadTitleEmoji$: Computed<Promise<string | null>>;
   threadTitleText$: Computed<Promise<string>>;
   // -- Composer model override ---------------------------------------------
-  // Seeded from threadData$ on first resolve; user edits via setModelSelection$
-  // take over and are preserved across subsequent threadData$ reloads.
+  // Seeded from remoteThreadDetail$ on first resolve; user edits via setModelSelection$
+  // take over and are preserved across subsequent remoteThreadDetail$ reloads.
   modelSelection$: Computed<Promise<ModelProviderSelection | null>>;
   setModelSelection$: Command<
     Promise<void>,
@@ -85,7 +85,7 @@ export interface ChatThreadSignals {
     (() => void) | undefined,
     [HTMLElement | null]
   >;
-  // -- Agent info (derived from threadData$.agentId) ------------------------
+  // -- Agent info (local meta first, remote detail fallback) ----------------
   agentId$: Computed<Promise<string | null>>;
   agentDisplayName$: Computed<Promise<string | null>>;
   defaultModelSelection$: Computed<Promise<ModelProviderSelection | null>>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -496,39 +496,23 @@ function cancellableRunIdsFromRawMessages(
 }
 
 // ---------------------------------------------------------------------------
-// Sub-factory: thread data fetching
+// Sub-factory: remote thread detail fetching
 // ---------------------------------------------------------------------------
 
-// The data source owns both `getThread$` (the resolved thread) and
+// The data source owns both `remoteThreadDetail$` (the resolved thread) and
 // `reloadThread$` (the invalidation lever). Local mode never reloads;
-// remote mode bumps an internal counter on its `getThread$` computed.
-function createThreadData(dataSource: ChatThreadDataSource) {
+// remote mode bumps an internal counter on its `remoteThreadDetail$` computed.
+function createRemoteThreadDetail(dataSource: ChatThreadDataSource) {
   return {
-    threadData$: dataSource.getThread$,
+    remoteThreadDetail$: dataSource.remoteThreadDetail$,
     reloadThread$: dataSource.reloadThread$,
   };
 }
 
-function threadMetaFromThreadData(threadData: ChatThread): ThreadMeta {
-  return {
-    threadId: threadData.id,
-    agentId: threadData.agentId,
-    title: threadData.title,
-  };
-}
-
-function createThreadMeta(
-  threadId: string,
-  threadData$: Computed<Promise<ChatThread | null>>,
-) {
+function createThreadMeta(threadId: string) {
   const eventDrivenThreadMeta$ = eventDrivenChatThreadMeta(threadId);
   return computed(async (get): Promise<ThreadMeta | null> => {
-    const eventMeta = await get(eventDrivenThreadMeta$);
-    if (eventMeta) {
-      return eventMeta;
-    }
-    const threadData = await get(threadData$);
-    return threadData ? threadMetaFromThreadData(threadData) : null;
+    return await get(eventDrivenThreadMeta$);
   });
 }
 
@@ -554,7 +538,7 @@ function createThreadTitleParts(
 
 function createModelSelection(
   threadId: string,
-  threadData$: Computed<Promise<ChatThread | null>>,
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>,
   dataSource: ChatThreadDataSource,
 ) {
   const optimisticCreateUnsettled$ =
@@ -573,7 +557,7 @@ function createModelSelection(
       if (user.kind === "set") {
         return user.value;
       }
-      const thread = await get(threadData$);
+      const thread = await get(remoteThreadDetail$);
       if (thread?.selectedModel) {
         return {
           modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
@@ -626,7 +610,7 @@ function createModelSelection(
 
 function createComputerUseHostSelection(
   threadId: string,
-  threadData$: Computed<Promise<ChatThread | null>>,
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>,
   dataSource: ChatThreadDataSource,
 ) {
   const optimisticCreateUnsettled$ =
@@ -640,7 +624,7 @@ function createComputerUseHostSelection(
     if (user.kind === "set") {
       return user.value;
     }
-    const thread = await get(threadData$);
+    const thread = await get(remoteThreadDetail$);
     return thread?.computerUseHostId ?? null;
   });
 
@@ -736,7 +720,7 @@ function createComposerFileInput() {
 
 function createAgentInfoSignals(
   threadId: string,
-  threadData$: Computed<Promise<ChatThread | null>>,
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>,
 ) {
   const eventDrivenThreadMeta$ = eventDrivenChatThreadMeta(threadId);
 
@@ -748,7 +732,7 @@ function createAgentInfoSignals(
     if (eventMeta) {
       return eventMeta.agentId;
     }
-    const thread = await get(threadData$);
+    const thread = await get(remoteThreadDetail$);
     return thread?.agentId ?? null;
   });
 
@@ -1659,7 +1643,7 @@ function createFetchUpdatedMessageCommand({
 
 function createPagedMessages(
   threadId: string,
-  threadData$: Computed<Promise<ChatThread | null>>,
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>,
   dataSource: ChatThreadDataSource,
 ) {
   const loadedHistoryHasMore$ = state<boolean | null>(null);
@@ -1772,7 +1756,7 @@ function createPagedMessages(
 
   const loadHistory$ = createLoadHistoryCommand({
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     earliestChatMessageId$,
     historyMessages$,
     loadedHistoryHasMore$,
@@ -1802,14 +1786,14 @@ function createPagedMessages(
 
 function createChatThreadMessagePipeline({
   threadId,
-  threadData$,
+  remoteThreadDetail$,
   dataSource,
   recordScrollHeightForPrepend$,
   clearScrollHeightForPrepend$,
   awayFromBottom$,
 }: {
   threadId: string;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   dataSource: ChatThreadDataSource;
   recordScrollHeightForPrepend$: Command<
     PrependScrollCompensationToken | null,
@@ -1821,7 +1805,11 @@ function createChatThreadMessagePipeline({
   >;
   awayFromBottom$: Computed<boolean>;
 }) {
-  const pagedMessages = createPagedMessages(threadId, threadData$, dataSource);
+  const pagedMessages = createPagedMessages(
+    threadId,
+    remoteThreadDetail$,
+    dataSource,
+  );
   const renderedMessages = createChatRenderWindow({
     threadId,
     groupedChatMessages$: pagedMessages.groupedChatMessages$,
@@ -1857,7 +1845,7 @@ function createChatThreadMessagePipeline({
 
 function createLoadHistoryCommand({
   threadId,
-  threadData$,
+  remoteThreadDetail$,
   earliestChatMessageId$,
   historyMessages$,
   loadedHistoryHasMore$,
@@ -1866,7 +1854,7 @@ function createLoadHistoryCommand({
   dataSource,
 }: {
   threadId: string;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   earliestChatMessageId$: Computed<Promise<string | undefined>>;
   historyMessages$: State<PagedChatMessage[]>;
   loadedHistoryHasMore$: State<boolean | null>;
@@ -1876,7 +1864,7 @@ function createLoadHistoryCommand({
 }): Command<Promise<LoadHistoryResult>, [AbortSignal]> {
   return command(
     async ({ get, set }, signal: AbortSignal): Promise<LoadHistoryResult> => {
-      const thread = await get(threadData$);
+      const thread = await get(remoteThreadDetail$);
       signal.throwIfAborted();
       if (!thread) {
         set(loadedHistoryHasMore$, false);
@@ -2146,7 +2134,7 @@ function createSilentBackfillHistoryCommand({
 interface RunTrackingDeps {
   threadId: string;
   reloadThread$: Command<void, []>;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   latestRunStatus$: Computed<Promise<string | null>>;
   initialPage$: Computed<Promise<InitialPage>>;
@@ -2160,7 +2148,7 @@ interface RunTrackingDeps {
 
 interface MarkThreadReadDeps {
   threadId: string;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   latestChatMessageId$: Computed<Promise<string | undefined>>;
   locallyMarkedReadMessageId$: State<string | undefined>;
   dataSource: ChatThreadDataSource;
@@ -2286,7 +2274,7 @@ function createChatRenderWindow({
 
 function createMarkThreadReadIfNeeded({
   threadId,
-  threadData$,
+  remoteThreadDetail$,
   latestChatMessageId$,
   locallyMarkedReadMessageId$,
   dataSource,
@@ -2307,7 +2295,7 @@ function createMarkThreadReadIfNeeded({
       return;
     }
 
-    const thread = await get(threadData$);
+    const thread = await get(remoteThreadDetail$);
     sig.throwIfAborted();
     const lastReadMessageId =
       get(locallyMarkedReadMessageId$) ?? thread?.lastReadMessageId ?? null;
@@ -2333,7 +2321,7 @@ function createMarkThreadReadIfNeeded({
 function createRunTracking({
   threadId,
   reloadThread$,
-  threadData$,
+  remoteThreadDetail$,
   latestChatMessageId$,
   latestRunStatus$,
   initialPage$,
@@ -2353,7 +2341,7 @@ function createRunTracking({
 
   const markThreadReadIfNeeded$ = createMarkThreadReadIfNeeded({
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     latestChatMessageId$,
     locallyMarkedReadMessageId$,
     dataSource,
@@ -2376,7 +2364,7 @@ function createRunTracking({
   const onSubscribed$ = command(async ({ get, set }, sig: AbortSignal) => {
     L.debug("subscribeChatThread$ catchup start", { threadId });
     set(reloadThread$);
-    await get(threadData$);
+    await get(remoteThreadDetail$);
     sig.throwIfAborted();
     if (await set(shouldRunSubscribeReadyCatchup$, sig)) {
       await set(fetchNextPage$, sig);
@@ -2424,7 +2412,7 @@ function createRunTracking({
       set(reloadThread$);
       await set(refreshLatestMessages$, sig);
       sig.throwIfAborted();
-      await get(threadData$);
+      await get(remoteThreadDetail$);
       animationFrame(
         () => {
           set(autoScroll$);
@@ -2577,7 +2565,7 @@ function hasVisualDraftAttachments(
 
 interface SendMessageDeps {
   threadId: string;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   draft: DraftSignals;
   cancelDraftSync$: Command<void, []>;
   flushDraftClear$: Command<Promise<void>, [AbortSignal]>;
@@ -2589,7 +2577,7 @@ interface SendMessageDeps {
 function createSendMessage(deps: SendMessageDeps) {
   const {
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     draft,
     cancelDraftSync$,
     flushDraftClear$,
@@ -2611,7 +2599,7 @@ function createSendMessage(deps: SendMessageDeps) {
       if (get(optimisticCreateUnsettled$)) {
         return;
       }
-      const thread = await get(threadData$);
+      const thread = await get(remoteThreadDetail$);
       signal.throwIfAborted();
       const agentId = thread?.agentId;
       if (!agentId) {
@@ -2719,7 +2707,7 @@ function createSendMessage(deps: SendMessageDeps) {
 
 interface QueueMessageDeps {
   threadId: string;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   modelSelection$: Computed<Promise<ModelProviderSelection | null>>;
   draft: DraftSignals;
   cancelDraftSync$: Command<void, []>;
@@ -2732,7 +2720,7 @@ interface QueueMessageDeps {
 function createQueueMessage(deps: QueueMessageDeps) {
   const {
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     modelSelection$,
     draft,
     cancelDraftSync$,
@@ -2758,10 +2746,10 @@ function createQueueMessage(deps: QueueMessageDeps) {
         });
         return;
       }
-      const thread = await get(threadData$);
+      const thread = await get(remoteThreadDetail$);
       signal.throwIfAborted();
       if (!thread) {
-        L.debug("queueMessage$ no thread data, abort", { threadId });
+        L.debug("queueMessage$ no remote thread detail, abort", { threadId });
         return;
       }
       const generationTemplate = get(draft.generationTemplate$);
@@ -2846,7 +2834,7 @@ function createQueueMessage(deps: QueueMessageDeps) {
 
 interface RecallMessageDeps {
   threadId: string;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   draft: DraftSignals;
   refreshGroupedChatMessagesCache$: Command<Promise<void>, [AbortSignal]>;
   dataSource: ChatThreadDataSource;
@@ -2855,7 +2843,7 @@ interface RecallMessageDeps {
 function createRecallMessage(deps: RecallMessageDeps) {
   const {
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     draft,
     refreshGroupedChatMessagesCache$,
     dataSource,
@@ -2871,7 +2859,7 @@ function createRecallMessage(deps: RecallMessageDeps) {
         return;
       }
 
-      const thread = await get(threadData$);
+      const thread = await get(remoteThreadDetail$);
       signal.throwIfAborted();
       if (!thread) {
         return;
@@ -2936,14 +2924,14 @@ function createThreadMessageActions(deps: ThreadMessageActionsDeps) {
 
 function createCancelRunWithQueuedRecall({
   threadId,
-  threadData$,
+  remoteThreadDetail$,
   rawMessages$,
   groupedChatMessages$,
   refreshGroupedChatMessagesCache$,
   dataSource,
 }: {
   threadId: string;
-  threadData$: Computed<Promise<ChatThread | null>>;
+  remoteThreadDetail$: Computed<Promise<ChatThread | null>>;
   rawMessages$: Computed<Promise<ChatMessageProjectionEntry[]>>;
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>;
   refreshGroupedChatMessagesCache$: Command<Promise<void>, [AbortSignal]>;
@@ -2958,7 +2946,7 @@ function createCancelRunWithQueuedRecall({
       });
       return;
     }
-    const thread = await get(threadData$);
+    const thread = await get(remoteThreadDetail$);
     signal.throwIfAborted();
     if (!thread) {
       return;
@@ -3545,18 +3533,19 @@ export function createChatThreadSignals(
   draft: DraftSignals,
   dataSource: ChatThreadDataSource = createRemoteChatThreadDataSource(threadId),
 ): ChatThreadSignals {
-  const { threadData$, reloadThread$ } = createThreadData(dataSource);
-  const threadMeta$ = createThreadMeta(threadId, threadData$);
+  const { remoteThreadDetail$, reloadThread$ } =
+    createRemoteThreadDetail(dataSource);
+  const threadMeta$ = createThreadMeta(threadId);
   const { threadTitleEmoji$, threadTitleText$ } =
     createThreadTitleParts(threadMeta$);
   const { modelSelection$, setModelSelection$ } = createModelSelection(
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     dataSource,
   );
   const computerUseHostSelection = createComputerUseHostSelection(
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     dataSource,
   );
   const {
@@ -3570,12 +3559,11 @@ export function createChatThreadSignals(
   const { containerEl$, setContainerRef$ } = createContainerRef();
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
-  const { agentId$, agentDisplayName$, defaultModelSelection$, agentPinned$ } =
-    createAgentInfoSignals(threadId, threadData$);
+  const agentInfo = createAgentInfoSignals(threadId, remoteThreadDetail$);
   const threadUi = createThreadUIState();
   const messages = createChatThreadMessagePipeline({
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     dataSource,
     recordScrollHeightForPrepend$,
     clearScrollHeightForPrepend$,
@@ -3587,7 +3575,7 @@ export function createChatThreadSignals(
   const runTracking = createRunTracking({
     threadId,
     reloadThread$,
-    threadData$,
+    remoteThreadDetail$,
     latestChatMessageId$: messages.latestChatMessageId$,
     latestRunStatus$: messages.latestRunStatus$,
     initialPage$: messages.initialPage$,
@@ -3601,7 +3589,7 @@ export function createChatThreadSignals(
 
   const messageActions = createThreadMessageActions({
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     modelSelection$,
     rawMessages$: messages.rawMessages$,
     groupedChatMessages$: messages.groupedChatMessages$,
@@ -3624,7 +3612,7 @@ export function createChatThreadSignals(
 
   return {
     threadId,
-    threadData$,
+    remoteThreadDetail$,
     threadMeta$,
     reloadThread$,
     threadTitleEmoji$,
@@ -3643,10 +3631,7 @@ export function createChatThreadSignals(
     draft,
     composerFileInput$,
     setComposerFileInput$,
-    agentId$,
-    agentDisplayName$,
-    defaultModelSelection$,
-    agentPinned$,
+    ...agentInfo,
     ...threadUi,
     ...inputRef,
     queueDraftSync$,

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -12,10 +12,7 @@ import {
 } from "../external/chat-idb-safe.ts";
 import { createIdbMessageStores } from "../external/idb-message-store.ts";
 import { logger } from "../log.ts";
-import type { ChatThread } from "../agent-chat.ts";
 import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
-import { eventDrivenChatThread } from "./chat-thread-event-sourcing.ts";
-import type { EventDrivenChatThread } from "./chat-thread-event-replay.ts";
 import type {
   ChatThreadDataSource,
   GetMessageArgs,
@@ -65,45 +62,6 @@ function rememberThreadStartMessageId(
   const next = new Map(threadStartMessageIds);
   next.set(threadStartMessageKey(userId, orgId, threadId), startMessageId);
   return next;
-}
-
-function eventDrivenThreadToChatThread(
-  thread: EventDrivenChatThread,
-): ChatThread {
-  return {
-    id: thread.id,
-    title: thread.title,
-    agentId: thread.agentId,
-    createdAt: thread.createdAt,
-    updatedAt: thread.updatedAt,
-    lastReadMessageId: null,
-    lastReadAt: null,
-    lastMessageAt: thread.sortAt,
-    pinnedAt: thread.pinnedAt,
-    activeRunIds: [],
-    isLegacySession: false,
-    draftContent: null,
-    draftAttachments: null,
-    modelProviderId: null,
-    selectedModel: null,
-    codexServiceTier: null,
-    computerUseHostId: null,
-  };
-}
-
-function createGetThreadWithEventFallback(
-  threadId: string,
-  remote: ChatThreadDataSource,
-) {
-  const eventDrivenThread$ = eventDrivenChatThread(threadId);
-  return computed(async (get): Promise<ChatThread | null> => {
-    const remoteThread = await get(remote.getThread$);
-    if (remoteThread) {
-      return remoteThread;
-    }
-    const eventThread = await get(eventDrivenThread$);
-    return eventThread ? eventDrivenThreadToChatThread(eventThread) : null;
-  });
 }
 
 const warmListMessagesAfter$ = command(
@@ -571,10 +529,9 @@ export function createIdbCachedDataSource(
 
   const listMessagesAfter$ = createListMessagesAfter(remote, getStores);
   const getMessage$ = createGetMessage(remote, getStores);
-  const getThread$ = createGetThreadWithEventFallback(threadId, remote);
 
   return {
-    getThread$,
+    remoteThreadDetail$: remote.remoteThreadDetail$,
     reloadThread$: remote.reloadThread$,
     initialPage$,
     patchDraft$: remote.patchDraft$,

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -6,7 +6,6 @@ import {
   type AttachFile,
   type ChatThreadEvent,
   type GenerationTemplateRequest,
-  type ChatThreadListItem,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { accept } from "../../lib/accept.ts";
@@ -14,17 +13,11 @@ import { nowDate } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 import {
   chatThreads$,
-  currentChatAgentId$,
   currentChatThreadId$,
   reloadChatThreads$,
-  type ChatThread,
 } from "../agent-chat.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
-import {
-  currentLeftThread$,
-  currentRightThread$,
-  loadRightThread$,
-} from "./chat-thread-panes.ts";
+import { loadRightThread$ } from "./chat-thread-panes.ts";
 import {
   clearArtifactSidebarParams,
   clearChatAutomationSidebarParams,
@@ -43,7 +36,6 @@ import {
   appendOptimisticChatMessage$,
   type OptimisticChatMessageEntry,
 } from "./optimistic-chat-messages.ts";
-import { sidebarChatThreadsExtraThreads$ } from "./sidebar-chat-threads-pagination.ts";
 import { resolveModelFirstUserDefaultSelection } from "../zero-page/model-default-selection.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
@@ -55,13 +47,12 @@ import {
 } from "./model-selection-request.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
-import type { ChatThreadSignals } from "./chat-thread-signals.ts";
 
-export type OptimisticChatPane = "main" | "sidebar";
+export type NewChatThreadPane = "main" | "sidebar";
 
 const SIDEBAR_PARAM = "sidebar";
 
-const L = logger("OptimisticChat");
+const L = logger("NewChatThread");
 
 export const newChatThreadDisabled$ = computed(() => {
   return false;
@@ -194,22 +185,20 @@ const settleNewThreadSend$ = command(
   },
 );
 
-const routeMainOptimisticChatThread$ = command(
-  ({ get, set }, threadId: string) => {
-    const next = new URLSearchParams(get(searchParams$));
-    if (next.get(SIDEBAR_PARAM) === threadId) {
-      next.delete(SIDEBAR_PARAM);
-    }
-    clearArtifactSidebarParams(next);
-    clearChatAutomationSidebarParams(next);
-    set(detachedNavigateTo$, "/chats/:threadId", {
-      pathParams: { threadId },
-      searchParams: next,
-    });
-  },
-);
+const routeMainChatThread$ = command(({ get, set }, threadId: string) => {
+  const next = new URLSearchParams(get(searchParams$));
+  if (next.get(SIDEBAR_PARAM) === threadId) {
+    next.delete(SIDEBAR_PARAM);
+  }
+  clearArtifactSidebarParams(next);
+  clearChatAutomationSidebarParams(next);
+  set(detachedNavigateTo$, "/chats/:threadId", {
+    pathParams: { threadId },
+    searchParams: next,
+  });
+});
 
-const routeSidebarOptimisticChatThread$ = command(
+const routeSidebarChatThread$ = command(
   async (
     { get, set },
     threadId: string,
@@ -222,14 +211,14 @@ const routeSidebarOptimisticChatThread$ = command(
   },
 );
 
-const routeOptimisticChatThread$ = command(
+const routeChatThread$ = command(
   async (
     { set },
     {
       pane,
       threadId,
     }: {
-      readonly pane: OptimisticChatPane;
+      readonly pane: NewChatThreadPane;
       readonly threadId: string;
     },
     signal: AbortSignal,
@@ -237,9 +226,9 @@ const routeOptimisticChatThread$ = command(
     signal.throwIfAborted();
 
     if (pane === "main") {
-      set(routeMainOptimisticChatThread$, threadId);
+      set(routeMainChatThread$, threadId);
     } else {
-      await set(routeSidebarOptimisticChatThread$, threadId, signal);
+      await set(routeSidebarChatThread$, threadId, signal);
     }
   },
 );
@@ -254,11 +243,11 @@ const mintOptimisticThreadWithEvent$ = command(
     },
     signal: AbortSignal,
   ): void => {
+    signal.throwIfAborted();
     L.debug("optimistic thread minted", {
       threadId: args.threadId,
       agentId: args.agentId,
     });
-    signal.throwIfAborted();
     const createdAt = nowDate().toISOString();
     set(registerOptimisticChatThreadEvent$, {
       id: args.eventId,
@@ -294,7 +283,7 @@ async function createChatThread(args: {
   );
 }
 
-const createNewChatThread$ = command(
+const startNewChatThreadCreate$ = command(
   async (
     { get, set },
     agentId: string,
@@ -312,7 +301,7 @@ const createNewChatThread$ = command(
     );
 
     const createClient = get(zeroClient$);
-    L.debug("createNewChatThread$ POST chat-threads start", { threadId });
+    L.debug("startNewChatThreadCreate$ POST chat-threads start", { threadId });
     const createResult = (async (): Promise<void> => {
       await createChatThread({
         createClient,
@@ -322,7 +311,7 @@ const createNewChatThread$ = command(
         clientThreadId: threadId,
         eventId,
       });
-      L.debug("createNewChatThread$ POST chat-threads 201", { threadId });
+      L.debug("startNewChatThreadCreate$ POST chat-threads 201", { threadId });
       signal.throwIfAborted();
     })();
 
@@ -330,19 +319,19 @@ const createNewChatThread$ = command(
   },
 );
 
-export const createNewChatThreadOptimistically$ = command(
+export const createNewChatThread$ = command(
   async (
     { get, set },
     agentId: string,
-    pane: OptimisticChatPane,
+    pane: NewChatThreadPane,
     signal: AbortSignal,
   ) => {
     const targetPane =
       pane === "sidebar" && get(currentChatThreadId$) ? "sidebar" : "main";
-    const result = await set(createNewChatThread$, agentId, signal);
+    const result = await set(startNewChatThreadCreate$, agentId, signal);
 
     await set(
-      routeOptimisticChatThread$,
+      routeChatThread$,
       { pane: targetPane, threadId: result.threadId },
       signal,
     );
@@ -350,108 +339,7 @@ export const createNewChatThreadOptimistically$ = command(
   },
 );
 
-function threadToSidebarListItem(thread: ChatThread): ChatThreadListItem {
-  return {
-    id: thread.id,
-    title: thread.title,
-    agent: { id: thread.agentId, avatarUrl: null },
-    createdAt: thread.createdAt ?? thread.lastMessageAt,
-    updatedAt: thread.updatedAt ?? thread.lastMessageAt,
-    running: thread.activeRunIds.length > 0,
-    pinnedAt: thread.pinnedAt ?? null,
-  };
-}
-
-function mergeMissingSidebarThreads(
-  threads: readonly ChatThreadListItem[],
-  missingThreads: readonly ChatThreadListItem[],
-): ChatThreadListItem[] {
-  if (missingThreads.length === 0) {
-    return [...threads];
-  }
-
-  const existingIds = new Set(
-    threads.map((thread) => {
-      return thread.id;
-    }),
-  );
-  const seenMissingIds = new Set<string>();
-  const dedupedMissingThreads = missingThreads.filter((thread) => {
-    if (existingIds.has(thread.id) || seenMissingIds.has(thread.id)) {
-      return false;
-    }
-    seenMissingIds.add(thread.id);
-    return true;
-  });
-  if (dedupedMissingThreads.length === 0) {
-    return [...threads];
-  }
-
-  const missingPinned = dedupedMissingThreads.filter((thread) => {
-    return thread.pinnedAt !== null && thread.pinnedAt !== undefined;
-  });
-  const missingUnpinned = dedupedMissingThreads.filter((thread) => {
-    return thread.pinnedAt === null || thread.pinnedAt === undefined;
-  });
-  const firstUnpinnedIndex = threads.findIndex((thread) => {
-    return thread.pinnedAt === null || thread.pinnedAt === undefined;
-  });
-
-  if (firstUnpinnedIndex === -1) {
-    return [...missingPinned, ...threads, ...missingUnpinned];
-  }
-
-  return [
-    ...missingPinned,
-    ...threads.slice(0, firstUnpinnedIndex),
-    ...missingUnpinned,
-    ...threads.slice(firstUnpinnedIndex),
-  ];
-}
-
-export const sidebarChatThreads$ = computed(
-  async (get): Promise<ChatThreadListItem[]> => {
-    const persisted = await get(chatThreads$);
-    const extraPersisted = await get(sidebarChatThreadsExtraThreads$);
-    const currentAgentId = await get(currentChatAgentId$);
-    if (!currentAgentId) {
-      return [...persisted, ...extraPersisted];
-    }
-
-    const mergedThreads = [...persisted, ...extraPersisted];
-    const mergedThreadIds = new Set(
-      mergedThreads.map((thread) => {
-        return thread.id;
-      }),
-    );
-    const activePaneThreads = [
-      get(currentLeftThread$),
-      get(currentRightThread$),
-    ].filter((thread): thread is ChatThreadSignals => {
-      return thread !== null && !mergedThreadIds.has(thread.threadId);
-    });
-
-    if (activePaneThreads.length === 0) {
-      return mergedThreads;
-    }
-
-    const activeItems = (
-      await Promise.all(
-        activePaneThreads.map(async (thread) => {
-          const threadData = await get(thread.threadData$);
-          if (!threadData || threadData.agentId !== currentAgentId) {
-            return null;
-          }
-          return threadToSidebarListItem(threadData);
-        }),
-      )
-    ).filter((thread): thread is ChatThreadListItem => {
-      return thread !== null;
-    });
-
-    return mergeMissingSidebarThreads(mergedThreads, activeItems);
-  },
-);
+export const sidebarChatThreads$ = chatThreads$;
 
 const sendNewThreadMessage$ = command(
   async (
@@ -541,7 +429,7 @@ const sendNewThreadMessage$ = command(
   },
 );
 
-export const sendNewThreadOptimistically$ = command(
+export const sendNewThread$ = command(
   async (
     { set },
     request: SendNewThreadMessageRequest,
@@ -553,7 +441,7 @@ export const sendNewThreadOptimistically$ = command(
     }
 
     await set(
-      routeOptimisticChatThread$,
+      routeChatThread$,
       { pane: "main", threadId: result.threadId },
       signal,
     );

--- a/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/remote-chat-thread-data-source.ts
@@ -457,37 +457,39 @@ export function createRemoteChatThreadDataSource(
   const reloadCounter$ = state(0);
   const subscribeRealtime$ = createSubscribeRealtime();
 
-  const getThread$ = computed(async (get): Promise<ChatThread | null> => {
-    get(reloadCounter$);
-    const threadClient = get(zeroClient$)(chatThreadByIdContract);
-    const threadResult = await accept(
-      threadClient.get({ params: { id: threadId } }),
-      [200, 404],
-    );
-    if (threadResult.status === 404) {
-      return null;
-    }
-    const body = threadResult.body;
-    return {
-      id: threadId,
-      title: body.title ?? null,
-      agentId: body.agentId,
-      createdAt: body.createdAt,
-      updatedAt: body.updatedAt,
-      lastReadMessageId: body.lastReadMessageId ?? null,
-      lastReadAt: body.lastReadAt ?? null,
-      lastMessageAt: body.lastMessageAt ?? body.updatedAt,
-      pinnedAt: body.pinnedAt ?? null,
-      activeRunIds: body.activeRunIds,
-      isLegacySession: false,
-      draftContent: body.draftContent ?? null,
-      draftAttachments: body.draftAttachments ?? null,
-      computerUseHostId: body.computerUseHostId ?? null,
-      modelProviderId: body.modelProviderId ?? null,
-      selectedModel: body.selectedModel ?? null,
-      codexServiceTier: body.codexServiceTier ?? null,
-    };
-  });
+  const remoteThreadDetail$ = computed(
+    async (get): Promise<ChatThread | null> => {
+      get(reloadCounter$);
+      const threadClient = get(zeroClient$)(chatThreadByIdContract);
+      const threadResult = await accept(
+        threadClient.get({ params: { id: threadId } }),
+        [200, 404],
+      );
+      if (threadResult.status === 404) {
+        return null;
+      }
+      const body = threadResult.body;
+      return {
+        id: threadId,
+        title: body.title ?? null,
+        agentId: body.agentId,
+        createdAt: body.createdAt,
+        updatedAt: body.updatedAt,
+        lastReadMessageId: body.lastReadMessageId ?? null,
+        lastReadAt: body.lastReadAt ?? null,
+        lastMessageAt: body.lastMessageAt ?? body.updatedAt,
+        pinnedAt: body.pinnedAt ?? null,
+        activeRunIds: body.activeRunIds,
+        isLegacySession: false,
+        draftContent: body.draftContent ?? null,
+        draftAttachments: body.draftAttachments ?? null,
+        computerUseHostId: body.computerUseHostId ?? null,
+        modelProviderId: body.modelProviderId ?? null,
+        selectedModel: body.selectedModel ?? null,
+        codexServiceTier: body.codexServiceTier ?? null,
+      };
+    },
+  );
 
   const reloadThread$ = command(({ set }) => {
     set(reloadCounter$, (v) => {
@@ -502,8 +504,8 @@ export function createRemoteChatThreadDataSource(
       [200, 404],
     );
     if (result.status === 404) {
-      // detects this via threadData$ being null and routes home; returning
-      // an empty page keeps the messages stream from rejecting in parallel.
+      // The pane detects this via remoteThreadDetail$ being null; returning an
+      // empty page keeps the messages stream from rejecting in parallel.
       return { messages: [], hasHistoryBefore: false };
     }
     const hasHistoryBefore = result.body.hasHistoryBefore ?? false;
@@ -520,7 +522,7 @@ export function createRemoteChatThreadDataSource(
   });
 
   return {
-    getThread$,
+    remoteThreadDetail$,
     reloadThread$,
     initialPage$,
     patchDraft$,

--- a/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sync-primary-thread.ts
@@ -4,6 +4,7 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { resetSignal } from "../utils.ts";
 import { createIdbCachedDataSource } from "./idb-cached-chat-thread-data-source.ts";
+import { eventDrivenChatThreadMeta } from "./chat-thread-event-sourcing.ts";
 
 const resetSyncPrimarySignal$ = resetSignal();
 
@@ -15,8 +16,8 @@ const resetSyncPrimarySignal$ = resetSignal();
  *
  * Lifecycle: call once per primary-thread switch with the new threadId
  * and parentSignal. The internal reset signal aborts any previous Ably
- * loop before the new one starts. 404 silently returns — the pane setup
- * path already throws on missing thread data; no need to double-error.
+ * loop before the new one starts. Missing remote detail silently returns:
+ * the visible pane renders its own missing-thread state.
  *
  * Owns its own data source (Option A from the plan) so it doesn't have to
  * thread state through the pane wiring. On non-IDB users this issues one
@@ -35,27 +36,37 @@ export const syncPrimaryThread$ = command(
     // very first frame after the pane switch.
     set(updateDocumentTitle$, "Chat");
 
-    const dataSource = createIdbCachedDataSource(threadId);
-
-    const threadData = await get(dataSource.getThread$);
+    const threadMeta = await get(eventDrivenChatThreadMeta(threadId));
     signal.throwIfAborted();
-    if (!threadData) {
-      // pane setup throws "Thread data missing" on the same condition; no
-      // value in double-erroring here.
+    if (threadMeta) {
+      const currentAgentId = await get(currentChatAgentId$);
+      signal.throwIfAborted();
+      if (currentAgentId !== threadMeta.agentId) {
+        set(setChatAgentId$, threadMeta.agentId);
+      }
+
+      set(updateDocumentTitle$, threadMeta.title ?? "New chat");
+    }
+
+    const dataSource = createIdbCachedDataSource(threadId);
+    const remoteThreadDetail = await get(dataSource.remoteThreadDetail$);
+    signal.throwIfAborted();
+    if (!threadMeta && !remoteThreadDetail) {
       return;
     }
 
-    const currentAgentId = await get(currentChatAgentId$);
-    signal.throwIfAborted();
-    if (currentAgentId !== threadData.agentId) {
-      set(setChatAgentId$, threadData.agentId);
+    if (!threadMeta && remoteThreadDetail) {
+      const currentAgentId = await get(currentChatAgentId$);
+      signal.throwIfAborted();
+      if (currentAgentId !== remoteThreadDetail.agentId) {
+        set(setChatAgentId$, remoteThreadDetail.agentId);
+      }
+      set(updateDocumentTitle$, remoteThreadDetail.title ?? "New chat");
     }
-
-    set(updateDocumentTitle$, threadData.title ?? "New chat");
 
     // Forever-running Ably loop until signal aborts.
     const onThreadUpdated$ = command(async ({ get, set }, sig: AbortSignal) => {
-      const data = await get(dataSource.getThread$);
+      const data = await get(dataSource.remoteThreadDetail$);
       sig.throwIfAborted();
       if (data) {
         set(updateDocumentTitle$, data.title ?? "New chat");

--- a/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
+++ b/turbo/apps/platform/src/signals/prompt-page/prompt-page-setup.ts
@@ -6,7 +6,7 @@ import {
   PRESENTATION_TEMPLATE_PICKER_ITEMS,
   findVideoTemplateItem,
 } from "@vm0/core";
-import { sendNewThreadOptimistically$ } from "../chat-page/optimistic-chat-thread-page.ts";
+import { sendNewThread$ } from "../chat-page/optimistic-chat-thread-page.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
@@ -144,7 +144,7 @@ export const setupPromptPage$ = command(
 
     const rootSignal = get(rootSignal$);
     await set(
-      sendNewThreadOptimistically$,
+      sendNewThread$,
       {
         agentId,
         prompt,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -5003,7 +5003,7 @@ describe("chat lifecycle", () => {
   });
 
   it("shows automation run messages as automation links in chat history", async () => {
-    const threadId = "thread-automation-message";
+    const threadId = "b0000000-0000-4000-a000-000000000721";
     const automationId = "f0000001-0000-4000-a000-000000000721";
     mockChatLifecycle(context, {
       threadId,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -440,7 +440,7 @@ export function mockChatLifecycle(
   let events: AgentEvent[] = [];
   let queuePosition = 0;
   let resultContent = "";
-  let threadList: ThreadListItem[] = [];
+  let threadListOverride: ThreadListItem[] | null = null;
   let runPrompt: string | null = null;
   let runUserMessageId = "msg-user-sent";
   let runAssociated = false;
@@ -524,6 +524,29 @@ export function mockChatLifecycle(
       optionActiveRunIds.length > 0 ||
       (runAssociated && !terminal.has(runStatus))
     );
+  };
+
+  const effectiveThreadList = () => {
+    if (threadListOverride !== null) {
+      return threadListOverride;
+    }
+    if (!UUID_PATTERN.test(threadId)) {
+      return [];
+    }
+    return [
+      {
+        id: threadId,
+        title: threadTitle,
+        agent: {
+          id: "c0000000-0000-4000-a000-000000000001",
+          avatarUrl: null,
+        },
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+        running: hasActiveRun(),
+        pinnedAt: null,
+      },
+    ];
   };
 
   const buildPagedMessages = () => {
@@ -792,7 +815,7 @@ export function mockChatLifecycle(
   );
   context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
     return respond(200, {
-      chatThreads: threadListSnapshot(threadList),
+      chatThreads: threadListSnapshot(effectiveThreadList()),
       latestEventId: null,
     });
   });
@@ -801,7 +824,7 @@ export function mockChatLifecycle(
   });
   context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
     const activeThreadIds = new Set(
-      threadList.flatMap((thread) => {
+      effectiveThreadList().flatMap((thread) => {
         return thread.running ? [thread.id] : [];
       }),
     );
@@ -909,7 +932,7 @@ export function mockChatLifecycle(
       events = e;
     },
     setThreadList: (list) => {
-      threadList = list;
+      threadListOverride = list;
     },
     completeRun: (content?: string) => {
       runStatus = "completed";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -612,7 +612,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("requests unread chat threads and keeps the current chat at the front of the unpinned section", async () => {
+  it("requests unread chat threads and filters the event-sourced list", async () => {
     prepareDefaultAgent();
     const pinnedUnreadThread = createThread(
       AUTOMATION_THREAD_ID,
@@ -686,12 +686,11 @@ describe("zero sidebar", () => {
     await waitFor(() => {
       expect(unreadsRequests).toBeGreaterThan(0);
       expect(
-        visibleThreadTitles([
-          "Pinned incident",
-          "Release plan",
-          "Incident notes",
-        ]),
-      ).toStrictEqual(["Pinned incident", "Release plan", "Incident notes"]);
+        visibleThreadTitles(["Pinned incident", "Incident notes"]),
+      ).toStrictEqual(["Pinned incident", "Incident notes"]);
+      expect(
+        within(sidebar()).queryByText("Release plan"),
+      ).not.toBeInTheDocument();
       expect(
         within(sidebar()).queryByText("Archived context"),
       ).not.toBeInTheDocument();
@@ -716,7 +715,7 @@ describe("zero sidebar", () => {
     expect(screen.queryByRole("switch", { name: "Unread" })).toBeNull();
   });
 
-  it("keeps a missing pinned current chat at the front of the pinned section", async () => {
+  it("keeps an event-sourced pinned current chat at the front of the pinned section", async () => {
     prepareDefaultAgent();
     const pinnedCurrentThread = createThread(
       EXISTING_THREAD_ID,
@@ -731,7 +730,7 @@ describe("zero sidebar", () => {
     const unpinnedThread = createThread(INCIDENT_THREAD_ID, "Incident notes");
 
     mockChatThreadSnapshot(() => {
-      return [pinnedThread, unpinnedThread];
+      return [pinnedCurrentThread, pinnedThread, unpinnedThread];
     });
     context.mocks.api(chatThreadByIdContract.get, ({ params, respond }) => {
       const thread = [pinnedCurrentThread, pinnedThread, unpinnedThread].find(

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -75,7 +75,7 @@ import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
-import { sendNewThreadOptimistically$ } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
+import { sendNewThread$ } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import { startChatNavigationTiming$ } from "../../lib/posthog.ts";
 import {
   typewriterDisplayed$,
@@ -490,7 +490,7 @@ function useAgentChatSendMessage({
   message: string,
   selectedGenerationTemplate: GenerationTemplateRequest | undefined,
 ) => void {
-  const sendNewThread = useSet(sendNewThreadOptimistically$);
+  const sendNewThread = useSet(sendNewThread$);
   const rootSignal = useGet(rootSignal$);
 
   return (message, selectedGenerationTemplate) => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -50,10 +50,7 @@ import {
   unpinChatThread$,
   renameChatThread$,
 } from "../../signals/chat-page/chat-message.ts";
-import {
-  openRenameChatThreadDialogForThreadId$,
-  reloadChatThreadDataForId$,
-} from "../../signals/chat-page/chat-thread-rename.ts";
+import { openRenameChatThreadDialogForThreadId$ } from "../../signals/chat-page/chat-thread-rename.ts";
 import {
   SIDEBAR_PARAM,
   currentLeftThread$,
@@ -64,9 +61,9 @@ import {
 } from "../../signals/chat-page/chat-thread-panes.ts";
 import { focusChatThreadContainer$ } from "../../signals/chat-page/chat-keyboard.ts";
 import {
-  createNewChatThreadOptimistically$,
+  createNewChatThread$,
   newChatThreadDisabled$,
-  type OptimisticChatPane,
+  type NewChatThreadPane,
   sidebarChatThreads$,
 } from "../../signals/chat-page/optimistic-chat-thread-page.ts";
 import {
@@ -588,7 +585,6 @@ function ChatThreadRenameDialog() {
   const setRenameDialogAgentId = useSet(setRenameDialogAgentId$);
   const setRenameDialogThreadId = useSet(setRenameDialogThreadId$);
   const renameChatThread = useSet(renameChatThread$);
-  const reloadChatThreadDataForId = useSet(reloadChatThreadDataForId$);
   const focusChatThreadContainer = useSet(focusChatThreadContainer$);
   const pageSignal = useGet(pageSignal$);
 
@@ -614,7 +610,6 @@ function ChatThreadRenameDialog() {
     detach(
       (async () => {
         await renameChatThread({ threadId, title, agentId }, pageSignal);
-        reloadChatThreadDataForId(threadId);
       })(),
       Reason.DomCallback,
     );
@@ -926,12 +921,12 @@ function ChatThreads({
 
 function ChatThreadsTitle() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$) ?? null;
-  const createNewChat = useSet(createNewChatThreadOptimistically$);
+  const createNewChat = useSet(createNewChatThread$);
   const setExpanded = useSet(setSidebarExpanded$);
   const rootSignal = useGet(rootSignal$);
   const { titleLabel } = useChatThreadsTitleLabels();
   const newChatDisabled = useGet(newChatThreadDisabled$);
-  const onNewChat = (pane: OptimisticChatPane) => {
+  const onNewChat = (pane: NewChatThreadPane) => {
     if (!currentChatAgentId) {
       return;
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -136,7 +136,7 @@ export function ArtifactSidebar({
 }: ArtifactSidebarProps) {
   if (thread) {
     return (
-      <ArtifactSidebarWithThreadData
+      <ArtifactSidebarWithThreadContext
         artifactRef={artifactRef}
         onBack={onBack}
         onClose={onClose}
@@ -185,7 +185,7 @@ type ArtifactSidebarContentProps = {
 type HtmlArtifactHeaderState = "idle" | "editing" | "working" | "preview";
 type HtmlEditState = ReturnType<typeof createHtmlEditState>;
 
-function ArtifactSidebarWithThreadData({
+function ArtifactSidebarWithThreadContext({
   artifactRef,
   onBack,
   onClose,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -299,7 +299,7 @@ interface ZeroChatComposerProps {
   /**
    * When true, render skeleton placeholders in place of the right-side
    * action cluster (model picker, mic, send/stop). Used during thread switch
-   * while thread data is still resolving — prevents briefly flashing stale
+   * while remote thread detail is still resolving — prevents briefly flashing stale
    * picker state and a wrong send/stop button derived from prior
    * `allFinished`.
    */

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -268,7 +268,7 @@ import {
   type PagedChatMessage,
 } from "../../signals/chat-page/chat-message.ts";
 import type { ChatThreadSignals } from "../../signals/chat-page/chat-thread-signals.ts";
-import { reloadChatThreadDataForId$ } from "../../signals/chat-page/chat-thread-rename.ts";
+import type { ThreadMeta } from "../../signals/chat-page/chat-thread-event-sourcing.ts";
 import {
   applyChatThreadEmoji,
   removeChatThreadEmoji,
@@ -1126,7 +1126,6 @@ function useChatThreadEmojiMenuActions({
   const openChatThreadEmojiMenu = useSet(openChatThreadEmojiMenu$);
   const closeChatThreadEmojiMenu = useSet(closeChatThreadEmojiMenu$);
   const renameChatThread = useSet(renameChatThread$);
-  const reloadChatThreadDataForId = useSet(reloadChatThreadDataForId$);
   const focusChatThreadContainer = useSet(focusChatThreadContainer$);
   const pageSignal = useGet(pageSignal$);
   const open = emojiMenuThreadId === threadId;
@@ -1155,7 +1154,6 @@ function useChatThreadEmojiMenuActions({
           },
           pageSignal,
         );
-        reloadChatThreadDataForId(activeThreadId);
         closeMenu();
       })(),
       Reason.DomCallback,
@@ -1178,7 +1176,6 @@ function useChatThreadEmojiMenuActions({
           { threadId: activeThreadId, title: nextTitle },
           pageSignal,
         );
-        reloadChatThreadDataForId(activeThreadId);
         closeMenu();
       })(),
       Reason.DomCallback,
@@ -3260,12 +3257,13 @@ type LoadableValue<T> =
   | { state: "hasError"; error: unknown };
 
 function resolveSessionError(
-  threadDataLoadable: LoadableValue<ChatThread | null>,
+  remoteThreadDetailLoadable: LoadableValue<ChatThread | null>,
+  threadMetaLoadable: LoadableValue<ThreadMeta | null>,
   groupsLoadable: LoadableValue<GroupedChatMessageGroup[]>,
 ): string | null {
-  if (threadDataLoadable.state === "hasError") {
-    return threadDataLoadable.error instanceof Error
-      ? threadDataLoadable.error.message
+  if (remoteThreadDetailLoadable.state === "hasError") {
+    return remoteThreadDetailLoadable.error instanceof Error
+      ? remoteThreadDetailLoadable.error.message
       : "Failed to load chat";
   }
   if (groupsLoadable.state === "hasError") {
@@ -3274,8 +3272,10 @@ function resolveSessionError(
       : "Failed to load messages";
   }
   if (
-    threadDataLoadable.state === "hasData" &&
-    threadDataLoadable.data === null
+    remoteThreadDetailLoadable.state === "hasData" &&
+    remoteThreadDetailLoadable.data === null &&
+    threadMetaLoadable.state === "hasData" &&
+    threadMetaLoadable.data === null
   ) {
     return "Chat not found";
   }
@@ -4168,8 +4168,15 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   const renderedGroupsLoadable = useLastLoadable(
     thread.renderedGroupedChatMessages$,
   );
-  const threadDataLoadable = useLastLoadable(thread.threadData$);
-  const sessionError = resolveSessionError(threadDataLoadable, groupsLoadable);
+  const remoteThreadDetailLoadable = useLastLoadable(
+    thread.remoteThreadDetail$,
+  );
+  const threadMetaLoadable = useLastLoadable(thread.threadMeta$);
+  const sessionError = resolveSessionError(
+    remoteThreadDetailLoadable,
+    threadMetaLoadable,
+    groupsLoadable,
+  );
   const messagesLoading = groupsLoadable.state === "loading";
   const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
   const renderedGroups =
@@ -4594,14 +4601,16 @@ function useChatComposerModel(
   pageSignal: AbortSignal,
 ) {
   // Per-thread composer state lives in ccstate signals on the factory so the
-  // initial value seeds from threadData once it resolves (a React useState
+  // initial value seeds from remoteThreadDetail once it resolves (a React useState
   // initializer would snapshot `undefined` on first render). `modelSelection$`
   // internally flips to a user-override once `setModelSelection$` is called,
-  // so unsaved edits survive subsequent threadData$ reloads. Read with
+  // so unsaved edits survive subsequent remoteThreadDetail$ reloads. Read with
   // useLastResolved so the picker keeps the previous value during the
-  // threadData$ refetches triggered by chatThreadRunUpdated Ably events —
+  // remoteThreadDetail$ refetches triggered by chatThreadRunUpdated Ably events —
   // otherwise the picker briefly flips to a skeleton on every run change.
-  const threadDataResolved = useLastResolved(thread.threadData$);
+  const remoteThreadDetailResolved = useLastResolved(
+    thread.remoteThreadDetail$,
+  );
   const modelSelectionResolved = useLastResolved(thread.modelSelection$);
   const defaultModelSelectionResolved = useLastResolved(
     thread.defaultModelSelection$,
@@ -4627,7 +4636,7 @@ function useChatComposerModel(
   // Explicit thread selections can render before default model selection
   // resolves; only inherited selections need that fallback before showing.
   const modelPickerLoading =
-    threadDataResolved === undefined ||
+    remoteThreadDetailResolved === undefined ||
     modelSelectionResolved === undefined ||
     (modelSelectionResolved === null &&
       defaultModelSelectionResolved === undefined);


### PR DESCRIPTION
## Summary
- rename thread detail signals to `remoteThreadDetail$` and keep `threadMeta$` sourced from event-driven chat thread metadata
- remove the IDB cached thread data source fallback that synthesized remote thread detail from event metadata
- simplify new-thread and first-message entrypoints to mint local event/message state, route by URL, and let server create/send settle globally
- remove sidebar current-pane merge behavior so the sidebar list comes directly from event-sourced `chatThreads$`

## Verification
- `pnpm exec vitest run src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts src/views/zero-page/__tests__/zero-sidebar.test.tsx src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app check-types`