### PR TITLE
fix: tighten html draft discard flow

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -88,6 +88,7 @@ export interface HtmlDomCommentEditorModel {
   readonly activeColorPanelProperty: HtmlDomStyleProperty | null;
   readonly canApplyStyleEdits: boolean;
   readonly canAddComment: boolean;
+  readonly canDiscard: boolean;
   readonly canEditSelectedStyle: boolean;
   readonly canSend: boolean;
   readonly colorPopoverOffset: HtmlDomColorPopoverOffset;
@@ -1295,6 +1296,34 @@ function commentForSelectedNodes(params: {
         return params.selectedNodeIds.includes(nodeId);
       });
     }) ?? null
+  );
+}
+
+function canDiscardHtmlDomEditorDraft(params: {
+  readonly comments: readonly HtmlDomEditComment[];
+  readonly commentText: string;
+  readonly editingCommentId: string | null;
+  readonly hasPendingImageEdits: boolean;
+  readonly hasPendingStyleEdits: boolean;
+  readonly imageBusy: boolean;
+  readonly loadState: EditorLoadState;
+  readonly selectedNodeIds: readonly string[];
+  readonly submitting: boolean;
+}): boolean {
+  if (
+    params.loadState.status !== "ready" ||
+    params.submitting ||
+    params.imageBusy
+  ) {
+    return false;
+  }
+  return (
+    params.comments.length > 0 ||
+    params.hasPendingStyleEdits ||
+    params.hasPendingImageEdits ||
+    params.commentText.trim() !== "" ||
+    params.selectedNodeIds.length > 0 ||
+    params.editingCommentId !== null
   );
 }
 
@@ -3174,6 +3203,32 @@ export const discardHtmlDomComments$ = command(({ get, set }) => {
   set(resetHtmlDomCommentDraft$);
 });
 
+export const clearHtmlDomCommentEditorDraft$ = command(({ get, set }) => {
+  const doc = currentFrameDocument(get(internalIframeElement$));
+  set(resetHtmlDomImageEditSignal$);
+  set(internalComments$, []);
+  set(internalCommentsOpen$, false);
+  set(internalCommentText$, "");
+  set(internalSelectedNodeIds$, []);
+  set(internalCommentPopoverAnchor$, null);
+  set(internalEditingCommentId$, null);
+  set(internalPreparedPayload$, null);
+  set(internalActiveColorPanelProperty$, null);
+  set(internalColorPopoverOffset$, { left: 0, top: 0 });
+  set(internalStyleEditsByNodeId$, {});
+  set(internalOriginalStylesByNodeId$, {});
+  set(internalImageEditsByNodeId$, {});
+  set(internalImageBusy$, false);
+  set(internalImageLinkOpen$, false);
+  set(internalImageLinkValue$, "");
+  set(internalImagePendingAction$, null);
+  syncFrameEditState(doc, {
+    hoveredNodeId: get(internalHoveredNodeId$),
+    selectedNodeIds: [],
+  });
+  syncFrameCommentMarkers(doc, []);
+});
+
 export const sendHtmlDomEditRequest$ = command(
   async (
     { get, set },
@@ -3226,6 +3281,7 @@ export const sendHtmlDomEditRequest$ = command(
           html: draftHtml,
         });
         signal.throwIfAborted();
+        set(clearHtmlDomCommentEditorDraft$);
         toast.success("Edit draft applied");
         return;
       }
