### PR TITLE
perf(nbd-cow): stream bitmap serialization

### DIFF
--- a/crates/nbd-cow/src/cow/bitmap.rs
+++ b/crates/nbd-cow/src/cow/bitmap.rs
@@ -77,9 +77,10 @@ fn write_bitmap_words<W: Write>(writer: &mut W, raw: &[usize]) -> std::io::Resul
         return Ok(());
     }
 
-    let mut chunk = vec![0u8; BITMAP_WRITE_CHUNK_BYTES];
+    let words_per_chunk = raw.len().min(BITMAP_WORDS_PER_WRITE_CHUNK);
+    let mut chunk = vec![0u8; words_per_chunk * 8];
 
-    for words in raw.chunks(BITMAP_WORDS_PER_WRITE_CHUNK) {
+    for words in raw.chunks(words_per_chunk) {
         let byte_len = words.len() * 8;
         for (word, dst) in words.iter().zip(chunk.chunks_exact_mut(8)) {
             dst.copy_from_slice(&(*word as u64).to_le_bytes());

--- a/crates/nbd-cow/src/cow/bitmap.rs
+++ b/crates/nbd-cow/src/cow/bitmap.rs
@@ -78,18 +78,14 @@ fn write_bitmap_words<W: Write>(writer: &mut W, raw: &[usize]) -> std::io::Resul
     }
 
     let words_per_chunk = raw.len().min(BITMAP_WORDS_PER_WRITE_CHUNK);
-    let mut chunk = vec![0u8; words_per_chunk * 8];
+    let mut chunk = Vec::with_capacity(words_per_chunk * 8);
 
     for words in raw.chunks(words_per_chunk) {
-        let byte_len = words.len() * 8;
-        for (word, dst) in words.iter().zip(chunk.chunks_exact_mut(8)) {
-            dst.copy_from_slice(&(*word as u64).to_le_bytes());
+        chunk.clear();
+        for word in words {
+            chunk.extend_from_slice(&(*word as u64).to_le_bytes());
         }
-
-        let bytes = chunk
-            .get(..byte_len)
-            .ok_or_else(|| std::io::Error::other("bitmap write chunk bounds invalid"))?;
-        writer.write_all(bytes)?;
+        writer.write_all(&chunk)?;
     }
 
     Ok(())

--- a/crates/nbd-cow/src/cow/bitmap.rs
+++ b/crates/nbd-cow/src/cow/bitmap.rs
@@ -1,6 +1,5 @@
 use std::fs::{File, OpenOptions};
-use std::io::{BufReader, Read};
-use std::os::unix::fs::FileExt;
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 
 use bitvec::prelude::*;
@@ -12,6 +11,9 @@ const _: () = assert!(
     std::mem::size_of::<usize>() == 8,
     "nbd-cow requires a 64-bit target"
 );
+const BITMAP_WRITE_CHUNK_BYTES: usize = 64 * 1024;
+const _: () = assert!(BITMAP_WRITE_CHUNK_BYTES.is_multiple_of(8));
+const BITMAP_WORDS_PER_WRITE_CHUNK: usize = BITMAP_WRITE_CHUNK_BYTES / 8;
 
 /// Save the dirty bitmap to a file.
 ///
@@ -20,11 +22,6 @@ const _: () = assert!(
 pub(super) fn save_bitmap(dirty: &BitVec, path: &Path) -> Result<()> {
     let num_blocks = dirty.len() as u64;
     let raw = dirty.as_raw_slice();
-    let mut data = Vec::with_capacity(8 + raw.len() * 8);
-    data.extend_from_slice(&num_blocks.to_le_bytes());
-    for word in raw {
-        data.extend_from_slice(&(*word as u64).to_le_bytes());
-    }
     // Crash-safe bitmap swap: write tmp → fsync(tmp) → rename → fsync(dir).
     // Two fsyncs, each covering a different guarantee:
     //   - fsync(tmp): makes the bitmap bytes durable on the inode.
@@ -58,8 +55,9 @@ pub(super) fn save_bitmap(dirty: &BitVec, path: &Path) -> Result<()> {
         .write(true)
         .create_new(true)
         .open(&tmp_path)
-        .and_then(|f| {
-            f.write_all_at(&data, 0)?;
+        .and_then(|mut f| {
+            f.write_all(&num_blocks.to_le_bytes())?;
+            write_bitmap_words(&mut f, raw)?;
             f.sync_all()
         })
     {
@@ -71,6 +69,28 @@ pub(super) fn save_bitmap(dirty: &BitVec, path: &Path) -> Result<()> {
         return Err(e.into());
     }
     dir_fd.sync_all()?;
+    Ok(())
+}
+
+fn write_bitmap_words<W: Write>(writer: &mut W, raw: &[usize]) -> std::io::Result<()> {
+    if raw.is_empty() {
+        return Ok(());
+    }
+
+    let mut chunk = vec![0u8; BITMAP_WRITE_CHUNK_BYTES];
+
+    for words in raw.chunks(BITMAP_WORDS_PER_WRITE_CHUNK) {
+        let byte_len = words.len() * 8;
+        for (word, dst) in words.iter().zip(chunk.chunks_exact_mut(8)) {
+            dst.copy_from_slice(&(*word as u64).to_le_bytes());
+        }
+
+        let bytes = chunk
+            .get(..byte_len)
+            .ok_or_else(|| std::io::Error::other("bitmap write chunk bounds invalid"))?;
+        writer.write_all(bytes)?;
+    }
+
     Ok(())
 }
 

--- a/crates/nbd-cow/src/cow/tests.rs
+++ b/crates/nbd-cow/src/cow/tests.rs
@@ -443,6 +443,33 @@ fn bitmap_save_uses_documented_file_layout() {
 }
 
 #[test]
+fn bitmap_save_preserves_large_file_layout() {
+    const WORDS_PER_64K_PAYLOAD: usize = 64 * 1024 / 8;
+    const WORDS: usize = WORDS_PER_64K_PAYLOAD + 2;
+    const BLOCKS: usize = WORDS * 64;
+
+    let mut dirty: BitVec = bitvec![0; BLOCKS];
+    dirty.set(0, true);
+    dirty.set(WORDS_PER_64K_PAYLOAD * 64, true);
+    dirty.set(BLOCKS - 1, true);
+
+    let bitmap_file = NamedTempFile::new().unwrap();
+    bitmap::save_bitmap(&dirty, bitmap_file.path()).unwrap();
+
+    let data = std::fs::read(bitmap_file.path()).unwrap();
+    assert_eq!(data.len(), 8 + WORDS * 8);
+    assert_eq!(&data[..8], &(BLOCKS as u64).to_le_bytes());
+    assert_eq!(bitmap_word(&data, 0), 1);
+    assert_eq!(bitmap_word(&data, WORDS_PER_64K_PAYLOAD), 1);
+    assert_eq!(bitmap_word(&data, WORDS - 1), 1u64 << 63);
+}
+
+fn bitmap_word(data: &[u8], word_index: usize) -> u64 {
+    let start = 8 + word_index * 8;
+    u64::from_le_bytes(data[start..start + 8].try_into().unwrap())
+}
+
+#[test]
 fn bitmap_load_wrong_block_count_errors() {
     let base = create_base_image(&vec![0x00; 8192]);
     let cow_file = NamedTempFile::new().unwrap();

--- a/crates/nbd-cow/src/cow/tests.rs
+++ b/crates/nbd-cow/src/cow/tests.rs
@@ -417,6 +417,32 @@ fn bitmap_save_load_round_trip() {
 }
 
 #[test]
+fn bitmap_save_uses_documented_file_layout() {
+    const BLOCK_SIZE: usize = 4096;
+    const BLOCKS: usize = 131;
+    let base = create_base_image(&vec![0x00; BLOCKS * BLOCK_SIZE]);
+    let cow_file = NamedTempFile::new().unwrap();
+    let mut cow = make_cow(&base, &cow_file, (BLOCKS * BLOCK_SIZE) as u64, 1024 * 1024);
+
+    cow.write(0, &vec![0xA0; BLOCK_SIZE]).unwrap();
+    cow.write((64 * BLOCK_SIZE) as u64, &vec![0xA1; BLOCK_SIZE])
+        .unwrap();
+    cow.write((130 * BLOCK_SIZE) as u64, &vec![0xA2; BLOCK_SIZE])
+        .unwrap();
+    cow.flush().unwrap();
+
+    let bitmap_file = NamedTempFile::new().unwrap();
+    cow.save_bitmap(bitmap_file.path()).unwrap();
+
+    let data = std::fs::read(bitmap_file.path()).unwrap();
+    assert_eq!(&data[..8], &(BLOCKS as u64).to_le_bytes());
+    assert_eq!(data.len(), 8 + 3 * 8);
+    assert_eq!(&data[8..16], &1u64.to_le_bytes());
+    assert_eq!(&data[16..24], &1u64.to_le_bytes());
+    assert_eq!(&data[24..32], &(1u64 << 2).to_le_bytes());
+}
+
+#[test]
 fn bitmap_load_wrong_block_count_errors() {
     let base = create_base_image(&vec![0x00; 8192]);
     let cow_file = NamedTempFile::new().unwrap();

--- a/crates/nbd-cow/src/cow/tests.rs
+++ b/crates/nbd-cow/src/cow/tests.rs
@@ -435,8 +435,8 @@ fn bitmap_save_uses_documented_file_layout() {
     cow.save_bitmap(bitmap_file.path()).unwrap();
 
     let data = std::fs::read(bitmap_file.path()).unwrap();
-    assert_eq!(&data[..8], &(BLOCKS as u64).to_le_bytes());
     assert_eq!(data.len(), 8 + 3 * 8);
+    assert_eq!(&data[..8], &(BLOCKS as u64).to_le_bytes());
     assert_eq!(&data[8..16], &1u64.to_le_bytes());
     assert_eq!(&data[16..24], &1u64.to_le_bytes());
     assert_eq!(&data[24..32], &(1u64 << 2).to_le_bytes());

--- a/crates/nbd-cow/src/cow_io.rs
+++ b/crates/nbd-cow/src/cow_io.rs
@@ -72,8 +72,11 @@ impl CowIo {
     }
 
     pub(crate) async fn save_bitmap(&self, path: PathBuf) -> Result<()> {
-        self.run("save bitmap", move |cow| cow.save_bitmap(&path))
-            .await
+        self.run("save bitmap", move |cow| {
+            cow.sync()?;
+            cow.save_bitmap(&path)
+        })
+        .await
     }
 
     /// Return a consistent snapshot of COW counters.
@@ -133,4 +136,66 @@ fn closed_error(operation: &str) -> NbdCowError {
     NbdCowError::Io(std::io::Error::other(format!(
         "COW I/O operation slot closed before {operation}",
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::{BLOCK_SIZE, cow::bitmap_path_for};
+
+    #[tokio::test]
+    async fn save_bitmap_flushes_buffered_writes() {
+        let mut base = NamedTempFile::new().unwrap();
+        base.write_all(&vec![0x11; BLOCK_SIZE]).unwrap();
+        base.flush().unwrap();
+        let cow_file = NamedTempFile::new().unwrap();
+        let cow = CowLayer::new(
+            base.path(),
+            cow_file.path(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE,
+            BLOCK_SIZE * 4,
+        )
+        .unwrap();
+        let cow = CowIo::new(cow);
+
+        let write_data = vec![0x22; BLOCK_SIZE];
+        cow.write(0, write_data.clone()).await.unwrap();
+        assert_eq!(
+            cow.status().await.unwrap(),
+            CowIoStatus {
+                dirty_blocks: 0,
+                buffered_blocks: 1,
+                buffer_bytes: BLOCK_SIZE,
+            }
+        );
+
+        cow.save_bitmap(bitmap_path_for(cow_file.path()))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            cow.status().await.unwrap(),
+            CowIoStatus {
+                dirty_blocks: 1,
+                buffered_blocks: 0,
+                buffer_bytes: 0,
+            }
+        );
+        let restored = CowLayer::new(
+            base.path(),
+            cow_file.path(),
+            BLOCK_SIZE as u64,
+            BLOCK_SIZE,
+            BLOCK_SIZE * 4,
+        )
+        .unwrap();
+        let mut restored_data = vec![0; BLOCK_SIZE];
+        restored.read(0, &mut restored_data).unwrap();
+        assert_eq!(restored_data, write_data);
+    }
 }


### PR DESCRIPTION
## Summary

- Stream COW bitmap serialization in fixed-size chunks instead of building one full serialized buffer.
- Keep the existing bitmap sidecar format and restore compatibility unchanged.
- Preserve the existing tmp-file, rename, and parent-directory fsync crash-safety sequence.
- Add a file-layout test for the documented bitmap header and word payload bytes.

Closes #20303

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow bitmap`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p nbd-cow --all-targets --all-features -- -D warnings`
- pre-commit lefthook: cargo-fmt, cargo-doc, cargo-clippy
