### PR TITLE
feat: write zstd session history blobs

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -13,7 +13,8 @@ use crate::session_history_identity::{
 };
 use api_contracts::generated::constants::runners::{
     RESUME_SESSION_HISTORY_MAX_BYTES, SESSION_HISTORY_ENCODING_GZIP,
-    SESSION_HISTORY_ENCODING_IDENTITY, SESSION_HISTORY_GZIP_MIN_BYTES,
+    SESSION_HISTORY_ENCODING_IDENTITY, SESSION_HISTORY_ENCODING_ZSTD,
+    SESSION_HISTORY_GZIP_MIN_BYTES,
 };
 use api_contracts::generated::types::runners::storage::ArtifactEntryMissingRootPolicy;
 use bytes::Bytes;
@@ -27,6 +28,9 @@ use std::io::{ErrorKind, Write};
 use std::time::Duration;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const SESSION_HISTORY_ZSTD_LEVEL: i32 = 3;
+const SESSION_HISTORY_COMPRESSION_MIN_BYTES: usize = SESSION_HISTORY_GZIP_MIN_BYTES as usize;
+
 #[derive(Clone, Copy)]
 enum CheckpointMode {
     Success,
@@ -36,6 +40,7 @@ enum CheckpointMode {
 enum SessionHistoryUploadBody {
     Identity(Vec<u8>),
     Gzip { raw: Vec<u8>, gzip: Vec<u8> },
+    Zstd { raw: Vec<u8>, zstd: Vec<u8> },
 }
 
 struct SessionHistoryUpload {
@@ -48,6 +53,7 @@ impl SessionHistoryUpload {
         match self.body {
             SessionHistoryUploadBody::Identity(_) => SESSION_HISTORY_ENCODING_IDENTITY,
             SessionHistoryUploadBody::Gzip { .. } => SESSION_HISTORY_ENCODING_GZIP,
+            SessionHistoryUploadBody::Zstd { .. } => SESSION_HISTORY_ENCODING_ZSTD,
         }
     }
 
@@ -55,24 +61,71 @@ impl SessionHistoryUpload {
         match &self.body {
             SessionHistoryUploadBody::Identity(raw) => raw.len() as u64,
             SessionHistoryUploadBody::Gzip { gzip, .. } => gzip.len() as u64,
+            SessionHistoryUploadBody::Zstd { zstd, .. } => zstd.len() as u64,
         }
     }
 
-    fn into_server_accepted_bytes(self, accepted_encoding: Option<&str>) -> (&'static str, Bytes) {
+    fn into_raw(self) -> Vec<u8> {
+        match self.body {
+            SessionHistoryUploadBody::Identity(raw)
+            | SessionHistoryUploadBody::Gzip { raw, .. }
+            | SessionHistoryUploadBody::Zstd { raw, .. } => raw,
+        }
+    }
+
+    fn into_server_accepted_bytes(
+        self,
+        accepted_encoding: Option<&str>,
+    ) -> SessionHistoryServerAcceptedBytes {
         match self.body {
             SessionHistoryUploadBody::Identity(raw) => {
-                (SESSION_HISTORY_ENCODING_IDENTITY, Bytes::from(raw))
+                SessionHistoryServerAcceptedBytes::Accepted {
+                    encoding: SESSION_HISTORY_ENCODING_IDENTITY,
+                    bytes: Bytes::from(raw),
+                }
             }
             SessionHistoryUploadBody::Gzip { raw: _, gzip }
                 if accepted_encoding == Some(SESSION_HISTORY_ENCODING_GZIP) =>
             {
-                (SESSION_HISTORY_ENCODING_GZIP, Bytes::from(gzip))
+                SessionHistoryServerAcceptedBytes::Accepted {
+                    encoding: SESSION_HISTORY_ENCODING_GZIP,
+                    bytes: Bytes::from(gzip),
+                }
             }
             SessionHistoryUploadBody::Gzip { raw, .. } => {
-                (SESSION_HISTORY_ENCODING_IDENTITY, Bytes::from(raw))
+                SessionHistoryServerAcceptedBytes::Accepted {
+                    encoding: SESSION_HISTORY_ENCODING_IDENTITY,
+                    bytes: Bytes::from(raw),
+                }
+            }
+            SessionHistoryUploadBody::Zstd { raw: _, zstd }
+                if accepted_encoding == Some(SESSION_HISTORY_ENCODING_ZSTD) =>
+            {
+                SessionHistoryServerAcceptedBytes::Accepted {
+                    encoding: SESSION_HISTORY_ENCODING_ZSTD,
+                    bytes: Bytes::from(zstd),
+                }
+            }
+            SessionHistoryUploadBody::Zstd { raw, .. } => {
+                SessionHistoryServerAcceptedBytes::UnsupportedZstd { raw }
             }
         }
     }
+}
+
+enum SessionHistoryServerAcceptedBytes {
+    Accepted {
+        encoding: &'static str,
+        bytes: Bytes,
+    },
+    UnsupportedZstd {
+        raw: Vec<u8>,
+    },
+}
+
+enum SessionHistoryUploadAttempt {
+    Complete,
+    RetryLegacy(Vec<u8>),
 }
 
 fn gzip_session_history(history_bytes: &[u8]) -> Result<Vec<u8>, AgentError> {
@@ -89,7 +142,35 @@ fn build_session_history_upload(
     history_bytes: Vec<u8>,
 ) -> Result<SessionHistoryUpload, AgentError> {
     let raw_size = history_bytes.len() as u64;
-    if history_bytes.len() < SESSION_HISTORY_GZIP_MIN_BYTES as usize {
+    if history_bytes.len() < SESSION_HISTORY_COMPRESSION_MIN_BYTES {
+        return Ok(SessionHistoryUpload {
+            raw_size,
+            body: SessionHistoryUploadBody::Identity(history_bytes),
+        });
+    }
+
+    let zstd_bytes = zstd_session_history(&history_bytes)?;
+    if zstd_bytes.len() >= history_bytes.len() {
+        return Ok(SessionHistoryUpload {
+            raw_size,
+            body: SessionHistoryUploadBody::Identity(history_bytes),
+        });
+    }
+
+    Ok(SessionHistoryUpload {
+        raw_size,
+        body: SessionHistoryUploadBody::Zstd {
+            raw: history_bytes,
+            zstd: zstd_bytes,
+        },
+    })
+}
+
+fn build_legacy_session_history_upload(
+    history_bytes: Vec<u8>,
+) -> Result<SessionHistoryUpload, AgentError> {
+    let raw_size = history_bytes.len() as u64;
+    if history_bytes.len() < SESSION_HISTORY_COMPRESSION_MIN_BYTES {
         return Ok(SessionHistoryUpload {
             raw_size,
             body: SessionHistoryUploadBody::Identity(history_bytes),
@@ -111,6 +192,17 @@ fn build_session_history_upload(
             gzip: gzip_bytes,
         },
     })
+}
+
+fn zstd_session_history(history_bytes: &[u8]) -> Result<Vec<u8>, AgentError> {
+    let mut encoder = zstd::stream::write::Encoder::new(Vec::new(), SESSION_HISTORY_ZSTD_LEVEL)
+        .map_err(|error| AgentError::Checkpoint(format!("zstd session history: {error}")))?;
+    encoder
+        .write_all(history_bytes)
+        .map_err(|error| AgentError::Checkpoint(format!("zstd session history: {error}")))?;
+    encoder
+        .finish()
+        .map_err(|error| AgentError::Checkpoint(format!("finish zstd session history: {error}")))
 }
 
 impl CheckpointMode {
@@ -208,16 +300,21 @@ impl<'a> CheckpointInputs<'a> {
     }
 }
 
-/// Prepare + upload the session history to S3 via a presigned URL. If the
-/// prepare endpoint reports `existing=true`, skip the upload (content-addressed
-/// dedup). Telemetry is recorded under `session_history_prepare` and
-/// `session_history_s3_upload` to match the pre-parallelization op names.
-async fn upload_session_history(
+fn is_zstd_prepare_compatibility_rejection(error: &AgentError) -> bool {
+    matches!(error, AgentError::HttpStatus { status: 400, .. })
+}
+
+/// Prepare + upload one session history candidate to S3 via a presigned URL. If
+/// the prepare endpoint reports `existing=true`, skip the upload
+/// (content-addressed dedup). Telemetry is recorded under
+/// `session_history_prepare` and `session_history_s3_upload` to match the
+/// pre-parallelization op names.
+async fn upload_session_history_candidate(
     http: &HttpClient,
     run_id: &str,
     history_hash: &str,
     history_upload: SessionHistoryUpload,
-) -> Result<(), AgentError> {
+) -> Result<SessionHistoryUploadAttempt, AgentError> {
     let prep_start = std::time::Instant::now();
     let url = http.checkpoint_prepare_history_url()?;
     let requested_encoding = history_upload.requested_encoding();
@@ -248,6 +345,17 @@ async fn upload_session_history(
         }
         Err(e) => {
             record_sandbox_op("session_history_prepare", prep_start.elapsed(), false, None);
+            if requested_encoding == SESSION_HISTORY_ENCODING_ZSTD
+                && is_zstd_prepare_compatibility_rejection(&e)
+            {
+                log_info!(
+                    LOG_TAG,
+                    "Prepare-history rejected zstd session history; retrying legacy encoding"
+                );
+                return Ok(SessionHistoryUploadAttempt::RetryLegacy(
+                    history_upload.into_raw(),
+                ));
+            }
             return Err(e);
         }
     };
@@ -263,7 +371,19 @@ async fn upload_session_history(
             LOG_TAG,
             "Session history already exists in S3 (deduplicated, encoding={accepted_encoding})"
         );
-        return Ok(());
+        return Ok(SessionHistoryUploadAttempt::Complete);
+    }
+
+    if requested_encoding == SESSION_HISTORY_ENCODING_ZSTD
+        && response_encoding != Some(SESSION_HISTORY_ENCODING_ZSTD)
+    {
+        log_info!(
+            LOG_TAG,
+            "Prepare-history response did not acknowledge zstd; retrying legacy encoding"
+        );
+        return Ok(SessionHistoryUploadAttempt::RetryLegacy(
+            history_upload.into_raw(),
+        ));
     }
 
     let presigned_url = prep_resp
@@ -274,7 +394,12 @@ async fn upload_session_history(
         })?;
 
     let (upload_encoding, upload_bytes) =
-        history_upload.into_server_accepted_bytes(response_encoding);
+        match history_upload.into_server_accepted_bytes(response_encoding) {
+            SessionHistoryServerAcceptedBytes::Accepted { encoding, bytes } => (encoding, bytes),
+            SessionHistoryServerAcceptedBytes::UnsupportedZstd { raw } => {
+                return Ok(SessionHistoryUploadAttempt::RetryLegacy(raw));
+            }
+        };
     if requested_encoding == SESSION_HISTORY_ENCODING_GZIP
         && upload_encoding == SESSION_HISTORY_ENCODING_IDENTITY
     {
@@ -308,7 +433,7 @@ async fn upload_session_history(
         None,
     );
     log_info!(LOG_TAG, "Session history uploaded to S3");
-    Ok(())
+    Ok(SessionHistoryUploadAttempt::Complete)
 }
 
 async fn build_and_upload_session_history(
@@ -318,7 +443,20 @@ async fn build_and_upload_session_history(
     history_bytes: Vec<u8>,
 ) -> Result<(), AgentError> {
     let history_upload = build_session_history_upload(history_bytes)?;
-    upload_session_history(http, run_id, history_hash, history_upload).await
+    match upload_session_history_candidate(http, run_id, history_hash, history_upload).await? {
+        SessionHistoryUploadAttempt::Complete => Ok(()),
+        SessionHistoryUploadAttempt::RetryLegacy(history_bytes) => {
+            let legacy_upload = build_legacy_session_history_upload(history_bytes)?;
+            match upload_session_history_candidate(http, run_id, history_hash, legacy_upload)
+                .await?
+            {
+                SessionHistoryUploadAttempt::Complete => Ok(()),
+                SessionHistoryUploadAttempt::RetryLegacy(_) => Err(AgentError::Checkpoint(
+                    "Legacy session history upload unexpectedly requested zstd fallback".into(),
+                )),
+            }
+        }
+    }
 }
 
 /// Snapshot artifact entries. Memory rides in `VM0_ARTIFACTS` post-#10602, so

--- a/crates/guest-agent/src/error.rs
+++ b/crates/guest-agent/src/error.rs
@@ -8,6 +8,12 @@ pub enum AgentError {
     #[error("http: {0}")]
     Http(String),
 
+    /// HTTP helper boundary failure with a concrete non-retriable response
+    /// status. This is used when callers need to distinguish compatibility
+    /// rejections from auth/not-found failures.
+    #[error("http: {message}")]
+    HttpStatus { status: u16, message: String },
+
     /// Local OS I/O failure outside the HTTP helper, such as filesystem access,
     /// temporary directory creation, or child-process stdout/stderr pipes.
     #[error("io: {0}")]

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -330,14 +330,20 @@ impl HttpClient {
                     match error_msg {
                         Some(msg) => {
                             log_warn!(LOG_TAG, "HTTP POST failed: HTTP {status} — {msg}",);
-                            AgentError::Http(format!("POST {url}: {msg}"))
+                            AgentError::HttpStatus {
+                                status: status.as_u16(),
+                                message: format!("POST {url}: {msg}"),
+                            }
                         }
                         None => {
                             log_warn!(
                                 LOG_TAG,
                                 "HTTP POST failed (attempt {attempt}/{max_retries}): HTTP {status}",
                             );
-                            AgentError::Http(format!("POST {url}: HTTP {status}"))
+                            AgentError::HttpStatus {
+                                status: status.as_u16(),
+                                message: format!("POST {url}: HTTP {status}"),
+                            }
                         }
                     }
                 }

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -93,6 +93,55 @@ fn write_literal_session_history(
     Ok(dir)
 }
 
+fn zstd_session_history_for_test(history: &[u8]) -> std::io::Result<Vec<u8>> {
+    zstd::stream::encode_all(history, 3)
+}
+
+fn high_entropy_history(size: usize) -> Vec<u8> {
+    let mut state = 0x6a09e667f3bcc909_u64;
+    let mut bytes = Vec::with_capacity(size);
+    for _ in 0..size {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let value = state.wrapping_mul(0x2545f4914f6cdd1d);
+        bytes.push((value >> 56) as u8);
+    }
+    bytes
+}
+
+fn upload_zstd_validation_response(
+    req: &HttpMockRequest,
+    expected_body: &[u8],
+) -> HttpMockResponse {
+    if request_header_absent(req, "authorization")
+        && request_header_absent(req, "x-vercel-protection-bypass")
+        && req.body_ref() != expected_body
+        && zstd::stream::decode_all(req.body_ref()).is_ok_and(|decoded| decoded == expected_body)
+    {
+        http_status(200)
+    } else {
+        http_status(400)
+    }
+}
+
+fn upload_gzip_validation_response(
+    req: &HttpMockRequest,
+    expected_body: &[u8],
+) -> HttpMockResponse {
+    if request_header_absent(req, "authorization")
+        && request_header_absent(req, "x-vercel-protection-bypass")
+        && req.body_ref() != expected_body
+    {
+        let mut decoded = Vec::new();
+        let decode_result = GzDecoder::new(req.body_ref()).read_to_end(&mut decoded);
+        if decode_result.is_ok() && decoded == expected_body {
+            return http_status(200);
+        }
+    }
+    http_status(400)
+}
+
 // =========================================================================
 // Success checkpoint
 // =========================================================================
@@ -169,7 +218,8 @@ async fn success_checkpoint_uploads_non_utf8_session_history() {
 }
 
 #[tokio::test]
-async fn success_checkpoint_writes_large_final_identity_metadata() {
+async fn success_checkpoint_writes_large_final_identity_metadata()
+-> Result<(), Box<dyn std::error::Error>> {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -180,27 +230,30 @@ async fn success_checkpoint_writes_large_final_identity_metadata() {
 
     let history_hash = hex::encode(Sha256::digest(&history));
     let history_size = history.len();
+    let zstd_history = zstd_session_history_for_test(&history)?;
+    let zstd_size = zstd_history.len();
     let prepare_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints/prepare-history")
             .json_body_includes(r#"{"runId":"test-run-001"}"#)
             .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
             .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
-            .json_body_includes(r#"{"encoding":"gzip"}"#);
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
             .json_body(json!({
                 "presignedUrl": server.url("/test/success-large-history-upload"),
-                "existing": false
+                "existing": false,
+                "encoding": "zstd"
             }));
     });
-    let upload_len = history_size.to_string();
     let upload_body = history.clone();
     let upload_mock = server.mock(|when, then| {
         when.method(PUT)
             .path("/test/success-large-history-upload")
             .header("Content-Type", "application/octet-stream");
-        then.respond_with(move |req| upload_validation_response(req, &upload_body, &upload_len));
+        then.respond_with(move |req| upload_zstd_validation_response(req, &upload_body));
     });
     let checkpoint_mock = server.mock(|when, then| {
         when.method(POST)
@@ -236,21 +289,40 @@ async fn success_checkpoint_writes_large_final_identity_metadata() {
         std::fs::read(&identity.history_marker_payload).unwrap(),
         history
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn success_checkpoint_uploads_gzip_session_history_when_acknowledged() {
+async fn success_checkpoint_downgrades_to_gzip_when_zstd_prepare_is_rejected()
+-> Result<(), Box<dyn std::error::Error>> {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
     let runtime = runtime_from_process_env().unwrap();
     let _files_guard = SessionCheckpointFilesGuard::new();
     let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
-    let _history_dir = write_literal_session_history("success-gzip-session", &history).unwrap();
+    let _history_dir = write_literal_session_history("fallback-gzip-session", &history).unwrap();
 
     let history_hash = hex::encode(Sha256::digest(&history));
     let history_size = history.len();
-    let prepare_mock = server.mock(|when, then| {
+    let zstd_size = zstd_session_history_for_test(&history)?.len();
+    let zstd_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
+        then.status(400)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "error": {
+                    "message": "Invalid enum value. Expected identity | gzip"
+                }
+            }));
+    });
+    let gzip_prepare_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints/prepare-history")
             .json_body_includes(r#"{"runId":"test-run-001"}"#)
@@ -270,24 +342,12 @@ async fn success_checkpoint_uploads_gzip_session_history_when_acknowledged() {
         when.method(PUT)
             .path("/test/success-gzip-history-upload")
             .header("Content-Type", "application/octet-stream");
-        then.respond_with(move |req| {
-            if request_header_absent(req, "authorization")
-                && request_header_absent(req, "x-vercel-protection-bypass")
-                && req.body_ref() != upload_body.as_slice()
-            {
-                let mut decoded = Vec::new();
-                let decode_result = GzDecoder::new(req.body_ref()).read_to_end(&mut decoded);
-                if decode_result.is_ok() && decoded == upload_body {
-                    return http_status(200);
-                }
-            }
-            http_status(400)
-        });
+        then.respond_with(move |req| upload_gzip_validation_response(req, &upload_body));
     });
     let checkpoint_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints")
-            .json_body_includes(r#"{"cliAgentSessionId":"success-gzip-session"}"#)
+            .json_body_includes(r#"{"cliAgentSessionId":"fallback-gzip-session"}"#)
             .json_body_includes(format!(
                 r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
             ));
@@ -299,13 +359,162 @@ async fn success_checkpoint_uploads_gzip_session_history_when_acknowledged() {
     let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
 
     assert!(result.is_ok());
-    prepare_mock.assert_calls_async(1).await;
+    zstd_prepare_mock.assert_calls_async(1).await;
+    gzip_prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn success_checkpoint_uploads_large_non_utf8_session_history_as_gzip_when_acknowledged() {
+async fn success_checkpoint_downgrades_when_zstd_prepare_is_not_acknowledged()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let runtime = runtime_from_process_env().unwrap();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
+    let _history_dir = write_literal_session_history("zstd-unack-session", &history).unwrap();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let zstd_size = zstd_session_history_for_test(&history)?.len();
+    let zstd_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/zstd-unack-history-upload"),
+                "existing": false
+            }));
+    });
+    let zstd_upload_mock = server.mock(|when, then| {
+        when.method(PUT).path("/test/zstd-unack-history-upload");
+        then.status(200);
+    });
+    let gzip_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(r#"{"encoding":"gzip"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/zstd-unack-gzip-history-upload"),
+                "existing": false,
+                "encoding": "gzip"
+            }));
+    });
+    let upload_body = history.clone();
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/zstd-unack-gzip-history-upload")
+            .header("Content-Type", "application/octet-stream");
+        then.respond_with(move |req| upload_gzip_validation_response(req, &upload_body));
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionId":"zstd-unack-session"}"#)
+            .json_body_includes(format!(
+                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+            ));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-zstd-unack"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
+
+    assert!(result.is_ok());
+    zstd_prepare_mock.assert_calls_async(1).await;
+    zstd_upload_mock.assert_calls_async(0).await;
+    gzip_prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn success_checkpoint_does_not_downgrade_zstd_auth_failure()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let runtime = runtime_from_process_env().unwrap();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
+    let _history_dir =
+        write_literal_session_history("zstd-auth-failure-session", &history).unwrap();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let zstd_size = zstd_session_history_for_test(&history)?.len();
+    let zstd_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
+        then.status(401)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "error": {
+                    "message": "unauthorized checkpoint history prepare"
+                }
+            }));
+    });
+    let gzip_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"encoding":"gzip"}"#);
+        then.status(200).json_body(json!({
+            "presignedUrl": server.url("/test/unexpected-gzip-history-upload"),
+            "existing": false,
+            "encoding": "gzip"
+        }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/unexpected-gzip-history-upload");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "unexpected"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("unauthorized checkpoint history prepare"),
+        "expected auth failure to propagate, got: {err}"
+    );
+    zstd_prepare_mock.assert_calls_async(1).await;
+    gzip_prepare_mock.assert_calls_async(0).await;
+    upload_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn success_checkpoint_uploads_large_non_utf8_session_history_as_zstd_when_acknowledged()
+-> Result<(), Box<dyn std::error::Error>> {
     let api = SharedApiMock::new().await;
     let server = api.server();
 
@@ -317,19 +526,21 @@ async fn success_checkpoint_uploads_large_non_utf8_session_history_as_gzip_when_
 
     let history_hash = hex::encode(Sha256::digest(&history));
     let history_size = history.len();
+    let zstd_size = zstd_session_history_for_test(&history)?.len();
     let prepare_mock = server.mock(|when, then| {
         when.method(POST)
             .path("/api/webhooks/agent/checkpoints/prepare-history")
             .json_body_includes(r#"{"runId":"test-run-001"}"#)
             .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
             .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
-            .json_body_includes(r#"{"encoding":"gzip"}"#);
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
         then.status(200)
             .header("Content-Type", "application/json")
             .json_body(json!({
                 "presignedUrl": server.url("/test/large-non-utf8-history-upload"),
                 "existing": false,
-                "encoding": "gzip"
+                "encoding": "zstd"
             }));
     });
     let upload_body = history.clone();
@@ -337,19 +548,7 @@ async fn success_checkpoint_uploads_large_non_utf8_session_history_as_gzip_when_
         when.method(PUT)
             .path("/test/large-non-utf8-history-upload")
             .header("Content-Type", "application/octet-stream");
-        then.respond_with(move |req| {
-            if request_header_absent(req, "authorization")
-                && request_header_absent(req, "x-vercel-protection-bypass")
-                && req.body_ref() != upload_body.as_slice()
-            {
-                let mut decoded = Vec::new();
-                let decode_result = GzDecoder::new(req.body_ref()).read_to_end(&mut decoded);
-                if decode_result.is_ok() && decoded == upload_body {
-                    return http_status(200);
-                }
-            }
-            http_status(400)
-        });
+        then.respond_with(move |req| upload_zstd_validation_response(req, &upload_body));
     });
     let checkpoint_mock = server.mock(|when, then| {
         when.method(POST)
@@ -369,6 +568,69 @@ async fn success_checkpoint_uploads_large_non_utf8_session_history_as_gzip_when_
     prepare_mock.assert_calls_async(1).await;
     upload_mock.assert_calls_async(1).await;
     checkpoint_mock.assert_calls_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn success_checkpoint_uploads_large_uncompressible_session_history_as_identity()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let runtime = runtime_from_process_env().unwrap();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = high_entropy_history(LARGE_SESSION_HISTORY_SIZE_BYTES);
+    let zstd_history = zstd_session_history_for_test(&history)?;
+    assert!(
+        zstd_history.len() >= history.len(),
+        "test fixture must not be zstd-compressible"
+    );
+    let _history_dir = write_literal_session_history("large-identity-session", &history).unwrap();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{history_size}}}"#))
+            .json_body_includes(r#"{"encoding":"identity"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/large-identity-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_len = history_size.to_string();
+    let upload_body = history.clone();
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/large-identity-history-upload")
+            .header("Content-Type", "application/octet-stream");
+        then.respond_with(move |req| upload_validation_response(req, &upload_body, &upload_len));
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints")
+            .json_body_includes(r#"{"cliAgentSessionId":"large-identity-session"}"#)
+            .json_body_includes(format!(
+                r#"{{"cliAgentSessionHistoryHash":"{history_hash}"}}"#
+            ));
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "checkpoint-large-identity"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
+
+    assert!(result.is_ok());
+    prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(1).await;
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/guest-agent/tests/integration/http_client.rs
+++ b/crates/guest-agent/tests/integration/http_client.rs
@@ -1,4 +1,5 @@
 use crate::support::*;
+use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
 use serde_json::json;
@@ -164,7 +165,37 @@ async fn post_json_4xx_returns_immediately_no_retry() {
 
     // Should fail immediately — only 1 call, no retries.
     mock.assert_calls_async(1).await;
-    assert!(result.is_err());
+    let Err(AgentError::HttpStatus { status, .. }) = result else {
+        panic!("expected structured HTTP status error");
+    };
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn post_json_4xx_error_body_preserves_status_and_message() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/test/post-401");
+        then.status(401)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "error": {
+                    "message": "token expired"
+                }
+            }));
+    });
+
+    let url = api.url("/test/post-401");
+    let result = http_client!().post_json(&url, &json!({}), 3).await;
+
+    mock.assert_calls_async(1).await;
+    let Err(AgentError::HttpStatus { status, message }) = result else {
+        panic!("expected structured HTTP status error");
+    };
+    assert_eq!(status, 401);
+    assert!(message.contains("token expired"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- write large compressible guest-agent session history uploads as zstd level 3 blobs
- keep raw SHA-256 hash semantics and identity selection for small or uncompressible histories
- retry the existing gzip/identity upload path only when zstd prepare-history is rejected with HTTP 400 or not acknowledged
- preserve non-compatibility failures such as auth errors and S3 upload failures

## Tests

- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent checkpoint
- cargo test --manifest-path crates/Cargo.toml -p guest-agent http_client
- cargo test --manifest-path crates/Cargo.toml -p guest-agent

Closes #20330