### PR TITLE
fix(platform): match artifact edit fullscreen preview layer

### DIFF
--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -79,4 +79,12 @@ describe("platform entrypoint safe area behavior", () => {
       /\.zero-viewport-shell\s*{[\s\S]*height:\s*var\(--zero-viewport-height\);[\s\S]*max-height:\s*var\(--zero-viewport-height\);[\s\S]*overflow:\s*hidden;/,
     );
   });
+
+  it("keeps artifact fullscreen above app chrome", () => {
+    const globalCss = readGlobalCss();
+
+    expect(globalCss).toMatch(
+      /\.zero-app\[data-zero-artifact-fullscreen="true"\]\s+\.zero-workspace-bg\s*{[\s\S]*z-index:\s*60;[\s\S]*}/,
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -1047,6 +1047,10 @@ details[open] > summary > span:first-child {
   z-index: 0;
 }
 
+.zero-app[data-zero-artifact-fullscreen="true"] .zero-workspace-bg {
+  z-index: 60;
+}
+
 .zero-workspace-bg::before {
   content: "";
   position: absolute;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -462,8 +462,12 @@ async function backToArtifactInbox(): Promise<void> {
   });
 }
 
-function expectFullscreenSafeAreaClass(element: HTMLElement): void {
+function expectFullscreenSafeAreaClass(
+  element: HTMLElement,
+  layerClassName = "z-[100]",
+): void {
   const className = element.getAttribute("class") ?? "";
+  expect(className).toContain(layerClassName);
   expect(className).toContain("pt-[var(--sat)]");
   expect(className).toContain("pb-[var(--sab)]");
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1269,6 +1269,41 @@ describe("zero artifact sidebar", () => {
     });
   });
 
+  it("marks app chrome while the artifact sidebar is fullscreen", async () => {
+    const user = userEvent.setup({ delay: null });
+    const imageUrl =
+      "https://cdn.vm7.io/artifacts/test/fullscreen-layer/photo.png";
+    setupChatThread({
+      content: `[photo](${imageUrl})`,
+      path: `${THREAD_PATH}?artifact=${encodeURIComponent(imageUrl)}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+      expect(screen.getByLabelText("Enter fullscreen")).toBeInTheDocument();
+    });
+
+    const app = document.querySelector(".zero-app");
+    if (!(app instanceof HTMLElement)) {
+      throw new Error("Zero app shell not found");
+    }
+
+    expect(app).not.toHaveAttribute("data-zero-artifact-fullscreen");
+
+    await user.click(screen.getByLabelText("Enter fullscreen"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
+      expect(app).toHaveAttribute("data-zero-artifact-fullscreen", "true");
+    });
+    expectFullscreenSafeAreaClass(screen.getByTestId("artifact-sidebar"));
+
+    await user.click(screen.getByLabelText("Exit fullscreen"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Enter fullscreen")).toBeInTheDocument();
+      expect(app).not.toHaveAttribute("data-zero-artifact-fullscreen");
+    });
+  });
+
   it("navigates sidebar image artifacts within the current run", async () => {
     const user = userEvent.setup({ delay: null });
     const firstImageUrl =

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -3989,6 +3989,7 @@ describe("zero attachment chips", () => {
       expect(screen.getByTestId("html-dom-comment-frame")).toBeInTheDocument();
       expectHostedSiteEditingHeader({ fullscreen: true });
     });
+    expect(screen.getByTestId("artifact-sidebar")).toHaveClass("z-[9999]");
 
     click(screen.getByTestId("artifact-sidebar-exit-html-edit"));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
@@ -267,6 +267,7 @@ describe("image editing", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
     });
+    expect(screen.getByTestId("artifact-sidebar")).toHaveClass("z-[9999]");
     expect(screen.queryByLabelText("Share artifact")).toBeNull();
     expect(screen.queryByLabelText("Download artifact")).toBeNull();
 
@@ -286,6 +287,7 @@ describe("image editing", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
     });
+    expect(screen.getByTestId("artifact-sidebar")).toHaveClass("z-[9999]");
     expect(
       screen.getByTestId("artifact-sidebar-image-edit-canvas"),
     ).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -48,6 +48,7 @@ import {
   IosInstallModal,
 } from "../pwa-install/install-banner.tsx";
 import {
+  artifactFullscreen$,
   currentArtifactInboxThreadId$,
   openArtifactInbox$,
 } from "../../signals/zero-page/zero-artifact-sidebar.ts";
@@ -251,9 +252,13 @@ function SettingsDialogMount() {
 function SidebarLayoutInner({ children }: { children: ReactNode }) {
   const expanded = useGet(sidebarExpanded$);
   const setExpanded = useSet(setSidebarExpanded$);
+  const artifactFullscreen = useGet(artifactFullscreen$);
 
   return (
-    <div className="zero-app zero-viewport-shell flex w-full bg-background">
+    <div
+      className="zero-app zero-viewport-shell flex w-full bg-background"
+      data-zero-artifact-fullscreen={artifactFullscreen || undefined}
+    >
       <OrgManageDialogMount />
       <SettingsDialogMount />
       <ChatShortcutHelpDialog />

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -135,7 +135,9 @@ import type { HtmlDomEditDraft } from "./html-dom-edit-types.ts";
 // ---------------------------------------------------------------------------
 
 const ARTIFACT_FULLSCREEN_SHELL_CLASSNAME =
-  "fixed inset-0 z-[100] flex min-h-0 flex-col bg-background pt-[var(--sat)] pb-[var(--sab)]";
+  "fixed inset-0 flex min-h-0 flex-col bg-background pt-[var(--sat)] pb-[var(--sab)]";
+const ARTIFACT_FULLSCREEN_DEFAULT_LAYER_CLASSNAME = "z-[100]";
+const ARTIFACT_FULLSCREEN_EDIT_LAYER_CLASSNAME = "z-[9999]";
 
 export function ArtifactSidebar({
   artifactRef,
@@ -694,7 +696,10 @@ function ArtifactSidebarResolvedContent({
   );
 
   return (
-    <ArtifactSidebarSurface fullscreen={fullscreen}>
+    <ArtifactSidebarSurface
+      editing={htmlCommentMode || imageEditActive}
+      fullscreen={fullscreen}
+    >
       <ArtifactSidebarHeader
         title={display.filename}
         kind={display.kind}
@@ -984,16 +989,23 @@ function artifactSidebarFullscreenToggleAction({
 
 function ArtifactSidebarSurface({
   children,
+  editing,
   fullscreen,
 }: {
   children: ReactNode;
+  editing: boolean;
   fullscreen: boolean;
 }) {
   return (
     <div
       className={cn(
         fullscreen
-          ? ARTIFACT_FULLSCREEN_SHELL_CLASSNAME
+          ? cn(
+              ARTIFACT_FULLSCREEN_SHELL_CLASSNAME,
+              editing
+                ? ARTIFACT_FULLSCREEN_EDIT_LAYER_CLASSNAME
+                : ARTIFACT_FULLSCREEN_DEFAULT_LAYER_CLASSNAME,
+            )
           : "flex h-full w-full min-h-0 flex-col border-l border-border/60 bg-background xl:border-l-0",
         "animate-in fade-in duration-[180ms] ease",
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -430,7 +430,11 @@ function HtmlEditSnapshotRestoreDialog({
         }
       }}
     >
-      <DialogContent data-testid="html-edit-snapshot-restore-dialog">
+      <DialogContent
+        className="!z-[10000]"
+        data-testid="html-edit-snapshot-restore-dialog"
+        overlayClassName="!z-[10000]"
+      >
         <DialogHeader>
           <DialogTitle>Resume HTML draft?</DialogTitle>
           <DialogDescription>

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -29,13 +29,19 @@ const DialogOverlay = React.forwardRef<
 });
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps extends React.ComponentPropsWithoutRef<
+  typeof DialogPrimitive.Content
+> {
+  readonly overlayClassName?: string;
+}
+
 const DialogContent = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => {
+  DialogContentProps
+>(({ className, overlayClassName, children, ...props }, ref) => {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         ref={ref}
         className={cn(


### PR DESCRIPTION
## Summary
- Keep the default artifact fullscreen layer at its existing `z-[100]` level.
- Use the fullscreen preview/lightbox layer `z-[9999]` only while the artifact sidebar is in hosted-site HTML edit or image edit mode.
- Add regression assertions for default artifact fullscreen, hosted-site edit fullscreen, and image edit fullscreen layer classes.

## Verification
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-image-edit.test.tsx -t "keeps fullscreen when opening image edit from a fullscreen lightbox"`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-attachment-chips.test.tsx -t "keeps hosted-site edit fullscreen when fullscreen is entered before editing"`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "keeps image sidebar zoom controls bounded and resettable"`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "browses artifact inbox sections, searches, and opens a result"`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx`
- `pnpm -F @vm0/app exec eslint src/views/zero-page/zero-artifact-sidebar.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx src/views/zero-page/__tests__/zero-image-edit.test.tsx --max-warnings 0`