### PR TITLE
fix: focus inline feedback composer from keyboard shortcut

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -108,6 +108,16 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
+function dispatchDocumentShortcut(key: string): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+  document.dispatchEvent(event);
+  return event;
+}
+
 describe("chat inline feedback", () => {
   it("turns selected assistant text into an inline feedback follow-up", async () => {
     const user = userEvent.setup({ delay: null });
@@ -192,6 +202,53 @@ describe("chat inline feedback", () => {
     expect(
       screen.queryByPlaceholderText("What should change about this?"),
     ).not.toBeInTheDocument();
+  });
+
+  it("focuses the inline feedback composer when started from the keyboard shortcut", async () => {
+    const assistantReply = "The launch summary needs more source context.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-shortcut-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-shortcut",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-shortcut-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-shortcut",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    selectTextForInlineFeedback(assistantReplyElement);
+
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+
+    const event = dispatchDocumentShortcut("f");
+    expect(event.defaultPrevented).toBeTruthy();
+
+    const feedbackComment = await screen.findByPlaceholderText(
+      "What should change about this?",
+    );
+    await waitFor(() => {
+      expect(feedbackComment).toHaveFocus();
+    });
   });
 
   it("shows the inline feedback toolbar for a multi-line selection", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -772,7 +772,14 @@ function autoGrowFeedbackNoteRef(element: HTMLTextAreaElement | null): void {
 }
 
 function focusFeedbackNoteRef(element: HTMLTextAreaElement | null): void {
-  element?.focus();
+  if (!element) {
+    return;
+  }
+  window.requestAnimationFrame(() => {
+    if (element.isConnected) {
+      element.focus({ preventScroll: true });
+    }
+  });
   autoGrowFeedbackNote(element);
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx
@@ -62,6 +62,9 @@ function FeedbackToolbar({
       onOpenAutoFocus={(event) => {
         return event.preventDefault();
       }}
+      onCloseAutoFocus={(event) => {
+        return event.preventDefault();
+      }}
       className="w-auto rounded-xl border-[0.7px] border-[hsl(var(--gray-400))] bg-[hsl(var(--card)/0.85)] p-1 text-foreground shadow-lg"
     >
       <div className="flex items-center gap-0.5">


### PR DESCRIPTION
## Summary
- Keep the inline feedback toolbar from restoring focus when it closes after the `f` shortcut.
- Defer feedback note focus until the next animation frame so the composer owns focus after the toolbar unmounts.
- Add a regression test for selecting assistant text and starting feedback with `f`.

## Verification
- `pnpm --filter @vm0/app exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/zero-chat-feedback-selection.tsx src/views/zero-page/__tests__/chat-inline-feedback.test.tsx --max-warnings 0`
- `pnpm exec prettier --check apps/platform/src/views/zero-page/zero-chat-composer.tsx apps/platform/src/views/zero-page/zero-chat-feedback-selection.tsx apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `git diff --check`

## Notes
- Targeted Vitest runs for `chat-inline-feedback.test.tsx` and `chat-feedback.test.ts` did not complete in this runner because the Vitest worker repeatedly restarted under the local container resource limits; they were interrupted and should run in PR CI.