### PR TITLE
refactor: migrate supervised cancel fixtures

### DIFF
--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -1,71 +1,60 @@
 use std::io;
-use std::sync::Arc;
 use std::time::Duration;
 
 use vsock_proto::{ExecTermination, MSG_EXEC_CANCEL};
 
 use super::super::super::support::{
     assert_connection_accepts_exec_operation, is_connected, normal_operation_readiness,
-    operation_count, read_guest_message, send_exec_result, send_exec_started, setup_host_and_guest,
-    wait_for_operation_count,
+    operation_count, read_guest_message, send_exec_result, wait_for_operation_count,
 };
-use super::support::{send_guest_error, supervised_request};
+use super::support::{
+    StartedSupervisedExec, assert_no_guest_frame, send_guest_error, start_supervised_exec_fixture,
+    supervised_request,
+};
 use crate::ExecOwnedCapturedOutput;
 use crate::exec_operation as exec_operation_impl;
 use crate::operation_tracker::NormalOperationReadiness;
 
 #[tokio::test]
 async fn supervised_exec_cancel_on_drop_sends_exec_cancel() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-on-drop"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host: _host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-on-drop")).await;
+    let start_seq = start.seq();
     let guard = exec_operation_impl::ExecOperationCancelOnDropGuard::new_supervised(&handle)
         .expect("supervised handle should have active seq");
     drop(guard);
 
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
-    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(cancel.seq, start_seq);
 
-    send_exec_result(&mut guest, start.seq, ExecTermination::Cancelled, b"", b"").await;
+    send_exec_result(&mut guest, start_seq, ExecTermination::Cancelled, b"", b"").await;
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Cancelled);
 }
 
 #[tokio::test]
 async fn supervised_exec_cancel_and_wait_sends_cancel_and_waits_for_cancelled_result() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-and-wait"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-and-wait")).await;
+    let start_seq = start.seq();
 
     let cancel_task =
         tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
-    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(cancel.seq, start_seq);
     vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
 
-    send_exec_result(&mut guest, start.seq, ExecTermination::Cancelled, b"", b"").await;
+    send_exec_result(&mut guest, start_seq, ExecTermination::Cancelled, b"", b"").await;
     let result = cancel_task.await.unwrap().unwrap();
     assert_eq!(result.termination, ExecTermination::Cancelled);
     assert_eq!(operation_count(&host), 0);
@@ -77,19 +66,12 @@ async fn supervised_exec_cancel_and_wait_sends_cancel_and_waits_for_cancelled_re
 
 #[tokio::test]
 async fn supervised_exec_cancel_and_wait_writer_lock_timeout_before_write_cleans_registration() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-lock-timeout"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        handle,
+        ..
+    } = start_supervised_exec_fixture(supervised_request("cancel-lock-timeout")).await;
     let writer_guard = host.shared.writer.lock().await;
 
     let mut cancel_task =
@@ -109,29 +91,17 @@ async fn supervised_exec_cancel_and_wait_writer_lock_timeout_before_write_cleans
 
     drop(writer_guard);
     tokio::task::yield_now().await;
-    let mut buf = [0u8; 1024];
-    match guest.try_read(&mut buf) {
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("timed-out cancel must not send exec cancel; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after cancel timeout: {err}"),
-    }
+    assert_no_guest_frame(&mut guest, "timed-out cancel must not send exec cancel");
 }
 
 #[tokio::test]
 async fn supervised_exec_cancel_zero_timeout_cleans_without_cancel_frame() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-timeout-zero"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        handle,
+        ..
+    } = start_supervised_exec_fixture(supervised_request("cancel-timeout-zero")).await;
 
     let err = handle.cancel_and_wait(Duration::ZERO).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
@@ -142,29 +112,17 @@ async fn supervised_exec_cancel_zero_timeout_cleans_without_cancel_frame() {
         NormalOperationReadiness::NotParkable
     );
 
-    let mut buf = [0u8; 1024];
-    match guest.try_read(&mut buf) {
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("zero-timeout cancel must not send exec cancel; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after zero-timeout cancel: {err}"),
-    }
+    assert_no_guest_frame(&mut guest, "zero-timeout cancel must not send exec cancel");
 }
 
 #[tokio::test]
 async fn supervised_exec_cancel_oversized_timeout_cleans_without_cancel_frame() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-timeout-overflow"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        handle,
