### PR TITLE
fix: reject oversized control frames before write

### DIFF
--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -136,10 +136,10 @@ pub enum TerminateResponse {
     },
 }
 
-/// Maximum frame size: 64 MiB (generous for large stdout/stderr).
+/// Maximum frame payload size: 64 MiB, excluding the 4-byte length prefix.
 const MAX_FRAME_SIZE: usize = 64 * 1024 * 1024;
 
-fn validate_frame_len(len: usize) -> io::Result<()> {
+fn validate_frame_payload_len(len: usize) -> io::Result<()> {
     if len > MAX_FRAME_SIZE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -153,7 +153,7 @@ fn validate_frame_len(len: usize) -> io::Result<()> {
 /// Read a length-prefixed frame from the stream.
 pub(super) async fn read_frame(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
     let len = stream.read_u32().await? as usize;
-    validate_frame_len(len)?;
+    validate_frame_payload_len(len)?;
     let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf).await?;
     Ok(buf)
@@ -161,7 +161,7 @@ pub(super) async fn read_frame(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
 
 /// Write a length-prefixed frame to the stream.
 pub(super) async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
-    validate_frame_len(data.len())?;
+    validate_frame_payload_len(data.len())?;
     let len = u32::try_from(data.len()).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidData,

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -151,7 +151,7 @@ fn validate_frame_payload_len(len: usize) -> io::Result<u32> {
         return Err(frame_payload_len_error(len));
     }
 
-    u32::try_from(len).map_err(|_| frame_payload_len_error(len))
+    Ok(len as u32)
 }
 
 /// Read a length-prefixed frame from the stream.

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -137,7 +137,7 @@ pub enum TerminateResponse {
 }
 
 /// Maximum frame payload size: 64 MiB, excluding the 4-byte length prefix.
-const MAX_FRAME_PAYLOAD_SIZE: usize = 64 * 1024 * 1024;
+const MAX_FRAME_PAYLOAD_SIZE: u32 = 64 * 1024 * 1024;
 
 fn frame_payload_len_error(len: usize) -> io::Error {
     io::Error::new(
@@ -147,7 +147,7 @@ fn frame_payload_len_error(len: usize) -> io::Error {
 }
 
 fn validate_frame_payload_len(len: usize) -> io::Result<u32> {
-    if len > MAX_FRAME_PAYLOAD_SIZE {
+    if len > MAX_FRAME_PAYLOAD_SIZE as usize {
         return Err(frame_payload_len_error(len));
     }
 
@@ -208,10 +208,7 @@ mod tests {
     async fn read_frame_rejects_frames_larger_than_max_size() {
         let (mut reader, mut writer) = UnixStream::pair().unwrap();
 
-        writer
-            .write_u32(u32::try_from(MAX_FRAME_PAYLOAD_SIZE + 1).unwrap())
-            .await
-            .unwrap();
+        writer.write_u32(MAX_FRAME_PAYLOAD_SIZE + 1).await.unwrap();
         drop(writer);
 
         let err = read_frame(&mut reader).await.unwrap_err();
@@ -222,7 +219,7 @@ mod tests {
     #[tokio::test]
     async fn write_frame_rejects_frames_larger_than_max_size_without_writing_prefix() {
         let (mut reader, mut writer) = UnixStream::pair().unwrap();
-        let payload = vec![0u8; MAX_FRAME_PAYLOAD_SIZE + 1];
+        let payload = vec![0u8; MAX_FRAME_PAYLOAD_SIZE as usize + 1];
 
         let err = write_frame(&mut writer, &payload).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -137,37 +137,34 @@ pub enum TerminateResponse {
 }
 
 /// Maximum frame payload size: 64 MiB, excluding the 4-byte length prefix.
-const MAX_FRAME_SIZE: usize = 64 * 1024 * 1024;
+const MAX_FRAME_PAYLOAD_SIZE: usize = 64 * 1024 * 1024;
 
-fn validate_frame_payload_len(len: usize) -> io::Result<()> {
-    if len > MAX_FRAME_SIZE {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("frame too large: {len} bytes"),
-        ));
+fn frame_payload_len_error(len: usize) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("frame too large: {len} bytes"),
+    )
+}
+
+fn validate_frame_payload_len(len: usize) -> io::Result<u32> {
+    if len > MAX_FRAME_PAYLOAD_SIZE {
+        return Err(frame_payload_len_error(len));
     }
 
-    Ok(())
+    u32::try_from(len).map_err(|_| frame_payload_len_error(len))
 }
 
 /// Read a length-prefixed frame from the stream.
 pub(super) async fn read_frame(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
-    let len = stream.read_u32().await? as usize;
-    validate_frame_payload_len(len)?;
-    let mut buf = vec![0u8; len];
+    let len = validate_frame_payload_len(stream.read_u32().await? as usize)?;
+    let mut buf = vec![0u8; len as usize];
     stream.read_exact(&mut buf).await?;
     Ok(buf)
 }
 
 /// Write a length-prefixed frame to the stream.
 pub(super) async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
-    validate_frame_payload_len(data.len())?;
-    let len = u32::try_from(data.len()).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("frame too large: {} bytes", data.len()),
-        )
-    })?;
+    let len = validate_frame_payload_len(data.len())?;
     stream.write_u32(len).await?;
     stream.write_all(data).await?;
     stream.flush().await?;
@@ -212,7 +209,7 @@ mod tests {
         let (mut reader, mut writer) = UnixStream::pair().unwrap();
 
         writer
-            .write_u32(u32::try_from(MAX_FRAME_SIZE + 1).unwrap())
+            .write_u32(u32::try_from(MAX_FRAME_PAYLOAD_SIZE + 1).unwrap())
             .await
             .unwrap();
         drop(writer);
@@ -225,7 +222,7 @@ mod tests {
     #[tokio::test]
     async fn write_frame_rejects_frames_larger_than_max_size_without_writing_prefix() {
         let (mut reader, mut writer) = UnixStream::pair().unwrap();
-        let payload = vec![0u8; MAX_FRAME_SIZE + 1];
+        let payload = vec![0u8; MAX_FRAME_PAYLOAD_SIZE + 1];
 
         let err = write_frame(&mut writer, &payload).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);

--- a/crates/sandbox-fc/src/control/protocol.rs
+++ b/crates/sandbox-fc/src/control/protocol.rs
@@ -137,28 +137,35 @@ pub enum TerminateResponse {
 }
 
 /// Maximum frame size: 64 MiB (generous for large stdout/stderr).
-const MAX_FRAME_SIZE: u32 = 64 * 1024 * 1024;
+const MAX_FRAME_SIZE: usize = 64 * 1024 * 1024;
 
-/// Read a length-prefixed frame from the stream.
-pub(super) async fn read_frame(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
-    let len = stream.read_u32().await?;
+fn validate_frame_len(len: usize) -> io::Result<()> {
     if len > MAX_FRAME_SIZE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("frame too large: {len} bytes"),
         ));
     }
-    let mut buf = vec![0u8; len as usize];
+
+    Ok(())
+}
+
+/// Read a length-prefixed frame from the stream.
+pub(super) async fn read_frame(stream: &mut UnixStream) -> io::Result<Vec<u8>> {
+    let len = stream.read_u32().await? as usize;
+    validate_frame_len(len)?;
+    let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf).await?;
     Ok(buf)
 }
 
 /// Write a length-prefixed frame to the stream.
 pub(super) async fn write_frame(stream: &mut UnixStream, data: &[u8]) -> io::Result<()> {
+    validate_frame_len(data.len())?;
     let len = u32::try_from(data.len()).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("payload too large: {} bytes", data.len()),
+            format!("frame too large: {} bytes", data.len()),
         )
     })?;
     stream.write_u32(len).await?;
@@ -173,7 +180,7 @@ mod tests {
 
     use base64::Engine;
     use base64::engine::general_purpose::STANDARD as BASE64;
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{UnixListener, UnixStream};
 
     #[tokio::test]
@@ -204,12 +211,29 @@ mod tests {
     async fn read_frame_rejects_frames_larger_than_max_size() {
         let (mut reader, mut writer) = UnixStream::pair().unwrap();
 
-        writer.write_u32(MAX_FRAME_SIZE + 1).await.unwrap();
+        writer
+            .write_u32(u32::try_from(MAX_FRAME_SIZE + 1).unwrap())
+            .await
+            .unwrap();
         drop(writer);
 
         let err = read_frame(&mut reader).await.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("frame too large"));
+    }
+
+    #[tokio::test]
+    async fn write_frame_rejects_frames_larger_than_max_size_without_writing_prefix() {
+        let (mut reader, mut writer) = UnixStream::pair().unwrap();
+        let payload = vec![0u8; MAX_FRAME_SIZE + 1];
+
+        let err = write_frame(&mut writer, &payload).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("frame too large"));
+
+        drop(writer);
+        let err = reader.read_u32().await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- centralize control socket frame payload length validation
- reject oversized writes before emitting the length prefix
- add coverage that oversized writes do not leave a partial frame for the peer

## Tests
- cargo test --manifest-path crates/Cargo.toml -p sandbox-fc control::protocol::tests
- cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc --all-targets -- -D warnings
- pre-commit hook: crates cargo-fmt, cargo-doc, cargo-clippy

Closes #20315