### PR TITLE
refactor: clarify sandbox process pid naming

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -627,10 +627,10 @@ impl AgentExecutionResult {
     }
 }
 pub(super) fn cancelled_agent_process_exit(
-    pid: u32,
+    guest_pid: u32,
     stream_overflowed: bool,
 ) -> sandbox::ProcessExit {
-    let mut exit = sandbox::ProcessExit::new(pid, EXIT_SIGKILL, Vec::new(), Vec::new());
+    let mut exit = sandbox::ProcessExit::new(guest_pid, EXIT_SIGKILL, Vec::new(), Vec::new());
     exit.termination = ExecTermination::Cancelled;
     exit.stream_overflowed = stream_overflowed;
     exit
@@ -1240,7 +1240,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // 6. Wait for exit (or cancellation). On cancel, ask the guest to cancel the
     // supervised process and briefly wait for its terminal status so the vsock
     // operation can be removed before sandbox cleanup closes the connection.
-    let process_pid = handle.pid;
+    let guest_process_pid = handle.guest_pid;
     let process_cancel = handle.take_cancel_handle();
     let wait_process = sandbox.wait_process(handle, job_terminal_wait_timeout());
     tokio::pin!(wait_process);
@@ -1253,7 +1253,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         () = cancel.cancelled() => {
             info!(run_id = %context.run_id, "cancel received, cancelling guest process");
             let cancelled_exit = || -> sandbox::Result<sandbox::ProcessExit> {
-                Ok(cancelled_agent_process_exit(process_pid, false))
+                Ok(cancelled_agent_process_exit(guest_process_pid, false))
             };
             match process_cancel {
                 Some(process_cancel) => match process_cancel.cancel(process_cancel_timeouts.write).await {
@@ -1267,12 +1267,12 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                             Ok(Ok(exit)) => {
                                 info!(
                                     run_id = %context.run_id,
-                                    pid = process_pid,
+                                    pid = guest_process_pid,
                                     "cancelled guest process reached terminal status"
                                 );
                                 (
                                     Ok(cancelled_agent_process_exit(
-                                        process_pid,
+                                        guest_process_pid,
                                         exit.stream_overflowed,
                                     )),
                                     true,
@@ -1282,7 +1282,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                             Ok(Err(error)) => {
                                 warn!(
                                     run_id = %context.run_id,
-                                    pid = process_pid,
+                                    pid = guest_process_pid,
                                     error = %error,
                                     "guest process wait failed after cancellation"
                                 );
@@ -1291,7 +1291,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                             Err(_) => {
                                 warn!(
                                     run_id = %context.run_id,
-                                    pid = process_pid,
+                                    pid = guest_process_pid,
                                     timeout_ms = process_cancel_timeouts.terminal_grace.as_millis(),
                                     "timed out waiting for cancelled guest process"
                                 );
@@ -1302,7 +1302,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     Err(error) => {
                         warn!(
                             run_id = %context.run_id,
-                            pid = process_pid,
+                            pid = guest_process_pid,
                             error = %error,
                             "failed to send guest process cancellation"
                         );
@@ -1312,7 +1312,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 None => {
                     warn!(
                         run_id = %context.run_id,
-                        pid = process_pid,
+                        pid = guest_process_pid,
                         "sandbox does not support guest process cancellation"
                     );
                     (cancelled_exit(), true, true)
@@ -1357,10 +1357,14 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         Err(e) => {
             // Sandbox crashed — check host dmesg for cgroup OOM kill of the
             // firecracker process before propagating a generic error.
-            if let Some(pid) = sandbox.process_pid()
-                && check_host_oom(pid).await
+            if let Some(host_process_pid) = sandbox.host_process_pid()
+                && check_host_oom(host_process_pid).await
             {
-                warn!(run_id = %context.run_id, pid, "host OOM kill detected for firecracker");
+                warn!(
+                    run_id = %context.run_id,
+                    pid = host_process_pid,
+                    "host OOM kill detected for firecracker"
+                );
                 let error = "Firecracker VM killed by host OOM killer \
                              (cgroup memory limit exceeded)"
                     .to_string();

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -148,8 +148,8 @@ impl Sandbox for CancelAfterWaitSandbox {
         self.inner.source_ip()
     }
 
-    fn process_pid(&self) -> Option<u32> {
-        self.inner.process_pid()
+    fn host_process_pid(&self) -> Option<u32> {
+        self.inner.host_process_pid()
     }
 
     async fn start(&mut self) -> sandbox::Result<()> {
@@ -260,8 +260,8 @@ impl Sandbox for QueuedCopyFileSandbox {
         self.inner.source_ip()
     }
 
-    fn process_pid(&self) -> Option<u32> {
-        self.inner.process_pid()
+    fn host_process_pid(&self) -> Option<u32> {
+        self.inner.host_process_pid()
     }
 
     async fn start(&mut self) -> sandbox::Result<()> {

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -2625,8 +2625,8 @@ mod tests {
             self.inner.source_ip()
         }
 
-        fn process_pid(&self) -> Option<u32> {
-            self.inner.process_pid()
+        fn host_process_pid(&self) -> Option<u32> {
+            self.inner.host_process_pid()
         }
 
         async fn start(&mut self) -> sandbox::Result<()> {

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -1349,14 +1349,14 @@ fn exec_result_from_operation_result(
 }
 
 fn supervised_exec_result_to_process_exit(
-    pid: u32,
+    guest_pid: u32,
     result: vsock_host::ExecOperationResult,
 ) -> ProcessExit {
     let (stdout, stdout_truncated) = captured_output_bytes(result.stdout);
     let (stderr, stderr_truncated) = captured_output_bytes(result.stderr);
 
     ProcessExit {
-        pid,
+        guest_pid,
         termination: exec_termination_from_vsock_termination(result.termination),
         guest_duration_ms: Some(result.duration_ms),
         stdout,
@@ -1464,7 +1464,7 @@ impl Sandbox for FirecrackerSandbox {
         self.network.peer_ip()
     }
 
-    fn process_pid(&self) -> Option<u32> {
+    fn host_process_pid(&self) -> Option<u32> {
         self.process_group_pid
     }
 
@@ -1937,7 +1937,7 @@ impl Sandbox for FirecrackerSandbox {
                         return Err(Self::operation_error(operation, error, backend_crashed));
                     }
                 };
-                let pid = handle.pid();
+                let guest_pid = handle.pid();
                 let process_control = handle.control_handle().map(|control| {
                     let coordinator = self.park_coordinator.clone();
                     let state = Arc::clone(&self.state);
@@ -1977,11 +1977,11 @@ impl Sandbox for FirecrackerSandbox {
                 let wait = GuestProcessWaiter::new(move |timeout| {
                     Box::pin(async move {
                         let result = handle.wait(timeout).await?;
-                        Ok(supervised_exec_result_to_process_exit(pid, result))
+                        Ok(supervised_exec_result_to_process_exit(guest_pid, result))
                     })
                 });
                 let mut public_handle =
-                    GuestProcessHandle::new(pid, stdout_rx, process_control, wait);
+                    GuestProcessHandle::new(guest_pid, stdout_rx, process_control, wait);
                 if let Some(process_cancel) = process_cancel {
                     public_handle = public_handle.with_cancel_handle(process_cancel);
                 }
@@ -5123,7 +5123,7 @@ mod tests {
             },
         );
 
-        assert_eq!(exit.pid, 42);
+        assert_eq!(exit.guest_pid, 42);
         assert_eq!(exit.termination, ExecTermination::WaitFailed);
         assert_eq!(exit.stdout, b"out");
         assert_eq!(exit.stderr, b"err");

--- a/crates/sandbox-mock/src/sandbox.rs
+++ b/crates/sandbox-mock/src/sandbox.rs
@@ -750,7 +750,12 @@ impl Sandbox for MockSandbox {
             }
             // Return override exit code when configured.
             if let Some(code) = overrides.process.wait_process_code {
-                return Ok(ProcessExit::new(handle.pid, code, Vec::new(), Vec::new()));
+                return Ok(ProcessExit::new(
+                    handle.guest_pid,
+                    code,
+                    Vec::new(),
+                    Vec::new(),
+                ));
             }
             if let Some(exit) = overrides
                 .process
@@ -761,6 +766,11 @@ impl Sandbox for MockSandbox {
                 return Ok(exit);
             }
         }
-        Ok(ProcessExit::new(handle.pid, 0, Vec::new(), Vec::new()))
+        Ok(ProcessExit::new(
+            handle.guest_pid,
+            0,
+            Vec::new(),
+            Vec::new(),
+        ))
     }
 }

--- a/crates/sandbox-mock/src/tests/process.rs
+++ b/crates/sandbox-mock/src/tests/process.rs
@@ -320,7 +320,7 @@ async fn wait_process_returns_queued_process_exit() {
         .await
         .unwrap();
 
-    assert_eq!(result.pid, 77);
+    assert_eq!(result.guest_pid, 77);
     assert_eq!(result.stdout, b"out");
     assert_eq!(result.stderr, b"err");
     assert!(result.stream_overflowed);
@@ -347,7 +347,7 @@ async fn wait_process_default_exit_is_unchanged_without_queued_exit() {
         .await
         .unwrap();
 
-    assert_eq!(result.pid, 1);
+    assert_eq!(result.guest_pid, 1);
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
     assert!(result.stdout.is_empty());
     assert!(result.stderr.is_empty());
@@ -409,7 +409,7 @@ async fn wait_process_lifecycle_gate_blocks_until_released() {
 
     gate.release_one();
     let result = wait.await.unwrap().unwrap();
-    assert_eq!(result.pid, 1);
+    assert_eq!(result.guest_pid, 1);
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
 }
 

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -94,9 +94,9 @@ pub trait Sandbox: Send + Sync + Any {
     /// The network-visible source IP address for this sandbox.
     /// Used as the key for proxy VM registration.
     fn source_ip(&self) -> &str;
-    /// PID of the sandbox's main process (e.g. firecracker).
-    /// Used for host-side diagnostics like OOM detection.
-    fn process_pid(&self) -> Option<u32> {
+    /// Host-side PID of the sandbox backing process (e.g. firecracker).
+    /// Used for host diagnostics like OOM detection.
+    fn host_process_pid(&self) -> Option<u32> {
         None
     }
 

--- a/crates/sandbox/src/types.rs
+++ b/crates/sandbox/src/types.rs
@@ -466,7 +466,11 @@ impl GuestProcessControlHandle {
 /// enabled, callers may use [`take_stdout_receiver`](Self::take_stdout_receiver)
 /// before waiting; if they do, they must drain it while the process runs.
 pub struct GuestProcessHandle {
-    pub pid: u32,
+    /// Guest process id reported by the provider.
+    ///
+    /// This is distinct from the host-side sandbox backing process id returned
+    /// by [`Sandbox::host_process_pid`](crate::Sandbox::host_process_pid).
+    pub guest_pid: u32,
     /// Receives stdout chunks in real-time when the guest streams them.
     /// `None` when the backend does not support streaming.
     stdout_rx: Option<ProcessOutputReceiver>,
@@ -479,13 +483,13 @@ pub struct GuestProcessHandle {
 impl GuestProcessHandle {
     /// Construct a guest process handle from backend-owned process state.
     pub fn new(
-        pid: u32,
+        guest_pid: u32,
         stdout_rx: Option<ProcessOutputReceiver>,
         control: Option<GuestProcessControlHandle>,
         wait: GuestProcessWaiter,
     ) -> Self {
         Self {
-            pid,
+            guest_pid,
             stdout_rx,
             control,
             cancel: None,
@@ -662,7 +666,7 @@ impl ProcessOutputMode {
 /// Terminal status and output metadata for a started guest process.
 pub struct ProcessExit {
     /// Guest process id reported by the provider.
-    pub pid: u32,
+    pub guest_pid: u32,
     /// Structured terminal state reported by the provider.
     pub termination: ExecTermination,
     /// Guest-reported wall-clock duration in milliseconds, when the provider has
@@ -698,9 +702,9 @@ impl ProcessExit {
     /// [`ExecTermination::Exited`], `guest_duration_ms` to `None`,
     /// `stdout_truncated` and `stderr_truncated` to `false`, `diagnostic` to an
     /// empty string, and `stream_overflowed` to `false`.
-    pub fn new(pid: u32, exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Self {
+    pub fn new(guest_pid: u32, exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Self {
         Self {
-            pid,
+            guest_pid,
             termination: ExecTermination::Exited { exit_code },
             guest_duration_ms: None,
             stdout,
@@ -1014,7 +1018,7 @@ mod tests {
     fn process_exit_new_defaults_supervised_metadata() {
         let exit = ProcessExit::new(42, 7, b"out".to_vec(), b"err".to_vec());
 
-        assert_eq!(exit.pid, 42);
+        assert_eq!(exit.guest_pid, 42);
         assert_eq!(exit.termination, ExecTermination::Exited { exit_code: 7 });
         assert_eq!(exit.guest_duration_ms, None);
         assert_eq!(exit.stdout, b"out");


### PR DESCRIPTION
## Summary

- rename the sandbox host backing process PID API to `host_process_pid()`
- rename guest process PID fields on `GuestProcessHandle` and `ProcessExit` to `guest_pid`
- update runner/provider local variables and tests so host and guest PID domains are explicit

## Testing

- `cargo check -p sandbox -p sandbox-fc -p sandbox-mock -p runner`
- `cargo test -p sandbox -p sandbox-mock`
- `cargo test -p runner diagnostics_tests`
- `cargo test -p sandbox-fc supervised_exec_result_to_process_exit`
- `git diff --check`

Fixes #20360