### PR TITLE
refactor: filter ideation connectors by catalog

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -29,8 +29,13 @@ export const chatPageTaglineIndex$ = computed((get) => {
 });
 
 // ---------------------------------------------------------------------------
-// Suggested prompts — filtered by active feature switches
+// Suggested prompts — filtered by active feature switches and connector catalog
 // ---------------------------------------------------------------------------
+
+export const unfilteredSuggestedPrompts$ = computed((get) => {
+  const features = get(featureSwitch$);
+  return getRandomPrompts(2, { features });
+});
 
 export const suggestedPrompts$ = computed(async (get) => {
   const features = await get(featureSwitch$);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import { talkDraft$ } from "./chat-draft.ts";
 import { getRandomPrompts } from "../../views/zero-page/zero-ideation-data.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
+import { connectorCatalogStatusByRef$ } from "../external/connectors.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
@@ -33,7 +34,11 @@ export const chatPageTaglineIndex$ = computed((get) => {
 
 export const suggestedPrompts$ = computed(async (get) => {
   const features = await get(featureSwitch$);
-  return getRandomPrompts(2, features);
+  const connectorStatusByRef = await get(connectorCatalogStatusByRef$);
+  return getRandomPrompts(2, {
+    features,
+    visibleConnectorRefs: new Set(connectorStatusByRef.keys()),
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -107,8 +107,14 @@ describe("zero ideation page", () => {
     );
   });
 
-  it("renders only catalog-visible connector chips for use cases", async () => {
-    mockConnectorCatalogStatus(["github", "slack"]);
+  it("renders use case connector chips when all connectors are catalog-visible", async () => {
+    mockConnectorCatalogStatus([
+      "github",
+      "sentry",
+      "axiom",
+      "plausible",
+      "slack",
+    ]);
 
     detachedSetupPage({
       context,
@@ -117,7 +123,21 @@ describe("zero ideation page", () => {
 
     const card = await cardByTitle("Daily standup report");
 
-    expect(card.querySelectorAll("img")).toHaveLength(2);
+    expect(card.querySelectorAll("img")).toHaveLength(5);
+  });
+
+  it("hides use cases when any required connector is omitted from catalog", async () => {
+    mockConnectorCatalogStatus(["github", "slack"]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    await expect(
+      screen.findByText("GitHub progress weekly"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText("Daily standup report")).not.toBeInTheDocument();
   });
 
   it("hides connector-only use cases when catalog omits all refs", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, waitForElementToBeRemoved } from "@testing-library/react";
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
@@ -128,6 +128,34 @@ describe("zero ideation page", () => {
     expect(
       screen.queryByText("RevenueCat subscription digest"),
     ).not.toBeInTheDocument();
+  });
+
+  it("does not treat pending catalog status as an empty catalog", async () => {
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        await catalogReady.promise;
+        return respond(200, {
+          connectors: [],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    await expect(
+      screen.findByText("Daily standup report"),
+    ).resolves.toBeInTheDocument();
+
+    catalogReady.resolve();
+    await waitForElementToBeRemoved(() => {
+      return screen.queryByText("Daily standup report");
+    });
+    expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
   });
 
   it("falls back to all use cases when the selected tab is hidden by catalog filtering", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -12,6 +12,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setIdeationActiveTab$ } from "../../../signals/zero-page/zero-ideation.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 
 const context = testContext();
@@ -133,6 +134,24 @@ describe("zero ideation page", () => {
     expect(
       screen.getByText("No use cases match your search."),
     ).toBeInTheDocument();
+  });
+
+  it("falls back to all use cases when the selected tab is hidden by catalog filtering", async () => {
+    mockConnectorCatalogStatus([]);
+    context.store.set(setIdeationActiveTab$, "reports");
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Reports")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("No use cases match your search."),
+    ).not.toBeInTheDocument();
   });
 
   it("does not render connector-dependent suggested prompts when catalog is empty", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -64,6 +64,19 @@ async function cardByTitle(title: string): Promise<HTMLElement> {
   return card;
 }
 
+async function suggestedPromptGrid(): Promise<HTMLElement> {
+  const ideasTitle = await screen.findByText("Ideas & use cases");
+  const ideasButton = ideasTitle.closest("button");
+  if (!(ideasButton instanceof HTMLElement)) {
+    throw new Error("Ideas & use cases button not found");
+  }
+  const promptGrid = ideasButton.parentElement;
+  if (!(promptGrid instanceof HTMLElement)) {
+    throw new Error("Suggested prompt grid not found");
+  }
+  return promptGrid;
+}
+
 describe("zero ideation page", () => {
   it("filters use cases and starts an agent chat from a selected idea", async () => {
     detachedSetupPage({
@@ -184,17 +197,35 @@ describe("zero ideation page", () => {
       path: `/agents/${agentId}/chat`,
     });
 
-    const ideasTitle = await screen.findByText("Ideas & use cases");
-    const ideasButton = ideasTitle.closest("button");
-    if (!(ideasButton instanceof HTMLElement)) {
-      throw new Error("Ideas & use cases button not found");
-    }
-    const promptGrid = ideasButton.parentElement;
-    if (!(promptGrid instanceof HTMLElement)) {
-      throw new Error("Suggested prompt grid not found");
-    }
+    const promptGrid = await suggestedPromptGrid();
 
     expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
     expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it("does not treat pending catalog status as empty for suggested prompts", async () => {
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        await catalogReady.promise;
+        return respond(200, {
+          connectors: [],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+    });
+
+    const promptGrid = await suggestedPromptGrid();
+    const pendingButtons = queryAllByRoleFast("button", promptGrid);
+    expect(pendingButtons).toHaveLength(3);
+
+    catalogReady.resolve();
+    await waitForElementToBeRemoved(pendingButtons.slice(0, 2));
+    expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -12,6 +12,7 @@ import {
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { reloadConnectors$ } from "../../../signals/external/connectors.ts";
 import { setIdeationActiveTab$ } from "../../../signals/zero-page/zero-ideation.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 
@@ -219,6 +220,44 @@ describe("zero ideation page", () => {
     expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
   });
 
+  it("does not reuse stale catalog data after an ideas page catalog reload errors", async () => {
+    mockConnectorCatalogStatus([
+      "github",
+      "sentry",
+      "axiom",
+      "plausible",
+      "slack",
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    await expect(
+      screen.findByText("Daily standup report"),
+    ).resolves.toBeInTheDocument();
+
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        await catalogReady.promise;
+        return respond(403, {
+          error: { message: "Forbidden", code: "FORBIDDEN" },
+        });
+      },
+    );
+    context.store.set(reloadConnectors$);
+
+    expect(screen.getByText("Daily standup report")).toBeInTheDocument();
+    catalogReady.resolve();
+    await waitForElementToBeRemoved(() => {
+      return screen.queryByText("Daily standup report");
+    });
+    expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
+  });
+
   it("falls back to all use cases when the selected tab is hidden by catalog filtering", async () => {
     mockConnectorCatalogStatus([]);
     context.store.set(setIdeationActiveTab$, "reports");
@@ -300,6 +339,46 @@ describe("zero ideation page", () => {
 
     catalogReady.resolve();
     await waitForElementToBeRemoved(pendingButtons.slice(0, 2));
+    expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
+  });
+
+  it("does not reuse stale catalog data after a suggested prompt catalog reload errors", async () => {
+    mockConnectorCatalogStatus([
+      "github",
+      "sentry",
+      "axiom",
+      "plausible",
+      "slack",
+    ]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+    });
+
+    const promptGrid = await suggestedPromptGrid();
+    await expect(
+      screen.findByPlaceholderText(PLACEHOLDER),
+    ).resolves.toBeInTheDocument();
+    expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(3);
+
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        await catalogReady.promise;
+        return respond(403, {
+          error: { message: "Forbidden", code: "FORBIDDEN" },
+        });
+      },
+    );
+    context.store.set(reloadConnectors$);
+
+    const loadingButtons = queryAllByRoleFast("button", promptGrid);
+    expect(loadingButtons).toHaveLength(3);
+
+    catalogReady.resolve();
+    await waitForElementToBeRemoved(loadingButtons.slice(0, 2));
     expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -126,14 +126,12 @@ describe("zero ideation page", () => {
 
     await fill(screen.getByLabelText("Search use cases"), "RevenueCat");
 
-    await waitFor(() => {
-      expect(
-        screen.queryByText("RevenueCat subscription digest"),
-      ).not.toBeInTheDocument();
-    });
     expect(
-      screen.getByText("No use cases match your search."),
+      await screen.findByText("No use cases match your search."),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText("RevenueCat subscription digest"),
+    ).not.toBeInTheDocument();
   });
 
   it("falls back to all use cases when the selected tab is hidden by catalog filtering", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
@@ -55,8 +55,9 @@ function mockConnectorCatalogStatus(connectorRefs: readonly string[]): void {
   });
 }
 
-function cardByTitle(title: string): HTMLElement {
-  const card = screen.getByText(title).closest(".zero-card");
+async function cardByTitle(title: string): Promise<HTMLElement> {
+  const titleElement = await screen.findByText(title);
+  const card = titleElement.closest(".zero-card");
   if (!(card instanceof HTMLElement)) {
     throw new Error(`${title} card not found`);
   }
@@ -70,27 +71,24 @@ describe("zero ideation page", () => {
       path: `/agents/${agentId}/ideas`,
     });
 
-    await waitFor(() => {
-      expect(screen.getAllByText("Ideas & Use Cases")[0]).toBeInTheDocument();
-    });
-    await waitFor(() => {
-      expect(screen.getByText("Daily standup report")).toBeInTheDocument();
-    });
+    const pageTitles = await screen.findAllByText("Ideas & Use Cases");
+    expect(pageTitles[0]).toBeInTheDocument();
+    await expect(
+      screen.findByText("Daily standup report"),
+    ).resolves.toBeInTheDocument();
 
     await fill(screen.getByLabelText("Search use cases"), "RevenueCat");
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("RevenueCat subscription digest"),
-      ).toBeInTheDocument();
-    });
+    await expect(
+      screen.findByText("RevenueCat subscription digest"),
+    ).resolves.toBeInTheDocument();
     expect(screen.queryByText("Daily standup report")).not.toBeInTheDocument();
 
     click(screen.getByText("RevenueCat subscription digest"));
 
-    const composer = await waitFor(() => {
-      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-    });
+    const composer = (await screen.findByPlaceholderText(
+      PLACEHOLDER,
+    )) as HTMLTextAreaElement;
     expect(composer).toHaveValue(
       "Set up a daily RevenueCat digest that tracks new subscriptions, renewals, and cancellations in Google Sheets and alerts on Slack for churn spikes",
     );
@@ -104,9 +102,7 @@ describe("zero ideation page", () => {
       path: `/agents/${agentId}/ideas`,
     });
 
-    const card = await waitFor(() => {
-      return cardByTitle("Daily standup report");
-    });
+    const card = await cardByTitle("Daily standup report");
 
     expect(card.querySelectorAll("img")).toHaveLength(2);
   });
@@ -119,16 +115,16 @@ describe("zero ideation page", () => {
       path: `/agents/${agentId}/ideas`,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
-    });
+    await expect(
+      screen.findByText("Browser screenshots"),
+    ).resolves.toBeInTheDocument();
     expect(screen.queryByText("Daily standup report")).not.toBeInTheDocument();
 
     await fill(screen.getByLabelText("Search use cases"), "RevenueCat");
 
-    expect(
-      await screen.findByText("No use cases match your search."),
-    ).toBeInTheDocument();
+    await expect(
+      screen.findByText("No use cases match your search."),
+    ).resolves.toBeInTheDocument();
     expect(
       screen.queryByText("RevenueCat subscription digest"),
     ).not.toBeInTheDocument();
@@ -143,9 +139,9 @@ describe("zero ideation page", () => {
       path: `/agents/${agentId}/ideas`,
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
-    });
+    await expect(
+      screen.findByText("Browser screenshots"),
+    ).resolves.toBeInTheDocument();
     expect(screen.queryByText("Reports")).not.toBeInTheDocument();
     expect(
       screen.queryByText("No use cases match your search."),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -191,6 +191,34 @@ describe("zero ideation page", () => {
     expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
   });
 
+  it("fails closed when catalog status errors on the ideas page", async () => {
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        await catalogReady.promise;
+        return respond(403, {
+          error: { message: "Forbidden", code: "FORBIDDEN" },
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    await expect(
+      screen.findByText("Daily standup report"),
+    ).resolves.toBeInTheDocument();
+
+    catalogReady.resolve();
+    await waitForElementToBeRemoved(() => {
+      return screen.queryByText("Daily standup report");
+    });
+    expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
+  });
+
   it("falls back to all use cases when the selected tab is hidden by catalog filtering", async () => {
     mockConnectorCatalogStatus([]);
     context.store.set(setIdeationActiveTab$, "reports");
@@ -231,6 +259,32 @@ describe("zero ideation page", () => {
         await catalogReady.promise;
         return respond(200, {
           connectors: [],
+        });
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+    });
+
+    const promptGrid = await suggestedPromptGrid();
+    const pendingButtons = queryAllByRoleFast("button", promptGrid);
+    expect(pendingButtons).toHaveLength(3);
+
+    catalogReady.resolve();
+    await waitForElementToBeRemoved(pendingButtons.slice(0, 2));
+    expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
+  });
+
+  it("fails closed when catalog status errors for suggested prompts", async () => {
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        await catalogReady.promise;
+        return respond(403, {
+          error: { message: "Forbidden", code: "FORBIDDEN" },
         });
       },
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -1,10 +1,15 @@
 import { screen, waitFor } from "@testing-library/react";
+import {
+  zeroConnectorCatalogContract,
+  type PublicConnectorCatalogStatusItem,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { describe, expect, it } from "vitest";
 
 import {
   click,
   detachedSetupPage,
   fill,
+  queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
@@ -12,6 +17,50 @@ import { PLACEHOLDER } from "./chat-test-helpers.ts";
 const context = testContext();
 
 const agentId = "c0000000-0000-4000-a000-000000000001";
+
+function publicConnectorStatusItem(
+  connectorRef: string,
+): PublicConnectorCatalogStatusItem {
+  return {
+    connectorRef,
+    label: connectorRef,
+    description: `${connectorRef} public description`,
+    category: "data-automation-infrastructure",
+    generation: [],
+    tags: [],
+    authMethods: [],
+    permissionSummary: {
+      hasPermissions: false,
+      permissionCount: 0,
+      hasCategories: false,
+      hasDefaultPolicyOverrides: false,
+    },
+    connection: null,
+    connected: false,
+    connectionStatus: "not-connected",
+    scopeMismatch: false,
+    authMethodSupportsRefresh: false,
+    tokenExpiresAt: null,
+    singleAuthCodeAuthMethodId: null,
+    connectNotice: null,
+  };
+}
+
+function mockConnectorCatalogStatus(connectorRefs: readonly string[]): void {
+  context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
+    return respond(200, {
+      connectors: connectorRefs.map(publicConnectorStatusItem),
+    });
+  });
+}
+
+function cardByTitle(title: string): HTMLElement {
+  const card = screen.getByText(title).closest(".zero-card");
+  if (!(card instanceof HTMLElement)) {
+    throw new Error(`${title} card not found`);
+  }
+  return card;
+}
 
 describe("zero ideation page", () => {
   it("filters use cases and starts an agent chat from a selected idea", async () => {
@@ -23,7 +72,9 @@ describe("zero ideation page", () => {
     await waitFor(() => {
       expect(screen.getAllByText("Ideas & Use Cases")[0]).toBeInTheDocument();
     });
-    expect(screen.getByText("Daily standup report")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Daily standup report")).toBeInTheDocument();
+    });
 
     await fill(screen.getByLabelText("Search use cases"), "RevenueCat");
 
@@ -42,5 +93,67 @@ describe("zero ideation page", () => {
     expect(composer).toHaveValue(
       "Set up a daily RevenueCat digest that tracks new subscriptions, renewals, and cancellations in Google Sheets and alerts on Slack for churn spikes",
     );
+  });
+
+  it("renders only catalog-visible connector chips for use cases", async () => {
+    mockConnectorCatalogStatus(["github", "slack"]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    const card = await waitFor(() => {
+      return cardByTitle("Daily standup report");
+    });
+
+    expect(card.querySelectorAll("img")).toHaveLength(2);
+  });
+
+  it("hides connector-only use cases when catalog omits all refs", async () => {
+    mockConnectorCatalogStatus([]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Browser screenshots")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Daily standup report")).not.toBeInTheDocument();
+
+    await fill(screen.getByLabelText("Search use cases"), "RevenueCat");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("RevenueCat subscription digest"),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("No use cases match your search."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render connector-dependent suggested prompts when catalog is empty", async () => {
+    mockConnectorCatalogStatus([]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+    });
+
+    const ideasTitle = await screen.findByText("Ideas & use cases");
+    const ideasButton = ideasTitle.closest("button");
+    if (!(ideasButton instanceof HTMLElement)) {
+      throw new Error("Ideas & use cases button not found");
+    }
+    const promptGrid = ideasButton.parentElement;
+    if (!(promptGrid instanceof HTMLElement)) {
+      throw new Error("Suggested prompt grid not found");
+    }
+
+    expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -164,6 +164,44 @@ describe("zero ideation page", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("keeps the last resolved ideas page catalog while a reload is pending", async () => {
+    mockConnectorCatalogStatus([]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/ideas`,
+    });
+
+    await expect(
+      screen.findByText("Browser screenshots"),
+    ).resolves.toBeInTheDocument();
+    expect(screen.queryByText("Daily standup report")).not.toBeInTheDocument();
+
+    const catalogRequested = context.mocks.deferred<void>();
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        catalogRequested.resolve();
+        await catalogReady.promise;
+        return respond(200, {
+          connectors: ["github", "sentry", "axiom", "plausible", "slack"].map(
+            publicConnectorStatusItem,
+          ),
+        });
+      },
+    );
+    context.store.set(reloadConnectors$);
+
+    await catalogRequested.promise;
+    expect(screen.queryByText("Daily standup report")).not.toBeInTheDocument();
+
+    catalogReady.resolve();
+    await expect(
+      screen.findByText("Daily standup report"),
+    ).resolves.toBeInTheDocument();
+  });
+
   it("does not treat pending catalog status as an empty catalog", async () => {
     const catalogReady = context.mocks.deferred<void>();
     context.mocks.api(
@@ -288,6 +326,42 @@ describe("zero ideation page", () => {
 
     expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
     expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it("keeps the last resolved suggested prompt catalog while a reload is pending", async () => {
+    mockConnectorCatalogStatus([]);
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+    });
+
+    const promptGrid = await suggestedPromptGrid();
+    expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
+
+    const catalogRequested = context.mocks.deferred<void>();
+    const catalogReady = context.mocks.deferred<void>();
+    context.mocks.api(
+      zeroConnectorCatalogContract.status,
+      async ({ respond }) => {
+        catalogRequested.resolve();
+        await catalogReady.promise;
+        return respond(200, {
+          connectors: ["github", "sentry", "axiom", "plausible", "slack"].map(
+            publicConnectorStatusItem,
+          ),
+        });
+      },
+    );
+    context.store.set(reloadConnectors$);
+
+    await catalogRequested.promise;
+    expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
+
+    catalogReady.resolve();
+    await expect(
+      screen.findByPlaceholderText(PLACEHOLDER),
+    ).resolves.toBeInTheDocument();
   });
 
   it("does not treat pending catalog status as empty for suggested prompts", async () => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -367,13 +367,13 @@ function SuggestedPromptsGrid({
 }) {
   const unfilteredSuggestedPrompts =
     useLastResolved(unfilteredSuggestedPrompts$) ?? [];
-  const suggestedPromptsLoadable = useLastLoadable(suggestedPrompts$);
-  const lastSuggestedPrompts = useLastResolved(suggestedPrompts$);
+  const suggestedPromptsLoadable = useLoadable(suggestedPrompts$);
   const suggestedPrompts =
-    lastSuggestedPrompts ??
-    (suggestedPromptsLoadable.state === "loading"
-      ? unfilteredSuggestedPrompts
-      : []);
+    suggestedPromptsLoadable.state === "hasData"
+      ? suggestedPromptsLoadable.data
+      : suggestedPromptsLoadable.state === "loading"
+        ? unfilteredSuggestedPrompts
+        : [];
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full">
       {suggestedPrompts.map((item) => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -10,7 +10,6 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
-import type { ConnectorType } from "@vm0/connectors/connectors";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import {
@@ -71,7 +70,10 @@ import {
   ZERO_DESKTOP_DOWNLOAD_URL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
-import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import {
+  ConnectorIcon,
+  isConnectorIconType,
+} from "./components/settings/connector-icons.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
@@ -273,7 +275,7 @@ interface SuggestedPrompt {
   title: string;
   description: string;
   prompt: string;
-  connectors?: readonly ConnectorType[];
+  connectors?: readonly string[];
 }
 
 function SuggestedPromptButton({
@@ -283,6 +285,7 @@ function SuggestedPromptButton({
   item: SuggestedPrompt;
   onSelectPrompt: (prompt: string) => void;
 }) {
+  const connectorIconTypes = item.connectors?.filter(isConnectorIconType) ?? [];
   return (
     <button
       type="button"
@@ -300,9 +303,9 @@ function SuggestedPromptButton({
       <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
         {item.description}
       </p>
-      {item.connectors && item.connectors.length > 0 && (
+      {connectorIconTypes.length > 0 && (
         <div className="flex items-center gap-1.5 mt-auto pt-2.5">
-          {item.connectors.map((type) => {
+          {connectorIconTypes.map((type) => {
             return (
               <span
                 key={type}

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -367,8 +367,13 @@ function SuggestedPromptsGrid({
 }) {
   const unfilteredSuggestedPrompts =
     useLastResolved(unfilteredSuggestedPrompts$) ?? [];
+  const suggestedPromptsLoadable = useLastLoadable(suggestedPrompts$);
+  const lastSuggestedPrompts = useLastResolved(suggestedPrompts$);
   const suggestedPrompts =
-    useLastResolved(suggestedPrompts$) ?? unfilteredSuggestedPrompts;
+    lastSuggestedPrompts ??
+    (suggestedPromptsLoadable.state === "loading"
+      ? unfilteredSuggestedPrompts
+      : []);
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full">
       {suggestedPrompts.map((item) => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -55,6 +55,7 @@ import {
   resetChatPageModelSelection$,
   chatPageTaglineIndex$,
   suggestedPrompts$,
+  unfilteredSuggestedPrompts$,
 } from "../../signals/zero-page/zero-chat-page.ts";
 import {
   newThreadGenerationTemplate$,
@@ -364,7 +365,10 @@ function SuggestedPromptsGrid({
 }: {
   onSelectPrompt: (prompt: string) => void;
 }) {
-  const suggestedPrompts = useLastResolved(suggestedPrompts$) ?? [];
+  const unfilteredSuggestedPrompts =
+    useLastResolved(unfilteredSuggestedPrompts$) ?? [];
+  const suggestedPrompts =
+    useLastResolved(suggestedPrompts$) ?? unfilteredSuggestedPrompts;
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full">
       {suggestedPrompts.map((item) => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -368,11 +368,12 @@ function SuggestedPromptsGrid({
   const unfilteredSuggestedPrompts =
     useLastResolved(unfilteredSuggestedPrompts$) ?? [];
   const suggestedPromptsLoadable = useLoadable(suggestedPrompts$);
+  const lastSuggestedPrompts = useLastResolved(suggestedPrompts$);
   const suggestedPrompts =
     suggestedPromptsLoadable.state === "hasData"
       ? suggestedPromptsLoadable.data
       : suggestedPromptsLoadable.state === "loading"
-        ? unfilteredSuggestedPrompts
+        ? (lastSuggestedPrompts ?? unfilteredSuggestedPrompts)
         : [];
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full">

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -660,16 +660,13 @@ function filterUseCase(
     return useCase;
   }
 
-  const connectors = useCase.connectors.filter((connectorRef) => {
+  const allConnectorsVisible = useCase.connectors.every((connectorRef) => {
     return visibleConnectorRefs.has(connectorRef);
   });
-  if (connectors.length === 0) {
+  if (!allConnectorsVisible) {
     return null;
   }
-  if (connectors.length === useCase.connectors.length) {
-    return useCase;
-  }
-  return { ...useCase, connectors };
+  return useCase;
 }
 
 export function getCategories(

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -1,10 +1,11 @@
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 interface UseCase {
   readonly title: string;
   readonly description: string;
   readonly prompt: string;
-  readonly connectors?: readonly string[];
+  readonly connectors?: readonly ConnectorType[];
   readonly featureFlag?: FeatureSwitchKey;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -651,7 +651,7 @@ function filterUseCase(
     return null;
   }
 
-  if (!useCase.connectors) {
+  if (!useCase.connectors || useCase.connectors.length === 0) {
     return useCase;
   }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -1,6 +1,6 @@
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
-export interface UseCase {
+interface UseCase {
   readonly title: string;
   readonly description: string;
   readonly prompt: string;
@@ -8,7 +8,7 @@ export interface UseCase {
   readonly featureFlag?: FeatureSwitchKey;
 }
 
-export interface Category {
+interface Category {
   readonly id: string;
   readonly title: string;
   readonly cases: readonly UseCase[];

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -16,7 +16,7 @@ interface Category {
 
 interface IdeationFilterOptions {
   readonly features?: Partial<Record<FeatureSwitchKey, boolean>>;
-  readonly visibleConnectorRefs: ReadonlySet<string>;
+  readonly visibleConnectorRefs?: ReadonlySet<string>;
 }
 
 const categories: readonly Category[] = [
@@ -647,16 +647,21 @@ function filterUseCase(
   useCase: UseCase,
   options: IdeationFilterOptions,
 ): UseCase | null {
+  const visibleConnectorRefs = options.visibleConnectorRefs;
   if (!isEnabled(useCase, options.features)) {
     return null;
   }
 
-  if (!useCase.connectors || useCase.connectors.length === 0) {
+  if (
+    !useCase.connectors ||
+    useCase.connectors.length === 0 ||
+    !visibleConnectorRefs
+  ) {
     return useCase;
   }
 
   const connectors = useCase.connectors.filter((connectorRef) => {
-    return options.visibleConnectorRefs.has(connectorRef);
+    return visibleConnectorRefs.has(connectorRef);
   });
   if (connectors.length === 0) {
     return null;

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -1,18 +1,22 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
-interface UseCase {
+export interface UseCase {
   readonly title: string;
   readonly description: string;
   readonly prompt: string;
-  readonly connectors?: readonly ConnectorType[];
+  readonly connectors?: readonly string[];
   readonly featureFlag?: FeatureSwitchKey;
 }
 
-interface Category {
+export interface Category {
   readonly id: string;
   readonly title: string;
   readonly cases: readonly UseCase[];
+}
+
+interface IdeationFilterOptions {
+  readonly features?: Partial<Record<FeatureSwitchKey, boolean>>;
+  readonly visibleConnectorRefs: ReadonlySet<string>;
 }
 
 const categories: readonly Category[] = [
@@ -639,15 +643,40 @@ function isEnabled(
   return !!features?.[useCase.featureFlag];
 }
 
+function filterUseCase(
+  useCase: UseCase,
+  options: IdeationFilterOptions,
+): UseCase | null {
+  if (!isEnabled(useCase, options.features)) {
+    return null;
+  }
+
+  if (!useCase.connectors) {
+    return useCase;
+  }
+
+  const connectors = useCase.connectors.filter((connectorRef) => {
+    return options.visibleConnectorRefs.has(connectorRef);
+  });
+  if (connectors.length === 0) {
+    return null;
+  }
+  if (connectors.length === useCase.connectors.length) {
+    return useCase;
+  }
+  return { ...useCase, connectors };
+}
+
 export function getCategories(
-  features?: Partial<Record<FeatureSwitchKey, boolean>>,
+  options: IdeationFilterOptions,
 ): readonly Category[] {
   return categories
     .map((c) => {
       return {
         ...c,
-        cases: c.cases.filter((u) => {
-          return isEnabled(u, features);
+        cases: c.cases.flatMap((u) => {
+          const useCase = filterUseCase(u, options);
+          return useCase ? [useCase] : [];
         }),
       };
     })
@@ -658,11 +687,11 @@ export function getCategories(
 
 export function getRandomPrompts(
   count: number,
-  features?: Partial<Record<FeatureSwitchKey, boolean>>,
+  options: IdeationFilterOptions,
 ): UseCase[] {
-  const all = categories.flatMap((c) => {
+  const all = getCategories(options).flatMap((c) => {
     return c.cases.filter((u) => {
-      return u.connectors && u.connectors.length > 0 && isEnabled(u, features);
+      return u.connectors && u.connectors.length > 0;
     });
   });
   const shuffled = [...all].sort(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -1,11 +1,6 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import {
-  useGet,
-  useLastLoadable,
-  useLastResolved,
-  useSet,
-} from "ccstate-react";
+import { useGet, useLoadable, useLastResolved, useSet } from "ccstate-react";
 import {
   IconArrowUpRight,
   IconMessageCircle,
@@ -29,11 +24,10 @@ import {
 } from "../../signals/zero-page/zero-ideation.ts";
 export function ZeroIdeationPage() {
   const features = useLastResolved(featureSwitch$);
-  const connectorStatusLoadable = useLastLoadable(connectorCatalogStatusByRef$);
-  const connectorStatusByRef = useLastResolved(connectorCatalogStatusByRef$);
+  const connectorStatusLoadable = useLoadable(connectorCatalogStatusByRef$);
   const visibleConnectorRefs =
-    connectorStatusByRef !== undefined
-      ? new Set(connectorStatusByRef.keys())
+    connectorStatusLoadable.state === "hasData"
+      ? new Set(connectorStatusLoadable.data.keys())
       : connectorStatusLoadable.state === "loading"
         ? undefined
         : new Set<string>();

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -25,7 +25,9 @@ import {
 export function ZeroIdeationPage() {
   const features = useLastResolved(featureSwitch$);
   const connectorStatusByRef = useLastResolved(connectorCatalogStatusByRef$);
-  const visibleConnectorRefs = new Set(connectorStatusByRef?.keys() ?? []);
+  const visibleConnectorRefs = connectorStatusByRef
+    ? new Set(connectorStatusByRef.keys())
+    : undefined;
   const categories = getCategories({
     features,
     visibleConnectorRefs,

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -36,6 +36,13 @@ export function ZeroIdeationPage() {
   const setSearchQuery = useSet(setIdeationSearchQuery$);
   const navigate = useSet(detachedNavigateTo$);
   const agentId = useGet(currentAgentId$);
+  const selectedTab =
+    activeTab === "all" ||
+    categories.some((category) => {
+      return category.id === activeTab;
+    })
+      ? activeTab
+      : "all";
 
   const navigateToChat = () => {
     if (agentId) {
@@ -46,10 +53,10 @@ export function ZeroIdeationPage() {
   };
 
   const baseCategories =
-    activeTab === "all"
+    selectedTab === "all"
       ? categories
       : categories.filter((c) => {
-          return c.id === activeTab;
+          return c.id === selectedTab;
         });
   const searchNeedle = searchQuery.trim().toLowerCase();
   const visibleCategories =
@@ -124,7 +131,7 @@ export function ZeroIdeationPage() {
                     type="button"
                     className={cn(
                       "h-7 shrink-0 rounded-md border border-border px-2.5 text-sm font-medium leading-none transition-colors cursor-pointer",
-                      activeTab === "all"
+                      selectedTab === "all"
                         ? "bg-muted text-foreground"
                         : "bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground",
                     )}
@@ -141,7 +148,7 @@ export function ZeroIdeationPage() {
                         type="button"
                         className={cn(
                           "h-7 shrink-0 rounded-md border border-border px-2.5 text-sm font-medium leading-none transition-colors cursor-pointer",
-                          activeTab === category.id
+                          selectedTab === category.id
                             ? "bg-muted text-foreground"
                             : "bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground",
                         )}

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -25,9 +25,18 @@ import {
 export function ZeroIdeationPage() {
   const features = useLastResolved(featureSwitch$);
   const connectorStatusLoadable = useLoadable(connectorCatalogStatusByRef$);
-  const visibleConnectorRefs =
+  const lastConnectorStatusByRef = useLastResolved(
+    connectorCatalogStatusByRef$,
+  );
+  const connectorStatusByRef =
     connectorStatusLoadable.state === "hasData"
-      ? new Set(connectorStatusLoadable.data.keys())
+      ? connectorStatusLoadable.data
+      : connectorStatusLoadable.state === "loading"
+        ? lastConnectorStatusByRef
+        : undefined;
+  const visibleConnectorRefs =
+    connectorStatusByRef !== undefined
+      ? new Set(connectorStatusByRef.keys())
       : connectorStatusLoadable.state === "loading"
         ? undefined
         : new Set<string>();

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -1,6 +1,11 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
-import { useGet, useLastResolved, useSet } from "ccstate-react";
+import {
+  useGet,
+  useLastLoadable,
+  useLastResolved,
+  useSet,
+} from "ccstate-react";
 import {
   IconArrowUpRight,
   IconMessageCircle,
@@ -24,10 +29,14 @@ import {
 } from "../../signals/zero-page/zero-ideation.ts";
 export function ZeroIdeationPage() {
   const features = useLastResolved(featureSwitch$);
+  const connectorStatusLoadable = useLastLoadable(connectorCatalogStatusByRef$);
   const connectorStatusByRef = useLastResolved(connectorCatalogStatusByRef$);
-  const visibleConnectorRefs = connectorStatusByRef
-    ? new Set(connectorStatusByRef.keys())
-    : undefined;
+  const visibleConnectorRefs =
+    connectorStatusByRef !== undefined
+      ? new Set(connectorStatusByRef.keys())
+      : connectorStatusLoadable.state === "loading"
+        ? undefined
+        : new Set<string>();
   const categories = getCategories({
     features,
     visibleConnectorRefs,

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -7,9 +7,13 @@ import {
   IconSearch,
 } from "@tabler/icons-react";
 import { Card, CardContent, cn, Input } from "@vm0/ui";
-import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import {
+  ConnectorIcon,
+  isConnectorIconType,
+} from "./components/settings/connector-icons.tsx";
 import { getCategories } from "./zero-ideation-data.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { currentAgentId$ } from "../../signals/agent.ts";
 import {
@@ -20,7 +24,12 @@ import {
 } from "../../signals/zero-page/zero-ideation.ts";
 export function ZeroIdeationPage() {
   const features = useLastResolved(featureSwitch$);
-  const categories = getCategories(features).slice(0, 5);
+  const connectorStatusByRef = useLastResolved(connectorCatalogStatusByRef$);
+  const visibleConnectorRefs = new Set(connectorStatusByRef?.keys() ?? []);
+  const categories = getCategories({
+    features,
+    visibleConnectorRefs,
+  }).slice(0, 5);
   const activeTab = useGet(ideationActiveTab$);
   const setActiveTab = useSet(setIdeationActiveTab$);
   const searchQuery = useGet(ideationSearchQuery$);
@@ -184,6 +193,9 @@ export function ZeroIdeationPage() {
 
                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                         {category.cases.map((useCase) => {
+                          const connectorIconTypes =
+                            useCase.connectors?.filter(isConnectorIconType) ??
+                            [];
                           return (
                             <Card
                               key={useCase.title}
@@ -204,24 +216,23 @@ export function ZeroIdeationPage() {
                                 <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
                                   {useCase.description}
                                 </p>
-                                {useCase.connectors &&
-                                  useCase.connectors.length > 0 && (
-                                    <div className="flex items-center gap-1.5 mt-2.5">
-                                      {useCase.connectors.map((type) => {
-                                        return (
-                                          <span
-                                            key={type}
-                                            className="flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background"
-                                          >
-                                            <ConnectorIcon
-                                              type={type}
-                                              size={14}
-                                            />
-                                          </span>
-                                        );
-                                      })}
-                                    </div>
-                                  )}
+                                {connectorIconTypes.length > 0 && (
+                                  <div className="flex items-center gap-1.5 mt-2.5">
+                                    {connectorIconTypes.map((type) => {
+                                      return (
+                                        <span
+                                          key={type}
+                                          className="flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background"
+                                        >
+                                          <ConnectorIcon
+                                            type={type}
+                                            size={14}
+                                          />
+                                        </span>
+                                      );
+                                    })}
+                                  </div>
+                                )}
                               </CardContent>
                             </Card>
                           );


### PR DESCRIPTION
## Summary

- filter Ideas & Use Cases connector refs through the public connector catalog/status response
- treat ideation connector refs as editorial strings instead of static `ConnectorType[]`
- apply the same catalog filtering to homepage suggested prompts before random selection
- guard static icon rendering with `isConnectorIconType()` so catalog-visible refs without bundled icons do not break UI

## Tests

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-ideation-page.test.tsx --reporter=dot`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- pre-commit: `pnpm knip --cache`
- pre-commit: `pnpm check-types`

Closes #20002
