### PR TITLE
feat: keep pinned agents visible while scrolling sidebar threads

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1117,6 +1117,74 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("keeps pinned agents and the chat title outside the switched thread list scroll area", async () => {
+    prepareAgentTeam();
+    context.mocks.data.userPreferences({
+      pinnedAgentIds: [RESEARCH_AGENT_ID],
+    });
+    const overflowThreads = Array.from({ length: 23 }, (_, index) => {
+      return createThread(
+        `b2500000-0000-4000-a000-${String(index).padStart(12, "0")}`,
+        `Switched overflow ${index + 1}`,
+      );
+    });
+    mockSidebarThreadStory(
+      [
+        createThread(EXISTING_THREAD_ID, "Release plan"),
+        createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+      ],
+      [
+        ...overflowThreads,
+        createThread(ARCHIVED_THREAD_ID, "Archived context"),
+      ],
+    );
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+      featureSwitches: {
+        [FeatureSwitchKey.SidebarThreadListScroll]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Research Agent")).toBeInTheDocument();
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("sidebar-chat-threads-virtual-list"),
+      ).toBeInTheDocument();
+    });
+
+    const scrollArea = screen.getByTestId("sidebar-scroll-area");
+    const pinnedHeader = screen.getByTestId("pinned-section-header");
+    const pinnedAgent = within(sidebar()).getByText("Research Agent");
+    const chatTitle = within(sidebar()).getByText("Chats with Zero");
+    expect(scrollArea).not.toContainElement(pinnedHeader);
+    expect(scrollArea).not.toContainElement(pinnedAgent);
+    expect(scrollArea).not.toContainElement(chatTitle);
+    expect(scrollArea).toContainElement(threadLinkByTitle("Release plan"));
+
+    Object.defineProperty(scrollArea, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scrollArea, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(scrollArea, "scrollTop", {
+      configurable: true,
+      value: 780,
+    });
+    fireEvent.scroll(scrollArea);
+
+    await waitFor(() => {
+      expect(
+        within(sidebar()).getByText("Archived context"),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("scrolls the current chat into the virtualized sidebar on page setup", async () => {
     prepareDefaultAgent();
     const leadingThreads = Array.from({ length: 24 }, (_, index) => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -88,6 +88,8 @@ import {
   setRenameDialogInput$,
   sessionListCollapsed$,
   setSessionListCollapsed$,
+  isScrolled$,
+  setIsScrolled$,
   overlayScrollMetrics$,
   overlayScrollViewport$,
   chatThreadVirtualListElement$,
@@ -96,6 +98,7 @@ import {
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { Link } from "../router/link.tsx";
+import { OverlayScrollArea } from "./zero-sidebar-scroll.tsx";
 
 type IndicatorState = "running" | "unread" | "draft";
 type ChatThreadPaneIndicator = "main" | "sidebar";
@@ -974,7 +977,11 @@ function ChatThreadsSkeleton() {
   );
 }
 
-function ChatThreadsContent() {
+function ChatThreadsContent({
+  threadListScroll,
+}: {
+  threadListScroll: boolean;
+}) {
   // useLastLoadable keeps the previous resolved list rendered while
   // sidebarChatThreads$ recomputes on a pane/thread switch; useLoadable would
   // flash the skeleton on every switch.
@@ -983,26 +990,57 @@ function ChatThreadsContent() {
     chatThreadsLoadable.state === "hasData" ? chatThreadsLoadable.data : [];
   const chatThreadsLoading = chatThreadsLoadable.state === "loading";
   const collapsed = useGet(sessionListCollapsed$);
+  const isScrolled = useGet(isScrolled$);
+  const setIsScrolledFn = useSet(setIsScrolled$);
 
-  return (
-    !collapsed && (
-      <div className="mt-1">
-        <div className="flex flex-col gap-1">
-          {chatThreadsLoading ? (
-            <ChatThreadsSkeleton />
-          ) : (
-            <ChatThreads chatThreads={chatThreads} />
-          )}
-        </div>
-      </div>
-    )
+  if (collapsed) {
+    return null;
+  }
+
+  const content = (
+    <div className="flex flex-col gap-1">
+      {chatThreadsLoading ? (
+        <ChatThreadsSkeleton />
+      ) : (
+        <ChatThreads chatThreads={chatThreads} />
+      )}
+    </div>
   );
+
+  if (threadListScroll) {
+    return (
+      <OverlayScrollArea
+        className="mt-1 min-h-0 flex-1"
+        data-testid="sidebar-scroll-area"
+        onScroll={(e) => {
+          return setIsScrolledFn(e.currentTarget.scrollTop > 0);
+        }}
+        style={{
+          boxShadow: isScrolled
+            ? "0 -1px 0 0 hsl(var(--border) / 0.4)"
+            : "none",
+        }}
+      >
+        {content}
+      </OverlayScrollArea>
+    );
+  }
+
+  return <div className="mt-1">{content}</div>;
 }
-export function ChatThreadsSection() {
+export function ChatThreadsSection({
+  threadListScroll = false,
+}: {
+  threadListScroll?: boolean;
+}) {
   return (
-    <div className="mt-4 flex flex-col">
+    <div
+      className={`mt-4 flex flex-col ${
+        threadListScroll ? "min-h-0 flex-1" : ""
+      }`}
+    >
       <ChatThreadsTitle />
-      <ChatThreadsContent />
+      <ChatThreadsContent threadListScroll={threadListScroll} />
       <ChatThreadRenameDialog />
       <DeleteChatThreadDialog />
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -127,9 +127,18 @@ const FOOTER_NAV = [
 // Leaf component: subscribes to currentChatAgentId$ so ZeroSidebar doesn't re-render on agent changes.
 // useLastResolved keeps the previously-resolved agent ID during re-loads, preventing unnecessary
 // remounts of ChatThreadsSection that would cause the chat list to flash.
-function ChatThreadsSectionWithKey() {
+function ChatThreadsSectionWithKey({
+  threadListScroll = false,
+}: {
+  threadListScroll?: boolean;
+}) {
   const currentChatAgentId = useLastResolved(currentChatAgentId$);
-  return <ChatThreadsSection key={currentChatAgentId} />;
+  return (
+    <ChatThreadsSection
+      key={currentChatAgentId}
+      threadListScroll={threadListScroll}
+    />
+  );
 }
 
 // Shared subscription hooks. Each sibling component pulls its own state from
@@ -390,7 +399,7 @@ function ExpandedMainNav() {
       className="flex-1 flex flex-col min-h-0 overflow-hidden p-2 pt-1"
     >
       <ExpandedManageSection />
-      <ExpandedScrollArea />
+      <ExpandedSidebarSections />
     </nav>
   );
 }
@@ -545,6 +554,22 @@ function CollapsedManageNav({
       </div>
     </div>
   );
+}
+
+function ExpandedSidebarSections() {
+  const features = useGet(featureSwitch$);
+  const threadListScroll =
+    features[FeatureSwitchKey.SidebarThreadListScroll] ?? false;
+  if (threadListScroll) {
+    return (
+      <div className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2 flex flex-col overflow-hidden">
+        <PinnedAgentListSection />
+        <ChatThreadsSectionWithKey threadListScroll />
+      </div>
+    );
+  }
+
+  return <ExpandedScrollArea />;
 }
 
 function ExpandedScrollArea() {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -59,6 +59,7 @@ export enum FeatureSwitchKey {
   ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",
   AgentsPageRedesign = "agentsPageRedesign",
   SidebarManageIconCollapse = "sidebarManageIconCollapse",
+  SidebarThreadListScroll = "sidebarThreadListScroll",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   ChatThreadLatestUserMessageScrollAnchor = "chatThreadLatestUserMessageScrollAnchor",
   TeamsIntegration = "teamsIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -348,6 +348,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show icon-only manage navigation buttons when the expanded sidebar manage section is collapsed.",
     enabled: false,
   },
+  [FeatureSwitchKey.SidebarThreadListScroll]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Scroll only the chat thread list in the Zero sidebar so pinned agents stay visible.",
+    enabled: false,
+  },
   [FeatureSwitchKey.SidebarSubscriptionUsage]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Add the `SidebarThreadListScroll` feature switch, defaulting off.
- Gate a new Zero sidebar layout where pinned agents and the `Chats with ...` header stay outside the scroll viewport.
- Move the overlay scroll area to the chat thread list itself when the switch is enabled, preserving the existing virtualized thread metrics and legacy layout when disabled.
- Add sidebar coverage that verifies pinned agents and the chat title sit outside the switched scroll area while virtualized thread scrolling still works.

## Verification
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`
