### PR TITLE
fix(platform): stop reloading deleted agent so delete shows only success toast

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/job-detail/delete.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/delete.ts
@@ -4,7 +4,7 @@ import { zeroAgentsByIdContract } from "@vm0/api-contracts/contracts/zero-agents
 import { zeroClient$ } from "../../api-client.ts";
 import { accept } from "../../../lib/accept.ts";
 import { agentDetail$ } from "./detail.ts";
-import { reloadAgentById$, reloadAgents$ } from "../../agent.ts";
+import { reloadAgents$ } from "../../agent.ts";
 
 // ---------------------------------------------------------------------------
 // Delete agent
@@ -23,7 +23,10 @@ export const deleteAgent$ = command(
     signal.throwIfAborted();
 
     toast.success("Agent deleted");
+    // Refresh the agents list only. Do NOT reload the agent-by-id cache here:
+    // the just-deleted agent is still subscribed via currentAgent$ until the
+    // caller navigates away, so reloading it would refetch a deleted agent and
+    // surface an "Agent not found" error toast on top of the success toast.
     set(reloadAgents$);
-    set(reloadAgentById$);
   },
 );

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -811,8 +811,37 @@ describe("team page navigation", () => {
 
   it("deletes an agent from the profile tab", async () => {
     mockTeamAPIs();
-    context.mocks.api(zeroAgentsByIdContract.delete, ({ respond }) => {
+    let deleted = false;
+    context.mocks.api(zeroAgentsByIdContract.delete, ({ params, respond }) => {
+      if (params.id === researchAgentId) {
+        deleted = true;
+      }
       return respond(204);
+    });
+    // Once the agent is deleted, any refetch of it must 404 — exactly as
+    // production behaves. This guards against reloading the just-deleted agent
+    // and surfacing an "Agent not found" error toast over the success toast.
+    context.mocks.api(zeroAgentsByIdContract.get, ({ params, respond }) => {
+      if (params.id === researchAgentId && deleted) {
+        return respond(404, {
+          error: {
+            message: `Agent not found: ${researchAgentId}`,
+            code: "NOT_FOUND",
+          },
+        });
+      }
+      const agent = params.id === zeroAgentId ? "Zero" : "Research Agent";
+      return respond(200, {
+        agentId: params.id,
+        ownerId: "test-owner-id",
+        displayName: agent,
+        description: "Finds and summarizes information",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
     });
 
     detachedSetupPage({
@@ -840,6 +869,7 @@ describe("team page navigation", () => {
         screen.getByRole("heading", { level: 1, name: /agents/i }),
       ).toBeInTheDocument();
     });
+    expect(screen.queryByText(/Agent not found/u)).not.toBeInTheDocument();
   });
 
   it("edits and creates automations from an agent page", async () => {


### PR DESCRIPTION
## Problem

Deleting an agent showed a red **"Agent not found: <agentId>"** error toast instead of a clean success confirmation (see #20288). The `Agent deleted` success toast already existed, but an error toast fired right after it on the Agents list page.

## Root cause

`deleteAgent$` (`turbo/apps/platform/src/signals/zero-page/job-detail/delete.ts`) called `reloadAgentById$` after a successful delete. That command bumps the shared agent-by-id reload counter, forcing **every** cached `agentById(id)` computed to refetch — including the agent that was just deleted, which is still subscribed via `currentAgent$` until the caller navigates to `/agents`. That refetch hits `GET /zero-agents/:id`, returns `404`, and `accept()` surfaces the API message (`Agent not found: <id>`) as an error toast.

## Fix

Drop the `set(reloadAgentById$)` call from the delete flow. The agents-list refresh (`reloadAgents$`) plus the subsequent navigation are sufficient, and the deleted agent's cache entry is no longer refetched — so only the `Agent deleted` success toast shows. `reloadAgentById$` is still used by the settings/permission flows, so its export is unchanged.

## User-visible impact

- Deleting an agent now shows only the **"Agent deleted"** success toast.
- The spurious **"Agent not found"** error toast no longer appears.

## Verification

- Updated `team-navigation.test.tsx` "deletes an agent from the profile tab" so the deleted agent's `GET` returns `404` on refetch (matching production) and asserts no `Agent not found` toast leaks.
- Confirmed the test **fails against the pre-fix code** (renders `Agent not found: <id>`) and **passes with the fix**.
- Relying on the PR pipeline for the full lint/type/test suite.

Fixes #20288

🤖 Generated with [Claude Code](https://claude.com/claude-code)