### PR TITLE
fix: add mobile spacing to dialog footers

### DIFF
--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -80,7 +80,7 @@ const DialogFooter = ({
   return (
     <div
       className={cn(
-        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}

--- a/turbo/packages/ui/src/components/ui/sheet.tsx
+++ b/turbo/packages/ui/src/components/ui/sheet.tsx
@@ -87,7 +87,7 @@ const SheetFooter = ({
   return (
     <div
       className={cn(
-        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Add a default `gap-2` to shared `DialogFooter` so stacked mobile dialog actions no longer touch each other.
- Apply the same footer spacing to `SheetFooter` for the matching mobile drawer pattern.
- Replace the old desktop-only `sm:space-x-2` spacing with breakpoint-independent flex gap spacing.

## Verification
- `pnpm -F @vm0/ui lint`
- `pnpm -F @vm0/ui check-types`
- `git diff --check`
- Browser CSS sanity check: mobile footer `rowGap: 8px`; desktop footer `columnGap: 8px`
