### PR TITLE
fix: prevent compressed session history identity fallback

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -335,33 +335,6 @@ async fn upload_session_history_candidate(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let response_encoding = prep_resp.get("encoding").and_then(|v| v.as_str());
-    if existing {
-        if requested_encoding == SESSION_HISTORY_ENCODING_ZSTD
-            && response_encoding != Some(SESSION_HISTORY_ENCODING_ZSTD)
-        {
-            log_info!(
-                LOG_TAG,
-                "Prepare-history response did not acknowledge zstd; retrying legacy encoding"
-            );
-            return Ok(SessionHistoryUploadAttempt::RetryLegacy(
-                history_upload.into_raw(),
-            ));
-        }
-        if requested_encoding == SESSION_HISTORY_ENCODING_GZIP
-            && response_encoding != Some(SESSION_HISTORY_ENCODING_GZIP)
-        {
-            return Err(compressed_encoding_not_acknowledged(
-                SESSION_HISTORY_ENCODING_GZIP,
-            ));
-        }
-        let accepted_encoding = response_encoding.unwrap_or(SESSION_HISTORY_ENCODING_IDENTITY);
-        log_info!(
-            LOG_TAG,
-            "Session history already exists in S3 (deduplicated, encoding={accepted_encoding})"
-        );
-        return Ok(SessionHistoryUploadAttempt::Complete);
-    }
-
     if requested_encoding == SESSION_HISTORY_ENCODING_ZSTD
         && response_encoding != Some(SESSION_HISTORY_ENCODING_ZSTD)
     {
@@ -379,6 +352,15 @@ async fn upload_session_history_candidate(
         return Err(compressed_encoding_not_acknowledged(
             SESSION_HISTORY_ENCODING_GZIP,
         ));
+    }
+
+    if existing {
+        let accepted_encoding = response_encoding.unwrap_or(SESSION_HISTORY_ENCODING_IDENTITY);
+        log_info!(
+            LOG_TAG,
+            "Session history already exists in S3 (deduplicated, encoding={accepted_encoding})"
+        );
+        return Ok(SessionHistoryUploadAttempt::Complete);
     }
 
     let presigned_url = prep_resp

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -73,54 +73,19 @@ impl SessionHistoryUpload {
         }
     }
 
-    fn into_server_accepted_bytes(
-        self,
-        accepted_encoding: Option<&str>,
-    ) -> SessionHistoryServerAcceptedBytes {
+    fn into_server_accepted_bytes(self) -> (&'static str, Bytes) {
         match self.body {
             SessionHistoryUploadBody::Identity(raw) => {
-                SessionHistoryServerAcceptedBytes::Accepted {
-                    encoding: SESSION_HISTORY_ENCODING_IDENTITY,
-                    bytes: Bytes::from(raw),
-                }
+                (SESSION_HISTORY_ENCODING_IDENTITY, Bytes::from(raw))
             }
-            SessionHistoryUploadBody::Gzip { raw: _, gzip }
-                if accepted_encoding == Some(SESSION_HISTORY_ENCODING_GZIP) =>
-            {
-                SessionHistoryServerAcceptedBytes::Accepted {
-                    encoding: SESSION_HISTORY_ENCODING_GZIP,
-                    bytes: Bytes::from(gzip),
-                }
+            SessionHistoryUploadBody::Gzip { raw: _, gzip } => {
+                (SESSION_HISTORY_ENCODING_GZIP, Bytes::from(gzip))
             }
-            SessionHistoryUploadBody::Gzip { raw, .. } => {
-                SessionHistoryServerAcceptedBytes::Accepted {
-                    encoding: SESSION_HISTORY_ENCODING_IDENTITY,
-                    bytes: Bytes::from(raw),
-                }
-            }
-            SessionHistoryUploadBody::Zstd { raw: _, zstd }
-                if accepted_encoding == Some(SESSION_HISTORY_ENCODING_ZSTD) =>
-            {
-                SessionHistoryServerAcceptedBytes::Accepted {
-                    encoding: SESSION_HISTORY_ENCODING_ZSTD,
-                    bytes: Bytes::from(zstd),
-                }
-            }
-            SessionHistoryUploadBody::Zstd { raw, .. } => {
-                SessionHistoryServerAcceptedBytes::UnsupportedZstd { raw }
+            SessionHistoryUploadBody::Zstd { raw: _, zstd } => {
+                (SESSION_HISTORY_ENCODING_ZSTD, Bytes::from(zstd))
             }
         }
     }
-}
-
-enum SessionHistoryServerAcceptedBytes {
-    Accepted {
-        encoding: &'static str,
-        bytes: Bytes,
-    },
-    UnsupportedZstd {
-        raw: Vec<u8>,
-    },
 }
 
 enum SessionHistoryUploadAttempt {
@@ -179,10 +144,9 @@ fn build_legacy_session_history_upload(
 
     let gzip_bytes = gzip_session_history(&history_bytes)?;
     if gzip_bytes.len() >= history_bytes.len() {
-        return Ok(SessionHistoryUpload {
-            raw_size,
-            body: SessionHistoryUploadBody::Identity(history_bytes),
-        });
+        return Err(AgentError::Checkpoint(
+            "legacy gzip session history was not smaller than identity".into(),
+        ));
     }
 
     Ok(SessionHistoryUpload {
@@ -203,6 +167,12 @@ fn zstd_session_history(history_bytes: &[u8]) -> Result<Vec<u8>, AgentError> {
     encoder
         .finish()
         .map_err(|error| AgentError::Checkpoint(format!("finish zstd session history: {error}")))
+}
+
+fn compressed_encoding_not_acknowledged(requested_encoding: &'static str) -> AgentError {
+    AgentError::Checkpoint(format!(
+        "Prepare-history response did not acknowledge {requested_encoding} session history"
+    ))
 }
 
 impl CheckpointMode {
@@ -366,6 +336,24 @@ async fn upload_session_history_candidate(
         .unwrap_or(false);
     let response_encoding = prep_resp.get("encoding").and_then(|v| v.as_str());
     if existing {
+        if requested_encoding == SESSION_HISTORY_ENCODING_ZSTD
+            && response_encoding != Some(SESSION_HISTORY_ENCODING_ZSTD)
+        {
+            log_info!(
+                LOG_TAG,
+                "Prepare-history response did not acknowledge zstd; retrying legacy encoding"
+            );
+            return Ok(SessionHistoryUploadAttempt::RetryLegacy(
+                history_upload.into_raw(),
+            ));
+        }
+        if requested_encoding == SESSION_HISTORY_ENCODING_GZIP
+            && response_encoding != Some(SESSION_HISTORY_ENCODING_GZIP)
+        {
+            return Err(compressed_encoding_not_acknowledged(
+                SESSION_HISTORY_ENCODING_GZIP,
+            ));
+        }
         let accepted_encoding = response_encoding.unwrap_or(SESSION_HISTORY_ENCODING_IDENTITY);
         log_info!(
             LOG_TAG,
@@ -385,6 +373,13 @@ async fn upload_session_history_candidate(
             history_upload.into_raw(),
         ));
     }
+    if requested_encoding == SESSION_HISTORY_ENCODING_GZIP
+        && response_encoding != Some(SESSION_HISTORY_ENCODING_GZIP)
+    {
+        return Err(compressed_encoding_not_acknowledged(
+            SESSION_HISTORY_ENCODING_GZIP,
+        ));
+    }
 
     let presigned_url = prep_resp
         .get("presignedUrl")
@@ -393,21 +388,7 @@ async fn upload_session_history_candidate(
             AgentError::Checkpoint("No presignedUrl in prepare-history response".into())
         })?;
 
-    let (upload_encoding, upload_bytes) =
-        match history_upload.into_server_accepted_bytes(response_encoding) {
-            SessionHistoryServerAcceptedBytes::Accepted { encoding, bytes } => (encoding, bytes),
-            SessionHistoryServerAcceptedBytes::UnsupportedZstd { raw } => {
-                return Ok(SessionHistoryUploadAttempt::RetryLegacy(raw));
-            }
-        };
-    if requested_encoding == SESSION_HISTORY_ENCODING_GZIP
-        && upload_encoding == SESSION_HISTORY_ENCODING_IDENTITY
-    {
-        log_info!(
-            LOG_TAG,
-            "Prepare-history response did not acknowledge gzip; uploading identity session history"
-        );
-    }
+    let (upload_encoding, upload_bytes) = history_upload.into_server_accepted_bytes();
 
     log_info!(
         LOG_TAG,
@@ -969,6 +950,19 @@ mod tests {
         let _ = std::fs::remove_file(guest_paths.session_history_path_file());
     }
 
+    fn high_entropy_bytes(size: usize) -> Vec<u8> {
+        let mut state = 0x6a09e667f3bcc909_u64;
+        let mut bytes = Vec::with_capacity(size);
+        for _ in 0..size {
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            let value = state.wrapping_mul(0x2545f4914f6cdd1d);
+            bytes.push((value >> 56) as u8);
+        }
+        bytes
+    }
+
     #[test]
     fn artifact_snapshot_entry_shape_matches_receiver_schema() {
         let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace", None);
@@ -1000,6 +994,19 @@ mod tests {
         assert!(obj.contains_key("missingRootPolicy"));
         assert!(!obj.contains_key("mount_path"));
         assert!(!obj.contains_key("missing_root_policy"));
+    }
+
+    #[test]
+    fn legacy_session_history_upload_rejects_large_uncompressible_fallback() {
+        let history = high_entropy_bytes(SESSION_HISTORY_COMPRESSION_MIN_BYTES + 1);
+
+        match build_legacy_session_history_upload(history) {
+            Err(AgentError::Checkpoint(message)) => {
+                assert!(message.contains("legacy gzip session history"));
+            }
+            Err(error) => panic!("expected checkpoint failure, got: {error}"),
+            Ok(_) => panic!("expected legacy gzip compression failure"),
+        }
     }
 
     #[tokio::test]

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -932,19 +932,6 @@ mod tests {
         let _ = std::fs::remove_file(guest_paths.session_history_path_file());
     }
 
-    fn high_entropy_bytes(size: usize) -> Vec<u8> {
-        let mut state = 0x6a09e667f3bcc909_u64;
-        let mut bytes = Vec::with_capacity(size);
-        for _ in 0..size {
-            state ^= state >> 12;
-            state ^= state << 25;
-            state ^= state >> 27;
-            let value = state.wrapping_mul(0x2545f4914f6cdd1d);
-            bytes.push((value >> 56) as u8);
-        }
-        bytes
-    }
-
     #[test]
     fn artifact_snapshot_entry_shape_matches_receiver_schema() {
         let entry = build_artifact_snapshot_entry("workspace", "v-abc-123", "/workspace", None);
@@ -976,19 +963,6 @@ mod tests {
         assert!(obj.contains_key("missingRootPolicy"));
         assert!(!obj.contains_key("mount_path"));
         assert!(!obj.contains_key("missing_root_policy"));
-    }
-
-    #[test]
-    fn legacy_session_history_upload_rejects_large_uncompressible_fallback() {
-        let history = high_entropy_bytes(SESSION_HISTORY_COMPRESSION_MIN_BYTES + 1);
-
-        match build_legacy_session_history_upload(history) {
-            Err(AgentError::Checkpoint(message)) => {
-                assert!(message.contains("legacy gzip session history"));
-            }
-            Err(error) => panic!("expected checkpoint failure, got: {error}"),
-            Ok(_) => panic!("expected legacy gzip compression failure"),
-        }
     }
 
     #[tokio::test]

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -1,5 +1,5 @@
 use crate::support::*;
-use flate2::read::GzDecoder;
+use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
 };
@@ -10,9 +10,6 @@ use std::{
     ffi::OsString,
     io::{Read, Write},
 };
-
-use flate2::{Compression, write::GzEncoder};
-
 const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
 
 fn runtime_from_process_env() -> Result<guest_agent::run_context::GuestRuntime, String> {

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -445,6 +445,141 @@ async fn success_checkpoint_downgrades_when_zstd_prepare_is_not_acknowledged()
 }
 
 #[tokio::test]
+async fn success_checkpoint_rejects_gzip_prepare_without_encoding_acknowledgement()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let runtime = runtime_from_process_env().unwrap();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
+    let _history_dir = write_literal_session_history("gzip-unack-session", &history).unwrap();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let zstd_size = zstd_session_history_for_test(&history)?.len();
+    let zstd_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
+        then.status(400)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "error": {
+                    "message": "Invalid enum value. Expected identity | gzip"
+                }
+            }));
+    });
+    let gzip_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(r#"{"encoding":"gzip"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/gzip-unack-history-upload"),
+                "existing": false
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT).path("/test/gzip-unack-history-upload");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "unexpected"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Prepare-history response did not acknowledge gzip"),
+        "expected gzip acknowledgement failure, got: {err}"
+    );
+    zstd_prepare_mock.assert_calls_async(1).await;
+    gzip_prepare_mock.assert_calls_async(1).await;
+    upload_mock.assert_calls_async(0).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn success_checkpoint_rejects_existing_gzip_without_encoding_acknowledgement()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let runtime = runtime_from_process_env().unwrap();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = vec![b'a'; LARGE_SESSION_HISTORY_SIZE_BYTES];
+    let _history_dir =
+        write_literal_session_history("gzip-existing-unack-session", &history).unwrap();
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let zstd_size = zstd_session_history_for_test(&history)?.len();
+    let zstd_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
+        then.status(400)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "error": {
+                    "message": "Invalid enum value. Expected identity | gzip"
+                }
+            }));
+    });
+    let gzip_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(r#"{"encoding":"gzip"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "existing": true
+            }));
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "unexpected"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("Prepare-history response did not acknowledge gzip"),
+        "expected gzip acknowledgement failure, got: {err}"
+    );
+    zstd_prepare_mock.assert_calls_async(1).await;
+    gzip_prepare_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn success_checkpoint_does_not_downgrade_zstd_auth_failure()
 -> Result<(), Box<dyn std::error::Error>> {
     let api = SharedApiMock::new().await;

--- a/crates/guest-agent/tests/integration/checkpoint.rs
+++ b/crates/guest-agent/tests/integration/checkpoint.rs
@@ -6,7 +6,12 @@ use guest_contracts::session_history_identity::{
 use httpmock::prelude::*;
 use serde_json::json;
 use sha2::{Digest, Sha256};
-use std::{ffi::OsString, io::Read};
+use std::{
+    ffi::OsString,
+    io::{Read, Write},
+};
+
+use flate2::{Compression, write::GzEncoder};
 
 const LARGE_SESSION_HISTORY_SIZE_BYTES: usize = 1024 * 1024 + 1;
 
@@ -97,6 +102,12 @@ fn zstd_session_history_for_test(history: &[u8]) -> std::io::Result<Vec<u8>> {
     zstd::stream::encode_all(history, 3)
 }
 
+fn gzip_session_history_for_test(history: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    encoder.write_all(history)?;
+    encoder.finish()
+}
+
 fn high_entropy_history(size: usize) -> Vec<u8> {
     let mut state = 0x6a09e667f3bcc909_u64;
     let mut bytes = Vec::with_capacity(size);
@@ -108,6 +119,11 @@ fn high_entropy_history(size: usize) -> Vec<u8> {
         bytes.push((value >> 56) as u8);
     }
     bytes
+}
+
+fn long_distance_repeated_history() -> Vec<u8> {
+    let chunk = high_entropy_history(64 * 1024);
+    [chunk.as_slice(), chunk.as_slice()].concat()
 }
 
 fn upload_zstd_validation_response(
@@ -575,6 +591,87 @@ async fn success_checkpoint_rejects_existing_gzip_without_encoding_acknowledgeme
     );
     zstd_prepare_mock.assert_calls_async(1).await;
     gzip_prepare_mock.assert_calls_async(1).await;
+    checkpoint_mock.assert_calls_async(0).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn success_checkpoint_rejects_legacy_gzip_when_not_smaller_than_identity()
+-> Result<(), Box<dyn std::error::Error>> {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+
+    let runtime = runtime_from_process_env().unwrap();
+    let _files_guard = SessionCheckpointFilesGuard::new();
+    let history = long_distance_repeated_history();
+    let _history_dir =
+        write_literal_session_history("gzip-not-beneficial-session", &history).unwrap();
+
+    let zstd_history = zstd_session_history_for_test(&history)?;
+    let gzip_history = gzip_session_history_for_test(&history)?;
+    assert!(
+        zstd_history.len() < history.len(),
+        "test fixture must be zstd-beneficial"
+    );
+    assert!(
+        gzip_history.len() >= history.len(),
+        "test fixture must not be gzip-beneficial"
+    );
+
+    let history_hash = hex::encode(Sha256::digest(&history));
+    let history_size = history.len();
+    let zstd_size = zstd_history.len();
+    let zstd_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"runId":"test-run-001"}"#)
+            .json_body_includes(format!(r#"{{"hash":"{history_hash}"}}"#))
+            .json_body_includes(format!(r#"{{"rawSize":{history_size}}}"#))
+            .json_body_includes(format!(r#"{{"encodedSize":{zstd_size}}}"#))
+            .json_body_includes(r#"{"encoding":"zstd"}"#);
+        then.status(400)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "error": {
+                    "message": "Invalid enum value. Expected identity | gzip"
+                }
+            }));
+    });
+    let gzip_prepare_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/webhooks/agent/checkpoints/prepare-history")
+            .json_body_includes(r#"{"encoding":"gzip"}"#);
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({
+                "presignedUrl": server.url("/test/unexpected-gzip-history-upload"),
+                "existing": false,
+                "encoding": "gzip"
+            }));
+    });
+    let upload_mock = server.mock(|when, then| {
+        when.method(PUT)
+            .path("/test/unexpected-gzip-history-upload");
+        then.status(200);
+    });
+    let checkpoint_mock = server.mock(|when, then| {
+        when.method(POST).path("/api/webhooks/agent/checkpoints");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body(json!({"checkpointId": "unexpected"}));
+    });
+
+    let result = guest_agent::checkpoint::create_checkpoint_for_runtime(&runtime).await;
+
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("legacy gzip session history was not smaller than identity"),
+        "expected gzip fallback compression failure, got: {err}"
+    );
+    zstd_prepare_mock.assert_calls_async(1).await;
+    gzip_prepare_mock.assert_calls_async(0).await;
+    upload_mock.assert_calls_async(0).await;
     checkpoint_mock.assert_calls_async(0).await;
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #20423.

- Prevent the guest-agent legacy gzip retry from silently uploading raw identity session history when `prepare-history` does not acknowledge gzip.
- Preserve the existing zstd-to-legacy gzip downgrade for old API responses, but require gzip acknowledgement before using an existing blob or PUT URL.
- Add guest-agent integration coverage for missing gzip acknowledgement on both upload and existing-blob responses, plus the legacy fallback case where zstd is beneficial but gzip is not smaller than identity.

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration checkpoint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts -t "checkpoint resume"` *(blocked locally: database schema is stale; `/api/zero/onboarding/setup` fails because `org_metadata.onboarding_complete` is missing. `pnpm -F @vm0/db db:migrate` is also blocked locally because `runner_state.available_profiles` already exists.)*
