### PR TITLE
test: rely on deferred abort cleanup

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/test-mocks.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/test-mocks.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { createTestMocks } from "./test-mocks.ts";
+
+describe("test mocks", () => {
+  it("rejects deferred promises when the backing signal aborts", async () => {
+    const reason = new Error("Aborted due to finished test");
+    reason.name = "AbortError";
+    const signal = AbortSignal.abort(reason);
+    const mocks = createTestMocks(() => {
+      return signal;
+    });
+
+    const deferred = mocks.deferred<void>();
+
+    await expect(deferred.promise).rejects.toBe(reason);
+    expect(deferred.settled()).toBeTruthy();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -1288,29 +1288,25 @@ describe("chat lifecycle", () => {
       },
     });
 
-    try {
-      detachedSetupPage({ context, path: AGENT_CHAT_PATH });
+    detachedSetupPage({ context, path: AGENT_CHAT_PATH });
 
-      const textarea = await waitFor(() => {
-        return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-      });
-      await sendMessageInUI(user, textarea, prompt);
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await sendMessageInUI(user, textarea, prompt);
 
-      await waitFor(() => {
-        expect(clientThreadId).toBeDefined();
-      });
-      if (!clientThreadId) {
-        throw new Error("Expected client thread id to be captured");
-      }
-
-      await expect(
-        context.store.get(eventDrivenChatThread(clientThreadId)),
-      ).resolves.toMatchObject({
-        selectedModel: "claude-sonnet-4-6",
-      });
-    } finally {
-      sendGate.resolve();
+    await waitFor(() => {
+      expect(clientThreadId).toBeDefined();
+    });
+    if (!clientThreadId) {
+      throw new Error("Expected client thread id to be captured");
     }
+
+    await expect(
+      context.store.get(eventDrivenChatThread(clientThreadId)),
+    ).resolves.toMatchObject({
+      selectedModel: "claude-sonnet-4-6",
+    });
   });
 
   it("renders the optimistic new chat message without skeleton when the initial message list is blocked", async () => {
@@ -1323,21 +1319,17 @@ describe("chat lifecycle", () => {
       return respond(200, { messages: [], hasHistoryBefore: false });
     });
 
-    try {
-      detachedSetupPage({ context, path: AGENT_CHAT_PATH });
+    detachedSetupPage({ context, path: AGENT_CHAT_PATH });
 
-      const textarea = await waitFor(() => {
-        return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-      });
-      await sendMessageInUI(user, textarea, prompt);
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await sendMessageInUI(user, textarea, prompt);
 
-      await waitFor(() => {
-        expect(screen.getByText(prompt)).toBeInTheDocument();
-        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
-      });
-    } finally {
-      initialMessageList.resolve();
-    }
+    await waitFor(() => {
+      expect(screen.getByText(prompt)).toBeInTheDocument();
+      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+    });
   });
 
   it("renders completed markdown and returns the composer to send mode", async () => {


### PR DESCRIPTION
## Summary

- Remove cleanup-only `try/finally` blocks from chat lifecycle tests that manually resolved pending deferred gates.
- Add coverage showing `context.mocks.deferred()` rejects when its backing abort signal is already aborted, matching the shared test context cleanup contract.
- Keep behavior-specific `resolve()` calls in place where the test needs to release a gate as part of the scenario.

## User-visible impact

This keeps platform tests closer to the intended async cleanup model: deferred test gates should be cleaned up by the test context abort signal instead of requiring every test to remember manual promise cleanup.

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/__tests__/test-mocks.test.ts apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx`
- `pnpm -F @vm0/app exec oxlint src/signals/__tests__/test-mocks.test.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx --deny-warnings`
- `pnpm -F @vm0/app exec eslint src/signals/__tests__/test-mocks.test.ts src/views/zero-page/__tests__/chat-lifecycle.test.tsx --max-warnings 0`
- `pnpm vitest --run apps/platform/src/signals/__tests__/test-mocks.test.ts`
- `pnpm vitest --run apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "projects the first-run model|renders the optimistic new chat message without skeleton"`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app run check-types`

Notes:
- Full `pnpm check-types` was attempted first and was killed in `@vm0/api-contracts` with exit 137 before reaching this app-only change.
- Full `pnpm turbo run lint --log-order grouped` was attempted and the platform type-aware lint process was SIGKILLed without code diagnostics; targeted lint on the changed files passed.
- The targeted chat lifecycle run still prints the existing transient retry 500 warning in the blocked-list case, but the selected tests pass.
