### PR TITLE
fix(mitm-addon): suppress ambiguous shared-base diagnostics

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -34,6 +34,11 @@ class SharedBaseOwnershipResolution:
 
 
 @dataclass(frozen=True)
+class _SharedBaseDiagnosticResolution:
+    candidate: ConnectorDiagnosticCandidate | None
+
+
+@dataclass(frozen=True)
 class _DiagnosticConnectorMatcher:
     base_authorities: frozenset[str]
     compiled_firewalls: matching.CompiledFirewallSet | None
@@ -80,6 +85,15 @@ def find_candidate(
     if _matches_model_provider_exclusion(url, method, catalog):
         return None
 
+    shared_base_resolution = _find_shared_base_candidate(
+        url,
+        method,
+        catalog,
+        active_firewall_names=active_firewall_names,
+    )
+    if shared_base_resolution is not None:
+        return shared_base_resolution.candidate
+
     match = matching.match_compiled_firewall_request(
         url,
         method,
@@ -92,6 +106,27 @@ def find_candidate(
         return None
 
     return _candidate_from_match(match)
+
+
+def _find_shared_base_candidate(
+    url: str,
+    method: str,
+    catalog: _DiagnosticCatalog,
+    *,
+    active_firewall_names: set[str],
+) -> _SharedBaseDiagnosticResolution | None:
+    matches = _ownership_matches(url, method, catalog)
+    if len(matches) < _SHARED_BASE_MIN_CANDIDATES:
+        return None
+
+    route_matches = [match for match in matches if match.route_specific]
+    if len(route_matches) != 1:
+        return _SharedBaseDiagnosticResolution(candidate=None)
+
+    selected = route_matches[0].candidate
+    if selected.connector_type in active_firewall_names:
+        return _SharedBaseDiagnosticResolution(candidate=None)
+    return _SharedBaseDiagnosticResolution(candidate=selected)
 
 
 def resolve_shared_base_ownership(

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -194,6 +194,135 @@ def test_classifies_connector_permission_path_on_model_provider_host():
     assert candidate.env_names == ("ANTHROPIC_MANAGED_AGENTS_TOKEN",)
 
 
+def test_find_candidate_suppresses_shared_base_only_candidate(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall("first", "FIRST_TOKEN"),
+            _shared_base_firewall("second", "SECOND_TOKEN"),
+        ],
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        "https://shared.example.com/messages/123",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is None
+
+
+def test_find_candidate_selects_shared_base_route_specific_inactive_owner(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall("active", "ACTIVE_TOKEN"),
+            _shared_base_firewall(
+                "inactive",
+                "INACTIVE_TOKEN",
+                permissions=[{"name": "inactive-read", "rules": ["GET /messages/{id}"]}],
+            ),
+        ],
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        "https://shared.example.com/messages/123",
+        "GET",
+        active_firewall_names={"active"},
+    )
+
+    assert candidate is not None
+    assert candidate.connector_type == "inactive"
+    assert candidate.env_names == ("INACTIVE_TOKEN",)
+
+
+def test_find_candidate_suppresses_shared_base_active_route_owner(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall(
+                "active",
+                "ACTIVE_TOKEN",
+                permissions=[{"name": "active-read", "rules": ["GET /messages/{id}"]}],
+            ),
+            _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
+        ],
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        "https://shared.example.com/messages/123",
+        "GET",
+        active_firewall_names={"active"},
+    )
+
+    assert candidate is None
+
+
+def test_find_candidate_suppresses_shared_base_multiple_route_owners(monkeypatch):
+    _patch_connector_diagnostics(
+        monkeypatch,
+        [
+            _shared_base_firewall(
+                "first",
+                "FIRST_TOKEN",
+                permissions=[{"name": "first-read", "rules": ["GET /messages/{id}"]}],
+            ),
+            _shared_base_firewall(
+                "second",
+                "SECOND_TOKEN",
+                permissions=[{"name": "second-read", "rules": ["GET /messages/{id}"]}],
+            ),
+        ],
+    )
+
+    candidate = builtin_connector_diagnostics.find_candidate(
+        "https://shared.example.com/messages/123",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is None
+
+
+def test_find_candidate_suppresses_current_graph_mail_and_calendar_base_only_diagnostics():
+    for url in (
+        "https://graph.microsoft.com/v1.0/me/messages",
+        "https://graph.microsoft.com/v1.0/me/events",
+    ):
+        candidate = builtin_connector_diagnostics.find_candidate(
+            url,
+            "GET",
+            active_firewall_names=set(),
+        )
+
+        assert candidate is None
+
+
+def test_find_candidate_keeps_current_graph_route_specific_microsoft_365_diagnostic():
+    candidate = builtin_connector_diagnostics.find_candidate(
+        "https://graph.microsoft.com/v1.0/teams",
+        "GET",
+        active_firewall_names=set(),
+    )
+
+    assert candidate is not None
+    assert candidate.connector_type == "microsoft-365"
+
+
+def test_find_candidate_suppresses_current_shared_base_only_diagnostics():
+    for url, method in (
+        ("https://backboard.railway.com/graphql/v2", "POST"),
+        ("https://graph.facebook.com/v22.0/123/ads_posts", "GET"),
+    ):
+        candidate = builtin_connector_diagnostics.find_candidate(
+            url,
+            method,
+            active_firewall_names=set(),
+        )
+
+        assert candidate is None
+
+
 def test_shared_base_ownership_selects_route_specific_inactive_sibling(monkeypatch):
     _patch_connector_diagnostics(
         monkeypatch,


### PR DESCRIPTION
## Summary

- make ordinary connector diagnostics use conservative shared-base candidate semantics before falling back to the folded matcher
- suppress base-only or multi-owner shared-base diagnostics instead of choosing by catalog order
- add generated and synthetic regression coverage for Graph, Meta Graph, Railway, and active/shared-base edge cases

## Tests

- PYTHONPATH=/tmp/vm0-mitm-pydeps:src python3 -m pytest tests/test_builtin_connector_diagnostics.py -q
- PYTHONPATH=/tmp/vm0-mitm-pydeps:src /tmp/vm0-ruff/bin/ruff check src tests/test_builtin_connector_diagnostics.py
- PYTHONPATH=/tmp/vm0-mitm-pydeps:src /tmp/vm0-ruff/bin/ruff format --check src tests/test_builtin_connector_diagnostics.py
- PYTHONPATH=/tmp/vm0-mitm-pydeps:src python3 -m pytest -q

Closes #19905
Related #20126
Related #20160