### PR TITLE
perf(runner): avoid preflight guest payload materialization

### DIFF
--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -127,18 +127,17 @@ pub(super) fn validate_execution_context_before_sandbox_with_host_env(
     validate_model_provider_env_placeholders(context)?;
     validate_user_environment_for_guest(context)?;
     validate_claude_tool_lists(context)?;
+    validate_run_payload_fields_before_sandbox(context)?;
     let bootstrap_env =
         build_env_json_with_host_env(context, api_url, sandbox_id, reuse_result, host_env)
             .map_err(|error| error.to_string())?;
     validate_bootstrap_environment_for_guest(&bootstrap_env)?;
-    let run_payload = build_run_payload_for_run(context).map_err(|error| error.to_string())?;
-    validate_run_payload_for_guest(&run_payload)?;
     Ok(())
 }
 
 fn validate_user_environment_for_guest(context: &ExecutionContext) -> Result<(), String> {
-    let user_env = build_user_env_json(context);
-    let mut entries: Vec<(&String, &String)> = user_env.iter().collect();
+    let mut entries: Vec<(&str, &str)> = Vec::new();
+    for_each_guest_user_env_entry(context, |key, value| entries.push((key, value)));
     entries.sort_by_key(|(key, _)| *key);
 
     for (key, value) in entries {
@@ -156,6 +155,30 @@ fn validate_user_environment_for_guest(context: &ExecutionContext) -> Result<(),
         }
     }
 
+    Ok(())
+}
+
+fn validate_run_payload_fields_before_sandbox(context: &ExecutionContext) -> Result<(), String> {
+    validate_run_payload_field(guest_contracts::env::PROMPT_ENV, &context.prompt)?;
+    validate_run_payload_field(
+        guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
+        context.append_system_prompt.as_deref().unwrap_or_default(),
+    )?;
+
+    if effective_cli_framework(&context.cli_agent_type) == EffectiveCliFramework::ClaudeCode
+        && let Some(settings) = &context.settings
+        && !settings.is_empty()
+    {
+        validate_run_payload_field(guest_contracts::env::SETTINGS_ENV, settings)?;
+    }
+
+    Ok(())
+}
+
+fn validate_run_payload_field(name: &str, value: &str) -> Result<(), String> {
+    if value.contains('\0') {
+        return Err(format!("run payload contains NUL byte for {name}"));
+    }
     Ok(())
 }
 
