### PR TITLE
perf: accept platform secret firewall auth metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3801,6 +3801,12 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(claim.secretConnectorMap).toMatchObject({
       GOOGLE_ADS_TOKEN: "google-ads",
     });
+    expect(claim.secretConnectorMap ?? {}).not.toHaveProperty(
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+    );
+    expect(claim.secretConnectorMetadataMap ?? {}).not.toHaveProperty(
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+    );
     expect(
       claim.firewalls?.map((firewall) => {
         return firewallEntryName(firewall);

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, onTestFinished } from "vitest";
 
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
+import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
@@ -1839,7 +1840,193 @@ describe("FW-9: codex model-provider access", () => {
   });
 });
 
-describe("FW-10: aws sigv4 template resolution", () => {
+describe("FW-10: platform connector secrets", () => {
+  it("resolves platform-secret aliases from current API env", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-access",
+      refreshToken: "google-ads-refresh",
+    });
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token-current");
+
+    const resolved = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({
+          GOOGLE_ADS_TOKEN: "google-ads-access",
+        }),
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("GOOGLE_ADS_TOKEN")}`,
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+        secretConnectorMap: {
+          GOOGLE_ADS_TOKEN: "google-ads",
+          GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
+        },
+        secretConnectorMetadataMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: {
+            sourceType: "platform-secret" as const,
+          },
+        },
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected platform-secret alias to resolve");
+    }
+    expect(resolved.body.headers.Authorization).toBe(
+      "Bearer google-ads-access",
+    );
+    expect(resolved.body.headers["developer-token"]).toBe(
+      "developer-token-current",
+    );
+    expect(resolved.body.resolvedSecrets).toStrictEqual([
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+      "GOOGLE_ADS_TOKEN",
+    ]);
+  });
+
+  it("reports missing platform env as connector-not-configured", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-access",
+      refreshToken: "google-ads-refresh",
+    });
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", undefined);
+
+    const missing = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({
+          GOOGLE_ADS_TOKEN: "google-ads-access",
+        }),
+        authHeaders: {
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+        secretConnectorMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
+        },
+        secretConnectorMetadataMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: {
+            sourceType: "platform-secret" as const,
+          },
+        },
+      },
+      [424],
+    );
+    if (missing.status !== 424) {
+      throw new Error("Expected missing platform env to fail with 424");
+    }
+    expect(missing.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+  });
+
+  it("does not fall back to stale encrypted values for platform metadata", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-access",
+      refreshToken: "google-ads-refresh",
+    });
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", " ");
+
+    const missing = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({
+          GOOGLE_ADS_DEVELOPER_TOKEN: "stale-developer-token",
+        }),
+        authHeaders: {
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+        secretConnectorMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
+        },
+        secretConnectorMetadataMap: {
+          GOOGLE_ADS_DEVELOPER_TOKEN: {
+            sourceType: "platform-secret" as const,
+          },
+        },
+      },
+      [424],
+    );
+    if (missing.status !== 424) {
+      throw new Error("Expected stale encrypted platform value to be ignored");
+    }
+    expect(missing.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+  });
+
+  it("rejects platform metadata for non-platform connector aliases", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-access",
+      refreshToken: "google-ads-refresh",
+    });
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token-current");
+
+    const invalid = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({
+          GOOGLE_ADS_TOKEN: "google-ads-access",
+        }),
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("GOOGLE_ADS_TOKEN")}`,
+        },
+        secretConnectorMap: {
+          GOOGLE_ADS_TOKEN: "google-ads",
+        },
+        secretConnectorMetadataMap: {
+          GOOGLE_ADS_TOKEN: {
+            sourceType: "platform-secret" as const,
+          },
+        },
+      },
+      [424],
+    );
+    if (invalid.status !== 424) {
+      throw new Error("Expected invalid platform alias to fail with 424");
+    }
+    expect(invalid.body.error.code).toBe("CONNECTOR_NOT_CONFIGURED");
+  });
+
+  it("keeps old encrypted platform-secret payloads working without metadata", async () => {
+    const fw = createFirewallApi(context);
+    const { headers } = await firewallRun();
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", undefined);
+
+    const resolved = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({
+          GOOGLE_ADS_DEVELOPER_TOKEN: "old-encrypted-developer-token",
+        }),
+        authHeaders: {
+          "developer-token": secretTemplate("GOOGLE_ADS_DEVELOPER_TOKEN"),
+        },
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected old encrypted platform payload to resolve");
+    }
+    expect(resolved.body.headers["developer-token"]).toBe(
+      "old-encrypted-developer-token",
+    );
+  });
+});
+
+describe("FW-11: aws sigv4 template resolution", () => {
   it("resolves aws sigv4 credentials from secret and var templates", async () => {
     const fw = createFirewallApi(context);
     const { headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -13,6 +13,7 @@ import {
   getConnectorAuthClientConfigForMethod,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodRuntimeMetadata,
+  getConnectorRuntimeBindingPlatformSecretName,
   getConnectorRuntimeBindingSecretName,
   resolveConnectorResolvedAuthMethodClientByAccessKind,
   connectorAuthMethodRefHasAccessKind,
@@ -88,9 +89,10 @@ import {
   type ConnectorCredentialStatus,
 } from "./connector-credential-status.service";
 
-type AccessSecretSource = "connector" | "model-provider";
+type AccessSecretSource = SecretConnectorMetadata["sourceType"];
+type StorageSecretSource = Exclude<AccessSecretSource, "platform-secret">;
 type FirewallAuthFailureReason = "upstream_provider" | "reconnect_required";
-type SecretType = AccessSecretSource;
+type SecretType = StorageSecretSource;
 const NORMAL_BILLABLE_FIREWALL_LEASE_SECONDS = 30;
 const LOW_BILLABLE_FIREWALL_LEASE_SECONDS = 5;
 const LOW_BILLABLE_FIREWALL_CREDIT_THRESHOLD = 1000;
@@ -316,7 +318,7 @@ interface SecretTokenLookupArgs {
   readonly connectorType: string;
   readonly orgId: string;
   readonly userId: string;
-  readonly sourceType: AccessSecretSource;
+  readonly sourceType: StorageSecretSource;
   readonly sourceUserId?: string;
   readonly metadataKey?: string;
   readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
@@ -619,7 +621,7 @@ function modelProviderTypeForProviderKey(
 }
 
 function resolveSecretUserId(
-  sourceType: AccessSecretSource,
+  sourceType: StorageSecretSource,
   userId: string,
   sourceUserId?: string,
 ): string {
@@ -992,6 +994,9 @@ function refreshableRuntimeSecretNameForSource(args: {
     return secretName && secretMetadata?.refreshableSecrets.includes(secretName)
       ? secretName
       : undefined;
+  }
+  if (args.metadata.sourceType === "platform-secret") {
+    return undefined;
   }
 
   const connectorAccess = args.connectorAccessByType.get(args.connectorType);
@@ -2448,6 +2453,13 @@ function isConnectorRuntimeSecretKey(
   return connectorRuntimeSecretName(key, connectorAccess) !== undefined;
 }
 
+function isConnectorRuntimePlatformSecretKey(
+  key: string,
+  connectorAccess: ConnectorAccessState,
+): boolean {
+  return connectorRuntimePlatformSecretName(key, connectorAccess) !== undefined;
+}
+
 function isRefreshableConnectorRuntimeSecretKey(
   key: string,
   connectorAccess: ConnectorAccessState,
@@ -2477,6 +2489,24 @@ function connectorRuntimeSecretName(
     }
     case "static": {
       return getConnectorRuntimeBindingSecretName(
+        connectorAccess.runtimeMetadata,
+        key,
+      );
+    }
+    case "none": {
+      return undefined;
+    }
+  }
+}
+
+function connectorRuntimePlatformSecretName(
+  key: string,
+  connectorAccess: ConnectorAccessState,
+): string | undefined {
+  switch (connectorAccess.accessMetadata.kind) {
+    case "refresh-token":
+    case "static": {
+      return getConnectorRuntimeBindingPlatformSecretName(
         connectorAccess.runtimeMetadata,
         key,
       );
@@ -2773,6 +2803,46 @@ async function syncModelProviderRuntimeSecrets(args: {
   );
 }
 
+function syncPlatformRuntimeSecrets(args: {
+  readonly secrets: Record<string, string>;
+  readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
+  readonly referencedKeys: Set<string>;
+  readonly connectorAccessByType: ReadonlyMap<string, ConnectorAccessState>;
+}): void {
+  if (!args.secretConnectorMap) {
+    return;
+  }
+
+  for (const key of args.referencedKeys) {
+    const connectorType = getOwnConnectorOwner(args.secretConnectorMap, key);
+    if (!connectorType) {
+      continue;
+    }
+    const metadata = resolveRefreshMetadata(
+      connectorType,
+      args.secretConnectorMetadataMap?.[key],
+    );
+    if (metadata.sourceType !== "platform-secret") {
+      continue;
+    }
+    const connectorAccess = args.connectorAccessByType.get(connectorType);
+    const platformSecretName =
+      connectorAccess &&
+      connectorRuntimePlatformSecretName(key, connectorAccess);
+    const value = platformSecretName
+      ? optionalEnv(platformSecretName)
+      : undefined;
+    if (value === undefined || value.trim().length === 0) {
+      delete args.secrets[key];
+    } else {
+      args.secrets[key] = value;
+    }
+  }
+}
+
 async function syncCustomConnectorRuntimeSecrets(args: {
   readonly db: Db;
   readonly runId: string;
@@ -2858,6 +2928,13 @@ async function syncFirewallRuntimeSecrets(args: {
     referencedKeys: args.referencedKeys,
     featureSwitchContext: args.featureSwitchContext,
   });
+  syncPlatformRuntimeSecrets({
+    secrets: args.secrets,
+    secretConnectorMap: args.body.secretConnectorMap,
+    secretConnectorMetadataMap: args.body.secretConnectorMetadataMap,
+    referencedKeys: args.referencedKeys,
+    connectorAccessByType: args.connectorAccessByType,
+  });
 }
 
 function canResolveMissingAccessSecret(args: {
@@ -2882,6 +2959,9 @@ function canResolveMissingAccessSecret(args: {
         metadata: refreshMetadata,
       }) !== undefined
     );
+  }
+  if (refreshMetadata.sourceType === "platform-secret") {
+    return false;
   }
 
   const connectorAccess = args.connectorAccessByType.get(connectorType);
@@ -2911,7 +2991,7 @@ function referencedConnectorTypes(args: {
       connectorType,
       args.secretConnectorMetadataMap?.[key],
     ).sourceType;
-    if (sourceType === "connector") {
+    if (sourceType === "connector" || sourceType === "platform-secret") {
       connectorTypes.add(connectorType);
     }
   }
@@ -2959,6 +3039,13 @@ function hasUnavailableAccessSource(args: {
         }) === undefined
       );
     }
+    if (metadata.sourceType === "platform-secret") {
+      const connectorAccess = args.connectorAccessByType.get(connectorType);
+      return (
+        !connectorAccess ||
+        !isConnectorRuntimePlatformSecretKey(key, connectorAccess)
+      );
+    }
 
     const connectorAccess = args.connectorAccessByType.get(connectorType);
     return (
@@ -3004,14 +3091,19 @@ function connectorAccessSourcesWithReconnectRequiredStatus(args: {
       connectorType,
       args.secretConnectorMetadataMap?.[key],
     );
-    if (metadata.sourceType !== "connector") {
+    if (
+      metadata.sourceType !== "connector" &&
+      metadata.sourceType !== "platform-secret"
+    ) {
       continue;
     }
     const connectorAccess = args.connectorAccessByType.get(connectorType);
-    if (
-      !connectorAccess ||
-      !isConnectorRuntimeSecretKey(key, connectorAccess)
-    ) {
+    const isAvailableKey =
+      metadata.sourceType === "platform-secret"
+        ? connectorAccess &&
+          isConnectorRuntimePlatformSecretKey(key, connectorAccess)
+        : connectorAccess && isConnectorRuntimeSecretKey(key, connectorAccess);
+    if (!connectorAccess || !isAvailableKey) {
       continue;
     }
     if (
@@ -3289,6 +3381,9 @@ async function refreshSelectedTokens(
         connectorType,
         context.metadataByConnector.get(connectorType),
       );
+      if (metadata.sourceType === "platform-secret") {
+        throw new Error("Platform secrets are not refreshable");
+      }
       const refreshResult = await refreshAccessTokenForSource({
         db: context.db,
         connectorType,
@@ -3362,6 +3457,9 @@ async function syncSkippedTokens(
         connectorType,
         context.metadataByConnector.get(connectorType),
       );
+      if (metadata.sourceType === "platform-secret") {
+        throw new Error("Platform secrets are not refreshable");
+      }
       return {
         connectorType,
         tokens: await getCurrentAccessSecrets({

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -296,7 +296,7 @@ export const resumeSessionSchema = z.union([
 export const runnerClaimCapabilitySchema = z.string().min(1);
 
 export const secretConnectorMetadataSchema = z.object({
-  sourceType: z.enum(["connector", "model-provider"]),
+  sourceType: z.enum(["connector", "model-provider", "platform-secret"]),
   sourceUserId: z.string().optional(),
   metadataKey: z.string().optional(),
 });

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -53,6 +53,7 @@ import {
   getConnectorAuthMethodDeviceAuthStartOptionsConfig,
   getConnectorAuthMethodAccessMetadata,
   getConnectorAuthMethodRuntimeMetadata,
+  getConnectorRuntimeBindingPlatformSecretName,
   getConnectorGrantOutputTarget,
   getConnectorRefreshOutputTarget,
   getConnectorStoredSecretDisplayInfo,
@@ -3056,9 +3057,14 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
   });
 
   it("represents platform secrets as platform runtime sources", () => {
-    expect(
-      getConnectorAuthMethodRuntimeMetadata("google-ads", "oauth"),
-    ).toStrictEqual({
+    const metadata = getConnectorAuthMethodRuntimeMetadata(
+      "google-ads",
+      "oauth",
+    );
+    if (!metadata) {
+      throw new Error("Expected Google Ads OAuth runtime metadata");
+    }
+    expect(metadata).toStrictEqual({
       storage: {
         secrets: ["GOOGLE_ADS_ACCESS_TOKEN", "GOOGLE_ADS_REFRESH_TOKEN"],
         variables: [],
@@ -3084,6 +3090,18 @@ describe("getConnectorAuthMethodRuntimeMetadata", () => {
         },
       ],
     });
+    expect(
+      getConnectorRuntimeBindingPlatformSecretName(
+        metadata,
+        "GOOGLE_ADS_DEVELOPER_TOKEN",
+      ),
+    ).toBe("GOOGLE_ADS_DEVELOPER_TOKEN");
+    expect(
+      getConnectorRuntimeBindingPlatformSecretName(
+        metadata,
+        "GOOGLE_ADS_TOKEN",
+      ),
+    ).toBeUndefined();
   });
 
   it("returns Meta Ads runtime token binding metadata", () => {

--- a/turbo/packages/connectors/src/connector-utils.ts
+++ b/turbo/packages/connectors/src/connector-utils.ts
@@ -793,6 +793,18 @@ export function getConnectorRuntimeBindingSecretName(
     : undefined;
 }
 
+export function getConnectorRuntimeBindingPlatformSecretName(
+  metadata: ConnectorAuthMethodRuntimeMetadata,
+  envName: string,
+): ConnectorPlatformSecretName | undefined {
+  const binding = metadata.runtimeBindings.find((entry) => {
+    return entry.envName === envName && entry.source.kind === "platform-secret";
+  });
+  return binding?.source.kind === "platform-secret"
+    ? binding.source.name
+    : undefined;
+}
+
 export function connectorRefreshMetadataHasRefreshableSecret(
   metadata: ConnectorAuthMethodAccessMetadata,
   secretName: string,


### PR DESCRIPTION
## Summary
- accept platform-secret in runner secret connector metadata
- resolve platform connector secrets from API env during firewall auth
- keep platform secrets out of stored secret refresh paths and current run creation output

## Tests
- pnpm -F @vm0/db db:migrate
- pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --testNamePattern "platform connector secrets"
- pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --testNamePattern "withholds platform secrets"
- pnpm -F @vm0/connectors exec vitest run src/__tests__/connectors.test.ts --testNamePattern "platform secrets"
- pnpm -F api check-types
- pnpm -F api lint
- pnpm -F @vm0/api-contracts check-types
- pnpm -F @vm0/api-contracts lint
- pnpm -F @vm0/api-contracts test
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/connectors lint
- git diff --check

Closes #20411