### PR TITLE
refactor: centralize run payload field validation

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -445,39 +445,10 @@ fn validate_run_payload_file_path_for_runtime(
 }
 
 fn validate_run_payload(payload: &guest_contracts::env::RunPayload) -> Result<(), String> {
-    for (name, value) in [
-        (guest_contracts::env::PROMPT_ENV, payload.prompt.as_str()),
-        (
-            guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
-            payload.append_system_prompt.as_str(),
-        ),
-        (
-            guest_contracts::env::SECRET_VALUES_ENV,
-            payload.secret_values.as_str(),
-        ),
-        (
-            guest_contracts::env::DISALLOWED_TOOLS_ENV,
-            payload.disallowed_tools.as_str(),
-        ),
-        (guest_contracts::env::TOOLS_ENV, payload.tools.as_str()),
-        (
-            guest_contracts::env::SETTINGS_ENV,
-            payload.settings.as_str(),
-        ),
-        (
-            guest_contracts::env::ARTIFACTS_ENV,
-            payload.artifacts.as_str(),
-        ),
-        (
-            guest_contracts::env::FEATURE_FLAGS_ENV,
-            payload.feature_flags.as_str(),
-        ),
-    ] {
-        if value.contains('\0') {
-            return Err(format!(
-                "{RUN_PAYLOAD_FILE_ENV_KEY} contains NUL byte for {name}"
-            ));
-        }
+    if let Some(name) = payload.first_nul_field() {
+        return Err(format!(
+            "{RUN_PAYLOAD_FILE_ENV_KEY} contains NUL byte for {name}"
+        ));
     }
 
     Ok(())

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -171,6 +171,74 @@ pub struct RunPayload {
     pub feature_flags: String,
 }
 
+/// Borrowed logical string field from [`RunPayload`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RunPayloadField<'a> {
+    /// Logical field name used in diagnostics.
+    pub name: &'static str,
+    /// Field value carried in the run payload.
+    pub value: &'a str,
+}
+
+impl RunPayload {
+    /// Return all logical string fields carried by this run payload.
+    pub fn fields(&self) -> [RunPayloadField<'_>; 8] {
+        let Self {
+            prompt,
+            append_system_prompt,
+            secret_values,
+            disallowed_tools,
+            tools,
+            settings,
+            artifacts,
+            feature_flags,
+        } = self;
+
+        [
+            RunPayloadField {
+                name: PROMPT_ENV,
+                value: prompt,
+            },
+            RunPayloadField {
+                name: APPEND_SYSTEM_PROMPT_ENV,
+                value: append_system_prompt,
+            },
+            RunPayloadField {
+                name: SECRET_VALUES_ENV,
+                value: secret_values,
+            },
+            RunPayloadField {
+                name: DISALLOWED_TOOLS_ENV,
+                value: disallowed_tools,
+            },
+            RunPayloadField {
+                name: TOOLS_ENV,
+                value: tools,
+            },
+            RunPayloadField {
+                name: SETTINGS_ENV,
+                value: settings,
+            },
+            RunPayloadField {
+                name: ARTIFACTS_ENV,
+                value: artifacts,
+            },
+            RunPayloadField {
+                name: FEATURE_FLAGS_ENV,
+                value: feature_flags,
+            },
+        ]
+    }
+
+    /// Return the first logical field name whose value contains a NUL byte.
+    pub fn first_nul_field(&self) -> Option<&'static str> {
+        self.fields()
+            .into_iter()
+            .find(|field| field.value.contains('\0'))
+            .map(|field| field.name)
+    }
+}
+
 /// Guest-agent stuck-tool timeout override in seconds.
 ///
 /// This is a tuning key: local execution may pass it through user env via
