### PR TITLE
feat: support zstd session history blobs

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -77,6 +77,10 @@ pub mod runners {
     /// Rust and TypeScript components use this shared contract value when negotiating session history uploads and claim responses.
     pub const SESSION_HISTORY_ENCODING_IDENTITY: &str = "identity";
 
+    /// Wire and blob metadata value for zstd-compressed resume session history.
+    /// Rust and TypeScript components use this shared contract value when negotiating session history uploads and claim responses.
+    pub const SESSION_HISTORY_ENCODING_ZSTD: &str = "zstd";
+
     /// Minimum raw resume session history size before the guest attempts gzip upload negotiation.
     /// Smaller histories stay identity-encoded to avoid gzip work when it cannot materially reduce transport size.
     pub const SESSION_HISTORY_GZIP_MIN_BYTES: u64 = 65536;

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -375,7 +375,7 @@ async fn download_resume_session_history(
             bytes
         }
         ResumeSessionHistoryEncoding::Gzip => {
-            let raw_size = validate_gzip_ref(&history_ref, timings)?;
+            let raw_size = validate_compressed_ref("gzip", &history_ref, timings)?;
             let encoded_bytes = download_body(
                 &http,
                 &history_ref.url,
@@ -384,7 +384,20 @@ async fn download_resume_session_history(
             )
             .await?;
             let raw_bytes = gunzip_session_history(&encoded_bytes, raw_size)?;
-            validate_gzip_raw_size(raw_size, raw_bytes.len(), timings)?;
+            validate_decompressed_raw_size(raw_size, raw_bytes.len(), timings)?;
+            raw_bytes
+        }
+        ResumeSessionHistoryEncoding::Zstd => {
+            let raw_size = validate_compressed_ref("zstd", &history_ref, timings)?;
+            let encoded_bytes = download_body(
+                &http,
+                &history_ref.url,
+                Some(history_ref.encoded_size),
+                timings,
+            )
+            .await?;
+            let raw_bytes = unzstd_session_history(&encoded_bytes, raw_size)?;
+            validate_decompressed_raw_size(raw_size, raw_bytes.len(), timings)?;
             raw_bytes
         }
     };
@@ -463,7 +476,8 @@ fn validate_identity_body_size(
     Ok(())
 }
 
-fn validate_gzip_ref(
+fn validate_compressed_ref(
+    encoding: &str,
     history_ref: &ResumeSessionHistoryRef,
     timings: &mut SessionHistoryDownloadTimings,
 ) -> RunnerResult<u64> {
@@ -471,9 +485,9 @@ fn validate_gzip_ref(
     let raw_size = history_ref.raw_size;
     if raw_size == 0 {
         timings.add_validation(validation_started.elapsed(), false);
-        return Err(RunnerError::Internal(
-            "gzip session history rawSize must be positive".into(),
-        ));
+        return Err(RunnerError::Internal(format!(
+            "{encoding} session history rawSize must be positive"
+        )));
     }
     if raw_size > RESUME_SESSION_HISTORY_MAX_BYTES {
         timings.add_validation(validation_started.elapsed(), false);
@@ -483,9 +497,9 @@ fn validate_gzip_ref(
     }
     if history_ref.encoded_size == 0 {
         timings.add_validation(validation_started.elapsed(), false);
-        return Err(RunnerError::Internal(
-            "gzip session history encodedSize must be positive".into(),
-        ));
+        return Err(RunnerError::Internal(format!(
+            "{encoding} session history encodedSize must be positive"
+        )));
     }
     if history_ref.encoded_size > RESUME_SESSION_HISTORY_MAX_BYTES {
         timings.add_validation(validation_started.elapsed(), false);
@@ -497,7 +511,7 @@ fn validate_gzip_ref(
     Ok(raw_size)
 }
 
-fn validate_gzip_raw_size(
+fn validate_decompressed_raw_size(
     expected_size: u64,
     byte_count: usize,
     timings: &mut SessionHistoryDownloadTimings,
@@ -515,12 +529,27 @@ fn validate_gzip_raw_size(
 
 fn gunzip_session_history(encoded_bytes: &[u8], max_raw_bytes: u64) -> RunnerResult<Vec<u8>> {
     let mut decoder = MultiGzDecoder::new(encoded_bytes);
+    read_compressed_session_history(&mut decoder, max_raw_bytes, "gzip")
+}
+
+fn unzstd_session_history(encoded_bytes: &[u8], max_raw_bytes: u64) -> RunnerResult<Vec<u8>> {
+    let mut decoder = zstd::stream::read::Decoder::new(encoded_bytes).map_err(|error| {
+        RunnerError::Internal(format!("decompress zstd session history: {error}"))
+    })?;
+    read_compressed_session_history(&mut decoder, max_raw_bytes, "zstd")
+}
+
+fn read_compressed_session_history(
+    decoder: &mut impl Read,
+    max_raw_bytes: u64,
+    encoding: &str,
+) -> RunnerResult<Vec<u8>> {
     let mut bytes = Vec::new();
     let mut buffer = [0u8; 8192];
     let mut decoded = 0u64;
     loop {
         let read = decoder.read(&mut buffer).map_err(|error| {
-            RunnerError::Internal(format!("decompress gzip session history: {error}"))
+            RunnerError::Internal(format!("decompress {encoding} session history: {error}"))
         })?;
         if read == 0 {
             break;
@@ -531,9 +560,9 @@ fn gunzip_session_history(encoded_bytes: &[u8], max_raw_bytes: u64) -> RunnerRes
                 "session history is too large after decompression: {decoded} bytes exceeds {max_raw_bytes} bytes"
             )));
         }
-        let chunk = buffer
-            .get(..read)
-            .ok_or_else(|| RunnerError::Internal("invalid gzip read chunk length".into()))?;
+        let chunk = buffer.get(..read).ok_or_else(|| {
+            RunnerError::Internal(format!("invalid {encoding} read chunk length"))
+        })?;
         bytes.extend_from_slice(chunk);
     }
     Ok(bytes)
@@ -704,6 +733,37 @@ mod tests {
         raw_size: u64,
         encoded_size: u64,
     ) -> ResumeSession {
+        compressed_ref_session(
+            url,
+            hash,
+            raw_size,
+            encoded_size,
+            ResumeSessionHistoryEncoding::Gzip,
+        )
+    }
+
+    fn zstd_ref_session(
+        url: String,
+        hash: String,
+        raw_size: u64,
+        encoded_size: u64,
+    ) -> ResumeSession {
+        compressed_ref_session(
+            url,
+            hash,
+            raw_size,
+            encoded_size,
+            ResumeSessionHistoryEncoding::Zstd,
+        )
+    }
+
+    fn compressed_ref_session(
+        url: String,
+        hash: String,
+        raw_size: u64,
+        encoded_size: u64,
+        encoding: ResumeSessionHistoryEncoding,
+    ) -> ResumeSession {
         ResumeSession {
             cli_agent_session_id: "sess-123".to_string(),
             history: ResumeSessionHistory::Ref {
@@ -711,7 +771,7 @@ mod tests {
                     kind: ResumeSessionHistoryRefKind::Blob,
                     hash,
                     url,
-                    encoding: Some(ResumeSessionHistoryEncoding::Gzip),
+                    encoding: Some(encoding),
                     raw_size,
                     encoded_size,
                 },
@@ -723,6 +783,10 @@ mod tests {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
         encoder.write_all(raw).unwrap();
         encoder.finish().unwrap()
+    }
+
+    fn zstd_bytes(raw: &[u8]) -> Vec<u8> {
+        zstd::encode_all(raw, 0).unwrap()
     }
 
     fn start_materializer(session: &ResumeSession) -> SessionHistoryMaterializer {
@@ -870,6 +934,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn materializer_downloads_decompresses_and_verifies_zstd_hash() {
+        let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
+        let compressed = zstd_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let hash = hex::encode(Sha256::digest(body));
+        let session = zstd_ref_session(
+            serve_once("200 OK", compressed, None).await,
+            hash,
+            body.len() as u64,
+            encoded_size,
+        );
+
+        let materializer = start_materializer(&session);
+        let result = materializer.finish(&CancellationToken::new()).await;
+
+        match result {
+            SessionHistoryMaterialization::Downloaded {
+                session, timings, ..
+            } => {
+                assert_eq!(session.cli_agent_session_id(), "sess-123");
+                assert_eq!(session.history_bytes(), body);
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_phase_success(timings.hash_verification());
+            }
+            _ => panic!("expected downloaded session"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materializer_rejects_zstd_body_under_declared_encoded_size_without_content_length() {
+        let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
+        let compressed = zstd_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let hash = hex::encode(Sha256::digest(body));
+        let session = zstd_ref_session(
+            serve_once("200 OK", compressed, None).await,
+            hash,
+            body.len() as u64,
+            encoded_size + 1,
+        );
+
+        let result = start_materializer(&session)
+            .finish(&CancellationToken::new())
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
+                assert!(
+                    error.to_string().contains("downloaded size mismatch"),
+                    "unexpected error: {error}"
+                );
+                assert_phase_success(timings.request_status());
+                assert_phase_failure(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_no_phase(timings.hash_verification());
+            }
+            _ => panic!("expected failed materialization"),
+        }
+    }
+
+    #[tokio::test]
     async fn materializer_rejects_gzip_body_under_declared_encoded_size_without_content_length() {
         let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
         let compressed = gzip_bytes(body);
@@ -978,6 +1105,70 @@ mod tests {
                 );
                 assert_phase_success(timings.request_status());
                 assert_phase_success(timings.body_read());
+            }
+            _ => panic!("expected failed materialization"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materializer_rejects_zstd_body_over_declared_raw_size() {
+        let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
+        let compressed = zstd_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let hash = hex::encode(Sha256::digest(body));
+        let session = zstd_ref_session(
+            serve_once("200 OK", compressed, None).await,
+            hash,
+            1,
+            encoded_size,
+        );
+
+        let materializer = start_materializer(&session);
+        let result = materializer.finish(&CancellationToken::new()).await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
+                assert!(
+                    error
+                        .to_string()
+                        .contains("session history is too large after decompression"),
+                    "unexpected error: {error}"
+                );
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+            }
+            _ => panic!("expected failed materialization"),
+        }
+    }
+
+    #[tokio::test]
+    async fn materializer_rejects_truncated_zstd_body() {
+        let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
+        let mut compressed = zstd_bytes(body);
+        compressed.truncate(compressed.len().saturating_sub(1));
+        let hash = hex::encode(Sha256::digest(body));
+        let session = zstd_ref_session(
+            serve_once("200 OK", compressed.clone(), None).await,
+            hash,
+            body.len() as u64,
+            compressed.len() as u64,
+        );
+
+        let materializer = start_materializer(&session);
+        let result = materializer.finish(&CancellationToken::new()).await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
+                assert!(
+                    error
+                        .to_string()
+                        .contains("decompress zstd session history"),
+                    "unexpected error: {error}"
+                );
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_no_phase(timings.hash_verification());
             }
             _ => panic!("expected failed materialization"),
         }

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -61,7 +61,8 @@ fn zstd_bytes(raw: &[u8]) -> Vec<u8> {
     zstd::encode_all(raw, 0).unwrap()
 }
 
-async fn serve_history_once(body: &'static [u8]) -> String {
+async fn serve_history_once(body: &[u8]) -> String {
+    let body = body.to_vec();
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -73,7 +74,7 @@ async fn serve_history_once(body: &'static [u8]) -> String {
             body.len()
         );
         stream.write_all(response.as_bytes()).await.unwrap();
-        stream.write_all(body).await.unwrap();
+        stream.write_all(&body).await.unwrap();
     });
     format!("http://{address}/history.blob?token=secret")
 }
@@ -756,7 +757,7 @@ async fn run_in_sandbox_records_gzip_session_history_download_encoding() {
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
     let history = b"{\"type\":\"init\"}\n\xff\n";
-    let compressed = Box::leak(gzip_bytes(history).into_boxed_slice());
+    let compressed = gzip_bytes(history);
     let mut ctx = minimal_context();
     ctx.resume_session = Some(ResumeSession {
         cli_agent_session_id: "sess-gzip-ref-123".into(),
@@ -764,7 +765,7 @@ async fn run_in_sandbox_records_gzip_session_history_download_encoding() {
             history_ref: ResumeSessionHistoryRef {
                 kind: ResumeSessionHistoryRefKind::Blob,
                 hash: hex::encode(Sha256::digest(history)),
-                url: serve_history_once(compressed).await,
+                url: serve_history_once(&compressed).await,
                 encoding: Some(ResumeSessionHistoryEncoding::Gzip),
                 raw_size: history.len() as u64,
                 encoded_size: compressed.len() as u64,
@@ -845,7 +846,7 @@ async fn run_in_sandbox_records_zstd_session_history_download_encoding() {
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
     let history = b"{\"type\":\"init\"}\n\xff\n";
-    let compressed = Box::leak(zstd_bytes(history).into_boxed_slice());
+    let compressed = zstd_bytes(history);
     let mut ctx = minimal_context();
     ctx.resume_session = Some(ResumeSession {
         cli_agent_session_id: "sess-zstd-ref-123".into(),
@@ -853,7 +854,7 @@ async fn run_in_sandbox_records_zstd_session_history_download_encoding() {
             history_ref: ResumeSessionHistoryRef {
                 kind: ResumeSessionHistoryRefKind::Blob,
                 hash: hex::encode(Sha256::digest(history)),
-                url: serve_history_once(compressed).await,
+                url: serve_history_once(&compressed).await,
                 encoding: Some(ResumeSessionHistoryEncoding::Zstd),
                 raw_size: history.len() as u64,
                 encoded_size: compressed.len() as u64,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -57,6 +57,10 @@ fn gzip_bytes(raw: &[u8]) -> Vec<u8> {
     encoder.finish().unwrap()
 }
 
+fn zstd_bytes(raw: &[u8]) -> Vec<u8> {
+    zstd::encode_all(raw, 0).unwrap()
+}
+
 async fn serve_history_once(body: &'static [u8]) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
@@ -829,6 +833,95 @@ async fn run_in_sandbox_records_gzip_session_history_download_encoding() {
         &ops,
         "session_history_download_hash_verification",
         "gzip",
+        "lt_64_kib",
+        "lt_64_kib",
+        "ge_1",
+    );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_records_zstd_session_history_download_encoding() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let history = b"{\"type\":\"init\"}\n\xff\n";
+    let compressed = Box::leak(zstd_bytes(history).into_boxed_slice());
+    let mut ctx = minimal_context();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: "sess-zstd-ref-123".into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: serve_history_once(compressed).await,
+                encoding: Some(ResumeSessionHistoryEncoding::Zstd),
+                raw_size: history.len() as u64,
+                encoded_size: compressed.len() as u64,
+            },
+        },
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.claude/projects/-home-user-workspace/sess-zstd-ref-123.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    let ops = telemetry.pending_ops_with_session_history_metadata_snapshot();
+    assert_successful_action_with_session_history_metadata(
+        &ops,
+        "session_history_download",
+        "zstd",
+        "lt_64_kib",
+        "lt_64_kib",
+        "ge_1",
+    );
+    assert_successful_action_with_session_history_metadata(
+        &ops,
+        "session_history_download_request_status",
+        "zstd",
+        "lt_64_kib",
+        "lt_64_kib",
+        "ge_1",
+    );
+    assert_successful_action_with_session_history_metadata(
+        &ops,
+        "session_history_download_body_read",
+        "zstd",
+        "lt_64_kib",
+        "lt_64_kib",
+        "ge_1",
+    );
+    assert_successful_action_with_session_history_metadata(
+        &ops,
+        "session_history_download_validation",
+        "zstd",
+        "lt_64_kib",
+        "lt_64_kib",
+        "ge_1",
+    );
+    assert_successful_action_with_session_history_metadata(
+        &ops,
+        "session_history_download_hash_verification",
+        "zstd",
         "lt_64_kib",
         "lt_64_kib",
         "ge_1",

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -368,6 +368,7 @@ const fn session_history_encoding_value(encoding: ResumeSessionHistoryEncoding) 
     match encoding {
         ResumeSessionHistoryEncoding::Identity => "identity",
         ResumeSessionHistoryEncoding::Gzip => "gzip",
+        ResumeSessionHistoryEncoding::Zstd => "zstd",
     }
 }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -356,6 +356,8 @@ pub enum ResumeSessionHistoryEncoding {
     Identity,
     #[serde(rename = "gzip")]
     Gzip,
+    #[serde(rename = "zstd")]
+    Zstd,
 }
 
 impl ResumeSession {
@@ -913,6 +915,40 @@ mod tests {
         );
         assert_eq!(history_ref.raw_size, 42);
         assert_eq!(history_ref.encoded_size, 24);
+    }
+
+    #[test]
+    fn cli_agent_session_id_returns_id_from_zstd_resume_session_history_ref() {
+        let json = json!({
+            "runId": "550e8400-e29b-41d4-a716-446655440000",
+            "prompt": "hello",
+            "sandboxToken": "tok",
+            "cliAgentType": "claude_code",
+            "resumeSession": {
+                "sessionId": "sess-ref-123",
+                "historyRef": {
+                    "kind": "blob",
+                    "hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "url": "https://r2.example.com/blobs/a.blob.zst?sig=secret",
+                    "encoding": "zstd",
+                    "rawSize": 42,
+                    "encodedSize": 18
+                }
+            },
+            "billableFirewalls": []
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        let session = ctx.resume_session.as_ref().unwrap();
+        let history_ref = session.history_ref().unwrap();
+        assert_eq!(ctx.cli_agent_session_id(), Some("sess-ref-123"));
+        assert!(session.session_history().is_none());
+        assert_eq!(history_ref.kind, ResumeSessionHistoryRefKind::Blob);
+        assert_eq!(
+            history_ref.encoding,
+            Some(ResumeSessionHistoryEncoding::Zstd)
+        );
+        assert_eq!(history_ref.raw_size, 42);
+        assert_eq!(history_ref.encoded_size, 18);
     }
 
     #[test]

--- a/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/ops-logs.bdd.test.ts
@@ -1,5 +1,5 @@
 import { createHash, createHmac, randomUUID } from "node:crypto";
-import { gzipSync } from "node:zlib";
+import { gzipSync, zstdCompressSync } from "node:zlib";
 
 import AdmZip from "adm-zip";
 import { createStore } from "ccstate";
@@ -1234,6 +1234,107 @@ describe("OPS-01: user data export", () => {
     expect(manifest.counts.sessionHistories).toBe(1);
   });
 
+  it("exports zstd-backed session history bytes as a jsonl conversation file", async () => {
+    const api = createOpsLogsApi(context);
+    const bdd = createBddApi(context);
+    const misc = createMiscRoutesApi(context);
+    const runs = createRunsAutomationsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const actor = await createUserExportActor(bdd);
+    const exportStartAt = Date.UTC(2026, 4, 12, 6, 30);
+    const downloadUrl =
+      "https://r2.example.com/bdd-export-zstd-history.zip?sig=test";
+
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD Export Zstd History Agent",
+      visibility: "private",
+    });
+    const run = await runs.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "checkpoint zstd compressed history",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await runs.claimRunnerJob(run.runId);
+    const headers = { authorization: `Bearer ${claim.sandboxToken}` };
+    const history = Buffer.concat([
+      Buffer.from(
+        `{"type":"init"}\n{"type":"human","text":"zstd-exported-${randomUUID()}"}\n`,
+        "utf8",
+      ),
+      Buffer.from([0xc3, 0x28, 0x0a]),
+    ]);
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    const compressedHistory = zstdCompressSync(history);
+    const compressedKey = `blobs/${historyHash}.blob.zst`;
+
+    const prepared = await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: run.runId,
+        hash: historyHash,
+        rawSize: history.length,
+        encodedSize: compressedHistory.length,
+        encoding: "zstd",
+      },
+      headers,
+      [200],
+    );
+    expect(prepared.body).toMatchObject({
+      existing: false,
+      encoding: "zstd",
+    });
+    const checkpoint = await webhooks.requestAgentCheckpoint(
+      {
+        runId: run.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-export-zstd-session-${run.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      headers,
+      [200],
+    );
+    if (checkpoint.status !== 200) {
+      throw new Error("Expected zstd history checkpoint to succeed");
+    }
+    expect(checkpoint.body.conversationId).not.toBe("");
+    await webhooks.requestAgentComplete(
+      { runId: run.runId, exitCode: 0 },
+      headers,
+      [200],
+    );
+
+    mockNow(exportStartAt);
+    context.mocks.s3.getSignedUrl.mockResolvedValue(downloadUrl);
+    misc.putS3Object(compressedKey, compressedHistory);
+
+    const started = await api.requestPostUserExport(actor, [202]);
+    const jobId = started.body.jobId;
+    const exportKey = `exports/${actor.userId}/${jobId}.zip`;
+
+    await waitForUserExportJobStatus(api, actor, jobId, "completed");
+    const zip = exportZip(exportKey);
+    const names = zipEntryNames(zip);
+    const historyEntry = singleZipEntry(names, (name) => {
+      return (
+        name.startsWith("conversations/") && name.endsWith("-history.jsonl")
+      );
+    });
+    expect(zipBytes(zip, historyEntry)).toStrictEqual(history);
+
+    const manifest = JSON.parse(zipText(zip, "export-manifest.json")) as {
+      readonly counts: {
+        readonly conversationThreads: number;
+        readonly sessionHistories: number;
+      };
+    };
+    expect(manifest.counts.conversationThreads).toBe(0);
+    expect(manifest.counts.sessionHistories).toBe(1);
+  });
+
   it("fails user export when gzip-backed session history does not match its hash", async () => {
     const api = createOpsLogsApi(context);
     const bdd = createBddApi(context);
@@ -1300,6 +1401,88 @@ describe("OPS-01: user data export", () => {
     mockNow(exportStartAt);
     context.mocks.s3.getSignedUrl.mockResolvedValue(
       "https://r2.example.com/bdd-export-corrupt-history.zip?sig=test",
+    );
+    misc.putS3Object(compressedKey, tamperedCompressedHistory);
+
+    const started = await api.requestPostUserExport(actor, [202]);
+    const failedStatus = await waitForUserExportJobStatus(
+      api,
+      actor,
+      started.body.jobId,
+      "failed",
+    );
+    if (!failedStatus.job) {
+      throw new Error("Expected failed export job");
+    }
+    expect(failedStatus.job.error).toContain("session history hash mismatch");
+  });
+
+  it("fails user export when zstd-backed session history does not match its hash", async () => {
+    const api = createOpsLogsApi(context);
+    const bdd = createBddApi(context);
+    const misc = createMiscRoutesApi(context);
+    const runs = createRunsAutomationsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const actor = await createUserExportActor(bdd);
+    const exportStartAt = Date.UTC(2026, 4, 12, 7, 30);
+
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await runs.ensureOrgModelProvider(actor);
+    const agent = await bdd.createAgent(actor, {
+      displayName: "BDD Export Corrupt Zstd History Agent",
+      visibility: "private",
+    });
+    const run = await runs.createRun(actor, {
+      agentId: agent.agentId,
+      prompt: "checkpoint corrupt zstd compressed history",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await runs.claimRunnerJob(run.runId);
+    const headers = { authorization: `Bearer ${claim.sandboxToken}` };
+    const history = `{"type":"init"}\n{"type":"human","text":"zstd-exported-${randomUUID()}"}\n`;
+    const tamperedHistory = history.replace("zstd-exported-", "zstd-tampered-");
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    const tamperedCompressedHistory = zstdCompressSync(
+      Buffer.from(tamperedHistory, "utf8"),
+    );
+    const compressedKey = `blobs/${historyHash}.blob.zst`;
+
+    await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: run.runId,
+        hash: historyHash,
+        rawSize: Buffer.byteLength(history, "utf8"),
+        encodedSize: tamperedCompressedHistory.length,
+        encoding: "zstd",
+      },
+      headers,
+      [200],
+    );
+    const checkpoint = await webhooks.requestAgentCheckpoint(
+      {
+        runId: run.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-export-corrupt-zstd-session-${run.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      headers,
+      [200],
+    );
+    if (checkpoint.status !== 200) {
+      throw new Error("Expected zstd history checkpoint to succeed");
+    }
+    await webhooks.requestAgentComplete(
+      { runId: run.runId, exitCode: 0 },
+      headers,
+      [200],
+    );
+
+    mockNow(exportStartAt);
+    context.mocks.s3.getSignedUrl.mockResolvedValue(
+      "https://r2.example.com/bdd-export-corrupt-zstd-history.zip?sig=test",
     );
     misc.putS3Object(compressedKey, tamperedCompressedHistory);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { gzipSync } from "node:zlib";
+import { gzipSync, zstdCompressSync } from "node:zlib";
 
 import { CANONICAL_CLAUDE_MEMORY_MOUNT_PATH } from "@vm0/api-contracts/contracts/runners";
 import { delay } from "signal-timers";
@@ -1046,6 +1046,109 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     await api.requestCancelRun(actor, compressedResume.runId, [200]);
   });
 
+  it("returns zstd-compressed resume history refs", async () => {
+    const actor = await entitledActor();
+    const composeName = `bdd-zstd-resume-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: { ANTHROPIC_API_KEY: "bdd-inline-key" },
+        },
+      },
+    });
+    const history = `{"type":"init"}\n{"type":"human","text":"zstd-${randomUUID()}"}\n`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    const compressedHistory = zstdCompressSync(Buffer.from(history, "utf8"));
+    const compressedKey = `blobs/${historyHash}.blob.zst`;
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      const commandKey = s3CommandKey(command);
+      if (commandKey === compressedKey) {
+        return Promise.resolve({
+          ContentLength: compressedHistory.length,
+          Body: s3BytesBody(compressedHistory),
+        });
+      }
+      if (commandKey?.startsWith(`blobs/${historyHash}.blob`)) {
+        return Promise.reject(s3ObjectNotFoundError());
+      }
+      return Promise.resolve({});
+    });
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "create zstd compressed checkpoint",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+    const headers = sandboxHeaders(claim.sandboxToken);
+    const prepared = await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: run.runId,
+        hash: historyHash,
+        rawSize: Buffer.byteLength(history, "utf8"),
+        encodedSize: compressedHistory.length,
+        encoding: "zstd",
+      },
+      headers,
+      [200],
+    );
+    expect(prepared.body).toMatchObject({
+      existing: false,
+      encoding: "zstd",
+    });
+    const duplicatePrepared =
+      await webhooks.requestAgentCheckpointPrepareHistory(
+        {
+          runId: run.runId,
+          hash: historyHash,
+          rawSize: Buffer.byteLength(history, "utf8"),
+          encodedSize: compressedHistory.length + 1,
+          encoding: "zstd",
+        },
+        headers,
+        [200],
+      );
+    expect(duplicatePrepared.body).toStrictEqual({
+      existing: true,
+      encoding: "zstd",
+    });
+    const checkpointed = await webhooks.requestAgentCheckpoint(
+      {
+        runId: run.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-cli-${run.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      headers,
+      [200],
+    );
+    mustOk(checkpointed, "zstd compressed resume checkpoint");
+    await webhooks.requestAgentComplete(
+      { runId: run.runId, exitCode: 0 },
+      headers,
+      [200],
+    );
+
+    const compressedResume = await api.createDirectRun(actor, {
+      checkpointId: checkpointed.body.checkpointId,
+      prompt: "resume with zstd compressed ref",
+    });
+    const compressedClaim = await api.claimRunnerJob(compressedResume.runId);
+    expect(compressedClaim.resumeSession).toMatchObject({
+      sessionId: `bdd-cli-${run.runId}`,
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: expect.any(String),
+        encoding: "zstd",
+        rawSize: Buffer.byteLength(history, "utf8"),
+        encodedSize: compressedHistory.length,
+      },
+    });
+    await api.requestCancelRun(actor, compressedResume.runId, [200]);
+  });
+
   it("rejects identity repair for a missing compressed session history blob", async () => {
     const actor = await entitledActor();
     const compose = await createClaudeCompose(actor, "bdd-gzip-repair");
@@ -1097,6 +1200,114 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     expectApiError(mismatchedEncodedSize.body);
     expect(mismatchedEncodedSize.body.error.message).toBe(
       "Session history encoded size does not match the existing blob",
+    );
+
+    const compressedRetry = await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: run.runId,
+        hash: historyHash,
+        rawSize: Buffer.byteLength(history, "utf8"),
+        encodedSize: gzipSync(Buffer.from(history, "utf8")).length,
+        encoding: "gzip",
+      },
+      headers,
+      [200],
+    );
+    expect(compressedRetry.body).toMatchObject({
+      existing: false,
+      encoding: "gzip",
+    });
+
+    const identityRepair = await webhooks.requestAgentCheckpointPrepareHistory(
+      {
+        runId: run.runId,
+        hash: historyHash,
+        rawSize: Buffer.byteLength(history, "utf8"),
+        encodedSize: Buffer.byteLength(history, "utf8"),
+        encoding: "identity",
+      },
+      headers,
+      [400],
+    );
+    expectApiError(identityRepair.body);
+    expect(identityRepair.body.error.message).toBe(
+      "Identity session history upload cannot repair a compressed blob",
+    );
+  });
+
+  it("rejects identity repair for a missing zstd session history blob", async () => {
+    const actor = await entitledActor();
+    const compose = await createClaudeCompose(actor, "bdd-zstd-repair");
+    const history = `{"type":"init"}\n{"type":"human","text":"repair-zstd-${randomUUID()}"}\n`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    const compressedHistory = zstdCompressSync(Buffer.from(history, "utf8"));
+    const compressedKey = `blobs/${historyHash}.blob.zst`;
+    context.mocks.s3.send.mockImplementation((command: unknown) => {
+      const commandKey = s3CommandKey(command);
+      if (commandKey === compressedKey) {
+        return Promise.reject(s3ObjectNotFoundError());
+      }
+      if (commandKey?.startsWith(`blobs/${historyHash}.blob`)) {
+        return Promise.reject(s3ObjectNotFoundError());
+      }
+      return Promise.resolve({});
+    });
+
+    const run = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "create missing zstd blob metadata",
+    });
+    const claim = await api.claimRunnerJob(run.runId);
+    const headers = sandboxHeaders(claim.sandboxToken);
+    const compressedPrepare =
+      await webhooks.requestAgentCheckpointPrepareHistory(
+        {
+          runId: run.runId,
+          hash: historyHash,
+          rawSize: Buffer.byteLength(history, "utf8"),
+          encodedSize: compressedHistory.length,
+          encoding: "zstd",
+        },
+        headers,
+        [200],
+      );
+    expect(compressedPrepare.body).toMatchObject({
+      existing: false,
+      encoding: "zstd",
+    });
+
+    const mismatchedEncodedSize =
+      await webhooks.requestAgentCheckpointPrepareHistory(
+        {
+          runId: run.runId,
+          hash: historyHash,
+          rawSize: Buffer.byteLength(history, "utf8"),
+          encodedSize: compressedHistory.length + 1,
+          encoding: "zstd",
+        },
+        headers,
+        [400],
+      );
+    expectApiError(mismatchedEncodedSize.body);
+    expect(mismatchedEncodedSize.body.error.message).toBe(
+      "Session history encoded size does not match the existing blob",
+    );
+
+    const mismatchedEncodingRepair =
+      await webhooks.requestAgentCheckpointPrepareHistory(
+        {
+          runId: run.runId,
+          hash: historyHash,
+          rawSize: Buffer.byteLength(history, "utf8"),
+          encodedSize: gzipSync(Buffer.from(history, "utf8")).length,
+          encoding: "gzip",
+        },
+        headers,
+        [400],
+      );
+    expectApiError(mismatchedEncodingRepair.body);
+    expect(mismatchedEncodingRepair.body.error.message).toBe(
+      "Compressed session history upload encoding must match the existing blob",
     );
 
     const identityRepair = await webhooks.requestAgentCheckpointPrepareHistory(

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -50,10 +50,10 @@ import {
 } from "../services/zero-user-permission-grants.service";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import {
+  type CompressedSessionHistoryBlobEncoding,
   resumeSessionHistoryBlobKey,
   resumeSessionHistoryRawBlobKey,
   SESSION_HISTORY_ENCODING_IDENTITY,
-  SESSION_HISTORY_ENCODING_GZIP,
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
@@ -969,8 +969,8 @@ type StoredResumeSessionWithHistoryRef = Extract<
   { historyRef: { kind: "blob"; hash: string } }
 >;
 
-interface GzipResumeSessionHistoryRepresentation {
-  readonly encoding: typeof SESSION_HISTORY_ENCODING_GZIP;
+interface CompressedResumeSessionHistoryRepresentation {
+  readonly encoding: CompressedSessionHistoryBlobEncoding;
   readonly rawSize: number;
   readonly encodedSize: number;
   readonly objectKey: string;
@@ -1027,14 +1027,15 @@ const generateResumeSessionHistoryObjectUrl$ = command(
   },
 );
 
-const loadGzipResumeSessionHistoryRepresentation$ = command(
+const loadCompressedResumeSessionHistoryRepresentation$ = command(
   async (
     _,
     args: {
       readonly db: Db;
+      readonly encoding: CompressedSessionHistoryBlobEncoding;
       readonly hash: string;
     },
-  ): Promise<GzipResumeSessionHistoryRepresentation | undefined> => {
+  ): Promise<CompressedResumeSessionHistoryRepresentation | undefined> => {
     const [blob] = await args.db
       .select({
         rawSize: blobs.rawSize,
@@ -1054,7 +1055,7 @@ const loadGzipResumeSessionHistoryRepresentation$ = command(
         new Error(`invalid session history blob encoding: ${blob.encoding}`),
       );
     }
-    if (encoding !== SESSION_HISTORY_ENCODING_GZIP) {
+    if (encoding !== args.encoding) {
       return undefined;
     }
     if (blob.rawSize <= 0 || blob.encodedSize <= 0) {
@@ -1062,7 +1063,7 @@ const loadGzipResumeSessionHistoryRepresentation$ = command(
     }
 
     return {
-      encoding: SESSION_HISTORY_ENCODING_GZIP,
+      encoding,
       rawSize: blob.rawSize,
       encodedSize: blob.encodedSize,
       objectKey: resumeSessionHistoryBlobKey(args.hash, encoding),
@@ -1070,9 +1071,9 @@ const loadGzipResumeSessionHistoryRepresentation$ = command(
   },
 );
 
-function validateGzipResumeSessionHistoryRepresentation(
+function validateCompressedResumeSessionHistoryRepresentation(
   hash: string,
-  representation: GzipResumeSessionHistoryRepresentation,
+  representation: CompressedResumeSessionHistoryRepresentation,
 ): void {
   if (
     representation.rawSize <= 0 ||
@@ -1082,7 +1083,9 @@ function validateGzipResumeSessionHistoryRepresentation(
   ) {
     throw invalidResumeSessionHistoryError(
       hash,
-      new Error(`invalid gzip rawSize: ${representation.rawSize}`),
+      new Error(
+        `invalid ${representation.encoding} rawSize: ${representation.rawSize}`,
+      ),
     );
   }
 }
@@ -1181,9 +1184,10 @@ async function resolveResumeSessionForClaim(args: {
   readonly loadIdentityRepresentation: (
     hash: string,
   ) => Promise<IdentityResumeSessionHistoryRepresentation | undefined>;
-  readonly loadGzipRepresentation: (
+  readonly loadCompressedRepresentation: (
     hash: string,
-  ) => Promise<GzipResumeSessionHistoryRepresentation | undefined>;
+    encoding: CompressedSessionHistoryBlobEncoding,
+  ) => Promise<CompressedResumeSessionHistoryRepresentation | undefined>;
   readonly generateResumeSessionHistoryUrl: (hash: string) => Promise<string>;
   readonly generateResumeSessionHistoryObjectUrl: (
     objectKey: string,
@@ -1195,29 +1199,24 @@ async function resolveResumeSessionForClaim(args: {
   }
 
   const { sessionId, historyRef } = resumeSession;
-  const gzipRepresentation =
-    historyRef.encoding === SESSION_HISTORY_ENCODING_GZIP
-      ? await args.loadGzipRepresentation(historyRef.hash)
-      : undefined;
-  if (
-    historyRef.encoding === SESSION_HISTORY_ENCODING_GZIP &&
-    gzipRepresentation === undefined
-  ) {
-    throw invalidResumeSessionHistoryError(
+  const encoding = historyRef.encoding ?? SESSION_HISTORY_ENCODING_IDENTITY;
+  if (encoding !== SESSION_HISTORY_ENCODING_IDENTITY) {
+    const compressedRepresentation = await args.loadCompressedRepresentation(
       historyRef.hash,
-      new Error("gzip session history metadata is missing"),
+      encoding,
     );
-  }
-  if (gzipRepresentation !== undefined) {
-    validateGzipResumeSessionHistoryRepresentation(
+    if (compressedRepresentation === undefined) {
+      throw invalidResumeSessionHistoryError(
+        historyRef.hash,
+        new Error(`${encoding} session history metadata is missing`),
+      );
+    }
+    validateCompressedResumeSessionHistoryRepresentation(
       historyRef.hash,
-      gzipRepresentation,
+      compressedRepresentation,
     );
-  }
-
-  if (gzipRepresentation !== undefined) {
     const url = await args.generateResumeSessionHistoryObjectUrl(
-      gzipRepresentation.objectKey,
+      compressedRepresentation.objectKey,
     );
     return {
       sessionId,
@@ -1225,9 +1224,9 @@ async function resolveResumeSessionForClaim(args: {
         kind: historyRef.kind,
         hash: historyRef.hash,
         url,
-        encoding: gzipRepresentation.encoding,
-        rawSize: gzipRepresentation.rawSize,
-        encodedSize: gzipRepresentation.encodedSize,
+        encoding: compressedRepresentation.encoding,
+        rawSize: compressedRepresentation.rawSize,
+        encodedSize: compressedRepresentation.encodedSize,
       },
     };
   }
@@ -1265,9 +1264,10 @@ async function buildClaimResponseBody(args: {
   readonly loadIdentityRepresentation: (
     hash: string,
   ) => Promise<IdentityResumeSessionHistoryRepresentation | undefined>;
-  readonly loadGzipRepresentation: (
+  readonly loadCompressedRepresentation: (
     hash: string,
-  ) => Promise<GzipResumeSessionHistoryRepresentation | undefined>;
+    encoding: CompressedSessionHistoryBlobEncoding,
+  ) => Promise<CompressedResumeSessionHistoryRepresentation | undefined>;
   readonly generateResumeSessionHistoryUrl: (hash: string) => Promise<string>;
   readonly generateResumeSessionHistoryObjectUrl: (
     objectKey: string,
@@ -1302,8 +1302,11 @@ async function buildClaimResponseBody(args: {
         loadIdentityRepresentation(hash: string) {
           return args.loadIdentityRepresentation(hash);
         },
-        loadGzipRepresentation(hash: string) {
-          return args.loadGzipRepresentation(hash);
+        loadCompressedRepresentation(
+          hash: string,
+          encoding: CompressedSessionHistoryBlobEncoding,
+        ) {
+          return args.loadCompressedRepresentation(hash, encoding);
         },
         generateResumeSessionHistoryUrl: args.generateResumeSessionHistoryUrl,
         generateResumeSessionHistoryObjectUrl:
@@ -1362,9 +1365,13 @@ const buildClaimResponseBodyForClaim$ = command(
           hash,
         });
       },
-      loadGzipRepresentation(hash: string) {
-        return set(loadGzipResumeSessionHistoryRepresentation$, {
+      loadCompressedRepresentation(
+        hash: string,
+        encoding: CompressedSessionHistoryBlobEncoding,
+      ) {
+        return set(loadCompressedResumeSessionHistoryRepresentation$, {
           db: args.db,
+          encoding,
           hash,
         });
       },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -190,8 +190,9 @@ import {
   loadZeroBackedComposeAgent,
 } from "./agent-connector-scope.service";
 import {
+  isCompressedSessionHistoryBlobEncoding,
   normalizeSessionHistoryBlobEncoding,
-  SESSION_HISTORY_ENCODING_GZIP,
+  type CompressedSessionHistoryBlobEncoding,
 } from "./session-history-blobs";
 
 const PENDING_RUN_TTL_MS = 15 * 60 * 1000;
@@ -4274,12 +4275,12 @@ function loadResumeSession(
         (): Promise<StoredExecutionContext["resumeSession"] | null> => {
           const cliAgentSessionId = conversation.cliAgentSessionId;
           const hash = conversation.cliAgentSessionHistoryHash;
-          let encoding: typeof SESSION_HISTORY_ENCODING_GZIP | undefined;
+          let encoding: CompressedSessionHistoryBlobEncoding | undefined;
           if (conversation.sessionHistoryBlobEncoding !== null) {
             const parsedEncoding = normalizeSessionHistoryBlobEncoding(
               conversation.sessionHistoryBlobEncoding,
             );
-            if (parsedEncoding === SESSION_HISTORY_ENCODING_GZIP) {
+            if (isCompressedSessionHistoryBlobEncoding(parsedEncoding)) {
               encoding = parsedEncoding;
             }
           }

--- a/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-checkpoints.service.ts
@@ -325,6 +325,14 @@ export const prepareCheckpointHistoryUpload$ = command(
       }
     }
     if (
+      encoding !== SESSION_HISTORY_ENCODING_IDENTITY &&
+      requestedEncoding !== encoding
+    ) {
+      return badRequestMessage(
+        "Compressed session history upload encoding must match the existing blob",
+      );
+    }
+    if (
       requestedEncoding === encoding &&
       blob.encodedSize !== input.body.encodedSize
     ) {

--- a/turbo/apps/api/src/signals/services/session-history-blobs.ts
+++ b/turbo/apps/api/src/signals/services/session-history-blobs.ts
@@ -1,13 +1,24 @@
 import {
   SESSION_HISTORY_ENCODING_GZIP,
   SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_ZSTD,
 } from "@vm0/api-contracts/contracts/runners";
 
-export { SESSION_HISTORY_ENCODING_GZIP, SESSION_HISTORY_ENCODING_IDENTITY };
+export {
+  SESSION_HISTORY_ENCODING_GZIP,
+  SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_ZSTD,
+};
 
 export type SessionHistoryBlobEncoding =
   | typeof SESSION_HISTORY_ENCODING_IDENTITY
-  | typeof SESSION_HISTORY_ENCODING_GZIP;
+  | typeof SESSION_HISTORY_ENCODING_GZIP
+  | typeof SESSION_HISTORY_ENCODING_ZSTD;
+
+export type CompressedSessionHistoryBlobEncoding = Exclude<
+  SessionHistoryBlobEncoding,
+  typeof SESSION_HISTORY_ENCODING_IDENTITY
+>;
 
 export function tryNormalizeSessionHistoryBlobEncoding(
   encoding: string | null,
@@ -17,6 +28,9 @@ export function tryNormalizeSessionHistoryBlobEncoding(
   }
   if (encoding === SESSION_HISTORY_ENCODING_GZIP) {
     return SESSION_HISTORY_ENCODING_GZIP;
+  }
+  if (encoding === SESSION_HISTORY_ENCODING_ZSTD) {
+    return SESSION_HISTORY_ENCODING_ZSTD;
   }
   return undefined;
 }
@@ -39,11 +53,29 @@ function resumeSessionHistoryGzipBlobKey(hash: string): string {
   return `blobs/${hash}.blob.gz`;
 }
 
+function resumeSessionHistoryZstdBlobKey(hash: string): string {
+  return `blobs/${hash}.blob.zst`;
+}
+
+export function isCompressedSessionHistoryBlobEncoding(
+  encoding: SessionHistoryBlobEncoding,
+): encoding is CompressedSessionHistoryBlobEncoding {
+  return encoding !== SESSION_HISTORY_ENCODING_IDENTITY;
+}
+
 export function resumeSessionHistoryBlobKey(
   hash: string,
   encoding: SessionHistoryBlobEncoding,
 ): string {
-  return encoding === SESSION_HISTORY_ENCODING_GZIP
-    ? resumeSessionHistoryGzipBlobKey(hash)
-    : resumeSessionHistoryRawBlobKey(hash);
+  switch (encoding) {
+    case SESSION_HISTORY_ENCODING_GZIP: {
+      return resumeSessionHistoryGzipBlobKey(hash);
+    }
+    case SESSION_HISTORY_ENCODING_ZSTD: {
+      return resumeSessionHistoryZstdBlobKey(hash);
+    }
+    case SESSION_HISTORY_ENCODING_IDENTITY: {
+      return resumeSessionHistoryRawBlobKey(hash);
+    }
+  }
 }

--- a/turbo/apps/api/src/signals/services/session-history-decompression.ts
+++ b/turbo/apps/api/src/signals/services/session-history-decompression.ts
@@ -15,6 +15,7 @@ async function decompressSessionHistoryBufferWithMaxBytes(
   const decompressor = createDecompressor();
   for await (const chunk of Readable.from([buffer]).pipe(decompressor)) {
     if (!(chunk instanceof Uint8Array)) {
+      decompressor.destroy();
       throw new Error(`${codec} stream yielded a non-byte chunk`);
     }
     const data = Buffer.from(chunk);

--- a/turbo/apps/api/src/signals/services/session-history-decompression.ts
+++ b/turbo/apps/api/src/signals/services/session-history-decompression.ts
@@ -1,27 +1,57 @@
-import { Readable } from "node:stream";
-import { createGunzip } from "node:zlib";
+import { Readable, type Transform } from "node:stream";
+import { createGunzip, createZstdDecompress } from "node:zlib";
 
 import { S3ObjectSizeLimitError } from "../external/s3";
+
+async function decompressSessionHistoryBufferWithMaxBytes(
+  key: string,
+  buffer: Buffer,
+  maxBytes: number,
+  createDecompressor: () => Transform,
+  codec: string,
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let totalLength = 0;
+  const decompressor = createDecompressor();
+  for await (const chunk of Readable.from([buffer]).pipe(decompressor)) {
+    if (!(chunk instanceof Uint8Array)) {
+      throw new Error(`${codec} stream yielded a non-byte chunk`);
+    }
+    const data = Buffer.from(chunk);
+    totalLength += data.length;
+    if (totalLength > maxBytes) {
+      decompressor.destroy();
+      throw new S3ObjectSizeLimitError(key, totalLength, maxBytes);
+    }
+    chunks.push(data);
+  }
+  return Buffer.concat(chunks, totalLength);
+}
 
 export async function gunzipSessionHistoryBufferWithMaxBytes(
   key: string,
   buffer: Buffer,
   maxBytes: number,
 ): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  let totalLength = 0;
-  const gunzip = createGunzip();
-  for await (const chunk of Readable.from([buffer]).pipe(gunzip)) {
-    if (!(chunk instanceof Uint8Array)) {
-      throw new Error("gzip stream yielded a non-byte chunk");
-    }
-    const data = Buffer.from(chunk);
-    totalLength += data.length;
-    if (totalLength > maxBytes) {
-      gunzip.destroy();
-      throw new S3ObjectSizeLimitError(key, totalLength, maxBytes);
-    }
-    chunks.push(data);
-  }
-  return Buffer.concat(chunks, totalLength);
+  return await decompressSessionHistoryBufferWithMaxBytes(
+    key,
+    buffer,
+    maxBytes,
+    createGunzip,
+    "gzip",
+  );
+}
+
+export async function unzstdSessionHistoryBufferWithMaxBytes(
+  key: string,
+  buffer: Buffer,
+  maxBytes: number,
+): Promise<Buffer> {
+  return await decompressSessionHistoryBufferWithMaxBytes(
+    key,
+    buffer,
+    maxBytes,
+    createZstdDecompress,
+    "zstd",
+  );
 }

--- a/turbo/apps/api/src/signals/services/user-export.service.ts
+++ b/turbo/apps/api/src/signals/services/user-export.service.ts
@@ -45,8 +45,13 @@ import {
   resumeSessionHistoryBlobKey,
   type SessionHistoryBlobEncoding,
   SESSION_HISTORY_ENCODING_GZIP,
+  SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_ZSTD,
 } from "./session-history-blobs";
-import { gunzipSessionHistoryBufferWithMaxBytes } from "./session-history-decompression";
+import {
+  gunzipSessionHistoryBufferWithMaxBytes,
+  unzstdSessionHistoryBufferWithMaxBytes,
+} from "./session-history-decompression";
 import { loadWorkflowVolumeFiles } from "./zero-workflow-volume.service";
 
 const RATE_LIMIT_MS = 24 * 60 * 60 * 1000;
@@ -696,15 +701,40 @@ async function loadSessionHistoryBlob(
       args.encodedSize ?? RESUME_SESSION_HISTORY_MAX_BYTES,
     ),
   );
-  const rawBuffer =
-    args.encoding === SESSION_HISTORY_ENCODING_GZIP
-      ? await gunzipSessionHistoryBufferWithMaxBytes(
-          args.key,
-          encodedBuffer,
-          args.rawSize ?? RESUME_SESSION_HISTORY_MAX_BYTES,
-        )
-      : encodedBuffer;
+  const rawBuffer = await decodeSessionHistoryBuffer({
+    encodedBuffer,
+    encoding: args.encoding,
+    key: args.key,
+    maxRawBytes: args.rawSize ?? RESUME_SESSION_HISTORY_MAX_BYTES,
+  });
   return verifySessionHistoryBuffer(args.hash, rawBuffer, args.rawSize);
+}
+
+async function decodeSessionHistoryBuffer(args: {
+  readonly encodedBuffer: Buffer;
+  readonly encoding: SessionHistoryBlobEncoding;
+  readonly key: string;
+  readonly maxRawBytes: number;
+}): Promise<Buffer> {
+  switch (args.encoding) {
+    case SESSION_HISTORY_ENCODING_GZIP: {
+      return await gunzipSessionHistoryBufferWithMaxBytes(
+        args.key,
+        args.encodedBuffer,
+        args.maxRawBytes,
+      );
+    }
+    case SESSION_HISTORY_ENCODING_ZSTD: {
+      return await unzstdSessionHistoryBufferWithMaxBytes(
+        args.key,
+        args.encodedBuffer,
+        args.maxRawBytes,
+      );
+    }
+    case SESSION_HISTORY_ENCODING_IDENTITY: {
+      return args.encodedBuffer;
+    }
+  }
 }
 
 function verifySessionHistoryBuffer(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -291,6 +291,35 @@ describe("runner resume session contract", () => {
     expect(resumeSessionSchema.parse(resumeSession)).toEqual(resumeSession);
   });
 
+  it("accepts zstd hash-backed stored and claim resume sessions", () => {
+    const storedResumeSession = {
+      sessionId: "sess-123",
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        encoding: "zstd",
+      },
+    };
+    const claimResumeSession = {
+      sessionId: "sess-123",
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: "https://r2.example.com/blobs/history.blob.zst?sig=secret",
+        encoding: "zstd",
+        rawSize: 1024,
+        encodedSize: 96,
+      },
+    };
+
+    expect(storedResumeSessionSchema.parse(storedResumeSession)).toEqual(
+      storedResumeSession,
+    );
+    expect(resumeSessionSchema.parse(claimResumeSession)).toEqual(
+      claimResumeSession,
+    );
+  });
+
   it("rejects malformed gzip claim resume sessions", () => {
     const resumeSession = {
       sessionId: "sess-123",
@@ -299,6 +328,20 @@ describe("runner resume session contract", () => {
         hash: historyHash,
         url: "https://r2.example.com/blobs/history.blob.gz?sig=secret",
         encoding: "gzip",
+      },
+    };
+
+    expect(resumeSessionSchema.safeParse(resumeSession).success).toBe(false);
+  });
+
+  it("rejects malformed zstd claim resume sessions", () => {
+    const resumeSession = {
+      sessionId: "sess-123",
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: "https://r2.example.com/blobs/history.blob.zst?sig=secret",
+        encoding: "zstd",
       },
     };
 

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -25,11 +25,13 @@ export const CANONICAL_CODEX_MEMORY_MOUNT_PATH = `${CANONICAL_GUEST_HOME_DIR}/.c
 export const RESUME_SESSION_HISTORY_MAX_BYTES = 128 * 1024 * 1024;
 export const SESSION_HISTORY_ENCODING_IDENTITY = "identity";
 export const SESSION_HISTORY_ENCODING_GZIP = "gzip";
+export const SESSION_HISTORY_ENCODING_ZSTD = "zstd";
 export const SESSION_HISTORY_GZIP_MIN_BYTES = 64 * 1024;
 export const NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX = 256;
 export const sessionHistoryEncodingSchema = z.enum([
   SESSION_HISTORY_ENCODING_IDENTITY,
   SESSION_HISTORY_ENCODING_GZIP,
+  SESSION_HISTORY_ENCODING_ZSTD,
 ]);
 
 export function elapsedSinceApiStartMs(
@@ -243,10 +245,20 @@ const resumeSessionGzipHistoryRefSchema = resumeSessionHistoryBlobRefSchema
   })
   .strict();
 
+const resumeSessionZstdHistoryRefSchema = resumeSessionHistoryBlobRefSchema
+  .extend({
+    url: z.string().url(),
+    encoding: z.literal("zstd"),
+    rawSize: resumeSessionHistoryRawSizeSchema,
+    encodedSize: resumeSessionHistoryEncodedSizeSchema,
+  })
+  .strict();
+
 const resumeSessionRefSchema = z.object({
   sessionId: z.string(),
   historyRef: z.union([
     resumeSessionGzipHistoryRefSchema,
+    resumeSessionZstdHistoryRefSchema,
     resumeSessionIdentityHistoryRefSchema,
   ]),
 });

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -20,6 +20,7 @@ import {
   RESUME_SESSION_HISTORY_MAX_BYTES,
   SESSION_HISTORY_ENCODING_GZIP,
   SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_ZSTD,
   SESSION_HISTORY_GZIP_MIN_BYTES,
 } from "../../contracts/runners";
 
@@ -50,6 +51,10 @@ const sessionHistoryEncodingGzipDoc = [
 ] as const;
 const sessionHistoryEncodingIdentityDoc = [
   "Wire and blob metadata value for uncompressed resume session history.",
+  "Rust and TypeScript components use this shared contract value when negotiating session history uploads and claim responses.",
+] as const;
+const sessionHistoryEncodingZstdDoc = [
+  "Wire and blob metadata value for zstd-compressed resume session history.",
   "Rust and TypeScript components use this shared contract value when negotiating session history uploads and claim responses.",
 ] as const;
 const sessionHistoryGzipMinBytesDoc = [
@@ -96,6 +101,12 @@ const expectedBindings = [
     rustConstName: "SESSION_HISTORY_ENCODING_IDENTITY",
     value: rustString(SESSION_HISTORY_ENCODING_IDENTITY),
     rustDoc: sessionHistoryEncodingIdentityDoc,
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "SESSION_HISTORY_ENCODING_ZSTD",
+    value: rustString(SESSION_HISTORY_ENCODING_ZSTD),
+    rustDoc: sessionHistoryEncodingZstdDoc,
   },
   {
     rustModulePath: ["runners"],
@@ -283,6 +294,9 @@ describe("Rust constant bindings", () => {
     );
     expect(firstRender).toContain(
       `pub const SESSION_HISTORY_ENCODING_IDENTITY: &str = "${SESSION_HISTORY_ENCODING_IDENTITY}";`,
+    );
+    expect(firstRender).toContain(
+      `pub const SESSION_HISTORY_ENCODING_ZSTD: &str = "${SESSION_HISTORY_ENCODING_ZSTD}";`,
     );
     expect(firstRender).toContain(
       `pub const SESSION_HISTORY_GZIP_MIN_BYTES: u64 = ${SESSION_HISTORY_GZIP_MIN_BYTES};`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -9,6 +9,7 @@ import {
   RESUME_SESSION_HISTORY_MAX_BYTES,
   SESSION_HISTORY_ENCODING_GZIP,
   SESSION_HISTORY_ENCODING_IDENTITY,
+  SESSION_HISTORY_ENCODING_ZSTD,
   SESSION_HISTORY_GZIP_MIN_BYTES,
 } from "../contracts/runners";
 
@@ -185,6 +186,15 @@ export const rustConstantBindings = [
     value: rustString(SESSION_HISTORY_ENCODING_IDENTITY),
     rustDoc: [
       "Wire and blob metadata value for uncompressed resume session history.",
+      "Rust and TypeScript components use this shared contract value when negotiating session history uploads and claim responses.",
+    ],
+  },
+  {
+    rustModulePath: ["runners"],
+    rustConstName: "SESSION_HISTORY_ENCODING_ZSTD",
+    value: rustString(SESSION_HISTORY_ENCODING_ZSTD),
+    rustDoc: [
+      "Wire and blob metadata value for zstd-compressed resume session history.",
       "Rust and TypeScript components use this shared contract value when negotiating session history uploads and claim responses.",
     ],
   },


### PR DESCRIPTION
## Summary
- add zstd session history encoding to the API contract and generated Rust constants
- support zstd blob keys, prepare-history metadata, claim materialization, and user export decompression on the API side
- support zstd resume history download/decompression/hash validation and telemetry in the runner
- keep the guest-agent writer path identity/gzip-only for the follow-up writer issue

## Tests
- pnpm format
- pnpm -F @vm0/api-contracts test -- src/contracts/__tests__/runners.test.ts src/rust-bindings/__tests__/constants.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts src/signals/routes/__tests__/ops-logs.bdd.test.ts
- pnpm -F api check-types
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api lint
- pnpm -F @vm0/api-contracts lint
- cargo test --manifest-path crates/Cargo.toml -p runner session_history_download
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings

Closes #20329