### PR TITLE
refactor: reduce fallback slop in api contracts

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/composes.ts
+++ b/turbo/packages/api-contracts/src/contracts/composes.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { firewallsSchema } from "@vm0/connectors/firewall-types";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import { CANONICAL_WORKING_DIR } from "./runners";
@@ -230,6 +231,17 @@ const artifactsArraySchema = z.array(artifactConfigSchema).refine((items) => {
   return new Set(names).size === names.length;
 }, "Artifact names must be unique");
 
+const agentFirewallsMapSchema = z.record(
+  z.string(),
+  z.object({
+    permissions: z.union([z.literal("all"), z.array(z.string()).min(1)]),
+  }),
+);
+const legacyAgentFirewallsSchema = z.union([
+  agentFirewallsMapSchema,
+  firewallsSchema,
+]);
+
 /**
  * Agent definition schema
  */
@@ -289,14 +301,7 @@ const agentDefinitionSchema = z.object({
    * Map format: { slack: { permissions: [...] | "all" } }
    * Resolved to full ExpandedFirewallConfig[] at runtime.
    */
-  firewalls: z
-    .record(
-      z.string(),
-      z.object({
-        permissions: z.union([z.literal("all"), z.array(z.string()).min(1)]),
-      }),
-    )
-    .optional(),
+  firewalls: agentFirewallsMapSchema.optional(),
 });
 
 /**
@@ -312,8 +317,8 @@ const agentComposeContentSchema = z.object({
 /**
  * Agent compose content schema for API requests.
  * firewalls is no longer stored in compose content — all firewalls
- * are injected at runtime. The field is accepted as unknown for backward
- * compatibility with older stored compose versions (ignored at runtime).
+ * are injected at runtime. The field accepts documented legacy map or expanded
+ * array shapes for backward compatibility (ignored at runtime).
  */
 const agentComposeApiContentSchema = z.object({
   version: z.string().min(1, "Version is required"),
@@ -322,7 +327,7 @@ const agentComposeApiContentSchema = z.object({
     agentDefinitionSchema.extend({
       // Legacy: older compose versions may have this field (map or expanded array).
       // Accepted for backward compat but ignored at runtime.
-      firewalls: z.unknown().optional(),
+      firewalls: legacyAgentFirewallsSchema.optional(),
     }),
   ),
   volumes: z.record(z.string(), volumeConfigSchema).optional(),

--- a/turbo/packages/api-contracts/src/contracts/internal-callbacks-shared.ts
+++ b/turbo/packages/api-contracts/src/contracts/internal-callbacks-shared.ts
@@ -5,6 +5,8 @@ export const internalCallbackHeadersSchema = z.object({
   "x-vm0-timestamp": z.string().optional(),
 });
 
+const internalCallbackPayloadSchema = z.record(z.string(), z.unknown());
+
 export const internalCallbackBodySchema = z
   .object({
     callbackId: z.string().optional(),
@@ -12,7 +14,7 @@ export const internalCallbackBodySchema = z
     status: z.enum(["completed", "failed", "progress"]),
     result: z.record(z.string(), z.unknown()).optional(),
     error: z.string().optional(),
-    payload: z.unknown().optional(),
+    payload: internalCallbackPayloadSchema.optional(),
   })
   .passthrough();
 

--- a/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import { initContract } from "./base";
-import { agentComposeApiContentSchema } from "./composes";
 
 const c = initContract();
 
@@ -29,7 +28,7 @@ export const testSlackStatePostBodySchema = z.object({
   seed_default_agent: z.boolean().optional(),
   default_agent_name: z.string().optional(),
   default_agent_display_name: z.string().nullable().optional(),
-  compose_content: agentComposeApiContentSchema.optional(),
+  compose_content: z.record(z.string(), z.unknown()).optional(),
   org_slug: z.string().optional(),
   org_name: z.string().optional(),
   seed_secret_names: z.array(z.string()).optional(),

--- a/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-slack-state.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { initContract } from "./base";
+import { agentComposeApiContentSchema } from "./composes";
 
 const c = initContract();
 
@@ -28,7 +29,7 @@ export const testSlackStatePostBodySchema = z.object({
   seed_default_agent: z.boolean().optional(),
   default_agent_name: z.string().optional(),
   default_agent_display_name: z.string().nullable().optional(),
-  compose_content: z.unknown().optional(),
+  compose_content: agentComposeApiContentSchema.optional(),
   org_slug: z.string().optional(),
   org_name: z.string().optional(),
   seed_secret_names: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
This daily cleanup narrows three high-confidence loose Zod fallback sites in `@vm0/api-contracts` without changing route handlers.

## Scan
- Scan timestamp: `2026-07-06T20:01:59.648Z`
- Base commit: `40f3442fda54f1064e92ea109ea51e922865660d`
- Scanner totals by category:
  - `nullish`: 5396
  - `nullish-chain`: 124
  - `field-fallback-chain`: 97
  - `optional-prop`: 5656
  - `zod-optional`: 2155
  - `zod-loose-optional`: 7
  - `loose-record`: 1247
  - `loose-index-signature`: 5
  - `as-any`: 0
  - `as-unknown-as`: 33
  - `empty-fallback`: 627
  - `string-fallback`: 678
  - `null-undefined-fallback`: 1503
  - `empty-catch`: 3
  - `promise-catch-swallow`: 14
  - `rust-unwrap-or`: 573
  - `rust-ok-discard`: 142
- `actionable_total`: 218
- `edit_budget`: 11
- Candidates changed: 3

## Changes
- `turbo/packages/api-contracts/src/contracts/composes.ts`
  - Reuses a single compose firewall map schema and narrows the legacy API compose `firewalls` field to the documented map or expanded firewall array shapes. This keeps backward-compatible legacy acceptance while removing the arbitrary `unknown` field.
- `turbo/packages/api-contracts/src/contracts/internal-callbacks-shared.ts`
  - Narrows internal callback `payload` from arbitrary `unknown` to an object record. Internal callbacks are vm0-controlled and downstream callback handlers already parse object payloads.
- `turbo/packages/api-contracts/src/contracts/test-slack-state.ts`
  - Narrows `compose_content` from arbitrary `unknown` to an object record. This preserves the legacy seeded environment JSON accepted by existing Slack integration tests while no longer accepting primitive values.

## Verification
- `git diff --check`
- `pnpm format`
- `pnpm --filter @vm0/api-contracts lint`
- `pnpm --filter @vm0/api-contracts check-types`
- Re-ran the scanner after changes: `zod-loose-optional` dropped from 7 to 4 and `highConfidenceProductionActionableTotal` dropped from 218 to 215.
- Attempted full `pnpm turbo run lint --log-order grouped`; local `oxlint-tsgolint` was killed by the runner during `@vm0/app:lint` after `@vm0/api-contracts:lint` passed.
- Attempted full `pnpm check-types` and the pre-commit hook's full typecheck; local `api#check-types` hit Node heap OOM in this runner. The PR pipeline will run the full checks.
- Attempted the targeted Slack integration vitest file; the local run failed because Postgres was unavailable (`ECONNREFUSED`).

This workflow intentionally leaves the remaining candidates for later daily runs.
