### PR TITLE
fix(runner): protect retained config image refs during gc

### DIFF
--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -731,79 +731,13 @@ async fn find_installed_services() -> Vec<InstalledService> {
             .strip_suffix(".service")
             .unwrap_or(name_str)
             .to_string();
-        let config_path = parse_unit_config_path(&entry.path()).await;
+        let config_path = super::service::read_unit_config_path(&entry.path()).await;
         services.push(InstalledService {
             unit_name,
             config_path,
         });
     }
     services
-}
-
-/// Parse the ExecStart line of a systemd unit file for `--config` path.
-async fn parse_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
-    let content = tokio::fs::read_to_string(unit_path).await.ok()?;
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("ExecStart=") {
-            return parse_exec_start_config(rest);
-        }
-    }
-    None
-}
-
-/// Extract the value following `--config` or `-c` from an `ExecStart` line body.
-///
-/// Handles both quoted (`--config "/path with spaces/f.yaml"`) and unquoted
-/// (`--config /simple/path.yaml`) forms. Only the argument *value* is
-/// extracted — the flag itself is found via substring search, which is safe
-/// because `--config` / `-c` never require quoting.
-fn parse_exec_start_config(line: &str) -> Option<PathBuf> {
-    extract_flag_value(line, "--config").or_else(|| extract_flag_value(line, "-c"))
-}
-
-/// Find `flag` in `line` as a standalone token, then return the next
-/// whitespace-delimited or quote-delimited value after it.
-///
-/// Supports both `--config /path` (space-separated) and `--config=/path`
-/// (equals-separated) forms.
-fn extract_flag_value(line: &str, flag: &str) -> Option<PathBuf> {
-    // Search for `flag` that appears as a standalone token: preceded by
-    // whitespace (or start-of-string) and followed by whitespace, `=`, or
-    // end-of-string.
-    let idx = line
-        .match_indices(flag)
-        .find(|&(i, _)| {
-            let before_ok = i == 0
-                || line
-                    .as_bytes()
-                    .get(i - 1)
-                    .is_some_and(|b| b.is_ascii_whitespace());
-            let after_ok = line
-                .as_bytes()
-                .get(i + flag.len())
-                .is_none_or(|b| b.is_ascii_whitespace() || b == &b'=');
-            before_ok && after_ok
-        })?
-        .0;
-    let after = line.get(idx + flag.len()..)?;
-    // Strip an optional `=` separator, then whitespace.
-    let after = after.strip_prefix('=').unwrap_or(after).trim_ascii_start();
-    if after.is_empty() {
-        return None;
-    }
-    let path_str = if after.starts_with('"') {
-        // Quoted value: take everything between the opening and closing `"`.
-        let end = after.get(1..)?.find('"')?;
-        after.get(1..1 + end)?
-    } else {
-        // Unquoted value: take until next ASCII whitespace or end-of-string.
-        let end = after
-            .find(|c: char| c.is_ascii_whitespace())
-            .unwrap_or(after.len());
-        after.get(..end)?
-    };
-    Some(PathBuf::from(path_str))
 }
 
 /// Find installed services that have no matching running runner.
