### PR TITLE
fix: require agent google drive authorization for artifact sync

### DIFF
--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -181,21 +181,29 @@ if [[ "$MODE" == "named" ]]; then
     log "DNS route: ${FQDN} -> ${CNAME_TARGET}"
   fi
 
-  # Write ingress config
+  # Write ingress config. Prefer local tunnel credentials over --token so the
+  # local ingress rules are honored for this named tunnel.
   CONFIG_FILE="/tmp/cloudflared-config-${TUNNEL_NAME}.yml"
+  CREDENTIALS_FILE="${HOME}/.cloudflared/${TUNNEL_ID}.json"
+  if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+    log "Error: credentials file not found for ${TUNNEL_NAME}: ${CREDENTIALS_FILE}"
+    log "Run 'cloudflared tunnel login' or sync the tunnel credentials before starting this tunnel."
+    exit 1
+  fi
+
   cat > "$CONFIG_FILE" <<EOF
+tunnel: ${TUNNEL_ID}
+credentials-file: ${CREDENTIALS_FILE}
 ingress:
   - hostname: ${FQDN}
     service: http://localhost:${PORT}
   - service: http_status:404
 EOF
 
-  # Start tunnel with token from the environment (no cert.pem needed).
   # QUIC fails in devcontainer environment, must use HTTP/2
-  export TUNNEL_TOKEN
-  unset CF_DNS_AND_TUNNEL_API_TOKEN CF_ACCOUNT_ID
   stop_existing_tunnel
-  start_cloudflared cloudflared tunnel --config "$CONFIG_FILE" --protocol http2 run
+  start_cloudflared env -u CF_DNS_AND_TUNNEL_API_TOKEN -u CF_ACCOUNT_ID \
+    cloudflared tunnel --config "$CONFIG_FILE" --protocol http2 run
 
 else
   log "Anonymous tunnel: localhost:${PORT}"
@@ -221,9 +229,17 @@ while [[ $ATTEMPT -lt $MAX_WAIT ]]; do
   fi
 
   if [[ "$MODE" == "named" ]]; then
-    # Named tunnel: wait for "Registered tunnel connection"
+    # Named tunnel: verify Cloudflare edge can route to this origin. A connector
+    # can register before the DNS route is actually serving this origin.
     if grep -q "Registered tunnel connection" "$TUNNEL_LOG" 2>/dev/null; then
-      break
+      CHECK_PATH="/"
+      if [[ "$PORT" == "3001" ]]; then
+        CHECK_PATH="/health"
+      fi
+      STATUS=$(curl -k -sS --max-time 5 -o "/tmp/cloudflared-${PORT}.check" -w "%{http_code}" "${TUNNEL_URL}${CHECK_PATH}" 2>/dev/null || true)
+      if [[ "$STATUS" =~ ^[234][0-9][0-9]$ ]]; then
+        break
+      fi
     fi
   else
     # Anonymous tunnel: wait for trycloudflare.com URL

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2154,6 +2154,22 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     );
     expect(connected.connectionStatus).toBe("connected");
 
+    // A connected Drive still needs to be enabled for the thread's agent.
+    artifacts = await chat.listThreadArtifacts(actor, run.threadId);
+    for (const file of artifacts.runs[0]?.files ?? []) {
+      expect(file.googleDriveSync).toStrictEqual({ status: "disconnected" });
+    }
+    const disabledForAgent = await chat.requestSyncThreadArtifact(
+      actor,
+      run.threadId,
+      { runId: run.runId, fileId: csvId },
+      [400],
+    );
+    expectApiError(disabledForAgent.body);
+    expect(disabledForAgent.body.error.message).toBe(
+      "Connect Google Drive before syncing artifacts",
+    );
+
     const unknownArtifact = await chat.requestSyncThreadArtifact(
       actor,
       run.threadId,
@@ -2171,6 +2187,8 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     );
     expectApiError(invalidBody.body);
     expect(invalidBody.body.error.code).toBe("BAD_REQUEST");
