### PR TITLE
feat: gate icon-only collapsed manage navigation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1993,6 +1993,80 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("keeps the old collapsed manage navigation when the icon switch is disabled", async () => {
+    prepareDefaultAgent();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.SidebarManageIconCollapse]: false,
+        [FeatureSwitchKey.WorkflowAutomation]: true,
+      },
+    });
+
+    const nav = await waitFor(() => {
+      const current = sidebar();
+      expect(within(current).getByText("Agents")).toBeInTheDocument();
+      return current;
+    });
+
+    click(within(nav).getByText("Manage"));
+
+    await waitFor(() => {
+      expect(within(nav).getByText("Manage")).toBeInTheDocument();
+      expect(
+        within(nav).queryByLabelText("Expand manage section"),
+      ).not.toBeInTheDocument();
+      expect(within(nav).queryByText("Agents")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows icon-only manage navigation when collapsed behind the feature switch", async () => {
+    prepareDefaultAgent();
+
+    setupSidebarPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      featureSwitches: {
+        [FeatureSwitchKey.SidebarManageIconCollapse]: true,
+        [FeatureSwitchKey.WorkflowAutomation]: true,
+      },
+    });
+
+    const nav = await waitFor(() => {
+      const current = sidebar();
+      expect(within(current).getByText("Agents")).toBeInTheDocument();
+      expect(within(current).getByText("Workflows")).toBeInTheDocument();
+      expect(within(current).getByText("Connectors")).toBeInTheDocument();
+      return current;
+    });
+
+    click(within(nav).getByText("Manage"));
+
+    await waitFor(() => {
+      expect(within(nav).queryByText("Manage")).not.toBeInTheDocument();
+      expect(within(nav).queryByText("Agents")).not.toBeInTheDocument();
+      expect(within(nav).queryByText("Workflows")).not.toBeInTheDocument();
+      expect(within(nav).queryByText("Connectors")).not.toBeInTheDocument();
+      expect(within(nav).getByLabelText("Agents")).toBeInTheDocument();
+      expect(within(nav).getByLabelText("Workflows")).toBeInTheDocument();
+      expect(within(nav).getByLabelText("Connectors")).toBeInTheDocument();
+      expect(
+        within(nav).getByLabelText("Expand manage section"),
+      ).toBeInTheDocument();
+    });
+
+    click(within(nav).getByLabelText("Expand manage section"));
+
+    await waitFor(() => {
+      expect(within(nav).getByText("Manage")).toBeInTheDocument();
+      expect(within(nav).getByText("Agents")).toBeInTheDocument();
+      expect(within(nav).getByText("Workflows")).toBeInTheDocument();
+      expect(within(nav).getByText("Connectors")).toBeInTheDocument();
+    });
+  });
+
   it("shows workflows in the sidebar manage navigation when enabled", async () => {
     prepareDefaultAgent();
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -415,8 +415,23 @@ function ExpandedManageSection() {
   const activeId = useGet(activeRoute$);
   const onSelect = useNavSelect();
   const { manageNav } = useResolvedNavItems();
+  const features = useLastResolved(featureSwitch$);
   const manageCollapsed = useGet(manageSectionCollapsed$);
   const setManageCollapsed = useSet(setManageSectionCollapsed$);
+  const compactCollapsedManage =
+    features?.[FeatureSwitchKey.SidebarManageIconCollapse] ?? false;
+  if (manageCollapsed && compactCollapsedManage) {
+    return (
+      <CollapsedManageNav
+        activeId={activeId}
+        manageNav={manageNav}
+        onSelect={onSelect}
+        onExpand={() => {
+          return setManageCollapsed(false);
+        }}
+      />
+    );
+  }
   return (
     <div className="shrink-0">
       <div
@@ -469,6 +484,81 @@ function ExpandedManageSection() {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function CollapsedManageNav({
+  activeId,
+  manageNav,
+  onSelect,
+  onExpand,
+}: {
+  activeId: RouteKey | null;
+  manageNav: readonly ManageNavItem[];
+  onSelect: (id: SidebarNavId) => void;
+  onExpand: () => void;
+}) {
+  return (
+    <div className="shrink-0">
+      <div className="flex h-8 shrink-0 items-center justify-between pl-2 pr-0">
+        <TooltipProvider delayDuration={150}>
+          <div className="flex min-w-0 items-center gap-1">
+            {manageNav.map(
+              ({ id, activeKeys, pathname: navPath, label, icon: Icon }) => {
+                const isActive =
+                  activeId !== null &&
+                  (activeKeys as readonly RouteKey[]).includes(activeId);
+                return (
+                  <Tooltip key={id}>
+                    <TooltipTrigger asChild>
+                      <Link
+                        pathname={
+                          navPath as Parameters<typeof Link>[0]["pathname"]
+                        }
+                        onClick={(e) => {
+                          if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                            return;
+                          }
+                          e.preventDefault();
+                          onSelect(id);
+                        }}
+                        aria-label={label}
+                        aria-current={isActive ? "page" : undefined}
+                        className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                          isActive
+                            ? "bg-gray-200 text-gray-900"
+                            : "text-sidebar-foreground hover:bg-sidebar-accent"
+                        }`}
+                      >
+                        <Icon size={16} className="shrink-0" />
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p className="text-xs">{label}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                );
+              },
+            )}
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
+                onClick={onExpand}
+                aria-label="Expand manage section"
+              >
+                <IconChevronRight size={15} stroke={2.5} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              <p className="text-xs">Expand manage section</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
     </div>
   );
 }

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -58,6 +58,7 @@ export enum FeatureSwitchKey {
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
   ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",
   AgentsPageRedesign = "agentsPageRedesign",
+  SidebarManageIconCollapse = "sidebarManageIconCollapse",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   ChatThreadLatestUserMessageScrollAnchor = "chatThreadLatestUserMessageScrollAnchor",
   TeamsIntegration = "teamsIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -341,6 +341,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "New Agents page with Public/Private tabs, a public-slot indicator, a Created by footer on every card, a name-first create dialog with a visibility select, and a private empty state.",
     enabled: false,
   },
+  [FeatureSwitchKey.SidebarManageIconCollapse]: {
+    maintainer: "ming@vm0.ai",
+    description:
+      "Show icon-only manage navigation buttons when the expanded sidebar manage section is collapsed.",
+    enabled: false,
+  },
   [FeatureSwitchKey.SidebarSubscriptionUsage]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- adds `SidebarManageIconCollapse` as a disabled-by-default feature switch
- renders the expanded sidebar Manage section collapsed state as icon-only nav controls when the switch is enabled
- keeps the existing `Manage` collapsed header behavior when the switch is disabled

## Verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts`
- `pnpm --filter @vm0/app exec oxlint src/views/zero-page/zero-sidebar.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm --filter @vm0/app exec eslint src/views/zero-page/zero-sidebar.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx --max-warnings 0`
- `pnpm --filter @vm0/app exec tsc -p tsconfig.production.json --noEmit --pretty false`
- `pnpm --filter @vm0/core test -- src/__tests__/feature-switch.test.ts`
- `pnpm --filter @vm0/core exec tsc --noEmit --pretty false`
- `pnpm --filter @vm0/connectors exec tsc --noEmit --pretty false`
- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx -t "manage navigation" --pool=threads --maxWorkers=1 --reporter=verbose`

## Notes
- Local app dev server starts and returns 200, but the agent runtime is missing local Clerk/Vite env, so authenticated browser verification is deferred to the PR preview.