### PR TITLE
ci: run atom version report with bash

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1491,6 +1491,7 @@ jobs:
           deployment-url: ${{ needs.build-app-production.outputs.deployment_url }}
 
       - name: Record Atom web client version
+        shell: bash
         env:
           ATOM_API_URL: ${{ vars.ATOM_API_URL || 'https://atom-api.vm6.ai' }}
           ATOM_DEPLOY_TOKEN: ${{ secrets.ATOM_DEPLOY_TOKEN }}


### PR DESCRIPTION
## Summary
- set the Atom web client version reporting step to run with bash inside the production app promotion container
- fixes release-please failure where the container defaulted to sh and rejected set -o pipefail before calling Atom

## Validation
- git diff --check -- .github/workflows/release-please.yml
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-please.yml'); puts 'yaml ok'"

Failed run: https://github.com/vm0-ai/vm0/actions/runs/28776439179/job/85323211277
