### PR TITLE
fix: upload presentation artifacts to google slides inline

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
@@ -145,4 +145,53 @@ describe("buildPresentationHtmlPptxExportHtml", () => {
       scriptText.indexOf("await materializeComplexSlideBackgrounds(nodes)"),
     ).toBeLessThan(scriptText.indexOf("window.domToPptx.exportToPptx"));
   });
+
+  it("reveals hidden staged slide ancestors before exporting", async () => {
+    const exportHtml = await buildPresentationHtmlPptxExportHtml({
+      baseUrl: "https://presentation.example.test/index.html",
+      html: `
+        <!doctype html>
+        <html>
+          <head>
+            <style>
+              .slide {
+                display: none;
+              }
+              .slide.active {
+                display: flex;
+              }
+            </style>
+          </head>
+          <body>
+            <section class="slide">
+              <div class="stage" data-vm0-slide>
+                <h1>Hidden slide</h1>
+              </div>
+            </section>
+          </body>
+        </html>
+      `,
+      options: {
+        fileName: "deck.pptx",
+        layout: "LAYOUT_WIDE",
+        skipDownload: true,
+        svgAsVector: true,
+      },
+      signal: AbortSignal.any([]),
+    });
+    const doc = new DOMParser().parseFromString(exportHtml, "text/html");
+    const scriptText = Array.from(doc.querySelectorAll("script"))
+      .map((script) => {
+        return script.textContent ?? "";
+      })
+      .join("\n");
+
+    expect(scriptText).toContain("revealElement(ancestor, false)");
+    expect(scriptText).toContain(
+      'window.getComputedStyle(element).display === "none"',
+    );
+    expect(scriptText.indexOf("revealSlideNodes(nodes)")).toBeLessThan(
+      scriptText.indexOf("window.domToPptx.exportToPptx"),
+    );
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -4,6 +4,7 @@ import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-s
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { describe, expect, it, vi } from "vitest";
 import JSZip from "jszip";
+import { HttpResponse } from "msw";
 
 import {
   chatThreadByIdContract,
@@ -325,6 +326,11 @@ function completePresentationPptxExport(
 function setupPresentationArtifactThread(
   presentationUrl: string,
   html = presentationHtml(),
+  options: {
+    readonly featureSwitches?: Parameters<
+      typeof detachedSetupPage
+    >[0]["featureSwitches"];
+  } = {},
 ): void {
   const filename =
     new URL(presentationUrl).pathname.split("/").pop() ?? "presentation.html";
@@ -349,6 +355,7 @@ function setupPresentationArtifactThread(
       }),
     ],
     content: `[Quarterly roadmap](${presentationUrl})`,
+    featureSwitches: options.featureSwitches,
     path: `${THREAD_PATH}?artifact=${encodeURIComponent(presentationUrl)}`,
   });
 }
@@ -1833,6 +1840,83 @@ describe("zero artifact sidebar", () => {
       expect(downloadButton).not.toBeDisabled();
       expect(downloadButton.querySelector(".animate-spin")).toBeNull();
     });
