### PR TITLE
feat: gate composer upload popover

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -143,12 +143,19 @@ describe("OPS-01: feature switches and report-error routes", () => {
         body: {
           switches: {
             [FeatureSwitchKey.Dummy]: false,
+            [FeatureSwitchKey.ComposerUploadPopover]: true,
           },
         },
       }),
       [200],
     );
     expect(enabled.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
+    expect(
+      enabled.body.switches[FeatureSwitchKey.ComposerUploadPopover],
+    ).toBeUndefined();
+    expect(
+      enabled.body.effectiveSwitches[FeatureSwitchKey.ComposerUploadPopover],
+    ).toBeFalsy();
 
     const merged = await accept(
       featureSwitchesClient().update({

--- a/turbo/apps/api/src/signals/services/feature-switches.service.ts
+++ b/turbo/apps/api/src/signals/services/feature-switches.service.ts
@@ -1,5 +1,8 @@
 import { command, computed, type Computed } from "ccstate";
-import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
+import {
+  filterUserOverridableFeatureSwitchOverrides,
+  type FeatureSwitchContext,
+} from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 import { userFeatureSwitches } from "@vm0/db/schema/user-feature-switches";
 import { and, eq } from "drizzle-orm";
@@ -23,10 +26,12 @@ function splitFeatureSwitchesByScope(switches: Record<string, boolean>): {
   readonly userSwitches: Record<string, boolean>;
   readonly orgSwitches: Record<string, boolean>;
 } {
+  const userOverridableSwitches =
+    filterUserOverridableFeatureSwitchOverrides(switches);
   const userSwitches: Record<string, boolean> = {};
   const orgSwitches: Record<string, boolean> = {};
 
-  for (const [key, value] of Object.entries(switches)) {
+  for (const [key, value] of Object.entries(userOverridableSwitches)) {
     if (isOrgScopedFeatureSwitchKey(key)) {
       orgSwitches[key] = value;
     } else {
@@ -78,7 +83,7 @@ async function loadFeatureSwitchOverrideRow(
     )
     .limit(1);
 
-  return row?.switches ?? {};
+  return filterUserOverridableFeatureSwitchOverrides(row?.switches ?? {});
 }
 
 async function loadUserFeatureSwitchOverrides(
@@ -193,7 +198,10 @@ async function upsertFeatureSwitches(
 
   const existing =
     (existingRow?.switches as Record<string, boolean> | undefined) ?? {};
-  const merged: Record<string, boolean> = { ...existing, ...switches };
+  const merged: Record<string, boolean> = {
+    ...filterUserOverridableFeatureSwitchOverrides(existing),
+    ...filterUserOverridableFeatureSwitchOverrides(switches),
+  };
   const now = nowDate();
 
   await writeDb

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -63,6 +63,9 @@ describe("lab page", () => {
       expect(screen.getByText("Other")).toBeInTheDocument();
       expect(screen.getAllByText("Connectors").length).toBeGreaterThan(0);
       expect(
+        screen.queryByText(FeatureSwitchKey.ComposerUploadPopover),
+      ).not.toBeInTheDocument();
+      expect(
         screen.getAllByText("Maintainer: liangyou@vm0.ai").length,
       ).toBeGreaterThan(0);
     });

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -2,6 +2,7 @@ import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import {
   getFeatureSwitchMetadata,
+  getUserOverridableFeatureSwitchKeys,
   type FeatureSwitchMetadata,
 } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
@@ -76,7 +77,7 @@ function sortedFeatureSwitchKeys(params: {
   readonly features: FeatureSwitchStates;
   readonly metadata: FeatureSwitchMetadataByKey;
 }): FeatureSwitchKey[] {
-  return Object.values(FeatureSwitchKey).sort((a, b) => {
+  return [...getUserOverridableFeatureSwitchKeys()].sort((a, b) => {
     return compareFeatureSwitches({ a, b, ...params });
   });
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -2188,11 +2188,46 @@ describe("chat composer templates", () => {
     }
   });
 
-  it("places the template control immediately after upload", async () => {
+  it("places the template control immediately after the legacy attach button by default", async () => {
     mockChatLifecycle(context, { threadId: THREAD_ID });
 
     detachedSetupPage({
       context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const composer = composerElementFrom(
+      await screen.findByPlaceholderText(PLACEHOLDER),
+    );
+
+    await waitFor(() => {
+      const controls = Array.from(
+        composer.querySelectorAll(
+          [
+            'button[aria-label="Attach"]',
+            'button[aria-label="Template"]',
+            'button[aria-label="Connectors"]',
+          ].join(","),
+        ),
+      ).map((button) => {
+        return button.getAttribute("aria-label");
+      });
+
+      expect(controls).toStrictEqual(["Attach", "Template", "Connectors"]);
+      expect(
+        composer.querySelector('button[aria-label="Upload"]'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("places the template control immediately after upload when the popover switch is enabled", async () => {
+    mockChatLifecycle(context, { threadId: THREAD_ID });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerUploadPopover]: true,
+      },
       path: `/chats/${THREAD_ID}`,
     });
 
@@ -2214,6 +2249,9 @@ describe("chat composer templates", () => {
       });
 
       expect(controls).toStrictEqual(["Upload", "Template", "Connectors"]);
+      expect(
+        composer.querySelector('button[aria-label="Attach"]'),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -2223,6 +2261,9 @@ describe("chat composer templates", () => {
 
     detachedSetupPage({
       context,
+      featureSwitches: {
+        [FeatureSwitchKey.ComposerUploadPopover]: true,
+      },
       path: `/chats/${THREAD_ID}`,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6091,6 +6091,32 @@ function MicButton({
   );
 }
 
+function ComposerAttachButton({
+  onSelectFile,
+}: {
+  readonly onSelectFile: () => void;
+}) {
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="rounded-lg p-2 transition-colors duration-200 hover:bg-accent hover:text-foreground sm:p-[9px]"
+            aria-label="Attach"
+            onClick={onSelectFile}
+          >
+            <IconPaperclip size={18} stroke={1.5} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          Attach
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function ComposerUploadMenu({
   input,
   onDraftChange,
@@ -6543,6 +6569,11 @@ function usePopoverModelPickerEnabled(): boolean {
   return features?.[FeatureSwitchKey.ComposerModelPickerPopover] ?? false;
 }
 
+function useUploadPopoverEnabled(): boolean {
+  const features = useLastResolved(featureSwitch$);
+  return features?.[FeatureSwitchKey.ComposerUploadPopover] ?? false;
+}
+
 export function ZeroChatComposer({
   input,
   onInputChange,
@@ -6581,6 +6612,7 @@ export function ZeroChatComposer({
   const openGoalDialog = useSet(openChatThreadGoalDialog$);
   const codexFastModeEnabled = useCodexFastModeEnabled();
   const popoverModelPickerEnabled = usePopoverModelPickerEnabled();
+  const uploadPopoverEnabled = useUploadPopoverEnabled();
 
   const resolved = useResolvedComposerSignals(
     input,
@@ -7018,12 +7050,16 @@ export function ZeroChatComposer({
               )}
               <div className="flex items-center justify-between gap-2 px-4 pb-3 pt-1">
                 <div className="flex items-center gap-1 text-muted-foreground sm:gap-1.5">
-                  <ComposerUploadMenu
-                    input={input}
-                    onDraftChange={onDraftChange}
-                    onInputChange={onInputChange}
-                    onSelectFile={handleFileSelect}
-                  />
+                  {uploadPopoverEnabled ? (
+                    <ComposerUploadMenu
+                      input={input}
+                      onDraftChange={onDraftChange}
+                      onInputChange={onInputChange}
+                      onSelectFile={handleFileSelect}
+                    />
+                  ) : (
+                    <ComposerAttachButton onSelectFile={handleFileSelect} />
+                  )}
                   <ComposerTemplatePickerSlot picker={templatePicker} />
                   <ComposerWorkflowPromptSlot
                     onCreateWorkflowPrompt={onCreateWorkflowPrompt}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -44,6 +44,7 @@ export enum FeatureSwitchKey {
   CodexFrameworkForMinimax = "codexFrameworkForMinimax",
   CodexFastMode = "codexFastMode",
   ComposerModelPickerPopover = "composerModelPickerPopover",
+  ComposerUploadPopover = "composerUploadPopover",
 
   ZapierConnector = "zapierConnector",
   ChatThreadEmoji = "chatThreadEmoji",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -3,8 +3,10 @@ import { FeatureSwitchKey } from "../feature-switch-key";
 import {
   isFeatureEnabled,
   getAllFeatureStates,
+  filterUserOverridableFeatureSwitchOverrides,
   getFeatureSwitchDescriptions,
   getFeatureSwitchMetadata,
+  getUserOverridableFeatureSwitchKeys,
 } from "../feature-switch";
 
 describe("isFeatureEnabled", () => {
@@ -27,6 +29,9 @@ describe("isFeatureEnabled", () => {
       isFeatureEnabled(FeatureSwitchKey.HtmlArtifactCommentEditing, {}),
     ).toBe(false);
     expect(isFeatureEnabled(FeatureSwitchKey.WebsiteTemplates, {})).toBe(false);
+    expect(isFeatureEnabled(FeatureSwitchKey.ComposerUploadPopover, {})).toBe(
+      false,
+    );
   });
 
   it("should return false for disabled switch with non-matching userId", () => {
@@ -135,6 +140,7 @@ describe("getAllFeatureStates", () => {
       true,
     );
     expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
 
     const otherOrgStates = getAllFeatureStates({
       orgId: "org_nonexistent",
@@ -160,6 +166,7 @@ describe("getAllFeatureStates", () => {
       false,
     );
     expect(otherOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
+    expect(otherOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.BytePlusVoiceInputStt]).toBe(true);
   });
 
@@ -196,6 +203,21 @@ describe("getAllFeatureStates", () => {
     });
 
     expect("removedFeature" in states).toBe(false);
+  });
+});
+
+describe("user-overridable switches", () => {
+  it("excludes internal switches from user override helpers", () => {
+    expect(getUserOverridableFeatureSwitchKeys()).not.toContain(
+      FeatureSwitchKey.ComposerUploadPopover,
+    );
+
+    expect(
+      filterUserOverridableFeatureSwitchOverrides({
+        [FeatureSwitchKey.ComposerUploadPopover]: true,
+        [FeatureSwitchKey.Dummy]: false,
+      }),
+    ).toStrictEqual({ [FeatureSwitchKey.Dummy]: false });
   });
 });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -21,11 +21,13 @@ export interface FeatureSwitch {
   readonly enabledUserHashes?: readonly string[];
   readonly enabledEmailHashes?: readonly string[];
   readonly enabledOrgIdHashes?: readonly string[];
+  readonly userOverridable?: boolean;
 }
 
 export interface FeatureSwitchMetadata {
   readonly maintainer: string;
   readonly description?: string;
+  readonly userOverridable: boolean;
 }
 
 export interface FeatureSwitchContext {
@@ -259,6 +261,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ComposerUploadPopover]: {
+    maintainer: "bingjie@vm0.ai",
+    description:
+      "Use the Upload popover in the chat composer instead of the legacy paperclip attachment button.",
+    enabled: false,
+    userOverridable: false,
+  },
   [FeatureSwitchKey.ZapierConnector]: {
     maintainer: "yuma@vm0.ai",
     description:
@@ -489,9 +498,35 @@ export function getFeatureSwitchMetadata(): Record<
     result[key] = {
       maintainer: featureSwitch.maintainer,
       description: featureSwitch.description,
+      userOverridable: featureSwitch.userOverridable !== false,
     };
   }
   return result;
+}
+
+export function isUserOverridableFeatureSwitch(
+  key: string,
+): key is FeatureSwitchKey {
+  if (!(key in FEATURE_SWITCHES)) {
+    return false;
+  }
+  return FEATURE_SWITCHES[key as FeatureSwitchKey].userOverridable !== false;
+}
+
+export function getUserOverridableFeatureSwitchKeys(): readonly FeatureSwitchKey[] {
+  return Object.values(FeatureSwitchKey).filter(isUserOverridableFeatureSwitch);
+}
+
+export function filterUserOverridableFeatureSwitchOverrides(
+  switches: Record<string, boolean>,
+): Record<string, boolean> {
+  const filtered: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(switches)) {
+    if (isUserOverridableFeatureSwitch(key)) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
 }
 
 /**

--- a/turbo/packages/core/src/index.ts
+++ b/turbo/packages/core/src/index.ts
@@ -838,9 +838,12 @@ export {
 export { FeatureSwitchKey } from "./feature-switch-key";
 export {
   getAllFeatureStates,
+  filterUserOverridableFeatureSwitchOverrides,
   getFeatureSwitchDescriptions,
   getFeatureSwitchMetadata,
+  getUserOverridableFeatureSwitchKeys,
   isFeatureEnabled,
+  isUserOverridableFeatureSwitch,
   type FeatureSwitch,
   type FeatureSwitchContext,
   type FeatureSwitchMetadata,


### PR DESCRIPTION
## Summary
- add an internal-only `composerUploadPopover` feature switch, defaulting off and hidden from Lab/user override APIs
- restore the legacy Paper Clip `Attach` composer upload button when the switch is off
- keep the current `Upload` popover behavior available when the switch is explicitly enabled internally

## Verification
- `pnpm exec prettier --write ...`
- `pnpm exec oxlint ...`
- `pnpm exec eslint ... --max-warnings 0`
- `pnpm exec tsc --noEmit --pretty false` for affected packages/apps
- `pnpm exec vitest run packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm exec vitest run apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t \"legacy attach|upload when|adds upload links\"`

Note: attempted the API BDD feature-switch route test locally, but the test DB was unavailable (`ECONNREFUSED`), so it could not complete in this environment.