### PR TITLE
refactor: remove runner profile compatibility fields

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -257,15 +257,13 @@ pub(super) fn collect_heartbeat_state(
         runner_id: runner_id.to_string(),
         runner_name: name.to_string(),
         group: group.to_string(),
-        profiles: profiles.keys().cloned().collect(),
         total_vcpu: budget.effective_vcpu(),
         total_memory_mb: budget.effective_memory_mb(),
         max_concurrent: budget.max_concurrent(),
         allocated_vcpu,
         allocated_memory_mb,
         running_count,
-        admittable_profiles: admittable_profiles.clone(),
-        available_profiles: admittable_profiles,
+        admittable_profiles,
         held_session_states: idle_pool.held_session_states(),
         mode: match mode {
             RunnerMode::Running => "running".to_string(),
@@ -441,7 +439,6 @@ mod tests {
         );
 
         assert_eq!(state.admittable_profiles, vec!["vm0/default"]);
-        assert_eq!(state.available_profiles, vec!["vm0/default"]);
     }
 
     #[test]
@@ -471,7 +468,6 @@ mod tests {
         );
 
         assert!(state.admittable_profiles.is_empty());
-        assert!(state.available_profiles.is_empty());
     }
 
     #[test]
@@ -494,7 +490,6 @@ mod tests {
         );
 
         assert!(state.admittable_profiles.is_empty());
