### PR TITLE
test(runner): stabilize startup cleanup child helper

### DIFF
--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -174,19 +174,24 @@ async fn live_runner_instance_publish_failure_shuts_down_startup_resources() {
     let status_path = dir.path().join("status.json");
     let status = StatusTracker::new(status_path.clone(), 4, None, None);
     let (mut mitm, _mitm_crash_rx) = crate::proxy::MitmProxy::noop();
-    let mut ignore_term_child = tokio::process::Command::new("python3")
+    let ignore_term_fifo = dir.path().join("ignore-term-child.fifo");
+    let mut ignore_term_child = tokio::process::Command::new("bash")
         .arg("-c")
         .arg(
             r#"
-import os
-import signal
-
-signal.signal(signal.SIGTERM, signal.SIG_IGN)
-os.write(1, b"ready\n")
-while True:
-    signal.pause()
+set -euo pipefail
+fifo="$1"
+mkfifo "$fifo"
+trap '' TERM
+exec 3<>"$fifo"
+printf 'ready\n'
+while true; do
+  read -r _ <&3 || true
+done
 "#,
         )
+        .arg("ignore-term-child")
+        .arg(&ignore_term_fifo)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
@@ -196,11 +201,15 @@ while True:
     let proxy_child_pid = ignore_term_child.id().expect("proxy child should have pid");
     let stdout = ignore_term_child.stdout.take().unwrap();
     let mut ready_lines = tokio::io::BufReader::new(stdout).lines();
-    let ready = tokio::time::timeout(Duration::from_secs(2), ready_lines.next_line())
+    let ready = tokio::time::timeout(Duration::from_secs(5), ready_lines.next_line())
         .await
         .expect("ignore-term child did not become ready")
         .unwrap();
     assert_eq!(ready.as_deref(), Some("ready"));
+    let proxy_child_starttime = crate::process::read_process_stat(proxy_child_pid)
+        .await
+        .expect("proxy child stat should be readable after readiness")
+        .starttime;
     mitm.set_child_for_test(ignore_term_child);
     let prefetch_cancel = CancellationToken::new();
     let task_cancel = prefetch_cancel.clone();
@@ -253,8 +262,12 @@ while True:
         .expect("prefetch task should observe cleanup cancellation")
         .expect("prefetch task should report cancellation");
     assert_eq!(memory_prefetch.task_count(), 0);
+    let proxy_child_still_exists = matches!(
+        crate::process::read_process_stat(proxy_child_pid).await,
+        Some(stat) if stat.starttime == proxy_child_starttime
+    );
     assert!(
-        !std::path::Path::new(&format!("/proc/{proxy_child_pid}")).exists(),
+        !proxy_child_still_exists,
         "proxy child should be killed and reaped during cleanup"
     );
     wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;


### PR DESCRIPTION
## Summary
- Replace the flaky Python ignore-SIGTERM test helper with a lightweight bash/FIFO helper.
- Record process starttime so the cleanup assertion does not fail if the PID is reused.

## Verification
- cargo fmt --manifest-path crates/Cargo.toml --package runner --check
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner cmd::start::tests::main_loop::startup
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings
- git diff --check
- target flaky test repeated 20 times locally