### PR TITLE
docs: correct r2 cache gc request cost

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -143,7 +143,7 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
 /// successful full-pass `(deleted_count, freed_bytes)`, or `(0, 0)` on init or
 /// scan failure. A failed scan may have already deleted earlier pages.
 ///
-/// Idempotent across the fleet — every host runs the same scan; DELETE on
+/// Idempotent across the fleet — every host attempts the same scan; DELETE on
 /// already-absent keys is a no-op success.
 async fn gc_r2(keep_days: u64, dry_run: bool) -> (u64, u64) {
     let cache = match R2ImageCache::from_env().await {

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -139,8 +139,9 @@ pub async fn run_gc(args: GcArgs) -> RunnerResult<()> {
 
 /// Delete R2 image cache objects older than `keep_days`. Errors (R2 not
 /// configured, network blip, etc.) are logged and swallowed: GC must not
-/// fail the deploy because the cache layer is misconfigured. Returns
-/// `(deleted_count, freed_bytes)`.
+/// fail the deploy because the cache layer is misconfigured. Returns the
+/// successful full-pass `(deleted_count, freed_bytes)`, or `(0, 0)` on init or
+/// scan failure. A failed scan may have already deleted earlier pages.
 ///
 /// Idempotent across the fleet — every host runs the same scan; DELETE on
 /// already-absent keys is a no-op success.

--- a/crates/runner/src/r2_cache/gc.rs
+++ b/crates/runner/src/r2_cache/gc.rs
@@ -12,7 +12,9 @@ impl R2ImageCache {
     /// one LIST, paginated prefixes cost one LIST per page, and DELETE is
     /// issued only for pages with expired objects. Idempotent under concurrent
     /// fleet execution: every host runs the same scan and `DeleteObjects`
-    /// returns success for already-absent keys (S3 spec).
+    /// returns success for already-absent keys (S3 spec). Per-host returned
+    /// counts are best-effort and are not fleet-unique when hosts race on the
+    /// same keys.
     ///
     /// Per-key errors (e.g. AccessDenied — NOT NoSuchKey) are surfaced via
     /// `tracing::warn!` and excluded from `deleted_count`.

--- a/crates/runner/src/r2_cache/gc.rs
+++ b/crates/runner/src/r2_cache/gc.rs
@@ -7,14 +7,14 @@ use super::{
 
 impl R2ImageCache {
     /// Delete legacy rootfs objects and shared template objects older
-    /// than `max_age`. Returns `(deleted_count, freed_bytes)`. Scans
-    /// `runner-images/` and `runner-templates/`; each prefix costs at least
-    /// one LIST, paginated prefixes cost one LIST per page, and DELETE is
-    /// issued only for pages with expired objects. Idempotent under concurrent
-    /// fleet execution: every host runs the same scan and `DeleteObjects`
-    /// returns success for already-absent keys (S3 spec). Per-host returned
-    /// counts are best-effort and are not fleet-unique when hosts race on the
-    /// same keys.
+    /// than `max_age`. Returns `(deleted_count, freed_bytes)`. Attempts to
+    /// scan `runner-images/` and `runner-templates/`; on a full pass, each
+    /// prefix costs at least one LIST, paginated prefixes cost one LIST per
+    /// page, and DELETE is issued only for pages with expired objects.
+    /// Idempotent under concurrent fleet execution: every host runs the same
+    /// scan and `DeleteObjects` returns success for already-absent keys (S3
+    /// spec). Per-host returned counts are best-effort and are not fleet-unique
+    /// when hosts race on the same keys.
     ///
     /// Per-key errors (e.g. AccessDenied — NOT NoSuchKey) are surfaced via
     /// `tracing::warn!` and excluded from `deleted_count`.

--- a/crates/runner/src/r2_cache/gc.rs
+++ b/crates/runner/src/r2_cache/gc.rs
@@ -7,10 +7,12 @@ use super::{
 
 impl R2ImageCache {
     /// Delete legacy rootfs objects and shared template objects older
-    /// than `max_age`. Returns `(deleted_count, freed_bytes)`. Idempotent under
-    /// concurrent fleet execution: every host runs the same scan and
-    /// `DeleteObjects` returns success for already-absent keys (S3 spec). Each
-    /// invocation costs ~1 LIST + 1 batched DELETE per non-empty page.
+    /// than `max_age`. Returns `(deleted_count, freed_bytes)`. Scans
+    /// `runner-images/` and `runner-templates/`; each prefix costs at least
+    /// one LIST, paginated prefixes cost one LIST per page, and DELETE is
+    /// issued only for pages with expired objects. Idempotent under concurrent
+    /// fleet execution: every host runs the same scan and `DeleteObjects`
+    /// returns success for already-absent keys (S3 spec).
     ///
     /// Per-key errors (e.g. AccessDenied — NOT NoSuchKey) are surfaced via
     /// `tracing::warn!` and excluded from `deleted_count`.

--- a/crates/runner/src/r2_cache/gc.rs
+++ b/crates/runner/src/r2_cache/gc.rs
@@ -11,7 +11,7 @@ impl R2ImageCache {
     /// scan `runner-images/` and `runner-templates/`; on a full pass, each
     /// prefix costs at least one LIST, paginated prefixes cost one LIST per
     /// page, and DELETE is issued only for pages with expired objects.
-    /// Idempotent under concurrent fleet execution: every host runs the same
+    /// Idempotent under concurrent fleet execution: hosts can attempt the same
     /// scan and `DeleteObjects` returns success for already-absent keys (S3
     /// spec). Per-host returned counts are best-effort and are not fleet-unique
     /// when hosts race on the same keys.

--- a/crates/runner/src/r2_cache/mod.rs
+++ b/crates/runner/src/r2_cache/mod.rs
@@ -53,14 +53,14 @@
 //!
 //! Cleanup happens via `gc_older_than`, called from `runner gc` (which the
 //! deploy playbook runs after every release). Default TTL is 7 days. Each
-//! host runs the same scan independently over the legacy rootfs prefix
+//! host attempts the same scan independently over the legacy rootfs prefix
 //! (`runner-images/`) and the shared template prefix (`runner-templates/`).
-//! Request cost scales with scanned prefixes and pagination: at least one LIST
-//! per prefix, one additional LIST per extra page, and one batched DELETE for
-//! each page that contains expired objects. `DeleteObjects` is idempotent for
-//! already-absent keys, so concurrent fleet execution is safe; per-host
-//! deleted-count and freed-byte logs are best-effort and are not fleet-unique
-//! when hosts race on the same keys.
+//! Request cost for a full pass scales with scanned prefixes and pagination:
+//! at least one LIST per prefix, one additional LIST per extra page, and one
+//! batched DELETE for each page that contains expired objects. `DeleteObjects`
+//! is idempotent for already-absent keys, so concurrent fleet execution is
+//! safe; per-host deleted-count and freed-byte logs are best-effort and are
+//! not fleet-unique when hosts race on the same keys.
 //!
 //! R2's default 7-day lifecycle rule only cleans abandoned multipart
 //! segments, **not** completed objects — which is why we need our own scan.

--- a/crates/runner/src/r2_cache/mod.rs
+++ b/crates/runner/src/r2_cache/mod.rs
@@ -58,7 +58,9 @@
 //! Request cost scales with scanned prefixes and pagination: at least one LIST
 //! per prefix, one additional LIST per extra page, and one batched DELETE for
 //! each page that contains expired objects. `DeleteObjects` is idempotent for
-//! already-absent keys, so concurrent fleet execution is safe.
+//! already-absent keys, so concurrent fleet execution is safe; per-host
+//! deleted-count and freed-byte logs are best-effort and are not fleet-unique
+//! when hosts race on the same keys.
 //!
 //! R2's default 7-day lifecycle rule only cleans abandoned multipart
 //! segments, **not** completed objects — which is why we need our own scan.

--- a/crates/runner/src/r2_cache/mod.rs
+++ b/crates/runner/src/r2_cache/mod.rs
@@ -53,9 +53,12 @@
 //!
 //! Cleanup happens via `gc_older_than`, called from `runner gc` (which the
 //! deploy playbook runs after every release). Default TTL is 7 days. Each
-//! host runs the same scan independently — `DeleteObjects` is idempotent for
-//! already-absent keys, so concurrent fleet execution is safe and costs
-//! ~1 LIST + 1 batched DELETE per host per gc cycle.
+//! host runs the same scan independently over the legacy rootfs prefix
+//! (`runner-images/`) and the shared template prefix (`runner-templates/`).
+//! Request cost scales with scanned prefixes and pagination: at least one LIST
+//! per prefix, one additional LIST per extra page, and one batched DELETE for
+//! each page that contains expired objects. `DeleteObjects` is idempotent for
+//! already-absent keys, so concurrent fleet execution is safe.
 //!
 //! R2's default 7-day lifecycle rule only cleans abandoned multipart
 //! segments, **not** completed objects — which is why we need our own scan.


### PR DESCRIPTION
## Summary

- Correct the R2 cache module docs for `runner gc` request cost.
- Document that GC scans both `runner-images/` and `runner-templates/`.
- Describe cost by scanned prefix, LIST pagination, and DELETE pages with expired objects.

## Scope

Docs-only. This does not change runner GC behavior, R2 cleanup ownership, CLI behavior, deploy scripts, or tests.

Closes #20118.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p runner r2_cache::tests::gc::gc_paginates_across_two_pages`
- `cargo test --manifest-path crates/Cargo.toml -p runner r2_cache::tests::gc::gc_deletes_shared_template_objects`
- pre-commit hook: cargo-doc, cargo-clippy