+  });
+
+  it("uploads a presentation artifact to Google Slides without opening a new tab", async () => {
+    const presentationUrl = "https://deck.sites.vm7.io/quarterly-roadmap.html";
+    const openMock = context.mocks.browser.open(
+      context.mocks.browser.authWindow(),
+    );
+    const successToast = vi.spyOn(toast, "success");
+    const upload = { file: null as File | null };
+    context.mocks.data.connectors([googleDriveConnector()]);
+    context.mocks.http.post(
+      "*/api/zero/chat-threads/:threadId/artifacts/google-slides",
+      async ({ request }) => {
+        const formData = await request.formData();
+        const file = formData.get("file");
+        if (!(file instanceof File)) {
+          throw new Error("Google Slides upload did not include a file");
+        }
+        upload.file = file;
+        return HttpResponse.json({
+          id: "slides-file-quarterly-roadmap",
+          name: "quarterly-roadmap",
+          webViewLink:
+            "https://docs.google.com/presentation/d/slides-file-quarterly-roadmap/edit",
+        });
+      },
+    );
+    setupPresentationArtifactThread(presentationUrl, presentationHtml(), {
+      featureSwitches: {
+        [FeatureSwitchKey.PresentationGoogleSlidesUpload]: true,
+      },
+    });
+
+    try {
+      await waitFor(() => {
+        expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+        expect(screen.getByLabelText("Download artifact")).toBeInTheDocument();
+      });
+
+      click(screen.getByLabelText("Download artifact"));
+      await waitFor(() => {
+        expect(menuItemByText("Upload to Google Slides")).toBeInTheDocument();
+      });
+      click(menuItemByText("Upload to Google Slides"));
+
+      const exportFrame = await waitFor(() => {
+        const frame = document.querySelector(
+          'iframe[title="Presentation PPTX export"]',
+        );
+        expect(frame).toBeInstanceOf(HTMLIFrameElement);
+        return frame as HTMLIFrameElement;
+      });
+      expect(openMock.calls).toStrictEqual([]);
+
+      completePresentationPptxExport(exportFrame, await presentationPptxBlob());
+
+      await waitFor(() => {
+        expect(upload.file).not.toBeNull();
+        expect(successToast).toHaveBeenCalledWith("Uploaded to Google Slides", {
+          id: expect.anything(),
+        });
+        expect(
+          document.querySelector('iframe[title="Presentation PPTX export"]'),
+        ).not.toBeInTheDocument();
+      });
+      if (!upload.file) {
+        throw new Error("Google Slides upload did not send a file");
+      }
+      expect(upload.file.name).toBe("quarterly-roadmap.pptx");
+      expect(upload.file.type).toBe(
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      );
+      expect(upload.file.size).toBeGreaterThan(0);
+      expect(openMock.calls).toStrictEqual([]);
+    } finally {
+      successToast.mockRestore();
+    }
   });
 
   it("preserves deck-level slide backgrounds for editable PPTX export", async () => {

--- a/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
+++ b/turbo/apps/platform/src/views/zero-page/presentation-html-pptx-download.ts
@@ -374,21 +374,26 @@ function createExportSlideScript(): string {
   };
 
   const revealSlideNodes = (nodes) => {
+    const revealElement = (element, forceDisplay) => {
+      if (forceDisplay || window.getComputedStyle(element).display === "none") {
+        element.style.setProperty("display", "block", "important");
+      }
+      element.style.setProperty("visibility", "visible", "important");
+      element.style.setProperty("opacity", "1", "important");
+      element.style.setProperty("clip", "auto", "important");
+      element.style.setProperty("clip-path", "none", "important");
+      element.removeAttribute("hidden");
+      element.setAttribute("aria-hidden", "false");
+    };
+
     for (const node of nodes) {
       if (!(node instanceof HTMLElement)) {
         continue;
       }
-      node.style.setProperty("display", "block", "important");
-      node.style.setProperty("visibility", "visible", "important");
-      node.style.setProperty("opacity", "1", "important");
-      node.style.setProperty("clip", "auto", "important");
-      node.style.setProperty("clip-path", "none", "important");
+      revealElement(node, true);
       node.style.setProperty("pointer-events", "none", "important");
-      node.removeAttribute("hidden");
-      node.setAttribute("aria-hidden", "false");
       for (const ancestor of ancestorsUntilBody(node)) {
-        ancestor.style.setProperty("visibility", "visible", "important");
-        ancestor.style.setProperty("opacity", "1", "important");
+        revealElement(ancestor, false);
       }
     }
   };

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -229,22 +229,13 @@ type UploadPresentationSlidesFn = (
   signal: AbortSignal,
 ) => Promise<{ readonly webViewLink: string | null }>;
 
-function uploadPresentationToGoogleSlidesAndOpen(params: {
+function uploadPresentationToGoogleSlides(params: {
   filename: string;
   pageSignal: AbortSignal;
   threadId: string;
   upload: UploadPresentationSlidesFn;
   url: string;
 }): void {
-  const slidesWindow = window.open(
-    "about:blank",
-    "_blank",
-    "width=1024,height=768",
-  );
-  if (!slidesWindow) {
-    toast.error("Failed to open Google Slides");
-    return;
-  }
   const toastId = toast.loading("Uploading to Google Slides...");
   detach(
     tapError(
@@ -254,7 +245,7 @@ function uploadPresentationToGoogleSlidesAndOpen(params: {
           signal: params.pageSignal,
           url: params.url,
         });
-        const result = await params.upload(
+        await params.upload(
           {
             threadId: params.threadId,
             filename: built.filename,
@@ -262,17 +253,9 @@ function uploadPresentationToGoogleSlidesAndOpen(params: {
           },
           params.pageSignal,
         );
-        if (result.webViewLink) {
-          slidesWindow.location.href = result.webViewLink;
-        } else {
-          slidesWindow.close();
-        }
         toast.success("Uploaded to Google Slides", { id: toastId });
       })(),
       () => {
-        // `accept` already surfaced any API-error toast; just clear the loader
-        // and dispose of the blank window we opened for the redirect.
-        slidesWindow.close();
         toast.dismiss(toastId);
       },
     ),
@@ -493,7 +476,7 @@ function GoogleSlidesMenuItem({
     <ArtifactDownloadMenuItem
       onClick={() => {
         closeMenu();
-        uploadPresentationToGoogleSlidesAndOpen({
+        uploadPresentationToGoogleSlides({
           filename,
           pageSignal,
           threadId,


### PR DESCRIPTION
## Summary
- keep presentation HTML Upload to Google Slides in-page instead of opening a Google Slides tab
- reveal hidden slide ancestors before dom-to-pptx export so staged decks do not upload as blank slides
- add regression coverage for inline Google Slides upload and hidden slide ancestor reveal

## Testing
- pnpm format
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx src/views/zero-page/__tests__/presentation-html-pptx-download.test.ts
- pnpm knip --workspace @vm0/app

## Notes
- Local Google Drive OAuth currently hits redirect_uri_mismatch because the dev OAuth client does not appear to allow https://www.vm7.ai:8443/api/connectors/google-drive/callback for this account/client, so real Google Drive connection needs the console config fixed before manual end-to-end upload verification.
