### PR TITLE
fix: align collapsed manage navigation icons

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -485,7 +485,7 @@ function CollapsedManageNav({
 }) {
   return (
     <div className="shrink-0">
-      <div className="flex h-8 shrink-0 items-center justify-between pl-2 pr-0">
+      <div className="flex h-8 shrink-0 items-center justify-between pr-0">
         <TooltipProvider delayDuration={150}>
           <div className="flex min-w-0 items-center gap-1">
             {manageNav.map(


### PR DESCRIPTION
## Summary
- Remove the left padding from the collapsed manage navigation row so the icon-only Agents, Workflows, and Connectors controls align with the sidebar content below.
- Keep the existing icon buttons, expand control, hover states, and navigation behavior unchanged.

## Verification
- git diff --check
- Not run: local vitest/dev server, per vm0 PR guidance for PR creation; relying on the PR pipeline for broader checks.