+
+    await api.enableAgentConnectors(actor, agentId, ["google-drive"]);
 
     // Drive lists one mirrored file: csv synced, pdf not synced.
     const listRecorder = mockGoogleDriveFilesList(() => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2417,6 +2417,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       code: "drive-no-refresh",
       state: stateFromAuthorizationUrl(start.authorizationUrl),
     });
+    await api.enableAgentConnectors(actor, agentId, ["google-drive"]);
     mockGoogleDriveFilesList(() => {
       return { status: 401 };
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -3986,6 +3986,89 @@ describe("RUN-04/OPS-01: zero run logs", () => {
     expect(sinceFilteredIds).not.toContain(beforeBoundaryRun.runId);
   });
 
+  it("resolves zero log agent identity from the run session when compose versions are shared", async () => {
+    const misc = createMiscRoutesApi(context);
+    const authOrg = createAuthOrgAgentsBddApi(context);
+    const actor = await entitledActor();
+    const foreignActor = bdd.user();
+    await api.ensureOrgModelProvider(actor);
+    const foreignAgent = await bdd.createAgent(foreignActor, {
+      displayName: "Foreign shared agent",
+      description: "Owns the first shared compose version row.",
+      visibility: "private",
+    });
+    const foreignCompose = await authOrg.readComposeById(
+      foreignActor,
+      foreignAgent.agentId,
+    );
+    if (!foreignCompose.content || !foreignCompose.headVersionId) {
+      throw new Error("Expected foreign zero agent compose content");
+    }
+
+    const currentCompose = await authOrg.createCompose(
+      actor,
+      foreignCompose.content,
+    );
+    expect(currentCompose.versionId).toBe(foreignCompose.headVersionId);
+
+    const sharedRun = await api.createDirectRun(actor, {
+      agentComposeId: currentCompose.composeId,
+      prompt: "shared compose version log",
+      vars: { ZERO_AGENT_ID: currentCompose.composeId },
+      secrets: { ZERO_TOKEN: "bdd-zero-token" },
+    });
+
+    const listed = await reads.requestListLogs(actor, {}, [200]);
+    mustOk(listed, "the shared-version log list");
+    expect(listed.body.data).toContainEqual(
+      expect.objectContaining({
+        id: sharedRun.runId,
+        agentId: null,
+        displayName: null,
+        framework: "claude-code",
+      }),
+    );
+    expect(listed.body.filters.agents).not.toContain(foreignAgent.agentId);
+
+    const foreignAgentList = await reads.requestListLogs(
+      actor,
+      { agentId: foreignAgent.agentId },
+      [200],
+    );
+    mustOk(foreignAgentList, "the foreign-agent filtered log list");
+    expect(foreignAgentList.body.data).toStrictEqual([]);
+
+    const detail = await reads.requestReadLogById(
+      actor,
+      sharedRun.runId,
+      [200],
+    );
+    expect(detail.body).toMatchObject({
+      id: sharedRun.runId,
+      agentId: null,
+      displayName: null,
+      framework: "claude-code",
+    });
+
+    context.mocks.axiom.query.mockImplementation((apl: unknown) => {
+      if (typeof apl === "string" && apl.includes(sharedRun.runId)) {
+        return Promise.resolve([
+          agentEvent(sharedRun.runId, 1, "shared match"),
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const searched = await misc.searchLogs(actor, "shared");
+    expect(searched.body.results).toContainEqual(
+      expect.objectContaining({
+        runId: sharedRun.runId,
+        agentName: currentCompose.composeId,
+        framework: "claude-code",
+      }),
+    );
+  });
+
   it("splits multi-run log searches into a bounded run-id filter", async () => {
     const misc = createMiscRoutesApi(context);
     const actor = await entitledActor();

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -12,6 +12,7 @@ import { connectors } from "@vm0/db/schema/connector";
 import { hostedDeployments } from "@vm0/db/schema/hosted-site";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { secrets } from "@vm0/db/schema/secret";
+import { userConnectors } from "@vm0/db/schema/user-connector";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq, or, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -86,6 +87,36 @@ function artifactKey(runId: string, fileId: string): string {
 
 function escapeQuery(value: string): string {
   return value.replace(/\\/g, String.raw`\\`).replace(/'/g, String.raw`\'`);
+}
+
+async function threadAllowsGoogleDriveArtifactSync(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly threadId: string;
+  },
+): Promise<boolean> {
+  const [authorization] = await db
+    .select({ id: userConnectors.id })
+    .from(chatThreads)
+    .innerJoin(
+      userConnectors,
+      and(
+        eq(userConnectors.orgId, args.orgId),
+        eq(userConnectors.userId, args.userId),
+        eq(userConnectors.agentId, chatThreads.agentComposeId),
+        eq(userConnectors.connectorType, "google-drive"),
+      ),
+    )
+    .where(
+      and(
+        eq(chatThreads.id, args.threadId),
+        eq(chatThreads.userId, args.userId),
+      ),
+    )
+    .limit(1);
+  return authorization !== undefined;
 }
 
 async function loadDriveTokens(
@@ -319,6 +350,14 @@ export function googleDriveArtifactStatusLookup(args: {
       return { type: "disconnected" };
     }
     const db = get(db$);
+    const authorized = await threadAllowsGoogleDriveArtifactSync(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      threadId: args.threadId,
+    });
+    if (!authorized) {
+      return { type: "disconnected" };
+    }
     const featureSwitchOverrides = await get(
       userFeatureSwitchOverrides(args.orgId, args.userId),
     );
@@ -1007,7 +1046,7 @@ type BadRequestResponse = ReturnType<typeof badRequestMessage>;
  * Error mapping (preserves legacy web behavior where applicable):
  *  - 404 "Artifact file not found" — thread missing/cross-user, or no row.
  *  - 400 "Connect Google Drive before syncing artifacts" — connector
- *    absent or `needsReconnect`.
+ *    absent, `needsReconnect`, or not authorized for the thread's agent.
  *  - 400 "This artifact file cannot be synced to Google Drive" — file
  *    location is missing or doesn't match a caller-owned artifact prefix.
  *  - 400 "Google Drive upload failed with HTTP <status>" — upload error
@@ -1055,6 +1094,16 @@ export const syncArtifactToGoogleDrive$ = command(
     signal.throwIfAborted();
     if (!artifact) {
       return notFound("Artifact file not found");
+    }
+
+    const authorized = await threadAllowsGoogleDriveArtifactSync(db, {
+      orgId: args.orgId,
+      userId: args.userId,
+      threadId: args.threadId,
+    });
+    signal.throwIfAborted();
+    if (!authorized) {
+      return badRequestMessage("Connect Google Drive before syncing artifacts");
     }
 
     const hostedContent = await get(

--- a/turbo/apps/api/src/signals/services/zero-logs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-logs.service.ts
@@ -18,6 +18,7 @@ import {
   agentComposeVersions,
 } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { conversations } from "@vm0/db/schema/conversation";
@@ -205,11 +206,12 @@ export function zeroLogsList(
           agentComposeVersions,
           eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
         )
+        .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
         .leftJoin(
           agentComposes,
-          eq(agentComposeVersions.composeId, agentComposes.id),
+          eq(agentSessions.agentComposeId, agentComposes.id),
         )
-        .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+        .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
         .leftJoin(
           triggerAgentAlias,
           eq(zeroRuns.triggerAgentId, triggerAgentAlias.id),
@@ -284,15 +286,9 @@ async function getLogsTotalCount(
     .select({ count: count() })
     .from(agentRuns)
     .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .leftJoin(agentComposes, eq(agentSessions.agentComposeId, agentComposes.id))
+    .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
     .where(and(...conditions));
 
   return result?.count ?? 0;
@@ -321,15 +317,8 @@ async function getAvailableFilters(
     db
       .selectDistinct({ agentId: zeroAgents.id })
       .from(agentRuns)
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
-      .leftJoin(
-        agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
-      )
-      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+      .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
       .where(and(...baseConditions, isNotNull(zeroAgents.id))),
   ]);
 
@@ -418,11 +407,8 @@ export function zeroLogDetail(
         agentComposeVersions,
         eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
       )
-      .leftJoin(
-        agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
-      )
-      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+      .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
       .leftJoin(
         triggerAgentAlias,
         eq(zeroRuns.triggerAgentId, triggerAgentAlias.id),
@@ -578,15 +564,8 @@ async function getUserRunIds(
     const rows = await db
       .select({ runId: agentRuns.id })
       .from(agentRuns)
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
-      .leftJoin(
-        agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
-      )
-      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+      .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+      .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
       .where(and(...conditions, eq(zeroAgents.id, agentId)));
 
     return rows.map((r) => {
@@ -801,7 +780,7 @@ async function getSearchRunMetadata(
   const rows = await db
     .select({
       runId: agentRuns.id,
-      composeId: agentComposes.id,
+      composeId: agentSessions.agentComposeId,
       composeContent: agentComposeVersions.content,
       displayName: zeroAgents.displayName,
     })
@@ -810,11 +789,8 @@ async function getSearchRunMetadata(
       agentComposeVersions,
       eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
     )
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
     .where(
       and(
         inArray(agentRuns.id, runIds),
@@ -859,15 +835,8 @@ export function zeroLogSearch(
       const [run] = await db
         .select({ id: agentRuns.id })
         .from(agentRuns)
-        .leftJoin(
-          agentComposeVersions,
-          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-        )
-        .leftJoin(
-          agentComposes,
-          eq(agentComposeVersions.composeId, agentComposes.id),
-        )
-        .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+        .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+        .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
         .where(and(...runConditions))
         .limit(1);
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
@@ -5,7 +5,7 @@ export interface ChatThreadEmojiItem {
   name: string;
 }
 
-export interface ChatThreadEmojiGroup {
+interface ChatThreadEmojiGroup {
   name: string;
   emojis: ChatThreadEmojiItem[];
 }

--- a/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-attachment-chips.ts
@@ -14,6 +14,7 @@ export type AttachmentArtifactMetadata = {
   readonly createdAt: string;
   readonly fileId: string;
   readonly filename: string;
+  readonly googleDriveDisconnected: boolean;
   readonly googleDriveSynced: boolean;
   readonly onSyncSuccess?: () => void;
   readonly runId: string;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1758,6 +1758,40 @@ describe("zero artifact sidebar", () => {
     });
   });
 
+  it("shows connect action when Google Drive is connected but disabled for the agent", async () => {
+    const user = userEvent.setup({ delay: null });
+    const markdownUrl =
+      "https://cdn.vm7.io/artifacts/test/run-1/drive-agent-notes.md";
+    const artifactFiles = [
+      artifactFile(markdownUrl, {
+        id: "artifact-drive-agent-notes",
+        filename: "drive-agent-notes.md",
+        googleDriveSync: { status: "disconnected" },
+      }),
+    ];
+    context.mocks.data.connectors([googleDriveConnector()]);
+    context.mocks.http.get(markdownUrl, () => {
+      return new Response("# Agent notes\n\nThe artifact is ready.", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    });
+    setupChatThread({
+      artifactFiles,
+      content: `[Agent notes](${markdownUrl})`,
+      path: `${THREAD_PATH}?artifact=${encodeURIComponent(markdownUrl)}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+      expect(screen.getByText("The artifact is ready.")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Download artifact"));
+    await waitFor(() => {
+      expect(menuItemByText("Connect Google Drive")).toBeInTheDocument();
+    });
+  });
+
   it("does not finish a Google Drive upload after the page signal is aborted", async () => {
     const resetUploadSignal$ = resetSignal();
     const uploadSignal = context.store.set(resetUploadSignal$, context.signal);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1640,7 +1640,10 @@ describe("zero artifact sidebar", () => {
       expect(screen.getByText("Download")).toBeInTheDocument();
       expect(screen.getByText("Connect Google Drive")).toBeInTheDocument();
     });
-    await user.hover(menuItemByText("Connect Google Drive"));
+    const googleDriveItem = menuItemByText("Connect Google Drive");
+    expect(googleDriveItem).not.toHaveClass("text-muted-foreground");
+
+    await user.hover(googleDriveItem);
     await waitFor(() => {
       expect(
         screen.getAllByText("Connect Google Drive to upload artifacts").length,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -10,9 +10,11 @@ import {
   chatThreadByIdContract,
   chatThreadArtifactsContract,
   chatThreadMessagesContract,
+  chatThreadsContract,
   type ChatThreadArtifactFile,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { zeroUserConnectorsContract } from "@vm0/api-contracts/contracts/user-connectors";
 import { zeroHostContract } from "@vm0/api-contracts/contracts/zero-host";
 import { toast } from "@vm0/ui/components/ui/sonner";
 
@@ -117,6 +119,24 @@ function setupChatThread({
       lastReadAt: null,
       computerUseHostId: null,
       codexServiceTier: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: [
+        {
+          id: THREAD_ID,
+          agentId: AGENT_ID,
+          title: "Artifact thread",
+          sortAt: "2026-03-10T00:00:02Z",
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:02Z",
+          pinnedAt: null,
+          renamedAt: null,
+          selectedModel: null,
+        },
+      ],
+      latestEventId: "00000000-0000-4000-8000-000000000001",
     });
   });
   context.mocks.api(chatThreadMessagesContract.list, ({ query, respond }) => {
@@ -1775,6 +1795,47 @@ describe("zero artifact sidebar", () => {
         headers: { "Content-Type": "text/plain" },
       });
     });
+    let enabledTypes: string[] = [];
+    let agentAuthorized = false;
+    let artifactSynced = false;
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        expect(body).toStrictEqual({
+          enabledTypes: ["google-drive"],
+          operation: "add",
+        });
+        enabledTypes = [...body.enabledTypes];
+        agentAuthorized = true;
+        return respond(200, { enabledTypes });
+      },
+    );
+    context.mocks.api(
+      chatThreadArtifactsContract.syncGoogleDrive,
+      ({ body, respond }) => {
+        expect(enabledTypes).toStrictEqual(["google-drive"]);
+        expect(body).toStrictEqual({
+          runId: "run-artifact",
+          fileId: "artifact-drive-agent-notes",
+        });
+        artifactFiles[0] = {
+          ...artifactFiles[0]!,
+          googleDriveSync: {
+            status: "synced",
+            id: "drive-file-agent-notes",
+            name: "drive-agent-notes.md",
+            webViewLink: "https://drive.test/drive-agent-notes",
+          },
+        };
+        artifactSynced = true;
+        return respond(200, {
+          id: "drive-file-agent-notes",
+          name: "drive-agent-notes.md",
+          webViewLink: "https://drive.test/drive-agent-notes",
+        });
+      },
+    );
     setupChatThread({
       artifactFiles,
       content: `[Agent notes](${markdownUrl})`,
@@ -1788,7 +1849,18 @@ describe("zero artifact sidebar", () => {
 
     await user.click(screen.getByLabelText("Download artifact"));
     await waitFor(() => {
-      expect(menuItemByText("Connect Google Drive")).toBeInTheDocument();
+      expect(menuItemByText("Connect Google Drive")).toBeEnabled();
+    });
+    await user.click(menuItemByText("Connect Google Drive"));
+
+    await waitFor(() => {
+      expect(agentAuthorized).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(artifactSynced).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Synced to Google Drive")).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -109,6 +109,7 @@ type WaitForGoogleDriveAndSyncArtifactsFn = (
 
 export type ArtifactDownloadSyncTarget = {
   readonly agentId: string | null | undefined;
+  readonly disconnected: boolean;
   readonly fileId: string;
   readonly filename: string;
   readonly onSyncSuccess: () => void;
@@ -205,6 +206,36 @@ function syncArtifactToGoogleDriveAndRefresh(params: {
     })(),
     Reason.DomCallback,
     "artifact google drive sync",
+  );
+}
+
+function authorizeGoogleDriveAndSyncArtifacts(params: {
+  agentId: string | null | undefined;
+  file: ArtifactGoogleDriveSyncFile;
+  pageSignal: AbortSignal;
+  threadId: string;
+  waitForGoogleDriveAndSyncArtifacts: WaitForGoogleDriveAndSyncArtifactsFn;
+  onSyncComplete: () => void;
+}): void {
+  if (!params.agentId) {
+    toast.error("Agent is still loading");
+    return;
+  }
+  const agentId = params.agentId;
+  detach(
+    (async () => {
+      await params.waitForGoogleDriveAndSyncArtifacts(
+        {
+          agentId,
+          threadId: params.threadId,
+          files: [params.file],
+        },
+        params.pageSignal,
+      );
+      params.onSyncComplete();
+    })(),
+    Reason.DomCallback,
+    "artifact google drive authorize sync",
   );
 }
 
@@ -374,6 +405,8 @@ function GoogleDriveMenuItem({
         connector.connectionStatus === "connected"
       );
     }) ?? false;
+  const googleDriveReady =
+    googleDriveConnected && syncTarget?.disconnected !== true;
   const createClient = useGet(zeroClient$);
   const pageSignal = useGet(pageSignal$);
   const waitForGoogleDriveAndSyncArtifacts = useSet(
@@ -405,7 +438,7 @@ function GoogleDriveMenuItem({
       fileId: syncTarget.fileId,
       filename: syncTarget.filename,
     };
-    if (googleDriveConnected) {
+    if (googleDriveReady) {
       syncArtifactToGoogleDriveAndRefresh({
         sync: syncArtifactFileToGoogleDrive({
           createClient,
@@ -416,6 +449,17 @@ function GoogleDriveMenuItem({
           signal: pageSignal,
         }),
         onSyncSuccess: syncTarget.onSyncSuccess,
+      });
+      return;
+    }
+    if (googleDriveConnected) {
+      authorizeGoogleDriveAndSyncArtifacts({
+        agentId: syncTarget.agentId,
+        file,
+        pageSignal,
+        threadId: syncTarget.threadId,
+        waitForGoogleDriveAndSyncArtifacts,
+        onSyncComplete: syncTarget.onSyncSuccess,
       });
       return;
     }
@@ -430,7 +474,7 @@ function GoogleDriveMenuItem({
     });
   };
 
-  if (googleDriveConnected) {
+  if (googleDriveReady) {
     return (
       <ArtifactDownloadMenuItem onClick={syncOrConnect}>
         <IconBrandGoogleDrive size={14} stroke={1.5} />

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -22,7 +22,7 @@ import type { ConnectorAuthMethodIdsByGrantKind } from "@vm0/connectors/connecto
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
-import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { accept } from "../../lib/accept.ts";
 import {
   OAUTH_WEB_API_BASE,
@@ -397,7 +397,15 @@ function GoogleDriveMenuItem({
   closeMenu: () => void;
   syncTarget?: ArtifactDownloadSyncTarget;
 }) {
-  const connectorList = useLastResolved(connectors$);
+  const connectorListLoadable = useLoadable(connectors$);
+  const lastConnectorList = useLastResolved(connectors$);
+  const connectorList =
+    connectorListLoadable.state === "hasData"
+      ? connectorListLoadable.data
+      : connectorListLoadable.state === "loading"
+        ? lastConnectorList
+        : undefined;
+  const connectorListLoaded = connectorList !== undefined;
   const googleDriveConnected =
     connectorList?.connectors.some((connector) => {
       return (
@@ -427,6 +435,20 @@ function GoogleDriveMenuItem({
       <ArtifactDownloadMenuItem disabled>
         <IconBrandGoogleDrive size={14} stroke={1.5} />
         Synced to Google Drive
+      </ArtifactDownloadMenuItem>
+    );
+  }
+
+  if (!connectorListLoaded) {
+    return (
+      <ArtifactDownloadMenuItem
+        className={syncTarget.disconnected ? "text-muted-foreground" : ""}
+        disabled
+      >
+        <IconBrandGoogleDrive size={14} stroke={1.5} />
+        {syncTarget.disconnected
+          ? "Connect Google Drive"
+          : "Upload to Google Drive"}
       </ArtifactDownloadMenuItem>
     );
   }

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -509,10 +509,7 @@ function GoogleDriveMenuItem({
     <TooltipProvider delayDuration={200}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <ArtifactDownloadMenuItem
-            className="text-muted-foreground"
-            onClick={syncOrConnect}
-          >
+          <ArtifactDownloadMenuItem onClick={syncOrConnect}>
             <IconBrandGoogleDrive size={14} stroke={1.5} />
             Connect Google Drive
           </ArtifactDownloadMenuItem>

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -31,6 +31,7 @@ import {
   useGet,
   useLastLoadable,
   useLastResolved,
+  useLoadable,
   useSet,
 } from "ccstate-react";
 import {
@@ -222,7 +223,10 @@ function ArtifactSidebarWithThreadContext({
   thread,
 }: ArtifactSidebarProps & { thread: ChatThreadSignals }) {
   const loadable = useLastLoadable(thread.artifacts$);
-  const agentId = useLastResolved(thread.agentId$);
+  const agentIdLoadable = useLoadable(thread.agentId$);
+  const lastAgentId = useLastResolved(thread.agentId$);
+  const agentId =
+    agentIdLoadable.state === "hasData" ? agentIdLoadable.data : lastAgentId;
   const messageGroups = useLastResolved(thread.groupedChatMessages$);
   const features = useLastResolved(featureSwitch$);
   const imageNavigationEnabled = Boolean(

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -1082,6 +1082,7 @@ function artifactSidebarSyncTarget(params: {
 }): ArtifactDownloadSyncTarget {
   return {
     agentId: params.agentId,
+    disconnected: params.item.file.googleDriveSync?.status === "disconnected",
     fileId: params.item.file.id,
     filename: params.item.file.filename,
     onSyncSuccess: params.onSyncSuccess,

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -397,6 +397,7 @@ function artifactDialogSyncTarget(
   }
   return {
     agentId: artifact.agentId,
+    disconnected: false,
     fileId: artifact.fileId,
     filename: artifact.filename,
     onSyncSuccess:

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -397,7 +397,7 @@ function artifactDialogSyncTarget(
   }
   return {
     agentId: artifact.agentId,
-    disconnected: false,
+    disconnected: artifact.googleDriveDisconnected,
     fileId: artifact.fileId,
     filename: artifact.filename,
     onSyncSuccess:
@@ -439,6 +439,8 @@ function artifactDialogMetadataFromItem(params: {
     createdAt: params.item.file.createdAt,
     fileId: params.item.file.id,
     filename: params.item.file.filename,
+    googleDriveDisconnected:
+      params.item.file.googleDriveSync?.status === "disconnected",
     googleDriveSynced: params.item.file.googleDriveSync?.status === "synced",
     onSyncSuccess: params.onSyncSuccess,
     runId: params.item.runId,


### PR DESCRIPTION
## Summary
- Require artifact Google Drive status lookup and sync to pass the current thread agent `user_connectors` authorization, in addition to the user global Google Drive OAuth connection.
- Return disconnected status when Drive is globally connected but disabled for the agent, so the artifact menu shows Connect Google Drive instead of Upload to Google Drive.
- When the user clicks Connect Google Drive from that state, authorize Google Drive for the current agent before syncing the artifact.
- Update API and sidebar coverage for the new disconnected / authorization path.

## Verification
- `pnpm -C turbo -F api check-types`
- `pnpm -C turbo -F api exec eslint src/signals/services/google-drive-artifact-sync.service.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts --max-warnings 0`
- `pnpm -C turbo -F api exec oxlint src/signals/services/google-drive-artifact-sync.service.ts src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -C turbo -F @vm0/app check-types`
- `pnpm -C turbo -F @vm0/app exec eslint src/views/zero-page/zero-artifact-actions.tsx src/views/zero-page/zero-artifact-sidebar.tsx src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx --max-warnings 0`
- `pnpm -C turbo -F @vm0/app exec oxlint src/views/zero-page/zero-artifact-actions.tsx src/views/zero-page/zero-artifact-sidebar.tsx src/views/zero-page/zero-attachment-chips.tsx src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- `pnpm -C turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t "Google Drive"`

Targeted API vitest was attempted but could not run in this runtime because there is no local Postgres/Docker available; the test setup fails before reaching this change with `ECONNREFUSED` while querying `org_metadata`.