### PR TITLE
feat: replace chat thread icon menu with searchable emoji picker

### DIFF
--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -45,6 +45,7 @@
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
     "signal-timers": "^1.0.4",
+    "unicode-emoji-json": "^0.9.0",
     "yaml": "^2.7.1"
   },
   "devDependencies": {

--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -9,13 +9,10 @@ import {
 } from "./chat-thread-panes.ts";
 import type { ChatThreadSignals } from "./chat-thread-signals.ts";
 import {
-  clearChatThreadEmojiFromThreadMeta$,
   openRenameChatThreadDialogFromThreadMeta$,
-  setChatThreadEmojiFromThreadMeta$,
   type RenameChatThreadDialogRequest,
 } from "./chat-thread-rename.ts";
 import { chatThreadMetaMap$ } from "./chat-thread-event-sourcing.ts";
-import { CHAT_THREAD_EMOJI_OPTIONS } from "./chat-thread-title.ts";
 import type { ScrollStepDirection } from "../auto-scroll.ts";
 import { onRef } from "../utils.ts";
 import { openChatThreadEmojiMenu$ } from "../zero-page/zero-sidebar-state.ts";
@@ -188,14 +185,12 @@ function setupKeyboardScrollPrepareListener({
 }
 
 interface ChatPageShortcutActions {
-  clearEmoji: () => void | Promise<void>;
   openEmojiMenu: () => void | Promise<void>;
   renameThread: () => void | Promise<void>;
   navigateNext: () => void | Promise<void>;
   navigatePrev: () => void | Promise<void>;
   scrollBottom: () => void | Promise<void>;
   scrollTop: () => void | Promise<void>;
-  setEmoji: (emoji: string) => void | Promise<void>;
 }
 
 interface ChatPageShortcutSetup {
@@ -224,29 +219,6 @@ function setupChatPageGlobalShortcutListener({
   });
 }
 
-const setFocusedThreadEmoji$ = command(
-  async (
-    { get, set },
-    args: {
-      thread: ChatThreadSignals;
-      emoji: string;
-    },
-    signal: AbortSignal,
-  ) => {
-    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
-      return;
-    }
-    await set(
-      setChatThreadEmojiFromThreadMeta$,
-      {
-        threadId: args.thread.threadId,
-        emoji: args.emoji,
-      },
-      signal,
-    );
-  },
-);
-
 const setupChatPageShortcutActions$ = command(
   (
     { get, set },
@@ -255,12 +227,6 @@ const setupChatPageShortcutActions$ = command(
   ) => {
     setupChatPageGlobalShortcutListener({
       actions: {
-        clearEmoji: async () => {
-          const thread = focusedThread();
-          if (thread) {
-            await set(clearFocusedThreadEmoji$, { thread }, signal);
-          }
-        },
         openEmojiMenu: async () => {
           const thread = focusedThread();
           if (thread) {
@@ -302,36 +268,11 @@ const setupChatPageShortcutActions$ = command(
             set(scrollCurrentThread$, thread, "top");
           }
         },
-        setEmoji: async (emoji) => {
-          const thread = focusedThread();
-          if (thread) {
-            await set(setFocusedThreadEmoji$, { thread, emoji }, signal);
-          }
-        },
       },
       doc,
       root,
       signal,
     });
-  },
-);
-
-const clearFocusedThreadEmoji$ = command(
-  async (
-    { get, set },
-    args: { thread: ChatThreadSignals },
-    signal: AbortSignal,
-  ) => {
-    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
-      return;
-    }
-    await set(
-      clearChatThreadEmojiFromThreadMeta$,
-      {
-        threadId: args.thread.threadId,
-      },
-      signal,
-    );
   },
 );
 
@@ -372,43 +313,13 @@ const renameDialogRequestForThread$ = command(
   },
 );
 
-function createEmojiShortcutBindings({
-  clearEmoji,
-  setEmoji,
-}: {
-  clearEmoji: () => void | Promise<void>;
-  setEmoji: (emoji: string) => void | Promise<void>;
-}): GlobalShortcutBindings {
-  return {
-    ...(Object.fromEntries(
-      CHAT_THREAD_EMOJI_OPTIONS.map((option, index) => {
-        return [
-          `ctrl+shift+${index + 1}`,
-          {
-            allowInEditableTarget: true,
-            run: async () => {
-              await setEmoji(option.emoji);
-            },
-          },
-        ];
-      }),
-    ) as GlobalShortcutBindings),
-    "ctrl+shift+0": {
-      allowInEditableTarget: true,
-      run: clearEmoji,
-    },
-  };
-}
-
 function createChatPageShortcutBindings({
-  clearEmoji,
   openEmojiMenu,
   renameThread,
   navigateNext,
   navigatePrev,
   scrollBottom,
   scrollTop,
-  setEmoji,
 }: ChatPageShortcutActions): GlobalShortcutBindings {
   return {
     "shift+f2": {
@@ -435,7 +346,6 @@ function createChatPageShortcutBindings({
       allowInEditableTarget: true,
       run: scrollBottom,
     },
-    ...createEmojiShortcutBindings({ clearEmoji, setEmoji }),
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
@@ -1,3 +1,5 @@
+import { command, computed, state } from "ccstate";
+
 export interface ChatThreadEmojiItem {
   emoji: string;
   name: string;
@@ -8,34 +10,31 @@ export interface ChatThreadEmojiGroup {
   emojis: ChatThreadEmojiItem[];
 }
 
-let cachedGroups: ChatThreadEmojiGroup[] | null = null;
-let pendingGroups: Promise<ChatThreadEmojiGroup[]> | null = null;
-
 // The full emoji dataset (~1,900 entries) is only needed once the user opens
 // the picker, so it is loaded on demand and kept out of the main bundle.
-export async function loadChatThreadEmojiGroups(): Promise<
-  ChatThreadEmojiGroup[]
-> {
-  if (cachedGroups) {
-    return cachedGroups;
-  }
-  if (!pendingGroups) {
-    pendingGroups = import("unicode-emoji-json/data-by-group.json").then(
-      (module) => {
-        const groups = module.default.map((group) => ({
-          name: group.name,
-          emojis: group.emojis.map((entry) => ({
-            emoji: entry.emoji,
-            name: entry.name,
-          })),
-        }));
-        cachedGroups = groups;
-        return groups;
-      },
-    );
-  }
-  return pendingGroups;
-}
+export const chatThreadEmojiGroups$ = computed(
+  async (): Promise<ChatThreadEmojiGroup[]> => {
+    const module = await import("unicode-emoji-json/data-by-group.json");
+    return module.default.map((group) => {
+      return {
+        name: group.name,
+        emojis: group.emojis.map((entry) => {
+          return { emoji: entry.emoji, name: entry.name };
+        }),
+      };
+    });
+  },
+);
+
+const internalChatThreadEmojiQuery$ = state("");
+
+export const chatThreadEmojiQuery$ = computed((get) => {
+  return get(internalChatThreadEmojiQuery$);
+});
+
+export const setChatThreadEmojiQuery$ = command(({ set }, value: string) => {
+  set(internalChatThreadEmojiQuery$, value);
+});
 
 export function filterChatThreadEmojiGroups(
   groups: ChatThreadEmojiGroup[],

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
@@ -1,11 +1,6 @@
 import { command } from "ccstate";
 import { chatThreadMetaMap$ } from "./chat-thread-event-sourcing.ts";
 import { openRenameChatThreadDialog$ } from "../zero-page/zero-sidebar-state.ts";
-import { renameChatThread$ } from "./chat-message.ts";
-import {
-  applyChatThreadEmoji,
-  removeChatThreadEmoji,
-} from "./chat-thread-title.ts";
 
 export interface RenameChatThreadDialogRequest {
   readonly threadId: string;
@@ -34,52 +29,6 @@ export const openRenameChatThreadDialogForThreadId$ = command(
         title: meta?.title,
         agentId: meta?.agentId,
       },
-      signal,
-    );
-  },
-);
-
-export const setChatThreadEmojiFromThreadMeta$ = command(
-  async (
-    { get, set },
-    {
-      threadId,
-      emoji,
-      title,
-    }: { threadId: string; emoji: string; title?: string | null },
-    signal: AbortSignal,
-  ) => {
-    const meta = (await get(chatThreadMetaMap$)).get(threadId) ?? null;
-    signal.throwIfAborted();
-    const currentTitle = title !== undefined ? title : meta?.title;
-    await set(
-      renameChatThread$,
-      {
-        threadId,
-        title: applyChatThreadEmoji(currentTitle, emoji),
-        agentId: meta?.agentId,
-      },
-      signal,
-    );
-  },
-);
-
-export const clearChatThreadEmojiFromThreadMeta$ = command(
-  async (
-    { get, set },
-    { threadId, title }: { threadId: string; title?: string | null },
-    signal: AbortSignal,
-  ) => {
-    const meta = (await get(chatThreadMetaMap$)).get(threadId) ?? null;
-    signal.throwIfAborted();
-    const currentTitle = title !== undefined ? title : meta?.title;
-    const nextTitle = removeChatThreadEmoji(currentTitle);
-    if (!nextTitle) {
-      return;
-    }
-    await set(
-      renameChatThread$,
-      { threadId, title: nextTitle, agentId: meta?.agentId },
       signal,
     );
   },

--- a/turbo/apps/platform/src/types/unicode-emoji-json.d.ts
+++ b/turbo/apps/platform/src/types/unicode-emoji-json.d.ts
@@ -1,0 +1,17 @@
+declare module "unicode-emoji-json/data-by-group.json" {
+  interface UnicodeEmojiEntry {
+    emoji: string;
+    name: string;
+    slug: string;
+    skin_tone_support: boolean;
+    unicode_version: string;
+    emoji_version: string;
+  }
+  interface UnicodeEmojiGroup {
+    name: string;
+    slug: string;
+    emojis: UnicodeEmojiEntry[];
+  }
+  const groups: UnicodeEmojiGroup[];
+  export default groups;
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -842,16 +842,6 @@ function buttonByLabel(label: string): HTMLElement {
   return button;
 }
 
-function menuItemByLabel(label: string, container: HTMLElement): HTMLElement {
-  const item = queryAllByRoleFast("menuitem", container).find((candidate) => {
-    return candidate.getAttribute("aria-label") === label;
-  });
-  if (!item) {
-    throw new Error(`${label} menu item not found`);
-  }
-  return item;
-}
-
 function linkByText(text: string): HTMLElement {
   const link = queryAllByRoleFast("link").find((candidate) => {
     return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
@@ -3739,7 +3729,7 @@ describe("chat lifecycle", () => {
     });
     const emojiButton = screen.getByLabelText("Change icon");
     expect(emojiButton).toHaveTextContent("");
-    expect(emojiButton.querySelector("svg")).not.toBeInTheDocument();
+    expect(emojiButton.querySelector("svg")).toBeInTheDocument();
     expect(emojiButton).toHaveClass("h-7", "w-7");
 
     const threadRegion = screen.getByLabelText("Chat thread");
@@ -3995,54 +3985,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("adds an emoji to the focused side chat directly with Ctrl+Shift+1", async () => {
-    const renameRequest = vi.fn();
-    mockResizeObserver();
-    mockKeyboardNavigationThreads({ currentDetailTitle: null });
-    context.mocks.api(
-      chatThreadRenameContract.rename,
-      ({ body, params, respond }) => {
-        renameRequest(params.id, body.title);
-        return respond(204);
-      },
-    );
-
-    detachedSetupPage({
-      context,
-      path: "/chats/b0000000-0000-4000-a000-000000000708?sidebar=b0000000-0000-4000-a000-000000000709",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
-      expect(screen.getByText("Next thread launch note")).toBeInTheDocument();
-    });
-
-    const threadRegions = screen.getAllByLabelText("Chat thread");
-    expect(threadRegions).toHaveLength(2);
-    const sideThreadRegion = threadRegions[1];
-    if (!sideThreadRegion) {
-      throw new Error("Side chat thread not found");
-    }
-    sideThreadRegion.focus();
-    fireEvent.keyDown(sideThreadRegion, {
-      key: "!",
-      code: "Digit1",
-      ctrlKey: true,
-      shiftKey: true,
-    });
-
-    await waitFor(() => {
-      expect(renameRequest).toHaveBeenCalledWith(
-        "b0000000-0000-4000-a000-000000000709",
-        "✅ Next keyboard thread",
-      );
-    });
-  });
-
-  it("adds an emoji to the current chat with Shift+F2", async () => {
+  it("adds an emoji to the current chat from the Shift+F2 picker", async () => {
     const renameRequest = vi.fn();
     mockResizeObserver();
     mockKeyboardNavigationThreads({ currentDetailTitle: null });
@@ -4073,15 +4016,8 @@ describe("chat lifecycle", () => {
     composer.focus();
     fireEvent.keyDown(composer, { key: "F2", shiftKey: true });
 
-    const menu = await screen.findByRole("menu");
-    expect(queryAllByRoleFast("menuitem", menu)).toHaveLength(10);
-    expect(within(menu).queryByText("Done")).not.toBeInTheDocument();
-    expect(within(menu).getByText("Clear icon")).toBeInTheDocument();
-    expect(within(menu).getAllByText("Ctrl").length).toBeGreaterThan(0);
-    expect(within(menu).getAllByText("Shift").length).toBeGreaterThan(0);
-    expect(within(menu).getByText("1")).toBeInTheDocument();
-    expect(within(menu).getByText("0")).toBeInTheDocument();
-    click(menuItemByLabel("Done icon Ctrl Shift 1", menu));
+    await screen.findByLabelText("Search emoji");
+    click(screen.getByRole("button", { name: "Done" }));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -4089,90 +4025,6 @@ describe("chat lifecycle", () => {
         "✅ Current keyboard thread",
       );
     });
-  });
-
-  it("adds an emoji to the current chat directly with Ctrl+Shift+1", async () => {
-    const renameRequest = vi.fn();
-    mockResizeObserver();
-    mockKeyboardNavigationThreads({ currentDetailTitle: null });
-    context.mocks.api(
-      chatThreadRenameContract.rename,
-      ({ body, params, respond }) => {
-        renameRequest(params.id, body.title);
-        return respond(204);
-      },
-    );
-
-    detachedSetupPage({
-      context,
-      path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
-    });
-
-    const threadRegion = screen.getByLabelText("Chat thread");
-    threadRegion.focus();
-    fireEvent.keyDown(threadRegion, {
-      key: "!",
-      code: "Digit1",
-      ctrlKey: true,
-      shiftKey: true,
-    });
-
-    await waitFor(() => {
-      expect(renameRequest).toHaveBeenCalledWith(
-        "b0000000-0000-4000-a000-000000000708",
-        "✅ Current keyboard thread",
-      );
-    });
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-  });
-
-  it("adds an emoji to the current chat directly from the composer with Ctrl+Shift+1", async () => {
-    const renameRequest = vi.fn();
-    mockResizeObserver();
-    mockKeyboardNavigationThreads({ currentDetailTitle: null });
-    context.mocks.api(
-      chatThreadRenameContract.rename,
-      ({ body, params, respond }) => {
-        renameRequest(params.id, body.title);
-        return respond(204);
-      },
-    );
-
-    detachedSetupPage({
-      context,
-      path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
-    });
-
-    const composer = chatComposerTextarea();
-    composer.focus();
-    fireEvent.keyDown(composer, {
-      key: "!",
-      code: "Digit1",
-      ctrlKey: true,
-      shiftKey: true,
-    });
-
-    await waitFor(() => {
-      expect(renameRequest).toHaveBeenCalledWith(
-        "b0000000-0000-4000-a000-000000000708",
-        "✅ Current keyboard thread",
-      );
-    });
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
   it("keeps shifted digit input editable in the chat composer", async () => {
@@ -4246,14 +4098,16 @@ describe("chat lifecycle", () => {
     });
 
     await user.click(emojiButton);
-    await expect(screen.findByRole("menu")).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByLabelText("Search emoji"),
+    ).resolves.toBeInTheDocument();
 
     fireEvent.pointerOut(emojiButton);
     fireEvent.mouseOut(emojiButton);
     click(document.body);
 
     await waitFor(() => {
-      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Search emoji")).not.toBeInTheDocument();
     });
     await waitFor(() => {
       expect(visibleChatThreadIconTooltip()).toBeUndefined();
@@ -4261,7 +4115,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("replaces the current chat emoji from the Shift+F2 picker item", async () => {
+  it("replaces the current chat emoji from the Shift+F2 picker", async () => {
     const renameRequest = vi.fn();
     mockResizeObserver();
     mockKeyboardNavigationThreads({
@@ -4294,19 +4148,8 @@ describe("chat lifecycle", () => {
     threadRegion.focus();
     fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
 
-    const menu = await screen.findByRole("menu");
-    expect(
-      queryAllByRoleFast("menuitem", menu).some((item) => {
-        return item.getAttribute("aria-label") === "Important 📌";
-      }),
-    ).toBeFalsy();
-    const doneItem = queryAllByRoleFast("menuitem", menu).find((item) => {
-      return item.getAttribute("aria-label") === "Done icon Ctrl Shift 1";
-    });
-    if (!doneItem) {
-      throw new Error("Done icon menu item not found");
-    }
-    click(doneItem);
+    await screen.findByLabelText("Search emoji");
+    click(screen.getByRole("button", { name: "Done" }));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -4316,7 +4159,7 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("clears the current chat emoji directly with Ctrl+Shift+0", async () => {
+  it("clears the current chat emoji from the picker Remove button", async () => {
     const renameRequest = vi.fn();
     mockResizeObserver();
     mockKeyboardNavigationThreads({
@@ -4342,12 +4185,10 @@ describe("chat lifecycle", () => {
 
     const threadRegion = screen.getByLabelText("Chat thread");
     threadRegion.focus();
-    fireEvent.keyDown(threadRegion, {
-      key: ")",
-      code: "Digit0",
-      ctrlKey: true,
-      shiftKey: true,
-    });
+    fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
+
+    await screen.findByLabelText("Search emoji");
+    click(screen.getByRole("button", { name: "Remove" }));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -4381,12 +4222,10 @@ describe("chat lifecycle", () => {
 
     const threadRegion = screen.getByLabelText("Chat thread");
     threadRegion.focus();
-    fireEvent.keyDown(threadRegion, {
-      key: ")",
-      code: "Digit0",
-      ctrlKey: true,
-      shiftKey: true,
-    });
+    fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
+
+    await screen.findByLabelText("Search emoji");
+    click(screen.getByRole("button", { name: "Remove" }));
 
     expect(renameRequest).not.toHaveBeenCalled();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -4017,7 +4017,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(composer, { key: "F2", shiftKey: true });
 
     await screen.findByLabelText("Search emoji");
-    click(screen.getByRole("button", { name: "Done" }));
+    click(screen.getByLabelText("Done"));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -4149,7 +4149,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
 
     await screen.findByLabelText("Search emoji");
-    click(screen.getByRole("button", { name: "Done" }));
+    click(screen.getByLabelText("Done"));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -4188,7 +4188,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
 
     await screen.findByLabelText("Search emoji");
-    click(screen.getByRole("button", { name: "Remove" }));
+    click(buttonByText("Remove"));
 
     await waitFor(() => {
       expect(renameRequest).toHaveBeenCalledWith(
@@ -4225,7 +4225,7 @@ describe("chat lifecycle", () => {
     fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
 
     await screen.findByLabelText("Search emoji");
-    click(screen.getByRole("button", { name: "Remove" }));
+    click(buttonByText("Remove"));
 
     expect(renameRequest).not.toHaveBeenCalled();
   });

--- a/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
@@ -21,8 +21,6 @@ const CHAT_THREAD_SHORTCUT_SECTIONS = [
       { key: "ctrl+shift+]", label: "Next agent" },
       { key: "f2", label: "Rename chat" },
       { key: "shift+f2", label: "Change icon" },
-      { key: "ctrl+shift+1", label: "Set icon (Ctrl+Shift+1-9)" },
-      { key: "ctrl+shift+0", label: "Clear icon" },
     ],
   },
   {
@@ -80,7 +78,7 @@ const SIDEBAR_SHORTCUT_SECTIONS = [
 ] as const;
 
 function isChatThreadEmojiShortcutKey(key: string): boolean {
-  return key === "shift+f2" || key === "ctrl+shift+1" || key === "ctrl+shift+0";
+  return key === "shift+f2";
 }
 
 function shortcutSectionsForRoute(

--- a/turbo/apps/platform/src/views/zero-page/chat-thread-emoji-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/chat-thread-emoji-data.ts
@@ -1,0 +1,57 @@
+export interface ChatThreadEmojiItem {
+  emoji: string;
+  name: string;
+}
+
+export interface ChatThreadEmojiGroup {
+  name: string;
+  emojis: ChatThreadEmojiItem[];
+}
+
+let cachedGroups: ChatThreadEmojiGroup[] | null = null;
+let pendingGroups: Promise<ChatThreadEmojiGroup[]> | null = null;
+
+// The full emoji dataset (~1,900 entries) is only needed once the user opens
+// the picker, so it is loaded on demand and kept out of the main bundle.
+export async function loadChatThreadEmojiGroups(): Promise<
+  ChatThreadEmojiGroup[]
+> {
+  if (cachedGroups) {
+    return cachedGroups;
+  }
+  if (!pendingGroups) {
+    pendingGroups = import("unicode-emoji-json/data-by-group.json").then(
+      (module) => {
+        const groups = module.default.map((group) => ({
+          name: group.name,
+          emojis: group.emojis.map((entry) => ({
+            emoji: entry.emoji,
+            name: entry.name,
+          })),
+        }));
+        cachedGroups = groups;
+        return groups;
+      },
+    );
+  }
+  return pendingGroups;
+}
+
+export function filterChatThreadEmojiGroups(
+  groups: ChatThreadEmojiGroup[],
+  query: string,
+): ChatThreadEmojiItem[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return [];
+  }
+  const matches: ChatThreadEmojiItem[] = [];
+  for (const group of groups) {
+    for (const item of group.emojis) {
+      if (item.name.includes(normalized)) {
+        matches.push(item);
+      }
+    }
+  }
+  return matches;
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6,7 +6,6 @@ import type {
   ReactNode,
   UIEvent as ReactUIEvent,
 } from "react";
-import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   useGet,
@@ -263,11 +262,12 @@ import {
   CHAT_THREAD_EMOJI_OPTIONS,
 } from "../../signals/chat-page/chat-thread-title.ts";
 import {
+  chatThreadEmojiGroups$,
+  chatThreadEmojiQuery$,
   filterChatThreadEmojiGroups,
-  loadChatThreadEmojiGroups,
-  type ChatThreadEmojiGroup,
+  setChatThreadEmojiQuery$,
   type ChatThreadEmojiItem,
-} from "./chat-thread-emoji-data.ts";
+} from "../../signals/chat-page/chat-thread-emoji.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import {
@@ -1183,6 +1183,7 @@ function ChatThreadEmojiMenuButton({
 }) {
   const { open, openChatThreadEmojiMenu, closeMenu, selectEmoji, clearEmoji } =
     useChatThreadEmojiMenuActions({ threadId, title });
+  const setEmojiQuery = useSet(setChatThreadEmojiQuery$);
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -1190,6 +1191,7 @@ function ChatThreadEmojiMenuButton({
         open={open}
         onOpenChange={(nextOpen) => {
           if (nextOpen) {
+            setEmojiQuery("");
             openChatThreadEmojiMenu({ threadId, title });
           } else {
             closeMenu();
@@ -1234,11 +1236,10 @@ function ChatThreadEmojiMenuButton({
   );
 }
 
-const FREQUENTLY_USED_EMOJI: ChatThreadEmojiItem[] = CHAT_THREAD_EMOJI_OPTIONS.map(
-  (option) => {
+const FREQUENTLY_USED_EMOJI: ChatThreadEmojiItem[] =
+  CHAT_THREAD_EMOJI_OPTIONS.map((option) => {
     return { emoji: option.emoji, name: option.label };
-  },
-);
+  });
 
 function ChatThreadEmojiPicker({
   hasEmoji,
@@ -1249,29 +1250,13 @@ function ChatThreadEmojiPicker({
   onSelect: (emoji: string) => void;
   onRemove: () => void;
 }) {
-  const [query, setQuery] = useState("");
-  const [groups, setGroups] = useState<ChatThreadEmojiGroup[] | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    void loadChatThreadEmojiGroups().then((loaded) => {
-      if (active) {
-        setGroups(loaded);
-      }
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  const searchResults = useMemo(() => {
-    if (!query.trim() || !groups) {
-      return [];
-    }
-    return filterChatThreadEmojiGroups(groups, query);
-  }, [groups, query]);
+  const query = useGet(chatThreadEmojiQuery$);
+  const setQuery = useSet(setChatThreadEmojiQuery$);
+  const groups = useLastResolved(chatThreadEmojiGroups$) ?? null;
 
   const isSearching = query.trim().length > 0;
+  const searchResults =
+    isSearching && groups ? filterChatThreadEmojiGroups(groups, query) : [];
 
   return (
     <div className="flex flex-col">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6,6 +6,7 @@ import type {
   ReactNode,
   UIEvent as ReactUIEvent,
 } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   useGet,
@@ -44,6 +45,7 @@ import {
   IconLink,
   IconLoader2,
   IconMessageCircle,
+  IconMoodPlus,
   IconPackage,
   IconPresentation,
   IconRoute,
@@ -57,13 +59,8 @@ import {
 import {
   cn,
   Button,
+  Input,
   Skeleton,
-  getShortcutParts,
-  DropdownMenu as UiDropdownMenu,
-  DropdownMenuContent as UiDropdownMenuContent,
-  DropdownMenuItem as UiDropdownMenuItem,
-  DropdownMenuSeparator as UiDropdownMenuSeparator,
-  DropdownMenuTrigger as UiDropdownMenuTrigger,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -265,6 +262,12 @@ import {
   removeChatThreadEmoji,
   CHAT_THREAD_EMOJI_OPTIONS,
 } from "../../signals/chat-page/chat-thread-title.ts";
+import {
+  filterChatThreadEmojiGroups,
+  loadChatThreadEmojiGroups,
+  type ChatThreadEmojiGroup,
+  type ChatThreadEmojiItem,
+} from "./chat-thread-emoji-data.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import {
@@ -1183,7 +1186,7 @@ function ChatThreadEmojiMenuButton({
 
   return (
     <TooltipProvider delayDuration={200}>
-      <UiDropdownMenu
+      <Popover
         open={open}
         onOpenChange={(nextOpen) => {
           if (nextOpen) {
@@ -1195,78 +1198,188 @@ function ChatThreadEmojiMenuButton({
       >
         <Tooltip>
           <TooltipTrigger asChild>
-            <UiDropdownMenuTrigger asChild>
+            <PopoverTrigger asChild>
               <button
                 type="button"
                 aria-label="Change icon"
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               >
-                {emoji && (
+                {emoji ? (
                   <span aria-hidden="true" className="text-base leading-none">
                     {emoji}
                   </span>
+                ) : (
+                  <IconMoodPlus size={18} stroke={1.75} aria-hidden="true" />
                 )}
               </button>
-            </UiDropdownMenuTrigger>
+            </PopoverTrigger>
           </TooltipTrigger>
           <TooltipContent side="bottom">Chat thread icon</TooltipContent>
         </Tooltip>
-        <UiDropdownMenuContent
+        <PopoverContent
           align="start"
-          className="w-48"
+          className="w-80 p-0"
           onCloseAutoFocus={(event) => {
             event.preventDefault();
           }}
         >
-          {CHAT_THREAD_EMOJI_OPTIONS.map((option, index) => {
-            const shortcut = `ctrl+shift+${index + 1}`;
-            return (
-              <UiDropdownMenuItem
-                key={option.emoji}
-                aria-label={`${option.label} icon Ctrl Shift ${index + 1}`}
-                className="justify-between gap-4"
-                onSelect={() => {
-                  selectEmoji(option.emoji);
-                }}
-              >
-                <span className="text-base leading-none" aria-hidden>
-                  {option.emoji}
-                </span>
-                <ChatThreadIconShortcutHint shortcut={shortcut} />
-              </UiDropdownMenuItem>
-            );
-          })}
-          <UiDropdownMenuSeparator />
-          <UiDropdownMenuItem
-            aria-label="Clear icon Ctrl Shift 0"
-            className="justify-between gap-4"
-            onSelect={() => {
-              clearEmoji();
-            }}
-          >
-            <span className="whitespace-nowrap">Clear icon</span>
-            <ChatThreadIconShortcutHint shortcut="ctrl+shift+0" />
-          </UiDropdownMenuItem>
-        </UiDropdownMenuContent>
-      </UiDropdownMenu>
+          <ChatThreadEmojiPicker
+            hasEmoji={Boolean(emoji)}
+            onSelect={selectEmoji}
+            onRemove={clearEmoji}
+          />
+        </PopoverContent>
+      </Popover>
     </TooltipProvider>
   );
 }
 
-function ChatThreadIconShortcutHint({ shortcut }: { shortcut: string }) {
+const FREQUENTLY_USED_EMOJI: ChatThreadEmojiItem[] = CHAT_THREAD_EMOJI_OPTIONS.map(
+  (option) => {
+    return { emoji: option.emoji, name: option.label };
+  },
+);
+
+function ChatThreadEmojiPicker({
+  hasEmoji,
+  onSelect,
+  onRemove,
+}: {
+  hasEmoji: boolean;
+  onSelect: (emoji: string) => void;
+  onRemove: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [groups, setGroups] = useState<ChatThreadEmojiGroup[] | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void loadChatThreadEmojiGroups().then((loaded) => {
+      if (active) {
+        setGroups(loaded);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const searchResults = useMemo(() => {
+    if (!query.trim() || !groups) {
+      return [];
+    }
+    return filterChatThreadEmojiGroups(groups, query);
+  }, [groups, query]);
+
+  const isSearching = query.trim().length > 0;
+
   return (
-    <span aria-hidden="true" className="ml-4 flex shrink-0 items-center gap-1">
-      {getShortcutParts(shortcut).map((part) => {
-        return (
-          <kbd
-            key={part}
-            className='inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-md bg-background px-1.5 text-[11px] font-medium text-foreground shadow-[inset_0_-1px_0_hsl(var(--border)),0_0_0_1px_hsl(var(--border))] font-["-apple-system",BlinkMacSystemFont,"Segoe_UI",system-ui,sans-serif]'
+    <div className="flex flex-col">
+      <div className="flex items-center gap-2 p-2">
+        <div className="relative flex-1">
+          <IconSearch
+            size={15}
+            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            aria-label="Search emoji"
+            placeholder="Search emoji"
+            value={query}
+            autoFocus
+            onChange={(event) => {
+              setQuery(event.target.value);
+            }}
+            className="h-8 pl-8"
+          />
+        </div>
+        {hasEmoji && (
+          <button
+            type="button"
+            className="shrink-0 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            onClick={onRemove}
           >
-            {part}
-          </kbd>
+            Remove
+          </button>
+        )}
+      </div>
+      <div className="max-h-72 overflow-y-auto px-2 pb-2">
+        {isSearching ? (
+          searchResults.length > 0 ? (
+            <ChatThreadEmojiGrid items={searchResults} onSelect={onSelect} />
+          ) : (
+            <p className="px-1 py-6 text-center text-xs text-muted-foreground">
+              No emoji found
+            </p>
+          )
+        ) : (
+          <>
+            <ChatThreadEmojiSection
+              label="Frequently used"
+              items={FREQUENTLY_USED_EMOJI}
+              onSelect={onSelect}
+            />
+            {groups?.map((group) => {
+              return (
+                <ChatThreadEmojiSection
+                  key={group.name}
+                  label={group.name}
+                  items={group.emojis}
+                  onSelect={onSelect}
+                />
+              );
+            })}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChatThreadEmojiSection({
+  label,
+  items,
+  onSelect,
+}: {
+  label: string;
+  items: ChatThreadEmojiItem[];
+  onSelect: (emoji: string) => void;
+}) {
+  return (
+    <div>
+      <p className="px-1 pb-1 pt-2 text-xs font-medium text-muted-foreground">
+        {label}
+      </p>
+      <ChatThreadEmojiGrid items={items} onSelect={onSelect} />
+    </div>
+  );
+}
+
+function ChatThreadEmojiGrid({
+  items,
+  onSelect,
+}: {
+  items: ChatThreadEmojiItem[];
+  onSelect: (emoji: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-8 gap-0.5">
+      {items.map((item) => {
+        return (
+          <button
+            key={`${item.name}-${item.emoji}`}
+            type="button"
+            aria-label={item.name}
+            className="flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-accent"
+            onClick={() => {
+              onSelect(item.emoji);
+            }}
+          >
+            <span aria-hidden="true">{item.emoji}</span>
+          </button>
         );
       })}
-    </span>
+    </div>
   );
 }
 

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -604,6 +604,9 @@ importers:
       signal-timers:
         specifier: ^1.0.4
         version: 1.0.4
+      unicode-emoji-json:
+        specifier: ^0.9.0
+        version: 0.9.0
       yaml:
         specifier: '>=2.8.3'
         version: 2.8.3
@@ -9379,6 +9382,9 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
+  unicode-emoji-json@0.9.0:
+    resolution: {integrity: sha512-HdrQW/7SdbXUsTd8uTATv7LvQJkCSgbAgRCDCtOhQ6xn3EAx+xZHQtRniOXWJK3ywIqPegkNhP4U4EbuFsiQng==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -9517,7 +9523,7 @@ packages:
     peerDependencies:
       '@types/node': 24.3.0
       '@vitejs/devtools': ^0.1.18
-      esbuild: 0.28.1
+      esbuild: '>=0.28.1'
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -19202,6 +19208,8 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unicode-emoji-json@0.9.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## What changed

Redesigns the Zero chat thread icon control (`ChatThreadEmojiMenuButton`) to address three problems Ming flagged:

1. **Empty state gave no reason to click.** With no icon the trigger rendered nothing. It now shows a `mood-plus` (smiley + plus) icon, so it reads as a clear "add an icon" affordance.
2. **Only 9 preset emoji.** The old dropdown listed 9 hardcoded emoji with no way to pick anything else. It's replaced by a **popover picker**: a `Search emoji` field + a large scrollable grid — `Frequently used` first, then every emoji category. Any emoji can now be chosen. Search filters by emoji name.
3. **Heavy shortcut visuals.** Each row rendered three `<kbd>` chips (`⌃ ⇧ N`), 30 chips total. Those are gone; the `Ctrl+Shift+1‑9` / `Ctrl+Shift+0` bindings and their help‑dialog rows are removed. `Shift+F2` still opens the picker.

A `Remove` action clears the icon.

## Implementation notes

- New dependency `unicode-emoji-json` (data only, ~32KB gzip) provides the emoji list grouped by category. It is **lazy‑loaded** on first open (`chat-thread-emoji-data.ts`) so it stays out of the main bundle.
- Built with existing primitives: `Popover` for the surface, the agent‑detail `Input` for search, Tabler `IconMoodPlus` / `IconSearch`, `bg-accent` hover states — matching Zero's design conventions (sentence case, gray‑50 surfaces, chat‑composer radii).
- **Data model unchanged**: emoji are still stored as characters embedded in the thread title (parsed by `getChatThreadTitleParts`). No backend/schema change; `Icons` / `Upload` tabs were intentionally left out of scope.
- Removed now‑dead signals (`setChatThreadEmojiFromThreadMeta$`, `clearChatThreadEmojiFromThreadMeta$`, the emoji shortcut bindings) and the `ChatThreadIconShortcutHint` component.

## Tests

Updated `chat-lifecycle.test.tsx`: dropped the removed `Ctrl+Shift+1‑9` / `Ctrl+Shift+0` shortcut tests, rewired the picker tests to the new search‑grid DOM (`Search emoji`, `Done` cell, `Remove` button), and updated the empty‑state assertion to expect the mood‑plus icon.

## Verification

Followed the team's PR workflow — relying on the CI pipeline for lint / type‑check / tests rather than a local full run. Design was reviewed with Ming across mockups; the empty‑state icon (`smile-plus`) and the simple search‑+‑grid picker were the chosen direction.