### PR TITLE
fix(nbd-cow): harden device lock files

### DIFF
--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -229,15 +229,16 @@ mod tests {
         let lock_dir = Arc::new(dir.path().to_owned());
         let worker_count = 8;
         let start = Arc::new(Barrier::new(worker_count + 1));
-        let finish = Arc::new(Barrier::new(worker_count + 1));
         let (result_tx, result_rx) = mpsc::channel();
+        let mut release_txs = Vec::with_capacity(worker_count);
         let mut handles = Vec::with_capacity(worker_count);
 
         for _ in 0..worker_count {
             let lock_dir = Arc::clone(&lock_dir);
             let start = Arc::clone(&start);
-            let finish = Arc::clone(&finish);
             let result_tx = result_tx.clone();
+            let (release_tx, release_rx) = mpsc::channel();
+            release_txs.push(release_tx);
             handles.push(std::thread::spawn(move || {
                 start.wait();
                 let claim = try_acquire_device_claim_in(7, &lock_dir);
@@ -245,8 +246,11 @@ mod tests {
                     .as_ref()
                     .map(|claim| claim.is_some())
                     .map_err(|error| error.to_string());
+                let holds_claim = matches!(&claim, Ok(Some(_)));
                 let _ = result_tx.send(result);
-                finish.wait();
+                if holds_claim {
+                    let _ = release_rx.recv();
+                }
                 drop(claim);
             }));
         }
@@ -256,7 +260,9 @@ mod tests {
         let results = (0..worker_count)
             .map(|_| result_rx.recv().expect("worker result"))
             .collect::<Vec<_>>();
-        finish.wait();
+        for release_tx in release_txs {
+            let _ = release_tx.send(());
+        }
 
         for handle in handles {
             handle.join().expect("worker should not panic");

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -248,6 +248,7 @@ mod tests {
                     .map_err(|error| error.to_string());
                 let holds_claim = matches!(&claim, Ok(Some(_)));
                 let _ = result_tx.send(result);
+                drop(result_tx);
                 if holds_claim {
                     let _ = release_rx.recv();
                 }
@@ -257,9 +258,13 @@ mod tests {
         drop(result_tx);
 
         start.wait();
-        let results = (0..worker_count)
-            .map(|_| result_rx.recv().expect("worker result"))
-            .collect::<Vec<_>>();
+        let mut results = Vec::with_capacity(worker_count);
+        while results.len() < worker_count {
+            let Ok(result) = result_rx.recv() else {
+                break;
+            };
+            results.push(result);
+        }
         for release_tx in release_txs {
             let _ = release_tx.send(());
         }
@@ -268,6 +273,7 @@ mod tests {
             handle.join().expect("worker should not panic");
         }
 
+        assert_eq!(results.len(), worker_count);
         let winner_count = results
             .into_iter()
             .map(|result| result.expect("lock attempt should not fail"))

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn claim_tightens_owner_only_lock_file_permissions() {
+    fn claim_tightens_world_readable_lock_file_permissions() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = device_lock_path_in(7, dir.path());
         std::fs::write(&path, b"").expect("write lock path");

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -197,6 +197,7 @@ fn file_inode_is_current(file: &File, path: &Path) -> io::Result<bool> {
 #[cfg(test)]
 mod tests {
     use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::sync::{Arc, Barrier, mpsc};
 
     use super::*;
 
@@ -220,6 +221,53 @@ mod tests {
                 .expect("third lock")
                 .is_some()
         );
+    }
+
+    #[test]
+    fn concurrent_claims_for_same_index_have_single_winner() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let lock_dir = Arc::new(dir.path().to_owned());
+        let worker_count = 8;
+        let start = Arc::new(Barrier::new(worker_count + 1));
+        let finish = Arc::new(Barrier::new(worker_count + 1));
+        let (result_tx, result_rx) = mpsc::channel();
+        let mut handles = Vec::with_capacity(worker_count);
+
+        for _ in 0..worker_count {
+            let lock_dir = Arc::clone(&lock_dir);
+            let start = Arc::clone(&start);
+            let finish = Arc::clone(&finish);
+            let result_tx = result_tx.clone();
+            handles.push(std::thread::spawn(move || {
+                start.wait();
+                let claim = try_acquire_device_claim_in(7, &lock_dir);
+                let result = claim
+                    .as_ref()
+                    .map(|claim| claim.is_some())
+                    .map_err(|error| error.to_string());
+                let _ = result_tx.send(result);
+                finish.wait();
+                drop(claim);
+            }));
+        }
+        drop(result_tx);
+
+        start.wait();
+        let results = (0..worker_count)
+            .map(|_| result_rx.recv().expect("worker result"))
+            .collect::<Vec<_>>();
+        finish.wait();
+
+        for handle in handles {
+            handle.join().expect("worker should not panic");
+        }
+
+        let winner_count = results
+            .into_iter()
+            .map(|result| result.expect("lock attempt should not fail"))
+            .filter(|acquired| *acquired)
+            .count();
+        assert_eq!(winner_count, 1);
     }
 
     #[test]
@@ -310,6 +358,35 @@ mod tests {
             .expect("lock")
             .expect("claim");
 
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("lock metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            PRIVATE_FILE_MODE
+        );
+    }
+
+    #[test]
+    fn claim_reports_busy_for_held_legacy_world_readable_lock_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = device_lock_path_in(7, dir.path());
+        std::fs::write(&path, b"").expect("write lock path");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("set legacy lock permissions");
+        let legacy_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open legacy lock file");
+        let _legacy_lock = Flock::lock(legacy_file, FlockArg::LockExclusiveNonblock)
+            .map_err(|(_file, errno)| errno)
+            .expect("hold legacy lock");
+
+        let claim =
+            try_acquire_device_claim_in(7, dir.path()).expect("new lock attempt should not fail");
+
+        assert!(claim.is_none());
         assert_eq!(
             std::fs::metadata(&path)
                 .expect("lock metadata")

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -6,6 +6,7 @@
 
 use std::fs::{File, OpenOptions};
 use std::io;
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
@@ -14,6 +15,8 @@ use nix::fcntl::{Flock, FlockArg};
 
 const LOCK_FILE_PREFIX: &str = "vm0-nbd";
 const MAX_STALE_INODE_RETRIES: usize = 16;
+const PRIVATE_FILE_MODE: u32 = 0o600;
+const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 
 /// Owned host-global claim for one NBD device index.
 ///
@@ -100,26 +103,87 @@ fn open_lock_file(path: &Path) -> io::Result<File> {
 
 fn base_open_options() -> OpenOptions {
     let mut options = OpenOptions::new();
-    options.write(true).custom_flags(libc::O_NOFOLLOW);
+    options
+        .read(true)
+        .write(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK);
     options
 }
 
 fn open_existing_lock_file(path: &Path) -> io::Result<File> {
-    base_open_options().open(path)
+    let file = base_open_options().open(path)?;
+    validate_lock_file(&file, path)?;
+    Ok(file)
 }
 
 fn create_lock_file(path: &Path) -> io::Result<File> {
     let mut options = base_open_options();
-    options.create(true).truncate(false).open(path)
+    let file = options
+        .create(true)
+        .truncate(false)
+        .mode(PRIVATE_FILE_MODE)
+        .open(path)?;
+    validate_lock_file(&file, path)?;
+    Ok(file)
+}
+
+fn validate_lock_file(file: &File, path: &Path) -> io::Result<()> {
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(permission_denied(format!(
+            "{} is not a regular lock file",
+            path.display()
+        )));
+    }
+
+    // SAFETY: `geteuid` has no preconditions and does not mutate Rust-owned memory.
+    let expected_uid = unsafe { libc::geteuid() };
+    if metadata.uid() != expected_uid {
+        return Err(permission_denied(format!(
+            "{} is owned by uid {}, but current euid is {expected_uid}",
+            path.display(),
+            metadata.uid()
+        )));
+    }
+
+    let mode = metadata.mode() & 0o7777;
+    if mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
+        return Err(permission_denied(format!(
+            "{} is group/other writable",
+            path.display()
+        )));
+    }
+    if mode != PRIVATE_FILE_MODE {
+        chmod_lock_file(file, path)?;
+    }
+    Ok(())
+}
+
+fn chmod_lock_file(file: &File, path: &Path) -> io::Result<()> {
+    // SAFETY: `fchmod` operates on the live fd and does not affect Rust aliasing.
+    let result = unsafe { libc::fchmod(file.as_raw_fd(), PRIVATE_FILE_MODE as libc::mode_t) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "chmod lock file {}: {}",
+            path.display(),
+            io::Error::last_os_error()
+        )))
+    }
+}
+
+fn permission_denied(message: String) -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, message)
 }
 
 fn metadata_inode_is_current(lock_meta: std::fs::Metadata, path: &Path) -> io::Result<bool> {
-    let path_meta = match std::fs::metadata(path) {
+    let path_meta = match std::fs::symlink_metadata(path) {
         Ok(meta) => meta,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
         Err(e) => return Err(e),
     };
-    Ok(lock_meta.ino() == path_meta.ino())
+    Ok(lock_meta.dev() == path_meta.dev() && lock_meta.ino() == path_meta.ino())
 }
 
 fn lock_inode_is_current(lock: &Flock<File>, path: &Path) -> io::Result<bool> {
@@ -132,6 +196,8 @@ fn file_inode_is_current(file: &File, path: &Path) -> io::Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
     use super::*;
 
     #[test]
@@ -170,6 +236,105 @@ mod tests {
         assert!(
             !lock_inode_is_current(&claim._lock, &path).expect("inode comparison"),
             "held claim should detect that the path was replaced"
+        );
+    }
+
+    #[test]
+    fn claim_rejects_symlink_lock_path_without_touching_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = device_lock_path_in(7, dir.path());
+        let target = dir.path().join("target.lock");
+        std::fs::write(&target, b"target").expect("write target");
+        symlink(&target, &path).expect("create lock path symlink");
+
+        try_acquire_device_claim_in(7, dir.path()).expect_err("symlink lock path should fail");
+
+        assert_eq!(std::fs::read(&target).expect("read target"), b"target");
+        assert!(
+            std::fs::symlink_metadata(&path)
+                .expect("lock path metadata")
+                .file_type()
+                .is_symlink(),
+            "lock path should remain a symlink"
+        );
+    }
+
+    #[test]
+    fn held_claim_rejects_symlink_replacement_to_same_inode() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = device_lock_path_in(7, dir.path());
+        let alias = dir.path().join("alias.lock");
+        let claim = try_acquire_device_claim_in(7, dir.path())
+            .expect("lock")
+            .expect("claim");
+
+        std::fs::hard_link(&path, &alias).expect("create lock alias");
+        std::fs::remove_file(&path).expect("remove lock path");
+        symlink(&alias, &path).expect("replace lock path with symlink");
+
+        assert!(
+            !lock_inode_is_current(&claim._lock, &path).expect("inode comparison"),
+            "held claim should reject a symlink replacement even when it resolves to the same inode"
+        );
+    }
+
+    #[test]
+    fn claim_rejects_fifo_lock_path_without_blocking() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = device_lock_path_in(7, dir.path());
+        nix::unistd::mkfifo(
+            &path,
+            nix::sys::stat::Mode::from_bits_truncate(PRIVATE_FILE_MODE),
+        )
+        .expect("create fifo lock path");
+
+        let error =
+            try_acquire_device_claim_in(7, dir.path()).expect_err("fifo lock path should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains("not a regular lock file"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn claim_tightens_owner_only_lock_file_permissions() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = device_lock_path_in(7, dir.path());
+        std::fs::write(&path, b"").expect("write lock path");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("set loose lock permissions");
+
+        let _claim = try_acquire_device_claim_in(7, dir.path())
+            .expect("lock")
+            .expect("claim");
+
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("lock metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            PRIVATE_FILE_MODE
+        );
+    }
+
+    #[test]
+    fn claim_rejects_group_writable_lock_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = device_lock_path_in(7, dir.path());
+        std::fs::write(&path, b"").expect("write lock path");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o620))
+            .expect("set group-writable lock permissions");
+
+        let error = try_acquire_device_claim_in(7, dir.path())
+            .expect_err("group-writable lock path should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains("group/other writable"),
+            "unexpected error: {error}"
         );
     }
 }

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -146,6 +146,13 @@ fn validate_lock_file(file: &File, path: &Path) -> io::Result<()> {
         )));
     }
 
