### PR TITLE
perf: lazy resolve connector platform secrets

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -38,7 +38,7 @@ import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
 import { createChatFilesBddApi } from "./helpers/api-bdd-chat-files";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
-import { createFirewallApi } from "./helpers/api-bdd-firewall";
+import { createFirewallApi, secretTemplate } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { storageTextFile } from "./helpers/api-bdd-storage-files";
@@ -3800,12 +3800,63 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(claim.environment).not.toHaveProperty("GOOGLE_ADS_DEVELOPER_TOKEN");
     expect(claim.secretConnectorMap).toMatchObject({
       GOOGLE_ADS_TOKEN: "google-ads",
+      GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
     });
+    expect(
+      claim.secretConnectorMetadataMap?.GOOGLE_ADS_DEVELOPER_TOKEN,
+    ).toStrictEqual({ sourceType: "platform-secret" });
     expect(
       claim.firewalls?.map((firewall) => {
         return firewallEntryName(firewall);
       }),
     ).toContain("google-ads");
+
+    if (!claim.encryptedSecrets) {
+      throw new Error("Expected claimed run to include encrypted secrets");
+    }
+    const eagerPlatformSecret = await fw.requestFirewallAuth(
+      fw.sandboxHeaders(actor, run.runId),
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+      },
+      [424],
+    );
+    if (eagerPlatformSecret.status !== 424) {
+      throw new Error(
+        "Expected platform secret to be absent from encrypted payload",
+      );
+    }
+    expect(eagerPlatformSecret.body.error.code).toBe(
+      "CONNECTOR_NOT_CONFIGURED",
+    );
+
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token-rotated");
+    const resolved = await fw.requestFirewallAuth(
+      fw.sandboxHeaders(actor, run.runId),
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("GOOGLE_ADS_TOKEN")}`,
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected Google Ads firewall auth to resolve");
+    }
+    expect(resolved.body.headers.Authorization).toBe(
+      "Bearer google-ads-bdd-access",
+    );
+    expect(resolved.body.headers["developer-token"]).toBe(
+      "developer-token-rotated",
+    );
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, onTestFinished } from "vitest";
 
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
+import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
@@ -1416,7 +1417,147 @@ describe("FW-8: static access tokens and unavailable sources", () => {
   });
 });
 
-describe("FW-9: codex model-provider access", () => {
+describe("FW-9: platform connector secrets", () => {
+  it("resolves platform secrets from current API env", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token-current");
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-access",
+      refreshToken: "google-ads-refresh",
+      expiresIn: 3600,
+    });
+
+    const resolved = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+        secretConnectorMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
+        },
+        secretConnectorMetadataMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: {
+            sourceType: "platform-secret" as const,
+          },
+        },
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected platform secret auth to resolve");
+    }
+    expect(resolved.body.headers["developer-token"]).toBe(
+      "developer-token-current",
+    );
+    expect(resolved.body.resolvedSecrets).toStrictEqual([
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+    ]);
+    expect(resolved.body.refreshedConnectors).toStrictEqual([]);
+  });
+
+  it("reports missing platform env as connector-not-configured", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", " ");
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-access",
+      refreshToken: "google-ads-refresh",
+      expiresIn: 3600,
+    });
+
+    const missing = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+        secretConnectorMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
+        },
+        secretConnectorMetadataMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: {
+            sourceType: "platform-secret" as const,
+          },
+        },
+      },
+      [424],
+    );
+    if (missing.status !== 424) {
+      throw new Error("Expected missing platform env to fail with 424");
+    }
+    expect(missing.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+  });
+
+  it("keeps old encrypted platform secret payloads working", async () => {
+    const fw = createFirewallApi(context);
+    const { headers } = await firewallRun();
+
+    const resolved = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({
+          GOOGLE_ADS_DEVELOPER_TOKEN: "legacy-developer-token",
+        }),
+        authHeaders: {
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected legacy platform payload to resolve");
+    }
+    expect(resolved.body.headers["developer-token"]).toBe(
+      "legacy-developer-token",
+    );
+  });
+
+  it("rejects platform metadata for non-platform aliases", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token-current");
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-access",
+      refreshToken: "google-ads-refresh",
+      expiresIn: 3600,
+    });
+
+    const invalid = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({}),
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("GOOGLE_ADS_TOKEN")}`,
+        },
+        secretConnectorMap: {
+          GOOGLE_ADS_TOKEN: "google-ads",
+        },
+        secretConnectorMetadataMap: {
+          GOOGLE_ADS_TOKEN: {
+            sourceType: "platform-secret" as const,
+          },
+        },
+      },
+      [424],
+    );
+    if (invalid.status !== 424) {
+      throw new Error("Expected invalid platform alias to fail with 424");
+    }
+    expect(invalid.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+  });
+});
+
+describe("FW-10: codex model-provider access", () => {
   it("resolves static model-provider auth from an empty runtime namespace", async () => {
     const fw = createFirewallApi(context);
     const { headers } = await firewallRun();
@@ -1839,7 +1980,7 @@ describe("FW-9: codex model-provider access", () => {
   });
 });
 
-describe("FW-10: aws sigv4 template resolution", () => {
+describe("FW-11: aws sigv4 template resolution", () => {
   it("resolves aws sigv4 credentials from secret and var templates", async () => {
     const fw = createFirewallApi(context);
     const { headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -583,6 +583,9 @@ interface ConnectorRuntimeContext {
   readonly secrets: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
   readonly connectorTypes: readonly ConnectorType[];
   readonly storedEnvironment: Record<string, string> | undefined;
 }
@@ -2186,6 +2189,7 @@ interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
   readonly vars: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
+  readonly secretConnectorMetadataMap: Record<string, SecretConnectorMetadata>;
   readonly environment: Record<string, string>;
 }
 
@@ -2194,6 +2198,7 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
     secrets: undefined,
     vars: undefined,
     secretConnectorMap: undefined,
+    secretConnectorMetadataMap: undefined,
     connectorTypes: [],
     storedEnvironment: undefined,
   };
@@ -2579,6 +2584,8 @@ function resolveStoredConnectorState(
   const secrets: Record<string, string> = {};
   const vars: Record<string, string> = {};
   const secretConnectorMap: Record<string, string> = {};
+  const secretConnectorMetadataMap: Record<string, SecretConnectorMetadata> =
+    {};
   const environment: Record<string, string> = {};
 
   for (const { connectorType, runtimeBindings } of bindingSets) {
@@ -2609,10 +2616,10 @@ function resolveStoredConnectorState(
           break;
         }
         case "platform-secret": {
-          const secretValue = optionalEnv(source.name);
-          if (secretValue) {
-            secrets[envName] = secretValue;
-          }
+          secretConnectorMap[envName] = connectorType;
+          secretConnectorMetadataMap[envName] = {
+            sourceType: "platform-secret",
+          };
           break;
         }
       }
@@ -2632,6 +2639,7 @@ function resolveStoredConnectorState(
     secrets,
     vars,
     secretConnectorMap,
+    secretConnectorMetadataMap,
     environment,
   };
 }
@@ -2651,6 +2659,7 @@ function storedConnectorContextFromSnapshot(
       ),
     ),
     secretConnectorMap: undefined,
+    secretConnectorMetadataMap: undefined,
     connectorTypes: snapshot.allowedConnectorRows.map((row) => {
       return row.connectorType;
     }),
@@ -2730,6 +2739,9 @@ async function materializeStoredConnectorContext(
         secrets: compactRecord(resolved.secrets),
         vars: compactRecord(resolved.vars),
         secretConnectorMap: compactRecord(resolved.secretConnectorMap),
+        secretConnectorMetadataMap: compactRecord(
+          resolved.secretConnectorMetadataMap,
+        ),
         connectorTypes: snapshot.allowedConnectorRows.map((row) => {
           return row.connectorType;
         }),
@@ -4954,8 +4966,18 @@ function buildStoredExecutionSecrets(args: {
     secretConnectorMetadataMap: args.modelProvider?.secretConnectorMetadataMap,
     secretConnectorMap: filteredModelProviderMap,
   });
+  const filteredConnectorMetadataMap = filterSecretConnectorMetadataMap({
+    secretConnectorMetadataMap:
+      args.connectorContext.secretConnectorMetadataMap,
+    secretConnectorMap: filteredConnectorMap,
+  });
   const secretConnectorMap =
     mergeRecords(filteredConnectorMap, filteredModelProviderMap) ?? null;
+  const secretConnectorMetadataMap =
+    mergeRecords(
+      filteredConnectorMetadataMap,
+      filteredModelProviderMetadataMap,
+    ) ?? null;
   const secrets = mergeRecords(
     args.connectorContext.secrets,
     args.modelProvider?.secrets,
@@ -4968,7 +4990,7 @@ function buildStoredExecutionSecrets(args: {
   return {
     secrets: secrets ?? (secretConnectorMap ? {} : undefined),
     secretConnectorMap,
-    secretConnectorMetadataMap: filteredModelProviderMetadataMap ?? null,
+    secretConnectorMetadataMap,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -13,6 +13,7 @@ import {
   getConnectorAuthClientConfigForMethod,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodRuntimeMetadata,
+  getConnectorRuntimeBindingPlatformSecretName,
   getConnectorRuntimeBindingSecretName,
   resolveConnectorResolvedAuthMethodClientByAccessKind,
   connectorAuthMethodRefHasAccessKind,
@@ -88,9 +89,10 @@ import {
   type ConnectorCredentialStatus,
 } from "./connector-credential-status.service";
 
-type AccessSecretSource = "connector" | "model-provider";
+type AccessSecretSource = SecretConnectorMetadata["sourceType"];
+type StorageSecretSource = Exclude<AccessSecretSource, "platform-secret">;
 type FirewallAuthFailureReason = "upstream_provider" | "reconnect_required";
-type SecretType = AccessSecretSource;
+type SecretType = StorageSecretSource;
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
 const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
 const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
@@ -316,7 +318,7 @@ interface SecretTokenLookupArgs {
   readonly connectorType: string;
   readonly orgId: string;
   readonly userId: string;
-  readonly sourceType: AccessSecretSource;
+  readonly sourceType: StorageSecretSource;
   readonly sourceUserId?: string;
   readonly metadataKey?: string;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
@@ -605,7 +607,7 @@ const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
 function getRefreshProviderKeySourceType(
   providerKey: string,
-): AccessSecretSource {
+): StorageSecretSource {
   return modelProviderTypeForProviderKey(providerKey)
     ? "model-provider"
     : "connector";
@@ -619,7 +621,7 @@ function modelProviderTypeForProviderKey(
 }
 
 function resolveSecretUserId(
-  sourceType: AccessSecretSource,
+  sourceType: StorageSecretSource,
   userId: string,
   sourceUserId?: string,
 ): string {
@@ -992,6 +994,9 @@ function refreshableRuntimeSecretNameForSource(args: {
     return secretName && secretMetadata?.refreshableSecrets.includes(secretName)
       ? secretName
       : undefined;
+  }
+  if (args.metadata.sourceType === "platform-secret") {
+    return undefined;
   }
 
   const connectorAccess = args.connectorAccessByType.get(args.connectorType);
@@ -2448,6 +2453,13 @@ function isConnectorRuntimeSecretKey(
   return connectorRuntimeSecretName(key, connectorAccess) !== undefined;
 }
 
+function isConnectorRuntimePlatformSecretKey(
+  key: string,
+  connectorAccess: ConnectorAccessState,
+): boolean {
+  return connectorRuntimePlatformSecretName(key, connectorAccess) !== undefined;
+}
+
 function isRefreshableConnectorRuntimeSecretKey(
   key: string,
   connectorAccess: ConnectorAccessState,
@@ -2477,6 +2489,24 @@ function connectorRuntimeSecretName(
     }
     case "static": {
       return getConnectorRuntimeBindingSecretName(
+        connectorAccess.runtimeMetadata,
+        key,
+      );
+    }
+    case "none": {
+      return undefined;
+    }
+  }
+}
+
+function connectorRuntimePlatformSecretName(
+  key: string,
+  connectorAccess: ConnectorAccessState,
+): string | undefined {
+  switch (connectorAccess.accessMetadata.kind) {
+    case "refresh-token":
+    case "static": {
+      return getConnectorRuntimeBindingPlatformSecretName(
         connectorAccess.runtimeMetadata,
         key,
       );
@@ -2773,6 +2803,46 @@ async function syncModelProviderRuntimeSecrets(args: {
   );
 }
 
+function syncPlatformRuntimeSecrets(args: {
+  readonly secrets: Record<string, string>;
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+  readonly referencedKeys: Set<string>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+}): void {
+  if (!args.secretConnectorMap) {
+    return;
+  }
+
+  for (const key of args.referencedKeys) {
+    const connectorType = getOwnConnectorOwner(args.secretConnectorMap, key);
+    if (!connectorType) {
+      continue;
+    }
+    const metadata = resolveRefreshMetadata(
+      connectorType,
+      args.secretConnectorMetadataMap?.[key],
+    );
+    if (metadata.sourceType !== "platform-secret") {
+      continue;
+    }
+    const connectorAccess = args.connectorAccessByType.get(connectorType);
+    const platformSecretName =
+      connectorAccess &&
+      connectorRuntimePlatformSecretName(key, connectorAccess);
+    const value = platformSecretName
+      ? optionalEnv(platformSecretName)
+      : undefined;
+    if (value === undefined || value.trim().length === 0) {
+      delete args.secrets[key];
+    } else {
+      args.secrets[key] = value;
+    }
+  }
+}
+
 async function syncCustomConnectorRuntimeSecrets(args: {
   readonly db: Db;
   readonly runId: string;
@@ -2851,6 +2921,13 @@ async function syncFirewallRuntimeSecrets(args: {
     referencedKeys: args.referencedKeys,
     featureSwitchContext: args.featureSwitchContext,
   });
+  syncPlatformRuntimeSecrets({
+    secrets: args.secrets,
+    secretConnectorMap: args.body.secretConnectorMap,
+    secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+    referencedKeys: args.referencedKeys,
+    connectorAccessByType: args.connectorAccessByType,
+  });
   await syncCustomConnectorRuntimeSecrets({
     db: args.db,
     runId: args.auth.runId,
@@ -2883,6 +2960,9 @@ function canResolveMissingAccessSecret(args: {
       }) !== undefined
     );
   }
+  if (refreshMetadata.sourceType === "platform-secret") {
+    return false;
+  }
 
   const connectorAccess = args.connectorAccessByType.get(connectorType);
   if (connectorAccess?.accessMetadata.kind !== "refresh-token") {
@@ -2911,7 +2991,7 @@ function referencedConnectorTypes(args: {
       connectorType,
       args.secretConnectorMetadataMap?.[key],
     ).sourceType;
-    if (sourceType === "connector") {
+    if (sourceType === "connector" || sourceType === "platform-secret") {
       connectorTypes.add(connectorType);
     }
   }
@@ -2959,6 +3039,13 @@ function hasUnavailableAccessSource(args: {
         }) === undefined
       );
     }
+    if (metadata.sourceType === "platform-secret") {
+      const connectorAccess = args.connectorAccessByType.get(connectorType);
+      return (
+        !connectorAccess ||
+        !isConnectorRuntimePlatformSecretKey(key, connectorAccess)
+      );
+    }
 
     const connectorAccess = args.connectorAccessByType.get(connectorType);
     return (
@@ -3004,14 +3091,19 @@ function connectorAccessSourcesWithReconnectRequiredStatus(args: {
       connectorType,
       args.secretConnectorMetadataMap?.[key],
     );
-    if (metadata.sourceType !== "connector") {
+    if (
+      metadata.sourceType !== "connector" &&
+      metadata.sourceType !== "platform-secret"
+    ) {
       continue;
     }
     const connectorAccess = args.connectorAccessByType.get(connectorType);
-    if (
-      !connectorAccess ||
-      !isConnectorRuntimeSecretKey(key, connectorAccess)
-    ) {
+    const isAvailableKey =
+      metadata.sourceType === "platform-secret"
+        ? connectorAccess &&
+          isConnectorRuntimePlatformSecretKey(key, connectorAccess)
+        : connectorAccess && isConnectorRuntimeSecretKey(key, connectorAccess);
+    if (!connectorAccess || !isAvailableKey) {
       continue;
     }
     if (
@@ -3289,6 +3381,9 @@ async function refreshSelectedTokens(
         connectorType,
         context.metadataByConnector.get(connectorType),
       );
+      if (metadata.sourceType === "platform-secret") {
+        throw new Error("Platform secrets are not refreshable");
+      }
       const refreshResult = await refreshAccessTokenForSource({
         db: context.db,
         connectorType,
@@ -3362,6 +3457,9 @@ async function syncSkippedTokens(
         connectorType,
         context.metadataByConnector.get(connectorType),
       );
+      if (metadata.sourceType === "platform-secret") {
+        throw new Error("Platform secrets are not refreshable");
+      }
       return {
         connectorType,
         tokens: await getCurrentAccessSecrets({

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -278,7 +278,9 @@ export const resumeSessionSchema = z.union([
 export const runnerClaimCapabilitySchema = z.string().min(1);
 
 export const secretConnectorMetadataSchema = z.object({
-  sourceType: z.enum(["connector", "model-provider"]),
+  // Runtime source type used by firewall auth. This is not the same as the DB
+  // secret storage type; platform secrets are resolved from API env instead.
+  sourceType: z.enum(["connector", "model-provider", "platform-secret"]),
   sourceUserId: z.string().optional(),
   metadataKey: z.string().optional(),
 });

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -793,6 +793,18 @@ export function getConnectorRuntimeBindingSecretName(
     : undefined;
 }
 
+export function getConnectorRuntimeBindingPlatformSecretName(
+  metadata: ConnectorAuthMethodRuntimeMetadata,
+  envName: string,
+): ConnectorPlatformSecretName | undefined {
+  const binding = metadata.runtimeBindings.find((entry) => {
+    return entry.envName === envName && entry.source.kind === "platform-secret";
+  });
+  return binding?.source.kind === "platform-secret"
+    ? binding.source.name
+    : undefined;
+}
+
 export function connectorRefreshMetadataHasRefreshableSecret(
   metadata: ConnectorAuthMethodAccessMetadata,
   secretName: string,


### PR DESCRIPTION
Closes #20387

## Summary
- Defer connector platform secret resolution from run creation to firewall auth time.
- Carry platform secret aliases through the existing secret connector metadata map with `sourceType: "platform-secret"`.
- Validate platform aliases against connector runtime metadata before reading current API env values.
- Preserve old encrypted platform-secret payload behavior when no platform metadata is present.

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --testNamePattern "withholds platform secrets"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts`
- pre-commit hook: `pnpm knip`, `pnpm format`, `pnpm check-types`

## Note
- `pnpm -F @vm0/connectors test` currently fails in unrelated firewall catalog baseline assertions for Sentry/Xero description metadata; this PR did not change generated firewall catalog files.