### PR TITLE
refactor: unify session history source resolution

### DIFF
--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -34,11 +34,9 @@ use crate::nofollow_fs::Dir;
 use guest_contracts::codex_thread_id::codex_thread_id_filename_key;
 use sha2::{Digest, Sha256};
 use std::ffi::OsStr;
-use std::io::{self, Read};
-use std::path::{Path, PathBuf};
-
-#[cfg(target_os = "linux")]
 use std::fs::File;
+use std::io::{self, BufReader, Read};
+use std::path::{Path, PathBuf};
 
 const CODEX_MARKER_PREFIX: &str = "CODEX_SEARCH:";
 pub(crate) const SESSION_HISTORY_MARKER_PAYLOAD_MAX_BYTES: usize = 64 * 1024;
@@ -138,46 +136,56 @@ pub(crate) fn digest_session_history_from_payload_bounded(
     payload: &str,
     max_bytes: u64,
 ) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
-    if is_codex_marker(payload) {
-        let Some((sessions_dir, thread_id)) = decode_marker(payload) else {
-            return Err(SessionHistoryDigestError::Read(AgentError::Checkpoint(
-                "Invalid Codex session history marker".to_string(),
-            )));
-        };
-        return digest_codex_session_history(&sessions_dir, thread_id, max_bytes)?.ok_or_else(
-            || {
-                SessionHistoryDigestError::Read(AgentError::Checkpoint(format!(
-                    "Codex session file not found under {}",
-                    sessions_dir.display()
-                )))
-            },
-        );
-    }
-
-    let session_path = PathBuf::from(payload);
-    digest_history_bytes(&session_path, max_bytes)
+    resolve_session_history_source(payload)?.digest(max_bytes)
 }
 
 fn read_session_history_from_payload_impl(
     payload: &str,
     max_bytes: Option<u64>,
 ) -> Result<Vec<u8>, AgentError> {
+    resolve_session_history_source(payload)?.read(max_bytes)
+}
+
+fn resolve_session_history_source(
+    payload: &str,
+) -> Result<ResolvedSessionHistorySource, AgentError> {
     if is_codex_marker(payload) {
         let Some((sessions_dir, thread_id)) = decode_marker(payload) else {
             return Err(AgentError::Checkpoint(
                 "Invalid Codex session history marker".to_string(),
             ));
         };
-        return read_codex_session_history(&sessions_dir, thread_id, max_bytes)?.ok_or_else(|| {
-            AgentError::Checkpoint(format!(
-                "Codex session file not found under {}",
-                sessions_dir.display()
-            ))
-        });
+        return resolve_codex_session_history(&sessions_dir, thread_id)?
+            .map(ResolvedSessionHistorySource::Codex)
+            .ok_or_else(|| codex_session_not_found_error(&sessions_dir));
     }
 
-    let session_path = PathBuf::from(payload);
-    read_history_bytes(&session_path, max_bytes)
+    Ok(ResolvedSessionHistorySource::Literal(PathBuf::from(
+        payload,
+    )))
+}
+
+enum ResolvedSessionHistorySource {
+    Literal(PathBuf),
+    Codex(ResolvedCodexSession),
+}
+
+impl ResolvedSessionHistorySource {
+    fn read(self, max_bytes: Option<u64>) -> Result<Vec<u8>, AgentError> {
+        self.open_decoded_reader()?.read(max_bytes)
+    }
+
+    fn digest(self, max_bytes: u64) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+        self.open_decoded_reader()?.digest(max_bytes)
+    }
+
+    fn open_decoded_reader(self) -> Result<DecodedSessionHistoryReader, AgentError> {
+        let (path, file) = match self {
+            Self::Literal(path) => open_session_history_file(path)?,
+            Self::Codex(session) => session.into_file()?,
+        };
+        DecodedSessionHistoryReader::open(path, file)
+    }
 }
 
 /// Parse a Codex marker into `(dir, thread_id)`. Markers are length-prefixed so
@@ -205,32 +213,17 @@ fn decode_len_prefixed_marker(rest: &str) -> Option<(PathBuf, &str)> {
     Some((PathBuf::from(dir), thread_id))
 }
 