+        ..
+    } = start_supervised_exec_fixture(supervised_request("cancel-timeout-overflow")).await;
 
     let err = handle.cancel_and_wait(Duration::MAX).await.unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -175,36 +133,25 @@ async fn supervised_exec_cancel_oversized_timeout_cleans_without_cancel_frame() 
         NormalOperationReadiness::NotParkable
     );
 
-    let mut buf = [0u8; 1024];
-    match guest.try_read(&mut buf) {
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("oversized timeout must not send exec cancel; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after oversized timeout: {err}"),
-    }
+    assert_no_guest_frame(&mut guest, "oversized timeout must not send exec cancel");
 }
 
 #[tokio::test]
 async fn supervised_exec_cancel_and_wait_terminal_result_wins_while_cancel_write_is_blocked() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-result-race"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-result-race")).await;
+    let start_seq = start.seq();
     let writer_guard = host.shared.writer.lock().await;
 
     let mut cancel_task =
         tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"done",
         b"",
@@ -225,31 +172,23 @@ async fn supervised_exec_cancel_and_wait_terminal_result_wins_while_cancel_write
 
     drop(writer_guard);
     tokio::task::yield_now().await;
-    let mut buf = [0u8; 1024];
-    match guest.try_read(&mut buf) {
-        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
-        Ok(n) => panic!("completed operation must not receive stale cancel; read {n} bytes"),
-        Err(err) => panic!("unexpected read error after terminal race: {err}"),
-    }
+    assert_no_guest_frame(
+        &mut guest,
+        "completed operation must not receive stale cancel",
+    );
 
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
 }
 
 #[tokio::test]
 async fn supervised_exec_cancel_handle_sends_cancel_without_consuming_wait() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-handle"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let mut handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        mut handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-handle")).await;
+    let start_seq = start.seq();
     let cancel_handle = handle
         .take_cancel_handle()
         .expect("supervised handle should expose a cancel handle");
@@ -259,13 +198,13 @@ async fn supervised_exec_cancel_handle_sends_cancel_without_consuming_wait() {
         tokio::spawn(async move { cancel_handle.cancel(Duration::from_secs(5)).await });
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
-    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(cancel.seq, start_seq);
     vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
 
     cancel_task.await.unwrap().unwrap();
     assert_eq!(operation_count(&host), 1);
 
-    send_exec_result(&mut guest, start.seq, ExecTermination::Cancelled, b"", b"").await;
+    send_exec_result(&mut guest, start_seq, ExecTermination::Cancelled, b"", b"").await;
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
     assert_eq!(result.termination, ExecTermination::Cancelled);
     assert_eq!(operation_count(&host), 0);
@@ -277,19 +216,13 @@ async fn supervised_exec_cancel_handle_sends_cancel_without_consuming_wait() {
 
 #[tokio::test]
 async fn supervised_exec_cancel_handle_timeout_before_write_does_not_poison_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-lock-wait"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let mut handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        mut handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-lock-wait")).await;
+    let start_seq = start.seq();
     let cancel_handle = handle
         .take_cancel_handle()
         .expect("supervised handle should expose a cancel handle");
@@ -303,7 +236,7 @@ async fn supervised_exec_cancel_handle_timeout_before_write_does_not_poison_conn
     drop(writer_guard);
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"",
         b"",
@@ -317,26 +250,20 @@ async fn supervised_exec_cancel_handle_timeout_before_write_does_not_poison_conn
 
 #[tokio::test]
 async fn supervised_exec_cancel_handle_after_terminal_result_preserves_wait_and_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-handle-after-result"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let mut handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        mut handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-handle-after-result")).await;
+    let start_seq = start.seq();
     let cancel_handle = handle
         .take_cancel_handle()
         .expect("supervised handle should expose a cancel handle");
 
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"done",
         b"",
@@ -347,7 +274,7 @@ async fn supervised_exec_cancel_handle_after_terminal_result_preserves_wait_and_
     cancel_handle.cancel(Duration::from_secs(5)).await.unwrap();
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
-    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(cancel.seq, start_seq);
     vsock_proto::decode_exec_cancel(&cancel.payload).unwrap();
 
     let result = handle.wait(Duration::from_secs(5)).await.unwrap();
@@ -367,22 +294,16 @@ async fn supervised_exec_cancel_handle_after_terminal_result_preserves_wait_and_
 
 #[tokio::test]
 async fn supervised_exec_cancel_after_terminal_result_returns_result_without_cancel_frame() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("already-done"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("already-done")).await;
