### PR TITLE
feat: filter lab switches by maintainer

### DIFF
--- a/turbo/apps/platform/src/signals/lab-page/lab-page-ui.ts
+++ b/turbo/apps/platform/src/signals/lab-page/lab-page-ui.ts
@@ -1,13 +1,27 @@
 import { command, computed, state } from "ccstate";
 
 export type LabSort = "name" | "maintainer" | "enabled";
+export const LAB_ALL_MAINTAINERS = "__all__";
+export type LabMaintainerFilter = string;
 
 const internalLabSort$ = state<LabSort>("name");
+const internalLabMaintainerFilter$ =
+  state<LabMaintainerFilter>(LAB_ALL_MAINTAINERS);
 
 export const labSort$ = computed((get): LabSort => {
   return get(internalLabSort$);
 });
 
+export const labMaintainerFilter$ = computed((get): LabMaintainerFilter => {
+  return get(internalLabMaintainerFilter$);
+});
+
 export const setLabSort$ = command(({ set }, sort: LabSort) => {
   set(internalLabSort$, sort);
 });
+
+export const setLabMaintainerFilter$ = command(
+  ({ set }, filter: LabMaintainerFilter) => {
+    set(internalLabMaintainerFilter$, filter);
+  },
+);

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -3,7 +3,11 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { click, detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import {
+  click,
+  detachedSetupPage,
+  queryAllByRoleFast,
+} from "../../../__tests__/page-helper.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
@@ -30,6 +34,16 @@ function expectBefore(first: HTMLElement, second: HTMLElement): void {
       first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING,
     ),
   ).toBeTruthy();
