### PR TITLE
perf: attribute guest-download overlap conflicts

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -829,6 +829,30 @@ mod tests {
     }
 
     #[test]
+    fn task_kind_classification_uses_normalized_component_paths() {
+        assert_eq!(
+            classify_download_task_kind("/home/user/.codex/skills/./workflow", None),
+            DownloadTaskKind::FrameworkSkillChild
+        );
+        assert_eq!(
+            classify_download_task_kind("/home/user/.claude/skills/./tool", None),
+            DownloadTaskKind::FrameworkSkillChild
+        );
+        assert_eq!(
+            classify_download_task_kind("/home/user/.codex/skills/../workflow", None),
+            DownloadTaskKind::Other
+        );
+        assert_eq!(
+            classify_download_task_kind("/home/user/.claude/skills", None),
+            DownloadTaskKind::Other
+        );
+        assert_eq!(
+            classify_download_task_kind("/home/user/.claude/skills-old/tool", None),
+            DownloadTaskKind::Other
+        );
+    }
+
+    #[test]
     fn conflict_classifier_buckets_exact_instruction_skill_and_other_parent_child() {
         assert_eq!(
             classify_download_conflict(

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -4,7 +4,7 @@ use crate::error::DownloadError;
 use crate::source;
 use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
 use std::any::Any;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::mpsc;
@@ -29,9 +29,11 @@ pub(crate) struct DownloadTask {
     url: String,
     mount_path: String,
     not_found_policy: NotFoundPolicy,
+    kind: DownloadTaskKind,
 }
 
 impl DownloadTask {
+    #[cfg(test)]
     pub(crate) fn new(
         label: String,
         op_name: &'static str,
@@ -39,17 +41,41 @@ impl DownloadTask {
         mount_path: String,
         not_found_policy: NotFoundPolicy,
     ) -> Self {
+        Self::new_with_kind(
+            label,
+            op_name,
+            url,
+            mount_path,
+            not_found_policy,
+            DownloadTaskKind::Other,
+        )
+    }
+
+    pub(crate) fn new_with_kind(
+        label: String,
+        op_name: &'static str,
+        url: String,
+        mount_path: String,
+        not_found_policy: NotFoundPolicy,
+        kind: DownloadTaskKind,
+    ) -> Self {
         Self {
             label,
             op_name,
             url,
             mount_path,
             not_found_policy,
+            kind,
         }
     }
 
     pub(crate) fn mount_path(&self) -> &str {
         &self.mount_path
+    }
+
+    #[cfg(test)]
+    pub(crate) fn kind(&self) -> DownloadTaskKind {
+        self.kind
     }
 
     fn is_remote_url(&self) -> bool {
@@ -65,9 +91,24 @@ impl DownloadTask {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DownloadTaskKind {
+    FrameworkHomeInstructions,
+    FrameworkSkillChild,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DownloadConflictKind {
+    InstructionsSkill,
+    ExactPath,
+    OtherParentChild,
+}
+
 struct ActiveDownload {
     id: usize,
     mount_path: PathBuf,
+    kind: DownloadTaskKind,
 }
 
 struct DownloadCompletion {
@@ -77,12 +118,38 @@ struct DownloadCompletion {
 
 #[derive(Default)]
 struct DownloadScheduleStats {
-    mount_conflict_deferrals: usize,
+    conflict_deferrals: DownloadConflictDeferralStats,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct DownloadConflictDeferralStats {
+    total: usize,
+    instructions_skill: usize,
+    exact_path: usize,
+    other_parent_child: usize,
+}
+
+impl DownloadConflictDeferralStats {
+    fn record(&mut self, kind: DownloadConflictKind) {
+        self.total += 1;
+        match kind {
+            DownloadConflictKind::InstructionsSkill => self.instructions_skill += 1,
+            DownloadConflictKind::ExactPath => self.exact_path += 1,
+            DownloadConflictKind::OtherParentChild => self.other_parent_child += 1,
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.total += other.total;
+        self.instructions_skill += other.instructions_skill;
+        self.exact_path += other.exact_path;
+        self.other_parent_child += other.other_parent_child;
+    }
 }
 
 struct StartableDownload {
-    selected: Option<(usize, PathBuf)>,
-    mount_conflict_deferrals: usize,
+    selected: Option<(usize, PathBuf, DownloadTaskKind)>,
+    conflict_deferrals: DownloadConflictDeferralStats,
 }
 
 enum DownloadOutcome {
@@ -118,6 +185,33 @@ fn record_download_attribution(tasks: &[DownloadTask]) {
         true,
         None,
     );
+    let skill_child_tasks = tasks
+        .iter()
+        .filter(|task| task.kind == DownloadTaskKind::FrameworkSkillChild)
+        .count();
+    record_sandbox_op(
+        guest_download_skill_child_task_count_action(skill_child_tasks),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    let instructions_present = tasks
+        .iter()
+        .any(|task| task.kind == DownloadTaskKind::FrameworkHomeInstructions);
+    record_sandbox_op(
+        guest_download_framework_home_instructions_task_action(instructions_present),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        guest_download_potential_parent_child_overlap_count_action(
+            potential_parent_child_overlap_count(tasks),
+        ),
+        Duration::ZERO,
+        true,
+        None,
+    );
 }
 
 fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: TaskRunner) -> bool {
@@ -129,6 +223,7 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
             true,
             None,
         );
+        record_conflict_deferral_attribution(DownloadConflictDeferralStats::default());
         return true;
     }
 
@@ -194,12 +289,34 @@ fn download_all_parallel_with_runner(tasks: Vec<DownloadTask>, task_runner: Task
         all_success && pending.is_empty()
     });
     record_sandbox_op(
-        guest_download_mount_conflict_deferral_count_action(stats.mount_conflict_deferrals),
+        guest_download_mount_conflict_deferral_count_action(stats.conflict_deferrals.total),
         Duration::ZERO,
         true,
         None,
     );
+    record_conflict_deferral_attribution(stats.conflict_deferrals);
     success
+}
+
+fn record_conflict_deferral_attribution(stats: DownloadConflictDeferralStats) {
+    record_sandbox_op(
+        guest_download_instructions_skill_conflict_deferral_count_action(stats.instructions_skill),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        guest_download_exact_path_conflict_deferral_count_action(stats.exact_path),
+        Duration::ZERO,
+        true,
+        None,
+    );
+    record_sandbox_op(
+        guest_download_other_parent_child_conflict_deferral_count_action(stats.other_parent_child),
+        Duration::ZERO,
+        true,
+        None,
+    );
 }
 
 fn guest_download_task_count_action(count: usize) -> &'static str {
@@ -238,6 +355,38 @@ fn guest_download_file_url_count_action(count: usize) -> &'static str {
     }
 }
 
+fn guest_download_skill_child_task_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_skill_child_task_count_0",
+        CountBucket::One => "guest_download_skill_child_task_count_1",
+        CountBucket::Two => "guest_download_skill_child_task_count_2",
+        CountBucket::ThreeToFour => "guest_download_skill_child_task_count_3_4",
+        CountBucket::FiveToEight => "guest_download_skill_child_task_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_skill_child_task_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_skill_child_task_count_17_plus",
+    }
+}
+
+fn guest_download_framework_home_instructions_task_action(present: bool) -> &'static str {
+    if present {
+        "guest_download_framework_home_instructions_task_present"
+    } else {
+        "guest_download_framework_home_instructions_task_absent"
+    }
+}
+
+fn guest_download_potential_parent_child_overlap_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_potential_parent_child_overlap_count_0",
+        CountBucket::One => "guest_download_potential_parent_child_overlap_count_1",
+        CountBucket::Two => "guest_download_potential_parent_child_overlap_count_2",
+        CountBucket::ThreeToFour => "guest_download_potential_parent_child_overlap_count_3_4",
+        CountBucket::FiveToEight => "guest_download_potential_parent_child_overlap_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_potential_parent_child_overlap_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_potential_parent_child_overlap_count_17_plus",
+    }
+}
+
 fn guest_download_mount_conflict_deferral_count_action(count: usize) -> &'static str {
     match count_bucket(count) {
         CountBucket::Zero => "guest_download_mount_conflict_deferral_count_0",
@@ -247,6 +396,50 @@ fn guest_download_mount_conflict_deferral_count_action(count: usize) -> &'static
         CountBucket::FiveToEight => "guest_download_mount_conflict_deferral_count_5_8",
         CountBucket::NineToSixteen => "guest_download_mount_conflict_deferral_count_9_16",
         CountBucket::SeventeenPlus => "guest_download_mount_conflict_deferral_count_17_plus",
+    }
+}
+
+fn guest_download_instructions_skill_conflict_deferral_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_instructions_skill_conflict_deferral_count_0",
+        CountBucket::One => "guest_download_instructions_skill_conflict_deferral_count_1",
+        CountBucket::Two => "guest_download_instructions_skill_conflict_deferral_count_2",
+        CountBucket::ThreeToFour => "guest_download_instructions_skill_conflict_deferral_count_3_4",
+        CountBucket::FiveToEight => "guest_download_instructions_skill_conflict_deferral_count_5_8",
+        CountBucket::NineToSixteen => {
+            "guest_download_instructions_skill_conflict_deferral_count_9_16"
+        }
+        CountBucket::SeventeenPlus => {
+            "guest_download_instructions_skill_conflict_deferral_count_17_plus"
+        }
+    }
+}
+
+fn guest_download_exact_path_conflict_deferral_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_exact_path_conflict_deferral_count_0",
+        CountBucket::One => "guest_download_exact_path_conflict_deferral_count_1",
+        CountBucket::Two => "guest_download_exact_path_conflict_deferral_count_2",
+        CountBucket::ThreeToFour => "guest_download_exact_path_conflict_deferral_count_3_4",
+        CountBucket::FiveToEight => "guest_download_exact_path_conflict_deferral_count_5_8",
+        CountBucket::NineToSixteen => "guest_download_exact_path_conflict_deferral_count_9_16",
+        CountBucket::SeventeenPlus => "guest_download_exact_path_conflict_deferral_count_17_plus",
+    }
+}
+
+fn guest_download_other_parent_child_conflict_deferral_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "guest_download_other_parent_child_conflict_deferral_count_0",
+        CountBucket::One => "guest_download_other_parent_child_conflict_deferral_count_1",
+        CountBucket::Two => "guest_download_other_parent_child_conflict_deferral_count_2",
+        CountBucket::ThreeToFour => "guest_download_other_parent_child_conflict_deferral_count_3_4",
+        CountBucket::FiveToEight => "guest_download_other_parent_child_conflict_deferral_count_5_8",
+        CountBucket::NineToSixteen => {
+            "guest_download_other_parent_child_conflict_deferral_count_9_16"
+        }
+        CountBucket::SeventeenPlus => {
+            "guest_download_other_parent_child_conflict_deferral_count_17_plus"
+        }
     }
 }
 
