### PR TITLE
fix: restore generated chat video preview size

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -4042,6 +4042,15 @@ describe("zero attachment chips", () => {
       expect(screen.getByLabelText("Download archive.bin")).toBeInTheDocument();
     });
 
+    const bodyVideoPreview = screen.getByLabelText("Preview demo.mp4");
+    expect(bodyVideoPreview).toHaveClass(
+      "aspect-[16/10]",
+      "w-[min(100%,400px)]",
+      "max-w-full",
+      "bg-black",
+    );
+    expect(bodyVideoPreview).not.toHaveClass("w-[50px]");
+
     click(screen.getByLabelText("Open audio preview for briefing.mp3"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -1606,17 +1606,25 @@ type ChatImagePreviewLinkProps = {
   url: string;
 };
 
-const CHAT_INLINE_MEDIA_PREVIEW_CLASS = cn(
-  "aspect-[10/9] w-[50px] max-w-full cursor-pointer rounded-lg",
+const CHAT_INLINE_MEDIA_PREVIEW_CHROME_CLASS = cn(
   "border border-foreground/10 shadow-sm transition-all duration-200",
   "hover:scale-[1.015] hover:border-foreground/20 hover:shadow-lg hover:shadow-black/10 dark:hover:shadow-black/30",
 );
+const CHAT_INLINE_MEDIA_THUMBNAIL_PREVIEW_CLASS = cn(
+  "aspect-[10/9] w-[50px] max-w-full cursor-pointer rounded-lg",
+  CHAT_INLINE_MEDIA_PREVIEW_CHROME_CLASS,
+);
 const CHAT_INLINE_IMAGE_PREVIEW_CLASS = cn(
-  CHAT_INLINE_MEDIA_PREVIEW_CLASS,
+  CHAT_INLINE_MEDIA_THUMBNAIL_PREVIEW_CLASS,
   "bg-muted/30",
 );
-const CHAT_INLINE_VIDEO_PREVIEW_CLASS = cn(
-  CHAT_INLINE_MEDIA_PREVIEW_CLASS,
+const CHAT_INLINE_VIDEO_ATTACHMENT_PREVIEW_CLASS = cn(
+  CHAT_INLINE_MEDIA_THUMBNAIL_PREVIEW_CLASS,
+  "bg-black",
+);
+const CHAT_INLINE_VIDEO_BODY_PREVIEW_CLASS = cn(
+  "aspect-[16/10] w-[min(100%,400px)] max-w-full cursor-pointer rounded-lg",
+  CHAT_INLINE_MEDIA_PREVIEW_CHROME_CLASS,
   "bg-black",
 );
 
@@ -5569,7 +5577,7 @@ function BodyContentBlocks({
             <ChatVideoPreviewButton
               key={block.id}
               ariaLabel={`Preview ${block.preview.filename}`}
-              buttonClassName={CHAT_INLINE_VIDEO_PREVIEW_CLASS}
+              buttonClassName={CHAT_INLINE_VIDEO_BODY_PREVIEW_CLASS}
               filename={block.preview.filename}
               onPreview={() => {
                 openVideoLightbox({
@@ -6918,7 +6926,7 @@ function UserMessageAttachments({
             <ChatVideoPreviewButton
               key={a.url}
               ariaLabel={`Preview ${a.filename}`}
-              buttonClassName={CHAT_INLINE_VIDEO_PREVIEW_CLASS}
+              buttonClassName={CHAT_INLINE_VIDEO_ATTACHMENT_PREVIEW_CLASS}
               filename={a.filename}
               onPreview={() => {
                 openVideoLightbox({


### PR DESCRIPTION
## Summary
- Split chat inline media preview sizing so generated assistant body videos render as 16:10, up to 400px wide again.
- Keep user-uploaded video attachments aligned with the compact image attachment thumbnail size.
- Add regression coverage that body video previews do not use the 50px attachment thumbnail class.

## Verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "opens media and file previews parsed from chat message links"`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "renders user video attachments at the same size as image attachments"`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "uploads a file dropped onto the composer"`
- Note: a whole-file run of `zero-attachment-chips.test.tsx` hit a one-off 5s timeout in the unrelated drop-upload test; that exact test passed when rerun by name.
