### PR TITLE
perf: stage agent instructions before guest download

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -893,6 +893,21 @@ mod tests {
     }
 
     #[test]
+    fn conflict_classifier_does_not_overlap_staged_instructions_with_skill_children() {
+        assert_eq!(
+            classify_download_conflict(
+                &normalize_mount_path("/home/user/.codex/skills/workflow"),
+                DownloadTaskKind::FrameworkSkillChild,
+                &normalize_mount_path(
+                    "/home/user/.vm0/guest-agent/runs/run-id/storage-instructions/0",
+                ),
+                DownloadTaskKind::FrameworkHomeInstructions,
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn potential_parent_child_overlap_count_excludes_exact_paths_and_siblings() {
         let tasks = [
             task_at("/workspace", DownloadTaskKind::Other),

--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -98,7 +98,8 @@ pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) 
                 Path::new(&entry.final_mount_path),
                 target_filename,
             );
-        } else if promote_staged_instruction_file(entry, target_filename) {
+        } else {
+            promote_staged_instruction_file(entry, target_filename);
             cleanup_staged_instruction_source(entry);
         }
     }
@@ -116,6 +117,12 @@ pub(crate) fn cleanup_instruction_files(entries: &[InstructionCleanup]) {
         for filename in filenames {
             remove_instruction_file_if_safe(&mount_path.join(filename.as_str()));
         }
+    }
+}
+
+pub(crate) fn cleanup_staged_instruction_sources(entries: &[InstructionNormalization]) {
+    for entry in entries {
+        cleanup_staged_instruction_source(entry);
     }
 }
 
@@ -665,6 +672,25 @@ mod tests {
         assert!(!staged.exists());
     }
 
+    #[test]
+    fn normalize_instruction_files_removes_staged_source_when_promote_has_no_instruction_file() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let final_home = dir.path().join(".codex");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(staged.join("extra.txt"), "ignored").unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::staged(
+            staged.to_string_lossy().into(),
+            final_home.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert!(!final_home.join("AGENTS.md").exists());
+        assert!(!staged.exists());
+    }
+
     #[cfg(unix)]
     #[test]
     fn normalize_instruction_files_does_not_follow_final_target_symlink() {
@@ -694,7 +720,7 @@ mod tests {
                 .file_type()
                 .is_symlink()
         );
-        assert!(staged.exists());
+        assert!(!staged.exists());
     }
 
     #[cfg(unix)]
@@ -724,7 +750,7 @@ mod tests {
                 .file_type()
                 .is_symlink()
         );
-        assert!(staged.exists());
+        assert!(!staged.exists());
     }
 
     #[test]