@@ -284,8 +477,8 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
 ) {
     while active.len() < MAX_CONCURRENT {
         let startable = find_startable_download(pending, active);
-        stats.mount_conflict_deferrals += startable.mount_conflict_deferrals;
-        let Some((index, mount_path)) = startable.selected else {
+        stats.conflict_deferrals.merge(startable.conflict_deferrals);
+        let Some((index, mount_path, kind)) = startable.selected else {
             break;
         };
         let Some(task) = pending.remove(index) else {
@@ -294,7 +487,11 @@ fn start_ready_downloads<'scope, 'env: 'scope>(
         };
         let id = *next_id;
         *next_id += 1;
-        active.push(ActiveDownload { id, mount_path });
+        active.push(ActiveDownload {
+            id,
+            mount_path,
+            kind,
+        });
 
         let completion_tx = completion_tx.clone();
         scope.spawn(move || {
@@ -314,28 +511,110 @@ fn find_startable_download(
     // Scan the pending queue instead of using strict FIFO so an active
     // parent/child mount-path conflict does not leave a slot idle when a later
     // independent task can start.
-    let mut mount_conflict_deferrals = 0;
+    let mut conflict_deferrals = DownloadConflictDeferralStats::default();
     for (index, task) in pending.iter().enumerate() {
         let mount_path = normalize_mount_path(task.mount_path());
-        let has_conflict = active.iter().any(|download| {
-            mount_paths_conflict(mount_path.as_path(), download.mount_path.as_path())
-        });
 
-        if has_conflict {
-            mount_conflict_deferrals += 1;
+        if let Some(conflict) = active.iter().find_map(|download| {
+            classify_download_conflict(
+                mount_path.as_path(),
+                task.kind,
+                download.mount_path.as_path(),
+                download.kind,
+            )
+        }) {
+            conflict_deferrals.record(conflict);
             continue;
         }
 
         return StartableDownload {
-            selected: Some((index, mount_path)),
-            mount_conflict_deferrals,
+            selected: Some((index, mount_path, task.kind)),
+            conflict_deferrals,
         };
     }
 
     StartableDownload {
         selected: None,
-        mount_conflict_deferrals,
+        conflict_deferrals,
     }
+}
+
+pub(crate) fn classify_download_task_kind(
+    mount_path: &str,
+    instructions_target_filename: Option<&str>,
+) -> DownloadTaskKind {
+    if instructions_target_filename.is_some() {
+        return DownloadTaskKind::FrameworkHomeInstructions;
+    }
+
+    if is_framework_skill_child_path(&normalize_mount_path(mount_path)) {
+        return DownloadTaskKind::FrameworkSkillChild;
+    }
+
+    DownloadTaskKind::Other
+}
+
+fn classify_download_conflict(
+    left_path: &Path,
+    left_kind: DownloadTaskKind,
+    right_path: &Path,
+    right_kind: DownloadTaskKind,
+) -> Option<DownloadConflictKind> {
+    if !mount_paths_conflict(left_path, right_path) {
+        return None;
+    }
+    if left_path == right_path {
+        return Some(DownloadConflictKind::ExactPath);
+    }
+    if task_kinds_are_instructions_and_skill(left_kind, right_kind) {
+        return Some(DownloadConflictKind::InstructionsSkill);
+    }
+    Some(DownloadConflictKind::OtherParentChild)
+}
+
+fn task_kinds_are_instructions_and_skill(left: DownloadTaskKind, right: DownloadTaskKind) -> bool {
+    matches!(
+        (left, right),
+        (
+            DownloadTaskKind::FrameworkHomeInstructions,
+            DownloadTaskKind::FrameworkSkillChild
+        ) | (
+            DownloadTaskKind::FrameworkSkillChild,
+            DownloadTaskKind::FrameworkHomeInstructions
+        )
+    )
+}
+
+fn potential_parent_child_overlap_count(tasks: &[DownloadTask]) -> usize {
+    let normalized_paths: Vec<PathBuf> = tasks
+        .iter()
+        .map(|task| normalize_mount_path(task.mount_path()))
+        .collect();
+    let mut path_counts = HashMap::new();
+    for path in &normalized_paths {
+        *path_counts.entry(path.clone()).or_insert(0usize) += 1;
+    }
+
+    let mut count = 0;
+
+    for path in &normalized_paths {
+        for ancestor in path.ancestors().skip(1) {
+            if let Some(ancestor_count) = path_counts.get(ancestor) {
+                count += ancestor_count;
+            }
+        }
+    }
+
+    count
+}
+
+fn is_framework_skill_child_path(path: &Path) -> bool {
+    is_child_path(path, Path::new("/home/user/.codex/skills"))
+        || is_child_path(path, Path::new("/home/user/.claude/skills"))
+}
+
+fn is_child_path(path: &Path, parent: &Path) -> bool {
+    path.starts_with(parent) && path != parent
 }
 
 fn normalize_mount_path(path: &str) -> PathBuf {
@@ -441,6 +720,28 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static SANDBOX_OP_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn task_at(path: &str, kind: DownloadTaskKind) -> DownloadTask {
+        DownloadTask::new_with_kind(
+            format!("task {path}"),
+            "storage_download",
+            "file:///tmp/archive.tar.gz".to_owned(),
+            path.to_owned(),
+            NotFoundPolicy::Fail,
+            kind,
+        )
+    }
+
+    fn active_at(path: &str, kind: DownloadTaskKind) -> ActiveDownload {
+        ActiveDownload {
+            id: 0,
+            mount_path: normalize_mount_path(path),
+            kind,
+        }
+    }
 
     #[test]
     fn mount_paths_conflict_for_exact_and_parent_child_paths() {
@@ -480,6 +781,83 @@ mod tests {
             &normalize_mount_path("/tmp/foo/bar/../barista"),
             &normalize_mount_path("/tmp/foo/bar")
         ));
+    }
+
+    #[test]
+    fn task_kind_classification_identifies_instructions_and_skill_children() {
+        assert_eq!(
+            classify_download_task_kind("/home/user/.codex", Some("AGENTS.md")),
+            DownloadTaskKind::FrameworkHomeInstructions
+        );
+        assert_eq!(
+            classify_download_task_kind("/home/user/.codex/skills/workflow", None),
+            DownloadTaskKind::FrameworkSkillChild
+        );
+        assert_eq!(
+            classify_download_task_kind("/home/user/.claude/skills/tool", None),
+            DownloadTaskKind::FrameworkSkillChild
+        );
+        assert_eq!(
+            classify_download_task_kind("/home/user/.codex/skills", None),
+            DownloadTaskKind::Other
+        );
+        assert_eq!(
+            classify_download_task_kind("/workspace", None),
+            DownloadTaskKind::Other
+        );
+    }
+
+    #[test]
+    fn conflict_classifier_buckets_exact_instruction_skill_and_other_parent_child() {
+        assert_eq!(
+            classify_download_conflict(
+                &normalize_mount_path("/home/user/.codex/skills/foo"),
+                DownloadTaskKind::FrameworkSkillChild,
+                &normalize_mount_path("/home/user/.codex"),
+                DownloadTaskKind::FrameworkHomeInstructions,
+            ),
+            Some(DownloadConflictKind::InstructionsSkill)
+        );
+        assert_eq!(
+            classify_download_conflict(
+                &normalize_mount_path("/same"),
+                DownloadTaskKind::Other,
+                &normalize_mount_path("/same"),
+                DownloadTaskKind::Other,
+            ),
+            Some(DownloadConflictKind::ExactPath)
+        );
+        assert_eq!(
+            classify_download_conflict(
+                &normalize_mount_path("/tmp/parent/child"),
+                DownloadTaskKind::Other,
+                &normalize_mount_path("/tmp/parent"),
+                DownloadTaskKind::Other,
+            ),
+            Some(DownloadConflictKind::OtherParentChild)
+        );
+        assert_eq!(
+            classify_download_conflict(
+                &normalize_mount_path("/home/user/.codex/skills/foo"),
+                DownloadTaskKind::FrameworkSkillChild,
+                &normalize_mount_path("/home/user/.codex/skills/bar"),
+                DownloadTaskKind::FrameworkSkillChild,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn potential_parent_child_overlap_count_excludes_exact_paths_and_siblings() {
+        let tasks = [
+            task_at("/workspace", DownloadTaskKind::Other),
+            task_at("/workspace/src", DownloadTaskKind::Other),
+            task_at("/workspace/tests", DownloadTaskKind::Other),
+            task_at("/workspace/src", DownloadTaskKind::Other),
+            task_at("/workspace/src/nested", DownloadTaskKind::Other),
+        ];
+
+        assert_eq!(potential_parent_child_overlap_count(&tasks), 6);
     }
 
     #[test]
@@ -539,12 +917,149 @@ mod tests {
         let active = vec![ActiveDownload {
             id: 0,
             mount_path: normalize_mount_path("/tmp/mount"),
+            kind: DownloadTaskKind::Other,
         }];
 
         let startable = find_startable_download(&pending, &active);
 
-        assert_eq!(startable.mount_conflict_deferrals, 1);
-        assert_eq!(startable.selected.map(|(index, _)| index), Some(1));
+        assert_eq!(
+            startable.conflict_deferrals,
+            DownloadConflictDeferralStats {
+                total: 1,
+                instructions_skill: 0,
+                exact_path: 0,
+                other_parent_child: 1,
+            }
+        );
+        assert_eq!(startable.selected.map(|(index, _, _)| index), Some(1));
+    }
+
+    #[test]
+    fn find_startable_download_buckets_instruction_skill_deferrals_in_both_directions() {
+        let independent = task_at("/tmp/other", DownloadTaskKind::Other);
+
+        let pending_child = VecDeque::from(vec![
+            task_at(
+                "/home/user/.codex/skills/workflow",
+                DownloadTaskKind::FrameworkSkillChild,
+            ),
+            independent,
+        ]);
+        let active_parent = vec![active_at(
+            "/home/user/.codex",
+            DownloadTaskKind::FrameworkHomeInstructions,
+        )];
+        let child_startable = find_startable_download(&pending_child, &active_parent);
+
+        assert_eq!(
+            child_startable.conflict_deferrals,
+            DownloadConflictDeferralStats {
+                total: 1,
+                instructions_skill: 1,
+                exact_path: 0,
+                other_parent_child: 0,
+            }
+        );
+        assert_eq!(child_startable.selected.map(|(index, _, _)| index), Some(1));
+
+        let pending_parent = VecDeque::from(vec![
+            task_at(
+                "/home/user/.claude",
+                DownloadTaskKind::FrameworkHomeInstructions,
+            ),
+            task_at("/tmp/other", DownloadTaskKind::Other),
+        ]);
+        let active_child = vec![active_at(
+            "/home/user/.claude/skills/workflow",
+            DownloadTaskKind::FrameworkSkillChild,
+        )];
+        let parent_startable = find_startable_download(&pending_parent, &active_child);
+
+        assert_eq!(
+            parent_startable.conflict_deferrals,
+            DownloadConflictDeferralStats {
+                total: 1,
+                instructions_skill: 1,
+                exact_path: 0,
+                other_parent_child: 0,
+            }
+        );
+        assert_eq!(
+            parent_startable.selected.map(|(index, _, _)| index),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn find_startable_download_buckets_exact_path_deferrals() {
+        let pending = VecDeque::from(vec![
+            task_at("/tmp/mount", DownloadTaskKind::Other),
+            task_at("/tmp/other", DownloadTaskKind::Other),
+        ]);
+        let active = vec![active_at("/tmp/mount", DownloadTaskKind::Other)];
+
+        let startable = find_startable_download(&pending, &active);
+
+        assert_eq!(
+            startable.conflict_deferrals,
+            DownloadConflictDeferralStats {
+                total: 1,
+                instructions_skill: 0,
+                exact_path: 1,
+                other_parent_child: 0,
+            }
+        );
+        assert_eq!(startable.selected.map(|(index, _, _)| index), Some(1));
+    }
+
+    #[test]
+    fn download_all_parallel_records_conflict_shape_actions() {
+        let _guard = SANDBOX_OP_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let ops_path = dir.path().join("sandbox-ops.jsonl");
+        guest_common::telemetry::set_sandbox_ops_log_file(&ops_path);
+
+        fn runner(_task: DownloadTask) -> bool {
+            true
+        }
+
+        let success = download_all_parallel_with_runner(
+            vec![
+                task_at(
+                    "/home/user/.codex",
+                    DownloadTaskKind::FrameworkHomeInstructions,
+                ),
+                task_at(
+                    "/home/user/.codex/skills/workflow",
+                    DownloadTaskKind::FrameworkSkillChild,
+                ),
+            ],
+            runner,
+        );
+        guest_common::telemetry::clear_sandbox_ops_log_file();
+
+        assert!(success);
+        let ops = std::fs::read_to_string(&ops_path).unwrap();
+        assert!(ops.contains(r#""action_type":"guest_download_task_count_2""#));
+        assert!(ops.contains(r#""action_type":"guest_download_skill_child_task_count_1""#));
+        assert!(ops.contains(
+            r#""action_type":"guest_download_framework_home_instructions_task_present""#
+        ));
+        assert!(
+            ops.contains(
+                r#""action_type":"guest_download_potential_parent_child_overlap_count_1""#
+            )
+        );
+        assert!(ops.contains(r#""action_type":"guest_download_mount_conflict_deferral_count_1""#));
+        assert!(ops.contains(
+            r#""action_type":"guest_download_instructions_skill_conflict_deferral_count_1""#
+        ));
+        assert!(
+            ops.contains(r#""action_type":"guest_download_exact_path_conflict_deferral_count_0""#)
+        );
+        assert!(ops.contains(
+            r#""action_type":"guest_download_other_parent_child_conflict_deferral_count_0""#
+        ));
     }
 
     #[test]

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -720,9 +720,30 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::path::Path;
+    use std::sync::{Mutex, MutexGuard};
 
     static SANDBOX_OP_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct SandboxOpsLogGuard {
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl SandboxOpsLogGuard {
+        fn set(path: impl AsRef<Path>) -> Self {
+            let lock = SANDBOX_OP_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            guest_common::telemetry::set_sandbox_ops_log_file(path);
+            Self { _lock: lock }
+        }
+    }
+
+    impl Drop for SandboxOpsLogGuard {
+        fn drop(&mut self) {
+            guest_common::telemetry::clear_sandbox_ops_log_file();
+        }
+    }
 
     fn task_at(path: &str, kind: DownloadTaskKind) -> DownloadTask {
         DownloadTask::new_with_kind(
@@ -1014,10 +1035,9 @@ mod tests {
 
     #[test]
     fn download_all_parallel_records_conflict_shape_actions() {
-        let _guard = SANDBOX_OP_TEST_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         let ops_path = dir.path().join("sandbox-ops.jsonl");
-        guest_common::telemetry::set_sandbox_ops_log_file(&ops_path);
+        let _ops_guard = SandboxOpsLogGuard::set(&ops_path);
 
         fn runner(_task: DownloadTask) -> bool {
             true
@@ -1036,7 +1056,6 @@ mod tests {
             ],
             runner,
         );
-        guest_common::telemetry::clear_sandbox_ops_log_file();
 
         assert!(success);
         let ops = std::fs::read_to_string(&ops_path).unwrap();

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -1,4 +1,4 @@
-use crate::download::{DownloadTask, NotFoundPolicy};
+use crate::download::{DownloadTask, NotFoundPolicy, classify_download_task_kind};
 use crate::instructions::InstructionNormalization;
 use crate::manifest::{Manifest, ManifestEntry};
 use std::path::Path;
@@ -122,12 +122,17 @@ fn append_download_tasks(
         if should_download_entry(entry, kind)
             && let Some(url) = entry.archive_url.clone()
         {
-            tasks.push(DownloadTask::new(
+            let task_kind = classify_download_task_kind(
+                &entry.mount_path,
+                entry.instructions_target_filename.as_deref(),
+            );
+            tasks.push(DownloadTask::new_with_kind(
                 format_entry_label(entry, kind, idx + 1, &url),
                 kind.op_name(),
                 url,
                 entry.mount_path.clone(),
                 kind.not_found_policy(),
+                task_kind,
             ));
         }
     }
@@ -303,6 +308,57 @@ mod tests {
         assert_eq!(
             plan.instruction_files[0],
             InstructionNormalization::new("/home/user/.codex".into(), "AGENTS.md".into())
+        );
+    }
+
+    #[test]
+    fn run_plan_derives_download_task_kinds() {
+        let json = r#"{
+            "storages": [
+                {
+                    "mountPath": "/home/user/.codex",
+                    "archiveUrl": "https://s3/instructions.tar.gz",
+                    "instructionsTargetFilename": "AGENTS.md"
+                },
+                {
+                    "mountPath": "/home/user/.codex/skills/workflow",
+                    "archiveUrl": "https://s3/codex-skill.tar.gz"
+                },
+                {
+                    "mountPath": "/home/user/.claude/skills/workflow",
+                    "archiveUrl": "https://s3/claude-skill.tar.gz"
+                },
+                {
+                    "mountPath": "/workspace/storage",
+                    "archiveUrl": "https://s3/storage.tar.gz"
+                }
+            ],
+            "artifacts": [
+                {
+                    "mountPath": "/workspace",
+                    "archiveUrl": "https://s3/artifact.tar.gz"
+                },
+                {
+                    "mountPath": "/home/user/.codex/skills/cached",
+                    "archiveUrl": null,
+                    "cached": true
+                }
+            ]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        let kinds: Vec<_> = plan.download_tasks.iter().map(DownloadTask::kind).collect();
+        assert_eq!(
+            kinds,
+            [
+                crate::download::DownloadTaskKind::FrameworkHomeInstructions,
+                crate::download::DownloadTaskKind::FrameworkSkillChild,
+                crate::download::DownloadTaskKind::FrameworkSkillChild,
+                crate::download::DownloadTaskKind::Other,
+                crate::download::DownloadTaskKind::Other,
+            ]
         );
     }
 

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -113,7 +113,28 @@ fn binary_writes_system_log_to_explicit_runtime_path() {
     assert_action_present(&actions, "guest_download_task_count_0");
     assert_action_present(&actions, "guest_download_remote_url_count_0");
     assert_action_present(&actions, "guest_download_file_url_count_0");
+    assert_action_present(&actions, "guest_download_skill_child_task_count_0");
+    assert_action_present(
+        &actions,
+        "guest_download_framework_home_instructions_task_absent",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_potential_parent_child_overlap_count_0",
+    );
     assert_action_present(&actions, "guest_download_mount_conflict_deferral_count_0");
+    assert_action_present(
+        &actions,
+        "guest_download_instructions_skill_conflict_deferral_count_0",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_exact_path_conflict_deferral_count_0",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_other_parent_child_conflict_deferral_count_0",
+    );
     let totals: Vec<serde_json::Value> = ops_content
         .lines()
         .map(|line| serde_json::from_str(line).unwrap())
@@ -147,7 +168,28 @@ fn binary_reads_manifest_from_stdin() {
     assert_action_present(&actions, "guest_download_task_count_0");
     assert_action_present(&actions, "guest_download_remote_url_count_0");
     assert_action_present(&actions, "guest_download_file_url_count_0");
+    assert_action_present(&actions, "guest_download_skill_child_task_count_0");
+    assert_action_present(
+        &actions,
+        "guest_download_framework_home_instructions_task_absent",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_potential_parent_child_overlap_count_0",
+    );
     assert_action_present(&actions, "guest_download_mount_conflict_deferral_count_0");
+    assert_action_present(
+        &actions,
+        "guest_download_instructions_skill_conflict_deferral_count_0",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_exact_path_conflict_deferral_count_0",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_other_parent_child_conflict_deferral_count_0",
+    );
     let totals: Vec<serde_json::Value> = ops_content
         .lines()
         .map(|line| serde_json::from_str(line).unwrap())
@@ -215,7 +257,28 @@ fn binary_records_download_scheduler_attribution() {
     assert_action_present(&actions, "guest_download_task_count_2");
     assert_action_present(&actions, "guest_download_remote_url_count_1");
     assert_action_present(&actions, "guest_download_file_url_count_1");
+    assert_action_present(&actions, "guest_download_skill_child_task_count_0");
+    assert_action_present(
+        &actions,
+        "guest_download_framework_home_instructions_task_absent",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_potential_parent_child_overlap_count_1",
+    );
     assert_action_present(&actions, "guest_download_mount_conflict_deferral_count_1");
+    assert_action_present(
+        &actions,
+        "guest_download_instructions_skill_conflict_deferral_count_0",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_exact_path_conflict_deferral_count_0",
+    );
+    assert_action_present(
+        &actions,
+        "guest_download_other_parent_child_conflict_deferral_count_1",
+    );
     assert_action_present(&actions, "storage_download");
     assert_action_present(&actions, "artifact_download");
     assert_action_present(&actions, "download_total");
@@ -274,6 +337,13 @@ fn binary_records_scheduler_attribution_for_failed_download() {
         .find(|entry| entry["action_type"] == "guest_download_mount_conflict_deferral_count_1")
         .unwrap_or_else(|| panic!("missing mount conflict count in {ops:?}"));
     assert_eq!(conflict["success"], true);
+    let other_parent_child_conflict = ops
+        .iter()
+        .find(|entry| {
+            entry["action_type"] == "guest_download_other_parent_child_conflict_deferral_count_1"
+        })
+        .unwrap_or_else(|| panic!("missing other parent/child conflict count in {ops:?}"));
+    assert_eq!(other_parent_child_conflict["success"], true);
     let total = ops
         .iter()
         .find(|entry| entry["action_type"] == "download_total")


### PR DESCRIPTION
## Summary
- classify guest-download tasks internally as framework home instructions, framework skill children, or other
- record additive sandbox operation actions for task shape and conflict deferral categories
- preserve existing guest-download manifest/API contracts and scheduler behavior

## Tests
- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo test --manifest-path Cargo.toml -p guest-download`
- `cd crates && cargo clippy --manifest-path Cargo.toml -p guest-download --all-targets -- -D warnings`
- pre-commit hook: crates cargo-fmt, cargo-clippy, cargo-doc

Closes #20300