### PR TITLE
refactor: clarify runner profile availability contract

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -210,7 +210,7 @@ fn merge_held_session_states(
     states
 }
 
-fn available_profiles_for_heartbeat(
+fn admittable_profiles_for_heartbeat(
     profiles: &BTreeMap<String, ProfileConfig>,
     budget: &ResourceBudget,
     mode: RunnerMode,
@@ -252,6 +252,7 @@ pub(super) fn collect_heartbeat_state(
     // Report only actively running jobs so the scheduler sees real capacity.
     let idle_count = idle_pool.len();
     let running_count = budget_running.saturating_sub(idle_count);
+    let admittable_profiles = admittable_profiles_for_heartbeat(profiles, budget, mode);
     HeartbeatState {
         runner_id: runner_id.to_string(),
         runner_name: name.to_string(),
@@ -263,7 +264,8 @@ pub(super) fn collect_heartbeat_state(
         allocated_vcpu,
         allocated_memory_mb,
         running_count,
-        available_profiles: available_profiles_for_heartbeat(profiles, budget, mode),
+        admittable_profiles: admittable_profiles.clone(),
+        available_profiles: admittable_profiles,
         held_session_states: idle_pool.held_session_states(),
         mode: match mode {
             RunnerMode::Running => "running".to_string(),
@@ -408,7 +410,7 @@ mod tests {
     }
 
     #[test]
-    fn heartbeat_available_profiles_match_current_budget() {
+    fn heartbeat_admittable_profiles_match_current_budget() {
         let budget = Arc::new(ResourceBudget::new(4, 8192, 1.0, 2));
         let _lease = ResourceBudget::try_reserve_lease(&budget, 2, 4096).unwrap();
         let mut profiles = test_profiles();
@@ -438,11 +440,12 @@ mod tests {
             RunnerMode::Running,
         );
 
+        assert_eq!(state.admittable_profiles, vec!["vm0/default"]);
         assert_eq!(state.available_profiles, vec!["vm0/default"]);
     }
 
     #[test]
-    fn heartbeat_available_profiles_exclude_unaffordable_parked_profiles() {
+    fn heartbeat_admittable_profiles_exclude_unaffordable_parked_profiles() {
         let budget = Arc::new(ResourceBudget::new(2, 4096, 1.0, 1));
         let mut pool = IdlePool::new(IdlePoolConfig {
             default_timeout: Duration::from_secs(300),
@@ -467,11 +470,12 @@ mod tests {
             RunnerMode::Running,
         );
 
+        assert!(state.admittable_profiles.is_empty());
         assert!(state.available_profiles.is_empty());
     }
 
     #[test]
-    fn heartbeat_available_profiles_empty_when_not_running() {
+    fn heartbeat_admittable_profiles_empty_when_not_running() {
         let budget = ResourceBudget::new(8, 32768, 1.0, 4);
         let pool = IdlePool::new(IdlePoolConfig {
             default_timeout: Duration::from_secs(300),
@@ -489,6 +493,7 @@ mod tests {
             RunnerMode::Draining,
         );
 
+        assert!(state.admittable_profiles.is_empty());
         assert!(state.available_profiles.is_empty());
     }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -91,7 +91,7 @@ pub struct ApiProvider {
     group: String,
     /// Profile names this runner supports (e.g., ["vm0/default"]).
     /// Sent in poll requests so the server only returns jobs this runner can handle.
-    profiles: Vec<String>,
+    supported_profiles: Vec<String>,
     /// Coalesced poll wakeup state updated by the Ably supervisor.
     poll_wakeups: Arc<PollWakeups>,
     /// Supported direct job candidates delivered by Ably notifications.
@@ -108,7 +108,7 @@ impl ApiProvider {
         http: HttpClient,
         token: String,
         group: String,
-        profiles: Vec<String>,
+        supported_profiles: Vec<String>,
         cancel: CancellationToken,
         cancel_tokens: SharedRunCancellationMap,
     ) -> Arc<Self> {
@@ -118,7 +118,7 @@ impl ApiProvider {
         let ably_supervisor = AblySupervisor::spawn(AblySupervisorConfig {
             api: api.clone(),
             group: group.clone(),
-            profiles: profiles.clone(),
+            profiles: supported_profiles.clone(),
             poll_wakeups: Arc::clone(&poll_wakeups),
             direct_candidates: Arc::clone(&direct_candidates),
             cancel_tokens,
@@ -128,7 +128,7 @@ impl ApiProvider {
         Arc::new(Self {
             api,
             group,
-            profiles,
+            supported_profiles,
             poll_wakeups,
             direct_candidates,
             ably_supervisor,
@@ -209,7 +209,7 @@ impl JobProvider for ApiProvider {
                     }
                     return None;
                 }
-                result = self.api.poll(&self.group, &self.profiles, reason) => result,
+                result = self.api.poll(&self.group, &self.supported_profiles, reason) => result,
             };
 
             match poll_result {
@@ -387,10 +387,10 @@ impl ApiClient {
     async fn poll(
         &self,
         group: &str,
-        profiles: &[String],
+        supported_profiles: &[String],
         reason: PollReason,
     ) -> RunnerResult<PollApiResult> {
-        let body = poll_request_body(group, profiles, reason);
+        let body = poll_request_body(group, supported_profiles, reason);
         let poll_started_at = Instant::now();
         let resp = send_api(
             self.http
@@ -544,10 +544,15 @@ fn claim_telemetry_duration_ms(duration: Duration) -> u64 {
     duration_ms(duration).min(CLAIM_TELEMETRY_DURATION_MS_MAX)
 }
 
-fn poll_request_body(group: &str, profiles: &[String], reason: PollReason) -> serde_json::Value {
+fn poll_request_body(
+    group: &str,
+    supported_profiles: &[String],
+    reason: PollReason,
+) -> serde_json::Value {
     serde_json::json!({
         "group": group,
-        "profiles": profiles,
+        "supportedProfiles": supported_profiles,
+        "profiles": supported_profiles,
         "telemetry": {
             "pollReason": poll_reason_value(reason),
         },
@@ -871,7 +876,7 @@ mod tests {
                 "runner-token".to_string(),
             ),
             group: "default".to_string(),
-            profiles: Vec::new(),
+            supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             poll_wakeups,
             direct_candidates: DirectCandidateInbox::new(DIRECT_CANDIDATE_INBOX_CAPACITY),
             ably_supervisor: AblySupervisor::disabled(),
@@ -985,6 +990,10 @@ mod tests {
         let body = poll_request_body("vm0/test", &profiles, PollReason::Immediate);
 
         assert_eq!(body["group"], "vm0/test");
+        assert_eq!(
+            body["supportedProfiles"][0],
+            crate::profile::DEFAULT_PROFILE
+        );
         assert_eq!(body["profiles"][0], crate::profile::DEFAULT_PROFILE);
         assert_eq!(body["telemetry"]["pollReason"], "immediate");
         assert!(body.get("heldSessionStates").is_none());
@@ -1278,7 +1287,8 @@ mod tests {
                     .path(routes::runners::poll::POLL.path)
                     .json_body(serde_json::json!({
                         "group": "default",
-                        "profiles": [],
+                        "supportedProfiles": [crate::profile::DEFAULT_PROFILE],
+                        "profiles": [crate::profile::DEFAULT_PROFILE],
                         "telemetry": {
                             "pollReason": "immediate"
                         }

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -661,7 +661,7 @@ struct JobNotification<'a> {
 }
 
 fn supports_profile(profiles: &[String], profile: &str) -> bool {
-    profiles.is_empty() || profiles.iter().any(|candidate| candidate == profile)
+    profiles.iter().any(|candidate| candidate == profile)
 }
 
 async fn enqueue_direct_candidate(
@@ -1611,6 +1611,35 @@ mod tests {
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000001",
                 "profile": "vm0/large"
+            }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        assert_no_direct_candidate(&direct_candidates).await;
+        let snapshot = wakeups.snapshot().await;
+        assert!(!snapshot.poll_now);
+        assert!(snapshot.deferred_poll_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_profile_support_job_notification_is_ignored() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let direct_candidates = direct_candidate_inbox();
+        let profiles = Vec::new();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000001",
+                "profile": "vm0/default"
             }),
         );
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -398,6 +398,7 @@ pub struct HeartbeatState {
     pub allocated_vcpu: u32,
     pub allocated_memory_mb: u32,
     pub running_count: usize,
+    pub admittable_profiles: Vec<String>,
     pub available_profiles: Vec<String>,
     pub held_session_states: Vec<HeldSessionState>,
     pub mode: String,
@@ -1043,6 +1044,7 @@ mod tests {
             allocated_vcpu: 6,
             allocated_memory_mb: 6144,
             running_count: 2,
+            admittable_profiles: vec!["vm0/default".into()],
             available_profiles: vec!["vm0/default".into()],
             held_session_states: vec![HeldSessionState {
                 session_id: "session-abc".into(),
@@ -1059,6 +1061,7 @@ mod tests {
         assert_eq!(json["allocatedVcpu"], 6);
         assert_eq!(json["allocatedMemoryMb"], 6144);
         assert_eq!(json["runningCount"], 2);
+        assert_eq!(json["admittableProfiles"], json!(["vm0/default"]));
         assert_eq!(json["availableProfiles"], json!(["vm0/default"]));
         assert_eq!(
             json["heldSessionStates"],

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -212,6 +212,8 @@ function runnerHeartbeatBody(
     readonly runnerId?: string;
     readonly group?: string;
     readonly profiles?: RunnerHeartbeatBody["profiles"];
+    readonly admittableProfiles?: RunnerHeartbeatBody["admittableProfiles"];
+    readonly omitAdmittableProfiles?: boolean;
     readonly availableProfiles?: RunnerHeartbeatBody["availableProfiles"];
     readonly omitAvailableProfiles?: boolean;
     readonly maxConcurrent?: RunnerHeartbeatBody["maxConcurrent"];
@@ -237,6 +239,10 @@ function runnerHeartbeatBody(
     heldSessionStates: args.heldSessionStates ?? [],
     mode: args.mode ?? "running",
   };
+  if (!args.omitAdmittableProfiles) {
+    body.admittableProfiles =
+      args.admittableProfiles ?? args.availableProfiles ?? profiles;
+  }
   if (!args.omitAvailableProfiles) {
     body.availableProfiles = args.availableProfiles ?? profiles;
   }
@@ -854,6 +860,8 @@ export function createRunsAutomationsApi(context: TestContext) {
       args: {
         readonly group?: string;
         readonly profiles?: RunnerHeartbeatBody["profiles"];
+        readonly admittableProfiles?: RunnerHeartbeatBody["admittableProfiles"];
+        readonly omitAdmittableProfiles?: boolean;
         readonly availableProfiles?: RunnerHeartbeatBody["availableProfiles"];
         readonly omitAvailableProfiles?: boolean;
         readonly maxConcurrent?: RunnerHeartbeatBody["maxConcurrent"];
@@ -879,6 +887,7 @@ export function createRunsAutomationsApi(context: TestContext) {
           headers: runnerHeaders(true),
           body: {
             group: group ?? "vm0/test",
+            supportedProfiles: ["vm0/default"],
             profiles: ["vm0/default"],
           },
         }),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1697,6 +1697,60 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expectApiError(uncancellable.body);
   });
 
+  it("filters runner polls by supported profiles without widening malformed polls", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    const missingSupport = await api.requestPollRunner(
+      true,
+      { group: runnerGroup },
+      [400],
+    );
+    expectApiError(missingSupport.body);
+    const emptySupport = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: [] },
+      [400],
+    );
+    expectApiError(emptySupport.body);
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt: "poll with explicit support list",
+      modelProvider: "anthropic-api-key",
+    });
+
+    const incompatiblePoll = await api.requestPollRunner(
+      true,
+      {
+        group: runnerGroup,
+        supportedProfiles: ["vm0/large"],
+        profiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (incompatiblePoll.status !== 200) {
+      throw new Error(
+        "Expected incompatible supportedProfiles poll to return 200",
+      );
+    }
+    expect(incompatiblePoll.body.job).toBeNull();
+
+    const compatiblePoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (compatiblePoll.status !== 200) {
+      throw new Error(
+        "Expected compatible supportedProfiles poll to return 200",
+      );
+    }
+    expect(compatiblePoll.body.job?.runId).toBe(created.runId);
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
   it("resumes the previous session when a run is created with the same sessionId", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
@@ -1768,6 +1822,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     async function heartbeatHolder(args: {
       readonly profiles?: string[];
+      readonly admittableProfiles?: string[];
+      readonly omitAdmittableProfiles?: boolean;
       readonly availableProfiles?: string[];
       readonly omitAvailableProfiles?: boolean;
       readonly mode?: "running" | "draining" | "stopping";
@@ -1775,6 +1831,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       await api.requestHeartbeatRunner(true, [200], {
         group: runnerGroup,
         profiles: args.profiles,
+        admittableProfiles: args.admittableProfiles,
+        omitAdmittableProfiles: args.omitAdmittableProfiles,
         availableProfiles: args.availableProfiles,
         omitAvailableProfiles: args.omitAvailableProfiles,
         heldSessionStates: [
@@ -1796,7 +1854,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       });
       const poll = await api.requestPollRunner(
         true,
-        { group: runnerGroup, profiles: ["vm0/default"] },
+        { group: runnerGroup, supportedProfiles: ["vm0/default"] },
         [200],
       );
       if (poll.status !== 200) {
@@ -1809,7 +1867,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       return { run, job: poll.body.job };
     }
 
-    await heartbeatHolder({ availableProfiles: [] });
+    await heartbeatHolder({
+      admittableProfiles: [],
+      availableProfiles: ["vm0/default"],
+    });
     const unavailableHolder = await pollFollowUp(
       "continue when holder is full",
       false,
@@ -1826,7 +1887,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     onTestFinished(() => {
       clearMockNow();
     });
-    await heartbeatHolder({ availableProfiles: ["vm0/default"] });
+    await heartbeatHolder({ admittableProfiles: ["vm0/default"] });
     clearMockNow();
     const staleHolder = await pollFollowUp(
       "continue after holder heartbeat is stale",
@@ -1836,7 +1897,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     await heartbeatHolder({
       profiles: ["vm0/default", "vm0/large"],
-      availableProfiles: ["vm0/large"],
+      admittableProfiles: ["vm0/large"],
+      availableProfiles: ["vm0/default"],
     });
     const profileIncompatibleHolder = await pollFollowUp(
       "continue when holder cannot run requested profile",
@@ -1847,7 +1909,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(profileIncompatibleHolder.job?.affinityProtectedUntil).toBeNull();
 
     await heartbeatHolder({
-      availableProfiles: ["vm0/default"],
+      admittableProfiles: ["vm0/default"],
       mode: "draining",
     });
     const drainingHolder = await pollFollowUp(
@@ -1856,7 +1918,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(drainingHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
     expect(drainingHolder.job?.affinityProtectedUntil).toBeNull();
 
-    await heartbeatHolder({ omitAvailableProfiles: true });
+    await heartbeatHolder({
+      omitAdmittableProfiles: true,
+      omitAvailableProfiles: true,
+    });
     const legacyHeartbeatFollowUp = await api.createRun(actor, {
       agentId,
       sessionId: first.sessionId,
@@ -1882,7 +1947,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     await api.requestCancelRun(actor, legacyHeartbeatFollowUp.runId, [200]);
 
-    await heartbeatHolder({ availableProfiles: ["vm0/default"] });
+    await heartbeatHolder({
+      admittableProfiles: ["vm0/default"],
+      availableProfiles: [],
+    });
     const protectedFollowUp = await api.createRun(actor, {
       agentId,
       sessionId: first.sessionId,
@@ -1892,7 +1960,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
 
     const protectedPoll = await api.requestPollRunner(
       true,
-      { group: runnerGroup, profiles: ["vm0/default"] },
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
       [200],
     );
     if (protectedPoll.status !== 200) {

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -261,17 +261,17 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
     }
     expect(heartbeat.body.ok).toBeTruthy();
 
-    const emptyWithoutProfiles = await api.requestPollRunner(
+    const emptyPoll = await api.requestPollRunner(
       true,
-      { group: runnerGroup },
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
       [200],
     );
-    if (emptyWithoutProfiles.status !== 200) {
+    if (emptyPoll.status !== 200) {
       throw new Error(
-        `Expected empty poll to succeed, got ${emptyWithoutProfiles.status}`,
+        `Expected empty poll to succeed, got ${emptyPoll.status}`,
       );
     }
-    expect(emptyWithoutProfiles.body.job).toBeNull();
+    expect(emptyPoll.body.job).toBeNull();
   });
 
   it("keeps missing run detail and context hidden for another organization", async () => {

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -292,7 +292,15 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const heldSessionStates =
     canonicalizeHeldSessionStates(body.data.heldSessionStates) ?? [];
-  const availableProfiles = body.data.availableProfiles ?? body.data.profiles;
+  const admittableProfiles =
+    body.data.admittableProfiles ??
+    body.data.availableProfiles ??
+    body.data.profiles;
+  if (admittableProfiles === undefined) {
+    return badRequestMessage("admittableProfiles is required");
+  }
+  // Stage 1 compatibility: remove the legacy static profile write in #20163.
+  const staticProfiles = body.data.profiles ?? [];
   const currentDate = nowDate();
   const db = set(writeDb$);
   await db
@@ -301,14 +309,14 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       runnerId: body.data.runnerId,
       runnerName: body.data.runnerName,
       runnerGroup: body.data.group,
-      profiles: body.data.profiles,
+      profiles: staticProfiles,
       totalVcpu: body.data.totalVcpu,
       totalMemoryMb: body.data.totalMemoryMb,
       maxConcurrent: body.data.maxConcurrent,
       allocatedVcpu: body.data.allocatedVcpu,
       allocatedMemoryMb: body.data.allocatedMemoryMb,
       runningCount: body.data.runningCount,
-      availableProfiles,
+      availableProfiles: admittableProfiles,
       heldSessionStates,
       mode: body.data.mode,
       lastSeenAt: currentDate,
@@ -318,14 +326,14 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       set: {
         runnerName: body.data.runnerName,
         runnerGroup: body.data.group,
-        profiles: body.data.profiles,
+        profiles: staticProfiles,
         totalVcpu: body.data.totalVcpu,
         totalMemoryMb: body.data.totalMemoryMb,
         maxConcurrent: body.data.maxConcurrent,
         allocatedVcpu: body.data.allocatedVcpu,
         allocatedMemoryMb: body.data.allocatedMemoryMb,
         runningCount: body.data.runningCount,
-        availableProfiles,
+        availableProfiles: admittableProfiles,
         heldSessionStates,
         mode: body.data.mode,
         lastSeenAt: currentDate,
@@ -419,7 +427,11 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return body.response;
   }
 
-  const { group, profiles } = body.data;
+  const { group } = body.data;
+  const supportedProfiles = body.data.supportedProfiles ?? body.data.profiles;
+  if (supportedProfiles === undefined || supportedProfiles.length === 0) {
+    return badRequestMessage("supportedProfiles is required");
+  }
   const whereConditions: SQL<unknown>[] = [
     eq(runnerJobQueue.runnerGroup, group),
     isNull(runnerJobQueue.claimedAt),
@@ -438,9 +450,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     whereConditions.push(eq(agentRuns.userId, auth.userId));
   }
 
-  if (profiles && profiles.length > 0) {
-    whereConditions.push(inArray(runnerJobQueue.profile, profiles));
-  }
+  whereConditions.push(inArray(runnerJobQueue.profile, supportedProfiles));
   const db = set(writeDb$);
   const pendingJobLookupStartedAtMs = now();
   const [pendingJob] = await db

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -292,6 +292,7 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const heldSessionStates =
     canonicalizeHeldSessionStates(body.data.heldSessionStates) ?? [];
+  // Stage 1 wire compatibility: accept legacy heartbeat fields until #20162.
   const admittableProfiles =
     body.data.admittableProfiles ??
     body.data.availableProfiles ??
@@ -428,6 +429,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const { group } = body.data;
+  // Stage 1 wire compatibility: accept legacy poll profiles until #20162.
   const supportedProfiles = body.data.supportedProfiles ?? body.data.profiles;
   if (supportedProfiles === undefined || supportedProfiles.length === 0) {
     return badRequestMessage("supportedProfiles is required");

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -68,6 +68,8 @@ const runnerPollTelemetrySchema = z.object({
   pollReason: runnerClaimPollReasonSchema.optional(),
 });
 
+const runnerProfileListSchema = z.array(z.string());
+
 /**
  * Default profile when none is specified.
  * Must stay in sync with Rust: crates/runner/src/profile.rs → DEFAULT_PROFILE
@@ -83,6 +85,26 @@ export const runnerGroupSchema = z
     /^[a-z0-9-]+\/[a-z0-9-]+$/,
     "Runner group must be in vm0/<name> format (e.g., vm0/production)",
   );
+
+const runnersPollBodySchema = z
+  .object({
+    group: runnerGroupSchema,
+    supportedProfiles: runnerProfileListSchema.optional(),
+    profiles: runnerProfileListSchema.optional(),
+    telemetry: runnerPollTelemetrySchema.optional(),
+  })
+  .superRefine((body, ctx) => {
+    const supportedProfiles = body.supportedProfiles ?? body.profiles;
+    if (supportedProfiles !== undefined && supportedProfiles.length > 0) {
+      return;
+    }
+
+    ctx.addIssue({
+      code: "custom",
+      path: ["supportedProfiles"],
+      message: "supportedProfiles is required",
+    });
+  });
 
 /**
  * Job schema for polling response
@@ -122,11 +144,7 @@ export const runnersPollContract = c.router({
     method: "POST",
     path: "/api/runners/poll",
     headers: authHeadersSchema,
-    body: z.object({
-      group: runnerGroupSchema,
-      profiles: z.array(z.string()).optional(),
-      telemetry: runnerPollTelemetrySchema.optional(),
-    }),
+    body: runnersPollBodySchema,
     responses: {
       200: z.object({
         job: jobSchema.nullable(),
@@ -415,21 +433,38 @@ export const runnersJobClaimContract = c.router({
 /**
  * Runner heartbeat body — periodic state report from each runner
  */
-export const heartbeatBodySchema = z.object({
-  runnerId: z.uuid(),
-  runnerName: z.string(),
-  group: runnerGroupSchema,
-  profiles: z.array(z.string()),
-  totalVcpu: z.number().int().nonnegative(),
-  totalMemoryMb: z.number().int().nonnegative(),
-  maxConcurrent: z.number().int().nonnegative(),
-  allocatedVcpu: z.number().int().nonnegative(),
-  allocatedMemoryMb: z.number().int().nonnegative(),
-  runningCount: z.number().int().nonnegative(),
-  availableProfiles: z.array(z.string()).optional(),
-  heldSessionStates: z.array(heldSessionStateSchema).max(1024),
-  mode: z.enum(["running", "draining", "stopping"]),
-});
+export const heartbeatBodySchema = z
+  .object({
+    runnerId: z.uuid(),
+    runnerName: z.string(),
+    group: runnerGroupSchema,
+    profiles: runnerProfileListSchema.optional(),
+    totalVcpu: z.number().int().nonnegative(),
+    totalMemoryMb: z.number().int().nonnegative(),
+    maxConcurrent: z.number().int().nonnegative(),
+    allocatedVcpu: z.number().int().nonnegative(),
+    allocatedMemoryMb: z.number().int().nonnegative(),
+    runningCount: z.number().int().nonnegative(),
+    admittableProfiles: runnerProfileListSchema.optional(),
+    availableProfiles: runnerProfileListSchema.optional(),
+    heldSessionStates: z.array(heldSessionStateSchema).max(1024),
+    mode: z.enum(["running", "draining", "stopping"]),
+  })
+  .superRefine((body, ctx) => {
+    if (
+      body.admittableProfiles !== undefined ||
+      body.availableProfiles !== undefined ||
+      body.profiles !== undefined
+    ) {
+      return;
+    }
+
+    ctx.addIssue({
+      code: "custom",
+      path: ["admittableProfiles"],
+      message: "admittableProfiles is required",
+    });
+  });
 
 /**
  * Runners heartbeat contract - POST /api/runners/heartbeat


### PR DESCRIPTION
## Summary
- add Stage 1 runner profile contract compatibility with preferred `supportedProfiles` and `admittableProfiles` fields
- normalize API poll and heartbeat handling so preferred fields win while legacy runner payloads remain accepted
- make malformed/empty poll support lists fail instead of widening scheduling
- update runner poll/heartbeat payloads to send both preferred and legacy fields during rollout
- harden Ably direct candidate profile matching so an empty support list is not a wildcard

## Tests
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runs-schedules.bdd.test.ts -t "held-session heartbeat"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "supported profiles|same-session affinity"`
- `pnpm -F api lint`
- `pnpm format`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --tests -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit hook: prettier, cargo-doc, knip, cargo-clippy, turbo check-types

Closes #20038
Refs #20159
Refs #20162
Refs #20163