### PR TITLE
chore: add structured unhandled request logs

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -323,7 +323,7 @@ describe("createApp", () => {
     expect(logFields.error).toMatchObject({
       message: "unreadable failure",
       cause: "[Unreadable]",
-      __unreadable: true,
+      request: "[Unreadable]",
     });
   });
 

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -89,7 +89,7 @@ describe("createApp", () => {
 
   it("logs sanitized root-cause fields for unhandled errors", async () => {
     const cause = new Error(
-      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 01890f9d-7b0d-7ccf-8f02-7d8a0c1b2c3d API key: sk-live-secret client secret=client-secret refresh_token=refresh-secret Authorization: Basic basic-secret",
+      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 01890f9d-7b0d-7ccf-8f02-7d8a0c1b2c3d org_abc123456789 user_def987654321 API key: sk-live-secret client secret=client-secret refresh_token=refresh-secret Authorization: Basic basic-secret",
     );
     const error = Object.assign(
       new Error("wrapped database failure", { cause }),
@@ -121,14 +121,14 @@ describe("createApp", () => {
     const [message, fields] =
       context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
     expect(message).toBe(
-      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
+      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] [id] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
     );
 
     const logFields = fields as Record<PropertyKey, unknown>;
     expect(logFields).toMatchObject({
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] [id] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -144,7 +144,7 @@ describe("createApp", () => {
       source: "api",
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] [id] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -160,6 +160,8 @@ describe("createApp", () => {
     expect(serialized).not.toContain("abcdef1234567890");
     expect(serialized).not.toContain("123456789012");
     expect(serialized).not.toContain("01890f9d-7b0d-7ccf-8f02-7d8a0c1b2c3d");
+    expect(serialized).not.toContain("org_abc123456789");
+    expect(serialized).not.toContain("user_def987654321");
     expect(serialized).not.toContain("550e8400-e29b-41d4-a716-446655440000");
     expect(serialized).not.toContain("sk-live-secret");
     expect(serialized).not.toContain("client-secret");

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -218,6 +218,35 @@ describe("createApp", () => {
     });
   });
 
+  it("bounds deep error cause chains while logging unhandled errors", async () => {
+    const error = new Error("depth-0");
+    let current = error;
+    for (let index = 1; index <= 80; index += 1) {
+      const next = new Error(`depth-${index}`);
+      Object.defineProperty(current, "cause", { value: next });
+      current = next;
+    }
+    const handler$ = computed((): never => {
+      throw error;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(message).toBe("Unhandled request error: depth-31");
+    expect(logFields.errorSummary).toBe("depth-31");
+    expect(JSON.stringify(logFields.error)).toContain("[Truncated]");
+    expect(JSON.stringify(logFields.error)).not.toContain("depth-80");
+  });
+
   it("summarizes response validation failures without schema details", async () => {
     const handler$ = computed(() => {
       return { status: 500, body: { error: 123 } };

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -87,6 +87,46 @@ describe("createApp", () => {
     expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(error);
   });
 
+  it("handles non-Error thrown values while logging unhandled errors", async () => {
+    const thrownValue = 1n;
+    const handler$ = computed((): never => {
+      throw thrownValue;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    const capturedError =
+      context.mocks.sentry.captureException.mock.calls.at(-1)?.[0];
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError).toMatchObject({
+      message: "Non-Error thrown: 1",
+      cause: thrownValue,
+    });
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    expect(message).toBe("Unhandled request error: Non-Error thrown: 1");
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(logFields).toMatchObject({
+      type: "unhandled_request_error",
+      errorSummary: "Non-Error thrown: 1",
+      route: "/__test/boom",
+      method: "GET",
+      error: {
+        message: "Non-Error thrown: 1",
+        cause: "1",
+      },
+    });
+    expect(() => {
+      JSON.stringify(logFields.error);
+    }).not.toThrow();
+  });
+
   it("logs sanitized root-cause fields for unhandled errors", async () => {
     const cause = new Error(
       "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 01890f9d-7b0d-7ccf-8f02-7d8a0c1b2c3d org_abc123456789 user_def987654321 API key: sk-live-secret client secret=client-secret refresh_token=refresh-secret Authorization: Basic basic-secret",

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -247,6 +247,43 @@ describe("createApp", () => {
     expect(JSON.stringify(logFields.error)).not.toContain("depth-80");
   });
 
+  it("handles cyclic enumerable error fields while logging unhandled errors", async () => {
+    const error = new Error("request failure") as Error &
+      Record<string, unknown>;
+    const request: Record<string, unknown> = {
+      url: "https://example.test/api",
+      retryAfter: 1n,
+    };
+    request.self = request;
+    error.request = request;
+    const handler$ = computed((): never => {
+      throw error;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+
+    const [, fields] = context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    const logFields = fields as Record<PropertyKey, unknown>;
+    const serializedError = logFields.error as Record<string, unknown>;
+    expect(serializedError).toMatchObject({
+      message: "request failure",
+      request: {
+        url: "https://example.test/api",
+        retryAfter: "1",
+        self: "[Circular]",
+      },
+    });
+    expect(() => {
+      JSON.stringify(serializedError);
+    }).not.toThrow();
+  });
+
   it("summarizes response validation failures without schema details", async () => {
     const handler$ = computed(() => {
       return { status: 500, body: { error: 123 } };

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -431,6 +431,29 @@ describe("createApp", () => {
     });
   });
 
+  it("summarizes response validation failures with leading whitespace", async () => {
+    const error = new Error("  response validation failed: schema details");
+    const handler$ = computed((): never => {
+      throw error;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    expect(message).toBe("Unhandled request error: response validation failed");
+    expect(fields).toMatchObject({
+      type: "unhandled_request_error",
+      errorSummary: "response validation failed",
+    });
+  });
+
   it("passes through expected HTTP client errors without capturing them", async () => {
     const error = new HTTPException(404, { message: "Missing" });
     const handler$ = computed((): never => {

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -170,7 +170,7 @@ describe("createApp", () => {
   });
 
   it("bounds long unhandled error summaries", async () => {
-    const error = new Error("x".repeat(300));
+    const error = new Error("x".repeat(10_000));
     const expectedSummary = `${"x".repeat(237)}...`;
     const handler$ = computed((): never => {
       throw error;

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -127,6 +127,36 @@ describe("createApp", () => {
     }).not.toThrow();
   });
 
+  it("bounds non-Error thrown value summaries", async () => {
+    const thrownValue = "x".repeat(10_000);
+    const expectedSummary = `Non-Error thrown: ${"x".repeat(219)}...`;
+    const handler$ = computed((): never => {
+      throw thrownValue;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    const capturedError =
+      context.mocks.sentry.captureException.mock.calls.at(-1)?.[0];
+    expect(capturedError).toMatchObject({
+      message: `Non-Error thrown: ${"x".repeat(4075)}...`,
+    });
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    expect(message).toBe(`Unhandled request error: ${expectedSummary}`);
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(logFields).toMatchObject({
+      type: "unhandled_request_error",
+      errorSummary: expectedSummary,
+    });
+  });
+
   it("logs sanitized root-cause fields for unhandled errors", async () => {
     const cause = new Error(
       "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 01890f9d-7b0d-7ccf-8f02-7d8a0c1b2c3d org_abc123456789 user_def987654321 API key: sk-live-secret client secret=client-secret refresh_token=refresh-secret Authorization: Basic basic-secret",

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -89,7 +89,7 @@ describe("createApp", () => {
 
   it("logs sanitized root-cause fields for unhandled errors", async () => {
     const cause = new Error(
-      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 550e8400-e29b-41d4-a716-446655440000",
+      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 550e8400-e29b-41d4-a716-446655440000 API key: sk-live-secret client_secret=client-secret refresh_token=refresh-secret",
     );
     const error = new Error("wrapped database failure", { cause }) as Error & {
       code: string;
@@ -119,14 +119,14 @@ describe("createApp", () => {
     const [message, fields] =
       context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
     expect(message).toBe(
-      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id]",
+      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client_secret=[redacted] refresh_token=[redacted]",
     );
 
     const logFields = fields as Record<PropertyKey, unknown>;
     expect(logFields).toMatchObject({
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client_secret=[redacted] refresh_token=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -142,7 +142,7 @@ describe("createApp", () => {
       source: "api",
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client_secret=[redacted] refresh_token=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -154,10 +154,13 @@ describe("createApp", () => {
       route: logFields.route,
     });
     expect(serialized).not.toContain("test@example.com");
-    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("token=secret");
     expect(serialized).not.toContain("abcdef1234567890");
     expect(serialized).not.toContain("123456789012");
     expect(serialized).not.toContain("550e8400-e29b-41d4-a716-446655440000");
+    expect(serialized).not.toContain("sk-live-secret");
+    expect(serialized).not.toContain("client-secret");
+    expect(serialized).not.toContain("refresh-secret");
   });
 
   it("summarizes response validation failures without schema details", async () => {

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -284,6 +284,49 @@ describe("createApp", () => {
     }).not.toThrow();
   });
 
+  it("handles unreadable error properties while logging unhandled errors", async () => {
+    const error = new Error("unreadable failure") as Error &
+      Record<string, unknown>;
+    Object.defineProperty(error, "cause", {
+      get() {
+        throw new Error("cause getter failed");
+      },
+    });
+    Object.defineProperty(error, "code", {
+      get() {
+        throw new Error("code getter failed");
+      },
+    });
+    Object.defineProperty(error, "request", {
+      enumerable: true,
+      get() {
+        throw new Error("request getter failed");
+      },
+    });
+    const handler$ = computed((): never => {
+      throw error;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(message).toBe("Unhandled request error: unreadable failure");
+    expect(logFields.errorCode).toBeUndefined();
+    expect(logFields.error).toMatchObject({
+      message: "unreadable failure",
+      cause: "[Unreadable]",
+      __unreadable: true,
+    });
+  });
+
   it("summarizes response validation failures without schema details", async () => {
     const handler$ = computed(() => {
       return { status: 500, body: { error: 123 } };

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -89,12 +89,14 @@ describe("createApp", () => {
 
   it("logs sanitized root-cause fields for unhandled errors", async () => {
     const cause = new Error(
-      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 550e8400-e29b-41d4-a716-446655440000 API key: sk-live-secret client_secret=client-secret refresh_token=refresh-secret",
+      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 550e8400-e29b-41d4-a716-446655440000 API key: sk-live-secret client secret=client-secret refresh_token=refresh-secret",
     );
-    const error = new Error("wrapped database failure", { cause }) as Error & {
-      code: string;
-    };
-    error.code = "42703";
+    const error = Object.assign(
+      new Error("wrapped database failure", { cause }),
+      {
+        code: "42703",
+      },
+    );
     const handler$ = computed((): never => {
       throw error;
     });
@@ -119,14 +121,14 @@ describe("createApp", () => {
     const [message, fields] =
       context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
     expect(message).toBe(
-      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client_secret=[redacted] refresh_token=[redacted]",
+      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted]",
     );
 
     const logFields = fields as Record<PropertyKey, unknown>;
     expect(logFields).toMatchObject({
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client_secret=[redacted] refresh_token=[redacted]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -142,7 +144,7 @@ describe("createApp", () => {
       source: "api",
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client_secret=[redacted] refresh_token=[redacted]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -161,6 +163,26 @@ describe("createApp", () => {
     expect(serialized).not.toContain("sk-live-secret");
     expect(serialized).not.toContain("client-secret");
     expect(serialized).not.toContain("refresh-secret");
+  });
+
+  it("bounds long unhandled error summaries", async () => {
+    const error = new Error("x".repeat(300));
+    const expectedSummary = `${"x".repeat(237)}...`;
+    const handler$ = computed((): never => {
+      throw error;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    await accept(client.boom(), [500]);
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(logFields.errorSummary).toBe(expectedSummary);
+    expect(message).toBe(`Unhandled request error: ${expectedSummary}`);
   });
 
   it("summarizes response validation failures without schema details", async () => {

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -89,7 +89,7 @@ describe("createApp", () => {
 
   it("logs sanitized root-cause fields for unhandled errors", async () => {
     const cause = new Error(
-      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 550e8400-e29b-41d4-a716-446655440000 API key: sk-live-secret client secret=client-secret refresh_token=refresh-secret",
+      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 01890f9d-7b0d-7ccf-8f02-7d8a0c1b2c3d API key: sk-live-secret client secret=client-secret refresh_token=refresh-secret Authorization: Basic basic-secret",
     );
     const error = Object.assign(
       new Error("wrapped database failure", { cause }),
@@ -121,14 +121,14 @@ describe("createApp", () => {
     const [message, fields] =
       context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
     expect(message).toBe(
-      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted]",
+      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
     );
 
     const logFields = fields as Record<PropertyKey, unknown>;
     expect(logFields).toMatchObject({
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -144,7 +144,7 @@ describe("createApp", () => {
       source: "api",
       type: "unhandled_request_error",
       errorSummary:
-        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted]",
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id] API key=[redacted] client secret=[redacted] refresh_token=[redacted] Authorization=[redacted]",
       route: "/__test/boom/:id",
       method: "GET",
       errorCode: "42703",
@@ -159,10 +159,12 @@ describe("createApp", () => {
     expect(serialized).not.toContain("token=secret");
     expect(serialized).not.toContain("abcdef1234567890");
     expect(serialized).not.toContain("123456789012");
+    expect(serialized).not.toContain("01890f9d-7b0d-7ccf-8f02-7d8a0c1b2c3d");
     expect(serialized).not.toContain("550e8400-e29b-41d4-a716-446655440000");
     expect(serialized).not.toContain("sk-live-secret");
     expect(serialized).not.toContain("client-secret");
     expect(serialized).not.toContain("refresh-secret");
+    expect(serialized).not.toContain("basic-secret");
   });
 
   it("bounds long unhandled error summaries", async () => {

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -1,4 +1,5 @@
 import { initContract } from "@vm0/api-contracts/contracts/trpc-contract";
+import { EVENT } from "@axiomhq/logging";
 import { computed } from "ccstate";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
@@ -32,6 +33,14 @@ const errorTestContract = c.router({
   boom: {
     method: "GET",
     path: "/__test/boom",
+    responses: {
+      500: z.object({ error: z.string() }),
+    },
+  },
+  boomById: {
+    method: "GET",
+    path: "/__test/boom/:id",
+    pathParams: z.object({ id: z.string() }),
     responses: {
       500: z.object({ error: z.string() }),
     },
@@ -76,6 +85,113 @@ describe("createApp", () => {
 
     expect(response.body).toStrictEqual({ error: "Internal server error" });
     expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(error);
+  });
+
+  it("logs sanitized root-cause fields for unhandled errors", async () => {
+    const cause = new Error(
+      "column chat_threads.last_read_message_id does not exist for user test@example.com at https://example.test/callback?token=secret Bearer abcdef1234567890 123456789012 550e8400-e29b-41d4-a716-446655440000",
+    );
+    const error = new Error("wrapped database failure", { cause }) as Error & {
+      code: string;
+    };
+    error.code = "42703";
+    const handler$ = computed((): never => {
+      throw error;
+    });
+    const client = setupApp({
+      context,
+      routes: [
+        ...ROUTES,
+        { route: errorTestContract.boomById, handler: handler$ },
+      ],
+    })(errorTestContract);
+
+    const response = await accept(
+      client.boomById({
+        params: { id: "550e8400-e29b-41d4-a716-446655440000" },
+      }),
+      [500],
+    );
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledWith(error);
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    expect(message).toBe(
+      "Unhandled request error: column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id]",
+    );
+
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(logFields).toMatchObject({
+      type: "unhandled_request_error",
+      errorSummary:
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id]",
+      route: "/__test/boom/:id",
+      method: "GET",
+      errorCode: "42703",
+      error: expect.objectContaining({
+        message: "wrapped database failure",
+        code: "42703",
+        cause: expect.objectContaining({
+          message: cause.message,
+        }),
+      }),
+    });
+    expect(logFields[EVENT]).toMatchObject({
+      source: "api",
+      type: "unhandled_request_error",
+      errorSummary:
+        "column chat_threads.last_read_message_id does not exist for user [email] at [url] Bearer [redacted] [number] [id]",
+      route: "/__test/boom/:id",
+      method: "GET",
+      errorCode: "42703",
+    });
+
+    const serialized = JSON.stringify({
+      message,
+      errorSummary: logFields.errorSummary,
+      route: logFields.route,
+    });
+    expect(serialized).not.toContain("test@example.com");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("abcdef1234567890");
+    expect(serialized).not.toContain("123456789012");
+    expect(serialized).not.toContain("550e8400-e29b-41d4-a716-446655440000");
+  });
+
+  it("summarizes response validation failures without schema details", async () => {
+    const handler$ = computed(() => {
+      return { status: 500, body: { error: 123 } };
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+    expect(context.mocks.sentry.captureException).toHaveBeenCalledOnce();
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    expect(message).toBe("Unhandled request error: response validation failed");
+
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(logFields).toMatchObject({
+      type: "unhandled_request_error",
+      errorSummary: "response validation failed",
+      route: "/__test/boom",
+      method: "GET",
+    });
+    expect(logFields[EVENT]).toMatchObject({
+      source: "api",
+      type: "unhandled_request_error",
+      errorSummary: "response validation failed",
+      route: "/__test/boom",
+      method: "GET",
+    });
   });
 
   it("passes through expected HTTP client errors without capturing them", async () => {

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -189,6 +189,35 @@ describe("createApp", () => {
     expect(message).toBe(`Unhandled request error: ${expectedSummary}`);
   });
 
+  it("handles cyclic error causes while logging unhandled errors", async () => {
+    const error = new Error("cyclic failure");
+    Object.defineProperty(error, "cause", { value: error });
+    const handler$ = computed((): never => {
+      throw error;
+    });
+    const client = setupApp({
+      context,
+      routes: [...ROUTES, { route: errorTestContract.boom, handler: handler$ }],
+    })(errorTestContract);
+
+    const response = await accept(client.boom(), [500]);
+
+    expect(response.body).toStrictEqual({ error: "Internal server error" });
+
+    const [message, fields] =
+      context.mocks.axiomLogging.error.mock.calls.at(-1) ?? [];
+    const logFields = fields as Record<PropertyKey, unknown>;
+    expect(message).toBe("Unhandled request error: cyclic failure");
+    expect(logFields).toMatchObject({
+      type: "unhandled_request_error",
+      errorSummary: "cyclic failure",
+      error: expect.objectContaining({
+        message: "cyclic failure",
+        cause: "[Circular]",
+      }),
+    });
+  });
+
   it("summarizes response validation failures without schema details", async () => {
     const handler$ = computed(() => {
       return { status: 500, body: { error: 123 } };

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -268,7 +268,7 @@ export function createAppWithRoutes({
   app.onError(handleError);
 
   app.use("*", (_context, next) => {
-    return normalizeThrown(next());
+    return normalizeThrown(next);
   });
 
   // OpenTelemetry: each request gets a SERVER span named after its matched

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -12,7 +12,7 @@ import { flushLogs, logger } from "./lib/log";
 import { waitUntil } from "./signals/context/wait-until";
 import { honoSignalHandler } from "./signals/context/route";
 import type { RouteEntry } from "./signals/route-entry";
-import { isAbortError } from "./signals/utils";
+import { isAbortError, safeSync } from "./signals/utils";
 
 const L = logger("App");
 
@@ -30,6 +30,8 @@ interface UnhandledRequestErrorLogFields {
   readonly errorCode?: string;
   readonly error: Record<string, unknown>;
 }
+
+type ErrorWithCode = Error & { readonly code?: unknown };
 
 function shouldCaptureError(error: Error): boolean {
   return !(error instanceof HTTPException) || error.status >= 500;
@@ -50,6 +52,38 @@ function redirectToWeb(context: Context): Response {
   return context.redirect(target.toString());
 }
 
+function readErrorValue(read: () => unknown): unknown {
+  const result = safeSync(read);
+  return "ok" in result ? result.ok : undefined;
+}
+
+function errorCause(error: Error): Error | undefined {
+  const cause = readErrorValue(() => {
+    return error.cause;
+  });
+  return cause instanceof Error ? cause : undefined;
+}
+
+function errorMessage(error: Error): string | undefined {
+  const message = readErrorValue(() => {
+    return error.message;
+  });
+  return typeof message === "string" ? message : undefined;
+}
+
+function errorName(error: Error): string | undefined {
+  const name = readErrorValue(() => {
+    return error.name;
+  });
+  return typeof name === "string" ? name : undefined;
+}
+
+function errorCode(error: Error): unknown {
+  return readErrorValue(() => {
+    return (error as ErrorWithCode).code;
+  });
+}
+
 function errorChain(error: Error): readonly Error[] {
   const chain: Error[] = [];
   const seen = new Set<Error>();
@@ -61,7 +95,7 @@ function errorChain(error: Error): readonly Error[] {
   ) {
     chain.push(current);
     seen.add(current);
-    current = current.cause instanceof Error ? current.cause : undefined;
+    current = errorCause(current);
   }
   return chain;
 }
@@ -69,12 +103,13 @@ function errorChain(error: Error): readonly Error[] {
 function sourceErrorMessage(error: Error): string {
   const chain = errorChain(error);
   for (let index = chain.length - 1; index >= 0; index -= 1) {
-    const message = chain[index]?.message.trim();
+    const current = chain[index];
+    const message = current ? errorMessage(current)?.trim() : "";
     if (message) {
       return message;
     }
   }
-  return error.name || "unknown error";
+  return errorName(error) || "unknown error";
 }
 
 function truncateSummary(summary: string): string {
@@ -132,7 +167,7 @@ function sanitizeErrorSummary(error: Error): string {
 
 function structuredErrorCode(error: Error): string | undefined {
   for (const current of errorChain(error)) {
-    const code = "code" in current ? current.code : undefined;
+    const code = errorCode(current);
     if (typeof code === "number" && Number.isFinite(code)) {
       return String(code);
     }

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -57,19 +57,33 @@ function readErrorValue(read: () => unknown): unknown {
   return "ok" in result ? result.ok : undefined;
 }
 
+function summarySource(value: string): string | undefined {
+  const source = value.slice(0, ERROR_SUMMARY_SOURCE_MAX_LENGTH).trim();
+  return source || undefined;
+}
+
 function readNonErrorMessage(error: unknown): string {
   if (error !== null && typeof error === "object") {
     const message = readErrorValue(() => {
       return (error as { readonly message?: unknown }).message;
     });
-    if (typeof message === "string" && message.trim()) {
-      return message;
+    if (typeof message === "string") {
+      const source = summarySource(message);
+      if (source) {
+        return source;
+      }
     }
   }
   const value = readErrorValue(() => {
     return String(error);
   });
-  return typeof value === "string" && value.trim() ? value : "unknown error";
+  if (typeof value === "string") {
+    const source = summarySource(value);
+    if (source) {
+      return source;
+    }
+  }
+  return "unknown error";
 }
 
 function errorCause(error: Error): Error | undefined {
@@ -122,12 +136,16 @@ function sourceErrorMessage(error: unknown): string {
   const chain = errorChain(error);
   for (let index = chain.length - 1; index >= 0; index -= 1) {
     const current = chain[index];
-    const message = current ? errorMessage(current)?.trim() : "";
+    const message = current ? errorMessage(current) : undefined;
     if (message) {
-      return message;
+      const source = summarySource(message);
+      if (source) {
+        return source;
+      }
     }
   }
-  return errorName(error) || "unknown error";
+  const name = errorName(error);
+  return name ? (summarySource(name) ?? "unknown error") : "unknown error";
 }
 
 function truncateSummary(summary: string): string {
@@ -147,10 +165,7 @@ function replaceControlCharacters(value: string): string {
 }
 
 function sanitizeErrorSummary(error: unknown): string {
-  const source = sourceErrorMessage(error).slice(
-    0,
-    ERROR_SUMMARY_SOURCE_MAX_LENGTH,
-  );
+  const source = sourceErrorMessage(error);
   if (/^response validation failed:/i.test(source)) {
     return "response validation failed";
   }

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -101,6 +101,10 @@ function sanitizeErrorSummary(error: Error): string {
       "[id]",
     )
     .replace(
+      /\b(?:user|org)_(?=[A-Za-z0-9_-]*\d)[A-Za-z0-9][A-Za-z0-9_-]{9,}\b/g,
+      "[id]",
+    )
+    .replace(
       /\bAuthorization\b\s*[:=]\s*["']?(?:Bearer|Basic|Digest|Token)\s+[^,\s"']+/gi,
       "Authorization=[redacted]",
     )

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -97,8 +97,12 @@ function sanitizeErrorSummary(error: Error): string {
     .replace(/\bhttps?:\/\/[^\s]+/gi, "[url]")
     .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[email]")
     .replace(
-      /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
+      /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
       "[id]",
+    )
+    .replace(
+      /\bAuthorization\b\s*[:=]\s*["']?(?:Bearer|Basic|Digest|Token)\s+[^,\s"']+/gi,
+      "Authorization=[redacted]",
     )
     .replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, "Bearer [redacted]")
     .replace(

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -12,7 +12,7 @@ import { flushLogs, logger } from "./lib/log";
 import { waitUntil } from "./signals/context/wait-until";
 import { honoSignalHandler } from "./signals/context/route";
 import type { RouteEntry } from "./signals/route-entry";
-import { isAbortError, safeSync } from "./signals/utils";
+import { isAbortError, normalizeThrown, safeSync } from "./signals/utils";
 
 const L = logger("App");
 
@@ -266,6 +266,10 @@ export function createAppWithRoutes({
 }: CreateAppWithRoutesOptions): Hono {
   const app = new Hono();
   app.onError(handleError);
+
+  app.use("*", (_context, next) => {
+    return normalizeThrown(next());
+  });
 
   // OpenTelemetry: each request gets a SERVER span named after its matched
   // route template (e.g. `GET /api/v1/chat-threads/:threadId`). Child spans

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -33,11 +33,11 @@ interface UnhandledRequestErrorLogFields {
 
 type ErrorWithCode = Error & { readonly code?: unknown };
 
-function shouldCaptureError(error: Error): boolean {
+function shouldCaptureError(error: unknown): boolean {
   return !(error instanceof HTTPException) || error.status >= 500;
 }
 
-function captureError(error: Error): void {
+function captureError(error: unknown): void {
   if (shouldCaptureError(error)) {
     Sentry.captureException(error);
   }
@@ -55,6 +55,21 @@ function redirectToWeb(context: Context): Response {
 function readErrorValue(read: () => unknown): unknown {
   const result = safeSync(read);
   return "ok" in result ? result.ok : undefined;
+}
+
+function readNonErrorMessage(error: unknown): string {
+  if (error !== null && typeof error === "object") {
+    const message = readErrorValue(() => {
+      return (error as { readonly message?: unknown }).message;
+    });
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+  const value = readErrorValue(() => {
+    return String(error);
+  });
+  return typeof value === "string" && value.trim() ? value : "unknown error";
 }
 
 function errorCause(error: Error): Error | undefined {
@@ -100,7 +115,10 @@ function errorChain(error: Error): readonly Error[] {
   return chain;
 }
 
-function sourceErrorMessage(error: Error): string {
+function sourceErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return readNonErrorMessage(error);
+  }
   const chain = errorChain(error);
   for (let index = chain.length - 1; index >= 0; index -= 1) {
     const current = chain[index];
@@ -128,7 +146,7 @@ function replaceControlCharacters(value: string): string {
   return result;
 }
 
-function sanitizeErrorSummary(error: Error): string {
+function sanitizeErrorSummary(error: unknown): string {
   const source = sourceErrorMessage(error).slice(
     0,
     ERROR_SUMMARY_SOURCE_MAX_LENGTH,
@@ -165,7 +183,10 @@ function sanitizeErrorSummary(error: Error): string {
   return truncateSummary(summary || "unknown error");
 }
 
-function structuredErrorCode(error: Error): string | undefined {
+function structuredErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
   for (const current of errorChain(error)) {
     const code = errorCode(current);
     if (typeof code === "number" && Number.isFinite(code)) {
@@ -203,7 +224,7 @@ function requestRouteTemplate(context: Context): string | undefined {
 }
 
 function unhandledRequestErrorLogFields(
-  error: Error,
+  error: unknown,
   context: Context,
 ): UnhandledRequestErrorLogFields {
   const route = requestRouteTemplate(context);
@@ -218,7 +239,7 @@ function unhandledRequestErrorLogFields(
   };
 }
 
-function handleError(error: Error, context: Context): Response {
+function handleError(error: unknown, context: Context): Response {
   if (isAbortError(error)) {
     return context.json({ error: "Internal server error" }, 500);
   }

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -18,6 +18,7 @@ const L = logger("App");
 
 const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
 const UNHANDLED_REQUEST_ERROR_TYPE = "unhandled_request_error" as const;
+const ERROR_CHAIN_MAX_DEPTH = 32;
 const ERROR_SUMMARY_MAX_LENGTH = 240;
 const ERROR_SUMMARY_SOURCE_MAX_LENGTH = 4096;
 
@@ -53,7 +54,11 @@ function errorChain(error: Error): readonly Error[] {
   const chain: Error[] = [];
   const seen = new Set<Error>();
   let current: Error | undefined = error;
-  while (current && !seen.has(current)) {
+  while (
+    current &&
+    !seen.has(current) &&
+    chain.length < ERROR_CHAIN_MAX_DEPTH
+  ) {
     chain.push(current);
     seen.add(current);
     current = current.cause instanceof Error ? current.cause : undefined;

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -102,7 +102,7 @@ function sanitizeErrorSummary(error: Error): string {
     )
     .replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, "Bearer [redacted]")
     .replace(
-      /\b(api[_\s-]?key|access[_\s-]?token|refresh[_\s-]?token|id[_\s-]?token|client[_-]?secret|authorization|password|secret|token)\b\s*[:=]\s*["']?[^,\s"']+/gi,
+      /\b(api[_\s-]?key|access[_\s-]?token|refresh[_\s-]?token|id[_\s-]?token|client[_\s-]?secret|authorization|password|secret|token)\b\s*[:=]\s*["']?[^,\s"']+/gi,
       "$1=[redacted]",
     )
     .replace(/\b[0-9a-f]{16,}\b/gi, "[hash]")

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -1,8 +1,10 @@
 import { httpInstrumentationMiddleware } from "@hono/otel";
 import * as Sentry from "@sentry/node";
+import { serializeError } from "@vm0/core/log-utils";
 // oxlint-disable-next-line no-restricted-imports -- app factory owns the Hono instance, confirmed by ethan@vm0.ai
 import { Hono, type Context } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { matchedRoutes } from "hono/route";
 
 import { corsMiddleware } from "./lib/cors";
 import { env } from "./lib/env";
@@ -15,6 +17,17 @@ import { isAbortError } from "./signals/utils";
 const L = logger("App");
 
 const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
+const UNHANDLED_REQUEST_ERROR_TYPE = "unhandled_request_error" as const;
+const ERROR_SUMMARY_MAX_LENGTH = 240;
+
+interface UnhandledRequestErrorLogFields {
+  readonly type: typeof UNHANDLED_REQUEST_ERROR_TYPE;
+  readonly errorSummary: string;
+  readonly method: string;
+  readonly route?: string;
+  readonly errorCode?: string;
+  readonly error: Record<string, unknown>;
+}
 
 function shouldCaptureError(error: Error): boolean {
   return !(error instanceof HTTPException) || error.status >= 500;
@@ -35,6 +48,118 @@ function redirectToWeb(context: Context): Response {
   return context.redirect(target.toString());
 }
 
+function errorChain(error: Error): readonly Error[] {
+  const chain: Error[] = [];
+  const seen = new Set<Error>();
+  let current: Error | undefined = error;
+  while (current && !seen.has(current)) {
+    chain.push(current);
+    seen.add(current);
+    current = current.cause instanceof Error ? current.cause : undefined;
+  }
+  return chain;
+}
+
+function sourceErrorMessage(error: Error): string {
+  const chain = errorChain(error);
+  for (let index = chain.length - 1; index >= 0; index -= 1) {
+    const message = chain[index]?.message.trim();
+    if (message) {
+      return message;
+    }
+  }
+  return error.name || "unknown error";
+}
+
+function truncateSummary(summary: string): string {
+  if (summary.length <= ERROR_SUMMARY_MAX_LENGTH) {
+    return summary;
+  }
+  return `${summary.slice(0, ERROR_SUMMARY_MAX_LENGTH - 3)}...`;
+}
+
+function replaceControlCharacters(value: string): string {
+  let result = "";
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    result += code <= 31 || code === 127 ? " " : char;
+  }
+  return result;
+}
+
+function sanitizeErrorSummary(error: Error): string {
+  const source = sourceErrorMessage(error);
+  if (/^response validation failed:/i.test(source)) {
+    return "response validation failed";
+  }
+
+  const summary = replaceControlCharacters(source)
+    .replace(/\bhttps?:\/\/[^\s]+/gi, "[url]")
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[email]")
+    .replace(
+      /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
+      "[id]",
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, "Bearer [redacted]")
+    .replace(
+      /\b(api[_-]?key|authorization|password|secret|token)\b\s*[:=]\s*["']?[^,\s"']+/gi,
+      "$1=[redacted]",
+    )
+    .replace(/\b[0-9a-f]{16,}\b/gi, "[hash]")
+    .replace(/\b\d{8,}\b/g, "[number]")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return truncateSummary(summary || "unknown error");
+}
+
+function structuredErrorCode(error: Error): string | undefined {
+  for (const current of errorChain(error)) {
+    const code = "code" in current ? current.code : undefined;
+    if (typeof code === "number" && Number.isFinite(code)) {
+      return String(code);
+    }
+    if (typeof code === "string") {
+      const normalized = code.trim();
+      if (/^[A-Za-z0-9_.:-]{1,80}$/.test(normalized)) {
+        return normalized;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isTemplateRoute(path: string): boolean {
+  return path !== "*" && path !== "/*";
+}
+
+function requestRouteTemplate(context: Context): string | undefined {
+  const routes = matchedRoutes(context);
+  for (let index = routes.length - 1; index >= 0; index -= 1) {
+    const path = routes[index]?.path;
+    if (path && isTemplateRoute(path)) {
+      return path;
+    }
+  }
+  return undefined;
+}
+
+function unhandledRequestErrorLogFields(
+  error: Error,
+  context: Context,
+): UnhandledRequestErrorLogFields {
+  const route = requestRouteTemplate(context);
+  const errorCode = structuredErrorCode(error);
+  return {
+    type: UNHANDLED_REQUEST_ERROR_TYPE,
+    errorSummary: sanitizeErrorSummary(error),
+    method: context.req.method,
+    ...(route ? { route } : {}),
+    ...(errorCode ? { errorCode } : {}),
+    error: serializeError(error),
+  };
+}
+
 function handleError(error: Error, context: Context): Response {
   if (isAbortError(error)) {
     return context.json({ error: "Internal server error" }, 500);
@@ -46,7 +171,8 @@ function handleError(error: Error, context: Context): Response {
     return error.getResponse();
   }
 
-  L.error("Unhandled request error", error);
+  const fields = unhandledRequestErrorLogFields(error, context);
+  L.error(`Unhandled request error: ${fields.errorSummary}`, fields);
   return context.json({ error: "Internal server error" }, 500);
 }
 

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -19,6 +19,7 @@ const L = logger("App");
 const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
 const UNHANDLED_REQUEST_ERROR_TYPE = "unhandled_request_error" as const;
 const ERROR_SUMMARY_MAX_LENGTH = 240;
+const ERROR_SUMMARY_SOURCE_MAX_LENGTH = 4096;
 
 interface UnhandledRequestErrorLogFields {
   readonly type: typeof UNHANDLED_REQUEST_ERROR_TYPE;
@@ -88,7 +89,10 @@ function replaceControlCharacters(value: string): string {
 }
 
 function sanitizeErrorSummary(error: Error): string {
-  const source = sourceErrorMessage(error);
+  const source = sourceErrorMessage(error).slice(
+    0,
+    ERROR_SUMMARY_SOURCE_MAX_LENGTH,
+  );
   if (/^response validation failed:/i.test(source)) {
     return "response validation failed";
   }

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -186,7 +186,13 @@ function isTemplateRoute(path: string): boolean {
 }
 
 function requestRouteTemplate(context: Context): string | undefined {
-  const routes = matchedRoutes(context);
+  const result = safeSync(() => {
+    return matchedRoutes(context);
+  });
+  if (!("ok" in result)) {
+    return undefined;
+  }
+  const routes = result.ok;
   for (let index = routes.length - 1; index >= 0; index -= 1) {
     const path = routes[index]?.path;
     if (path && isTemplateRoute(path)) {

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -102,7 +102,7 @@ function sanitizeErrorSummary(error: Error): string {
     )
     .replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi, "Bearer [redacted]")
     .replace(
-      /\b(api[_-]?key|authorization|password|secret|token)\b\s*[:=]\s*["']?[^,\s"']+/gi,
+      /\b(api[_\s-]?key|access[_\s-]?token|refresh[_\s-]?token|id[_\s-]?token|client[_-]?secret|authorization|password|secret|token)\b\s*[:=]\s*["']?[^,\s"']+/gi,
       "$1=[redacted]",
     )
     .replace(/\b[0-9a-f]{16,}\b/gi, "[hash]")

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -393,8 +393,46 @@ describe("serializeError via logging", () => {
     expect(fields?.error).toMatchObject({
       message: "request failed",
       cause: "[Unreadable]",
-      __unreadable: true,
+      request: "[Unreadable]",
     });
+  });
+
+  it("bounds enumerable object fields before reading later properties", () => {
+    const log = logger("large-enumerable-test");
+    const err = new Error("request failed") as Error & Record<string, unknown>;
+    const request: Record<string, unknown> = {};
+    for (let index = 0; index < 80; index += 1) {
+      Object.defineProperty(request, `field${index}`, {
+        enumerable: true,
+        get() {
+          if (index >= 64) {
+            throw new Error("late getter should not be read");
+          }
+          return index;
+        },
+      });
+    }
+    err.request = request;
+
+    expect(() => {
+      log.error(err);
+    }).not.toThrow();
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const serializedError = fields?.error as Record<string, unknown>;
+    const serializedRequest = serializedError.request as Record<
+      string,
+      unknown
+    >;
+    expect(serializedRequest.field0).toBe(0);
+    expect(serializedRequest.field63).toBe(63);
+    expect(serializedRequest.field64).toBeUndefined();
+    expect(serializedRequest.__truncated).toBeTruthy();
+    expect(() => {
+      JSON.stringify(serializedError);
+    }).not.toThrow();
   });
 
   it("surfaces custom enumerable properties on Error", () => {

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -74,6 +74,24 @@ describe("logToAxiom level dispatch", () => {
       expect.objectContaining({ [EVENT]: { source: "api" } }),
     );
   });
+
+  it("uses a fallback Axiom message when string conversion throws", () => {
+    const log = logger("test-bad-string");
+    const value = {
+      [Symbol.toPrimitive]() {
+        throw new Error("string conversion failed");
+      },
+    };
+
+    expect(() => {
+      log.info(value);
+    }).not.toThrow();
+
+    expect(axiomLogging.info).toHaveBeenCalledWith(
+      "[Unreadable]",
+      expect.objectContaining({ [EVENT]: { source: "api" } }),
+    );
+  });
 });
 
 // ── Axiom log calls include [EVENT]: { source: "api" } ───────────────────────────────────
@@ -97,6 +115,30 @@ describe("Axiom log source field", () => {
     expect(axiomLogging.error).toHaveBeenCalledWith(
       "fail",
       expect.objectContaining({ [EVENT]: { source: "api" } }),
+    );
+  });
+
+  it("uses a fallback Axiom message when Error.message is unreadable", () => {
+    const log = logger("source-unreadable-err");
+    const err = new Error("fail");
+    Object.defineProperty(err, "message", {
+      get() {
+        throw new Error("message getter failed");
+      },
+    });
+
+    expect(() => {
+      log.error(err);
+    }).not.toThrow();
+
+    expect(axiomLogging.error).toHaveBeenCalledWith(
+      "[Unreadable]",
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: "[Unreadable]",
+        }),
+        [EVENT]: { source: "api" },
+      }),
     );
   });
 

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -479,9 +479,9 @@ describe("serializeError via logging", () => {
     const log = logger("special-key-error-test");
     const err = new Error("special") as Error & Record<string, unknown>;
     const payload: Record<string, unknown> = {};
-    Object.defineProperty(err, "__proto__", {
+    Object.defineProperty(err, "constructor", {
       enumerable: true,
-      value: "error-proto-field",
+      value: "error-constructor-field",
     });
     Object.defineProperty(payload, "__proto__", {
       enumerable: true,
@@ -502,12 +502,14 @@ describe("serializeError via logging", () => {
     expect(Object.getPrototypeOf(serializedError)).toBe(Object.prototype);
     expect(Object.getPrototypeOf(serializedPayload)).toBe(Object.prototype);
     expect(
-      Object.prototype.hasOwnProperty.call(serializedError, "__proto__"),
+      Object.prototype.hasOwnProperty.call(serializedError, "constructor"),
     ).toBeTruthy();
     expect(
       Object.prototype.hasOwnProperty.call(serializedPayload, "__proto__"),
     ).toBeTruthy();
-    expect(Reflect.get(serializedError, "__proto__")).toBe("error-proto-field");
+    expect(Reflect.get(serializedError, "constructor")).toBe(
+      "error-constructor-field",
+    );
     expect(Reflect.get(serializedPayload, "__proto__")).toStrictEqual({
       nested: true,
     });

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -297,6 +297,35 @@ describe("serializeError via logging", () => {
     expect(serialized).not.toContain("depth-80");
   });
 
+  it("serializes cyclic enumerable error fields into JSON-safe values", () => {
+    const log = logger("cyclic-enumerable-test");
+    const err = new Error("request failed") as Error & Record<string, unknown>;
+    const request: Record<string, unknown> = {
+      url: "https://example.test/api",
+      retryAfter: 1n,
+    };
+    request.self = request;
+    err.request = request;
+
+    log.error(err);
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const serializedError = fields?.error as Record<string, unknown>;
+    expect(serializedError).toMatchObject({
+      message: "request failed",
+      request: {
+        url: "https://example.test/api",
+        retryAfter: "1",
+        self: "[Circular]",
+      },
+    });
+    expect(() => {
+      JSON.stringify(serializedError);
+    }).not.toThrow();
+  });
+
   it("surfaces custom enumerable properties on Error", () => {
     const log = logger("custom-err");
     const err = new Error("custom") as Error & Record<string, unknown>;

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -458,6 +458,61 @@ describe("serializeError via logging", () => {
     }).not.toThrow();
   });
 
+  it("bounds serialized error string fields", () => {
+    const log = logger("long-error-string-test");
+    const err = new Error("x".repeat(10_000));
+    Object.defineProperty(err, "stack", {
+      value: "s".repeat(10_000),
+    });
+
+    log.error("msg", err);
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const serializedError = fields?.error as Record<string, unknown>;
+    expect(serializedError.message).toBe(`${"x".repeat(4093)}...`);
+    expect(serializedError.stack).toBe(`${"s".repeat(4093)}...`);
+  });
+
+  it("preserves special enumerable keys as data fields", () => {
+    const log = logger("special-key-error-test");
+    const err = new Error("special") as Error & Record<string, unknown>;
+    const payload: Record<string, unknown> = {};
+    Object.defineProperty(err, "__proto__", {
+      enumerable: true,
+      value: "error-proto-field",
+    });
+    Object.defineProperty(payload, "__proto__", {
+      enumerable: true,
+      value: { nested: true },
+    });
+    err.payload = payload;
+
+    log.error(err);
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const serializedError = fields?.error as Record<string, unknown>;
+    const serializedPayload = serializedError.payload as Record<
+      string,
+      unknown
+    >;
+    expect(Object.getPrototypeOf(serializedError)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(serializedPayload)).toBe(Object.prototype);
+    expect(
+      Object.prototype.hasOwnProperty.call(serializedError, "__proto__"),
+    ).toBeTruthy();
+    expect(
+      Object.prototype.hasOwnProperty.call(serializedPayload, "__proto__"),
+    ).toBeTruthy();
+    expect(Reflect.get(serializedError, "__proto__")).toBe("error-proto-field");
+    expect(Reflect.get(serializedPayload, "__proto__")).toStrictEqual({
+      nested: true,
+    });
+  });
+
   it("surfaces custom enumerable properties on Error", () => {
     const log = logger("custom-err");
     const err = new Error("custom") as Error & Record<string, unknown>;

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -513,6 +513,30 @@ describe("serializeError via logging", () => {
     });
   });
 
+  it("bounds the total serialized error graph", () => {
+    const log = logger("wide-error-graph-test");
+    const err = new Error("wide") as Error & Record<string, unknown>;
+    const payload: Record<string, unknown> = {};
+    for (let childIndex = 0; childIndex < 64; childIndex += 1) {
+      const child: Record<string, unknown> = {};
+      for (let fieldIndex = 0; fieldIndex < 64; fieldIndex += 1) {
+        child[`field${fieldIndex}`] = `${childIndex}:${fieldIndex}`;
+      }
+      payload[`child${childIndex}`] = child;
+    }
+    err.payload = payload;
+
+    log.error(err);
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const serializedError = fields?.error as Record<string, unknown>;
+    const serialized = JSON.stringify(serializedError);
+    expect(serialized).toContain("[Truncated]");
+    expect(serialized.length).toBeLessThan(100_000);
+  });
+
   it("surfaces custom enumerable properties on Error", () => {
     const log = logger("custom-err");
     const err = new Error("custom") as Error & Record<string, unknown>;

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -137,6 +137,58 @@ describe("Axiom log source field", () => {
       },
     });
   });
+
+  it("lifts unhandled request error fields into the Axiom event root", () => {
+    const log = logger("unhandled-request-test");
+    log.error("Unhandled request error: database column missing", {
+      type: "unhandled_request_error",
+      errorSummary: "database column missing",
+      route: "/api/test/:id",
+      method: "GET",
+      errorCode: "42703",
+      error: { message: "database column missing" },
+    });
+
+    expect(axiomLogging.error).toHaveBeenCalledWith(
+      "Unhandled request error: database column missing",
+      {
+        type: "unhandled_request_error",
+        errorSummary: "database column missing",
+        route: "/api/test/:id",
+        method: "GET",
+        errorCode: "42703",
+        error: { message: "database column missing" },
+        context: "unhandled-request-test",
+        [EVENT]: {
+          source: "api",
+          type: "unhandled_request_error",
+          errorSummary: "database column missing",
+          route: "/api/test/:id",
+          method: "GET",
+          errorCode: "42703",
+        },
+      },
+    );
+  });
+
+  it("does not lift unknown type fields into the Axiom event root", () => {
+    const log = logger("unknown-type-test");
+    log.error("custom event", {
+      type: "custom_event",
+      errorSummary: "summary",
+      route: "/api/test/:id",
+      method: "GET",
+    });
+
+    expect(axiomLogging.error).toHaveBeenCalledWith("custom event", {
+      type: "custom_event",
+      errorSummary: "summary",
+      route: "/api/test/:id",
+      method: "GET",
+      context: "unknown-type-test",
+      [EVENT]: { source: "api" },
+    });
+  });
 });
 
 // ── flushLogs ───────────────────────────────────────────────────────────────

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -258,6 +258,24 @@ describe("serializeError via logging", () => {
     );
   });
 
+  it("serializes cyclic error causes without throwing", () => {
+    const log = logger("cyclic-cause-test");
+    const err = new Error("wrapped");
+    Object.defineProperty(err, "cause", { value: err });
+
+    log.error(err);
+
+    expect(axiomLogging.error).toHaveBeenCalledWith(
+      "wrapped",
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: "wrapped",
+          cause: "[Circular]",
+        }),
+      }),
+    );
+  });
+
   it("surfaces custom enumerable properties on Error", () => {
     const log = logger("custom-err");
     const err = new Error("custom") as Error & Record<string, unknown>;

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -326,6 +326,35 @@ describe("serializeError via logging", () => {
     }).not.toThrow();
   });
 
+  it("serializes unreadable error properties without throwing", () => {
+    const log = logger("unreadable-error-test");
+    const err = new Error("request failed") as Error & Record<string, unknown>;
+    Object.defineProperty(err, "cause", {
+      get() {
+        throw new Error("cause getter failed");
+      },
+    });
+    Object.defineProperty(err, "request", {
+      enumerable: true,
+      get() {
+        throw new Error("request getter failed");
+      },
+    });
+
+    expect(() => {
+      log.error(err);
+    }).not.toThrow();
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(fields?.error).toMatchObject({
+      message: "request failed",
+      cause: "[Unreadable]",
+      __unreadable: true,
+    });
+  });
+
   it("surfaces custom enumerable properties on Error", () => {
     const log = logger("custom-err");
     const err = new Error("custom") as Error & Record<string, unknown>;

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -435,6 +435,29 @@ describe("serializeError via logging", () => {
     }).not.toThrow();
   });
 
+  it("serializes non-string error stacks into JSON-safe values", () => {
+    const log = logger("non-string-stack-test");
+    const err = new Error("request failed");
+    Object.defineProperty(err, "stack", {
+      get() {
+        return 1n;
+      },
+    });
+
+    expect(() => {
+      log.error(err);
+    }).not.toThrow();
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const serializedError = fields?.error as Record<string, unknown>;
+    expect(serializedError.stack).toBe("1");
+    expect(() => {
+      JSON.stringify(serializedError);
+    }).not.toThrow();
+  });
+
   it("surfaces custom enumerable properties on Error", () => {
     const log = logger("custom-err");
     const err = new Error("custom") as Error & Record<string, unknown>;

--- a/turbo/apps/api/src/lib/__tests__/log.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/log.test.ts
@@ -276,6 +276,27 @@ describe("serializeError via logging", () => {
     );
   });
 
+  it("truncates deep error cause chains", () => {
+    const log = logger("deep-cause-test");
+    const err = new Error("depth-0");
+    let current = err;
+    for (let index = 1; index <= 80; index += 1) {
+      const next = new Error(`depth-${index}`);
+      Object.defineProperty(current, "cause", { value: next });
+      current = next;
+    }
+
+    log.error(err);
+
+    const fields = axiomLogging.error.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    const serialized = JSON.stringify(fields?.error);
+    expect(serialized).toContain("depth-32");
+    expect(serialized).toContain("[Truncated]");
+    expect(serialized).not.toContain("depth-80");
+  });
+
   it("surfaces custom enumerable properties on Error", () => {
     const log = logger("custom-err");
     const err = new Error("custom") as Error & Record<string, unknown>;

--- a/turbo/apps/api/src/lib/log.ts
+++ b/turbo/apps/api/src/lib/log.ts
@@ -145,6 +145,14 @@ interface UsageUnderbillingRootFields {
   readonly component: string;
 }
 
+interface UnhandledRequestErrorRootFields {
+  readonly type: "unhandled_request_error";
+  readonly errorSummary: string;
+  readonly method: string;
+  readonly route?: string;
+  readonly errorCode?: string;
+}
+
 function usageUnderbillingRootFields(
   fields: Record<string, unknown>,
 ): UsageUnderbillingRootFields | null {
@@ -170,6 +178,43 @@ function usageUnderbillingRootFields(
   };
 }
 
+function unhandledRequestErrorRootFields(
+  fields: Record<string, unknown>,
+): UnhandledRequestErrorRootFields | null {
+  const type = fields.type;
+  const errorSummary = fields.errorSummary;
+  const method = fields.method;
+  const route = fields.route;
+  const errorCode = fields.errorCode;
+
+  if (
+    type !== "unhandled_request_error" ||
+    typeof errorSummary !== "string" ||
+    typeof method !== "string" ||
+    (route !== undefined && typeof route !== "string") ||
+    (errorCode !== undefined && typeof errorCode !== "string")
+  ) {
+    return null;
+  }
+
+  return {
+    type,
+    errorSummary,
+    method,
+    ...(route ? { route } : {}),
+    ...(errorCode ? { errorCode } : {}),
+  };
+}
+
+function rootEventFields(
+  fields: Record<string, unknown>,
+): UsageUnderbillingRootFields | UnhandledRequestErrorRootFields | null {
+  return (
+    usageUnderbillingRootFields(fields) ??
+    unhandledRequestErrorRootFields(fields)
+  );
+}
+
 function logToAxiom(level: Level, name: string, args: unknown[]): void {
   const alog = getAxiomLogger();
   if (!alog) {
@@ -178,11 +223,11 @@ function logToAxiom(level: Level, name: string, args: unknown[]): void {
 
   const message = formatMessage(args);
   const fields = extractFields(args);
-  const underbillingRootFields = usageUnderbillingRootFields(fields);
+  const eventRootFields = rootEventFields(fields);
   const data = {
     [EVENT]: {
       source: "api",
-      ...underbillingRootFields,
+      ...eventRootFields,
     },
     ...fields,
     context: name,

--- a/turbo/apps/api/src/signals/context/route.ts
+++ b/turbo/apps/api/src/signals/context/route.ts
@@ -9,6 +9,7 @@ import type { ContentfulStatusCode, StatusCode } from "hono/utils/http-status";
 import { initHono$ } from "./hono";
 import { requestValidation$ } from "./request";
 import { setRootSignal$ } from "./root";
+import { normalizeThrown } from "../utils";
 
 export type SignalRouteHandler<T> = Computed<T> | Command<T, [AbortSignal]>;
 
@@ -93,48 +94,54 @@ export function honoSignalHandler(
   contract: AppRoute,
   signal: AbortSignal,
 ): Handler {
-  return async (context) => {
-    const store = createStore();
-    store.set(setRootSignal$, signal);
-    store.set(initHono$, context, contract);
+  return (context) => {
+    return normalizeThrown(
+      (async () => {
+        const store = createStore();
+        store.set(setRootSignal$, signal);
+        store.set(initHono$, context, contract);
 
-    // Mirror the contract client order: path/query validation
-    // precedes auth and downstream services, so a malformed request returns
-    // 400 without touching either.
-    const validationError = store.get(requestValidation$);
-    if (validationError) {
-      return context.json(validationError.body, validationError.status);
-    }
+        // Mirror the contract client order: path/query validation
+        // precedes auth and downstream services, so a malformed request returns
+        // 400 without touching either.
+        const validationError = store.get(requestValidation$);
+        if (validationError) {
+          return context.json(validationError.body, validationError.status);
+        }
 
-    const data = await (isCommand(handler$)
-      ? store.set(handler$, signal)
-      : store.get(handler$));
+        const data = await (isCommand(handler$)
+          ? store.set(handler$, signal)
+          : store.get(handler$));
 
-    if (data instanceof Response) {
-      return data;
-    }
+        if (data instanceof Response) {
+          return data;
+        }
 
-    if (isResponseLike(data)) {
-      return toResponse(data);
-    }
+        if (isResponseLike(data)) {
+          return toResponse(data);
+        }
 
-    if (!isRouteResult(data)) {
-      throw new Error("Route handler must return a contract response object");
-    }
+        if (!isRouteResult(data)) {
+          throw new Error(
+            "Route handler must return a contract response object",
+          );
+        }
 
-    const response = validateResponse({
-      appRoute: contract,
-      response: data,
-    });
-    const status = response.status as StatusCode;
-    if (
-      isContentlessStatus(status) ||
-      !("body" in response) ||
-      response.body === undefined
-    ) {
-      return context.body(null, status);
-    }
+        const response = validateResponse({
+          appRoute: contract,
+          response: data,
+        });
+        const status = response.status as StatusCode;
+        if (
+          isContentlessStatus(status) ||
+          !("body" in response) ||
+          response.body === undefined
+        ) {
+          return context.body(null, status);
+        }
 
-    return context.json(response.body, status as ContentfulStatusCode);
+        return context.json(response.body, status as ContentfulStatusCode);
+      })(),
+    );
   };
 }

--- a/turbo/apps/api/src/signals/context/route.ts
+++ b/turbo/apps/api/src/signals/context/route.ts
@@ -9,7 +9,6 @@ import type { ContentfulStatusCode, StatusCode } from "hono/utils/http-status";
 import { initHono$ } from "./hono";
 import { requestValidation$ } from "./request";
 import { setRootSignal$ } from "./root";
-import { normalizeThrown } from "../utils";
 
 export type SignalRouteHandler<T> = Computed<T> | Command<T, [AbortSignal]>;
 
@@ -94,54 +93,48 @@ export function honoSignalHandler(
   contract: AppRoute,
   signal: AbortSignal,
 ): Handler {
-  return (context) => {
-    return normalizeThrown(
-      (async () => {
-        const store = createStore();
-        store.set(setRootSignal$, signal);
-        store.set(initHono$, context, contract);
+  return async (context) => {
+    const store = createStore();
+    store.set(setRootSignal$, signal);
+    store.set(initHono$, context, contract);
 
-        // Mirror the contract client order: path/query validation
-        // precedes auth and downstream services, so a malformed request returns
-        // 400 without touching either.
-        const validationError = store.get(requestValidation$);
-        if (validationError) {
-          return context.json(validationError.body, validationError.status);
-        }
+    // Mirror the contract client order: path/query validation
+    // precedes auth and downstream services, so a malformed request returns
+    // 400 without touching either.
+    const validationError = store.get(requestValidation$);
+    if (validationError) {
+      return context.json(validationError.body, validationError.status);
+    }
 
-        const data = await (isCommand(handler$)
-          ? store.set(handler$, signal)
-          : store.get(handler$));
+    const data = await (isCommand(handler$)
+      ? store.set(handler$, signal)
+      : store.get(handler$));
 
-        if (data instanceof Response) {
-          return data;
-        }
+    if (data instanceof Response) {
+      return data;
+    }
 
-        if (isResponseLike(data)) {
-          return toResponse(data);
-        }
+    if (isResponseLike(data)) {
+      return toResponse(data);
+    }
 
-        if (!isRouteResult(data)) {
-          throw new Error(
-            "Route handler must return a contract response object",
-          );
-        }
+    if (!isRouteResult(data)) {
+      throw new Error("Route handler must return a contract response object");
+    }
 
-        const response = validateResponse({
-          appRoute: contract,
-          response: data,
-        });
-        const status = response.status as StatusCode;
-        if (
-          isContentlessStatus(status) ||
-          !("body" in response) ||
-          response.body === undefined
-        ) {
-          return context.body(null, status);
-        }
+    const response = validateResponse({
+      appRoute: contract,
+      response: data,
+    });
+    const status = response.status as StatusCode;
+    if (
+      isContentlessStatus(status) ||
+      !("body" in response) ||
+      response.body === undefined
+    ) {
+      return context.body(null, status);
+    }
 
-        return context.json(response.body, status as ContentfulStatusCode);
-      })(),
-    );
+    return context.json(response.body, status as ContentfulStatusCode);
   };
 }

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -10,6 +10,8 @@ export enum Mechanism {
 
 const IN_VITEST = env("VITEST") === "true";
 const L = logger("Promise");
+const NON_ERROR_THROWN_PREFIX = "Non-Error thrown: ";
+const NORMALIZED_THROWN_MESSAGE_MAX_LENGTH = 4096;
 
 class PromiseTracker {
   collected = new Set<Promise<unknown>>();
@@ -73,11 +75,18 @@ export function safeSync<T>(
   }
 }
 
-function safeThrownValueString(value: unknown): string {
+function safeThrownValueMessage(value: unknown): string {
   const result = safeSync(() => {
     return String(value);
   });
-  return "ok" in result ? result.ok : "unknown thrown value";
+  const serialized = "ok" in result ? result.ok : "unknown thrown value";
+  const valueMaxLength =
+    NORMALIZED_THROWN_MESSAGE_MAX_LENGTH - NON_ERROR_THROWN_PREFIX.length;
+  const serializedValue =
+    serialized.length <= valueMaxLength
+      ? serialized
+      : `${serialized.slice(0, valueMaxLength - 3)}...`;
+  return `${NON_ERROR_THROWN_PREFIX}${serializedValue}`;
 }
 
 function normalizeThrownError(value: unknown): Error {
@@ -85,15 +94,15 @@ function normalizeThrownError(value: unknown): Error {
   if (value instanceof Error) {
     return value;
   }
-  return new Error(`Non-Error thrown: ${safeThrownValueString(value)}`, {
+  return new Error(safeThrownValueMessage(value), {
     cause: value,
   });
 }
 
-export async function normalizeThrown<T>(p: Promise<T>): Promise<T> {
+export async function normalizeThrown<T>(run: () => Promise<T>): Promise<T> {
   // eslint-disable-next-line no-restricted-syntax -- centralized thrown value normalization
   try {
-    return await p;
+    return await run();
   } catch (error) {
     throwIfAbort(error);
     throw normalizeThrownError(error);

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -73,6 +73,33 @@ export function safeSync<T>(
   }
 }
 
+function safeThrownValueString(value: unknown): string {
+  const result = safeSync(() => {
+    return String(value);
+  });
+  return "ok" in result ? result.ok : "unknown thrown value";
+}
+
+function normalizeThrownError(value: unknown): Error {
+  throwIfAbort(value);
+  if (value instanceof Error) {
+    return value;
+  }
+  return new Error(`Non-Error thrown: ${safeThrownValueString(value)}`, {
+    cause: value,
+  });
+}
+
+export async function normalizeThrown<T>(p: Promise<T>): Promise<T> {
+  // eslint-disable-next-line no-restricted-syntax -- centralized thrown value normalization
+  try {
+    return await p;
+  } catch (error) {
+    throwIfAbort(error);
+    throw normalizeThrownError(error);
+  }
+}
+
 export function isValidTimeZone(input: string): boolean {
   // eslint-disable-next-line no-restricted-syntax -- centralized guarded Intl timezone validation
   try {

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -14,22 +14,39 @@ export function formatMessage(args: unknown[]): string {
  * an Error loses them. This explicitly copies them plus any additional
  * enumerable own properties (e.g. code, statusCode on custom errors).
  */
-export function serializeError(err: Error): Record<string, unknown> {
+function serializeErrorWithSeen(
+  err: Error,
+  seen: WeakSet<Error>,
+): Record<string, unknown> {
   const serialized: Record<string, unknown> = {
     name: err.name,
     message: err.message,
     stack: err.stack,
   };
+  seen.add(err);
   if (err.cause !== undefined) {
     serialized.cause =
-      err.cause instanceof Error ? serializeError(err.cause) : err.cause;
+      err.cause instanceof Error
+        ? seen.has(err.cause)
+          ? "[Circular]"
+          : serializeErrorWithSeen(err.cause, seen)
+        : err.cause;
   }
   for (const [key, value] of Object.entries(err)) {
     if (!(key in serialized)) {
-      serialized[key] = value;
+      serialized[key] =
+        value instanceof Error
+          ? seen.has(value)
+            ? "[Circular]"
+            : serializeErrorWithSeen(value, seen)
+          : value;
     }
   }
   return serialized;
+}
+
+export function serializeError(err: Error): Record<string, unknown> {
+  return serializeErrorWithSeen(err, new WeakSet<Error>());
 }
 
 /**

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -77,8 +77,12 @@ function serializeErrorWithSeen(
   return serialized;
 }
 
-export function serializeError(err: Error): Record<string, unknown> {
-  return serializeErrorWithSeen(err, new WeakSet<object>(), 0);
+export function serializeError(err: unknown): Record<string, unknown> {
+  const seen = new WeakSet<object>();
+  if (err instanceof Error) {
+    return serializeErrorWithSeen(err, seen, 0);
+  }
+  return { value: serializeErrorValue(err, seen, 0) };
 }
 
 function safeReadValue(read: () => unknown): unknown {

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -1,5 +1,6 @@
 const SERIALIZED_VALUE_MAX_DEPTH = 32;
 const SERIALIZED_OBJECT_MAX_ENTRIES = 64;
+const SERIALIZED_STRING_MAX_LENGTH = 4096;
 const CIRCULAR_MARKER = "[Circular]";
 const TRUNCATED_MARKER = "[Truncated]";
 const UNREADABLE_MARKER = "[Unreadable]";
@@ -7,6 +8,26 @@ const UNREADABLE_MARKER = "[Unreadable]";
 interface BoundedEntries {
   readonly entries: readonly [string, unknown][];
   readonly truncated: boolean;
+}
+
+function hasOwnSerializedField(
+  value: Record<string, unknown>,
+  key: string,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function setSerializedField(
+  value: Record<string, unknown>,
+  key: string,
+  child: unknown,
+): void {
+  Object.defineProperty(value, key, {
+    value: child,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
 }
 
 /**
@@ -43,23 +64,33 @@ function serializeErrorWithSeen(
   });
   const serialized: Record<string, unknown> = {
     name: typeof name === "string" ? name : "Error",
-    message: typeof message === "string" ? message : UNREADABLE_MARKER,
+    message:
+      typeof message === "string"
+        ? serializeStringValue(message)
+        : UNREADABLE_MARKER,
   };
   seen.add(err);
   const stack = safeReadValue(() => {
     return err.stack;
   });
   if (stack !== undefined) {
-    serialized.stack =
+    setSerializedField(
+      serialized,
+      "stack",
       typeof stack === "string"
-        ? stack
-        : serializeErrorValue(stack, seen, depth + 1);
+        ? serializeStringValue(stack)
+        : serializeErrorValue(stack, seen, depth + 1),
+    );
   }
   const cause = safeReadValue(() => {
     return err.cause;
   });
   if (cause !== undefined) {
-    serialized.cause = serializeErrorValue(cause, seen, depth + 1);
+    setSerializedField(
+      serialized,
+      "cause",
+      serializeErrorValue(cause, seen, depth + 1),
+    );
   }
   const result = safeOwnEnumerableEntries(err);
   if (!result) {
@@ -67,12 +98,16 @@ function serializeErrorWithSeen(
     return serialized;
   }
   for (const [key, value] of result.entries) {
-    if (!(key in serialized)) {
-      serialized[key] = serializeErrorValue(value, seen, depth + 1);
+    if (!hasOwnSerializedField(serialized, key)) {
+      setSerializedField(
+        serialized,
+        key,
+        serializeErrorValue(value, seen, depth + 1),
+      );
     }
   }
   if (result.truncated) {
-    serialized.__truncated = true;
+    setSerializedField(serialized, "__truncated", true);
   }
   return serialized;
 }
@@ -124,16 +159,28 @@ function safeString(value: unknown): string {
   return typeof result === "string" ? result : UNREADABLE_MARKER;
 }
 
+function serializeStringValue(value: string): string {
+  if (value.length <= SERIALIZED_STRING_MAX_LENGTH) {
+    return value;
+  }
+  return `${value.slice(0, SERIALIZED_STRING_MAX_LENGTH - 3)}...`;
+}
+
 function serializeFunctionValue(value: { readonly name: string }): string {
   const name = safeReadValue(() => {
     return value.name;
   });
-  return typeof name === "string" && name ? `[Function ${name}]` : "[Function]";
+  return typeof name === "string" && name
+    ? serializeStringValue(`[Function ${name}]`)
+    : "[Function]";
 }
 
 function serializeNonObjectValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return serializeStringValue(value);
+  }
   if (typeof value === "bigint" || typeof value === "symbol") {
-    return safeString(value);
+    return serializeStringValue(safeString(value));
   }
   if (typeof value === "function") {
     return serializeFunctionValue(value);
@@ -150,7 +197,7 @@ function serializeDateValue(value: Date): unknown {
     return value.getTime();
   });
   if (typeof time !== "number" || Number.isNaN(time)) {
-    return safeString(value);
+    return serializeStringValue(safeString(value));
   }
   const iso = safeReadValue(() => {
     return value.toISOString();
@@ -188,10 +235,14 @@ function serializePlainObjectValue(
   }
   const serialized: Record<string, unknown> = {};
   for (const [key, child] of result.entries) {
-    serialized[key] = serializeErrorValue(child, seen, depth + 1);
+    setSerializedField(
+      serialized,
+      key,
+      serializeErrorValue(child, seen, depth + 1),
+    );
   }
   if (result.truncated) {
-    serialized.__truncated = true;
+    setSerializedField(serialized, "__truncated", true);
   }
   return serialized;
 }
@@ -217,7 +268,7 @@ function serializeErrorValue(
     return serializeDateValue(value);
   }
   if (value instanceof RegExp) {
-    return safeString(value);
+    return serializeStringValue(safeString(value));
   }
 
   seen.add(value);

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -10,8 +10,13 @@ const UNREADABLE_MARKER = "[Unreadable]";
 export function formatMessage(args: unknown[]): string {
   if (args.length === 0) return "";
   if (typeof args[0] === "string") return args[0];
-  if (args[0] instanceof Error) return args[0].message;
-  return String(args[0]);
+  if (args[0] instanceof Error) {
+    const message = safeReadValue(() => {
+      return args[0] instanceof Error ? args[0].message : undefined;
+    });
+    return typeof message === "string" ? message : UNREADABLE_MARKER;
+  }
+  return safeString(args[0]);
 }
 
 /**
@@ -78,22 +83,95 @@ function safeObjectEntries(value: object): readonly [string, unknown][] | null {
   }
 }
 
+function safeString(value: unknown): string {
+  const result = safeReadValue(() => {
+    return String(value);
+  });
+  return typeof result === "string" ? result : UNREADABLE_MARKER;
+}
+
+function serializeFunctionValue(value: { readonly name: string }): string {
+  const name = safeReadValue(() => {
+    return value.name;
+  });
+  return typeof name === "string" && name ? `[Function ${name}]` : "[Function]";
+}
+
+function serializeNonObjectValue(value: unknown): unknown {
+  if (typeof value === "bigint" || typeof value === "symbol") {
+    return safeString(value);
+  }
+  if (typeof value === "function") {
+    return serializeFunctionValue(value);
+  }
+  return value;
+}
+
+function isObjectValue(value: unknown): value is object {
+  return value !== null && typeof value === "object";
+}
+
+function serializeDateValue(value: Date): unknown {
+  const time = safeReadValue(() => {
+    return value.getTime();
+  });
+  if (typeof time !== "number" || Number.isNaN(time)) {
+    return safeString(value);
+  }
+  const iso = safeReadValue(() => {
+    return value.toISOString();
+  });
+  return typeof iso === "string" ? iso : UNREADABLE_MARKER;
+}
+
+function serializeArrayValue(
+  value: readonly unknown[],
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  const entries = safeObjectEntries(value);
+  if (!entries) {
+    return UNREADABLE_MARKER;
+  }
+  const items = entries.slice(0, SERIALIZED_OBJECT_MAX_ENTRIES).map((item) => {
+    const [, child] = item;
+    return serializeErrorValue(child, seen, depth + 1);
+  });
+  if (entries.length > SERIALIZED_OBJECT_MAX_ENTRIES) {
+    items.push(TRUNCATED_MARKER);
+  }
+  return items;
+}
+
+function serializePlainObjectValue(
+  value: object,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  const entries = safeObjectEntries(value);
+  if (!entries) {
+    return UNREADABLE_MARKER;
+  }
+  const serialized: Record<string, unknown> = {};
+  let entryCount = 0;
+  for (const [key, child] of entries) {
+    if (entryCount >= SERIALIZED_OBJECT_MAX_ENTRIES) {
+      serialized.__truncated = true;
+      break;
+    }
+    serialized[key] = serializeErrorValue(child, seen, depth + 1);
+    entryCount += 1;
+  }
+  return serialized;
+}
+
 function serializeErrorValue(
   value: unknown,
   seen: WeakSet<object>,
   depth: number,
 ): unknown {
-  if (typeof value === "bigint") {
-    return value.toString();
-  }
-  if (typeof value === "symbol") {
-    return value.toString();
-  }
-  if (typeof value === "function") {
-    return value.name ? `[Function ${value.name}]` : "[Function]";
-  }
-  if (value === null || typeof value !== "object") {
-    return value;
+  if (!isObjectValue(value)) {
+    return serializeNonObjectValue(value);
   }
   if (seen.has(value)) {
     return CIRCULAR_MARKER;
@@ -105,46 +183,17 @@ function serializeErrorValue(
     return serializeErrorWithSeen(value, seen, depth);
   }
   if (value instanceof Date) {
-    const time = value.getTime();
-    return Number.isNaN(time) ? value.toString() : value.toISOString();
+    return serializeDateValue(value);
   }
   if (value instanceof RegExp) {
-    return value.toString();
+    return safeString(value);
   }
 
   seen.add(value);
   if (Array.isArray(value)) {
-    const entries = safeObjectEntries(value);
-    if (!entries) {
-      return UNREADABLE_MARKER;
-    }
-    const items = entries
-      .slice(0, SERIALIZED_OBJECT_MAX_ENTRIES)
-      .map((item) => {
-        const [, child] = item;
-        return serializeErrorValue(child, seen, depth + 1);
-      });
-    if (entries.length > SERIALIZED_OBJECT_MAX_ENTRIES) {
-      items.push(TRUNCATED_MARKER);
-    }
-    return items;
+    return serializeArrayValue(value, seen, depth);
   }
-
-  const serialized: Record<string, unknown> = {};
-  let entryCount = 0;
-  const entries = safeObjectEntries(value);
-  if (!entries) {
-    return UNREADABLE_MARKER;
-  }
-  for (const [key, child] of entries) {
-    if (entryCount >= SERIALIZED_OBJECT_MAX_ENTRIES) {
-      serialized.__truncated = true;
-      break;
-    }
-    serialized[key] = serializeErrorValue(child, seen, depth + 1);
-    entryCount += 1;
-  }
-  return serialized;
+  return serializePlainObjectValue(value, seen, depth);
 }
 
 /**

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -4,6 +4,11 @@ const CIRCULAR_MARKER = "[Circular]";
 const TRUNCATED_MARKER = "[Truncated]";
 const UNREADABLE_MARKER = "[Unreadable]";
 
+interface BoundedEntries {
+  readonly entries: readonly [string, unknown][];
+  readonly truncated: boolean;
+}
+
 /**
  * Extract message string from log arguments.
  */
@@ -50,15 +55,18 @@ function serializeErrorWithSeen(
   if (cause !== undefined) {
     serialized.cause = serializeErrorValue(cause, seen, depth + 1);
   }
-  const entries = safeObjectEntries(err);
-  if (!entries) {
+  const result = safeOwnEnumerableEntries(err);
+  if (!result) {
     serialized.__unreadable = true;
     return serialized;
   }
-  for (const [key, value] of entries) {
+  for (const [key, value] of result.entries) {
     if (!(key in serialized)) {
       serialized[key] = serializeErrorValue(value, seen, depth + 1);
     }
+  }
+  if (result.truncated) {
+    serialized.__truncated = true;
   }
   return serialized;
 }
@@ -75,12 +83,28 @@ function safeReadValue(read: () => unknown): unknown {
   }
 }
 
-function safeObjectEntries(value: object): readonly [string, unknown][] | null {
+function safeOwnEnumerableEntries(value: object): BoundedEntries | null {
+  const entries: [string, unknown][] = [];
   try {
-    return Object.entries(value as unknown as Record<string, unknown>);
+    for (const key in value) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) {
+        continue;
+      }
+      if (!Object.prototype.propertyIsEnumerable.call(value, key)) {
+        continue;
+      }
+      if (entries.length >= SERIALIZED_OBJECT_MAX_ENTRIES) {
+        return { entries, truncated: true };
+      }
+      const child = safeReadValue(() => {
+        return (value as Record<string, unknown>)[key];
+      });
+      entries.push([key, child]);
+    }
   } catch {
     return null;
   }
+  return { entries, truncated: false };
 }
 
 function safeString(value: unknown): string {
@@ -129,15 +153,15 @@ function serializeArrayValue(
   seen: WeakSet<object>,
   depth: number,
 ): unknown {
-  const entries = safeObjectEntries(value);
-  if (!entries) {
+  const result = safeOwnEnumerableEntries(value);
+  if (!result) {
     return UNREADABLE_MARKER;
   }
-  const items = entries.slice(0, SERIALIZED_OBJECT_MAX_ENTRIES).map((item) => {
+  const items = result.entries.map((item) => {
     const [, child] = item;
     return serializeErrorValue(child, seen, depth + 1);
   });
-  if (entries.length > SERIALIZED_OBJECT_MAX_ENTRIES) {
+  if (result.truncated) {
     items.push(TRUNCATED_MARKER);
   }
   return items;
@@ -148,19 +172,16 @@ function serializePlainObjectValue(
   seen: WeakSet<object>,
   depth: number,
 ): unknown {
-  const entries = safeObjectEntries(value);
-  if (!entries) {
+  const result = safeOwnEnumerableEntries(value);
+  if (!result) {
     return UNREADABLE_MARKER;
   }
   const serialized: Record<string, unknown> = {};
-  let entryCount = 0;
-  for (const [key, child] of entries) {
-    if (entryCount >= SERIALIZED_OBJECT_MAX_ENTRIES) {
-      serialized.__truncated = true;
-      break;
-    }
+  for (const [key, child] of result.entries) {
     serialized[key] = serializeErrorValue(child, seen, depth + 1);
-    entryCount += 1;
+  }
+  if (result.truncated) {
+    serialized.__truncated = true;
   }
   return serialized;
 }

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -2,6 +2,7 @@ const SERIALIZED_VALUE_MAX_DEPTH = 32;
 const SERIALIZED_OBJECT_MAX_ENTRIES = 64;
 const CIRCULAR_MARKER = "[Circular]";
 const TRUNCATED_MARKER = "[Truncated]";
+const UNREADABLE_MARKER = "[Unreadable]";
 
 /**
  * Extract message string from log arguments.
@@ -24,18 +25,32 @@ function serializeErrorWithSeen(
   seen: WeakSet<object>,
   depth: number,
 ): Record<string, unknown> {
+  const name = safeReadValue(() => {
+    return err.name;
+  });
+  const message = safeReadValue(() => {
+    return err.message;
+  });
   const serialized: Record<string, unknown> = {
-    name: err.name,
-    message: err.message,
-    stack: err.stack,
+    name: typeof name === "string" ? name : "Error",
+    message: typeof message === "string" ? message : UNREADABLE_MARKER,
+    stack: safeReadValue(() => {
+      return err.stack;
+    }),
   };
   seen.add(err);
-  if (err.cause !== undefined) {
-    serialized.cause = serializeErrorValue(err.cause, seen, depth + 1);
+  const cause = safeReadValue(() => {
+    return err.cause;
+  });
+  if (cause !== undefined) {
+    serialized.cause = serializeErrorValue(cause, seen, depth + 1);
   }
-  for (const [key, value] of Object.entries(
-    err as unknown as Record<string, unknown>,
-  )) {
+  const entries = safeObjectEntries(err);
+  if (!entries) {
+    serialized.__unreadable = true;
+    return serialized;
+  }
+  for (const [key, value] of entries) {
     if (!(key in serialized)) {
       serialized[key] = serializeErrorValue(value, seen, depth + 1);
     }
@@ -45,6 +60,22 @@ function serializeErrorWithSeen(
 
 export function serializeError(err: Error): Record<string, unknown> {
   return serializeErrorWithSeen(err, new WeakSet<object>(), 0);
+}
+
+function safeReadValue(read: () => unknown): unknown {
+  try {
+    return read();
+  } catch {
+    return UNREADABLE_MARKER;
+  }
+}
+
+function safeObjectEntries(value: object): readonly [string, unknown][] | null {
+  try {
+    return Object.entries(value as unknown as Record<string, unknown>);
+  } catch {
+    return null;
+  }
 }
 
 function serializeErrorValue(
@@ -83,10 +114,17 @@ function serializeErrorValue(
 
   seen.add(value);
   if (Array.isArray(value)) {
-    const items = value.slice(0, SERIALIZED_OBJECT_MAX_ENTRIES).map((item) => {
-      return serializeErrorValue(item, seen, depth + 1);
-    });
-    if (value.length > SERIALIZED_OBJECT_MAX_ENTRIES) {
+    const entries = safeObjectEntries(value);
+    if (!entries) {
+      return UNREADABLE_MARKER;
+    }
+    const items = entries
+      .slice(0, SERIALIZED_OBJECT_MAX_ENTRIES)
+      .map((item) => {
+        const [, child] = item;
+        return serializeErrorValue(child, seen, depth + 1);
+      });
+    if (entries.length > SERIALIZED_OBJECT_MAX_ENTRIES) {
       items.push(TRUNCATED_MARKER);
     }
     return items;
@@ -94,7 +132,11 @@ function serializeErrorValue(
 
   const serialized: Record<string, unknown> = {};
   let entryCount = 0;
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+  const entries = safeObjectEntries(value);
+  if (!entries) {
+    return UNREADABLE_MARKER;
+  }
+  for (const [key, child] of entries) {
     if (entryCount >= SERIALIZED_OBJECT_MAX_ENTRIES) {
       serialized.__truncated = true;
       break;

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -44,11 +44,17 @@ function serializeErrorWithSeen(
   const serialized: Record<string, unknown> = {
     name: typeof name === "string" ? name : "Error",
     message: typeof message === "string" ? message : UNREADABLE_MARKER,
-    stack: safeReadValue(() => {
-      return err.stack;
-    }),
   };
   seen.add(err);
+  const stack = safeReadValue(() => {
+    return err.stack;
+  });
+  if (stack !== undefined) {
+    serialized.stack =
+      typeof stack === "string"
+        ? stack
+        : serializeErrorValue(stack, seen, depth + 1);
+  }
   const cause = safeReadValue(() => {
     return err.cause;
   });

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -1,4 +1,7 @@
-const SERIALIZED_ERROR_MAX_DEPTH = 32;
+const SERIALIZED_VALUE_MAX_DEPTH = 32;
+const SERIALIZED_OBJECT_MAX_ENTRIES = 64;
+const CIRCULAR_MARKER = "[Circular]";
+const TRUNCATED_MARKER = "[Truncated]";
 
 /**
  * Extract message string from log arguments.
@@ -18,7 +21,7 @@ export function formatMessage(args: unknown[]): string {
  */
 function serializeErrorWithSeen(
   err: Error,
-  seen: WeakSet<Error>,
+  seen: WeakSet<object>,
   depth: number,
 ): Record<string, unknown> {
   const serialized: Record<string, unknown> = {
@@ -28,32 +31,78 @@ function serializeErrorWithSeen(
   };
   seen.add(err);
   if (err.cause !== undefined) {
-    serialized.cause =
-      err.cause instanceof Error
-        ? seen.has(err.cause)
-          ? "[Circular]"
-          : depth >= SERIALIZED_ERROR_MAX_DEPTH
-            ? "[Truncated]"
-            : serializeErrorWithSeen(err.cause, seen, depth + 1)
-        : err.cause;
+    serialized.cause = serializeErrorValue(err.cause, seen, depth + 1);
   }
-  for (const [key, value] of Object.entries(err)) {
+  for (const [key, value] of Object.entries(
+    err as unknown as Record<string, unknown>,
+  )) {
     if (!(key in serialized)) {
-      serialized[key] =
-        value instanceof Error
-          ? seen.has(value)
-            ? "[Circular]"
-            : depth >= SERIALIZED_ERROR_MAX_DEPTH
-              ? "[Truncated]"
-              : serializeErrorWithSeen(value, seen, depth + 1)
-          : value;
+      serialized[key] = serializeErrorValue(value, seen, depth + 1);
     }
   }
   return serialized;
 }
 
 export function serializeError(err: Error): Record<string, unknown> {
-  return serializeErrorWithSeen(err, new WeakSet<Error>(), 0);
+  return serializeErrorWithSeen(err, new WeakSet<object>(), 0);
+}
+
+function serializeErrorValue(
+  value: unknown,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "symbol") {
+    return value.toString();
+  }
+  if (typeof value === "function") {
+    return value.name ? `[Function ${value.name}]` : "[Function]";
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return CIRCULAR_MARKER;
+  }
+  if (depth > SERIALIZED_VALUE_MAX_DEPTH) {
+    return TRUNCATED_MARKER;
+  }
+  if (value instanceof Error) {
+    return serializeErrorWithSeen(value, seen, depth);
+  }
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isNaN(time) ? value.toString() : value.toISOString();
+  }
+  if (value instanceof RegExp) {
+    return value.toString();
+  }
+
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const items = value.slice(0, SERIALIZED_OBJECT_MAX_ENTRIES).map((item) => {
+      return serializeErrorValue(item, seen, depth + 1);
+    });
+    if (value.length > SERIALIZED_OBJECT_MAX_ENTRIES) {
+      items.push(TRUNCATED_MARKER);
+    }
+    return items;
+  }
+
+  const serialized: Record<string, unknown> = {};
+  let entryCount = 0;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (entryCount >= SERIALIZED_OBJECT_MAX_ENTRIES) {
+      serialized.__truncated = true;
+      break;
+    }
+    serialized[key] = serializeErrorValue(child, seen, depth + 1);
+    entryCount += 1;
+  }
+  return serialized;
 }
 
 /**

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -1,3 +1,5 @@
+const SERIALIZED_ERROR_MAX_DEPTH = 32;
+
 /**
  * Extract message string from log arguments.
  */
@@ -17,6 +19,7 @@ export function formatMessage(args: unknown[]): string {
 function serializeErrorWithSeen(
   err: Error,
   seen: WeakSet<Error>,
+  depth: number,
 ): Record<string, unknown> {
   const serialized: Record<string, unknown> = {
     name: err.name,
@@ -29,7 +32,9 @@ function serializeErrorWithSeen(
       err.cause instanceof Error
         ? seen.has(err.cause)
           ? "[Circular]"
-          : serializeErrorWithSeen(err.cause, seen)
+          : depth >= SERIALIZED_ERROR_MAX_DEPTH
+            ? "[Truncated]"
+            : serializeErrorWithSeen(err.cause, seen, depth + 1)
         : err.cause;
   }
   for (const [key, value] of Object.entries(err)) {
@@ -38,7 +43,9 @@ function serializeErrorWithSeen(
         value instanceof Error
           ? seen.has(value)
             ? "[Circular]"
-            : serializeErrorWithSeen(value, seen)
+            : depth >= SERIALIZED_ERROR_MAX_DEPTH
+              ? "[Truncated]"
+              : serializeErrorWithSeen(value, seen, depth + 1)
           : value;
     }
   }
@@ -46,7 +53,7 @@ function serializeErrorWithSeen(
 }
 
 export function serializeError(err: Error): Record<string, unknown> {
-  return serializeErrorWithSeen(err, new WeakSet<Error>());
+  return serializeErrorWithSeen(err, new WeakSet<Error>(), 0);
 }
 
 /**

--- a/turbo/packages/core/src/log-utils.ts
+++ b/turbo/packages/core/src/log-utils.ts
@@ -1,9 +1,15 @@
 const SERIALIZED_VALUE_MAX_DEPTH = 32;
 const SERIALIZED_OBJECT_MAX_ENTRIES = 64;
+const SERIALIZED_VALUE_MAX_NODES = 1024;
 const SERIALIZED_STRING_MAX_LENGTH = 4096;
 const CIRCULAR_MARKER = "[Circular]";
 const TRUNCATED_MARKER = "[Truncated]";
 const UNREADABLE_MARKER = "[Unreadable]";
+
+interface SerializationState {
+  readonly seen: WeakSet<object>;
+  nodes: number;
+}
 
 interface BoundedEntries {
   readonly entries: readonly [string, unknown][];
@@ -53,7 +59,7 @@ export function formatMessage(args: unknown[]): string {
  */
 function serializeErrorWithSeen(
   err: Error,
-  seen: WeakSet<object>,
+  state: SerializationState,
   depth: number,
 ): Record<string, unknown> {
   const name = safeReadValue(() => {
@@ -69,7 +75,7 @@ function serializeErrorWithSeen(
         ? serializeStringValue(message)
         : UNREADABLE_MARKER,
   };
-  seen.add(err);
+  state.seen.add(err);
   const stack = safeReadValue(() => {
     return err.stack;
   });
@@ -79,7 +85,7 @@ function serializeErrorWithSeen(
       "stack",
       typeof stack === "string"
         ? serializeStringValue(stack)
-        : serializeErrorValue(stack, seen, depth + 1),
+        : serializeErrorValue(stack, state, depth + 1),
     );
   }
   const cause = safeReadValue(() => {
@@ -89,7 +95,7 @@ function serializeErrorWithSeen(
     setSerializedField(
       serialized,
       "cause",
-      serializeErrorValue(cause, seen, depth + 1),
+      serializeErrorValue(cause, state, depth + 1),
     );
   }
   const result = safeOwnEnumerableEntries(err);
@@ -102,7 +108,7 @@ function serializeErrorWithSeen(
       setSerializedField(
         serialized,
         key,
-        serializeErrorValue(value, seen, depth + 1),
+        serializeErrorValue(value, state, depth + 1),
       );
     }
   }
@@ -113,11 +119,12 @@ function serializeErrorWithSeen(
 }
 
 export function serializeError(err: unknown): Record<string, unknown> {
-  const seen = new WeakSet<object>();
+  const state: SerializationState = { seen: new WeakSet<object>(), nodes: 0 };
   if (err instanceof Error) {
-    return serializeErrorWithSeen(err, seen, 0);
+    reserveSerializedNode(state);
+    return serializeErrorWithSeen(err, state, 0);
   }
-  return { value: serializeErrorValue(err, seen, 0) };
+  return { value: serializeErrorValue(err, state, 0) };
 }
 
 function safeReadValue(read: () => unknown): unknown {
@@ -207,7 +214,7 @@ function serializeDateValue(value: Date): unknown {
 
 function serializeArrayValue(
   value: readonly unknown[],
-  seen: WeakSet<object>,
+  state: SerializationState,
   depth: number,
 ): unknown {
   const result = safeOwnEnumerableEntries(value);
@@ -216,7 +223,7 @@ function serializeArrayValue(
   }
   const items = result.entries.map((item) => {
     const [, child] = item;
-    return serializeErrorValue(child, seen, depth + 1);
+    return serializeErrorValue(child, state, depth + 1);
   });
   if (result.truncated) {
     items.push(TRUNCATED_MARKER);
@@ -226,7 +233,7 @@ function serializeArrayValue(
 
 function serializePlainObjectValue(
   value: object,
-  seen: WeakSet<object>,
+  state: SerializationState,
   depth: number,
 ): unknown {
   const result = safeOwnEnumerableEntries(value);
@@ -238,7 +245,7 @@ function serializePlainObjectValue(
     setSerializedField(
       serialized,
       key,
-      serializeErrorValue(child, seen, depth + 1),
+      serializeErrorValue(child, state, depth + 1),
     );
   }
   if (result.truncated) {
@@ -247,22 +254,33 @@ function serializePlainObjectValue(
   return serialized;
 }
 
+function reserveSerializedNode(state: SerializationState): boolean {
+  if (state.nodes >= SERIALIZED_VALUE_MAX_NODES) {
+    return false;
+  }
+  state.nodes += 1;
+  return true;
+}
+
 function serializeErrorValue(
   value: unknown,
-  seen: WeakSet<object>,
+  state: SerializationState,
   depth: number,
 ): unknown {
+  if (!reserveSerializedNode(state)) {
+    return TRUNCATED_MARKER;
+  }
   if (!isObjectValue(value)) {
     return serializeNonObjectValue(value);
   }
-  if (seen.has(value)) {
+  if (state.seen.has(value)) {
     return CIRCULAR_MARKER;
   }
   if (depth > SERIALIZED_VALUE_MAX_DEPTH) {
     return TRUNCATED_MARKER;
   }
   if (value instanceof Error) {
-    return serializeErrorWithSeen(value, seen, depth);
+    return serializeErrorWithSeen(value, state, depth);
   }
   if (value instanceof Date) {
     return serializeDateValue(value);
@@ -271,11 +289,11 @@ function serializeErrorValue(
     return serializeStringValue(safeString(value));
   }
 
-  seen.add(value);
+  state.seen.add(value);
   if (Array.isArray(value)) {
-    return serializeArrayValue(value, seen, depth);
+    return serializeArrayValue(value, state, depth);
   }
-  return serializePlainObjectValue(value, seen, depth);
+  return serializePlainObjectValue(value, state, depth);
 }
 
 /**


### PR DESCRIPTION
## Summary

- add sanitized unhandled API error summaries to the top-level log message
- add stable structured fields for Axiom queries: type, errorSummary, route, method, and optional errorCode
- lift known unhandled request fields into the Axiom event root while preserving serialized error details

Closes #20345

## Verification

- pnpm -F api exec vitest run src/__tests__/app-factory.test.ts src/lib/__tests__/log.test.ts
- pnpm -F api lint
- pnpm -F api check-types
- pnpm format
- git diff --check
- pre-commit: knip and turbo check-types