-fn read_codex_session_history(
+fn resolve_codex_session_history(
     sessions_dir: &Path,
     thread_id: &str,
-    max_bytes: Option<u64>,
-) -> Result<Option<Vec<u8>>, AgentError> {
+) -> Result<Option<ResolvedCodexSession>, AgentError> {
     let Some(id_norm) = codex_thread_id_filename_key(thread_id) else {
         return Ok(None);
     };
     if !codex_sessions_parent_is_usable(sessions_dir)? {
         return Ok(None);
     }
-    read_codex_session_history_impl(sessions_dir, &id_norm, max_bytes)
-}
-
-fn digest_codex_session_history(
-    sessions_dir: &Path,
-    thread_id: &str,
-    max_bytes: u64,
-) -> Result<Option<SessionHistoryDigest>, SessionHistoryDigestError> {
-    let Some(id_norm) = codex_thread_id_filename_key(thread_id) else {
-        return Ok(None);
-    };
-    if !codex_sessions_parent_is_usable(sessions_dir)? {
-        return Ok(None);
-    }
-    digest_codex_session_history_impl(sessions_dir, &id_norm, max_bytes)
+    resolve_codex_session_history_impl(sessions_dir, &id_norm)
 }
 
 fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentError> {
@@ -247,11 +240,10 @@ fn codex_sessions_parent_is_usable(sessions_dir: &Path) -> Result<bool, AgentErr
     }
 }
 
