### PR TITLE
refactor(runner): centralize workspace cache gc traversal

### DIFF
--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -171,14 +171,16 @@ impl SessionWorkspaceCache {
         Ok(freed)
     }
 
-    async fn gc_cache_entries(&self) -> RunnerResult<Vec<GcCacheEntry>> {
+    async fn gc_cache_entry_reader(&self) -> RunnerResult<Option<fs::ReadDir>> {
         let root = self.workspace_image_cache_dir().to_path_buf();
-        let mut entries = match fs::read_dir(&root).await {
-            Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(e) => return Err(e.into()),
-        };
-        let mut cache_entries = Vec::new();
+        match fs::read_dir(&root).await {
+            Ok(entries) => Ok(Some(entries)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn next_gc_cache_entry(entries: &mut fs::ReadDir) -> RunnerResult<Option<GcCacheEntry>> {
         while let Some(entry) = entries.next_entry().await? {
             if !entry_file_type_is_dir(&entry).await? {
                 continue;
@@ -189,12 +191,12 @@ impl SessionWorkspaceCache {
             if !is_cache_key_name(&cache_key) {
                 continue;
             }
-            cache_entries.push(GcCacheEntry {
+            return Ok(Some(GcCacheEntry {
                 cache_key,
                 entry_dir: entry.path(),
-            });
+            }));
         }
-        Ok(cache_entries)
+        Ok(None)
     }
 
     async fn try_lock_gc_cache_entry(
@@ -212,8 +214,11 @@ impl SessionWorkspaceCache {
     }
 
     async fn gc_unusable_current_entries(&self, dry_run: bool) -> RunnerResult<GcEntryCleanup> {
+        let Some(mut entries) = self.gc_cache_entry_reader().await? else {
+            return Ok(GcEntryCleanup::default());
+        };
         let mut cleanup = GcEntryCleanup::default();
-        for entry in self.gc_cache_entries().await? {
+        while let Some(entry) = Self::next_gc_cache_entry(&mut entries).await? {
             let Some((entry, lock)) = self.try_lock_gc_cache_entry(entry).await? else {
                 continue;
             };
@@ -321,8 +326,11 @@ impl SessionWorkspaceCache {
         &self,
         dry_run: bool,
     ) -> RunnerResult<GcEntryCleanup> {
+        let Some(mut entries) = self.gc_cache_entry_reader().await? else {
+            return Ok(GcEntryCleanup::default());
+        };
         let mut cleanup = GcEntryCleanup::default();
-        for entry in self.gc_cache_entries().await? {
+        while let Some(entry) = Self::next_gc_cache_entry(&mut entries).await? {
             let Some((entry, lock)) = self.try_lock_gc_cache_entry(entry).await? else {
                 continue;
             };
@@ -377,8 +385,11 @@ impl SessionWorkspaceCache {
         dry_run: bool,
         skip_entry_keys: &BTreeSet<String>,
     ) -> RunnerResult<u64> {
+        let Some(mut entries) = self.gc_cache_entry_reader().await? else {
+            return Ok(0);
+        };
         let mut freed: u64 = 0;
-        for entry in self.gc_cache_entries().await? {
+        while let Some(entry) = Self::next_gc_cache_entry(&mut entries).await? {
             if skip_entry_keys.contains(&entry.cache_key) {
                 continue;
             }
@@ -445,8 +456,11 @@ impl SessionWorkspaceCache {
     }
 
     pub(super) async fn gc_candidates(&self) -> RunnerResult<Vec<GcCandidate>> {
+        let Some(mut entries) = self.gc_cache_entry_reader().await? else {
+            return Ok(Vec::new());
+        };
         let mut candidates = Vec::new();
-        for entry in self.gc_cache_entries().await? {
+        while let Some(entry) = Self::next_gc_cache_entry(&mut entries).await? {
             let Some(candidate) = self.gc_candidate(entry.cache_key).await else {
                 continue;
             };

--- a/crates/runner/src/workspace_image_cache/gc.rs
+++ b/crates/runner/src/workspace_image_cache/gc.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeSet;
+use std::fs::File;
 use std::os::unix::fs::MetadataExt;
+use std::path::PathBuf;
 
+use nix::fcntl::Flock;
 use tokio::fs;
 use tracing::{info, warn};
 
@@ -28,6 +31,11 @@ pub(super) struct GcCandidate {
     file_dev: u64,
     file_ino: u64,
     pub(super) last_used_at: String,
+}
+
+struct GcCacheEntry {
+    cache_key: String,
+    entry_dir: PathBuf,
 }
 
 #[derive(Default)]
@@ -163,16 +171,14 @@ impl SessionWorkspaceCache {
         Ok(freed)
     }
 
-    async fn gc_unusable_current_entries(&self, dry_run: bool) -> RunnerResult<GcEntryCleanup> {
+    async fn gc_cache_entries(&self) -> RunnerResult<Vec<GcCacheEntry>> {
         let root = self.workspace_image_cache_dir().to_path_buf();
         let mut entries = match fs::read_dir(&root).await {
             Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(GcEntryCleanup::default());
-            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
             Err(e) => return Err(e.into()),
         };
-        let mut cleanup = GcEntryCleanup::default();
+        let mut cache_entries = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
             if !entry_file_type_is_dir(&entry).await? {
                 continue;
@@ -183,14 +189,38 @@ impl SessionWorkspaceCache {
             if !is_cache_key_name(&cache_key) {
                 continue;
             }
-            let Ok(lock) = crate::lock::try_acquire(self.entry_lock_path(&cache_key)).await else {
+            cache_entries.push(GcCacheEntry {
+                cache_key,
+                entry_dir: entry.path(),
+            });
+        }
+        Ok(cache_entries)
+    }
+
+    async fn try_lock_gc_cache_entry(
+        &self,
+        entry: GcCacheEntry,
+    ) -> RunnerResult<Option<(GcCacheEntry, Flock<File>)>> {
+        let Ok(lock) = crate::lock::try_acquire(self.entry_lock_path(&entry.cache_key)).await
+        else {
+            return Ok(None);
+        };
+        if !cache_entry_dir_is_dir(&entry.entry_dir).await? {
+            return Ok(None);
+        }
+        Ok(Some((entry, lock)))
+    }
+
+    async fn gc_unusable_current_entries(&self, dry_run: bool) -> RunnerResult<GcEntryCleanup> {
+        let mut cleanup = GcEntryCleanup::default();
+        for entry in self.gc_cache_entries().await? {
+            let Some((entry, lock)) = self.try_lock_gc_cache_entry(entry).await? else {
                 continue;
             };
-            let entry_dir = entry.path();
-            if !cache_entry_dir_is_dir(&entry_dir).await? {
-                drop(lock);
-                continue;
-            }
+            let GcCacheEntry {
+                cache_key,
+                entry_dir,
+            } = entry;
             let current = self.session_workspace_cache_current_image(&cache_key);
             let current_metadata = match fs::symlink_metadata(&current).await {
                 Ok(metadata) => metadata,
@@ -291,33 +321,15 @@ impl SessionWorkspaceCache {
         &self,
         dry_run: bool,
     ) -> RunnerResult<GcEntryCleanup> {
-        let root = self.workspace_image_cache_dir().to_path_buf();
-        let mut entries = match fs::read_dir(&root).await {
-            Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(GcEntryCleanup::default());
-            }
-            Err(e) => return Err(e.into()),
-        };
         let mut cleanup = GcEntryCleanup::default();
-        while let Some(entry) = entries.next_entry().await? {
-            if !entry_file_type_is_dir(&entry).await? {
-                continue;
-            }
-            let Some(cache_key) = entry.file_name().to_str().map(str::to_owned) else {
+        for entry in self.gc_cache_entries().await? {
+            let Some((entry, lock)) = self.try_lock_gc_cache_entry(entry).await? else {
                 continue;
             };
-            if !is_cache_key_name(&cache_key) {
-                continue;
-            }
-            let Ok(lock) = crate::lock::try_acquire(self.entry_lock_path(&cache_key)).await else {
-                continue;
-            };
-            let entry_dir = entry.path();
-            if !cache_entry_dir_is_dir(&entry_dir).await? {
-                drop(lock);
-                continue;
-            }
+            let GcCacheEntry {
+                cache_key,
+                entry_dir,
+            } = entry;
             let current = self.session_workspace_cache_current_image(&cache_key);
             match fs::symlink_metadata(&current).await {
                 Ok(_) => {
@@ -365,34 +377,18 @@ impl SessionWorkspaceCache {
         dry_run: bool,
         skip_entry_keys: &BTreeSet<String>,
     ) -> RunnerResult<u64> {
-        let root = self.workspace_image_cache_dir().to_path_buf();
-        let mut entries = match fs::read_dir(&root).await {
-            Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-            Err(e) => return Err(e.into()),
-        };
         let mut freed: u64 = 0;
-        while let Some(entry) = entries.next_entry().await? {
-            if !entry_file_type_is_dir(&entry).await? {
+        for entry in self.gc_cache_entries().await? {
+            if skip_entry_keys.contains(&entry.cache_key) {
                 continue;
             }
-            let Some(cache_key) = entry.file_name().to_str().map(str::to_owned) else {
+            let Some((entry, lock)) = self.try_lock_gc_cache_entry(entry).await? else {
                 continue;
             };
-            if !is_cache_key_name(&cache_key) {
-                continue;
-            }
-            if skip_entry_keys.contains(&cache_key) {
-                continue;
-            }
-            let Ok(lock) = crate::lock::try_acquire(self.entry_lock_path(&cache_key)).await else {
-                continue;
-            };
-            let entry_dir = entry.path();
-            if !cache_entry_dir_is_dir(&entry_dir).await? {
-                drop(lock);
-                continue;
-            }
+            let GcCacheEntry {
+                cache_key,
+                entry_dir,
+            } = entry;
             let mut files = match fs::read_dir(&entry_dir).await {
                 Ok(files) => files,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -449,24 +445,9 @@ impl SessionWorkspaceCache {
     }
 
     pub(super) async fn gc_candidates(&self) -> RunnerResult<Vec<GcCandidate>> {
-        let root = self.workspace_image_cache_dir().to_path_buf();
-        let mut entries = match fs::read_dir(&root).await {
-            Ok(entries) => entries,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(e) => return Err(e.into()),
-        };
         let mut candidates = Vec::new();
-        while let Some(entry) = entries.next_entry().await? {
-            if !entry_file_type_is_dir(&entry).await? {
-                continue;
-            }
-            let Some(cache_key) = entry.file_name().to_str().map(str::to_owned) else {
-                continue;
-            };
-            if !is_cache_key_name(&cache_key) {
-                continue;
-            }
-            let Some(candidate) = self.gc_candidate(cache_key).await else {
+        for entry in self.gc_cache_entries().await? {
+            let Some(candidate) = self.gc_candidate(entry.cache_key).await else {
                 continue;
             };
             candidates.push(candidate);


### PR DESCRIPTION
## Summary

- centralize workspace image cache GC root scanning and cache-key filtering in a GC-local helper
- centralize mutating GC entry lock acquisition and post-lock directory revalidation
- preserve existing stale, unusable, temporary cleanup, and budget candidate phases

Closes #20117

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p runner workspace_image_cache
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- pre-commit hook: cargo-doc, cargo-clippy, cargo-fmt
