### PR TITLE
fix: stabilize codex zero byok polling

### DIFF
--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -48,6 +48,38 @@
         state: stopped
       become: true
 
+    - name: Persist runner sysctl limits
+      copy:
+        dest: /etc/sysctl.d/99-vm0-runner.conf
+        content: |
+          # Managed by ansible/playbooks/provision-runner.yml - do not edit.
+          fs.inotify.max_user_instances = 8192
+          fs.inotify.max_user_watches = 1048576
+        mode: '0644'
+      become: true
+
+    - name: Apply runner sysctl limits
+      shell: |
+        set -euo pipefail
+        changed=0
+        apply_sysctl() {
+          name="$1"
+          value="$2"
+          current="$(sysctl -n "$name")"
+          if [ "$current" != "$value" ]; then
+            sysctl -w "$name=$value"
+            changed=1
+          fi
+        }
+        apply_sysctl fs.inotify.max_user_instances 8192
+        apply_sysctl fs.inotify.max_user_watches 1048576
+        echo "changed=$changed"
+      args:
+        executable: /bin/bash
+      become: true
+      register: runner_sysctl_apply
+      changed_when: "'changed=1' in runner_sysctl_apply.stdout"
+
     # unattended-upgrades + needrestart (default on Ubuntu 22.04+) would
     # `systemctl restart` our runner when a depended-on library (libc,
     # libssl, systemd, ...) is patched. That sends SIGTERM, which the

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -23,9 +23,9 @@ use gate::{check_active_jobs_gate, read_runner_status, runner_base_dir};
 use signal::{ServiceSignalOutcome, signal_service_main};
 use systemctl::{journalctl_logs_status, run_systemctl};
 use unit_file::{
-    cleanup_unit_staging_files, generate_unit_file, remove_unit_file_if_exists,
-    resolve_config_path, validate_current_exe_path, validate_env_vars, validate_systemd_path,
-    write_unit_file,
+    RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE, cleanup_unit_staging_files, generate_unit_file,
+    remove_unit_file_if_exists, resolve_config_path, validate_current_exe_path, validate_env_vars,
+    validate_systemd_path, write_unit_file,
 };
 
 const SERVICE_CONFIG_SNAPSHOT_DIR: &str = "service-config-snapshots";
@@ -171,6 +171,10 @@ fn service_activation_config_snapshot_path(
         .join(format!("{}-{digest}.yaml", unit.suffix()))
 }
 
+fn systemd_run_limit_nofile_property_arg() -> String {
+    format!("--property={RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE}")
+}
+
 async fn prepare_service_activation_config(
     unit: &RunnerServiceUnit,
     config_path: &Path,
@@ -261,6 +265,7 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     let unit_arg = format!("--unit={}", unit.unit_name());
     let desc_arg = format!("--description=VM0 Runner ({})", unit.unit_name());
     let syslog_arg = format!("--property=SyslogIdentifier={}", unit.unit_name());
+    let nofile_arg = systemd_run_limit_nofile_property_arg();
     with_service_activation_image_artifacts(
         &unit,
         &config_path,
@@ -277,6 +282,7 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
                 "--property=StandardError=journal",
                 "--property=KillSignal=SIGTERM",
                 "--property=TimeoutStopSec=300",
+                &*nofile_arg,
                 &*syslog_arg,
             ]);
             for entry in &args.env {
@@ -778,6 +784,14 @@ profiles:
 
     fn service_unit() -> RunnerServiceUnit {
         RunnerServiceUnit::from_suffix("test").unwrap()
+    }
+
+    #[test]
+    fn systemd_run_uses_explicit_soft_and_hard_nofile_limit() {
+        assert_eq!(
+            systemd_run_limit_nofile_property_arg(),
+            "--property=LimitNOFILE=524288:524288"
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/unit_file.rs
+++ b/crates/runner/src/cmd/service/unit_file.rs
@@ -15,6 +15,7 @@ const UNIT_STAGING_MAX_ATTEMPTS: u64 = 32;
 // Older runner binaries created dot-UUID staging files without holding the
 // service lock, so only age them out after the rolling-upgrade window.
 const LEGACY_UNIT_STAGING_MIN_AGE: Duration = Duration::from_secs(10 * 60);
+pub(super) const RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE: &str = "LimitNOFILE=524288:524288";
 #[cfg(unix)]
 const UNIT_FILE_MODE: u32 = 0o600;
 static UNIT_STAGING_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -93,6 +94,7 @@ Restart=on-failure
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=300
+{RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE}
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier={unit_name}
@@ -510,6 +512,7 @@ mod tests {
         assert!(!content.contains("EnvironmentFile="));
         assert!(content.contains("Restart=on-failure"));
         assert!(content.contains("TimeoutStopSec=300"));
+        assert!(content.contains("LimitNOFILE=524288:524288"));
         assert!(content.contains("[Install]"));
         assert!(content.contains("WantedBy=multi-user.target"));
         assert!(!content.contains("Environment="));

--- a/e2e/helpers/codex-zero.bash
+++ b/e2e/helpers/codex-zero.bash
@@ -72,8 +72,8 @@ disable_codex_beta() {
     return 0
 }
 
-# Poll /api/zero/chat-threads/:id/messages until the current run has a
-# terminal runLifecycleEvent (the paged message API no longer exposes agent run
+# Poll /api/zero/chat-threads/:id/messages until the current run has a terminal
+# assistant lifecycle marker (the paged message API no longer exposes agent run
 # status; terminal runs append a null-content lifecycle marker row instead).
 # Other assistant marker rows, such as recommended followups, may be inserted
 # after the terminal marker and must not hide it. LAST_MSG_CONTENT comes from
@@ -87,7 +87,11 @@ wait_for_chat_assistant_done() {
     local timeout="${2:-180}"
     local start=$SECONDS
     local body status_value run_id content terminal
-    local expected_run_id="${LAST_RUN_ID:-}"
+    if [[ -z "${LAST_RUN_ID:-}" ]]; then
+        echo "# wait_for_chat_assistant_done: LAST_RUN_ID is required" >&2
+        return 1
+    fi
+    local expected_run_id="$LAST_RUN_ID"
     while (( SECONDS - start < timeout )); do
         body=$(_codex_zero_curl "/api/zero/chat-threads/$thread_id/messages?limit=50" 2>/dev/null || true)
         if [[ -n "$body" ]]; then
@@ -96,7 +100,7 @@ wait_for_chat_assistant_done() {
                     [
                         .messages[]
                         | select(.role == "assistant")
-                        | select($expectedRunId == "" or ((.runId // "") == $expectedRunId))
+                        | select((.runId // "") == $expectedRunId)
                         | select(
                             (.runLifecycleEvent // "") as $event
                             | ["completed", "failed", "timeout", "cancelled"]


### PR DESCRIPTION
## Summary
- fix the Codex zero BYOK e2e poller to look for the current run's lifecycle marker
- ignore later assistant helper messages such as recommended followups when determining terminal state

## Testing
- bash -n e2e/helpers/codex-zero.bash
- git diff --check -- e2e/helpers/codex-zero.bash
- verified the jq filter against the CI failure message shape where followups appear after completed
