### PR TITLE
fix: align next thread shortcut to sidebar bottom

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/zero-sidebar-state.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/zero-sidebar-state.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { testContext } from "./test-helpers.ts";
+import {
+  CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+  scrollChatThreadVirtualListToIndex$,
+  setChatThreadVirtualListElement$,
+  setOverlayScrollViewport$,
+} from "../zero-page/zero-sidebar-state.ts";
+
+const context = testContext();
+
+function defineLayoutMetric(
+  element: HTMLElement,
+  key: "clientHeight" | "offsetTop" | "scrollHeight" | "scrollTop",
+  value: number,
+  writable = false,
+): void {
+  Object.defineProperty(element, key, {
+    configurable: true,
+    value,
+    writable,
+  });
+}
+
+function setupVirtualThreadList({
+  scrollTop,
+  viewportHeight,
+}: {
+  scrollTop: number;
+  viewportHeight: number;
+}): HTMLElement {
+  const scrollViewport = document.createElement("div");
+  const virtualListElement = document.createElement("div");
+
+  defineLayoutMetric(scrollViewport, "offsetTop", 0);
+  defineLayoutMetric(scrollViewport, "scrollHeight", 1000);
+  defineLayoutMetric(scrollViewport, "clientHeight", viewportHeight);
+  defineLayoutMetric(scrollViewport, "scrollTop", scrollTop, true);
+  defineLayoutMetric(virtualListElement, "offsetTop", 0);
+
+  context.store.set(setOverlayScrollViewport$, scrollViewport);
+  context.store.set(setChatThreadVirtualListElement$, virtualListElement);
+  return scrollViewport;
+}
+
+describe("zero sidebar virtual thread scrolling", () => {
+  it("aligns a hidden target row bottom with the viewport bottom when requested", () => {
+    const viewportHeight = CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 2;
+    const scrollViewport = setupVirtualThreadList({
+      scrollTop: CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 20,
+      viewportHeight,
+    });
+
+    context.store.set(scrollChatThreadVirtualListToIndex$, 22, "bottom");
+
+    expect(scrollViewport.scrollTop).toBe(
+      23 * CHAT_THREAD_VIRTUAL_ROW_HEIGHT - viewportHeight,
+    );
+  });
+});

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -532,7 +532,14 @@ export const setChatKeyboardScrollRoot$ = onRef(
           : set(loadRightThread$, targetId, signal);
       await Promise.all([
         promise,
-        set(scrollToThread$, targetId, get(rootSignal$)),
+        set(
+          scrollToThread$,
+          {
+            threadId: targetId,
+            align: direction === "next" ? "bottom" : "top",
+          },
+          get(rootSignal$),
+        ),
       ]);
     };
     const navigateFocusedThread = (direction: "prev" | "next") => {

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts
@@ -1,8 +1,16 @@
 import { command } from "ccstate";
 import { animationFrame } from "signal-timers";
 import { createDeferredPromise } from "../utils.ts";
-import { scrollChatThreadVirtualListToIndex$ } from "../zero-page/zero-sidebar-state.ts";
+import {
+  scrollChatThreadVirtualListToIndex$,
+  type ChatThreadVirtualListScrollAlign,
+} from "../zero-page/zero-sidebar-state.ts";
 import { sidebarChatThreads$ } from "./optimistic-chat-thread-page.ts";
+
+interface ScrollToThreadRequest {
+  threadId: string;
+  align?: ChatThreadVirtualListScrollAlign;
+}
 
 async function waitForAnimationFrame(signal: AbortSignal): Promise<void> {
   signal.throwIfAborted();
@@ -19,7 +27,13 @@ async function waitForAnimationFrame(signal: AbortSignal): Promise<void> {
 }
 
 export const scrollToThread$ = command(
-  async ({ get, set }, threadId: string, signal: AbortSignal) => {
+  async (
+    { get, set },
+    request: string | ScrollToThreadRequest,
+    signal: AbortSignal,
+  ) => {
+    const threadId = typeof request === "string" ? request : request.threadId;
+    const align = typeof request === "string" ? "top" : request.align;
     const chatThreads = await get(sidebarChatThreads$);
     signal.throwIfAborted();
 
@@ -32,6 +46,6 @@ export const scrollToThread$ = command(
 
     await waitForAnimationFrame(signal);
     signal.throwIfAborted();
-    return set(scrollChatThreadVirtualListToIndex$, index);
+    return set(scrollChatThreadVirtualListToIndex$, index, align);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -267,6 +267,7 @@ export const CHAT_THREAD_VIRTUAL_ROW_HEIGHT = 36;
 const CHAT_THREAD_VIRTUAL_FALLBACK_VIEWPORT_HEIGHT =
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 12;
 const internalChatThreadVirtualListElement$ = state<HTMLElement | null>(null);
+export type ChatThreadVirtualListScrollAlign = "top" | "bottom";
 
 function hasUsableLayoutPosition(rect: DOMRectReadOnly): boolean {
   return rect.top !== 0 || rect.left !== 0;
@@ -304,7 +305,11 @@ export const setChatThreadVirtualListElement$ = command(
   },
 );
 export const scrollChatThreadVirtualListToIndex$ = command(
-  ({ get, set }, index: number): boolean => {
+  (
+    { get, set },
+    index: number,
+    align: ChatThreadVirtualListScrollAlign = "top",
+  ): boolean => {
     if (!Number.isInteger(index) || index < 0) {
       return false;
     }
@@ -328,11 +333,15 @@ export const scrollChatThreadVirtualListToIndex$ = command(
     const rowBottom = rowTop + CHAT_THREAD_VIRTUAL_ROW_HEIGHT;
     const viewportTop = scrollViewport.scrollTop;
     const viewportBottom = viewportTop + viewportHeight;
-    const targetScrollTop = Math.max(0, rowTop);
-    const nextScrollTop =
-      rowTop < viewportTop || rowBottom > viewportBottom
-        ? targetScrollTop
-        : viewportTop;
+    let nextScrollTop = viewportTop;
+    if (rowBottom > viewportBottom) {
+      nextScrollTop =
+        align === "bottom"
+          ? Math.max(0, rowBottom - viewportHeight)
+          : Math.max(0, rowTop);
+    } else if (rowTop < viewportTop) {
+      nextScrollTop = Math.max(0, rowTop);
+    }
 
     scrollViewport.scrollTop = nextScrollTop;
     set(internalOverlayScrollMetrics$, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -44,6 +44,7 @@ import {
 } from "../../../mocks/handlers/automations-store.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
+import { CHAT_THREAD_VIRTUAL_ROW_HEIGHT } from "../../../signals/zero-page/zero-sidebar-state.ts";
 import {
   click,
   detachedSetupPage as baseDetachedSetupPage,
@@ -3621,9 +3622,19 @@ describe("chat lifecycle", () => {
 
     const sidebarScrollArea = screen.getByTestId("sidebar-scroll-area");
     Object.defineProperties(sidebarScrollArea, {
-      clientHeight: { configurable: true, value: 36 },
-      scrollHeight: { configurable: true, value: 108 },
-      scrollTop: { configurable: true, value: 0, writable: true },
+      clientHeight: {
+        configurable: true,
+        value: CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 2,
+      },
+      scrollHeight: {
+        configurable: true,
+        value: CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 24,
+      },
+      scrollTop: {
+        configurable: true,
+        value: CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 20,
+        writable: true,
+      },
     });
     fireEvent.scroll(sidebarScrollArea);
 
@@ -3639,9 +3650,9 @@ describe("chat lifecycle", () => {
       expect(screen.getByText("Next thread launch note")).toBeInTheDocument();
     });
     await waitFor(() => {
-      expect(
-        screen.getByTestId("sidebar-scroll-area").scrollTop,
-      ).toBeGreaterThan(0);
+      expect(screen.getByTestId("sidebar-scroll-area").scrollTop).toBe(
+        CHAT_THREAD_VIRTUAL_ROW_HEIGHT * 21,
+      );
     });
 
     composer = chatComposerTextarea();


### PR DESCRIPTION
## Summary
- Align the sidebar row for `cmd+shift+down` / `ctrl+shift+down` to the bottom of the visible sidebar when the next target thread is partially below the viewport.
- Keep existing top-alignment behavior for page setup, direct thread scrolling, and previous-thread keyboard navigation.
- Add a focused virtual-list scroll test and tighten the keyboard navigation integration test around the expected bottom alignment.

## Verification
- `pnpm exec prettier --check apps/platform/src/signals/zero-page/zero-sidebar-state.ts apps/platform/src/signals/chat-page/sidebar-chat-thread-scroll.ts apps/platform/src/signals/chat-page/chat-keyboard.ts apps/platform/src/signals/__tests__/zero-sidebar-state.test.ts apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/app exec oxlint src/signals/zero-page/zero-sidebar-state.ts src/signals/chat-page/sidebar-chat-thread-scroll.ts src/signals/chat-page/chat-keyboard.ts src/signals/__tests__/zero-sidebar-state.test.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm exec vitest run src/signals/__tests__/zero-sidebar-state.test.ts --reporter=verbose --maxWorkers=1 --no-file-parallelism`
- `pnpm exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --testNamePattern "moves between chat threads with page shortcuts from the composer" --reporter=verbose --maxWorkers=1 --no-file-parallelism`
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm -F @vm0/app check-types`