--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -59,6 +59,7 @@ enum InstructionFilename {
 
 enum InstructionPathState {
     Missing,
+    Directory,
     RegularFile,
     Symlink,
     OtherNonRegular,
@@ -109,6 +110,9 @@ pub(crate) fn cleanup_instruction_files(entries: &[InstructionCleanup]) {
             continue;
         };
         let mount_path = Path::new(&entry.mount_path);
+        if !existing_instruction_dir_is_safe(mount_path) {
+            continue;
+        }
         for filename in filenames {
             remove_instruction_file_if_safe(&mount_path.join(filename.as_str()));
         }
@@ -139,7 +143,9 @@ fn normalize_instruction_files_in_place(mount_path: &Path, target_filename: Inst
             return;
         }
         InstructionPathState::Missing => {}
-        InstructionPathState::Symlink | InstructionPathState::OtherNonRegular => {
+        InstructionPathState::Directory
+        | InstructionPathState::Symlink
+        | InstructionPathState::OtherNonRegular => {
             log_warn!(
                 LOG_TAG,
                 "Skipping instructions normalization because target is not a regular file"
@@ -176,12 +182,7 @@ fn promote_staged_instruction_file(
         return false;
     };
 
-    if let Err(e) = fs::create_dir_all(final_mount_path) {
-        log_warn!(
-            LOG_TAG,
-            "Failed to create final instructions directory: {}",
-            e
-        );
+    if !ensure_final_instruction_dir(final_mount_path) {
         return false;
     }
 
@@ -191,6 +192,56 @@ fn promote_staged_instruction_file(
         target_filename,
         "Promoted staged instructions file",
     )
+}
+
+fn ensure_final_instruction_dir(path: &Path) -> bool {
+    match lstat_instruction_path_state(path) {
+        InstructionPathState::Directory => true,
+        InstructionPathState::Missing => match fs::create_dir_all(path) {
+            Ok(()) => existing_instruction_dir_is_safe(path),
+            Err(e) => {
+                log_warn!(
+                    LOG_TAG,
+                    "Failed to create final instructions directory: {}",
+                    e
+                );
+                false
+            }
+        },
+        InstructionPathState::RegularFile
+        | InstructionPathState::Symlink
+        | InstructionPathState::OtherNonRegular => {
+            log_warn!(
+                LOG_TAG,
+                "Skipping instructions operation because framework home is not a directory"
+            );
+            false
+        }
+        InstructionPathState::MetadataError(e) => {
+            log_warn!(LOG_TAG, "Failed to inspect instructions directory: {}", e);
+            false
+        }
+    }
+}
+
+fn existing_instruction_dir_is_safe(path: &Path) -> bool {
+    match lstat_instruction_path_state(path) {
+        InstructionPathState::Directory => true,
+        InstructionPathState::Missing => false,
+        InstructionPathState::RegularFile
+        | InstructionPathState::Symlink
+        | InstructionPathState::OtherNonRegular => {
+            log_warn!(
+                LOG_TAG,
+                "Skipping instructions operation because framework home is not a directory"
+            );
+            false
+        }
+        InstructionPathState::MetadataError(e) => {
+            log_warn!(LOG_TAG, "Failed to inspect instructions directory: {}", e);
+            false
+        }
+    }
 }
 
 fn instruction_source(
@@ -233,7 +284,9 @@ fn copy_instruction_file(
     let target_path = final_mount_path.join(target_filename.as_str());
     match lstat_instruction_path_state(&target_path) {
         InstructionPathState::RegularFile | InstructionPathState::Missing => {}
-        InstructionPathState::Symlink | InstructionPathState::OtherNonRegular => {
+        InstructionPathState::Directory
+        | InstructionPathState::Symlink
+        | InstructionPathState::OtherNonRegular => {
             log_warn!(
                 LOG_TAG,
                 "Skipping instructions copy because target is not a regular file"
@@ -281,6 +334,7 @@ fn cleanup_staged_instruction_source(entry: &InstructionNormalization) {
 
 fn lstat_instruction_path_state(path: &Path) -> InstructionPathState {
     match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => InstructionPathState::Directory,
         Ok(metadata) if metadata.file_type().is_file() => InstructionPathState::RegularFile,
         Ok(metadata) if metadata.file_type().is_symlink() => InstructionPathState::Symlink,
         Ok(_) => InstructionPathState::OtherNonRegular,
@@ -298,6 +352,10 @@ fn remove_alternates_after_successful_copy(
         InstructionPathState::RegularFile => {
             remove_alternate_instruction_files(mount_path, target_filename);
         }
+        InstructionPathState::Directory => log_warn!(
+            LOG_TAG,
+            "Normalized instructions target is a directory after copy"
+        ),
         InstructionPathState::Missing => log_warn!(
             LOG_TAG,
             "Normalized instructions target is missing after copy"
@@ -341,6 +399,7 @@ fn remove_alternate_instruction_files(mount_path: &Path, target_filename: Instru
         let path = mount_path.join(candidate.as_str());
         match lstat_instruction_path_state(&path) {
             InstructionPathState::Missing => continue,
+            InstructionPathState::Directory => continue,
             InstructionPathState::RegularFile | InstructionPathState::Symlink => {}
             InstructionPathState::OtherNonRegular => continue,
             InstructionPathState::MetadataError(e) => {
@@ -367,6 +426,7 @@ fn remove_alternate_instruction_files(mount_path: &Path, target_filename: Instru
 fn remove_instruction_file_if_safe(path: &Path) {
     match lstat_instruction_path_state(path) {
         InstructionPathState::Missing => {}
+        InstructionPathState::Directory => {}
         InstructionPathState::RegularFile | InstructionPathState::Symlink => {
             match fs::remove_file(path) {
                 Ok(_) => log_info!(LOG_TAG, "Removed stale instructions file"),
@@ -637,6 +697,36 @@ mod tests {
         assert!(staged.exists());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn normalize_instruction_files_does_not_follow_final_home_symlink() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let final_home = dir.path().join(".codex");
+        let outside_home = dir.path().join("outside-home");
+        fs::create_dir_all(&staged).unwrap();
+        fs::create_dir_all(&outside_home).unwrap();
+        fs::write(staged.join("AGENTS.md"), "new instructions").unwrap();
+        std::os::unix::fs::symlink(&outside_home, &final_home).unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::staged(
+            staged.to_string_lossy().into(),
+            final_home.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert!(!outside_home.join("AGENTS.md").exists());
+        assert!(
+            final_home
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(staged.exists());
+    }
+
     #[test]
     fn cleanup_instruction_files_removes_only_known_instruction_files() {
         disable_system_log();
@@ -687,6 +777,29 @@ mod tests {
 
         assert!(mount.join("AGENTS.md").symlink_metadata().is_err());
         assert_eq!(fs::read_to_string(&linked_target).unwrap(), "outside");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_instruction_files_does_not_follow_home_symlink() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        let outside_home = dir.path().join("outside-home");
+        fs::create_dir_all(&outside_home).unwrap();
+        fs::write(outside_home.join("AGENTS.md"), "outside").unwrap();
+        std::os::unix::fs::symlink(&outside_home, &mount).unwrap();
+
+        cleanup_instruction_files(&[InstructionCleanup::new(
+            mount.to_string_lossy().into(),
+            None,
+        )]);
+
+        assert_eq!(
+            fs::read_to_string(outside_home.join("AGENTS.md")).unwrap(),
+            "outside"
+        );
+        assert!(mount.symlink_metadata().unwrap().file_type().is_symlink());
     }
 
     #[test]

--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -4,6 +4,8 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+const STAGED_INSTRUCTIONS_DIR_NAME: &str = "storage-instructions";
+
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct InstructionNormalization {
     source_path: String,
@@ -90,6 +92,7 @@ pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) 
         let raw_target_filename = entry.target_filename.as_str();
         let Some(target_filename) = InstructionFilename::parse(raw_target_filename) else {
             log_warn!(LOG_TAG, "Skipping invalid instructions target filename");
+            cleanup_staged_instruction_source(entry);
             continue;
         };
 
@@ -328,12 +331,43 @@ fn cleanup_staged_instruction_source(entry: &InstructionNormalization) {
     let Some(path) = entry.cleanup_source_path.as_deref() else {
         return;
     };
+    let path = Path::new(path);
     match fs::remove_dir_all(path) {
-        Ok(_) => log_info!(LOG_TAG, "Removed staged instructions directory"),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Ok(_) => {
+            log_info!(LOG_TAG, "Removed staged instructions directory");
+            cleanup_empty_staged_instruction_parent(path);
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            cleanup_empty_staged_instruction_parent(path);
+        }
         Err(e) => log_warn!(
             LOG_TAG,
             "Failed to remove staged instructions directory: {}",
+            e
+        ),
+    }
+}
+
+fn cleanup_empty_staged_instruction_parent(path: &Path) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if parent.file_name().and_then(|name| name.to_str()) != Some(STAGED_INSTRUCTIONS_DIR_NAME) {
+        return;
+    }
+    match fs::remove_dir(parent) {
+        Ok(_) => log_info!(
+            LOG_TAG,
+            "Removed empty staged instructions parent directory"
+        ),
+        Err(e)
+            if matches!(
+                e.kind(),
+                io::ErrorKind::NotFound | io::ErrorKind::DirectoryNotEmpty
+            ) => {}
+        Err(e) => log_warn!(
+            LOG_TAG,
+            "Failed to remove empty staged instructions parent directory: {}",
             e
         ),
     }
@@ -685,6 +719,25 @@ mod tests {
             staged.to_string_lossy().into(),
             final_home.to_string_lossy().into(),
             "AGENTS.md".into(),
+        )]);
+
+        assert!(!final_home.join("AGENTS.md").exists());
+        assert!(!staged.exists());
+    }
+
+    #[test]
+    fn normalize_instruction_files_removes_staged_source_for_invalid_target() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let final_home = dir.path().join(".codex");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(staged.join("AGENTS.md"), "new instructions").unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::staged(
+            staged.to_string_lossy().into(),
+            final_home.to_string_lossy().into(),
+            "../outside.md".into(),
         )]);
 
         assert!(!final_home.join("AGENTS.md").exists());

--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -2,7 +2,7 @@ use crate::LOG_TAG;
 use guest_common::{log_info, log_warn};
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const STAGED_INSTRUCTIONS_DIR_NAME: &str = "storage-instructions";
 
@@ -309,8 +309,8 @@ fn copy_instruction_file(
         }
     }
 
-    match fs::copy(source_path, &target_path) {
-        Ok(_) => {
+    match copy_instruction_file_atomically(source_path, &target_path) {
+        Ok(()) => {
             log_info!(LOG_TAG, "{}", success_message);
             remove_alternates_after_successful_copy(
                 final_mount_path,
@@ -321,10 +321,57 @@ fn copy_instruction_file(
         }
         Err(e) => {
             log_warn!(LOG_TAG, "Failed to copy instructions file: {}", e);
-            remove_failed_instruction_target(&target_path);
             false
         }
     }
+}
+
+fn copy_instruction_file_atomically(source_path: &Path, target_path: &Path) -> io::Result<()> {
+    let mut source = fs::File::open(source_path)?;
+    let source_permissions = source.metadata()?.permissions();
+    let (mut temp_file, temp_path) = create_instruction_temp_file(target_path)?;
+    let result = (|| {
+        io::copy(&mut source, &mut temp_file)?;
+        drop(temp_file);
+        fs::set_permissions(&temp_path, source_permissions)?;
+        fs::rename(&temp_path, target_path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+fn create_instruction_temp_file(target_path: &Path) -> io::Result<(fs::File, PathBuf)> {
+    let Some(parent) = target_path.parent() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "instructions target has no parent directory",
+        ));
+    };
+    let target_name = target_path
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "instructions".into());
+    for attempt in 0..16 {
+        let temp_path = parent.join(format!(
+            ".{target_name}.vm0-copy-{}-{attempt}.tmp",
+            std::process::id()
+        ));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+        {
+            Ok(file) => return Ok((file, temp_path)),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "failed to create instructions temp file",
+    ))
 }
 
 fn cleanup_staged_instruction_source(entry: &InstructionNormalization) {
@@ -408,24 +455,6 @@ fn remove_alternates_after_successful_copy(
         InstructionPathState::MetadataError(e) => log_warn!(
             LOG_TAG,
             "Failed to inspect normalized instructions target: {}",
-            e
-        ),
-    }
-}
-
-fn remove_failed_instruction_target(target_path: &Path) {
-    if !matches!(
-        lstat_instruction_path_state(target_path),
-        InstructionPathState::RegularFile
-    ) {
-        return;
-    }
-
-    match fs::remove_file(target_path) {
-        Ok(_) => log_info!(LOG_TAG, "Removed failed instructions target"),
-        Err(e) => log_warn!(
-            LOG_TAG,
-            "Failed to remove failed instructions target: {}",
             e
         ),
     }
@@ -655,6 +684,7 @@ mod tests {
         fs::write(staged.join("AGENTS.md"), "new instructions").unwrap();
         fs::write(staged.join("extra.txt"), "extra").unwrap();
         fs::write(staged.join("nested").join("AGENTS.md"), "nested").unwrap();
+        fs::write(final_home.join("AGENTS.md"), "old instructions").unwrap();
         fs::write(final_home.join("CLAUDE.md"), "old alternate").unwrap();
         fs::write(
             final_home.join("skills").join("workflow").join("SKILL.md"),
@@ -681,6 +711,28 @@ mod tests {
             "skill"
         );
         assert!(!staged.exists());
+    }
+
+    #[test]
+    fn copy_instruction_file_failure_keeps_existing_target() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let final_home = dir.path().join(".codex");
+        fs::create_dir_all(&final_home).unwrap();
+        fs::write(final_home.join("AGENTS.md"), "old instructions").unwrap();
+
+        assert!(!copy_instruction_file(
+            &dir.path().join("missing.md"),
+            &final_home,
+            InstructionFilename::Agents,
+            "Copied instructions file",
+        ));
+
+        assert_eq!(
+            fs::read_to_string(final_home.join("AGENTS.md")).unwrap(),
+            "old instructions"
+        );
+        assert_eq!(fs::read_dir(&final_home).unwrap().count(), 1);
     }
 
     #[test]

--- a/crates/guest-download/src/instructions.rs
+++ b/crates/guest-download/src/instructions.rs
@@ -6,12 +6,44 @@ use std::path::Path;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct InstructionNormalization {
-    mount_path: String,
+    source_path: String,
+    final_mount_path: String,
     target_filename: String,
+    cleanup_source_path: Option<String>,
 }
 
 impl InstructionNormalization {
-    pub(crate) fn new(mount_path: String, target_filename: String) -> Self {
+    pub(crate) fn in_place(mount_path: String, target_filename: String) -> Self {
+        Self {
+            source_path: mount_path.clone(),
+            final_mount_path: mount_path,
+            target_filename,
+            cleanup_source_path: None,
+        }
+    }
+
+    pub(crate) fn staged(
+        source_path: String,
+        final_mount_path: String,
+        target_filename: String,
+    ) -> Self {
+        Self {
+            cleanup_source_path: Some(source_path.clone()),
+            source_path,
+            final_mount_path,
+            target_filename,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct InstructionCleanup {
+    mount_path: String,
+    target_filename: Option<String>,
+}
+
+impl InstructionCleanup {
+    pub(crate) fn new(mount_path: String, target_filename: Option<String>) -> Self {
         Self {
             mount_path,
             target_filename,
@@ -28,7 +60,8 @@ enum InstructionFilename {
 enum InstructionPathState {
     Missing,
     RegularFile,
-    NonRegular,
+    Symlink,
+    OtherNonRegular,
     MetadataError(io::Error),
 }
 
@@ -55,90 +88,202 @@ pub(crate) fn normalize_instruction_files(entries: &[InstructionNormalization]) 
     for entry in entries {
         let raw_target_filename = entry.target_filename.as_str();
         let Some(target_filename) = InstructionFilename::parse(raw_target_filename) else {
-            log_warn!(
-                LOG_TAG,
-                "Skipping invalid instructions target filename: {}",
-                raw_target_filename
-            );
+            log_warn!(LOG_TAG, "Skipping invalid instructions target filename");
             continue;
         };
 
+        if entry.source_path == entry.final_mount_path {
+            normalize_instruction_files_in_place(
+                Path::new(&entry.final_mount_path),
+                target_filename,
+            );
+        } else if promote_staged_instruction_file(entry, target_filename) {
+            cleanup_staged_instruction_source(entry);
+        }
+    }
+}
+
+pub(crate) fn cleanup_instruction_files(entries: &[InstructionCleanup]) {
+    for entry in entries {
+        let Some(filenames) = cleanup_filenames(entry) else {
+            continue;
+        };
         let mount_path = Path::new(&entry.mount_path);
-        let target_path = mount_path.join(target_filename.as_str());
-        match lstat_instruction_path_state(&target_path) {
-            InstructionPathState::RegularFile => {
-                remove_alternate_instruction_files(mount_path, target_filename);
-                continue;
-            }
-            InstructionPathState::Missing => {}
-            InstructionPathState::NonRegular => {
-                log_warn!(
-                    LOG_TAG,
-                    "Skipping instructions normalization because target is not a regular file: {}",
-                    target_path.display()
-                );
-                continue;
-            }
-            InstructionPathState::MetadataError(e) => {
-                log_warn!(
-                    LOG_TAG,
-                    "Failed to inspect instructions target {}: {}",
-                    target_path.display(),
-                    e
-                );
-                continue;
-            }
+        for filename in filenames {
+            remove_instruction_file_if_safe(&mount_path.join(filename.as_str()));
         }
+    }
+}
 
-        let source = InstructionFilename::ALL
-            .iter()
-            .copied()
-            .filter(|candidate| *candidate != target_filename)
-            .map(|candidate| mount_path.join(candidate.as_str()))
-            .find(|path| {
-                matches!(
-                    lstat_instruction_path_state(path),
-                    InstructionPathState::RegularFile
-                )
-            });
+fn cleanup_filenames(entry: &InstructionCleanup) -> Option<Vec<InstructionFilename>> {
+    match entry.target_filename.as_deref() {
+        Some(raw) => match InstructionFilename::parse(raw) {
+            Some(filename) => Some(vec![filename]),
+            None => {
+                log_warn!(
+                    LOG_TAG,
+                    "Skipping invalid instructions cleanup target filename"
+                );
+                None
+            }
+        },
+        None => Some(InstructionFilename::ALL.to_vec()),
+    }
+}
 
-        let Some(source_path) = source else {
+fn normalize_instruction_files_in_place(mount_path: &Path, target_filename: InstructionFilename) {
+    let target_path = mount_path.join(target_filename.as_str());
+    match lstat_instruction_path_state(&target_path) {
+        InstructionPathState::RegularFile => {
+            remove_alternate_instruction_files(mount_path, target_filename);
+            return;
+        }
+        InstructionPathState::Missing => {}
+        InstructionPathState::Symlink | InstructionPathState::OtherNonRegular => {
             log_warn!(
                 LOG_TAG,
-                "No instructions file found to normalize at {}",
-                entry.mount_path
+                "Skipping instructions normalization because target is not a regular file"
             );
-            continue;
-        };
-
-        match fs::copy(&source_path, &target_path) {
-            Ok(_) => {
-                log_info!(
-                    LOG_TAG,
-                    "Normalized instructions file {} -> {}",
-                    source_path.display(),
-                    target_path.display()
-                );
-                remove_alternates_after_successful_copy(mount_path, target_filename, &target_path);
-            }
-            Err(e) => {
-                log_warn!(
-                    LOG_TAG,
-                    "Failed to normalize instructions file {} -> {}: {}",
-                    source_path.display(),
-                    target_path.display(),
-                    e
-                );
-                remove_failed_instruction_target(&target_path);
-            }
+            return;
         }
+        InstructionPathState::MetadataError(e) => {
+            log_warn!(LOG_TAG, "Failed to inspect instructions target: {}", e);
+            return;
+        }
+    }
+
+    let Some(source_path) = alternate_instruction_source(mount_path, target_filename) else {
+        log_warn!(LOG_TAG, "No instructions file found to normalize");
+        return;
+    };
+
+    copy_instruction_file(
+        &source_path,
+        mount_path,
+        target_filename,
+        "Normalized instructions file",
+    );
+}
+
+fn promote_staged_instruction_file(
+    entry: &InstructionNormalization,
+    target_filename: InstructionFilename,
+) -> bool {
+    let source_mount_path = Path::new(&entry.source_path);
+    let final_mount_path = Path::new(&entry.final_mount_path);
+    let Some(source_path) = instruction_source(source_mount_path, target_filename) else {
+        log_warn!(LOG_TAG, "No staged instructions file found to promote");
+        return false;
+    };
+
+    if let Err(e) = fs::create_dir_all(final_mount_path) {
+        log_warn!(
+            LOG_TAG,
+            "Failed to create final instructions directory: {}",
+            e
+        );
+        return false;
+    }
+
+    copy_instruction_file(
+        &source_path,
+        final_mount_path,
+        target_filename,
+        "Promoted staged instructions file",
+    )
+}
+
+fn instruction_source(
+    mount_path: &Path,
+    target_filename: InstructionFilename,
+) -> Option<std::path::PathBuf> {
+    let target_path = mount_path.join(target_filename.as_str());
+    if matches!(
+        lstat_instruction_path_state(&target_path),
+        InstructionPathState::RegularFile
+    ) {
+        return Some(target_path);
+    }
+    alternate_instruction_source(mount_path, target_filename)
+}
+
+fn alternate_instruction_source(
+    mount_path: &Path,
+    target_filename: InstructionFilename,
+) -> Option<std::path::PathBuf> {
+    InstructionFilename::ALL
+        .iter()
+        .copied()
+        .filter(|candidate| *candidate != target_filename)
+        .map(|candidate| mount_path.join(candidate.as_str()))
+        .find(|path| {
+            matches!(
+                lstat_instruction_path_state(path),
+                InstructionPathState::RegularFile
+            )
+        })
+}
+
+fn copy_instruction_file(
+    source_path: &Path,
+    final_mount_path: &Path,
+    target_filename: InstructionFilename,
+    success_message: &str,
+) -> bool {
+    let target_path = final_mount_path.join(target_filename.as_str());
+    match lstat_instruction_path_state(&target_path) {
+        InstructionPathState::RegularFile | InstructionPathState::Missing => {}
+        InstructionPathState::Symlink | InstructionPathState::OtherNonRegular => {
+            log_warn!(
+                LOG_TAG,
+                "Skipping instructions copy because target is not a regular file"
+            );
+            return false;
+        }
+        InstructionPathState::MetadataError(e) => {
+            log_warn!(LOG_TAG, "Failed to inspect instructions target: {}", e);
+            return false;
+        }
+    }
+
+    match fs::copy(source_path, &target_path) {
+        Ok(_) => {
+            log_info!(LOG_TAG, "{}", success_message);
+            remove_alternates_after_successful_copy(
+                final_mount_path,
+                target_filename,
+                &target_path,
+            );
+            true
+        }
+        Err(e) => {
+            log_warn!(LOG_TAG, "Failed to copy instructions file: {}", e);
+            remove_failed_instruction_target(&target_path);
+            false
+        }
+    }
+}
+
+fn cleanup_staged_instruction_source(entry: &InstructionNormalization) {
+    let Some(path) = entry.cleanup_source_path.as_deref() else {
+        return;
+    };
+    match fs::remove_dir_all(path) {
+        Ok(_) => log_info!(LOG_TAG, "Removed staged instructions directory"),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+        Err(e) => log_warn!(
+            LOG_TAG,
+            "Failed to remove staged instructions directory: {}",
+            e
+        ),
     }
 }
 
 fn lstat_instruction_path_state(path: &Path) -> InstructionPathState {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_file() => InstructionPathState::RegularFile,
-        Ok(_) => InstructionPathState::NonRegular,
+        Ok(metadata) if metadata.file_type().is_symlink() => InstructionPathState::Symlink,
+        Ok(_) => InstructionPathState::OtherNonRegular,
         Err(e) if e.kind() == io::ErrorKind::NotFound => InstructionPathState::Missing,
         Err(e) => InstructionPathState::MetadataError(e),
     }
@@ -155,18 +300,15 @@ fn remove_alternates_after_successful_copy(
         }
         InstructionPathState::Missing => log_warn!(
             LOG_TAG,
-            "Normalized instructions target is missing after copy: {}",
-            target_path.display()
+            "Normalized instructions target is missing after copy"
         ),
-        InstructionPathState::NonRegular => log_warn!(
+        InstructionPathState::Symlink | InstructionPathState::OtherNonRegular => log_warn!(
             LOG_TAG,
-            "Normalized instructions target is not a regular file after copy: {}",
-            target_path.display()
+            "Normalized instructions target is not a regular file after copy"
         ),
         InstructionPathState::MetadataError(e) => log_warn!(
             LOG_TAG,
-            "Failed to inspect normalized instructions target {}: {}",
-            target_path.display(),
+            "Failed to inspect normalized instructions target: {}",
             e
         ),
     }
@@ -181,15 +323,10 @@ fn remove_failed_instruction_target(target_path: &Path) {
     }
 
     match fs::remove_file(target_path) {
-        Ok(_) => log_info!(
-            LOG_TAG,
-            "Removed failed instructions target {}",
-            target_path.display()
-        ),
+        Ok(_) => log_info!(LOG_TAG, "Removed failed instructions target"),
         Err(e) => log_warn!(
             LOG_TAG,
-            "Failed to remove failed instructions target {}: {}",
-            target_path.display(),
+            "Failed to remove failed instructions target: {}",
             e
         ),
     }
@@ -204,12 +341,12 @@ fn remove_alternate_instruction_files(mount_path: &Path, target_filename: Instru
         let path = mount_path.join(candidate.as_str());
         match lstat_instruction_path_state(&path) {
             InstructionPathState::Missing => continue,
-            InstructionPathState::RegularFile | InstructionPathState::NonRegular => {}
+            InstructionPathState::RegularFile | InstructionPathState::Symlink => {}
+            InstructionPathState::OtherNonRegular => continue,
             InstructionPathState::MetadataError(e) => {
                 log_warn!(
                     LOG_TAG,
-                    "Failed to inspect non-runtime instructions file {}: {}",
-                    path.display(),
+                    "Failed to inspect non-runtime instructions file: {}",
                     e
                 );
                 continue;
@@ -217,17 +354,28 @@ fn remove_alternate_instruction_files(mount_path: &Path, target_filename: Instru
         }
 
         match fs::remove_file(&path) {
-            Ok(_) => log_info!(
-                LOG_TAG,
-                "Removed non-runtime instructions file {}",
-                path.display()
-            ),
+            Ok(_) => log_info!(LOG_TAG, "Removed non-runtime instructions file"),
             Err(e) => log_warn!(
                 LOG_TAG,
-                "Failed to remove non-runtime instructions file {}: {}",
-                path.display(),
+                "Failed to remove non-runtime instructions file: {}",
                 e
             ),
+        }
+    }
+}
+
+fn remove_instruction_file_if_safe(path: &Path) {
+    match lstat_instruction_path_state(path) {
+        InstructionPathState::Missing => {}
+        InstructionPathState::RegularFile | InstructionPathState::Symlink => {
+            match fs::remove_file(path) {
+                Ok(_) => log_info!(LOG_TAG, "Removed stale instructions file"),
+                Err(e) => log_warn!(LOG_TAG, "Failed to remove stale instructions file: {}", e),
+            }
+        }
+        InstructionPathState::OtherNonRegular => {}
+        InstructionPathState::MetadataError(e) => {
+            log_warn!(LOG_TAG, "Failed to inspect stale instructions file: {}", e)
         }
     }
 }
@@ -248,7 +396,7 @@ mod tests {
         fs::create_dir_all(&mount).unwrap();
         fs::write(mount.join("CLAUDE.md"), "runtime instructions").unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "AGENTS.md".into(),
         )]);
@@ -268,7 +416,7 @@ mod tests {
         fs::create_dir_all(&mount).unwrap();
         fs::write(mount.join("AGENTS.md"), "runtime instructions").unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "CLAUDE.md".into(),
         )]);
@@ -289,7 +437,7 @@ mod tests {
         fs::write(mount.join("CLAUDE.md"), "legacy").unwrap();
         fs::write(mount.join("AGENTS.md"), "canonical").unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "AGENTS.md".into(),
         )]);
@@ -309,7 +457,7 @@ mod tests {
         fs::create_dir_all(mount.join("AGENTS.md")).unwrap();
         fs::write(mount.join("CLAUDE.md"), "runtime instructions").unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "AGENTS.md".into(),
         )]);
@@ -332,7 +480,7 @@ mod tests {
         fs::write(mount.join("CLAUDE.md"), "runtime instructions").unwrap();
         std::os::unix::fs::symlink(mount.join("target.md"), mount.join("AGENTS.md")).unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "AGENTS.md".into(),
         )]);
@@ -361,7 +509,7 @@ mod tests {
         fs::write(mount.join("AGENTS.md"), "runtime instructions").unwrap();
         std::os::unix::fs::symlink(mount.join("missing.md"), mount.join("CLAUDE.md")).unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "AGENTS.md".into(),
         )]);
@@ -379,7 +527,7 @@ mod tests {
         fs::write(mount.join("linked.md"), "runtime instructions").unwrap();
         std::os::unix::fs::symlink(mount.join("linked.md"), mount.join("CLAUDE.md")).unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "AGENTS.md".into(),
         )]);
@@ -396,6 +544,152 @@ mod tests {
     }
 
     #[test]
+    fn normalize_instruction_files_promotes_staged_target_to_final_home() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let final_home = dir.path().join(".codex");
+        fs::create_dir_all(staged.join("nested")).unwrap();
+        fs::create_dir_all(final_home.join("skills").join("workflow")).unwrap();
+        fs::write(staged.join("AGENTS.md"), "new instructions").unwrap();
+        fs::write(staged.join("extra.txt"), "extra").unwrap();
+        fs::write(staged.join("nested").join("AGENTS.md"), "nested").unwrap();
+        fs::write(final_home.join("CLAUDE.md"), "old alternate").unwrap();
+        fs::write(
+            final_home.join("skills").join("workflow").join("SKILL.md"),
+            "skill",
+        )
+        .unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::staged(
+            staged.to_string_lossy().into(),
+            final_home.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert_eq!(
+            fs::read_to_string(final_home.join("AGENTS.md")).unwrap(),
+            "new instructions"
+        );
+        assert!(!final_home.join("CLAUDE.md").exists());
+        assert!(!final_home.join("extra.txt").exists());
+        assert!(!final_home.join("nested").exists());
+        assert_eq!(
+            fs::read_to_string(final_home.join("skills").join("workflow").join("SKILL.md"))
+                .unwrap(),
+            "skill"
+        );
+        assert!(!staged.exists());
+    }
+
+    #[test]
+    fn normalize_instruction_files_promotes_staged_alternate_when_target_is_missing() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let final_home = dir.path().join(".codex");
+        fs::create_dir_all(&staged).unwrap();
+        fs::write(staged.join("CLAUDE.md"), "alternate instructions").unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::staged(
+            staged.to_string_lossy().into(),
+            final_home.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert_eq!(
+            fs::read_to_string(final_home.join("AGENTS.md")).unwrap(),
+            "alternate instructions"
+        );
+        assert!(!final_home.join("CLAUDE.md").exists());
+        assert!(!staged.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_instruction_files_does_not_follow_final_target_symlink() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let staged = dir.path().join("staged");
+        let final_home = dir.path().join(".codex");
+        let linked_target = dir.path().join("outside.md");
+        fs::create_dir_all(&staged).unwrap();
+        fs::create_dir_all(&final_home).unwrap();
+        fs::write(staged.join("AGENTS.md"), "new instructions").unwrap();
+        fs::write(&linked_target, "outside").unwrap();
+        std::os::unix::fs::symlink(&linked_target, final_home.join("AGENTS.md")).unwrap();
+
+        normalize_instruction_files(&[InstructionNormalization::staged(
+            staged.to_string_lossy().into(),
+            final_home.to_string_lossy().into(),
+            "AGENTS.md".into(),
+        )]);
+
+        assert_eq!(fs::read_to_string(&linked_target).unwrap(), "outside");
+        assert!(
+            final_home
+                .join("AGENTS.md")
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(staged.exists());
+    }
+
+    #[test]
+    fn cleanup_instruction_files_removes_only_known_instruction_files() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        fs::create_dir_all(mount.join("skills").join("workflow")).unwrap();
+        fs::create_dir_all(mount.join("CLAUDE.md")).unwrap();
+        fs::write(mount.join("AGENTS.md"), "old").unwrap();
+        fs::write(mount.join("settings.json"), "{}").unwrap();
+        fs::write(
+            mount.join("skills").join("workflow").join("SKILL.md"),
+            "skill",
+        )
+        .unwrap();
+
+        cleanup_instruction_files(&[InstructionCleanup::new(
+            mount.to_string_lossy().into(),
+            None,
+        )]);
+
+        assert!(!mount.join("AGENTS.md").exists());
+        assert!(mount.join("CLAUDE.md").is_dir());
+        assert_eq!(
+            fs::read_to_string(mount.join("settings.json")).unwrap(),
+            "{}"
+        );
+        assert_eq!(
+            fs::read_to_string(mount.join("skills").join("workflow").join("SKILL.md")).unwrap(),
+            "skill"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cleanup_instruction_files_removes_instruction_symlink_without_following_it() {
+        disable_system_log();
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join(".codex");
+        let linked_target = dir.path().join("outside.md");
+        fs::create_dir_all(&mount).unwrap();
+        fs::write(&linked_target, "outside").unwrap();
+        std::os::unix::fs::symlink(&linked_target, mount.join("AGENTS.md")).unwrap();
+
+        cleanup_instruction_files(&[InstructionCleanup::new(
+            mount.to_string_lossy().into(),
+            Some("AGENTS.md".into()),
+        )]);
+
+        assert!(mount.join("AGENTS.md").symlink_metadata().is_err());
+        assert_eq!(fs::read_to_string(&linked_target).unwrap(), "outside");
+    }
+
+    #[test]
     fn normalize_instruction_files_skips_invalid_target_without_deleting_files() {
         disable_system_log();
         let dir = tempfile::tempdir().unwrap();
@@ -404,7 +698,7 @@ mod tests {
         fs::write(mount.join("CLAUDE.md"), "claude").unwrap();
         fs::write(mount.join("AGENTS.md"), "agents").unwrap();
 
-        normalize_instruction_files(&[InstructionNormalization::new(
+        normalize_instruction_files(&[InstructionNormalization::in_place(
             mount.to_string_lossy().into(),
             "../outside.md".into(),
         )]);

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run_manifest_bytes(manifest_json: &[u8]) -> bool {
 fn run_manifest(manifest: Manifest) -> bool {
     let RunPlan {
         cleanup_paths,
+        instruction_cleanups,
         preserved_paths,
         download_tasks,
         instruction_files,
@@ -66,6 +67,9 @@ fn run_manifest(manifest: Manifest) -> bool {
     // parent-child mount path overlaps.
     if !cleanup_paths.is_empty() {
         cleanup::cleanup_stale_paths(&cleanup_paths, &preserved_paths);
+    }
+    if !instruction_cleanups.is_empty() {
+        instructions::cleanup_instruction_files(&instruction_cleanups);
     }
 
     // Pre-create all target directories before downloads. This keeps directory

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -105,6 +105,7 @@ mod tests {
             .join("runtime")
             .join("storage-instructions")
             .join("0");
+        let extract_parent = extract_path.parent().unwrap().to_path_buf();
         let missing_archive = dir.path().join("missing.tar.gz");
         let manifest = json!({
             "storages": [{
@@ -119,6 +120,7 @@ mod tests {
 
         assert!(!success);
         assert!(!extract_path.exists());
+        assert!(!extract_parent.exists());
     }
 
     #[test]
@@ -129,6 +131,7 @@ mod tests {
             .join("runtime")
             .join("storage-instructions")
             .join("0");
+        let first_extract_parent = first_extract_path.parent().unwrap().to_path_buf();
         let blocker = dir.path().join("blocker");
         let blocked_extract_path = blocker.join("storage-instructions").join("1");
         std::fs::write(&blocker, "not a directory").unwrap();
@@ -154,5 +157,6 @@ mod tests {
 
         assert!(!success);
         assert!(!first_extract_path.exists());
+        assert!(!first_extract_parent.exists());
     }
 }

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -79,6 +79,7 @@ fn run_manifest(manifest: Manifest) -> bool {
         let mount_path = task.mount_path();
         if let Err(e) = fs::create_dir_all(mount_path) {
             log_error!(LOG_TAG, "Failed to create directory {}: {e}", mount_path);
+            instructions::cleanup_staged_instruction_sources(&instruction_files);
             return false;
         }
     }
@@ -86,6 +87,72 @@ fn run_manifest(manifest: Manifest) -> bool {
     let success = download::download_all_parallel(download_tasks);
     if success {
         instructions::normalize_instruction_files(&instruction_files);
+    } else {
+        instructions::cleanup_staged_instruction_sources(&instruction_files);
     }
     success
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    #[test]
+    fn run_manifest_removes_staged_instruction_source_when_download_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let extract_path = dir
+            .path()
+            .join("runtime")
+            .join("storage-instructions")
+            .join("0");
+        let missing_archive = dir.path().join("missing.tar.gz");
+        let manifest = json!({
+            "storages": [{
+                "mountPath": dir.path().join(".codex"),
+                "extractPath": extract_path,
+                "archiveUrl": format!("file://{}", missing_archive.display()),
+                "instructionsTargetFilename": "AGENTS.md"
+            }]
+        });
+
+        let success = super::run_manifest_bytes(&serde_json::to_vec(&manifest).unwrap());
+
+        assert!(!success);
+        assert!(!extract_path.exists());
+    }
+
+    #[test]
+    fn run_manifest_removes_created_staged_instruction_sources_when_precreate_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let first_extract_path = dir
+            .path()
+            .join("runtime")
+            .join("storage-instructions")
+            .join("0");
+        let blocker = dir.path().join("blocker");
+        let blocked_extract_path = blocker.join("storage-instructions").join("1");
+        std::fs::write(&blocker, "not a directory").unwrap();
+        let archive = dir.path().join("archive.tar.gz");
+        let manifest = json!({
+            "storages": [
+                {
+                    "mountPath": dir.path().join(".codex"),
+                    "extractPath": first_extract_path,
+                    "archiveUrl": format!("file://{}", archive.display()),
+                    "instructionsTargetFilename": "AGENTS.md"
+                },
+                {
+                    "mountPath": dir.path().join(".claude"),
+                    "extractPath": blocked_extract_path,
+                    "archiveUrl": format!("file://{}", archive.display()),
+                    "instructionsTargetFilename": "CLAUDE.md"
+                }
+            ]
+        });
+
+        let success = super::run_manifest_bytes(&serde_json::to_vec(&manifest).unwrap());
+
+        assert!(!success);
+        assert!(!first_extract_path.exists());
+    }
 }

--- a/crates/guest-download/src/manifest.rs
+++ b/crates/guest-download/src/manifest.rs
@@ -13,6 +13,8 @@ pub(crate) struct Manifest {
     /// Paths to clean before downloading (stale file cleanup on VM reuse).
     #[serde(default)]
     pub(crate) cleanup_paths: Vec<String>,
+    #[serde(default)]
+    pub(crate) instruction_cleanups: Vec<InstructionCleanupEntry>,
 }
 
 impl Manifest {
@@ -35,6 +37,8 @@ pub(crate) enum ManifestLoadError {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ManifestEntry {
     pub(crate) mount_path: String,
+    #[serde(default)]
+    pub(crate) extract_path: Option<String>,
     pub(crate) archive_url: Option<String>,
     #[serde(default)]
     pub(crate) instructions_target_filename: Option<String>,
@@ -46,6 +50,14 @@ pub(crate) struct ManifestEntry {
     pub(crate) vas_version_id: Option<String>,
     #[serde(default)]
     pub(crate) missing_root_policy: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InstructionCleanupEntry {
+    pub(crate) mount_path: String,
+    #[serde(default)]
+    pub(crate) target_filename: Option<String>,
 }
 
 #[cfg(test)]
@@ -61,6 +73,7 @@ mod tests {
         let manifest: Manifest = serde_json::from_str(json).unwrap();
         assert_eq!(manifest.cleanup_paths.len(), 2);
         assert_eq!(manifest.cleanup_paths[0], "/home/user/.claude");
+        assert!(manifest.instruction_cleanups.is_empty());
     }
 
     #[test]
@@ -68,6 +81,7 @@ mod tests {
         let json = r#"{"storages": []}"#;
         let manifest: Manifest = serde_json::from_str(json).unwrap();
         assert!(manifest.cleanup_paths.is_empty());
+        assert!(manifest.instruction_cleanups.is_empty());
     }
 
     #[test]
@@ -122,6 +136,7 @@ mod tests {
         );
         assert_eq!(manifest.storages[0].vas_version_id.as_deref(), Some("v1"));
         assert_eq!(manifest.artifacts[0].mount_path, "/workspace");
+        assert_eq!(manifest.storages[0].extract_path, None);
         assert_eq!(
             manifest.artifacts[0].vas_storage_name.as_deref(),
             Some("artifact")
@@ -131,5 +146,40 @@ mod tests {
             manifest.artifacts[0].missing_root_policy.as_deref(),
             Some("preserveParentVersion")
         );
+    }
+
+    #[test]
+    fn manifest_deserializes_instruction_staging_fields() {
+        let json = r#"{
+            "storages": [{
+                "mountPath": "/home/user/.codex",
+                "extractPath": "/home/user/.vm0/guest-agent/runs/run/storage-instructions/0",
+                "archiveUrl": "https://s3/instructions.tar.gz",
+                "instructionsTargetFilename": "AGENTS.md"
+            }],
+            "instructionCleanups": [{
+                "mountPath": "/home/user/.codex",
+                "targetFilename": "AGENTS.md"
+            }, {
+                "mountPath": "/home/user/.claude"
+            }]
+        }"#;
+
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            manifest.storages[0].extract_path.as_deref(),
+            Some("/home/user/.vm0/guest-agent/runs/run/storage-instructions/0")
+        );
+        assert_eq!(manifest.instruction_cleanups.len(), 2);
+        assert_eq!(
+            manifest.instruction_cleanups[0].mount_path,
+            "/home/user/.codex"
+        );
+        assert_eq!(
+            manifest.instruction_cleanups[0].target_filename.as_deref(),
+            Some("AGENTS.md")
+        );
+        assert_eq!(manifest.instruction_cleanups[1].target_filename, None);
     }
 }

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -46,6 +46,10 @@ impl ManifestEntryKind {
     fn skip_cached_existing_root(self) -> bool {
         matches!(self, Self::Artifact)
     }
+
+    fn uses_extract_path(self, entry: &ManifestEntry) -> bool {
+        matches!(self, Self::Storage) && entry.instructions_target_filename.is_some()
+    }
 }
 
 impl RunPlan {
@@ -141,10 +145,7 @@ fn append_download_tasks(
         if should_download_entry(entry, kind)
             && let Some(url) = entry.archive_url.clone()
         {
-            let download_mount_path = entry
-                .extract_path
-                .as_deref()
-                .unwrap_or(entry.mount_path.as_str());
+            let download_mount_path = download_mount_path(entry, kind);
             let task_kind = classify_download_task_kind(
                 download_mount_path,
                 entry.instructions_target_filename.as_deref(),
@@ -158,6 +159,17 @@ fn append_download_tasks(
                 task_kind,
             ));
         }
+    }
+}
+
+fn download_mount_path(entry: &ManifestEntry, kind: ManifestEntryKind) -> &str {
+    if kind.uses_extract_path(entry) {
+        entry
+            .extract_path
+            .as_deref()
+            .unwrap_or(entry.mount_path.as_str())
+    } else {
+        entry.mount_path.as_str()
     }
 }
 
@@ -367,6 +379,61 @@ mod tests {
                 "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0".into(),
                 NotFoundPolicy::Fail,
                 crate::download::DownloadTaskKind::FrameworkHomeInstructions,
+            )
+        );
+    }
+
+    #[test]
+    fn run_plan_ignores_extract_path_for_non_instruction_storage() {
+        let json = r#"{
+            "storages": [{
+                "mountPath": "/data",
+                "extractPath": "/tmp/staged-data",
+                "archiveUrl": "https://s3/data.tar.gz"
+            }]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert!(plan.instruction_files.is_empty());
+        assert_eq!(plan.download_tasks.len(), 1);
+        assert_eq!(
+            plan.download_tasks[0],
+            DownloadTask::new_with_kind(
+                "storage 1 mountPath=/data vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
+                "storage_download",
+                "https://s3/data.tar.gz".into(),
+                "/data".into(),
+                NotFoundPolicy::Fail,
+                crate::download::DownloadTaskKind::Other,
+            )
+        );
+    }
+
+    #[test]
+    fn run_plan_ignores_extract_path_for_artifacts() {
+        let json = r#"{
+            "artifacts": [{
+                "mountPath": "/workspace",
+                "extractPath": "/tmp/staged-artifact",
+                "archiveUrl": "https://s3/workspace.tar.gz"
+            }]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert_eq!(plan.download_tasks.len(), 1);
+        assert_eq!(
+            plan.download_tasks[0],
+            DownloadTask::new_with_kind(
+                "artifact 1 mountPath=/workspace vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false missingRootPolicy=fail".into(),
+                "artifact_download",
+                "https://s3/workspace.tar.gz".into(),
+                "/workspace".into(),
+                NotFoundPolicy::Ignore404,
+                crate::download::DownloadTaskKind::Other,
             )
         );
     }

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -1,10 +1,11 @@
 use crate::download::{DownloadTask, NotFoundPolicy, classify_download_task_kind};
-use crate::instructions::InstructionNormalization;
+use crate::instructions::{InstructionCleanup, InstructionNormalization};
 use crate::manifest::{Manifest, ManifestEntry};
 use std::path::Path;
 
 pub(crate) struct RunPlan {
     pub(crate) cleanup_paths: Vec<String>,
+    pub(crate) instruction_cleanups: Vec<InstructionCleanup>,
     pub(crate) preserved_paths: Vec<String>,
     pub(crate) download_tasks: Vec<DownloadTask>,
     pub(crate) instruction_files: Vec<InstructionNormalization>,
@@ -74,11 +75,28 @@ impl RunPlan {
                     .instructions_target_filename
                     .as_ref()
                     .map(|target_filename| {
-                        InstructionNormalization::new(
-                            entry.mount_path.clone(),
-                            target_filename.clone(),
-                        )
+                        if is_valid_url(&entry.archive_url)
+                            && let Some(extract_path) = entry.extract_path.clone()
+                        {
+                            InstructionNormalization::staged(
+                                extract_path,
+                                entry.mount_path.clone(),
+                                target_filename.clone(),
+                            )
+                        } else {
+                            InstructionNormalization::in_place(
+                                entry.mount_path.clone(),
+                                target_filename.clone(),
+                            )
+                        }
                     })
+            })
+            .collect();
+        let instruction_cleanups = manifest
+            .instruction_cleanups
+            .iter()
+            .map(|entry| {
+                InstructionCleanup::new(entry.mount_path.clone(), entry.target_filename.clone())
             })
             .collect();
 
@@ -101,6 +119,7 @@ impl RunPlan {
 
         Self {
             cleanup_paths: manifest.cleanup_paths.clone(),
+            instruction_cleanups,
             preserved_paths,
             download_tasks,
             instruction_files,
@@ -122,15 +141,19 @@ fn append_download_tasks(
         if should_download_entry(entry, kind)
             && let Some(url) = entry.archive_url.clone()
         {
+            let download_mount_path = entry
+                .extract_path
+                .as_deref()
+                .unwrap_or(entry.mount_path.as_str());
             let task_kind = classify_download_task_kind(
-                &entry.mount_path,
+                download_mount_path,
                 entry.instructions_target_filename.as_deref(),
             );
             tasks.push(DownloadTask::new_with_kind(
                 format_entry_label(entry, kind, idx + 1, &url),
                 kind.op_name(),
                 url,
-                entry.mount_path.clone(),
+                download_mount_path.to_string(),
                 kind.not_found_policy(),
                 task_kind,
             ));
@@ -303,11 +326,72 @@ mod tests {
         let plan = RunPlan::from_manifest(&manifest);
 
         assert_eq!(plan.cleanup_paths, ["/home/user/.codex"]);
+        assert!(plan.instruction_cleanups.is_empty());
         assert_eq!(plan.preserved_paths, ["/home/user/.codex", "/workspace"]);
         assert_eq!(plan.instruction_files.len(), 1);
         assert_eq!(
             plan.instruction_files[0],
-            InstructionNormalization::new("/home/user/.codex".into(), "AGENTS.md".into())
+            InstructionNormalization::in_place("/home/user/.codex".into(), "AGENTS.md".into())
+        );
+    }
+
+    #[test]
+    fn run_plan_downloads_instruction_archive_to_extract_path() {
+        let json = r#"{
+            "storages": [{
+                "mountPath": "/home/user/.codex",
+                "extractPath": "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0",
+                "archiveUrl": "https://s3/instructions.tar.gz",
+                "instructionsTargetFilename": "AGENTS.md"
+            }]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert_eq!(
+            plan.instruction_files,
+            [InstructionNormalization::staged(
+                "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0".into(),
+                "/home/user/.codex".into(),
+                "AGENTS.md".into()
+            )]
+        );
+        assert_eq!(plan.download_tasks.len(), 1);
+        assert_eq!(
+            plan.download_tasks[0],
+            DownloadTask::new_with_kind(
+                "storage 1 mountPath=/home/user/.codex vasStorageName=unknown vasVersionId=unknown urlScheme=https cached=false".into(),
+                "storage_download",
+                "https://s3/instructions.tar.gz".into(),
+                "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0".into(),
+                NotFoundPolicy::Fail,
+                crate::download::DownloadTaskKind::FrameworkHomeInstructions,
+            )
+        );
+    }
+
+    #[test]
+    fn run_plan_collects_instruction_cleanups() {
+        let json = r#"{
+            "storages": [],
+            "instructionCleanups": [{
+                "mountPath": "/home/user/.codex",
+                "targetFilename": "AGENTS.md"
+            }, {
+                "mountPath": "/home/user/.claude"
+            }]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert_eq!(
+            plan.instruction_cleanups,
+            [
+                InstructionCleanup::new("/home/user/.codex".into(), Some("AGENTS.md".into())),
+                InstructionCleanup::new("/home/user/.claude".into(), None),
+            ]
         );
     }
 
@@ -372,6 +456,7 @@ mod tests {
             storages: vec![],
             artifacts: vec![ManifestEntry {
                 mount_path: mount_path.clone(),
+                extract_path: None,
                 archive_url: Some("https://s3/artifact.tar.gz".into()),
                 instructions_target_filename: None,
                 cached: true,
@@ -380,6 +465,7 @@ mod tests {
                 missing_root_policy: None,
             }],
             cleanup_paths: vec![],
+            instruction_cleanups: Vec::new(),
         };
 
         let plan = RunPlan::from_manifest(&manifest);
@@ -397,6 +483,7 @@ mod tests {
         let manifest = Manifest {
             storages: vec![ManifestEntry {
                 mount_path: mount_path.clone(),
+                extract_path: None,
                 archive_url: Some("https://s3/storage.tar.gz".into()),
                 instructions_target_filename: None,
                 cached: true,
@@ -406,6 +493,7 @@ mod tests {
             }],
             artifacts: vec![],
             cleanup_paths: vec![],
+            instruction_cleanups: Vec::new(),
         };
 
         let plan = RunPlan::from_manifest(&manifest);
@@ -437,6 +525,7 @@ mod tests {
             storages: vec![],
             artifacts: vec![ManifestEntry {
                 mount_path: mount_path.clone(),
+                extract_path: None,
                 archive_url: Some("https://s3/artifact.tar.gz".into()),
                 instructions_target_filename: None,
                 cached: true,
@@ -445,6 +534,7 @@ mod tests {
                 missing_root_policy: None,
             }],
             cleanup_paths: vec![],
+            instruction_cleanups: Vec::new(),
         };
 
         let plan = RunPlan::from_manifest(&manifest);

--- a/crates/guest-download/tests/integration/file_scheme.rs
+++ b/crates/guest-download/tests/integration/file_scheme.rs
@@ -1,6 +1,7 @@
 use crate::support::{
     TarEntry, create_tar_gz, create_tar_gz_entries, run_guest_download, write_manifest,
 };
+use serde_json::json;
 
 // ---------------------------------------------------------------------------
 // file:// scheme — runner-staged local archives (epic #10800)
@@ -72,6 +73,67 @@ fn file_scheme_malicious_entries_are_skipped_while_safe_entries_extract() {
     assert!(!dir.path().join("path_escape.txt").exists());
     assert!(mount.join("evil_symlink").symlink_metadata().is_err());
     assert!(!mount.join("evil_hardlink").exists());
+}
+
+#[test]
+fn file_scheme_staged_instructions_promote_without_touching_skill_child() {
+    let instructions_tar_gz = create_tar_gz(&[
+        ("AGENTS.md", b"runtime instructions"),
+        ("CLAUDE.md", b"old alternate from archive"),
+        ("extra.txt", b"ignored"),
+        ("skills/evil/SKILL.md", b"ignored staged skill"),
+    ])
+    .unwrap();
+    let skill_tar_gz = create_tar_gz(&[("SKILL.md", b"workflow skill")]).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let instructions_archive = dir.path().join("instructions.tar.gz");
+    let skill_archive = dir.path().join("skill.tar.gz");
+    std::fs::write(&instructions_archive, &instructions_tar_gz).unwrap();
+    std::fs::write(&skill_archive, &skill_tar_gz).unwrap();
+
+    let final_home = dir.path().join(".codex");
+    let extract_path = dir
+        .path()
+        .join("runtime")
+        .join("storage-instructions")
+        .join("0");
+    let skill_mount = final_home.join("skills").join("workflow");
+    std::fs::create_dir_all(&final_home).unwrap();
+    std::fs::write(final_home.join("CLAUDE.md"), "stale alternate").unwrap();
+
+    let manifest_path = dir.path().join("manifest.json");
+    let manifest = json!({
+        "storages": [
+            {
+                "mountPath": final_home,
+                "extractPath": extract_path,
+                "archiveUrl": format!("file://{}", instructions_archive.display()),
+                "instructionsTargetFilename": "AGENTS.md"
+            },
+            {
+                "mountPath": skill_mount,
+                "archiveUrl": format!("file://{}", skill_archive.display())
+            }
+        ]
+    });
+    std::fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+    let result = run_guest_download(manifest_path.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(final_home.join("AGENTS.md")).unwrap(),
+        "runtime instructions"
+    );
+    assert_eq!(
+        std::fs::read_to_string(skill_mount.join("SKILL.md")).unwrap(),
+        "workflow skill"
+    );
+    assert!(!final_home.join("CLAUDE.md").exists());
+    assert!(!final_home.join("extra.txt").exists());
+    assert!(!final_home.join("skills").join("evil").exists());
+    assert!(!extract_path.exists());
 }
 
 // Security regression: this exercises the ancestor symlink guard directly. The

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -821,7 +821,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
 
     // 3. Download storage manifest entries (skipping entries unchanged since the previous turn).
     if let Some(manifest) = &context.storage_manifest {
-        let guest_manifest = GuestDownloadManifest::from(manifest);
+        let runtime_dir = guest_runtime_dir(context.run_id)?;
+        let guest_manifest =
+            GuestDownloadManifest::from_storage_manifest_for_run(manifest, runtime_dir.as_str());
         let mut effective: GuestDownloadManifest = match start.prev_storage {
             Some(prev) => {
                 let t = Instant::now();

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -18,6 +18,7 @@ use crate::types::{
 const STORAGE_MANIFEST_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 const CODEX_FRAMEWORK_HOME: &str = "/home/user/.codex";
 const CLAUDE_FRAMEWORK_HOME: &str = "/home/user/.claude";
+const AGENT_INSTRUCTIONS_STORAGE_NAME_PREFIX: &str = "agent-instructions@";
 
 #[derive(Default)]
 struct ManifestReuseFilter {
@@ -63,9 +64,9 @@ impl ManifestReuseFilter {
         current_paths: impl IntoIterator<Item = &'a str>,
     ) {
         let current_paths: HashSet<&str> = current_paths.into_iter().collect();
-        for prev_path in previous.keys() {
+        for (prev_path, previous_fingerprint) in previous {
             if !current_paths.contains(prev_path.as_str()) {
-                if is_framework_home_path(prev_path) {
+                if is_removed_framework_home_instruction(prev_path, previous_fingerprint) {
                     self.instruction_cleanups
                         .push(GuestDownloadInstructionCleanupEntry {
                             mount_path: prev_path.clone(),
@@ -198,6 +199,13 @@ pub(super) fn guest_download_has_work(manifest: &GuestDownloadManifest) -> bool 
 
 fn is_framework_home_path(path: &str) -> bool {
     matches!(path, CODEX_FRAMEWORK_HOME | CLAUDE_FRAMEWORK_HOME)
+}
+
+fn is_removed_framework_home_instruction(path: &str, fingerprint: &StorageFingerprint) -> bool {
+    is_framework_home_path(path)
+        && fingerprint
+            .vas_storage_name()
+            .is_some_and(|name| name.starts_with(AGENT_INSTRUCTIONS_STORAGE_NAME_PREFIX))
 }
 
 /// Download storage volumes into the guest.

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -57,7 +57,7 @@ impl ManifestReuseFilter {
         self.cleanup_paths.push(artifact.mount_path.clone());
     }
 
-    fn record_removed_paths<'a>(
+    fn record_removed_storages<'a>(
         &mut self,
         previous: &HashMap<String, StorageFingerprint>,
         current_paths: impl IntoIterator<Item = &'a str>,
@@ -74,6 +74,19 @@ impl ManifestReuseFilter {
                 } else {
                     self.cleanup_paths.push(prev_path.clone());
                 }
+            }
+        }
+    }
+
+    fn record_removed_artifacts<'a>(
+        &mut self,
+        previous: &HashMap<String, StorageFingerprint>,
+        current_paths: impl IntoIterator<Item = &'a str>,
+    ) {
+        let current_paths: HashSet<&str> = current_paths.into_iter().collect();
+        for prev_path in previous.keys() {
+            if !current_paths.contains(prev_path.as_str()) {
+                self.cleanup_paths.push(prev_path.clone());
             }
         }
     }
@@ -110,7 +123,7 @@ pub(super) fn apply_storage_fingerprint_reuse(
         })
         .collect();
 
-    filter.record_removed_paths(
+    filter.record_removed_storages(
         &prev.storages,
         manifest.storages.iter().map(|s| s.mount_path.as_str()),
     );
@@ -135,7 +148,7 @@ pub(super) fn apply_storage_fingerprint_reuse(
         })
         .collect();
 
-    filter.record_removed_paths(
+    filter.record_removed_artifacts(
         &prev.artifacts,
         manifest.artifacts.iter().map(|a| a.mount_path.as_str()),
     );

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -203,9 +203,10 @@ fn is_framework_home_path(path: &str) -> bool {
 
 fn is_removed_framework_home_instruction(path: &str, fingerprint: &StorageFingerprint) -> bool {
     is_framework_home_path(path)
-        && fingerprint
-            .vas_storage_name()
-            .is_some_and(|name| name.starts_with(AGENT_INSTRUCTIONS_STORAGE_NAME_PREFIX))
+        && (fingerprint.is_tainted()
+            || fingerprint
+                .vas_storage_name()
+                .is_some_and(|name| name.starts_with(AGENT_INSTRUCTIONS_STORAGE_NAME_PREFIX)))
 }
 
 /// Download storage volumes into the guest.

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -11,22 +11,25 @@ use crate::helper_exec::{format_helper_exec_failure, helper_exec_succeeded};
 use crate::paths::guest;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
 use crate::types::{
-    ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry,
+    ExecutionContext, GuestDownloadArtifactEntry, GuestDownloadInstructionCleanupEntry,
+    GuestDownloadManifest, GuestDownloadStorageEntry,
 };
 
 const STORAGE_MANIFEST_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+const CODEX_FRAMEWORK_HOME: &str = "/home/user/.codex";
+const CLAUDE_FRAMEWORK_HOME: &str = "/home/user/.claude";
 
 #[derive(Default)]
 struct ManifestReuseFilter {
     skipped: usize,
     cleanup_paths: Vec<String>,
+    instruction_cleanups: Vec<GuestDownloadInstructionCleanupEntry>,
 }
 
 impl ManifestReuseFilter {
     fn record_entry(
         &mut self,
         previous: Option<&StorageFingerprint>,
-        mount_path: &str,
         vas_storage_name: &str,
         vas_version_id: &str,
     ) -> bool {
@@ -34,10 +37,24 @@ impl ManifestReuseFilter {
             .is_some_and(|fingerprint| fingerprint.matches(vas_storage_name, vas_version_id));
         if unchanged {
             self.skipped += 1;
-        } else {
-            self.cleanup_paths.push(mount_path.to_string());
         }
         unchanged
+    }
+
+    fn record_changed_storage(&mut self, storage: &GuestDownloadStorageEntry) {
+        if storage.instructions_target_filename.is_some() {
+            self.instruction_cleanups
+                .push(GuestDownloadInstructionCleanupEntry {
+                    mount_path: storage.mount_path.clone(),
+                    target_filename: storage.instructions_target_filename.clone(),
+                });
+        } else {
+            self.cleanup_paths.push(storage.mount_path.clone());
+        }
+    }
+
+    fn record_changed_artifact(&mut self, artifact: &GuestDownloadArtifactEntry) {
+        self.cleanup_paths.push(artifact.mount_path.clone());
     }
 
     fn record_removed_paths<'a>(
@@ -48,7 +65,15 @@ impl ManifestReuseFilter {
         let current_paths: HashSet<&str> = current_paths.into_iter().collect();
         for prev_path in previous.keys() {
             if !current_paths.contains(prev_path.as_str()) {
-                self.cleanup_paths.push(prev_path.clone());
+                if is_framework_home_path(prev_path) {
+                    self.instruction_cleanups
+                        .push(GuestDownloadInstructionCleanupEntry {
+                            mount_path: prev_path.clone(),
+                            target_filename: None,
+                        });
+                } else {
+                    self.cleanup_paths.push(prev_path.clone());
+                }
             }
         }
     }
@@ -66,10 +91,12 @@ pub(super) fn apply_storage_fingerprint_reuse(
         .map(|s| {
             let unchanged = filter.record_entry(
                 prev.storages.get(&s.mount_path),
-                &s.mount_path,
                 &s.vas_storage_name,
                 &s.vas_version_id,
             );
+            if !unchanged {
+                filter.record_changed_storage(s);
+            }
             GuestDownloadStorageEntry {
                 archive_url: if unchanged {
                     None
@@ -94,10 +121,12 @@ pub(super) fn apply_storage_fingerprint_reuse(
         .map(|a| {
             let unchanged = filter.record_entry(
                 prev.artifacts.get(&a.mount_path),
-                &a.mount_path,
                 &a.vas_storage_name,
                 &a.vas_version_id,
             );
+            if !unchanged {
+                filter.record_changed_artifact(a);
+            }
             GuestDownloadArtifactEntry {
                 archive_url: a.archive_url.clone(),
                 cached: unchanged,
@@ -114,6 +143,7 @@ pub(super) fn apply_storage_fingerprint_reuse(
     let ManifestReuseFilter {
         skipped,
         cleanup_paths,
+        instruction_cleanups,
     } = filter;
 
     if skipped > 0 {
@@ -127,11 +157,18 @@ pub(super) fn apply_storage_fingerprint_reuse(
             "computed cleanup paths for stale file removal"
         );
     }
+    if !instruction_cleanups.is_empty() {
+        info!(
+            count = instruction_cleanups.len(),
+            "computed instruction cleanup entries for stale file removal"
+        );
+    }
 
     GuestDownloadManifest {
         storages,
         artifacts,
         cleanup_paths,
+        instruction_cleanups,
     }
 }
 
@@ -139,10 +176,15 @@ pub(super) fn guest_download_has_work(manifest: &GuestDownloadManifest) -> bool 
     manifest.storages.iter().any(|s| s.archive_url.is_some())
         || manifest.artifacts.iter().any(|a| a.archive_url.is_some())
         || !manifest.cleanup_paths.is_empty()
+        || !manifest.instruction_cleanups.is_empty()
         || manifest
             .storages
             .iter()
             .any(|s| s.instructions_target_filename.is_some())
+}
+
+fn is_framework_home_path(path: &str) -> bool {
+    matches!(path, CODEX_FRAMEWORK_HOME | CLAUDE_FRAMEWORK_HOME)
 }
 
 /// Download storage volumes into the guest.

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -14,7 +14,10 @@ use super::support::{minimal_context, sandbox_exec_error, sandbox_write_file_err
 use crate::helper_exec::{HELPER_EXEC_OUTPUT_EXCERPT_BYTES, format_command_output_excerpt};
 use crate::paths::guest;
 use crate::storage_fingerprints::{StorageFingerprint, StorageFingerprints};
-use crate::types::{GuestDownloadArtifactEntry, GuestDownloadManifest, GuestDownloadStorageEntry};
+use crate::types::{
+    GuestDownloadArtifactEntry, GuestDownloadInstructionCleanupEntry, GuestDownloadManifest,
+    GuestDownloadStorageEntry,
+};
 
 #[tokio::test]
 async fn download_storages_success() {
@@ -30,6 +33,7 @@ async fn download_storages_success() {
         )],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let manifest_json = serde_json::to_vec(&manifest).unwrap();
     download_storages(&sandbox, &ctx, &manifest).await.unwrap();
@@ -252,6 +256,7 @@ async fn download_storages_nonzero_exit_code() {
         storages: vec![],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let err = download_storages(&sandbox, &ctx, &manifest)
         .await
@@ -281,6 +286,7 @@ async fn download_storages_fails_on_non_exited_result() {
         storages: vec![],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
 
     let err = download_storages(&sandbox, &ctx, &manifest)
@@ -424,6 +430,7 @@ fn manifest_with_serialized_len(len: usize) -> GuestDownloadManifest {
         storages: vec![],
         artifacts: vec![],
         cleanup_paths: vec![String::new()],
+        instruction_cleanups: Vec::new(),
     };
     let empty_len = serde_json::to_vec(&manifest).unwrap().len();
     assert!(len >= empty_len);
@@ -457,6 +464,7 @@ fn guest_storage(
 ) -> GuestDownloadStorageEntry {
     GuestDownloadStorageEntry {
         mount_path: mount_path.into(),
+        extract_path: None,
         archive_url: url.map(str::to_string),
         instructions_target_filename: None,
         cached: false,
@@ -487,6 +495,7 @@ fn guest_download_has_work_detects_instruction_normalization_without_archives() 
         storages: vec![storage],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
 
     assert!(guest_download_has_work(&manifest));
@@ -500,6 +509,7 @@ fn guest_download_has_work_skips_fully_empty_cached_manifest() {
         storages: vec![storage],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
 
     assert!(!guest_download_has_work(&manifest));
@@ -516,6 +526,7 @@ fn guest_download_has_work_detects_archive_urls_and_cleanup_paths() {
         )],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     assert!(guest_download_has_work(&storage_work));
 
@@ -523,6 +534,7 @@ fn guest_download_has_work_detects_archive_urls_and_cleanup_paths() {
         storages: vec![],
         artifacts: vec![guest_art("workspace", "v1", Some("https://s3/workspace"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     assert!(guest_download_has_work(&artifact_work));
 
@@ -530,8 +542,20 @@ fn guest_download_has_work_detects_archive_urls_and_cleanup_paths() {
         storages: vec![],
         artifacts: vec![],
         cleanup_paths: vec!["/old".into()],
+        instruction_cleanups: Vec::new(),
     };
     assert!(guest_download_has_work(&cleanup_work));
+
+    let instruction_cleanup_work = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![],
+        cleanup_paths: Vec::new(),
+        instruction_cleanups: vec![GuestDownloadInstructionCleanupEntry {
+            mount_path: "/home/user/.codex".into(),
+            target_filename: Some("AGENTS.md".into()),
+        }],
+    };
+    assert!(guest_download_has_work(&instruction_cleanup_work));
 }
 
 #[test]
@@ -540,6 +564,7 @@ fn filter_same_artifact_version_keeps_url_for_mount_repair() {
         storages: vec![],
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::new(),
@@ -560,6 +585,7 @@ fn filter_different_artifact_version_keeps_url() {
         storages: vec![],
         artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::new(),
@@ -578,6 +604,7 @@ fn filter_different_artifact_name_keeps_url() {
         storages: vec![],
         artifacts: vec![guest_art("other-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::new(),
@@ -593,6 +620,7 @@ fn filter_new_artifact_not_in_prev_keeps_url() {
         storages: vec![],
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints::default();
     let result = apply_storage_fingerprint_reuse(&manifest, &prev);
@@ -610,6 +638,7 @@ fn filter_empty_prev_downloads_everything() {
         )],
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints::default();
     let result = apply_storage_fingerprint_reuse(&manifest, &prev);
@@ -628,6 +657,7 @@ fn filter_all_unchanged_nulls_storage_urls_and_keeps_artifact_urls() {
         )],
         artifacts: vec![guest_art("my-art", "v1", Some("https://s3/v1"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let mut storages = HashMap::new();
     storages.insert("/data".into(), fp("vol-1", "v1"));
@@ -669,6 +699,7 @@ fn filter_two_artifacts_at_different_mount_paths() {
         storages: vec![],
         artifacts: vec![art_a, art_b],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     // Previous fingerprints: art-a was v1 (changed), art-b was v1 (unchanged).
     let mut artifacts = HashMap::new();
@@ -699,6 +730,7 @@ fn filter_detects_removed_artifacts() {
         storages: vec![],
         artifacts: vec![guest_art("kept", "v1", Some("https://s3/kept"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let mut artifacts = HashMap::new();
     artifacts.insert("/workspace".into(), fp("kept", "v1"));
@@ -731,6 +763,7 @@ fn filter_cleanup_paths_keep_broad_phase_order() {
             missing_root_policy: None,
         }],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::from([
@@ -758,14 +791,16 @@ fn filter_cleanup_paths_keep_broad_phase_order() {
 
 #[test]
 fn filter_computes_cleanup_for_changed_storages() {
+    let mut instructions = guest_storage(
+        "/home/user/.claude",
+        "instructions",
+        "v2",
+        Some("https://s3/instructions"),
+    );
+    instructions.instructions_target_filename = Some("CLAUDE.md".into());
     let manifest = GuestDownloadManifest {
         storages: vec![
-            guest_storage(
-                "/home/user/.claude",
-                "instructions",
-                "v2",
-                Some("https://s3/instructions"),
-            ),
+            instructions,
             guest_storage(
                 "/home/user/.claude/skills/foo",
                 "skill-foo",
@@ -775,6 +810,7 @@ fn filter_computes_cleanup_for_changed_storages() {
         ],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let mut storages = HashMap::new();
     storages.insert("/home/user/.claude".into(), fp("instructions", "v1"));
@@ -792,8 +828,16 @@ fn filter_computes_cleanup_for_changed_storages() {
     assert!(!result.storages[0].cached);
     assert!(result.storages[1].archive_url.is_none());
     assert!(result.storages[1].cached);
-    // Only changed storage in cleanup_paths
-    assert_eq!(result.cleanup_paths, vec!["/home/user/.claude"]);
+    assert!(result.cleanup_paths.is_empty());
+    assert_eq!(result.instruction_cleanups.len(), 1);
+    assert_eq!(
+        result.instruction_cleanups[0].mount_path,
+        "/home/user/.claude"
+    );
+    assert_eq!(
+        result.instruction_cleanups[0].target_filename.as_deref(),
+        Some("CLAUDE.md")
+    );
 }
 
 #[test]
@@ -807,6 +851,7 @@ fn filter_detects_removed_storages() {
         )],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let mut storages = HashMap::new();
     storages.insert("/home/user/.claude".into(), fp("instructions", "v1"));
@@ -829,11 +874,48 @@ fn filter_detects_removed_storages() {
 }
 
 #[test]
+fn filter_removed_framework_home_storage_uses_instruction_cleanup() {
+    let manifest = GuestDownloadManifest {
+        storages: vec![guest_storage(
+            "/home/user/.claude/skills/foo",
+            "skill-foo",
+            "v1",
+            Some("https://s3/foo"),
+        )],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
+    };
+    let prev = StorageFingerprints {
+        storages: HashMap::from([
+            ("/home/user/.claude".into(), fp("instructions", "v1")),
+            (
+                "/home/user/.claude/skills/foo".into(),
+                fp("skill-foo", "v1"),
+            ),
+        ]),
+        artifacts: HashMap::new(),
+    };
+
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
+
+    assert!(result.cleanup_paths.is_empty());
+    assert_eq!(result.instruction_cleanups.len(), 1);
+    assert_eq!(
+        result.instruction_cleanups[0].mount_path,
+        "/home/user/.claude"
+    );
+    assert_eq!(result.instruction_cleanups[0].target_filename, None);
+    assert!(result.storages[0].cached);
+}
+
+#[test]
 fn filter_changed_artifact_adds_cleanup_path() {
     let manifest = GuestDownloadManifest {
         storages: vec![],
         artifacts: vec![guest_art("my-art", "v2", Some("https://s3/v2"))],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::new(),
@@ -854,6 +936,7 @@ fn filter_changed_artifact_with_null_url_adds_cleanup_path() {
         storages: vec![],
         artifacts: vec![guest_art("my-art", "v2", None)],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::new(),
@@ -876,6 +959,7 @@ fn filter_unchanged_artifact_policy_does_not_force_redownload() {
             Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
         )],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::new(),
@@ -898,6 +982,7 @@ fn filter_changed_storage_with_null_url_adds_cleanup_path() {
         storages: vec![guest_storage("/data", "vol-1", "v2", None)],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let mut storages = HashMap::new();
     storages.insert("/data".into(), fp("vol-1", "v1"));
@@ -922,6 +1007,7 @@ fn filter_unchanged_storage_sets_cached_true() {
         )],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let mut storages = HashMap::new();
     storages.insert("/data".into(), fp("vol-1", "v1"));
@@ -947,6 +1033,7 @@ fn filter_unchanged_storage_leaves_instruction_normalization_work() {
         storages: vec![storage],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::from([("/home/user/.codex".into(), fp("instructions", "v1"))]),
@@ -984,6 +1071,7 @@ fn filter_tainted_paths_force_download_even_when_versions_match() {
             missing_root_policy: None,
         }],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::from([("/workspace/repo".into(), fp("repo", "v1"))]),
@@ -1021,6 +1109,7 @@ fn filter_tainted_removed_paths_are_cleaned() {
         storages: vec![],
         artifacts: vec![],
         cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
     };
     let prev = StorageFingerprints {
         storages: HashMap::from([("/workspace/removed-storage".into(), fp("repo", "v1"))]),

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -932,6 +932,39 @@ fn filter_removed_framework_home_non_instruction_storage_uses_cleanup_path() {
 }
 
 #[test]
+fn filter_removed_tainted_framework_home_storage_uses_instruction_cleanup() {
+    let manifest = GuestDownloadManifest {
+        storages: vec![guest_storage(
+            "/home/user/.codex/skills/foo",
+            "skill-foo",
+            "v1",
+            Some("https://s3/foo"),
+        )],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
+    };
+    let prev = StorageFingerprints {
+        storages: HashMap::from([
+            ("/home/user/.codex".into(), StorageFingerprint::tainted()),
+            ("/home/user/.codex/skills/foo".into(), fp("skill-foo", "v1")),
+        ]),
+        artifacts: HashMap::new(),
+    };
+
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
+
+    assert!(result.cleanup_paths.is_empty());
+    assert_eq!(result.instruction_cleanups.len(), 1);
+    assert_eq!(
+        result.instruction_cleanups[0].mount_path,
+        "/home/user/.codex"
+    );
+    assert_eq!(result.instruction_cleanups[0].target_filename, None);
+    assert!(result.storages[0].cached);
+}
+
+#[test]
 fn filter_removed_framework_home_artifact_uses_cleanup_path() {
     let manifest = GuestDownloadManifest {
         storages: vec![],

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -910,6 +910,25 @@ fn filter_removed_framework_home_storage_uses_instruction_cleanup() {
 }
 
 #[test]
+fn filter_removed_framework_home_artifact_uses_cleanup_path() {
+    let manifest = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
+    };
+    let prev = StorageFingerprints {
+        storages: HashMap::new(),
+        artifacts: HashMap::from([("/home/user/.codex".into(), fp("artifact", "v1"))]),
+    };
+
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
+
+    assert_eq!(result.cleanup_paths, ["/home/user/.codex"]);
+    assert!(result.instruction_cleanups.is_empty());
+}
+
+#[test]
 fn filter_changed_artifact_adds_cleanup_path() {
     let manifest = GuestDownloadManifest {
         storages: vec![],

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -888,7 +888,10 @@ fn filter_removed_framework_home_storage_uses_instruction_cleanup() {
     };
     let prev = StorageFingerprints {
         storages: HashMap::from([
-            ("/home/user/.claude".into(), fp("instructions", "v1")),
+            (
+                "/home/user/.claude".into(),
+                fp("agent-instructions@assistant", "v1"),
+            ),
             (
                 "/home/user/.claude/skills/foo".into(),
                 fp("skill-foo", "v1"),
@@ -907,6 +910,25 @@ fn filter_removed_framework_home_storage_uses_instruction_cleanup() {
     );
     assert_eq!(result.instruction_cleanups[0].target_filename, None);
     assert!(result.storages[0].cached);
+}
+
+#[test]
+fn filter_removed_framework_home_non_instruction_storage_uses_cleanup_path() {
+    let manifest = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![],
+        cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
+    };
+    let prev = StorageFingerprints {
+        storages: HashMap::from([("/home/user/.codex".into(), fp("custom-config", "v1"))]),
+        artifacts: HashMap::new(),
+    };
+
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
+
+    assert_eq!(result.cleanup_paths, ["/home/user/.codex"]);
+    assert!(result.instruction_cleanups.is_empty());
 }
 
 #[test]

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -2502,6 +2502,7 @@ mod tests {
         GuestDownloadManifest {
             storages: vec![GuestDownloadStorageEntry {
                 mount_path: format!("/mnt/{name}"),
+                extract_path: None,
                 archive_url: Some(url),
                 cached: false,
                 instructions_target_filename: None,
@@ -2510,6 +2511,7 @@ mod tests {
             }],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         }
     }
 
@@ -2523,6 +2525,7 @@ mod tests {
             storages: vec![
                 GuestDownloadStorageEntry {
                     mount_path: "/mnt/duplicate-a".into(),
+                    extract_path: None,
                     archive_url: Some(first_url),
                     cached: false,
                     instructions_target_filename: None,
@@ -2531,6 +2534,7 @@ mod tests {
                 },
                 GuestDownloadStorageEntry {
                     mount_path: "/mnt/duplicate-b".into(),
+                    extract_path: None,
                     archive_url: Some(second_url),
                     cached: false,
                     instructions_target_filename: None,
@@ -2540,6 +2544,7 @@ mod tests {
             ],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         }
     }
 
@@ -2556,6 +2561,7 @@ mod tests {
                 missing_root_policy: None,
             }],
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         }
     }
 
@@ -3387,6 +3393,7 @@ mod tests {
             storages: vec![
                 GuestDownloadStorageEntry {
                     mount_path: "/mnt/empty".into(),
+                    extract_path: None,
                     archive_url: Some(empty_url.clone()),
                     cached: false,
                     instructions_target_filename: None,
@@ -3395,6 +3402,7 @@ mod tests {
                 },
                 GuestDownloadStorageEntry {
                     mount_path: "/mnt/oversized".into(),
+                    extract_path: None,
                     archive_url: Some(oversized_url.clone()),
                     cached: false,
                     instructions_target_filename: None,
@@ -3404,6 +3412,7 @@ mod tests {
             ],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_passthrough_without_background(
@@ -3550,6 +3559,7 @@ mod tests {
             storages: vec![
                 GuestDownloadStorageEntry {
                     mount_path: "/mnt/a".into(),
+                    extract_path: None,
                     archive_url: Some("https://r2.example.com/a.tar.gz".into()),
                     cached: false,
                     instructions_target_filename: None,
@@ -3558,6 +3568,7 @@ mod tests {
                 },
                 GuestDownloadStorageEntry {
                     mount_path: "/mnt/b".into(),
+                    extract_path: None,
                     archive_url: Some("https://r2.example.com/b.tar.gz".into()),
                     cached: false,
                     instructions_target_filename: None,
@@ -3567,6 +3578,7 @@ mod tests {
             ],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_blocking(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -4451,6 +4463,7 @@ mod tests {
         let mut manifest = GuestDownloadManifest {
             storages: vec![GuestDownloadStorageEntry {
                 mount_path: "/mnt/foo".into(),
+                extract_path: None,
                 archive_url: None,
                 cached: true,
                 instructions_target_filename: None,
@@ -4459,6 +4472,7 @@ mod tests {
             }],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_blocking(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -4483,6 +4497,7 @@ mod tests {
         let mut manifest = GuestDownloadManifest {
             storages: vec![GuestDownloadStorageEntry {
                 mount_path: "/mnt/legacy".into(),
+                extract_path: None,
                 archive_url: Some("https://r2.example.com/legacy.tar.gz".into()),
                 cached: false,
                 instructions_target_filename: None,
@@ -4491,6 +4506,7 @@ mod tests {
             }],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_blocking(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -4759,6 +4775,7 @@ mod tests {
                 missing_root_policy: None,
             }],
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_blocking(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -5444,6 +5461,7 @@ mod tests {
                     storages: vec![
                         GuestDownloadStorageEntry {
                             mount_path: "/mnt/ready".into(),
+                            extract_path: None,
                             archive_url: Some(format!("http://{ready_addr}/ready.tar.gz")),
                             cached: false,
                             instructions_target_filename: None,
@@ -5452,6 +5470,7 @@ mod tests {
                         },
                         GuestDownloadStorageEntry {
                             mount_path: "/mnt/cold".into(),
+                            extract_path: None,
                             archive_url: Some(format!("http://{cold_addr}/cold.tar.gz")),
                             cached: false,
                             instructions_target_filename: None,
@@ -5461,6 +5480,7 @@ mod tests {
                     ],
                     artifacts: Vec::new(),
                     cleanup_paths: Vec::new(),
+                    instruction_cleanups: Vec::new(),
                 };
                 let mut telemetry = new_telemetry();
                 populate_cache_blocking(&mut manifest, sandbox.as_ref(), &home, &mut telemetry)
@@ -5678,6 +5698,7 @@ mod tests {
         let mut manifest = GuestDownloadManifest {
             storages: vec![GuestDownloadStorageEntry {
                 mount_path: "/mnt/storage".into(),
+                extract_path: None,
                 archive_url: Some("https://r2.example.com/storage.tar.gz".into()),
                 cached: false,
                 instructions_target_filename: None,
@@ -5694,6 +5715,7 @@ mod tests {
                 missing_root_policy: None,
             }],
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_blocking(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -6118,6 +6140,7 @@ mod tests {
             storages: vec![
                 GuestDownloadStorageEntry {
                     mount_path: format!("/mnt/{name_a}"),
+                    extract_path: None,
                     archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
                     cached: false,
                     instructions_target_filename: None,
@@ -6126,6 +6149,7 @@ mod tests {
                 },
                 GuestDownloadStorageEntry {
                     mount_path: format!("/mnt/{name_b}"),
+                    extract_path: None,
                     archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
                     cached: false,
                     instructions_target_filename: None,
@@ -6135,6 +6159,7 @@ mod tests {
             ],
             artifacts: Vec::new(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_blocking(&mut manifest, &sandbox, &home, &mut telemetry)
@@ -6182,6 +6207,7 @@ mod tests {
                 missing_root_policy: None,
             }],
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         };
 
         populate_cache_blocking(&mut manifest, &sandbox, &home, &mut telemetry)

--- a/crates/runner/src/storage_fingerprints.rs
+++ b/crates/runner/src/storage_fingerprints.rs
@@ -72,6 +72,15 @@ impl StorageFingerprint {
             StorageFingerprintKind::Tainted => false,
         }
     }
+
+    pub(crate) fn vas_storage_name(&self) -> Option<&str> {
+        match &self.kind {
+            StorageFingerprintKind::Known {
+                vas_storage_name, ..
+            } => Some(vas_storage_name.as_str()),
+            StorageFingerprintKind::Tainted => None,
+        }
+    }
 }
 
 impl Serialize for StorageFingerprint {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
 use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
@@ -244,12 +245,16 @@ pub struct GuestDownloadManifest {
     /// Used on VM reuse to remove stale files from changed/removed storages.
     #[serde(default)]
     pub cleanup_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub instruction_cleanups: Vec<GuestDownloadInstructionCleanupEntry>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GuestDownloadStorageEntry {
     pub mount_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extract_path: Option<String>,
     pub archive_url: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions_target_filename: Option<String>,
@@ -259,6 +264,14 @@ pub struct GuestDownloadStorageEntry {
     pub cached: bool,
     pub vas_storage_name: String,
     pub vas_version_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GuestDownloadInstructionCleanupEntry {
+    pub mount_path: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_filename: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -277,17 +290,38 @@ pub struct GuestDownloadArtifactEntry {
 
 impl From<&StorageManifest> for GuestDownloadManifest {
     fn from(manifest: &StorageManifest) -> Self {
+        Self::from_storage_manifest(manifest, None)
+    }
+}
+
+impl GuestDownloadManifest {
+    pub(crate) fn from_storage_manifest_for_run(
+        manifest: &StorageManifest,
+        runtime_dir: &str,
+    ) -> Self {
+        Self::from_storage_manifest(manifest, Some(runtime_dir))
+    }
+
+    fn from_storage_manifest(manifest: &StorageManifest, runtime_dir: Option<&str>) -> Self {
         Self {
             storages: manifest
                 .storages
                 .iter()
-                .map(|storage| GuestDownloadStorageEntry {
-                    mount_path: storage.mount_path.clone(),
-                    archive_url: Some(storage.archive_url.clone()),
-                    instructions_target_filename: storage.instructions_target_filename.clone(),
-                    cached: false,
-                    vas_storage_name: storage.vas_storage_name.clone(),
-                    vas_version_id: storage.vas_version_id.clone(),
+                .enumerate()
+                .map(|(index, storage)| {
+                    let extract_path = storage
+                        .instructions_target_filename
+                        .as_ref()
+                        .and_then(|_| runtime_dir.map(|dir| instruction_extract_path(dir, index)));
+                    GuestDownloadStorageEntry {
+                        mount_path: storage.mount_path.clone(),
+                        extract_path,
+                        archive_url: Some(storage.archive_url.clone()),
+                        instructions_target_filename: storage.instructions_target_filename.clone(),
+                        cached: false,
+                        vas_storage_name: storage.vas_storage_name.clone(),
+                        vas_version_id: storage.vas_version_id.clone(),
+                    }
                 })
                 .collect(),
             artifacts: manifest
@@ -304,8 +338,16 @@ impl From<&StorageManifest> for GuestDownloadManifest {
                 })
                 .collect(),
             cleanup_paths: Vec::new(),
+            instruction_cleanups: Vec::new(),
         }
     }
+}
+
+fn instruction_extract_path(runtime_dir: &str, index: usize) -> String {
+    let mut path = PathBuf::from(runtime_dir);
+    path.push("storage-instructions");
+    path.push(index.to_string());
+    path.to_string_lossy().into_owned()
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1035,7 +1077,9 @@ mod tests {
         let guest_manifest = GuestDownloadManifest::from(&manifest);
 
         assert!(guest_manifest.cleanup_paths.is_empty());
+        assert!(guest_manifest.instruction_cleanups.is_empty());
         assert!(!guest_manifest.storages[0].cached);
+        assert!(guest_manifest.storages[0].extract_path.is_none());
         assert_eq!(
             guest_manifest.storages[0].archive_url.as_deref(),
             Some("https://example.com/workspace.tar.gz")
@@ -1055,6 +1099,47 @@ mod tests {
             guest_manifest.artifacts[0].missing_root_policy,
             Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
         );
+    }
+
+    #[test]
+    fn storage_manifest_for_run_stages_instruction_storages_only() {
+        let manifest = StorageManifest {
+            storages: vec![
+                StorageEntry {
+                    name: "instructions".into(),
+                    mount_path: "/home/user/.codex".into(),
+                    archive_url: "https://example.com/instructions.tar.gz".into(),
+                    vas_storage_name: "instructions".into(),
+                    vas_version_id: "v1".into(),
+                    instructions_target_filename: Some("AGENTS.md".into()),
+                },
+                StorageEntry {
+                    name: "skill".into(),
+                    mount_path: "/home/user/.codex/skills/workflow".into(),
+                    archive_url: "https://example.com/skill.tar.gz".into(),
+                    vas_storage_name: "skill".into(),
+                    vas_version_id: "v1".into(),
+                    instructions_target_filename: None,
+                },
+            ],
+            artifacts: vec![],
+        };
+
+        let guest_manifest = GuestDownloadManifest::from_storage_manifest_for_run(
+            &manifest,
+            "/home/user/.vm0/guest-agent/runs/run-1",
+        );
+
+        assert_eq!(guest_manifest.storages[0].mount_path, "/home/user/.codex");
+        assert_eq!(
+            guest_manifest.storages[0].extract_path.as_deref(),
+            Some("/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0")
+        );
+        assert_eq!(
+            guest_manifest.storages[1].mount_path,
+            "/home/user/.codex/skills/workflow"
+        );
+        assert!(guest_manifest.storages[1].extract_path.is_none());
     }
 
     #[test]
@@ -1081,7 +1166,9 @@ mod tests {
         let value = serde_json::to_value(GuestDownloadManifest::from(&manifest)).unwrap();
 
         assert!(value["cleanupPaths"].is_array());
+        assert!(value.get("instructionCleanups").is_none());
         assert_eq!(value["storages"][0]["cached"], false);
+        assert!(value["storages"][0].get("extractPath").is_none());
         assert!(value["storages"][0].get("name").is_none());
         assert_eq!(value["artifacts"][0]["cached"], false);
         assert!(value["artifacts"][0].get("manifestUrl").is_none());


### PR DESCRIPTION
## Summary

- use `instructionsTargetFilename` as the framework-instruction marker and derive runner-only extract paths only for those storage entries
- extract instruction archives into per-run staging, then promote only the selected `AGENTS.md`/`CLAUDE.md` file into the final framework home
- replace broad framework-home cleanup for changed/removed instructions with typed instruction-file cleanup

## Tests

- `cargo test -p guest-download`
- `cargo test -p runner executor::tests::storage_tests`
- `cargo test -p runner types::tests::storage_manifest`
- `cargo check -p runner -p guest-download --all-targets`
- `cargo clippy -p runner -p guest-download --all-targets -- -D warnings`
- pre-commit `cargo-doc` and `cargo-clippy`

Closes #20333