### PR TITLE
feat: enable sidebar manage icon collapse for staff orgs

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -347,6 +347,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show icon-only manage navigation buttons when the expanded sidebar manage section is collapsed.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SidebarSubscriptionUsage]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
Summary:
- Enables the sidebarManageIconCollapse feature switch for internal/staff orgs by adding STAFF_ORG_ID_HASHES to the switch registry entry.
- Keeps the switch globally disabled for non-staff orgs and leaves frontend behavior unchanged.

Verification:
- pnpm format
- pnpm --filter @vm0/core lint
- pnpm --filter @vm0/core check-types
- pnpm exec vitest run packages/core/src/__tests__/feature-switch.test.ts