### PR TITLE
test: add firewall base url validation contract

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -198,10 +198,10 @@ jobs:
           rm -f "$changed_files"
           echo "python-firewalls-changed=$python_firewalls_changed" >> "$GITHUB_OUTPUT"
 
-          # The shared firewall semantics contract is stored under turbo but is
-          # read by mitm-addon tests. Keep this separate from python-firewalls
-          # because it is not an input to generated Python firewall artifacts.
-          if git diff --name-only "$BASE_REF" HEAD | grep -qx "turbo/packages/connectors/src/__tests__/firewall-semantics-contract.json"; then
+          # Shared firewall contracts are stored under turbo but are read by
+          # mitm-addon tests. Keep this separate from python-firewalls because
+          # they are not inputs to generated Python firewall artifacts.
+          if git diff --name-only "$BASE_REF" HEAD | grep -Eqx "turbo/packages/connectors/src/__tests__/(firewall-semantics-contract|firewall-base-url-validation-contract)\\.json"; then
             echo "mitm-addon-test-inputs-changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "mitm-addon-test-inputs-changed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -674,7 +674,7 @@ jobs:
       - name: Test Other Packages
         working-directory: turbo
         run: pnpm vitest run --project=@vm0/core --project=@vm0/ui --project=@vm0/firewalls-generator --project=@vm0/api-contracts --project=@vm0/db --coverage.enabled --coverage.reporter=json
-      - name: Test Connectors Firewall Semantics Contract
+      - name: Test Connectors Firewall Contracts
         working-directory: turbo
         run: pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-semantics-contract.test.ts src/__tests__/firewall-base-url-validation-contract.test.ts --reporter=default
       - name: Upload coverage to Codecov

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -676,7 +676,7 @@ jobs:
         run: pnpm vitest run --project=@vm0/core --project=@vm0/ui --project=@vm0/firewalls-generator --project=@vm0/api-contracts --project=@vm0/db --coverage.enabled --coverage.reporter=json
       - name: Test Connectors Firewall Semantics Contract
         working-directory: turbo
-        run: pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-semantics-contract.test.ts --reporter=default
+        run: pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-semantics-contract.test.ts src/__tests__/firewall-base-url-validation-contract.test.ts --reporter=default
       - name: Upload coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v7

