### PR TITLE
fix: simplify mobile unread chat shortcuts

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -419,14 +419,16 @@ describe("zero ideation page", () => {
       name: "Unread chats",
     });
     expect(unreadRegion).toHaveClass("md:hidden");
-    expect(within(unreadRegion).getByText("2")).toBeInTheDocument();
+    expect(within(unreadRegion).queryByText("Unread chats")).toBeNull();
+    expect(within(unreadRegion).queryByText("2")).toBeNull();
     expect(
       within(unreadRegion).getByText("Unread research brief"),
     ).toBeInTheDocument();
     expect(
       within(unreadRegion).getByText("Running incident follow-up"),
     ).toBeInTheDocument();
-    expect(within(unreadRegion).getByText("Running now")).toBeInTheDocument();
+    expect(within(unreadRegion).queryByText("Unread")).toBeNull();
+    expect(within(unreadRegion).queryByText("Running now")).toBeNull();
     expect(
       screen.queryByText("Other agent unread chat"),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -24,7 +24,6 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-  cn,
 } from "@vm0/ui";
 import {
   currentChatAgentId$,
@@ -387,20 +386,6 @@ function MobileUnreadThreadShortcuts() {
       className="md:hidden flex flex-col gap-2"
       aria-label="Unread chats"
     >
-      <div className="flex items-center justify-between gap-3 px-1">
-        <div className="flex min-w-0 items-center gap-1.5">
-          <span
-            className="h-2 w-2 shrink-0 rounded-full bg-sky-600"
-            aria-hidden
-          />
-          <h3 className="truncate text-sm font-semibold text-foreground">
-            Unread chats
-          </h3>
-        </div>
-        <span className="shrink-0 text-xs font-medium text-muted-foreground">
-          {unreadThreads.length}
-        </span>
-      </div>
       <div className="zero-card divide-y divide-border/60 overflow-hidden">
         {unreadThreads.map((thread) => {
           return (
@@ -410,18 +395,9 @@ function MobileUnreadThreadShortcuts() {
               options={{ pathParams: { threadId: thread.id } }}
               className="flex min-h-12 items-center gap-2.5 px-3 py-2.5 text-left transition-colors hover:bg-muted/40"
             >
-              <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-sky-600" />
               <span className="min-w-0 flex-1">
                 <span className="block truncate text-sm font-semibold leading-5 text-foreground">
                   {thread.title ?? "New chat"}
-                </span>
-                <span
-                  className={cn(
-                    "block truncate text-xs leading-4 text-muted-foreground",
-                    thread.running ? "text-primary" : "",
-                  )}
-                >
-                  {thread.running ? "Running now" : "Unread"}
                 </span>
               </span>
               {thread.running ? (


### PR DESCRIPTION
## Summary
- Removes the visible mobile unread shortcut header, unread count, per-thread unread dot, and unread/running subtitle copy.
- Leaves the shortcut region and row navigation behavior intact, with each row reduced to the chat title and trailing status/navigation icon.
- Updates the mobile unread shortcut test to lock in the simpler presentation.

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-ideation-page.test.tsx -t "shows current-agent unread chat shortcuts on mobile behind the feature switch"`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/agent-chat-page.tsx apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx`
- `git diff --check`

## Notes
- Browser verification on local dev was attempted, but the local Vite app could not render without `VITE_API_URL`; staging preview verification will be done after the PR preview is ready.
