### PR TITLE
chore(rust): update cc and jobserver dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1912,11 +1912,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 


### PR DESCRIPTION
## Summary

Updates the Rust workspace lockfile under `crates/`:

- `cc` `1.2.65 -> 1.2.66`
- `jobserver` `0.1.34 -> 0.1.35`

Only `crates/Cargo.lock` changed.

## Dependencies Not Updated

- `generic-array` remains at `0.14.7` even though `0.14.9` is available.
- Reason: transitive `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` through the `digest v0.10.7` dependency path. This is not blocked by a direct workspace `Cargo.toml` constraint.

## Manual Version Bumps

None. No `Cargo.toml` changes were needed.

## Tests

Passed:

```bash
umask 0022 && \
CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target-2026-07-06 \
TMPDIR=/home/user/workspace/secure-tmp \
CARGO_BUILD_JOBS=1 \
CARGO_INCREMENTAL=0 \
CARGO_PROFILE_TEST_DEBUG=0 \
cargo test --workspace
```

Also passed:

```bash
cargo fmt --check
```

The extra environment variables are local runtime workarounds for disk and memory limits in the agent environment; no tests were skipped or disabled.
