### PR TITLE
test: isolate codex resume fixtures

### DIFF
--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -39,11 +39,18 @@ impl CodexResumeFixture {
             .path()
             .file_name()
             .and_then(|name| name.to_str())
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(|| "unknown".to_string());
+            .ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "tempdir path has no utf-8 file name: {}",
+                    home.path().display()
+                ))
+            })?
+            .to_string();
         let run_id_suffix = home_name
             .strip_prefix("codex-resume-home-")
-            .unwrap_or(&home_name);
+            .ok_or_else(|| {
+                std::io::Error::other(format!("unexpected tempdir name: {home_name}"))
+            })?;
         let run_id = format!("codex-resume-{run_id_suffix}");
         let runtime_dir = home
             .path()
@@ -289,10 +296,9 @@ fn recovery_checkpoint_derives_missing_codex_history_marker() -> TestResult {
         paths: fixture.paths().clone(),
         http,
     };
-    let result = runtime
-        .block_on(guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&guest_runtime));
-
-    assert!(result.is_ok());
+    runtime.block_on(
+        guest_agent::checkpoint::create_recovery_checkpoint_for_runtime(&guest_runtime),
+    )?;
     prepare_mock.assert_calls(1);
     upload_mock.assert_calls(1);
     checkpoint_mock.assert_calls(1);

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -35,23 +35,7 @@ impl CodexResumeFixture {
         let home = tempfile::Builder::new()
             .prefix("codex-resume-home-")
             .tempdir()?;
-        let home_name = home
-            .path()
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| {
-                std::io::Error::other(format!(
-                    "tempdir path has no utf-8 file name: {}",
-                    home.path().display()
-                ))
-            })?
-            .to_string();
-        let run_id_suffix = home_name
-            .strip_prefix("codex-resume-home-")
-            .ok_or_else(|| {
-                std::io::Error::other(format!("unexpected tempdir name: {home_name}"))
-            })?;
-        let run_id = format!("codex-resume-{run_id_suffix}");
+        let run_id = "codex-resume-test".to_string();
         let runtime_dir = home
             .path()
             .join(".vm0")

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -1,4 +1,4 @@
-//! Integration tests for codex session-resume metadata capture.
+//! Integration tests for Codex session-resume metadata capture.
 //!
 //! # Why a dedicated test binary
 //!
@@ -6,153 +6,132 @@
 //! binary keeps Codex metadata tests separate so their setup can stay focused
 //! on Codex config and file layout.
 //!
-//! Each test serialises behind a `std::sync::Mutex` because they touch the same
-//! on-disk session-id / history-path files.
-//!
 //! # Coverage
 //!
-//! - End-to-end `send_event` → session metadata capture → marker write for the
-//!   codex `thread.started` event shape.
+//! - End-to-end `send_event` -> session metadata capture -> marker write for the
+//!   Codex `thread.started` event shape.
 //! - Checkpoint metadata remains repairable after a partial metadata write.
 //! - Invalid/non-Codex events do not persist Codex session metadata.
 
 mod common;
 
