### PR TITLE
fix: keep recommended follow-ups plain text

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -697,6 +697,7 @@ describe("CHAT-02: completed chat callback", () => {
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const titlePrompts: string[] = [];
+    const followupSystemPrompts: string[] = [];
     const followupPrompts: string[] = [];
     mockOptionalEnv("OPENROUTER_API_KEY", "bdd-openrouter-key");
     chatCallbacks.mockOpenRouterCompletions((body) => {
@@ -706,6 +707,7 @@ describe("CHAT-02: completed chat callback", () => {
         return "Debugging Node Apps";
       }
       if (systemContent.includes("concise follow-up prompts")) {
+        followupSystemPrompts.push(systemContent);
         followupPrompts.push(body.messages[1]?.content ?? "");
         return JSON.stringify([
           { prompt: "Turn this into a checklist", kind: "talk" },
@@ -816,6 +818,11 @@ describe("CHAT-02: completed chat callback", () => {
     expect(followupPrompts).toHaveLength(1);
     expect(followupPrompts[0]).toContain("final answer");
     expect(followupPrompts[0]).not.toContain("queued next turn");
+    expect(followupSystemPrompts).toStrictEqual([
+      expect.stringContaining(
+        'The "prompt" values are shown as plain text, not rendered as Markdown',
+      ),
+    ]);
     await expect
       .poll(() => {
         return publishedChatThreadRunFinished(first.threadId);

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -448,6 +448,7 @@ async function generateRecommendedFollowups(
         content: [
           `Generate up to ${RECOMMENDED_FOLLOWUP_LIMIT.toString()} concise follow-up prompts the user may ask next in this chat.`,
           "Make each prompt specific to the latest assistant reply, actionable, and useful. Match the user's language.",
+          'The "prompt" values are shown as plain text, not rendered as Markdown, so formatting characters will appear literally. Do not use Markdown or presentation-only syntax inside prompt values, including backticks around technical names, bold or italic markers, links, or bullet markers.',
           'Classify each item as kind "talk" for normal discussion, planning, analysis, or refinement, or kind "generate" when the prompt asks VM0 to create one of the supported built-in generation outputs.',
           BUILT_IN_GENERATION_FOLLOWUP_CONTEXT,
           "For generate items, include generationType as one of: image, video, presentation, website.",


### PR DESCRIPTION
## Summary
- Add plain-text display context to recommended follow-up prompt generation so suggested prompts avoid Markdown markers that render literally in the follow-up UI.
- Explicitly tell the model not to wrap technical names in backticks or use bold, italic, links, or bullet syntax inside `prompt` values.
- Cover the prompt contract in the chat callback BDD test by asserting the OpenRouter system prompt includes the plain-text guidance.

## Verification
- `pnpm exec prettier --write apps/api/src/signals/services/zero-chat-title.service.ts apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`
- `git diff --check`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F api test src/signals/routes/__tests__/chat-callbacks.bdd.test.ts` (blocked locally: this environment has no running Postgres and no Postgres 16 tooling; the file fails during onboarding DB setup with `ECONNREFUSED` before reaching the changed assertion)
