### PR TITLE
fix: show owner name and avatar in workflow detail created-by tooltip

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -738,6 +738,9 @@ describe("zero workflows", () => {
       createdByUserId: creator.userId,
       updatedByUserId: creator.userId,
       instruction: "# audit workflow",
+      // The detail endpoint resolves the owner to a display name so the UI does
+      // not fall back to rendering the raw Clerk `ownerUserId`.
+      ownerUserDisplayName: "BDD User",
     });
     expect(typeof initial.body.createdAt).toBe("string");
     expect(typeof initial.body.updatedAt).toBe("string");

--- a/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
@@ -62,7 +62,7 @@ interface WorkflowShadow {
   readonly displayName: string | null;
 }
 
-interface WorkflowOwnerProfile {
+export interface WorkflowOwnerProfile {
   readonly displayName: string | null;
   readonly imageUrl: string | null;
 }
@@ -386,6 +386,49 @@ async function refreshOwnerProfiles(
       });
   }
   return profiles;
+}
+
+/**
+ * Resolve a single workflow owner's display name and avatar, mirroring the list
+ * path: prefer a fresh `userCache` row, refresh stale/missing entries from
+ * Clerk, and fall back to a stale cache row when Clerk yields nothing. Returns
+ * `null` only when no identity is known, letting callers fall back to the raw
+ * owner user id.
+ */
+export async function loadWorkflowOwnerProfile(
+  db: Db,
+  client: ReturnType<typeof clerk$.read>,
+  ownerUserId: string,
+): Promise<WorkflowOwnerProfile | null> {
+  const [cachedRow] = await db
+    .select({
+      name: userCache.name,
+      email: userCache.email,
+      imageUrl: userCache.imageUrl,
+      cachedAt: userCache.cachedAt,
+    })
+    .from(userCache)
+    .where(eq(userCache.userId, ownerUserId))
+    .limit(1);
+
+  const cached = ownerProfileFromCache(cachedRow, now());
+  if (cached) {
+    return cached;
+  }
+
+  const refreshed = await refreshOwnerProfiles(db, client, [ownerUserId]);
+  const profile = refreshed.get(ownerUserId);
+  if (profile) {
+    return profile;
+  }
+
+  if (cachedRow?.name || cachedRow?.email || cachedRow?.imageUrl) {
+    return {
+      displayName: cachedRow.name ?? cachedRow.email ?? null,
+      imageUrl: cachedRow.imageUrl ?? null,
+    };
+  }
+  return null;
 }
 
 export function zeroWorkflowList(args: {

--- a/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-data.service.ts
@@ -62,7 +62,7 @@ interface WorkflowShadow {
   readonly displayName: string | null;
 }
 
-export interface WorkflowOwnerProfile {
+interface WorkflowOwnerProfile {
   readonly displayName: string | null;
   readonly imageUrl: string | null;
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-detail.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-detail.service.ts
@@ -5,10 +5,12 @@ import type {
   ZeroWorkflowDetailResponse,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 
-import { db$ } from "../external/db";
+import { db$, type Db } from "../external/db";
+import { clerk$ } from "../external/clerk";
 import {
   loadWorkflowShadowWinner,
   loadVisibleWorkflowById,
+  loadWorkflowOwnerProfile,
   workflowSummary,
   type WorkflowMember,
 } from "./zero-workflow-data.service";
@@ -42,10 +44,17 @@ export function zeroWorkflowDetail(args: {
       workflow,
     });
 
+    const ownerProfile = await loadWorkflowOwnerProfile(
+      db as Db,
+      get(clerk$),
+      workflow.ownerUserId,
+    );
+
     const summary = workflowSummary({
       workflow,
       agent,
       member: args.member,
+      ownerProfile,
       shadowedBy,
     });
 


### PR DESCRIPTION
## Problem

On the workflow detail page, the header tooltip's **Created by** row rendered the raw Clerk owner user id (e.g. `user_36PnTFtD4dBQ9zg5jj6E5r918aV`) with an initials-only avatar, so it looked like garbled text to users. The **Runs as** row and the workflow list / home surface both show a proper name + avatar for the same person.

## Root cause

`zeroWorkflowDetail` builds its summary with `workflowSummary({ ... })` **without** passing an `ownerProfile`, so `ownerUserDisplayName` and `ownerUserImageUrl` default to `null`. The frontend `ownerLabel()` then falls back to `ownerUserId`, and `MemberAvatar` falls back to initials (`user_...` → "US").

The list surface (`zeroWorkflowList`) already resolves the owner via a `userCache` join plus a Clerk refresh, which is why the home page renders correctly.

## Fix

- Extract a reusable `loadWorkflowOwnerProfile(db, clerkClient, ownerUserId)` in `zero-workflow-data.service.ts`. It mirrors the list path: prefer a fresh `userCache` row, refresh stale/missing entries from Clerk (writing back to `userCache`), and fall back to a stale cache row before returning `null`.
- Call it in `zeroWorkflowDetail` and pass the resolved `ownerProfile` into `workflowSummary`, so **Created by** shows the owner's display name and avatar — consistent with **Runs as** and the workflow list.

## User-visible impact

The workflow detail **Created by** field now shows the creator's name and avatar instead of the raw Clerk user id.

## Verification

- Added a regression assertion to the existing `zero-workflows` API integration test (`reads and updates workflow content...`): the detail response now includes `ownerUserDisplayName: "BDD User"` (was `null` before this change).
- Relying on the PR pipeline for lint / type-check / full test execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)