### PR TITLE
perf: add storage miss attribution telemetry

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -52,6 +52,14 @@ impl DownloadTask {
         &self.mount_path
     }
 
+    fn is_remote_url(&self) -> bool {
+        self.url.starts_with("http://") || self.url.starts_with("https://")
+    }
+
+    fn is_file_url(&self) -> bool {
+        self.url.starts_with("file://")
+    }
+
     fn failure_detail(&self, error: &DownloadError) -> String {
         format!("{} download failed: {}", self.label, error)
     }
@@ -67,6 +75,16 @@ struct DownloadCompletion {
     outcome: DownloadOutcome,
 }
 
+#[derive(Default)]
+struct DownloadScheduleStats {
+    mount_conflict_deferrals: usize,
+}
+
+struct StartableDownload {
+    selected: Option<(usize, PathBuf)>,
+    mount_conflict_deferrals: usize,
+}
+
 enum DownloadOutcome {
     Finished(bool),
     Panicked(String),
@@ -79,8 +97,38 @@ pub(crate) fn download_all_parallel(tasks: Vec<DownloadTask>) -> bool {
     download_all_parallel_with_runner(tasks, run_download_task)
 }
 
+fn record_download_attribution(tasks: &[DownloadTask]) {
+    record_sandbox_op(
+        guest_download_task_count_action(tasks.len()),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    let remote_urls = tasks.iter().filter(|task| task.is_remote_url()).count();
+    record_sandbox_op(
+        guest_download_remote_url_count_action(remote_urls),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    let file_urls = tasks.iter().filter(|task| task.is_file_url()).count();
+    record_sandbox_op(
+        guest_download_file_url_count_action(file_urls),
+        Duration::ZERO,
+        true,
+        None,
+    );
+}
+
 fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: TaskRunner) -> bool {
+    record_download_attribution(&tasks);
     if tasks.is_empty() {
+        record_sandbox_op(
+            guest_download_mount_conflict_count_action(0),
+            Duration::ZERO,
+            true,
+            None,
+        );
         return true;
     }
 
@@ -91,7 +139,8 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
         MAX_CONCURRENT
     );
 
-    thread::scope(|scope| {
+    let mut stats = DownloadScheduleStats::default();
+    let success = thread::scope(|scope| {
         let (completion_tx, completion_rx) = mpsc::channel();
         let mut pending = VecDeque::from(tasks);
         let mut active = Vec::new();
@@ -105,6 +154,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
             &completion_tx,
             &mut next_id,
             task_runner,
+            &mut stats,
         );
 
         while !active.is_empty() {
@@ -137,11 +187,90 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
                 &completion_tx,
                 &mut next_id,
                 task_runner,
+                &mut stats,
             );
         }
 
         all_success && pending.is_empty()
-    })
+    });
+    record_sandbox_op(
+        guest_download_mount_conflict_count_action(stats.mount_conflict_deferrals),
+        Duration::ZERO,
+        success,
+        None,
+    );
+    success
+}
+
+fn guest_download_task_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_task_count_0",
+        CountBucket::One => "guest_download_task_count_1",
+        CountBucket::Two => "guest_download_task_count_2",
+        CountBucket::ThreeToFour => "guest_download_task_count_3_4",
+        CountBucket::FiveToEight => "guest_download_task_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_task_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_task_count_17_plus",
+    }
+}
+
+fn guest_download_remote_url_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_remote_url_count_0",
+        CountBucket::One => "guest_download_remote_url_count_1",
+        CountBucket::Two => "guest_download_remote_url_count_2",
+        CountBucket::ThreeToFour => "guest_download_remote_url_count_3_4",
+        CountBucket::FiveToEight => "guest_download_remote_url_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_remote_url_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_remote_url_count_17_plus",
+    }
+}
+
+fn guest_download_file_url_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_file_url_count_0",
+        CountBucket::One => "guest_download_file_url_count_1",
+        CountBucket::Two => "guest_download_file_url_count_2",
+        CountBucket::ThreeToFour => "guest_download_file_url_count_3_4",
+        CountBucket::FiveToEight => "guest_download_file_url_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_file_url_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_file_url_count_17_plus",
+    }
+}
+
+fn guest_download_mount_conflict_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_mount_conflict_count_0",
+        CountBucket::One => "guest_download_mount_conflict_count_1",
+        CountBucket::Two => "guest_download_mount_conflict_count_2",
+        CountBucket::ThreeToFour => "guest_download_mount_conflict_count_3_4",
+        CountBucket::FiveToEight => "guest_download_mount_conflict_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_mount_conflict_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_mount_conflict_count_17_plus",
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CountBucket {
+    Zero,
+    One,
+    Two,
+    ThreeToFour,
+    FiveToEight,
+    NineToSixteen,
+    SeventeenPlus,
+}
+
+fn count_bucket(count: usize) -> CountBucket {
+    match count {
+        0 => CountBucket::Zero,
+        1 => CountBucket::One,
+        2 => CountBucket::Two,
+        3 | 4 => CountBucket::ThreeToFour,
+        5..=8 => CountBucket::FiveToEight,
+        9..=16 => CountBucket::NineToSixteen,
+        _ => CountBucket::SeventeenPlus,
+    }
 }
 
 fn start_ready_downloads<'scope, 'env: 'scope>(
@@ -151,9 +280,12 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
     completion_tx: &mpsc::Sender<DownloadCompletion>,
     next_id: &mut usize,
     task_runner: TaskRunner,
