### PR TITLE
Fix mobile composer tap target height

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -764,10 +764,10 @@ describe("chat composer models", () => {
     const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
     expect(textarea).toHaveAttribute("rows", "3");
     expect(textarea).toHaveClass("min-h-[96px]");
-    expect(textarea).not.toHaveClass("min-h-[44px]");
+    expect(textarea).not.toHaveClass("min-h-[72px]");
   });
 
-  it("uses the mobile single-line height in chat thread composers", async () => {
+  it("uses a larger mobile tap target in chat thread composers", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();
     mockThread();
@@ -780,7 +780,7 @@ describe("chat composer models", () => {
 
     const textarea = await screen.findByPlaceholderText(PLACEHOLDER);
     expect(textarea).toHaveAttribute("rows", "1");
-    expect(textarea).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
+    expect(textarea).toHaveClass("min-h-[72px]", "md:min-h-[96px]");
   });
 
   it("keeps the agent chat slash composer at three-line height", async () => {
@@ -800,10 +800,10 @@ describe("chat composer models", () => {
 
     const editor = await findComposerEditor();
     expect(editor).toHaveClass("min-h-[96px]");
-    expect(editor).not.toHaveClass("min-h-[44px]");
+    expect(editor).not.toHaveClass("min-h-[72px]");
   });
 
-  it("uses the mobile single-line height in chat thread slash composers", async () => {
+  it("uses a larger mobile tap target in chat thread slash composers", async () => {
     mockOrgModelRoutes("kimi-k2.7-code");
     mockAgent();
     mockThread();
@@ -820,7 +820,7 @@ describe("chat composer models", () => {
     });
 
     const editor = await findComposerEditor();
-    expect(editor).toHaveClass("min-h-[44px]", "md:min-h-[96px]");
+    expect(editor).toHaveClass("min-h-[72px]", "md:min-h-[96px]");
   });
 
   it("suggests current agent workflows from slash input and highlights inserted workflow tokens", async () => {

--- a/turbo/apps/platform/src/views/zero-page/composer-input-layout.ts
+++ b/turbo/apps/platform/src/views/zero-page/composer-input-layout.ts
@@ -1,0 +1,5 @@
+export function composerInputMinHeightClass(
+  singleLineOnMobile: boolean,
+): string {
+  return singleLineOnMobile ? "min-h-[72px] md:min-h-[96px]" : "min-h-[96px]";
+}

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -36,6 +36,7 @@ import {
   type SlashWorkflowRange,
 } from "./slash-workflow.tsx";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
+import { composerInputMinHeightClass } from "./composer-input-layout.ts";
 
 // Match the textarea metrics so swapping inputs is visually seamless. The editor
 // element itself scrolls (single layer), so there is no overlay to sync. The
@@ -47,13 +48,8 @@ const EDITOR_CONTENT_CLASS =
   "caret-foreground outline-none focus:outline-none [&_p]:m-0 " +
   "selection:bg-primary/20";
 
-// Resting height: a single line on mobile (below the md breakpoint) when the
-// switch is on, otherwise the three-line desktop height on every viewport. This
-// mirrors the textarea composer in zero-chat-composer.tsx.
 function editorContentClass(singleLineOnMobile: boolean): string {
-  return singleLineOnMobile
-    ? `${EDITOR_CONTENT_CLASS} min-h-[44px] md:min-h-[96px]`
-    : `${EDITOR_CONTENT_CLASS} min-h-[96px]`;
+  return `${EDITOR_CONTENT_CLASS} ${composerInputMinHeightClass(singleLineOnMobile)}`;
 }
 
 const WORKFLOW_HIGHLIGHT_CLASS = "text-primary";
@@ -621,7 +617,7 @@ export function TiptapWorkflowComposer({
     <Popover open={showSlashWorkflowMenu}>
       <SlashCaretAnchor editor={editor} slashRange={slashRange} />
       <div
-        className={`relative ${singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]"}`}
+        className={`relative ${composerInputMinHeightClass(singleLineOnMobile)}`}
       >
         {input === "" && (
           <div

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -106,6 +106,7 @@ import { AttachmentChips } from "./zero-attachment-chips.tsx";
 import { TiptapWorkflowComposer } from "./tiptap-workflow-composer.tsx";
 import { computerUseIllustrationImg } from "./platform-assets.ts";
 import type { ComposerPasteEvent } from "./composer-input-types.ts";
+import { composerInputMinHeightClass } from "./composer-input-layout.ts";
 import {
   parsePresentationEditDraft,
   previewPresentationHtml,
@@ -6202,10 +6203,7 @@ function ComposerTextarea({
       }}
       className={cn(
         "relative z-10 w-full resize-none bg-transparent px-4 pt-4 pb-0 text-[0.9375rem] leading-6 text-foreground caret-foreground placeholder:text-muted-foreground/40 border-0 focus:outline-none focus:ring-0 selection:bg-primary/20",
-        // The resting height is floored by min-height; rows is kept at 1 so the
-        // floor governs. Mobile rests at a single line and grows back to the
-        // three-line desktop height from the md breakpoint up.
-        singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]",
+        composerInputMinHeightClass(singleLineOnMobile),
       )}
       rows={singleLineOnMobile ? 1 : 3}
       placeholder={
@@ -6278,7 +6276,7 @@ function ComposerInputSlot({
     <div
       className={cn(
         "relative",
-        singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]",
+        composerInputMinHeightClass(singleLineOnMobile),
       )}
     >
       <ComposerTextarea


### PR DESCRIPTION
## Summary
- Increase the mobile chat thread composer input tap target from 44px to 72px while keeping the desktop three-line height unchanged.
- Share the composer input min-height class between the textarea composer and the TipTap workflow composer so both feature-switch paths match.
- Update composer height tests to assert the larger mobile tap target.

## Verification
- `git diff --check`
- `pnpm exec prettier --write apps/platform/src/views/zero-page/composer-input-layout.ts apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`

Targeted Vitest for `chat-composer-models-and-templates.test.tsx` was attempted, but the fresh runtime produced no progress output after an extended wait and was interrupted; PR CI should run the suite.