### PR TITLE
fix: align sidebar virtual thread scrolling

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -267,6 +267,34 @@ export const CHAT_THREAD_VIRTUAL_ROW_HEIGHT = 36;
 const CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT =
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 12;
 const internalChatThreadVirtualListElement$ = state<HTMLElement | null>(null);
+
+function hasUsableLayoutPosition(rect: DOMRectReadOnly): boolean {
+  return rect.top !== 0 || rect.left !== 0;
+}
+
+export function getChatThreadVirtualListScrollMargin(
+  scrollViewport: HTMLElement | null,
+  virtualListElement: HTMLElement | null,
+): number {
+  if (!scrollViewport || !virtualListElement) {
+    return 0;
+  }
+
+  const viewportRect = scrollViewport.getBoundingClientRect();
+  const virtualListRect = virtualListElement.getBoundingClientRect();
+  if (
+    hasUsableLayoutPosition(viewportRect) ||
+    hasUsableLayoutPosition(virtualListRect)
+  ) {
+    return Math.max(
+      0,
+      scrollViewport.scrollTop + virtualListRect.top - viewportRect.top,
+    );
+  }
+
+  return Math.max(0, virtualListElement.offsetTop - scrollViewport.offsetTop);
+}
+
 export const chatThreadVirtualListElement$ = computed((get) => {
   return get(internalChatThreadVirtualListElement$);
 });
@@ -288,7 +316,10 @@ export const scrollChatThreadVirtualListToIndex$ = command(
     }
 
     const currentMetrics = get(internalOverlayScrollMetrics$);
-    const scrollMargin = virtualListElement.offsetTop;
+    const scrollMargin = getChatThreadVirtualListScrollMargin(
+      scrollViewport,
+      virtualListElement,
+    );
     const viewportHeight =
       currentMetrics.clientHeight ||
       scrollViewport.clientHeight ||
@@ -297,9 +328,10 @@ export const scrollChatThreadVirtualListToIndex$ = command(
     const rowBottom = rowTop + CHAT_THREAD_VIRTUAL_ROW_HEIGHT;
     const viewportTop = scrollViewport.scrollTop;
     const viewportBottom = viewportTop + viewportHeight;
+    const targetScrollTop = Math.max(0, rowTop);
     const nextScrollTop =
       rowTop < viewportTop || rowBottom > viewportBottom
-        ? Math.max(0, rowTop - CHAT_THREAD_VIRTUAL_ROW_HEIGHT)
+        ? targetScrollTop
         : viewportTop;
 
     scrollViewport.scrollTop = nextScrollTop;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -25,6 +25,10 @@ import {
 import { createMockAutomationView } from "../../../mocks/handlers/automations-store.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
+import {
+  CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+  getChatThreadVirtualListScrollMargin,
+} from "../../../signals/zero-page/zero-sidebar-state.ts";
 import { PLACEHOLDER } from "./chat-test-helpers.ts";
 
 const context = testContext();
@@ -1195,6 +1199,65 @@ describe("zero sidebar", () => {
       expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
       expect(scrollArea.scrollTop).toBeGreaterThan(0);
     });
+  });
+
+  it("aligns the current virtualized chat row with the sidebar scroll area top on page setup", async () => {
+    prepareDefaultAgent();
+    const leadingThreads = Array.from({ length: 24 }, (_, index) => {
+      return createThread(
+        `b3100000-0000-4000-a000-${String(index).padStart(12, "0")}`,
+        `Leading precise chat ${index + 1}`,
+      );
+    });
+    mockSidebarThreadStory([
+      ...leadingThreads,
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+    ]);
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+    });
+
+    const scrollArea = screen.getByTestId("sidebar-scroll-area");
+    const virtualList = screen.getByTestId("sidebar-chat-threads-virtual-list");
+    const currentRow = threadLinkByTitle("Release plan").closest(
+      '[data-testid="sidebar-chat-thread-virtual-row"]',
+    );
+    if (!(currentRow instanceof HTMLElement)) {
+      throw new Error("Release plan virtual row not found");
+    }
+    const currentIndex = Number(currentRow.dataset.index);
+    const scrollMargin = getChatThreadVirtualListScrollMargin(
+      scrollArea,
+      virtualList,
+    );
+
+    expect(scrollArea.scrollTop).toBe(
+      scrollMargin + currentIndex * CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+    );
+  });
+
+  it("computes the virtual chat list margin relative to the scroll viewport", () => {
+    const scrollViewport = document.createElement("div");
+    const virtualList = document.createElement("div");
+    Object.defineProperty(scrollViewport, "offsetTop", {
+      configurable: true,
+      value: 8,
+    });
+    Object.defineProperty(virtualList, "offsetTop", {
+      configurable: true,
+      value: 88,
+    });
+
+    expect(
+      getChatThreadVirtualListScrollMargin(scrollViewport, virtualList),
+    ).toBe(80);
   });
 
   it("cancels and confirms deleting a regular chat from the sidebar", async () => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -91,6 +91,7 @@ import {
   overlayScrollViewport$,
   chatThreadVirtualListElement$,
   setChatThreadVirtualListElement$,
+  getChatThreadVirtualListScrollMargin,
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { Link } from "../router/link.tsx";
@@ -776,7 +777,10 @@ function VirtualizedChatThreads({
   const scrollMetrics = useGet(overlayScrollMetrics$);
   const virtualListElement = useGet(chatThreadVirtualListElement$);
   const setVirtualListElement = useSet(setChatThreadVirtualListElement$);
-  const scrollMargin = virtualListElement?.offsetTop ?? 0;
+  const scrollMargin = getChatThreadVirtualListScrollMargin(
+    scrollViewport,
+    virtualListElement,
+  );
   const viewportHeight =
     scrollMetrics.clientHeight ||
     scrollViewport?.clientHeight ||


### PR DESCRIPTION
## Summary
- Compute the virtual chat list offset relative to the actual sidebar scroll viewport instead of the outer positioned wrapper.
- Align scroll-to-thread targets to the virtual row top so opening a deep thread no longer leaves the previous row clipped under the sidebar divider.
- Add Vitest coverage for the exact row alignment and the 8px outer offset case from the sidebar scroll wrapper.

## Verification
- `pnpm exec prettier --check apps/platform/src/signals/zero-page/zero-sidebar-state.ts apps/platform/src/views/zero-page/sidebar-threads.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app exec eslint src/signals/zero-page/zero-sidebar-state.ts src/views/zero-page/sidebar-threads.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx --max-warnings 0`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t \"(scrolls the current chat into the virtualized sidebar|aligns the current virtualized chat row with the sidebar scroll area top|computes the virtual chat list margin relative to the scroll viewport)\" --reporter=verbose --teardownTimeout=1000`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app exec tsc -p tsconfig.tests.json --noEmit`