### PR TITLE
refactor: reduce fallback slop in api contracts

### DIFF
--- a/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
@@ -79,9 +79,7 @@ export async function readRuntimeApiSchemaDocument(
 function parseRuntimeApiSchemaDocument(
   value: unknown,
 ): RuntimeApiSchemaDocument {
-  const document = runtimeApiSchemaDocumentSchema.parse(
-    value,
-  ) as unknown as RuntimeApiSchemaDocument;
+  const document = runtimeApiSchemaDocumentSchema.parse(value);
   if (document.schemaFormatVersion !== runtimeApiSchemaFormatVersion) {
     throw new Error(
       `Unsupported runtime API schema format version ${document.schemaFormatVersion}`,
@@ -187,10 +185,11 @@ function isZodSchema(schema: unknown): schema is z.ZodType {
 }
 
 function normalizeJsonValue(value: unknown, label: string): JsonObject {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  const parsed = jsonObjectSchema.safeParse(value);
+  if (!parsed.success) {
     throw new Error(`${label} JSON Schema must be an object`);
   }
-  return value as JsonObject;
+  return parsed.data;
 }
 
 function validateString(value: unknown, label: string): string {
@@ -224,10 +223,26 @@ function sortJsonValue(value: unknown): unknown {
   return value;
 }
 
-const runtimeSchemaSnapshotSchema = z.union([
+const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => {
+  return z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]);
+});
+
+const jsonObjectSchema: z.ZodType<JsonObject> = z.record(
+  z.string(),
+  jsonValueSchema,
+);
+
+const runtimeSchemaSnapshotSchema: z.ZodType<RuntimeSchemaSnapshot> = z.union([
   z.object({
     kind: z.literal("json-schema"),
-    schema: z.record(z.string(), z.unknown()),
+    schema: jsonObjectSchema,
   }),
   z.object({
     kind: z.literal("opaque"),
@@ -235,26 +250,28 @@ const runtimeSchemaSnapshotSchema = z.union([
   }),
 ]);
 
-const runtimeApiRouteSnapshotSchema = z.object({
-  id: z.string().min(1),
-  owner: z.enum(["runner", "guest-agent", "mitm-addon"]),
-  method: z.string().min(1),
-  path: z.string().min(1),
-  summary: z.string().optional(),
-  contentType: z.string().optional(),
-  request: z.object({
-    headers: runtimeSchemaSnapshotSchema.optional(),
-    query: runtimeSchemaSnapshotSchema.optional(),
-    pathParams: runtimeSchemaSnapshotSchema.optional(),
-    body: runtimeSchemaSnapshotSchema.optional(),
-  }),
-  responses: z.record(z.string(), runtimeSchemaSnapshotSchema),
-});
+const runtimeApiRouteSnapshotSchema: z.ZodType<RuntimeApiRouteSnapshot> =
+  z.object({
+    id: z.string().min(1),
+    owner: z.enum(["runner", "guest-agent", "mitm-addon"]),
+    method: z.string().min(1),
+    path: z.string().min(1),
+    summary: z.string().optional(),
+    contentType: z.string().optional(),
+    request: z.object({
+      headers: runtimeSchemaSnapshotSchema.optional(),
+      query: runtimeSchemaSnapshotSchema.optional(),
+      pathParams: runtimeSchemaSnapshotSchema.optional(),
+      body: runtimeSchemaSnapshotSchema.optional(),
+    }),
+    responses: z.record(z.string(), runtimeSchemaSnapshotSchema),
+  });
 
-const runtimeApiSchemaDocumentSchema = z.object({
-  schemaFormatVersion: z.number(),
-  packageName: z.string(),
-  packageVersion: z.string(),
-  generatedAt: z.string(),
-  routes: z.array(runtimeApiRouteSnapshotSchema),
-});
+const runtimeApiSchemaDocumentSchema: z.ZodType<RuntimeApiSchemaDocument> =
+  z.object({
+    schemaFormatVersion: z.number(),
+    packageName: z.string(),
+    packageVersion: z.string(),
+    generatedAt: z.string(),
+    routes: z.array(runtimeApiRouteSnapshotSchema),
+  });

--- a/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/schema.ts
@@ -185,7 +185,12 @@ function isZodSchema(schema: unknown): schema is z.ZodType {
 }
 
 function normalizeJsonValue(value: unknown, label: string): JsonObject {
-  const parsed = jsonObjectSchema.safeParse(value);
+  const rendered = JSON.stringify(value);
+  if (!rendered) {
+    throw new Error(`${label} JSON Schema must be an object`);
+  }
+
+  const parsed = jsonObjectSchema.safeParse(JSON.parse(rendered));
   if (!parsed.success) {
     throw new Error(`${label} JSON Schema must be an object`);
   }


### PR DESCRIPTION
## Summary

Daily AI-slop fallback cleanup focused on the runtime API schema parser in `@vm0/api-contracts`.

## Scan

- Scan timestamp: `2026-07-04T20:01:35.357Z`
- Base commit: `4acee71a265fa97256d6b136f4af54ebb847fe38`
- Files scanned: `3,874`
- Raw actionable matches: `4,243`
- High-confidence production actionable candidates: `214`
- Edit budget: `11`
- Candidates changed: `1`

Total matches by category:

- `nullish`: 5372
- `nullish-chain`: 120
- `field-fallback-chain`: 94
- `optional-prop`: 5575
- `zod-optional`: 2115
- `zod-loose-optional`: 7
- `loose-record`: 1183
- `loose-index-signature`: 5
- `as-any`: 0
- `as-unknown-as`: 36
- `empty-fallback`: 601
- `string-fallback`: 672
- `null-undefined-fallback`: 1508
- `empty-catch`: 3
- `promise-catch-swallow`: 14
- `rust-unwrap-or`: 574
- `rust-ok-discard`: 141

## Files changed

- `turbo/packages/api-contracts/src/runtime-api-schema/schema.ts`: replaced the post-Zod `as unknown as RuntimeApiSchemaDocument` cast with typed Zod schemas for the schema document, route snapshots, runtime schema snapshots, and recursive JSON object/value validation. This is safe because the parser already owns the runtime validation boundary, and the new typed schemas match the declared `RuntimeApiSchemaDocument` / `JsonObject` contracts instead of trusting a double cast.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm -F @vm0/api-contracts exec tsc -p tsconfig.runtime-api-schema.json --noEmit`
- `pnpm -F @vm0/api-contracts exec vitest run src/runtime-api-schema/__tests__/compat.test.ts`
- `git diff --check`
- Re-ran the fallback scanner to confirm the touched file no longer reports the high-confidence `as-unknown-as` candidate.

This workflow intentionally leaves the remaining candidates for later daily runs.
