### PR TITLE
perf(runner): avoid cloning active input queue path

### DIFF
--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -58,12 +58,12 @@ pub(crate) fn active_input_payload_len(text: &str) -> Result<usize, serde_json::
     Ok(counter.len())
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 pub(crate) enum ActiveInputSource {
     LocalQueue(LocalQueueActiveInputSource),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 pub(crate) struct LocalQueueActiveInputSource {
     pub(crate) queue: LocalQueue,
     pub(crate) run_id: RunId,

--- a/crates/runner/src/active_input.rs
+++ b/crates/runner/src/active_input.rs
@@ -1,5 +1,4 @@
 use std::io::{self, Write};
-use std::path::PathBuf;
 
 use crate::ids::RunId;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -66,13 +65,13 @@ pub(crate) enum ActiveInputSource {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct LocalQueueActiveInputSource {
-    pub(crate) group_dir: PathBuf,
+    pub(crate) queue: LocalQueue,
     pub(crate) run_id: RunId,
 }
 
 impl ActiveInputSource {
-    pub(crate) fn local_queue(group_dir: PathBuf, run_id: RunId) -> Self {
-        Self::LocalQueue(LocalQueueActiveInputSource { group_dir, run_id })
+    pub(crate) fn local_queue(queue: LocalQueue, run_id: RunId) -> Self {
+        Self::LocalQueue(LocalQueueActiveInputSource { queue, run_id })
     }
 
     pub(crate) fn read_entries_from_sequence_sync(
@@ -80,7 +79,8 @@ impl ActiveInputSource {
         min_sequence: u64,
     ) -> Vec<ActiveInputEntry> {
         match self {
-            Self::LocalQueue(source) => LocalQueue::new(source.group_dir.clone())
+            Self::LocalQueue(source) => source
+                .queue
                 .read_active_input_entries_from_sequence_sync(source.run_id, min_sequence),
         }
     }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -298,6 +298,7 @@ impl ActiveInputProducer {
         let stop_for_task = stop.clone();
         let task = tokio::spawn(async move {
             let started_at = tokio::time::Instant::now();
+            let queue_state = local_queue::LocalQueue::new(queue.group_dir.clone());
             for input in inputs {
                 let sleep_for = input.after.saturating_sub(started_at.elapsed());
                 tokio::select! {
@@ -312,7 +313,7 @@ impl ActiveInputProducer {
                             message_id: input.message_id,
                             text: input.text,
                         };
-                        let queue_state = local_queue::LocalQueue::new(queue.group_dir.clone());
+                        let queue_state = queue_state.clone();
                         let write_result = tokio::task::spawn_blocking(move || {
                             queue_state.write_active_input_sync(&entry)
                         })

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -2132,7 +2132,7 @@ async fn run_in_sandbox_forwards_local_active_inputs_in_order_and_dedupes() {
     ] {
         queue.write_active_input_sync(&entry).unwrap();
     }
-    let source = ActiveInputSource::local_queue(group_dir, ctx.run_id);
+    let source = ActiveInputSource::local_queue(LocalQueue::new(group_dir), ctx.run_id);
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -2189,7 +2189,7 @@ async fn run_in_sandbox_sets_codex_app_server_backend_for_active_input_source() 
     let mut ctx = minimal_context();
     ctx.cli_agent_type = "codex".into();
     let group_dir = dir.path().join("active-inputs");
-    let source = ActiveInputSource::local_queue(group_dir, ctx.run_id);
+    let source = ActiveInputSource::local_queue(LocalQueue::new(group_dir), ctx.run_id);
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
 
@@ -2255,7 +2255,7 @@ async fn run_in_sandbox_retries_active_input_after_control_error() {
             text: "second".to_string(),
         })
         .unwrap();
-    let source = ActiveInputSource::local_queue(group_dir, ctx.run_id);
+    let source = ActiveInputSource::local_queue(LocalQueue::new(group_dir), ctx.run_id);
     let cancel = tokio_util::sync::CancellationToken::new();
     let mut telemetry = test_telemetry(&config, &ctx);
 

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -35,7 +35,7 @@ pub(crate) struct LocalCancelMarker {
 }
 
 /// Shared file-state checks for the local queue protocol.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 pub(crate) struct LocalQueue {
     group_dir: Arc<PathBuf>,
 }

--- a/crates/runner/src/local_queue/state.rs
+++ b/crates/runner/src/local_queue/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use tracing::{info, warn};
 
@@ -34,9 +35,9 @@ pub(crate) struct LocalCancelMarker {
 }
 
 /// Shared file-state checks for the local queue protocol.
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct LocalQueue {
-    group_dir: PathBuf,
+    group_dir: Arc<PathBuf>,
 }
 
 enum CancelTargetLookup {
@@ -73,11 +74,13 @@ impl JobPresenceScan {
 
 impl LocalQueue {
     pub(crate) fn new(group_dir: PathBuf) -> Self {
-        Self { group_dir }
+        Self {
+            group_dir: Arc::new(group_dir),
+        }
     }
 
     pub(crate) fn group_dir(&self) -> &Path {
-        &self.group_dir
+        self.group_dir.as_ref()
     }
 
     pub(crate) fn discover_candidate_sync(

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -66,12 +66,12 @@ impl LocalProvider {
     ) -> Arc<Self> {
         supported_profiles.sort();
         supported_profiles.dedup();
+        let queue = LocalQueue::new(group_dir);
         info!(
-            path = %group_dir.display(),
+            path = %queue.group_dir().display(),
             profiles = ?supported_profiles,
             "local provider watching"
         );
-        let queue = LocalQueue::new(group_dir.clone());
         let owned_claims = Arc::new(tokio::sync::Mutex::new(HashSet::new()));
         let cancel_scanner = LocalCancelScanner::new(queue.clone(), cancel_tokens, owned_claims);
         let cancel_watcher = if start_cancel_watcher {
@@ -204,10 +204,7 @@ impl JobProvider for LocalProvider {
             model_usage_provider: None,
         };
         let active_input_source = req.active_input.unwrap_or(false).then(|| {
-            crate::active_input::ActiveInputSource::local_queue(
-                self.queue.group_dir().to_path_buf(),
-                run_id,
-            )
+            crate::active_input::ActiveInputSource::local_queue(self.queue.clone(), run_id)
         });
         match ClaimedJob::local_with_active_input_source(run_id, context, active_input_source) {
             Ok(claimed) => {

--- a/crates/runner/src/provider/local/tests/claim.rs
+++ b/crates/runner/src/provider/local/tests/claim.rs
@@ -15,7 +15,7 @@ async fn claim_attaches_active_input_source_when_requested() {
     assert!(matches!(
         claimed.active_input_source(),
         Some(crate::active_input::ActiveInputSource::LocalQueue(source))
-            if source.run_id == job_id && source.group_dir == dir.path()
+            if source.run_id == job_id && source.queue.group_dir() == dir.path()
     ));
 }
 


### PR DESCRIPTION
## Summary

- make `LocalQueue` a cheap-clone handle by sharing its immutable queue root path
- store `LocalQueue` directly in `LocalQueueActiveInputSource`
- reuse the provider's existing queue handle when attaching active-input sources
- reuse the submit-side active-input writer queue handle across delayed input writes

Closes #20120.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner active_input_`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_forwards_local_active_inputs_in_order_and_dedupes`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
