### PR TITLE
fix: give add automation trigger picker a minimum height so it no longer looks squished

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -2553,7 +2553,7 @@ function TriggerCreateMenu({
             Choose a trigger to start this workflow.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-5 sm:flex-row sm:gap-7">
+        <div className="flex flex-col gap-5 sm:min-h-[20rem] sm:flex-row sm:gap-7">
           <nav className="-ml-2 flex gap-1 overflow-x-auto pb-1 sm:w-44 sm:shrink-0 sm:flex-col sm:gap-1 sm:overflow-visible sm:border-r sm:border-border/60 sm:pb-0 sm:pr-4">
             {categories.map((category) => {
               return (


### PR DESCRIPTION
## Problem

The **Add automation** trigger picker dialog (`TriggerCreateMenu` in `turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx`) sizes its height purely from content. Categories with only a few cards — e.g. **Schedule** with 3 cards (2 rows) — collapse the modal into a short, flat box. The height also jumps when switching between categories that hold different numbers of cards.

## Fix

Added a `sm:min-h-[20rem]` (320px) floor to the dialog body row:

```
<div className="flex flex-col gap-5 sm:min-h-[20rem] sm:flex-row sm:gap-7">
```

## User-visible impact

- The modal keeps a comfortable minimum height, so sparse categories no longer look squished.
- Height stays stable when switching categories, removing the jump.
- The left category rail's divider stays nicely proportioned.
- Scoped to the `sm` breakpoint and up, so the mobile stacked layout is unaffected.

## Verification

Tailwind class-only change; relying on the PR pipeline for lint/type/test checks.