### PR TITLE
feat: enable sidebar thread list scroll by default

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1117,7 +1117,7 @@ describe("zero sidebar", () => {
     });
   });
 
-  it("keeps pinned agents and the chat title outside the switched thread list scroll area", async () => {
+  it("keeps pinned agents and the chat title outside the thread list scroll area", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({
       pinnedAgentIds: [RESEARCH_AGENT_ID],
@@ -1142,9 +1142,6 @@ describe("zero sidebar", () => {
     setupSidebarPage({
       context,
       path: `/chats/${EXISTING_THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.SidebarThreadListScroll]: true,
-      },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -977,11 +977,7 @@ function ChatThreadsSkeleton() {
   );
 }
 
-function ChatThreadsContent({
-  threadListScroll,
-}: {
-  threadListScroll: boolean;
-}) {
+function ChatThreadsContent() {
   // useLastLoadable keeps the previous resolved list rendered while
   // sidebarChatThreads$ recomputes on a pane/thread switch; useLoadable would
   // flash the skeleton on every switch.
@@ -1007,40 +1003,26 @@ function ChatThreadsContent({
     </div>
   );
 
-  if (threadListScroll) {
-    return (
-      <OverlayScrollArea
-        className="mt-1 min-h-0 flex-1"
-        data-testid="sidebar-scroll-area"
-        onScroll={(e) => {
-          return setIsScrolledFn(e.currentTarget.scrollTop > 0);
-        }}
-        style={{
-          boxShadow: isScrolled
-            ? "0 -1px 0 0 hsl(var(--border) / 0.4)"
-            : "none",
-        }}
-      >
-        {content}
-      </OverlayScrollArea>
-    );
-  }
-
-  return <div className="mt-1">{content}</div>;
-}
-export function ChatThreadsSection({
-  threadListScroll = false,
-}: {
-  threadListScroll?: boolean;
-}) {
   return (
-    <div
-      className={`mt-4 flex flex-col ${
-        threadListScroll ? "min-h-0 flex-1" : ""
-      }`}
+    <OverlayScrollArea
+      className="mt-1 min-h-0 flex-1"
+      data-testid="sidebar-scroll-area"
+      onScroll={(e) => {
+        return setIsScrolledFn(e.currentTarget.scrollTop > 0);
+      }}
+      style={{
+        boxShadow: isScrolled ? "0 -1px 0 0 hsl(var(--border) / 0.4)" : "none",
+      }}
     >
+      {content}
+    </OverlayScrollArea>
+  );
+}
+export function ChatThreadsSection() {
+  return (
+    <div className="mt-4 flex flex-col min-h-0 flex-1">
       <ChatThreadsTitle />
-      <ChatThreadsContent threadListScroll={threadListScroll} />
+      <ChatThreadsContent />
       <ChatThreadRenameDialog />
       <DeleteChatThreadDialog />
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -34,8 +34,6 @@ import type { RouteKey } from "../../signals/route-paths.ts";
 import { defaultAgentName$ } from "../../signals/agent.ts";
 import { currentChatAgentId$ } from "../../signals/agent-chat.ts";
 import {
-  isScrolled$,
-  setIsScrolled$,
   manageSectionCollapsed$,
   setManageSectionCollapsed$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
@@ -47,7 +45,6 @@ import { slackOrgScopeMismatch$ } from "../../signals/zero-page/zero-slack.ts";
 import { AccountDropdown } from "./zero-sidebar-account.tsx";
 import { ChatThreadsSection } from "./sidebar-threads.tsx";
 import { PinnedAgentListSection } from "./zero-sidebar-pinned.tsx";
-import { OverlayScrollArea } from "./zero-sidebar-scroll.tsx";
 import { SidebarUpgradeCard } from "./zero-sidebar-upgrade.tsx";
 
 export { AccountDropdown } from "./zero-sidebar-account.tsx";
@@ -127,18 +124,9 @@ const FOOTER_NAV = [
 // Leaf component: subscribes to currentChatAgentId$ so ZeroSidebar doesn't re-render on agent changes.
 // useLastResolved keeps the previously-resolved agent ID during re-loads, preventing unnecessary
 // remounts of ChatThreadsSection that would cause the chat list to flash.
-function ChatThreadsSectionWithKey({
-  threadListScroll = false,
-}: {
-  threadListScroll?: boolean;
-}) {
+function ChatThreadsSectionWithKey() {
   const currentChatAgentId = useLastResolved(currentChatAgentId$);
-  return (
-    <ChatThreadsSection
-      key={currentChatAgentId}
-      threadListScroll={threadListScroll}
-    />
-  );
+  return <ChatThreadsSection key={currentChatAgentId} />;
 }
 
 // Shared subscription hooks. Each sibling component pulls its own state from
@@ -557,38 +545,11 @@ function CollapsedManageNav({
 }
 
 function ExpandedSidebarSections() {
-  const features = useGet(featureSwitch$);
-  const threadListScroll =
-    features[FeatureSwitchKey.SidebarThreadListScroll] ?? false;
-  if (threadListScroll) {
-    return (
-      <div className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2 flex flex-col overflow-hidden">
-        <PinnedAgentListSection />
-        <ChatThreadsSectionWithKey threadListScroll />
-      </div>
-    );
-  }
-
-  return <ExpandedScrollArea />;
-}
-
-function ExpandedScrollArea() {
-  const isScrolled = useGet(isScrolled$);
-  const setIsScrolledFn = useSet(setIsScrolled$);
   return (
-    <OverlayScrollArea
-      className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2"
-      data-testid="sidebar-scroll-area"
-      onScroll={(e) => {
-        return setIsScrolledFn(e.currentTarget.scrollTop > 0);
-      }}
-      style={{
-        boxShadow: isScrolled ? "0 -1px 0 0 hsl(var(--border) / 0.4)" : "none",
-      }}
-    >
+    <div className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2 flex flex-col overflow-hidden">
       <PinnedAgentListSection />
       <ChatThreadsSectionWithKey />
-    </OverlayScrollArea>
+    </div>
   );
 }
 

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -59,7 +59,6 @@ export enum FeatureSwitchKey {
   ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",
   AgentsPageRedesign = "agentsPageRedesign",
   SidebarManageIconCollapse = "sidebarManageIconCollapse",
-  SidebarThreadListScroll = "sidebarThreadListScroll",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   ChatThreadLatestUserMessageScrollAnchor = "chatThreadLatestUserMessageScrollAnchor",
   TeamsIntegration = "teamsIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -349,12 +349,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.SidebarThreadListScroll]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Scroll only the chat thread list in the Zero sidebar so pinned agents stay visible.",
-    enabled: false,
-  },
   [FeatureSwitchKey.SidebarSubscriptionUsage]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Enable the Zero sidebar thread-list-only scroll behavior for everyone by making it the only expanded sidebar layout.
- Remove the retired `sidebarThreadListScroll` feature switch from the shared key enum and server-side switch registry.
- Clean up the old full-sidebar scroll branch and simplify the sidebar thread components/tests around the default behavior.

## Verification
- `pnpm exec prettier --write packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts apps/platform/src/views/zero-page/zero-sidebar.tsx apps/platform/src/views/zero-page/sidebar-threads.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`

Note: The first app type-check attempt hit Node's default heap limit; rerunning the same check with a larger heap passed.