-use common::SystemLogOverrideGuard;
+use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
 use serde_json::json;
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
-use guest_agent::masker::SecretMasker;
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
-static CODEX_RESUME_HOME: LazyLock<PathBuf> =
-    LazyLock::new(|| common::unique_temp_path("codex-resume-home"));
-static CODEX_RESUME_RUN_ID: LazyLock<String> =
-    LazyLock::new(|| format!("codex-resume-{}", std::process::id()));
-
-/// Serialise tests — they share the run-id-scoped runtime metadata files
-/// written by session metadata capture.
-static TEST_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-fn send_event_for_test(
-    event: serde_json::Value,
-    seq: u32,
-    masker: &SecretMasker,
-) -> Result<(), guest_agent::error::AgentError> {
-    let config = codex_resume_config("http://127.0.0.1:1", "")
-        .map_err(guest_agent::error::AgentError::Execution)?;
-    let paths = codex_resume_paths();
-    let http = guest_agent::http::HttpClient::for_config(&config)?;
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()?;
-    runtime.block_on(guest_agent::events::send_event_for_config(
-        &http, event, seq, masker, &config, &paths,
-    ))
+struct CodexResumeFixture {
+    home: tempfile::TempDir,
+    run_id: String,
+    runtime_dir: PathBuf,
+    paths: guest_agent::paths::GuestPaths,
 }
 
-fn codex_resume_paths() -> guest_agent::paths::GuestPaths {
-    guest_agent::paths::GuestPaths::from_runtime_dir(codex_resume_runtime_dir())
-}
+impl CodexResumeFixture {
+    fn new() -> TestResult<Self> {
+        let home = tempfile::Builder::new()
+            .prefix("codex-resume-home-")
+            .tempdir()?;
+        let home_name = home
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| "unknown".to_string());
+        let run_id_suffix = home_name
+            .strip_prefix("codex-resume-home-")
+            .unwrap_or(&home_name);
+        let run_id = format!("codex-resume-{run_id_suffix}");
+        let runtime_dir = home
+            .path()
+            .join(".vm0")
+            .join("guest-agent")
+            .join("runs")
+            .join(&run_id);
+        let paths = guest_agent::paths::GuestPaths::from_runtime_dir(&runtime_dir);
 
-fn codex_resume_runtime_dir() -> PathBuf {
-    CODEX_RESUME_HOME
-        .join(".vm0")
-        .join("guest-agent")
-        .join("runs")
-        .join(CODEX_RESUME_RUN_ID.as_str())
-}
-
-fn codex_resume_config(
-    api_url: &str,
-    api_token: &str,
-) -> Result<guest_agent::env::GuestConfig, String> {
-    let runtime_dir = codex_resume_runtime_dir();
-    let run_payload_file = common::write_run_payload_file_for_test(
-        &runtime_dir,
-        &guest_contracts::env::RunPayload {
-            prompt: "test prompt".to_string(),
-            ..guest_contracts::env::RunPayload::default()
-        },
-    )?;
-    guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
-        run_id: CODEX_RESUME_RUN_ID.clone(),
-        api_url: api_url.to_string(),
-        api_token: api_token.to_string(),
-        sandbox_id: "00000000-0000-4000-8000-000000000abc".to_string(),
-        sandbox_reuse_result: "reused".to_string(),
-        cli_agent_type: "codex".to_string(),
-        home: Some(CODEX_RESUME_HOME.to_string_lossy().into_owned()),
-        run_payload_file: run_payload_file.to_string_lossy().into_owned(),
-        guest_runtime_dir: Some(runtime_dir),
-        ..Default::default()
-    })
-}
-
-fn session_file_paths() -> (String, String) {
-    let paths = codex_resume_paths();
-    (
-        paths.session_id_file().to_string(),
-        paths.session_history_path_file().to_string(),
-    )
-}
-
-/// Wipe the per-run session-id / history-path files so each test starts
-/// from a clean slate. Session metadata capture is idempotent (first id wins),
-/// so leaving stale files would mask real failures.
-fn reset_session_files() {
-    let (session_id_file, session_history_path_file) = session_file_paths();
-    let _ = std::fs::remove_file(session_id_file);
-    let _ = std::fs::remove_file(session_history_path_file);
-}
-
-struct CodexResumeFilesGuard;
-
-impl CodexResumeFilesGuard {
-    fn new() -> Self {
-        cleanup_codex_resume_files();
-        Self
+        Ok(Self {
+            home,
+            run_id,
+            runtime_dir,
+            paths,
+        })
     }
-}
 
