### PR TITLE
feat: add mobile unread chat shortcuts to agent chat

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import {
   chatThreadMarkAgentReadContract,
   chatThreadsContract,
+  type ChatThreadListItem,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { accept } from "../../lib/accept.ts";
@@ -13,6 +14,10 @@ import {
   reloadChatUnreadStateCounter$,
 } from "../chat-thread-list-reload.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
+import {
+  eventDrivenActiveRunChatThreadIds$,
+  eventDrivenChatThreads$,
+} from "./chat-thread-event-sourcing.ts";
 
 type UnreadSnapshot = readonly { threadId: string; unreadAt: string }[];
 
@@ -92,6 +97,43 @@ export const unreadAgentIds$ = computed(
       toast: false,
     });
     return new Set(result.body.agentIds);
+  },
+);
+
+export const currentAgentUnreadChatThreads$ = computed(
+  async (get): Promise<ChatThreadListItem[]> => {
+    const features = get(featureSwitch$);
+    if (!features[FeatureSwitchKey.MobileUnreadChatThreadShortcuts]) {
+      return [];
+    }
+    const agentId = await get(currentChatAgentId$);
+    if (!agentId) {
+      return [];
+    }
+    const unreadThreadIds = await get(sidebarUnreadThreadIds$);
+    if (unreadThreadIds.size === 0) {
+      return [];
+    }
+    const activeRunThreadIds = get(eventDrivenActiveRunChatThreadIds$);
+    return (await get(eventDrivenChatThreads$))
+      .filter((thread) => {
+        return thread.agentId === agentId && unreadThreadIds.has(thread.id);
+      })
+      .map((thread) => {
+        return {
+          id: thread.id,
+          title: thread.title,
+          agent: {
+            id: thread.agentId,
+            avatarUrl: null,
+          },
+          createdAt: thread.createdAt,
+          updatedAt: thread.updatedAt,
+          running: activeRunThreadIds.has(thread.id),
+          pinnedAt: thread.pinnedAt,
+          renamedAt: thread.renamedAt,
+        };
+      });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -1,8 +1,15 @@
-import { screen, waitForElementToBeRemoved } from "@testing-library/react";
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from "@testing-library/react";
+import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -13,8 +20,9 @@ import {
 } from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { reloadConnectors$ } from "../../../signals/external/connectors.ts";
+import { pathname } from "../../../signals/location.ts";
 import { setIdeationActiveTab$ } from "../../../signals/zero-page/zero-ideation.ts";
-import { PLACEHOLDER } from "./chat-test-helpers.ts";
+import { PLACEHOLDER, threadListSnapshot } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -52,6 +60,73 @@ function mockConnectorCatalogStatus(connectorRefs: readonly string[]): void {
   context.mocks.api(zeroConnectorCatalogContract.status, ({ respond }) => {
     return respond(200, {
       connectors: connectorRefs.map(publicConnectorStatusItem),
+    });
+  });
+}
+
+function mockUnreadShortcutThreads(): void {
+  const currentAgentUnreadThreadId = "b0000000-0000-4000-a000-000000000901";
+  const currentAgentRunningThreadId = "b0000000-0000-4000-a000-000000000902";
+  const otherAgentUnreadThreadId = "b0000000-0000-4000-a000-000000000903";
+  const otherAgentId = "c0000000-0000-4000-a000-000000000099";
+  const threads = [
+    {
+      id: currentAgentUnreadThreadId,
+      title: "Unread research brief",
+      agent: { id: agentId, avatarUrl: null },
+      createdAt: "2026-06-01T00:00:00Z",
+      updatedAt: "2026-06-01T00:03:00Z",
+      running: false,
+      pinnedAt: null,
+    },
+    {
+      id: currentAgentRunningThreadId,
+      title: "Running incident follow-up",
+      agent: { id: agentId, avatarUrl: null },
+      createdAt: "2026-06-01T00:00:00Z",
+      updatedAt: "2026-06-01T00:02:00Z",
+      running: true,
+      pinnedAt: null,
+    },
+    {
+      id: otherAgentUnreadThreadId,
+      title: "Other agent unread chat",
+      agent: { id: otherAgentId, avatarUrl: null },
+      createdAt: "2026-06-01T00:00:00Z",
+      updatedAt: "2026-06-01T00:01:00Z",
+      running: false,
+      pinnedAt: null,
+    },
+  ];
+
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: threadListSnapshot(threads),
+      latestEventId: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+    return respond(200, { events: [], hasMore: false });
+  });
+  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
+    return respond(200, { threadIds: [currentAgentRunningThreadId] });
+  });
+  context.mocks.api(chatThreadsContract.unreads, ({ respond }) => {
+    return respond(200, {
+      unreads: [
+        {
+          threadId: currentAgentUnreadThreadId,
+          unreadAt: "2026-06-01T00:03:00Z",
+        },
+        {
+          threadId: currentAgentRunningThreadId,
+          unreadAt: "2026-06-01T00:02:00Z",
+        },
+        {
+          threadId: otherAgentUnreadThreadId,
+          unreadAt: "2026-06-01T00:01:00Z",
+        },
+      ],
     });
   });
 }
