### PR TITLE
refactor: decouple ideation connector refs from runtime enum

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -1,11 +1,12 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+
+type IdeationConnectorRef = string;
 
 interface UseCase {
   readonly title: string;
   readonly description: string;
   readonly prompt: string;
-  readonly connectors?: readonly ConnectorType[];
+  readonly connectors?: readonly IdeationConnectorRef[];
   readonly featureFlag?: FeatureSwitchKey;
 }
 


### PR DESCRIPTION
## Summary

- remove the static runtime `ConnectorType` dependency from ideation editorial data
- add a local ideation connector ref alias for catalog/display connector refs
- keep existing catalog/status filtering and guarded icon rendering behavior unchanged

Closes #20223.

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-ideation-page.test.tsx --reporter=dot`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm format`
- pre-commit hook: prettier, knip, monorepo `turbo run check-types --concurrency=1`
