### PR TITLE
fix: remove composer model picker open ring

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1659,7 +1659,8 @@ describe("chat composer models", () => {
       });
       expect(openTrigger).toHaveAttribute("aria-expanded", "true");
       expect(openTrigger).toHaveAttribute("data-state", "open");
-      expect(openTrigger).toHaveClass("data-[state=open]:ring-2");
+      expect(openTrigger).toHaveClass("data-[state=open]:bg-accent");
+      expect(openTrigger).not.toHaveClass("data-[state=open]:ring-2");
     });
     expect(screen.getByRole("listbox", { name: "Models" })).toBeInTheDocument();
     expect(

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -751,7 +751,7 @@ function ModelFirstModelPickerPopoverTrigger({
         aria-expanded={open}
         aria-haspopup="listbox"
         className={cn(
-          "flex h-9 w-full items-center justify-start gap-2 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:ring-2 data-[state=open]:ring-ring data-[state=open]:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:w-full [&>span]:text-left",
+          "flex h-9 w-full items-center justify-start gap-2 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:w-full [&>span]:text-left",
           triggerClassName,
         )}
       >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6513,7 +6513,7 @@ function ComposerModelPickerSlot({
           triggerClassName={cn(
             "h-9 w-9 max-w-none gap-0 border-transparent bg-transparent px-0 text-sm text-muted-foreground transition-colors sm:w-auto sm:max-w-[14rem] sm:gap-1 sm:px-2",
             "[&>span]:flex [&>span]:items-center [&>span]:justify-center sm:[&>span]:justify-start [&>svg]:hidden sm:[&>svg]:block",
-            "hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-accent data-[state=open]:text-foreground data-[state=open]:ring-2 data-[state=open]:ring-ring data-[state=open]:ring-offset-2",
+            "hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=open]:bg-accent data-[state=open]:text-foreground",
           )}
           compactTrigger
           mobileIconTrigger


### PR DESCRIPTION
## Summary
- Removes the open-state ring and ring offset from the composer model picker popover trigger.
- Keeps the opened picker visually aligned with the connector trigger by retaining the subtle accent background/text state.
- Updates the composer model picker test to assert the open trigger no longer carries the ring class.

## Verification
- git diff --check origin/main...HEAD
- pnpm vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t "uses the popover model picker behind the feature switch"

## Notes
- Attempted local browser verification with Vite, but the platform app did not mount without VITE_API_URL in this fresh checkout.