### PR TITLE
feat: add website template catalog foundation

### DIFF
--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -66,4 +66,5 @@ export enum FeatureSwitchKey {
   BytePlusVoiceInputStt = "bytePlusVoiceInputStt",
   ImageEditing = "imageEditing",
   PresentationGoogleSlidesUpload = "presentationGoogleSlidesUpload",
+  WebsiteTemplates = "websiteTemplates",
 }

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -22,6 +22,7 @@ describe("isFeatureEnabled", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.HtmlArtifactCommentEditing, {}),
     ).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.WebsiteTemplates, {})).toBe(false);
   });
 
   it("should return false for disabled switch with non-matching userId", () => {
@@ -141,6 +142,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       true,
     );
+    expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -167,6 +169,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       false,
     );
+    expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -142,7 +142,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(true);
+    expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  WEBSITE_TEMPLATE_ITEMS,
+  findWebsiteTemplateItem,
+} from "../website-template-items";
+
+describe("website template items", () => {
+  it("exposes the built-in website template catalog in picker order", () => {
+    expect(
+      WEBSITE_TEMPLATE_ITEMS.map((item) => {
+        return item.id;
+      }),
+    ).toEqual(["website-template:warm-cards"]);
+
+    const item = WEBSITE_TEMPLATE_ITEMS[0]!;
+    expect(item).toMatchObject({
+      id: "website-template:warm-cards",
+      slug: "warm-cards",
+      title: "Warm Cards",
+      templateId: "template:warm-cards",
+      resourceId: "template:warm-cards",
+      previewKind: "iframe",
+      sourcePath: "warm-cards",
+      target: "website",
+    });
+  });
+
+  it("uses a CDN-hosted iframe preview asset", () => {
+    for (const item of WEBSITE_TEMPLATE_ITEMS) {
+      expect(item.previewKind).toBe("iframe");
+      expect(item.previewUrl).toMatch(
+        /^https:\/\/cdn\.vm0\.io\/artifacts\/.+\.html$/u,
+      );
+      expect(item.previewUrl).not.toContain("drive.google.com");
+      expect(item.previewUrl).not.toContain("docs.google.com");
+      expect(item.previewUrl).not.toContain("raw.githubusercontent.com");
+    }
+  });
+
+  it("resolves picker, slug, template, and resource identifiers", () => {
+    const item = WEBSITE_TEMPLATE_ITEMS[0]!;
+
+    expect(findWebsiteTemplateItem(item.id)).toBe(item);
+    expect(findWebsiteTemplateItem(item.slug)).toBe(item);
+    expect(findWebsiteTemplateItem(item.templateId)).toBe(item);
+    expect(findWebsiteTemplateItem(item.resourceId)).toBe(item);
+    expect(findWebsiteTemplateItem("template:web-prototype")).toBeUndefined();
+  });
+
+  it("does not expose existing Open Design website templates through the picker catalog", () => {
+    const websiteTemplateIds = WEBSITE_TEMPLATE_ITEMS.flatMap((item) => {
+      return [item.id, item.templateId, item.resourceId];
+    });
+
+    expect(websiteTemplateIds).not.toContain("template:web-prototype");
+    expect(websiteTemplateIds).not.toContain(
+      "template:web-prototype-taste-editorial",
+    );
+    expect(websiteTemplateIds).not.toContain(
+      "template:web-prototype-taste-brutalist",
+    );
+    expect(websiteTemplateIds).not.toContain(
+      "template:web-prototype-taste-soft",
+    );
+  });
+});

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -396,6 +396,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.WebsiteTemplates]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Enable the built-in R2-backed website template picker and generation-template flow.",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -401,7 +401,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable the built-in R2-backed website template picker and generation-template flow.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -36,6 +36,11 @@ export {
   type VideoTemplateItem,
 } from "./video-template-items";
 export {
+  WEBSITE_TEMPLATE_ITEMS,
+  findWebsiteTemplateItem,
+  type WebsiteTemplateItem,
+} from "./website-template-items";
+export {
   WORKFLOW_TEMPLATE_ITEMS,
   findWorkflowTemplateItem,
   type WorkflowTemplateItem,

--- a/turbo/packages/core/src/website-template-items.ts
+++ b/turbo/packages/core/src/website-template-items.ts
@@ -1,0 +1,45 @@
+export interface WebsiteTemplateItem {
+  readonly id: `website-template:${string}`;
+  readonly slug: string;
+  readonly title: string;
+  readonly description: string;
+  readonly templateId: `template:${string}`;
+  readonly resourceId: `template:${string}`;
+  readonly previewKind: "iframe";
+  readonly previewUrl: string;
+  readonly sourcePath: string;
+  readonly target: "website";
+}
+
+// Curated user-facing website picker catalog. Keep this separate from the
+// generic Open Design website registry so feature-switched users only see vm0
+// built-in R2-backed website templates.
+export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
+  {
+    id: "website-template:warm-cards",
+    slug: "warm-cards",
+    title: "Warm Cards",
+    description:
+      "Editorial website template with warm color blocks, rounded content cards, image-led sections, numbered navigation, and a bold footer wordmark.",
+    templateId: "template:warm-cards",
+    resourceId: "template:warm-cards",
+    previewKind: "iframe",
+    previewUrl:
+      "https://cdn.vm0.io/artifacts/user_3EWY21Oe3f15kfs3yYmbGgDb3NV/dbd6ac19-bed3-4abf-bb51-da0bead40914/warm-cards-example.html",
+    sourcePath: "warm-cards",
+    target: "website",
+  },
+];
+
+export function findWebsiteTemplateItem(
+  id: string,
+): WebsiteTemplateItem | undefined {
+  return WEBSITE_TEMPLATE_ITEMS.find((item) => {
+    return (
+      item.id === id ||
+      item.slug === id ||
+      item.templateId === id ||
+      item.resourceId === id
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds the PR1 foundation for the website template work tracked in #20350. This introduces the `websiteTemplates` feature switch, a curated `WEBSITE_TEMPLATE_ITEMS` catalog in `@vm0/core`, and the first `warm-cards` metadata entry with a CDN-hosted iframe preview URL.

The catalog is intentionally separate from the existing Open Design website registry so later picker work can show only vm0 built-in R2-backed website templates behind the feature switch. This PR does not wire the R2 archive, API generationTemplate contract, prompt injection, or frontend picker UI; those remain in later PRs from the issue breakdown.

## Verification

- `pnpm prettier --write packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts packages/core/src/index.ts packages/core/src/website-template-items.ts packages/core/src/__tests__/feature-switch.test.ts packages/core/src/__tests__/website-template-items.spec.ts`
- `pnpm -F @vm0/core exec vitest run src/__tests__/website-template-items.spec.ts src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`

Refs #20350