### PR TITLE
chore(rust): update crossbeam, rustversion, and zerocopy dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -914,18 +914,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -2749,9 +2749,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -4168,18 +4168,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Updated the Rust workspace lockfile in `crates/Cargo.lock`.

Resolved dependency updates:
- `crossbeam-channel` `0.5.15 -> 0.5.16`
- `crossbeam-utils` `0.8.21 -> 0.8.22`
- `rustversion` `1.0.22 -> 1.0.23`
- `zerocopy` `0.8.52 -> 0.8.53`
- `zerocopy-derive` `0.8.52 -> 0.8.53`

This branch was refreshed onto the latest `main` after the base advanced, keeping the dependency update as a lockfile-only change.

## Dependencies Not Updated

- `generic-array` remains at `0.14.7` while `0.14.9` is available. This is blocked by transitive `crypto-common v0.1.7`, which requires `generic-array = "=0.14.7"` through the `digest v0.10.7` dependency path. There is no direct workspace `Cargo.toml` dependency to safely bump for this package.

## Manual Version Bumps

None. No `Cargo.toml` files were changed.

## Verification

Passed:
- `cargo fmt --check`
- `umask 0022 && CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target-rerun-2026-07-07 TMPDIR=/home/user/workspace/t CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --workspace`

Note: the first local full-workspace test attempt used a longer `TMPDIR` and one `guest-agent` Unix-socket path exceeded `SUN_LEN`. The targeted rerun of that test passed with the shorter `TMPDIR`, and the full workspace test passed with the same shorter `TMPDIR`.
