### PR TITLE
feat: show owning agent as read-only field on workflow settings

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1253,6 +1253,10 @@ describe("workflow detail page", () => {
       expect(screen.getAllByText("Visibility").length).toBeGreaterThan(0);
     });
     expect(
+      screen.getByText("This workflow belongs to this agent."),
+    ).toBeInTheDocument();
+    expect(screen.getByTitle("Research Bot")).toHaveTextContent("Research Bot");
+    expect(
       screen.queryByText("Gather CRM context before outreach."),
     ).not.toBeInTheDocument();
     click(buttonByText("Instructions"));

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -752,9 +752,21 @@ function WorkflowMetadataFields({
   readonly values: WorkflowMetadataValues;
 }) {
   const slugCommand = `/${values.name.trim() || "slug"}`;
+  const ownerAgentLabel = agentLabel(detail);
 
   return (
     <div className="p-4 sm:p-5">
+      <InlineSettingsRow
+        label="Agent"
+        description="This workflow belongs to this agent."
+        wideControls
+      >
+        <div className="flex h-9 w-full items-center rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-gray-50 px-3 text-sm text-muted-foreground">
+          <span className="truncate" title={ownerAgentLabel}>
+            {ownerAgentLabel}
+          </span>
+        </div>
+      </InlineSettingsRow>
       <InlineSettingsRow
         label="Name"
         description="Shown in workflow lists and when choosing a workflow."


### PR DESCRIPTION
## What & why

The workflow settings page (**Settings** tab) lets you edit Name, Slug, Description, and Visibility, but nothing shows **which agent the workflow belongs to**. This adds a non-editable **Agent** row at the top of the settings card so ownership is visible at a glance.

Requested by Ming — keep it simple, "just a non-editable field."

## Change

- New read-only **Agent** row as the first row of `WorkflowMetadataFields` in `workflow-detail-page.tsx`.
- Value comes from the existing detail payload via `agentLabel(detail)` (`agentDisplayName ?? agentName ?? agentId`) — **no backend/API change**.
- Rendered as a muted `bg-gray-50` field matching the Name/Slug input rhythm (same height, radius, border) but visibly non-editable. Long agent names truncate with a native `title` tooltip on hover.
- Sentence-case label and helper text, per the vm0 UI conventions.

## User-visible impact

On any workflow's Settings tab, the owning agent now appears as the first field — read-only, so it can't be edited from here (ownership changes still go through **Copy workflow**).

## Design

Chosen from a visuals-first review with Ming (before/after + variant explorations); landed on the simplest "muted-fill non-editable field" direction.

Before → After (anchor):

![before-after](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/685ead1b-829e-4c83-a9ba-1cc5a29407ab/before-after.png)

Final simple field (Option A · muted fill):

![simple](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/8aabb3dd-382c-4705-a533-07a751d5994d/simple.png)

## Verification

- Extended the existing Settings-tab integration test in `workflows-page.test.tsx` to assert the Agent row's helper text and the owning agent value (`Research Bot`) render on the Settings tab.
- Relying on the PR pipeline for lint / type-check / full test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
