### PR TITLE
feat(cli): add notion child page trigger creation

### DIFF
--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/__tests__/trigger.test.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/__tests__/trigger.test.ts
@@ -140,6 +140,27 @@ const googleCalendarTrigger = {
   nextRunAt: null,
 };
 
+const notionTrigger = {
+  ...triggerBase,
+  kind: "event",
+  eventType: "notion-child-page-created",
+  eventConfig: {
+    provider: "notion",
+    event: "child_page_created",
+    connectorId: "55555555-5555-4555-8555-555555555555",
+    parentPage: {
+      id: "66666666-6666-4666-8666-666666666666",
+      title: "Product notes",
+      url: "https://www.notion.so/workspace/Product-notes-66666666666646668666666666666666",
+      rawUrl:
+        "https://www.notion.so/workspace/Product-notes-66666666666646668666666666666666?pvs=4",
+    },
+  },
+  schedule: null,
+  scheduleSummary: null,
+  nextRunAt: null,
+};
+
 const webhookTrigger = {
   ...triggerBase,
   kind: "event",
@@ -573,6 +594,36 @@ describe("zero workflow trigger commands", () => {
       expect(logCalls).toContain("team@example.com");
     });
 
+    it("should add a Notion child page trigger", async () => {
+      const captured = captureCreateTrigger(notionTrigger);
+
+      await triggerCommand.parseAsync([
+        "node",
+        "cli",
+        "add",
+        WORKFLOW_ID,
+        "notion-child-page-created",
+        "--parent-page-url",
+        " https://www.notion.so/workspace/Product-notes-66666666666646668666666666666666?pvs=4 ",
+      ]);
+
+      expect(captured.workflowId).toBe(WORKFLOW_ID);
+      expect(captured.body).toEqual({
+        kind: "event",
+        eventType: "notion-child-page-created",
+        eventConfig: {
+          provider: "notion",
+          event: "child_page_created",
+          parentPageUrl:
+            "https://www.notion.so/workspace/Product-notes-66666666666646668666666666666666?pvs=4",
+        },
+      });
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("New Notion child page");
+      expect(logCalls).toContain("Product notes");
+      expect(logCalls).toContain(notionTrigger.eventConfig.parentPage.url);
+    });
+
     it("should add a webhook trigger", async () => {
       const captured = captureCreateTrigger(webhookTrigger);
 
@@ -653,6 +704,25 @@ describe("zero workflow trigger commands", () => {
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining('Unknown trigger kind: "not-a-trigger"'),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject a Notion child page trigger without a parent page URL", async () => {
+      await expect(async () => {
+        await triggerCommand.parseAsync([
+          "node",
+          "cli",
+          "add",
+          WORKFLOW_ID,
+          "notion-child-page-created",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "notion-child-page-created triggers require --parent-page-url",
+        ),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -1000,6 +1070,7 @@ describe("zero workflow trigger commands", () => {
               loopTrigger,
               gmailTrigger,
               githubLabelTrigger,
+              notionTrigger,
             ]);
           },
         ),
@@ -1015,6 +1086,8 @@ describe("zero workflow trigger commands", () => {
       expect(logCalls).toContain('from contains "@acme.com"');
       expect(logCalls).toContain("GitHub label applied");
       expect(logCalls).toContain("triage");
+      expect(logCalls).toContain("New Notion child page");
+      expect(logCalls).toContain("Product notes");
     });
 
     it("should display an empty state with an add hint", async () => {

--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/display.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/display.ts
@@ -22,11 +22,24 @@ type WorkflowWebhookTriggerSummary = Extract<
   ZeroWorkflowTriggerSummary,
   { readonly kind: "event"; readonly eventType: "webhook-received" }
 >;
+type WorkflowNotionChildPageTriggerSummary = Extract<
+  ZeroWorkflowTriggerSummary,
+  { readonly kind: "event"; readonly eventType: "notion-child-page-created" }
+>;
 
 function isWebhookTrigger(
   trigger: ZeroWorkflowTriggerSummary,
 ): trigger is WorkflowWebhookTriggerSummary {
   return trigger.kind === "event" && trigger.eventType === "webhook-received";
+}
+
+function isNotionChildPageTrigger(
+  trigger: ZeroWorkflowTriggerSummary,
+): trigger is WorkflowNotionChildPageTriggerSummary {
+  return (
+    trigger.kind === "event" &&
+    trigger.eventType === "notion-child-page-created"
+  );
 }
 
 function isGoogleCalendarTrigger(
@@ -106,6 +119,14 @@ function formatWebhookTriggerEntry(
   trigger: WorkflowWebhookTriggerSummary,
 ): string {
   return `Webhook: ${trigger.webhookUrl ?? "hidden"}`;
+}
+
+function formatNotionParentPage(
+  trigger: WorkflowNotionChildPageTriggerSummary,
+): string {
+  return (
+    trigger.eventConfig.parentPage.title ?? trigger.eventConfig.parentPage.url
+  );
 }
 
 function formatWorkflowTriggerEntry(
@@ -192,7 +213,7 @@ function workflowTriggerKindLabel(trigger: ZeroWorkflowTriggerSummary): string {
     case "google-meet-transcript-generated":
       return "Google Meet transcript ready";
     case "notion-child-page-created":
-      return "New Notion child page";
+      return `New Notion child page: ${formatNotionParentPage(trigger)}`;
     case "webhook-received":
       return "Webhook";
   }
@@ -294,6 +315,14 @@ export function printWorkflowTriggerDetails(
   }
   if (isGoogleCalendarTrigger(trigger)) {
     console.log(`${"Calendar:".padEnd(14)}${trigger.eventConfig.calendarId}`);
+  }
+  if (isNotionChildPageTrigger(trigger)) {
+    console.log(
+      `${"Parent page:".padEnd(14)}${formatNotionParentPage(trigger)}`,
+    );
+    console.log(
+      `${"Parent URL:".padEnd(14)}${trigger.eventConfig.parentPage.url}`,
+    );
   }
   if (isWebhookTrigger(trigger)) {
     console.log(

--- a/turbo/apps/cli/src/commands/zero/workflow/trigger/index.ts
+++ b/turbo/apps/cli/src/commands/zero/workflow/trigger/index.ts
@@ -43,6 +43,7 @@ interface AddOptions extends GmailTriggerOptions {
   readonly subject?: string;
   readonly actor?: string;
   readonly calendarId?: string;
+  readonly parentPageUrl?: string;
 }
 
 interface UpdateOptions extends GmailTriggerOptions {
@@ -62,6 +63,7 @@ const EVENT_KINDS = [
   "google-calendar-event-created",
   "google-calendar-event-updated",
   "google-calendar-event-cancelled",
+  "notion-child-page-created",
   "webhook",
 ] as const;
 const TRIGGER_KINDS = [...SCHEDULE_KINDS, ...EVENT_KINDS] as const;
@@ -300,12 +302,17 @@ function hasCalendarTriggerOptions(options: AddOptions): boolean {
   return options.calendarId !== undefined;
 }
 
+function hasNotionTriggerOptions(options: AddOptions): boolean {
+  return options.parentPageUrl !== undefined;
+}
+
 function hasEventAddOptions(options: AddOptions): boolean {
   return (
     hasGmailTriggerOptions(options) ||
     hasGmailLabelOption(options) ||
     hasGithubTriggerOptions(options) ||
-    hasCalendarTriggerOptions(options)
+    hasCalendarTriggerOptions(options) ||
+    hasNotionTriggerOptions(options)
   );
 }
 
@@ -331,6 +338,12 @@ function assertNoCalendarTriggerOptions(options: AddOptions): void {
     throw new Error(
       "Google Calendar trigger flags only apply to Google Calendar event triggers",
     );
+  }
+}
+
+function assertNoNotionTriggerOptions(options: AddOptions): void {
+  if (hasNotionTriggerOptions(options)) {
+    throw new Error("Notion trigger flags only apply to Notion event triggers");
   }
 }
 
@@ -419,6 +432,7 @@ function buildGmailNewMessageCreateRequest(
   }
   assertNoGithubTriggerOptions(options);
   assertNoCalendarTriggerOptions(options);
+  assertNoNotionTriggerOptions(options);
   return {
     kind: "event",
     eventType: "gmail-new-message",
@@ -437,6 +451,7 @@ function buildGmailLabelAppliedCreateRequest(
   }
   assertNoGithubTriggerOptions(options);
   assertNoCalendarTriggerOptions(options);
+  assertNoNotionTriggerOptions(options);
   return {
     kind: "event",
     eventType: "gmail-label-applied",
@@ -454,6 +469,7 @@ function buildGithubLabelAppliedCreateRequest(
     );
   }
   assertNoCalendarTriggerOptions(options);
+  assertNoNotionTriggerOptions(options);
   return {
     kind: "event",
     eventType: "github-label-applied",
@@ -472,10 +488,11 @@ function buildGoogleCalendarEventCreateRequest(
   if (
     hasGmailTriggerOptions(options) ||
     hasGmailLabelOption(options) ||
-    hasGithubTriggerOptions(options)
+    hasGithubTriggerOptions(options) ||
+    hasNotionTriggerOptions(options)
   ) {
     throw new Error(
-      "Gmail and GitHub trigger flags only apply to their event triggers",
+      "Gmail, GitHub, and Notion trigger flags only apply to their event triggers",
     );
   }
   const calendarId = options.calendarId?.trim() || "primary";
@@ -508,6 +525,39 @@ function buildGoogleCalendarEventCreateRequest(
       provider: "google-calendar",
       event: "event_cancelled",
       calendarId,
+    },
+  };
+}
+
+function buildNotionChildPageCreatedCreateRequest(
+  options: AddOptions,
+): ZeroWorkflowTriggerCreateRequest {
+  assertNoScheduleAddOptions(options);
+  if (
+    hasGmailTriggerOptions(options) ||
+    hasGmailLabelOption(options) ||
+    hasGithubTriggerOptions(options) ||
+    hasCalendarTriggerOptions(options)
+  ) {
+    throw new Error(
+      "Gmail, GitHub, and Google Calendar trigger flags only apply to their event triggers",
+    );
+  }
+
+  const parentPageUrl = options.parentPageUrl?.trim();
+  if (!parentPageUrl) {
+    throw new Error(
+      'notion-child-page-created triggers require --parent-page-url "https://www.notion.so/..."',
+    );
+  }
+
+  return {
+    kind: "event",
+    eventType: "notion-child-page-created",
+    eventConfig: {
+      provider: "notion",
+      event: "child_page_created",
+      parentPageUrl,
     },
   };
 }
@@ -557,6 +607,8 @@ function buildCreateRequest(
       return buildGoogleCalendarEventCreateRequest(kind, options);
     case "google-calendar-event-cancelled":
       return buildGoogleCalendarEventCreateRequest(kind, options);
+    case "notion-child-page-created":
+      return buildNotionChildPageCreatedCreateRequest(options);
     case "webhook":
       return buildWebhookCreateRequest(options);
     default:
@@ -686,6 +738,10 @@ const addCommand = addGithubTriggerOptions(
     "--calendar-id <id>",
     "Google Calendar ID for Google Calendar event triggers (default: primary)",
   )
+  .option(
+    "--parent-page-url <url>",
+    "Parent Notion page URL for notion-child-page-created triggers",
+  )
   .option("--agent <id>", "Agent ID for resolving a workflow name")
   .addHelpText(
     "after",
@@ -701,6 +757,7 @@ Examples:
   zero workflow trigger add triage --agent <agent-id> google-calendar-event-created
   zero workflow trigger add triage --agent <agent-id> google-calendar-event-updated
   zero workflow trigger add triage --agent <agent-id> google-calendar-event-cancelled
+  zero workflow trigger add research-notes --agent <agent-id> notion-child-page-created --parent-page-url "https://www.notion.so/workspace/Page-title-1234567890abcdef1234567890abcdef"
   zero workflow trigger add triage --agent <agent-id> webhook
 
 Notes:
@@ -866,6 +923,7 @@ export const triggerCommand = new Command()
     `
 Examples:
   Add a trigger:      zero workflow trigger add <workflow-id> cron --expr "0 9 * * *"
+  Add a Notion page:  zero workflow trigger add <workflow-id> notion-child-page-created --parent-page-url "https://www.notion.so/..."
   Add a webhook:      zero workflow trigger add <workflow-id> webhook
   Update a schedule:  zero workflow trigger update <trigger-id> --every 10m
   List triggers:      zero workflow trigger list <workflow-id>


### PR DESCRIPTION
## Summary
- Add `notion-child-page-created` to `zero workflow trigger add`
- Add `--parent-page-url` for Notion parent page URLs and build the matching create request
- Show the configured Notion parent page in CLI trigger list/detail output
- Cover Notion add/list behavior and missing parent URL validation in CLI tests

## Verification
- `pnpm format`
- `pnpm -F cli lint`
- `pnpm -F cli check-types`
- `pnpm -F cli exec vitest run src/commands/zero/workflow/trigger/__tests__/trigger.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F cli build`
- `node apps/cli/dist/zero.js workflow trigger add --help`