@@ -219,24 +242,34 @@ pub(super) fn validate_claude_tool_lists(context: &ExecutionContext) -> Result<(
 pub(super) fn build_user_env_json(context: &ExecutionContext) -> HashMap<String, String> {
     let mut env = HashMap::new();
 
+    for_each_guest_user_env_entry(context, |key, value| {
+        env.insert(key.to_string(), value.to_string());
+    });
+
+    env
+}
+
+fn for_each_guest_user_env_entry<'a>(
+    context: &'a ExecutionContext,
+    mut visit: impl FnMut(&'a str, &'a str),
+) {
     if let Some(user_env) = &context.environment {
-        for (k, v) in user_env {
-            env.insert(k.clone(), v.clone());
+        for (key, value) in user_env {
+            if !is_runner_owned_env_key(key) {
+                visit(key, value);
+            }
         }
     }
-    scrub_runner_owned_env(&mut env);
 
     if let Some(tz) = &context.user_timezone {
         let has_tz = context
             .environment
             .as_ref()
-            .is_some_and(|e| e.contains_key("TZ"));
+            .is_some_and(|env| env.contains_key("TZ"));
         if !has_tz {
-            env.insert("TZ".into(), tz.clone());
+            visit("TZ", tz);
         }
     }
-
-    env
 }
 
 pub(super) fn guest_user_env_file_path(run_id: RunId) -> RunnerResult<String> {
@@ -571,10 +604,6 @@ pub(super) fn is_runner_owned_env_key(key: &str) -> bool {
     guest_contracts::env::is_runner_owned_env_key(key)
 }
 
-pub(super) fn scrub_runner_owned_env(env: &mut HashMap<String, String>) {
-    env.retain(|key, _| !is_runner_owned_env_key(key));
-}
-
 pub(super) fn insert_claude_code_env(
     env: &mut HashMap<String, String>,
     context: &ExecutionContext,
@@ -618,6 +647,11 @@ pub(super) fn validate_claude_tool_env_entries(
         if tool.contains(',') {
             return Err(format!(
                 "{env_name} entry at index {index} must not contain commas"
+            ));
+        }
+        if tool.contains('\0') {
+            return Err(format!(
+                "{env_name} entry at index {index} must not contain NUL bytes"
             ));
         }
         if tool.trim_start().starts_with('-') {

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -164,6 +164,20 @@ fn execution_context_validation_rejects_user_timezone_nul_before_sandbox() {
 }
 
 #[test]
+fn execution_context_validation_ignores_runner_owned_user_env_before_sandbox() {
+    let mut ctx = minimal_context();
+    ctx.environment = Some(HashMap::from([
+        ("VM0_PROMPT".into(), "ignored\0secret".into()),
+        ("CUSTOM_ENV".into(), "kept".into()),
+    ]));
+
+    assert!(validate_context_for_test(&ctx).is_ok());
+    let user_env = build_user_env_json(&ctx);
+    assert_eq!(user_env.get("CUSTOM_ENV").unwrap(), "kept");
+    assert!(!user_env.contains_key("VM0_PROMPT"));
+}
+
+#[test]
 fn execution_context_validation_rejects_tuning_env_nul_before_sandbox() {
     let secret = "3\0";
     let ctx = context_with_env(HashMap::from([(
@@ -180,7 +194,7 @@ fn execution_context_validation_rejects_tuning_env_nul_before_sandbox() {
 }
 
 #[test]
-fn execution_context_validation_rejects_bootstrap_env_nul_before_sandbox() {
+fn execution_context_validation_rejects_prompt_nul_before_sandbox() {
     let secret = "before\0after";
     let mut ctx = minimal_context();
     ctx.prompt = secret.into();
@@ -191,6 +205,65 @@ fn execution_context_validation_rejects_bootstrap_env_nul_before_sandbox() {
     assert!(error.contains("NUL byte"));
     assert!(error.contains("VM0_PROMPT"));
     assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_append_system_prompt_nul_before_sandbox() {
+    let secret = "system\0prompt";
+    let mut ctx = minimal_context();
+    ctx.append_system_prompt = Some(secret.into());
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("run payload"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_APPEND_SYSTEM_PROMPT"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_claude_settings_nul_before_sandbox() {
+    let secret = "{\"hooks\":\"bad\0value\"}";
+    let mut ctx = minimal_context();
+    ctx.settings = Some(secret.into());
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("run payload"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_SETTINGS"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_ignores_codex_settings_nul_before_sandbox() {
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    ctx.settings = Some("{\"hooks\":\"bad\0value\"}".into());
+
+    assert!(validate_context_for_test(&ctx).is_ok());
+    assert!(build_run_payload_for_run(&ctx).unwrap().settings.is_empty());
+}
+
+#[test]
+fn execution_context_validation_accepts_raw_secret_value_nul_before_sandbox() {
+    let mut ctx = minimal_context();
+    ctx.secret_values = Some(vec!["secret\0value".into()]);
+
+    assert!(validate_context_for_test(&ctx).is_ok());
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    assert!(!payload.secret_values.contains('\0'));
+}
+
+#[test]
+fn execution_context_validation_rejects_tool_nul_before_sandbox() {
+    let mut ctx = minimal_context();
+    ctx.tools = Some(vec!["Bash\0Read".into()]);
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("VM0_TOOLS"));
+    assert!(error.contains("NUL"));
 }
 
 #[test]
@@ -1123,6 +1196,23 @@ fn build_env_json_empty_append_system_prompt_omitted() {
 }
 
 #[test]
+fn build_run_payload_for_run_rejects_prompt_nul() {
+    let secret = "before\0after";
+    let mut ctx = minimal_context();
+    ctx.prompt = secret.into();
+
+    let error = match build_run_payload_for_run(&ctx) {
+        Err(RunnerError::Internal(error)) => error,
+        other => panic!("expected internal error, got {other:?}"),
+    };
+
+    assert!(error.contains("run payload"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_PROMPT"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
 fn build_env_json_with_user_timezone() {
     let mut ctx = minimal_context();
     ctx.user_timezone = Some("Asia/Shanghai".into());
@@ -1390,6 +1480,7 @@ fn build_env_json_rejects_invalid_disallowed_tools_entries() {
         ("", "must not be empty"),
         ("   ", "must not be empty"),
         ("CronCreate,CronDelete", "must not contain commas"),
+        ("CronCreate\0CronDelete", "must not contain NUL bytes"),
         ("--help", "must not start with a hyphen"),
         (" -v", "must not start with a hyphen"),
     ] {
@@ -1406,6 +1497,7 @@ fn build_env_json_rejects_invalid_tools_entries() {
         ("", "must not be empty"),
         ("   ", "must not be empty"),
         ("Bash,Read", "must not contain commas"),
+        ("Bash\0Read", "must not contain NUL bytes"),
         ("--help", "must not start with a hyphen"),
         (" -x", "must not start with a hyphen"),
     ] {


### PR DESCRIPTION
## Summary

- replace pre-sandbox user env validation with borrowed guest-facing entry validation
- stop building `RunPayload` during pre-sandbox validation while keeping final payload validation before guest write
- preserve fail-fast checks for prompt, append system prompt, Claude settings, and tool-list NUL values

Closes #20115

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::env_tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::agent_run_tests::run_in_sandbox_sets_codex_app_server_backend_for_active_input_source`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`