@@ -326,6 +401,67 @@ describe("zero ideation page", () => {
 
     expect(queryAllByRoleFast("button", promptGrid)).toHaveLength(1);
     expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+  });
+
+  it("shows current-agent unread chat shortcuts on mobile behind the feature switch", async () => {
+    mockConnectorCatalogStatus([]);
+    mockUnreadShortcutThreads();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: true,
+      },
+    });
+
+    const unreadRegion = await screen.findByRole("region", {
+      name: "Unread chats",
+    });
+    expect(unreadRegion).toHaveClass("md:hidden");
+    expect(within(unreadRegion).getByText("2")).toBeInTheDocument();
+    expect(
+      within(unreadRegion).getByText("Unread research brief"),
+    ).toBeInTheDocument();
+    expect(
+      within(unreadRegion).getByText("Running incident follow-up"),
+    ).toBeInTheDocument();
+    expect(within(unreadRegion).getByText("Running now")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Other agent unread chat"),
+    ).not.toBeInTheDocument();
+
+    const shortcut = within(unreadRegion)
+      .getByText("Unread research brief")
+      .closest("a");
+    if (!shortcut) {
+      throw new Error("Unread research shortcut not found");
+    }
+    click(shortcut);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/b0000000-0000-4000-a000-000000000901");
+    });
+  });
+
+  it("hides current-agent unread chat shortcuts when the feature switch is off", async () => {
+    mockConnectorCatalogStatus([]);
+    mockUnreadShortcutThreads();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: false,
+      },
+    });
+
+    await expect(
+      screen.findByPlaceholderText(PLACEHOLDER),
+    ).resolves.toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Unread chats" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the last resolved suggested prompt catalog while a reload is pending", async () => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -2,14 +2,20 @@ import {
   useGet,
   useSet,
   useLoadable,
-  useLastLoadable,
   useLastResolved,
+  useLastLoadable,
 } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { user$ } from "../../signals/auth.ts";
