### PR TITLE
perf: lazily materialize custom connector auth

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3910,13 +3910,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     );
     expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("allow");
 
-    if (!claim.encryptedSecrets) {
-      throw new Error("Expected the custom claim to carry encrypted secrets");
-    }
     const resolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       {
-        encryptedSecrets: claim.encryptedSecrets,
+        encryptedSecrets: fw.encryptedSecretsBody({}),
         authHeaders: {
           Authorization: `Bearer \${{ secrets.${secretKey} }}`,
         },
@@ -3981,11 +3978,19 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       agentId,
     });
 
+    await enableAutomationsFakeKms(context);
+    onTestFinished(async () => {
+      await resetAutomationsFakeKms(context);
+    });
+
     const run = await api.createRun(actor, {
       agentId,
       prompt: "use the custom connector auth ref",
       modelProvider: "anthropic-api-key",
     });
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      0,
+    );
     await api.heartbeatRunner(runnerGroup);
     const claim = await api.claimRunnerJob(run.runId);
 
@@ -4192,11 +4197,19 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       agentId,
     });
 
+    await enableAutomationsFakeKms(context);
+    onTestFinished(async () => {
+      await resetAutomationsFakeKms(context);
+    });
+
     const run = await api.createRun(actor, {
       agentId,
       prompt: "use the proposed custom connector",
       modelProvider: "anthropic-api-key",
     });
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      1,
+    );
     const timingEvents = apiDispatchTimingEventsForRun(run.runId);
     expectApiDispatchActions(
       timingEvents,
@@ -4225,13 +4238,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       `\${{ secrets.${variableKey} }}`,
     );
 
