### PR TITLE
feat: restore ctrl+shift+1-9 chat thread status emoji shortcuts

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -9,10 +9,13 @@ import {
 } from "./chat-thread-panes.ts";
 import type { ChatThreadSignals } from "./chat-thread-signals.ts";
 import {
+  clearChatThreadEmojiFromThreadMeta$,
   openRenameChatThreadDialogFromThreadMeta$,
+  setChatThreadEmojiFromThreadMeta$,
   type RenameChatThreadDialogRequest,
 } from "./chat-thread-rename.ts";
 import { chatThreadMetaMap$ } from "./chat-thread-event-sourcing.ts";
+import { CHAT_THREAD_EMOJI_OPTIONS } from "./chat-thread-title.ts";
 import type { ScrollStepDirection } from "../auto-scroll.ts";
 import { onRef } from "../utils.ts";
 import { openChatThreadEmojiMenu$ } from "../zero-page/zero-sidebar-state.ts";
@@ -185,12 +188,14 @@ function setupKeyboardScrollPrepareListener({
 }
 
 interface ChatPageShortcutActions {
+  clearEmoji: () => void | Promise<void>;
   openEmojiMenu: () => void | Promise<void>;
   renameThread: () => void | Promise<void>;
   navigateNext: () => void | Promise<void>;
   navigatePrev: () => void | Promise<void>;
   scrollBottom: () => void | Promise<void>;
   scrollTop: () => void | Promise<void>;
+  setEmoji: (emoji: string) => void | Promise<void>;
 }
 
 interface ChatPageShortcutSetup {
@@ -219,6 +224,48 @@ function setupChatPageGlobalShortcutListener({
   });
 }
 
+const setFocusedThreadEmoji$ = command(
+  async (
+    { get, set },
+    args: {
+      thread: ChatThreadSignals;
+      emoji: string;
+    },
+    signal: AbortSignal,
+  ) => {
+    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
+      return;
+    }
+    await set(
+      setChatThreadEmojiFromThreadMeta$,
+      {
+        threadId: args.thread.threadId,
+        emoji: args.emoji,
+      },
+      signal,
+    );
+  },
+);
+
+const clearFocusedThreadEmoji$ = command(
+  async (
+    { get, set },
+    args: { thread: ChatThreadSignals },
+    signal: AbortSignal,
+  ) => {
+    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
+      return;
+    }
+    await set(
+      clearChatThreadEmojiFromThreadMeta$,
+      {
+        threadId: args.thread.threadId,
+      },
+      signal,
+    );
+  },
+);
+
 const setupChatPageShortcutActions$ = command(
   (
     { get, set },
@@ -227,6 +274,12 @@ const setupChatPageShortcutActions$ = command(
   ) => {
     setupChatPageGlobalShortcutListener({
       actions: {
+        clearEmoji: async () => {
+          const thread = focusedThread();
+          if (thread) {
+            await set(clearFocusedThreadEmoji$, { thread }, signal);
+          }
+        },
         openEmojiMenu: async () => {
           const thread = focusedThread();
           if (thread) {
@@ -266,6 +319,12 @@ const setupChatPageShortcutActions$ = command(
           const thread = focusedThread();
           if (thread) {
             set(scrollCurrentThread$, thread, "top");
+          }
+        },
+        setEmoji: async (emoji) => {
+          const thread = focusedThread();
+          if (thread) {
+            await set(setFocusedThreadEmoji$, { thread, emoji }, signal);
           }
         },
       },
@@ -313,13 +372,43 @@ const renameDialogRequestForThread$ = command(
   },
 );
 
+function createEmojiShortcutBindings({
+  clearEmoji,
+  setEmoji,
+}: {
+  clearEmoji: () => void | Promise<void>;
+  setEmoji: (emoji: string) => void | Promise<void>;
+}): GlobalShortcutBindings {
+  return {
+    ...(Object.fromEntries(
+      CHAT_THREAD_EMOJI_OPTIONS.map((option, index) => {
+        return [
+          `ctrl+shift+${index + 1}`,
+          {
+            allowInEditableTarget: true,
+            run: async () => {
+              await setEmoji(option.emoji);
+            },
+          },
+        ];
+      }),
+    ) as GlobalShortcutBindings),
+    "ctrl+shift+0": {
+      allowInEditableTarget: true,
+      run: clearEmoji,
+    },
+  };
+}
+
 function createChatPageShortcutBindings({
+  clearEmoji,
   openEmojiMenu,
   renameThread,
   navigateNext,
   navigatePrev,
   scrollBottom,
   scrollTop,
+  setEmoji,
 }: ChatPageShortcutActions): GlobalShortcutBindings {
   return {
     "shift+f2": {
@@ -346,6 +435,7 @@ function createChatPageShortcutBindings({
       allowInEditableTarget: true,
       run: scrollBottom,
     },
+    ...createEmojiShortcutBindings({ clearEmoji, setEmoji }),
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-rename.ts
@@ -1,6 +1,11 @@
 import { command } from "ccstate";
 import { chatThreadMetaMap$ } from "./chat-thread-event-sourcing.ts";
 import { openRenameChatThreadDialog$ } from "../zero-page/zero-sidebar-state.ts";
+import { renameChatThread$ } from "./chat-message.ts";
+import {
+  applyChatThreadEmoji,
+  removeChatThreadEmoji,
+} from "./chat-thread-title.ts";
 
 export interface RenameChatThreadDialogRequest {
   readonly threadId: string;
@@ -29,6 +34,52 @@ export const openRenameChatThreadDialogForThreadId$ = command(
         title: meta?.title,
         agentId: meta?.agentId,
       },
+      signal,
+    );
+  },
+);
+
+export const setChatThreadEmojiFromThreadMeta$ = command(
+  async (
+    { get, set },
+    {
+      threadId,
+      emoji,
+      title,
+    }: { threadId: string; emoji: string; title?: string | null },
+    signal: AbortSignal,
+  ) => {
+    const meta = (await get(chatThreadMetaMap$)).get(threadId) ?? null;
+    signal.throwIfAborted();
+    const currentTitle = title !== undefined ? title : meta?.title;
+    await set(
+      renameChatThread$,
+      {
+        threadId,
+        title: applyChatThreadEmoji(currentTitle, emoji),
+        agentId: meta?.agentId,
+      },
+      signal,
+    );
+  },
+);
+
+export const clearChatThreadEmojiFromThreadMeta$ = command(
+  async (
+    { get, set },
+    { threadId, title }: { threadId: string; title?: string | null },
+    signal: AbortSignal,
+  ) => {
+    const meta = (await get(chatThreadMetaMap$)).get(threadId) ?? null;
+    signal.throwIfAborted();
+    const currentTitle = title !== undefined ? title : meta?.title;
+    const nextTitle = removeChatThreadEmoji(currentTitle);
+    if (!nextTitle) {
+      return;
+    }
+    await set(
+      renameChatThread$,
+      { threadId, title: nextTitle, agentId: meta?.agentId },
       signal,
     );
   },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3866,6 +3866,175 @@ describe("chat lifecycle", () => {
     });
   });
 
+  it("adds an emoji to the current chat directly with Ctrl+Shift+1", async () => {
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads({ currentDetailTitle: null });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/b0000000-0000-4000-a000-000000000708",
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+    });
+
+    const threadRegion = screen.getByLabelText("Chat thread");
+    threadRegion.focus();
+    fireEvent.keyDown(threadRegion, {
+      key: "!",
+      code: "Digit1",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        "b0000000-0000-4000-a000-000000000708",
+        "✅ Current keyboard thread",
+      );
+    });
+    expect(screen.queryByLabelText("Search emoji")).not.toBeInTheDocument();
+  });
+
+  it("adds an emoji to the focused side chat directly with Ctrl+Shift+1", async () => {
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads({ currentDetailTitle: null });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/b0000000-0000-4000-a000-000000000708?sidebar=b0000000-0000-4000-a000-000000000709",
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Next thread launch note")).toBeInTheDocument();
+    });
+
+    const sideThreadRegion = screen.getAllByLabelText("Chat thread")[1];
+    if (!sideThreadRegion) {
+      throw new Error("Side chat thread not found");
+    }
+    sideThreadRegion.focus();
+    fireEvent.keyDown(sideThreadRegion, {
+      key: "!",
+      code: "Digit1",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        "b0000000-0000-4000-a000-000000000709",
+        "✅ Next keyboard thread",
+      );
+    });
+  });
+
+  it("adds an emoji from the composer with Ctrl+Shift+1", async () => {
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads({ currentDetailTitle: null });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/b0000000-0000-4000-a000-000000000708",
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Current thread launch note"),
+      ).toBeInTheDocument();
+    });
+
+    const composer = chatComposerTextarea();
+    composer.focus();
+    fireEvent.keyDown(composer, {
+      key: "!",
+      code: "Digit1",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        "b0000000-0000-4000-a000-000000000708",
+        "✅ Current keyboard thread",
+      );
+    });
+  });
+
+  it("clears the current chat emoji directly with Ctrl+Shift+0", async () => {
+    const renameRequest = vi.fn();
+    mockResizeObserver();
+    mockKeyboardNavigationThreads({
+      currentTitle: "🔥 Current keyboard thread",
+    });
+    context.mocks.api(
+      chatThreadRenameContract.rename,
+      ({ body, params, respond }) => {
+        renameRequest(params.id, body.title);
+        return respond(204);
+      },
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/chats/b0000000-0000-4000-a000-000000000708",
+      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Change icon")).toHaveTextContent("🔥");
+    });
+
+    const threadRegion = screen.getByLabelText("Chat thread");
+    threadRegion.focus();
+    fireEvent.keyDown(threadRegion, {
+      key: ")",
+      code: "Digit0",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(renameRequest).toHaveBeenCalledWith(
+        "b0000000-0000-4000-a000-000000000708",
+        "Current keyboard thread",
+      );
+    });
+  });
+
   it("keeps shifted digit input editable in the chat composer", async () => {
     const user = userEvent.setup({ delay: null });
     const renameRequest = vi.fn();

--- a/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
@@ -21,6 +21,8 @@ const CHAT_THREAD_SHORTCUT_SECTIONS = [
       { key: "ctrl+shift+]", label: "Next agent" },
       { key: "f2", label: "Rename chat" },
       { key: "shift+f2", label: "Change icon" },
+      { key: "ctrl+shift+1", label: "Set icon (Ctrl+Shift+1-9)" },
+      { key: "ctrl+shift+0", label: "Clear icon" },
     ],
   },
   {
@@ -78,7 +80,7 @@ const SIDEBAR_SHORTCUT_SECTIONS = [
 ] as const;
 
 function isChatThreadEmojiShortcutKey(key: string): boolean {
-  return key === "shift+f2";
+  return key === "shift+f2" || key === "ctrl+shift+1" || key === "ctrl+shift+0";
 }
 
 function shortcutSectionsForRoute(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -668,6 +668,7 @@ function ChatThreadEmojiPicker({
               label="Frequently used"
               items={FREQUENTLY_USED_EMOJI}
               onSelect={onSelect}
+              showShortcutDigits
             />
             {groups?.map((group) => {
               return (
@@ -690,17 +691,23 @@ function ChatThreadEmojiSection({
   label,
   items,
   onSelect,
+  showShortcutDigits = false,
 }: {
   label: string;
   items: ChatThreadEmojiItem[];
   onSelect: (emoji: string) => void;
+  showShortcutDigits?: boolean;
 }) {
   return (
     <div>
       <p className="px-1 pb-1 pt-2 text-xs font-medium text-muted-foreground">
         {label}
       </p>
-      <ChatThreadEmojiGrid items={items} onSelect={onSelect} />
+      <ChatThreadEmojiGrid
+        items={items}
+        onSelect={onSelect}
+        showShortcutDigits={showShortcutDigits}
+      />
     </div>
   );
 }
@@ -708,24 +715,38 @@ function ChatThreadEmojiSection({
 function ChatThreadEmojiGrid({
   items,
   onSelect,
+  showShortcutDigits = false,
 }: {
   items: ChatThreadEmojiItem[];
   onSelect: (emoji: string) => void;
+  showShortcutDigits?: boolean;
 }) {
   return (
     <div className="grid grid-cols-8 gap-0.5">
-      {items.map((item) => {
+      {items.map((item, index) => {
+        // Ctrl+Shift+1-9 set the first nine "frequently used" icons; surface a
+        // faint digit so the shortcut is discoverable without adding clutter.
+        const shortcutDigit =
+          showShortcutDigits && index < 9 ? index + 1 : null;
         return (
           <button
             key={`${item.name}-${item.emoji}`}
             type="button"
             aria-label={item.name}
-            className="flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-accent"
+            className="relative flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-accent"
             onClick={() => {
               onSelect(item.emoji);
             }}
           >
             <span aria-hidden="true">{item.emoji}</span>
+            {shortcutDigit !== null && (
+              <span
+                aria-hidden="true"
+                className="absolute bottom-0 right-0.5 text-[9px] leading-none text-muted-foreground/60"
+              >
+                {shortcutDigit}
+              </span>
+            )}
           </button>
         );
       })}


### PR DESCRIPTION
## What changed

Brings back the keyboard shortcuts for quickly marking a chat thread's status with a familiar emoji — the `Ctrl+Shift+1‑9` / `Ctrl+Shift+0` bindings that #20395 removed along with the old 30-chip layout. This restores the power-user flow **without** re-introducing the visual clutter.

- **`Ctrl+Shift+1‑9`** set the nine "Frequently used" status emoji on the focused thread (`1 ✅ · 2 🔥 · 3 ❌ · 4 ⚠️ · 5 💡 · 6 ❓ · 7 ⏳ · 8 👀 · 9 🚀`); **`Ctrl+Shift+0`** clears the icon. Global (works from the composer too), gated behind the `ChatThreadEmoji` feature switch.
- **Picker stays clean**: only the `Frequently used` row gains a faint `1‑9` digit in the corner so the shortcut is discoverable — the 30 per-row `<kbd>` chips do **not** come back.
- Restores the `Set icon (Ctrl+Shift+1‑9)` and `Clear icon` rows in the shortcut help dialog (`⇧/`).

Emoji are still stored as characters embedded in the thread title — no data-model change. This effectively re-adds the shortcut half of what #20395 removed while keeping the new searchable picker.

## Testing

Verified locally on `@vm0/app`: type-check (prod + tests), oxlint + eslint, knip, Prettier, and the `chat-lifecycle` emoji suite all pass — including the re-added tests: `Ctrl+Shift+1` on the current chat, on the focused side chat, and from the composer; `Ctrl+Shift+0` clear; plus the existing Shift+F2 picker / Remove / empty-state tests. The shortcut-help-dialog test passes with the two rows back.