### PR TITLE
docs: clarify migration promotion ordering

### DIFF
--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -1,11 +1,17 @@
 # Deployment Compatibility
 
-VM0 has three independently deployed surfaces:
+This document focuses on three independently deployed surfaces that have
+cross-version API or persisted-state compatibility boundaries:
 
 - **Frontend**: browser-delivered web application code.
 - **Backend**: API service code in `turbo/apps/api`, plus any intentional
   web-origin rewrites that forward selected `/api/*` paths to the API service.
-- **Runner**: long-running runner processes plus the guest binaries shipped with that runner.
+- **Runner**: long-running runner processes plus the guest binaries shipped
+  with that runner.
+
+Other release artifacts, such as the desktop app and host-worker deployments,
+have their own release paths and are outside this compatibility model unless
+they interact with these frontend, backend, or runner boundaries.
 
 New versions are normally deployed together, but they do not become active at the
 same instant. Code and tests must account for short periods where different

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -47,6 +47,12 @@ briefly run against the migrated schema. Migrations must be backward-compatible
 with the currently deployed backend until that backend is no longer serving
 traffic.
 
+This is a traffic-promotion guarantee, not a guarantee that no deployment
+preparation has happened yet. Staged Vercel builds, runner rootfs/snapshot
+builds, host provisioning, and other non-serving preparation jobs may complete
+before migrations run; new production traffic must not be promoted until the
+required migrations have completed.
+
 Backend changes must be safe with:
 
 - old frontend -> new backend

--- a/docs/deployment-compatibility.md
+++ b/docs/deployment-compatibility.md
@@ -50,8 +50,9 @@ traffic.
 This is a traffic-promotion guarantee, not a guarantee that no deployment
 preparation has happened yet. Staged Vercel builds, runner rootfs/snapshot
 builds, host provisioning, and other non-serving preparation jobs may complete
-before migrations run; new production traffic must not be promoted until the
-required migrations have completed.
+before migrations run. API traffic promotion must wait until the required
+migrations have completed; app and runner promotion also wait for API promotion
+when the same release changes the API.
 
 Backend changes must be safe with:
 


### PR DESCRIPTION
## Summary
- clarify that production migrations are guaranteed before traffic promotion, not before all deployment preparation
- call out staged builds, runner image preparation, and host provisioning as non-serving preparation that may happen earlier

## Testing
- not run (documentation-only change)