-fn read_codex_session_history_impl(
+fn resolve_codex_session_history_impl(
     sessions_dir: &Path,
     id_norm: &str,
-    max_bytes: Option<u64>,
-) -> Result<Option<Vec<u8>>, AgentError> {
+) -> Result<Option<ResolvedCodexSession>, AgentError> {
     let Some(root) = CodexSessionDir::open_root(sessions_dir)? else {
         return Ok(None);
     };
@@ -265,28 +257,14 @@ fn read_codex_session_history_impl(
         &mut found,
         &mut budget,
     )?;
-    found.map(|session| session.read(max_bytes)).transpose()
+    Ok(found)
 }
 
-fn digest_codex_session_history_impl(
-    sessions_dir: &Path,
-    id_norm: &str,
-    max_bytes: u64,
-) -> Result<Option<SessionHistoryDigest>, SessionHistoryDigestError> {
-    let Some(root) = CodexSessionDir::open_root(sessions_dir)? else {
-        return Ok(None);
-    };
-    let mut found = None;
-    let mut budget = CodexSessionLookupBudget::new();
-    scan_codex_session_dirs(
-        &root,
-        root.path(),
-        CodexSessionDateLevel::Year,
-        id_norm,
-        &mut found,
-        &mut budget,
-    )?;
-    found.map(|session| session.digest(max_bytes)).transpose()
+fn codex_session_not_found_error(sessions_dir: &Path) -> AgentError {
+    AgentError::Checkpoint(format!(
+        "Codex session file not found under {}",
+        sessions_dir.display()
+    ))
 }
 
 fn scan_codex_session_dirs(
@@ -509,27 +487,15 @@ struct ResolvedCodexSession {
 }
 
 impl ResolvedCodexSession {
-    fn read(self, max_bytes: Option<u64>) -> Result<Vec<u8>, AgentError> {
+    fn into_file(self) -> Result<(PathBuf, File), AgentError> {
         #[cfg(target_os = "linux")]
         {
-            read_history_bytes_from_file(&self.path, self.file, max_bytes)
+            Ok((self.path, self.file))
         }
 
         #[cfg(not(target_os = "linux"))]
         {
-            read_history_bytes(&self.path, max_bytes)
-        }
-    }
-
-    fn digest(self, max_bytes: u64) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
-        #[cfg(target_os = "linux")]
-        {
-            digest_history_bytes_from_file(&self.path, self.file, max_bytes)
-        }
-
-        #[cfg(not(target_os = "linux"))]
-        {
-            digest_history_bytes(&self.path, max_bytes)
+            open_session_history_file(self.path)
         }
     }
 }
@@ -618,120 +584,76 @@ fn is_filesystem_loop_error(_: &io::Error) -> bool {
     false
 }
 
-/// Read the bytes at `path`, decompressing legacy zstd files if the extension is `.zst`.
-fn read_history_bytes(path: &Path, max_bytes: Option<u64>) -> Result<Vec<u8>, AgentError> {
-    let file = std::fs::File::open(path).map_err(|e| read_history_error(path, e))?;
-    read_history_bytes_from_reader(path, file, max_bytes)
-}
-
-fn digest_history_bytes(
-    path: &Path,
-    max_bytes: u64,
-) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
-    let file = std::fs::File::open(path).map_err(|e| read_history_error(path, e))?;
-    digest_history_bytes_from_reader(path, file, max_bytes)
-}
-
-#[cfg(target_os = "linux")]
-fn read_history_bytes_from_file(
-    path: &Path,
-    file: File,
-    max_bytes: Option<u64>,
-) -> Result<Vec<u8>, AgentError> {
-    read_history_bytes_from_reader(path, file, max_bytes)
-}
-
-#[cfg(target_os = "linux")]
-fn digest_history_bytes_from_file(
-    path: &Path,
-    file: File,
-    max_bytes: u64,
-) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
-    digest_history_bytes_from_reader(path, file, max_bytes)
+fn open_session_history_file(path: PathBuf) -> Result<(PathBuf, File), AgentError> {
+    let file = File::open(&path).map_err(|e| read_history_error(&path, e))?;
+    Ok((path, file))
 }
 
 fn read_history_error(_path: &Path, source: io::Error) -> AgentError {
     AgentError::Checkpoint(format!("Failed to read session history: {source}"))
 }
 
-fn read_history_bytes_from_reader(
-    path: &Path,
-    reader: impl Read,
-    max_bytes: Option<u64>,
-) -> Result<Vec<u8>, AgentError> {
-    if path
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
-    {
-        let decoder = zstd::stream::read::Decoder::new(reader).map_err(|e| {
-            AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
-        })?;
-        return read_zstd_history_reader(decoder, max_bytes);
-    }
-    read_history_reader(path, reader, max_bytes)
+enum DecodedSessionHistoryReader {
+    Plain { path: PathBuf, reader: File },
+    Zstd(zstd::stream::read::Decoder<'static, BufReader<File>>),
 }
 
-fn digest_history_bytes_from_reader(
-    path: &Path,
-    reader: impl Read,
-    max_bytes: u64,
-) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
-    if path
-        .extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
-    {
-        let decoder = zstd::stream::read::Decoder::new(reader).map_err(|e| {
-            SessionHistoryDigestError::Read(AgentError::Checkpoint(format!(
-                "Failed to decompress zstd session history: {e}"
-            )))
-        })?;
-        return digest_history_reader(decoder, max_bytes, |e| {
-            AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
-        });
+impl DecodedSessionHistoryReader {
+    fn open(path: PathBuf, file: File) -> Result<Self, AgentError> {
+        if is_zstd_session_history(&path) {
+            let decoder =
+                zstd::stream::read::Decoder::new(file).map_err(zstd_session_history_error)?;
+            return Ok(Self::Zstd(decoder));
+        }
+
+        Ok(Self::Plain { path, reader: file })
     }
-    digest_history_reader(reader, max_bytes, |e| read_history_error(path, e))
+
+    fn read(self, max_bytes: Option<u64>) -> Result<Vec<u8>, AgentError> {
+        match self {
+            Self::Plain { path, reader } => {
+                read_history_reader(reader, max_bytes, |e| read_history_error(&path, e))
+            }
+            Self::Zstd(reader) => {
+                read_history_reader(reader, max_bytes, zstd_session_history_error)
+            }
+        }
+    }
+
+    fn digest(self, max_bytes: u64) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+        match self {
+            Self::Plain { path, reader } => {
+                digest_history_reader(reader, max_bytes, |e| read_history_error(&path, e))
+            }
+            Self::Zstd(reader) => {
+                digest_history_reader(reader, max_bytes, zstd_session_history_error)
+            }
+        }
+    }
 }
 
-fn read_zstd_history_reader(
+fn zstd_session_history_error(source: io::Error) -> AgentError {
+    AgentError::Checkpoint(format!(
+        "Failed to decompress zstd session history: {source}"
+    ))
+}
+
+fn is_zstd_session_history(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("zst"))
+}
+
+fn read_history_reader(
     mut reader: impl Read,
     max_bytes: Option<u64>,
+    map_error: impl Fn(io::Error) -> AgentError,
 ) -> Result<Vec<u8>, AgentError> {
     let mut bytes = Vec::new();
     match decoded_read_limit(max_bytes) {
         Some(limit) => reader.by_ref().take(limit).read_to_end(&mut bytes),
         None => reader.read_to_end(&mut bytes),
     }
-    .map_err(|e| {
-        AgentError::Checkpoint(format!("Failed to decompress zstd session history: {e}"))
-    })?;
-    if let Some(max_bytes) = max_bytes
-        && bytes.len() as u64 > max_bytes
-    {
-        return Err(session_history_exceeds_max_error(max_bytes));
-    }
-    Ok(bytes)
-}
-
-fn read_history_reader(
-    path: &Path,
-    mut reader: impl Read,
-    max_bytes: Option<u64>,
-) -> Result<Vec<u8>, AgentError> {
-    let mut bytes = Vec::new();
-    match decoded_read_limit(max_bytes) {
-        Some(limit) => {
-            reader
-                .by_ref()
-                .take(limit)
-                .read_to_end(&mut bytes)
-                .map_err(|e| read_history_error(path, e))?;
-        }
-        None => {
-            reader
-                .read_to_end(&mut bytes)
-                .map_err(|e| read_history_error(path, e))?;
-        }
-    }
+    .map_err(map_error)?;
     if let Some(max_bytes) = max_bytes
         && bytes.len() as u64 > max_bytes
     {
@@ -888,6 +810,29 @@ mod tests {
     }
 
     #[test]
+    fn codex_zstd_marker_read_and_digest_are_consistent() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        let day_dir = sessions_dir.join("2026").join("07").join("02");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+        let history = br#"{"type":"session_meta","timestamp":"2026-07-02T10:00:00Z"}"#;
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        let path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
+        std::fs::write(path, compressed).unwrap();
+        let payload = codex_marker_payload(&sessions_dir, thread_id);
+
+        let bytes =
+            read_session_history_from_payload_bounded(&payload, history.len() as u64).unwrap();
+        let digest =
+            digest_session_history_from_payload_bounded(&payload, history.len() as u64).unwrap();
+
+        assert_eq!(bytes, history);
+        assert_eq!(digest.size_bytes, history.len() as u64);
+        assert_eq!(digest.sha256_hex, hex::encode(Sha256::digest(history)));
+    }
+
+    #[test]
     fn bounded_read_allows_literal_history_with_u64_max_limit() {
         let dir = tempfile::tempdir().unwrap();
         let path = write_history_file(&dir, "history.jsonl", b"abcde");
@@ -954,11 +899,11 @@ mod tests {
 // (both Claude literal-path and codex marker -> bounded layout scan + zstd
 // decode) lives in `crates/guest-agent/tests/session_history_read.rs`.
 // The internal helpers
-// (`read_codex_session_history`, `codex_session_filename_matches`,
-// `read_history_bytes`, `decode_marker`) are exercised transitively by
-// those integration tests. Inline coverage above is limited to the
-// `read_session_history_from_payload_bounded` cap contract because the public
-// entry point cannot pass a small test cap.
+// (`resolve_session_history_source`, `codex_session_filename_matches`,
+// `DecodedSessionHistoryReader`, `decode_marker`) are exercised transitively by
+// those integration tests. Inline coverage above focuses on the bounded read
+// cap contract and read/digest parity because the public entry point cannot
+// pass a small test cap.
 //
 // `decode_marker` is the one piece of non-trivial parsing logic; if it
 // regresses, the integration tests will catch it because the codex flow


### PR DESCRIPTION
## Summary

- Resolve literal and Codex session-history payloads through one shared source-resolution path.
- Open resolved sources through one decoded-reader layer so plain and zstd history handling is shared by read and digest consumers.
- Keep checkpoint reads byte-collecting and final identity digest streaming, preserving the existing digest over-limit error path.
- Add Codex marker + zstd parity coverage for bounded read and digest.

Closes #20293

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent session_history`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent session_history_identity`
- `cargo fmt --all --check` from `crates/`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- pre-commit hooks: cargo fmt, cargo doc, cargo clippy
