### PR TITLE
fix: reset chat indexeddb thread event caches

### DIFF
--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
@@ -100,6 +100,14 @@ function expectThreadEventStoresCreated(
   ).toHaveBeenCalledWith(CHAT_THREAD_EVENTS_ORDER_INDEX, ["createdAt", "id"]);
 }
 
+function expectThreadEventStoresDeleted(
+  deleteObjectStore: ReturnType<typeof fakeDb>["deleteObjectStore"],
+): void {
+  expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_THREAD_SNAPSHOT_STORE);
+  expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_THREAD_EVENTS_STORE);
+  expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_THREAD_EVENT_SYNC_STORE);
+}
+
 describe("upgradeChatIdb", () => {
   it("clears legacy chat cache when upgrading from before v4", () => {
     const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
@@ -154,7 +162,7 @@ describe("upgradeChatIdb", () => {
     expectThreadEventStoresCreated(createdStores, createObjectStore);
   });
 
-  it("resets v9 messages so cached unread calculations include run-finish markers", () => {
+  it("resets v9 chat caches so cached unread calculations include run-finish markers", () => {
     const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
       CHAT_MESSAGES_STORE,
       CHAT_THREAD_SNAPSHOT_STORE,
@@ -164,9 +172,29 @@ describe("upgradeChatIdb", () => {
 
     upgradeChatIdb(db, 9);
 
-    expect(deleteObjectStore).toHaveBeenCalledTimes(1);
+    expect(deleteObjectStore).toHaveBeenCalledTimes(4);
     expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_MESSAGES_STORE);
-    expect(createObjectStore).toHaveBeenCalledTimes(1);
+    expectThreadEventStoresDeleted(deleteObjectStore);
+    expect(createObjectStore).toHaveBeenCalledTimes(4);
     expectChatMessagesStoreCreated(createdStores, createObjectStore);
+    expectThreadEventStoresCreated(createdStores, createObjectStore);
+  });
+
+  it("resets v10 chat, thread, and event caches", () => {
+    const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
+      CHAT_MESSAGES_STORE,
+      CHAT_THREAD_SNAPSHOT_STORE,
+      CHAT_THREAD_EVENTS_STORE,
+      CHAT_THREAD_EVENT_SYNC_STORE,
+    ]);
+
+    upgradeChatIdb(db, 10);
+
+    expect(deleteObjectStore).toHaveBeenCalledTimes(4);
+    expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_MESSAGES_STORE);
+    expectThreadEventStoresDeleted(deleteObjectStore);
+    expect(createObjectStore).toHaveBeenCalledTimes(4);
+    expectChatMessagesStoreCreated(createdStores, createObjectStore);
+    expectThreadEventStoresCreated(createdStores, createObjectStore);
   });
 });

--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
@@ -3,7 +3,8 @@ import type { IDBPDatabase } from "idb";
 const CHAT_IDB_FULL_CACHE_RESET_VERSION = 4;
 const CHAT_IDB_MESSAGES_ORDER_RESET_VERSION = 6;
 const CHAT_IDB_RUN_FINISH_UNREAD_RESET_VERSION = 10;
-const CHAT_IDB_SCHEMA_VERSION = 10;
+const CHAT_IDB_THREAD_EVENT_CACHE_RESET_VERSION = 11;
+const CHAT_IDB_SCHEMA_VERSION = 11;
 const LEGACY_CHAT_THREAD_META_STORE = "chat_thread_agents";
 
 export const CHAT_IDB_VERSION = CHAT_IDB_SCHEMA_VERSION;
@@ -40,19 +41,26 @@ function createChatThreadEventSyncStore(db: IDBPDatabase): void {
   db.createObjectStore(CHAT_THREAD_EVENT_SYNC_STORE, { keyPath: "id" });
 }
 
+function deleteObjectStoreIfExists(db: IDBPDatabase, storeName: string): void {
+  if (db.objectStoreNames.contains(storeName)) {
+    db.deleteObjectStore(storeName);
+  }
+}
+
 export function upgradeChatIdb(db: IDBPDatabase, oldVersion: number): void {
   if (oldVersion < CHAT_IDB_FULL_CACHE_RESET_VERSION) {
-    if (db.objectStoreNames.contains(CHAT_MESSAGES_STORE)) {
-      db.deleteObjectStore(CHAT_MESSAGES_STORE);
-    }
+    deleteObjectStoreIfExists(db, CHAT_MESSAGES_STORE);
   } else if (oldVersion < CHAT_IDB_MESSAGES_ORDER_RESET_VERSION) {
-    if (db.objectStoreNames.contains(CHAT_MESSAGES_STORE)) {
-      db.deleteObjectStore(CHAT_MESSAGES_STORE);
-    }
+    deleteObjectStoreIfExists(db, CHAT_MESSAGES_STORE);
   } else if (oldVersion < CHAT_IDB_RUN_FINISH_UNREAD_RESET_VERSION) {
-    if (db.objectStoreNames.contains(CHAT_MESSAGES_STORE)) {
-      db.deleteObjectStore(CHAT_MESSAGES_STORE);
-    }
+    deleteObjectStoreIfExists(db, CHAT_MESSAGES_STORE);
+  }
+
+  if (oldVersion < CHAT_IDB_THREAD_EVENT_CACHE_RESET_VERSION) {
+    deleteObjectStoreIfExists(db, CHAT_MESSAGES_STORE);
+    deleteObjectStoreIfExists(db, CHAT_THREAD_SNAPSHOT_STORE);
+    deleteObjectStoreIfExists(db, CHAT_THREAD_EVENTS_STORE);
+    deleteObjectStoreIfExists(db, CHAT_THREAD_EVENT_SYNC_STORE);
   }
 
   if (


### PR DESCRIPTION
## Summary
- bump chat IndexedDB schema version to v11
- reset the chat message cache plus thread snapshot, thread events, and event sync stores during the v10 -> v11 upgrade
- cover the new v10 upgrade path and update the v9 migration expectation now that the newer reset also rebuilds thread event stores

## Verification
- pnpm -F @vm0/app exec vitest run src/signals/external/chat-idb-schema.test.ts
- NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec eslint src/signals/external/chat-idb-schema.ts src/signals/external/chat-idb-schema.test.ts --max-warnings 0
- pnpm -F @vm0/app exec oxlint src/signals/external/chat-idb-schema.ts src/signals/external/chat-idb-schema.test.ts --deny-warnings
- git diff --check