### PR TITLE
docs: clarify sandbox mock batch write controls

### DIFF
--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -6,8 +6,8 @@
 //! [`MockSandboxControl::push_exec_remote_result`], or
 //! [`MockSandboxControl::push_kill_remote_result`] to queue custom responses
 //! consumed in FIFO order.
-//! Write-file results also apply to batched writes; see the method docs for
-//! details.
+//! Results queued with [`MockSandbox::push_write_file_result`] also apply to
+//! batched writes; see the method docs for details.
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -6,6 +6,8 @@
 //! [`MockSandboxControl::push_exec_remote_result`], or
 //! [`MockSandboxControl::push_kill_remote_result`] to queue custom responses
 //! consumed in FIFO order.
+//! Write-file results also apply to batched writes; see the method docs for
+//! details.
 //!
 //! For advanced control, create [`MockSandboxOverrides`] and pass it via
 //! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -170,9 +170,9 @@ impl MockSandbox {
     ///
     /// Batch entries are also expanded into [`Self::write_file_calls`] so tests
     /// that only need path/content assertions can use one observation surface.
-    /// That expansion is only for call recording: queued write results and the
-    /// write lifecycle gate are consumed per write operation, not per expanded
-    /// file entry.
+    /// That expansion is only for call recording: queued write results are
+    /// consumed, and the write lifecycle gate is entered, per write operation
+    /// rather than per expanded file entry.
     pub fn write_files_calls(&self) -> Vec<WriteFilesCall> {
         self.write_files_calls.lock_ignoring_poison().clone()
     }
@@ -204,7 +204,7 @@ impl MockSandbox {
         *self.write_file_gate.lock_ignoring_poison() = Some(gate);
     }
 
-    /// Remove the durable write-operation gate for future write calls.
+    /// Remove the durable write-operation gate for future write operations.
     ///
     /// Already-entered writes keep waiting on their cloned gate until the test
     /// releases it.

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -144,8 +144,13 @@ impl MockSandbox {
         self.copy_file_calls.lock_ignoring_poison().clone()
     }
 
-    /// Queue a write_file result. Results are consumed in FIFO order.
-    /// When the queue is empty, write_file returns `Ok(())`.
+    /// Queue a write-operation result.
+    ///
+    /// Results are consumed in FIFO order by both
+    /// [`write_file`](Sandbox::write_file) and [`write_files`](Sandbox::write_files).
+    /// When the queue is empty, both operations return `Ok(())`.
+    /// Each `write_files` invocation consumes one queued result for the whole
+    /// batch, not one result per file.
     pub fn push_write_file_result(&self, result: Result<()>) {
         self.write_file_results
             .lock_ignoring_poison()
@@ -165,6 +170,9 @@ impl MockSandbox {
     ///
     /// Batch entries are also expanded into [`Self::write_file_calls`] so tests
     /// that only need path/content assertions can use one observation surface.
+    /// That expansion is only for call recording: queued write results and the
+    /// write lifecycle gate are consumed per write operation, not per expanded
+    /// file entry.
     pub fn write_files_calls(&self) -> Vec<WriteFilesCall> {
         self.write_files_calls.lock_ignoring_poison().clone()
     }
@@ -186,15 +194,17 @@ impl MockSandbox {
         self.private_write_file_calls.lock_ignoring_poison().clone()
     }
 
-    /// Block every write_file call with a durable lifecycle gate.
+    /// Block every write operation with a durable lifecycle gate.
     ///
     /// Calls are recorded before they enter the gate, so tests can assert that a
-    /// write was attempted while keeping the mock response pending.
+    /// write was attempted while keeping the mock response pending. Both
+    /// [`write_file`](Sandbox::write_file) and [`write_files`](Sandbox::write_files)
+    /// enter this gate; `write_files` enters it once for the whole batch.
     pub fn set_write_file_lifecycle_gate(&self, gate: MockLifecycleGate) {
         *self.write_file_gate.lock_ignoring_poison() = Some(gate);
     }
 
-    /// Remove the durable write_file gate for future write calls.
+    /// Remove the durable write-operation gate for future write calls.
     ///
     /// Already-entered writes keep waiting on their cloned gate until the test
     /// releases it.

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -519,3 +519,49 @@ async fn sandbox_write_file_lifecycle_gate_blocks_until_released() {
     gate.release_one();
     task.await.unwrap().unwrap();
 }
+
+#[tokio::test]
+async fn sandbox_write_files_lifecycle_gate_blocks_batch_until_released() {
+    let sandbox = Arc::new(MockSandbox::new("test-1"));
+    let gate = MockLifecycleGate::new();
+    sandbox.set_write_file_lifecycle_gate(gate.clone());
+
+    let task = {
+        let sandbox = Arc::clone(&sandbox);
+        tokio::spawn(async move {
+            let files = [
+                WriteFileEntry {
+                    path: "/tmp/a.txt",
+                    content: b"a",
+                },
+                WriteFileEntry {
+                    path: "/tmp/b.txt",
+                    content: b"b",
+                },
+            ];
+            sandbox.write_files(&files).await
+        })
+    };
+
+    assert_eq!(gate.wait_entered(1, test_timeout()).await.unwrap(), 1);
+    assert_eq!(gate.entered_count(), 1);
+
+    let batch_calls = sandbox.write_files_calls();
+    assert_eq!(batch_calls.len(), 1);
+    assert_eq!(batch_calls[0].files.len(), 2);
+    assert_eq!(batch_calls[0].files[0].path, "/tmp/a.txt");
+    assert_eq!(batch_calls[0].files[1].path, "/tmp/b.txt");
+
+    let write_calls = sandbox.write_file_calls();
+    assert_eq!(write_calls.len(), 2);
+    assert_eq!(write_calls[0].path, "/tmp/a.txt");
+    assert_eq!(write_calls[1].path, "/tmp/b.txt");
+    assert!(
+        !task.is_finished(),
+        "write_files must wait for one batch gate release"
+    );
+
+    gate.release_one();
+    task.await.unwrap().unwrap();
+    assert_eq!(gate.entered_count(), 1);
+}

--- a/crates/sandbox-mock/src/tests/files.rs
+++ b/crates/sandbox-mock/src/tests/files.rs
@@ -562,6 +562,10 @@ async fn sandbox_write_files_lifecycle_gate_blocks_batch_until_released() {
     );
 
     gate.release_one();
-    task.await.unwrap().unwrap();
+    tokio::time::timeout(test_timeout(), task)
+        .await
+        .expect("write_files must finish after one batch gate release")
+        .unwrap()
+        .unwrap();
     assert_eq!(gate.entered_count(), 1);
 }


### PR DESCRIPTION
## Summary

- Clarify that `MockSandbox::push_write_file_result` applies to both `write_file` and `write_files`.
- Document that one `write_files` batch consumes one queued result and enters the write lifecycle gate once.
- Add a focused `write_files` lifecycle gate test for the documented batch behavior.

Closes #20211

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock write_files`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-mock --no-deps`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- pre-commit hook: `cargo-doc`, `cargo-clippy`, commitlint