+    let start_seq = start.seq();
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"done",
         b"",
@@ -402,19 +323,13 @@ async fn supervised_exec_cancel_after_terminal_result_returns_result_without_can
 
 #[tokio::test(flavor = "current_thread")]
 async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-before-write-race"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-before-write-race")).await;
+    let start_seq = start.seq();
 
     let writer_guard = host.shared.writer.lock().await;
     let cancel_task =
@@ -423,7 +338,7 @@ async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
 
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"done",
         b"",
@@ -449,26 +364,20 @@ async fn supervised_exec_cancel_terminal_before_cancel_write_returns_result() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn supervised_exec_cancel_error_before_cancel_write_returns_error_without_cancel_frame() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-before-error-race"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-before-error-race")).await;
+    let start_seq = start.seq();
 
     let writer_guard = host.shared.writer.lock().await;
     let cancel_task =
         tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     tokio::task::yield_now().await;
 
-    send_guest_error(&mut guest, start.seq, "guest rejected supervised exec").await;
+    send_guest_error(&mut guest, start_seq, "guest rejected supervised exec").await;
     wait_for_operation_count(&host, 0).await;
 
     drop(writer_guard);
@@ -490,29 +399,23 @@ async fn supervised_exec_cancel_error_before_cancel_write_returns_error_without_
 
 #[tokio::test]
 async fn supervised_exec_cancel_non_cancelled_terminal_result_cleans_without_poisoning() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-race"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-race")).await;
+    let start_seq = start.seq();
 
     let cancel_task =
         tokio::spawn(async move { handle.cancel_and_wait(Duration::from_secs(5)).await });
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
-    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(cancel.seq, start_seq);
 
     send_exec_result(
         &mut guest,
-        start.seq,
+        start_seq,
         ExecTermination::Exited { exit_code: 0 },
         b"",
         b"",
@@ -528,25 +431,19 @@ async fn supervised_exec_cancel_non_cancelled_terminal_result_cleans_without_poi
 
 #[tokio::test]
 async fn supervised_exec_cancel_result_timeout_poisons_connection() {
-    let (host, mut guest) = setup_host_and_guest().await;
-    let host = Arc::new(host);
-    let task = {
-        let host = Arc::clone(&host);
-        tokio::spawn(async move {
-            host.start_supervised_exec(supervised_request("cancel-timeout"))
-                .await
-        })
-    };
-
-    let start = read_guest_message(&mut guest).await;
-    send_exec_started(&mut guest, start.seq, 123).await;
-    let handle = task.await.unwrap().unwrap();
+    let StartedSupervisedExec {
+        host,
+        mut guest,
+        start,
+        handle,
+    } = start_supervised_exec_fixture(supervised_request("cancel-timeout")).await;
+    let start_seq = start.seq();
 
     let cancel_task =
         tokio::spawn(async move { handle.cancel_and_wait(Duration::from_millis(50)).await });
     let cancel = read_guest_message(&mut guest).await;
     assert_eq!(cancel.msg_type, MSG_EXEC_CANCEL);
-    assert_eq!(cancel.seq, start.seq);
+    assert_eq!(cancel.seq, start_seq);
 
     let err = cancel_task.await.unwrap().unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);

--- a/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
+++ b/crates/vsock-host/src/tests/exec_operation/supervised/cancel.rs
@@ -18,6 +18,7 @@ use crate::operation_tracker::NormalOperationReadiness;
 #[tokio::test]
 async fn supervised_exec_cancel_on_drop_sends_exec_cancel() {
     let StartedSupervisedExec {
+        // Keep the host alive while the cancel-on-drop guard writes its cancel frame.
         host: _host,
         mut guest,
         start,


### PR DESCRIPTION
## Summary

- migrate supervised cancel tests to the shared `StartedSupervisedExec` startup fixture
- keep cancellation frame assertions, writer-lock ordering, and race choreography inline in each test
- reuse the existing generic `assert_no_guest_frame` helper for repeated no-frame checks

Closes #20312

## Verification

```bash
cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised::cancel
cargo test --manifest-path crates/Cargo.toml -p vsock-host supervised
cargo fmt --manifest-path crates/Cargo.toml --all --check
cargo clippy --manifest-path crates/Cargo.toml -p vsock-host --all-targets -- -D warnings
```

Pre-commit also ran the Rust checks for staged changes.