-        assert!(state.available_profiles.is_empty());
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -596,7 +596,6 @@ fn poll_request_body(
     serde_json::json!({
         "group": group,
         "supportedProfiles": supported_profiles,
-        "profiles": supported_profiles,
         "telemetry": {
             "pollReason": poll_reason_value(reason),
         },
@@ -1067,7 +1066,7 @@ mod tests {
             body["supportedProfiles"][0],
             crate::profile::DEFAULT_PROFILE
         );
-        assert_eq!(body["profiles"][0], crate::profile::DEFAULT_PROFILE);
+        assert!(body.get("profiles").is_none());
         assert_eq!(body["telemetry"]["pollReason"], "immediate");
         assert!(body.get("heldSessionStates").is_none());
     }
@@ -1361,7 +1360,6 @@ mod tests {
                     .json_body(serde_json::json!({
                         "group": "default",
                         "supportedProfiles": [crate::profile::DEFAULT_PROFILE],
-                        "profiles": [crate::profile::DEFAULT_PROFILE],
                         "telemetry": {
                             "pollReason": "immediate"
                         }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -414,7 +414,6 @@ pub struct HeartbeatState {
     pub runner_id: String,
     pub runner_name: String,
     pub group: String,
-    pub profiles: Vec<String>,
     pub total_vcpu: u32,
     pub total_memory_mb: u32,
     pub max_concurrent: usize,
@@ -422,7 +421,6 @@ pub struct HeartbeatState {
     pub allocated_memory_mb: u32,
     pub running_count: usize,
     pub admittable_profiles: Vec<String>,
-    pub available_profiles: Vec<String>,
     pub held_session_states: Vec<HeldSessionState>,
     pub mode: String,
 }
@@ -1060,7 +1058,6 @@ mod tests {
             runner_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             runner_name: "runner-1".into(),
             group: "vm0/production".into(),
-            profiles: vec!["vm0/default".into()],
             total_vcpu: 16,
             total_memory_mb: 32768,
             max_concurrent: 8,
@@ -1068,7 +1065,6 @@ mod tests {
             allocated_memory_mb: 6144,
             running_count: 2,
             admittable_profiles: vec!["vm0/default".into()],
-            available_profiles: vec!["vm0/default".into()],
             held_session_states: vec![HeldSessionState {
                 session_id: "session-abc".into(),
                 last_completed_at: "2026-05-28T00:00:00.000Z".into(),
@@ -1085,7 +1081,8 @@ mod tests {
         assert_eq!(json["allocatedMemoryMb"], 6144);
         assert_eq!(json["runningCount"], 2);
         assert_eq!(json["admittableProfiles"], json!(["vm0/default"]));
-        assert_eq!(json["availableProfiles"], json!(["vm0/default"]));
+        assert!(json.get("profiles").is_none());
+        assert!(json.get("availableProfiles").is_none());
         assert_eq!(
             json["heldSessionStates"],
             json!([{

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -213,11 +213,7 @@ function runnerHeartbeatBody(
   args: {
     readonly runnerId?: string;
     readonly group?: string;
-    readonly profiles?: RunnerHeartbeatBody["profiles"];
     readonly admittableProfiles?: RunnerHeartbeatBody["admittableProfiles"];
-    readonly omitAdmittableProfiles?: boolean;
-    readonly availableProfiles?: RunnerHeartbeatBody["availableProfiles"];
-    readonly omitAvailableProfiles?: boolean;
     readonly maxConcurrent?: RunnerHeartbeatBody["maxConcurrent"];
     readonly allocatedVcpu?: RunnerHeartbeatBody["allocatedVcpu"];
     readonly allocatedMemoryMb?: RunnerHeartbeatBody["allocatedMemoryMb"];
@@ -226,29 +222,20 @@ function runnerHeartbeatBody(
     readonly mode?: RunnerHeartbeatBody["mode"];
   } = {},
 ): RunnerHeartbeatBody {
-  const profiles = args.profiles ?? ["vm0/default"];
-  const body: RunnerHeartbeatBody = {
+  return {
     runnerId: args.runnerId ?? randomUUID(),
     runnerName: "bdd-runner",
     group: args.group ?? "vm0/test",
-    profiles,
     totalVcpu: 8,
     totalMemoryMb: 16_384,
     maxConcurrent: args.maxConcurrent ?? 2,
     allocatedVcpu: args.allocatedVcpu ?? 0,
     allocatedMemoryMb: args.allocatedMemoryMb ?? 0,
     runningCount: args.runningCount ?? 0,
+    admittableProfiles: args.admittableProfiles ?? ["vm0/default"],
     heldSessionStates: args.heldSessionStates ?? [],
     mode: args.mode ?? "running",
   };
-  if (!args.omitAdmittableProfiles) {
-    body.admittableProfiles =
-      args.admittableProfiles ?? args.availableProfiles ?? profiles;
-  }
-  if (!args.omitAvailableProfiles) {
-    body.availableProfiles = args.availableProfiles ?? profiles;
-  }
-  return body;
 }
 
 export function createRunsAutomationsApi(context: TestContext) {
@@ -925,11 +912,7 @@ export function createRunsAutomationsApi(context: TestContext) {
       statuses: readonly (200 | 400 | 401 | 500)[],
       args: {
         readonly group?: string;
-        readonly profiles?: RunnerHeartbeatBody["profiles"];
         readonly admittableProfiles?: RunnerHeartbeatBody["admittableProfiles"];
-        readonly omitAdmittableProfiles?: boolean;
-        readonly availableProfiles?: RunnerHeartbeatBody["availableProfiles"];
-        readonly omitAvailableProfiles?: boolean;
         readonly maxConcurrent?: RunnerHeartbeatBody["maxConcurrent"];
         readonly allocatedVcpu?: RunnerHeartbeatBody["allocatedVcpu"];
         readonly allocatedMemoryMb?: RunnerHeartbeatBody["allocatedMemoryMb"];
@@ -947,6 +930,20 @@ export function createRunsAutomationsApi(context: TestContext) {
       );
     },
 
+    async requestMalformedHeartbeatRunner(
+      validAuth: boolean,
+      statuses: readonly (400 | 401 | 500)[],
+      body: unknown,
+    ) {
+      return await accept(
+        runsAutomationApp(context)(runnersHeartbeatContract).heartbeat({
+          headers: runnerHeaders(validAuth),
+          body: body as RunnerHeartbeatBody,
+        }),
+        statuses,
+      );
+    },
+
     async pollRunner(group?: string) {
       return await accept(
         runsAutomationApp(context)(runnersPollContract).poll({
@@ -954,7 +951,6 @@ export function createRunsAutomationsApi(context: TestContext) {
           body: {
             group: group ?? "vm0/test",
             supportedProfiles: ["vm0/default"],
-            profiles: ["vm0/default"],
           },
         }),
         [200],
@@ -970,6 +966,20 @@ export function createRunsAutomationsApi(context: TestContext) {
         runsAutomationApp(context)(runnersPollContract).poll({
           headers: runnerHeaders(validAuth),
           body,
+        }),
+        statuses,
+      );
+    },
+
+    async requestMalformedPollRunner(
+      validAuth: boolean,
+      body: unknown,
+      statuses: readonly (400 | 401 | 500)[],
+    ) {
+      return await accept(
+        runsAutomationApp(context)(runnersPollContract).poll({
+          headers: runnerHeaders(validAuth),
+          body: body as RunnerPollBody,
         }),
         statuses,
       );

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -911,6 +911,7 @@ export function createRunsAutomationsApi(context: TestContext) {
       validAuth: boolean,
       statuses: readonly (200 | 400 | 401 | 500)[],
       args: {
+        readonly runnerId?: string;
         readonly group?: string;
         readonly admittableProfiles?: RunnerHeartbeatBody["admittableProfiles"];
         readonly maxConcurrent?: RunnerHeartbeatBody["maxConcurrent"];
@@ -930,9 +931,9 @@ export function createRunsAutomationsApi(context: TestContext) {
       );
     },
 
-    async requestMalformedHeartbeatRunner(
+    async requestRawHeartbeatRunner(
       validAuth: boolean,
-      statuses: readonly (400 | 401 | 500)[],
+      statuses: readonly (200 | 400 | 401 | 500)[],
       body: unknown,
     ) {
       return await accept(
@@ -971,10 +972,10 @@ export function createRunsAutomationsApi(context: TestContext) {
       );
     },
 
-    async requestMalformedPollRunner(
+    async requestRawPollRunner(
       validAuth: boolean,
       body: unknown,
-      statuses: readonly (400 | 401 | 500)[],
+      statuses: readonly (200 | 400 | 401 | 500)[],
     ) {
       return await accept(
         runsAutomationApp(context)(runnersPollContract).poll({

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1707,28 +1707,18 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
-    const missingSupport = await api.requestMalformedPollRunner(
+    const missingSupport = await api.requestRawPollRunner(
       true,
       { group: runnerGroup },
       [400],
     );
     expectApiError(missingSupport.body);
-    const legacySupport = await api.requestMalformedPollRunner(
+    const legacySupport = await api.requestRawPollRunner(
       true,
       { group: runnerGroup, profiles: ["vm0/default"] },
       [400],
     );
     expectApiError(legacySupport.body);
-    const conflictingLegacySupport = await api.requestMalformedPollRunner(
-      true,
-      {
-        group: runnerGroup,
-        supportedProfiles: ["vm0/default"],
-        profiles: ["vm0/large"],
-      },
-      [400],
-    );
-    expectApiError(conflictingLegacySupport.body);
     const emptySupport = await api.requestPollRunner(
       true,
       { group: runnerGroup, supportedProfiles: [] },
@@ -1757,9 +1747,13 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     }
     expect(incompatiblePoll.body.job).toBeNull();
 
-    const compatiblePoll = await api.requestPollRunner(
+    const compatiblePoll = await api.requestRawPollRunner(
       true,
-      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      {
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+        profiles: ["vm0/large"],
+      },
       [200],
     );
     if (compatiblePoll.status !== 200) {
@@ -1822,6 +1816,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(first).toMatchObject({ status: "pending" });
     const firstClaim = await api.claimRunnerJob(first.runId);
     const cliAgentSessionId = `bdd-affinity-cli-${first.runId}`;
+    const affinityRunnerId = randomUUID();
     const history = `bdd affinity history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
     mockSessionHistoryBlob(historyHash, history);
@@ -1846,6 +1841,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       readonly mode?: "running" | "draining" | "stopping";
     }): Promise<void> {
       await api.requestHeartbeatRunner(true, [200], {
+        runnerId: affinityRunnerId,
         group: runnerGroup,
         admittableProfiles: args.admittableProfiles,
         heldSessionStates: [
@@ -1884,7 +1880,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       extra: Record<string, unknown>,
     ): Record<string, unknown> {
       return {
-        runnerId: randomUUID(),
+        runnerId: affinityRunnerId,
         runnerName: "legacy-bdd-runner",
         group: runnerGroup,
         totalVcpu: 8,
@@ -1904,28 +1900,35 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       };
     }
 
-    const legacyAvailableHeartbeat = await api.requestMalformedHeartbeatRunner(
+    const legacyAvailableHeartbeat = await api.requestRawHeartbeatRunner(
       true,
       [400],
       legacyHeartbeatBody({ availableProfiles: ["vm0/default"] }),
     );
     expectApiError(legacyAvailableHeartbeat.body);
-    const legacyStaticHeartbeat = await api.requestMalformedHeartbeatRunner(
+    const legacyStaticHeartbeat = await api.requestRawHeartbeatRunner(
       true,
       [400],
       legacyHeartbeatBody({ profiles: ["vm0/default"] }),
     );
     expectApiError(legacyStaticHeartbeat.body);
-    const conflictingLegacyHeartbeat =
-      await api.requestMalformedHeartbeatRunner(
-        true,
-        [400],
-        legacyHeartbeatBody({
-          admittableProfiles: ["vm0/default"],
-          profiles: ["vm0/large"],
-        }),
-      );
-    expectApiError(conflictingLegacyHeartbeat.body);
+    const heartbeatWithIgnoredLegacy = await api.requestRawHeartbeatRunner(
+      true,
+      [200],
+      legacyHeartbeatBody({
+        admittableProfiles: ["vm0/default"],
+        availableProfiles: ["vm0/large"],
+        profiles: ["vm0/large"],
+      }),
+    );
+    expect(heartbeatWithIgnoredLegacy.body).toStrictEqual({ ok: true });
+    const ignoredLegacyHolder = await pollFollowUp(
+      "continue when heartbeat ignores legacy fields",
+    );
+    expect(ignoredLegacyHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
+    expect(ignoredLegacyHolder.job?.affinityProtectedUntil).toStrictEqual(
+      expect.any(String),
+    );
 
     await heartbeatHolder({
       admittableProfiles: [],

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1707,12 +1707,28 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
 
-    const missingSupport = await api.requestPollRunner(
+    const missingSupport = await api.requestMalformedPollRunner(
       true,
       { group: runnerGroup },
       [400],
     );
     expectApiError(missingSupport.body);
+    const legacySupport = await api.requestMalformedPollRunner(
+      true,
+      { group: runnerGroup, profiles: ["vm0/default"] },
+      [400],
+    );
+    expectApiError(legacySupport.body);
+    const conflictingLegacySupport = await api.requestMalformedPollRunner(
+      true,
+      {
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+        profiles: ["vm0/large"],
+      },
+      [400],
+    );
+    expectApiError(conflictingLegacySupport.body);
     const emptySupport = await api.requestPollRunner(
       true,
       { group: runnerGroup, supportedProfiles: [] },
@@ -1731,7 +1747,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       {
         group: runnerGroup,
         supportedProfiles: ["vm0/large"],
-        profiles: ["vm0/default"],
       },
       [200],
     );
@@ -1827,20 +1842,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
 
     async function heartbeatHolder(args: {
-      readonly profiles?: string[];
       readonly admittableProfiles?: string[];
-      readonly omitAdmittableProfiles?: boolean;
-      readonly availableProfiles?: string[];
-      readonly omitAvailableProfiles?: boolean;
       readonly mode?: "running" | "draining" | "stopping";
     }): Promise<void> {
       await api.requestHeartbeatRunner(true, [200], {
         group: runnerGroup,
-        profiles: args.profiles,
         admittableProfiles: args.admittableProfiles,
-        omitAdmittableProfiles: args.omitAdmittableProfiles,
-        availableProfiles: args.availableProfiles,
-        omitAvailableProfiles: args.omitAvailableProfiles,
         heldSessionStates: [
           {
             sessionId: cliAgentSessionId,
@@ -1873,9 +1880,55 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       return { run, job: poll.body.job };
     }
 
+    function legacyHeartbeatBody(
+      extra: Record<string, unknown>,
+    ): Record<string, unknown> {
+      return {
+        runnerId: randomUUID(),
+        runnerName: "legacy-bdd-runner",
+        group: runnerGroup,
+        totalVcpu: 8,
+        totalMemoryMb: 16_384,
+        maxConcurrent: 2,
+        allocatedVcpu: 0,
+        allocatedMemoryMb: 0,
+        runningCount: 0,
+        heldSessionStates: [
+          {
+            sessionId: cliAgentSessionId,
+            lastCompletedAt: nowDate().toISOString(),
+          },
+        ],
+        mode: "running",
+        ...extra,
+      };
+    }
+
+    const legacyAvailableHeartbeat = await api.requestMalformedHeartbeatRunner(
+      true,
+      [400],
+      legacyHeartbeatBody({ availableProfiles: ["vm0/default"] }),
+    );
+    expectApiError(legacyAvailableHeartbeat.body);
+    const legacyStaticHeartbeat = await api.requestMalformedHeartbeatRunner(
+      true,
+      [400],
+      legacyHeartbeatBody({ profiles: ["vm0/default"] }),
+    );
+    expectApiError(legacyStaticHeartbeat.body);
+    const conflictingLegacyHeartbeat =
+      await api.requestMalformedHeartbeatRunner(
+        true,
+        [400],
+        legacyHeartbeatBody({
+          admittableProfiles: ["vm0/default"],
+          profiles: ["vm0/large"],
+        }),
+      );
+    expectApiError(conflictingLegacyHeartbeat.body);
+
     await heartbeatHolder({
       admittableProfiles: [],
-      availableProfiles: ["vm0/default"],
     });
     const unavailableHolder = await pollFollowUp(
       "continue when holder is full",
@@ -1902,9 +1955,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(staleHolder.job?.affinityProtectedUntil).toBeNull();
 
     await heartbeatHolder({
-      profiles: ["vm0/default", "vm0/large"],
       admittableProfiles: ["vm0/large"],
-      availableProfiles: ["vm0/default"],
     });
     const profileIncompatibleHolder = await pollFollowUp(
       "continue when holder cannot run requested profile",
@@ -1925,37 +1976,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(drainingHolder.job?.affinityProtectedUntil).toBeNull();
 
     await heartbeatHolder({
-      omitAdmittableProfiles: true,
-      omitAvailableProfiles: true,
-    });
-    const legacyHeartbeatFollowUp = await api.createRun(actor, {
-      agentId,
-      sessionId: first.sessionId,
-      prompt: "continue with legacy holder heartbeat",
-      modelProvider: "anthropic-api-key",
-    });
-    const legacyHeartbeatPoll = await api.requestPollRunner(
-      true,
-      { group: runnerGroup, profiles: ["vm0/default"] },
-      [200],
-    );
-    if (legacyHeartbeatPoll.status !== 200) {
-      throw new Error("Expected legacy heartbeat affinity poll to return 200");
-    }
-    expect(legacyHeartbeatPoll.body.job?.runId).toBe(
-      legacyHeartbeatFollowUp.runId,
-    );
-    expect(legacyHeartbeatPoll.body.job?.cliAgentSessionId).toBe(
-      cliAgentSessionId,
-    );
-    expect(legacyHeartbeatPoll.body.job?.affinityProtectedUntil).toStrictEqual(
-      expect.any(String),
-    );
-    await api.requestCancelRun(actor, legacyHeartbeatFollowUp.runId, [200]);
-
-    await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
-      availableProfiles: [],
     });
     const protectedFollowUp = await api.createRun(actor, {
       agentId,
@@ -5140,7 +5161,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       bearer,
       {
         group: runnerGroup,
-        profiles: ["vm0/default"],
+        supportedProfiles: ["vm0/default"],
         telemetry: { pollReason: "deferred" },
       },
       [200],
@@ -5361,7 +5382,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     const outsiderBearer = `Bearer ${outsiderKey.token}`;
     const outsiderPoll = await api.requestPollRunnerAs(
       outsiderBearer,
-      { group: runnerGroup, profiles: ["vm0/default"] },
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
       [200],
     );
     if (outsiderPoll.status !== 200) {
@@ -5410,7 +5431,10 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     const api = createRunsAutomationsApi(context);
     const bdd = createBddApi(context);
     const actor = bdd.user();
-    const pollBody = { group: "vm0/bdd-auth", profiles: ["vm0/default"] };
+    const pollBody = {
+      group: "vm0/bdd-auth",
+      supportedProfiles: ["vm0/default"],
+    };
 
     const rejectedAuthorizations = [
       "Basic vm0_official_credentials",

--- a/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runs-schedules.bdd.test.ts
@@ -421,7 +421,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 
     const unauthenticatedPoll = await api.requestPollRunner(
       false,
-      { group: "vm0/test", profiles: ["vm0/default"] },
+      { group: "vm0/test", supportedProfiles: ["vm0/default"] },
       [401],
     );
     expectApiError(unauthenticatedPoll.body);
@@ -429,7 +429,7 @@ describe("RUN-01..04 and CHAIN-RUN: run admission, runner, and visible reads", (
 
     const invalidPollGroup = await api.requestPollRunner(
       true,
-      { group: "not-a-group", profiles: ["vm0/default"] },
+      { group: "not-a-group", supportedProfiles: ["vm0/default"] },
       [400],
     );
     expectApiError(invalidPollGroup.body);

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -196,7 +196,7 @@ async function heartbeatRunner() {
         runnerId: randomUUID(),
         runnerName: "slack-dispatch-probe-runner",
         group: "vm0/test",
-        profiles: ["vm0/default"],
+        admittableProfiles: ["vm0/default"],
         totalVcpu: 8,
         totalMemoryMb: 16_384,
         maxConcurrent: 2,

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts
@@ -178,7 +178,7 @@ async function heartbeatRunner() {
         runnerId: randomUUID(),
         runnerName: "telegram-dispatch-probe-runner",
         group: "vm0/test",
-        profiles: ["vm0/default"],
+        admittableProfiles: ["vm0/default"],
         totalVcpu: 8,
         totalMemoryMb: 16_384,
         maxConcurrent: 2,

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -3902,7 +3902,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
     const doomedBearer = `Bearer ${doomedKey.token}`;
     const livePoll = await runs.requestPollRunnerAs(
       doomedBearer,
-      { group: runnerGroup, profiles: ["vm0/default"] },
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
       [200],
     );
     expect(livePoll.status).toBe(200);
@@ -3970,7 +3970,7 @@ describe("WHCB-08: Clerk deletion webhooks tear down account state", () => {
       .poll(async () => {
         revokedPoll = await runs.requestPollRunnerAs(
           doomedBearer,
-          { group: runnerGroup, profiles: ["vm0/default"] },
+          { group: runnerGroup, supportedProfiles: ["vm0/default"] },
           [200, 401],
         );
         return revokedPoll.status;

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -300,16 +300,8 @@ const heartbeatInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 
   const heldSessionStates =
     canonicalizeHeldSessionStates(body.data.heldSessionStates) ?? [];
-  // Stage 1 wire compatibility: accept legacy heartbeat fields until #20162.
-  const admittableProfiles =
-    body.data.admittableProfiles ??
-    body.data.availableProfiles ??
-    body.data.profiles;
-  if (admittableProfiles === undefined) {
-    return badRequestMessage("admittableProfiles is required");
-  }
-  // Stage 1 compatibility: remove the legacy static profile write in #20163.
-  const staticProfiles = body.data.profiles ?? [];
+  const admittableProfiles = body.data.admittableProfiles;
+  const staticProfiles: string[] = [];
   const currentDate = nowDate();
   const db = set(writeDb$);
   await db
@@ -437,11 +429,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   }
 
   const { group } = body.data;
-  // Stage 1 wire compatibility: accept legacy poll profiles until #20162.
-  const supportedProfiles = body.data.supportedProfiles ?? body.data.profiles;
-  if (supportedProfiles === undefined || supportedProfiles.length === 0) {
-    return badRequestMessage("supportedProfiles is required");
-  }
+  const supportedProfiles = body.data.supportedProfiles;
   const whereConditions: SQL<unknown>[] = [
     eq(runnerJobQueue.runnerGroup, group),
     isNull(runnerJobQueue.claimedAt),

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -71,6 +71,7 @@ const runnerPollTelemetrySchema = z.object({
 });
 
 const runnerProfileListSchema = z.array(z.string());
+const runnerSupportedProfileListSchema = runnerProfileListSchema.min(1);
 
 const networkPolicyRefreshSchema = z.object({
   nextRefreshAt: z.string().datetime({ offset: true }),
@@ -100,22 +101,10 @@ export const runnerGroupSchema = z
 const runnersPollBodySchema = z
   .object({
     group: runnerGroupSchema,
-    supportedProfiles: runnerProfileListSchema.optional(),
-    profiles: runnerProfileListSchema.optional(),
+    supportedProfiles: runnerSupportedProfileListSchema,
     telemetry: runnerPollTelemetrySchema.optional(),
   })
-  .superRefine((body, ctx) => {
-    const supportedProfiles = body.supportedProfiles ?? body.profiles;
-    if (supportedProfiles !== undefined && supportedProfiles.length > 0) {
-      return;
-    }
-
-    ctx.addIssue({
-      code: "custom",
-      path: ["supportedProfiles"],
-      message: "supportedProfiles is required",
-    });
-  });
+  .strict();
 
 /**
  * Job schema for polling response
@@ -489,33 +478,17 @@ export const heartbeatBodySchema = z
     runnerId: z.uuid(),
     runnerName: z.string(),
     group: runnerGroupSchema,
-    profiles: runnerProfileListSchema.optional(),
     totalVcpu: z.number().int().nonnegative(),
     totalMemoryMb: z.number().int().nonnegative(),
     maxConcurrent: z.number().int().nonnegative(),
     allocatedVcpu: z.number().int().nonnegative(),
     allocatedMemoryMb: z.number().int().nonnegative(),
     runningCount: z.number().int().nonnegative(),
-    admittableProfiles: runnerProfileListSchema.optional(),
-    availableProfiles: runnerProfileListSchema.optional(),
+    admittableProfiles: runnerProfileListSchema,
     heldSessionStates: z.array(heldSessionStateSchema).max(1024),
     mode: z.enum(["running", "draining", "stopping"]),
   })
-  .superRefine((body, ctx) => {
-    if (
-      body.admittableProfiles !== undefined ||
-      body.availableProfiles !== undefined ||
-      body.profiles !== undefined
-    ) {
-      return;
-    }
-
-    ctx.addIssue({
-      code: "custom",
-      path: ["admittableProfiles"],
-      message: "admittableProfiles is required",
-    });
-  });
+  .strict();
 
 /**
  * Runners heartbeat contract - POST /api/runners/heartbeat

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -98,13 +98,11 @@ export const runnerGroupSchema = z
     "Runner group must be in vm0/<name> format (e.g., vm0/production)",
   );
 
-const runnersPollBodySchema = z
-  .object({
-    group: runnerGroupSchema,
-    supportedProfiles: runnerSupportedProfileListSchema,
-    telemetry: runnerPollTelemetrySchema.optional(),
-  })
-  .strict();
+const runnersPollBodySchema = z.object({
+  group: runnerGroupSchema,
+  supportedProfiles: runnerSupportedProfileListSchema,
+  telemetry: runnerPollTelemetrySchema.optional(),
+});
 
 /**
  * Job schema for polling response
@@ -473,22 +471,20 @@ export const runnersNetworkPolicyRefreshContract = c.router({
 /**
  * Runner heartbeat body — periodic state report from each runner
  */
-export const heartbeatBodySchema = z
-  .object({
-    runnerId: z.uuid(),
-    runnerName: z.string(),
-    group: runnerGroupSchema,
-    totalVcpu: z.number().int().nonnegative(),
-    totalMemoryMb: z.number().int().nonnegative(),
-    maxConcurrent: z.number().int().nonnegative(),
-    allocatedVcpu: z.number().int().nonnegative(),
-    allocatedMemoryMb: z.number().int().nonnegative(),
-    runningCount: z.number().int().nonnegative(),
-    admittableProfiles: runnerProfileListSchema,
-    heldSessionStates: z.array(heldSessionStateSchema).max(1024),
-    mode: z.enum(["running", "draining", "stopping"]),
-  })
-  .strict();
+export const heartbeatBodySchema = z.object({
+  runnerId: z.uuid(),
+  runnerName: z.string(),
+  group: runnerGroupSchema,
+  totalVcpu: z.number().int().nonnegative(),
+  totalMemoryMb: z.number().int().nonnegative(),
+  maxConcurrent: z.number().int().nonnegative(),
+  allocatedVcpu: z.number().int().nonnegative(),
+  allocatedMemoryMb: z.number().int().nonnegative(),
+  runningCount: z.number().int().nonnegative(),
+  admittableProfiles: runnerProfileListSchema,
+  heldSessionStates: z.array(heldSessionStateSchema).max(1024),
+  mode: z.enum(["running", "draining", "stopping"]),
+});
 
 /**
  * Runners heartbeat contract - POST /api/runners/heartbeat


### PR DESCRIPTION
## Summary
- require final runner poll `supportedProfiles`; legacy-only `profiles` no longer satisfies the contract
- require final heartbeat `admittableProfiles`; legacy-only `profiles` / `availableProfiles` no longer satisfies the contract
- ignore extra legacy profile fields when the final field is present, so old extra fields cannot override final semantics
- stop the Rust runner from sending duplicate legacy poll/heartbeat profile fields
- keep DB writes to existing `runner_state` columns until #20163 handles schema cleanup

Closes #20162.

## Tests
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api lint`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "supported profiles|same-session affinity"`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/runs-schedules.bdd.test.ts src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts`
- `cd turbo && pnpm -F @vm0/api-contracts generate:rust`
- `cd turbo && pnpm exec prettier --write ...changed TS files...`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner heartbeat_ --quiet`
- `cargo test --manifest-path crates/Cargo.toml -p runner poll_request_body_serializes_poll_reason_telemetry --quiet`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --tests -- -D warnings`
- pre-commit hook: prettier, knip, cargo-doc, cargo-clippy, workspace `pnpm check-types`

Note: the first full `run-lifecycle.bdd.test.ts` attempt failed because the local DB had not applied the latest migration for `agent_run_custom_connector_auth_refs`; after `cd turbo && pnpm -F @vm0/db db:migrate`, the same test passed.