### PR TITLE
fix(api): enforce signal-aware deferred promises

### DIFF
--- a/turbo/apps/api/custom-eslint/__tests__/no-new-promise.test.ts
+++ b/turbo/apps/api/custom-eslint/__tests__/no-new-promise.test.ts
@@ -1,0 +1,36 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { afterAll, describe, it } from "vitest";
+
+import { noNewPromise } from "../rules/no-new-promise.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-new-promise", noNewPromise, {
+  valid: [
+    {
+      code: `
+        const deferred = createDeferredPromise(signal);
+        await deferred.promise;
+      `,
+    },
+    {
+      code: `
+        await delay(100, { signal });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const pending = new Promise((resolve) => {
+          resolve(1);
+        });
+      `,
+      errors: [{ messageId: "noNewPromise" }],
+    },
+  ],
+});

--- a/turbo/apps/api/custom-eslint/index.ts
+++ b/turbo/apps/api/custom-eslint/index.ts
@@ -2,6 +2,7 @@ import { noCatchAbort } from "./rules/no-catch-abort.ts";
 import { noFnDollarSuffix } from "./rules/no-fn-dollar-suffix.ts";
 import { noGetterSetterParams } from "./rules/no-getter-setter-params.ts";
 import { noLoggerInfo } from "./rules/no-logger-info.ts";
+import { noNewPromise } from "./rules/no-new-promise.ts";
 import { noPackageVariable } from "./rules/no-package-variable.ts";
 import { noStoreInParams } from "./rules/no-store-in-params.ts";
 import { noTestViMocks } from "./rules/no-test-vi-mocks.ts";
