### PR TITLE
feat: enable agents page redesign

### DIFF
--- a/e2e/playwright/lib/auth.ts
+++ b/e2e/playwright/lib/auth.ts
@@ -5,6 +5,12 @@ export interface HostedAuthSession {
   readonly token: string;
 }
 
+export interface HostedAuthOptions {
+  readonly followRedirect?: boolean;
+  readonly activeOrganizationId?: string;
+  readonly mirrorStorageToUrls?: readonly string[];
+}
+
 export async function refreshClerkSessionToken(
   page: Page,
   options: { readonly activeOrganizationId?: string } = {},
@@ -28,11 +34,7 @@ export async function signInThroughHostedAuth(
   page: Page,
   email: string,
   appUrl: string,
-  options: {
-    readonly followRedirect?: boolean;
-    readonly activeOrganizationId?: string;
-    readonly mirrorStorageToUrls?: readonly string[];
-  } = {},
+  options: HostedAuthOptions = {},
 ): Promise<HostedAuthSession> {
   await page.goto(appUrl, { waitUntil: "domcontentloaded" });
   await page.waitForURL((url) => url.pathname.includes("/sign-in"), {
@@ -51,17 +53,31 @@ export async function signInThroughHostedAuth(
   );
 }
 
+export async function signInFromCurrentHostedAuthPage(
+  page: Page,
+  email: string,
+  options: HostedAuthOptions = {},
+): Promise<HostedAuthSession> {
+  const authUrl = page.url();
+  const appUrl = new URL(authUrl).origin;
+  const redirectUrl = redirectUrlFromAuthUrl(new URL(authUrl));
+  return await signInWithClerkTestingHelper(
+    page,
+    email,
+    appUrl,
+    authUrl,
+    redirectUrl,
+    options,
+  );
+}
+
 async function signInWithClerkTestingHelper(
   page: Page,
   email: string,
   appUrl: string,
   authUrl: string,
   redirectUrl: string | null,
-  options: {
-    readonly followRedirect?: boolean;
-    readonly activeOrganizationId?: string;
-    readonly mirrorStorageToUrls?: readonly string[];
-  },
+  options: HostedAuthOptions,
 ): Promise<HostedAuthSession> {
   const helperUrl = new URL("/_/skeleton", appUrl);
   await page.goto(helperUrl.toString(), { waitUntil: "domcontentloaded" });

--- a/e2e/playwright/lib/onboarding.ts
+++ b/e2e/playwright/lib/onboarding.ts
@@ -1,12 +1,19 @@
 import { expect, type Page } from "@playwright/test";
 import { deriveServiceOrigin } from "../playwright.config";
+import { signInFromCurrentHostedAuthPage } from "./auth";
 
 type AuthHeaders = Readonly<Record<"Authorization", string>>;
+
+interface OnboardingAuthOptions {
+  readonly email: string;
+  readonly activeOrganizationId?: string;
+}
 
 interface OnboardingFlowOptions {
   readonly apiUrl: string;
   readonly appUrl: string;
   readonly onboardingUrl: string;
+  readonly auth?: OnboardingAuthOptions;
 }
 
 export function authHeadersForToken(token: string): AuthHeaders {
@@ -22,9 +29,10 @@ export async function completeExploreOnboarding(
   options: OnboardingFlowOptions,
 ): Promise<void> {
   await openOnboarding(page, options);
-  await chooseMakeOption(page, "I will explore on my own");
-  await clickOnboardingButton(page, /^Continue$/i);
-  await waitForChatPage(page, options.appUrl);
+  await submitExploreOnboarding(page);
+  await waitForChatPage(page, options, async () => {
+    await submitExploreOnboarding(page);
+  });
 }
 
 export async function startVideoOnboardingCheckout(
@@ -51,15 +59,12 @@ export async function startVideoOnboardingCheckout(
 
 export async function waitForPaidOnboardingAppHandoff(
   page: Page,
-  appUrl: string,
-): Promise<void> {
-  await waitForExpectedAppUrl(
+  options: Pick<OnboardingFlowOptions, "appUrl" | "auth">,
+): Promise<URL> {
+  return await waitForOnboardingHandoff(
     page,
-    appUrl,
-    (url, appOrigin) =>
-      url.origin === appOrigin &&
-      (url.pathname === "/prompt" ||
-        /\/agents\/[^/]+\/chat/.test(url.pathname)),
+    options,
+    isPromptOrChatUrl,
     180_000,
   );
 }
@@ -74,6 +79,14 @@ async function openOnboarding(
   await expect(
     page.getByRole("heading", { name: "What do you want to make first" }),
   ).toBeVisible({ timeout: 60_000 });
+}
+
+async function submitExploreOnboarding(page: Page): Promise<void> {
+  await expect(
+    page.getByRole("heading", { name: "What do you want to make first" }),
+  ).toBeVisible({ timeout: 60_000 });
+  await chooseMakeOption(page, "I will explore on my own");
+  await clickOnboardingButton(page, /^Continue$/i);
 }
 
 async function chooseMakeOption(page: Page, name: string): Promise<void> {
@@ -91,14 +104,85 @@ async function clickOnboardingButton(page: Page, name: RegExp): Promise<void> {
   await button.click();
 }
 
-async function waitForChatPage(page: Page, appUrl: string): Promise<void> {
-  await waitForExpectedAppUrl(
+async function waitForChatPage(
+  page: Page,
+  options: Pick<OnboardingFlowOptions, "appUrl" | "auth">,
+  continueAfterAuth: (() => Promise<void>) | undefined,
+): Promise<void> {
+  await waitForOnboardingHandoff(
     page,
-    appUrl,
-    (url, appOrigin) =>
-      url.origin === appOrigin && /\/agents\/[^/]+\/chat/.test(url.pathname),
+    options,
+    isChatUrl,
     120_000,
+    continueAfterAuth,
   );
+}
+
+async function waitForOnboardingHandoff(
+  page: Page,
+  options: Pick<OnboardingFlowOptions, "appUrl" | "auth">,
+  isTargetUrl: (url: URL) => boolean,
+  timeout: number,
+  continueAfterAuth?: () => Promise<void>,
+): Promise<URL> {
+  const configuredAppOrigin = new URL(options.appUrl).origin;
+  await waitForExpectedUrl(
+    page,
+    configuredAppOrigin,
+    (url) =>
+      (url.origin === configuredAppOrigin && isTargetUrl(url)) ||
+      isHostedSignInUrl(url),
+    timeout,
+  );
+
+  const currentUrl = new URL(page.url());
+  if (isTargetUrl(currentUrl)) {
+    return currentUrl;
+  }
+
+  if (!options.auth) {
+    throw new Error(
+      `Onboarding handoff required sign-in at ${currentUrl.origin}, but no auth options were provided`,
+    );
+  }
+
+  const redirectOrigin = redirectOriginFromAuthUrl(currentUrl);
+  await signInFromCurrentHostedAuthPage(page, options.auth.email, {
+    activeOrganizationId: options.auth.activeOrganizationId,
+  });
+  const isAllowedTargetUrl = (url: URL) => {
+    return (
+      isTargetUrl(url) &&
+      (url.origin === configuredAppOrigin ||
+        url.origin === redirectOrigin ||
+        redirectOrigin === null)
+    );
+  };
+  await waitForExpectedUrl(
+    page,
+    configuredAppOrigin,
+    (url) => isAllowedTargetUrl(url) || isOnboardingUrl(url),
+    timeout,
+  );
+  const postAuthUrl = new URL(page.url());
+  if (isAllowedTargetUrl(postAuthUrl)) {
+    return postAuthUrl;
+  }
+
+  if (!continueAfterAuth) {
+    throw new Error(
+      `Onboarding handoff returned to ${postAuthUrl.origin}${postAuthUrl.pathname} after sign-in`,
+    );
+  }
+
+  await continueAfterAuth();
+  await waitForExpectedUrl(
+    page,
+    configuredAppOrigin,
+    isAllowedTargetUrl,
+    timeout,
+  );
+  return new URL(page.url());
 }
 
 function onboardingEntryUrl(options: OnboardingFlowOptions): string {
@@ -108,23 +192,18 @@ function onboardingEntryUrl(options: OnboardingFlowOptions): string {
   return url.toString();
 }
 
-type AppUrlMatcher = (url: URL, appOrigin: string) => boolean;
+type UrlMatcher = (url: URL) => boolean;
 
-async function waitForExpectedAppUrl(
+async function waitForExpectedUrl(
   page: Page,
-  appUrl: string,
-  matchesExpectedUrl: AppUrlMatcher,
+  appOrigin: string,
+  matchesExpectedUrl: UrlMatcher,
   timeoutMs: number,
-): Promise<void> {
-  const appOrigin = new URL(appUrl).origin;
+): Promise<URL> {
   const deadline = Date.now() + timeoutMs;
 
   while (true) {
     const currentUrl = new URL(page.url());
-    if (matchesExpectedUrl(currentUrl, appOrigin)) {
-      return;
-    }
-
     const rewrittenUrl = rewritePreviewAppFallbackUrl(currentUrl, appOrigin);
     if (rewrittenUrl) {
       console.log("[e2e] rewriting onboarding preview handoff", {
@@ -133,6 +212,10 @@ async function waitForExpectedAppUrl(
       });
       await page.goto(rewrittenUrl, { waitUntil: "domcontentloaded" });
       continue;
+    }
+
+    if (matchesExpectedUrl(currentUrl)) {
+      return currentUrl;
     }
 
     const remainingMs = deadline - Date.now();
@@ -144,7 +227,7 @@ async function waitForExpectedAppUrl(
 
     await page.waitForURL(
       (url) =>
-        matchesExpectedUrl(url, appOrigin) ||
+        matchesExpectedUrl(url) ||
         rewritePreviewAppFallbackUrl(url, appOrigin) !== null,
       { timeout: remainingMs, waitUntil: "domcontentloaded" },
     );
@@ -208,4 +291,25 @@ function rewriteNestedRedirectUrl(url: URL, appOrigin: string): void {
       throw error;
     }
   }
+}
+
+function isChatUrl(url: URL): boolean {
+  return /\/agents\/[^/]+\/chat/.test(url.pathname);
+}
+
+function isPromptOrChatUrl(url: URL): boolean {
+  return url.pathname === "/prompt" || isChatUrl(url);
+}
+
+function isHostedSignInUrl(url: URL): boolean {
+  return url.pathname.includes("/sign-in");
+}
+
+function isOnboardingUrl(url: URL): boolean {
+  return url.pathname.startsWith("/onboarding/");
+}
+
+function redirectOriginFromAuthUrl(url: URL): string | null {
+  const redirectUrl = url.searchParams.get("redirect_url");
+  return redirectUrl ? new URL(redirectUrl).origin : null;
 }

--- a/e2e/playwright/tests/create-agent.spec.ts
+++ b/e2e/playwright/tests/create-agent.spec.ts
@@ -14,11 +14,19 @@ test("create a new agent and verify it appears in the list", async ({
     timeout: 20_000,
   });
 
-  // Click the Private section's Create button
-  const privateSection = page.locator("section").filter({
-    has: page.getByRole("heading", { name: "Private", exact: true }),
-  });
-  await privateSection.getByRole("button", { name: "Create" }).click();
+  const privateTab = page.getByRole("tab", { name: "Private", exact: true });
+  if (await privateTab.isVisible()) {
+    await privateTab.click();
+    await page
+      .getByRole("button", { name: /^(New agent|Create agent)$/ })
+      .first()
+      .click();
+  } else {
+    const privateSection = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Private", exact: true }),
+    });
+    await privateSection.getByRole("button", { name: "Create" }).click();
+  }
   await expect(page.getByRole("dialog")).toBeVisible();
 
   // Fill name and submit

--- a/e2e/playwright/tests/paid-onboarding.spec.ts
+++ b/e2e/playwright/tests/paid-onboarding.spec.ts
@@ -39,9 +39,15 @@ test("paid onboarding completes through the video workflow", async ({
 
     await startVideoOnboardingCheckout(page, { apiUrl, appUrl, onboardingUrl });
     await fillStripeCheckout(page);
-    await waitForPaidOnboardingAppHandoff(page, appUrl);
+    const handoffUrl = await waitForPaidOnboardingAppHandoff(page, {
+      appUrl,
+      auth: { email, activeOrganizationId: orgId },
+    });
 
-    expect(new URL(page.url()).origin).toBe(new URL(appUrl).origin);
+    expect(
+      handoffUrl.pathname === "/prompt" ||
+        /\/agents\/[^/]+\/chat/.test(handoffUrl.pathname),
+    ).toBe(true);
   } finally {
     await deleteUserByEmail(email);
   }

--- a/e2e/playwright/tests/smoke.spec.ts
+++ b/e2e/playwright/tests/smoke.spec.ts
@@ -25,7 +25,12 @@ test("sign in through onboarding handoff to chat page", async ({ page }) => {
     mirrorStorageToUrls: [onboardingUrl],
   });
 
-  await completeExploreOnboarding(page, { apiUrl, appUrl, onboardingUrl });
+  await completeExploreOnboarding(page, {
+    apiUrl,
+    appUrl,
+    onboardingUrl,
+    auth: { email, activeOrganizationId: orgId },
+  });
 
   // Verify: landed on chat page
   await page.waitForURL("**/agents/*/chat", {

--- a/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
+++ b/turbo/apps/platform/src/views/agents-page/__tests__/agents-page.test.tsx
@@ -59,7 +59,7 @@ async function expectVisibleTooltip(text: string): Promise<void> {
   expect(visibleMatch).toBeDefined();
 }
 
-describe("agents page", () => {
+describe("agents page (legacy)", () => {
   it("shows the creator of a public agent on hover", async () => {
     const user = userEvent.setup();
     context.mocks.data.team(agents);
@@ -86,7 +86,11 @@ describe("agents page", () => {
       ],
     });
 
-    detachedSetupPage({ context, path: "/agents" });
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      featureSwitches: { [FeatureSwitchKey.AgentsPageRedesign]: false },
+    });
 
     await waitFor(() => {
       expect(agentCard("Research Agent")).toBeInTheDocument();
@@ -126,7 +130,10 @@ describe("agents page", () => {
     detachedSetupPage({
       context,
       path: "/agents",
-      featureSwitches: { [FeatureSwitchKey.AgentUnreadIndicators]: true },
+      featureSwitches: {
+        [FeatureSwitchKey.AgentsPageRedesign]: false,
+        [FeatureSwitchKey.AgentUnreadIndicators]: true,
+      },
     });
 
     await waitFor(() => {
@@ -157,7 +164,10 @@ describe("agents page", () => {
     detachedSetupPage({
       context,
       path: "/agents",
-      featureSwitches: { [FeatureSwitchKey.AgentUnreadIndicators]: false },
+      featureSwitches: {
+        [FeatureSwitchKey.AgentsPageRedesign]: false,
+        [FeatureSwitchKey.AgentUnreadIndicators]: false,
+      },
     });
 
     await waitFor(() => {
@@ -177,7 +187,11 @@ describe("agents page", () => {
     context.mocks.data.team(agents);
     context.mocks.data.orgMembers({ members: [] });
 
-    detachedSetupPage({ context, path: "/agents" });
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      featureSwitches: { [FeatureSwitchKey.AgentsPageRedesign]: false },
+    });
 
     await waitFor(() => {
       expect(agentCard("Research Agent")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -17,6 +17,7 @@ import {
   type TeamComposeItem,
   zeroTeamContract,
 } from "@vm0/api-contracts/contracts/zero-team";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 const context = testContext();
 
@@ -157,7 +158,11 @@ describe("zero jobs page", () => {
         updatedAt: "2024-01-03T00:00:00Z",
       },
     ]);
-    detachedSetupPage({ context, path: "/agents" });
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      featureSwitches: { [FeatureSwitchKey.AgentsPageRedesign]: false },
+    });
 
     await waitFor(() => {
       expect(screen.getByText("Research Agent")).toBeInTheDocument();
@@ -231,7 +236,11 @@ describe("zero jobs page", () => {
       },
     );
 
-    detachedSetupPage({ context, path: "/agents" });
+    detachedSetupPage({
+      context,
+      path: "/agents",
+      featureSwitches: { [FeatureSwitchKey.AgentsPageRedesign]: false },
+    });
 
     let dialog = await openCreateDialog("Public");
     await fill(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -144,6 +144,7 @@ describe("getAllFeatureStates", () => {
     );
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.AgentsPageRedesign]).toBe(true);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -171,6 +172,7 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.BytePlusVoiceInputStt]).toBe(true);
+    expect(otherOrgStates[FeatureSwitchKey.AgentsPageRedesign]).toBe(true);
   });
 
   it("should apply overrides to enable disabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -366,7 +366,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ming@vm0.ai",
     description:
       "New Agents page with Public/Private tabs, a public-slot indicator, a Created by footer on every card, a name-first create dialog with a visibility select, and a private empty state.",
-    enabled: false,
+    enabled: true,
   },
   [FeatureSwitchKey.SidebarManageIconCollapse]: {
     maintainer: "ming@vm0.ai",


### PR DESCRIPTION
## Summary
- Enables `AgentsPageRedesign` by default so the Agents page uses the Public/Private tab layout for all users.
- Updates the feature-switch rollout matrix test to lock the new default-on state for both staff and non-staff orgs.

## Verification
- `npx pnpm@10.33.4 -F @vm0/core test -- src/__tests__/feature-switch.test.ts`
- `npx pnpm@10.33.4 -F @vm0/core check-types`
- `git diff --check`