-impl Drop for CodexResumeFilesGuard {
-    fn drop(&mut self) {
-        cleanup_codex_resume_files();
+    fn paths(&self) -> &guest_agent::paths::GuestPaths {
+        &self.paths
     }
-}
 
-fn cleanup_codex_resume_files() {
-    reset_session_files();
-    let home = CODEX_RESUME_HOME.as_path();
-    let is_test_home = home
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| name.starts_with("codex-resume-home-"))
-        .unwrap_or(false);
-    if is_test_home && home.starts_with(std::env::temp_dir()) {
-        let _ = std::fs::remove_dir_all(home);
+    fn config(&self, api_url: &str, api_token: &str) -> TestResult<guest_agent::env::GuestConfig> {
+        let run_payload_file = common::write_run_payload_file_for_test(
+            &self.runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "test prompt".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )
+        .map_err(std::io::Error::other)?;
+        let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
+            run_id: self.run_id.clone(),
+            api_url: api_url.to_string(),
+            api_token: api_token.to_string(),
+            sandbox_id: "00000000-0000-4000-8000-000000000abc".to_string(),
+            sandbox_reuse_result: "reused".to_string(),
+            cli_agent_type: "codex".to_string(),
+            home: Some(self.home.path().to_string_lossy().into_owned()),
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(self.runtime_dir.clone()),
+            ..Default::default()
+        })
+        .map_err(std::io::Error::other)?;
+        Ok(config)
     }
-}
 
