### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -116,7 +116,7 @@ CODEX_CLI_VERSION="0.142.5"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"
 AGENT_BROWSER_VERSION="0.31.1"
-PNPM_VERSION="11.9.0"
+PNPM_VERSION="11.10.0"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary
- Updated `pnpm` from `11.9.0` to `11.10.0` in the reusable rootfs template build script.

## Version checks
- `GO_VERSION`: `1.26.4` is current from `https://go.dev/dl/?mode=json`.
- `CLAUDE_CODE_VERSION`: `2.1.201` is current from npm package `@anthropic-ai/claude-code`.
- `CODEX_CLI_VERSION`: `0.142.5` is current from npm package `@openai/codex`.
- `GWS_CLI_VERSION`: `0.22.5` is current from npm package `@googleworkspace/cli`.
- `XURL_VERSION`: `1.2.2` is current from npm package `@xdevplatform/xurl`.
- `AGENT_BROWSER_VERSION`: `0.31.1` is current from npm package `agent-browser`.
- `PNPM_VERSION`: updated from `11.9.0` to `11.10.0`; npm marks `11.10.0` as both `latest` and `latest-11`.

## Verification
- Not run; version-only update to `crates/runner/scripts/build-template.sh`.