@@ -3336,6 +3392,8 @@ export const htmlDomCommentEditorModel$ = computed(
     const styleEditsByNodeId = get(internalStyleEditsByNodeId$);
     const imageEditsByNodeId = get(internalImageEditsByNodeId$);
     const imageBusy = get(internalImageBusy$);
+    const hasPendingStyleEdits = hasStyleEdits(styleEditsByNodeId);
+    const hasPendingImageEdits = hasImageEdits(imageEditsByNodeId);
     const doc = currentFrameDocument(get(internalIframeElement$));
     const editableStyleProperties = editableStylePropertiesForSelectedNodes({
       doc,
@@ -3351,8 +3409,7 @@ export const htmlDomCommentEditorModel$ = computed(
       canApplyStyleEdits:
         loadState.status === "ready" &&
         comments.length === 0 &&
-        (hasStyleEdits(styleEditsByNodeId) ||
-          hasImageEdits(imageEditsByNodeId)) &&
+        (hasPendingStyleEdits || hasPendingImageEdits) &&
         !submitting &&
         !imageBusy,
       canAddComment: editingCommentId
@@ -3361,6 +3418,17 @@ export const htmlDomCommentEditorModel$ = computed(
           commentText.trim() !== "" &&
           !hasCommentForSelectedNodes({ comments, selectedNodeIds }) &&
           !imageBusy,
+      canDiscard: canDiscardHtmlDomEditorDraft({
+        comments,
+        commentText,
+        editingCommentId,
+        hasPendingImageEdits,
+        hasPendingStyleEdits,
+        imageBusy,
+        loadState,
+        selectedNodeIds,
+        submitting,
+      }),
       canEditSelectedStyle: editableStyleProperties.length > 0,
       canSend:
         loadState.status === "ready" &&

--- a/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
+++ b/turbo/apps/platform/src/signals/zero-page/html-dom-comment-editor.ts
@@ -86,6 +86,7 @@ interface HtmlDomImageEdits {
 
 export interface HtmlDomCommentEditorModel {
   readonly activeColorPanelProperty: HtmlDomStyleProperty | null;
+  readonly activeFrameKey: number;
   readonly canApplyStyleEdits: boolean;
   readonly canAddComment: boolean;
   readonly canDiscard: boolean;
@@ -104,6 +105,7 @@ export interface HtmlDomCommentEditorModel {
   readonly imageLinkValue: string;
   readonly imagePendingAction: HtmlDomImagePendingAction | null;
   readonly loadState: EditorLoadState;
+  readonly pendingFrameKey: number | null;
   readonly popoverTextAreaKey: string;
   readonly prepared: boolean;
   readonly selectedImage: HtmlDomSelectedImage | null;
@@ -204,6 +206,8 @@ const SUPPORTED_IMAGE_UPLOAD_CONTENT_TYPES = [
   "image/webp",
 ] as const;
 const internalLoadState$ = state<EditorLoadState>({ status: "loading" });
+const internalActiveFrameKey$ = state(0);
+const internalPendingFrameKey$ = state<number | null>(null);
 const internalStageElement$ = state<HTMLDivElement | null>(null);
 const internalIframeElement$ = state<HTMLIFrameElement | null>(null);
 const internalSelectedNodeIds$ = state<readonly string[]>([]);
@@ -1260,32 +1264,6 @@ function rgbChannelsToHex(red: number, green: number, blue: number): string {
     .toUpperCase()}`;
 }
 
-function restoreFrameDocumentHtml(params: {
-  readonly doc: Document;
-  readonly html: string;
-}): void {
-  const Parser = params.doc.defaultView?.DOMParser ?? DOMParser;
-  const parser = new Parser();
-  const nextDocument = parser.parseFromString(params.html, "text/html");
-  for (const attr of Array.from(params.doc.documentElement.attributes)) {
-    params.doc.documentElement.removeAttribute(attr.name);
-  }
-  for (const attr of Array.from(nextDocument.documentElement.attributes)) {
-    params.doc.documentElement.setAttribute(attr.name, attr.value);
-  }
-  params.doc.head.replaceChildren(
-    ...Array.from(nextDocument.head.childNodes, (node) => {
-      return params.doc.importNode(node, true);
-    }),
-  );
-  params.doc.body.replaceChildren(
-    ...Array.from(nextDocument.body.childNodes, (node) => {
-      return params.doc.importNode(node, true);
-    }),
-  );
-  installFrameStyles(params.doc);
-}
-
 function commentForSelectedNodes(params: {
   readonly comments: readonly HtmlDomEditComment[];
   readonly selectedNodeIds: readonly string[];
@@ -1307,7 +1285,6 @@ function canDiscardHtmlDomEditorDraft(params: {
   readonly hasPendingStyleEdits: boolean;
   readonly imageBusy: boolean;
   readonly loadState: EditorLoadState;
-  readonly selectedNodeIds: readonly string[];
   readonly submitting: boolean;
 }): boolean {
   if (
@@ -1322,7 +1299,6 @@ function canDiscardHtmlDomEditorDraft(params: {
     params.hasPendingStyleEdits ||
     params.hasPendingImageEdits ||
     params.commentText.trim() !== "" ||
-    params.selectedNodeIds.length > 0 ||
     params.editingCommentId !== null
   );
 }
@@ -2202,6 +2178,8 @@ const resetHtmlDomCommentEditor$ = command(({ set }) => {
   set(cleanupCurrentFrameBinding$);
   set(resetHtmlDomImageEditSignal$);
   set(internalLoadState$, { status: "loading" });
+  set(internalActiveFrameKey$, 0);
+  set(internalPendingFrameKey$, null);
   set(internalStageElement$, null);
   set(internalIframeElement$, null);
   set(internalSelectedNodeIds$, []);
@@ -2253,13 +2231,15 @@ export const setHtmlDomCommentStageRef$ = onRef(
 );
 
 export const setHtmlDomCommentIframeRef$ = onRef(
-  command(({ set }, iframe: HTMLIFrameElement, signal: AbortSignal) => {
+  command(({ get, set }, iframe: HTMLIFrameElement, signal: AbortSignal) => {
     set(internalIframeElement$, iframe);
     signal.addEventListener(
       "abort",
       () => {
-        set(cleanupCurrentFrameBinding$);
-        set(internalIframeElement$, null);
+        if (get(internalIframeElement$) === iframe) {
+          set(cleanupCurrentFrameBinding$);
+          set(internalIframeElement$, null);
+        }
       },
       { once: true },
     );
@@ -2650,6 +2630,7 @@ function updateFrameSelectedNodeIds(params: {
 export const bindHtmlDomCommentFrame$ = command(
   ({ get, set }, iframe: HTMLIFrameElement) => {
     set(cleanupCurrentFrameBinding$);
+    set(internalIframeElement$, iframe);
 
     const doc = iframe.contentDocument;
     const stage = get(internalStageElement$);
@@ -2769,6 +2750,20 @@ export const bindHtmlDomCommentFrame$ = command(
       },
     });
     syncMarkers();
+  },
+);
+
+export const activatePendingHtmlDomCommentFrame$ = command(
+  (
+    { get, set },
+    params: { readonly frameKey: number; readonly iframe: HTMLIFrameElement },
+  ) => {
+    if (get(internalPendingFrameKey$) !== params.frameKey) {
+      return;
+    }
+    set(bindHtmlDomCommentFrame$, params.iframe);
+    set(internalActiveFrameKey$, params.frameKey);
+    set(internalPendingFrameKey$, null);
   },
 );
 
@@ -3192,11 +3187,14 @@ export const discardHtmlDomComments$ = command(({ get, set }) => {
   set(internalImageLinkOpen$, false);
   set(internalImageLinkValue$, "");
   set(internalImagePendingAction$, null);
-  if (readyLoadState.status === "ready" && doc) {
-    restoreFrameDocumentHtml({
-      doc,
-      html: readyLoadState.html,
-    });
+  if (readyLoadState.status === "ready") {
+    set(
+      internalPendingFrameKey$,
+      Math.max(
+        get(internalActiveFrameKey$),
+        get(internalPendingFrameKey$) ?? 0,
+      ) + 1,
+    );
   } else {
     syncFrameCommentMarkers(doc, []);
   }
@@ -3406,6 +3404,7 @@ export const htmlDomCommentEditorModel$ = computed(
 
     return {
       activeColorPanelProperty: get(internalActiveColorPanelProperty$),
+      activeFrameKey: get(internalActiveFrameKey$),
       canApplyStyleEdits:
         loadState.status === "ready" &&
         comments.length === 0 &&
@@ -3426,7 +3425,6 @@ export const htmlDomCommentEditorModel$ = computed(
         hasPendingStyleEdits,
         imageBusy,
         loadState,
-        selectedNodeIds,
         submitting,
       }),
       canEditSelectedStyle: editableStyleProperties.length > 0,
@@ -3448,6 +3446,7 @@ export const htmlDomCommentEditorModel$ = computed(
       imageLinkValue: get(internalImageLinkValue$),
       imagePendingAction: get(internalImagePendingAction$),
       loadState,
+      pendingFrameKey: get(internalPendingFrameKey$),
       popoverTextAreaKey: [
         selectedNodeIds.join(":"),
         editingCommentId ?? "new",

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -86,6 +86,10 @@ interface HtmlEditSnapshotSaveArgs {
 
 const internalHtmlEditSnapshotRestoreDraft$ =
   state<HtmlEditSnapshotRestoreDraft | null>(null);
+const internalHtmlEditSnapshotRestorePendingResumeKey$ = state<string | null>(
+  null,
+);
+const internalHtmlEditSnapshotRestoreIntentUrl$ = state<string | null>(null);
 const internalActiveHtmlEditSnapshotTarget$ =
   state<ActiveHtmlEditSnapshotTarget | null>(null);
 // In-flight save chain per `threadId\nurl`, so delete can await it.
@@ -338,6 +342,7 @@ export const openArtifactSidebarHtmlEdit$ = command(
     const params = new URLSearchParams(get(searchParams$));
     const args =
       typeof value === "string" ? { fullscreen: false, url: value } : value;
+    set(internalHtmlEditSnapshotRestoreIntentUrl$, args.url);
     setArtifactPreviewParams(params, {
       fullscreen: args.fullscreen,
       htmlEdit: true,
@@ -470,6 +475,36 @@ export const htmlEditSnapshotRestoreDraft$ = computed((get) => {
   return get(internalHtmlEditSnapshotRestoreDraft$);
 });
 
+export const htmlEditSnapshotRestorePendingResumeKey$ = computed((get) => {
+  return get(internalHtmlEditSnapshotRestorePendingResumeKey$);
+});
+
+export const htmlEditSnapshotRestoreIntentUrl$ = computed((get) => {
+  return get(internalHtmlEditSnapshotRestoreIntentUrl$);
+});
+
+export const setHtmlEditSnapshotRestorePendingResumeKey$ = command(
+  ({ set }, key: string) => {
+    set(internalHtmlEditSnapshotRestorePendingResumeKey$, key);
+  },
+);
+
+export const clearHtmlEditSnapshotRestorePendingResumeKey$ = command(
+  ({ get, set }, key: string) => {
+    if (get(internalHtmlEditSnapshotRestorePendingResumeKey$) === key) {
+      set(internalHtmlEditSnapshotRestorePendingResumeKey$, null);
+    }
+  },
+);
+
+const clearHtmlEditSnapshotRestoreIntentForUrl$ = command(
+  ({ get, set }, url: string) => {
+    if (get(internalHtmlEditSnapshotRestoreIntentUrl$) === url) {
+      set(internalHtmlEditSnapshotRestoreIntentUrl$, null);
+    }
+  },
+);
+
 // Dismiss the restore prompt without acting on it (the draft stays in the DB and
 // is offered again next time the artifact is opened).
 export const dismissHtmlEditSnapshotRestoreDraft$ = command(({ set }) => {
@@ -547,6 +582,9 @@ export const loadHtmlEditSnapshotRestoreDraft$ = command(
       return;
     }
     const { snapshotUrl } = response.body.snapshot;
+    const key = htmlEditSnapshotKey(args.threadId, args.url);
+    const deleteEpoch =
+      get(internalHtmlEditSnapshotDeleteEpochByKey$)[key] ?? 0;
     set(internalHtmlEditSnapshotRestoreDraft$, {
       threadId: args.threadId,
       updatedAt: response.body.snapshot.updatedAt,
@@ -563,6 +601,8 @@ export const loadHtmlEditSnapshotRestoreDraft$ = command(
     loadSignal.throwIfAborted();
     if (
       typeof html === "string" &&
+      (get(internalHtmlEditSnapshotDeleteEpochByKey$)[key] ?? 0) ===
+        deleteEpoch &&
       htmlEditSnapshotTargetMatches(
         get(internalActiveHtmlEditSnapshotTarget$),
         args,
@@ -589,6 +629,18 @@ export const deleteHtmlEditSnapshotDraft$ = command(
       ...get(internalHtmlEditSnapshotDeleteEpochByKey$),
       [key]: (get(internalHtmlEditSnapshotDeleteEpochByKey$)[key] ?? 0) + 1,
     });
+    const restoreDraft = get(internalHtmlEditSnapshotRestoreDraft$);
+    if (
+      restoreDraft?.threadId === args.threadId &&
+      restoreDraft.url === args.url
+    ) {
+      set(internalHtmlEditSnapshotRestoreDraft$, null);
+    }
+    if (key in get(internalHtmlEditSnapshotContentByKey$)) {
+      const nextContent = { ...get(internalHtmlEditSnapshotContentByKey$) };
+      delete nextContent[key];
+      set(internalHtmlEditSnapshotContentByKey$, nextContent);
+    }
     // Let any in-flight save settle first so its upsert can't land after the
     // delete and resurrect a stale snapshot.
     await set(
@@ -615,16 +667,10 @@ export const deleteHtmlEditSnapshotDraft$ = command(
     );
     signal.throwIfAborted();
 
-    const nextContent = { ...get(internalHtmlEditSnapshotContentByKey$) };
-    delete nextContent[key];
-    set(internalHtmlEditSnapshotContentByKey$, nextContent);
-
-    const restoreDraft = get(internalHtmlEditSnapshotRestoreDraft$);
-    if (
-      restoreDraft?.threadId === args.threadId &&
-      restoreDraft.url === args.url
-    ) {
-      set(internalHtmlEditSnapshotRestoreDraft$, null);
+    if (key in get(internalHtmlEditSnapshotContentByKey$)) {
+      const nextContent = { ...get(internalHtmlEditSnapshotContentByKey$) };
+      delete nextContent[key];
+      set(internalHtmlEditSnapshotContentByKey$, nextContent);
     }
   },
 );
@@ -754,6 +800,7 @@ export const discardHtmlDomEditPreviewDraft$ = command(
     const next = { ...get(internalHtmlDomEditPreviewHtmlByUrl$) };
     delete next[url];
     set(internalHtmlDomEditPreviewHtmlByUrl$, next);
+    set(clearHtmlEditSnapshotRestoreIntentForUrl$, url);
 
     const params = new URLSearchParams(get(searchParams$));
     params.set(ARTIFACT_HTML_EDIT_PARAM, "1");
@@ -850,6 +897,10 @@ export const clearHtmlDomEditPending$ = command(
 
 export const openArtifactHtmlEditMode$ = command(({ get, set }) => {
   const params = new URLSearchParams(get(searchParams$));
+  const artifactRef = get(currentArtifactRef$);
+  if (artifactRef?.source === "url" && artifactRef.kind === "html") {
+    set(internalHtmlEditSnapshotRestoreIntentUrl$, artifactRef.url);
+  }
   params.set(ARTIFACT_HTML_EDIT_PARAM, "1");
   set(replaceSearchParams$, params);
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -24,9 +24,11 @@ import {
 import type { ZeroClientFactory } from "../../../signals/api-client.ts";
 import { syncArtifactFileToGoogleDrive } from "../../../signals/chat-page/artifact-google-drive-sync.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { resetSignal } from "../../../signals/utils.ts";
+import { createDeferredPromise, resetSignal } from "../../../signals/utils.ts";
 import {
+  applyHtmlDomEditPreview$,
   artifactPanelWidth$,
+  closeArtifactHtmlEditMode$,
   saveCapturedHtmlEditSnapshotDraft$,
 } from "../../../signals/zero-page/zero-artifact-sidebar.ts";
 import { ARTIFACT_HTML_EDIT_PARAM } from "../../../signals/zero-page/right-sidebar-search-params.ts";
@@ -360,6 +362,7 @@ function setupHostedSiteArtifactThread(
   siteUrl: string,
   html = "<!doctype html><html><body><h1>Original site</h1></body></html>",
   artifactUrl = siteUrl,
+  path = `${THREAD_PATH}?artifact=${encodeURIComponent(siteUrl)}`,
 ): void {
   const filename =
     new URL(artifactUrl).pathname.split("/").pop() || "site.html";
@@ -382,8 +385,22 @@ function setupHostedSiteArtifactThread(
     featureSwitches: {
       [FeatureSwitchKey.HtmlArtifactCommentEditing]: true,
     },
-    path: `${THREAD_PATH}?artifact=${encodeURIComponent(siteUrl)}`,
+    path,
   });
+}
+
+function hostedSiteEditPath(siteUrl: string): string {
+  const params = new URLSearchParams();
+  params.set("artifact", siteUrl);
+  params.set(ARTIFACT_HTML_EDIT_PARAM, "1");
+  return `${THREAD_PATH}?${params.toString()}`;
+}
+
+async function enterHostedSiteEditMode(
+  user: ReturnType<typeof userEvent.setup>,
+) {
+  const sidebar = await screen.findByTestId("artifact-sidebar");
+  await user.click(within(sidebar).getByLabelText("Edit page"));
 }
 
 function assetBackedPresentationHtml(assetUrl: string): string {
@@ -617,6 +634,79 @@ describe("zero artifact sidebar", () => {
     });
   });
 
+  it("offers to resume a saved HTML edit snapshot after entering edit mode from preview", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://resume-after-preview.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/resume-after-preview.html?v=1";
+    let snapshotLoads = 0;
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ respond }) => {
+        snapshotLoads += 1;
+        return respond(200, {
+          snapshot: {
+            artifactUrl: siteUrl,
+            snapshotUrl,
+            updatedAt: "2026-03-10T00:05:00Z",
+          },
+        });
+      },
+    );
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(
+        "<!doctype html><html><body><h1>Saved draft</h1></body></html>",
+        { headers: { "Content-Type": "text/html" } },
+      );
+    });
+    setupHostedSiteArtifactThread(siteUrl);
+
+    const sidebar = await screen.findByTestId("artifact-sidebar");
+    expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
+    expect(snapshotLoads).toBe(0);
+
+    await user.click(within(sidebar).getByLabelText("Edit page"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
+      expect(snapshotLoads).toBe(1);
+    });
+  });
+
+  it("does not offer to resume a saved HTML edit snapshot from the initial chat load", async () => {
+    const siteUrl = "https://resume-initial-load.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/resume-initial-load.html?v=1";
+    let snapshotLoads = 0;
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ respond }) => {
+        snapshotLoads += 1;
+        return respond(200, {
+          snapshot: {
+            artifactUrl: siteUrl,
+            snapshotUrl,
+            updatedAt: "2026-03-10T00:05:00Z",
+          },
+        });
+      },
+    );
+    setupHostedSiteArtifactThread(
+      siteUrl,
+      undefined,
+      siteUrl,
+      hostedSiteEditPath(siteUrl),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-comment-editor")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
+    expect(snapshotLoads).toBe(0);
+  });
+
   it("offers to resume a saved HTML edit snapshot", async () => {
     const user = userEvent.setup({ delay: null });
     const siteUrl = "https://resume-draft.sites.vm7.io/index.html";
@@ -667,6 +757,7 @@ describe("zero artifact sidebar", () => {
       },
     );
     setupHostedSiteArtifactThread(siteUrl);
+    await enterHostedSiteEditMode(user);
 
     // Content is prefetched once when the draft is detected, before Resume.
     await waitFor(() => {
@@ -693,6 +784,68 @@ describe("zero artifact sidebar", () => {
       context.store.get(searchParams$).get(ARTIFACT_HTML_EDIT_PARAM),
     ).toBeNull();
     expect(savedBodies).toStrictEqual([]);
+  });
+
+  it("shows loading while resuming a saved HTML edit snapshot", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://resume-loading.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/resume-loading.html?v=1";
+    const restoredHtml =
+      "<!doctype html><html><body><h1>Saved draft</h1></body></html>";
+    const fetchReleased = createDeferredPromise<void>(context.signal);
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ respond }) => {
+        return respond(200, {
+          snapshot: {
+            artifactUrl: siteUrl,
+            snapshotUrl,
+            updatedAt: "2026-03-10T00:05:00Z",
+          },
+        });
+      },
+    );
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", async () => {
+      await fetchReleased.promise;
+      return new Response(restoredHtml, {
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+    context.mocks.api(
+      chatThreadArtifactsContract.deleteHtmlEditSnapshot,
+      ({ respond }) => {
+        return respond(204);
+      },
+    );
+    setupHostedSiteArtifactThread(siteUrl);
+    await enterHostedSiteEditMode(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
+    });
+    const resumeButton = queryAllByRoleFast("button").find((button) => {
+      return button.textContent?.trim() === "Resume";
+    });
+    if (!resumeButton) {
+      throw new Error("Resume button not found");
+    }
+    await user.click(resumeButton);
+
+    await waitFor(() => {
+      expect(resumeButton).toBeDisabled();
+      expect(resumeButton).toHaveAttribute("aria-busy", "true");
+    });
+    fetchReleased.resolve();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
+      expect(screen.getByTestId("artifact-sidebar-body-html")).toHaveAttribute(
+        "srcdoc",
+        expect.stringContaining("Saved draft"),
+      );
+    });
   });
 
   it("applies the resumed draft as a publishable preview state", async () => {
@@ -738,6 +891,7 @@ describe("zero artifact sidebar", () => {
       });
     });
     setupHostedSiteArtifactThread(siteUrl);
+    await enterHostedSiteEditMode(user);
 
     await waitFor(() => {
       expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
@@ -793,12 +947,110 @@ describe("zero artifact sidebar", () => {
     });
   });
 
+  it("discards a generated HTML edit draft without reopening the restore dialog", async () => {
+    const user = userEvent.setup({ delay: null });
+    const siteUrl = "https://discard-generated-draft.sites.vm7.io/index.html";
+    const snapshotUrl =
+      "https://cdn.vm7.io/artifacts/html-edit-drafts/discard-generated-draft.html?v=1";
+    const draftHtml =
+      "<!doctype html><html><body><h1>Generated draft</h1></body></html>";
+    const deletedUrls: string[] = [];
+    const savedBodies: string[] = [];
+    const deleteFinished = createDeferredPromise<void>(context.signal);
+    const deleteStarted = createDeferredPromise<void>(context.signal);
+    let snapshotLoads = 0;
+
+    context.mocks.api(
+      chatThreadArtifactsContract.getHtmlEditSnapshot,
+      ({ respond }) => {
+        snapshotLoads += 1;
+        return respond(200, {
+          snapshot:
+            savedBodies.length > 0
+              ? {
+                  artifactUrl: siteUrl,
+                  snapshotUrl,
+                  updatedAt: "2026-03-10T00:06:00Z",
+                }
+              : null,
+        });
+      },
+    );
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(draftHtml, {
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+    context.mocks.api(
+      chatThreadArtifactsContract.upsertHtmlEditSnapshot,
+      ({ body, respond }) => {
+        savedBodies.push(body.html);
+        return respond(200, {
+          artifactUrl: body.url,
+          snapshotUrl,
+          updatedAt: "2026-03-10T00:06:00Z",
+        });
+      },
+    );
+    context.mocks.api(
+      chatThreadArtifactsContract.deleteHtmlEditSnapshot,
+      async ({ query, respond }) => {
+        deletedUrls.push(query.url);
+        deleteStarted.resolve();
+        await deleteFinished.promise;
+        return respond(204);
+      },
+    );
+    setupHostedSiteArtifactThread(siteUrl);
+    await enterHostedSiteEditMode(user);
+
+    await waitFor(() => {
+      expect(snapshotLoads).toBe(1);
+    });
+    expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
+
+    context.store.set(saveCapturedHtmlEditSnapshotDraft$, {
+      html: draftHtml,
+      threadId: THREAD_ID,
+      url: siteUrl,
+    });
+    await waitFor(() => {
+      expect(savedBodies).toStrictEqual([draftHtml]);
+    });
+    context.store.set(applyHtmlDomEditPreview$, {
+      html: draftHtml,
+      url: siteUrl,
+    });
+    context.store.set(closeArtifactHtmlEditMode$);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-draft-toolbar")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("html-dom-draft-discard"));
+    await deleteStarted.promise;
+    await Promise.resolve();
+
+    expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
+    expect(snapshotLoads).toBe(1);
+    expect(deletedUrls).toStrictEqual([siteUrl]);
+    expect(
+      screen.queryByTestId("html-dom-draft-toolbar"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("html-dom-comment-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("html-dom-toolbar-discard")).toBeDisabled();
+    expect(screen.queryByTestId("html-dom-toolbar-comments-count")).toBeNull();
+    deleteFinished.resolve();
+  });
+
   it("discards a saved HTML edit snapshot from the restore dialog", async () => {
     const user = userEvent.setup({ delay: null });
     const siteUrl = "https://discard-draft.sites.vm7.io/index.html";
     const snapshotUrl =
       "https://cdn.vm7.io/artifacts/html-edit-drafts/discard-draft.html?v=1";
     const deletedUrls: string[] = [];
+    const deleteFinished = createDeferredPromise<void>(context.signal);
+    const deleteStarted = createDeferredPromise<void>(context.signal);
+    const deleteCompleted = createDeferredPromise<void>(context.signal);
 
     context.mocks.api(
       chatThreadArtifactsContract.getHtmlEditSnapshot,
@@ -820,28 +1072,37 @@ describe("zero artifact sidebar", () => {
     });
     context.mocks.api(
       chatThreadArtifactsContract.deleteHtmlEditSnapshot,
-      ({ query, respond }) => {
+      async ({ query, respond }) => {
         deletedUrls.push(query.url);
+        deleteStarted.resolve();
+        await deleteFinished.promise;
+        deleteCompleted.resolve();
         return respond(204);
       },
     );
     setupHostedSiteArtifactThread(siteUrl);
+    await enterHostedSiteEditMode(user);
 
     await waitFor(() => {
       expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
     });
-    await user.click(screen.getByText("Discard"));
+    await user.click(
+      within(screen.getByTestId("html-edit-snapshot-restore-dialog")).getByText(
+        "Discard",
+      ),
+    );
 
     await waitFor(() => {
       expect(screen.queryByText("Resume HTML draft?")).not.toBeInTheDocument();
-      expect(deletedUrls).toStrictEqual([siteUrl]);
     });
     expect(
       screen.queryByTestId("html-dom-draft-toolbar"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId("artifact-sidebar-body-html"),
-    ).not.toHaveAttribute("srcdoc");
+    expect(screen.getByTestId("html-dom-comment-editor")).toBeInTheDocument();
+    await deleteStarted.promise;
+    expect(deletedUrls).toStrictEqual([siteUrl]);
+    deleteFinished.resolve();
+    await deleteCompleted.promise;
   });
 
   it("dismisses the restore dialog with Escape without deleting the draft", async () => {
@@ -877,6 +1138,7 @@ describe("zero artifact sidebar", () => {
       },
     );
     setupHostedSiteArtifactThread(siteUrl);
+    await enterHostedSiteEditMode(user);
 
     await waitFor(() => {
       expect(screen.getByText("Resume HTML draft?")).toBeInTheDocument();
@@ -891,9 +1153,7 @@ describe("zero artifact sidebar", () => {
     expect(
       screen.queryByTestId("html-dom-draft-toolbar"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId("artifact-sidebar-body-html"),
-    ).not.toHaveAttribute("srcdoc");
+    expect(screen.getByTestId("html-dom-comment-editor")).toBeInTheDocument();
   });
 
   it("resizes the artifact preview pane and persists the width", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2405,6 +2405,10 @@ describe("zero attachment chips", () => {
       expect(
         screen.getByTestId("html-dom-comment-toolbar"),
       ).toBeInTheDocument();
+      expect(screen.getByTestId("html-dom-toolbar-discard")).toBeDisabled();
+      expect(
+        screen.queryByTestId("html-dom-toolbar-comments-count"),
+      ).toBeNull();
       expect(
         within(sidebar).getByTestId("artifact-sidebar-html-edit-status"),
       ).toHaveTextContent("Editing");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2280,8 +2280,13 @@ describe("zero attachment chips", () => {
       ).toHaveLength(2);
     });
 
-    click(screen.getByTestId("html-dom-toolbar-comments"));
+    const commentsButton = screen.getByTestId("html-dom-toolbar-comments");
+    expect(commentsButton).toHaveAttribute("aria-pressed", "false");
+
+    click(commentsButton);
     const commentsList = await screen.findByTestId("html-dom-comments-list");
+    expect(commentsButton).toHaveAttribute("aria-pressed", "true");
+    expect(commentsButton).toHaveClass("bg-blue-50");
     expect(within(commentsList).queryByText("Comment 1")).toBeNull();
     const heroListItem = within(commentsList).getByText(
       "Make the hero headline shorter",
@@ -2352,7 +2357,11 @@ describe("zero attachment chips", () => {
       ).toHaveTextContent("1");
     });
 
-    click(screen.getByTestId("html-dom-toolbar-comments"));
+    click(commentsButton);
+    await waitFor(() => {
+      expect(screen.queryByTestId("html-dom-comments-list")).toBeNull();
+      expect(commentsButton).toHaveAttribute("aria-pressed", "false");
+    });
     fireEvent.click(bodyCopy!);
     await waitFor(() => {
       expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue("");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1779,7 +1779,7 @@ describe("zero attachment chips", () => {
         `<!doctype html>
         <html>
           <head><title>Launch site</title></head>
-          <body>
+          <body class="launch-page" data-theme="retro">
             <main>
               <h1>Launch faster</h1>
               <p>Ship the first version today.</p>
@@ -1896,7 +1896,7 @@ describe("zero attachment chips", () => {
       ).toBeInTheDocument();
       expect(screen.queryByLabelText("Exit comment mode")).toBeNull();
     });
-    const frame = (await screen.findByTestId(
+    let frame = (await screen.findByTestId(
       "html-dom-comment-frame",
     )) as HTMLIFrameElement;
     expect(frame).toHaveAttribute("sandbox", "allow-same-origin allow-scripts");
@@ -1906,6 +1906,13 @@ describe("zero attachment chips", () => {
           ?.querySelector("h1")
           ?.hasAttribute(HTML_DOM_NODE_ID_ATTR),
       ).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(frame.contentDocument?.body).toHaveClass("launch-page");
+      expect(frame.contentDocument?.body).toHaveAttribute(
+        "data-theme",
+        "retro",
+      );
     });
     let title = frame.contentDocument?.querySelector("h1");
     expect(title).not.toBeNull();
@@ -2003,15 +2010,24 @@ describe("zero attachment chips", () => {
       screen.getByTestId("html-dom-toolbar-comments-count"),
     ).toHaveTextContent("1");
 
+    const frameBeforeDiscard = frame;
     title!.textContent = "Changed during edit";
     click(screen.getByTestId("html-dom-toolbar-discard"));
     await waitFor(() => {
-      expect(screen.getByTestId("html-dom-comment-frame")).toBeInTheDocument();
-      expect(frame.contentDocument?.querySelector("h1")).toHaveTextContent(
+      const nextFrame = screen.getByTestId(
+        "html-dom-comment-frame",
+      ) as HTMLIFrameElement;
+      expect(nextFrame).not.toBe(frameBeforeDiscard);
+      expect(nextFrame.contentDocument?.querySelector("h1")).toHaveTextContent(
         "Launch faster",
       );
+      expect(nextFrame.contentDocument?.body).toHaveClass("launch-page");
+      expect(nextFrame.contentDocument?.body).toHaveAttribute(
+        "data-theme",
+        "retro",
+      );
       expect(
-        frame.contentDocument?.querySelector(
+        nextFrame.contentDocument?.querySelector(
           "[data-testid='html-dom-comment-marker']",
         ),
       ).toBeNull();
@@ -2024,6 +2040,7 @@ describe("zero attachment chips", () => {
       ).toHaveTextContent("Editing");
     });
 
+    frame = screen.getByTestId("html-dom-comment-frame") as HTMLIFrameElement;
     title = frame.contentDocument?.querySelector("h1");
     expect(title).not.toBeNull();
     mockElementRect(title!, {
@@ -2033,6 +2050,10 @@ describe("zero attachment chips", () => {
       width: 32,
     });
     fireEvent.click(title!);
+    await waitFor(() => {
+      expect(screen.getByTestId("html-dom-comment-textarea")).toHaveValue("");
+      expect(screen.getByTestId("html-dom-toolbar-discard")).toBeDisabled();
+    });
     const nextCommentTextArea = await screen.findByTestId(
       "html-dom-comment-textarea",
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -2307,7 +2307,6 @@ describe("zero attachment chips", () => {
     click(commentsButton);
     const commentsList = await screen.findByTestId("html-dom-comments-list");
     expect(commentsButton).toHaveAttribute("aria-pressed", "true");
-    expect(commentsButton).toHaveClass("bg-blue-50");
     expect(within(commentsList).queryByText("Comment 1")).toBeNull();
     const heroListItem = within(commentsList).getByText(
       "Make the hero headline shorter",

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -275,7 +275,7 @@ function HtmlDomCommentToolbar({
           <button
             type="button"
             className="inline-flex h-9 items-center justify-center rounded-full px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
-            disabled={disabled}
+            disabled={disabled || !model.canDiscard}
             onClick={discardComments}
             data-testid="html-dom-toolbar-discard"
           >

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -256,10 +256,15 @@ function HtmlDomCommentToolbar({
         >
           <button
             type="button"
-            className="relative inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45"
+            className={`relative inline-flex h-9 w-9 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-45 ${
+              model.commentsOpen
+                ? "bg-blue-50 text-blue-700 ring-2 ring-blue-500/20 hover:bg-blue-100"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground"
+            }`}
             disabled={disabled}
             onClick={toggleCommentsOpen}
             aria-label="Show comments"
+            aria-pressed={model.commentsOpen}
             data-testid="html-dom-toolbar-comments"
           >
             <IconMessageCircle size={18} stroke={1.9} />

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -18,9 +18,16 @@ import {
   IconUpload,
 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
-import { detach, Reason, tapError, withCleanup } from "../../signals/utils.ts";
+import {
+  createDeferredPromise,
+  detach,
+  Reason,
+  tapError,
+  withCleanup,
+} from "../../signals/utils.ts";
 import {
   addHtmlDomComment$,
+  activatePendingHtmlDomCommentFrame$,
   applySelectedHtmlDomImageLayout$,
   applyHtmlDomColorStyle$,
   applyHtmlDomStyleEdits$,
@@ -67,6 +74,64 @@ interface HtmlDomCommentEditorProps {
   readonly url: string;
 }
 
+function waitForIframePaint(
+  iframe: HTMLIFrameElement,
+  signal: AbortSignal,
+): Promise<void> {
+  const view = iframe.contentWindow;
+  if (
+    !view ||
+    typeof view.requestAnimationFrame !== "function" ||
+    typeof view.cancelAnimationFrame !== "function"
+  ) {
+    return Promise.resolve();
+  }
+  const frameView = view;
+
+  const deferred = createDeferredPromise<void>(signal);
+  if (signal.aborted) {
+    return deferred.promise;
+  }
+
+  let firstFrameId: number | null = null;
+  let secondFrameId: number | null = null;
+  let timeoutId: number | null = null;
+
+  function cleanup(): void {
+    signal.removeEventListener("abort", handleAbort);
+    if (timeoutId !== null) {
+      frameView.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    if (firstFrameId !== null) {
+      frameView.cancelAnimationFrame(firstFrameId);
+      firstFrameId = null;
+    }
+    if (secondFrameId !== null) {
+      frameView.cancelAnimationFrame(secondFrameId);
+      secondFrameId = null;
+    }
+  }
+
+  function finish(): void {
+    cleanup();
+    if (!deferred.settled()) {
+      deferred.resolve(undefined);
+    }
+  }
+
+  function handleAbort(): void {
+    cleanup();
+  }
+
+  signal.addEventListener("abort", handleAbort, { once: true });
+  firstFrameId = frameView.requestAnimationFrame(() => {
+    secondFrameId = frameView.requestAnimationFrame(finish);
+  });
+  timeoutId = frameView.setTimeout(finish, 100);
+  return deferred.promise;
+}
+
 function HtmlDomCommentStage({
   filename,
   model,
@@ -91,10 +156,17 @@ function HtmlDomCommentStage({
   readonly url: string;
 }) {
   const bindFrame = useSet(bindHtmlDomCommentFrame$);
+  const activatePendingFrame = useSet(activatePendingHtmlDomCommentFrame$);
   const setIframeRef = useSet(setHtmlDomCommentIframeRef$);
   const setStageRef = useSet(setHtmlDomCommentStageRef$);
   const loadState = model.loadState;
   const working = status === "working" || model.submitting;
+  const frameKeys =
+    loadState.status === "ready"
+      ? model.pendingFrameKey === null
+        ? [model.activeFrameKey]
+        : [model.activeFrameKey, model.pendingFrameKey]
+      : [];
 
   return (
     <div
@@ -113,19 +185,45 @@ function HtmlDomCommentStage({
           {loadState.message}
         </div>
       )}
-      {loadState.status === "ready" && (
-        <iframe
-          ref={setIframeRef}
-          srcDoc={loadState.html}
-          title={`${filename} comment preview`}
-          sandbox="allow-same-origin allow-scripts"
-          className="block h-full w-full border-0 bg-background"
-          data-testid="html-dom-comment-frame"
-          onLoad={(event) => {
-            bindFrame(event.currentTarget);
-          }}
-        />
-      )}
+      {loadState.status === "ready" &&
+        frameKeys.map((frameKey) => {
+          const active = frameKey === model.activeFrameKey;
+          return (
+            <iframe
+              key={frameKey}
+              ref={active ? setIframeRef : undefined}
+              srcDoc={loadState.html}
+              title={`${filename} comment preview`}
+              sandbox="allow-same-origin allow-scripts"
+              className={
+                active
+                  ? "block h-full w-full border-0 bg-background"
+                  : "pointer-events-none absolute inset-0 h-full w-full border-0 bg-background opacity-0"
+              }
+              aria-hidden={active ? undefined : true}
+              data-testid={
+                active
+                  ? "html-dom-comment-frame"
+                  : "html-dom-comment-frame-pending"
+              }
+              onLoad={(event) => {
+                const iframe = event.currentTarget;
+                if (active) {
+                  bindFrame(iframe);
+                  return;
+                }
+                detach(
+                  (async () => {
+                    await waitForIframePaint(iframe, pageSignal);
+                    activatePendingFrame({ frameKey, iframe });
+                  })(),
+                  Reason.DomCallback,
+                  "activatePendingHtmlDomCommentFrame",
+                );
+              }}
+            />
+          );
+        })}
       {!working && (
         <HtmlDomCommentPopover model={model} pageSignal={pageSignal} />
       )}

--- a/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/html-dom-comment-editor.tsx
@@ -95,14 +95,9 @@ function waitForIframePaint(
 
   let firstFrameId: number | null = null;
   let secondFrameId: number | null = null;
-  let timeoutId: number | null = null;
 
   function cleanup(): void {
     signal.removeEventListener("abort", handleAbort);
-    if (timeoutId !== null) {
-      frameView.clearTimeout(timeoutId);
-      timeoutId = null;
-    }
     if (firstFrameId !== null) {
       frameView.cancelAnimationFrame(firstFrameId);
       firstFrameId = null;
@@ -128,7 +123,6 @@ function waitForIframePaint(
   firstFrameId = frameView.requestAnimationFrame(() => {
     secondFrameId = frameView.requestAnimationFrame(finish);
   });
-  timeoutId = frameView.setTimeout(finish, 100);
   return deferred.promise;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -46,11 +46,14 @@ import {
   clearHtmlDomEditPending$,
   closeArtifactHtmlEditMode$,
   closeArtifact$,
+  clearHtmlEditSnapshotRestorePendingResumeKey$,
   deleteHtmlEditSnapshotDraft$,
   dismissHtmlEditSnapshotRestoreDraft$,
   discardHtmlDomEditPreviewDraft$,
   continueHtmlEditSnapshotDraft$,
   htmlEditSnapshotRestoreDraft$,
+  htmlEditSnapshotRestoreIntentUrl$,
+  htmlEditSnapshotRestorePendingResumeKey$,
   htmlDomEditPreviewHtmlByUrl$,
   htmlDomEditPendingUrl$,
   htmlDomEditPublishingUrl$,
@@ -61,6 +64,7 @@ import {
   publishHtmlDomEditPreviewDraft$,
   saveCapturedHtmlEditSnapshotDraft$,
   setHtmlEditSnapshotControllerRef$,
+  setHtmlEditSnapshotRestorePendingResumeKey$,
   toggleArtifactFullscreen$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
 import {
@@ -80,7 +84,12 @@ import {
 } from "../../signals/zero-page/zero-image-edit.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { detach, jsonParseOr, Reason } from "../../signals/utils.ts";
+import {
+  detach,
+  jsonParseOr,
+  Reason,
+  withCleanup,
+} from "../../signals/utils.ts";
 import { resetZoomableImageCanvasZoom$ } from "../../signals/view-component-state.ts";
 import {
   ZoomableArtifactImageCanvas,
@@ -326,18 +335,34 @@ function htmlEditSnapshotRestoreDraftForTarget(
 
 function htmlEditSnapshotTargetForDisplay({
   display,
-  htmlEditEnabled,
+  htmlCommentMode,
   threadId,
 }: {
   readonly display: ArtifactDisplay | null;
-  readonly htmlEditEnabled: boolean;
+  readonly htmlCommentMode: boolean;
   readonly threadId?: string;
 }): HtmlEditSnapshotTargetView | null {
   return threadId &&
-    htmlEditEnabled &&
+    htmlCommentMode &&
     display?.kind === "html" &&
     display.artifactKind === "hosted-site"
     ? { threadId, url: display.url }
+    : null;
+}
+
+function htmlEditSnapshotRestoreTargetForDisplay({
+  display,
+  htmlCommentMode,
+  restoreIntentUrl,
+  threadId,
+}: {
+  readonly display: ArtifactDisplay | null;
+  readonly htmlCommentMode: boolean;
+  readonly restoreIntentUrl: string | null;
+  readonly threadId?: string;
+}): HtmlEditSnapshotTargetView | null {
+  return restoreIntentUrl === display?.url
+    ? htmlEditSnapshotTargetForDisplay({ display, htmlCommentMode, threadId })
     : null;
 }
 
@@ -361,6 +386,39 @@ function HtmlEditSnapshotRestoreDialog({
   readonly signal: AbortSignal;
 }) {
   const open = Boolean(restoreDraft);
+  const restoreDraftKey = restoreDraft
+    ? `${restoreDraft.threadId}\n${restoreDraft.url}\n${restoreDraft.updatedAt}`
+    : null;
+  const pendingResumeDraftKey = useGet(
+    htmlEditSnapshotRestorePendingResumeKey$,
+  );
+  const setPendingResumeDraftKey = useSet(
+    setHtmlEditSnapshotRestorePendingResumeKey$,
+  );
+  const clearPendingResumeDraftKey = useSet(
+    clearHtmlEditSnapshotRestorePendingResumeKey$,
+  );
+  const resumePending =
+    restoreDraftKey !== null && pendingResumeDraftKey === restoreDraftKey;
+  const resumeDraft = async (
+    currentDraft: HtmlEditSnapshotRestoreDraftView,
+    currentDraftKey: string,
+  ): Promise<void> => {
+    setPendingResumeDraftKey(currentDraftKey);
+    await withCleanup(
+      onContinue(
+        {
+          threadId: currentDraft.threadId,
+          url: currentDraft.url,
+        },
+        signal,
+      ),
+      () => {
+        clearPendingResumeDraftKey(currentDraftKey);
+      },
+    );
+  };
+
   return (
     <Dialog
       open={open}
@@ -380,6 +438,7 @@ function HtmlEditSnapshotRestoreDialog({
         <DialogFooter>
           <Button
             variant="outline"
+            disabled={resumePending}
             onClick={() => {
               if (restoreDraft) {
                 onDiscard(restoreDraft);
@@ -389,23 +448,22 @@ function HtmlEditSnapshotRestoreDialog({
             Discard
           </Button>
           <Button
+            aria-busy={resumePending ? true : undefined}
+            disabled={resumePending}
             onClick={() => {
-              if (!restoreDraft) {
+              if (!restoreDraft || !restoreDraftKey || resumePending) {
                 return;
               }
               detach(
-                onContinue(
-                  {
-                    threadId: restoreDraft.threadId,
-                    url: restoreDraft.url,
-                  },
-                  signal,
-                ),
+                resumeDraft(restoreDraft, restoreDraftKey),
                 Reason.DomCallback,
                 "continueHtmlEditSnapshotDraft",
               );
             }}
           >
+            {resumePending ? (
+              <IconLoader2 size={16} className="animate-spin" />
+            ) : null}
             Resume
           </Button>
         </DialogFooter>
@@ -466,6 +524,9 @@ function ArtifactSidebarContent({
   const requestedHtmlCommentMode = useGet(artifactHtmlEditMode$);
   const requestedImageEditMode = useGet(artifactImageEditMode$);
   const htmlDomEditPreviewHtmlByUrl = useGet(htmlDomEditPreviewHtmlByUrl$);
+  const htmlEditSnapshotRestoreIntentUrl = useGet(
+    htmlEditSnapshotRestoreIntentUrl$,
+  );
   const htmlDomEditPendingUrl = useGet(htmlDomEditPendingUrl$);
   const htmlDomEditPublishingUrl = useGet(htmlDomEditPublishingUrl$);
   const applyHtmlDomEditPreview = useSet(applyHtmlDomEditPreview$);
@@ -489,14 +550,22 @@ function ArtifactSidebarContent({
 
   const display = resolveArtifactDisplay(artifactRef, item);
   const htmlEditEnabled = isHtmlEditFeatureEnabled(features);
-  const htmlEditSnapshotTarget = htmlEditSnapshotTargetForDisplay({
-    display,
-    htmlEditEnabled,
-    threadId,
-  });
   const htmlCommentMode =
     htmlEditEnabled &&
     shouldOpenHtmlCommentMode(display, requestedHtmlCommentMode);
+  const htmlEditSnapshotTarget = htmlEditSnapshotTargetForDisplay({
+    display,
+    htmlCommentMode,
+    threadId,
+  });
+  const htmlEditSnapshotRestoreTarget = htmlEditSnapshotRestoreTargetForDisplay(
+    {
+      display,
+      htmlCommentMode,
+      restoreIntentUrl: htmlEditSnapshotRestoreIntentUrl,
+      threadId,
+    },
+  );
   const syncTarget = artifactSidebarSyncTargetForItem({
     agentId,
     item,
@@ -538,7 +607,7 @@ function ArtifactSidebarContent({
       display={display}
       fullscreen={fullscreen}
       htmlCommentMode={htmlCommentMode}
-      htmlEditSnapshotTarget={htmlEditSnapshotTarget}
+      htmlEditSnapshotRestoreTarget={htmlEditSnapshotRestoreTarget}
       htmlEditState={htmlEditState}
       htmlHeaderState={htmlHeaderState}
       imageEditActive={imageEditActive}
@@ -562,7 +631,7 @@ function ArtifactSidebarResolvedContent({
   display,
   fullscreen,
   htmlCommentMode,
-  htmlEditSnapshotTarget,
+  htmlEditSnapshotRestoreTarget,
   htmlEditState,
   htmlHeaderState,
   imageEditActive,
@@ -582,7 +651,7 @@ function ArtifactSidebarResolvedContent({
   readonly display: ArtifactDisplay;
   readonly fullscreen: boolean;
   readonly htmlCommentMode: boolean;
-  readonly htmlEditSnapshotTarget: HtmlEditSnapshotTargetView | null;
+  readonly htmlEditSnapshotRestoreTarget: HtmlEditSnapshotTargetView | null;
   readonly htmlEditState: HtmlEditState;
   readonly htmlHeaderState: HtmlArtifactHeaderState | undefined;
   readonly imageEditActive: boolean;
@@ -670,7 +739,7 @@ function ArtifactSidebarResolvedContent({
       <HtmlEditSnapshotController
         previewHtml={htmlEditState.previewHtml}
         signal={pageSignal}
-        target={htmlEditSnapshotTarget}
+        target={htmlEditSnapshotRestoreTarget}
       />
     </ArtifactSidebarSurface>
   );


### PR DESCRIPTION
## Summary
- show the saved HTML draft restore dialog only after an explicit edit intent, with a Resume loading state and optimistic Discard
- keep snapshot saving separate from restore prompting so generated-preview discard flows do not re-open the restore dialog
- clear consumed HTML comment drafts after generated previews and disable the comment Discard button when there is nothing left to discard
- show an active state on the bottom comments button while the comments panel is expanded

## Tests
- pnpm format
- pnpm turbo run lint
- pnpm check-types
- pnpm knip
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "prepares a hosted-site HTML comment edit session"
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres pnpm vitest (fails locally in unrelated firewall metadata/Xero expectations, workflow-template picker submission, chat snapshot timeout, usage credits mismatch, and workflow trigger runner job tests)