--- a/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
@@ -19,11 +19,14 @@ _CONTRACT_PATH = (
 
 
 def _load_cases() -> list[dict[str, object]]:
-    raw_contract = json.loads(_CONTRACT_PATH.read_text())
+    raw_contract = json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
     assert isinstance(raw_contract, dict)
     cases = raw_contract["baseUrlValidationCases"]
     assert isinstance(cases, list)
+    assert cases
     assert all(isinstance(case, dict) for case in cases)
+    names = [_case_name(case) for case in cases]
+    assert len(names) == len(set(names))
     return cases
 
 

--- a/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_base_url_validation_contract.py
@@ -1,0 +1,48 @@
+"""Shared firewall base URL validation contract tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import matching
+
+_CONTRACT_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "turbo"
+    / "packages"
+    / "connectors"
+    / "src"
+    / "__tests__"
+    / "firewall-base-url-validation-contract.json"
+)
+
+
+def _load_cases() -> list[dict[str, object]]:
+    raw_contract = json.loads(_CONTRACT_PATH.read_text())
+    assert isinstance(raw_contract, dict)
+    cases = raw_contract["baseUrlValidationCases"]
+    assert isinstance(cases, list)
+    assert all(isinstance(case, dict) for case in cases)
+    return cases
+
+
+def _case_name(case: dict[str, object]) -> str:
+    name = case["name"]
+    assert isinstance(name, str)
+    return name
+
+
+_BASE_URL_VALIDATION_CASES = _load_cases()
+
+
+@pytest.mark.parametrize("case", _BASE_URL_VALIDATION_CASES, ids=_case_name)
+def test_firewall_base_url_config_validity_matches_shared_contract(
+    case: dict[str, object],
+) -> None:
+    base = case["base"]
+    assert isinstance(base, str)
+    expected_valid = case["expectedValid"]
+    assert isinstance(expected_valid, bool)
+
+    assert matching.firewall_base_config_is_valid(base) is expected_valid

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -152,6 +152,12 @@
     },
     {
       "category": "authority",
+      "name": "parameterized empty authority is invalid",
+      "base": "https:///{org}",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
       "name": "bracketed non-ipv6 authority is invalid",
       "base": "https://[v1.invalid]",
       "expectedValid": false
@@ -202,6 +208,12 @@
       "category": "scheme",
       "name": "missing scheme delimiter is invalid",
       "base": "https:/api.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "scheme",
+      "name": "parameterized scheme is invalid",
+      "base": "{scheme}://api.example.com",
       "expectedValid": false
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -20,6 +20,30 @@
     },
     {
       "category": "valid",
+      "name": "static base with default https port",
+      "base": "https://api.example.com:443",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "static base with trailing host dot",
+      "base": "https://api.example.com.",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "static ipv6 base",
+      "base": "https://[2001:db8::1]",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "percent-encoded unicode host is valid",
+      "base": "https://%E2%98%83.example.com",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
       "name": "parameterized host base",
       "base": "https://{sub}.example.com",
       "expectedValid": true
@@ -40,6 +64,18 @@
       "category": "valid",
       "name": "parameterized path base",
       "base": "https://api.example.com/v1/{org}",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "parameterized host with trailing dot",
+      "base": "https://{sub}.example.com.",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "parameterized path with explicit empty segment",
+      "base": "https://api.example.com/v1//{org}",
       "expectedValid": true
     },
     {
@@ -82,6 +118,18 @@
       "category": "authority",
       "name": "non-numeric port is invalid",
       "base": "https://api.example.com:bad",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "out-of-range port is invalid",
+      "base": "https://api.example.com:99999",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "empty host label is invalid",
+      "base": "https://api..example.com",
       "expectedValid": false
     },
     {
@@ -130,6 +178,24 @@
       "category": "parameters",
       "name": "host without static segment is invalid",
       "base": "https://{a}.{b}",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "parameterized out-of-range port is invalid",
+      "base": "https://{sub}.example.com:99999",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "parameterized empty host label is invalid",
+      "base": "https://{sub}..example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "parameterized ipv6 base is invalid",
+      "base": "https://[2001:db8::1]/v1/{org}",
       "expectedValid": false
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -1,0 +1,136 @@
+{
+  "baseUrlValidationCases": [
+    {
+      "category": "valid",
+      "name": "static https base",
+      "base": "https://api.example.com",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "static http base",
+      "base": "http://api.example.com",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "static base with path",
+      "base": "https://api.example.com/v1",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "parameterized host base",
+      "base": "https://{sub}.example.com",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "leftmost star-greedy host parameter",
+      "base": "https://{sub*}.example.com",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "parameterized path base",
+      "base": "https://api.example.com/v1/{org}",
+      "expectedValid": true
+    },
+    {
+      "category": "query-fragment",
+      "name": "query string is invalid",
+      "base": "https://api.example.com?token=1",
+      "expectedValid": false
+    },
+    {
+      "category": "query-fragment",
+      "name": "fragment is invalid",
+      "base": "https://api.example.com#section",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "userinfo is invalid",
+      "base": "https://user:pass@api.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "empty port is invalid",
+      "base": "https://api.example.com:",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "non-numeric port is invalid",
+      "base": "https://api.example.com:bad",
+      "expectedValid": false
+    },
+    {
+      "category": "scheme",
+      "name": "unsupported scheme is invalid",
+      "base": "ftp://api.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "raw-syntax",
+      "name": "backslash is invalid",
+      "base": "https://api.example.com\\v1",
+      "expectedValid": false
+    },
+    {
+      "category": "raw-syntax",
+      "name": "raw path whitespace is invalid",
+      "base": "https://api.example.com/pa th",
+      "expectedValid": false
+    },
+    {
+      "category": "raw-syntax",
+      "name": "raw control character is invalid",
+      "base": "https://api.example.com/pa\u0000th",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "raw wildcard host is invalid",
+      "base": "https://*.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "percent-encoded authority syntax is invalid",
+      "base": "https://api%2eexample.com",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "duplicate host parameter name is invalid",
+      "base": "https://{sub}.{sub}.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "host without static segment is invalid",
+      "base": "https://{a}.{b}",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "non-leftmost greedy host parameter is invalid",
+      "base": "https://api.{sub+}.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "greedy path parameter is invalid",
+      "base": "https://api.example.com/{path+}",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "duplicate host and path parameter name is invalid",
+      "base": "https://{org}.example.com/{org}",
+      "expectedValid": false
+    }
+  ]
+}

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -140,6 +140,12 @@
     },
     {
       "category": "authority",
+      "name": "bracketed ipv4 authority is invalid",
+      "base": "https://[127.0.0.1]",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
       "name": "empty port is invalid",
       "base": "https://api.example.com:",
       "expectedValid": false
@@ -218,8 +224,26 @@
     },
     {
       "category": "authority",
+      "name": "invalid authority percent encoding is invalid",
+      "base": "https://api%ZZexample.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "percent-encoded userinfo delimiter is invalid",
+      "base": "https://api%40example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
       "name": "percent-encoded slash in authority is invalid",
       "base": "https://api%2Fexample.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "percent-encoded backslash in authority is invalid",
+      "base": "https://api%5Cexample.com",
       "expectedValid": false
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -50,6 +50,12 @@
     },
     {
       "category": "valid",
+      "name": "static canonical ipv4 base",
+      "base": "https://127.0.0.1",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
       "name": "percent-encoded unicode host is valid",
       "base": "https://%E2%98%83.example.com",
       "expectedValid": true
@@ -208,6 +214,30 @@
       "category": "authority",
       "name": "percent-encoded authority delimiter is invalid",
       "base": "https://api%2Cexample.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "percent-encoded slash in authority is invalid",
+      "base": "https://api%2Fexample.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "percent-encoded control character in authority is invalid",
+      "base": "https://api%00example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "non-canonical ipv4 with leading zeros is invalid",
+      "base": "https://127.000.000.001",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "single-number ipv4 literal is invalid",
+      "base": "https://2130706433",
       "expectedValid": false
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -121,9 +121,27 @@
       "expectedValid": false
     },
     {
+      "category": "query-fragment",
+      "name": "parameterized query string is invalid",
+      "base": "https://{sub}.example.com?token=1",
+      "expectedValid": false
+    },
+    {
+      "category": "query-fragment",
+      "name": "parameterized fragment is invalid",
+      "base": "https://{sub}.example.com#section",
+      "expectedValid": false
+    },
+    {
       "category": "authority",
       "name": "userinfo is invalid",
       "base": "https://user:pass@api.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "parameterized userinfo is invalid",
+      "base": "https://user:pass@{sub}.example.com",
       "expectedValid": false
     },
     {
@@ -364,6 +382,12 @@
       "category": "parameters",
       "name": "duplicate host and path parameter name is invalid",
       "base": "https://{org}.example.com/{org}",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "duplicate path parameter name is invalid",
+      "base": "https://api.example.com/{org}/{org}",
       "expectedValid": false
     }
   ]

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -241,6 +241,36 @@
       "expectedValid": false
     },
     {
+      "category": "authority",
+      "name": "unicode decimal ipv4-like host is invalid",
+      "base": "https://\u0668.\u0668.\u0668.\u0668",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "unicode dot ipv4-like host is invalid",
+      "base": "https://127\u30020\u30020\u30021",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "unsafe idna compatibility mapping is invalid",
+      "base": "https://\u212a.example",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "percent-encoded unsafe idna compatibility mapping is invalid",
+      "base": "https://%E2%84%AA.example",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "parameterized percent-encoded unsafe idna suffix is invalid",
+      "base": "https://{sub}.%EF%BC%A1.example",
+      "expectedValid": false
+    },
+    {
       "category": "parameters",
       "name": "duplicate host parameter name is invalid",
       "base": "https://{sub}.{sub}.example.com",

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -32,6 +32,12 @@
     },
     {
       "category": "valid",
+      "name": "leftmost plus-greedy host parameter",
+      "base": "https://{sub+}.example.com",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
       "name": "parameterized path base",
       "base": "https://api.example.com/v1/{org}",
       "expectedValid": true
@@ -134,8 +140,20 @@
     },
     {
       "category": "parameters",
+      "name": "non-leftmost star-greedy host parameter is invalid",
+      "base": "https://api.{sub*}.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
       "name": "greedy path parameter is invalid",
       "base": "https://api.example.com/{path+}",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "star-greedy path parameter is invalid",
+      "base": "https://api.example.com/{path*}",
       "expectedValid": false
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -56,6 +56,18 @@
     },
     {
       "category": "authority",
+      "name": "empty authority is invalid",
+      "base": "https:///v1",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
+      "name": "bracketed non-ipv6 authority is invalid",
+      "base": "https://[v1.invalid]",
+      "expectedValid": false
+    },
+    {
+      "category": "authority",
       "name": "empty port is invalid",
       "base": "https://api.example.com:",
       "expectedValid": false

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -8,6 +8,12 @@
     },
     {
       "category": "valid",
+      "name": "uppercase scheme and host base",
+      "base": "HTTPS://API.EXAMPLE.COM",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
       "name": "static http base",
       "base": "http://api.example.com",
       "expectedValid": true
@@ -22,6 +28,12 @@
       "category": "valid",
       "name": "static base with default https port",
       "base": "https://api.example.com:443",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "static base with non-default port",
+      "base": "https://api.example.com:8443",
       "expectedValid": true
     },
     {
@@ -50,6 +62,12 @@
     },
     {
       "category": "valid",
+      "name": "mixed parameterized host segment",
+      "base": "https://api-{sub}.example.com",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
       "name": "leftmost star-greedy host parameter",
       "base": "https://{sub*}.example.com",
       "expectedValid": true
@@ -64,6 +82,12 @@
       "category": "valid",
       "name": "parameterized path base",
       "base": "https://api.example.com/v1/{org}",
+      "expectedValid": true
+    },
+    {
+      "category": "valid",
+      "name": "parameterized path base with trailing literal segment",
+      "base": "https://api.example.com/v1/{org}/projects",
       "expectedValid": true
     },
     {
@@ -139,6 +163,18 @@
       "expectedValid": false
     },
     {
+      "category": "scheme",
+      "name": "missing scheme is invalid",
+      "base": "not-a-url",
+      "expectedValid": false
+    },
+    {
+      "category": "scheme",
+      "name": "missing scheme delimiter is invalid",
+      "base": "https:/api.example.com",
+      "expectedValid": false
+    },
+    {
       "category": "raw-syntax",
       "name": "backslash is invalid",
       "base": "https://api.example.com\\v1",
@@ -169,6 +205,12 @@
       "expectedValid": false
     },
     {
+      "category": "authority",
+      "name": "percent-encoded authority delimiter is invalid",
+      "base": "https://api%2Cexample.com",
+      "expectedValid": false
+    },
+    {
       "category": "parameters",
       "name": "duplicate host parameter name is invalid",
       "base": "https://{sub}.{sub}.example.com",
@@ -196,6 +238,18 @@
       "category": "parameters",
       "name": "parameterized ipv6 base is invalid",
       "base": "https://[2001:db8::1]/v1/{org}",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "empty host parameter name is invalid",
+      "base": "https://{}.example.com",
+      "expectedValid": false
+    },
+    {
+      "category": "parameters",
+      "name": "empty path parameter name is invalid",
+      "base": "https://api.example.com/v1/{}",
       "expectedValid": false
     },
     {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
@@ -13,9 +13,23 @@ const baseUrlValidationCaseSchema = z.object({
   expectedValid: z.boolean(),
 });
 
-const contractSchema = z.object({
-  baseUrlValidationCases: z.array(baseUrlValidationCaseSchema),
-});
+const contractSchema = z
+  .object({
+    baseUrlValidationCases: z.array(baseUrlValidationCaseSchema).min(1),
+  })
+  .superRefine((contract, ctx) => {
+    const seenNames = new Set<string>();
+    for (const [index, testCase] of contract.baseUrlValidationCases.entries()) {
+      if (seenNames.has(testCase.name)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["baseUrlValidationCases", index, "name"],
+          message: `duplicate case name "${testCase.name}"`,
+        });
+      }
+      seenNames.add(testCase.name);
+    }
+  });
 
 type BaseUrlValidationCase = z.infer<typeof baseUrlValidationCaseSchema>;
 

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.test.ts
@@ -1,0 +1,56 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { validateBaseUrl } from "../firewall-types";
+
+const baseUrlValidationCaseSchema = z.object({
+  name: z.string(),
+  category: z.string().optional(),
+  note: z.string().optional(),
+  base: z.string(),
+  expectedValid: z.boolean(),
+});
+
+const contractSchema = z.object({
+  baseUrlValidationCases: z.array(baseUrlValidationCaseSchema),
+});
+
+type BaseUrlValidationCase = z.infer<typeof baseUrlValidationCaseSchema>;
+
+function loadContract(): z.infer<typeof contractSchema> {
+  const rawContract: unknown = JSON.parse(
+    fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "firewall-base-url-validation-contract.json",
+      ),
+      "utf-8",
+    ),
+  );
+  return contractSchema.parse(rawContract);
+}
+
+function assertValidationResult(testCase: BaseUrlValidationCase): void {
+  const validate = (): void => {
+    validateBaseUrl(testCase.base, "contract");
+  };
+
+  if (testCase.expectedValid) {
+    expect(validate).not.toThrow();
+    return;
+  }
+
+  expect(validate).toThrow();
+}
+
+const contract = loadContract();
+
+describe("firewall base URL validation contract", () => {
+  for (const testCase of contract.baseUrlValidationCases) {
+    it(testCase.name, () => {
+      assertValidationResult(testCase);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Add a dedicated shared firewall base URL validation contract for resolved config bases.
- Add TypeScript coverage through `validateBaseUrl(base, "contract")`.
- Add Python mitm-addon coverage through `matching.firewall_base_config_is_valid(base)`.

Closes #20084.

## Tests

- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-base-url-validation-contract.test.ts`
- `pnpm -F @vm0/connectors exec vitest src/__tests__/firewall-semantics-contract.test.ts`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `.venv/bin/python -m pytest tests/test_firewall_base_url_validation_contract.py`
- `.venv/bin/python -m pytest tests/test_firewall_semantics_contract.py`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- pre-commit hook: `pnpm check-types`, `pnpm knip`, prettier, ruff
