### PR TITLE
fix: align connector access dialog scrollbar to modal edge

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -202,7 +202,7 @@ function AgentAccessList({
   }
 
   return (
-    <div className="h-full min-h-0 overflow-y-auto pr-1">
+    <div className="-mr-6 h-full min-h-0 overflow-y-auto pr-6">
       {rows.map((row) => {
         return (
           <AgentAccessRow
@@ -287,7 +287,7 @@ function ConnectorAccessDialog({
 
         <div
           className={cn(
-            "min-h-0 flex-1 overflow-hidden rounded-lg",
+            "min-h-0 flex-1",
             !rowsLoaded && "flex",
             rowsLoaded && "flex flex-col",
           )}


### PR DESCRIPTION
## What

The scrollbar in the **Manage connector access** dialog (the per-connector "Choose which agents can use this connector" modal) rendered inset ~24px from the modal's right border, appearing to float in the middle of the surface next to the toggles.

Root cause: the scrollable agent list lives inside `DialogContent`'s `p-6` padding, so `overflow-y-auto` placed the scrollbar at the inner content edge, leaving a 24px empty gutter to its right.

## Change

`connector-access-management-dialog.tsx` (2 lines):
- Scroll list: `pr-1` → `-mr-6 ... pr-6`. The negative right margin bleeds the scroll region out to the modal's right border so the scrollbar hugs the container edge; `pr-6` restores the row inset so the toggles stay **exactly where they were** (~28px from the border).
- Removed `overflow-hidden rounded-lg` from the list wrapper so the negative-margin bleed isn't clipped.

Header, search field, avatars, and toggle positions are unchanged. Left/top/bottom modal padding is untouched.

## Verification

Pure className change. Verified visually on the PR app preview (see walkthrough in comments).