### PR TITLE
feat(platform): add ccstate-scoped feedback selection shortcuts

### DIFF
--- a/turbo/apps/platform/src/lib/setup-global-shortcut.ts
+++ b/turbo/apps/platform/src/lib/setup-global-shortcut.ts
@@ -12,6 +12,7 @@ export type GlobalShortcutBindings = Record<string, GlobalShortcutBinding>;
 
 interface GlobalShortcutSetupOptions {
   readonly doc?: Document;
+  readonly allowWhenDialogOpen?: boolean;
   readonly shouldHandleEvent?: (e: KeyboardEvent) => boolean;
 }
 
@@ -37,7 +38,7 @@ export function setupGlobalShortcut(
     onDomEventFn((e: KeyboardEvent) => {
       if (
         e.defaultPrevented ||
-        hasOpenDialog(doc) ||
+        (!options.allowWhenDialogOpen && hasOpenDialog(doc)) ||
         options.shouldHandleEvent?.(e) === false
       ) {
         return;

--- a/turbo/apps/platform/src/lib/setup-global-shortcut.ts
+++ b/turbo/apps/platform/src/lib/setup-global-shortcut.ts
@@ -12,7 +12,6 @@ export type GlobalShortcutBindings = Record<string, GlobalShortcutBinding>;
 
 interface GlobalShortcutSetupOptions {
   readonly doc?: Document;
-  readonly allowWhenDialogOpen?: boolean;
   readonly shouldHandleEvent?: (e: KeyboardEvent) => boolean;
 }
 
@@ -38,7 +37,7 @@ export function setupGlobalShortcut(
     onDomEventFn((e: KeyboardEvent) => {
       if (
         e.defaultPrevented ||
-        (!options.allowWhenDialogOpen && hasOpenDialog(doc)) ||
+        hasOpenDialog(doc) ||
         options.shouldHandleEvent?.(e) === false
       ) {
         return;

--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -140,6 +140,9 @@ describe("inline feedback thread scoping", () => {
       setFeedbackSelectionToolbarRef$,
       toolbarScope,
     );
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
     const event = dispatchShortcut("f");
 
     expect(event.defaultPrevented).toBeTruthy();
@@ -152,6 +155,7 @@ describe("inline feedback thread scoping", () => {
     dispatchShortcut("f");
 
     expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(1);
+    dialog.remove();
     cleanup?.();
   });
 

--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -1,12 +1,15 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   captureFeedbackSelection$,
+  closeFeedbackSelectionToolbar$,
   startFeedback$,
   removeFeedbackItem$,
   dismissFeedback$,
   feedbackItemsValue$,
+  feedbackSelectionValue$,
   feedbackThreadIdValue$,
+  setFeedbackSelectionToolbarRef$,
 } from "../zero-page/chat-feedback.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
 import { testContext } from "./test-helpers.ts";
@@ -30,6 +33,16 @@ function selectContents(element: HTMLElement): void {
   const selection = window.getSelection();
   selection?.removeAllRanges();
   selection?.addRange(range);
+}
+
+function dispatchShortcut(key: string): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+  document.dispatchEvent(event);
+  return event;
 }
 
 describe("inline feedback thread scoping", () => {
@@ -114,6 +127,86 @@ describe("inline feedback thread scoping", () => {
 
     expect(ctx.store.get(feedbackThreadIdValue$)).toBeNull();
     expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(0);
+  });
+
+  it("scopes feedback selection shortcuts to the toolbar reset signal", () => {
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    expect(ctx.store.get(feedbackSelectionValue$)).not.toBeNull();
+
+    const toolbarScope = document.createElement("span");
+    const cleanup = ctx.store.set(
+      setFeedbackSelectionToolbarRef$,
+      toolbarScope,
+    );
+    const event = dispatchShortcut("f");
+
+    expect(event.defaultPrevented).toBeTruthy();
+    expect(ctx.store.get(feedbackSelectionValue$)).toBeNull();
+    expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(1);
+
+    const second = mountThreadBubble("thread-a", "Second passage");
+    selectContents(second);
+    ctx.store.set(captureFeedbackSelection$);
+    dispatchShortcut("f");
+
+    expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(1);
+    cleanup?.();
+  });
+
+  it("copies the selected passage with the toolbar copy shortcut", async () => {
+    const originalClipboard = navigator.clipboard;
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    let cleanup: (() => void) | undefined;
+
+    try {
+      const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+      selectContents(bubble);
+      ctx.store.set(captureFeedbackSelection$);
+
+      const toolbarScope = document.createElement("span");
+      cleanup = ctx.store.set(setFeedbackSelectionToolbarRef$, toolbarScope);
+      const event = dispatchShortcut("c");
+
+      expect(event.defaultPrevented).toBeTruthy();
+      await vi.waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith("Reply from thread A");
+      });
+    } finally {
+      cleanup?.();
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      });
+    }
+  });
+
+  it("aborts toolbar shortcuts when the toolbar is closed", () => {
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    expect(ctx.store.get(feedbackSelectionValue$)).not.toBeNull();
+
+    const toolbarScope = document.createElement("span");
+    const cleanup = ctx.store.set(
+      setFeedbackSelectionToolbarRef$,
+      toolbarScope,
+    );
+    ctx.store.set(closeFeedbackSelectionToolbar$);
+
+    const second = mountThreadBubble("thread-a", "Second passage");
+    selectContents(second);
+    ctx.store.set(captureFeedbackSelection$);
+    const event = dispatchShortcut("f");
+
+    expect(event.defaultPrevented).toBeFalsy();
+    expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(0);
+    cleanup?.();
   });
 });
 

--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 import {
   captureFeedbackSelection$,
@@ -159,9 +160,28 @@ describe("inline feedback thread scoping", () => {
     cleanup?.();
   });
 
-  it("copies the selected passage with the toolbar copy shortcut", async () => {
+  it("closes the toolbar with Escape", () => {
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    expect(ctx.store.get(feedbackSelectionValue$)).not.toBeNull();
+
+    const toolbarScope = document.createElement("span");
+    const cleanup = ctx.store.set(
+      setFeedbackSelectionToolbarRef$,
+      toolbarScope,
+    );
+    const event = dispatchShortcut("Escape");
+
+    expect(event.defaultPrevented).toBeTruthy();
+    expect(ctx.store.get(feedbackSelectionValue$)).toBeNull();
+    cleanup?.();
+  });
+
+  it("copies the selected passage, closes the toolbar, and shows a toast", async () => {
     const originalClipboard = navigator.clipboard;
     const writeText = vi.fn().mockResolvedValue(undefined);
+    const successToast = vi.spyOn(toast, "success");
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
@@ -181,8 +201,13 @@ describe("inline feedback thread scoping", () => {
       await vi.waitFor(() => {
         expect(writeText).toHaveBeenCalledWith("Reply from thread A");
       });
+      await vi.waitFor(() => {
+        expect(ctx.store.get(feedbackSelectionValue$)).toBeNull();
+      });
+      expect(successToast).toHaveBeenCalledWith("Copied");
     } finally {
       cleanup?.();
+      successToast.mockRestore();
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,
         value: originalClipboard,

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -347,6 +347,7 @@ export const setFeedbackSelectionToolbarRef$ = onRef(
       },
       toolbarSignal,
       {
+        allowWhenDialogOpen: true,
         doc: el.ownerDocument,
         shouldHandleEvent: () => {
           return !toolbarSignal.aborted;

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -1,6 +1,8 @@
 import { state, computed, command } from "ccstate";
+import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
 import { writeToClipboard } from "./clipboard.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
+import { onRef, resetSignal } from "../utils.ts";
 
 // Assistant message bubbles carry this class in the chat thread. Text selected
 // inside one of them is what we offer feedback on.
@@ -46,6 +48,7 @@ const feedbackRanges$ = state<ReadonlyMap<number, Range>>(new Map());
 const feedbackNextId$ = state<number>(1);
 const feedbackCopied$ = state<boolean>(false);
 const feedbackCopiedTimerId$ = state<number | null>(null);
+const resetFeedbackSelectionToolbarSignal$ = resetSignal();
 
 export const feedbackSelectionValue$ = computed((get) => {
   return get(feedbackSelection$);
@@ -162,6 +165,17 @@ function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }
 
+export const closeFeedbackSelectionToolbar$ = command(({ get, set }) => {
+  set(resetFeedbackSelectionToolbarSignal$);
+  const timerId = get(feedbackCopiedTimerId$);
+  if (timerId !== null) {
+    window.clearTimeout(timerId);
+    set(feedbackCopiedTimerId$, null);
+  }
+  set(feedbackSelection$, null);
+  set(feedbackCopied$, false);
+});
+
 // Watch the document selection and drive the floating toolbar. The toolbar
 // shows whether or not the tray is open — selecting another passage and
 // clicking "Provide feedback" again is how a further fragment is added.
@@ -169,7 +183,7 @@ export const captureFeedbackSelection$ = command(({ get, set }) => {
   const found = readAssistantSelection();
   if (!found) {
     if (get(feedbackSelection$) !== null) {
-      set(feedbackSelection$, null);
+      set(closeFeedbackSelectionToolbar$);
     }
     return;
   }
@@ -229,7 +243,7 @@ export const startFeedback$ = command(({ get, set }) => {
   }
   set(feedbackRanges$, ranges);
   applyFeedbackHighlight(ranges);
-  set(feedbackSelection$, null);
+  set(closeFeedbackSelectionToolbar$);
 });
 
 export const setFeedbackItemNote$ = command(
@@ -269,32 +283,18 @@ export const submitFeedback$ = command(({ get }): string | null => {
   return formatFeedbackPrompt(noted);
 });
 
-export const dismissFeedback$ = command(({ get, set }) => {
-  const timerId = get(feedbackCopiedTimerId$);
-  if (timerId !== null) {
-    window.clearTimeout(timerId);
-    set(feedbackCopiedTimerId$, null);
-  }
+export const dismissFeedback$ = command(({ set }) => {
+  set(closeFeedbackSelectionToolbar$);
   const emptyRanges = new Map<number, Range>();
   set(feedbackRanges$, emptyRanges);
   applyFeedbackHighlight(emptyRanges);
-  set(feedbackSelection$, null);
   set(feedbackItems$, []);
   set(feedbackThreadId$, null);
-  set(feedbackCopied$, false);
 });
 
 // Dismiss only the floating selection toolbar — the docked tray keeps its
 // comments, so clicking away from a fresh selection never wipes earlier notes.
-export const dismissFeedbackSelection$ = command(({ get, set }) => {
-  const timerId = get(feedbackCopiedTimerId$);
-  if (timerId !== null) {
-    window.clearTimeout(timerId);
-    set(feedbackCopiedTimerId$, null);
-  }
-  set(feedbackSelection$, null);
-  set(feedbackCopied$, false);
-});
+export const dismissFeedbackSelection$ = closeFeedbackSelectionToolbar$;
 
 // Scrolling detaches the toolbar from its passage, so hide it. The docked tray
 // is pinned above the composer, not to the selection, so it stays put.
@@ -302,7 +302,7 @@ export const dismissFeedbackOnScroll$ = command(({ get, set }) => {
   if (get(feedbackSelection$) === null) {
     return;
   }
-  set(feedbackSelection$, null);
+  set(closeFeedbackSelectionToolbar$);
 });
 
 export const copyFeedbackSelection$ = command(
@@ -327,4 +327,74 @@ export const copyFeedbackSelection$ = command(
     }, 1500);
     set(feedbackCopiedTimerId$, timerId);
   },
+);
+
+export const setFeedbackSelectionToolbarRef$ = onRef(
+  command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+    const toolbarSignal = set(resetFeedbackSelectionToolbarSignal$, signal);
+    setupGlobalShortcut(
+      {
+        c: {
+          run: async () => {
+            await set(copyFeedbackSelection$, toolbarSignal);
+          },
+        },
+        f: {
+          run: () => {
+            set(startFeedback$);
+          },
+        },
+      },
+      toolbarSignal,
+      {
+        doc: el.ownerDocument,
+        shouldHandleEvent: () => {
+          return !toolbarSignal.aborted;
+        },
+      },
+    );
+  }),
+);
+
+export const setFeedbackSelectionListenersRef$ = onRef(
+  command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+    const doc = el.ownerDocument;
+    let captureTimerId: number | null = null;
+    const capture = () => {
+      set(captureFeedbackSelection$);
+    };
+    const captureDeferred = () => {
+      if (captureTimerId !== null) {
+        window.clearTimeout(captureTimerId);
+      }
+      captureTimerId = window.setTimeout(() => {
+        captureTimerId = null;
+        capture();
+      }, 0);
+    };
+
+    doc.addEventListener("mouseup", captureDeferred, { signal });
+    doc.addEventListener("keyup", capture, { signal });
+    doc.addEventListener(
+      "scroll",
+      () => {
+        set(dismissFeedbackOnScroll$);
+      },
+      {
+        capture: true,
+        passive: true,
+        signal,
+      },
+    );
+    signal.addEventListener(
+      "abort",
+      () => {
+        if (captureTimerId !== null) {
+          window.clearTimeout(captureTimerId);
+          captureTimerId = null;
+        }
+      },
+      { once: true },
+    );
+  }),
 );

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -1,8 +1,9 @@
 import { state, computed, command } from "ccstate";
-import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
+import { isEditableTarget, matchShortcut } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { writeToClipboard } from "./clipboard.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
-import { onRef, resetSignal } from "../utils.ts";
+import { onDomEventFn, onRef, resetSignal } from "../utils.ts";
 
 // Assistant message bubbles carry this class in the chat thread. Text selected
 // inside one of them is what we offer feedback on.
@@ -46,8 +47,6 @@ const feedbackThreadId$ = state<string | null>(null);
 // passage highlighted while its draft lives.
 const feedbackRanges$ = state<ReadonlyMap<number, Range>>(new Map());
 const feedbackNextId$ = state<number>(1);
-const feedbackCopied$ = state<boolean>(false);
-const feedbackCopiedTimerId$ = state<number | null>(null);
 const resetFeedbackSelectionToolbarSignal$ = resetSignal();
 
 export const feedbackSelectionValue$ = computed((get) => {
@@ -62,10 +61,6 @@ export const feedbackItemsValue$ = computed((get) => {
 // its own thread id so a draft only ever shows in the thread it came from.
 export const feedbackThreadIdValue$ = computed((get) => {
   return get(feedbackThreadId$);
-});
-
-export const feedbackCopiedValue$ = computed((get) => {
-  return get(feedbackCopied$);
 });
 
 // What "Send" will dispatch: every fragment that carries a non-empty note.
@@ -165,15 +160,10 @@ function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }
 
-export const closeFeedbackSelectionToolbar$ = command(({ get, set }) => {
+export const closeFeedbackSelectionToolbar$ = command(({ set }) => {
   set(resetFeedbackSelectionToolbarSignal$);
-  const timerId = get(feedbackCopiedTimerId$);
-  if (timerId !== null) {
-    window.clearTimeout(timerId);
-    set(feedbackCopiedTimerId$, null);
-  }
+  window.getSelection()?.removeAllRanges();
   set(feedbackSelection$, null);
-  set(feedbackCopied$, false);
 });
 
 // Watch the document selection and drive the floating toolbar. The toolbar
@@ -311,48 +301,49 @@ export const copyFeedbackSelection$ = command(
     if (!selection) {
       return;
     }
-    const ok = await writeToClipboard(selection.text);
     signal.throwIfAborted();
-    if (!ok) {
-      return;
+    const text = selection.text;
+    const ok = await writeToClipboard(text);
+    signal.throwIfAborted();
+    if (ok) {
+      set(closeFeedbackSelectionToolbar$);
+      toast.success("Copied");
     }
-    const existingTimerId = get(feedbackCopiedTimerId$);
-    if (existingTimerId !== null) {
-      window.clearTimeout(existingTimerId);
-    }
-    set(feedbackCopied$, true);
-    const timerId = window.setTimeout(() => {
-      set(feedbackCopied$, false);
-      set(feedbackCopiedTimerId$, null);
-    }, 1500);
-    set(feedbackCopiedTimerId$, timerId);
   },
 );
+
+function shouldIgnoreTextShortcut(event: KeyboardEvent): boolean {
+  return isEditableTarget(event.target);
+}
 
 export const setFeedbackSelectionToolbarRef$ = onRef(
   command(({ set }, el: HTMLElement, signal: AbortSignal) => {
     const toolbarSignal = set(resetFeedbackSelectionToolbarSignal$, signal);
-    setupGlobalShortcut(
-      {
-        c: {
-          run: async () => {
-            await set(copyFeedbackSelection$, toolbarSignal);
-          },
-        },
-        f: {
-          run: () => {
-            set(startFeedback$);
-          },
-        },
-      },
-      toolbarSignal,
-      {
-        allowWhenDialogOpen: true,
-        doc: el.ownerDocument,
-        shouldHandleEvent: () => {
-          return !toolbarSignal.aborted;
-        },
-      },
+    el.ownerDocument.addEventListener(
+      "keydown",
+      onDomEventFn(async (event: KeyboardEvent) => {
+        if (event.defaultPrevented || toolbarSignal.aborted) {
+          return;
+        }
+        if (matchShortcut("escape", event)) {
+          event.preventDefault();
+          set(closeFeedbackSelectionToolbar$);
+          return;
+        }
+        if (shouldIgnoreTextShortcut(event)) {
+          return;
+        }
+        if (matchShortcut("c", event)) {
+          event.preventDefault();
+          await set(copyFeedbackSelection$, signal);
+          return;
+        }
+        if (matchShortcut("f", event)) {
+          event.preventDefault();
+          set(startFeedback$);
+        }
+      }),
+      { signal: toolbarSignal },
     );
   }),
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -1,11 +1,12 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type {
   GenerationTemplateRequest,
   ModelSelectionRequest,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import {
   detachedSetupPage,
@@ -54,7 +55,14 @@ function selectTextForInlineFeedback(element: HTMLElement): void {
 
 function buttonByText(text: string): HTMLElement {
   const button = queryAllByRoleFast("button").find((candidate) => {
-    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+    const label = candidate.textContent?.replace(/\s+/g, " ").trim();
+    return (
+      label === text ||
+      label === `${text}C` ||
+      label === `${text} C` ||
+      label === `${text}F` ||
+      label === `${text} F`
+    );
   });
   if (!button) {
     throw new Error(`${text} button not found`);
@@ -67,6 +75,7 @@ describe("chat inline feedback", () => {
     const user = userEvent.setup({ delay: null });
     const assistantReply = "The rollout dates are unclear in this summary.";
     const sentPrompts: string[] = [];
+    const successToast = vi.spyOn(toast, "success");
     context.mocks.browser.clipboardWriteText();
 
     mockChatLifecycle(context, {
@@ -111,10 +120,15 @@ describe("chat inline feedback", () => {
     await user.click(buttonByText("Copy"));
 
     await waitFor(() => {
-      expect(screen.getByText("Copied")).toBeInTheDocument();
+      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
     });
+    expect(successToast).toHaveBeenCalledWith("Copied");
+    successToast.mockRestore();
 
     selectTextForInlineFeedback(assistantReplyElement);
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
     await user.click(buttonByText("Provide feedback"));
 
     const feedbackComment = await screen.findByPlaceholderText(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -1,68 +1,24 @@
-import type { CSSProperties, RefCallback } from "react";
+import type { CSSProperties } from "react";
 import { IconCheck, IconCopy, IconMessageCircle } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
-import { Popover, PopoverAnchor, PopoverContent } from "@vm0/ui";
+import {
+  getShortcutParts,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@vm0/ui";
 import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
-  captureFeedbackSelection$,
+  closeFeedbackSelectionToolbar$,
   copyFeedbackSelection$,
-  dismissFeedbackOnScroll$,
-  dismissFeedbackSelection$,
   feedbackCopiedValue$,
   feedbackSelectionValue$,
+  setFeedbackSelectionListenersRef$,
+  setFeedbackSelectionToolbarRef$,
   startFeedback$,
   type FeedbackSelection,
 } from "../../signals/zero-page/chat-feedback.ts";
-
-// Watches document selection (and dismisses the toolbar on scroll) for the
-// whole thread, via a ref on a persistent hidden node — the platform's
-// listener-lifecycle idiom in place of an effect.
-function selectionListenersRef(
-  capture: () => void,
-  dismissOnScroll: () => void,
-): RefCallback<HTMLSpanElement> {
-  let detachListeners: (() => void) | null = null;
-  return (element) => {
-    detachListeners?.();
-    detachListeners = null;
-    if (!element) {
-      return;
-    }
-    // A mouse click inside an existing selection collapses it *after* the
-    // mouseup event fires, so reading the selection synchronously here would
-    // still see the stale range and keep the toolbar floating once the
-    // highlight is gone. Defer the read to the next tick so the selection has
-    // settled — clicking to clear the selection then dismisses the toolbar.
-    let captureTimerId: number | null = null;
-    const captureDeferred = () => {
-      if (captureTimerId !== null) {
-        window.clearTimeout(captureTimerId);
-      }
-      captureTimerId = window.setTimeout(() => {
-        captureTimerId = null;
-        capture();
-      }, 0);
-    };
-    document.addEventListener("mouseup", captureDeferred);
-    document.addEventListener("keyup", capture);
-    document.addEventListener("scroll", dismissOnScroll, {
-      capture: true,
-      passive: true,
-    });
-    detachListeners = () => {
-      if (captureTimerId !== null) {
-        window.clearTimeout(captureTimerId);
-        captureTimerId = null;
-      }
-      document.removeEventListener("mouseup", captureDeferred);
-      document.removeEventListener("keyup", capture);
-      document.removeEventListener("scroll", dismissOnScroll, {
-        capture: true,
-      });
-    };
-  };
-}
 
 function anchorStyle(selection: FeedbackSelection): CSSProperties {
   return {
@@ -73,6 +29,23 @@ function anchorStyle(selection: FeedbackSelection): CSSProperties {
     height: selection.rect.height,
     pointerEvents: "none",
   };
+}
+
+function ShortcutHint({ shortcut }: { readonly shortcut: string }) {
+  return (
+    <span aria-hidden="true" className="ml-0.5 inline-flex items-center gap-1">
+      {getShortcutParts(shortcut).map((part) => {
+        return (
+          <kbd
+            key={part}
+            className='inline-flex h-5 min-w-5 items-center justify-center rounded-md bg-background px-1 text-[10px] font-medium leading-none text-muted-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]'
+          >
+            {part.length === 1 ? part.toUpperCase() : part}
+          </kbd>
+        );
+      })}
+    </span>
+  );
 }
 
 function FeedbackToolbar({
@@ -98,6 +71,7 @@ function FeedbackToolbar({
         <button
           type="button"
           onClick={onCopy}
+          aria-keyshortcuts="c"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
         >
           {copied ? (
@@ -106,15 +80,18 @@ function FeedbackToolbar({
             <IconCopy size={14} stroke={2} />
           )}
           {copied ? "Copied" : "Copy"}
+          <ShortcutHint shortcut="c" />
         </button>
         <div className="h-4 w-px bg-border" />
         <button
           type="button"
           onClick={onProvideFeedback}
+          aria-keyshortcuts="f"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
         >
           <IconMessageCircle size={14} stroke={2} />
           Provide feedback
+          <ShortcutHint shortcut="f" />
         </button>
       </div>
     </PopoverContent>
@@ -129,27 +106,32 @@ export function ChatFeedbackSelection() {
   const selection = useGet(feedbackSelectionValue$);
   const copied = useGet(feedbackCopiedValue$);
   const rootSignal = useGet(rootSignal$);
-  const capture = useSet(captureFeedbackSelection$);
-  const dismissOnScroll = useSet(dismissFeedbackOnScroll$);
+  const setFeedbackSelectionListenersRef = useSet(
+    setFeedbackSelectionListenersRef$,
+  );
+  const setFeedbackSelectionToolbarRef = useSet(
+    setFeedbackSelectionToolbarRef$,
+  );
   const startFeedback = useSet(startFeedback$);
-  const dismissSelection = useSet(dismissFeedbackSelection$);
+  const closeSelectionToolbar = useSet(closeFeedbackSelectionToolbar$);
   const copy = useSet(copyFeedbackSelection$);
 
   return (
     <>
-      <span ref={selectionListenersRef(capture, dismissOnScroll)} hidden />
+      <span ref={setFeedbackSelectionListenersRef} hidden />
       {selection ? (
         <Popover
           open
           onOpenChange={(next) => {
             if (!next) {
-              dismissSelection();
+              closeSelectionToolbar();
             }
           }}
         >
           <PopoverAnchor asChild>
             <div style={anchorStyle(selection)} aria-hidden />
           </PopoverAnchor>
+          <span ref={setFeedbackSelectionToolbarRef} hidden />
           <FeedbackToolbar
             copied={copied}
             onCopy={() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { IconCheck, IconCopy, IconMessageCircle } from "@tabler/icons-react";
+import { IconCopy, IconMessageCircle } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import {
   getShortcutParts,
@@ -12,7 +12,6 @@ import { detach, Reason } from "../../signals/utils.ts";
 import {
   closeFeedbackSelectionToolbar$,
   copyFeedbackSelection$,
-  feedbackCopiedValue$,
   feedbackSelectionValue$,
   setFeedbackSelectionListenersRef$,
   setFeedbackSelectionToolbarRef$,
@@ -49,11 +48,9 @@ function ShortcutHint({ shortcut }: { readonly shortcut: string }) {
 }
 
 function FeedbackToolbar({
-  copied,
   onCopy,
   onProvideFeedback,
 }: {
-  copied: boolean;
   onCopy: () => void;
   onProvideFeedback: () => void;
 }) {
@@ -74,12 +71,8 @@ function FeedbackToolbar({
           aria-keyshortcuts="c"
           className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
         >
-          {copied ? (
-            <IconCheck size={14} stroke={2} />
-          ) : (
-            <IconCopy size={14} stroke={2} />
-          )}
-          {copied ? "Copied" : "Copy"}
+          <IconCopy size={14} stroke={2} />
+          Copy
           <ShortcutHint shortcut="c" />
         </button>
         <div className="h-4 w-px bg-border" />
@@ -104,7 +97,6 @@ function FeedbackToolbar({
 // in zero-chat-composer.tsx) — there is no separate feedback panel.
 export function ChatFeedbackSelection() {
   const selection = useGet(feedbackSelectionValue$);
-  const copied = useGet(feedbackCopiedValue$);
   const rootSignal = useGet(rootSignal$);
   const setFeedbackSelectionListenersRef = useSet(
     setFeedbackSelectionListenersRef$,
@@ -133,7 +125,6 @@ export function ChatFeedbackSelection() {
           </PopoverAnchor>
           <span ref={setFeedbackSelectionToolbarRef} hidden />
           <FeedbackToolbar
-            copied={copied}
             onCopy={() => {
               return detach(copy(rootSignal), Reason.DomCallback);
             }}


### PR DESCRIPTION
## Summary
- Adds `c` and `f` shortcuts to the floating chat feedback selection toolbar for copy and feedback actions.
- Moves the selection listener and toolbar shortcut lifecycle into ccstate `onRef` commands, with `resetSignal()` backing the toolbar shortcut scope.
- Routes toolbar close paths through `closeFeedbackSelectionToolbar$`, which clears copied/selection state and aborts the shortcut scope.
- Adds inline keycap hints and `aria-keyshortcuts` on the toolbar actions.

## Verification
- `pnpm exec vitest run apps/platform/src/signals/__tests__/chat-feedback.test.ts`
- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`

Note: did not start a local dev server or run full vitest, per vm0 PR verification preference.
