### PR TITLE
fix(platform): cache personal model provider blocker state

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-page-setup.ts
@@ -16,13 +16,11 @@ import {
   captureNavigationTiming$,
   markRouteSetupBegin$,
 } from "../../lib/posthog.ts";
-import { reloadUserModelPreference$ } from "../external/user-model-preference.ts";
 import { scrollToThread$ } from "./sidebar-chat-thread-scroll.ts";
 
 const internalSetupChatPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(markRouteSetupBegin$);
-    set(reloadUserModelPreference$);
     const threadId = get(currentChatThreadId$);
     if (!threadId) {
       throw new Error("threadId is required to load chat page");

--- a/turbo/apps/platform/src/signals/zero-page/model-first-personal-oauth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-first-personal-oauth.ts
@@ -1,31 +1,95 @@
-import { computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import type {
   ModelProviderResponse,
+  ModelProviderType,
   OrgModelPoliciesResponse,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
-import { personalModelProviders$ } from "../external/personal-model-providers.ts";
-import { userModelPreference$ } from "../external/user-model-preference.ts";
+import {
+  personalModelProviders$,
+  reloadPersonalModelProviders$,
+} from "../external/personal-model-providers.ts";
 
-export interface ModelFirstPersonalOauthState {
-  policies: OrgModelPoliciesResponse;
-  personalProviders: ModelProviderResponse[];
-  userModelPreference: {
-    selectedModel: string | null;
+export type PersonalOauthProviderType =
+  | "claude-code-oauth-token"
+  | "codex-oauth-token";
+
+export type PersonalModelProviderStatus =
+  | {
+      status: "connected";
+      providerType: PersonalOauthProviderType;
+      modelLabel: string;
+    }
+  | {
+      status: "missing";
+      providerType: PersonalOauthProviderType;
+      modelLabel: string;
+    }
+  | {
+      status: "needs_reconnect";
+      providerType: PersonalOauthProviderType;
+      modelLabel: string;
+    };
+
+export type PersonalModelProviderStatusByModel = Readonly<
+  Record<string, PersonalModelProviderStatus>
+>;
+
+const internalReloadPersonalModelProvider$ = state(0);
+
+export const reloadPersonalModelProvider$ = command(({ set }) => {
+  set(reloadPersonalModelProviders$);
+  set(internalReloadPersonalModelProvider$, (value) => {
+    return value + 1;
+  });
+});
+
+function isPersonalOauthProviderType(
+  type: ModelProviderType,
+): type is PersonalOauthProviderType {
+  return type === "claude-code-oauth-token" || type === "codex-oauth-token";
+}
+
+function personalStatusForPolicy(
+  policy: OrgModelPoliciesResponse["policies"][number],
+  personalProviders: readonly ModelProviderResponse[],
+): PersonalModelProviderStatus | null {
+  if (
+    policy.credentialScope !== "member" ||
+    !isPersonalOauthProviderType(policy.defaultProviderType)
+  ) {
+    return null;
+  }
+
+  const provider = personalProviders.find((candidate) => {
+    return candidate.type === policy.defaultProviderType;
+  });
+  return {
+    providerType: policy.defaultProviderType,
+    modelLabel: policy.modelLabel,
+    status: !provider
+      ? "missing"
+      : provider.needsReconnect
+        ? "needs_reconnect"
+        : "connected",
   };
 }
 
-export const modelFirstPersonalOauthState$ = computed(
-  async (get): Promise<ModelFirstPersonalOauthState> => {
-    const [policies, personal, userModelPreference] = await Promise.all([
+export const personalModelProvider$ = computed(
+  async (get): Promise<PersonalModelProviderStatusByModel> => {
+    get(internalReloadPersonalModelProvider$);
+    const [policies, personal] = await Promise.all([
       get(orgModelPolicies$),
       get(personalModelProviders$),
-      get(userModelPreference$),
     ]);
-    return {
-      policies,
-      personalProviders: personal.modelProviders,
-      userModelPreference,
-    };
+
+    const statuses: Record<string, PersonalModelProviderStatus> = {};
+    for (const policy of policies.policies) {
+      const status = personalStatusForPolicy(policy, personal.modelProviders);
+      if (status) {
+        statuses[policy.model] = status;
+      }
+    }
+    return statuses;
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -435,9 +435,6 @@ export const {
   close$: closeClaudeCodeDeviceAuthDialogPersonal$,
   run$: runClaudeCodeDeviceAuthPersonal$,
   autoStartRef$: claudeCodeDeviceAuthAutoStartRefPersonal$,
-} = createClaudeCodeDeviceAuthSignals(
-  "personal",
-  reloadPersonalModelProvider$,
-);
+} = createClaudeCodeDeviceAuthSignals("personal", reloadPersonalModelProvider$);
 
 export type { ClaudeCodeDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/claude-code-device-auth.ts
@@ -9,8 +9,8 @@ import { ApiError, accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
-import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
 import { onRef, resetSignal, settle } from "../../utils.ts";
+import { reloadPersonalModelProvider$ } from "../model-first-personal-oauth.ts";
 
 type ClaudeCodeDeviceAuthDialogMode = "connect" | "reconnect";
 
@@ -437,7 +437,7 @@ export const {
   autoStartRef$: claudeCodeDeviceAuthAutoStartRefPersonal$,
 } = createClaudeCodeDeviceAuthSignals(
   "personal",
-  reloadPersonalModelProviders$,
+  reloadPersonalModelProvider$,
 );
 
 export type { ClaudeCodeDeviceAuthFlowState };

--- a/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/codex-device-auth.ts
@@ -10,9 +10,9 @@ import { ApiError, accept } from "../../../lib/accept.ts";
 import { now } from "../../../lib/time.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { reloadOrgModelProviders$ } from "../../external/org-model-providers.ts";
-import { reloadPersonalModelProviders$ } from "../../external/personal-model-providers.ts";
 import { onRef, resetSignal, settle, setLoop } from "../../utils.ts";
 import { writeToClipboard } from "../clipboard.ts";
+import { reloadPersonalModelProvider$ } from "../model-first-personal-oauth.ts";
 
 type CodexDeviceAuthDialogMode = "connect" | "reconnect";
 
@@ -466,6 +466,6 @@ export const {
   close$: closeCodexDeviceAuthDialogPersonal$,
   run$: runCodexDeviceAuthPersonal$,
   autoStartRef$: codexDeviceAuthAutoStartRefPersonal$,
-} = createCodexDeviceAuthSignals("personal", reloadPersonalModelProviders$);
+} = createCodexDeviceAuthSignals("personal", reloadPersonalModelProvider$);
 
 export type { CodexDeviceAuthFlowState };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1572,23 +1572,18 @@ describe("chat composer models", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("edits thread override before user default model selection resolves", async () => {
+  it("edits thread override without loading user default model selection", async () => {
     const user = userEvent.setup({ delay: null });
-    const pendingPreference = context.mocks.deferred<void>();
     let preferenceRequestStarted = false;
 
     mockOrgModelRoutes("kimi-k2.7-code");
-    context.mocks.api(
-      zeroUserModelPreferenceContract.get,
-      async ({ respond, withSignal }) => {
-        preferenceRequestStarted = true;
-        await withSignal(pendingPreference.promise);
-        return respond(200, {
-          selectedModel: "claude-opus-4-7",
-          updatedAt: "2026-03-10T00:00:00Z",
-        });
-      },
-    );
+    context.mocks.api(zeroUserModelPreferenceContract.get, ({ respond }) => {
+      preferenceRequestStarted = true;
+      return respond(200, {
+        selectedModel: "claude-opus-4-7",
+        updatedAt: "2026-03-10T00:00:00Z",
+      });
+    });
     mockAgent();
     mockThread({
       selectedModel: "glm-5.1",
@@ -1604,19 +1599,13 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    try {
-      await waitFor(() => {
-        expect(preferenceRequestStarted).toBeTruthy();
-      });
-      await screen.findByText("Use GLM");
-      await user.click(await findComposerModel("GLM-5.1"));
-      await user.click(
-        await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
-      );
-      await expectComposerModel("Claude Sonnet 4.6");
-    } finally {
-      pendingPreference.resolve();
-    }
+    await screen.findByText("Use GLM");
+    await user.click(await findComposerModel("GLM-5.1"));
+    await user.click(
+      await screen.findByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    );
+    await expectComposerModel("Claude Sonnet 4.6");
+    expect(preferenceRequestStarted).toBeFalsy();
   });
 
   it("opens compare plans from limited-free-1 Pro composer model items", async () => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -89,7 +89,7 @@ import {
   typewriterDisplayed$,
   typewriterRef$,
 } from "../../signals/view-component-state.ts";
-import { modelFirstPersonalOauthState$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
+import { personalModelProvider$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
 import { updateUserModelPreference$ } from "../../signals/external/user-model-preference.ts";
 import {
   resolveChatComposerSubmitBlocker,
@@ -462,7 +462,7 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
       : null;
   const setModelSelection = useSet(setChatPageModelSelection$);
   const updateUserModelPreference = useSet(updateUserModelPreference$);
-  const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
+  const personalModelProvider = useLastResolved(personalModelProvider$);
   const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
 
   const handleModelSelectionChange = (
@@ -483,11 +483,13 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
     onChange: handleModelSelectionChange,
     resolveDefaultSelection: false,
   };
-  const submitBlockerProps = resolveChatComposerSubmitBlocker({
-    state: modelFirstOauthState,
-    modelSelection,
-    onAction: openPersonalOauthConfiguration,
-  });
+  const submitBlockerProps = modelSelection
+    ? resolveChatComposerSubmitBlocker({
+        personalModelProvider,
+        selectedModel: modelSelection.selectedModel,
+        onAction: openPersonalOauthConfiguration,
+      })
+    : undefined;
   const modelPickerLoading = modelSelectionLoadable.state === "loading";
 
   return {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-model-policies-section.tsx
@@ -69,6 +69,7 @@ import {
   type ModelPolicyDialogMode,
   type ModelPolicyRouteKind,
 } from "../../../../signals/zero-page/settings/org-model-policy-dialog.ts";
+import { reloadPersonalModelProvider$ } from "../../../../signals/zero-page/model-first-personal-oauth.ts";
 import {
   billingStatusAsync$,
   startCheckout$,
@@ -1217,6 +1218,7 @@ export function OrgModelPoliciesSection() {
   const openEditModelDialog = useSet(openEditModelPolicyDialog$);
   const openOrgBillingPlans = useSet(openBillingPlans$);
   const openSettingsBillingPlans = useSet(openSettingsBillingPlans$);
+  const reloadPersonalModelProvider = useSet(reloadPersonalModelProvider$);
   const [updateLoadable, updatePolicies] = useLoadableSet(
     updateOrgModelPolicies$,
   );
@@ -1263,10 +1265,14 @@ export function OrgModelPoliciesSection() {
 
   const submit = (next: UpdateOrgModelPolicy[]) => {
     detach(
-      updatePolicies(
-        { policies: filterPolicyUpdatesForTier(next, limitedFree1) },
-        pageSignal,
-      ),
+      (async () => {
+        await updatePolicies(
+          { policies: filterPolicyUpdatesForTier(next, limitedFree1) },
+          pageSignal,
+        );
+        pageSignal.throwIfAborted();
+        reloadPersonalModelProvider();
+      })(),
       Reason.DomCallback,
     );
   };

--- a/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
+++ b/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
@@ -1,15 +1,12 @@
-import type {
-  ModelProviderResponse,
-  ModelProviderType,
-  OrgModelPoliciesResponse,
-} from "@vm0/api-contracts/contracts/model-providers";
 import { useSet } from "ccstate-react";
 import { setClaudeCodeDeviceAuthDialogStatePersonal$ } from "../../signals/zero-page/settings/claude-code-device-auth.ts";
 import { setCodexDeviceAuthDialogStatePersonal$ } from "../../signals/zero-page/settings/codex-device-auth.ts";
-import type { ModelFirstPersonalOauthState } from "../../signals/zero-page/model-first-personal-oauth.ts";
-import type { ModelProviderSelection } from "./components/model-provider-picker.tsx";
+import type {
+  PersonalModelProviderStatusByModel,
+  PersonalOauthProviderType,
+} from "../../signals/zero-page/model-first-personal-oauth.ts";
 
-type MemberOauthProviderType = "claude-code-oauth-token" | "codex-oauth-token";
+type MemberOauthProviderType = PersonalOauthProviderType;
 type CodexDeviceAuthDialogMode = "connect" | "reconnect";
 
 interface ModelConfigurationSubmitBlocker {
@@ -20,101 +17,40 @@ interface ModelConfigurationSubmitBlocker {
   onAction: () => void;
 }
 
-function isMemberOauthProviderType(
-  type: ModelProviderType,
-): type is MemberOauthProviderType {
-  return type === "claude-code-oauth-token" || type === "codex-oauth-token";
-}
-
 function getMemberOauthProviderLabel(type: MemberOauthProviderType): string {
   return type === "codex-oauth-token" ? "ChatGPT (Codex)" : "Claude Code OAuth";
 }
 
-function findPolicyForSelectedModel(
-  policies: OrgModelPoliciesResponse,
-  selectedModel: string | null,
-) {
-  const model = selectedModel ?? policies.workspaceDefaultModel;
-  if (model) {
-    const policy = policies.policies.find((item) => {
-      return item.model === model;
-    });
-    if (policy) {
-      return policy;
-    }
-  }
-  return (
-    policies.policies.find((item) => {
-      return item.isDefault;
-    }) ?? null
-  );
-}
-
-function hasUsablePersonalProvider(
-  providers: ModelProviderResponse[],
-  providerType: MemberOauthProviderType,
-): boolean {
-  return providers.some((provider) => {
-    return provider.type === providerType && !provider.needsReconnect;
-  });
-}
-
-function resolveModelConfigurationSubmitBlocker(params: {
-  state: ModelFirstPersonalOauthState | null;
-  selectedModel: string | null;
-}): Omit<ModelConfigurationSubmitBlocker, "onAction"> | null {
-  if (!params.state) {
+function resolveModelConfigurationSubmitBlocker(
+  status: PersonalModelProviderStatusByModel[string] | null | undefined,
+): Omit<ModelConfigurationSubmitBlocker, "onAction"> | null {
+  if (!status || status.status === "connected") {
     return null;
   }
-  const policy = findPolicyForSelectedModel(
-    params.state.policies,
-    params.selectedModel,
-  );
-  if (
-    !policy ||
-    policy.credentialScope !== "member" ||
-    !isMemberOauthProviderType(policy.defaultProviderType)
-  ) {
-    return null;
-  }
-  const providerType = policy.defaultProviderType;
-  if (hasUsablePersonalProvider(params.state.personalProviders, providerType)) {
-    return null;
-  }
-  const label = getMemberOauthProviderLabel(providerType);
-  const modelLabel = policy.modelLabel;
-  const existingProvider = params.state.personalProviders.find((provider) => {
-    return provider.type === providerType;
-  });
+  const label = getMemberOauthProviderLabel(status.providerType);
   return {
-    providerType,
-    codexDeviceAuthMode: existingProvider?.needsReconnect
+    providerType: status.providerType,
+    codexDeviceAuthMode: status.status === "needs_reconnect"
       ? "reconnect"
       : "connect",
-    message: existingProvider?.needsReconnect
-      ? `${label} needs to be reconnected before you can use ${modelLabel}.`
-      : `This workspace routes ${modelLabel} through your personal ${label}. Configure it before sending.`,
+    message: status.status === "needs_reconnect"
+      ? `${label} needs to be reconnected before you can use ${status.modelLabel}.`
+      : `This workspace routes ${status.modelLabel} through your personal ${label}. Configure it before sending.`,
     actionLabel: "Model Configure",
   };
 }
 
 export function resolveChatComposerSubmitBlocker(params: {
-  state: ModelFirstPersonalOauthState | null | undefined;
-  modelSelection: ModelProviderSelection | null;
+  personalModelProvider: PersonalModelProviderStatusByModel | null | undefined;
+  selectedModel: string;
   onAction: (
     providerType: MemberOauthProviderType,
     codexDeviceAuthMode: CodexDeviceAuthDialogMode,
   ) => void;
 }): ModelConfigurationSubmitBlocker | undefined {
-  const selectedModel =
-    params.modelSelection?.selectedModel ??
-    params.state?.userModelPreference.selectedModel ??
-    params.state?.policies.workspaceDefaultModel ??
-    null;
-  const blocker = resolveModelConfigurationSubmitBlocker({
-    state: params.state ?? null,
-    selectedModel,
-  });
+  const blocker = resolveModelConfigurationSubmitBlocker(
+    params.personalModelProvider?.[params.selectedModel],
+  );
   return blocker
     ? {
         ...blocker,

--- a/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
+++ b/turbo/apps/platform/src/views/zero-page/model-first-oauth-submit-blocker.ts
@@ -30,12 +30,12 @@ function resolveModelConfigurationSubmitBlocker(
   const label = getMemberOauthProviderLabel(status.providerType);
   return {
     providerType: status.providerType,
-    codexDeviceAuthMode: status.status === "needs_reconnect"
-      ? "reconnect"
-      : "connect",
-    message: status.status === "needs_reconnect"
-      ? `${label} needs to be reconnected before you can use ${status.modelLabel}.`
-      : `This workspace routes ${status.modelLabel} through your personal ${label}. Configure it before sending.`,
+    codexDeviceAuthMode:
+      status.status === "needs_reconnect" ? "reconnect" : "connect",
+    message:
+      status.status === "needs_reconnect"
+        ? `${label} needs to be reconnected before you can use ${status.modelLabel}.`
+        : `This workspace routes ${status.modelLabel} through your personal ${label}. Configure it before sending.`,
     actionLabel: "Model Configure",
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -297,7 +297,7 @@ import {
   ZERO_DESKTOP_DOWNLOAD_URL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import type { ModelProviderSelection } from "./components/model-provider-picker.tsx";
-import { modelFirstPersonalOauthState$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
+import { personalModelProvider$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
 import {
   resolveChatComposerSubmitBlocker,
   usePersonalOauthConfigurationAction,
@@ -4603,7 +4603,7 @@ function useChatComposerModel(
         }
       : baseModelSelection;
   const setModelSelection = useSet(thread.setModelSelection$);
-  const modelFirstOauthState = useLastResolved(modelFirstPersonalOauthState$);
+  const personalModelProvider = useLastResolved(personalModelProvider$);
   const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
 
   const handleModelSelectionChange = (
@@ -4618,11 +4618,13 @@ function useChatComposerModel(
     disabled: false,
   });
   const modelPickerLoading = modelSelectionResolved === undefined;
-  const submitBlockerProps = resolveChatComposerSubmitBlocker({
-    state: modelFirstOauthState,
-    modelSelection,
-    onAction: openPersonalOauthConfiguration,
-  });
+  const submitBlockerProps = modelSelection
+    ? resolveChatComposerSubmitBlocker({
+        personalModelProvider,
+        selectedModel: modelSelection.selectedModel,
+        onAction: openPersonalOauthConfiguration,
+      })
+    : undefined;
 
   return {
     modelPicker,


### PR DESCRIPTION
## Summary
- Replace the composer OAuth blocker dependency with `personalModelProvider$`, a compact status map keyed by selected model.
- Remove user model preference, workspace default, and default-policy fallbacks from the submit blocker path for chat threads.
- Stop reloading user model preference on chat thread setup, and explicitly refresh the personal provider status map after personal OAuth completion or org model policy saves.

## Verification
- `git diff --check`
- Not run: local Vitest/tsc because this checkout has no `node_modules`; per vm0 PR preference, no full local test suite or dev server was run for PR creation.
