### PR TITLE
fix: fail artifact walk on unreadable children

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -48,60 +48,71 @@ fn walk_entries(
             parent: artifact_directory_path(relative),
             source,
         })?;
-        let name = entry.file_name();
-        if is_excluded_artifact_entry(&name) {
-            continue;
-        }
+        walk_entry(current, relative, entry, out)?;
+    }
+    Ok(())
+}
 
-        let file_type = entry.file_type().map_err(|source| ArchiveError::FileType {
-            parent: artifact_directory_path(relative),
-            component: format!("{name:?}"),
-            source,
-        })?;
+#[cfg(target_os = "linux")]
+fn walk_entry(
+    current: &Dir,
+    relative: &str,
+    entry: fs::DirEntry,
+    out: &mut Vec<FileEntry>,
+) -> Result<(), ArchiveError> {
+    let name = entry.file_name();
+    if is_excluded_artifact_entry(&name) {
+        return Ok(());
+    }
 
-        if file_type.is_dir() {
-            let name_str = artifact_path_component(&name, relative)?;
-            let rel = relative_artifact_path(relative, name_str);
-            let dir = current
-                .open_child_dir(&name)
-                .map_err(|source| ArchiveError::Open {
-                    path: rel.clone(),
-                    source,
-                })?;
-            walk_dir(&dir, &rel, out)?;
-            continue;
-        }
+    let file_type = entry.file_type().map_err(|source| ArchiveError::FileType {
+        parent: artifact_directory_path(relative),
+        component: format!("{name:?}"),
+        source,
+    })?;
 
-        if !file_type.is_file() {
-            continue;
-        }
-
+    if file_type.is_dir() {
         let name_str = artifact_path_component(&name, relative)?;
         let rel = relative_artifact_path(relative, name_str);
-        let file = current
-            .open_child_file(&name)
+        let dir = current
+            .open_child_dir(&name)
             .map_err(|source| ArchiveError::Open {
                 path: rel.clone(),
                 source,
             })?;
-        let metadata = file.metadata().map_err(|source| ArchiveError::Metadata {
+        walk_dir(&dir, &rel, out)?;
+        return Ok(());
+    }
+
+    if !file_type.is_file() {
+        return Ok(());
+    }
+
+    let name_str = artifact_path_component(&name, relative)?;
+    let rel = relative_artifact_path(relative, name_str);
+    let file = current
+        .open_child_file(&name)
+        .map_err(|source| ArchiveError::Open {
             path: rel.clone(),
             source,
         })?;
-        if !metadata.is_file() {
-            return Err(ArchiveError::NonRegular { path: rel });
-        }
-        let (hash, size) =
-            compute_file_hash_from_reader(file).map_err(|source| ArchiveError::Hash {
-                path: rel.clone(),
-                source,
-            })?;
-        out.push(FileEntry {
-            path: rel,
-            hash,
-            size,
-        });
+    let metadata = file.metadata().map_err(|source| ArchiveError::Metadata {
+        path: rel.clone(),
+        source,
+    })?;
+    if !metadata.is_file() {
+        return Err(ArchiveError::NonRegular { path: rel });
     }
+    let (hash, size) =
+        compute_file_hash_from_reader(file).map_err(|source| ArchiveError::Hash {
+            path: rel.clone(),
+            source,
+        })?;
+    out.push(FileEntry {
+        path: rel,
+        hash,
+        size,
+    });
     Ok(())
 }
 
@@ -599,29 +610,6 @@ mod tests {
         guest_common::log::clear_system_log_file();
     }
 
-    struct PermissionGuard {
-        path: PathBuf,
-        mode: u32,
-    }
-
-    impl PermissionGuard {
-        fn set(path: &Path, mode: u32) -> io::Result<Self> {
-            let original = std::fs::metadata(path)?.permissions().mode();
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
-            Ok(Self {
-                path: path.to_owned(),
-                mode: original,
-            })
-        }
-    }
-
-    impl Drop for PermissionGuard {
-        fn drop(&mut self) {
-            let _ =
-                std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(self.mode));
-        }
-    }
-
     struct FailingWriter;
 
     impl io::Write for FailingWriter {
@@ -685,30 +673,32 @@ mod tests {
     }
 
     #[test]
-    fn collect_file_metadata_fails_on_unreadable_nested_directory() {
+    fn walk_entry_fails_when_listed_directory_disappears() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let private = root.join("private");
         std::fs::create_dir(&private).unwrap();
         std::fs::write(private.join("secret.txt"), "secret").unwrap();
-        std::fs::write(root.join("visible.txt"), "visible").unwrap();
-        let _guard = PermissionGuard::set(&private, 0o000).unwrap();
+        let root_dir = Dir::open(root).unwrap();
+        let entry = std::fs::read_dir(root).unwrap().next().unwrap().unwrap();
+        std::fs::remove_dir_all(&private).unwrap();
 
-        let err = collect_file_metadata(root.to_str().unwrap()).unwrap_err();
+        let err = walk_entry(&root_dir, "", entry, &mut Vec::new()).unwrap_err();
 
         assert_error_contains(&err, &["private"]);
     }
 
     #[test]
-    fn collect_file_metadata_fails_on_unreadable_regular_file() {
+    fn walk_entry_fails_when_listed_regular_file_disappears() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
-        std::fs::write(root.join("visible.txt"), "visible").unwrap();
         let private_file = root.join("secret.txt");
         std::fs::write(&private_file, "secret").unwrap();
-        let _guard = PermissionGuard::set(&private_file, 0o000).unwrap();
+        let root_dir = Dir::open(root).unwrap();
+        let entry = std::fs::read_dir(root).unwrap().next().unwrap().unwrap();
+        std::fs::remove_file(&private_file).unwrap();
 
-        let err = collect_file_metadata(root.to_str().unwrap()).unwrap_err();
+        let err = walk_entry(&root_dir, "", entry, &mut Vec::new()).unwrap_err();
 
         assert_error_contains(&err, &["secret.txt"]);
     }

--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -3,14 +3,11 @@ use super::FileEntry;
 use crate::nofollow_fs::Dir;
 use flate2::Compression;
 use flate2::write::GzEncoder;
-use guest_common::log_warn;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, Metadata};
 use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
 use thiserror::Error;
-
-const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Walk directory and compute SHA-256 for each file, skipping `.git` and `.vm0`.
 #[cfg(target_os = "linux")]
@@ -32,10 +29,10 @@ pub(super) fn collect_file_metadata(dir_path: &str) -> Result<Vec<FileEntry>, Ar
 
 #[cfg(target_os = "linux")]
 fn walk_dir(current: &Dir, relative: &str, out: &mut Vec<FileEntry>) -> Result<(), ArchiveError> {
-    let entries = match current.read_dir() {
-        Ok(e) => e,
-        Err(_) => return Ok(()),
-    };
+    let entries = current.read_dir().map_err(|source| ArchiveError::ReadDir {
+        path: artifact_directory_path(relative),
+        source,
+    })?;
     walk_entries(current, relative, entries, out)
 }
 
@@ -46,40 +43,64 @@ fn walk_entries(
     entries: fs::ReadDir,
     out: &mut Vec<FileEntry>,
 ) -> Result<(), ArchiveError> {
-    for entry in entries.flatten() {
+    for entry_result in entries {
+        let entry = entry_result.map_err(|source| ArchiveError::ReadDirEntry {
+            parent: artifact_directory_path(relative),
+            source,
+        })?;
         let name = entry.file_name();
         if is_excluded_artifact_entry(&name) {
             continue;
         }
 
-        if let Ok(dir) = current.open_child_dir(&name) {
+        let file_type = entry.file_type().map_err(|source| ArchiveError::FileType {
+            parent: artifact_directory_path(relative),
+            component: format!("{name:?}"),
+            source,
+        })?;
+
+        if file_type.is_dir() {
             let name_str = artifact_path_component(&name, relative)?;
             let rel = relative_artifact_path(relative, name_str);
+            let dir = current
+                .open_child_dir(&name)
+                .map_err(|source| ArchiveError::Open {
+                    path: rel.clone(),
+                    source,
+                })?;
             walk_dir(&dir, &rel, out)?;
             continue;
         }
 
-        let Ok(file) = current.open_child_file(&name) else {
-            continue;
-        };
-        let Ok(metadata) = file.metadata() else {
-            continue;
-        };
-        if !metadata.is_file() {
+        if !file_type.is_file() {
             continue;
         }
+
         let name_str = artifact_path_component(&name, relative)?;
         let rel = relative_artifact_path(relative, name_str);
-        match compute_file_hash_from_reader(file) {
-            Ok((hash, size)) => out.push(FileEntry {
-                path: rel,
-                hash,
-                size,
-            }),
-            Err(e) => {
-                log_warn!(LOG_TAG, "Could not process file {rel}: {e}");
-            }
+        let file = current
+            .open_child_file(&name)
+            .map_err(|source| ArchiveError::Open {
+                path: rel.clone(),
+                source,
+            })?;
+        let metadata = file.metadata().map_err(|source| ArchiveError::Metadata {
+            path: rel.clone(),
+            source,
+        })?;
+        if !metadata.is_file() {
+            return Err(ArchiveError::NonRegular { path: rel });
         }
+        let (hash, size) =
+            compute_file_hash_from_reader(file).map_err(|source| ArchiveError::Hash {
+                path: rel.clone(),
+                source,
+            })?;
+        out.push(FileEntry {
+            path: rel,
+            hash,
+            size,
+        });
     }
     Ok(())
 }
@@ -95,6 +116,15 @@ fn relative_artifact_path(parent: &str, component: &str) -> String {
         component.to_string()
     } else {
         format!("{parent}/{component}")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn artifact_directory_path(relative: &str) -> String {
+    if relative.is_empty() {
+        ".".to_string()
+    } else {
+        relative.to_string()
     }
 }
 
@@ -152,6 +182,16 @@ pub(super) enum ArchiveError {
         "artifact path component is not valid UTF-8 under {parent:?}: {component}; artifact paths must be valid UTF-8"
     )]
     NonUtf8PathComponent { parent: String, component: String },
+    #[error("failed to read artifact directory {path:?}: {source}")]
+    ReadDir { path: String, source: io::Error },
+    #[error("failed to read artifact directory entry under {parent:?}: {source}")]
+    ReadDirEntry { parent: String, source: io::Error },
+    #[error("failed to read artifact entry type under {parent:?} for {component}: {source}")]
+    FileType {
+        parent: String,
+        component: String,
+        source: io::Error,
+    },
     #[error("failed to create archive output {}: {source}", path.display())]
     CreateOutput { path: PathBuf, source: io::Error },
     #[error("invalid archive path {path:?}: path must be relative and stay within the artifact")]
@@ -182,6 +222,8 @@ pub(super) enum ArchiveError {
     Append { path: String, source: io::Error },
     #[error("failed to verify archived content for {path:?}: {source}")]
     Verify { path: String, source: io::Error },
+    #[error("failed to hash {path:?}: {source}")]
+    Hash { path: String, source: io::Error },
     #[error("failed to finish tar archive: {source}")]
     FinishTar { source: io::Error },
     #[error("failed to finish gzip stream: {source}")]
@@ -557,6 +599,29 @@ mod tests {
         guest_common::log::clear_system_log_file();
     }
 
+    struct PermissionGuard {
+        path: PathBuf,
+        mode: u32,
+    }
+
+    impl PermissionGuard {
+        fn set(path: &Path, mode: u32) -> io::Result<Self> {
+            let original = std::fs::metadata(path)?.permissions().mode();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+            Ok(Self {
+                path: path.to_owned(),
+                mode: original,
+            })
+        }
+    }
+
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            let _ =
+                std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(self.mode));
+        }
+    }
+
     struct FailingWriter;
 
     impl io::Write for FailingWriter {
@@ -617,6 +682,35 @@ mod tests {
         for fragment in expected_fragments {
             assert!(msg.contains(fragment), "got: {msg}");
         }
+    }
+
+    #[test]
+    fn collect_file_metadata_fails_on_unreadable_nested_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let private = root.join("private");
+        std::fs::create_dir(&private).unwrap();
+        std::fs::write(private.join("secret.txt"), "secret").unwrap();
+        std::fs::write(root.join("visible.txt"), "visible").unwrap();
+        let _guard = PermissionGuard::set(&private, 0o000).unwrap();
+
+        let err = collect_file_metadata(root.to_str().unwrap()).unwrap_err();
+
+        assert_error_contains(&err, &["private"]);
+    }
+
+    #[test]
+    fn collect_file_metadata_fails_on_unreadable_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("visible.txt"), "visible").unwrap();
+        let private_file = root.join("secret.txt");
+        std::fs::write(&private_file, "secret").unwrap();
+        let _guard = PermissionGuard::set(&private_file, 0o000).unwrap();
+
+        let err = collect_file_metadata(root.to_str().unwrap()).unwrap_err();
+
+        assert_error_contains(&err, &["secret.txt"]);
     }
 
     #[test]

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -805,6 +805,10 @@ mod tests {
     use super::*;
     use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
     use httpmock::prelude::*;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(target_os = "linux")]
+    use std::path::{Path, PathBuf};
     use std::time::Duration;
 
     struct CheckpointFilesGuard {
@@ -829,6 +833,32 @@ mod tests {
     fn cleanup_checkpoint_files(guest_paths: &crate::paths::GuestPaths) {
         let _ = std::fs::remove_file(guest_paths.session_id_file());
         let _ = std::fs::remove_file(guest_paths.session_history_path_file());
+    }
+
+    #[cfg(target_os = "linux")]
+    struct PermissionGuard {
+        path: PathBuf,
+        mode: u32,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl PermissionGuard {
+        fn set(path: &Path, mode: u32) -> std::io::Result<Self> {
+            let original = std::fs::metadata(path)?.permissions().mode();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+            Ok(Self {
+                path: path.to_owned(),
+                mode: original,
+            })
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for PermissionGuard {
+        fn drop(&mut self) {
+            let _ =
+                std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(self.mode));
+        }
     }
 
     #[test]
@@ -1066,6 +1096,50 @@ mod tests {
             err.to_string().contains("Failed to walk artifact files"),
             "got: {err}"
         );
+        prepare.assert_calls(0);
+        commit.assert_calls(0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn artifact_snapshot_unreadable_child_fails_before_storage_api_calls() {
+        let server = MockServer::start();
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/prepare");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let commit = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/storages/commit");
+            then.status(200).json_body(json!({"unreachable": true}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("workspace");
+        std::fs::create_dir(&mount).unwrap();
+        std::fs::write(mount.join("visible.txt"), "visible").unwrap();
+        let private_file = mount.join("secret.txt");
+        std::fs::write(&private_file, "secret").unwrap();
+        let _guard = PermissionGuard::set(&private_file, 0o000).unwrap();
+        let entries = vec![env::ArtifactEnv {
+            name: "workspace".to_string(),
+            mount_path: mount.to_string_lossy().into_owned(),
+            storage_id: "storage-id".to_string(),
+            version_id: "parent-version".to_string(),
+            missing_root_policy: None,
+        }];
+
+        let err = snapshot_artifact_entries(&http, "test-run", &entries)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("Failed to walk artifact files"),
+            "got: {err}"
+        );
+        assert!(err.to_string().contains("secret.txt"), "got: {err}");
         prepare.assert_calls(0);
         commit.assert_calls(0);
     }

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -805,10 +805,6 @@ mod tests {
     use super::*;
     use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
     use httpmock::prelude::*;
-    #[cfg(target_os = "linux")]
-    use std::os::unix::fs::PermissionsExt;
-    #[cfg(target_os = "linux")]
-    use std::path::{Path, PathBuf};
     use std::time::Duration;
 
     struct CheckpointFilesGuard {
@@ -833,32 +829,6 @@ mod tests {
     fn cleanup_checkpoint_files(guest_paths: &crate::paths::GuestPaths) {
         let _ = std::fs::remove_file(guest_paths.session_id_file());
         let _ = std::fs::remove_file(guest_paths.session_history_path_file());
-    }
-
-    #[cfg(target_os = "linux")]
-    struct PermissionGuard {
-        path: PathBuf,
-        mode: u32,
-    }
-
-    #[cfg(target_os = "linux")]
-    impl PermissionGuard {
-        fn set(path: &Path, mode: u32) -> std::io::Result<Self> {
-            let original = std::fs::metadata(path)?.permissions().mode();
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
-            Ok(Self {
-                path: path.to_owned(),
-                mode: original,
-            })
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    impl Drop for PermissionGuard {
-        fn drop(&mut self) {
-            let _ =
-                std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(self.mode));
-        }
     }
 
     #[test]
@@ -1102,7 +1072,10 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn artifact_snapshot_unreadable_child_fails_before_storage_api_calls() {
+    async fn artifact_snapshot_walk_error_fails_before_storage_api_calls() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
         let server = MockServer::start();
         let prepare = server.mock(|when, then| {
             when.method(POST)
@@ -1120,9 +1093,8 @@ mod tests {
         let mount = dir.path().join("workspace");
         std::fs::create_dir(&mount).unwrap();
         std::fs::write(mount.join("visible.txt"), "visible").unwrap();
-        let private_file = mount.join("secret.txt");
-        std::fs::write(&private_file, "secret").unwrap();
-        let _guard = PermissionGuard::set(&private_file, 0o000).unwrap();
+        let invalid_name = OsStr::from_bytes(b"secret\xff.txt");
+        std::fs::write(mount.join(std::path::Path::new(invalid_name)), "secret").unwrap();
         let entries = vec![env::ArtifactEnv {
             name: "workspace".to_string(),
             mount_path: mount.to_string_lossy().into_owned(),
@@ -1139,7 +1111,7 @@ mod tests {
             err.to_string().contains("Failed to walk artifact files"),
             "got: {err}"
         );
-        assert!(err.to_string().contains("secret.txt"), "got: {err}");
+        assert!(err.to_string().contains("valid UTF-8"), "got: {err}");
         prepare.assert_calls(0);
         commit.assert_calls(0);
     }


### PR DESCRIPTION
## Summary

- fail artifact metadata collection when discovered child directories or regular files cannot be fully read
- classify artifact entries before traversal so symlinks/FIFOs remain intentional skips
- add regression coverage for unreadable child paths and checkpoint storage API short-circuiting

Closes #20302

## Tests

- cargo test --manifest-path crates/Cargo.toml -p guest-agent collect_file_metadata_fails_on_unreadable -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent artifact_snapshot_unreadable_child_fails_before_storage_api_calls -- --nocapture
- cargo test --manifest-path crates/Cargo.toml -p guest-agent artifact
- cargo test --manifest-path crates/Cargo.toml -p guest-agent checkpoint
- cargo test --manifest-path crates/Cargo.toml -p guest-agent
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings