### PR TITLE
feat: regroup use case gallery by role instead of output type

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -373,7 +373,7 @@ describe("zero ideation page", () => {
 
   it("falls back to all use cases when the selected tab is hidden by catalog filtering", async () => {
     mockConnectorCatalogStatus([]);
-    context.store.set(setIdeationActiveTab$, "reports");
+    context.store.set(setIdeationActiveTab$, "engineering");
 
     detachedSetupPage({
       context,
@@ -383,7 +383,7 @@ describe("zero ideation page", () => {
     await expect(
       screen.findByText("Browser screenshots"),
     ).resolves.toBeInTheDocument();
-    expect(screen.queryByText("Reports")).not.toBeInTheDocument();
+    expect(screen.queryByText("Engineering")).not.toBeInTheDocument();
     expect(
       screen.queryByText("No use cases match your search."),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -23,8 +23,8 @@ interface IdeationFilterOptions {
 
 const categories: readonly Category[] = [
   {
-    id: "reports",
-    title: "Reports",
+    id: "engineering",
+    title: "Engineering",
     cases: [
       {
         title: "Daily standup report",
@@ -34,26 +34,11 @@ const categories: readonly Category[] = [
         connectors: ["github", "sentry", "axiom", "plausible", "slack"],
       },
       {
-        title: "Personal weekly digest",
-        description: "Pull requests, email, and calendar in one Slack update",
-        prompt:
-          "Create a personal weekly report workflow that merges GitHub PRs, Gmail, and Calendar data into a summary and sends it to Slack",
-        connectors: ["github", "gmail", "google-calendar", "slack"],
-      },
-      {
         title: "GitHub progress weekly",
         description: "Weekly repo activity summarized by feature",
         prompt:
           "Generate a weekly GitHub progress report summarized by feature modules",
         connectors: ["github"],
-      },
-      {
-        title: "Morning brief",
-        description:
-          "Email, calendar, and notes turned into a short daily plan",
-        prompt:
-          "Set up a morning brief that pulls updates from Gmail, Calendar, and Notion every morning and posts a daily plan to Slack",
-        connectors: ["gmail", "google-calendar", "notion", "slack"],
       },
       {
         title: "GitHub PR summarizer",
@@ -86,48 +71,6 @@ const categories: readonly Category[] = [
         connectors: ["cloudflare", "slack"],
       },
       {
-        title: "Metabase dashboard digest",
-        description: "Dashboard snapshots posted to Slack automatically",
-        prompt:
-          "Set up a weekly Metabase digest that snapshots key dashboards, captures charts, and posts them to Slack every Monday morning",
-        connectors: ["metabase", "slack"],
-      },
-      {
-        title: "RevenueCat subscription digest",
-        description:
-          "Subscription metrics in Sheets with churn alerts in Slack",
-        prompt:
-          "Set up a daily RevenueCat digest that tracks new subscriptions, renewals, and cancellations in Google Sheets and alerts on Slack for churn spikes",
-        connectors: ["revenuecat", "google-sheets", "slack"],
-      },
-      {
-        title: "Xero financial summary",
-        description: "Weekly profit and cash flow from Xero in Slack",
-        prompt:
-          "Set up a weekly Xero financial summary that pulls profit & loss and cash flow data and posts a formatted report to Slack",
-        connectors: ["xero", "slack"],
-      },
-      {
-        title: "Strava team fitness digest",
-        description: "Weekly team activity summary posted to Slack",
-        prompt:
-          "Set up a weekly Strava digest that summarizes team members' running and cycling activities and posts a leaderboard to Slack",
-        connectors: ["strava", "slack"],
-      },
-      {
-        title: "Streak pipeline report",
-        description: "Weekly CRM pipeline stats from Gmail in Slack",
-        prompt:
-          "Set up a weekly Streak pipeline report that summarizes deal stages, win rates, and upcoming follow-ups, then posts to Slack",
-        connectors: ["streak", "slack"],
-      },
-    ],
-  },
-  {
-    id: "github",
-    title: "GitHub",
-    cases: [
-      {
         title: "Batch-create issues",
         description: "Paste a list and Zero opens the issues for you",
         prompt:
@@ -156,7 +99,7 @@ const categories: readonly Category[] = [
         connectors: ["github", "slack"],
       },
       {
-        title: "Jira \u2194 GitHub issue sync",
+        title: "Jira ↔ GitHub issue sync",
         description: "Keeps Jira tickets and GitHub issues in sync",
         prompt:
           "Set up a bidirectional sync between Jira and GitHub so that issue status, labels, and comments stay in sync across both platforms",
@@ -169,127 +112,80 @@ const categories: readonly Category[] = [
           "Set up a workflow that mirrors GitLab issues to GitHub issues and notifies on Slack when new items are synced",
         connectors: ["gitlab", "github", "slack"],
       },
+      {
+        title: "Browserbase web testing",
+        description: "Automated browser tests for your web app",
+        prompt:
+          "Set up automated browser tests using Browserbase that check our landing page, login flow, and dashboard every day and report failures to Slack",
+        connectors: ["browserbase", "slack"],
+      },
+      {
+        title: "Zapier → VM0 migration",
+        description: "Recreate your Zapier workflows as VM0 agents",
+        prompt:
+          "Help me migrate my Zapier workflows to VM0. I have zaps for: new Slack message → Notion, Gmail → Google Sheets, and GitHub PR → Slack",
+        connectors: ["zapier", "slack", "notion"],
+        featureFlag: FeatureSwitchKey.ZapierConnector,
+      },
+      {
+        title: "Make scenario builder",
+        description: "Design multi-step Make scenarios from a description",
+        prompt:
+          "Design a Make scenario that watches a Gmail inbox for invoices, extracts amounts and dates, logs them to Google Sheets, and alerts on Slack",
+        connectors: ["make", "gmail", "google-sheets", "slack"],
+      },
     ],
   },
   {
-    id: "collaboration",
-    title: "Collaboration",
+    id: "product",
+    title: "Product",
     cases: [
       {
-        title: "Email assistant",
-        description: "Morning inbox summary with suggested next steps",
+        title: "Product copy & naming",
+        description: "Friendlier names for technical terms in the product",
         prompt:
-          "Set up a daily email assistant that summarizes my inbox every morning and suggests actions for each thread",
-        connectors: ["gmail"],
+          'Suggest user-friendly alternative names for "logs" in our product UI',
       },
       {
-        title: "Calendar optimizer",
-        description: "Helps with conflicts, overload, and focus time",
-        prompt:
-          "Analyze my calendar for today and recommend how to manage conflicts, prevent overload, and schedule focus time",
-        connectors: ["google-calendar"],
-      },
-      {
-        title: "Send messages on your behalf",
-        description: "Posts team announcements to Slack for you",
-        prompt:
-          "Send a message to the team on my behalf: I'll be taking a day off tomorrow. Please reach out to [name] for urgent matters.",
-        connectors: ["slack"],
-      },
-      {
-        title: "Browser screenshots",
-        description: "Opens a page in the browser and returns a screenshot",
-        prompt:
-          "Open this URL in the browser and take a screenshot: [paste URL]",
-      },
-      {
-        title: "Self-update instructions",
-        description: "Update the agent instructions right in chat",
-        prompt: "Update yourself: add the following instructions \u2014 ...",
-      },
-      {
-        title: "Support ticket router",
-        description: "Tickets go to Notion and urgent ones ping Slack",
-        prompt:
-          "Set up a support ticket router that monitors Gmail for support emails, classifies them by category and priority, creates Notion entries, and sends Slack alerts for critical tickets",
-        connectors: ["gmail", "notion", "slack"],
-      },
-      {
-        title: "Meeting notes pipeline",
-        description: "Fireflies notes to Notion with follow ups in Slack",
-        prompt:
-          "Set up a meeting notes pipeline that takes Fireflies transcripts, generates a summary in Notion, and posts action items to Slack after each meeting",
-        connectors: ["fireflies", "notion", "slack"],
-      },
-      {
-        title: "Calendly booking sync",
-        description: "New bookings on your calendar with a Slack ping",
-        prompt:
-          "Set up a Calendly sync that adds new bookings to Google Calendar and sends a Slack notification with meeting details",
-        connectors: ["calendly", "google-calendar", "slack"],
-      },
-      {
-        title: "Todoist \u2192 Notion task sync",
-        description: "Todoist tasks mirrored in Notion for the team",
-        prompt:
-          "Set up a sync that mirrors my Todoist tasks into a Notion database so the team can see what I'm working on",
-        connectors: ["todoist", "notion"],
-      },
-      {
-        title: "Lark \u2194 Slack message relay",
-        description: "Forwards messages between Lark and Slack both ways",
-        prompt:
-          "Set up a message relay between a Lark group and a Slack channel so that messages are forwarded both ways",
-        connectors: ["lark", "slack"],
-      },
-      {
-        title: "Google Drive file organizer",
-        description: "New files sorted into folders automatically",
-        prompt:
-          "Set up a workflow that watches Google Drive for new files, classifies them by content, and moves them into the right folders",
-        connectors: ["google-drive"],
-      },
-      {
-        title: "tl;dv meeting recap",
+        title: "Pricing analysis",
         description:
-          "Meeting recordings summarized in Notion with action items",
+          "Analyze competitor pricing strategies and compare with similar products",
         prompt:
-          "Set up a workflow that takes tl;dv meeting recordings, generates a summary with action items in Notion, and posts highlights to Slack",
-        connectors: ["tldv", "notion", "slack"],
+          "Analyze the pricing strategy of Claude Code and compare it with similar products",
       },
       {
-        title: "Granola notes to Notion",
-        description: "Granola meeting notes synced to a Notion database",
+        title: "Linear PRD implementer",
+        description: "Notion specs become Linear projects and issues",
         prompt:
-          "Set up a sync that takes meeting notes from Granola and organizes them in a Notion database grouped by project",
-        connectors: ["granola", "notion"],
+          "Take the product spec from Notion and create a structured Linear project with epics and issues",
+        connectors: ["notion", "linear"],
       },
       {
-        title: "LINE message relay",
-        description: "Forward LINE messages to Slack and vice versa",
+        title: "Feedback router",
+        description: "Slack feedback routed by your rules to the right place",
         prompt:
-          "Set up a message relay between a LINE group and a Slack channel so messages flow both ways",
-        connectors: ["line", "slack"],
+          "Set up a feedback router that watches a Slack channel and routes messages to the right team based on keywords and labels",
+        connectors: ["slack", "notion"],
       },
       {
-        title: "Loops email campaign",
-        description: "Draft and send transactional emails via Loops",
+        title: "Metabase dashboard digest",
+        description: "Dashboard snapshots posted to Slack automatically",
         prompt:
-          "Set up a workflow that drafts email campaigns from Notion content and sends them through Loops",
-        connectors: ["loops", "notion"],
+          "Set up a weekly Metabase digest that snapshots key dashboards, captures charts, and posts them to Slack every Monday morning",
+        connectors: ["metabase", "slack"],
       },
       {
-        title: "Brevo email nurture sequence",
-        description: "Automated email sequences from CRM events",
+        title: "Asana → Notion project sync",
+        description: "Asana milestones and tasks mirrored in Notion",
         prompt:
-          "Set up a Brevo nurture sequence that sends onboarding emails when new contacts are added to a Notion database",
-        connectors: ["brevo", "notion", "slack"],
+          "Set up a sync between Asana and Notion that mirrors project milestones, task progress, and due dates into a Notion dashboard",
+        connectors: ["asana", "notion", "slack"],
       },
     ],
   },
   {
-    id: "content",
-    title: "Growth",
+    id: "marketing",
+    title: "Marketing",
     cases: [
       {
         title: "Content planner",
@@ -314,24 +210,11 @@ const categories: readonly Category[] = [
         connectors: ["slack"],
       },
       {
-        title: "Product copy & naming",
-        description: "Friendlier names for technical terms in the product",
-        prompt:
-          'Suggest user-friendly alternative names for "logs" in our product UI',
-      },
-      {
         title: "Competitor research to Notion",
         description: "Research on X saved as structured notes in Notion",
         prompt:
           "Research competitor [name] on X/Twitter and save the findings into our Notion research database",
         connectors: ["x", "notion"],
-      },
-      {
-        title: "Pricing analysis",
-        description:
-          "Analyze competitor pricing strategies and compare with similar products",
-        prompt:
-          "Analyze the pricing strategy of Claude Code and compare it with similar products",
       },
       {
         title: "Social media content calendar",
@@ -378,6 +261,56 @@ const categories: readonly Category[] = [
         connectors: ["similarweb", "notion"],
       },
       {
+        title: "SerpAPI keyword tracker",
+        description: "Track keyword rankings weekly and log to Sheets",
+        prompt:
+          "Set up a weekly keyword ranking tracker using SerpAPI that monitors our target keywords and logs position changes to Google Sheets with a Slack summary",
+        connectors: ["serpapi", "google-sheets", "slack"],
+      },
+      {
+        title: "Apify web scraper to Sheets",
+        description: "Apify scrapes sites into structured Google Sheets rows",
+        prompt:
+          "Set up an Apify scraper that extracts product listings from a competitor website and saves them to Google Sheets daily",
+        connectors: ["apify", "google-sheets", "slack"],
+      },
+      {
+        title: "Marketing automation system",
+        description:
+          "Three agents for research, weekly monitoring, and ad hoc work",
+        prompt:
+          "Set up a marketing automation system with three agents: a daily researcher for information collection, a weekly monitor for tracking, and an on-demand agent for ad-hoc tasks",
+        connectors: ["slack"],
+      },
+      {
+        title: "Discord community insights",
+        description: "Discord feedback in Notion with a weekly Slack digest",
+        prompt:
+          "Set up a Discord community monitor that watches for feature requests and bug reports, categorizes them in Notion, and posts a weekly digest to Slack",
+        connectors: ["discord", "notion", "slack"],
+      },
+      {
+        title: "X brand monitor",
+        description: "Brand mentions on X saved in Notion with team alerts",
+        prompt:
+          "Set up an X brand monitor that watches for mentions of our product, saves relevant posts to Notion, and sends Slack alerts for high-engagement posts",
+        connectors: ["x", "notion", "slack"],
+      },
+      {
+        title: "Loops email campaign",
+        description: "Draft and send transactional emails via Loops",
+        prompt:
+          "Set up a workflow that drafts email campaigns from Notion content and sends them through Loops",
+        connectors: ["loops", "notion"],
+      },
+      {
+        title: "Brevo email nurture sequence",
+        description: "Automated email sequences from CRM events",
+        prompt:
+          "Set up a Brevo nurture sequence that sends onboarding emails when new contacts are added to a Notion database",
+        connectors: ["brevo", "notion", "slack"],
+      },
+      {
         title: "ElevenLabs audio content",
         description: "Voice narration from Notion articles saved to Drive",
         prompt:
@@ -390,70 +323,6 @@ const categories: readonly Category[] = [
         prompt:
           "Set up a workflow that takes a script from Notion, generates a video with HeyGen, and sends a Slack notification when it's ready",
         connectors: ["heygen", "notion", "slack"],
-      },
-      {
-        title: "Lead follow-up pipeline",
-        description: "New leads become HubSpot tasks with Slack alerts",
-        prompt:
-          "Set up a lead follow-up pipeline that monitors Gmail for new leads, analyzes them with AI, creates HubSpot tasks, and notifies the sales team on Slack",
-        connectors: ["gmail", "hubspot", "slack"],
-      },
-      {
-        title: "Win/loss reporter",
-        description: "Win and loss trends from the pipeline in Slack",
-        prompt:
-          "Set up a weekly win/loss report that analyzes our HubSpot pipeline, tracks deal outcomes, and posts trends to Slack",
-        connectors: ["hubspot", "slack"],
-      },
-      {
-        title: "Intercom conversation triager",
-        description: "Intercom chats become prioritized Notion tasks",
-        prompt:
-          "Set up a workflow that takes Intercom conversations, classifies them, and creates structured tasks in Notion",
-        connectors: ["intercom", "notion"],
-      },
-      {
-        title: "Salesforce pipeline digest",
-        description: "Weekly Salesforce opportunity updates in Slack",
-        prompt:
-          "Set up a weekly Salesforce pipeline digest that summarizes new opportunities, stage changes, and close dates, then posts to Slack",
-        connectors: ["salesforce", "slack"],
-      },
-      {
-        title: "Zendesk \u2192 Notion knowledge base",
-        description:
-          "Extract frequently asked Zendesk questions and auto-add them to a Notion FAQ",
-        prompt:
-          "Set up a workflow that identifies recurring Zendesk questions, drafts FAQ entries, and adds them to our Notion knowledge base",
-        connectors: ["zendesk", "notion", "slack"],
-      },
-      {
-        title: "Jotform intake to Notion",
-        description: "Form answers land in Notion with Slack notifications",
-        prompt:
-          "Set up a Jotform intake that routes new form submissions to the right Notion database and sends a Slack notification",
-        connectors: ["jotform", "notion", "slack"],
-      },
-      {
-        title: "Airtable deal tracker",
-        description: "Deals sync to Sheets and Slack when they close",
-        prompt:
-          "Set up an Airtable deal tracker that syncs deal records to Google Sheets and sends a Slack notification when a deal is marked as closed-won",
-        connectors: ["airtable", "google-sheets", "slack"],
-      },
-      {
-        title: "SerpAPI keyword tracker",
-        description: "Track keyword rankings weekly and log to Sheets",
-        prompt:
-          "Set up a weekly keyword ranking tracker using SerpAPI that monitors our target keywords and logs position changes to Google Sheets with a Slack summary",
-        connectors: ["serpapi", "google-sheets", "slack"],
-      },
-      {
-        title: "Perplexity deep research",
-        description: "AI-powered research summaries saved to Notion",
-        prompt:
-          "Use Perplexity to research a topic in depth, compile findings into a structured Notion page with sources and key insights",
-        connectors: ["perplexity", "notion"],
       },
       {
         title: "Runway video from brief",
@@ -479,44 +348,43 @@ const categories: readonly Category[] = [
     ],
   },
   {
-    id: "workflows",
-    title: "Workflows",
+    id: "sales",
+    title: "Sales",
     cases: [
       {
-        title: "Marketing automation system",
-        description:
-          "Three agents for research, weekly monitoring, and ad hoc work",
+        title: "Streak pipeline report",
+        description: "Weekly CRM pipeline stats from Gmail in Slack",
         prompt:
-          "Set up a marketing automation system with three agents: a daily researcher for information collection, a weekly monitor for tracking, and an on-demand agent for ad-hoc tasks",
-        connectors: ["slack"],
+          "Set up a weekly Streak pipeline report that summarizes deal stages, win rates, and upcoming follow-ups, then posts to Slack",
+        connectors: ["streak", "slack"],
       },
       {
-        title: "Linear PRD implementer",
-        description: "Notion specs become Linear projects and issues",
+        title: "Lead follow-up pipeline",
+        description: "New leads become HubSpot tasks with Slack alerts",
         prompt:
-          "Take the product spec from Notion and create a structured Linear project with epics and issues",
-        connectors: ["notion", "linear"],
+          "Set up a lead follow-up pipeline that monitors Gmail for new leads, analyzes them with AI, creates HubSpot tasks, and notifies the sales team on Slack",
+        connectors: ["gmail", "hubspot", "slack"],
       },
       {
-        title: "AgentMail inbox",
-        description: "Create and manage inboxes with the AgentMail API",
+        title: "Win/loss reporter",
+        description: "Win and loss trends from the pipeline in Slack",
         prompt:
-          "Create a new AgentMail inbox and set up email forwarding rules",
-        connectors: ["agentmail"],
+          "Set up a weekly win/loss report that analyzes our HubSpot pipeline, tracks deal outcomes, and posts trends to Slack",
+        connectors: ["hubspot", "slack"],
       },
       {
-        title: "Customer support bot",
-        description: "Answers from the knowledge base and tasks for gaps",
+        title: "Salesforce pipeline digest",
+        description: "Weekly Salesforce opportunity updates in Slack",
         prompt:
-          "Set up a customer support bot that answers questions from our Notion knowledge base and creates tasks for unanswered questions",
-        connectors: ["slack", "notion"],
+          "Set up a weekly Salesforce pipeline digest that summarizes new opportunities, stage changes, and close dates, then posts to Slack",
+        connectors: ["salesforce", "slack"],
       },
       {
-        title: "Feedback router",
-        description: "Slack feedback routed by your rules to the right place",
+        title: "Airtable deal tracker",
+        description: "Deals sync to Sheets and Slack when they close",
         prompt:
-          "Set up a feedback router that watches a Slack channel and routes messages to the right team based on keywords and labels",
-        connectors: ["slack", "notion"],
+          "Set up an Airtable deal tracker that syncs deal records to Google Sheets and sends a Slack notification when a deal is marked as closed-won",
+        connectors: ["airtable", "google-sheets", "slack"],
       },
       {
         title: "HubSpot sales reporter",
@@ -526,60 +394,74 @@ const categories: readonly Category[] = [
         connectors: ["hubspot", "notion"],
       },
       {
-        title: "Discord community insights",
-        description: "Discord feedback in Notion with a weekly Slack digest",
+        title: "Bitrix24 lead nurture",
+        description: "New Bitrix leads get follow-up tasks and Slack pings",
         prompt:
-          "Set up a Discord community monitor that watches for feature requests and bug reports, categorizes them in Notion, and posts a weekly digest to Slack",
-        connectors: ["discord", "notion", "slack"],
+          "Set up a lead nurture workflow that monitors Bitrix24 for new leads, creates follow-up tasks, and notifies sales on Slack",
+        connectors: ["bitrix", "slack"],
+      },
+    ],
+  },
+  {
+    id: "support",
+    title: "Support",
+    cases: [
+      {
+        title: "Support ticket router",
+        description: "Tickets go to Notion and urgent ones ping Slack",
+        prompt:
+          "Set up a support ticket router that monitors Gmail for support emails, classifies them by category and priority, creates Notion entries, and sends Slack alerts for critical tickets",
+        connectors: ["gmail", "notion", "slack"],
       },
       {
-        title: "X brand monitor",
-        description: "Brand mentions on X saved in Notion with team alerts",
+        title: "Intercom conversation triager",
+        description: "Intercom chats become prioritized Notion tasks",
         prompt:
-          "Set up an X brand monitor that watches for mentions of our product, saves relevant posts to Notion, and sends Slack alerts for high-engagement posts",
-        connectors: ["x", "notion", "slack"],
+          "Set up a workflow that takes Intercom conversations, classifies them, and creates structured tasks in Notion",
+        connectors: ["intercom", "notion"],
       },
       {
-        title: "Asana \u2192 Notion project sync",
-        description: "Asana milestones and tasks mirrored in Notion",
+        title: "Zendesk → Notion knowledge base",
+        description:
+          "Extract frequently asked Zendesk questions and auto-add them to a Notion FAQ",
         prompt:
-          "Set up a sync between Asana and Notion that mirrors project milestones, task progress, and due dates into a Notion dashboard",
-        connectors: ["asana", "notion", "slack"],
+          "Set up a workflow that identifies recurring Zendesk questions, drafts FAQ entries, and adds them to our Notion knowledge base",
+        connectors: ["zendesk", "notion", "slack"],
       },
       {
-        title: "ClickUp \u2192 Slack standups",
-        description: "Daily ClickUp tasks posted as a standup in Slack",
+        title: "Customer support bot",
+        description: "Answers from the knowledge base and tasks for gaps",
         prompt:
-          "Set up a daily standup that pulls each team member's tasks from ClickUp and posts a formatted summary to Slack every morning",
-        connectors: ["clickup", "slack"],
+          "Set up a customer support bot that answers questions from our Notion knowledge base and creates tasks for unanswered questions",
+        connectors: ["slack", "notion"],
       },
       {
-        title: "Monday.com weekly digest",
-        description: "Weekly board progress from Monday.com in Slack",
+        title: "Chatwoot → Notion support log",
+        description: "Customer conversations logged and categorized in Notion",
         prompt:
-          "Set up a weekly Monday.com digest that summarizes board activity, completed items, and blockers, then posts to Slack",
-        connectors: ["monday", "slack"],
+          "Set up a workflow that takes Chatwoot customer conversations, categorizes them by topic, and creates structured entries in Notion",
+        connectors: ["chatwoot", "notion", "slack"],
+      },
+    ],
+  },
+  {
+    id: "operations",
+    title: "Operations",
+    cases: [
+      {
+        title: "RevenueCat subscription digest",
+        description:
+          "Subscription metrics in Sheets with churn alerts in Slack",
+        prompt:
+          "Set up a daily RevenueCat digest that tracks new subscriptions, renewals, and cancellations in Google Sheets and alerts on Slack for churn spikes",
+        connectors: ["revenuecat", "google-sheets", "slack"],
       },
       {
-        title: "Google Docs \u2192 Notion migrator",
-        description: "Google Docs batches into Notion with layout preserved",
+        title: "Xero financial summary",
+        description: "Weekly profit and cash flow from Xero in Slack",
         prompt:
-          "Set up a workflow that converts a folder of Google Docs into Notion pages, preserving headings, tables, and images",
-        connectors: ["google-docs", "notion"],
-      },
-      {
-        title: "Apify web scraper to Sheets",
-        description: "Apify scrapes sites into structured Google Sheets rows",
-        prompt:
-          "Set up an Apify scraper that extracts product listings from a competitor website and saves them to Google Sheets daily",
-        connectors: ["apify", "google-sheets", "slack"],
-      },
-      {
-        title: "Wrike project reporter",
-        description: "Weekly Wrike progress summaries in Slack",
-        prompt:
-          "Set up a weekly Wrike report that summarizes task completion, overdue items, and blockers across all projects, then posts to Slack",
-        connectors: ["wrike", "slack"],
+          "Set up a weekly Xero financial summary that pulls profit & loss and cash flow data and posts a formatted report to Slack",
+        connectors: ["xero", "slack"],
       },
       {
         title: "PDF contract processor",
@@ -589,19 +471,170 @@ const categories: readonly Category[] = [
         connectors: ["pdfco", "notion", "slack"],
       },
       {
-        title: "Zapier → VM0 migration",
-        description: "Recreate your Zapier workflows as VM0 agents",
+        title: "Jotform intake to Notion",
+        description: "Form answers land in Notion with Slack notifications",
         prompt:
-          "Help me migrate my Zapier workflows to VM0. I have zaps for: new Slack message → Notion, Gmail → Google Sheets, and GitHub PR → Slack",
-        connectors: ["zapier", "slack", "notion"],
-        featureFlag: FeatureSwitchKey.ZapierConnector,
+          "Set up a Jotform intake that routes new form submissions to the right Notion database and sends a Slack notification",
+        connectors: ["jotform", "notion", "slack"],
       },
       {
-        title: "Make scenario builder",
-        description: "Design multi-step Make scenarios from a description",
+        title: "Google Drive file organizer",
+        description: "New files sorted into folders automatically",
         prompt:
-          "Design a Make scenario that watches a Gmail inbox for invoices, extracts amounts and dates, logs them to Google Sheets, and alerts on Slack",
-        connectors: ["make", "gmail", "google-sheets", "slack"],
+          "Set up a workflow that watches Google Drive for new files, classifies them by content, and moves them into the right folders",
+        connectors: ["google-drive"],
+      },
+      {
+        title: "Google Docs → Notion migrator",
+        description: "Google Docs batches into Notion with layout preserved",
+        prompt:
+          "Set up a workflow that converts a folder of Google Docs into Notion pages, preserving headings, tables, and images",
+        connectors: ["google-docs", "notion"],
+      },
+      {
+        title: "Monday.com weekly digest",
+        description: "Weekly board progress from Monday.com in Slack",
+        prompt:
+          "Set up a weekly Monday.com digest that summarizes board activity, completed items, and blockers, then posts to Slack",
+        connectors: ["monday", "slack"],
+      },
+      {
+        title: "Wrike project reporter",
+        description: "Weekly Wrike progress summaries in Slack",
+        prompt:
+          "Set up a weekly Wrike report that summarizes task completion, overdue items, and blockers across all projects, then posts to Slack",
+        connectors: ["wrike", "slack"],
+      },
+      {
+        title: "Todoist → Notion task sync",
+        description: "Todoist tasks mirrored in Notion for the team",
+        prompt:
+          "Set up a sync that mirrors my Todoist tasks into a Notion database so the team can see what I'm working on",
+        connectors: ["todoist", "notion"],
+      },
+      {
+        title: "ClickUp → Slack standups",
+        description: "Daily ClickUp tasks posted as a standup in Slack",
+        prompt:
+          "Set up a daily standup that pulls each team member's tasks from ClickUp and posts a formatted summary to Slack every morning",
+        connectors: ["clickup", "slack"],
+      },
+      {
+        title: "AgentMail inbox",
+        description: "Create and manage inboxes with the AgentMail API",
+        prompt:
+          "Create a new AgentMail inbox and set up email forwarding rules",
+        connectors: ["agentmail"],
+      },
+    ],
+  },
+  {
+    id: "personal",
+    title: "Personal",
+    cases: [
+      {
+        title: "Personal weekly digest",
+        description: "Pull requests, email, and calendar in one Slack update",
+        prompt:
+          "Create a personal weekly report workflow that merges GitHub PRs, Gmail, and Calendar data into a summary and sends it to Slack",
+        connectors: ["github", "gmail", "google-calendar", "slack"],
+      },
+      {
+        title: "Morning brief",
+        description:
+          "Email, calendar, and notes turned into a short daily plan",
+        prompt:
+          "Set up a morning brief that pulls updates from Gmail, Calendar, and Notion every morning and posts a daily plan to Slack",
+        connectors: ["gmail", "google-calendar", "notion", "slack"],
+      },
+      {
+        title: "Strava team fitness digest",
+        description: "Weekly team activity summary posted to Slack",
+        prompt:
+          "Set up a weekly Strava digest that summarizes team members' running and cycling activities and posts a leaderboard to Slack",
+        connectors: ["strava", "slack"],
+      },
+      {
+        title: "Email assistant",
+        description: "Morning inbox summary with suggested next steps",
+        prompt:
+          "Set up a daily email assistant that summarizes my inbox every morning and suggests actions for each thread",
+        connectors: ["gmail"],
+      },
+      {
+        title: "Calendar optimizer",
+        description: "Helps with conflicts, overload, and focus time",
+        prompt:
+          "Analyze my calendar for today and recommend how to manage conflicts, prevent overload, and schedule focus time",
+        connectors: ["google-calendar"],
+      },
+      {
+        title: "Send messages on your behalf",
+        description: "Posts team announcements to Slack for you",
+        prompt:
+          "Send a message to the team on my behalf: I'll be taking a day off tomorrow. Please reach out to [name] for urgent matters.",
+        connectors: ["slack"],
+      },
+      {
+        title: "Browser screenshots",
+        description: "Opens a page in the browser and returns a screenshot",
+        prompt:
+          "Open this URL in the browser and take a screenshot: [paste URL]",
+      },
+      {
+        title: "Self-update instructions",
+        description: "Update the agent instructions right in chat",
+        prompt: "Update yourself: add the following instructions — ...",
+      },
+      {
+        title: "Meeting notes pipeline",
+        description: "Fireflies notes to Notion with follow ups in Slack",
+        prompt:
+          "Set up a meeting notes pipeline that takes Fireflies transcripts, generates a summary in Notion, and posts action items to Slack after each meeting",
+        connectors: ["fireflies", "notion", "slack"],
+      },
+      {
+        title: "Calendly booking sync",
+        description: "New bookings on your calendar with a Slack ping",
+        prompt:
+          "Set up a Calendly sync that adds new bookings to Google Calendar and sends a Slack notification with meeting details",
+        connectors: ["calendly", "google-calendar", "slack"],
+      },
+      {
+        title: "Lark ↔ Slack message relay",
+        description: "Forwards messages between Lark and Slack both ways",
+        prompt:
+          "Set up a message relay between a Lark group and a Slack channel so that messages are forwarded both ways",
+        connectors: ["lark", "slack"],
+      },
+      {
+        title: "LINE message relay",
+        description: "Forward LINE messages to Slack and vice versa",
+        prompt:
+          "Set up a message relay between a LINE group and a Slack channel so messages flow both ways",
+        connectors: ["line", "slack"],
+      },
+      {
+        title: "tl;dv meeting recap",
+        description:
+          "Meeting recordings summarized in Notion with action items",
+        prompt:
+          "Set up a workflow that takes tl;dv meeting recordings, generates a summary with action items in Notion, and posts highlights to Slack",
+        connectors: ["tldv", "notion", "slack"],
+      },
+      {
+        title: "Granola notes to Notion",
+        description: "Granola meeting notes synced to a Notion database",
+        prompt:
+          "Set up a sync that takes meeting notes from Granola and organizes them in a Notion database grouped by project",
+        connectors: ["granola", "notion"],
+      },
+      {
+        title: "Perplexity deep research",
+        description: "AI-powered research summaries saved to Notion",
+        prompt:
+          "Use Perplexity to research a topic in depth, compile findings into a structured Notion page with sources and key insights",
+        connectors: ["perplexity", "notion"],
       },
       {
         title: "Tavily web research pipeline",
@@ -609,27 +642,6 @@ const categories: readonly Category[] = [
         prompt:
           "Use Tavily to research the latest trends in AI agents, compile a structured report in Notion with sources and key takeaways",
         connectors: ["tavily", "notion"],
-      },
-      {
-        title: "Browserbase web testing",
-        description: "Automated browser tests for your web app",
-        prompt:
-          "Set up automated browser tests using Browserbase that check our landing page, login flow, and dashboard every day and report failures to Slack",
-        connectors: ["browserbase", "slack"],
-      },
-      {
-        title: "Chatwoot → Notion support log",
-        description: "Customer conversations logged and categorized in Notion",
-        prompt:
-          "Set up a workflow that takes Chatwoot customer conversations, categorizes them by topic, and creates structured entries in Notion",
-        connectors: ["chatwoot", "notion", "slack"],
-      },
-      {
-        title: "Bitrix24 lead nurture",
-        description: "New Bitrix leads get follow-up tasks and Slack pings",
-        prompt:
-          "Set up a lead nurture workflow that monitors Bitrix24 for new leads, creates follow-up tasks, and notifies sales on Slack",
-        connectors: ["bitrix", "slack"],
       },
     ],
   },

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -310,6 +310,12 @@ const categories: readonly Category[] = [
           "Set up a Brevo nurture sequence that sends onboarding emails when new contacts are added to a Notion database",
         connectors: ["brevo", "notion", "slack"],
       },
+    ],
+  },
+  {
+    id: "creative",
+    title: "Creative",
+    cases: [
       {
         title: "ElevenLabs audio content",
         description: "Voice narration from Notion articles saved to Drive",
@@ -445,8 +451,8 @@ const categories: readonly Category[] = [
     ],
   },
   {
-    id: "operations",
-    title: "Operations",
+    id: "ops",
+    title: "Ops",
     cases: [
       {
         title: "RevenueCat subscription digest",
@@ -529,8 +535,8 @@ const categories: readonly Category[] = [
     ],
   },
   {
-    id: "personal",
-    title: "Personal",
+    id: "everyone",
+    title: "Everyone",
     cases: [
       {
         title: "Personal weekly digest",

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -43,7 +43,7 @@ export function ZeroIdeationPage() {
   const categories = getCategories({
     features,
     visibleConnectorRefs,
-  }).slice(0, 5);
+  }).slice(0, 7);
   const activeTab = useGet(ideationActiveTab$);
   const setActiveTab = useSet(setIdeationActiveTab$);
   const searchQuery = useGet(ideationSearchQuery$);

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -43,7 +43,7 @@ export function ZeroIdeationPage() {
   const categories = getCategories({
     features,
     visibleConnectorRefs,
-  }).slice(0, 7);
+  }).slice(0, 8);
   const activeTab = useGet(ideationActiveTab$);
   const setActiveTab = useSet(setIdeationActiveTab$);
   const searchQuery = useGet(ideationSearchQuery$);


### PR DESCRIPTION
## What & why

The **Ideas & Use Cases** gallery filter was organized by output type — **Reports / GitHub / Collaboration / Growth / Workflows**. That grouping mixes personas (a marketer's "Reports" sits next to an engineer's) and makes it hard for a user to find the cases relevant to their job. This PR re-categorizes the gallery by **role / domain** so a user can jump straight to their function.

## New categories (8)

| Tab | Count | Examples |
|-----|-------|----------|
| **Engineering** | 15 | Daily standup report, GitHub PR summarizer, Sentry issue digest, Codebase investigation, Browserbase web testing |
| **Product** | 6 | Product copy & naming, Pricing analysis, Linear PRD implementer, Feedback router, Metabase digest |
| **Marketing** | 17 | Content planner, Social media calendar, Competitive intel scraper, X brand monitor, SerpAPI keyword tracker |
| **Creative** | 5 | ElevenLabs audio, HeyGen video, Runway video, Fal image gen, Cloudinary optimizer |
| **Sales** | 7 | Streak/Salesforce/HubSpot pipeline, Lead follow-up, Win/loss reporter, Bitrix24 nurture |
| **Support** | 5 | Support ticket router, Intercom triager, Zendesk KB, Customer support bot, Chatwoot log |
| **Ops** | 11 | RevenueCat/Xero finance, PDF contracts, Google Drive/Docs, Monday/Wrike/ClickUp, AgentMail |
| **Everyone** | 16 | Personal weekly digest, Morning brief, Email assistant, Calendar optimizer, meeting notes, research |

## Changes

- `zero-ideation-data.ts` — regroup all **82** use cases into the eight role buckets with new category `id`/`title`. Every use case (title, description, prompt, connectors, feature flag) is preserved verbatim; the full set of 82 is unchanged — only the grouping and category ids differ. Verified the title set is identical before/after. AI media-generation cases are split out of Marketing into a dedicated **Creative** bucket to keep Marketing from being oversized.
- `zero-ideation-page.tsx` — bump the tab cap from `.slice(0, 5)` to `.slice(0, 8)` so all eight role tabs render (tabs already wrap).
- `zero-ideation-page.test.tsx` — the tab-fallback test referenced the removed `reports` id; updated to `engineering` so it still exercises "selected tab hidden by catalog filtering → fall back to All".

## User-visible impact

The gallery filter bar changes from **All / Reports / GitHub / Collaboration / Growth / Workflows** to **All / Engineering / Product / Marketing / Creative / Sales / Support / Ops / Everyone**. Card content, click-to-chat behavior, connector-visibility filtering, and search are unchanged.

## Verification

- Confirmed the 82-item title set is identical (aside from `\uXXXX` vs literal arrow escaping) between old and new data.
- Prettier: changed files conform. Relying on the CI pipeline for lint / type-check / tests per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)