### PR TITLE
fix: keep chat composer model and voice actions visible

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1561,9 +1561,8 @@ describe("chat composer models", () => {
 
     detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-    await expect(
-      screen.findByRole("combobox", { name: "Default" }),
-    ).resolves.toBeInTheDocument();
+    await screen.findByPlaceholderText(PLACEHOLDER);
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("combobox", { name: "Kimi K2.7 Code" }),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -202,6 +202,8 @@ const THREAD_ID = "b0000000-0000-4000-a000-000000000001";
 const THREAD_EVENT_ID = "d0000000-0000-4000-a000-000000000001";
 const RUN_ID = "e0000000-0000-4000-a000-000000000001";
 const THREAD_TITLE = "GEO pricing research";
+const THREAD_MODEL_LABEL = "Claude Sonnet 4.6";
+const THREAD_SELECTED_MODEL = "claude-sonnet-4-6";
 const USER_MESSAGE = "Summarize the launch plan";
 const ASSISTANT_MESSAGE = "Here is the result";
 
@@ -297,7 +299,11 @@ function cachedChatMessages(): PagedChatMessage[] {
   ];
 }
 
-function seedCachedThreadEvents(): void {
+function seedCachedThreadEvents({
+  selectedModel = THREAD_SELECTED_MODEL,
+}: {
+  readonly selectedModel?: string | null;
+} = {}): void {
   idbThreadEventStoreMock.setData({
     snapshot: {
       latestEventId: THREAD_EVENT_ID,
@@ -311,7 +317,7 @@ function seedCachedThreadEvents(): void {
           updatedAt: "2026-03-10T00:00:00Z",
           pinnedAt: null,
           renamedAt: null,
-          selectedModel: null,
+          selectedModel,
         },
       ],
     },
@@ -322,7 +328,7 @@ function seedCachedThreadEvents(): void {
         chatThreadId: THREAD_ID,
         agentId: AGENT_ID,
         title: THREAD_TITLE,
-        selectedModel: null,
+        selectedModel,
         createdAt: "2026-03-10T00:00:02Z",
       },
     ],
@@ -410,8 +416,100 @@ describe("zero chat thread IndexedDB fallback", () => {
     }
   });
 
+  it("keeps model and voice actions visible while uncached messages are blocked", async () => {
+    prepareDefaultAgent();
+    context.mocks.browser.voiceInput({ rms: 0.1 });
+    mockCurrentThreadDetail();
+    seedCachedThreadEvents();
+
+    const initialMessageList = context.mocks.deferred<void>();
+    let messageListRequests = 0;
+    context.mocks.api(chatThreadMessagesContract.list, async ({ respond }) => {
+      messageListRequests += 1;
+      await initialMessageList.promise;
+      return respond(200, { messages: [], hasHistoryBefore: false });
+    });
+    context.mocks.api(chatThreadsContract.snapshot, ({ never }) => {
+      return never();
+    });
+    context.mocks.api(chatThreadsContract.events, ({ never }) => {
+      return never();
+    });
+    context.mocks.api(chatThreadsContract.activeIds, ({ never }) => {
+      return never();
+    });
+
+    try {
+      detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+      await waitFor(() => {
+        expect(messageListRequests).toBeGreaterThan(0);
+        expect(screen.getAllByText(THREAD_TITLE).length).toBeGreaterThan(0);
+      });
+
+      const composer = document.querySelector("[data-chat-composer]");
+      expect(composer).toBeInstanceOf(HTMLElement);
+      expect(
+        (composer as HTMLElement).querySelector(".animate-pulse"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("combobox", { name: THREAD_MODEL_LABEL }),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+      const sendButton = queryAllByRoleFast(
+        "button",
+        composer as HTMLElement,
+      ).find((button) => {
+        return button.getAttribute("aria-label") === "Send";
+      });
+      expect(sendButton).toBeInstanceOf(HTMLButtonElement);
+      expect(sendButton).toBeDisabled();
+    } finally {
+      initialMessageList.resolve();
+    }
+  });
+
+  it("hides the model picker when an uncached thread has no selected model", async () => {
+    prepareDefaultAgent();
+    context.mocks.browser.voiceInput({ rms: 0.1 });
+    mockCurrentThreadDetail();
+    seedCachedThreadEvents({ selectedModel: null });
+
+    const initialMessageList = context.mocks.deferred<void>();
+    let messageListRequests = 0;
+    context.mocks.api(chatThreadMessagesContract.list, async ({ respond }) => {
+      messageListRequests += 1;
+      await initialMessageList.promise;
+      return respond(200, { messages: [], hasHistoryBefore: false });
+    });
+    context.mocks.api(chatThreadsContract.snapshot, ({ never }) => {
+      return never();
+    });
+    context.mocks.api(chatThreadsContract.events, ({ never }) => {
+      return never();
+    });
+    context.mocks.api(chatThreadsContract.activeIds, ({ never }) => {
+      return never();
+    });
+
+    try {
+      detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+
+      await waitFor(() => {
+        expect(messageListRequests).toBeGreaterThan(0);
+        expect(screen.getAllByText(THREAD_TITLE).length).toBeGreaterThan(0);
+      });
+
+      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+    } finally {
+      initialMessageList.resolve();
+    }
+  });
+
   it("renders cached sidebar and chat messages while chat thread data APIs are blocked", async () => {
     prepareDefaultAgent();
+    context.mocks.browser.voiceInput({ rms: 0.1 });
     idbMessageStoreMock.setMessages(cachedChatMessages());
     seedCachedThreadEvents();
 
@@ -453,6 +551,15 @@ describe("zero chat thread IndexedDB fallback", () => {
       expect(screen.getAllByText(THREAD_TITLE).length).toBeGreaterThan(1);
     });
     expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    const composer = document.querySelector("[data-chat-composer]");
+    expect(composer).toBeInstanceOf(HTMLElement);
+    expect(
+      (composer as HTMLElement).querySelector(".animate-pulse"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: THREAD_MODEL_LABEL }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
 
     await expect(screen.findByText(USER_MESSAGE)).resolves.toBeInTheDocument();
     await expect(

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -481,7 +481,6 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
   const modelPicker = {
     value: modelSelection,
     onChange: handleModelSelectionChange,
-    resolveDefaultSelection: false,
   };
   const submitBlockerProps = modelSelection
     ? resolveChatComposerSubmitBlocker({

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -55,7 +55,6 @@ import {
   PopoverClose,
   PopoverContent,
   PopoverTrigger,
-  Skeleton,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -297,11 +296,9 @@ interface ZeroChatComposerProps {
   /** Called after attachment upload/remove mutations so the caller can trigger side-effects (e.g. draft sync). */
   onDraftChange?: () => void;
   /**
-   * When true, render skeleton placeholders in place of the right-side
-   * action cluster (model picker, mic, send/stop). Used during thread switch
-   * while remote thread detail is still resolving — prevents briefly flashing stale
-   * picker state and a wrong send/stop button derived from prior
-   * `allFinished`.
+   * When true, keep the send control in its disabled empty-composer state.
+   * Model and voice controls resolve independently and should not be hidden by
+   * message list loading.
    */
   actionsLoading?: boolean;
   /**
@@ -315,7 +312,6 @@ interface ZeroChatComposerProps {
     onChange: (value: ModelProviderSelection | null) => void;
     // When true, picker is read-only for the current composer state.
     disabled?: boolean;
-    resolveDefaultSelection?: boolean;
   };
   templatePicker?: {
     value: GenerationTemplateRequest | undefined;
@@ -329,7 +325,7 @@ interface ZeroChatComposerProps {
     onChange: (hostId: string | null) => void;
     downloadUrl: string;
   };
-  /** When true, render a skeleton in the model picker slot. */
+  /** When true, hide the model picker until the selected model resolves. */
   modelPickerLoading?: boolean;
   submitBlocker?: {
     message: string;
@@ -6372,6 +6368,40 @@ function ComposerSendButton({
   );
 }
 
+function resolveSendButtonStateForActionsLoading({
+  actionsLoading,
+  showStopButton,
+  onCancel,
+  activeFeedback,
+  sendAction,
+}: {
+  actionsLoading: boolean;
+  showStopButton: boolean;
+  onCancel: (() => void) | undefined;
+  activeFeedback: ComposerFeedback | null;
+  sendAction: KeyboardSendAction;
+}): {
+  showStopButton: boolean;
+  onCancel: (() => void) | undefined;
+  activeFeedback: ComposerFeedback | null;
+  sendAction: KeyboardSendAction;
+} {
+  if (actionsLoading) {
+    return {
+      showStopButton: false,
+      onCancel: undefined,
+      activeFeedback: null,
+      sendAction: "none",
+    };
+  }
+  return {
+    showStopButton,
+    onCancel,
+    activeFeedback,
+    sendAction,
+  };
+}
+
 function ModelConfigurationWarning({
   blocker,
 }: {
@@ -6400,7 +6430,6 @@ function ModelConfigurationWarning({
 }
 
 function ComposerModelPickerSlot({
-  actionsLoading,
   modelPicker,
   modelPickerLoading,
   submitBlocker,
@@ -6409,7 +6438,6 @@ function ComposerModelPickerSlot({
   onModelPickerChange,
   onModelPickerOpenChange,
 }: {
-  actionsLoading: boolean;
   modelPicker: ComposerModelPicker | undefined;
   modelPickerLoading: boolean;
   submitBlocker: ZeroChatComposerProps["submitBlocker"];
@@ -6418,29 +6446,20 @@ function ComposerModelPickerSlot({
   onModelPickerChange: (value: ModelProviderSelection | null) => void;
   onModelPickerOpenChange: (open: boolean) => void;
 }) {
-  if (actionsLoading) {
-    return (
-      <Skeleton
-        className={cn(
-          "h-9 rounded-md",
-          modelPicker || modelPickerLoading ? "w-[184px]" : "w-20",
-        )}
-      />
-    );
-  }
-
   if (modelPickerLoading) {
-    return <Skeleton className="h-9 w-9 rounded-md sm:w-32" />;
+    return null;
   }
+  const shouldRenderModelPicker =
+    modelPicker !== undefined && modelPicker.value !== null;
 
   return (
     <>
       {submitBlocker && <ModelConfigurationWarning blocker={submitBlocker} />}
-      {modelPicker && (
+      {shouldRenderModelPicker && (
         <ModelProviderPicker
           value={modelPicker.value}
           onChange={onModelPickerChange}
-          placeholder="Default"
+          placeholder="Select model"
           triggerClassName={cn(
             "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
             "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
@@ -6452,7 +6471,7 @@ function ComposerModelPickerSlot({
           open={modelPickerOpen}
           onOpenChange={onModelPickerOpenChange}
           disabled={modelPicker.disabled}
-          resolveDefaultSelection={modelPicker.resolveDefaultSelection}
+          resolveDefaultSelection={false}
         />
       )}
     </>
@@ -6785,6 +6804,13 @@ export function ZeroChatComposer({
   // the composer is empty during an active run. With draft content present
   // the Send button stays visible so the click can queue the message.
   const showStopButton = Boolean(sending && onCancel) && !canSend;
+  const sendButtonState = resolveSendButtonStateForActionsLoading({
+    actionsLoading,
+    showStopButton,
+    onCancel,
+    activeFeedback,
+    sendAction,
+  });
 
   // Routes a button click to the queue path while the current thread is sending,
   // otherwise to the normal send path.
@@ -6975,7 +7001,6 @@ export function ZeroChatComposer({
                 </div>
                 <div className="flex items-center gap-1 sm:gap-2">
                   <ComposerModelPickerSlot
-                    actionsLoading={actionsLoading}
                     modelPicker={modelPicker}
                     modelPickerLoading={modelPickerLoading}
                     submitBlocker={submitBlocker}
@@ -6984,27 +7009,20 @@ export function ZeroChatComposer({
                     onModelPickerChange={handleModelPickerChange}
                     onModelPickerOpenChange={setModelPickerOpen}
                   />
-                  {actionsLoading ? null : (
-                    <>
-                      <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
-                      <MicButton
-                        onTranscribed={(text) => {
-                          const base = input;
-                          const separator =
-                            base.length > 0 && !base.endsWith(" ") ? " " : "";
-                          onInputChange(base + separator + text);
-                          onDraftChange?.();
-                        }}
-                      />
-                      <ComposerSendButton
-                        showStopButton={showStopButton}
-                        onCancel={onCancel}
-                        activeFeedback={activeFeedback}
-                        sendAction={sendAction}
-                        onSend={handleButtonSend}
-                      />
-                    </>
-                  )}
+                  <div className="mx-0 h-5 w-px bg-border/60 sm:mx-0.5" />
+                  <MicButton
+                    onTranscribed={(text) => {
+                      const base = input;
+                      const separator =
+                        base.length > 0 && !base.endsWith(" ") ? " " : "";
+                      onInputChange(base + separator + text);
+                      onDraftChange?.();
+                    }}
+                  />
+                  <ComposerSendButton
+                    {...sendButtonState}
+                    onSend={handleButtonSend}
+                  />
                 </div>
               </div>
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4507,7 +4507,6 @@ interface ChatComposerModelPickerConfig {
   value: ModelProviderSelection | null;
   onChange: (value: ModelProviderSelection | null) => void;
   disabled: boolean;
-  resolveDefaultSelection: boolean;
 }
 
 function resolveChatComposerModelPicker(params: {
@@ -4519,7 +4518,6 @@ function resolveChatComposerModelPicker(params: {
     value: params.modelSelection,
     onChange: params.setModelSelection,
     disabled: params.disabled,
-    resolveDefaultSelection: false,
   };
 }
 
@@ -4612,11 +4610,13 @@ function useChatComposerModel(
     detach(setModelSelection(selection, pageSignal), Reason.DomCallback);
   };
 
-  const modelPicker = resolveChatComposerModelPicker({
-    modelSelection,
-    setModelSelection: handleModelSelectionChange,
-    disabled: false,
-  });
+  const modelPicker = modelSelection
+    ? resolveChatComposerModelPicker({
+        modelSelection,
+        setModelSelection: handleModelSelectionChange,
+        disabled: false,
+      })
+    : undefined;
   const modelPickerLoading = modelSelectionResolved === undefined;
   const submitBlockerProps = modelSelection
     ? resolveChatComposerSubmitBlocker({


### PR DESCRIPTION
## Summary
- Keep the chat composer's voice input visible while the thread message list is still loading from remote after an IndexedDB message-cache miss.
- Keep the thread model picker visible only when the thread has a resolved selected model; missing thread model state no longer falls back to a `Default` picker.
- Remove composer-level default model fallback plumbing: `ZeroChatComposer` no longer accepts a default-selection toggle, hides the picker when its model value is null, and explicitly disables generic picker default resolution.
- Use the normal disabled send button state during message hydration instead of a pulsing skeleton, reducing visual flicker while keeping the action unavailable.
- Add IndexedDB fallback coverage for cached-message, uncached-message, and missing-thread-model entry states.

## Verification
- `pnpm --filter @vm0/app lint`
- `pnpm exec vitest --run apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`