+}
+
+function maintainerFilterButton(label: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.trim().toLowerCase().startsWith(label);
+  });
+  if (!button) {
+    throw new Error(`${label} maintainer filter not found`);
+  }
+  return button;
 }
 
 describe("lab page", () => {
@@ -114,6 +128,37 @@ describe("lab page", () => {
         featureSwitchRow(FeatureSwitchKey.ApiKeys),
         featureSwitchRow(FeatureSwitchKey.AgentsPageRedesign),
       );
+    });
+  });
+
+  it("filters feature switches by maintainer", async () => {
+    context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
+      return respond(200, { switches: {}, effectiveSwitches: {} });
+    });
+
+    detachedSetupPage({ context, path: "/_/lab" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Lab" })).toBeInTheDocument();
+    });
+
+    click(maintainerFilterButton("lancy"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(FeatureSwitchKey.WorkflowWebhookTriggers),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(FeatureSwitchKey.AhrefsConnector),
+      ).not.toBeInTheDocument();
+    });
+
+    click(maintainerFilterButton("all"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(FeatureSwitchKey.AhrefsConnector),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -9,6 +9,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   Switch,
   Button,
+  cn,
   Select,
   SelectContent,
   SelectItem,
@@ -23,8 +24,12 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
+  LAB_ALL_MAINTAINERS,
+  labMaintainerFilter$,
   labSort$,
+  setLabMaintainerFilter$,
   setLabSort$,
+  type LabMaintainerFilter,
   type LabSort,
 } from "../../signals/lab-page/lab-page-ui.ts";
 
@@ -39,6 +44,12 @@ const SORT_OPTIONS: readonly { value: LabSort; label: string }[] = [
   { value: "maintainer", label: "Maintainer" },
   { value: "enabled", label: "Enabled first" },
 ];
+
+interface MaintainerFilterOption {
+  readonly value: LabMaintainerFilter;
+  readonly label: string;
+  readonly count: number;
+}
 
 function compareByName(a: FeatureSwitchKey, b: FeatureSwitchKey): number {
   return a.localeCompare(b, undefined, { sensitivity: "base" });
@@ -82,58 +93,160 @@ function sortedFeatureSwitchKeys(params: {
   });
 }
 
-function LabHeader(props: {
+function maintainerLabel(email: string): string {
+  return email.split("@")[0] ?? email;
+}
+
+function maintainerFilterOptions(params: {
+  readonly keys: readonly FeatureSwitchKey[];
+  readonly metadata: FeatureSwitchMetadataByKey;
+}): readonly MaintainerFilterOption[] {
+  const countsByMaintainer = new Map<string, number>();
+  for (const key of params.keys) {
+    const maintainer = params.metadata[key].maintainer;
+    countsByMaintainer.set(
+      maintainer,
+      (countsByMaintainer.get(maintainer) ?? 0) + 1,
+    );
+  }
+  return [...countsByMaintainer.entries()]
+    .map(([email, count]) => {
+      return {
+        value: email,
+        label: maintainerLabel(email),
+        count,
+      };
+    })
+    .sort((a, b) => {
+      return a.label.localeCompare(b.label, undefined, {
+        sensitivity: "base",
+      });
+    });
+}
+
+function filterFeatureSwitchKeys(params: {
+  readonly keys: readonly FeatureSwitchKey[];
+  readonly maintainerFilter: LabMaintainerFilter;
+  readonly metadata: FeatureSwitchMetadataByKey;
+}): FeatureSwitchKey[] {
+  if (params.maintainerFilter === LAB_ALL_MAINTAINERS) {
+    return [...params.keys];
+  }
+  return params.keys.filter((key) => {
+    return params.metadata[key].maintainer === params.maintainerFilter;
+  });
+}
+
+function LabHeader() {
+  return (
+    <header className="shrink-0 px-4 sm:px-6 pt-10 pb-3">
+      <div className="mx-auto max-w-[900px]">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">
+          Lab
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Toggle experimental features on or off.
+        </p>
+      </div>
+    </header>
+  );
+}
+
+function MaintainerFilterPills(props: {
+  readonly value: LabMaintainerFilter;
+  readonly totalCount: number;
+  readonly options: readonly MaintainerFilterOption[];
+  readonly onChange: (value: LabMaintainerFilter) => void;
+}) {
+  const options: readonly MaintainerFilterOption[] = [
+    {
+      value: LAB_ALL_MAINTAINERS,
+      label: "All",
+      count: props.totalCount,
+    },
+    ...props.options,
+  ];
+  return (
+    <>
+      {options.map((option) => {
+        const active = option.value === props.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => {
+              props.onChange(option.value);
+            }}
+            className={cn(
+              "inline-flex h-7 shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-border px-2.5 text-sm font-medium leading-none transition-colors",
+              active
+                ? "bg-muted text-foreground"
+                : "bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+            )}
+          >
+            <span>{option.label}</span>
+            <span className="text-xs text-muted-foreground">
+              {option.count}
+            </span>
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+function LabFilterBar(props: {
   readonly sort: LabSort;
+  readonly maintainerFilter: LabMaintainerFilter;
+  readonly maintainerOptions: readonly MaintainerFilterOption[];
+  readonly totalCount: number;
   readonly busy: boolean;
   readonly resetting: boolean;
   readonly onSortChange: (sort: LabSort) => void;
+  readonly onMaintainerFilterChange: (filter: LabMaintainerFilter) => void;
   readonly onReset: () => void;
 }) {
   return (
-    <header className="shrink-0 px-4 sm:px-6 pt-10 pb-3">
-      <div className="mx-auto max-w-[900px] flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">
-            Lab
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Toggle experimental features on or off.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
-          <Select
-            value={props.sort}
-            onValueChange={(value) => {
-              props.onSortChange(value as LabSort);
-            }}
+    <div className="flex flex-wrap items-center gap-1.5">
+      <MaintainerFilterPills
+        value={props.maintainerFilter}
+        totalCount={props.totalCount}
+        options={props.maintainerOptions}
+        onChange={props.onMaintainerFilterChange}
+      />
+      <div className="ml-auto flex items-center gap-1.5">
+        <Select
+          value={props.sort}
+          onValueChange={(value) => {
+            props.onSortChange(value as LabSort);
+          }}
+        >
+          <SelectTrigger
+            aria-label="Sort features"
+            className="zero-btn-morandi h-9 w-[160px] gap-1.5 rounded-lg px-3.5 text-sm font-medium"
           >
-            <SelectTrigger
-              aria-label="Sort features"
-              className="zero-btn-morandi h-9 w-[160px] gap-1.5 rounded-lg px-3.5 text-sm font-medium"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {SORT_OPTIONS.map((option) => {
-                return (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={props.busy}
-            onPointerDown={props.onReset}
-          >
-            {props.resetting ? "Resetting…" : "Reset all"}
-          </Button>
-        </div>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SORT_OPTIONS.map((option) => {
+              return (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={props.busy}
+          onPointerDown={props.onReset}
+        >
+          {props.resetting ? "Resetting…" : "Reset all"}
+        </Button>
       </div>
-    </header>
+    </div>
   );
 }
 
@@ -186,22 +299,45 @@ function LabFeatureGroup(props: {
   );
 }
 
+function LabEmptyState() {
+  return (
+    <div className="zero-card flex min-h-[14rem] flex-col items-center justify-center px-6 text-center">
+      <p className="text-sm font-medium text-foreground">No feature switches</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        No feature switches for this maintainer.
+      </p>
+    </div>
+  );
+}
+
 export function LabPage() {
   const features = useLastResolved(featureSwitch$);
   const [toggleLoadable, setFeature] = useLoadableSet(setFeatureSwitch$);
   const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitches$);
   const sort = useGet(labSort$);
+  const maintainerFilter = useGet(labMaintainerFilter$);
   const setSort = useSet(setLabSort$);
+  const setMaintainerFilter = useSet(setLabMaintainerFilter$);
   const resetting = resetLoadable.state === "loading";
   const toggling = toggleLoadable.state === "loading";
   const busy = resetting || toggling;
   const pageSignal = useGet(pageSignal$);
   const metadata = getFeatureSwitchMetadata();
   const sorted = sortedFeatureSwitchKeys({ sort, features, metadata });
-  const connectorKeys = sorted.filter((key) => {
+  const allKeys = getUserOverridableFeatureSwitchKeys();
+  const maintainerOptions = maintainerFilterOptions({
+    keys: allKeys,
+    metadata,
+  });
+  const filtered = filterFeatureSwitchKeys({
+    keys: sorted,
+    maintainerFilter,
+    metadata,
+  });
+  const connectorKeys = filtered.filter((key) => {
     return key.endsWith("Connector");
   });
-  const otherKeys = sorted.filter((key) => {
+  const otherKeys = filtered.filter((key) => {
     return !key.endsWith("Connector");
   });
 
@@ -219,32 +355,49 @@ export function LabPage() {
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
-      <LabHeader
-        sort={sort}
-        busy={busy}
-        resetting={resetting}
-        onSortChange={setSort}
-        onReset={handleReset}
-      />
+      <LabHeader />
 
       <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-10">
-        <div className="mx-auto max-w-[900px] space-y-6">
-          <LabFeatureGroup
-            title="Other"
-            keys={otherKeys}
-            features={features}
-            metadata={metadata}
+        <div className="mx-auto max-w-[900px] space-y-4">
+          <LabFilterBar
+            sort={sort}
+            maintainerFilter={maintainerFilter}
+            maintainerOptions={maintainerOptions}
+            totalCount={allKeys.length}
             busy={busy}
-            onToggle={handleToggle}
+            resetting={resetting}
+            onSortChange={setSort}
+            onMaintainerFilterChange={setMaintainerFilter}
+            onReset={handleReset}
           />
-          <LabFeatureGroup
-            title="Connectors"
-            keys={connectorKeys}
-            features={features}
-            metadata={metadata}
-            busy={busy}
-            onToggle={handleToggle}
-          />
+          <div className="space-y-6">
+            {filtered.length === 0 ? (
+              <LabEmptyState />
+            ) : (
+              <>
+                {otherKeys.length > 0 ? (
+                  <LabFeatureGroup
+                    title="Other"
+                    keys={otherKeys}
+                    features={features}
+                    metadata={metadata}
+                    busy={busy}
+                    onToggle={handleToggle}
+                  />
+                ) : null}
+                {connectorKeys.length > 0 ? (
+                  <LabFeatureGroup
+                    title="Connectors"
+                    keys={connectorKeys}
+                    features={features}
+                    metadata={metadata}
+                    busy={busy}
+                    onToggle={handleToggle}
+                  />
+                ) : null}
+              </>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add Workflows-style maintainer filter pills above the Lab feature switch list.
- Derive maintainer options and counts from visible user-overridable feature switch metadata.
- Keep existing sort and reset controls on the same filter row, with maintainer filtering composed before the existing Other/Connectors grouping.

## Verification
- pnpm exec prettier --write apps/platform/src/signals/lab-page/lab-page-ui.ts apps/platform/src/views/lab-page/lab-page.tsx apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm exec vitest run apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx

Did not start a local dev server per vm0 PR workflow preference; PR CI will run the broader suite.