### PR TITLE
fix: narrow org-scoped feature switch rollouts

### DIFF
--- a/.claude/skills/feature-switch/SKILL.md
+++ b/.claude/skills/feature-switch/SKILL.md
@@ -152,7 +152,8 @@ Evaluation has two layers (lowest to highest priority):
 2. **DB overrides** — most switches are per-user rows in
    `user_feature_switches` keyed by `(orgId, userId)`. Some switches are
    org-scoped and stored under the org sentinel user id (`__org__`); currently
-   `AgentUnreadIndicators` is org-scoped. Written via the Lab
+   `RelationshipMemory`, `AgentUnreadIndicators`, and
+   `ChatThreadUnifiedSearch` are org-scoped. Written via the Lab
    page toggles or `window._vm0.featureSwitches.myFeature = true` (both call
    `POST /api/zero/feature-switches`). Cleared via the Lab page "Reset all"
    button (`DELETE /api/zero/feature-switches`).

--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -195,7 +195,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
         headers: headersFor(owner),
         body: {
           switches: {
+            [FeatureSwitchKey.RelationshipMemory]: true,
             [FeatureSwitchKey.AgentUnreadIndicators]: true,
+            [FeatureSwitchKey.ChatThreadUnifiedSearch]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
         },
@@ -203,7 +205,13 @@ describe("OPS-01: feature switches and report-error routes", () => {
       [200],
     );
     expect(
+      ownerUpdate.body.switches[FeatureSwitchKey.RelationshipMemory],
+    ).toBeTruthy();
+    expect(
       ownerUpdate.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeTruthy();
+    expect(
+      ownerUpdate.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeTruthy();
     expect(ownerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
 
@@ -212,7 +220,13 @@ describe("OPS-01: feature switches and report-error routes", () => {
       [200],
     );
     expect(
+      peerRead.body.switches[FeatureSwitchKey.RelationshipMemory],
+    ).toBeTruthy();
+    expect(
       peerRead.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeTruthy();
+    expect(
+      peerRead.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeTruthy();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
@@ -221,7 +235,13 @@ describe("OPS-01: feature switches and report-error routes", () => {
       [200],
     );
     expect(
+      outsiderRead.body.switches[FeatureSwitchKey.RelationshipMemory],
+    ).toBeUndefined();
+    expect(
       outsiderRead.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeUndefined();
+    expect(
+      outsiderRead.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeUndefined();
 
     const peerUpdate = await accept(
@@ -229,14 +249,22 @@ describe("OPS-01: feature switches and report-error routes", () => {
         headers: headersFor(peer),
         body: {
           switches: {
+            [FeatureSwitchKey.RelationshipMemory]: false,
             [FeatureSwitchKey.AgentUnreadIndicators]: false,
+            [FeatureSwitchKey.ChatThreadUnifiedSearch]: false,
           },
         },
       }),
       [200],
     );
     expect(
+      peerUpdate.body.switches[FeatureSwitchKey.RelationshipMemory],
+    ).toBeFalsy();
+    expect(
       peerUpdate.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeFalsy();
+    expect(
+      peerUpdate.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeFalsy();
     expect(peerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
@@ -246,7 +274,17 @@ describe("OPS-01: feature switches and report-error routes", () => {
     );
     expect(
       ownerReadAfterPeerUpdate.body.switches[
+        FeatureSwitchKey.RelationshipMemory
+      ],
+    ).toBeFalsy();
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[
         FeatureSwitchKey.AgentUnreadIndicators
+      ],
+    ).toBeFalsy();
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[
+        FeatureSwitchKey.ChatThreadUnifiedSearch
       ],
     ).toBeFalsy();
     expect(
@@ -264,7 +302,15 @@ describe("OPS-01: feature switches and report-error routes", () => {
       [200],
     );
     expect(
+      peerReadAfterDelete.body.switches[FeatureSwitchKey.RelationshipMemory],
+    ).toBeUndefined();
+    expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.AgentUnreadIndicators],
+    ).toBeUndefined();
+    expect(
+      peerReadAfterDelete.body.switches[
+        FeatureSwitchKey.ChatThreadUnifiedSearch
+      ],
     ).toBeUndefined();
     expect(
       peerReadAfterDelete.body.switches[FeatureSwitchKey.Dummy],

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-relationships.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-relationships.test.ts
@@ -230,13 +230,11 @@ async function seedRelationshipFixture(
     { orgId, userId, role: "admin" },
     context.signal,
   );
-  if (!enabled) {
-    await updateFeatureSwitchesForUser(
-      context,
-      { orgId, userId },
-      { [FeatureSwitchKey.RelationshipMemory]: false },
-    );
-  }
+  await updateFeatureSwitchesForUser(
+    context,
+    { orgId, userId },
+    { [FeatureSwitchKey.RelationshipMemory]: enabled },
+  );
   mocks.clerk.session(userId, orgId);
   return { orgId, userId };
 }

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -10,7 +10,9 @@ import { nowDate } from "../external/time";
 const ORG_SENTINEL_USER_ID = "__org__";
 
 const ORG_SCOPED_FEATURE_SWITCH_KEYS: readonly string[] = [
+  FeatureSwitchKey.RelationshipMemory,
   FeatureSwitchKey.AgentUnreadIndicators,
+  FeatureSwitchKey.ChatThreadUnifiedSearch,
 ];
 
 function isOrgScopedFeatureSwitchKey(key: string): boolean {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -153,9 +153,11 @@ describe("getAllFeatureStates", () => {
     );
     expect(otherOrgStates[FeatureSwitchKey.ChatGithubPrTracking]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ChatThreadEmoji]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.RelationshipMemory]).toBe(true);
-    expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
-    expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.RelationshipMemory]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(
+      false,
+    );
+    expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -278,7 +278,8 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show the experimental relationship memory tab in the Memory page for org-user-scoped relationship context.",
-    enabled: true,
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.HtmlArtifactCommentEditing]: {
     maintainer: "bingjie@vm0.ai",
@@ -310,13 +311,15 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     description:
       "Show chat unread indicators in sidebar pinned agent lists and the conversation picker.",
-    enabled: true,
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatThreadUnifiedSearch]: {
     maintainer: "ethan@vm0.ai",
     description:
       "Show chat thread title results from the local event-driven thread cache in the command-shift-a conversation picker.",
-    enabled: true,
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: {
     maintainer: "bingjie@vm0.ai",


### PR DESCRIPTION
## Summary
- Change `relationshipMemory`, `agentUnreadIndicators`, and `chatThreadUnifiedSearch` from globally enabled registry switches to staff-org gated switches.
- Treat all three switches as org-scoped DB overrides stored under the `__org__` sentinel, so Lab/API toggles apply to the whole organization instead of one user.
- Update feature-switch matrix coverage, API org-scoped override coverage, and the feature-switch guide.

## Verification
- `git diff --check`
- `pnpm exec prettier --write ...` on touched TS files
- `pnpm -F @vm0/core test -- src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`

## Notes
- Attempted `pnpm -F api test -- src/signals/routes/__tests__/hooks-ops.bdd.test.ts`; the local runtime had no Postgres available and the BDD command expanded beyond the target file, so it was interrupted after `ECONNREFUSED` database errors. CI should run this in the normal test environment.