### PR TITLE
refactor: migrate supervised lifecycle fixtures

### DIFF
--- a/crates/vsock-host/src/tests/exec_operation/supervised/lifecycle.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/lifecycle.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use vsock_proto::{
     ExecControlPolicy, ExecLifecyclePolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy,
-    MSG_EXEC_START,
 };
 
 use super::super::super::support::{
@@ -14,170 +13,129 @@ use super::super::super::support::{
 };
 use super::super::start_capture_operation;
 use super::support::{
-    send_guest_error, send_start_failed, supervised_request, supervised_stream_request,
+    send_guest_error, send_start_failed, start_pending_supervised_exec, supervised_request,
+    supervised_stream_request,
 };
 use crate::SupervisedExecRequest;
 use crate::operation_tracker::NormalOperationReadiness;
 
 #[tokio::test]
 async fn supervised_exec_returns_handle_after_exec_started() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("long-running"))
-                .await
-        })
-    };
+    let pending = start_pending_supervised_exec(supervised_request("long-running")).await;
 
-    let start = read_guest_message(&mut guest).await;
-    assert_eq!(start.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&start.payload).unwrap();
+    let decoded = vsock_proto::decode_exec_start(&pending.start.msg.payload).unwrap();
     assert_eq!(decoded.lifecycle, ExecLifecyclePolicy::Supervised);
     assert_eq!(decoded.timeout, ExecTimeoutPolicy::None);
     assert_eq!(decoded.control, ExecControlPolicy::Disabled);
 
-    assert!(
-        !task.is_finished(),
-        "supervised start must wait for exec_started"
-    );
+    pending.assert_waiting_for_started();
 
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
-    assert_eq!(handle.pid(), 123);
+    let mut started = pending.started_with_pid(123).await;
+    assert_eq!(started.handle.pid(), 123);
+    let start_seq = started.start.seq();
 
     send_exec_result(
-        &mut guest,
-        start.seq,
+        &mut started.guest,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"ok",
         b"",
     )
     .await;
-    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    let result = started.handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert_eq!(
-        normal_operation_readiness(&host),
+        normal_operation_readiness(&started.host),
         NormalOperationReadiness::Idle
     );
 }
 
 #[tokio::test]
 async fn supervised_exec_sends_stdin_bytes() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(SupervisedExecRequest {
-                stdin_bytes: Some(b"supervised-stdin"),
-                ..supervised_request("cat")
-            })
-            .await
-        })
-    };
+    let pending = start_pending_supervised_exec(SupervisedExecRequest {
+        stdin_bytes: Some(b"supervised-stdin"),
+        ..supervised_request("cat")
+    })
+    .await;
 
-    let start = read_guest_message(&mut guest).await;
-    assert_eq!(start.msg_type, MSG_EXEC_START);
-    let decoded = vsock_proto::decode_exec_start(&start.payload).unwrap();
+    let decoded = vsock_proto::decode_exec_start(&pending.start.msg.payload).unwrap();
     assert_eq!(decoded.lifecycle, ExecLifecyclePolicy::Supervised);
     assert_eq!(decoded.command, "cat");
     assert_eq!(decoded.stdin_bytes, Some(&b"supervised-stdin"[..]));
 
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let mut started = pending.started().await;
+    let start_seq = started.start.seq();
     send_exec_result(
-        &mut guest,
-        start.seq,
+        &mut started.guest,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"",
         b"",
     )
     .await;
-    let result = handle.wait(Duration::from_secs(5)).await.unwrap();
+    let result = started.handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
 }
 
 #[tokio::test]
 async fn supervised_exec_start_failed_before_started_returns_error() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("missing-binary"))
-                .await
-        })
-    };
+    let mut pending = start_pending_supervised_exec(supervised_request("missing-binary")).await;
+    let start_seq = pending.start.seq();
 
-    let start = read_guest_message(&mut guest).await;
-    send_start_failed(&mut guest, start.seq, "spawn failed").await;
+    send_start_failed(&mut pending.guest, start_seq, "spawn failed").await;
 
-    let err = match task.await.unwrap() {
+    let finished = pending.wait_start_result().await;
+    let err = match finished.start_result {
         Ok(_) => panic!("supervised exec should fail when start fails"),
         Err(err) => err,
     };
     assert_eq!(err.kind(), io::ErrorKind::Other);
     assert_eq!(err.to_string(), "spawn failed");
-    assert_eq!(operation_count(&host), 0);
+    assert_eq!(operation_count(&finished.host), 0);
     assert_eq!(
-        normal_operation_readiness(&host),
+        normal_operation_readiness(&finished.host),
         NormalOperationReadiness::Idle
     );
 }
 
 #[tokio::test]
 async fn supervised_exec_error_before_started_returns_error_without_cancel() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("guest-error-before-started"))
-                .await
-        })
-    };
+    let mut pending =
+        start_pending_supervised_exec(supervised_request("guest-error-before-started")).await;
+    let start_seq = pending.start.seq();
 
-    let start = read_guest_message(&mut guest).await;
-    send_guest_error(&mut guest, start.seq, "guest rejected start").await;
+    send_guest_error(&mut pending.guest, start_seq, "guest rejected start").await;
 
