### PR TITLE
fix: exclude active runs and goals from unread thread ids

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -44,6 +44,7 @@ import {
   setUsageOrgTier$,
 } from "./helpers/zero-usage";
 import {
+  seedZeroChatThreadGoal$,
   seedZeroChatThreadRun$,
   updateZeroChatThreadRunStatus$,
 } from "./helpers/zero-chat-threads";
@@ -1125,6 +1126,101 @@ describe("CHAT-01 chat thread read state", () => {
 
     expect(new Set(await chat.listActiveChatThreadIds(owner))).toStrictEqual(
       new Set([queuedThread]),
+    );
+  }, 60_000);
+
+  it("excludes unread chat threads that have active runs or goals", async () => {
+    const owner = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    const agent = await bdd.createAgent(owner, {
+      displayName: "Unread active state agent",
+    });
+
+    const runningThread = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: "unread thread with active run",
+    });
+    const completedThread = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: "unread thread with completed run",
+    });
+    const activeGoalThread = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: "unread thread with active goal",
+    });
+    const completeGoalThread = await sendNoCreditMessage(owner, {
+      agentId: agent.agentId,
+      prompt: "unread thread with complete goal",
+    });
+    if (!owner.orgId) {
+      throw new Error("Expected owner to belong to an org");
+    }
+    const runningRunId = await store.set(
+      seedZeroChatThreadRun$,
+      {
+        userId: owner.userId,
+        orgId: owner.orgId,
+        agentId: agent.agentId,
+        threadId: runningThread,
+        status: "running",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatThreadRun$,
+      {
+        userId: owner.userId,
+        orgId: owner.orgId,
+        agentId: agent.agentId,
+        threadId: completedThread,
+        status: "completed",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatThreadGoal$,
+      {
+        userId: owner.userId,
+        orgId: owner.orgId,
+        agentId: agent.agentId,
+        threadId: activeGoalThread,
+        status: "active",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatThreadGoal$,
+      {
+        userId: owner.userId,
+        orgId: owner.orgId,
+        agentId: agent.agentId,
+        threadId: completeGoalThread,
+        status: "complete",
+      },
+      context.signal,
+    );
+
+    expect(
+      new Set(
+        (await chat.listThreadUnreads(owner, agent.agentId)).map((unread) => {
+          return unread.threadId;
+        }),
+      ),
+    ).toStrictEqual(new Set([completedThread, completeGoalThread]));
+
+    await store.set(
+      updateZeroChatThreadRunStatus$,
+      { runId: runningRunId, status: "completed" },
+      context.signal,
+    );
+    expect(
+      new Set(
+        (await chat.listThreadUnreads(owner, agent.agentId)).map((unread) => {
+          return unread.threadId;
+        }),
+      ),
+    ).toStrictEqual(
+      new Set([runningThread, completedThread, completeGoalThread]),
     );
   }, 60_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -993,6 +993,42 @@ describe("CHAT-01 chat thread read state", () => {
     await chat.markThreadRead(owner, activeUnreadThread);
     await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
 
+    const activeGoalThread = await sendNoCreditMessage(owner, {
+      agentId: agentA.agentId,
+      prompt: "unread aggregate with active goal",
+    });
+    const completeGoalThread = await sendNoCreditMessage(owner, {
+      agentId: agentB.agentId,
+      prompt: "unread aggregate with complete goal",
+    });
+    await store.set(
+      seedZeroChatThreadGoal$,
+      {
+        userId: owner.userId,
+        orgId: owner.orgId,
+        agentId: agentA.agentId,
+        threadId: activeGoalThread,
+        status: "active",
+      },
+      context.signal,
+    );
+    await store.set(
+      seedZeroChatThreadGoal$,
+      {
+        userId: owner.userId,
+        orgId: owner.orgId,
+        agentId: agentB.agentId,
+        threadId: completeGoalThread,
+        status: "complete",
+      },
+      context.signal,
+    );
+    await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([
+      agentB.agentId,
+    ]);
+    await chat.markThreadRead(owner, completeGoalThread);
+    await expect(chat.listUnreadAgents(owner)).resolves.toStrictEqual([]);
+
     const threadA = await sendNoCreditMessage(owner, {
       agentId: agentA.agentId,
       prompt: "unread aggregate A",

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts
@@ -39,6 +39,7 @@ type ChatThreadRunStatus =
   | "pending"
   | "queued"
   | "running";
+type ChatThreadGoalStatus = "active" | "paused" | "blocked" | "complete";
 
 interface SeedChatThreadRunOptions {
   readonly userId: string;
@@ -46,6 +47,14 @@ interface SeedChatThreadRunOptions {
   readonly agentId: string;
   readonly threadId: string;
   readonly status: ChatThreadRunStatus;
+}
+
+interface SeedChatThreadGoalOptions {
+  readonly userId: string;
+  readonly orgId: string;
+  readonly agentId: string;
+  readonly threadId: string;
+  readonly status: ChatThreadGoalStatus;
 }
 
 function dateToWire(value: Date | null | undefined): string | null | undefined {
@@ -180,6 +189,27 @@ export const seedZeroChatThreadRun$ = command(
       throw new Error("seedZeroChatThreadRun$: response missing run id");
     }
     return response.run_id;
+  },
+);
+
+export const seedZeroChatThreadGoal$ = command(
+  async (
+    _,
+    options: SeedChatThreadGoalOptions,
+    signal: AbortSignal,
+  ): Promise<string> => {
+    const response = await postAction(signal, {
+      action: "seed-thread-goal",
+      user_id: options.userId,
+      org_id: options.orgId,
+      agent_id: options.agentId,
+      thread_id: options.threadId,
+      status: options.status,
+    });
+    if (!response.goal_id) {
+      throw new Error("seedZeroChatThreadGoal$: response missing goal id");
+    }
+    return response.goal_id;
   },
 );
 

--- a/turbo/apps/api/src/signals/routes/test-chat-thread-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-chat-thread-state.ts
@@ -14,6 +14,7 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatMessages } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { eq, inArray } from "drizzle-orm";
@@ -265,6 +266,33 @@ async function seedThreadRunForAction(
   };
 }
 
+async function seedThreadGoalForAction(
+  db: Db,
+  body: ChatThreadStateAction<"seed-thread-goal">,
+  signal: AbortSignal,
+) {
+  const [goal] = await db
+    .insert(threadGoals)
+    .values({
+      orgId: body.org_id,
+      ownerUserId: body.user_id,
+      agentId: body.agent_id,
+      chatThreadId: body.thread_id,
+      status: body.status,
+      objective: "bdd unread goal",
+      objectiveBrief: "bdd unread goal",
+    })
+    .returning({ id: threadGoals.id });
+  signal.throwIfAborted();
+  if (!goal) {
+    throw new Error("seedThreadGoalForAction: goal insert returned no row");
+  }
+  return {
+    status: 200 as const,
+    body: { ok: true as const, goal_id: goal.id },
+  };
+}
+
 async function updateThreadRunStatusForAction(
   db: Db,
   body: ChatThreadStateAction<"update-thread-run-status">,
@@ -341,6 +369,9 @@ const mutateTestChatThreadState$ = command(
       }
       case "seed-thread-run": {
         return await seedThreadRunForAction(db, body, signal);
+      }
+      case "seed-thread-goal": {
+        return await seedThreadGoalForAction(db, body, signal);
       }
       case "update-thread-run-status": {
         return await updateThreadRunStatusForAction(db, body, signal);

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -29,6 +29,7 @@ import {
   type ChatMessageGoalSnapshot,
 } from "@vm0/db/schema/chat-message";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
+import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { automations } from "@vm0/db/schema/automation";
@@ -611,6 +612,15 @@ function noActiveRunsForCurrentThreadCondition() {
   )`;
 }
 
+function noActiveGoalsForCurrentThreadCondition() {
+  return sql<boolean>`NOT EXISTS (
+    SELECT 1
+    FROM ${threadGoals}
+    WHERE ${threadGoals.chatThreadId} = ${chatThreads.id}
+      AND ${threadGoals.status} = 'active'
+  )`;
+}
+
 interface ThreadRunSummaryRow {
   readonly id: string;
   readonly status: string;
@@ -724,6 +734,8 @@ export function zeroChatThreadUnreads(args: {
             isNull(chatThreads.lastReadMessageId),
             sql`${chatThreads.lastReadMessageId} <> ${lastMessage.id}`,
           ),
+          noActiveRunsForCurrentThreadCondition(),
+          noActiveGoalsForCurrentThreadCondition(),
         ),
       );
     return rows.flatMap((row) => {
@@ -763,6 +775,7 @@ export function zeroChatThreadUnreadAgentIds(args: {
             sql`${chatThreads.lastReadMessageId} <> ${lastMessage.id}`,
           ),
           noActiveRunsForCurrentThreadCondition(),
+          noActiveGoalsForCurrentThreadCondition(),
         ),
       );
     return rows.map((row) => {

--- a/turbo/packages/api-contracts/src/contracts/test-chat-thread-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-chat-thread-state.ts
@@ -15,6 +15,7 @@ const runStatusSchema = z.enum([
   "queued",
   "running",
 ]);
+const goalStatusSchema = z.enum(["active", "paused", "blocked", "complete"]);
 
 export const testChatThreadStateErrorSchema = z.object({
   error: z.string(),
@@ -62,6 +63,14 @@ export const testChatThreadStateActionBodySchema = z.discriminatedUnion(
       status: runStatusSchema,
     }),
     z.object({
+      action: z.literal("seed-thread-goal"),
+      user_id: z.string(),
+      org_id: z.string(),
+      agent_id: z.string(),
+      thread_id: z.string(),
+      status: goalStatusSchema,
+    }),
+    z.object({
       action: z.literal("update-thread-run-status"),
       run_id: z.string(),
       status: runStatusSchema,
@@ -73,6 +82,7 @@ export const testChatThreadStateActionResponseSchema = z.object({
   ok: z.literal(true),
   fixture: testChatThreadStateFixtureSchema.optional(),
   run_id: z.string().optional(),
+  goal_id: z.string().optional(),
 });
 
 export const testChatThreadStateContract = c.router({


### PR DESCRIPTION
## Summary

- Filter `/api/zero/chat-thread-unreads` with the existing active-run exclusion so unread thread ids omit threads that still have queued, pending, or running runs.
- Also filter unread thread ids and unread agent aggregates for threads with an active thread goal (`thread_goals.status = active`).
- Add API BDD coverage showing active-run and active-goal threads are excluded while completed-run and complete-goal threads remain unread.
- Extend the chat-thread test support route with a `seed-thread-goal` action for this behavior test.

## Verification

- `pnpm exec prettier --write apps/api/src/signals/services/zero-chat-thread.service.ts apps/api/src/signals/routes/test-chat-thread-state.ts apps/api/src/signals/routes/__tests__/helpers/zero-chat-threads.ts apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts packages/api-contracts/src/contracts/test-chat-thread-state.ts`
- `git diff --check`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t "excludes unread chat threads that have active runs or goals"` failed locally because Postgres at `localhost:5432/vm0_test` refused the connection before the assertion ran.
- `NODE_OPTIONS=--max-old-space-size=2560 pnpm -F api check-types` was attempted on this runner before the latest amend and failed with Node heap OOM on the 3.8GB machine.
