### PR TITLE
fix(platform): show feedback toolbar for multiline assistant selections

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -8,6 +8,7 @@ import { onDomEventFn, onRef, resetSignal } from "../utils.ts";
 // Assistant message bubbles carry this class in the chat thread. Text selected
 // inside one of them is what we offer feedback on.
 const ASSISTANT_BUBBLE_SELECTOR = ".zero-chat-bubble-assistant";
+const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
 
 // Each chat thread renders inside a container tagged with its thread id. We
 // read it off the selection so a feedback draft stays bound to its own thread.
@@ -70,10 +71,38 @@ export const feedbackSendCountValue$ = computed((get) => {
   }).length;
 });
 
-function resolveSelectionBubble(range: Range): Element | null {
-  const node = range.commonAncestorContainer;
+function closestAssistantBubble(node: Node | null): Element | null {
+  if (!node) {
+    return null;
+  }
   const element = node instanceof Element ? node : node.parentElement;
   return element?.closest(ASSISTANT_BUBBLE_SELECTOR) ?? null;
+}
+
+function resolveSelectionBubble(range: Range): Element | null {
+  const commonBubble = closestAssistantBubble(range.commonAncestorContainer);
+  if (commonBubble) {
+    return commonBubble;
+  }
+
+  // Multi-line selections can report an outer message group as the range's
+  // common ancestor even when both endpoints are inside assistant bubbles.
+  const startBubble = closestAssistantBubble(range.startContainer);
+  const endBubble = closestAssistantBubble(range.endContainer);
+  if (!startBubble || !endBubble) {
+    return null;
+  }
+  if (startBubble === endBubble) {
+    return startBubble;
+  }
+
+  const startGroup = startBubble.closest(ASSISTANT_GROUP_SELECTOR);
+  const endGroup = endBubble.closest(ASSISTANT_GROUP_SELECTOR);
+  if (startGroup !== null && startGroup === endGroup) {
+    return startBubble;
+  }
+
+  return null;
 }
 
 // The id of the thread that owns the selected passage, or null when it sits

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -53,6 +53,44 @@ function selectTextForInlineFeedback(element: HTMLElement): void {
   document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 }
 
+function selectTextAcrossElementsForInlineFeedback(
+  startElement: HTMLElement,
+  endElement: HTMLElement,
+): void {
+  const startNode = startElement.firstChild;
+  const endNode = endElement.firstChild;
+  if (!(startNode instanceof Text) || !(endNode instanceof Text)) {
+    throw new Error("Selection endpoints must be text nodes");
+  }
+  const range = document.createRange();
+  range.setStart(startNode, 0);
+  range.setEnd(endNode, endNode.textContent?.length ?? 0);
+  const assistantGroup = startElement.closest('[data-role="assistant"]');
+  if (!assistantGroup) {
+    throw new Error("Assistant group not found");
+  }
+  // Browser multi-line selections can report a message group rather than the
+  // assistant bubble as the range's common ancestor.
+  Object.defineProperty(range, "commonAncestorContainer", {
+    configurable: true,
+    value: assistantGroup,
+  });
+  Object.defineProperty(range, "getBoundingClientRect", {
+    configurable: true,
+    value: () => {
+      return new DOMRect(24, 32, 180, 44);
+    },
+  });
+
+  const selection = window.getSelection();
+  if (!selection) {
+    throw new Error("Selection API is not available");
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+  document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
 function buttonByText(text: string): HTMLElement {
   const button = queryAllByRoleFast("button").find((candidate) => {
     const label = candidate.textContent?.replace(/\s+/g, " ").trim();
@@ -155,6 +193,50 @@ describe("chat inline feedback", () => {
     expect(
       screen.queryByPlaceholderText("What should change about this?"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the inline feedback toolbar for a multi-line selection", async () => {
+    const firstReply = "The rollout dates are unclear in this summary.";
+    const secondReply = "The risk owners are missing from the plan.";
+    const assistantReply = `${firstReply}\n\n${secondReply}`;
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-multiline-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-multiline",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-multiline-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-multiline",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+      featureSwitches: {},
+    });
+
+    const firstReplyElement = await screen.findByText(firstReply);
+    const secondReplyElement = await screen.findByText(secondReply);
+    selectTextAcrossElementsForInlineFeedback(
+      firstReplyElement,
+      secondReplyElement,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
   });
 
   it("dismisses the inline feedback toolbar when a click clears the selection", async () => {


### PR DESCRIPTION
## Summary
- Detect inline feedback selections by falling back to the range start/end assistant bubbles when a multi-line selection reports an outer assistant group as its common ancestor.
- Keep the fallback scoped to the same assistant bubble or contiguous assistant group so broad selections across unrelated messages are ignored.
- Add a platform view test covering a first-time multi-line assistant selection that previously failed to show the feedback toolbar.

## Verification
- `pnpm exec prettier --check apps/platform/src/signals/zero-page/chat-feedback.ts apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app test src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `pnpm -F @vm0/app test src/signals/__tests__/chat-feedback.test.ts`