### PR TITLE
fix: ignore expired user permission grants

### DIFF
--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-signals.ts
@@ -12,15 +12,12 @@ import {
   UNKNOWN_PERMISSION_GRANT,
   type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
-import {
-  permissionGrantsToFirewallPolicies,
-  resolveFirewallMetadataPolicies,
-} from "@vm0/connectors/firewall-metadata/policy";
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
 import { agentById, reloadAgentById$ } from "../agent.ts";
 import { retryTransientLoad } from "../utils.ts";
+import { resolveActiveUserPermissionGrantPolicy } from "../user-permission-grants.ts";
 import { parseUserPermissionGrantExpiresIn } from "./permission-grant-expiration.ts";
 
 // ---------------------------------------------------------------------------
@@ -106,13 +103,7 @@ export function resolveUserPermissionGrantPolicy(
   metadata: PublicConnectorCatalogPermissionDetail,
   permission: string,
 ): FirewallPolicyValue | undefined {
-  const policies = resolveFirewallMetadataPolicies(
-    permissionGrantsToFirewallPolicies(grants),
-    [metadata],
-  )?.[metadata.connectorRef];
-  return permission === UNKNOWN_PERMISSION_GRANT
-    ? policies?.unknownPolicy
-    : policies?.policies[permission];
+  return resolveActiveUserPermissionGrantPolicy(grants, metadata, permission);
 }
 
 interface UserPermissionGrantsByAgentParams {

--- a/turbo/apps/platform/src/signals/user-permission-grants.ts
+++ b/turbo/apps/platform/src/signals/user-permission-grants.ts
@@ -1,0 +1,125 @@
+import { computed, type Computed } from "ccstate";
+import { delay } from "signal-timers";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import {
+  UNKNOWN_PERMISSION_GRANT,
+  type FirewallPolicies,
+  type FirewallPolicyValue,
+} from "@vm0/connectors/firewall-types";
+import {
+  permissionGrantsToFirewallPolicies,
+  resolveFirewallMetadataPolicies,
+} from "@vm0/connectors/firewall-metadata/policy";
+import { now } from "../lib/time.ts";
+
+const TIMER_POLL_CEILING_MS = 60 * 60 * 1000;
+
+function createUserPermissionGrantExpiryTimerFactory(): (
+  nextExpiryMs: number | null,
+) => Computed<Promise<number | null>> {
+  const cache = new Map<string, Computed<Promise<number | null>>>();
+  return (nextExpiryMs) => {
+    const key = nextExpiryMs?.toString() ?? "none";
+    const existing = cache.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const atom$ = computed(async () => {
+      if (nextExpiryMs === null) {
+        return null;
+      }
+      const delayMs = Math.min(
+        Math.max(0, nextExpiryMs - now() + 1),
+        TIMER_POLL_CEILING_MS,
+      );
+      await delay(delayMs);
+      cache.delete(key);
+      return nextExpiryMs;
+    });
+    cache.set(key, atom$);
+    return atom$;
+  };
+}
+
+export function isActiveUserPermissionGrant(
+  grant: Pick<UserPermissionGrantResponse, "expiresAt">,
+  checkedAtMs = now(),
+): boolean {
+  if (!grant.expiresAt) {
+    return true;
+  }
+  const expiresAtMs = Date.parse(grant.expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs > checkedAtMs;
+}
+
+function activeUserPermissionGrants(
+  grants: readonly UserPermissionGrantResponse[],
+  checkedAtMs = now(),
+): readonly UserPermissionGrantResponse[] {
+  return grants.filter((grant) => {
+    return isActiveUserPermissionGrant(grant, checkedAtMs);
+  });
+}
+
+export function nextUserPermissionGrantExpiryMs(
+  grants: readonly Pick<UserPermissionGrantResponse, "expiresAt">[],
+  checkedAtMs = now(),
+): number | null {
+  let nextExpiryMs: number | null = null;
+  for (const grant of grants) {
+    if (!grant.expiresAt) {
+      continue;
+    }
+    const expiresAtMs = Date.parse(grant.expiresAt);
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= checkedAtMs) {
+      continue;
+    }
+    if (nextExpiryMs === null || expiresAtMs < nextExpiryMs) {
+      nextExpiryMs = expiresAtMs;
+    }
+  }
+  return nextExpiryMs;
+}
+
+export const userPermissionGrantExpiryTimer =
+  createUserPermissionGrantExpiryTimerFactory();
+
+function userPermissionGrantsToActiveFirewallPolicies(
+  grants: readonly UserPermissionGrantResponse[],
+  checkedAtMs = now(),
+): FirewallPolicies | null {
+  return permissionGrantsToFirewallPolicies(
+    activeUserPermissionGrants(grants, checkedAtMs),
+  );
+}
+
+export function activeUserPermissionGrantSnapshot(
+  grants: readonly UserPermissionGrantResponse[],
+  checkedAtMs = now(),
+): {
+  readonly grants: readonly UserPermissionGrantResponse[];
+  readonly policies: FirewallPolicies | null;
+} {
+  const activeGrants = activeUserPermissionGrants(grants, checkedAtMs);
+  return {
+    grants: activeGrants,
+    policies: permissionGrantsToFirewallPolicies(activeGrants),
+  };
+}
+
+export function resolveActiveUserPermissionGrantPolicy(
+  grants: readonly UserPermissionGrantResponse[],
+  metadata: PublicConnectorCatalogPermissionDetail,
+  permission: string,
+  checkedAtMs = now(),
+): FirewallPolicyValue | undefined {
+  const policies = resolveFirewallMetadataPolicies(
+    userPermissionGrantsToActiveFirewallPolicies(grants, checkedAtMs),
+    [metadata],
+  )?.[metadata.connectorRef];
+  return permission === UNKNOWN_PERMISSION_GRANT
+    ? policies?.unknownPolicy
+    : policies?.policies[permission];
+}

--- a/turbo/apps/platform/src/signals/user-permission-grants.ts
+++ b/turbo/apps/platform/src/signals/user-permission-grants.ts
@@ -47,7 +47,7 @@ export function isActiveUserPermissionGrant(
   grant: Pick<UserPermissionGrantResponse, "expiresAt">,
   checkedAtMs = now(),
 ): boolean {
-  if (!grant.expiresAt) {
+  if (grant.expiresAt === null) {
     return true;
   }
   const expiresAtMs = Date.parse(grant.expiresAt);

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -349,6 +349,126 @@ describe("permission allow page", () => {
     expect(screen.queryByText("Duration")).not.toBeInTheDocument();
   });
 
+  it("shows the confirmation flow when an existing allow grant is expired", async () => {
+    mockNow();
+    const agentId = "c0000000-0000-4000-a000-000000000009";
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Expired Grant Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId,
+          connectorRef: "slack",
+          permission: "admin.analytics:read",
+          action: "allow",
+          expiresAt: isoFromNowMs(-60 * 1000),
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:01:00Z",
+        },
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      user: {
+        id: "test-user-123",
+        fullName: "Taylor Reviewer",
+        firstName: "Taylor",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Hey Taylor, you're updating your permissions/u),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Confirm")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Already allowed")).not.toBeInTheDocument();
+  });
+
+  it("does not show expired grant text when the default policy already allows the permission", async () => {
+    mockNow();
+    const agentId = "c0000000-0000-4000-a000-000000000010";
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Default Allow Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(
+      zeroConnectorCatalogContract.permissions,
+      ({ params, respond }) => {
+        expect(params.connectorRef).toBe("slack");
+        return respond(200, {
+          permissions: catalogPermissionDetail({
+            connectorRef: "slack",
+            label: "Catalog Slack",
+            permissions: [
+              {
+                name: "admin.analytics:read",
+                description: "Access workspace analytics data",
+              },
+            ],
+            defaultPolicy: {
+              permissionDefault: "allow",
+              unknownPolicy: "ask",
+            },
+          }),
+        });
+      },
+    );
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId,
+          connectorRef: "slack",
+          permission: "admin.analytics:read",
+          action: "allow",
+          expiresAt: isoFromNowMs(-60 * 1000),
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:01:00Z",
+        },
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      user: {
+        id: "test-user-123",
+        fullName: "Taylor Reviewer",
+        firstName: "Taylor",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Already allowed")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Expired")).not.toBeInTheDocument();
+    expect(screen.queryByText("Confirm")).not.toBeInTheDocument();
+  });
+
   it("shows already denied when the permission is already denied", async () => {
     const agentId = "c0000000-0000-4000-a000-000000000006";
 
@@ -401,6 +521,7 @@ describe("permission allow page", () => {
   });
 
   it("lets a user grant unknown endpoints to an agent", async () => {
+    mockNow();
     const agentId = "c0000000-0000-4000-a000-000000000004";
     let grants: UserPermissionGrantResponse[] = [];
 
@@ -433,7 +554,7 @@ describe("permission allow page", () => {
           connectorRef: body.connectorRef,
           permission: appliedGrant.permission,
           action: appliedGrant.action,
-          expiresAt: "2026-03-10T01:00:00Z",
+          expiresAt: isoFromNowMs(60 * 60 * 1000),
           createdAt: "2026-03-10T00:00:00Z",
           updatedAt: "2026-03-10T00:01:00Z",
         };

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -399,6 +399,56 @@ describe("permission allow page", () => {
     expect(screen.queryByText("Already allowed")).not.toBeInTheDocument();
   });
 
+  it("shows the confirmation flow when an existing allow grant has an invalid expiration", async () => {
+    mockNow();
+    const agentId = "c0000000-0000-4000-a000-000000000011";
+
+    context.mocks.api(zeroAgentsByIdContract.get, ({ respond }) => {
+      return respond(200, {
+        agentId,
+        ownerId: "test-user-123",
+        description: null,
+        displayName: "Invalid Grant Bot",
+        sound: null,
+        avatarUrl: null,
+        modelProviderId: null,
+        selectedModel: null,
+        preferPersonalProvider: false,
+      });
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId,
+          connectorRef: "slack",
+          permission: "admin.analytics:read",
+          action: "allow",
+          expiresAt: "",
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:01:00Z",
+        },
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${agentId}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`,
+      user: {
+        id: "test-user-123",
+        fullName: "Taylor Reviewer",
+        firstName: "Taylor",
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Hey Taylor, you're updating your permissions/u),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Confirm")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Already allowed")).not.toBeInTheDocument();
+  });
+
   it("does not show expired grant text when the default policy already allows the permission", async () => {
     mockNow();
     const agentId = "c0000000-0000-4000-a000-000000000010";

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -36,9 +36,11 @@ import {
   permissionGrantExpiryText,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
+import { isActiveUserPermissionGrant } from "../../signals/user-permission-grants.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
+import { useUserPermissionGrantExpiryTick } from "../user-permission-grant-expiry-tick.ts";
 import {
   ConnectorIcon,
   isConnectorIconType,
@@ -300,7 +302,12 @@ function resolveExistingPermissionGrantResult({
   if (effectivePolicy !== action) {
     return null;
   }
-  return { expiresAt: explicitGrant?.expiresAt };
+  return {
+    expiresAt:
+      explicitGrant && isActiveUserPermissionGrant(explicitGrant)
+        ? explicitGrant.expiresAt
+        : null,
+  };
 }
 
 function ConfirmGrantCard({
@@ -443,6 +450,12 @@ function PermissionAllowDoctorPage({
     firewallPermissionMetadataByConnector({ connectorRef: ref }),
   );
   const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
+  const grants = grantsLoadable.state === "hasData" ? grantsLoadable.data : [];
+  const savedGrant =
+    grantLoadable.state === "hasData" ? grantLoadable.data : null;
+  useUserPermissionGrantExpiryTick(
+    savedGrant ? [...grants, savedGrant] : grants,
+  );
 
   if (
     anyLoadableIsLoading([
@@ -484,12 +497,11 @@ function PermissionAllowDoctorPage({
     return <ErrorMessage message={`Unknown permission: ${permission}`} />;
   }
 
-  const grants = grantsLoadable.state === "hasData" ? grantsLoadable.data : [];
-  if (grantLoadable.state === "hasData") {
+  if (savedGrant && isActiveUserPermissionGrant(savedGrant)) {
     return (
       <ResultCard
         action={action}
-        expiresAt={grantLoadable.data.expiresAt}
+        expiresAt={savedGrant.expiresAt}
         showExpiry={action === "allow"}
       />
     );

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -1229,6 +1229,57 @@ describe("team page navigation", () => {
     ]);
   });
 
+  it("ignores expired allow grants when opening connector permissions", async () => {
+    mockNow();
+    mockTeamAPIs();
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId: researchAgentId,
+          connectorRef: "slack",
+          permission: "channels:join",
+          action: "allow",
+          expiresAt: isoFromNowMs(-60 * 1000),
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${researchAgentId}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Research Agent" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("@ops")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Manage Slack permissions"));
+
+    const miscGroupLabel = await connectorCategoryLabel("slack", "Misc");
+    const miscGroupElement = await screen.findByText(miscGroupLabel);
+    const permissionsDialog = dialogForElement(miscGroupElement);
+    click(miscGroupElement);
+
+    const channelsJoinRow = await permissionRowByName(
+      permissionsDialog,
+      "channels:join",
+    );
+    expect(buttonByText("Deny", channelsJoinRow)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(buttonByText("Allow", channelsJoinRow)).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(buttonByText("Restore", permissionsDialog)).toBeDisabled();
+  });
+
   it("saves permission duration changes from an agent page", async () => {
     mockNow();
     mockTeamAPIs();

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -111,9 +111,10 @@ import {
   setPermSavingType$,
 } from "../../signals/zero-page/zero-job-detail-page.ts";
 import type { FirewallPolicies } from "@vm0/connectors/firewall-types";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import { activeUserPermissionGrantSnapshot } from "../../signals/user-permission-grants.ts";
+import { useUserPermissionGrantExpiryTick } from "../user-permission-grant-expiry-tick.ts";
 import {
   DetailPageBreadcrumbBar,
   DetailPageHeader,
@@ -695,9 +696,11 @@ function JobPermissionsTab({
   );
   const userGrants =
     userGrantsLoadable.state === "hasData" ? userGrantsLoadable.data : [];
+  useUserPermissionGrantExpiryTick(userGrants);
+  const activeUserGrantSnapshot = activeUserPermissionGrantSnapshot(userGrants);
   const userGrantPolicies =
     userGrantsLoadable.state === "hasData"
-      ? permissionGrantsToFirewallPolicies(userGrants)
+      ? activeUserGrantSnapshot.policies
       : null;
   const drawerInitialPolicies = userGrantPolicies ?? {};
   const [, applyGrantPolicies] = useLoadableSet(applyUserPermissionGrants$);
@@ -784,7 +787,7 @@ function JobPermissionsTab({
             connectorLabel={connectorLabel}
             displayName={displayName}
             initialPolicies={drawerInitialPolicies}
-            initialGrants={userGrants}
+            initialGrants={activeUserGrantSnapshot.grants}
             resetEnabled
             readOnly={!canManagePermissions}
             onApply={async (intent, { metadata }) => {
@@ -796,7 +799,7 @@ function JobPermissionsTab({
                 connectorRef: connectorType,
                 metadata,
                 initialPolicies: drawerInitialPolicies,
-                initialGrants: userGrants,
+                initialGrants: activeUserGrantSnapshot.grants,
                 intent,
                 pageSignal,
                 applyGrantPolicies,

--- a/turbo/apps/platform/src/views/user-permission-grant-expiry-tick.ts
+++ b/turbo/apps/platform/src/views/user-permission-grant-expiry-tick.ts
@@ -1,0 +1,13 @@
+import { useLoadable } from "ccstate-react";
+import type { UserPermissionGrantResponse } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
+import {
+  nextUserPermissionGrantExpiryMs,
+  userPermissionGrantExpiryTimer,
+} from "../signals/user-permission-grants.ts";
+
+export function useUserPermissionGrantExpiryTick(
+  grants: readonly Pick<UserPermissionGrantResponse, "expiresAt">[],
+): void {
+  const nextExpiryMs = nextUserPermissionGrantExpiryMs(grants);
+  useLoadable(userPermissionGrantExpiryTimer(nextExpiryMs));
+}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -188,6 +188,7 @@ async function confirmPermissionAction(
 
 describe("chat message action cards", () => {
   it("lets users authorize connectors and confirm permissions from assistant messages", async () => {
+    mockNow();
     const user = userEvent.setup({ delay: null });
     const connectorAuthorizeUrl = `https://app.vm0.ai/connectors/github/authorize?agentId=${AGENT_ID}`;
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=catalog.analytics%3Aread&action=allow&expiresIn=24h`;
@@ -537,6 +538,84 @@ describe("chat message action cards", () => {
     expect(applyRequests).toBe(0);
   });
 
+  it("lets users re-confirm expired allow permission action cards", async () => {
+    mockNow();
+    const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=youtube&permission=videos.write&action=allow&expiresIn=24h`;
+    let applyRequests = 0;
+    context.mocks.api(zeroUserPermissionGrantsContract.list, ({ respond }) => {
+      return respond(200, [
+        {
+          agentId: AGENT_ID,
+          connectorRef: "youtube",
+          permission: "videos.write",
+          action: "allow",
+          expiresAt: isoFromNowMs(-60 * 1000),
+          createdAt: "2026-06-09T11:00:00Z",
+          updatedAt: "2026-06-09T11:01:00Z",
+        },
+      ]);
+    });
+    context.mocks.api(zeroUserPermissionGrantsContract.apply, ({ respond }) => {
+      applyRequests += 1;
+      return respond(200, [
+        {
+          agentId: AGENT_ID,
+          connectorRef: "youtube",
+          permission: "videos.write",
+          action: "allow",
+          expiresAt: isoFromNowMs(24 * 60 * 60 * 1000),
+          createdAt: "2026-06-09T11:00:00Z",
+          updatedAt: "2026-06-09T12:00:00Z",
+        },
+      ]);
+    });
+    mockChatLifecycle(context, {
+      threadId: `${THREAD_ID}-expired-allowed-permission`,
+      threadTitle: "Expired permission allow",
+      chatMessages: [
+        {
+          id: "msg-user-expired-allowed-permission",
+          role: "user",
+          content: "Upload the video",
+          runId: "run-expired-allowed-permission",
+          createdAt: "2026-06-09T11:00:00Z",
+        },
+        {
+          id: "msg-assistant-expired-allowed-permission-card",
+          role: "assistant",
+          content: permissionAuthorizeUrl,
+          runId: "run-expired-allowed-permission",
+          createdAt: "2026-06-09T11:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}-expired-allowed-permission`,
+    });
+
+    const permissionCard = await screen.findByTestId("permission-action-card");
+    await waitFor(() => {
+      expect(within(permissionCard).getByText("Expired")).toBeInTheDocument();
+      expect(within(permissionCard).getByText("Confirm")).toBeInTheDocument();
+    });
+    expect(
+      within(permissionCard).queryByText("Already allowed"),
+    ).not.toBeInTheDocument();
+
+    await confirmPermissionAction(
+      userEvent.setup({ delay: null }),
+      permissionCard,
+    );
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Permissions updated"),
+      ).toBeInTheDocument();
+    });
+    expect(applyRequests).toBe(1);
+  });
+
   it("shows already denied permission action cards as read-only after refresh", async () => {
     const permissionDenyUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=deny`;
     let applyRequests = 0;
@@ -716,6 +795,7 @@ describe("chat message action cards", () => {
   });
 
   it("automatically retries permission action loading before showing an error", async () => {
+    mockNow();
     const user = userEvent.setup({ delay: null });
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     let listRequests = 0;
@@ -741,7 +821,7 @@ describe("chat message action cards", () => {
             connectorRef: body.connectorRef,
             permission: grant.permission,
             action: grant.action,
-            expiresAt: "2026-06-09T12:00:00.000Z",
+            expiresAt: isoFromNowMs(60 * 60 * 1000),
             createdAt: "2026-06-09T11:00:00Z",
             updatedAt: "2026-06-09T11:01:00Z",
           },
@@ -982,6 +1062,7 @@ describe("chat message action cards", () => {
   });
 
   it("keeps permission success visible while permission grants reload", async () => {
+    mockNow();
     const user = userEvent.setup({ delay: null });
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=gmail&permission=messages.write&action=allow&expiresIn=1h`;
     let listRequests = 0;
@@ -1019,7 +1100,7 @@ describe("chat message action cards", () => {
             connectorRef: body.connectorRef,
             permission: grant.permission,
             action: grant.action,
-            expiresAt: "2026-06-09T12:00:00.000Z",
+            expiresAt: isoFromNowMs(60 * 60 * 1000),
             createdAt: "2026-06-09T11:00:00Z",
             updatedAt: "2026-06-09T11:01:00Z",
           },
@@ -1076,6 +1157,7 @@ describe("chat message action cards", () => {
   });
 
   it("lets users change permission duration before confirming", async () => {
+    mockNow();
     const user = userEvent.setup({ delay: null });
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=slack&permission=admin.analytics%3Aread&action=allow&expiresIn=24h`;
     let capturedBody: unknown = null;
@@ -1096,7 +1178,7 @@ describe("chat message action cards", () => {
             connectorRef: body.connectorRef,
             permission: grant.permission,
             action: grant.action,
-            expiresAt: "2026-06-16T11:01:00.000Z",
+            expiresAt: isoFromNowMs(7 * 24 * 60 * 60 * 1000),
             createdAt: "2026-06-09T11:00:00Z",
             updatedAt: "2026-06-09T11:01:00Z",
           },
@@ -1162,6 +1244,7 @@ describe("chat message action cards", () => {
   });
 
   it("lets users confirm unknown endpoint permissions from assistant messages", async () => {
+    mockNow();
     const user = userEvent.setup({ delay: null });
     const permissionAuthorizeUrl = `https://app.vm0.ai/agents/${AGENT_ID}/permissions?ref=cloudflare&permission=${UNKNOWN_PERMISSION_GRANT}&action=allow&expiresIn=1h`;
     let capturedBody: unknown = null;
@@ -1182,7 +1265,7 @@ describe("chat message action cards", () => {
             connectorRef: body.connectorRef,
             permission: grant.permission,
             action: grant.action,
-            expiresAt: "2026-06-09T12:00:00.000Z",
+            expiresAt: isoFromNowMs(60 * 60 * 1000),
             createdAt: "2026-06-09T11:00:00Z",
             updatedAt: "2026-06-09T11:01:00Z",
           },

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -20,11 +20,11 @@ import {
 } from "@vm0/ui";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import { firewallPermissionMetadataByConnector } from "../../../../signals/firewall-permission-metadata.ts";
 import { applyUserPermissionGrants$ } from "../../../../signals/permission-allow/permission-allow-signals.ts";
+import { activeUserPermissionGrantSnapshot } from "../../../../signals/user-permission-grants.ts";
 import {
   connectorAgentAccessRows,
   connectorAccessManagementPermissionAgentId$,
@@ -46,6 +46,7 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import { AvatarFromUrl } from "../../zero-sidebar-shared.tsx";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import { PermissionsDialog } from "./permissions-dialog.tsx";
+import { useUserPermissionGrantExpiryTick } from "../../../user-permission-grant-expiry-tick.ts";
 
 interface ConnectorAccessManagementDialogProps {
   readonly connectorType: ConnectorType;
@@ -328,10 +329,13 @@ function AgentPermissionDialog({
   readonly applyGrantPolicies: ApplyUserPermissionGrants;
   readonly onClose: () => void;
 }) {
+  const grants = row?.grants ?? [];
+  useUserPermissionGrantExpiryTick(grants);
   if (!row || !metadata) {
     return null;
   }
-  const initialPolicies = permissionGrantsToFirewallPolicies(row.grants) ?? {};
+  const activeSnapshot = activeUserPermissionGrantSnapshot(grants);
+  const initialPolicies = activeSnapshot.policies ?? {};
 
   return (
     <PermissionsDialog
@@ -340,7 +344,7 @@ function AgentPermissionDialog({
       connectorLabel={connectorLabel}
       displayName={agentName(row.agent)}
       initialPolicies={initialPolicies}
-      initialGrants={row.grants}
+      initialGrants={activeSnapshot.grants}
       resetEnabled
       readOnly={false}
       onApply={async (intent, { metadata: appliedMetadata }) => {
@@ -349,7 +353,7 @@ function AgentPermissionDialog({
           connectorRef: connectorType,
           metadata: appliedMetadata,
           initialPolicies,
-          initialGrants: row.grants,
+          initialGrants: activeSnapshot.grants,
           intent,
           pageSignal,
           applyGrantPolicies,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -166,6 +166,8 @@ import {
   permissionGrantExpiryText,
   setPermissionGrantExpiresIn$,
 } from "../../signals/permission-allow/permission-grant-expiration.ts";
+import { isActiveUserPermissionGrant } from "../../signals/user-permission-grants.ts";
+import { useUserPermissionGrantExpiryTick } from "../user-permission-grant-expiry-tick.ts";
 import {
   artifactFullscreen$,
   artifactInboxQuery$,
@@ -5099,6 +5101,31 @@ function permissionActionUserGrant(
   });
 }
 
+function permissionActionGrantExpiresAt({
+  savedGrant,
+  savedGrantActive,
+  existingGrant,
+  existingGrantActive,
+  status,
+}: {
+  savedGrant: PermissionActionUserGrant | null;
+  savedGrantActive: boolean;
+  existingGrant: PermissionActionUserGrant | undefined;
+  existingGrantActive: boolean;
+  status: PermissionActionCardStatus;
+}): string | null {
+  if (savedGrantActive) {
+    return savedGrant?.expiresAt ?? null;
+  }
+  if (existingGrantActive) {
+    return existingGrant?.expiresAt ?? null;
+  }
+  if (status.kind !== "ready") {
+    return null;
+  }
+  return savedGrant?.expiresAt ?? existingGrant?.expiresAt ?? null;
+}
+
 function createPermissionActionCardStatus(params: {
   hasAgent: boolean;
   hasPermission: boolean;
@@ -5143,6 +5170,7 @@ function createPermissionActionCardViewState(params: {
   permissionMetadataLoadable: LoadableLike<PublicConnectorCatalogPermissionDetail | null>;
   userGrantsLoadable: LoadableLike<readonly PermissionActionUserGrant[]>;
   grantLoadableState: string;
+  savedGrantActive: boolean;
 }) {
   const permissionMetadata =
     params.permissionMetadataLoadable.state === "hasData"
@@ -5179,7 +5207,8 @@ function createPermissionActionCardViewState(params: {
     userGrantPolicy,
     action: params.block.action,
   });
-  const saveDone = params.grantLoadableState === "hasData";
+  const saveDone =
+    params.grantLoadableState === "hasData" && params.savedGrantActive;
   const status = createPermissionActionCardStatus({
     hasAgent: params.hasAgent,
     hasPermission: Boolean(focusedPermission),
@@ -5345,7 +5374,19 @@ function PermissionActionCardForTarget({
     }),
   );
   const [grantLoadable, applyGrant] = useLoadableSet(applyUserPermissionGrant$);
+  const savedGrant =
+    grantLoadable.state === "hasData" ? grantLoadable.data : null;
+  const savedGrantActive = savedGrant
+    ? isActiveUserPermissionGrant(savedGrant)
+    : false;
+  const rawUserGrants = loadableData(userGrantsLoadable) ?? [];
+  useUserPermissionGrantExpiryTick(
+    savedGrant ? [...rawUserGrants, savedGrant] : rawUserGrants,
+  );
   const existingGrant = permissionActionUserGrant(userGrantsLoadable, block);
+  const existingGrantActive = existingGrant
+    ? isActiveUserPermissionGrant(existingGrant)
+    : false;
   const actionState = createPermissionActionCardViewState({
     block,
     hasAgent: hasTarget,
@@ -5353,15 +5394,19 @@ function PermissionActionCardForTarget({
     permissionMetadataLoadable,
     userGrantsLoadable,
     grantLoadableState: grantLoadable.state,
+    savedGrantActive,
   });
   const permissionMetadata =
     permissionMetadataLoadable.state === "hasData"
       ? permissionMetadataLoadable.data
       : null;
-  const grantExpiresAt =
-    grantLoadable.state === "hasData"
-      ? grantLoadable.data.expiresAt
-      : (existingGrant?.expiresAt ?? null);
+  const grantExpiresAt = permissionActionGrantExpiresAt({
+    savedGrant,
+    savedGrantActive,
+    existingGrant,
+    existingGrantActive,
+    status: actionState.status,
+  });
 
   return (
     <PermissionActionCardContent


### PR DESCRIPTION
## Summary
- Treat expired current-user permission grants as inactive when resolving frontend permission policy.
- Keep expired grants visible only as context for re-confirmable permission cards, not as already-applied state.
- Filter expired grants out of permission drawer initial state and add an expiry timer so stale loaded grants re-evaluate after expiration.

Fixes #20389

## Verification
- `cd turbo && pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/chat-message-action-cards.test.tsx src/views/permission-allow/__tests__/permission-allow-page.test.tsx src/views/team-page/__tests__/team-navigation.test.tsx`
- `cd turbo && pnpm turbo run lint --filter=@vm0/app`
- `cd turbo && pnpm -F @vm0/app exec tsc --noEmit`
- pre-commit: `cd turbo && pnpm check-types`

Note: local full check-types initially needed ignored firewall metadata generated by `pnpm -F @vm0/firewalls-generator generate:metadata`; those generated files are not part of this PR.