### PR TITLE
feat: prompt for force upgrade

### DIFF
--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -53,16 +53,14 @@ export async function waitForPaidOnboardingAppHandoff(
   page: Page,
   appUrl: string,
 ): Promise<void> {
-  const appOrigin = new URL(appUrl).origin;
-  await page.waitForURL(
-    (url) => {
-      return (
-        url.origin === appOrigin &&
-        (url.pathname === "/prompt" ||
-          /\/agents\/[^/]+\/chat/.test(url.pathname))
-      );
-    },
-    { timeout: 180_000, waitUntil: "domcontentloaded" },
+  await waitForExpectedAppUrl(
+    page,
+    appUrl,
+    (url, appOrigin) =>
+      url.origin === appOrigin &&
+      (url.pathname === "/prompt" ||
+        /\/agents\/[^/]+\/chat/.test(url.pathname)),
+    180_000,
   );
 }
 
@@ -94,14 +92,12 @@ async function clickOnboardingButton(page: Page, name: RegExp): Promise<void> {
 }
 
 async function waitForChatPage(page: Page, appUrl: string): Promise<void> {
-  const appOrigin = new URL(appUrl).origin;
-  await page.waitForURL(
-    (url) => {
-      return (
-        url.origin === appOrigin && /\/agents\/[^/]+\/chat/.test(url.pathname)
-      );
-    },
-    { timeout: 120_000, waitUntil: "domcontentloaded" },
+  await waitForExpectedAppUrl(
+    page,
+    appUrl,
+    (url, appOrigin) =>
+      url.origin === appOrigin && /\/agents\/[^/]+\/chat/.test(url.pathname),
+    120_000,
   );
 }
 
@@ -110,4 +106,106 @@ function onboardingEntryUrl(options: OnboardingFlowOptions): string {
   url.searchParams.set("domain", new URL(options.apiUrl).host);
   url.searchParams.set("vm0_theme", "light");
   return url.toString();
+}
+
+type AppUrlMatcher = (url: URL, appOrigin: string) => boolean;
+
+async function waitForExpectedAppUrl(
+  page: Page,
+  appUrl: string,
+  matchesExpectedUrl: AppUrlMatcher,
+  timeoutMs: number,
+): Promise<void> {
+  const appOrigin = new URL(appUrl).origin;
+  const deadline = Date.now() + timeoutMs;
+
+  while (true) {
+    const currentUrl = new URL(page.url());
+    if (matchesExpectedUrl(currentUrl, appOrigin)) {
+      return;
+    }
+
+    const rewrittenUrl = rewritePreviewAppFallbackUrl(currentUrl, appOrigin);
+    if (rewrittenUrl) {
+      console.log("[e2e] rewriting onboarding preview handoff", {
+        from: currentUrl.toString(),
+        to: rewrittenUrl,
+      });
+      await page.goto(rewrittenUrl, { waitUntil: "domcontentloaded" });
+      continue;
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      throw new Error(
+        `Timed out waiting for onboarding app handoff to ${appOrigin}; current URL is ${page.url()}`,
+      );
+    }
+
+    await page.waitForURL(
+      (url) =>
+        matchesExpectedUrl(url, appOrigin) ||
+        rewritePreviewAppFallbackUrl(url, appOrigin) !== null,
+      { timeout: remainingMs, waitUntil: "domcontentloaded" },
+    );
+  }
+}
+
+function rewritePreviewAppFallbackUrl(
+  url: URL,
+  appOrigin: string,
+): string | null {
+  const rewrittenUrl = withExpectedPreviewAppOrigin(url, appOrigin);
+  if (!rewrittenUrl) {
+    return null;
+  }
+
+  rewriteNestedRedirectUrl(rewrittenUrl, appOrigin);
+  return rewrittenUrl.toString();
+}
+
+function withExpectedPreviewAppOrigin(url: URL, appOrigin: string): URL | null {
+  if (!isPreviewAppStagingFallback(url, appOrigin)) {
+    return null;
+  }
+
+  const appUrl = new URL(appOrigin);
+  const rewrittenUrl = new URL(url.toString());
+  rewrittenUrl.protocol = appUrl.protocol;
+  rewrittenUrl.host = appUrl.host;
+  return rewrittenUrl;
+}
+
+function isPreviewAppStagingFallback(url: URL, appOrigin: string): boolean {
+  const appUrl = new URL(appOrigin);
+  const previewDomainMatch = /^pr-\d+-app\.(.+)$/.exec(appUrl.hostname);
+  if (!previewDomainMatch) {
+    return false;
+  }
+
+  return (
+    url.protocol === appUrl.protocol &&
+    url.hostname === `staging-app.${previewDomainMatch[1]}`
+  );
+}
+
+function rewriteNestedRedirectUrl(url: URL, appOrigin: string): void {
+  const redirectUrl = url.searchParams.get("redirect_url");
+  if (!redirectUrl) {
+    return;
+  }
+
+  try {
+    const rewrittenRedirectUrl = withExpectedPreviewAppOrigin(
+      new URL(redirectUrl),
+      appOrigin,
+    );
+    if (rewrittenRedirectUrl) {
+      url.searchParams.set("redirect_url", rewrittenRedirectUrl.toString());
+    }
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
+  }
 }

--- a/turbo/apps/api/.env.local.tpl
+++ b/turbo/apps/api/.env.local.tpl
@@ -12,7 +12,7 @@ APP_URL=https://app.vm7.ai:8443
 ONBOARDING_URL=https://www.vm7.ai:8443
 
 # Optional: Atom redeem service for onboarding codes
-ATOM_URL=https://tunnel-yuma-atom-api.vm7.ai
+ATOM_URL=https://atom-api.vm7.ai:8442
 VM0_MACHINE_SECRET_KEY=op://Development/clerk/VM0_MACHINE_SECRET_KEY
 
 # Required: API deploy stage tag

--- a/turbo/apps/platform/.env.local.tpl
+++ b/turbo/apps/platform/.env.local.tpl
@@ -4,6 +4,7 @@ VITE_CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VITE_API_URL=http://localhost:3000
 PUBLIC_ARTIFACTS_BASE_URL=https://cdn.vm7.io
 VITE_ZERO_HOST_DOMAIN=sites.vm7.io
+ATOM_URL=https://atom-api.vm7.ai:8442
 
 # Web Push (VAPID public key for push subscription)
 VITE_VAPID_PUBLIC_KEY=op://Development/vapid/VAPID_PUBLIC_KEY

--- a/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
@@ -17,8 +17,8 @@ function jsonResponse(body: unknown, ok = true) {
 
 describe("force upgrade", () => {
   it("builds the Atom force-upgrade URL with the current version", () => {
-    expect(buildForceUpgradeUrl("0.540.0", "https://atom-api.vm6.ai/")).toBe(
-      "https://atom-api.vm6.ai/api/client/force-upgrade?version=0.540.0",
+    expect(buildForceUpgradeUrl("0.540.0", "https://atom.example.test/")).toBe(
+      "https://atom.example.test/api/client/force-upgrade?version=0.540.0",
     );
   });
 
@@ -29,13 +29,13 @@ describe("force upgrade", () => {
 
     await expect(
       shouldForceUpgrade("0.540.0", {
-        apiBase: "https://atom-api.vm6.ai",
+        apiBase: "https://atom.example.test",
         fetcher,
       }),
     ).resolves.toBeTruthy();
 
     expect(fetcher).toHaveBeenCalledWith(
-      "https://atom-api.vm6.ai/api/client/force-upgrade?version=0.540.0",
+      "https://atom.example.test/api/client/force-upgrade?version=0.540.0",
       {
         cache: "no-store",
         credentials: "omit",
@@ -69,9 +69,28 @@ describe("force upgrade", () => {
     }
   });
 
+  it("skips the request when ATOM_URL is not configured", async () => {
+    const previousAtomUrl = import.meta.env.ATOM_URL as string | undefined;
+    vi.stubEnv("ATOM_URL", "");
+    const fetcher = vi.fn(() => {
+      return Promise.resolve(jsonResponse({ forceUpgrade: true }));
+    });
+
+    try {
+      await expect(
+        shouldForceUpgrade("0.540.0", { fetcher }),
+      ).resolves.toBeFalsy();
+
+      expect(fetcher).not.toHaveBeenCalled();
+    } finally {
+      vi.stubEnv("ATOM_URL", previousAtomUrl);
+    }
+  });
+
   it("returns false when Atom does not require a force upgrade", async () => {
     await expect(
       checkForceUpgrade({
+        apiBase: "https://atom.example.test",
         fetcher: vi.fn(() => {
           return Promise.resolve(jsonResponse({ forceUpgrade: false }));
         }),
@@ -83,6 +102,7 @@ describe("force upgrade", () => {
   it("returns true when Atom requires a force upgrade", async () => {
     await expect(
       checkForceUpgrade({
+        apiBase: "https://atom.example.test",
         fetcher: vi.fn(() => {
           return Promise.resolve(jsonResponse({ forceUpgrade: true }));
         }),
@@ -94,6 +114,7 @@ describe("force upgrade", () => {
   it("returns false when the response is not OK", async () => {
     await expect(
       checkForceUpgrade({
+        apiBase: "https://atom.example.test",
         fetcher: vi.fn(() => {
           return Promise.resolve(jsonResponse({ forceUpgrade: true }, false));
         }),
@@ -120,6 +141,7 @@ describe("force upgrade", () => {
   it("returns false when the force-upgrade request fails", async () => {
     await expect(
       checkForceUpgrade({
+        apiBase: "https://atom.example.test",
         fetcher: vi.fn(() => {
           return Promise.reject(new Error("network unavailable"));
         }),

--- a/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
@@ -17,9 +17,9 @@ function jsonResponse(body: unknown, ok = true) {
 
 describe("force upgrade", () => {
   it("builds the Atom force-upgrade URL with the current version", () => {
-    expect(
-      buildForceUpgradeUrl("0.540.0", "https://atom-api.vm6.ai/"),
-    ).toBe("https://atom-api.vm6.ai/api/client/force-upgrade?version=0.540.0");
+    expect(buildForceUpgradeUrl("0.540.0", "https://atom-api.vm6.ai/")).toBe(
+      "https://atom-api.vm6.ai/api/client/force-upgrade?version=0.540.0",
+    );
   });
 
   it("returns true only when Atom explicitly requires a force upgrade", async () => {
@@ -42,6 +42,31 @@ describe("force upgrade", () => {
         method: "GET",
       },
     );
+  });
+
+  it("uses ATOM_URL when no API base override is provided", async () => {
+    const previousAtomUrl = import.meta.env.ATOM_URL as string | undefined;
+    vi.stubEnv("ATOM_URL", "https://atom.example.test/");
+    const fetcher = vi.fn(() => {
+      return Promise.resolve(jsonResponse({ forceUpgrade: true }));
+    });
+
+    try {
+      await expect(
+        shouldForceUpgrade("0.540.0", { fetcher }),
+      ).resolves.toBeTruthy();
+
+      expect(fetcher).toHaveBeenCalledWith(
+        "https://atom.example.test/api/client/force-upgrade?version=0.540.0",
+        {
+          cache: "no-store",
+          credentials: "omit",
+          method: "GET",
+        },
+      );
+    } finally {
+      vi.stubEnv("ATOM_URL", previousAtomUrl);
+    }
   });
 
   it("returns false when Atom does not require a force upgrade", async () => {

--- a/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildForceUpgradeUrl,
+  checkForceUpgrade,
+  shouldForceUpgrade,
+} from "../force-upgrade.ts";
+
+function jsonResponse(body: unknown, ok = true) {
+  return {
+    ok,
+    json: vi.fn(() => {
+      return Promise.resolve(body);
+    }),
+  };
+}
+
+describe("force upgrade", () => {
+  it("builds the Atom force-upgrade URL with the current version", () => {
+    expect(
+      buildForceUpgradeUrl("0.540.0", "https://atom-api.vm6.ai/"),
+    ).toBe("https://atom-api.vm6.ai/api/client/force-upgrade?version=0.540.0");
+  });
+
+  it("returns true only when Atom explicitly requires a force upgrade", async () => {
+    const fetcher = vi.fn(() => {
+      return Promise.resolve(jsonResponse({ forceUpgrade: true }));
+    });
+
+    await expect(
+      shouldForceUpgrade("0.540.0", {
+        apiBase: "https://atom-api.vm6.ai",
+        fetcher,
+      }),
+    ).resolves.toBeTruthy();
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://atom-api.vm6.ai/api/client/force-upgrade?version=0.540.0",
+      {
+        cache: "no-store",
+        credentials: "omit",
+        method: "GET",
+      },
+    );
+  });
+
+  it("returns false when Atom does not require a force upgrade", async () => {
+    await expect(
+      checkForceUpgrade({
+        fetcher: vi.fn(() => {
+          return Promise.resolve(jsonResponse({ forceUpgrade: false }));
+        }),
+        version: "0.540.0",
+      }),
+    ).resolves.toBeFalsy();
+  });
+
+  it("returns true when Atom requires a force upgrade", async () => {
+    await expect(
+      checkForceUpgrade({
+        fetcher: vi.fn(() => {
+          return Promise.resolve(jsonResponse({ forceUpgrade: true }));
+        }),
+        version: "0.540.0",
+      }),
+    ).resolves.toBeTruthy();
+  });
+
+  it("returns false when the response is not OK", async () => {
+    await expect(
+      checkForceUpgrade({
+        fetcher: vi.fn(() => {
+          return Promise.resolve(jsonResponse({ forceUpgrade: true }, false));
+        }),
+        version: "0.540.0",
+      }),
+    ).resolves.toBeFalsy();
+  });
+
+  it("skips the request when the build version is unavailable", async () => {
+    const fetcher = vi.fn(() => {
+      return Promise.resolve(jsonResponse({ forceUpgrade: true }));
+    });
+
+    await expect(
+      checkForceUpgrade({
+        fetcher,
+        version: null,
+      }),
+    ).resolves.toBeFalsy();
+
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the force-upgrade request fails", async () => {
+    await expect(
+      checkForceUpgrade({
+        fetcher: vi.fn(() => {
+          return Promise.reject(new Error("network unavailable"));
+        }),
+        version: "0.540.0",
+      }),
+    ).resolves.toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/lib/force-upgrade.ts
+++ b/turbo/apps/platform/src/lib/force-upgrade.ts
@@ -1,0 +1,79 @@
+import { getBuildVersion } from "./build-info.ts";
+import { settle } from "../signals/utils.ts";
+
+const DEFAULT_FORCE_UPGRADE_API_BASE = "https://atom-api.vm6.ai";
+// eslint-disable-next-line ccstate/no-non-zero-api -- external Atom public endpoint, not a vm0 API contract route
+const FORCE_UPGRADE_PATH = "/api/client/force-upgrade";
+
+type ForceUpgradeFetch = (
+  input: string,
+  init: RequestInit,
+) => Promise<Pick<Response, "json" | "ok">>;
+
+type ForceUpgradeResponse = {
+  forceUpgrade?: unknown;
+};
+
+export type ForceUpgradeCheckOptions = {
+  apiBase?: string;
+  fetcher?: ForceUpgradeFetch;
+  version?: string | null;
+};
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function resolveForceUpgradeApiBase(): string {
+  const configured = import.meta.env.VITE_ATOM_API_URL as string | undefined;
+  const apiBase = configured?.trim() || DEFAULT_FORCE_UPGRADE_API_BASE;
+  return trimTrailingSlash(apiBase);
+}
+
+function isForceUpgradeResponse(value: unknown): value is ForceUpgradeResponse {
+  return typeof value === "object" && value !== null;
+}
+
+export function buildForceUpgradeUrl(
+  version: string,
+  apiBase = resolveForceUpgradeApiBase(),
+): string {
+  const url = new URL(FORCE_UPGRADE_PATH, `${trimTrailingSlash(apiBase)}/`);
+  url.searchParams.set("version", version);
+  return url.toString();
+}
+
+export async function shouldForceUpgrade(
+  version: string,
+  options: Pick<ForceUpgradeCheckOptions, "apiBase" | "fetcher"> = {},
+): Promise<boolean> {
+  const fetcher = options.fetcher ?? window.fetch.bind(window);
+  const response = await fetcher(buildForceUpgradeUrl(version, options.apiBase), {
+    cache: "no-store",
+    credentials: "omit",
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    return false;
+  }
+
+  const body: unknown = await response.json();
+  return isForceUpgradeResponse(body) && body.forceUpgrade === true;
+}
+
+export async function checkForceUpgrade(
+  options: ForceUpgradeCheckOptions = {},
+): Promise<boolean> {
+  const version = "version" in options ? options.version : getBuildVersion();
+  if (!version) {
+    return false;
+  }
+
+  const result = await settle(shouldForceUpgrade(version, options));
+  if (!result.ok) {
+    return false;
+  }
+
+  return result.value;
+}

--- a/turbo/apps/platform/src/lib/force-upgrade.ts
+++ b/turbo/apps/platform/src/lib/force-upgrade.ts
@@ -1,9 +1,7 @@
 import { getBuildVersion } from "./build-info.ts";
 import { settle } from "../signals/utils.ts";
 
-const DEFAULT_FORCE_UPGRADE_API_BASE = "https://atom-api.vm6.ai";
-// eslint-disable-next-line ccstate/no-non-zero-api -- external Atom public endpoint, not a vm0 API contract route
-const FORCE_UPGRADE_PATH = "/api/client/force-upgrade";
+const FORCE_UPGRADE_PATH = "api/client/force-upgrade";
 
 type ForceUpgradeFetch = (
   input: string,
@@ -24,20 +22,23 @@ function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
 }
 
-function resolveForceUpgradeApiBase(): string {
+function normalizeForceUpgradeApiBase(
+  value: string | undefined,
+): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimTrailingSlash(trimmed) : null;
+}
+
+function resolveForceUpgradeApiBase(): string | null {
   const configured = import.meta.env.ATOM_URL as string | undefined;
-  const apiBase = configured?.trim() || DEFAULT_FORCE_UPGRADE_API_BASE;
-  return trimTrailingSlash(apiBase);
+  return normalizeForceUpgradeApiBase(configured);
 }
 
 function isForceUpgradeResponse(value: unknown): value is ForceUpgradeResponse {
   return typeof value === "object" && value !== null;
 }
 
-export function buildForceUpgradeUrl(
-  version: string,
-  apiBase = resolveForceUpgradeApiBase(),
-): string {
+export function buildForceUpgradeUrl(version: string, apiBase: string): string {
   const url = new URL(FORCE_UPGRADE_PATH, `${trimTrailingSlash(apiBase)}/`);
   url.searchParams.set("version", version);
   return url.toString();
@@ -48,14 +49,19 @@ export async function shouldForceUpgrade(
   options: Pick<ForceUpgradeCheckOptions, "apiBase" | "fetcher"> = {},
 ): Promise<boolean> {
   const fetcher = options.fetcher ?? window.fetch.bind(window);
-  const response = await fetcher(
-    buildForceUpgradeUrl(version, options.apiBase),
-    {
-      cache: "no-store",
-      credentials: "omit",
-      method: "GET",
-    },
-  );
+  const apiBase =
+    options.apiBase === undefined
+      ? resolveForceUpgradeApiBase()
+      : normalizeForceUpgradeApiBase(options.apiBase);
+  if (!apiBase) {
+    return false;
+  }
+
+  const response = await fetcher(buildForceUpgradeUrl(version, apiBase), {
+    cache: "no-store",
+    credentials: "omit",
+    method: "GET",
+  });
 
   if (!response.ok) {
     return false;

--- a/turbo/apps/platform/src/lib/force-upgrade.ts
+++ b/turbo/apps/platform/src/lib/force-upgrade.ts
@@ -25,7 +25,7 @@ function trimTrailingSlash(value: string): string {
 }
 
 function resolveForceUpgradeApiBase(): string {
-  const configured = import.meta.env.VITE_ATOM_API_URL as string | undefined;
+  const configured = import.meta.env.ATOM_URL as string | undefined;
   const apiBase = configured?.trim() || DEFAULT_FORCE_UPGRADE_API_BASE;
   return trimTrailingSlash(apiBase);
 }
@@ -48,11 +48,14 @@ export async function shouldForceUpgrade(
   options: Pick<ForceUpgradeCheckOptions, "apiBase" | "fetcher"> = {},
 ): Promise<boolean> {
   const fetcher = options.fetcher ?? window.fetch.bind(window);
-  const response = await fetcher(buildForceUpgradeUrl(version, options.apiBase), {
-    cache: "no-store",
-    credentials: "omit",
-    method: "GET",
-  });
+  const response = await fetcher(
+    buildForceUpgradeUrl(version, options.apiBase),
+    {
+      cache: "no-store",
+      credentials: "omit",
+      method: "GET",
+    },
+  );
 
   if (!response.ok) {
     return false;

--- a/turbo/apps/platform/src/signals/__tests__/force-upgrade.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/force-upgrade.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { pollForceUpgradeRequirement } from "../force-upgrade.ts";
+
+describe("force upgrade polling", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("checks immediately and then polls every 60 seconds until an upgrade is required", async () => {
+    vi.useFakeTimers();
+
+    const check = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const onRequired = vi.fn();
+
+    const poll = pollForceUpgradeRequirement({
+      check,
+      onRequired,
+      pollIntervalMs: 60_000,
+      signal: AbortSignal.any([]),
+    });
+
+    await vi.waitFor(() => {
+      expect(check).toHaveBeenCalledTimes(1);
+    });
+    expect(onRequired).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(check).toHaveBeenCalledTimes(2);
+    expect(onRequired).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await poll;
+
+    expect(check).toHaveBeenCalledTimes(3);
+    expect(onRequired).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/platform/src/signals/force-upgrade.ts
+++ b/turbo/apps/platform/src/signals/force-upgrade.ts
@@ -1,16 +1,46 @@
 import { command, state } from "ccstate";
+import { delay } from "signal-timers";
 
 import { checkForceUpgrade } from "../lib/force-upgrade.ts";
+
+const FORCE_UPGRADE_POLL_INTERVAL_MS = 60_000;
 
 const forceUpgradeDialogOpenState$ = state(false);
 
 export const forceUpgradeDialogOpen$ = forceUpgradeDialogOpenState$;
 
-export const checkForceUpgradeDialog$ = command(
-  async ({ set }, _signal: AbortSignal) => {
-    const required = await checkForceUpgrade();
+export type ForceUpgradePollOptions = {
+  readonly check: () => Promise<boolean>;
+  readonly onRequired: () => void;
+  readonly pollIntervalMs?: number;
+  readonly signal: AbortSignal;
+};
+
+export async function pollForceUpgradeRequirement({
+  check,
+  onRequired,
+  pollIntervalMs = FORCE_UPGRADE_POLL_INTERVAL_MS,
+  signal,
+}: ForceUpgradePollOptions): Promise<void> {
+  while (!signal.aborted) {
+    signal.throwIfAborted();
+    const required = await check();
     if (required) {
-      set(forceUpgradeDialogOpenState$, true);
+      onRequired();
+      return;
     }
+    await delay(pollIntervalMs, { signal });
+  }
+}
+
+export const pollForceUpgradeDialog$ = command(
+  async ({ set }, _signal: AbortSignal) => {
+    await pollForceUpgradeRequirement({
+      check: checkForceUpgrade,
+      onRequired: () => {
+        set(forceUpgradeDialogOpenState$, true);
+      },
+      signal: _signal,
+    });
   },
 );

--- a/turbo/apps/platform/src/signals/force-upgrade.ts
+++ b/turbo/apps/platform/src/signals/force-upgrade.ts
@@ -1,0 +1,16 @@
+import { command, state } from "ccstate";
+
+import { checkForceUpgrade } from "../lib/force-upgrade.ts";
+
+const forceUpgradeDialogOpenState$ = state(false);
+
+export const forceUpgradeDialogOpen$ = forceUpgradeDialogOpenState$;
+
+export const checkForceUpgradeDialog$ = command(
+  async ({ set }, _signal: AbortSignal) => {
+    const required = await checkForceUpgrade();
+    if (required) {
+      set(forceUpgradeDialogOpenState$, true);
+    }
+  },
+);

--- a/turbo/apps/platform/src/views/components/__tests__/force-upgrade-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/force-upgrade-dialog.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StoreProvider } from "ccstate-react";
+import { describe, expect, it, vi } from "vitest";
+
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { forceUpgradeDialogOpen$ } from "../../../signals/force-upgrade.ts";
+import { ForceUpgradeDialog } from "../force-upgrade-dialog.tsx";
+
+const context = testContext();
+
+describe("force upgrade dialog", () => {
+  it("stays hidden when the client does not need a force upgrade", async () => {
+    render(
+      <StoreProvider value={context.store}>
+        <ForceUpgradeDialog />
+      </StoreProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("shows an update dialog and refreshes after confirmation", async () => {
+    const reload = vi.fn();
+    context.store.set(forceUpgradeDialogOpen$, true);
+
+    render(
+      <StoreProvider value={context.store}>
+        <ForceUpgradeDialog reload={reload} />
+      </StoreProvider>,
+    );
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Update required",
+    });
+    expect(dialog).toHaveTextContent(
+      "This version of vm0 is no longer supported.",
+    );
+
+    await userEvent.click(screen.getByText("Refresh"));
+
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});

--- a/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
+++ b/turbo/apps/platform/src/views/components/force-upgrade-dialog.tsx
@@ -1,0 +1,56 @@
+import { useGet } from "ccstate-react";
+import { Button } from "@vm0/ui/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+
+import { forceUpgradeDialogOpen$ } from "../../signals/force-upgrade.ts";
+
+type ForceUpgradeDialogProps = {
+  readonly reload?: () => void;
+};
+
+function reloadPage(): void {
+  window.location.reload();
+}
+
+export function ForceUpgradeDialog({
+  reload = reloadPage,
+}: ForceUpgradeDialogProps) {
+  const open = useGet(forceUpgradeDialogOpen$);
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        className="max-w-md [&_[aria-label='Close']]:hidden"
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          event.preventDefault();
+        }}
+        onPointerDownOutside={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>Update required</DialogTitle>
+          <DialogDescription>
+            This version of vm0 is no longer supported. Refresh to load the
+            latest version.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" onClick={reload}>
+            Refresh
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -5,11 +5,13 @@ import { Toaster } from "@vm0/ui/components/ui/sonner";
 import { ErrorBoundary } from "./error-boundary.tsx";
 import { AppSkeletonOverlay, Router } from "./router.tsx";
 import { VM0ClerkProvider } from "./clerk/clerk-provider.tsx";
+import { ForceUpgradeDialog } from "./components/force-upgrade-dialog.tsx";
 import { InspectLogFileInput } from "./inspect-log-file-input.tsx";
 import {
   subscribeChatThreadReadCursorUpdated$,
   subscribeThreadListChanged$,
 } from "../signals/chat-thread-list-reload.ts";
+import { checkForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
 import { subscribeBackgroundChatThreadRunFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
 import { subscribeEventDrivenChatThreads$ } from "../signals/chat-page/chat-thread-event-sourcing.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
@@ -23,6 +25,11 @@ export const setupRouter = (
 ) => {
   const signal = store.get(rootSignal$);
   detach(store.set(subscribeThreadListChanged$, signal), Reason.Daemon);
+  detach(
+    store.set(checkForceUpgradeDialog$, signal),
+    Reason.Daemon,
+    "force-upgrade",
+  );
   detach(
     store.set(subscribeChatThreadReadCursorUpdated$, signal),
     Reason.Daemon,
@@ -41,6 +48,7 @@ export const setupRouter = (
             <Router />
           </VM0ClerkProvider>
           <InspectLogFileInput />
+          <ForceUpgradeDialog />
         </ErrorBoundary>
         <Toaster
           position="top-center"

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -11,7 +11,7 @@ import {
   subscribeChatThreadReadCursorUpdated$,
   subscribeThreadListChanged$,
 } from "../signals/chat-thread-list-reload.ts";
-import { checkForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
+import { pollForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
 import { subscribeBackgroundChatThreadRunFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
 import { subscribeEventDrivenChatThreads$ } from "../signals/chat-page/chat-thread-event-sourcing.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
@@ -26,7 +26,7 @@ export const setupRouter = (
   const signal = store.get(rootSignal$);
   detach(store.set(subscribeThreadListChanged$, signal), Reason.Daemon);
   detach(
-    store.set(checkForceUpgradeDialog$, signal),
+    store.set(pollForceUpgradeDialog$, signal),
     Reason.Daemon,
     "force-upgrade",
   );

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -144,7 +144,7 @@ function devArtifactFetchProxy(): PluginOption {
 
 export default defineConfig({
   base: process.env.VITE_BASE_URL || "/",
-  envPrefix: ["VITE_", "PUBLIC_"],
+  envPrefix: ["VITE_", "PUBLIC_", "ATOM_URL"],
   plugins: [
     tailwindcss(),
     react(),


### PR DESCRIPTION
## Summary
- check Atom's public force-upgrade endpoint immediately during platform app startup, then poll it every 60 seconds
- store the result in ccstate and show an in-app ForceUpgradeDialog when Atom returns forceUpgrade=true
- use the app's dialog/button components; the only action is Refresh, which reloads the page
- keep startup resilient by ignoring missing versions, non-OK responses, falsey responses, and request failures

## Validation
- pnpm --dir turbo/apps/platform exec vitest run src/lib/__tests__/force-upgrade.test.ts src/signals/__tests__/force-upgrade.test.ts src/views/components/__tests__/force-upgrade-dialog.test.tsx
- pnpm --dir turbo/apps/platform exec eslint src/lib/force-upgrade.ts src/lib/__tests__/force-upgrade.test.ts src/signals/force-upgrade.ts src/signals/__tests__/force-upgrade.test.ts src/views/components/force-upgrade-dialog.tsx src/views/components/__tests__/force-upgrade-dialog.test.tsx src/views/main.tsx --max-warnings 0
- pnpm --dir turbo/apps/platform exec oxlint src/lib/force-upgrade.ts src/lib/__tests__/force-upgrade.test.ts src/signals/force-upgrade.ts src/signals/__tests__/force-upgrade.test.ts src/views/components/force-upgrade-dialog.tsx src/views/components/__tests__/force-upgrade-dialog.test.tsx src/views/main.tsx
- pnpm --filter @vm0/app check-types
