### PR TITLE
feat: add runner builtin firewall resolver

### DIFF
--- a/crates/api-contracts/src/generated/routes.rs
+++ b/crates/api-contracts/src/generated/routes.rs
@@ -8,6 +8,19 @@
 
 /// Generated route bindings under `runners`.
 pub mod runners {
+    /// Generated route bindings under `runners::builtin_firewalls`.
+    pub mod builtin_firewalls {
+        /// Generated route bindings under `runners::builtin_firewalls::resolve`.
+        pub mod resolve {
+            /// Resolve builtin firewall definitions for runners.
+            /// Route contract: `POST /api/runners/builtin-firewalls/resolve`.
+            pub const RESOLVE: crate::Route = crate::Route {
+                method: crate::Method::Post,
+                path: "/api/runners/builtin-firewalls/resolve",
+            };
+        }
+    }
+
     /// Generated route bindings under `runners::heartbeat`.
     pub mod heartbeat {
         /// Report runner heartbeat with capacity and state.

--- a/turbo/.prettierignore
+++ b/turbo/.prettierignore
@@ -10,6 +10,7 @@ packages/connectors/src/firewall-metadata/.*.previous-*
 packages/connectors/src/firewall-metadata/permission-details/*.generated.ts
 packages/connectors/src/firewall-metadata/details/*.generated.ts
 packages/connectors/src/firewall-metadata/routing-details/*.generated.ts
+packages/connectors/src/firewall-metadata/runner-runtime-details/*.generated.ts
 packages/connectors/src/firewall-execution-metadata/*.generated.ts
 packages/connectors/src/firewall-execution-metadata/.metadata-*
 packages/connectors/src/firewall-execution-metadata/.*.previous-*

--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -1,0 +1,87 @@
+import {
+  runnersBuiltinFirewallsResolveContract,
+  type RunnerBuiltinFirewallsResolveResponse,
+} from "@vm0/api-contracts/contracts/runners";
+import {
+  RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
+} from "@vm0/connectors/firewall-metadata/runner-runtime";
+import { describe, expect, it } from "vitest";
+
+import { setupAppWithRoutes } from "../../../__tests__/test-app";
+import { accept, testContext } from "../../../__tests__/test-context";
+import { runnersRoutes } from "../runners";
+
+const context = testContext();
+const OFFICIAL_RUNNER_AUTHORIZATION =
+  "Bearer vm0_official_abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+const OPENAI_API_KEY_AUTH_HEADER = [
+  "Bearer $",
+  "{{ secrets.OPENAI_API_KEY }}",
+].join("");
+
+function client() {
+  return setupAppWithRoutes({ context, routes: runnersRoutes })(
+    runnersBuiltinFirewallsResolveContract,
+  );
+}
+
+describe("runner builtin firewall resolver", () => {
+  it("requires runner authentication", async () => {
+    const response = await accept(
+      client().resolve({
+        headers: {},
+        body: { names: ["github"] },
+      }),
+      [401],
+    );
+
+    expect(response.body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects unknown builtin firewall names", async () => {
+    const response = await accept(
+      client().resolve({
+        headers: { authorization: OFFICIAL_RUNNER_AUTHORIZATION },
+        body: { names: ["github", "not-a-builtin-firewall"] },
+      }),
+      [400],
+    );
+
+    expect(response.body.error.message).toBe(
+      "Unknown builtin firewall: not-a-builtin-firewall",
+    );
+  });
+
+  it("resolves connector and model-provider builtin firewalls", async () => {
+    const response = await accept(
+      client().resolve({
+        headers: { authorization: OFFICIAL_RUNNER_AUTHORIZATION },
+        body: {
+          names: ["github", "github", "model-provider:openai-api-key"],
+        },
+      }),
+      [200],
+    );
+    const body: RunnerBuiltinFirewallsResolveResponse = response.body;
+
+    expect(body.catalogDigest).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST);
+    expect(body.catalogVersion).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION);
+    expect(Object.keys(body.firewalls).sort()).toStrictEqual([
+      "github",
+      "model-provider:openai-api-key",
+    ]);
+    expect(body.firewalls.github?.name).toBe("github");
+    expect(
+      body.firewalls["model-provider:openai-api-key"]?.apis[0],
+    ).toStrictEqual({
+      base: "https://api.openai.com/v1/responses",
+      auth: {
+        headers: {
+          Authorization: OPENAI_API_KEY_AUTH_HEADER,
+        },
+      },
+      permissions: [],
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -3,6 +3,7 @@ import {
   elapsedSinceApiStartMs,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   runnersNetworkPolicyRefreshContract,
+  runnersBuiltinFirewallsResolveContract,
   runnersHeartbeatContract,
   runnersJobClaimContract,
   runnersPollContract,
@@ -11,6 +12,12 @@ import {
   type HeldSessionState,
   type StoredExecutionContext,
 } from "@vm0/api-contracts/contracts/runners";
+import {
+  RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
+  hasRunnerRuntimeFirewall,
+  loadRunnerRuntimeFirewalls,
+} from "@vm0/connectors/firewall-metadata/runner-runtime";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
@@ -531,6 +538,9 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
 const claimBody$ = bodyResultOf(runnersJobClaimContract.claim);
 const networkPolicyRefreshBody$ = bodyResultOf(
   runnersNetworkPolicyRefreshContract.refresh,
+);
+const builtinFirewallsResolveBody$ = bodyResultOf(
+  runnersBuiltinFirewallsResolveContract.resolve,
 );
 
 interface ClaimableJob {
@@ -1922,6 +1932,44 @@ const runnerRealtimeTokenInner$ = command(
   },
 );
 
+const builtinFirewallsResolveInner$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const auth = await set(runnerAuth$, get(authorization$), signal);
+    signal.throwIfAborted();
+    if (!auth) {
+      return unauthorizedAuthenticationRequired;
+    }
+
+    const body = await get(builtinFirewallsResolveBody$);
+    signal.throwIfAborted();
+    if (!body.ok) {
+      return body.response;
+    }
+
+    const names = [...new Set(body.data.names)];
+    const missingNames = names.filter((name) => {
+      return !hasRunnerRuntimeFirewall(name);
+    });
+    if (missingNames.length > 0) {
+      return badRequestMessage(
+        `Unknown builtin firewall: ${missingNames.join(", ")}`,
+      );
+    }
+
+    const firewalls = await loadRunnerRuntimeFirewalls(names);
+    signal.throwIfAborted();
+
+    return {
+      status: 200 as const,
+      body: {
+        catalogDigest: RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+        catalogVersion: RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
+        firewalls,
+      },
+    };
+  },
+);
+
 export const runnersRoutes: readonly RouteEntry[] = [
   {
     route: runnersHeartbeatContract.heartbeat,
@@ -1938,6 +1986,10 @@ export const runnersRoutes: readonly RouteEntry[] = [
   {
     route: runnersNetworkPolicyRefreshContract.refresh,
     handler: networkPolicyRefreshInner$,
+  },
+  {
+    route: runnersBuiltinFirewallsResolveContract.resolve,
+    handler: builtinFirewallsResolveInner$,
   },
   {
     route: runnerRealtimeTokenContract.create,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from "vitest";
 import {
   elapsedSinceApiStartMs,
   executionContextSchema,
+  RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   RESUME_SESSION_HISTORY_MAX_BYTES,
   resumeSessionSchema,
+  runnersBuiltinFirewallsResolveContract,
   runnersJobClaimContract,
   storageManifestSchema,
   storedExecutionContextSchema,
@@ -356,6 +358,40 @@ describe("runner claim capability contract", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+});
+
+describe("runner builtin firewall resolve contract", () => {
+  it("accepts connector and model-provider names", () => {
+    const result =
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: ["github", "model-provider:openai-api-key"],
+      });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects malformed and oversized requests", () => {
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: ["ModelProvider:openai-api-key"],
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: ["model-provider:"],
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: Array.from(
+          { length: RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX + 1 },
+          (_, index) => {
+            return `github-${index}`;
+          },
+        ),
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -836,6 +836,7 @@ export {
   runnersPollContract,
   runnersJobClaimContract,
   runnersNetworkPolicyRefreshContract,
+  runnersBuiltinFirewallsResolveContract,
   runnersHeartbeatContract,
   heartbeatBodySchema,
   runnerGroupSchema,
@@ -850,12 +851,14 @@ export {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
   DEFAULT_PROFILE,
+  RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX,
   artifactEntrySchema,
   storageManifestSchema,
   resumeSessionSchema,
   type RunnersPollContract,
   type RunnersJobClaimContract,
   type RunnersNetworkPolicyRefreshContract,
+  type RunnersBuiltinFirewallsResolveContract,
   type RunnersHeartbeatContract,
   type Job,
   type ExecutionContext,
@@ -866,6 +869,8 @@ export {
   type ArtifactEntry,
   type StorageManifest,
   type ResumeSession,
+  type RunnerBuiltinFirewallsResolveBody,
+  type RunnerBuiltinFirewallsResolveResponse,
 } from "./runners";
 
 export {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import {
   executionFirewallsSchema,
+  firewallSchema,
   networkPolicySchema,
   networkPoliciesSchema,
 } from "@vm0/connectors/firewall-types";
@@ -28,6 +29,7 @@ export const SESSION_HISTORY_ENCODING_GZIP = "gzip";
 export const SESSION_HISTORY_ENCODING_ZSTD = "zstd";
 export const SESSION_HISTORY_GZIP_MIN_BYTES = 64 * 1024;
 export const NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX = 256;
+export const RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX = 512;
 export const sessionHistoryEncodingSchema = z.enum([
   SESSION_HISTORY_ENCODING_IDENTITY,
   SESSION_HISTORY_ENCODING_GZIP,
@@ -83,6 +85,22 @@ const networkPolicyRefreshesSchema = z.record(
   z.string(),
   networkPolicyRefreshSchema,
 );
+const runnerBuiltinFirewallNameSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^(?:[a-z0-9][a-z0-9-]*|model-provider:[a-z0-9][a-z0-9-]*)$/);
+const runnerBuiltinFirewallsResolveBodySchema = z.object({
+  names: z
+    .array(runnerBuiltinFirewallNameSchema)
+    .min(1)
+    .max(RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX),
+});
+const runnerBuiltinFirewallsResolveResponseSchema = z.object({
+  catalogDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  catalogVersion: z.string().min(1),
+  firewalls: z.record(runnerBuiltinFirewallNameSchema, firewallSchema),
+});
 
 /**
  * Default profile when none is specified.
@@ -480,6 +498,22 @@ export const runnersNetworkPolicyRefreshContract = c.router({
   },
 });
 
+export const runnersBuiltinFirewallsResolveContract = c.router({
+  resolve: {
+    method: "POST",
+    path: "/api/runners/builtin-firewalls/resolve",
+    headers: authHeadersSchema,
+    body: runnerBuiltinFirewallsResolveBodySchema,
+    responses: {
+      200: runnerBuiltinFirewallsResolveResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Resolve builtin firewall definitions for runners",
+  },
+});
+
 /**
  * Runner heartbeat body — periodic state report from each runner
  */
@@ -523,6 +557,8 @@ export type RunnersJobClaimContract = typeof runnersJobClaimContract;
 export type RunnersNetworkPolicyRefreshContract =
   typeof runnersNetworkPolicyRefreshContract;
 export type RunnersHeartbeatContract = typeof runnersHeartbeatContract;
+export type RunnersBuiltinFirewallsResolveContract =
+  typeof runnersBuiltinFirewallsResolveContract;
 export type Job = z.infer<typeof jobSchema>;
 export type HeldSessionState = z.infer<typeof heldSessionStateSchema>;
 export type ExecutionContext = z.infer<typeof executionContextSchema>;
@@ -530,6 +566,12 @@ export type StoredExecutionContext = z.infer<
   typeof storedExecutionContextSchema
 >;
 export type NetworkPolicyRefresh = z.infer<typeof networkPolicyRefreshSchema>;
+export type RunnerBuiltinFirewallsResolveBody = z.infer<
+  typeof runnerBuiltinFirewallsResolveBodySchema
+>;
+export type RunnerBuiltinFirewallsResolveResponse = z.infer<
+  typeof runnerBuiltinFirewallsResolveResponseSchema
+>;
 export type SecretConnectorMetadata = z.infer<
   typeof secretConnectorMetadataSchema
 >;

--- a/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
+++ b/turbo/packages/api-contracts/src/runtime-api-schema/routes.ts
@@ -1,5 +1,6 @@
 import { runnerRealtimeTokenContract } from "../contracts/realtime";
 import {
+  runnersBuiltinFirewallsResolveContract,
   runnersHeartbeatContract,
   runnersJobClaimContract,
   runnersPollContract,
@@ -58,6 +59,11 @@ export const runtimeApiRouteBindings = [
     id: "runners.realtime.token",
     owner: "runner",
     route: runnerRealtimeTokenContract.create,
+  },
+  {
+    id: "runners.builtinFirewalls.resolve",
+    owner: "runner",
+    route: runnersBuiltinFirewallsResolveContract.resolve,
   },
   {
     id: "webhooks.agent.events",

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/routes.test.ts
@@ -22,6 +22,12 @@ const expectedBindings = [
   },
   {
     method: "POST",
+    path: "/api/runners/builtin-firewalls/resolve",
+    rustModulePath: ["runners", "builtin_firewalls", "resolve"],
+    rustConstName: "RESOLVE",
+  },
+  {
+    method: "POST",
     path: "/api/runners/heartbeat",
     rustModulePath: ["runners", "heartbeat"],
     rustConstName: "HEARTBEAT",

--- a/turbo/packages/api-contracts/src/rust-bindings/routes.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/routes.ts
@@ -1,6 +1,7 @@
 import { runnerRealtimeTokenContract } from "../contracts/realtime";
 import {
   runnersNetworkPolicyRefreshContract,
+  runnersBuiltinFirewallsResolveContract,
   runnersHeartbeatContract,
   runnersJobClaimContract,
   runnersPollContract,
@@ -43,6 +44,11 @@ export const rustRouteBindings = [
     route: runnersNetworkPolicyRefreshContract.refresh,
     rustModulePath: ["runners", "runs", "by_run_id", "network_policy_refresh"],
     rustConstName: "REFRESH",
+  },
+  {
+    route: runnersBuiltinFirewallsResolveContract.resolve,
+    rustModulePath: ["runners", "builtin_firewalls", "resolve"],
+    rustConstName: "RESOLVE",
   },
   {
     route: runnersHeartbeatContract.heartbeat,

--- a/turbo/packages/connectors/.gitignore
+++ b/turbo/packages/connectors/.gitignore
@@ -4,3 +4,4 @@ src/firewall-metadata/.metadata-*
 src/firewall-metadata/.*.previous-*
 src/firewall-metadata/permission-details/*
 src/firewall-metadata/routing-details/*
+src/firewall-metadata/runner-runtime-details/*

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -56,6 +56,10 @@
       "import": "./src/firewall-metadata/routing.ts",
       "types": "./src/firewall-metadata/routing.ts"
     },
+    "./firewall-metadata/runner-runtime": {
+      "import": "./src/firewall-metadata/runner-runtime.ts",
+      "types": "./src/firewall-metadata/runner-runtime.ts"
+    },
     "./firewalls": null,
     "./firewalls/*": null,
     "./auth-providers": {

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -3,6 +3,13 @@ import * as path from "node:path";
 import * as ts from "typescript";
 import { describe, expect, it } from "vitest";
 
+import {
+  RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
+  hasRunnerRuntimeFirewall,
+  loadRunnerRuntimeFirewall,
+} from "../firewall-metadata/runner-runtime";
+
 function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
@@ -348,6 +355,89 @@ describe("firewall runtime surface", () => {
     expect(
       fs.existsSync(path.resolve(import.meta.dirname, "../firewalls")),
     ).toBe(false);
+  });
+
+  it("exposes runner runtime firewalls only through the firewall metadata subpath", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.resolve(import.meta.dirname, "../../package.json"),
+        "utf-8",
+      ),
+    ) as { exports: Record<string, unknown> };
+    const rootEntrypoint = fs.readFileSync(
+      path.resolve(import.meta.dirname, "../index.ts"),
+      "utf-8",
+    );
+    const runnerRuntimeEntrypoint = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../firewall-metadata/runner-runtime.ts",
+      ),
+      "utf-8",
+    );
+    const runnerRuntimeLoader = fs.readFileSync(
+      path.resolve(
+        import.meta.dirname,
+        "../firewall-metadata/runner-runtime-loader.generated.ts",
+      ),
+      "utf-8",
+    );
+    const dynamicSpecifiers = dynamicImportSpecifiers(runnerRuntimeLoader);
+
+    expect(packageJson.exports["./firewall-metadata/runner-runtime"]).toEqual({
+      import: "./src/firewall-metadata/runner-runtime.ts",
+      types: "./src/firewall-metadata/runner-runtime.ts",
+    });
+    expect(rootEntrypoint).not.toContain("firewall-metadata/runner-runtime");
+    expect(staticValueModuleSpecifiers(runnerRuntimeEntrypoint)).toStrictEqual([
+      "./runner-runtime-loader.generated",
+    ]);
+    expect(dynamicSpecifiers).toContain(
+      "./runner-runtime-details/github.generated",
+    );
+    expect(dynamicSpecifiers).toContainEqual(
+      expect.stringMatching(
+        /^\.\/runner-runtime-details\/model-provider-openai-api-key-[a-f0-9]{12}\.generated$/,
+      ),
+    );
+    expect(new Set(dynamicSpecifiers).size).toBe(dynamicSpecifiers.length);
+  });
+
+  it("loads connector and model-provider runner runtime firewalls lazily", async () => {
+    expect(RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST).toMatch(
+      /^sha256:[a-f0-9]{64}$/,
+    );
+    expect(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION).toMatch(
+      /^sha256-[a-f0-9]{12}$/,
+    );
+    expect(hasRunnerRuntimeFirewall("github")).toBe(true);
+    expect(hasRunnerRuntimeFirewall("model-provider:openai-api-key")).toBe(
+      true,
+    );
+    expect(hasRunnerRuntimeFirewall("not-a-builtin-firewall")).toBe(false);
+
+    const github = await loadRunnerRuntimeFirewall("github");
+    const openai = await loadRunnerRuntimeFirewall(
+      "model-provider:openai-api-key",
+    );
+    const missing = await loadRunnerRuntimeFirewall("not-a-builtin-firewall");
+
+    expect(github?.name).toBe("github");
+    expect(openai).toStrictEqual({
+      name: "model-provider:openai-api-key",
+      apis: [
+        {
+          base: "https://api.openai.com/v1/responses",
+          auth: {
+            headers: {
+              Authorization: "Bearer ${{ secrets.OPENAI_API_KEY }}",
+            },
+          },
+          permissions: [],
+        },
+      ],
+    });
+    expect(missing).toBeNull();
   });
 
   it("does not statically import the eager registry or connector runtime modules", () => {

--- a/turbo/packages/connectors/src/firewall-metadata/runner-runtime.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/runner-runtime.ts
@@ -1,0 +1,37 @@
+import type { Firewall } from "../firewall-types";
+import {
+  RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
+  hasGeneratedRunnerRuntimeFirewall,
+  loadGeneratedRunnerRuntimeFirewall,
+} from "./runner-runtime-loader.generated";
+
+export {
+  RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
+};
+
+export function hasRunnerRuntimeFirewall(type: string): boolean {
+  return hasGeneratedRunnerRuntimeFirewall(type);
+}
+
+export async function loadRunnerRuntimeFirewall(
+  type: string,
+): Promise<Firewall | null> {
+  return await loadGeneratedRunnerRuntimeFirewall(type);
+}
+
+export async function loadRunnerRuntimeFirewalls(
+  types: readonly string[],
+): Promise<Record<string, Firewall>> {
+  const entries = await Promise.all(
+    types.map(async (type) => {
+      const firewall = await loadRunnerRuntimeFirewall(type);
+      if (!firewall) {
+        throw new Error(`Missing runner runtime firewall: ${type}`);
+      }
+      return [type, firewall] as const;
+    }),
+  );
+  return Object.fromEntries(entries);
+}

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "@vm0/api-contracts/contracts/model-provider-firewalls";
 import {
   generatedFirewallExportName,
   generatedConnectorMetadataFileName,
@@ -781,6 +782,51 @@ describe("firewall metadata generator", () => {
         );
         assertRoutingMetadataSourceExcludesAuthData(detailSource, filename);
       }
+    },
+    FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "projects runner runtime firewalls from connector and model provider data",
+    async () => {
+      const sourceSet = await loadConnectorFirewallSourceSet({
+        connectorsDir: CONNECTORS_DIR,
+      });
+      const loaderSource = fs.readFileSync(
+        path.resolve(
+          import.meta.dirname,
+          "../../../connectors/src/firewall-metadata/runner-runtime-loader.generated.ts",
+        ),
+        "utf-8",
+      );
+      const dynamicSpecifiers = dynamicImportSpecifiers(loaderSource);
+
+      expect(dynamicSpecifiers.length).toBe(
+        sourceSet.sources.length +
+          Object.keys(MODEL_PROVIDER_FIREWALL_CONFIGS).length,
+      );
+      expect(dynamicSpecifiers).toContain(
+        "./runner-runtime-details/github.generated",
+      );
+      expect(dynamicSpecifiers).toContainEqual(
+        expect.stringMatching(
+          /^\.\/runner-runtime-details\/model-provider-openai-api-key-[a-f0-9]{12}\.generated$/,
+        ),
+      );
+      expect(loaderSource).toContain('["model-provider:openai-api-key"]');
+      expect(loaderSource).toContain("RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST");
+
+      const googleDriveRuntimeSource = fs.readFileSync(
+        path.resolve(
+          import.meta.dirname,
+          "../../../connectors/src/firewall-metadata/runner-runtime-details/google-drive.generated.ts",
+        ),
+        "utf-8",
+      );
+      expect(googleDriveRuntimeSource).toMatch(/"?name"?:\s*"google-drive"/);
+      expect(googleDriveRuntimeSource).not.toContain('"description"');
+      expect(googleDriveRuntimeSource).not.toContain("placeholders");
+      expect(googleDriveRuntimeSource).not.toContain("defaultPolicies");
     },
     FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
   );

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -1,6 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createHash } from "node:crypto";
 
+import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "@vm0/api-contracts/contracts/model-provider-firewalls";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import type {
   FirewallPermissionDefaultPolicyMetadata,
@@ -15,6 +17,7 @@ import type {
 import type { FirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
 import type {
   FirewallConfig,
+  Firewall,
   FirewallBaseHostPolicy,
   FirewallPolicy,
   FirewallPolicyValue,
@@ -32,6 +35,7 @@ import {
 } from "./lazy-loader-renderer";
 
 const POLICY_VALUES = ["allow", "deny", "ask"] as const;
+const GENERATED_METADATA_FILE_STEM_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
   "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
 const BASE_URL_VARS_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/;
@@ -96,6 +100,31 @@ function generatedRoutingDetailModuleSpecifier(
   type: FirewallConnectorType,
 ): string {
   return `./routing-details/${generatedConnectorMetadataFileName(type).replace(/\.ts$/, "")}`;
+}
+
+function generatedRunnerRuntimeDetailModuleSpecifier(name: string): string {
+  return `./runner-runtime-details/${generatedRunnerRuntimeDetailFileName(name).replace(/\.ts$/, "")}`;
+}
+
+function runnerRuntimeDetailFileStem(name: string): string {
+  if (GENERATED_METADATA_FILE_STEM_PATTERN.test(name)) {
+    return name;
+  }
+
+  const sanitized = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-");
+  const base = sanitized.length > 0 ? sanitized : "firewall";
+  const hash = createHash("sha256").update(name).digest("hex").slice(0, 12);
+  const maxPrefixLength = 96 - hash.length - "-".length;
+  const prefix = base.slice(0, maxPrefixLength).replace(/-+$/g, "");
+  return `${prefix.length > 0 ? prefix : "firewall"}-${hash}`;
+}
+
+function generatedRunnerRuntimeDetailFileName(name: string): string {
+  return `${runnerRuntimeDetailFileStem(name)}.generated.ts`;
 }
 
 function replaceGeneratedPath(
@@ -210,6 +239,73 @@ function buildFixedHostOwners(
     }
   }
   return sortedRecord(owners.entries());
+}
+
+interface RunnerRuntimePermissionSource {
+  readonly name: string;
+  readonly rules: readonly string[];
+}
+
+interface RunnerRuntimeApiSource {
+  readonly base: string;
+  readonly hostPolicy?: FirewallBaseHostPolicy;
+  readonly auth: Firewall["apis"][number]["auth"];
+  readonly permissions?: readonly RunnerRuntimePermissionSource[];
+}
+
+interface RunnerRuntimeFirewallSource {
+  readonly name: string;
+  readonly apis: readonly RunnerRuntimeApiSource[];
+}
+
+interface RunnerRuntimeDetail {
+  readonly name: string;
+  readonly fileName: string;
+  readonly moduleSpecifier: string;
+  readonly firewall: Firewall;
+  readonly content: string;
+}
+
+function buildRunnerRuntimeFirewall(
+  firewall: RunnerRuntimeFirewallSource,
+): Firewall {
+  return {
+    name: firewall.name,
+    apis: firewall.apis.map((api) => {
+      return {
+        base: api.base,
+        ...(api.hostPolicy !== undefined ? { hostPolicy: api.hostPolicy } : {}),
+        auth: api.auth,
+        permissions: (api.permissions ?? []).map((permission) => {
+          return {
+            name: permission.name,
+            rules: [...permission.rules],
+          };
+        }),
+      };
+    }),
+  };
+}
+
+function assertUniqueRunnerRuntimeDetails(
+  details: readonly RunnerRuntimeDetail[],
+): void {
+  const names = new Set<string>();
+  const fileNames = new Map<string, string>();
+  for (const detail of details) {
+    if (names.has(detail.name)) {
+      throw new Error(`Duplicate runner runtime firewall name: ${detail.name}`);
+    }
+    names.add(detail.name);
+
+    const previousFileOwner = fileNames.get(detail.fileName);
+    if (previousFileOwner) {
+      throw new Error(
+        `Duplicate runner runtime firewall file name: ${detail.fileName} (${previousFileOwner}, ${detail.name})`,
+      );
+    }
+    fileNames.set(detail.fileName, detail.name);
+  }
 }
 
 function choosePermissionDefault(policy: FirewallPolicy): FirewallPolicyValue {
@@ -573,6 +669,13 @@ export const firewallRoutingMetadata = ${stableJson(metadata)} as const satisfie
 `;
 }
 
+function renderRunnerRuntimeDetailFile(firewall: Firewall): string {
+  return `${generatedHeader()}import type { Firewall } from "../../firewall-types";
+
+export const runnerRuntimeFirewall = ${stableJson(firewall)} as const satisfies Firewall;
+`;
+}
+
 function renderRoutingIndexFile(
   metadata: Record<string, FirewallRoutingIndexMetadata>,
 ): string {
@@ -669,6 +772,67 @@ export async function loadGeneratedFirewallRoutingMetadata(
 `;
 }
 
+function renderRunnerRuntimeLoaderFile(args: {
+  readonly catalogDigest: string;
+  readonly catalogVersion: string;
+  readonly entries: readonly {
+    readonly name: string;
+    readonly moduleSpecifier: string;
+  }[];
+}): string {
+  const loaderEntries = args.entries.map((entry): LazyLoaderEntry => {
+    return {
+      key: entry.name,
+      moduleSpecifier: entry.moduleSpecifier,
+      exportName: "runnerRuntimeFirewall",
+    };
+  });
+
+  return `${generatedHeader()}import type { Firewall } from "../firewall-types";
+
+export const RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST = ${JSON.stringify(args.catalogDigest)};
+export const RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION = ${JSON.stringify(args.catalogVersion)};
+
+${renderLazyLoaderRecord({
+  constName: "RUNNER_RUNTIME_FIREWALL_LOADERS",
+  recordType: "Record<string, () => Promise<Firewall>>",
+  entries: loaderEntries,
+})}
+
+export function hasGeneratedRunnerRuntimeFirewall(
+  type: string,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(
+    RUNNER_RUNTIME_FIREWALL_LOADERS,
+    type,
+  );
+}
+
+export async function loadGeneratedRunnerRuntimeFirewall(
+  type: string,
+): Promise<Firewall | null> {
+  const load = RUNNER_RUNTIME_FIREWALL_LOADERS[type];
+  if (!load) {
+    return null;
+  }
+  return await load();
+}
+`;
+}
+
+function catalogDigest(runtimeFirewalls: Readonly<Record<string, Firewall>>): {
+  readonly digest: string;
+  readonly version: string;
+} {
+  const hex = createHash("sha256")
+    .update(stableJson(runtimeFirewalls))
+    .digest("hex");
+  return {
+    digest: `sha256:${hex}`,
+    version: `sha256-${hex.slice(0, 12)}`,
+  };
+}
+
 export async function generateFirewallMetadata(): Promise<void> {
   console.error("\n=== firewall metadata ===");
 
@@ -699,8 +863,16 @@ export async function generateFirewallMetadata(): Promise<void> {
     outputDir,
     "server-execution.generated.ts",
   );
+  const runnerRuntimeLoaderFile = path.join(
+    outputDir,
+    "runner-runtime-loader.generated.ts",
+  );
   const permissionDetailsDir = path.join(outputDir, "permission-details");
   const routingDetailsDir = path.join(outputDir, "routing-details");
+  const runnerRuntimeDetailsDir = path.join(
+    outputDir,
+    "runner-runtime-details",
+  );
 
   const { sources, registryOrderedSources, billableTypes } =
     await loadConnectorFirewallSourceSet({
@@ -717,10 +889,12 @@ export async function generateFirewallMetadata(): Promise<void> {
     readonly type: FirewallConnectorType;
     readonly content: string;
   }[] = [];
+  const runnerRuntimeDetails: RunnerRuntimeDetail[] = [];
 
   for (const source of sources) {
     const detail = buildDetailMetadata(source);
     const executionDetail = buildExecutionMetadata(source, billableTypes);
+    const runnerRuntimeFirewall = buildRunnerRuntimeFirewall(source.firewall);
     summaries[source.type] = buildSummaryMetadata(detail);
     executionMetadata[source.type] = executionDetail;
     permissionDetails.push({
@@ -732,7 +906,43 @@ export async function generateFirewallMetadata(): Promise<void> {
       type: source.type,
       content: renderRoutingDetailFile(buildRoutingMetadata(source)),
     });
+    runnerRuntimeDetails.push({
+      name: runnerRuntimeFirewall.name,
+      fileName: generatedRunnerRuntimeDetailFileName(
+        runnerRuntimeFirewall.name,
+      ),
+      moduleSpecifier: generatedRunnerRuntimeDetailModuleSpecifier(
+        runnerRuntimeFirewall.name,
+      ),
+      firewall: runnerRuntimeFirewall,
+      content: renderRunnerRuntimeDetailFile(runnerRuntimeFirewall),
+    });
   }
+  for (const firewall of Object.values(MODEL_PROVIDER_FIREWALL_CONFIGS)) {
+    const runnerRuntimeFirewall = buildRunnerRuntimeFirewall(firewall);
+    runnerRuntimeDetails.push({
+      name: runnerRuntimeFirewall.name,
+      fileName: generatedRunnerRuntimeDetailFileName(
+        runnerRuntimeFirewall.name,
+      ),
+      moduleSpecifier: generatedRunnerRuntimeDetailModuleSpecifier(
+        runnerRuntimeFirewall.name,
+      ),
+      firewall: runnerRuntimeFirewall,
+      content: renderRunnerRuntimeDetailFile(runnerRuntimeFirewall),
+    });
+  }
+  assertUniqueRunnerRuntimeDetails(runnerRuntimeDetails);
+  const runnerRuntimeCatalog = Object.fromEntries(
+    runnerRuntimeDetails
+      .map((detail) => {
+        return [detail.name, detail.firewall] as const;
+      })
+      .sort(([a], [b]) => {
+        return compareStrings(a, b);
+      }),
+  );
+  const runnerRuntimeCatalogDigest = catalogDigest(runnerRuntimeCatalog);
 
   const nextOutputDir = fs.mkdtempSync(path.join(outputDir, ".metadata-"));
   const nextPermissionDetailsDir = path.join(
@@ -740,6 +950,10 @@ export async function generateFirewallMetadata(): Promise<void> {
     "permission-details",
   );
   const nextRoutingDetailsDir = path.join(nextOutputDir, "routing-details");
+  const nextRunnerRuntimeDetailsDir = path.join(
+    nextOutputDir,
+    "runner-runtime-details",
+  );
 
   for (const detail of permissionDetails) {
     writeGeneratedFile(
@@ -756,6 +970,12 @@ export async function generateFirewallMetadata(): Promise<void> {
         nextRoutingDetailsDir,
         generatedConnectorMetadataFileName(detail.type),
       ),
+      detail.content,
+    );
+  }
+  for (const detail of runnerRuntimeDetails) {
+    writeGeneratedFile(
+      path.join(nextRunnerRuntimeDetailsDir, detail.fileName),
       detail.content,
     );
   }
@@ -791,6 +1011,23 @@ export async function generateFirewallMetadata(): Promise<void> {
       }),
     ),
   );
+  writeGeneratedFile(
+    path.join(nextOutputDir, "runner-runtime-loader.generated.ts"),
+    renderRunnerRuntimeLoaderFile({
+      catalogDigest: runnerRuntimeCatalogDigest.digest,
+      catalogVersion: runnerRuntimeCatalogDigest.version,
+      entries: runnerRuntimeDetails
+        .map((detail) => {
+          return {
+            name: detail.name,
+            moduleSpecifier: detail.moduleSpecifier,
+          };
+        })
+        .sort((a, b) => {
+          return compareStrings(a.name, b.name);
+        }),
+    }),
+  );
   const replacements: GeneratedPathReplacement[] = [];
   try {
     replacements.push(
@@ -798,6 +1035,12 @@ export async function generateFirewallMetadata(): Promise<void> {
     );
     replacements.push(
       replaceGeneratedPath(routingDetailsDir, nextRoutingDetailsDir),
+    );
+    replacements.push(
+      replaceGeneratedPath(
+        runnerRuntimeDetailsDir,
+        nextRunnerRuntimeDetailsDir,
+      ),
     );
     replacements.push(
       replaceGeneratedPath(
@@ -833,6 +1076,12 @@ export async function generateFirewallMetadata(): Promise<void> {
       replaceGeneratedPath(
         serverExecutionFile,
         path.join(nextOutputDir, "server-execution.generated.ts"),
+      ),
+    );
+    replacements.push(
+      replaceGeneratedPath(
+        runnerRuntimeLoaderFile,
+        path.join(nextOutputDir, "runner-runtime-loader.generated.ts"),
       ),
     );
   } catch (error) {


### PR DESCRIPTION
Closes #20352

## Summary
- add `POST /api/runners/builtin-firewalls/resolve` to resolve `{ kind: "builtin", name }` firewall references through the vm0 API
- generate a lazy runner runtime firewall catalog from connector firewall metadata plus model-provider firewall configs, with catalog digest/version
- expose the server-only catalog through `@vm0/connectors/firewall-metadata/runner-runtime` and update Rust/runtime API route bindings

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runners-builtin-firewalls.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts src/rust-bindings/__tests__/routes.test.ts`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts`
- `pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/metadata.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- pre-commit hook: prettier, knip, cargo doc, cargo clippy, full `turbo run check-types --concurrency=1`