@@ -17,6 +18,7 @@ export const apiLintPlugin = {
     "no-fn-dollar-suffix": noFnDollarSuffix,
     "no-getter-setter-params": noGetterSetterParams,
     "no-logger-info": noLoggerInfo,
+    "no-new-promise": noNewPromise,
     "no-package-variable": noPackageVariable,
     "no-store-in-params": noStoreInParams,
     "no-test-vi-mocks": noTestViMocks,

--- a/turbo/apps/api/custom-eslint/rules/no-new-promise.ts
+++ b/turbo/apps/api/custom-eslint/rules/no-new-promise.ts
@@ -1,0 +1,35 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+import { createRule } from "../utils.ts";
+
+export const noNewPromise = createRule({
+  name: "no-new-promise",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow direct Promise construction",
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noNewPromise:
+        "`new Promise()` is not allowed. Use signal-aware helpers such as createDeferredPromise(), delay(), or an existing abstraction instead.",
+    },
+  },
+  create(context) {
+    return {
+      NewExpression(node: TSESTree.NewExpression): void {
+        if (
+          node.callee.type === AST_NODE_TYPES.Identifier &&
+          node.callee.name === "Promise"
+        ) {
+          context.report({
+            node,
+            messageId: "noNewPromise",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -134,6 +134,7 @@ export default [
       "api/no-fn-dollar-suffix": "error",
       "api/no-getter-setter-params": "error",
       "api/no-logger-info": "error",
+      "api/no-new-promise": "error",
       "api/no-store-in-params": "error",
       "api/signal-check-await": "error",
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -24,6 +24,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
+import { createDeferredPromise } from "../../utils";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -643,16 +644,18 @@ function deferredGate(): {
   readonly wait: () => Promise<void>;
   readonly release: () => void;
 } {
-  let releaseGate = (): void => {};
-  const promise = new Promise<void>((resolve) => {
-    releaseGate = resolve;
-  });
+  const gate = createDeferredPromise<void>(context.signal);
+  const releaseGate = (): void => {
+    if (!gate.settled()) {
+      gate.resolve(undefined);
+    }
+  };
   onTestFinished(() => {
     releaseGate();
   });
   return {
     wait: () => {
-      return promise;
+      return gate.promise;
     },
     release: releaseGate,
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -58,6 +58,7 @@ import { createApp } from "../../../../app-factory";
 import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
 import { now } from "../../../../lib/time";
 import { server } from "../../../../mocks/server";
+import { createDeferredPromise } from "../../../utils";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
 
@@ -707,17 +708,21 @@ interface DeferredTestOAuthTokenEndpoint {
  */
 export function mockDeferredTestOAuthTokenEndpoint(): DeferredTestOAuthTokenEndpoint {
   let callCount = 0;
-  let releaseGate = (): void => {};
-  const gate = new Promise<void>((resolve) => {
-    releaseGate = resolve;
-  });
+  const gate = createDeferredPromise<void>(AbortSignal.any([]));
+  const releaseGate = (): void => {
+    if (!gate.settled()) {
+      gate.resolve(undefined);
+    }
+  };
   onTestFinished(() => {
     releaseGate();
   });
-  let markStarted = (): void => {};
-  const started = new Promise<void>((resolve) => {
-    markStarted = resolve;
-  });
+  const started = createDeferredPromise<void>(AbortSignal.any([]));
+  const markStarted = (): void => {
+    if (!started.settled()) {
+      started.resolve(undefined);
+    }
+  };
 
   server.use(
     http.post(TEST_OAUTH_TOKEN_URL, async ({ request }) => {
@@ -730,7 +735,7 @@ export function mockDeferredTestOAuthTokenEndpoint(): DeferredTestOAuthTokenEndp
         );
       }
       markStarted();
-      await gate;
+      await gate.promise;
       return HttpResponse.json({
         access_token: `test-device-access:${body.get("device_code") ?? ""}`,
         token_type: "Bearer",
@@ -741,7 +746,7 @@ export function mockDeferredTestOAuthTokenEndpoint(): DeferredTestOAuthTokenEndp
   );
 
   return {
-    started,
+    started: started.promise,
     release() {
       releaseGate();
     },
@@ -1046,24 +1051,28 @@ export function mockAwsExternalCodeProvider(
  */
 export function mockAwsDeferredTokenExchange(): AwsDeferredTokenExchange {
   const tokenRequests: AwsTokenRequest[] = [];
-  let releaseGate = (): void => {};
-  const gate = new Promise<void>((resolve) => {
-    releaseGate = resolve;
-  });
+  const gate = createDeferredPromise<void>(AbortSignal.any([]));
+  const releaseGate = (): void => {
+    if (!gate.settled()) {
+      gate.resolve(undefined);
+    }
+  };
   onTestFinished(() => {
     releaseGate();
   });
-  let markStarted = (): void => {};
-  const started = new Promise<void>((resolve) => {
-    markStarted = resolve;
-  });
+  const started = createDeferredPromise<void>(AbortSignal.any([]));
+  const markStarted = (): void => {
+    if (!started.settled()) {
+      started.resolve(undefined);
+    }
+  };
 
   server.use(
     http.post(AWS_SIGNIN_TOKEN_URL, async ({ request }) => {
       const body = awsTokenRequestSchema.parse(await request.json());
       tokenRequests.push(body);
       markStarted();
-      await gate;
+      await gate.promise;
       return HttpResponse.json({ tokenOutput: awsTokenEndpointResponseBody() });
     }),
     http.get(AWS_STS_URL, () => {
@@ -1072,7 +1081,7 @@ export function mockAwsDeferredTokenExchange(): AwsDeferredTokenExchange {
   );
 
   return {
-    tokenRequestStarted: started,
+    tokenRequestStarted: started.promise,
     tokenRequests,
     releaseTokenResponse() {
       releaseGate();

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-ops-logs.ts
@@ -10,6 +10,7 @@ import {
   setupApp,
   type TestContext,
 } from "../../../../__tests__/test-helpers";
+import { createDeferredPromise } from "../../../utils";
 import { modelStatsContract } from "../../model-stats";
 import type { ApiTestUser } from "./api-bdd";
 import { createZeroRouteMocks } from "./zero-route-test";
@@ -192,13 +193,13 @@ export function createOpsLogsApi(context: TestContext) {
      * `s3.send` call.
      */
     deferS3PutOnce(): { readonly resolve: () => void } {
-      let resolvePut = (): void => {};
-      const pending = new Promise<unknown>((resolve) => {
-        resolvePut = () => {
-          resolve({});
-        };
-      });
-      context.mocks.s3.send.mockReturnValueOnce(pending);
+      const pending = createDeferredPromise<unknown>(context.signal);
+      const resolvePut = (): void => {
+        if (!pending.settled()) {
+          pending.resolve({});
+        }
+      };
+      context.mocks.s3.send.mockReturnValueOnce(pending.promise);
       return { resolve: resolvePut };
     },
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -31,6 +31,7 @@ import {
   expectApiError,
   type ApiTestUser,
 } from "./helpers/api-bdd";
+import { createDeferredPromise } from "../../utils";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -1274,14 +1275,18 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       compose.composeId,
     );
 
-    let releaseEmptyUploads = (): void => {};
-    const emptyUploadsGate = new Promise<void>((resolve) => {
-      releaseEmptyUploads = resolve;
-    });
-    let markEmptyUploadStarted = (): void => {};
-    const emptyUploadStarted = new Promise<void>((resolve) => {
-      markEmptyUploadStarted = resolve;
-    });
+    const emptyUploadsGate = createDeferredPromise<void>(context.signal);
+    const releaseEmptyUploads = (): void => {
+      if (!emptyUploadsGate.settled()) {
+        emptyUploadsGate.resolve(undefined);
+      }
+    };
+    const emptyUploadStarted = createDeferredPromise<void>(context.signal);
+    const markEmptyUploadStarted = (): void => {
+      if (!emptyUploadStarted.settled()) {
+        emptyUploadStarted.resolve(undefined);
+      }
+    };
 
     let blockedEmptyPutCount = 0;
     context.mocks.s3.send.mockImplementation((command: unknown) => {
@@ -1291,7 +1296,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       ) {
         blockedEmptyPutCount += 1;
         markEmptyUploadStarted();
-        return emptyUploadsGate.then(() => {
+        return emptyUploadsGate.promise.then(() => {
           return {};
         });
       }
@@ -1318,7 +1323,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const gateResult = await Promise.race([
-      emptyUploadStarted.then(() => {
+      emptyUploadStarted.promise.then(() => {
         return "empty-upload-started" as const;
       }),
       staleInitializerRun.then(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-image-io-generate.test.ts
@@ -12,6 +12,7 @@ import { clearMockNow, mockNow } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { now } from "../../external/time";
+import { createDeferredPromise } from "../../utils";
 import { webhooksBuiltInGenerationRoutes } from "../webhooks-built-in-generations";
 import { zeroBuiltInGenerationRoutes } from "../zero-built-in-generation";
 import { zeroImageIoGenerateRoutes } from "../zero-image-io-generate";
@@ -1020,10 +1021,12 @@ describe("POST /api/zero/image-io/generate", () => {
     );
     mocks.clerk.session(fixture.userId, fixture.orgId);
 
-    let markFalStarted = (): void => {};
-    const falStarted = new Promise<void>((resolve) => {
-      markFalStarted = resolve;
-    });
+    const falStarted = createDeferredPromise<void>(context.signal);
+    const markFalStarted = (): void => {
+      if (!falStarted.settled()) {
+        falStarted.resolve(undefined);
+      }
+    };
     let observedRequestUrl: string | null = null;
 
     server.use(

--- a/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-sync-skills.service.ts
@@ -36,7 +36,7 @@ import {
   listS3ObjectsUnderPrefix,
   putS3Object,
 } from "../external/s3";
-import { settle } from "../utils";
+import { createDeferredPromise, safeSync, settle } from "../utils";
 import type { FileEntryWithHash } from "./storage-content-hash.service";
 
 interface SyncSkillsResult {
@@ -117,62 +117,79 @@ async function fetchHeadCommitSha(signal: AbortSignal): Promise<string> {
   return parseHeadRef(await response.text(), DEFAULT_SKILLS_BRANCH);
 }
 
-function extractSkillsFromTarball(gzipped: Buffer): Promise<ExtractedSkill[]> {
+function extractSkillsFromTarball(
+  gzipped: Buffer,
+  signal: AbortSignal,
+): Promise<ExtractedSkill[]> {
   const decompressed = gunzipSync(gzipped);
   const filesBySkill = new Map<string, ExtractedFile[]>();
+  const deferred = createDeferredPromise<ExtractedSkill[]>(signal);
 
-  return new Promise((resolve, reject) => {
-    const parser = new Parser({
-      onReadEntry: (entry) => {
-        if (entry.type !== "File") {
-          entry.resume();
-          return;
-        }
-
-        const parts = entry.path.split("/");
-        if (parts.length < 3) {
-          entry.resume();
-          return;
-        }
-
-        const skillName = parts[1]!;
-        const relativePath = parts.slice(2).join("/");
-        const chunks: Buffer[] = [];
-        entry.on("data", (chunk: Buffer) => {
-          chunks.push(chunk);
-        });
-        entry.on("end", () => {
-          const content = Buffer.concat(chunks);
-          const hash = createHash("sha256").update(content).digest("hex");
-          const files = filesBySkill.get(skillName) ?? [];
-          files.push({
-            path: relativePath,
-            content,
-            hash,
-            size: content.length,
-          });
-          filesBySkill.set(skillName, files);
-        });
-      },
-    });
-
-    parser.on("end", () => {
-      const extracted: ExtractedSkill[] = [];
-      for (const [skillName, files] of filesBySkill) {
-        if (
-          files.some((file) => {
-            return file.path === "SKILL.md";
-          })
-        ) {
-          extracted.push({ skillName, files });
-        }
+  const parser = new Parser({
+    onReadEntry: (entry) => {
+      if (entry.type !== "File") {
+        entry.resume();
+        return;
       }
-      resolve(extracted);
-    });
-    parser.on("error", reject);
+
+      const parts = entry.path.split("/");
+      if (parts.length < 3) {
+        entry.resume();
+        return;
+      }
+
+      const skillName = parts[1]!;
+      const relativePath = parts.slice(2).join("/");
+      const chunks: Buffer[] = [];
+      entry.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+      entry.on("end", () => {
+        const content = Buffer.concat(chunks);
+        const hash = createHash("sha256").update(content).digest("hex");
+        const files = filesBySkill.get(skillName) ?? [];
+        files.push({
+          path: relativePath,
+          content,
+          hash,
+          size: content.length,
+        });
+        filesBySkill.set(skillName, files);
+      });
+    },
+  });
+
+  parser.on("end", () => {
+    if (deferred.settled()) {
+      return;
+    }
+
+    const extracted: ExtractedSkill[] = [];
+    for (const [skillName, files] of filesBySkill) {
+      if (
+        files.some((file) => {
+          return file.path === "SKILL.md";
+        })
+      ) {
+        extracted.push({ skillName, files });
+      }
+    }
+    deferred.resolve(extracted);
+  });
+  parser.on("error", (error) => {
+    if (!deferred.settled()) {
+      deferred.reject(error);
+    }
+  });
+  const parseResult = safeSync(() => {
     parser.write(decompressed);
     parser.end();
   });
+  if ("error" in parseResult && !deferred.settled()) {
+    deferred.reject(parseResult.error);
+  }
+
+  return deferred.promise;
 }
 
 async function downloadAndExtractSkills(
@@ -185,6 +202,7 @@ async function downloadAndExtractSkills(
 
   return await extractSkillsFromTarball(
     Buffer.from(await response.arrayBuffer()),
+    signal,
   );
 }
 

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -158,10 +158,7 @@ async function assembleZip(
     }
     return await done.promise;
   })();
-  return await Promise.race([
-    done.promise,
-    finalized,
-  ]);
+  return await Promise.race([done.promise, finalized]);
 }
 
 export function submitDiagnosticBundle(

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -20,7 +20,7 @@ import { clerk$ } from "../external/clerk";
 import { getDatasetName, queryAxiom } from "../external/axiom";
 import { generatePresignedGetUrl, putS3Object } from "../external/s3";
 import { db$, type Db } from "../external/db";
-import { settle, tapError } from "../utils";
+import { createDeferredPromise, safeSync, settle, tapError } from "../utils";
 import { zeroConnectorList } from "./zero-connector-data.service";
 import { createPlainSupportThread } from "./plain-support.service";
 import { normalizeRunContextSnapshot } from "./run-context-snapshot.service";
@@ -117,26 +117,51 @@ interface UploadResult {
   readonly expiresAt: string;
 }
 
-async function assembleZip(entries: readonly ZipEntry[]): Promise<Buffer> {
+async function assembleZip(
+  entries: readonly ZipEntry[],
+  signal: AbortSignal,
+): Promise<Buffer> {
   const archive = archiver("zip", { zlib: { level: 6 } });
   const chunks: Buffer[] = [];
+  const done = createDeferredPromise<Buffer>(signal);
 
-  const done = new Promise<Buffer>((resolve, reject) => {
-    archive.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
-    archive.on("end", () => {
-      resolve(Buffer.concat(chunks));
-    });
-    archive.on("error", reject);
+  archive.on("data", (chunk: Buffer) => {
+    chunks.push(chunk);
+  });
+  archive.on("end", () => {
+    if (!done.settled()) {
+      done.resolve(Buffer.concat(chunks));
+    }
+  });
+  archive.on("error", (error) => {
+    if (!done.settled()) {
+      done.reject(error);
+    }
   });
 
-  for (const entry of entries) {
-    archive.append(Buffer.from(entry.content), { name: entry.path });
+  const appendResult = safeSync(() => {
+    for (const entry of entries) {
+      archive.append(Buffer.from(entry.content), { name: entry.path });
+    }
+  });
+  if ("error" in appendResult) {
+    if (!done.settled()) {
+      done.reject(appendResult.error);
+    }
+    return await done.promise;
   }
 
-  await archive.finalize();
-  return done;
+  const finalized = (async () => {
+    const result = await settle(archive.finalize(), signal);
+    if (!result.ok && !done.settled()) {
+      done.reject(result.error);
+    }
+    return await done.promise;
+  })();
+  return await Promise.race([
+    done.promise,
+    finalized,
+  ]);
 }
 
 export function submitDiagnosticBundle(
@@ -421,7 +446,7 @@ function uploadDiagnosticZip(params: {
   readonly reference: string;
 }): Computed<Promise<UploadResult>> {
   return computed(async (get): Promise<UploadResult> => {
-    const zipBuffer = await assembleZip(params.zipEntries);
+    const zipBuffer = await assembleZip(params.zipEntries, AbortSignal.any([]));
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
     const s3Key = `${params.s3PathPrefix}/${params.orgId}/${params.reference}.zip`;
     await get(putS3Object(bucket, s3Key, zipBuffer, "application/zip"));

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -29,7 +29,7 @@ import {
   downloadS3Buffer,
   s3ObjectExists,
 } from "../external/s3";
-import { safeSync, settle } from "../utils";
+import { createDeferredPromise, safeSync, settle } from "../utils";
 import { decryptStoredSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 
@@ -461,26 +461,51 @@ function zipEntryPath(path: string): string {
   return segments.join("/");
 }
 
-async function assembleZip(entries: readonly ZipEntry[]): Promise<Buffer> {
+async function assembleZip(
+  entries: readonly ZipEntry[],
+  signal: AbortSignal,
+): Promise<Buffer> {
   const archive = archiver("zip", { zlib: { level: 6 } });
   const chunks: Buffer[] = [];
+  const done = createDeferredPromise<Buffer>(signal);
 
-  const done = new Promise<Buffer>((resolve, reject) => {
-    archive.on("data", (chunk: Buffer) => {
-      return chunks.push(chunk);
-    });
-    archive.on("end", () => {
-      return resolve(Buffer.concat(chunks));
-    });
-    archive.on("error", reject);
+  archive.on("data", (chunk: Buffer) => {
+    chunks.push(chunk);
+  });
+  archive.on("end", () => {
+    if (!done.settled()) {
+      done.resolve(Buffer.concat(chunks));
+    }
+  });
+  archive.on("error", (error) => {
+    if (!done.settled()) {
+      done.reject(error);
+    }
   });
 
-  for (const entry of entries) {
-    archive.append(entry.content, { name: entry.path });
+  const appendResult = safeSync(() => {
+    for (const entry of entries) {
+      archive.append(entry.content, { name: entry.path });
+    }
+  });
+  if ("error" in appendResult) {
+    if (!done.settled()) {
+      done.reject(appendResult.error);
+    }
+    return await done.promise;
   }
 
-  await archive.finalize();
-  return done;
+  const finalized = (async () => {
+    const result = await settle(archive.finalize(), signal);
+    if (!result.ok && !done.settled()) {
+      done.reject(result.error);
+    }
+    return await done.promise;
+  })();
+  return await Promise.race([
+    done.promise,
+    finalized,
+  ]);
 }
 
 async function loadArtifactFile(
@@ -673,6 +698,7 @@ function resolveHostedArtifactContent(
   db: ReadonlyDb,
   artifact: ArtifactFileRow,
   userId: string,
+  signal: AbortSignal,
 ): Computed<Promise<ResolvedArtifactContent | null>> {
   return computed(async (get): Promise<ResolvedArtifactContent | null> => {
     const metadata = hostedArtifactMetadata(artifact.metadata);
@@ -721,7 +747,7 @@ function resolveHostedArtifactContent(
       }
       return {
         contentType: "application/zip",
-        file: await assembleZip(entries),
+        file: await assembleZip(entries, signal),
         filename: `${deployment.manifest.publicSlug}.zip`,
       };
     }
@@ -1035,7 +1061,7 @@ export const syncArtifactToGoogleDrive$ = command(
     }
 
     const hostedContent = await get(
-      resolveHostedArtifactContent(db, artifact, args.userId),
+      resolveHostedArtifactContent(db, artifact, args.userId, signal),
     );
     signal.throwIfAborted();
     const s3Object = hostedContent

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -502,10 +502,7 @@ async function assembleZip(
     }
     return await done.promise;
   })();
-  return await Promise.race([
-    done.promise,
-    finalized,
-  ]);
+  return await Promise.race([done.promise, finalized]);
 }
 
 async function loadArtifactFile(

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -911,10 +911,7 @@ async function assembleZip(
     }
     return await done.promise;
   })();
-  return await Promise.race([
-    done.promise,
-    finalized,
-  ]);
+  return await Promise.race([done.promise, finalized]);
 }
 
 async function isUserUnsubscribed(db: Db, userId: string): Promise<boolean> {

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -39,7 +39,7 @@ import {
   putS3Object,
 } from "../external/s3";
 import { nowDate } from "../external/time";
-import { settle } from "../utils";
+import { createDeferredPromise, safeSync, settle } from "../utils";
 import {
   normalizeSessionHistoryBlobEncoding,
   resumeSessionHistoryBlobKey,
@@ -865,31 +865,56 @@ async function collectUserData(
   return { zipEntries };
 }
 
-async function assembleZip(entries: readonly ZipEntry[]): Promise<Buffer> {
+async function assembleZip(
+  entries: readonly ZipEntry[],
+  signal: AbortSignal,
+): Promise<Buffer> {
   const archive = archiver("zip", { zlib: { level: 6 } });
   const chunks: Buffer[] = [];
+  const done = createDeferredPromise<Buffer>(signal);
 
-  const done = new Promise<Buffer>((resolve, reject) => {
-    archive.on("data", (chunk: Buffer) => {
-      return chunks.push(chunk);
-    });
-    archive.on("end", () => {
-      return resolve(Buffer.concat(chunks));
-    });
-    archive.on("error", reject);
+  archive.on("data", (chunk: Buffer) => {
+    chunks.push(chunk);
+  });
+  archive.on("end", () => {
+    if (!done.settled()) {
+      done.resolve(Buffer.concat(chunks));
+    }
+  });
+  archive.on("error", (error) => {
+    if (!done.settled()) {
+      done.reject(error);
+    }
   });
 
-  for (const entry of entries) {
-    archive.append(
-      typeof entry.content === "string"
-        ? Buffer.from(entry.content)
-        : entry.content,
-      { name: entry.path },
-    );
+  const appendResult = safeSync(() => {
+    for (const entry of entries) {
+      archive.append(
+        typeof entry.content === "string"
+          ? Buffer.from(entry.content)
+          : entry.content,
+        { name: entry.path },
+      );
+    }
+  });
+  if ("error" in appendResult) {
+    if (!done.settled()) {
+      done.reject(appendResult.error);
+    }
+    return await done.promise;
   }
 
-  await archive.finalize();
-  return done;
+  const finalized = (async () => {
+    const result = await settle(archive.finalize(), signal);
+    if (!result.ok && !done.settled()) {
+      done.reject(result.error);
+    }
+    return await done.promise;
+  })();
+  return await Promise.race([
+    done.promise,
+    finalized,
+  ]);
 }
 
 async function isUserUnsubscribed(db: Db, userId: string): Promise<boolean> {
@@ -1036,7 +1061,7 @@ async function runExportJob(
   );
   runtime.signal.throwIfAborted();
 
-  const zipBuffer = await assembleZip(zipEntries);
+  const zipBuffer = await assembleZip(zipEntries, runtime.signal);
   runtime.signal.throwIfAborted();
 
   const s3Key = `exports/${args.userId}/${args.jobId}.zip`;

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -5,6 +5,7 @@ import { singleton } from "../lib/singleton";
 export enum Mechanism {
   WaitUntil = "wait_until",
   BestEffortCleanup = "best_effort_cleanup",
+  Deferred = "deferred",
 }
 
 const IN_VITEST = env("VITEST") === "true";
@@ -146,6 +147,12 @@ type Settled<T> =
   | { readonly ok: true; readonly value: T }
   | { readonly ok: false; readonly error: unknown };
 
+interface PromiseResolvers<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (reason?: unknown) => void;
+}
+
 /**
  * Settle `p` into a discriminated union. AbortError propagates (re-throws),
  * either from `p` itself or from `signal` if one is passed — so the returned
@@ -195,6 +202,68 @@ export function detach(
       tracker().descriptions.set(promise, description);
     }
   }
+}
+
+export function createDeferredPromise<T>(signal: AbortSignal): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason?: unknown) => void;
+  readonly settled: () => boolean;
+} {
+  const { promise, resolve, reject } = (
+    Promise as PromiseConstructor & {
+      withResolvers<T>(): PromiseResolvers<T>;
+    }
+  ).withResolvers<T>();
+  let settled = false;
+  let removeAbortListener = () => {};
+
+  const settleOnce = (settlePromise: () => void) => {
+    if (settled) {
+      throw new Error("Deferred promise already settled");
+    }
+    settled = true;
+    removeAbortListener();
+    settlePromise();
+  };
+
+  detach(promise, Mechanism.Deferred);
+
+  const guardedResolve = (value: T) => {
+    settleOnce(() => {
+      resolve(value);
+    });
+  };
+
+  const guardedReject = (reason?: unknown) => {
+    settleOnce(() => {
+      reject(reason);
+    });
+  };
+
+  const onAbort = () => {
+    if (!settled) {
+      guardedReject(signal.reason);
+    }
+  };
+
+  if (signal.aborted) {
+    guardedReject(signal.reason);
+  } else {
+    removeAbortListener = () => {
+      signal.removeEventListener("abort", onAbort);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  return {
+    promise,
+    resolve: guardedResolve,
+    reject: guardedReject,
+    settled: () => {
+      return settled;
+    },
+  };
 }
 
 export async function clearAllDetached(): Promise<void> {


### PR DESCRIPTION
## Summary
- add an API `no-new-promise` ESLint rule and enable it for API/custom-eslint sources
- introduce `createDeferredPromise(signal)` in API signal utilities so event/stream wrappers inherit abort semantics and detached-promise tracking
- replace raw `new Promise` wrappers in skill tarball parsing, diagnostic bundle zipping, Google Drive artifact zipping, user export zipping, and API test gates

## Verification
- `pnpm --filter api run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter api exec tsc --noEmit`
- `pnpm --filter api exec vitest run custom-eslint/__tests__/no-new-promise.test.ts`
- `rg -n "new\s+Promise\b" turbo/apps/api/src turbo/apps/api/custom-eslint` only reports the new rule invalid fixture and rule message