-    if (!claim.encryptedSecrets) {
-      throw new Error("Expected the custom claim to carry encrypted secrets");
-    }
     const resolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       {
-        encryptedSecrets: claim.encryptedSecrets,
+        encryptedSecrets: fw.encryptedSecretsBody({}),
         authHeaders: {
           Authorization: `Bearer \${{ secrets.${secretKey} }}`,
         },
@@ -4328,13 +4338,10 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(JSON.stringify(customApis)).not.toContain(secondarySecretKey);
     expect(JSON.stringify(customApis)).not.toContain(tenantVarKey);
 
-    if (!claim.encryptedSecrets) {
-      throw new Error("Expected the custom claim to carry encrypted secrets");
-    }
     const resolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
       {
-        encryptedSecrets: claim.encryptedSecrets,
+        encryptedSecrets: fw.encryptedSecretsBody({}),
         authHeaders: {
           Authorization: `Bearer \${{ secrets.${secretKey} }}`,
         },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -141,7 +141,9 @@ import {
 } from "./crypto.utils";
 import {
   customConnectorInternalName,
+  customConnectorPrefixTemplateVariableKeys,
   customConnectorSecretKey,
+  customConnectorValueMarkerKey,
   decryptCustomConnectorValues,
   loadCustomConnectorRuntimeData,
   renderCustomConnectorRuntimePrefix,
@@ -615,7 +617,7 @@ interface CreditCheckRow extends Record<string, unknown> {
 
 interface CustomConnectorRuntimeContext {
   readonly firewalls: readonly ExpandedFirewallConfig[];
-  readonly secrets: Record<string, string> | undefined;
+  readonly reservedSecretAliases: Record<string, true> | undefined;
   readonly authRefs: readonly CustomConnectorAuthRef[];
 }
 
@@ -2100,7 +2102,10 @@ function mergeRecords<T>(
 
 function filterSecretConnectorMap(args: {
   readonly secretConnectorMap: Record<string, string> | undefined;
-  readonly overriddenSecrets: readonly (Record<string, string> | undefined)[];
+  readonly overriddenSecrets: readonly (
+    | Readonly<Record<string, unknown>>
+    | undefined
+  )[];
 }): Record<string, string> | undefined {
   if (!args.secretConnectorMap) {
     return undefined;
@@ -3245,31 +3250,27 @@ async function buildCustomConnectorRuntimeContext(args: {
   readonly timing?: ApiDispatchTimingCollector;
 }): Promise<CustomConnectorRuntimeContext> {
   const firewalls: ExpandedFirewallConfig[] = [];
-  const secrets: Record<string, string> = {};
+  const reservedSecretAliases: Record<string, true> = {};
   const authRefs: CustomConnectorAuthRef[] = [];
   const stats = new CustomConnectorRuntimeBuildStats(args.rows);
   for (const row of args.rows) {
     const missingRequiredStartedAt = now();
     const valueMarkers = new Set(
       row.values.map((value) => {
-        return `${value.kind}:${value.key}`;
+        return customConnectorValueMarkerKey(value);
       }),
     );
     const missingRequired = row.connector.fields.some((field) => {
-      return field.required && !valueMarkers.has(`${field.kind}:${field.key}`);
+      return (
+        field.required &&
+        !valueMarkers.has(customConnectorValueMarkerKey(field))
+      );
     });
     stats.recordPhaseDuration("assembleFirewalls", missingRequiredStartedAt);
     if (missingRequired) {
       stats.recordMissingRequiredConnector();
       continue;
     }
-    const decryptStartedAt = now();
-    const decryptedValues = await decryptCustomConnectorValues({
-      values: row.values,
-      featureSwitchContext: args.featureSwitchContext,
-    });
-    stats.recordPhaseDuration("decryptValues", decryptStartedAt);
-    stats.recordDecryptedValues(row.values.length);
     const apis: ExpandedFirewallConfig["apis"] = [];
     const authTemplateStartedAt = now();
     const headers = Object.fromEntries(
@@ -3299,6 +3300,22 @@ async function buildCustomConnectorRuntimeContext(args: {
       stats.recordNoAuthInjectionConnector();
       continue;
     }
+    const prefixVariableKeys = customConnectorPrefixTemplateVariableKeys(
+      row.connector.prefixTemplates,
+    );
+    const prefixValues = row.values.filter((value) => {
+      return value.kind === "variable" && prefixVariableKeys.has(value.key);
+    });
+    const decryptStartedAt = now();
+    const decryptedValues =
+      prefixValues.length === 0
+        ? {}
+        : await decryptCustomConnectorValues({
+            values: prefixValues,
+            featureSwitchContext: args.featureSwitchContext,
+          });
+    stats.recordPhaseDuration("decryptValues", decryptStartedAt);
+    stats.recordDecryptedValues(prefixValues.length);
     const prefixStartedAt = now();
     for (const prefixTemplate of row.connector.prefixTemplates) {
       const renderedPrefix = renderCustomConnectorRuntimePrefix({
@@ -3329,37 +3346,24 @@ async function buildCustomConnectorRuntimeContext(args: {
       description: row.connector.displayName,
       apis,
     });
-    authRefs.push(
-      ...customConnectorAuthRefsForApis({
-        connectorId: row.connector.id,
-        values: row.values,
-        apis,
-      }),
-    );
-    for (const value of row.values) {
-      const field = row.connector.fields.find((candidate) => {
-        return candidate.kind === value.kind && candidate.key === value.key;
-      });
-      if (!field) {
-        continue;
-      }
-      const decryptedValue = decryptedValues[`${value.kind}:${value.key}`];
-      if (decryptedValue === undefined) {
-        continue;
-      }
-      secrets[
-        customConnectorSecretKey({
-          connectorId: row.connector.id,
-          kind: value.kind,
-          key: value.key,
-        })
-      ] = decryptedValue;
+    const rowAuthRefs = customConnectorAuthRefsForApis({
+      connectorId: row.connector.id,
+      values: row.values,
+      apis,
+    });
+    for (const ref of rowAuthRefs) {
+      reservedSecretAliases[ref.secretName] = true;
     }
+    authRefs.push(...rowAuthRefs);
     stats.recordPhaseDuration("assembleFirewalls", assemblyStartedAt);
   }
 
   const finalAssemblyStartedAt = now();
-  const result = { firewalls, secrets: compactRecord(secrets), authRefs };
+  const result = {
+    firewalls,
+    reservedSecretAliases: compactRecord(reservedSecretAliases),
+    authRefs,
+  };
   stats.recordPhaseDuration("assembleFirewalls", finalAssemblyStartedAt);
   stats.flush(args.timing);
   return result;
@@ -3376,7 +3380,7 @@ async function loadCustomConnectorContext(
   timing?: ApiDispatchTimingCollector,
 ): Promise<CustomConnectorRuntimeContext> {
   if (args.allowedCustomConnectorIds?.length === 0) {
-    return { firewalls: [], secrets: undefined, authRefs: [] };
+    return { firewalls: [], reservedSecretAliases: undefined, authRefs: [] };
   }
 
   const rows = await loadCustomConnectorRuntimeData(db, {
@@ -3397,7 +3401,7 @@ async function loadCustomConnectorContext(
     },
   });
   if (rows.length === 0) {
-    return { firewalls: [], secrets: undefined, authRefs: [] };
+    return { firewalls: [], reservedSecretAliases: undefined, authRefs: [] };
   }
 
   return await measureApiDispatchTiming(
@@ -4953,12 +4957,15 @@ function buildStoredExecutionSecrets(args: {
       args.modelProvider?.secrets,
       args.modelProvider?.secretConnectorMap,
       args.bodySecrets,
-      args.customConnectorContext.secrets,
+      args.customConnectorContext.reservedSecretAliases,
     ],
   });
   const filteredModelProviderMap = filterSecretConnectorMap({
     secretConnectorMap: args.modelProvider?.secretConnectorMap,
-    overriddenSecrets: [args.bodySecrets, args.customConnectorContext.secrets],
+    overriddenSecrets: [
+      args.bodySecrets,
+      args.customConnectorContext.reservedSecretAliases,
+    ],
   });
   const filteredModelProviderMetadataMap = filterSecretConnectorMetadataMap({
     secretConnectorMetadataMap: args.modelProvider?.secretConnectorMetadataMap,
@@ -4970,7 +4977,6 @@ function buildStoredExecutionSecrets(args: {
     args.connectorContext.secrets,
     args.modelProvider?.secrets,
     args.bodySecrets,
-    args.customConnectorContext.secrets,
   );
   // The merged map is the runtime `secrets.NAME` namespace consumed by firewall
   // auth and environment expansion. Stored connectors and model providers enter

--- a/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-custom-connector.service.ts
@@ -236,7 +236,7 @@ export function normaliseCustomConnectorRow(
   };
 }
 
-function valueMarkerKey(marker: {
+export function customConnectorValueMarkerKey(marker: {
   readonly kind: CustomConnectorFieldKind;
   readonly key: string;
 }): string {
@@ -249,7 +249,7 @@ function configuredValueMarkerKeys(
   return [
     ...new Set(
       markers.map((marker) => {
-        return valueMarkerKey(marker);
+        return customConnectorValueMarkerKey(marker);
       }),
     ),
   ].sort();
@@ -262,7 +262,7 @@ function configuredFieldKeys(args: {
   const configured = new Set(configuredValueMarkerKeys(args.markers));
   return args.fields
     .filter((field) => {
-      return configured.has(valueMarkerKey(field));
+      return configured.has(customConnectorValueMarkerKey(field));
     })
     .map((field) => {
       return field.key;
@@ -277,7 +277,9 @@ function computeMissingRequiredFields(args: {
   const configured = new Set(configuredValueMarkerKeys(args.markers));
   return args.fields
     .filter((field) => {
-      return field.required && !configured.has(valueMarkerKey(field));
+      return (
+        field.required && !configured.has(customConnectorValueMarkerKey(field))
+      );
     })
     .map((field) => {
       return field.key;
@@ -382,7 +384,7 @@ function extractTemplateReferences(template: string): readonly {
   });
 }
 
-function prefixTemplateVariableKeys(
+export function customConnectorPrefixTemplateVariableKeys(
   prefixTemplates: readonly string[],
 ): ReadonlySet<string> {
   const keys = new Set<string>();
@@ -541,7 +543,7 @@ function validateFields(
         "Field keys must start with a lowercase letter and contain only lowercase letters, digits, and underscores",
       );
     }
-    const marker = valueMarkerKey({ kind: field.kind, key });
+    const marker = customConnectorValueMarkerKey({ kind: field.kind, key });
     if (seen.has(marker) || seen.has(key)) {
       return badRequestMessage(`Duplicate field key: ${key}`);
     }
@@ -820,7 +822,7 @@ async function loadConnectorValueMarkers(args: {
     });
   const existing = new Set(
     markers.map((marker) => {
-      return `${marker.connectorId}:${valueMarkerKey(marker)}`;
+      return `${marker.connectorId}:${customConnectorValueMarkerKey(marker)}`;
     }),
   );
   for (const row of legacyRows) {
@@ -829,7 +831,7 @@ async function loadConnectorValueMarkers(args: {
       kind: "secret" as const,
       key: LEGACY_SECRET_KEY,
     };
-    const key = `${marker.connectorId}:${valueMarkerKey(marker)}`;
+    const key = `${marker.connectorId}:${customConnectorValueMarkerKey(marker)}`;
     if (!existing.has(key)) {
       markers.push(marker);
       existing.add(key);
@@ -1036,15 +1038,17 @@ function validateValueInputsForDefinition(args: {
 }): readonly CustomConnectorValueInput[] | BadRequestResponse {
   const allowed = new Set(
     args.fields.map((field) => {
-      return valueMarkerKey(field);
+      return customConnectorValueMarkerKey(field);
     }),
   );
-  const prefixVariables = prefixTemplateVariableKeys(args.prefixTemplates);
+  const prefixVariables = customConnectorPrefixTemplateVariableKeys(
+    args.prefixTemplates,
+  );
   const seen = new Set<string>();
   const values: CustomConnectorValueInput[] = [];
   for (const value of args.values) {
     const key = value.key.trim();
-    const marker = valueMarkerKey({ kind: value.kind, key });
+    const marker = customConnectorValueMarkerKey({ kind: value.kind, key });
     if (!allowed.has(marker)) {
       return badRequestMessage(
         `Value references undeclared custom connector field: ${marker}`,
@@ -1345,10 +1349,11 @@ export async function decryptCustomConnectorValues(args: {
 }): Promise<Record<string, string>> {
   const result: Record<string, string> = {};
   for (const value of args.values) {
-    result[valueMarkerKey(value)] = await decryptStoredSecretValue(
-      value.encryptedValue,
-      args.featureSwitchContext,
-    );
+    result[customConnectorValueMarkerKey(value)] =
+      await decryptStoredSecretValue(
+        value.encryptedValue,
+        args.featureSwitchContext,
+      );
   }
   return result;
 }
@@ -1388,7 +1393,9 @@ export function renderTemplateForRuntime(args: {
     const legacyField = fieldByReference.get(`secrets.${LEGACY_SECRET_KEY}`);
     if (
       !legacyField ||
-      !args.configuredValueMarkers.has(valueMarkerKey(legacyField))
+      !args.configuredValueMarkers.has(
+        customConnectorValueMarkerKey(legacyField),
+      )
     ) {
       return null;
     }
@@ -1405,7 +1412,7 @@ export function renderTemplateForRuntime(args: {
     }
     if (
       args.configuredValueMarkers &&
-      !args.configuredValueMarkers.has(valueMarkerKey(field))
+      !args.configuredValueMarkers.has(customConnectorValueMarkerKey(field))
     ) {
       return null;
     }
@@ -1448,7 +1455,8 @@ function renderPrefixTemplate(args: {
         missing = true;
         return TEMPLATE_PLACEHOLDER_VALUE;
       }
-      const value = args.values[valueMarkerKey({ kind: "variable", key })];
+      const value =
+        args.values[customConnectorValueMarkerKey({ kind: "variable", key })];
       if (!value || !isSafeHostTemplateVariableValue(value)) {
         missing = true;
         return TEMPLATE_PLACEHOLDER_VALUE;


### PR DESCRIPTION
## Summary
- cut create-run custom connector decrypts down to prefix/base URL variables only
- keep generated custom connector aliases as reservations for lazy map filtering without emitting plaintext into encryptedSecrets
- update custom connector route tests to resolve header/query auth through run-scoped refs

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm format
- pre-commit: pnpm knip; pnpm check-types

Closes #20203