### PR TITLE
feat: refresh runner builtin firewalls from api

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_catalog.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_catalog.py
@@ -1,0 +1,151 @@
+"""Local runner cache provider for builtin firewall definitions."""
+
+import json
+import os
+import stat
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, TypeGuard
+
+from mitmproxy import ctx
+
+SCHEMA_VERSION = 1
+MAX_CACHE_BYTES = 16 * 1024 * 1024
+_READ_CHUNK_BYTES = 1024 * 1024
+_FILE_CACHE_KEY_LENGTH = 5
+
+_CacheKey = tuple[str, int, int, int, int] | tuple[str, str] | None
+_loaded_key: _CacheKey = None
+_loaded_entries: dict[str, dict[str, Any]] = {}
+
+
+def reset_cache_for_tests() -> None:
+    global _loaded_key, _loaded_entries
+    _loaded_key = None
+    _loaded_entries = {}
+
+
+def cache_key() -> _CacheKey:
+    path = _cache_path()
+    if not path:
+        return None
+    try:
+        st = Path(path).stat(follow_symlinks=False)
+    except OSError:
+        return (path, "missing")
+    if not stat.S_ISREG(st.st_mode):
+        return (path, "not-regular")
+    return (path, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+
+
+def get_builtin_firewall(
+    name: str,
+    bundled_catalog: Mapping[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    entries = _local_entries()
+    local = entries.get(name)
+    if local is not None:
+        return local
+    return bundled_catalog.get(name)
+
+
+def _cache_path() -> str:
+    options = getattr(ctx, "options", None)
+    return getattr(options, "vm0_builtin_firewall_catalog_cache_path", "") or ""
+
+
+def _local_entries() -> dict[str, dict[str, Any]]:
+    global _loaded_key, _loaded_entries
+    key = cache_key()
+    if key is None:
+        _loaded_key = key
+        _loaded_entries = {}
+        return _loaded_entries
+    if key == _loaded_key:
+        return _loaded_entries
+
+    path = _cache_path()
+    entries = _read_local_entries(Path(path), key)
+    _loaded_key = key
+    _loaded_entries = entries
+    return _loaded_entries
+
+
+def _read_local_entries(path: Path, key: _CacheKey) -> dict[str, dict[str, Any]]:
+    if not _is_file_cache_key(key):
+        return {}
+    try:
+        raw_cache = json.loads(_read_cache_bytes(path).decode("utf-8"))
+    except (OSError, ValueError, RecursionError) as exc:
+        ctx.log.warn(f"Failed to read builtin firewall catalog cache: {type(exc).__name__}: {exc}")
+        return {}
+
+    if not isinstance(raw_cache, dict):
+        ctx.log.warn("Ignoring builtin firewall catalog cache: root must be an object")
+        return {}
+    if raw_cache.get("schemaVersion") != SCHEMA_VERSION:
+        ctx.log.warn("Ignoring builtin firewall catalog cache: unsupported schemaVersion")
+        return {}
+    raw_entries = raw_cache.get("entries")
+    if not isinstance(raw_entries, dict):
+        ctx.log.warn("Ignoring builtin firewall catalog cache: entries must be an object")
+        return {}
+
+    entries: dict[str, dict[str, Any]] = {}
+    for name, raw_entry in raw_entries.items():
+        if not isinstance(name, str) or not isinstance(raw_entry, dict):
+            continue
+        firewall = raw_entry.get("firewall")
+        if _is_valid_firewall(firewall, name=name):
+            entries[name] = firewall
+    return entries
+
+
+def _is_file_cache_key(key: _CacheKey) -> bool:
+    return isinstance(key, tuple) and len(key) == _FILE_CACHE_KEY_LENGTH
+
+
+def _is_valid_firewall(firewall: object, *, name: str) -> TypeGuard[dict[str, Any]]:
+    if not isinstance(firewall, dict):
+        return False
+    raw_name = firewall.get("name")
+    if raw_name is not None and raw_name != name:
+        return False
+    apis = firewall.get("apis")
+    return isinstance(apis, list) and all(isinstance(api, dict) for api in apis)
+
+
+def _read_cache_bytes(path: Path) -> bytes:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    fd = os.open(path, flags)
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise OSError(f"builtin firewall catalog cache {path} is not a regular file")
+        if st.st_size > MAX_CACHE_BYTES:
+            raise OSError(f"builtin firewall catalog cache {path} exceeds {MAX_CACHE_BYTES} bytes")
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            to_read = min(_READ_CHUNK_BYTES, MAX_CACHE_BYTES + 1 - total)
+            if to_read <= 0:
+                raise OSError(
+                    f"builtin firewall catalog cache {path} exceeds {MAX_CACHE_BYTES} bytes"
+                )
+            chunk = os.read(fd, to_read)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        if total > MAX_CACHE_BYTES:
+            raise OSError(f"builtin firewall catalog cache {path} exceeds {MAX_CACHE_BYTES} bytes")
+        return b"".join(chunks)
+    finally:
+        os.close(fd)

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -316,6 +316,12 @@ def load(loader: Loader) -> None:
         help="Runner-generated usage-pending state id",
     )
     loader.add_option(
+        name="vm0_builtin_firewall_catalog_cache_path",
+        typespec=str,
+        default="",
+        help="Path to runner-local builtin firewall catalog cache",
+    )
+    loader.add_option(
         name="vm0_usage_flush_interval_seconds",
         typespec=float,
         default=usage.DEFAULT_FLUSH_INTERVAL_SECONDS,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -18,7 +18,8 @@ VmContext = tuple[
     matching.CompiledFirewallSet | None,
     matching.CompiledNetworkPolicies,
 ]
-_RegistryCacheKey = tuple[str, int, int, int, int]
+_RegistryFileCacheKey = tuple[str, int, int, int, int]
+_RegistryCacheKey = tuple[_RegistryFileCacheKey, object]
 MAX_REGISTRY_BYTES = 16 * 1024 * 1024
 _READ_CHUNK_BYTES = 1024 * 1024
 
@@ -356,7 +357,8 @@ def load_registry_state(registry_path: str) -> RegistryState:
         return _mark_unavailable(state, reason="stat_failed", message=message)
 
     try:
-        key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+        registry_file_key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
+        key = (registry_file_key, registry_firewalls.builtin_catalog_cache_key())
         if key == state.snapshot.loaded_key:
             state.unavailable = None
             state.stat_error_logged = False

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -4,6 +4,7 @@ import copy
 from dataclasses import dataclass
 
 import builtin_base_url
+import builtin_firewall_catalog
 import builtin_host_policy
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
 
@@ -59,7 +60,7 @@ def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntr
     if not isinstance(raw_name, str) or raw_name == "":
         raise FirewallEntryResolutionError("builtin firewall entry name must be a non-empty string")
 
-    catalog_firewall = BUILTIN_FIREWALLS.get(raw_name)
+    catalog_firewall = builtin_firewall_catalog.get_builtin_firewall(raw_name, BUILTIN_FIREWALLS)
     if catalog_firewall is None:
         raise FirewallEntryResolutionError(f'unknown builtin firewall "{raw_name}"')
 
@@ -111,6 +112,10 @@ def _resolve_builtin_firewall_entry(entry: dict) -> _ResolvedBuiltinFirewallEntr
             tuple(resolved_bases),
         ),
     )
+
+
+def builtin_catalog_cache_key() -> object:
+    return builtin_firewall_catalog.cache_key()
 
 
 def _assign_firewall_api_ids(firewalls: list[dict], run_id: str) -> None:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -28,6 +28,7 @@ from mitmproxy.test import tflow, tutils
 import auth
 import auth_base_forwarder
 import builtin_connector_diagnostics
+import builtin_firewall_catalog
 import logging_utils
 import mitm_addon
 import registry
@@ -52,6 +53,7 @@ def _reset_module_state() -> Iterator[None]:
     """
     auth_base_forwarder.reset_forward_request_state_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
+    builtin_firewall_catalog.reset_cache_for_tests()
     registry.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
     mitm_addon.reset_upstream_destination_resolution_cache_for_tests()
@@ -69,6 +71,7 @@ def _reset_module_state() -> Iterator[None]:
     logging_utils.reset_log_writer_for_tests()
     auth_base_forwarder.reset_forward_request_state_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
+    builtin_firewall_catalog.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
     mitm_addon.reset_upstream_destination_resolution_cache_for_tests()
     mitm_addon.reset_tls_admission_state_for_tests()
@@ -304,11 +307,14 @@ def real_tcp_flow():
 
 
 class _StubOptions:
-    """Plain stand-in for the two addon-specific ``ctx.options`` fields."""
+    """Plain stand-in for addon-specific ``ctx.options`` fields."""
 
-    def __init__(self, *, registry_path: str, api_url: str) -> None:
+    def __init__(
+        self, *, registry_path: str, api_url: str, builtin_firewall_cache_path: str
+    ) -> None:
         self.vm0_proxy_registry_path = registry_path
         self.vm0_api_url = api_url
+        self.vm0_builtin_firewall_catalog_cache_path = builtin_firewall_cache_path
         self.vm0_usage_flush_interval_seconds = usage.DEFAULT_FLUSH_INTERVAL_SECONDS
 
 
@@ -335,10 +341,15 @@ def mitm_ctx(tmp_path):
         *,
         registry_path: str | None = None,
         api_url: str = "https://api.vm0.ai",
+        builtin_firewall_cache_path: str = "",
     ) -> Iterator[MagicMock]:
         if registry_path is None:
             registry_path = default_registry_path
-        options = _StubOptions(registry_path=registry_path, api_url=api_url)
+        options = _StubOptions(
+            registry_path=registry_path,
+            api_url=api_url,
+            builtin_firewall_cache_path=builtin_firewall_cache_path,
+        )
         log = MagicMock()
         with (
             patch.object(mitm_addon.ctx, "options", options, create=True),

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -104,6 +104,7 @@ class TestAddonConfiguration:
             mitm_addon.load(loader)
 
         option_names = [option.name for option in master.options.added]
+        assert "vm0_builtin_firewall_catalog_cache_path" in option_names
         assert "vm0_usage_state_id" in option_names
         assert "vm0_usage_flush_interval_seconds" in option_names
         assert not pending_path.exists()

--- a/crates/runner/mitm-addon/tests/test_builtin_firewall_catalog_cache.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_firewall_catalog_cache.py
@@ -1,0 +1,143 @@
+"""Tests for runner-local builtin firewall catalog cache resolution."""
+
+import json
+
+import builtin_host_policy
+import registry
+import registry_firewalls
+from tests.registry_helpers import builtin_vm, write_multi_vm_registry
+
+
+def _firewall(name: str, base: str) -> dict:
+    return {
+        "name": name,
+        "apis": [
+            {
+                "base": base,
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+                "permissions": [],
+                "hostPolicy": {"kind": "publicDestination"},
+            }
+        ],
+    }
+
+
+def _write_cache(path, *, name: str, base: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "updatedAt": "2026-07-07T00:00:00.000Z",
+                "entries": {
+                    name: {
+                        "catalogDigest": "sha256:test",
+                        "catalogVersion": "test.1",
+                        "firewall": _firewall(name, base),
+                    }
+                },
+            }
+        )
+    )
+
+
+def _install_bundled(monkeypatch, *, name: str, base: str) -> None:
+    monkeypatch.setattr(
+        registry_firewalls,
+        "BUILTIN_FIREWALLS",
+        {name: _firewall(name, base)},
+    )
+
+
+def test_local_cache_entry_is_preferred_over_bundled_catalog(tmp_path, monkeypatch, mitm_ctx):
+    registry_path = tmp_path / "registry.json"
+    cache_path = tmp_path / "builtin-firewall-cache.json"
+    _install_bundled(monkeypatch, name="demo", base="https://bundled.example.com")
+    _write_cache(cache_path, name="demo", base="https://cached.example.com")
+    write_multi_vm_registry(registry_path, {"10.200.0.1": builtin_vm("run-demo", "demo")})
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_cache_path=str(cache_path),
+    ):
+        context = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+    assert context is not None
+    vm_info, _, _ = context
+    api = vm_info["firewalls"][0]["apis"][0]
+    assert api["base"] == "https://cached.example.com"
+    assert api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] is True
+
+
+def test_malformed_cache_falls_back_to_bundled_catalog(tmp_path, monkeypatch, mitm_ctx):
+    registry_path = tmp_path / "registry.json"
+    cache_path = tmp_path / "builtin-firewall-cache.json"
+    _install_bundled(monkeypatch, name="demo", base="https://bundled.example.com")
+    cache_path.write_text("{not json")
+    write_multi_vm_registry(registry_path, {"10.200.0.1": builtin_vm("run-demo", "demo")})
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_cache_path=str(cache_path),
+    ):
+        context = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+    assert context is not None
+    vm_info, _, _ = context
+    assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
+
+
+def test_invalid_cache_entry_falls_back_to_bundled_catalog(tmp_path, monkeypatch, mitm_ctx):
+    registry_path = tmp_path / "registry.json"
+    cache_path = tmp_path / "builtin-firewall-cache.json"
+    _install_bundled(monkeypatch, name="demo", base="https://bundled.example.com")
+    cache_path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "updatedAt": "2026-07-07T00:00:00.000Z",
+                "entries": {
+                    "demo": {
+                        "catalogDigest": "sha256:test",
+                        "catalogVersion": "test.1",
+                        "firewall": {"name": "demo", "apis": "not-a-list"},
+                    }
+                },
+            }
+        )
+    )
+    write_multi_vm_registry(registry_path, {"10.200.0.1": builtin_vm("run-demo", "demo")})
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_cache_path=str(cache_path),
+    ):
+        context = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+    assert context is not None
+    vm_info, _, _ = context
+    assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
+
+
+def test_cache_file_change_reloads_registry_context_without_registry_change(
+    tmp_path, monkeypatch, mitm_ctx
+):
+    registry_path = tmp_path / "registry.json"
+    cache_path = tmp_path / "builtin-firewall-cache.json"
+    _install_bundled(monkeypatch, name="demo", base="https://bundled.example.com")
+    write_multi_vm_registry(registry_path, {"10.200.0.1": builtin_vm("run-demo", "demo")})
+    _write_cache(cache_path, name="demo", base="https://old-cache.example.com")
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_cache_path=str(cache_path),
+    ):
+        first = registry.get_vm_context("10.200.0.1", str(registry_path))
+        _write_cache(cache_path, name="demo", base="https://new-cache.example.com/longer")
+        second = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+    assert first is not None
+    assert second is not None
+    first_vm, _, _ = first
+    second_vm, _, _ = second
+    assert first_vm["firewalls"][0]["apis"][0]["base"] == "https://old-cache.example.com"
+    assert second_vm["firewalls"][0]["apis"][0]["base"] == "https://new-cache.example.com/longer"

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -139,6 +139,7 @@ pub async fn run_benchmark(
         addon_dir: runner_paths.mitm_addon_dir(),
         registry_path: runner_paths.proxy_registry(),
         registry_lock_path: runner_paths.proxy_registry_lock(),
+        builtin_firewall_catalog_cache_path: None,
         api_url: runner_config.server.as_ref().map(|s| s.url.clone()),
     })
     .await?;

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -201,6 +201,9 @@ impl ExecutorInvocation {
                 if let Some(refresh) = exec_config_for_panic.network_policy_refresh.as_ref() {
                     refresh.unregister_run(run_id).await;
                 }
+                if let Some(refresh) = exec_config_for_panic.builtin_firewall_refresh.as_ref() {
+                    refresh.unregister_run(run_id).await;
+                }
                 // Panic lost the in-flight telemetry buffer; substitute an
                 // empty collector so the post-complete flush path stays
                 // unconditional. `flush` early-returns on empty pending_ops.

--- a/crates/runner/src/cmd/start/mitm_restart.rs
+++ b/crates/runner/src/cmd/start/mitm_restart.rs
@@ -130,6 +130,7 @@ mod tests {
             addon_dir: dir.path().join("addon"),
             registry_path: dir.path().join("registry.json"),
             registry_lock_path: dir.path().join("registry.lock"),
+            builtin_firewall_catalog_cache_path: None,
             api_url: None,
         })
         .await

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -56,7 +56,10 @@ use crate::network_log_drain::NetworkLogDrainCoordinator;
 use crate::network_log_manager::NetworkLogManager;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
-use crate::provider::{ApiProvider, JobProvider, LocalProvider, NetworkPolicyRefreshHandle};
+use crate::provider::{
+    ApiProvider, BuiltinFirewallRefreshHandle, JobProvider, LocalProvider,
+    NetworkPolicyRefreshHandle,
+};
 use crate::proxy;
 use crate::resource_budget::ResourceBudget;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
@@ -408,12 +411,16 @@ async fn run_start_with_home(
         .unwrap_or(1);
 
     // Start proxy before factory so proxy_port is available for netns pool.
+    let builtin_firewall_catalog_cache_path = local_group_dir
+        .is_none()
+        .then(|| paths.builtin_firewall_catalog_cache());
     let (mut mitm, mitm_crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
         mitmdump_bin: home.mitmdump_bin(deps::MITMPROXY_VERSION),
         ca_dir: runner_config.ca_dir.clone(),
         addon_dir: paths.mitm_addon_dir(),
         registry_path: paths.proxy_registry(),
         registry_lock_path: paths.proxy_registry_lock(),
+        builtin_firewall_catalog_cache_path,
         api_url: Some(server.url.clone()),
     })
     .await?;
@@ -579,10 +586,11 @@ async fn run_start_with_home(
     // Create provider — handles discovery + claim + complete
     let (usage_flush_tx, usage_flush_rx) = mpsc::channel(1);
 
-    let (provider, group_name, network_policy_refresh): (
+    let (provider, group_name, network_policy_refresh, builtin_firewall_refresh): (
         Arc<dyn JobProvider>,
         String,
         Option<NetworkPolicyRefreshHandle>,
+        Option<BuiltinFirewallRefreshHandle>,
     ) = if let Some(group_dir) = local_group_dir {
         let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
         let provider = LocalProvider::new(
@@ -591,7 +599,7 @@ async fn run_start_with_home(
             cancel.clone(),
             Arc::clone(&cancel_tokens),
         );
-        (provider, group, None)
+        (provider, group, None, None)
     } else {
         let group_name = group.clone();
         let profiles: Vec<String> = runner_config.profiles.keys().cloned().collect();
@@ -605,7 +613,16 @@ async fn run_start_with_home(
         )
         .await;
         let network_policy_refresh = provider.network_policy_refresh_handle();
-        (provider, group_name, Some(network_policy_refresh))
+        let builtin_firewall_refresh = provider.builtin_firewall_refresh_handle(
+            paths.builtin_firewall_catalog_cache(),
+            paths.builtin_firewall_catalog_cache_lock(),
+        );
+        (
+            provider,
+            group_name,
+            Some(network_policy_refresh),
+            Some(builtin_firewall_refresh),
+        )
     };
 
     let exec_config = Arc::new(ExecutorConfig {
@@ -617,6 +634,7 @@ async fn run_start_with_home(
         network_log_drain,
         mitm_jsonl_flush: Some(mitm.jsonl_flush_handle(usage_flush_tx.clone())),
         network_policy_refresh,
+        builtin_firewall_refresh,
         home: home.clone(),
         workspace_cache: Some(SessionWorkspaceCache::shared(
             paths.clone(),
@@ -1135,6 +1153,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     {
         Ok(factories) => factories,
         Err(e) => {
+            if let Some(refresh) = exec_config.builtin_firewall_refresh.as_ref() {
+                refresh.shutdown().await;
+            }
             shutdown_startup_resources_after_factory_failure(
                 provider_state.provider.as_ref(),
                 &mut mitm,
@@ -1573,6 +1594,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     teardown.phase_complete("drain_idle_pool", phase);
 
     let phase = teardown.phase_start("provider_shutdown");
+    if let Some(refresh) = exec_config.builtin_firewall_refresh.as_ref() {
+        refresh.shutdown().await;
+    }
     provider_state.provider.shutdown().await;
     teardown.phase_complete("provider_shutdown", phase);
 

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -253,6 +253,7 @@ fn build_mock_run_config_with_runtime(
             network_log_drain: NetworkLogDrainCoordinator::noop(),
             mitm_jsonl_flush: None,
             network_policy_refresh: None,
+            builtin_firewall_refresh: None,
             home,
             workspace_cache: None,
         }),

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -158,6 +158,7 @@ pub struct ExecutorConfig {
     pub network_log_drain: NetworkLogDrainCoordinator,
     pub mitm_jsonl_flush: Option<MitmJsonlFlushHandle>,
     pub(crate) network_policy_refresh: Option<crate::provider::NetworkPolicyRefreshHandle>,
+    pub(crate) builtin_firewall_refresh: Option<crate::provider::BuiltinFirewallRefreshHandle>,
     pub home: HomePaths,
     pub workspace_cache: Option<SessionWorkspaceCache>,
 }

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -727,6 +727,12 @@ pub(super) async fn register_proxy(
     let proxy_log_path = config.log_paths.proxy_log(context.run_id);
     let run_id_str = context.run_id.to_string();
     let cli_agent_type = normalized_cli_agent_type(&context.cli_agent_type);
+    if let Some(refresh) = config.builtin_firewall_refresh.as_ref() {
+        refresh
+            .ensure_firewalls_available(context.firewalls.as_deref())
+            .await
+            .map_err(|e| RunnerError::Internal(format!("refresh builtin firewalls: {e}")))?;
+    }
     let registration = proxy::VmRegistration {
         run_id: &run_id_str,
         cli_agent_type,
@@ -748,6 +754,11 @@ pub(super) async fn register_proxy(
         .register_vm(source_ip, &registration)
         .await
         .map_err(|e| RunnerError::Internal(format!("register VM in proxy registry: {e}")))?;
+    if let Some(refresh) = config.builtin_firewall_refresh.as_ref() {
+        refresh
+            .register_run(context.run_id, context.firewalls.as_deref())
+            .await;
+    }
     let network_log_session = config
         .network_log_manager
         .register_source_ip(source_ip, network_log_path)
@@ -849,6 +860,9 @@ pub(super) async fn unregister_proxy_registry(
         .await
         .map_err(|e| RunnerError::Internal(format!("unregister VM from proxy registry: {e}")));
     if let Some(refresh) = config.network_policy_refresh.as_ref() {
+        refresh.unregister_run(run_id).await;
+    }
+    if let Some(refresh) = config.builtin_firewall_refresh.as_ref() {
         refresh.unregister_run(run_id).await;
     }
     result

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -36,6 +36,7 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
         network_log_drain: NetworkLogDrainCoordinator::noop(),
         mitm_jsonl_flush: None,
         network_policy_refresh: None,
+        builtin_firewall_refresh: None,
         home: HomePaths::with_root(dir.to_path_buf()),
         workspace_cache: None,
     }

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -136,6 +136,15 @@ impl RunnerPaths {
         self.base_dir.join("proxy-registry.json.lock")
     }
 
+    pub fn builtin_firewall_catalog_cache(&self) -> PathBuf {
+        self.base_dir.join("builtin-firewall-catalog-cache.json")
+    }
+
+    pub fn builtin_firewall_catalog_cache_lock(&self) -> PathBuf {
+        self.base_dir
+            .join("builtin-firewall-catalog-cache.json.lock")
+    }
+
     pub fn workspaces_dir(&self) -> PathBuf {
         self.base_dir.join("workspaces")
     }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1,5 +1,6 @@
 //! [`JobProvider`] backed by an Ably control plane + HTTP polling + REST API.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -14,6 +15,10 @@ use super::api_ably_supervisor::{
     AblySupervisor, AblySupervisorConfig, PollDue, PollOutcome, PollReason, PollWakeups,
 };
 use super::api_direct_candidates::{DirectCandidateInbox, DirectJobCandidate};
+use super::builtin_firewall_refresh::{
+    BuiltinFirewallRefreshHandle, BuiltinFirewallResolveError, BuiltinFirewallsResolveRequest,
+    BuiltinFirewallsResolveResponse,
+};
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
     ClaimedJob, CompletionAuth, CompletionAuthError, JobCandidate, JobDiscoverySource, JobProvider,
@@ -71,6 +76,7 @@ const POLL_FAST: Duration = Duration::from_secs(5);
 const POLL_WAKEUP_RETRY: Duration = POLL_FAST;
 const DIRECT_CANDIDATE_INBOX_CAPACITY: usize = 128;
 const NETWORK_POLICY_REFRESH_TIMEOUT: Duration = Duration::from_secs(3);
+const BUILTIN_FIREWALL_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
 
 enum DiscoveryWakeup {
     Direct(DirectJobCandidate),
@@ -145,6 +151,14 @@ impl ApiProvider {
 
     pub(crate) fn network_policy_refresh_handle(&self) -> NetworkPolicyRefreshHandle {
         self.network_policy_refresh.clone()
+    }
+
+    pub(crate) fn builtin_firewall_refresh_handle(
+        &self,
+        cache_path: PathBuf,
+        lock_path: PathBuf,
+    ) -> BuiltinFirewallRefreshHandle {
+        BuiltinFirewallRefreshHandle::new(self.api.clone(), cache_path, lock_path)
     }
 
     async fn try_recv_direct_candidate(&self) -> Option<DirectJobCandidate> {
@@ -528,6 +542,40 @@ impl ApiClient {
         decode_api_json(resp, "realtime token").await
     }
 
+    pub(super) async fn resolve_builtin_firewalls(
+        &self,
+        names: &[String],
+    ) -> Result<BuiltinFirewallsResolveResponse, BuiltinFirewallResolveError> {
+        let body = BuiltinFirewallsResolveRequest { names };
+        let resp = send_api(
+            self.http
+                .request_route(
+                    routes::runners::builtin_firewalls::resolve::RESOLVE,
+                    &self.token,
+                )
+                .timeout(BUILTIN_FIREWALL_RESOLVE_TIMEOUT)
+                .json(&body),
+            "builtin firewall resolve",
+        )
+        .await
+        .map_err(|e| BuiltinFirewallResolveError::Transient(e.to_string()))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let (status, body) = read_api_error(resp).await;
+            let message = format!("builtin firewall resolve {status}: {body}");
+            return if is_transient_builtin_firewall_resolve_status(status) {
+                Err(BuiltinFirewallResolveError::Transient(message))
+            } else {
+                Err(BuiltinFirewallResolveError::Permanent(message))
+            };
+        }
+
+        decode_api_json(resp, "builtin firewall resolve")
+            .await
+            .map_err(|e| BuiltinFirewallResolveError::Permanent(e.to_string()))
+    }
+
     pub(super) async fn refresh_network_policies(
         &self,
         run_id: RunId,
@@ -559,6 +607,17 @@ impl ApiClient {
             .timeout(NETWORK_POLICY_REFRESH_TIMEOUT)
             .json(&serde_json::json!({ "connectorRefs": connector_refs }))
     }
+}
+
+fn is_transient_builtin_firewall_resolve_status(status: StatusCode) -> bool {
+    status.is_server_error()
+        || matches!(
+            status,
+            StatusCode::NOT_FOUND
+                | StatusCode::METHOD_NOT_ALLOWED
+                | StatusCode::TOO_MANY_REQUESTS
+                | StatusCode::REQUEST_TIMEOUT
+        )
 }
 
 fn claim_request_body(candidate: &JobCandidate) -> ClaimRequestBody {

--- a/crates/runner/src/provider/builtin_firewall_refresh.rs
+++ b/crates/runner/src/provider/builtin_firewall_refresh.rs
@@ -640,7 +640,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn periodic_refresh_updates_active_builtin_names() {
+    async fn active_refresh_updates_registered_builtin_names() {
         let server = MockServer::start_async().await;
         let mock = server
             .mock_async(|when, then| {
@@ -665,7 +665,7 @@ mod tests {
             ApiClient::new(http_client(server.base_url()), "runner-token".to_string()),
             cache_path.clone(),
             dir.path().join("builtin-firewall-cache.json.lock"),
-            Duration::from_millis(20),
+            Duration::from_secs(3600),
         );
         let firewalls = vec![FirewallEntry::Builtin {
             name: "github".to_string(),
@@ -673,10 +673,12 @@ mod tests {
         }];
 
         handle.register_run(RunId::new_v4(), Some(&firewalls)).await;
-        wait_for_cache_entry(&cache_path, "github").await;
+        handle.core.refresh_active_names().await;
         handle.shutdown().await;
 
-        assert!(mock.calls_async().await >= 1);
+        mock.assert_async().await;
+        let cache = read_cache(&cache_path).await;
+        assert!(cache.entries.contains_key("github"));
     }
 
     #[tokio::test]
@@ -729,22 +731,5 @@ mod tests {
             cache.entries["github"].firewall["apis"][0]["base"],
             "https://old.example.com"
         );
-    }
-
-    async fn wait_for_cache_entry(path: &std::path::Path, name: &str) {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
-        loop {
-            if let Ok(content) = tokio::fs::read_to_string(path).await
-                && let Ok(cache) = serde_json::from_str::<BuiltinFirewallCatalogCache>(&content)
-                && cache.entries.contains_key(name)
-            {
-                return;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "cache entry {name} was not written"
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
     }
 }

--- a/crates/runner/src/provider/builtin_firewall_refresh.rs
+++ b/crates/runner/src/provider/builtin_firewall_refresh.rs
@@ -381,8 +381,7 @@ impl BuiltinFirewallCacheStore {
         let mut cache = self.read_cache_or_empty().await;
         cache.entries.extend(entries);
         cache.updated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
-        let content = serde_json::to_vec(&cache)
-            .map_err(|e| RunnerError::Internal(format!("serialize builtin firewall cache: {e}")))?;
+        let content = serialize_cache(&cache)?;
         state_file::write_private_atomic(&self.path, &content)
             .await
             .map_err(|e| {
@@ -447,6 +446,18 @@ impl BuiltinFirewallCacheStore {
             }
         }
     }
+}
+
+fn serialize_cache(cache: &BuiltinFirewallCatalogCache) -> RunnerResult<Vec<u8>> {
+    let content = serde_json::to_vec(cache)
+        .map_err(|e| RunnerError::Internal(format!("serialize builtin firewall cache: {e}")))?;
+    if content.len() as u64 > BUILTIN_FIREWALL_CACHE_MAX_BYTES {
+        return Err(RunnerError::Internal(format!(
+            "builtin firewall cache exceeds {} bytes",
+            BUILTIN_FIREWALL_CACHE_MAX_BYTES
+        )));
+    }
+    Ok(content)
 }
 
 fn empty_cache() -> BuiltinFirewallCatalogCache {
@@ -564,6 +575,38 @@ mod tests {
         assert!(cache.entries.contains_key("github"));
         assert!(cache.entries.contains_key("slack"));
         assert!(!cache.entries.contains_key("bad"));
+    }
+
+    #[tokio::test]
+    async fn cache_merge_rejects_oversized_cache_without_overwriting_existing_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = cache_store(&dir);
+        store
+            .merge(BTreeMap::from([(
+                "github".to_string(),
+                cached_firewall("github", "https://api.github.com"),
+            )]))
+            .await
+            .unwrap();
+        let original_content = tokio::fs::read_to_string(&store.path).await.unwrap();
+        let oversized_base = format!(
+            "https://{}.example.com",
+            "a".repeat(BUILTIN_FIREWALL_CACHE_MAX_BYTES as usize)
+        );
+
+        let error = store
+            .merge(BTreeMap::from([(
+                "slack".to_string(),
+                cached_firewall("slack", &oversized_base),
+            )]))
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("builtin firewall cache exceeds"));
+        assert_eq!(
+            tokio::fs::read_to_string(&store.path).await.unwrap(),
+            original_content
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/builtin_firewall_refresh.rs
+++ b/crates/runner/src/provider/builtin_firewall_refresh.rs
@@ -1,0 +1,750 @@
+//! Runner-side builtin firewall catalog refresh and local cache.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+use super::api::ApiClient;
+use crate::error::{RunnerError, RunnerResult};
+use crate::ids::RunId;
+use crate::lock;
+use crate::state_file::{self, OwnerCheck};
+use crate::types::FirewallEntry;
+
+const BUILTIN_FIREWALL_CACHE_SCHEMA_VERSION: u32 = 1;
+const BUILTIN_FIREWALL_CACHE_MAX_BYTES: u64 = 16 * 1024 * 1024;
+const BUILTIN_FIREWALL_PERIODIC_REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct BuiltinFirewallsResolveRequest<'a> {
+    pub(super) names: &'a [String],
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct BuiltinFirewallsResolveResponse {
+    pub(super) catalog_digest: String,
+    pub(super) catalog_version: String,
+    pub(super) firewalls: BTreeMap<String, Value>,
+}
+
+#[derive(Debug)]
+pub(super) enum BuiltinFirewallResolveError {
+    Permanent(String),
+    Transient(String),
+}
+
+impl fmt::Display for BuiltinFirewallResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Permanent(message) | Self::Transient(message) => f.write_str(message),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct BuiltinFirewallRefreshHandle {
+    core: BuiltinFirewallRefreshCore,
+    worker: Arc<BuiltinFirewallRefreshWorker>,
+}
+
+#[derive(Clone)]
+struct BuiltinFirewallRefreshCore {
+    inner: Arc<BuiltinFirewallRefreshState>,
+}
+
+struct BuiltinFirewallRefreshState {
+    api: ApiClient,
+    store: BuiltinFirewallCacheStore,
+    active_runs: Mutex<HashMap<RunId, BTreeSet<String>>>,
+    cancel: CancellationToken,
+    interval: Duration,
+}
+
+struct BuiltinFirewallRefreshWorker {
+    core: BuiltinFirewallRefreshCore,
+    task: StdMutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+#[derive(Clone)]
+struct BuiltinFirewallCacheStore {
+    path: PathBuf,
+    lock_path: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuiltinFirewallCatalogCache {
+    schema_version: u32,
+    updated_at: String,
+    entries: BTreeMap<String, CachedBuiltinFirewall>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CachedBuiltinFirewall {
+    catalog_digest: String,
+    catalog_version: String,
+    firewall: Value,
+}
+
+impl BuiltinFirewallRefreshHandle {
+    pub(super) fn new(api: ApiClient, cache_path: PathBuf, lock_path: PathBuf) -> Self {
+        Self::new_with_interval(
+            api,
+            cache_path,
+            lock_path,
+            BUILTIN_FIREWALL_PERIODIC_REFRESH_INTERVAL,
+        )
+    }
+
+    fn new_with_interval(
+        api: ApiClient,
+        cache_path: PathBuf,
+        lock_path: PathBuf,
+        interval: Duration,
+    ) -> Self {
+        let core = BuiltinFirewallRefreshCore {
+            inner: Arc::new(BuiltinFirewallRefreshState {
+                api,
+                store: BuiltinFirewallCacheStore {
+                    path: cache_path,
+                    lock_path,
+                },
+                active_runs: Mutex::new(HashMap::new()),
+                cancel: CancellationToken::new(),
+                interval,
+            }),
+        };
+        let task = tokio::spawn(periodic_refresh_worker(core.clone()));
+        Self {
+            core: core.clone(),
+            worker: Arc::new(BuiltinFirewallRefreshWorker {
+                core,
+                task: StdMutex::new(Some(task)),
+            }),
+        }
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.core.inner.cancel.cancel();
+        let worker_task = self.take_worker_task();
+        if let Some(worker_task) = worker_task
+            && let Err(error) = worker_task.await
+        {
+            warn!(error = %error, "builtin firewall refresh worker failed during shutdown");
+        }
+    }
+
+    pub(crate) async fn ensure_firewalls_available(
+        &self,
+        firewalls: Option<&[FirewallEntry]>,
+    ) -> RunnerResult<()> {
+        let names = builtin_firewall_names(firewalls);
+        self.core.refresh_required_names(names).await
+    }
+
+    pub(crate) async fn register_run(&self, run_id: RunId, firewalls: Option<&[FirewallEntry]>) {
+        self.core
+            .register_run(run_id, builtin_firewall_names(firewalls))
+            .await;
+    }
+
+    pub(crate) async fn unregister_run(&self, run_id: RunId) {
+        self.core.unregister_run(run_id).await;
+    }
+
+    fn take_worker_task(&self) -> Option<tokio::task::JoinHandle<()>> {
+        self.worker.take_task()
+    }
+}
+
+impl BuiltinFirewallRefreshWorker {
+    fn take_task(&self) -> Option<tokio::task::JoinHandle<()>> {
+        self.task
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .take()
+    }
+}
+
+impl Drop for BuiltinFirewallRefreshWorker {
+    fn drop(&mut self) {
+        self.core.inner.cancel.cancel();
+        if let Some(worker_task) = self.take_task() {
+            worker_task.abort();
+        }
+    }
+}
+
+impl BuiltinFirewallRefreshCore {
+    async fn refresh_required_names(&self, names: BTreeSet<String>) -> RunnerResult<()> {
+        if names.is_empty() || self.inner.cancel.is_cancelled() {
+            return Ok(());
+        }
+
+        let requested = names.iter().cloned().collect::<Vec<_>>();
+        match self.inner.api.resolve_builtin_firewalls(&requested).await {
+            Ok(response) => {
+                let entries = validate_required_response(&requested, response)?;
+                self.inner.store.merge(entries).await?;
+            }
+            Err(BuiltinFirewallResolveError::Transient(error)) => {
+                warn!(
+                    builtin_count = requested.len(),
+                    error,
+                    "builtin firewall resolve failed; falling back to existing local or bundled catalog"
+                );
+            }
+            Err(BuiltinFirewallResolveError::Permanent(error)) => {
+                return Err(RunnerError::Api(format!(
+                    "builtin firewall resolve failed: {error}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    async fn register_run(&self, run_id: RunId, names: BTreeSet<String>) {
+        if self.inner.cancel.is_cancelled() {
+            return;
+        }
+        let mut active_runs = self.inner.active_runs.lock().await;
+        if names.is_empty() {
+            active_runs.remove(&run_id);
+        } else {
+            active_runs.insert(run_id, names);
+        }
+    }
+
+    async fn unregister_run(&self, run_id: RunId) {
+        self.inner.active_runs.lock().await.remove(&run_id);
+    }
+
+    async fn refresh_active_names(&self) {
+        if self.inner.cancel.is_cancelled() {
+            return;
+        }
+        let names = self.active_builtin_names().await;
+        if names.is_empty() {
+            return;
+        }
+        let requested = names.iter().cloned().collect::<Vec<_>>();
+        match self.inner.api.resolve_builtin_firewalls(&requested).await {
+            Ok(response) => {
+                let entries = validate_periodic_response(&requested, response);
+                if entries.is_empty() {
+                    return;
+                }
+                if let Err(error) = self.inner.store.merge(entries).await {
+                    warn!(error = %error, "failed to write periodic builtin firewall cache refresh");
+                }
+            }
+            Err(error) => {
+                warn!(
+                    builtin_count = requested.len(),
+                    error = %error,
+                    "periodic builtin firewall resolve failed; keeping previous cache"
+                );
+            }
+        }
+    }
+
+    async fn active_builtin_names(&self) -> BTreeSet<String> {
+        let active_runs = self.inner.active_runs.lock().await;
+        active_runs
+            .values()
+            .flat_map(|names| names.iter().cloned())
+            .collect()
+    }
+}
+
+async fn periodic_refresh_worker(core: BuiltinFirewallRefreshCore) {
+    loop {
+        tokio::select! {
+            () = core.inner.cancel.cancelled() => break,
+            () = tokio::time::sleep(core.inner.interval) => {
+                core.refresh_active_names().await;
+            }
+        }
+    }
+}
+
+fn builtin_firewall_names(firewalls: Option<&[FirewallEntry]>) -> BTreeSet<String> {
+    firewalls
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|entry| match entry {
+            FirewallEntry::Builtin { name, .. } if !name.is_empty() => Some(name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn validate_required_response(
+    requested: &[String],
+    response: BuiltinFirewallsResolveResponse,
+) -> RunnerResult<BTreeMap<String, CachedBuiltinFirewall>> {
+    let mut entries = BTreeMap::new();
+    for name in requested {
+        let firewall = response.firewalls.get(name).ok_or_else(|| {
+            RunnerError::Api(format!(
+                "builtin firewall resolve response missing required firewall {name}"
+            ))
+        })?;
+        validate_firewall_value(name, firewall).map_err(|message| {
+            RunnerError::Api(format!("invalid builtin firewall {name}: {message}"))
+        })?;
+        entries.insert(
+            name.clone(),
+            CachedBuiltinFirewall {
+                catalog_digest: response.catalog_digest.clone(),
+                catalog_version: response.catalog_version.clone(),
+                firewall: firewall.clone(),
+            },
+        );
+    }
+    Ok(entries)
+}
+
+fn validate_periodic_response(
+    requested: &[String],
+    response: BuiltinFirewallsResolveResponse,
+) -> BTreeMap<String, CachedBuiltinFirewall> {
+    let mut entries = BTreeMap::new();
+    for name in requested {
+        let Some(firewall) = response.firewalls.get(name) else {
+            warn!(
+                builtin = name,
+                "periodic builtin firewall response missing active firewall"
+            );
+            continue;
+        };
+        if let Err(error) = validate_firewall_value(name, firewall) {
+            warn!(
+                builtin = name,
+                error, "skipping invalid periodic builtin firewall response"
+            );
+            continue;
+        }
+        entries.insert(
+            name.clone(),
+            CachedBuiltinFirewall {
+                catalog_digest: response.catalog_digest.clone(),
+                catalog_version: response.catalog_version.clone(),
+                firewall: firewall.clone(),
+            },
+        );
+    }
+    entries
+}
+
+fn validate_firewall_value(name: &str, firewall: &Value) -> Result<(), String> {
+    let object = firewall
+        .as_object()
+        .ok_or_else(|| "firewall must be a JSON object".to_string())?;
+    if let Some(raw_name) = object.get("name") {
+        match raw_name.as_str() {
+            Some(actual) if actual == name => {}
+            Some(actual) => {
+                return Err(format!("name field {actual:?} does not match response key"));
+            }
+            None => return Err("name field must be a string when present".to_string()),
+        }
+    }
+    let apis = object
+        .get("apis")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "apis must be a list".to_string())?;
+    if apis.iter().any(|api| !api.is_object()) {
+        return Err("api entries must be objects".to_string());
+    }
+    Ok(())
+}
+
+impl BuiltinFirewallCacheStore {
+    async fn merge(&self, entries: BTreeMap<String, CachedBuiltinFirewall>) -> RunnerResult<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        let _guard = lock::acquire(self.lock_path.clone()).await?;
+        let mut cache = self.read_cache_or_empty().await;
+        cache.entries.extend(entries);
+        cache.updated_at = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+        let content = serde_json::to_vec(&cache)
+            .map_err(|e| RunnerError::Internal(format!("serialize builtin firewall cache: {e}")))?;
+        state_file::write_private_atomic(&self.path, &content)
+            .await
+            .map_err(|e| {
+                RunnerError::Internal(format!(
+                    "write builtin firewall cache {}: {e}",
+                    self.path.display()
+                ))
+            })
+    }
+
+    async fn read_cache_or_empty(&self) -> BuiltinFirewallCatalogCache {
+        let content = match state_file::read_to_string(
+            &self.path,
+            BUILTIN_FIREWALL_CACHE_MAX_BYTES,
+            OwnerCheck::CurrentEuid,
+        )
+        .await
+        {
+            Ok(Some(content)) => content,
+            Ok(None) => return empty_cache(),
+            Err(error) => {
+                warn!(
+                    path = %self.path.display(),
+                    error = %error,
+                    "ignoring unreadable builtin firewall cache before merge"
+                );
+                return empty_cache();
+            }
+        };
+
+        match serde_json::from_str::<BuiltinFirewallCatalogCache>(&content) {
+            Ok(mut cache) if cache.schema_version == BUILTIN_FIREWALL_CACHE_SCHEMA_VERSION => {
+                cache.entries.retain(|name, entry| {
+                    if let Err(error) = validate_firewall_value(name, &entry.firewall) {
+                        warn!(
+                            path = %self.path.display(),
+                            builtin = name,
+                            error,
+                            "dropping invalid existing builtin firewall cache entry before merge"
+                        );
+                        return false;
+                    }
+                    true
+                });
+                cache
+            }
+            Ok(cache) => {
+                warn!(
+                    path = %self.path.display(),
+                    schema_version = cache.schema_version,
+                    "ignoring unsupported builtin firewall cache schema before merge"
+                );
+                empty_cache()
+            }
+            Err(error) => {
+                warn!(
+                    path = %self.path.display(),
+                    error = %error,
+                    "ignoring malformed builtin firewall cache before merge"
+                );
+                empty_cache()
+            }
+        }
+    }
+}
+
+fn empty_cache() -> BuiltinFirewallCatalogCache {
+    BuiltinFirewallCatalogCache {
+        schema_version: BUILTIN_FIREWALL_CACHE_SCHEMA_VERSION,
+        updated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+        entries: BTreeMap::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::Method::POST;
+    use httpmock::MockServer;
+    use serde_json::json;
+
+    use crate::http::{HttpClient, HttpClientConfig};
+
+    fn cache_store(dir: &tempfile::TempDir) -> BuiltinFirewallCacheStore {
+        BuiltinFirewallCacheStore {
+            path: dir.path().join("builtin-firewall-cache.json"),
+            lock_path: dir.path().join("builtin-firewall-cache.json.lock"),
+        }
+    }
+
+    fn cached_firewall(name: &str, base: &str) -> CachedBuiltinFirewall {
+        CachedBuiltinFirewall {
+            catalog_digest: "sha256:test".to_string(),
+            catalog_version: "test.1".to_string(),
+            firewall: json!({
+                "name": name,
+                "apis": [
+                    {
+                        "base": base,
+                        "auth": {},
+                        "hostPolicy": {"type": "fixed"}
+                    }
+                ]
+            }),
+        }
+    }
+
+    async fn read_cache(path: &std::path::Path) -> BuiltinFirewallCatalogCache {
+        let content = tokio::fs::read_to_string(path).await.unwrap();
+        serde_json::from_str(&content).unwrap()
+    }
+
+    fn http_client(api_url: String) -> HttpClient {
+        HttpClient::new(HttpClientConfig {
+            api_url,
+            vercel_bypass: None,
+        })
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn cache_merge_preserves_unrelated_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = cache_store(&dir);
+        store
+            .merge(BTreeMap::from([(
+                "github".to_string(),
+                cached_firewall("github", "https://api.github.com"),
+            )]))
+            .await
+            .unwrap();
+        store
+            .merge(BTreeMap::from([(
+                "slack".to_string(),
+                cached_firewall("slack", "https://slack.com/api"),
+            )]))
+            .await
+            .unwrap();
+
+        let cache = read_cache(&store.path).await;
+        assert!(cache.entries.contains_key("github"));
+        assert!(cache.entries.contains_key("slack"));
+    }
+
+    #[tokio::test]
+    async fn cache_merge_drops_invalid_existing_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = cache_store(&dir);
+        store
+            .merge(BTreeMap::from([(
+                "github".to_string(),
+                cached_firewall("github", "https://api.github.com"),
+            )]))
+            .await
+            .unwrap();
+        let mut cache = read_cache(&store.path).await;
+        cache.entries.insert(
+            "bad".to_string(),
+            CachedBuiltinFirewall {
+                catalog_digest: "sha256:bad".to_string(),
+                catalog_version: "bad.1".to_string(),
+                firewall: json!({"name": "bad", "apis": "invalid"}),
+            },
+        );
+        let content = serde_json::to_vec(&cache).unwrap();
+        state_file::write_private_atomic(&store.path, &content)
+            .await
+            .unwrap();
+
+        store
+            .merge(BTreeMap::from([(
+                "slack".to_string(),
+                cached_firewall("slack", "https://slack.com/api"),
+            )]))
+            .await
+            .unwrap();
+
+        let cache = read_cache(&store.path).await;
+        assert!(cache.entries.contains_key("github"));
+        assert!(cache.entries.contains_key("slack"));
+        assert!(!cache.entries.contains_key("bad"));
+    }
+
+    #[tokio::test]
+    async fn invalid_required_response_is_not_cached() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = cache_store(&dir);
+        let response = BuiltinFirewallsResolveResponse {
+            catalog_digest: "sha256:test".to_string(),
+            catalog_version: "test.1".to_string(),
+            firewalls: BTreeMap::from([(
+                "github".to_string(),
+                json!({"name": "github", "apis": "not-a-list"}),
+            )]),
+        };
+
+        let error = validate_required_response(&["github".to_string()], response).unwrap_err();
+
+        assert!(error.to_string().contains("apis must be a list"));
+        assert!(!store.path.exists());
+    }
+
+    #[tokio::test]
+    async fn on_demand_refresh_preserves_raw_runtime_fields() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/api/runners/builtin-firewalls/resolve")
+                    .header("authorization", "Bearer runner-token")
+                    .json_body(json!({"names": ["github"]}));
+                then.status(200).json_body(json!({
+                    "catalogDigest": "sha256:live",
+                    "catalogVersion": "live.1",
+                    "firewalls": {
+                        "github": {
+                            "name": "github",
+                            "apis": [
+                                {
+                                    "base": "https://api.github.com",
+                                    "auth": {},
+                                    "hostPolicy": {"type": "fixed"}
+                                }
+                            ]
+                        }
+                    }
+                }));
+            })
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let handle = BuiltinFirewallRefreshHandle::new_with_interval(
+            ApiClient::new(http_client(server.base_url()), "runner-token".to_string()),
+            dir.path().join("builtin-firewall-cache.json"),
+            dir.path().join("builtin-firewall-cache.json.lock"),
+            Duration::from_secs(3600),
+        );
+        let firewalls = vec![FirewallEntry::Builtin {
+            name: "github".to_string(),
+            base_url_vars: None,
+        }];
+
+        handle
+            .ensure_firewalls_available(Some(&firewalls))
+            .await
+            .unwrap();
+        handle.shutdown().await;
+
+        mock.assert_async().await;
+        let cache = read_cache(&dir.path().join("builtin-firewall-cache.json")).await;
+        assert_eq!(cache.entries["github"].catalog_digest, "sha256:live");
+        assert_eq!(
+            cache.entries["github"].firewall["apis"][0]["hostPolicy"]["type"],
+            "fixed"
+        );
+    }
+
+    #[tokio::test]
+    async fn periodic_refresh_updates_active_builtin_names() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/api/runners/builtin-firewalls/resolve")
+                    .json_body(json!({"names": ["github"]}));
+                then.status(200).json_body(json!({
+                    "catalogDigest": "sha256:periodic",
+                    "catalogVersion": "periodic.1",
+                    "firewalls": {
+                        "github": {
+                            "name": "github",
+                            "apis": [{"base": "https://api.github.com", "auth": {}}]
+                        }
+                    }
+                }));
+            })
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("builtin-firewall-cache.json");
+        let handle = BuiltinFirewallRefreshHandle::new_with_interval(
+            ApiClient::new(http_client(server.base_url()), "runner-token".to_string()),
+            cache_path.clone(),
+            dir.path().join("builtin-firewall-cache.json.lock"),
+            Duration::from_millis(20),
+        );
+        let firewalls = vec![FirewallEntry::Builtin {
+            name: "github".to_string(),
+            base_url_vars: None,
+        }];
+
+        handle.register_run(RunId::new_v4(), Some(&firewalls)).await;
+        wait_for_cache_entry(&cache_path, "github").await;
+        handle.shutdown().await;
+
+        assert!(mock.calls_async().await >= 1);
+    }
+
+    #[tokio::test]
+    async fn periodic_refresh_skips_invalid_entries_without_overwriting_cache() {
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path("/api/runners/builtin-firewalls/resolve")
+                    .json_body(json!({"names": ["github"]}));
+                then.status(200).json_body(json!({
+                    "catalogDigest": "sha256:invalid",
+                    "catalogVersion": "invalid.1",
+                    "firewalls": {
+                        "github": {"name": "github", "apis": "bad"}
+                    }
+                }));
+            })
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("builtin-firewall-cache.json");
+        let store = BuiltinFirewallCacheStore {
+            path: cache_path.clone(),
+            lock_path: dir.path().join("builtin-firewall-cache.json.lock"),
+        };
+        store
+            .merge(BTreeMap::from([(
+                "github".to_string(),
+                cached_firewall("github", "https://old.example.com"),
+            )]))
+            .await
+            .unwrap();
+        let handle = BuiltinFirewallRefreshHandle::new_with_interval(
+            ApiClient::new(http_client(server.base_url()), "runner-token".to_string()),
+            cache_path.clone(),
+            dir.path().join("builtin-firewall-cache.json.lock"),
+            Duration::from_secs(3600),
+        );
+        let firewalls = vec![FirewallEntry::Builtin {
+            name: "github".to_string(),
+            base_url_vars: None,
+        }];
+
+        handle.register_run(RunId::new_v4(), Some(&firewalls)).await;
+        handle.core.refresh_active_names().await;
+        handle.shutdown().await;
+
+        let cache = read_cache(&cache_path).await;
+        assert_eq!(
+            cache.entries["github"].firewall["apis"][0]["base"],
+            "https://old.example.com"
+        );
+    }
+
+    async fn wait_for_cache_entry(path: &std::path::Path, name: &str) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Ok(content) = tokio::fs::read_to_string(path).await
+                && let Ok(cache) = serde_json::from_str::<BuiltinFirewallCatalogCache>(&content)
+                && cache.entries.contains_key(name)
+            {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "cache entry {name} was not written"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+}

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -7,12 +7,14 @@
 mod api;
 mod api_ably_supervisor;
 mod api_direct_candidates;
+mod builtin_firewall_refresh;
 mod local;
 #[cfg(test)]
 pub mod mock;
 mod network_policy_refresh;
 
 pub use api::ApiProvider;
+pub(crate) use builtin_firewall_refresh::BuiltinFirewallRefreshHandle;
 pub use local::LocalProvider;
 pub(crate) use network_policy_refresh::{
     NetworkPolicyRefreshHandle, NetworkPolicyRefreshRegistration,

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -45,6 +45,8 @@ pub struct ProxyConfig {
     pub registry_path: PathBuf,
     /// Lock file path for coordinating concurrent registry access.
     pub registry_lock_path: PathBuf,
+    /// Local builtin firewall catalog cache path read by the addon.
+    pub builtin_firewall_catalog_cache_path: Option<PathBuf>,
     /// VM0 API URL passed to the addon (optional).
     pub api_url: Option<String>,
 }
@@ -427,6 +429,7 @@ impl MitmProxy {
                     addon_dir: std::path::PathBuf::new(),
                     registry_path: std::path::PathBuf::new(),
                     registry_lock_path: std::path::PathBuf::new(),
+                    builtin_firewall_catalog_cache_path: None,
                     api_url: None,
                 },
                 child: None,
@@ -524,6 +527,12 @@ pub(crate) async fn spawn_mitmdump(
             "ssl_verify_upstream_trusted_ca={}",
             crate::deps::SYSTEM_CA_BUNDLE
         ));
+    if let Some(path) = &config.builtin_firewall_catalog_cache_path {
+        cmd.arg("--set").arg(format!(
+            "vm0_builtin_firewall_catalog_cache_path={}",
+            path.display()
+        ));
+    }
     if let Some(url) = &config.api_url {
         cmd.arg("--set").arg(format!("vm0_api_url={url}"));
     }
@@ -873,6 +882,7 @@ PY
             "body_capture.py",
             "body_decoding.py",
             "body_limits.py",
+            "builtin_firewall_catalog.py",
             "flow_metadata_keys.py",
             "generated/__init__.py",
             "generated/builtin_firewalls/__init__.py",
@@ -954,6 +964,7 @@ PY
             addon_dir: addon_dir.clone(),
             registry_path: dir.path().join("proxy-registry.json"),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            builtin_firewall_catalog_cache_path: None,
             api_url: None,
         };
 
@@ -981,6 +992,7 @@ PY
             addon_dir: addon_dir.clone(),
             registry_path: registry_path.clone(),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            builtin_firewall_catalog_cache_path: None,
             api_url: None,
         };
 
@@ -1056,6 +1068,9 @@ PY
             addon_dir: dir.path().join("addon"),
             registry_path: dir.path().join("proxy-registry.json"),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            builtin_firewall_catalog_cache_path: Some(
+                dir.path().join("builtin-firewall-cache.json"),
+            ),
             api_url: None,
         };
         let (crash_tx, _crash_rx) = mpsc::channel(1);
@@ -1075,6 +1090,13 @@ PY
             "mitmdump args should include vm0_usage_state_id option; got:\n{args}",
         );
         assert!(
+            args.lines().any(|arg| {
+                arg.starts_with("vm0_builtin_firewall_catalog_cache_path=")
+                    && arg.ends_with("builtin-firewall-cache.json")
+            }),
+            "mitmdump args should include builtin firewall cache path; got:\n{args}",
+        );
+        assert!(
             args.lines().all(|arg| arg != "connection_strategy=lazy"),
             "mitmdump args must not use global lazy upstream connections because server-first TCP protocols must keep working; got:\n{args}",
         );
@@ -1092,6 +1114,7 @@ PY
             addon_dir: dir.path().join("addon"),
             registry_path: dir.path().join("proxy-registry.json"),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            builtin_firewall_catalog_cache_path: None,
             api_url: None,
         };
         let (crash_tx, _crash_rx) = mpsc::channel(1);


### PR DESCRIPTION
## Summary
- add a runner-side builtin firewall refresh handle that resolves compact builtin firewall refs through the vm0 API and writes a validated private local cache atomically
- pass the local cache path to mitm-addon only for API-backed runners, and keep local/benchmark paths on the bundled catalog
- teach mitm-addon to prefer valid local cache entries, fall back to bundled generated firewalls, and reload registry state when the cache file changes

Closes #20354

## Tests
- cargo test -p runner builtin_firewall -- --nocapture
- cargo test -p runner spawn_mitmdump_passes_usage_state_id_option -- --nocapture
- cargo test -p runner addon_scripts_are_embedded -- --nocapture
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/python -m basedpyright -p .
- ./.venv/bin/python -m pytest tests/test_builtin_firewall_catalog_cache.py tests/test_addon_configuration.py -v