### PR TITLE
feat: wire warm cards website template resource

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts
@@ -4,9 +4,11 @@ import { registryResourceDownloadContract } from "@vm0/api-contracts/contracts/r
 import {
   findColorSystem,
   findDesignSystem,
+  findPresentationRunbookResource,
   findSkill,
   findTemplate,
   findTool,
+  findWebsiteTemplateResource,
 } from "@vm0/core/resource-registry";
 import { VOLUME_ORG_USER_ID } from "@vm0/core/storage-names";
 import { command, createStore, state } from "ccstate";
@@ -170,6 +172,11 @@ const PRIVATE_ARCHIVE_FIXTURES = [
     versionId:
       "e9ea329a25491e347cb3c1156735201a4ff7f8a299dd8990b024d31854b49050",
   },
+  {
+    id: "template:warm-cards",
+    versionId:
+      "dae4ff30aaf7408ae1679d4b5eb25b7cea5c889c00e44b413a572880617e68ce",
+  },
 ] as const;
 
 function storageNameFor(id: string): string {
@@ -182,7 +189,9 @@ function findArchiveSha256(id: string): string {
     findTool(id) ??
     findTemplate(id) ??
     findDesignSystem(id) ??
-    findColorSystem(id);
+    findColorSystem(id) ??
+    findPresentationRunbookResource(id) ??
+    findWebsiteTemplateResource(id);
   const sha256 = entry?.source.archive?.sha256;
   if (!sha256) {
     throw new Error(`missing archive sha for ${id}`);

--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -9,6 +9,7 @@ import {
   findTemplate,
   findTool,
   findVideoTemplate,
+  findWebsiteTemplateResource,
   type RegistryEntry,
   type VideoTemplateRegistryEntry,
 } from "@vm0/core/resource-registry";
@@ -130,6 +131,9 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
     "423c53c83c3f7a4b3ca9c6f9ce314b8bec4555cf2497a0fcc9fbd20c36a13acb",
   "template:html-ppt-vantage-runbook":
     "366c1c2028815fcb13b4c8798550ded9e0853cf55fd2df9124ab4327ff012362",
+  // Website template packages (self-contained per-template archives).
+  "template:warm-cards":
+    "dae4ff30aaf7408ae1679d4b5eb25b7cea5c889c00e44b413a572880617e68ce",
 } as const satisfies Record<string, string>;
 
 function privateRegistryResourceArchive(
@@ -158,7 +162,8 @@ function findRegistryResource(id: string): PullableRegistryEntry | undefined {
     findColorSystem(id) ??
     findImageStyle(id) ??
     findVideoTemplate(id) ??
-    findPresentationRunbookResource(id)
+    findPresentationRunbookResource(id) ??
+    findWebsiteTemplateResource(id)
   );
 }
 

--- a/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
@@ -21,4 +21,28 @@ describe("zero resource pull registry resolver", () => {
       "color-system:carnival",
     );
   });
+
+  it("resolves a built-in website template package archive", () => {
+    expect(findRegistryResourceForPull("template:warm-cards")).toEqual(
+      expect.objectContaining({
+        id: "template:warm-cards",
+        kind: "template",
+        targets: ["website"],
+        source: expect.objectContaining({
+          path: "warm-cards",
+          archive: expect.objectContaining({
+            type: "tar.gz",
+            sha256:
+              "1fafd9e5541dfe53ffdfafcbb6e45d525328c9a0cc5bb4afb2a06b4685e153d2",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("canonicalizes unprefixed built-in website template ids", () => {
+    expect(findRegistryResourceForPull("warm-cards")?.id).toBe(
+      "template:warm-cards",
+    );
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/resource/index.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/index.ts
@@ -14,6 +14,7 @@ import {
   findTool,
   findTemplate,
   findVideoTemplate,
+  findWebsiteTemplateResource,
   type RegistryEntry,
   type VideoTemplateRegistryEntry,
 } from "@vm0/core/resource-registry";
@@ -52,7 +53,8 @@ export function findRegistryResourceForPull(
       findTool(candidate) ??
       findImageStyle(candidate) ??
       findVideoTemplate(candidate) ??
-      findPresentationRunbookResource(candidate);
+      findPresentationRunbookResource(candidate) ??
+      findWebsiteTemplateResource(candidate);
     if (entry) {
       return entry;
     }

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -3,6 +3,12 @@ import {
   WEBSITE_TEMPLATE_ITEMS,
   findWebsiteTemplateItem,
 } from "../website-template-items";
+import {
+  findWebsiteTemplatePackage,
+  findWebsiteTemplateResource,
+  listTemplates,
+  listWebsiteTemplatePackages,
+} from "../resource-registry";
 
 describe("website template items", () => {
   it("exposes the built-in website template catalog in picker order", () => {
@@ -62,5 +68,46 @@ describe("website template items", () => {
     expect(websiteTemplateIds).not.toContain(
       "template:web-prototype-taste-soft",
     );
+  });
+
+  it("resolves the built-in website template as a private R2 pull resource", () => {
+    const item = WEBSITE_TEMPLATE_ITEMS[0]!;
+    const [pkg] = listWebsiteTemplatePackages();
+
+    expect(pkg).toMatchObject({
+      templateId: item.templateId,
+      resourceId: item.resourceId,
+      slug: item.sourcePath,
+      name: item.title,
+      description: item.description,
+      source: {
+        path: item.sourcePath,
+        archive: {
+          type: "tar.gz",
+          sha256:
+            "1fafd9e5541dfe53ffdfafcbb6e45d525328c9a0cc5bb4afb2a06b4685e153d2",
+        },
+      },
+    });
+    expect(findWebsiteTemplatePackage(item.templateId)).toBe(pkg);
+    expect(findWebsiteTemplateResource(item.resourceId)).toEqual(
+      expect.objectContaining({
+        id: item.resourceId,
+        kind: "template",
+        targets: ["website"],
+        source: expect.objectContaining({
+          path: item.sourcePath,
+          archive: expect.objectContaining({ type: "tar.gz" }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps built-in R2 website packages out of the generic template list", () => {
+    expect(
+      listTemplates("website").some((template) => {
+        return template.id === "template:warm-cards";
+      }),
+    ).toBe(false);
   });
 });

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -1,3 +1,8 @@
+import {
+  WEBSITE_TEMPLATE_ITEMS,
+  type WebsiteTemplateItem,
+} from "./website-template-items";
+
 export type GenerationTarget =
   | "image"
   | "presentation"
@@ -3610,6 +3615,82 @@ export function findPresentationRunbookResource(
     description: pkg.description,
     source: pkg.source,
     targets: ["presentation"],
+  };
+}
+
+// ── Website template packages ────────────────────────────────────────────────
+// Self-contained website packages uploaded to private R2. Keep these pull-only
+// resources out of RESOURCE_REGISTRY so the feature-switched picker remains the
+// only user-facing catalog for built-in website templates.
+
+export interface WebsiteTemplatePackage {
+  /** Picker template id; this is also the pull id for website packages. */
+  readonly templateId: WebsiteTemplateItem["templateId"];
+  readonly resourceId: WebsiteTemplateItem["resourceId"];
+  readonly slug: WebsiteTemplateItem["slug"];
+  readonly name: WebsiteTemplateItem["title"];
+  readonly description: WebsiteTemplateItem["description"];
+  readonly source: ResourceSourceRef;
+}
+
+// Archive digests for uploaded private R2 website template packages. Keep these
+// in sync with the private R2 version ids served by the API download route.
+const WEBSITE_TEMPLATE_ARCHIVE_SHA256: Record<string, string> = {
+  "warm-cards":
+    "1fafd9e5541dfe53ffdfafcbb6e45d525328c9a0cc5bb4afb2a06b4685e153d2",
+};
+
+function websiteTemplateArchiveSha256(slug: string): string {
+  const sha256 = WEBSITE_TEMPLATE_ARCHIVE_SHA256[slug];
+  if (!sha256) {
+    throw new Error(`Missing website template archive sha256 for ${slug}`);
+  }
+  return sha256;
+}
+
+const WEBSITE_TEMPLATE_PACKAGES: readonly WebsiteTemplatePackage[] =
+  WEBSITE_TEMPLATE_ITEMS.map((item) => {
+    return {
+      templateId: item.templateId,
+      resourceId: item.resourceId,
+      slug: item.sourcePath,
+      name: item.title,
+      description: item.description,
+      source: privateR2ArchiveSource(
+        item.sourcePath,
+        websiteTemplateArchiveSha256(item.slug),
+      ),
+    };
+  });
+
+export function listWebsiteTemplatePackages(): readonly WebsiteTemplatePackage[] {
+  return WEBSITE_TEMPLATE_PACKAGES;
+}
+
+export function findWebsiteTemplatePackage(
+  templateId: string,
+): WebsiteTemplatePackage | undefined {
+  return WEBSITE_TEMPLATE_PACKAGES.find((pkg) => {
+    return pkg.templateId === templateId;
+  });
+}
+
+export function findWebsiteTemplateResource(
+  resourceId: string,
+): RegistryEntry | undefined {
+  const pkg = WEBSITE_TEMPLATE_PACKAGES.find((entry) => {
+    return entry.resourceId === resourceId;
+  });
+  if (!pkg) {
+    return undefined;
+  }
+  return {
+    id: pkg.resourceId,
+    kind: "template",
+    name: pkg.name,
+    description: pkg.description,
+    source: pkg.source,
+    targets: ["website"],
   };
 }
 


### PR DESCRIPTION
## Summary
- Add a pull-only website template package registry for `template:warm-cards`, backed by the uploaded private R2 archive and its sha256 metadata.
- Allowlist the uploaded archive version in the API registry-resource download route.
- Extend `zero resource pull` resolution so both `template:warm-cards` and `warm-cards` resolve to the website package.
- Add focused core, CLI, and API registry-resource coverage for the website template archive.

Part of #20350.

## Verification
- `node /tmp/vm0-website-template-pr2/warm-cards/render.mjs /tmp/vm0-website-template-pr2/warm-cards/sample-plan.json /tmp/vm0-website-template-pr2/warm-cards/out-smoke.html`
- Verified downloaded private R2 archive sha256: `1fafd9e5541dfe53ffdfafcbb6e45d525328c9a0cc5bb4afb2a06b4685e153d2`
- `git diff --check`
- `pnpm exec vitest run packages/core/src/__tests__/website-template-items.spec.ts apps/cli/src/commands/zero/resource/__tests__/index.test.ts --reporter=dot`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/cli check-types`

## Local limitations
- `pnpm exec vitest run packages/core/src/__tests__/website-template-items.spec.ts apps/cli/src/commands/zero/resource/__tests__/index.test.ts apps/api/src/signals/routes/__tests__/registry-resources-download.test.ts --reporter=dot` passed the core and CLI suites, but the API route suite could not seed local storage because this runtime has no local Postgres/docker (`ECONNREFUSED` to `localhost:5432/vm0_test`).
- `pnpm --filter api check-types` was killed by the runtime with exit 137 before TypeScript output.