@@ -2947,106 +2881,6 @@ mod tests {
         assert!(!is_test_tld("not-a-url"));
         assert!(!is_test_tld("https://example.com/.test"));
         assert!(!is_test_tld("https://example.com?q=.test"));
-    }
-
-    #[test]
-    fn parse_config_plain_path() {
-        let line = r#""/usr/bin/runner" start --config /data/runner.yaml"#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/data/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_quoted_path_with_spaces() {
-        let line = r#""/opt/my runner/vm0-runner" start --config "/opt/my config/runner.yaml""#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/opt/my config/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_quoted_path_without_spaces() {
-        let line = r#""/usr/bin/runner" start --config "/etc/runner.yaml" --local"#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/etc/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_short_flag() {
-        let line = r#""/usr/bin/runner" start -c "/data/runner.yaml""#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/data/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_missing_flag() {
-        let line = r#""/usr/bin/runner" start --local"#;
-        assert_eq!(parse_exec_start_config(line), None);
-    }
-
-    #[test]
-    fn parse_config_flag_at_end_without_value() {
-        let line = r#""/usr/bin/runner" start --config"#;
-        assert_eq!(parse_exec_start_config(line), None);
-    }
-
-    #[test]
-    fn parse_config_equals_form() {
-        let line = r#""/usr/bin/runner" start --config=/data/runner.yaml"#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/data/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_equals_form_quoted() {
-        let line = r#""/usr/bin/runner" start --config="/data/my config/runner.yaml""#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/data/my config/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_ignores_flag_substring_in_exe_path() {
-        // The exe path contains "-c" but it should not match as the -c flag.
-        let line = r#""/opt/nice-cli/runner" start -c "/data/runner.yaml""#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/data/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_unclosed_quote_returns_none() {
-        let line = r#""/usr/bin/runner" start --config "/data/no-close"#;
-        assert_eq!(parse_exec_start_config(line), None);
-    }
-
-    #[test]
-    fn parse_config_tab_separated() {
-        let line = "\"/usr/bin/runner\" start --config\t/data/runner.yaml";
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/data/runner.yaml"))
-        );
-    }
-
-    #[test]
-    fn parse_config_short_flag_equals_form() {
-        let line = r#""/usr/bin/runner" start -c=/data/runner.yaml"#;
-        assert_eq!(
-            parse_exec_start_config(line),
-            Some(PathBuf::from("/data/runner.yaml"))
-        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1470,17 +1470,17 @@ async fn collect_config_image_refs(
             return;
         }
     };
-    for (profile_name, profile_ref) in config.profiles {
+    for (_, profile_ref) in config.profiles {
         if image_hash::validate_or_err(&profile_ref.rootfs_hash).is_err() {
             warn!(
-                "runner image refs: {source} config {} profile {profile_name} has an invalid rootfs hash, skipping profile",
+                "runner image refs: {source} config {} has a profile with an invalid rootfs hash, skipping profile",
                 config_path.display()
             );
             continue;
         }
         if image_hash::validate_or_err(&profile_ref.snapshot_hash).is_err() {
             warn!(
-                "runner image refs: {source} config {} profile {profile_name} has an invalid snapshot hash, skipping profile",
+                "runner image refs: {source} config {} has a profile with an invalid snapshot hash, skipping profile",
                 config_path.display()
             );
             continue;

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -528,7 +528,7 @@ async fn gc_nested_images_with_protected_refs(
             if is_protected_image_ref(protected_image_refs, &rootfs_hash, &snap_hash) {
                 mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
                 info!(
-                    "images/{rootfs_hash}/snapshots/{snap_hash}: referenced by retained runner config, keeping"
+                    "images/{rootfs_hash}/snapshots/{snap_hash}: referenced by retained runner or service config, keeping"
                 );
                 continue;
             }

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsString;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
@@ -10,8 +10,10 @@ use nix::fcntl::{Flock, FlockArg};
 use tracing::{info, warn};
 
 use crate::cmd::service;
+use crate::config;
 use crate::error::{RunnerError, RunnerResult};
 use crate::host_file;
+use crate::image_hash;
 use crate::lock;
 use crate::paths::{HomePaths, LogPaths, base_dir_lock_name};
 use crate::r2_cache::R2ImageCache;
@@ -63,8 +65,17 @@ pub struct GcArgs {
 
 pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     let home = HomePaths::new()?;
+    let version_analysis =
+        analyze_version_gc(&home, args.protect_version.as_deref(), args.keep_latest).await?;
+    let protected_image_refs = protected_image_refs_for_gc(&home, &version_analysis).await;
 
-    let images_freed = gc_nested_images(&home, args.keep_latest, args.dry_run).await?;
+    let images_freed = gc_nested_images_with_protected_refs(
+        &home,
+        args.keep_latest,
+        args.dry_run,
+        &protected_image_refs,
+    )
+    .await?;
 
     // Workspace GC must run BEFORE orphaned lock cleanup: it reads base_dir
     // paths from lock files to discover workspaces from dead runners. If
@@ -76,13 +87,7 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
     let locks_removed =
         gc_orphaned_locks(&home, args.dry_run).await? + workspace_gc.base_dir_locks_removed;
     let (job_logs_removed, job_logs_freed) = gc_job_logs(&home, args.dry_run).await?;
-    let versions_removed = gc_versions(
-        &home,
-        args.dry_run,
-        args.protect_version.as_deref(),
-        args.keep_latest,
-    )
-    .await?;
+    let versions_removed = gc_versions_with_analysis(&home, args.dry_run, version_analysis).await?;
     let version_service_locks_removed =
         gc_orphaned_version_service_locks(&home, args.dry_run).await?;
 
@@ -197,6 +202,40 @@ struct GcCandidate {
     /// Exclusive lock held until the candidate is deleted or explicitly kept.
     /// Prevents a `runner start` from acquiring a shared lock between probe and delete.
     _lock: Flock<std::fs::File>,
+}
+
+type ProtectedImageRefs = HashMap<String, HashSet<String>>;
+
+#[derive(serde::Deserialize)]
+struct ConfigImageRefs {
+    profiles: BTreeMap<String, ConfigProfileImageRef>,
+}
+
+#[derive(serde::Deserialize)]
+struct ConfigProfileImageRef {
+    rootfs_hash: String,
+    snapshot_hash: String,
+}
+
+fn insert_protected_image_ref(
+    protected_image_refs: &mut ProtectedImageRefs,
+    rootfs_hash: String,
+    snapshot_hash: String,
+) {
+    protected_image_refs
+        .entry(rootfs_hash)
+        .or_default()
+        .insert(snapshot_hash);
+}
+
+fn is_protected_image_ref(
+    protected_image_refs: &ProtectedImageRefs,
+    rootfs_hash: &str,
+    snapshot_hash: &str,
+) -> bool {
+    protected_image_refs
+        .get(rootfs_hash)
+        .is_some_and(|snapshot_hashes| snapshot_hashes.contains(snapshot_hash))
 }
 
 /// Per-rootfs state carried through the two-phase global GC for rootfs
@@ -355,10 +394,21 @@ async fn gc_template_warm_dir(
 /// accumulated many distinct rootfs hashes (e.g. per-PR builds) can be
 /// trimmed down — per-rootfs top-N kept every rootfs forever whenever
 /// each had ≤ N snapshots.
+#[cfg(test)]
 async fn gc_nested_images(
     home: &HomePaths,
     keep_latest: Option<usize>,
     dry_run: bool,
+) -> RunnerResult<u64> {
+    let protected_image_refs = ProtectedImageRefs::new();
+    gc_nested_images_with_protected_refs(home, keep_latest, dry_run, &protected_image_refs).await
+}
+
+async fn gc_nested_images_with_protected_refs(
+    home: &HomePaths,
+    keep_latest: Option<usize>,
+    dry_run: bool,
+    protected_image_refs: &ProtectedImageRefs,
 ) -> RunnerResult<u64> {
     let images_dir = home.images_dir();
     let Some(mut rootfs_entries) = read_dir_or_missing(&images_dir).await? else {
@@ -473,6 +523,14 @@ async fn gc_nested_images(
                     );
                     continue;
                 }
+            }
+
+            if is_protected_image_ref(protected_image_refs, &rootfs_hash, &snap_hash) {
+                mark_rootfs_survives(&mut rootfs_states, rootfs_idx);
+                info!(
+                    "images/{rootfs_hash}/snapshots/{snap_hash}: referenced by retained runner config, keeping"
+                );
+                continue;
             }
 
             let lock_path = home.snapshot_lock(&snap_hash);
@@ -1241,31 +1299,206 @@ async fn version_gc_age(home: &HomePaths, bin_dir: &Path, name: &str) -> Duratio
         .unwrap_or_default()
 }
 
-/// Remove old deployment version directories that are not actively running.
-///
-/// Scans `home.bin_dir()` for semver-named subdirectories (e.g. `v0.2.0`) and
-/// deletes inactive versions (bin dir, runner config dir, and systemd unit).
-///
-/// Survival rules (any one keeps the version):
-/// - `--protect-version` matches the name.
-/// - The version is in the top `keep_latest` by semver descending. This covers
-///   the "staged but not yet installed" case where two overlapping releases
-///   race: the older release's promote must not wipe the newer release's
-///   just-staged binary even though the newer unit isn't active yet.
-/// - The version binary, config file, or their directories are too recent to
-///   safely delete.
-/// - The corresponding service lifecycle lock is held by another install,
-///   uninstall, or GC pass.
-/// - The corresponding systemd unit is active.
-async fn gc_versions(
+/// Why a version survives the current GC pass.
+#[derive(Debug, Clone, Eq, PartialEq)]
+enum VersionRetentionReason {
+    ProtectVersion,
+    KeepLatest,
+    Recent(Duration),
+    InvalidServiceSuffix(String),
+    ServiceLockHeld,
+    ServiceLockProbeError(String),
+    Active,
+}
+
+impl VersionRetentionReason {
+    fn log_skip(&self, name: &str) {
+        match self {
+            Self::ProtectVersion => {
+                info!("version {name}: protected (--protect-version), skipping");
+            }
+            Self::KeepLatest => {
+                info!("version {name}: within --keep-latest, skipping");
+            }
+            Self::Recent(age) => {
+                info!("version {name}: too recent ({}s), skipping", age.as_secs());
+            }
+            Self::InvalidServiceSuffix(error) => {
+                warn!("version {name}: invalid service unit suffix ({error}), skipping");
+            }
+            Self::ServiceLockHeld => {
+                info!("version {name}: service lock held, skipping");
+            }
+            Self::ServiceLockProbeError(error) => {
+                warn!("version {name}: cannot probe service lock ({error}), skipping");
+            }
+            Self::Active => {
+                info!("version {name}: active, skipping");
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct VersionGcEntry {
+    name: String,
+    retained: Option<VersionRetentionReason>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct VersionGcAnalysis {
+    entries: Vec<VersionGcEntry>,
+}
+
+impl VersionGcAnalysis {
+    fn retained_entries(&self) -> impl Iterator<Item = &VersionGcEntry> {
+        self.entries.iter().filter(|entry| entry.retained.is_some())
+    }
+}
+
+async fn protected_image_refs_for_gc(
     home: &HomePaths,
-    dry_run: bool,
+    version_analysis: &VersionGcAnalysis,
+) -> ProtectedImageRefs {
+    let mut refs = ProtectedImageRefs::new();
+    collect_retained_version_image_refs(home, version_analysis, &mut refs).await;
+    collect_enabled_service_image_refs(&mut refs).await;
+    refs
+}
+
+async fn collect_retained_version_image_refs(
+    home: &HomePaths,
+    version_analysis: &VersionGcAnalysis,
+    refs: &mut ProtectedImageRefs,
+) {
+    for entry in version_analysis.retained_entries() {
+        let config_path = home.runners_dir().join(&entry.name).join("runner.yaml");
+        collect_config_image_refs(&config_path, "retained version", refs).await;
+    }
+}
+
+async fn collect_enabled_service_image_refs(refs: &mut ProtectedImageRefs) {
+    for config_path in enabled_runner_service_config_paths(Path::new("/etc/systemd/system")).await {
+        collect_config_image_refs(&config_path, "enabled service", refs).await;
+    }
+}
+
+async fn enabled_runner_service_config_paths(system_dir: &Path) -> Vec<PathBuf> {
+    let Some(mut entries) = (match read_dir_or_missing(system_dir).await {
+        Ok(entries) => entries,
+        Err(e) => {
+            warn!(
+                "runner service image refs: cannot read {} ({e}), skipping service-derived refs",
+                system_dir.display()
+            );
+            return Vec::new();
+        }
+    }) else {
+        return Vec::new();
+    };
+
+    let mut paths = Vec::new();
+    while let Some(entry) =
+        next_entry_warn(&mut entries, "runner_service_config_refs", system_dir).await
+    {
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        let Some(unit) = runner_service_unit_from_file_name(file_name) else {
+            continue;
+        };
+        match service::is_unit_enabled(&unit).await {
+            Ok(true) => {}
+            Ok(false) => continue,
+            Err(e) => {
+                warn!(
+                    "runner service image refs: cannot check whether {} is enabled ({e}), skipping",
+                    unit.service_name()
+                );
+                continue;
+            }
+        }
+        let Some(config_path) = service::read_unit_config_path(&entry.path()).await else {
+            warn!(
+                "runner service image refs: enabled service {} has no parseable config path, skipping",
+                unit.service_name()
+            );
+            continue;
+        };
+        paths.push(config_path);
+    }
+    paths
+}
+
+fn runner_service_unit_from_file_name(file_name: &str) -> Option<service::RunnerServiceUnit> {
+    let suffix = file_name
+        .strip_prefix("vm0-runner-")?
+        .strip_suffix(".service")?;
+    service::RunnerServiceUnit::from_suffix(suffix).ok()
+}
+
+async fn collect_config_image_refs(
+    config_path: &Path,
+    source: &str,
+    refs: &mut ProtectedImageRefs,
+) {
+    let Some(content) = (match config::read_diagnostic_config_to_string(config_path).await {
+        Ok(content) => content,
+        Err(e) => {
+            warn!(
+                "runner image refs: cannot read {source} config {} ({e}), skipping",
+                config_path.display()
+            );
+            return;
+        }
+    }) else {
+        warn!(
+            "runner image refs: {source} config {} is missing, skipping",
+            config_path.display()
+        );
+        return;
+    };
+
+    let config = match serde_yaml_ng::from_str::<ConfigImageRefs>(&content) {
+        Ok(config) => config,
+        Err(_) => {
+            warn!(
+                "runner image refs: cannot parse {source} config {}, skipping",
+                config_path.display()
+            );
+            return;
+        }
+    };
+    for (profile_name, profile_ref) in config.profiles {
+        if image_hash::validate_or_err(&profile_ref.rootfs_hash).is_err() {
+            warn!(
+                "runner image refs: {source} config {} profile {profile_name} has an invalid rootfs hash, skipping profile",
+                config_path.display()
+            );
+            continue;
+        }
+        if image_hash::validate_or_err(&profile_ref.snapshot_hash).is_err() {
+            warn!(
+                "runner image refs: {source} config {} profile {profile_name} has an invalid snapshot hash, skipping profile",
+                config_path.display()
+            );
+            continue;
+        }
+        insert_protected_image_ref(refs, profile_ref.rootfs_hash, profile_ref.snapshot_hash);
+    }
+}
+
+async fn analyze_version_gc(
+    home: &HomePaths,
     protect: Option<&str>,
     keep_latest: Option<usize>,
-) -> RunnerResult<Vec<String>> {
+) -> RunnerResult<VersionGcAnalysis> {
     let bin_dir = home.bin_dir();
     let Some(mut entries) = read_dir_or_missing(&bin_dir).await? else {
-        return Ok(Vec::new());
+        return Ok(VersionGcAnalysis {
+            entries: Vec::new(),
+        });
     };
 
     // First pass: collect all semver-named dirs. We need the full set to
@@ -1308,15 +1541,110 @@ async fn gc_versions(
             .collect()
     };
 
-    let mut removed: Vec<String> = Vec::new();
+    let mut entries = Vec::new();
     for (name, _) in &semver_dirs {
-        if protect == Some(name.as_str()) {
-            info!("version {name}: protected (--protect-version), skipping");
-            continue;
-        }
+        let retained =
+            version_retention_reason(home, &bin_dir, name, protect, &kept_by_latest).await;
+        entries.push(VersionGcEntry {
+            name: name.clone(),
+            retained,
+        });
+    }
 
-        if kept_by_latest.contains(name) {
-            info!("version {name}: within --keep-latest, skipping");
+    Ok(VersionGcAnalysis { entries })
+}
+
+async fn version_retention_reason(
+    home: &HomePaths,
+    bin_dir: &Path,
+    name: &str,
+    protect: Option<&str>,
+    kept_by_latest: &HashSet<String>,
+) -> Option<VersionRetentionReason> {
+    if protect == Some(name) {
+        return Some(VersionRetentionReason::ProtectVersion);
+    }
+
+    if kept_by_latest.contains(name) {
+        return Some(VersionRetentionReason::KeepLatest);
+    }
+
+    let age = version_gc_age(home, bin_dir, name).await;
+    if age < GC_MIN_AGE {
+        return Some(VersionRetentionReason::Recent(age));
+    }
+
+    let unit = match service::RunnerServiceUnit::from_suffix(name) {
+        Ok(unit) => unit,
+        Err(e) => return Some(VersionRetentionReason::InvalidServiceSuffix(e.to_string())),
+    };
+    let service_lock_path = home.service_lock(unit.unit_name());
+    let service_lock_parent = host_file::file_parent(&service_lock_path);
+    match tokio::fs::symlink_metadata(service_lock_parent).await {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Ok(_) => match probe_existing_lock(&service_lock_path) {
+            ExistingLockProbe::Free(_) | ExistingLockProbe::Missing => {}
+            ExistingLockProbe::Held => return Some(VersionRetentionReason::ServiceLockHeld),
+            ExistingLockProbe::Error(e) => {
+                return Some(VersionRetentionReason::ServiceLockProbeError(e));
+            }
+        },
+        Err(e) => {
+            return Some(VersionRetentionReason::ServiceLockProbeError(format!(
+                "inspect service lock parent {}: {e}",
+                service_lock_parent.display()
+            )));
+        }
+    }
+
+    match service::is_unit_active(&unit).await {
+        Ok(true) => Some(VersionRetentionReason::Active),
+        Ok(false) => None,
+        Err(e) => {
+            warn!("version {name}: cannot check unit status ({e}), assuming inactive");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+async fn gc_versions(
+    home: &HomePaths,
+    dry_run: bool,
+    protect: Option<&str>,
+    keep_latest: Option<usize>,
+) -> RunnerResult<Vec<String>> {
+    let analysis = analyze_version_gc(home, protect, keep_latest).await?;
+    gc_versions_with_analysis(home, dry_run, analysis).await
+}
+
+/// Remove old deployment version directories that are not actively running.
+///
+/// Scans `home.bin_dir()` for semver-named subdirectories (e.g. `v0.2.0`) and
+/// deletes inactive versions (bin dir, runner config dir, and systemd unit).
+///
+/// Survival rules (any one keeps the version):
+/// - `--protect-version` matches the name.
+/// - The version is in the top `keep_latest` by semver descending. This covers
+///   the "staged but not yet installed" case where two overlapping releases
+///   race: the older release's promote must not wipe the newer release's
+///   just-staged binary even though the newer unit isn't active yet.
+/// - The version binary, config file, or their directories are too recent to
+///   safely delete.
+/// - The corresponding service lifecycle lock is held by another install,
+///   uninstall, or GC pass.
+/// - The corresponding systemd unit is active.
+async fn gc_versions_with_analysis(
+    home: &HomePaths,
+    dry_run: bool,
+    analysis: VersionGcAnalysis,
+) -> RunnerResult<Vec<String>> {
+    let bin_dir = home.bin_dir();
+    let mut removed: Vec<String> = Vec::new();
+    for entry in &analysis.entries {
+        let name = &entry.name;
+        if let Some(reason) = &entry.retained {
+            reason.log_skip(name);
             continue;
         }
 
@@ -2856,6 +3184,104 @@ mod tests {
         }
     }
 
+    fn test_hash(ch: char) -> String {
+        std::iter::repeat_n(ch, 64).collect()
+    }
+
+    fn write_test_runner_config(
+        home: &HomePaths,
+        version: &str,
+        rootfs_hash: &str,
+        snapshot_hash: &str,
+    ) -> PathBuf {
+        let config_dir = home.runners_dir().join(version);
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("runner.yaml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"name: {version}
+group: vm0/test
+base_dir: /tmp/{version}
+ca_dir: /tmp/{version}/ca
+firecracker:
+  binary: /tmp/firecracker
+  kernel: /tmp/vmlinux
+profiles:
+  vm0/default:
+    rootfs_hash: {rootfs_hash}
+    snapshot_hash: {snapshot_hash}
+    vcpu: 1
+    memory_mb: 1024
+    rootfs_disk_mb: 8192
+    workspace_disk_mb: 8192
+server:
+  url: https://api.example.test
+  token: test-secret-token
+"#
+            ),
+        )
+        .unwrap();
+        config_path
+    }
+
+    fn create_test_version_with_config(
+        home: &HomePaths,
+        version: &str,
+        rootfs_hash: &str,
+        snapshot_hash: &str,
+    ) -> PathBuf {
+        std::fs::create_dir_all(home.bin_dir().join(version)).unwrap();
+        let config_path = write_test_runner_config(home, version, rootfs_hash, snapshot_hash);
+        age_version_past_gc_min_age(home, version);
+        config_path
+    }
+
+    fn create_old_test_snapshot(
+        home: &HomePaths,
+        rootfs_hash: &str,
+        snapshot_hash: &str,
+    ) -> PathBuf {
+        let rootfs_dir = home.images_dir().join(rootfs_hash);
+        let snapshot_dir = rootfs_dir.join("snapshots").join(snapshot_hash);
+        std::fs::create_dir_all(&snapshot_dir).unwrap();
+        std::fs::write(rootfs_dir.join("rootfs.ext4"), b"rootfs").unwrap();
+        std::fs::write(snapshot_dir.join("snapshot.bin"), b"snapshot").unwrap();
+        let old_time = old_gc_time();
+        for path in [&rootfs_dir, &snapshot_dir] {
+            std::fs::File::open(path)
+                .unwrap()
+                .set_times(std::fs::FileTimes::new().set_modified(old_time))
+                .unwrap();
+        }
+        snapshot_dir
+    }
+
+    async fn protected_refs_from_versions(
+        home: &HomePaths,
+        protect: Option<&str>,
+        keep_latest: Option<usize>,
+    ) -> ProtectedImageRefs {
+        let analysis = analyze_version_gc(home, protect, keep_latest)
+            .await
+            .unwrap();
+        let mut refs = ProtectedImageRefs::new();
+        collect_retained_version_image_refs(home, &analysis, &mut refs).await;
+        refs
+    }
+
+    fn protected_refs_from_pairs(pairs: &[(&str, &str)]) -> ProtectedImageRefs {
+        let mut refs = ProtectedImageRefs::new();
+        for (rootfs_hash, snapshot_hash) in pairs {
+            insert_protected_image_ref(
+                &mut refs,
+                (*rootfs_hash).to_string(),
+                (*snapshot_hash).to_string(),
+            );
+        }
+        refs
+    }
+
     #[tokio::test]
     async fn gc_debootstrap_missing_cache_dir_does_not_create_lock() {
         let dir = tempfile::tempdir().unwrap();
@@ -3813,6 +4239,203 @@ mod tests {
         let removed = gc_versions(&home, false, None, Some(1)).await.unwrap();
         assert_eq!(removed, ["v0.9.0"]);
         assert!(bin_dir.join("v0.10.0").exists());
+    }
+
+    #[tokio::test]
+    async fn protected_version_config_ref_keeps_image_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let rootfs_hash = test_hash('a');
+        let snapshot_hash = test_hash('b');
+        let snapshot_dir = create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
+        create_test_version_with_config(&home, "v1.0.0", &rootfs_hash, &snapshot_hash);
+        let refs = protected_refs_from_versions(&home, Some("v1.0.0"), None).await;
+
+        let freed = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+            .await
+            .unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            snapshot_dir.exists(),
+            "protect-version config refs must keep the referenced snapshot"
+        );
+        assert!(home.images_dir().join(&rootfs_hash).exists());
+    }
+
+    #[tokio::test]
+    async fn keep_latest_version_config_ref_keeps_image_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let old_rootfs = test_hash('a');
+        let old_snapshot = test_hash('b');
+        let new_rootfs = test_hash('c');
+        let new_snapshot = test_hash('d');
+        let old_snapshot_dir = create_old_test_snapshot(&home, &old_rootfs, &old_snapshot);
+        let new_snapshot_dir = create_old_test_snapshot(&home, &new_rootfs, &new_snapshot);
+        create_test_version_with_config(&home, "v1.0.0", &old_rootfs, &old_snapshot);
+        create_test_version_with_config(&home, "v2.0.0", &new_rootfs, &new_snapshot);
+        let refs = protected_refs_from_versions(&home, None, Some(1)).await;
+
+        let freed = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+            .await
+            .unwrap();
+
+        assert!(freed > 0);
+        assert!(
+            new_snapshot_dir.exists(),
+            "newest retained version should protect its config snapshot"
+        );
+        assert!(
+            !old_snapshot_dir.exists(),
+            "removable version config should not protect its snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn protected_image_refs_do_not_consume_keep_latest_slots() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let protected_rootfs = test_hash('a');
+        let protected_snapshot = test_hash('b');
+        let older_rootfs = test_hash('c');
+        let older_snapshot = test_hash('d');
+        let newer_rootfs = test_hash('e');
+        let newer_snapshot = test_hash('f');
+        let protected_dir = create_old_test_snapshot(&home, &protected_rootfs, &protected_snapshot);
+        let older_dir = create_old_test_snapshot(&home, &older_rootfs, &older_snapshot);
+        let newer_dir = create_old_test_snapshot(&home, &newer_rootfs, &newer_snapshot);
+        set_mtime(&older_dir, old_gc_time());
+        set_mtime(
+            &newer_dir,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000),
+        );
+        let refs = protected_refs_from_pairs(&[(&protected_rootfs, &protected_snapshot)]);
+
+        let freed = gc_nested_images_with_protected_refs(&home, Some(1), false, &refs)
+            .await
+            .unwrap();
+
+        assert!(freed > 0);
+        assert!(protected_dir.exists(), "protected snapshot must survive");
+        assert!(
+            newer_dir.exists(),
+            "image keep_latest slot should still apply to newest eligible snapshot"
+        );
+        assert!(
+            !older_dir.exists(),
+            "older eligible snapshot should be deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn protected_image_ref_keeps_only_exact_snapshot_pair() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let rootfs_hash = test_hash('a');
+        let protected_snapshot = test_hash('b');
+        let sibling_snapshot = test_hash('c');
+        let protected_dir = create_old_test_snapshot(&home, &rootfs_hash, &protected_snapshot);
+        let sibling_dir = create_old_test_snapshot(&home, &rootfs_hash, &sibling_snapshot);
+        let refs = protected_refs_from_pairs(&[(&rootfs_hash, &protected_snapshot)]);
+
+        let freed = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+            .await
+            .unwrap();
+
+        assert!(freed > 0);
+        assert!(
+            protected_dir.exists(),
+            "exact protected snapshot must survive"
+        );
+        assert!(
+            !sibling_dir.exists(),
+            "unreferenced sibling snapshot under same rootfs should remain eligible"
+        );
+        assert!(
+            home.images_dir().join(&rootfs_hash).exists(),
+            "rootfs with protected snapshot should survive"
+        );
+    }
+
+    #[tokio::test]
+    async fn removable_version_config_does_not_protect_image_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let rootfs_hash = test_hash('a');
+        let snapshot_hash = test_hash('b');
+        let snapshot_dir = create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
+        create_test_version_with_config(&home, "v1.0.0", &rootfs_hash, &snapshot_hash);
+        let refs = protected_refs_from_versions(&home, None, None).await;
+
+        let freed = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+            .await
+            .unwrap();
+
+        assert!(freed > 0);
+        assert!(
+            !snapshot_dir.exists(),
+            "old removable version config should not pin image artifacts"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_retained_version_config_is_ignored_for_image_refs() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let version = "v1.0.0";
+        std::fs::create_dir_all(home.bin_dir().join(version)).unwrap();
+        let config_dir = home.runners_dir().join(version);
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("runner.yaml"),
+            "server:\n  token: should-not-appear-in-errors\nprofiles: [",
+        )
+        .unwrap();
+        age_version_past_gc_min_age(&home, version);
+
+        let refs = protected_refs_from_versions(&home, Some(version), None).await;
+
+        assert!(
+            refs.is_empty(),
+            "malformed retained config should be skipped instead of protecting images"
+        );
+    }
+
+    #[tokio::test]
+    async fn service_config_image_ref_keeps_image_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let rootfs_hash = test_hash('a');
+        let snapshot_hash = test_hash('b');
+        let snapshot_dir = create_old_test_snapshot(&home, &rootfs_hash, &snapshot_hash);
+        let config_path =
+            write_test_runner_config(&home, "service-config", &rootfs_hash, &snapshot_hash);
+        let mut refs = ProtectedImageRefs::new();
+        collect_config_image_refs(&config_path, "enabled service", &mut refs).await;
+
+        let freed = gc_nested_images_with_protected_refs(&home, Some(0), false, &refs)
+            .await
+            .unwrap();
+
+        assert_eq!(freed, 0);
+        assert!(
+            snapshot_dir.exists(),
+            "enabled service config refs must keep the referenced snapshot"
+        );
+    }
+
+    #[test]
+    fn runner_service_unit_from_file_name_accepts_only_runner_services() {
+        assert_eq!(
+            runner_service_unit_from_file_name("vm0-runner-v1.0.0.service")
+                .unwrap()
+                .service_name(),
+            "vm0-runner-v1.0.0.service"
+        );
+        assert!(runner_service_unit_from_file_name("other-v1.0.0.service").is_none());
+        assert!(runner_service_unit_from_file_name("vm0-runner-v1.0.0.timer").is_none());
+        assert!(runner_service_unit_from_file_name("vm0-runner-.service").is_none());
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -10,10 +10,12 @@ mod gate;
 mod signal;
 mod systemctl;
 mod target;
+mod unit_config;
 mod unit_file;
 
-pub(crate) use systemctl::is_unit_active;
+pub(crate) use systemctl::{is_unit_active, is_unit_enabled};
 pub(crate) use target::RunnerServiceUnit;
+pub(crate) use unit_config::read_unit_config_path;
 
 use gate::{check_active_jobs_gate, read_runner_status, runner_base_dir};
 use signal::{ServiceSignalOutcome, signal_service_main};

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -51,6 +51,17 @@ pub(crate) async fn is_unit_active(unit: &RunnerServiceUnit) -> RunnerResult<boo
     unit_active_from_systemctl_show(svc, &properties, &output.status, &values, &output.stderr)
 }
 
+/// Check whether a systemd unit is enabled for boot.
+pub(crate) async fn is_unit_enabled(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+    let svc = unit.service_name();
+    let output = tokio::process::Command::new("systemctl")
+        .args(["is-enabled", svc])
+        .output()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("spawn systemctl is-enabled: {e}")))?;
+    unit_enabled_from_systemctl_is_enabled(svc, &output.status, &output.stdout, &output.stderr)
+}
+
 /// Get the main PID of a systemd unit.
 pub(super) async fn get_service_pid(unit: &RunnerServiceUnit) -> RunnerResult<Option<u32>> {
     let svc = unit.service_name();
@@ -207,6 +218,48 @@ fn parse_main_pid(svc: &str, value: &str) -> RunnerResult<Option<u32>> {
         ))
     })?;
     if pid == 0 { Ok(None) } else { Ok(Some(pid)) }
+}
+
+fn unit_enabled_from_systemctl_is_enabled(
+    svc: &str,
+    status: &ExitStatus,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> RunnerResult<bool> {
+    let state = std::str::from_utf8(stdout).map_err(|e| {
+        RunnerError::Internal(format!(
+            "systemctl is-enabled {svc} returned non-UTF-8 output: {e}"
+        ))
+    })?;
+    let state = state.trim();
+    match state {
+        "enabled" | "enabled-runtime" => Ok(true),
+        "alias" | "disabled" | "generated" | "indirect" | "linked" | "linked-runtime"
+        | "masked" | "masked-runtime" | "static" | "transient" => Ok(false),
+        "" if !status.success() => Err(systemctl_is_enabled_status_error(svc, status, stderr)),
+        other if !status.success() => {
+            tracing::debug!(
+                "systemctl is-enabled {svc} exited with {status} and state {other:?}; treating as disabled"
+            );
+            Ok(false)
+        }
+        other => Err(RunnerError::Internal(format!(
+            "unknown UnitFileState for {svc}: {other:?}"
+        ))),
+    }
+}
+
+fn systemctl_is_enabled_status_error(svc: &str, status: &ExitStatus, stderr: &[u8]) -> RunnerError {
+    let stderr = String::from_utf8_lossy(stderr);
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        RunnerError::Internal(format!("systemctl is-enabled {svc} exited with {status}"))
+    } else {
+        RunnerError::Internal(format!(
+            "systemctl is-enabled {svc} exited with {status}: stderr={:?}",
+            status_field_preview(stderr)
+        ))
+    }
 }
 
 fn ensure_systemctl_show_status(
@@ -437,6 +490,71 @@ mod tests {
         let message = err.to_string();
 
         assert!(message.contains("unknown ActiveState"));
+    }
+
+    #[test]
+    fn unit_enabled_from_systemctl_is_enabled_accepts_enabled_states() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = ExitStatus::from_raw(0);
+        for state in ["enabled", "enabled-runtime"] {
+            assert!(
+                unit_enabled_from_systemctl_is_enabled(
+                    "vm0-runner-test.service",
+                    &status,
+                    format!("{state}\n").as_bytes(),
+                    b"",
+                )
+                .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn unit_enabled_from_systemctl_is_enabled_rejects_disabled_states() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = ExitStatus::from_raw(0x100);
+        for state in [
+            "alias",
+            "disabled",
+            "generated",
+            "indirect",
+            "linked",
+            "linked-runtime",
+            "masked",
+            "masked-runtime",
+            "static",
+            "transient",
+        ] {
+            assert!(
+                !unit_enabled_from_systemctl_is_enabled(
+                    "vm0-runner-test.service",
+                    &status,
+                    format!("{state}\n").as_bytes(),
+                    b"",
+                )
+                .unwrap(),
+                "{state} should not be treated as enabled"
+            );
+        }
+    }
+
+    #[test]
+    fn unit_enabled_from_systemctl_is_enabled_rejects_unknown_success_state() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let status = ExitStatus::from_raw(0);
+        let err = unit_enabled_from_systemctl_is_enabled(
+            "vm0-runner-test.service",
+            &status,
+            b"half-enabled\n",
+            b"",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("unknown UnitFileState"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -7,7 +7,7 @@ pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
 }
 
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
-    for line in content.lines() {
+    for line in logical_unit_lines(content) {
         let trimmed = line.trim();
         if let Some((key, rest)) = trimmed.split_once('=')
             && key.trim() == "ExecStart"
@@ -17,6 +17,32 @@ pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+fn logical_unit_lines(content: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut continued = String::new();
+    for raw_line in content.lines() {
+        let line = raw_line.trim_end();
+        if let Some(prefix) = line.strip_suffix('\\') {
+            continued.push_str(prefix);
+            continued.push(' ');
+            continue;
+        }
+
+        if continued.is_empty() {
+            lines.push(line.to_string());
+        } else {
+            continued.push_str(line.trim_start());
+            lines.push(std::mem::take(&mut continued));
+        }
+    }
+
+    if !continued.is_empty() {
+        lines.push(continued);
+    }
+
+    lines
 }
 
 /// Extract the value following `--config` or `-c` from an `ExecStart` line body.
@@ -295,6 +321,21 @@ ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
         let content = r#"
 [Service]
 ExecStart = "/usr/bin/runner" start --config "/etc/runner.yaml"
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_unit_config_path_handles_continued_exec_start() {
+        let content = r#"
+[Service]
+ExecStart="/usr/bin/runner" start \
+  --config "/etc/runner.yaml" \
+  --local
 "#;
 
         assert_eq!(

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -1,0 +1,182 @@
+use std::path::{Path, PathBuf};
+
+/// Parse the ExecStart line of a systemd unit file for a runner `--config` path.
+pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
+    let content = tokio::fs::read_to_string(unit_path).await.ok()?;
+    parse_unit_config_path(&content)
+}
+
+pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("ExecStart=") {
+            return parse_exec_start_config(rest);
+        }
+    }
+    None
+}
+
+/// Extract the value following `--config` or `-c` from an `ExecStart` line body.
+///
+/// Handles both quoted (`--config "/path with spaces/f.yaml"`) and unquoted
+/// (`--config /simple/path.yaml`) forms. Only the argument value is extracted.
+pub(crate) fn parse_exec_start_config(line: &str) -> Option<PathBuf> {
+    extract_flag_value(line, "--config").or_else(|| extract_flag_value(line, "-c"))
+}
+
+/// Find `flag` in `line` as a standalone token, then return the next
+/// whitespace-delimited or quote-delimited value after it.
+///
+/// Supports both `--config /path` and `--config=/path` forms.
+fn extract_flag_value(line: &str, flag: &str) -> Option<PathBuf> {
+    let idx = line
+        .match_indices(flag)
+        .find(|&(i, _)| {
+            let before_ok = i == 0
+                || line
+                    .as_bytes()
+                    .get(i - 1)
+                    .is_some_and(|b| b.is_ascii_whitespace());
+            let after_ok = line
+                .as_bytes()
+                .get(i + flag.len())
+                .is_none_or(|b| b.is_ascii_whitespace() || b == &b'=');
+            before_ok && after_ok
+        })?
+        .0;
+    let after = line.get(idx + flag.len()..)?;
+    let after = after.strip_prefix('=').unwrap_or(after).trim_ascii_start();
+    if after.is_empty() {
+        return None;
+    }
+    let path_str = if after.starts_with('"') {
+        let end = after.get(1..)?.find('"')?;
+        after.get(1..1 + end)?
+    } else {
+        let end = after
+            .find(|c: char| c.is_ascii_whitespace())
+            .unwrap_or(after.len());
+        after.get(..end)?
+    };
+    Some(PathBuf::from(path_str))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_config_plain_path() {
+        let line = r#""/usr/bin/runner" start --config /data/runner.yaml"#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_quoted_path_with_spaces() {
+        let line = r#""/opt/my runner/vm0-runner" start --config "/opt/my config/runner.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/opt/my config/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_quoted_path_without_spaces() {
+        let line = r#""/usr/bin/runner" start --config "/etc/runner.yaml" --local"#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_short_flag() {
+        let line = r#""/usr/bin/runner" start -c "/data/runner.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_missing_flag() {
+        let line = r#""/usr/bin/runner" start --local"#;
+        assert_eq!(parse_exec_start_config(line), None);
+    }
+
+    #[test]
+    fn parse_config_flag_at_end_without_value() {
+        let line = r#""/usr/bin/runner" start --config"#;
+        assert_eq!(parse_exec_start_config(line), None);
+    }
+
+    #[test]
+    fn parse_config_equals_form() {
+        let line = r#""/usr/bin/runner" start --config=/data/runner.yaml"#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_equals_form_quoted() {
+        let line = r#""/usr/bin/runner" start --config="/data/my config/runner.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/my config/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_ignores_flag_substring_in_exe_path() {
+        let line = r#""/opt/nice-cli/runner" start -c "/data/runner.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_unclosed_quote_returns_none() {
+        let line = r#""/usr/bin/runner" start --config "/data/no-close"#;
+        assert_eq!(parse_exec_start_config(line), None);
+    }
+
+    #[test]
+    fn parse_config_tab_separated() {
+        let line = "\"/usr/bin/runner\" start --config\t/data/runner.yaml";
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_short_flag_equals_form() {
+        let line = r#""/usr/bin/runner" start -c=/data/runner.yaml"#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_unit_config_path_reads_first_exec_start() {
+        let content = r#"
+[Unit]
+Description=runner
+
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+}

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -9,7 +9,8 @@ pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
     for line in content.lines() {
         let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("ExecStart=")
+        if let Some((key, rest)) = trimmed.split_once('=')
+            && key.trim() == "ExecStart"
             && let Some(config_path) = parse_exec_start_config(rest)
         {
             return Some(config_path);
@@ -56,14 +57,14 @@ fn tokenize_systemd_exec_start(input: &str) -> Option<Vec<String>> {
     let mut tokens = Vec::new();
     let mut token = String::new();
     let mut chars = input.chars().peekable();
-    let mut in_quote = false;
+    let mut quote = None;
     let mut has_token = false;
     while let Some(ch) = chars.next() {
-        if in_quote {
+        if let Some(quote_char) = quote {
             match ch {
-                '"' => in_quote = false,
+                ch if ch == quote_char => quote = None,
                 '\\' => match chars.next() {
-                    Some(next @ ('\\' | '"')) => token.push(next),
+                    Some(next @ ('\\' | '"' | '\'')) => token.push(next),
                     Some(next) => {
                         token.push('\\');
                         token.push(next);
@@ -85,14 +86,14 @@ fn tokenize_systemd_exec_start(input: &str) -> Option<Vec<String>> {
                         has_token = false;
                     }
                 }
-                '"' => {
-                    in_quote = true;
+                '"' | '\'' => {
+                    quote = Some(ch);
                     has_token = true;
                 }
                 '\\' => {
                     has_token = true;
                     match chars.next() {
-                        Some(next @ ('\\' | '"')) => token.push(next),
+                        Some(next @ ('\\' | '"' | '\'')) => token.push(next),
                         Some(next) => {
                             token.push('\\');
                             token.push(next);
@@ -116,7 +117,7 @@ fn tokenize_systemd_exec_start(input: &str) -> Option<Vec<String>> {
             }
         }
     }
-    if in_quote {
+    if quote.is_some() {
         return None;
     }
     if has_token {
@@ -141,6 +142,15 @@ mod tests {
     #[test]
     fn parse_config_quoted_path_with_spaces() {
         let line = r#""/opt/my runner/vm0-runner" start --config "/opt/my config/runner.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/opt/my config/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_single_quoted_path_with_spaces() {
+        let line = r#""/usr/bin/runner" start --config '/opt/my config/runner.yaml'"#;
         assert_eq!(
             parse_exec_start_config(line),
             Some(PathBuf::from("/opt/my config/runner.yaml"))
@@ -272,6 +282,19 @@ Description=runner
 
 [Service]
 ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_unit_config_path_allows_space_before_equals() {
+        let content = r#"
+[Service]
+ExecStart = "/usr/bin/runner" start --config "/etc/runner.yaml"
 "#;
 
         assert_eq!(

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -26,21 +26,30 @@ pub(crate) fn parse_exec_start_config(line: &str) -> Option<PathBuf> {
     let tokens = tokenize_systemd_exec_start(line)?;
     for (idx, token) in tokens.iter().enumerate() {
         if token == "--config" || token == "-c" {
-            let value = tokens.get(idx + 1)?;
-            if !value.is_empty() {
-                return Some(PathBuf::from(value));
+            if let Some(config_path) = tokens
+                .get(idx + 1)
+                .and_then(|value| config_path_from_arg(value))
+            {
+                return Some(config_path);
             }
             continue;
         }
         if let Some(value) = token
             .strip_prefix("--config=")
             .or_else(|| token.strip_prefix("-c="))
-            && !value.is_empty()
+            .and_then(config_path_from_arg)
         {
-            return Some(PathBuf::from(value));
+            return Some(value);
         }
     }
     None
+}
+
+fn config_path_from_arg(value: &str) -> Option<PathBuf> {
+    if value.is_empty() || value.starts_with('-') {
+        return None;
+    }
+    Some(PathBuf::from(value))
 }
 
 fn tokenize_systemd_exec_start(input: &str) -> Option<Vec<String>> {
@@ -175,6 +184,15 @@ mod tests {
     fn parse_config_flag_at_end_without_value() {
         let line = r#""/usr/bin/runner" start --config"#;
         assert_eq!(parse_exec_start_config(line), None);
+    }
+
+    #[test]
+    fn parse_config_skips_flag_value_before_valid_config() {
+        let line = r#""/usr/bin/runner" start --config --local --config "/data/runner.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -21,92 +21,97 @@ pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
 /// Handles both quoted (`--config "/path with spaces/f.yaml"`) and unquoted
 /// (`--config /simple/path.yaml`) forms. Only the argument value is extracted.
 pub(crate) fn parse_exec_start_config(line: &str) -> Option<PathBuf> {
-    extract_flag_value(line, "--config").or_else(|| extract_flag_value(line, "-c"))
-}
-
-/// Find `flag` in `line` as a standalone token, then return the next
-/// whitespace-delimited or quote-delimited value after it.
-///
-/// Supports both `--config /path` and `--config=/path` forms.
-fn extract_flag_value(line: &str, flag: &str) -> Option<PathBuf> {
-    let idx = line
-        .match_indices(flag)
-        .find(|&(i, _)| {
-            let before_ok = i == 0
-                || line
-                    .as_bytes()
-                    .get(i - 1)
-                    .is_some_and(|b| b.is_ascii_whitespace());
-            let after_ok = line
-                .as_bytes()
-                .get(i + flag.len())
-                .is_none_or(|b| b.is_ascii_whitespace() || b == &b'=');
-            before_ok && after_ok
-        })?
-        .0;
-    let after = line.get(idx + flag.len()..)?;
-    let after = after.strip_prefix('=').unwrap_or(after).trim_ascii_start();
-    if after.is_empty() {
-        return None;
-    }
-    let path = if after.starts_with('"') {
-        parse_quoted_systemd_value(after.get(1..)?)?
-    } else {
-        let end = after
-            .find(|c: char| c.is_ascii_whitespace())
-            .unwrap_or(after.len());
-        unescape_systemd_value(after.get(..end)?)
-    };
-    Some(PathBuf::from(path))
-}
-
-fn parse_quoted_systemd_value(input: &str) -> Option<String> {
-    let mut value = String::new();
-    let mut chars = input.chars().peekable();
-    while let Some(ch) = chars.next() {
-        match ch {
-            '"' => return Some(value),
-            '\\' => match chars.next() {
-                Some(next @ ('\\' | '"')) => value.push(next),
-                Some(next) => {
-                    value.push('\\');
-                    value.push(next);
-                }
-                None => return None,
-            },
-            '%' if chars.peek() == Some(&'%') => {
-                chars.next();
-                value.push('%');
+    let tokens = tokenize_systemd_exec_start(line)?;
+    for (idx, token) in tokens.iter().enumerate() {
+        if token == "--config" || token == "-c" {
+            let value = tokens.get(idx + 1)?;
+            if !value.is_empty() {
+                return Some(PathBuf::from(value));
             }
-            '%' => value.push('%'),
-            _ => value.push(ch),
+            continue;
+        }
+        if let Some(value) = token
+            .strip_prefix("--config=")
+            .or_else(|| token.strip_prefix("-c="))
+            && !value.is_empty()
+        {
+            return Some(PathBuf::from(value));
         }
     }
     None
 }
 
-fn unescape_systemd_value(input: &str) -> String {
-    let mut value = String::new();
+fn tokenize_systemd_exec_start(input: &str) -> Option<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
     let mut chars = input.chars().peekable();
+    let mut in_quote = false;
+    let mut has_token = false;
     while let Some(ch) = chars.next() {
-        match ch {
-            '\\' => match chars.next() {
-                Some(next @ ('\\' | '"')) => value.push(next),
-                Some(next) => {
-                    value.push('\\');
-                    value.push(next);
+        if in_quote {
+            match ch {
+                '"' => in_quote = false,
+                '\\' => match chars.next() {
+                    Some(next @ ('\\' | '"')) => token.push(next),
+                    Some(next) => {
+                        token.push('\\');
+                        token.push(next);
+                    }
+                    None => return None,
+                },
+                '%' if chars.peek() == Some(&'%') => {
+                    chars.next();
+                    token.push('%');
                 }
-                None => value.push('\\'),
-            },
-            '%' if chars.peek() == Some(&'%') => {
-                chars.next();
-                value.push('%');
+                '%' => token.push('%'),
+                _ => token.push(ch),
             }
-            '%' => value.push('%'),
-            _ => value.push(ch),
+        } else {
+            match ch {
+                ch if ch.is_ascii_whitespace() => {
+                    if has_token {
+                        tokens.push(std::mem::take(&mut token));
+                        has_token = false;
+                    }
+                }
+                '"' => {
+                    in_quote = true;
+                    has_token = true;
+                }
+                '\\' => {
+                    has_token = true;
+                    match chars.next() {
+                        Some(next @ ('\\' | '"')) => token.push(next),
+                        Some(next) => {
+                            token.push('\\');
+                            token.push(next);
+                        }
+                        None => token.push('\\'),
+                    }
+                }
+                '%' if chars.peek() == Some(&'%') => {
+                    chars.next();
+                    token.push('%');
+                    has_token = true;
+                }
+                '%' => {
+                    token.push('%');
+                    has_token = true;
+                }
+                _ => {
+                    token.push(ch);
+                    has_token = true;
+                }
+            }
         }
     }
-    value
+    if in_quote {
+        return None;
+    }
+    if has_token {
+        tokens.push(token);
+    }
+    Some(tokens)
 }
 
 #[cfg(test)]
@@ -200,6 +205,15 @@ mod tests {
     #[test]
     fn parse_config_ignores_flag_substring_in_exe_path() {
         let line = r#""/opt/nice-cli/runner" start -c "/data/runner.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_ignores_flag_token_inside_quoted_exe_path() {
+        let line = r#""/opt/my --config fake/runner" start --config "/data/runner.yaml""#;
         assert_eq!(
             parse_exec_start_config(line),
             Some(PathBuf::from("/data/runner.yaml"))

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -4,22 +4,21 @@ use std::path::{Path, PathBuf};
 /// Parse the ExecStart line of a systemd unit file for a runner `--config` path.
 pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
     let mut content = tokio::fs::read_to_string(unit_path).await.ok()?;
-    content.push_str(&read_unit_dropin_content(unit_path).await?);
+    content.push_str(&read_unit_dropin_content(unit_path).await);
     parse_unit_config_path(&content)
 }
 
-async fn read_unit_dropin_content(unit_path: &Path) -> Option<String> {
+async fn read_unit_dropin_content(unit_path: &Path) -> String {
     let mut dir = OsString::from(unit_path.as_os_str());
     dir.push(".d");
     let dir = PathBuf::from(dir);
     let mut entries = match tokio::fs::read_dir(&dir).await {
         Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Some(String::new()),
-        Err(_) => return None,
+        Err(_) => return String::new(),
     };
 
     let mut paths = Vec::new();
-    while let Some(entry) = entries.next_entry().await.ok()? {
+    while let Ok(Some(entry)) = entries.next_entry().await {
         let path = entry.path();
         if path
             .extension()
@@ -32,10 +31,12 @@ async fn read_unit_dropin_content(unit_path: &Path) -> Option<String> {
 
     let mut content = String::new();
     for path in paths {
-        content.push('\n');
-        content.push_str(&tokio::fs::read_to_string(path).await.ok()?);
+        if let Ok(dropin) = tokio::fs::read_to_string(path).await {
+            content.push('\n');
+            content.push_str(&dropin);
+        }
     }
-    Some(content)
+    content
 }
 
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
@@ -451,6 +452,28 @@ ExecStart="/usr/bin/runner" start --config "/etc/new-runner.yaml"
         assert_eq!(
             read_unit_config_path(&unit_path).await,
             Some(PathBuf::from("/etc/new-runner.yaml"))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_unit_config_path_ignores_unreadable_dropin_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
+        std::fs::write(
+            &unit_path,
+            r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
+"#,
+        )
+        .unwrap();
+        let dropin_dir = dir.path().join("vm0-runner-v1.0.0.service.d");
+        std::fs::create_dir(&dropin_dir).unwrap();
+        std::fs::create_dir(dropin_dir.join("10-broken.conf")).unwrap();
+
+        assert_eq!(
+            read_unit_config_path(&unit_path).await,
+            Some(PathBuf::from("/etc/runner.yaml"))
         );
     }
 }

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -75,8 +75,16 @@ fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
 
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
     let mut config_path = None;
+    let mut in_service_section = false;
     for line in logical_unit_lines(content) {
         let trimmed = line.trim();
+        if let Some(section) = unit_section_name(trimmed) {
+            in_service_section = section == "Service";
+            continue;
+        }
+        if !in_service_section {
+            continue;
+        }
         let Some((key, rest)) = trimmed.split_once('=') else {
             continue;
         };
@@ -94,11 +102,24 @@ pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
     config_path
 }
 
+fn unit_section_name(line: &str) -> Option<&str> {
+    let section = line.strip_prefix('[')?.strip_suffix(']')?;
+    Some(section.trim())
+}
+
 fn logical_unit_lines(content: &str) -> Vec<String> {
     let mut lines = Vec::new();
     let mut continued = String::new();
     for raw_line in content.lines() {
         let line = raw_line.trim_end();
+        let trimmed_start = line.trim_start();
+        if !continued.is_empty()
+            && (trimmed_start.is_empty()
+                || trimmed_start.starts_with('#')
+                || trimmed_start.starts_with(';'))
+        {
+            continue;
+        }
         if let Some(prefix) = line.strip_suffix('\\') {
             continued.push_str(prefix);
             continued.push(' ');
@@ -405,12 +426,44 @@ ExecStart = "/usr/bin/runner" start --config "/etc/runner.yaml"
     }
 
     #[test]
+    fn parse_unit_config_path_ignores_exec_start_outside_service_section() {
+        let content = r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
+
+[Unit]
+ExecStart="/usr/bin/runner" start --config "/etc/wrong-runner.yaml"
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+
+    #[test]
     fn parse_unit_config_path_handles_continued_exec_start() {
         let content = r#"
 [Service]
 ExecStart="/usr/bin/runner" start \
   --config "/etc/runner.yaml" \
   --local
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_unit_config_path_continues_past_comment_lines() {
+        let content = r#"
+[Service]
+ExecStart="/usr/bin/runner" start \
+  # comment between continued lines
+  ; another comment
+  --config "/etc/runner.yaml"
 "#;
 
         assert_eq!(

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -49,16 +49,64 @@ fn extract_flag_value(line: &str, flag: &str) -> Option<PathBuf> {
     if after.is_empty() {
         return None;
     }
-    let path_str = if after.starts_with('"') {
-        let end = after.get(1..)?.find('"')?;
-        after.get(1..1 + end)?
+    let path = if after.starts_with('"') {
+        parse_quoted_systemd_value(after.get(1..)?)?
     } else {
         let end = after
             .find(|c: char| c.is_ascii_whitespace())
             .unwrap_or(after.len());
-        after.get(..end)?
+        unescape_systemd_value(after.get(..end)?)
     };
-    Some(PathBuf::from(path_str))
+    Some(PathBuf::from(path))
+}
+
+fn parse_quoted_systemd_value(input: &str) -> Option<String> {
+    let mut value = String::new();
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' => return Some(value),
+            '\\' => match chars.next() {
+                Some(next @ ('\\' | '"')) => value.push(next),
+                Some(next) => {
+                    value.push('\\');
+                    value.push(next);
+                }
+                None => return None,
+            },
+            '%' if chars.peek() == Some(&'%') => {
+                chars.next();
+                value.push('%');
+            }
+            '%' => value.push('%'),
+            _ => value.push(ch),
+        }
+    }
+    None
+}
+
+fn unescape_systemd_value(input: &str) -> String {
+    let mut value = String::new();
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => match chars.next() {
+                Some(next @ ('\\' | '"')) => value.push(next),
+                Some(next) => {
+                    value.push('\\');
+                    value.push(next);
+                }
+                None => value.push('\\'),
+            },
+            '%' if chars.peek() == Some(&'%') => {
+                chars.next();
+                value.push('%');
+            }
+            '%' => value.push('%'),
+            _ => value.push(ch),
+        }
+    }
+    value
 }
 
 #[cfg(test)]
@@ -80,6 +128,15 @@ mod tests {
         assert_eq!(
             parse_exec_start_config(line),
             Some(PathBuf::from("/opt/my config/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_quoted_path_with_escaped_characters() {
+        let line = r#""/usr/bin/runner" start --config "/tmp/a\"b\\c%%d.yaml""#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from(r#"/tmp/a"b\c%d.yaml"#))
         );
     }
 
@@ -128,6 +185,15 @@ mod tests {
         assert_eq!(
             parse_exec_start_config(line),
             Some(PathBuf::from("/data/my config/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_config_equals_form_unescapes_percent() {
+        let line = r#""/usr/bin/runner" start --config=/data/runner%%config.yaml"#;
+        assert_eq!(
+            parse_exec_start_config(line),
+            Some(PathBuf::from("/data/runner%config.yaml"))
         );
     }
 

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -1,9 +1,41 @@
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 /// Parse the ExecStart line of a systemd unit file for a runner `--config` path.
 pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
-    let content = tokio::fs::read_to_string(unit_path).await.ok()?;
+    let mut content = tokio::fs::read_to_string(unit_path).await.ok()?;
+    content.push_str(&read_unit_dropin_content(unit_path).await?);
     parse_unit_config_path(&content)
+}
+
+async fn read_unit_dropin_content(unit_path: &Path) -> Option<String> {
+    let mut dir = OsString::from(unit_path.as_os_str());
+    dir.push(".d");
+    let dir = PathBuf::from(dir);
+    let mut entries = match tokio::fs::read_dir(&dir).await {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Some(String::new()),
+        Err(_) => return None,
+    };
+
+    let mut paths = Vec::new();
+    while let Some(entry) = entries.next_entry().await.ok()? {
+        let path = entry.path();
+        if path
+            .extension()
+            .is_some_and(|extension| extension == "conf")
+        {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    let mut content = String::new();
+    for path in paths {
+        content.push('\n');
+        content.push_str(&tokio::fs::read_to_string(path).await.ok()?);
+    }
+    Some(content)
 }
 
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
@@ -389,6 +421,36 @@ ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
         assert_eq!(
             parse_unit_config_path(content),
             Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_unit_config_path_applies_dropin_exec_start_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
+        std::fs::write(
+            &unit_path,
+            r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
+"#,
+        )
+        .unwrap();
+        let dropin_dir = dir.path().join("vm0-runner-v1.0.0.service.d");
+        std::fs::create_dir(&dropin_dir).unwrap();
+        std::fs::write(
+            dropin_dir.join("10-override.conf"),
+            r#"
+[Service]
+ExecStart=
+ExecStart="/usr/bin/runner" start --config "/etc/new-runner.yaml"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_unit_config_path(&unit_path).await,
+            Some(PathBuf::from("/etc/new-runner.yaml"))
         );
     }
 }

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -7,16 +7,24 @@ pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
 }
 
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
+    let mut config_path = None;
     for line in logical_unit_lines(content) {
         let trimmed = line.trim();
-        if let Some((key, rest)) = trimmed.split_once('=')
-            && key.trim() == "ExecStart"
-            && let Some(config_path) = parse_exec_start_config(rest)
-        {
-            return Some(config_path);
+        let Some((key, rest)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if key.trim() != "ExecStart" {
+            continue;
+        }
+        if rest.trim().is_empty() {
+            config_path = None;
+            continue;
+        }
+        if let Some(next_config_path) = parse_exec_start_config(rest) {
+            config_path = Some(next_config_path);
         }
     }
-    None
+    config_path
 }
 
 fn logical_unit_lines(content: &str) -> Vec<String> {
@@ -342,6 +350,32 @@ ExecStart="/usr/bin/runner" start \
             parse_unit_config_path(content),
             Some(PathBuf::from("/etc/runner.yaml"))
         );
+    }
+
+    #[test]
+    fn parse_unit_config_path_honors_exec_start_reset() {
+        let content = r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
+ExecStart=
+ExecStart="/usr/bin/runner" start --config "/etc/new-runner.yaml"
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/new-runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_unit_config_path_reset_without_replacement_returns_none() {
+        let content = r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
+ExecStart=
+"#;
+
+        assert_eq!(parse_unit_config_path(content), None);
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -9,8 +9,10 @@ pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
     for line in content.lines() {
         let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("ExecStart=") {
-            return parse_exec_start_config(rest);
+        if let Some(rest) = trimmed.strip_prefix("ExecStart=")
+            && let Some(config_path) = parse_exec_start_config(rest)
+        {
+            return Some(config_path);
         }
     }
     None
@@ -251,6 +253,20 @@ mod tests {
 Description=runner
 
 [Service]
+ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
+"#;
+
+        assert_eq!(
+            parse_unit_config_path(content),
+            Some(PathBuf::from("/etc/runner.yaml"))
+        );
+    }
+
+    #[test]
+    fn parse_unit_config_path_skips_unparseable_exec_start() {
+        let content = r#"
+[Service]
+ExecStart=
 ExecStart="/usr/bin/runner" start --config "/etc/runner.yaml"
 "#;
 

--- a/crates/runner/src/cmd/service/unit_config.rs
+++ b/crates/runner/src/cmd/service/unit_config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -9,34 +10,67 @@ pub(crate) async fn read_unit_config_path(unit_path: &Path) -> Option<PathBuf> {
 }
 
 async fn read_unit_dropin_content(unit_path: &Path) -> String {
-    let mut dir = OsString::from(unit_path.as_os_str());
-    dir.push(".d");
-    let dir = PathBuf::from(dir);
-    let mut entries = match tokio::fs::read_dir(&dir).await {
-        Ok(entries) => entries,
-        Err(_) => return String::new(),
-    };
-
-    let mut paths = Vec::new();
-    while let Ok(Some(entry)) = entries.next_entry().await {
-        let path = entry.path();
-        if path
-            .extension()
-            .is_some_and(|extension| extension == "conf")
-        {
-            paths.push(path);
+    let mut dropins = BTreeMap::new();
+    for (specificity, dir) in unit_dropin_dirs(unit_path).into_iter().enumerate() {
+        let mut entries = match tokio::fs::read_dir(&dir).await {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if path.extension().is_none_or(|extension| extension != "conf") {
+                continue;
+            }
+            let Some(file_name) = path.file_name() else {
+                continue;
+            };
+            dropins
+                .entry(file_name.to_os_string())
+                .and_modify(|(current_specificity, current_path)| {
+                    if specificity >= *current_specificity {
+                        *current_specificity = specificity;
+                        *current_path = path.clone();
+                    }
+                })
+                .or_insert((specificity, path));
         }
     }
-    paths.sort();
 
     let mut content = String::new();
-    for path in paths {
+    for (_, path) in dropins.into_values() {
         if let Ok(dropin) = tokio::fs::read_to_string(path).await {
             content.push('\n');
             content.push_str(&dropin);
         }
     }
     content
+}
+
+fn unit_dropin_dirs(unit_path: &Path) -> Vec<PathBuf> {
+    let Some(parent) = unit_path.parent() else {
+        return vec![path_with_suffix(unit_path, ".d")];
+    };
+    let Some(file_name) = unit_path.file_name().and_then(|name| name.to_str()) else {
+        return vec![path_with_suffix(unit_path, ".d")];
+    };
+    let Some((unit_name, unit_type)) = file_name.rsplit_once('.') else {
+        return vec![path_with_suffix(unit_path, ".d")];
+    };
+
+    let mut dirs = vec![parent.join(format!("{unit_type}.d"))];
+    for (idx, ch) in unit_name.char_indices() {
+        if ch == '-' {
+            dirs.push(parent.join(format!("{}.{unit_type}.d", &unit_name[..=idx])));
+        }
+    }
+    dirs.push(parent.join(format!("{file_name}.d")));
+    dirs
+}
+
+fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = OsString::from(path.as_os_str());
+    value.push(suffix);
+    PathBuf::from(value)
 }
 
 pub(crate) fn parse_unit_config_path(content: &str) -> Option<PathBuf> {
@@ -452,6 +486,107 @@ ExecStart="/usr/bin/runner" start --config "/etc/new-runner.yaml"
         assert_eq!(
             read_unit_config_path(&unit_path).await,
             Some(PathBuf::from("/etc/new-runner.yaml"))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_unit_config_path_applies_prefix_dropin_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
+        std::fs::write(
+            &unit_path,
+            r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
+"#,
+        )
+        .unwrap();
+        let dropin_dir = dir.path().join("vm0-runner-.service.d");
+        std::fs::create_dir(&dropin_dir).unwrap();
+        std::fs::write(
+            dropin_dir.join("10-override.conf"),
+            r#"
+[Service]
+ExecStart=
+ExecStart="/usr/bin/runner" start --config "/etc/prefix-runner.yaml"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_unit_config_path(&unit_path).await,
+            Some(PathBuf::from("/etc/prefix-runner.yaml"))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_unit_config_path_applies_service_type_dropin_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
+        std::fs::write(
+            &unit_path,
+            r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
+"#,
+        )
+        .unwrap();
+        let dropin_dir = dir.path().join("service.d");
+        std::fs::create_dir(&dropin_dir).unwrap();
+        std::fs::write(
+            dropin_dir.join("10-override.conf"),
+            r#"
+[Service]
+ExecStart=
+ExecStart="/usr/bin/runner" start --config "/etc/type-runner.yaml"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_unit_config_path(&unit_path).await,
+            Some(PathBuf::from("/etc/type-runner.yaml"))
+        );
+    }
+
+    #[tokio::test]
+    async fn read_unit_config_path_applies_most_specific_same_named_dropin() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit_path = dir.path().join("vm0-runner-v1.0.0.service");
+        std::fs::write(
+            &unit_path,
+            r#"
+[Service]
+ExecStart="/usr/bin/runner" start --config "/etc/old-runner.yaml"
+"#,
+        )
+        .unwrap();
+        let prefix_dropin_dir = dir.path().join("vm0-runner-.service.d");
+        std::fs::create_dir(&prefix_dropin_dir).unwrap();
+        std::fs::write(
+            prefix_dropin_dir.join("10-override.conf"),
+            r#"
+[Service]
+ExecStart=
+ExecStart="/usr/bin/runner" start --config "/etc/prefix-runner.yaml"
+"#,
+        )
+        .unwrap();
+        let exact_dropin_dir = dir.path().join("vm0-runner-v1.0.0.service.d");
+        std::fs::create_dir(&exact_dropin_dir).unwrap();
+        std::fs::write(
+            exact_dropin_dir.join("10-override.conf"),
+            r#"
+[Service]
+ExecStart=
+ExecStart="/usr/bin/runner" start --config "/etc/exact-runner.yaml"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_unit_config_path(&unit_path).await,
+            Some(PathBuf::from("/etc/exact-runner.yaml"))
         );
     }
 


### PR DESCRIPTION
Fixes #20085

## Summary
- analyze runner version retention before image GC and share that analysis with version GC
- protect exact `(rootfs_hash, snapshot_hash)` image refs from retained runner version configs
- also protect exact image refs from enabled persistent runner service configs
- extract systemd unit config parsing for reuse and add a `systemctl is-enabled` helper

## Tests
- `cargo fmt --manifest-path crates/runner/Cargo.toml --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::gc --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p runner --quiet`
- `git diff --check`
- pre-commit crates cargo-fmt/doc/clippy hooks