-    let err = match task.await.unwrap() {
+    let mut finished = pending.wait_start_result().await;
+    let err = match finished.start_result {
         Ok(_) => panic!("supervised exec should fail when guest returns an error before started"),
         Err(err) => err,
     };
     assert_eq!(err.kind(), io::ErrorKind::Other);
     assert_eq!(err.to_string(), "guest rejected start");
-    assert_eq!(operation_count(&host), 0);
+    assert_eq!(operation_count(&finished.host), 0);
     assert_eq!(
-        normal_operation_readiness(&host),
+        normal_operation_readiness(&finished.host),
         NormalOperationReadiness::Idle
     );
-    match guest.try_read(&mut [0u8; 1]) {
+    match finished.guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
         Ok(n) => panic!("guest start error must not send exec cancel; read {n} bytes"),
         Err(err) => panic!("unexpected read error after guest start error: {err}"),
     }
 
-    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+    assert_connection_accepts_exec_operation(&finished.host, &mut finished.guest).await;
 }
 
 #[tokio::test]
 async fn supervised_exec_output_before_started_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_stream_request("stream-before-start"))
-                .await
-        })
-    };
+    let mut pending =
+        start_pending_supervised_exec(supervised_stream_request("stream-before-start")).await;
+    let start_seq = pending.start.seq();
 
-    let start = read_guest_message(&mut guest).await;
     send_exec_output(
-        &mut guest,
-        start.seq,
+        &mut pending.guest,
+        start_seq,
         0,
         ExecOutputStream::Stdout,
         b"early",
@@ -185,10 +143,13 @@ async fn supervised_exec_output_before_started_poisons_connection() {
     )
     .await;
 
-    host.wait_until_closed(Duration::from_secs(5))
+    pending
+        .host
+        .wait_until_closed(Duration::from_secs(5))
         .await
         .unwrap();
-    let err = match task.await.unwrap() {
+    let finished = pending.wait_start_result().await;
+    let err = match finished.start_result {
         Ok(_) => panic!("supervised exec should fail when early output poisons the connection"),
         Err(err) => err,
     };
@@ -197,30 +158,26 @@ async fn supervised_exec_output_before_started_poisons_connection() {
 
 #[tokio::test]
 async fn supervised_exec_non_start_failed_result_before_started_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("result-before-start"))
-                .await
-        })
-    };
+    let mut pending =
+        start_pending_supervised_exec(supervised_request("result-before-start")).await;
+    let start_seq = pending.start.seq();
 
-    let start = read_guest_message(&mut guest).await;
     send_exec_result(
-        &mut guest,
-        start.seq,
+        &mut pending.guest,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"done",
         b"",
     )
     .await;
 
-    host.wait_until_closed(Duration::from_secs(5))
+    pending
+        .host
+        .wait_until_closed(Duration::from_secs(5))
         .await
         .unwrap();
-    let err = match task.await.unwrap() {
+    let finished = pending.wait_start_result().await;
+    let err = match finished.start_result {
         Ok(_) => panic!("supervised exec should fail when early result poisons the connection"),
         Err(err) => err,
     };
@@ -229,25 +186,21 @@ async fn supervised_exec_non_start_failed_result_before_started_poisons_connecti
 
 #[tokio::test]
 async fn supervised_exec_duplicate_started_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("duplicate-started"))
-                .await
-        })
-    };
+    let pending = start_pending_supervised_exec(supervised_request("duplicate-started")).await;
+    let mut started = pending.started_with_pid(123).await;
+    let start_seq = started.start.seq();
+    send_exec_started(&mut started.guest, start_seq, 456).await;
 
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
-    send_exec_started(&mut guest, start.seq, 456).await;
-
-    host.wait_until_closed(Duration::from_secs(5))
+    started
+        .host
+        .wait_until_closed(Duration::from_secs(5))
         .await
         .unwrap();
-    let err = handle.wait(Duration::from_secs(5)).await.unwrap_err();
+    let err = started
+        .handle
+        .wait(Duration::from_secs(5))
+        .await
+        .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
 }
 

--- a/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/support.rs
@@ -80,6 +80,22 @@ pub(super) struct PendingSupervisedExec {
 }
 
 impl PendingSupervisedExec {
+    pub(super) fn assert_waiting_for_started(&self) {
+        assert!(
+            !self.task.is_finished(),
+            "supervised start must wait for exec_started"
+        );
+    }
+
+    pub(super) async fn wait_start_result(self) -> PendingSupervisedExecResult {
+        let result = self.task.await.unwrap();
+        PendingSupervisedExecResult {
+            host: self.host,
+            guest: self.guest,
+            start_result: result,
+        }
+    }
+
     pub(super) async fn started(self) -> StartedSupervisedExec {
         self.started_with_pid(123).await
     }
@@ -94,6 +110,12 @@ impl PendingSupervisedExec {
             handle,
         }
     }
+}
+
+pub(super) struct PendingSupervisedExecResult {
+    pub(super) host: Arc<VsockHost>,
+    pub(super) guest: UnixStream,
+    pub(super) start_result: io::Result<SupervisedExecHandle>,
 }
 
 pub(super) struct StartedSupervisedExec {


### PR DESCRIPTION
## Summary

- add narrow pending-state helpers to the supervised exec test fixture
- migrate supervised lifecycle tests onto the shared pending/started fixture states
- keep protocol frame injection and decoded start assertions inline in the lifecycle tests

Closes #20301.

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised::lifecycle`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings`
- pre-commit hook: cargo-fmt, cargo-doc, cargo-clippy
