### PR TITLE
fix: parse lefthook timeouts as seconds

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -30,13 +30,13 @@ pre-commit:
               - merge
               - rebase
             fail_text: "Knip found unused code. Run 'cd turbo && pnpm knip' to see details."
-            timeout: 60
+            timeout: "60s"
           - name: check-types
             run: pnpm check-types
             root: turbo/
             glob: "turbo/**/*.{ts,tsx}"
             fail_text: "TypeScript errors found. Run 'cd turbo && pnpm check-types' to see details."
-            timeout: 120
+            timeout: "120s"
     - name: crates
       group:
         parallel: true


### PR DESCRIPTION
## Summary
- Quote Lefthook timeout values with explicit seconds units so Lefthook parses them as duration strings.
- Keeps the existing 60-second Knip timeout and 120-second type-check timeout semantics.

## Verification
- `npx lefthook validate`
- Commit hooks: pre-commit skipped unrelated jobs as expected; commit-msg passed commitlint.