-import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
+import {
+  IconArrowUpRight,
+  IconChevronRight,
+  IconLoader2,
+  IconPin,
+  IconUserPlus,
+} from "@tabler/icons-react";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
 import {
@@ -18,6 +24,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  cn,
 } from "@vm0/ui";
 import {
   currentChatAgentId$,
@@ -93,6 +100,7 @@ import {
 import { PersonalClaudeCodeDeviceAuthDialog } from "./components/settings/claude-code-device-auth-dialog.tsx";
 import { PersonalCodexDeviceAuthDialog } from "./components/settings/codex-device-auth-dialog.tsx";
 import { queueCurrentAgentDraftSync$ } from "../../signals/zero-page/agent-draft.ts";
+import { currentAgentUnreadChatThreads$ } from "../../signals/chat-page/sidebar-unread-threads.ts";
 
 function getTagline(
   agentName: string,
@@ -357,6 +365,86 @@ function IdeasUseCasesButton() {
         <IconArrowUpRight size={14} stroke={2} />
       </div>
     </button>
+  );
+}
+
+function MobileUnreadThreadShortcuts() {
+  const features = useGet(featureSwitch$);
+  const enabled =
+    features[FeatureSwitchKey.MobileUnreadChatThreadShortcuts] ?? false;
+  const unreadThreadsLoadable = useLoadable(currentAgentUnreadChatThreads$);
+  const lastUnreadThreads = useLastResolved(currentAgentUnreadChatThreads$);
+  const unreadThreads =
+    unreadThreadsLoadable.state === "hasData"
+      ? unreadThreadsLoadable.data
+      : (lastUnreadThreads ?? []);
+
+  if (!enabled || unreadThreads.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className="md:hidden flex flex-col gap-2"
+      aria-label="Unread chats"
+    >
+      <div className="flex items-center justify-between gap-3 px-1">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span
+            className="h-2 w-2 shrink-0 rounded-full bg-sky-600"
+            aria-hidden
+          />
+          <h3 className="truncate text-sm font-semibold text-foreground">
+            Unread chats
+          </h3>
+        </div>
+        <span className="shrink-0 text-xs font-medium text-muted-foreground">
+          {unreadThreads.length}
+        </span>
+      </div>
+      <div className="zero-card divide-y divide-border/60 overflow-hidden">
+        {unreadThreads.map((thread) => {
+          return (
+            <Link
+              key={thread.id}
+              pathname="/chats/:threadId"
+              options={{ pathParams: { threadId: thread.id } }}
+              className="flex min-h-12 items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-muted/40"
+            >
+              <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-sky-600" />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-semibold leading-5 text-foreground">
+                  {thread.title ?? "New chat"}
+                </span>
+                <span
+                  className={cn(
+                    "block truncate text-xs leading-4 text-muted-foreground",
+                    thread.running ? "text-primary" : "",
+                  )}
+                >
+                  {thread.running ? "Running now" : "Unread"}
+                </span>
+              </span>
+              {thread.running ? (
+                <IconLoader2
+                  size={14}
+                  stroke={1.8}
+                  className="shrink-0 animate-spin text-primary"
+                  aria-hidden
+                />
+              ) : (
+                <IconChevronRight
+                  size={16}
+                  stroke={1.8}
+                  className="shrink-0 text-muted-foreground"
+                  aria-hidden
+                />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
@@ -706,6 +794,8 @@ export function AgentChatPage() {
             onOpenChange={workflowPrompt.onReplaceDialogOpenChange}
             onConfirm={workflowPrompt.onConfirmReplaceDraft}
           />
+
+          <MobileUnreadThreadShortcuts />
 
           <SuggestedPromptsGrid onSelectPrompt={handleInputChange} />
         </div>

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -54,6 +54,7 @@ export enum FeatureSwitchKey {
   DesktopX64Download = "desktopX64Download",
   PresentationImageUnsplashPreferred = "presentationImageUnsplashPreferred",
   AgentUnreadIndicators = "agentUnreadIndicators",
+  MobileUnreadChatThreadShortcuts = "mobileUnreadChatThreadShortcuts",
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
   ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",
   AgentsPageRedesign = "agentsPageRedesign",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -135,6 +135,9 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.RelationshipMemory]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadUnifiedSearch]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(true);
+    expect(
+      staffOrgStates[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
+    ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );
@@ -158,6 +161,9 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(false);
+    expect(
+      otherOrgStates[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
+    ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -314,6 +314,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show unread chat thread shortcuts between the mobile agent chat composer and suggested prompt cards.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ChatThreadUnifiedSearch]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
Summary:
- Adds a staff-org-gated feature switch for mobile unread chat thread shortcuts.
- Shows current-agent unread chat threads between the mobile agent chat composer and suggested prompt cards, with direct links to each thread.
- Reuses the existing unread snapshot and event-driven thread cache so no new API surface is needed.

Verification:
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-ideation-page.test.tsx
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types
- pnpm -F @vm0/core check-types && pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/app lint
- pnpm -F @vm0/core lint && pnpm -F @vm0/connectors lint