@@ -349,6 +417,86 @@ mod tests {
         assert_eq!(json["secretValues"], "secret");
         assert_eq!(json["disallowedTools"], "WebFetch");
         assert_eq!(json["featureFlags"], r#"{"flag":true}"#);
+    }
+
+    #[test]
+    fn run_payload_fields_returns_logical_names_and_values() {
+        let payload = RunPayload {
+            prompt: "prompt".to_string(),
+            append_system_prompt: "system".to_string(),
+            secret_values: "secret".to_string(),
+            disallowed_tools: "WebFetch".to_string(),
+            tools: "Bash".to_string(),
+            settings: "{}".to_string(),
+            artifacts: "[]".to_string(),
+            feature_flags: r#"{"flag":true}"#.to_string(),
+        };
+
+        let fields = payload.fields();
+
+        assert_eq!(
+            fields,
+            [
+                RunPayloadField {
+                    name: PROMPT_ENV,
+                    value: "prompt"
+                },
+                RunPayloadField {
+                    name: APPEND_SYSTEM_PROMPT_ENV,
+                    value: "system"
+                },
+                RunPayloadField {
+                    name: SECRET_VALUES_ENV,
+                    value: "secret"
+                },
+                RunPayloadField {
+                    name: DISALLOWED_TOOLS_ENV,
+                    value: "WebFetch"
+                },
+                RunPayloadField {
+                    name: TOOLS_ENV,
+                    value: "Bash"
+                },
+                RunPayloadField {
+                    name: SETTINGS_ENV,
+                    value: "{}"
+                },
+                RunPayloadField {
+                    name: ARTIFACTS_ENV,
+                    value: "[]"
+                },
+                RunPayloadField {
+                    name: FEATURE_FLAGS_ENV,
+                    value: r#"{"flag":true}"#
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn run_payload_first_nul_field_reports_logical_name() {
+        let payload = RunPayload {
+            settings: "bad\0settings".to_string(),
+            ..RunPayload::default()
+        };
+
+        assert_eq!(payload.first_nul_field(), Some(SETTINGS_ENV));
+    }
+
+    #[test]
+    fn run_payload_first_nul_field_accepts_clean_payload() {
+        let payload = RunPayload {
+            prompt: "prompt".to_string(),
+            append_system_prompt: "system".to_string(),
+            secret_values: "secret".to_string(),
+            disallowed_tools: "WebFetch".to_string(),
+            tools: "Bash".to_string(),
+            settings: "{}".to_string(),
+            artifacts: "[]".to_string(),
+            feature_flags: r#"{"flag":true}"#.to_string(),
+        };
+
+        assert_eq!(payload.first_nul_field(), None);
     }
 
     #[test]

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -531,37 +531,8 @@ fn serialize_feature_flags_payload(context: &ExecutionContext) -> RunnerResult<S
 fn validate_run_payload_for_guest(
     payload: &guest_contracts::env::RunPayload,
 ) -> Result<(), String> {
-    for (name, value) in [
-        (guest_contracts::env::PROMPT_ENV, payload.prompt.as_str()),
-        (
-            guest_contracts::env::APPEND_SYSTEM_PROMPT_ENV,
-            payload.append_system_prompt.as_str(),
-        ),
-        (
-            guest_contracts::env::SECRET_VALUES_ENV,
-            payload.secret_values.as_str(),
-        ),
-        (
-            guest_contracts::env::DISALLOWED_TOOLS_ENV,
-            payload.disallowed_tools.as_str(),
-        ),
-        (guest_contracts::env::TOOLS_ENV, payload.tools.as_str()),
-        (
-            guest_contracts::env::SETTINGS_ENV,
-            payload.settings.as_str(),
-        ),
-        (
-            guest_contracts::env::ARTIFACTS_ENV,
-            payload.artifacts.as_str(),
-        ),
-        (
-            guest_contracts::env::FEATURE_FLAGS_ENV,
-            payload.feature_flags.as_str(),
-        ),
-    ] {
-        if value.contains('\0') {
-            return Err(format!("run payload contains NUL byte for {name}"));
-        }
+    if let Some(name) = payload.first_nul_field() {
+        return Err(format!("run payload contains NUL byte for {name}"));
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- add a shared `RunPayload` logical field list and NUL detector in `guest-contracts`
- switch runner and guest-agent payload NUL checks to use the shared helper while preserving local diagnostics
- keep runner pre-sandbox validation borrowed-only and leave the run payload wire shape unchanged

## Tests

- `cargo fmt --all`
- `cargo test -p guest-contracts`
- `cargo test -p runner build_run_payload_for_run_rejects_prompt_nul`
- `cargo test -p guest-agent load_run_payload_from_path_rejects_nul_without_value_leak`
- `cargo clippy -p guest-contracts -p runner -p guest-agent --all-targets -- -D warnings`
- pre-commit hook: cargo-doc and cargo-clippy

Closes #20157