### PR TITLE
fix: remove google oauth preconnect notice

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -392,6 +392,13 @@ describe("GET /api/zero/connector-catalog", () => {
         startOptions: [],
       },
     ]);
+    const googleMaps = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "google-maps";
+    });
+    expect(googleMaps).toMatchObject({
+      connectorRef: "google-maps",
+      connectNotice: null,
+    });
     const neon = response.body.connectors.find((connector) => {
       return connector.connectorRef === "neon";
     });

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -15,7 +15,6 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import type { ConnectorSearchItem } from "@vm0/api-contracts/contracts/zero-connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
 import {
   CONNECTOR_TYPE_KEYS,
   CONNECTOR_TYPES,
@@ -307,9 +306,7 @@ function connectorCatalogStatusItem(args: {
       args.type,
       args.authMethods,
     ),
-    connectNotice: isGoogleOAuthConnector(args.type)
-      ? "google-security-warning"
-      : null,
+    connectNotice: null,
   };
 }
 

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -29,7 +29,6 @@ import {
   zeroConnectorScopeDiffContract,
   zeroConnectorsMainContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
-import { isGoogleOAuthConnector } from "@vm0/connectors/auth-providers/oauth/google-connectors";
 import {
   getAvailableConnectorAuthMethodIds,
   getConnectorAuthMethod,
@@ -394,9 +393,7 @@ function mockConnectorCatalogStatusItem(
       type,
       authMethods,
     ),
-    connectNotice: isGoogleOAuthConnector(type)
-      ? "google-security-warning"
-      : null,
+    connectNotice: null,
   };
 }
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -213,14 +213,8 @@ export function hasConnectorStatusAuthCodeGrant(
 
 export function getConnectorStatusConnectLaunchMode(
   connector: ConnectorTypeWithStatus,
-  {
-    preferModalForConnectorNotice = false,
-  }: { readonly preferModalForConnectorNotice?: boolean } = {},
 ): ConnectorConnectLaunchMode {
   if (!getOnlyAvailableStatusAuthCodeAuthMethod(connector)) {
-    return "modal";
-  }
-  if (preferModalForConnectorNotice && connector.connectNotice) {
     return "modal";
   }
   return "oauth-auth-code";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -1306,8 +1306,19 @@ describe("connectors page", () => {
     expect(queryButtonByText("Manage", dialog)).not.toBeInTheDocument();
   });
 
-  it("shows Google Maps approval guidance before OAuth", async () => {
+  it("starts Google Maps OAuth without review guidance", async () => {
     mockConnectors([]);
+    const authWindow = createMockAuthWindow();
+    context.mocks.browser.open(authWindow);
+    context.mocks.api(
+      zeroConnectorOauthStartContract.start,
+      ({ params, respond }) => {
+        expect(params.type).toBe("google-maps");
+        return respond(200, {
+          authorizationUrl: "https://oauth.test/google-maps/authorize",
+        });
+      },
+    );
 
     detachedSetupPage({
       context,
@@ -1317,10 +1328,14 @@ describe("connectors page", () => {
     await fill(await screen.findByPlaceholderText("Find connectors"), "maps");
     click(await screen.findByLabelText("Connect Google Maps"));
 
-    const dialog = await screen.findByRole("dialog", { name: "Google Maps" });
+    await waitFor(() => {
+      expect(authWindow.location.href).toBe(
+        "https://oauth.test/google-maps/authorize",
+      );
+    });
     expect(
-      within(dialog).getByText(/Google will show a security warning/),
-    ).toBeInTheDocument();
+      screen.queryByRole("dialog", { name: "Google Maps" }),
+    ).not.toBeInTheDocument();
   });
 
   it("starts Meta Ads OAuth without review guidance", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -61,7 +61,6 @@ import { hasTokenInputValue } from "../../../../signals/zero-page/settings/token
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { detach, onDomEventFn, Reason } from "../../../../signals/utils.ts";
-import { GoogleSecurityWarningNotice } from "../../zero-directed-shared.tsx";
 import { ConnectorHelpText } from "./connector-help-text.tsx";
 
 // ---------------------------------------------------------------------------
@@ -1037,14 +1036,8 @@ function StandardConnectMethodsContent({
   signal: AbortSignal;
   entries: readonly ConnectMethodContentEntry[];
 }) {
-  const showGoogleSecurityWarningNotice =
-    hasConnectorStatusAuthCodeGrant(item) &&
-    item.connectNotice === "google-security-warning";
-
   return (
     <div className="flex flex-col gap-4">
-      {showGoogleSecurityWarningNotice && <GoogleSecurityWarningNotice />}
-
       <ConnectMethodsContent
         entries={entries}
         availableAuthMethodCount={item.availableAuthMethods.length}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -88,10 +88,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
 } from "@vm0/ui";
 
 const CONNECTOR_CARD_AGENT_NAME_LIMIT = 2;
@@ -804,31 +800,7 @@ function AvailableConnectorCard({
           data-testid="connector-help-text"
           className="text-xs text-muted-foreground line-clamp-2"
         >
-          {connector.connectNotice === "google-security-warning" ? (
-            <>
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="font-medium text-muted-foreground cursor-default underline decoration-dotted underline-offset-2 decoration-muted-foreground/40">
-                      Early Access
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="bottom"
-                    className="max-w-xs text-xs leading-relaxed"
-                  >
-                    Our Google OAuth is under Google&apos;s verification review.
-                    This is a standard compliance step and does not affect
-                    vm0&apos;s functionality or security. You can safely proceed
-                    by clicking &quot;Continue&quot;.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              {connector.helpText && <span>: {connector.helpText}</span>}
-            </>
-          ) : (
-            (connector.helpText ?? "")
-          )}
+          {connector.helpText ?? ""}
         </div>
       </div>
     </div>
@@ -993,9 +965,7 @@ export function ZeroConnectorsPage() {
     if (!ct) {
       return;
     }
-    const launchMode = getConnectorStatusConnectLaunchMode(ct, {
-      preferModalForConnectorNotice: true,
-    });
+    const launchMode = getConnectorStatusConnectLaunchMode(ct);
     if (launchMode === "modal") {
       setSelected(type);
     } else {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -28,10 +28,7 @@ import {
 } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import {
-  Vm0LogoLink,
-  GoogleSecurityWarningNotice,
-} from "./zero-directed-shared.tsx";
+import { Vm0LogoLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 
 // ---------------------------------------------------------------------------
@@ -167,18 +164,6 @@ function canAuthorizeConnector(
   return isConnected || (item ? item.availableAuthMethods.length > 0 : false);
 }
 
-function shouldShowDirectedAuthorizeGoogleSecurityWarning(args: {
-  readonly isAuthorized: boolean;
-  readonly isConnected: boolean;
-  readonly item: ConnectorTypeWithStatus | undefined;
-}): boolean {
-  return (
-    !args.isAuthorized &&
-    !args.isConnected &&
-    args.item?.connectNotice === "google-security-warning"
-  );
-}
-
 function directedAuthorizeConnectModalOpen(
   key: DirectedAuthorizeConnectModalKey | null,
   args: {
@@ -203,7 +188,6 @@ function DirectedAuthorizeCardContent({
   isConnecting,
   isLoading,
   canAuthorize,
-  showGoogleSecurityWarningNotice,
   onAuthorize,
 }: {
   readonly connectorType: ConnectorType;
@@ -214,7 +198,6 @@ function DirectedAuthorizeCardContent({
   readonly isConnecting: boolean;
   readonly isLoading: boolean;
   readonly canAuthorize: boolean;
-  readonly showGoogleSecurityWarningNotice: boolean;
   readonly onAuthorize: () => void;
 }) {
   return (
@@ -241,9 +224,6 @@ function DirectedAuthorizeCardContent({
                 <p className="w-60 text-sm text-muted-foreground">
                   {connectorDescription}
                 </p>
-                {showGoogleSecurityWarningNotice && (
-                  <GoogleSecurityWarningNotice />
-                )}
               </>
             )}
           </div>
@@ -364,12 +344,6 @@ function DirectedAuthorizeCard() {
   const selectedAuthMethod = item
     ? getOnlyAvailableStatusAuthCodeAuthMethod(item)
     : null;
-  const showGoogleSecurityWarningNotice =
-    shouldShowDirectedAuthorizeGoogleSecurityWarning({
-      isAuthorized,
-      isConnected,
-      item,
-    });
   const connectorLabel = item?.label ?? connectorType;
   const connectorDescription = item?.helpText ?? "";
 
@@ -402,7 +376,6 @@ function DirectedAuthorizeCard() {
         isConnecting={isConnecting}
         isLoading={isLoading}
         canAuthorize={canAuthorize}
-        showGoogleSecurityWarningNotice={showGoogleSecurityWarningNotice}
         onAuthorize={handleAuthorize}
       />
       {connectModalOpen && (

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -54,10 +54,7 @@ import {
 import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconCheck, IconLoader2 } from "@tabler/icons-react";
-import {
-  Vm0LogoLink,
-  GoogleSecurityWarningNotice,
-} from "./zero-directed-shared.tsx";
+import { Vm0LogoLink } from "./zero-directed-shared.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import type { FormEvent } from "react";
 import { ConnectorHelpText } from "./components/settings/connector-help-text.tsx";
@@ -378,22 +375,6 @@ function useDirectedConnectConnectorType(): ConnectorType | null {
   return parsed.success ? parsed.data : null;
 }
 
-function ConnectorConnectNotices({
-  connectNotice,
-  isConnected,
-}: {
-  readonly connectNotice: ConnectorTypeWithStatus["connectNotice"] | null;
-  readonly isConnected: boolean;
-}) {
-  if (isConnected) {
-    return null;
-  }
-  if (connectNotice === "google-security-warning") {
-    return <GoogleSecurityWarningNotice />;
-  }
-  return null;
-}
-
 function useDirectedConnectCatalogState(connectorType: ConnectorType | null): {
   readonly item: ConnectorTypeWithStatus | undefined;
   readonly isConnected: boolean;
@@ -461,7 +442,6 @@ function DirectedConnectCardContent({
   connectorType,
   connectorLabel,
   connectorDescription,
-  connectNotice,
   agentName,
   isLoading,
   isConnected,
@@ -472,7 +452,6 @@ function DirectedConnectCardContent({
   readonly connectorType: ConnectorType;
   readonly connectorLabel: string;
   readonly connectorDescription: string;
-  readonly connectNotice: ConnectorTypeWithStatus["connectNotice"] | null;
   readonly agentName: string;
   readonly isLoading: boolean;
   readonly isConnected: boolean;
@@ -504,10 +483,6 @@ function DirectedConnectCardContent({
                 <p className="w-60 text-sm text-muted-foreground">
                   {connectorDescription}
                 </p>
-                <ConnectorConnectNotices
-                  connectNotice={connectNotice}
-                  isConnected={isConnected}
-                />
               </>
             )}
           </div>
@@ -607,7 +582,6 @@ function DirectedConnectCard() {
         connectorType={connectorType}
         connectorLabel={connectorLabel}
         connectorDescription={connectorDescription}
-        connectNotice={item?.connectNotice ?? null}
         agentName={agentName}
         isLoading={isLoading}
         isConnected={isConnected}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from "react";
 import { useGet, useSet } from "ccstate-react";
-import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
-import { getAvatarPresets } from "./zero-avatars.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
@@ -85,32 +83,5 @@ export function Vm0LogoLink() {
         />
       </svg>
     </Link>
-  );
-}
-
-export function GoogleSecurityWarningNotice() {
-  return (
-    <div className="w-full mt-2 flex flex-col gap-3 rounded-lg bg-muted/50 px-4 py-4 text-left">
-      <AvatarSvgPreview
-        config={getAvatarPresets()[0]}
-        size={36}
-        className="h-9 w-9 rounded-full"
-        alt="Zero"
-      />
-      <div className="text-xs leading-relaxed text-muted-foreground space-y-1.5">
-        <p>
-          Google will show a security warning because we&rsquo;re still
-          completing their app verification. This is a standard review process
-          for new integrations and does not affect your security.
-        </p>
-        <p>
-          To continue, select{" "}
-          <strong className="text-foreground">Advanced</strong> then{" "}
-          <strong className="text-foreground">Go to vm0.ai (unsafe)</strong>. We
-          only request the minimum permissions needed, and your connection
-          tokens are encrypted at rest.
-        </p>
-      </div>
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- stop returning the Google OAuth verification warning notice from the connector catalog
- remove Google pre-connect warning UI from connector list, connect dialog, directed connect, and directed authorize flows
- update connector catalog and Google Maps connector page coverage

## Verification
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-connectors-page.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts
- pnpm format
- pnpm -F @vm0/app lint
- pnpm -F api lint
- pnpm -F @vm0/app check-types
- pnpm -F api check-types
- pre-commit: prettier, knip, full check-types