-fn write_codex_session_file(thread_id: &str, history: &str) -> Result<(), String> {
-    let id_no_dashes = thread_id.replace('-', "");
-    let path = CODEX_RESUME_HOME
-        .join(".codex")
-        .join("sessions")
-        .join("2026")
-        .join("06")
-        .join("18")
-        .join(format!("rollout-2026-06-18T10-00-00-{id_no_dashes}.jsonl"));
-    let parent = path
-        .parent()
-        .ok_or_else(|| format!("session path has no parent: {}", path.display()))?;
-    std::fs::create_dir_all(parent)
-        .map_err(|e| format!("create codex session dir {}: {e}", parent.display()))?;
-    std::fs::write(&path, history)
-        .map_err(|e| format!("write codex session history {}: {e}", path.display()))?;
-    Ok(())
+    fn send_event(&self, event: serde_json::Value, seq: u32, masker: &SecretMasker) -> TestResult {
+        let config = self.config("http://127.0.0.1:1", "")?;
+        let http = guest_agent::http::HttpClient::for_config(&config)?;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(guest_agent::events::send_event_for_config(
+            &http,
+            event,
+            seq,
+            masker,
+            &config,
+            &self.paths,
+        ))?;
+        Ok(())
+    }
+
+    fn session_file_paths(&self) -> (&str, &str) {
+        (
+            self.paths.session_id_file(),
+            self.paths.session_history_path_file(),
+        )
+    }
+
+    fn write_codex_session_file(&self, thread_id: &str, history: &str) -> TestResult {
+        let id_no_dashes = thread_id.replace('-', "");
+        let path = self
+            .home
+            .path()
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("06")
+            .join("18")
+            .join(format!("rollout-2026-06-18T10-00-00-{id_no_dashes}.jsonl"));
+        let parent = path.parent().ok_or_else(|| {
+            std::io::Error::other(format!("session path has no parent: {}", path.display()))
+        })?;
+        std::fs::create_dir_all(parent)?;
+        std::fs::write(&path, history)?;
+        Ok(())
+    }
 }
 
 fn checkpoint_http_client(
@@ -167,13 +146,8 @@ fn checkpoint_http_client(
 }
 
 #[test]
-fn send_event_extracts_codex_thread_id_and_writes_marker() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _files_guard = CodexResumeFilesGuard::new();
-    let tmp = tempfile::tempdir().unwrap();
-    let system_log_path = tmp.path().join("system.log");
-    let _system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
-
+fn send_event_extracts_codex_thread_id_and_writes_marker() -> TestResult {
+    let fixture = CodexResumeFixture::new()?;
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     let masker = SecretMasker::from_raw("");
     let event = json!({
@@ -183,18 +157,13 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
 
     // No API token -> send_event skips the HTTP POST but still captures
     // session metadata, which is the part we want to assert.
-    let result = send_event_for_test(event, 1, &masker);
-    assert!(
-        result.is_ok(),
-        "send_event should succeed when no API token"
-    );
+    fixture.send_event(event, 1, &masker)?;
 
-    let (session_id_file, session_history_path_file) = session_file_paths();
-    let stored_id = std::fs::read_to_string(&session_id_file).expect("session id written");
+    let (session_id_file, session_history_path_file) = fixture.session_file_paths();
+    let stored_id = std::fs::read_to_string(session_id_file)?;
     assert_eq!(stored_id, thread_id);
 
-    let marker =
-        std::fs::read_to_string(&session_history_path_file).expect("history-path file written");
+    let marker = std::fs::read_to_string(session_history_path_file)?;
     assert!(
         marker.starts_with("CODEX_SEARCH:"),
         "codex framework should write a marker, got: {marker}"
@@ -208,31 +177,12 @@ fn send_event_extracts_codex_thread_id_and_writes_marker() {
         "marker should end with the thread id, got: {marker}"
     );
     assert_eq!(masker.mask_string(thread_id), thread_id);
-
-    let system_log = std::fs::read_to_string(&system_log_path).expect("system log written");
-    assert!(
-        system_log.contains("Session history marker written to"),
-        "system log should confirm marker creation, got: {system_log}"
-    );
-    assert!(
-        !system_log.contains(thread_id),
-        "system log must not contain the raw thread id, got: {system_log}"
-    );
-    assert!(
-        !system_log.contains("CODEX_SEARCH"),
-        "system log must not contain the codex marker payload, got: {system_log}"
-    );
-    assert!(
-        !system_log.contains(&marker),
-        "system log must not contain the full marker payload, got: {system_log}"
-    );
+    Ok(())
 }
 
 #[test]
-fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _files_guard = CodexResumeFilesGuard::new();
-
+fn send_event_canonicalizes_codex_thread_id_before_writing_marker() -> TestResult {
+    let fixture = CodexResumeFixture::new()?;
     let masker = SecretMasker::from_raw("");
     let event = json!({
         "type": "thread.started",
@@ -240,41 +190,32 @@ fn send_event_canonicalizes_codex_thread_id_before_writing_marker() {
     });
     let expected = "0193abcd-ef01-7234-89ab-cdef01234567";
 
-    let result = send_event_for_test(event, 1, &masker);
-    assert!(
-        result.is_ok(),
-        "send_event should succeed when no API token"
-    );
+    fixture.send_event(event, 1, &masker)?;
 
-    let (session_id_file, session_history_path_file) = session_file_paths();
-    let stored_id = std::fs::read_to_string(&session_id_file).expect("session id written");
+    let (session_id_file, session_history_path_file) = fixture.session_file_paths();
+    let stored_id = std::fs::read_to_string(session_id_file)?;
     assert_eq!(stored_id, expected);
 
-    let marker =
-        std::fs::read_to_string(&session_history_path_file).expect("history-path file written");
+    let marker = std::fs::read_to_string(session_history_path_file)?;
     assert!(
         marker.ends_with(&format!(":{expected}")),
         "marker should use canonical thread id, got: {marker}"
     );
+    Ok(())
 }
 
 #[test]
-fn send_event_keeps_existing_codex_thread_id_without_repairing_history_marker() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _files_guard = CodexResumeFilesGuard::new();
-
+fn send_event_keeps_existing_codex_thread_id_without_repairing_history_marker() -> TestResult {
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     for seed_empty_marker in [false, true] {
-        reset_session_files();
-        let (session_id_file, session_history_path_file) = session_file_paths();
-        guest_agent::paths::write_private(&session_id_file, thread_id)
-            .expect("seed existing session id");
+        let fixture = CodexResumeFixture::new()?;
+        let (session_id_file, session_history_path_file) = fixture.session_file_paths();
+        guest_agent::paths::write_private(session_id_file, thread_id)?;
         if seed_empty_marker {
-            guest_agent::paths::write_private(&session_history_path_file, "")
-                .expect("seed empty history marker");
+            guest_agent::paths::write_private(session_history_path_file, "")?;
         } else {
             assert!(
-                !Path::new(&session_history_path_file).exists(),
+                !Path::new(session_history_path_file).exists(),
                 "history marker should start missing"
             );
         }
@@ -282,43 +223,39 @@ fn send_event_keeps_existing_codex_thread_id_without_repairing_history_marker() 
         let masker = SecretMasker::from_raw("");
         let event = json!({"type": "turn.completed"});
 
-        let result = send_event_for_test(event, 1, &masker);
-        assert!(result.is_ok());
+        fixture.send_event(event, 1, &masker)?;
 
-        let stored_id = std::fs::read_to_string(&session_id_file).expect("session id kept");
+        let stored_id = std::fs::read_to_string(session_id_file)?;
         assert_eq!(stored_id, thread_id);
         if seed_empty_marker {
             assert_eq!(
-                std::fs::read_to_string(&session_history_path_file).unwrap(),
+                std::fs::read_to_string(session_history_path_file)?,
                 "",
                 "ordinary events must not repair empty history markers"
             );
         } else {
             assert!(
-                !Path::new(&session_history_path_file).exists(),
+                !Path::new(session_history_path_file).exists(),
                 "ordinary events must not create missing history markers"
             );
         }
         assert_eq!(masker.mask_string(thread_id), thread_id);
     }
+    Ok(())
 }
 
 #[test]
-fn recovery_checkpoint_derives_missing_codex_history_marker() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _files_guard = CodexResumeFilesGuard::new();
-
+fn recovery_checkpoint_derives_missing_codex_history_marker() -> TestResult {
+    let fixture = CodexResumeFixture::new()?;
     let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
     let history = r#"{"type":"thread.started"}"#.to_string() + "\n";
-    let (session_id_file, _) = session_file_paths();
-    guest_agent::paths::write_private(&session_id_file, thread_id)
-        .expect("seed existing session id");
-    write_codex_session_file(thread_id, &history).unwrap();
+    let (session_id_file, _) = fixture.session_file_paths();
+    guest_agent::paths::write_private(session_id_file, thread_id)?;
+    fixture.write_codex_session_file(thread_id, &history)?;
 
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
-        .build()
-        .expect("build runtime");
+        .build()?;
     let server = MockServer::start();
     let prepare_mock = server.mock(|when, then| {
         when.method(POST)
@@ -345,13 +282,11 @@ fn recovery_checkpoint_derives_missing_codex_history_marker() {
             .json_body(json!({"checkpointId": "codex-derived-checkpoint"}));
     });
 
-    let config =
-        codex_resume_config(&server.base_url(), "test-token").expect("build codex resume config");
-    let paths = codex_resume_paths();
-    let http = checkpoint_http_client(&server).expect("build http client");
+    let config = fixture.config(&server.base_url(), "test-token")?;
+    let http = checkpoint_http_client(&server)?;
     let guest_runtime = guest_agent::run_context::GuestRuntime {
         config,
-        paths,
+        paths: fixture.paths().clone(),
         http,
     };
     let result = runtime
@@ -361,65 +296,58 @@ fn recovery_checkpoint_derives_missing_codex_history_marker() {
     prepare_mock.assert_calls(1);
     upload_mock.assert_calls(1);
     checkpoint_mock.assert_calls(1);
+    Ok(())
 }
 
 #[test]
-fn send_event_codex_ignores_non_thread_started_event() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _files_guard = CodexResumeFilesGuard::new();
-
+fn send_event_codex_ignores_non_thread_started_event() -> TestResult {
+    let fixture = CodexResumeFixture::new()?;
     let masker = SecretMasker::from_raw("");
     let event = json!({"type": "turn.completed"});
-    let result = send_event_for_test(event, 1, &masker);
-    assert!(result.is_ok());
+    fixture.send_event(event, 1, &masker)?;
 
-    let (session_id_file, _) = session_file_paths();
+    let (session_id_file, _) = fixture.session_file_paths();
     assert!(
-        !Path::new(&session_id_file).exists(),
+        !Path::new(session_id_file).exists(),
         "session id file must not be written for non-thread.started events"
     );
+    Ok(())
 }
 
 #[test]
-fn send_event_codex_ignores_empty_thread_id() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _files_guard = CodexResumeFilesGuard::new();
-
+fn send_event_codex_ignores_empty_thread_id() -> TestResult {
+    let fixture = CodexResumeFixture::new()?;
     let masker = SecretMasker::from_raw("");
     let event = json!({"type": "thread.started", "thread_id": ""});
-    let result = send_event_for_test(event, 1, &masker);
-    assert!(result.is_ok());
+    fixture.send_event(event, 1, &masker)?;
 
-    let (session_id_file, _) = session_file_paths();
+    let (session_id_file, _) = fixture.session_file_paths();
     assert!(
-        !Path::new(&session_id_file).exists(),
+        !Path::new(session_id_file).exists(),
         "empty thread_id must not be persisted"
     );
+    Ok(())
 }
 
 #[test]
-fn send_event_codex_ignores_malformed_thread_id() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    let _files_guard = CodexResumeFilesGuard::new();
-
+fn send_event_codex_ignores_malformed_thread_id() -> TestResult {
     for thread_id in [
         "abc",
         "0193-abcd-ef01-7234-89abcdef01234567",
         "{0193abcd-ef01-7234-89ab-cdef01234567}",
         "urn:uuid:0193abcd-ef01-7234-89ab-cdef01234567",
     ] {
-        reset_session_files();
-
+        let fixture = CodexResumeFixture::new()?;
         let masker = SecretMasker::from_raw("");
         let event = json!({"type": "thread.started", "thread_id": thread_id});
-        let result = send_event_for_test(event, 1, &masker);
-        assert!(result.is_ok());
+        fixture.send_event(event, 1, &masker)?;
 
-        let (session_id_file, _) = session_file_paths();
+        let (session_id_file, _) = fixture.session_file_paths();
         assert!(
-            !Path::new(&session_id_file).exists(),
+            !Path::new(session_id_file).exists(),
             "malformed thread_id must not be persisted: {thread_id}"
         );
         assert_eq!(masker.mask_string(thread_id), thread_id);
     }
+    Ok(())
 }

--- a/crates/guest-agent/tests/codex_session_resume_logging.rs
+++ b/crates/guest-agent/tests/codex_session_resume_logging.rs
@@ -24,23 +24,7 @@ impl CodexResumeLogFixture {
         let home = tempfile::Builder::new()
             .prefix("codex-resume-log-home-")
             .tempdir()?;
-        let home_name = home
-            .path()
-            .file_name()
-            .and_then(|name| name.to_str())
-            .ok_or_else(|| {
-                std::io::Error::other(format!(
-                    "tempdir path has no utf-8 file name: {}",
-                    home.path().display()
-                ))
-            })?
-            .to_string();
-        let run_id_suffix = home_name
-            .strip_prefix("codex-resume-log-home-")
-            .ok_or_else(|| {
-                std::io::Error::other(format!("unexpected tempdir name: {home_name}"))
-            })?;
-        let run_id = format!("codex-resume-log-{run_id_suffix}");
+        let run_id = "codex-resume-log-test".to_string();
         let runtime_dir = home
             .path()
             .join(".vm0")

--- a/crates/guest-agent/tests/codex_session_resume_logging.rs
+++ b/crates/guest-agent/tests/codex_session_resume_logging.rs
@@ -1,0 +1,132 @@
+//! Codex session-resume marker logging should not expose session identifiers.
+//!
+//! This test lives in its own binary because `SystemLogOverrideGuard` configures
+//! a process-global system log sink.
+
+mod common;
+
+use common::SystemLogOverrideGuard;
+use guest_agent::masker::SecretMasker;
+use serde_json::json;
+use std::path::PathBuf;
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+struct CodexResumeLogFixture {
+    home: tempfile::TempDir,
+    run_id: String,
+    runtime_dir: PathBuf,
+    paths: guest_agent::paths::GuestPaths,
+}
+
+impl CodexResumeLogFixture {
+    fn new() -> TestResult<Self> {
+        let home = tempfile::Builder::new()
+            .prefix("codex-resume-log-home-")
+            .tempdir()?;
+        let home_name = home
+            .path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| "unknown".to_string());
+        let run_id_suffix = home_name
+            .strip_prefix("codex-resume-log-home-")
+            .unwrap_or(&home_name);
+        let run_id = format!("codex-resume-log-{run_id_suffix}");
+        let runtime_dir = home
+            .path()
+            .join(".vm0")
+            .join("guest-agent")
+            .join("runs")
+            .join(&run_id);
+        let paths = guest_agent::paths::GuestPaths::from_runtime_dir(&runtime_dir);
+
+        Ok(Self {
+            home,
+            run_id,
+            runtime_dir,
+            paths,
+        })
+    }
+
+    fn config(&self) -> TestResult<guest_agent::env::GuestConfig> {
+        let run_payload_file = common::write_run_payload_file_for_test(
+            &self.runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: "test prompt".to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )
+        .map_err(std::io::Error::other)?;
+        let config = guest_agent::env::GuestConfig::from_raw(guest_agent::env::GuestConfigRaw {
+            run_id: self.run_id.clone(),
+            api_url: "http://127.0.0.1:1".to_string(),
+            api_token: "".to_string(),
+            sandbox_id: "00000000-0000-4000-8000-000000000abc".to_string(),
+            sandbox_reuse_result: "reused".to_string(),
+            cli_agent_type: "codex".to_string(),
+            home: Some(self.home.path().to_string_lossy().into_owned()),
+            run_payload_file: run_payload_file.to_string_lossy().into_owned(),
+            guest_runtime_dir: Some(self.runtime_dir.clone()),
+            ..Default::default()
+        })
+        .map_err(std::io::Error::other)?;
+        Ok(config)
+    }
+
+    fn send_event(&self, event: serde_json::Value, masker: &SecretMasker) -> TestResult {
+        let config = self.config()?;
+        let http = guest_agent::http::HttpClient::for_config(&config)?;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(guest_agent::events::send_event_for_config(
+            &http,
+            event,
+            1,
+            masker,
+            &config,
+            &self.paths,
+        ))?;
+        Ok(())
+    }
+}
+
+#[test]
+fn codex_session_marker_log_does_not_leak_thread_id_or_marker_payload() -> TestResult {
+    let fixture = CodexResumeLogFixture::new()?;
+    let log_dir = tempfile::tempdir()?;
+    let system_log_path = log_dir.path().join("system.log");
+    let system_log_guard = SystemLogOverrideGuard::set(&system_log_path);
+
+    let thread_id = "0193abcd-ef01-7234-89ab-cdef01234567";
+    let masker = SecretMasker::from_raw("");
+    let event = json!({
+        "type": "thread.started",
+        "thread_id": thread_id
+    });
+
+    fixture.send_event(event, &masker)?;
+
+    let marker = std::fs::read_to_string(fixture.paths.session_history_path_file())?;
+    drop(system_log_guard);
+    let system_log = std::fs::read_to_string(&system_log_path)?;
+    assert!(
+        system_log.contains("Session history marker written to"),
+        "system log should confirm marker creation, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(thread_id),
+        "system log must not contain the raw thread id, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains("CODEX_SEARCH"),
+        "system log must not contain the codex marker payload, got: {system_log}"
+    );
+    assert!(
+        !system_log.contains(&marker),
+        "system log must not contain the full marker payload, got: {system_log}"
+    );
+    Ok(())
+}

--- a/crates/guest-agent/tests/codex_session_resume_logging.rs
+++ b/crates/guest-agent/tests/codex_session_resume_logging.rs
@@ -28,11 +28,18 @@ impl CodexResumeLogFixture {
             .path()
             .file_name()
             .and_then(|name| name.to_str())
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(|| "unknown".to_string());
+            .ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "tempdir path has no utf-8 file name: {}",
+                    home.path().display()
+                ))
+            })?
+            .to_string();
         let run_id_suffix = home_name
             .strip_prefix("codex-resume-log-home-")
-            .unwrap_or(&home_name);
+            .ok_or_else(|| {
+                std::io::Error::other(format!("unexpected tempdir name: {home_name}"))
+            })?;
         let run_id = format!("codex-resume-log-{run_id_suffix}");
         let runtime_dir = home
             .path()


### PR DESCRIPTION
## Summary
- isolate Codex session-resume tests with per-test temp home/runtime directories
- move process-global system log assertions into a dedicated integration test binary
- remove shared run-id cleanup and the cross-test mutex from the resume fixture tests

Closes #20321

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all --check
- cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --tests -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p guest-agent --quiet