+    stats: &mut DownloadScheduleStats,
 ) {
     while active.len() < MAX_CONCURRENT {
-        let Some((index, mount_path)) = find_startable_download(pending, active) else {
+        let startable = find_startable_download(pending, active);
+        stats.mount_conflict_deferrals += startable.mount_conflict_deferrals;
+        let Some((index, mount_path)) = startable.selected else {
             break;
         };
         let Some(task) = pending.remove(index) else {
@@ -178,18 +310,32 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
 fn find_startable_download(
     pending: &VecDeque<DownloadTask>,
     active: &[ActiveDownload],
-) -> Option<(usize, PathBuf)> {
+) -> StartableDownload {
     // Scan the pending queue instead of using strict FIFO so an active
     // parent/child mount-path conflict does not leave a slot idle when a later
     // independent task can start.
-    pending.iter().enumerate().find_map(|(index, task)| {
+    let mut mount_conflict_deferrals = 0;
+    for (index, task) in pending.iter().enumerate() {
         let mount_path = normalize_mount_path(task.mount_path());
         let has_conflict = active.iter().any(|download| {
             mount_paths_conflict(mount_path.as_path(), download.mount_path.as_path())
         });
 
-        (!has_conflict).then_some((index, mount_path))
-    })
+        if has_conflict {
+            mount_conflict_deferrals += 1;
+            continue;
+        }
+
+        return StartableDownload {
+            selected: Some((index, mount_path)),
+            mount_conflict_deferrals,
+        };
+    }
+
+    StartableDownload {
+        selected: None,
+        mount_conflict_deferrals,
+    }
 }
 
 fn normalize_mount_path(path: &str) -> PathBuf {
@@ -370,6 +516,35 @@ mod tests {
         });
 
         assert!(matches!(result, Ok(false)));
+    }
+
+    #[test]
+    fn find_startable_download_counts_mount_conflict_deferrals() {
+        let pending = VecDeque::from(vec![
+            DownloadTask::new(
+                "blocked child".to_owned(),
+                "storage_download",
+                "file:///tmp/archive.tar.gz".to_owned(),
+                "/tmp/mount/child".to_owned(),
+                NotFoundPolicy::Fail,
+            ),
+            DownloadTask::new(
+                "independent".to_owned(),
+                "artifact_download",
+                "https://example.com/archive.tar.gz".to_owned(),
+                "/tmp/other".to_owned(),
+                NotFoundPolicy::Fail,
+            ),
+        ]);
+        let active = vec![ActiveDownload {
+            id: 0,
+            mount_path: normalize_mount_path("/tmp/mount"),
+        }];
+
+        let startable = find_startable_download(&pending, &active);
+
+        assert_eq!(startable.mount_conflict_deferrals, 1);
+        assert_eq!(startable.selected.map(|(index, _)| index), Some(1));
     }
 
     #[test]

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -124,7 +124,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
     record_download_attribution(&tasks);
     if tasks.is_empty() {
         record_sandbox_op(
-            guest_download_mount_conflict_count_action(0),
+            guest_download_mount_conflict_deferral_count_action(0),
             Duration::ZERO,
             true,
             None,
@@ -194,7 +194,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
         all_success && pending.is_empty()
     });
     record_sandbox_op(
-        guest_download_mount_conflict_count_action(stats.mount_conflict_deferrals),
+        guest_download_mount_conflict_deferral_count_action(stats.mount_conflict_deferrals),
         Duration::ZERO,
         true,
         None,
@@ -238,15 +238,15 @@ fn guest_download_file_url_count_action(count: usize) -> &'static str {
     }
 }
 
-fn guest_download_mount_conflict_count_action(count: usize) -> &'static str {
+fn guest_download_mount_conflict_deferral_count_action(count: usize) -> &'static str {
     match count_bucket(count) {
-        CountBucket::Zero => "guest_download_mount_conflict_count_0",
-        CountBucket::One => "guest_download_mount_conflict_count_1",
-        CountBucket::Two => "guest_download_mount_conflict_count_2",
-        CountBucket::ThreeToFour => "guest_download_mount_conflict_count_3_4",
-        CountBucket::FiveToEight => "guest_download_mount_conflict_count_5_8",
-        CountBucket::NineToSixteen => "guest_download_mount_conflict_count_9_16",
-        CountBucket::SeventeenPlus => "guest_download_mount_conflict_count_17_plus",
+        CountBucket::Zero => "guest_download_mount_conflict_deferral_count_0",
+        CountBucket::One => "guest_download_mount_conflict_deferral_count_1",
+        CountBucket::Two => "guest_download_mount_conflict_deferral_count_2",
+        CountBucket::ThreeToFour => "guest_download_mount_conflict_deferral_count_3_4",
+        CountBucket::FiveToEight => "guest_download_mount_conflict_deferral_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_mount_conflict_deferral_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_mount_conflict_deferral_count_17_plus",
     }
 }
 

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -196,7 +196,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
     record_sandbox_op(
         guest_download_mount_conflict_count_action(stats.mount_conflict_deferrals),
         Duration::ZERO,
-        success,
+        true,
         None,
     );
     success

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -113,7 +113,7 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
     assert_action_present(&actions, "guest_download_task_count_0");
     assert_action_present(&actions, "guest_download_remote_url_count_0");
     assert_action_present(&actions, "guest_download_file_url_count_0");
-    assert_action_present(&actions, "guest_download_mount_conflict_count_0");
+    assert_action_present(&actions, "guest_download_mount_conflict_deferral_count_0");
     let totals: Vec<serde_json::Value> = ops_content
         .lines()
         .map(|line| serde_json::from_str(line).unwrap())
@@ -147,7 +147,7 @@ fn binary_reads_manifest_from_stdin() {
     assert_action_present(&actions, "guest_download_task_count_0");
     assert_action_present(&actions, "guest_download_remote_url_count_0");
     assert_action_present(&actions, "guest_download_file_url_count_0");
-    assert_action_present(&actions, "guest_download_mount_conflict_count_0");
+    assert_action_present(&actions, "guest_download_mount_conflict_deferral_count_0");
     let totals: Vec<serde_json::Value> = ops_content
         .lines()
         .map(|line| serde_json::from_str(line).unwrap())
@@ -215,7 +215,7 @@ fn binary_records_download_scheduler_attribution() {
     assert_action_present(&actions, "guest_download_task_count_2");
     assert_action_present(&actions, "guest_download_remote_url_count_1");
     assert_action_present(&actions, "guest_download_file_url_count_1");
-    assert_action_present(&actions, "guest_download_mount_conflict_count_1");
+    assert_action_present(&actions, "guest_download_mount_conflict_deferral_count_1");
     assert_action_present(&actions, "storage_download");
     assert_action_present(&actions, "artifact_download");
     assert_action_present(&actions, "download_total");
@@ -271,7 +271,7 @@ fn binary_records_scheduler_attribution_for_failed_download() {
     let ops = sandbox_ops(&ops_content).unwrap();
     let conflict = ops
         .iter()
-        .find(|entry| entry["action_type"] == "guest_download_mount_conflict_count_1")
+        .find(|entry| entry["action_type"] == "guest_download_mount_conflict_deferral_count_1")
         .unwrap_or_else(|| panic!("missing mount conflict count in {ops:?}"));
     assert_eq!(conflict["success"], true);
     let total = ops

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -46,17 +46,25 @@ fn run_binary_with_manifest_stdin(
     child.wait_with_output()
 }
 
-fn sandbox_op_action_types(content: &str) -> Result<Vec<String>, String> {
+fn sandbox_ops(content: &str) -> Result<Vec<serde_json::Value>, String> {
     content
         .lines()
         .map(|line| {
-            let entry = serde_json::from_str::<serde_json::Value>(line)
-                .map_err(|error| format!("invalid sandbox op JSON {line:?}: {error}"))?;
+            serde_json::from_str::<serde_json::Value>(line)
+                .map_err(|error| format!("invalid sandbox op JSON {line:?}: {error}"))
+        })
+        .collect()
+}
+
+fn sandbox_op_action_types(content: &str) -> Result<Vec<String>, String> {
+    sandbox_ops(content)?
+        .into_iter()
+        .map(|entry| {
             entry
                 .get("action_type")
                 .and_then(serde_json::Value::as_str)
                 .map(str::to_owned)
-                .ok_or_else(|| format!("missing action_type in sandbox op JSON {line:?}"))
+                .ok_or_else(|| format!("missing action_type in sandbox op JSON {entry:?}"))
         })
         .collect()
 }
@@ -211,6 +219,66 @@ fn binary_records_download_scheduler_attribution() {
     assert_action_present(&actions, "storage_download");
     assert_action_present(&actions, "artifact_download");
     assert_action_present(&actions, "download_total");
+}
+
+#[test]
+fn binary_records_scheduler_attribution_for_failed_download() {
+    let server = MockServer::start();
+    let remote_mock = server.mock(|when, then| {
+        when.method(GET).path("/missing.tar.gz");
+        then.status(404);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let local_tar = create_tar_gz(&[("local.txt", b"local")]).unwrap();
+    let local_archive = dir.path().join("local.tar.gz");
+    std::fs::write(&local_archive, local_tar).unwrap();
+    let parent_mount = dir.path().join("mount");
+    let child_mount = parent_mount.join("child");
+    let remote_url = server.url("/missing.tar.gz");
+    let local_url = format!("file://{}", local_archive.display());
+    let manifest = write_manifest(
+        &dir,
+        &[(parent_mount.to_str().unwrap(), Some(&remote_url))],
+        Some((child_mount.to_str().unwrap(), Some(&local_url))),
+    )
+    .unwrap();
+    let run_id = unique_run_id("scheduler-attribution-failure");
+    let logs = RuntimeLogPaths::new(&dir);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest)
+        .env("VM0_RUN_ID", &run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &logs.runtime_dir,
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    remote_mock.assert_calls(1);
+    assert_eq!(
+        std::fs::read_to_string(child_mount.join("local.txt")).unwrap(),
+        "local"
+    );
+
+    let ops_content = std::fs::read_to_string(&logs.ops_log).unwrap();
+    let ops = sandbox_ops(&ops_content).unwrap();
+    let conflict = ops
+        .iter()
+        .find(|entry| entry["action_type"] == "guest_download_mount_conflict_count_1")
+        .unwrap_or_else(|| panic!("missing mount conflict count in {ops:?}"));
+    assert_eq!(conflict["success"], true);
+    let total = ops
+        .iter()
+        .find(|entry| entry["action_type"] == "download_total")
+        .unwrap_or_else(|| panic!("missing download_total in {ops:?}"));
+    assert_eq!(total["success"], false);
 }
 
 #[test]

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -46,6 +46,28 @@ fn run_binary_with_manifest_stdin(
     child.wait_with_output()
 }
 
+fn sandbox_op_action_types(content: &str) -> Result<Vec<String>, String> {
+    content
+        .lines()
+        .map(|line| {
+            let entry = serde_json::from_str::<serde_json::Value>(line)
+                .map_err(|error| format!("invalid sandbox op JSON {line:?}: {error}"))?;
+            entry
+                .get("action_type")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| format!("missing action_type in sandbox op JSON {line:?}"))
+        })
+        .collect()
+}
+
+fn assert_action_present(actions: &[String], expected: &str) {
+    assert!(
+        actions.iter().any(|action| action == expected),
+        "missing {expected} in {actions:?}"
+    );
+}
+
 #[test]
 fn binary_writes_system_log_to_explicit_runtime_path() {
     let dir = tempfile::tempdir().unwrap();
@@ -79,6 +101,11 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("[INFO] [sandbox:download] Download completed"));
     let ops_content = std::fs::read_to_string(&logs.ops_log).unwrap();
+    let actions = sandbox_op_action_types(&ops_content).unwrap();
+    assert_action_present(&actions, "guest_download_task_count_0");
+    assert_action_present(&actions, "guest_download_remote_url_count_0");
+    assert_action_present(&actions, "guest_download_file_url_count_0");
+    assert_action_present(&actions, "guest_download_mount_conflict_count_0");
     let totals: Vec<serde_json::Value> = ops_content
         .lines()
         .map(|line| serde_json::from_str(line).unwrap())
@@ -108,6 +135,11 @@ fn binary_reads_manifest_from_stdin() {
         "unexpected system log: {content:?}"
     );
     let ops_content = std::fs::read_to_string(&logs.ops_log).unwrap();
+    let actions = sandbox_op_action_types(&ops_content).unwrap();
+    assert_action_present(&actions, "guest_download_task_count_0");
+    assert_action_present(&actions, "guest_download_remote_url_count_0");
+    assert_action_present(&actions, "guest_download_file_url_count_0");
+    assert_action_present(&actions, "guest_download_mount_conflict_count_0");
     let totals: Vec<serde_json::Value> = ops_content
         .lines()
         .map(|line| serde_json::from_str(line).unwrap())
@@ -115,6 +147,70 @@ fn binary_reads_manifest_from_stdin() {
         .collect();
     assert_eq!(totals.len(), 1, "unexpected ops log: {ops_content}");
     assert_eq!(totals[0]["success"], true);
+}
+
+#[test]
+fn binary_records_download_scheduler_attribution() {
+    let server = MockServer::start();
+    let remote_tar = create_tar_gz(&[("remote.txt", b"remote")]).unwrap();
+    let remote_mock = server.mock(|when, then| {
+        when.method(GET).path("/remote.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&remote_tar);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let local_tar = create_tar_gz(&[("local.txt", b"local")]).unwrap();
+    let local_archive = dir.path().join("local.tar.gz");
+    std::fs::write(&local_archive, local_tar).unwrap();
+    let parent_mount = dir.path().join("mount");
+    let child_mount = parent_mount.join("child");
+    let remote_url = server.url("/remote.tar.gz");
+    let local_url = format!("file://{}", local_archive.display());
+    let manifest = write_manifest(
+        &dir,
+        &[(parent_mount.to_str().unwrap(), Some(&remote_url))],
+        Some((child_mount.to_str().unwrap(), Some(&local_url))),
+    )
+    .unwrap();
+    let run_id = unique_run_id("scheduler-attribution");
+    let logs = RuntimeLogPaths::new(&dir);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest)
+        .env("VM0_RUN_ID", &run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &logs.runtime_dir,
+        )
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    remote_mock.assert_calls(1);
+    assert_eq!(
+        std::fs::read_to_string(parent_mount.join("remote.txt")).unwrap(),
+        "remote"
+    );
+    assert_eq!(
+        std::fs::read_to_string(child_mount.join("local.txt")).unwrap(),
+        "local"
+    );
+
+    let ops_content = std::fs::read_to_string(&logs.ops_log).unwrap();
+    let actions = sandbox_op_action_types(&ops_content).unwrap();
+    assert_action_present(&actions, "guest_download_task_count_2");
+    assert_action_present(&actions, "guest_download_remote_url_count_1");
+    assert_action_present(&actions, "guest_download_file_url_count_1");
+    assert_action_present(&actions, "guest_download_mount_conflict_count_1");
+    assert_action_present(&actions, "storage_download");
+    assert_action_present(&actions, "artifact_download");
+    assert_action_present(&actions, "download_total");
 }
 
 #[test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -3267,6 +3267,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn background_fill_preserves_retryable_skipped_outcome() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let group = CacheTargetGroup {
+            targets: vec![CacheTarget {
+                kind: TargetKind::Storage,
+                index: 0,
+                name: "background-retryable".to_string(),
+                version: "v1".to_string(),
+                archive_url: "http://127.0.0.1:9/archive.tar.gz".to_string(),
+            }],
+        };
+        let http = Client::builder().build().unwrap();
+
+        let outcome = process_group_background_fill(&group, &http, &home)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, BackgroundFillOutcome::RetryableSkipped));
+    }
+
+    #[tokio::test]
     async fn guarded_missing_archive_with_existing_lock_removes_orphan_lock() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -1056,13 +1056,20 @@ async fn process_group_background_fill(
     http: &Client,
     home: &HomePaths,
 ) -> RunnerResult<BackgroundFillOutcome> {
+    let mut saw_retryable_skipped = false;
     for target in &group.targets {
         match process_one_background_fill(target, http, home).await? {
-            BackgroundFillOutcome::RetryableSkipped => {}
+            BackgroundFillOutcome::RetryableSkipped => {
+                saw_retryable_skipped = true;
+            }
             outcome => return Ok(outcome),
         }
     }
-    Ok(BackgroundFillOutcome::Skipped)
+    if saw_retryable_skipped {
+        Ok(BackgroundFillOutcome::RetryableSkipped)
+    } else {
+        Ok(BackgroundFillOutcome::Skipped)
+    }
 }
 
 async fn process_group_hit_or_passthrough(
@@ -3209,6 +3216,17 @@ mod tests {
         .into_records();
         assert_eq!(busy.len(), 1);
         assert_eq!(busy[0].action_type, STORAGE_CACHE_BACKGROUND_FILL_BUSY);
+
+        let retryable_skipped = BackgroundFillReport::from_outcome(
+            BackgroundFillOutcome::RetryableSkipped,
+            Duration::from_millis(6),
+        )
+        .into_records();
+        assert_eq!(retryable_skipped.len(), 1);
+        assert_eq!(
+            retryable_skipped[0].action_type,
+            STORAGE_CACHE_BACKGROUND_FILL_RETRYABLE_SKIPPED
+        );
 
         let failed = BackgroundFillReport::failed(Duration::from_millis(7)).into_records();
         assert_eq!(failed.len(), 1);

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -45,7 +45,7 @@ use tracing::{info, warn};
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::paths::{HomePaths, short_digest, touch_mtime};
-use crate::telemetry::JobTelemetry;
+use crate::telemetry::{JobTelemetry, SandboxOpRecord, SandboxOpReporter};
 use crate::types::GuestDownloadManifest;
 
 /// Archive sizes strictly larger than this are passthrough.
@@ -81,6 +81,15 @@ const STORAGE_CACHE_LOCK_WAIT_FAILED: &str = "storage-cache-lock-wait-failed";
 const STORAGE_CACHE_HIT_READ: &str = "storage_cache_hit_read";
 const STORAGE_CACHE_MISS_PASSTHROUGH: &str = "storage_cache_miss_passthrough";
 const STORAGE_CACHE_LOCK_BUSY_PASSTHROUGH: &str = "storage_cache_lock_busy_passthrough";
+const STORAGE_CACHE_BACKGROUND_FILL_FILLED: &str = "storage_cache_background_fill_filled";
+const STORAGE_CACHE_BACKGROUND_FILL_ALREADY_CACHED: &str =
+    "storage_cache_background_fill_already_cached";
+const STORAGE_CACHE_BACKGROUND_FILL_BUSY: &str = "storage_cache_background_fill_busy";
+const STORAGE_CACHE_BACKGROUND_FILL_RETRYABLE_SKIPPED: &str =
+    "storage_cache_background_fill_retryable_skipped";
+const STORAGE_CACHE_BACKGROUND_FILL_SKIPPED: &str = "storage_cache_background_fill_skipped";
+const STORAGE_CACHE_BACKGROUND_FILL_FAILED: &str = "storage_cache_background_fill_failed";
+const STORAGE_CACHE_BACKGROUND_FILL_FAILED_ERROR: &str = "background-fill-failed";
 
 /// Guest-side filename for a cached archive.
 ///
@@ -255,11 +264,65 @@ enum CacheFetchOutcome {
 }
 
 enum BackgroundFillOutcome {
-    Filled,
-    AlreadyCached,
+    Filled { size: u64 },
+    AlreadyCached { size: u64 },
     Busy,
     Skipped,
     RetryableSkipped,
+}
+
+struct BackgroundFillReport {
+    outcome: SandboxOpRecord,
+    size_bucket: Option<SandboxOpRecord>,
+}
+
+impl BackgroundFillReport {
+    fn from_outcome(outcome: BackgroundFillOutcome, duration: Duration) -> Self {
+        let (action_type, size) = match outcome {
+            BackgroundFillOutcome::Filled { size } => {
+                (STORAGE_CACHE_BACKGROUND_FILL_FILLED, Some(size))
+            }
+            BackgroundFillOutcome::AlreadyCached { size } => {
+                (STORAGE_CACHE_BACKGROUND_FILL_ALREADY_CACHED, Some(size))
+            }
+            BackgroundFillOutcome::Busy => (STORAGE_CACHE_BACKGROUND_FILL_BUSY, None),
+            BackgroundFillOutcome::RetryableSkipped => {
+                (STORAGE_CACHE_BACKGROUND_FILL_RETRYABLE_SKIPPED, None)
+            }
+            BackgroundFillOutcome::Skipped => (STORAGE_CACHE_BACKGROUND_FILL_SKIPPED, None),
+        };
+        Self {
+            outcome: SandboxOpRecord::new(action_type, duration, true, None),
+            size_bucket: size.map(|size| {
+                SandboxOpRecord::new(
+                    background_fill_size_bucket_action(size),
+                    Duration::ZERO,
+                    true,
+                    None,
+                )
+            }),
+        }
+    }
+
+    fn failed(duration: Duration) -> Self {
+        Self {
+            outcome: SandboxOpRecord::new(
+                STORAGE_CACHE_BACKGROUND_FILL_FAILED,
+                duration,
+                false,
+                Some(STORAGE_CACHE_BACKGROUND_FILL_FAILED_ERROR),
+            ),
+            size_bucket: None,
+        }
+    }
+
+    fn into_records(self) -> Vec<SandboxOpRecord> {
+        let mut records = vec![self.outcome];
+        if let Some(size_bucket) = self.size_bucket {
+            records.push(size_bucket);
+        }
+        records
+    }
 }
 
 #[derive(Default)]
@@ -745,7 +808,7 @@ async fn populate_cache_with_mode(
     if mode.uses_hit_or_passthrough() {
         record_passthrough_summary(&outcomes, telemetry);
         if mode.schedules_background_fill() {
-            spawn_background_fill_groups(&outcomes, home.clone());
+            spawn_background_fill_groups(&outcomes, home.clone(), telemetry);
         }
     }
     for (group, outcome) in outcomes {
@@ -754,7 +817,11 @@ async fn populate_cache_with_mode(
     Ok(())
 }
 
-fn spawn_background_fill_groups(outcomes: &[(CacheTargetGroup, GroupOutcome)], home: HomePaths) {
+fn spawn_background_fill_groups(
+    outcomes: &[(CacheTargetGroup, GroupOutcome)],
+    home: HomePaths,
+    telemetry: &mut JobTelemetry,
+) {
     let groups = outcomes
         .iter()
         .filter(|(_, outcome)| should_background_fill(outcome))
@@ -764,8 +831,15 @@ fn spawn_background_fill_groups(outcomes: &[(CacheTargetGroup, GroupOutcome)], h
         return;
     }
 
+    telemetry.record(
+        background_fill_scheduled_count_action(groups.len()),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    let reporter = telemetry.reporter();
     tokio::spawn(async move {
-        run_background_fill_groups(groups, home).await;
+        run_background_fill_groups(groups, home, reporter).await;
     });
 }
 
@@ -781,50 +855,70 @@ fn should_background_fill(outcome: &GroupOutcome) -> bool {
     }
 }
 
-async fn run_background_fill_groups(groups: Vec<CacheTargetGroup>, home: HomePaths) {
+async fn run_background_fill_groups(
+    groups: Vec<CacheTargetGroup>,
+    home: HomePaths,
+    reporter: SandboxOpReporter,
+) {
     let http = match Client::builder().build() {
         Ok(http) => http,
         Err(error) => {
             warn!(%error, "storage_cache: failed to build background fill http client");
+            let records = (0..groups.len())
+                .map(|_| {
+                    SandboxOpRecord::new(
+                        STORAGE_CACHE_BACKGROUND_FILL_FAILED,
+                        Duration::ZERO,
+                        false,
+                        Some(STORAGE_CACHE_BACKGROUND_FILL_FAILED_ERROR),
+                    )
+                })
+                .collect();
+            reporter.report(records).await;
             return;
         }
     };
 
     let mut fills = JoinSet::new();
+    let mut reports = Vec::new();
     for group in groups {
         while fills.len() >= CONCURRENCY {
-            join_next_background_fill(&mut fills).await;
+            if let Some(report) = join_next_background_fill(&mut fills).await {
+                reports.extend(report.into_records());
+            }
         }
 
         let http = http.clone();
         let home = home.clone();
         fills.spawn(async move {
-            let Some(first_target) = group.targets.first() else {
-                return;
-            };
-            let name = first_target.name.clone();
-            let version = first_target.version.clone();
-            if let Err(error) = process_group_background_fill(&group, &http, &home).await {
-                warn!(
-                    %error,
-                    vas_storage_name = name,
-                    vas_version_id = version,
-                    "storage_cache: background fill failed"
-                );
+            let started_at = Instant::now();
+            match process_group_background_fill(&group, &http, &home).await {
+                Ok(outcome) => BackgroundFillReport::from_outcome(outcome, started_at.elapsed()),
+                Err(error) => {
+                    warn!(%error, "storage_cache: background fill failed");
+                    BackgroundFillReport::failed(started_at.elapsed())
+                }
             }
         });
     }
 
     while !fills.is_empty() {
-        join_next_background_fill(&mut fills).await;
+        if let Some(report) = join_next_background_fill(&mut fills).await {
+            reports.extend(report.into_records());
+        }
     }
+    reporter.report(reports).await;
 }
 
-async fn join_next_background_fill(fills: &mut JoinSet<()>) {
+async fn join_next_background_fill(
+    fills: &mut JoinSet<BackgroundFillReport>,
+) -> Option<BackgroundFillReport> {
     match fills.join_next().await {
-        Some(Ok(())) | None => {}
+        Some(Ok(report)) => Some(report),
+        None => None,
         Some(Err(error)) => {
             warn!(%error, "storage_cache: background fill task failed");
+            Some(BackgroundFillReport::failed(Duration::ZERO))
         }
     }
 }
@@ -1102,9 +1196,10 @@ async fn process_one_background_fill(
             evict_empty_cache(target, &cache_dir).await?;
         }
         Ok(metadata) if metadata.len() <= CACHE_MAX_SIZE => {
+            let size = metadata.len();
             touch_mtime(&cache_dir);
             drop(writer);
-            return Ok(BackgroundFillOutcome::AlreadyCached);
+            return Ok(BackgroundFillOutcome::AlreadyCached { size });
         }
         Ok(metadata) => {
             evict_oversized_cache(target, &cache_dir, metadata.len()).await?;
@@ -1124,8 +1219,9 @@ async fn process_one_background_fill(
             download_duration,
         } => {
             let _ = download_duration;
+            let size = bytes.len() as u64;
             write_to_cache(&cache_dir, &bytes).await?;
-            BackgroundFillOutcome::Filled
+            BackgroundFillOutcome::Filled { size }
         }
         CacheFetchOutcome::Skipped(TargetOutcome::SkippedHeadFailed { .. })
         | CacheFetchOutcome::Skipped(TargetOutcome::SkippedInvalidDownload { .. }) => {
@@ -2196,6 +2292,34 @@ fn passthrough_lock_busy_count_action(count: usize) -> &'static str {
     }
 }
 
+fn background_fill_scheduled_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "storage_cache_background_fill_scheduled_count_0",
+        CountBucket::One => "storage_cache_background_fill_scheduled_count_1",
+        CountBucket::Two => "storage_cache_background_fill_scheduled_count_2",
+        CountBucket::ThreeToFour => "storage_cache_background_fill_scheduled_count_3_4",
+        CountBucket::FiveToEight => "storage_cache_background_fill_scheduled_count_5_8",
+        CountBucket::NineToSixteen => "storage_cache_background_fill_scheduled_count_9_16",
+        CountBucket::SeventeenPlus => "storage_cache_background_fill_scheduled_count_17_plus",
+    }
+}
+
+fn background_fill_size_bucket_action(size: u64) -> &'static str {
+    if size < 64 * 1024 {
+        "storage_cache_background_fill_size_lt_64_kib"
+    } else if size < 256 * 1024 {
+        "storage_cache_background_fill_size_64_256_kib"
+    } else if size < 1024 * 1024 {
+        "storage_cache_background_fill_size_256_kib_1_mib"
+    } else if size < 4 * 1024 * 1024 {
+        "storage_cache_background_fill_size_1_4_mib"
+    } else if size <= CACHE_MAX_SIZE {
+        "storage_cache_background_fill_size_4_8_mib"
+    } else {
+        "storage_cache_background_fill_size_gt_8_mib"
+    }
+}
+
 #[derive(Clone, Copy)]
 enum CountBucket {
     Zero,
@@ -2301,8 +2425,12 @@ mod tests {
     };
 
     fn new_telemetry() -> JobTelemetry {
+        new_telemetry_for_api_url("http://localhost:0")
+    }
+
+    fn new_telemetry_for_api_url(api_url: &str) -> JobTelemetry {
         let http = HttpClient::new(HttpClientConfig {
-            api_url: "http://localhost:0".to_string(),
+            api_url: api_url.to_string(),
             vercel_bypass: None,
         })
         .unwrap();
@@ -2630,6 +2758,50 @@ mod tests {
             .expect("raw HTTP sequence server should not fail");
     }
 
+    fn http_headers_end(buf: &[u8]) -> Option<usize> {
+        buf.windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|index| index + 4)
+    }
+
+    fn content_length(headers: &str) -> usize {
+        headers
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find_map(|(name, value)| {
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().unwrap())
+            })
+            .unwrap_or(0)
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt as _;
+
+        let mut buf = Vec::new();
+        let header_end = loop {
+            let mut chunk = [0; 1024];
+            let len = socket.read(&mut chunk).await.unwrap();
+            assert!(len > 0, "connection closed before HTTP headers completed");
+            buf.extend_from_slice(&chunk[..len]);
+
+            if let Some(header_end) = http_headers_end(&buf) {
+                break header_end;
+            }
+        };
+
+        let headers = String::from_utf8_lossy(&buf[..header_end]);
+        let body_len = content_length(&headers);
+        while buf.len() < header_end + body_len {
+            let mut chunk = [0; 1024];
+            let len = socket.read(&mut chunk).await.unwrap();
+            assert!(len > 0, "connection closed before HTTP body completed");
+            buf.extend_from_slice(&chunk[..len]);
+        }
+
+        String::from_utf8(buf).unwrap()
+    }
+
     async fn wait_cached_archive(home: &HomePaths, name: &str, version: &str) -> Vec<u8> {
         let lock_path = home.storage_lock(name, version);
         let path = home.storage_cache_dir(name, version).join("archive.tar.gz");
@@ -2944,8 +3116,108 @@ mod tests {
 
         let ops = telemetry.pending_ops_snapshot();
         assert_op_error(&ops, STORAGE_CACHE_MISS_PASSTHROUGH, "missing");
+        assert_op(
+            &ops,
+            "storage_cache_background_fill_scheduled_count_1",
+            true,
+        );
         assert_no_op(&ops, "storage_cache_miss");
         assert_no_op(&ops, "storage_cache_download");
+    }
+
+    #[tokio::test]
+    async fn background_fill_reports_filled_outcome_batch() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let body = tarball_bytes();
+        let (archive_url, archive_server) = raw_http_sequence_url(vec![
+            partial_content_response(body.len()),
+            ok_response(&body),
+        ])
+        .await;
+        let telemetry_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let telemetry_api_url = format!("http://{}", telemetry_listener.local_addr().unwrap());
+        let telemetry_server = tokio::spawn(async move {
+            let (mut socket, _) = telemetry_listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            socket
+                .write_all(
+                    concat!(
+                        "HTTP/1.1 200 OK\r\n",
+                        "content-length: 16\r\n",
+                        "content-type: application/json\r\n",
+                        "connection: close\r\n",
+                        "\r\n",
+                        r#"{"success":true}"#
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            request
+        });
+        let reporter = new_telemetry_for_api_url(&telemetry_api_url).reporter();
+        let name = "background-report";
+        let version = "v1";
+        let group = CacheTargetGroup {
+            targets: vec![CacheTarget {
+                kind: TargetKind::Storage,
+                index: 0,
+                name: name.to_string(),
+                version: version.to_string(),
+                archive_url,
+            }],
+        };
+
+        run_background_fill_groups(vec![group], home.clone(), reporter).await;
+
+        await_raw_http_sequence(archive_server).await;
+        assert_eq!(wait_cached_archive(&home, name, version).await, body);
+        let request = tokio::time::timeout(Duration::from_secs(1), telemetry_server)
+            .await
+            .expect("telemetry server should receive background fill payload")
+            .unwrap();
+        assert!(request.contains(r#""action_type":"storage_cache_background_fill_filled""#));
+        assert!(
+            request.contains(r#""action_type":"storage_cache_background_fill_size_lt_64_kib""#)
+        );
+        assert!(!request.contains(name));
+        assert!(!request.contains(version));
+        assert!(!request.contains("archive.tar.gz"));
+    }
+
+    #[test]
+    fn background_fill_report_uses_fixed_outcome_and_size_actions() {
+        let filled = BackgroundFillReport::from_outcome(
+            BackgroundFillOutcome::Filled { size: 70 * 1024 },
+            Duration::from_millis(12),
+        )
+        .into_records();
+        assert_eq!(filled.len(), 2);
+        assert_eq!(filled[0].action_type, STORAGE_CACHE_BACKGROUND_FILL_FILLED);
+        assert_eq!(filled[0].duration, Duration::from_millis(12));
+        assert!(filled[0].success);
+        assert_eq!(
+            filled[1].action_type,
+            "storage_cache_background_fill_size_64_256_kib"
+        );
+
+        let busy = BackgroundFillReport::from_outcome(
+            BackgroundFillOutcome::Busy,
+            Duration::from_millis(5),
+        )
+        .into_records();
+        assert_eq!(busy.len(), 1);
+        assert_eq!(busy[0].action_type, STORAGE_CACHE_BACKGROUND_FILL_BUSY);
+
+        let failed = BackgroundFillReport::failed(Duration::from_millis(7)).into_records();
+        assert_eq!(failed.len(), 1);
+        assert_eq!(failed[0].action_type, STORAGE_CACHE_BACKGROUND_FILL_FAILED);
+        assert!(!failed[0].success);
+        assert_eq!(
+            failed[0].error,
+            Some(STORAGE_CACHE_BACKGROUND_FILL_FAILED_ERROR)
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -150,6 +150,14 @@ impl JobTelemetry {
         );
     }
 
+    pub(crate) fn reporter(&self) -> SandboxOpReporter {
+        SandboxOpReporter {
+            http: self.http.clone(),
+            run_id: self.run_id,
+            sandbox_token: self.sandbox_token.clone(),
+        }
+    }
+
     fn record_inner(
         &mut self,
         action_type: &str,
@@ -159,23 +167,14 @@ impl JobTelemetry {
         encoding: Option<&'static str>,
         metadata: Option<SessionHistoryTelemetryMetadata>,
     ) {
-        self.pending_ops.push(SandboxOp {
-            ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-            action_type: action_type.to_string(),
-            duration_ms: duration_ms(duration),
+        self.pending_ops.push(sandbox_op(
+            action_type,
+            duration,
             success,
-            error: error.map(String::from),
-            encoding: encoding.map(String::from),
-            session_history_raw_size_bucket: metadata
-                .map(SessionHistoryTelemetryMetadata::raw_size_bucket)
-                .map(String::from),
-            session_history_encoded_size_bucket: metadata
-                .map(SessionHistoryTelemetryMetadata::encoded_size_bucket)
-                .map(String::from),
-            session_history_compression_ratio_bucket: metadata
-                .map(SessionHistoryTelemetryMetadata::compression_ratio_bucket)
-                .map(String::from),
-        });
+            error,
+            encoding,
+            metadata,
+        ));
         if self.oldest_pending.is_none() {
             self.oldest_pending = Some(Instant::now());
         }
@@ -277,6 +276,56 @@ impl JobTelemetry {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct SandboxOpReporter {
+    http: HttpClient,
+    run_id: RunId,
+    sandbox_token: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SandboxOpRecord {
+    pub(crate) action_type: &'static str,
+    pub(crate) duration: Duration,
+    pub(crate) success: bool,
+    pub(crate) error: Option<&'static str>,
+}
+
+impl SandboxOpRecord {
+    pub(crate) const fn new(
+        action_type: &'static str,
+        duration: Duration,
+        success: bool,
+        error: Option<&'static str>,
+    ) -> Self {
+        Self {
+            action_type,
+            duration,
+            success,
+            error,
+        }
+    }
+}
+
+impl SandboxOpReporter {
+    pub(crate) async fn report(&self, records: Vec<SandboxOpRecord>) {
+        let ops = records
+            .into_iter()
+            .map(|record| {
+                sandbox_op(
+                    record.action_type,
+                    record.duration,
+                    record.success,
+                    record.error,
+                    None,
+                    None,
+                )
+            })
+            .collect();
+        send_telemetry(&self.http, self.run_id, &self.sandbox_token, ops).await;
+    }
+}
+
 #[cfg(test)]
 type SessionHistoryTelemetrySnapshot = (
     String,
@@ -287,6 +336,33 @@ type SessionHistoryTelemetrySnapshot = (
     Option<String>,
     Option<String>,
 );
+
+fn sandbox_op(
+    action_type: &str,
+    duration: Duration,
+    success: bool,
+    error: Option<&str>,
+    encoding: Option<&'static str>,
+    metadata: Option<SessionHistoryTelemetryMetadata>,
+) -> SandboxOp {
+    SandboxOp {
+        ts: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        action_type: action_type.to_string(),
+        duration_ms: duration_ms(duration),
+        success,
+        error: error.map(String::from),
+        encoding: encoding.map(String::from),
+        session_history_raw_size_bucket: metadata
+            .map(SessionHistoryTelemetryMetadata::raw_size_bucket)
+            .map(String::from),
+        session_history_encoded_size_bucket: metadata
+            .map(SessionHistoryTelemetryMetadata::encoded_size_bucket)
+            .map(String::from),
+        session_history_compression_ratio_bucket: metadata
+            .map(SessionHistoryTelemetryMetadata::compression_ratio_bucket)
+            .map(String::from),
+    }
+}
 
 const fn session_history_encoding_value(encoding: ResumeSessionHistoryEncoding) -> &'static str {
     match encoding {
@@ -676,5 +752,63 @@ mod tests {
             .await
             .expect("server should exit")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn detached_reporter_sends_sandbox_operations_payload() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let request = read_http_request(&mut socket).await;
+            socket
+                .write_all(
+                    concat!(
+                        "HTTP/1.1 200 OK\r\n",
+                        "content-length: 16\r\n",
+                        "content-type: application/json\r\n",
+                        "connection: close\r\n",
+                        "\r\n",
+                        r#"{"success":true}"#
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            request
+        });
+
+        let telemetry = JobTelemetry::new(
+            http_client_for_api_url(&api_url),
+            RunId::nil(),
+            "tok".to_string(),
+        );
+        let reporter = telemetry.reporter();
+
+        reporter
+            .report(vec![SandboxOpRecord::new(
+                "storage_cache_background_fill_filled",
+                Duration::from_millis(42),
+                true,
+                None,
+            )])
+            .await;
+
+        let request = tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server should receive reporter request")
+            .unwrap();
+        assert!(request.starts_with("POST /api/webhooks/agent/telemetry "));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer tok")
+        );
+        assert!(request.contains(r#""runId":"00000000-0000-0000-0000-000000000000""#));
+        assert!(request.contains(r#""action_type":"storage_cache_background_fill_filled""#));
+        assert!(request.contains(r#""duration_ms":42"#));
+        assert!(request.contains(r#""success":true"#));
     }
 }


### PR DESCRIPTION
## Summary

- Add a cloneable runner sandbox-operation reporter for detached background fill telemetry.
- Record storage-cache background fill scheduled-count, outcome, and filled/already-cached size buckets with fixed low-cardinality `action_type` values.
- Record guest-download task-count, remote URL count, local `file://` URL count, and mount-conflict deferral buckets without changing scheduling or concurrency.

## Scope

This is attribution-only for #20173. It does not change current-run storage miss passthrough behavior, does not add a bounded warmer, does not change `MAX_CONCURRENT`, and does not expand `/api/webhooks/agent/telemetry` schema fields.

## Post-Deploy Checks

- Compare `artifact + storage_miss` executor / guest-download / `download_total` cohorts before and after deploy.
- Compare `storage_cache_background_fill_scheduled_count_*` against filled / already-cached / busy / skipped / failed outcome rows.
- Compare miss counts after warmup against background filled counts to decide whether misses are repeated and warmable.
- Compare `guest_download_mount_conflict_deferral_count_*` with slow `download_total` cohorts to see whether mount serialization explains tail latency.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner storage_cache`
- `cargo test --manifest-path crates/Cargo.toml -p runner telemetry`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets --all-features -- -D warnings`

Closes #20173