+    if metadata.nlink() > 1 {
+        return Err(permission_denied(format!(
+            "{} has multiple hard links",
+            path.display()
+        )));
+    }
+
     let mode = metadata.mode() & 0o7777;
     if mode & GROUP_OR_OTHER_WRITE_BITS != 0 {
         return Err(permission_denied(format!(
@@ -355,6 +362,35 @@ mod tests {
         assert!(
             error.to_string().contains("not a regular lock file"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn claim_rejects_hard_link_lock_path_without_chmod_target() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = device_lock_path_in(7, dir.path());
+        let target = dir.path().join("target.lock");
+        std::fs::write(&target, b"target").expect("write target");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644))
+            .expect("set target permissions");
+        std::fs::hard_link(&target, &path).expect("create lock hard link");
+
+        let error = try_acquire_device_claim_in(7, dir.path())
+            .expect_err("hard-linked lock path should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            error.to_string().contains("multiple hard links"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(std::fs::read(&target).expect("read target"), b"target");
+        assert_eq!(
+            std::fs::metadata(&target)
+                .expect("target metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
         );
     }
 


### PR DESCRIPTION
## Summary

- harden NBD device lock file opens with read/write access, `O_CLOEXEC`, `O_NONBLOCK`, `O_NOFOLLOW`, and `0600` creation mode
- validate opened lock fds as current-user regular private files before `flock`
- switch current-inode checks to no-follow path metadata and compare `(dev, ino)`
- add regression coverage for symlink lock paths, symlink replacement, FIFO lock paths, permission tightening, and group-writable rejection

Closes #20210

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow device_lock`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`