### PR TITLE
perf: skip empty artifact uploads during run creation

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -35,6 +35,9 @@ pub mod runners {
             pub vas_version_id: String,
             /// Presigned URL for downloading the artifact archive.
             pub archive_url: String,
+            /// Whether this artifact version is explicitly empty and can be prepared without downloading an archive.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub empty: Option<bool>,
             /// Optional policy for a missing artifact root; absence behaves like `fail`.
             #[serde(default, skip_serializing_if = "Option::is_none")]
             pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -212,6 +212,7 @@ fn generated_storage_manifest_ignores_legacy_artifact_manifest_url() {
         Some("AGENTS.md")
     );
     assert_eq!(manifest.artifacts[0].vas_storage_id, "storage-id-1");
+    assert_eq!(manifest.artifacts[0].empty, None);
 }
 
 #[test]
@@ -231,6 +232,7 @@ fn generated_storage_manifest_serializes_claim_shape() {
             vas_storage_id: "storage-id-1".to_string(),
             vas_version_id: "version-2".to_string(),
             archive_url: "https://storage.example/artifact.tar.gz".to_string(),
+            empty: None,
             missing_root_policy: None,
         }],
     };
@@ -256,6 +258,28 @@ fn generated_storage_manifest_serializes_claim_shape() {
             }],
         })
     );
+}
+
+#[test]
+fn generated_storage_manifest_accepts_explicit_empty_artifacts() {
+    let manifest: runner_storage::StorageManifest = serde_json::from_value(json!({
+        "storages": [],
+        "artifacts": [{
+            "mountPath": "/home/user/.claude/projects/project",
+            "vasStorageName": "memory",
+            "vasStorageId": "storage-id-1",
+            "vasVersionId": "version-2",
+            "archiveUrl": "https://storage.example/artifact.tar.gz",
+            "empty": true,
+        }],
+    }))
+    .unwrap();
+
+    assert_eq!(manifest.artifacts[0].empty, Some(true));
+
+    let value = serde_json::to_value(manifest).unwrap();
+    assert_eq!(value["artifacts"][0]["empty"], true);
+    assert!(value["artifacts"][0]["archiveUrl"].is_string());
 }
 
 #[test]

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -14,10 +14,11 @@ mod manifest;
 mod plan;
 mod source;
 
-use guest_common::log_error;
+use guest_common::{log_error, log_info, telemetry::record_sandbox_op};
 use manifest::{Manifest, ManifestLoadError};
-use plan::RunPlan;
+use plan::{EmptyArtifactPreparation, RunPlan};
 use std::fs;
+use std::time::Instant;
 
 const LOG_TAG: &str = "sandbox:download";
 
@@ -58,6 +59,7 @@ fn run_manifest(manifest: Manifest) -> bool {
         cleanup_paths,
         instruction_cleanups,
         preserved_paths,
+        empty_artifacts,
         download_tasks,
         instruction_files,
     } = RunPlan::from_manifest(&manifest);
@@ -83,6 +85,10 @@ fn run_manifest(manifest: Manifest) -> bool {
             return false;
         }
     }
+    if !prepare_empty_artifacts(&empty_artifacts) {
+        instructions::cleanup_staged_instruction_sources(&instruction_files);
+        return false;
+    }
 
     let success = download::download_all_parallel(download_tasks);
     if success {
@@ -91,6 +97,38 @@ fn run_manifest(manifest: Manifest) -> bool {
         instructions::cleanup_staged_instruction_sources(&instruction_files);
     }
     success
+}
+
+fn prepare_empty_artifacts(entries: &[EmptyArtifactPreparation]) -> bool {
+    for entry in entries {
+        let start = Instant::now();
+        match fs::create_dir_all(&entry.mount_path) {
+            Ok(()) => {
+                record_sandbox_op("artifact_empty_prepare", start.elapsed(), true, None);
+                log_info!(
+                    LOG_TAG,
+                    "{} prepared in {}ms",
+                    entry.label,
+                    start.elapsed().as_millis()
+                );
+            }
+            Err(e) => {
+                let failure_detail = format!(
+                    "{} prepare failed: failed to create directory: {e}",
+                    entry.label
+                );
+                record_sandbox_op(
+                    "artifact_empty_prepare",
+                    start.elapsed(),
+                    false,
+                    Some(&failure_detail),
+                );
+                log_error!(LOG_TAG, "{failure_detail}");
+                return false;
+            }
+        }
+    }
+    true
 }
 
 #[cfg(test)]
@@ -121,6 +159,28 @@ mod tests {
         assert!(!success);
         assert!(!extract_path.exists());
         assert!(!extract_parent.exists());
+    }
+
+    #[test]
+    fn run_manifest_prepares_explicit_empty_artifact_without_opening_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("memory");
+        let missing_archive = dir.path().join("missing-empty.tar.gz");
+        let manifest = json!({
+            "storages": [],
+            "artifacts": [{
+                "mountPath": mount,
+                "archiveUrl": format!("file://{}", missing_archive.display()),
+                "empty": true,
+                "vasStorageName": "memory",
+                "vasVersionId": "empty-v1"
+            }]
+        });
+
+        let success = super::run_manifest_bytes(&serde_json::to_vec(&manifest).unwrap());
+
+        assert!(success);
+        assert!(mount.is_dir());
     }
 
     #[test]

--- a/crates/guest-download/src/manifest.rs
+++ b/crates/guest-download/src/manifest.rs
@@ -45,6 +45,8 @@ pub(crate) struct ManifestEntry {
     #[serde(default)]
     pub(crate) cached: bool,
     #[serde(default)]
+    pub(crate) empty: bool,
+    #[serde(default)]
     pub(crate) vas_storage_name: Option<String>,
     #[serde(default)]
     pub(crate) vas_version_id: Option<String>,
@@ -108,6 +110,18 @@ mod tests {
         let manifest: Manifest = serde_json::from_str(json).unwrap();
         assert!(!manifest.storages[0].cached);
         assert!(!manifest.artifacts[0].cached);
+        assert!(!manifest.artifacts[0].empty);
+    }
+
+    #[test]
+    fn manifest_deserializes_empty_artifact_field() {
+        let json = r#"{
+            "storages": [{"mountPath": "/data", "empty": true}],
+            "artifacts": [{"mountPath": "/workspace", "empty": true}]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.storages[0].empty);
+        assert!(manifest.artifacts[0].empty);
     }
 
     #[test]

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -7,8 +7,15 @@ pub(crate) struct RunPlan {
     pub(crate) cleanup_paths: Vec<String>,
     pub(crate) instruction_cleanups: Vec<InstructionCleanup>,
     pub(crate) preserved_paths: Vec<String>,
+    pub(crate) empty_artifacts: Vec<EmptyArtifactPreparation>,
     pub(crate) download_tasks: Vec<DownloadTask>,
     pub(crate) instruction_files: Vec<InstructionNormalization>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EmptyArtifactPreparation {
+    pub(crate) label: String,
+    pub(crate) mount_path: String,
 }
 
 #[derive(Clone, Copy)]
@@ -120,11 +127,22 @@ impl RunPlan {
             &manifest.artifacts,
             ManifestEntryKind::Artifact,
         );
+        let empty_artifacts = manifest
+            .artifacts
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.empty)
+            .map(|(index, entry)| EmptyArtifactPreparation {
+                label: format_empty_artifact_label(entry, index + 1),
+                mount_path: entry.mount_path.clone(),
+            })
+            .collect();
 
         Self {
             cleanup_paths: manifest.cleanup_paths.clone(),
             instruction_cleanups,
             preserved_paths,
+            empty_artifacts,
             download_tasks,
             instruction_files,
         }
@@ -142,6 +160,9 @@ fn append_download_tasks(
     kind: ManifestEntryKind,
 ) {
     for (idx, entry) in entries.iter().enumerate() {
+        if matches!(kind, ManifestEntryKind::Artifact) && entry.empty {
+            continue;
+        }
         if should_download_entry(entry, kind)
             && let Some(url) = entry.archive_url.clone()
         {
@@ -160,6 +181,16 @@ fn append_download_tasks(
             ));
         }
     }
+}
+
+fn format_empty_artifact_label(entry: &ManifestEntry, index: usize) -> String {
+    let storage_name = entry.vas_storage_name.as_deref().unwrap_or("unknown");
+    let version_id = entry.vas_version_id.as_deref().unwrap_or("unknown");
+    let missing_root_policy = entry.missing_root_policy.as_deref().unwrap_or("fail");
+    format!(
+        "artifact {index} mountPath={} vasStorageName={} vasVersionId={} empty=true cached={} missingRootPolicy={}",
+        entry.mount_path, storage_name, version_id, entry.cached, missing_root_policy
+    )
 }
 
 fn download_mount_path(entry: &ManifestEntry, kind: ManifestEntryKind) -> &str {
@@ -309,6 +340,62 @@ mod tests {
                 "/workspace/b".into(),
                 NotFoundPolicy::Ignore404,
             )
+        );
+    }
+
+    #[test]
+    fn run_plan_prepares_explicit_empty_artifact_without_download_task() {
+        let json = r#"{
+            "storages": [],
+            "artifacts": [{
+                "mountPath": "/workspace",
+                "archiveUrl": "https://s3/compat-empty-artifact.tar.gz",
+                "empty": true,
+                "vasStorageName": "memory",
+                "vasVersionId": "empty-v1",
+                "missingRootPolicy": "preserveParentVersion"
+            }]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert!(plan.download_tasks.is_empty());
+        assert_eq!(
+            plan.empty_artifacts,
+            [EmptyArtifactPreparation {
+                label: "artifact 1 mountPath=/workspace vasStorageName=memory vasVersionId=empty-v1 empty=true cached=false missingRootPolicy=preserveParentVersion".into(),
+                mount_path: "/workspace".into(),
+            }]
+        );
+    }
+
+    #[test]
+    fn run_plan_does_not_treat_storage_empty_field_as_special() {
+        let json = r#"{
+            "storages": [{
+                "mountPath": "/data",
+                "archiveUrl": "https://s3/storage.tar.gz",
+                "empty": true,
+                "vasStorageName": "data",
+                "vasVersionId": "storage-v1"
+            }],
+            "artifacts": []
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+
+        let plan = RunPlan::from_manifest(&manifest);
+
+        assert_eq!(plan.empty_artifacts, []);
+        assert_eq!(
+            plan.download_tasks,
+            [DownloadTask::new(
+                "storage 1 mountPath=/data vasStorageName=data vasVersionId=storage-v1 urlScheme=https cached=false".into(),
+                "storage_download",
+                "https://s3/storage.tar.gz".into(),
+                "/data".into(),
+                NotFoundPolicy::Fail,
+            )]
         );
     }
 
@@ -527,6 +614,7 @@ mod tests {
                 archive_url: Some("https://s3/artifact.tar.gz".into()),
                 instructions_target_filename: None,
                 cached: true,
+                empty: false,
                 vas_storage_name: Some("artifact".into()),
                 vas_version_id: Some("artifact-v1".into()),
                 missing_root_policy: None,
@@ -554,6 +642,7 @@ mod tests {
                 archive_url: Some("https://s3/storage.tar.gz".into()),
                 instructions_target_filename: None,
                 cached: true,
+                empty: false,
                 vas_storage_name: Some("storage".into()),
                 vas_version_id: Some("storage-v1".into()),
                 missing_root_policy: None,
@@ -596,6 +685,7 @@ mod tests {
                 archive_url: Some("https://s3/artifact.tar.gz".into()),
                 instructions_target_filename: None,
                 cached: true,
+                empty: false,
                 vas_storage_name: Some("artifact".into()),
                 vas_version_id: Some("artifact-v1".into()),
                 missing_root_policy: None,

--- a/crates/runner/src/executor/storage.rs
+++ b/crates/runner/src/executor/storage.rs
@@ -188,7 +188,10 @@ pub(super) fn apply_storage_fingerprint_reuse(
 
 pub(super) fn guest_download_has_work(manifest: &GuestDownloadManifest) -> bool {
     manifest.storages.iter().any(|s| s.archive_url.is_some())
-        || manifest.artifacts.iter().any(|a| a.archive_url.is_some())
+        || manifest
+            .artifacts
+            .iter()
+            .any(|a| a.archive_url.is_some() || a.empty)
         || !manifest.cleanup_paths.is_empty()
         || !manifest.instruction_cleanups.is_empty()
         || manifest

--- a/crates/runner/src/executor/tests/storage_tests.rs
+++ b/crates/runner/src/executor/tests/storage_tests.rs
@@ -448,6 +448,7 @@ fn guest_art_with_policy(
     GuestDownloadArtifactEntry {
         mount_path: "/workspace".into(),
         archive_url: url.map(str::to_string),
+        empty: false,
         cached: false,
         vas_storage_name: name.into(),
         vas_storage_id: String::new(),
@@ -513,6 +514,20 @@ fn guest_download_has_work_skips_fully_empty_cached_manifest() {
     };
 
     assert!(!guest_download_has_work(&manifest));
+}
+
+#[test]
+fn guest_download_has_work_detects_explicit_empty_artifacts() {
+    let mut artifact = guest_art("memory", "v-empty", None);
+    artifact.empty = true;
+    let manifest = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![artifact],
+        cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
+    };
+
+    assert!(guest_download_has_work(&manifest));
 }
 
 #[test]
@@ -680,6 +695,7 @@ fn filter_two_artifacts_at_different_mount_paths() {
     let art_a = GuestDownloadArtifactEntry {
         mount_path: "/workspace".into(),
         archive_url: Some("https://s3/a-v2".into()),
+        empty: false,
         cached: false,
         vas_storage_name: "art-a".into(),
         vas_storage_id: String::new(),
@@ -689,6 +705,7 @@ fn filter_two_artifacts_at_different_mount_paths() {
     let art_b = GuestDownloadArtifactEntry {
         mount_path: "/data".into(),
         archive_url: Some("https://s3/b-v1".into()),
+        empty: false,
         cached: false,
         vas_storage_name: "art-b".into(),
         vas_storage_id: String::new(),
@@ -756,6 +773,7 @@ fn filter_cleanup_paths_keep_broad_phase_order() {
         artifacts: vec![GuestDownloadArtifactEntry {
             mount_path: "/artifact-changed".into(),
             archive_url: Some("https://s3/artifact".into()),
+            empty: false,
             cached: false,
             vas_storage_name: "artifact".into(),
             vas_storage_id: String::new(),
@@ -1051,6 +1069,29 @@ fn filter_unchanged_artifact_policy_does_not_force_redownload() {
 }
 
 #[test]
+fn filter_unchanged_explicit_empty_artifact_still_has_prepare_work() {
+    let mut artifact = guest_art("memory", "empty-v1", None);
+    artifact.empty = true;
+    let manifest = GuestDownloadManifest {
+        storages: vec![],
+        artifacts: vec![artifact],
+        cleanup_paths: vec![],
+        instruction_cleanups: Vec::new(),
+    };
+    let prev = StorageFingerprints {
+        storages: HashMap::new(),
+        artifacts: art_fp("/workspace", "memory", "empty-v1"),
+    };
+
+    let result = apply_storage_fingerprint_reuse(&manifest, &prev);
+
+    assert!(result.artifacts[0].empty);
+    assert!(result.artifacts[0].archive_url.is_none());
+    assert!(result.artifacts[0].cached);
+    assert!(guest_download_has_work(&result));
+}
+
+#[test]
 fn filter_changed_storage_with_null_url_adds_cleanup_path() {
     let manifest = GuestDownloadManifest {
         storages: vec![guest_storage("/data", "vol-1", "v2", None)],
@@ -1138,6 +1179,7 @@ fn filter_tainted_paths_force_download_even_when_versions_match() {
         artifacts: vec![GuestDownloadArtifactEntry {
             mount_path: "/workspace/artifact".into(),
             archive_url: Some("https://s3/artifact".into()),
+            empty: false,
             cached: false,
             vas_storage_name: "artifact".into(),
             vas_storage_id: String::new(),

--- a/crates/runner/src/executor/tests/support/manifest.rs
+++ b/crates/runner/src/executor/tests/support/manifest.rs
@@ -29,6 +29,7 @@ pub(in crate::executor::tests) fn api_artifact(
         vas_storage_name: name.into(),
         vas_storage_id: storage_id.into(),
         vas_version_id: version.into(),
+        empty: None,
         missing_root_policy: None,
     }
 }

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -2554,6 +2554,7 @@ mod tests {
             artifacts: vec![GuestDownloadArtifactEntry {
                 mount_path: format!("/mnt/artifact-{name}"),
                 archive_url: Some(url),
+                empty: false,
                 cached: false,
                 vas_storage_name: name.to_string(),
                 vas_storage_id: format!("{name}-id"),
@@ -4768,6 +4769,7 @@ mod tests {
             artifacts: vec![GuestDownloadArtifactEntry {
                 mount_path: "/mnt/artifact".into(),
                 archive_url: Some("https://r2.example.com/ignored.tar.gz".into()),
+                empty: false,
                 cached: false,
                 vas_storage_name: name.to_string(),
                 vas_storage_id: String::new(),
@@ -5708,6 +5710,7 @@ mod tests {
             artifacts: vec![GuestDownloadArtifactEntry {
                 mount_path: "/mnt/artifact".into(),
                 archive_url: Some("https://r2.example.com/artifact.tar.gz".into()),
+                empty: false,
                 cached: false,
                 vas_storage_name: name.to_string(),
                 vas_storage_id: "storage-id".into(),
@@ -6200,6 +6203,7 @@ mod tests {
             artifacts: vec![GuestDownloadArtifactEntry {
                 mount_path: "/mnt/nameless".into(),
                 archive_url: Some(original.clone()),
+                empty: false,
                 cached: false,
                 vas_storage_name: String::new(),
                 vas_storage_id: String::new(),

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -13,6 +13,10 @@ use crate::ids::RunId;
 
 pub(crate) const MAX_HELD_SESSION_STATES: usize = 1024;
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 // ---------------------------------------------------------------------------
 // Poll
 // ---------------------------------------------------------------------------
@@ -279,6 +283,8 @@ pub struct GuestDownloadInstructionCleanupEntry {
 pub struct GuestDownloadArtifactEntry {
     pub mount_path: String,
     pub archive_url: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub empty: bool,
     /// Whether this entry is cached from a previous turn (fingerprint matched).
     pub cached: bool,
     pub vas_storage_name: String,
@@ -329,7 +335,12 @@ impl GuestDownloadManifest {
                 .iter()
                 .map(|artifact| GuestDownloadArtifactEntry {
                     mount_path: artifact.mount_path.clone(),
-                    archive_url: Some(artifact.archive_url.clone()),
+                    archive_url: if artifact.empty == Some(true) {
+                        None
+                    } else {
+                        Some(artifact.archive_url.clone())
+                    },
+                    empty: artifact.empty.unwrap_or(false),
                     cached: false,
                     vas_storage_name: artifact.vas_storage_name.clone(),
                     vas_storage_id: artifact.vas_storage_id.clone(),
@@ -1070,6 +1081,7 @@ mod tests {
                 vas_storage_name: "memory".into(),
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
+                empty: None,
                 missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
             }],
         };
@@ -1091,10 +1103,36 @@ mod tests {
             Some("AGENTS.md")
         );
         assert!(!guest_manifest.artifacts[0].cached);
+        assert!(!guest_manifest.artifacts[0].empty);
         assert_eq!(
             guest_manifest.artifacts[0].archive_url.as_deref(),
             Some("https://example.com/artifact.tar.gz")
         );
+        assert_eq!(
+            guest_manifest.artifacts[0].missing_root_policy,
+            Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
+        );
+    }
+
+    #[test]
+    fn storage_manifest_conversion_marks_explicit_empty_artifacts_without_archive_urls() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifacts: vec![ArtifactEntry {
+                mount_path: "/artifacts".into(),
+                archive_url: "https://example.com/compat-empty-artifact.tar.gz".into(),
+                vas_storage_name: "memory".into(),
+                vas_storage_id: "sid-1".into(),
+                vas_version_id: "v-empty".into(),
+                empty: Some(true),
+                missing_root_policy: Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion),
+            }],
+        };
+
+        let guest_manifest = GuestDownloadManifest::from(&manifest);
+
+        assert!(guest_manifest.artifacts[0].empty);
+        assert!(guest_manifest.artifacts[0].archive_url.is_none());
         assert_eq!(
             guest_manifest.artifacts[0].missing_root_policy,
             Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
@@ -1159,6 +1197,7 @@ mod tests {
                 vas_storage_name: "memory".into(),
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
+                empty: None,
                 missing_root_policy: None,
             }],
         };
@@ -1171,6 +1210,7 @@ mod tests {
         assert!(value["storages"][0].get("extractPath").is_none());
         assert!(value["storages"][0].get("name").is_none());
         assert_eq!(value["artifacts"][0]["cached"], false);
+        assert!(value["artifacts"][0].get("empty").is_none());
         assert!(value["artifacts"][0].get("manifestUrl").is_none());
         assert!(value["artifacts"][0].get("missingRootPolicy").is_none());
     }

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -622,13 +622,15 @@ export function verifyS3FilesExist(
   fileCount: number,
 ): Computed<Promise<boolean>> {
   return computed(async (get): Promise<boolean> => {
+    if (fileCount === 0) {
+      return true;
+    }
+
     const manifestKey = `${s3Key}/manifest.json`;
     const archiveKey = `${s3Key}/archive.tar.gz`;
     const [manifestExists, archiveExists] = await Promise.all([
       get(s3ObjectExists(bucket, manifestKey)),
-      fileCount > 0
-        ? get(s3ObjectExists(bucket, archiveKey))
-        : Promise.resolve(true),
+      get(s3ObjectExists(bucket, archiveKey)),
     ]);
 
     return manifestExists && archiveExists;

--- a/turbo/apps/api/src/signals/external/s3.ts
+++ b/turbo/apps/api/src/signals/external/s3.ts
@@ -620,9 +620,15 @@ export function verifyS3FilesExist(
   bucket: string,
   s3Key: string,
   fileCount: number,
+  options?: {
+    readonly allowMissingObjectsForEmptyVersion?: boolean;
+  },
 ): Computed<Promise<boolean>> {
   return computed(async (get): Promise<boolean> => {
-    if (fileCount === 0) {
+    if (
+      fileCount === 0 &&
+      options?.allowMissingObjectsForEmptyVersion === true
+    ) {
       return true;
     }
 
@@ -630,7 +636,9 @@ export function verifyS3FilesExist(
     const archiveKey = `${s3Key}/archive.tar.gz`;
     const [manifestExists, archiveExists] = await Promise.all([
       get(s3ObjectExists(bucket, manifestKey)),
-      get(s3ObjectExists(bucket, archiveKey)),
+      fileCount > 0
+        ? get(s3ObjectExists(bucket, archiveKey))
+        : Promise.resolve(true),
     ]);
 
     return manifestExists && archiveExists;

--- a/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/cron-summarize-memory.test.ts
@@ -168,6 +168,7 @@ async function seedTwoVersions(
       storageId,
       versionId: v2Id,
       s3Key: v2Key,
+      fileCount: files2.length,
       userId: fixture.userId,
       createdAt: new Date("2999-01-02T09:00:00.000Z"),
     },
@@ -235,6 +236,7 @@ async function seedTwoVersionsNoMock(): Promise<{
       storageId,
       versionId: v2Id,
       s3Key: v2Key,
+      fileCount: 1,
       userId: fixture.userId,
       createdAt: new Date("2999-01-02T09:00:00.000Z"),
     },
@@ -304,6 +306,7 @@ async function seedVersions(versions: readonly DayVersion[]): Promise<{
         storageId,
         versionId: `v${index}-${randomUUID()}`,
         s3Key: key,
+        fileCount: version.files.length,
         userId: fixture.userId,
         createdAt: version.createdAt,
       },
@@ -539,6 +542,75 @@ describe("GET /api/cron/summarize-memory", () => {
     expect(items).toHaveLength(2);
     expect(items).toContain("MEMORY.md");
     expect(items).toContain("facts/coffee.md");
+  });
+
+  it("treats zero-file memory versions as empty without S3 objects", async () => {
+    const llm = mockLlm("Zero learned your preferred package manager.");
+    const fixture = await track(
+      store.set(seedMemoryFixture$, undefined, context.signal),
+    );
+    await enableMemoryViewer(fixture);
+    const base = `orgs/${fixture.orgId}/users/${fixture.userId}/memory`;
+    const emptyKey = `${base}/empty`;
+    const nonEmptyKey = `${base}/v2`;
+    const emptyVersionId = `empty-${randomUUID()}`;
+    const nonEmptyVersionId = `v2-${randomUUID()}`;
+
+    await store.set(
+      seedMemoryStorage$,
+      {
+        orgId: fixture.orgId,
+        userId: fixture.userId,
+        s3Key: emptyKey,
+        headVersionId: emptyVersionId,
+        fileCount: 0,
+        updatedAt: new Date(BASELINE_BEFORE_LOOKBACK),
+      },
+      context.signal,
+    );
+
+    const storageId = await store.set(
+      findMemoryStorageId$,
+      fixture.orgId,
+      context.signal,
+    );
+    await updateMemoryVersionCreatedAt(
+      context.signal,
+      emptyVersionId,
+      new Date(BASELINE_BEFORE_LOOKBACK),
+    );
+    await store.set(
+      seedMemoryVersion$,
+      {
+        storageId,
+        versionId: nonEmptyVersionId,
+        s3Key: nonEmptyKey,
+        fileCount: 1,
+        userId: fixture.userId,
+        createdAt: new Date("2999-01-02T09:00:00.000Z"),
+      },
+      context.signal,
+    );
+    mockMemoryVersions(context, [
+      {
+        s3Key: nonEmptyKey,
+        files: [{ path: "facts/package-manager.md", content: "Uses pnpm" }],
+      },
+    ]);
+
+    const response = await accept(
+      apiClient().summarize({ headers: cronHeaders() }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({ summarized: 7 });
+    expect(llm.calls).toBe(1);
+    const summary = await findSummary(fixture);
+    expect(summary?.fromVersionId).toBe(emptyVersionId);
+    expect(summary?.toVersionId).toBe(nonEmptyVersionId);
+    await expect(findItems(summary?.id ?? "")).resolves.toStrictEqual([
+      "facts/package-manager.md",
+    ]);
   });
 
   it("backfills quiet cards and makes no LLM call when memory did not change", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-storages.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-storages.ts
@@ -32,6 +32,10 @@ interface BddStoragePrepareBody {
   readonly storageType: StorageType;
   readonly files: readonly BddStorageFileEntry[];
   readonly force?: boolean;
+  readonly baseVersion?: string;
+  readonly changes?: z.infer<
+    typeof storagesPrepareContract.prepare.body
+  >["changes"];
 }
 
 interface BddStorageCommitBody {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/zero-memory.ts
@@ -332,6 +332,7 @@ interface MemoryVersionSeed {
   readonly storageId: string;
   readonly versionId: string;
   readonly s3Key: string;
+  readonly fileCount?: number;
   readonly userId: string;
   readonly createdAt: Date;
 }
@@ -343,6 +344,7 @@ export const seedMemoryVersion$ = command(
       storage_id: args.storageId,
       version_id: args.versionId,
       s3_key: args.s3Key,
+      file_count: args.fileCount,
       user_id: args.userId,
       created_at: args.createdAt.toISOString(),
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1302,16 +1302,38 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       archiveUrl: expect.any(String),
       vasVersionId: expect.any(String),
     });
+    const initialMemoryVersionId = initialMemory?.vasVersionId;
+    if (!initialMemoryVersionId) {
+      throw new Error("Expected initial memory artifact version id");
+    }
 
     const artifactFile = storageTextFile(
       "artifact.txt",
       `committed artifact ${randomUUID()}`,
     );
+    context.mocks.s3.send.mockClear();
     const prepared = await storages.prepareStorage(actor, {
       storageName: "memory",
       storageType: "artifact",
+      baseVersion: initialMemoryVersionId,
+      changes: {
+        added: [artifactFile.path],
+        modified: [],
+        deleted: [],
+      },
       files: [artifactFile],
     });
+    const emptyBaseManifestReads = context.mocks.s3.send.mock.calls.filter(
+      ([command]) => {
+        return (
+          s3CommandName(command) === "GetObjectCommand" &&
+          s3CommandKey(command)?.includes(
+            `/artifact/memory/${initialMemoryVersionId}/manifest.json`,
+          ) === true
+        );
+      },
+    );
+    expect(emptyBaseManifestReads).toHaveLength(0);
     await storages.commitStorage(actor, {
       storageName: "memory",
       storageType: "artifact",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1307,6 +1307,30 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected initial memory artifact version id");
     }
 
+    context.mocks.s3.send.mockClear();
+    const preparedInitialEmpty = await storages.prepareStorage(actor, {
+      storageName: "memory",
+      storageType: "artifact",
+      files: [],
+    });
+    expect(preparedInitialEmpty).toStrictEqual({
+      versionId: initialMemoryVersionId,
+      existing: true,
+    });
+    const committedInitialEmpty = await storages.commitStorage(actor, {
+      storageName: "memory",
+      storageType: "artifact",
+      versionId: initialMemoryVersionId,
+      files: [],
+    });
+    expect(committedInitialEmpty).toMatchObject({
+      success: true,
+      versionId: initialMemoryVersionId,
+      fileCount: 0,
+      deduplicated: true,
+    });
+    expect(context.mocks.s3.send).not.toHaveBeenCalled();
+
     const artifactFile = storageTextFile(
       "artifact.txt",
       `committed artifact ${randomUUID()}`,

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -31,7 +31,6 @@ import {
   expectApiError,
   type ApiTestUser,
 } from "./helpers/api-bdd";
-import { createDeferredPromise } from "../../utils";
 import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import { createBillingMediaApi } from "./helpers/api-bdd-billing-media";
 import { createChatCallbacksApi } from "./helpers/api-bdd-chat-callbacks";
@@ -154,7 +153,6 @@ const API_DISPATCH_TIMING_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_storage",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_refetch_storage",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_skip_initialized",
-  "api_dispatch_prepare_storage_manifest_ensure_artifact_upload_empty_objects",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_initial_version",
   "api_dispatch_prepare_storage_manifest_load_storage_index",
   "api_dispatch_prepare_storage_manifest_build_entries",
@@ -177,7 +175,6 @@ const API_DISPATCH_STORAGE_MANIFEST_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_storage",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_refetch_storage",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_skip_initialized",
-  "api_dispatch_prepare_storage_manifest_ensure_artifact_upload_empty_objects",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_initial_version",
   "api_dispatch_prepare_storage_manifest_load_storage_index",
   "api_dispatch_prepare_storage_manifest_build_entries",
@@ -919,6 +916,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       compose.composeId,
     );
 
+    context.mocks.s3.send.mockClear();
     const created = await api.createDirectRun(actor, {
       agentComposeVersionId: headVersionId,
       prompt,
@@ -1023,6 +1021,18 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
 
     const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    const emptyArtifactPutCount = context.mocks.s3.send.mock.calls.filter(
+      ([command]) => {
+        return (
+          s3CommandName(command) === "PutObjectCommand" &&
+          s3CommandKey(command)?.includes("/artifact/memory/")
+        );
+      },
+    ).length;
+    expect(emptyArtifactPutCount).toBe(0);
+    expectNoApiDispatchActions(timingEvents, [
+      "api_dispatch_prepare_storage_manifest_ensure_artifact_upload_empty_objects",
+    ]);
     expect(
       singleApiDispatchEvent(
         timingEvents,
@@ -1175,6 +1185,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     expect(memoryArtifact).toMatchObject({
       archiveUrl: expect.any(String),
+      empty: true,
       vasStorageId: expect.any(String),
       vasVersionId: expect.any(String),
       missingRootPolicy: "preserveParentVersion",
@@ -1234,12 +1245,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           "0",
       }),
     );
-    expect(
-      singleApiDispatchEvent(
-        initializedTimingEvents,
-        "api_dispatch_prepare_storage_manifest_ensure_artifact_upload_empty_objects",
-      ).duration_ms,
-    ).toBe(0);
+    expectNoApiDispatchActions(initializedTimingEvents, [
+      "api_dispatch_prepare_storage_manifest_ensure_artifact_upload_empty_objects",
+    ]);
     expect(
       singleApiDispatchEvent(
         initializedTimingEvents,
@@ -1257,11 +1265,11 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, initialized.runId, [200]);
   });
 
-  it("keeps a committed artifact head when stale empty initialization finishes later", async () => {
+  it("keeps a committed artifact head after initial empty artifact creation", async () => {
     const api = createRunsAutomationsApi(context);
     const storages = createStoragesBddApi(context);
     const { actor } = await entitledRunActor();
-    const composeName = `bdd-artifact-head-race-${randomUUID().slice(0, 8)}`;
+    const composeName = `bdd-artifact-head-commit-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
       version: "1",
       agents: {
@@ -1276,62 +1284,24 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       compose.composeId,
     );
 
-    const emptyUploadsGate = createDeferredPromise<void>(context.signal);
-    const releaseEmptyUploads = (): void => {
-      if (!emptyUploadsGate.settled()) {
-        emptyUploadsGate.resolve(undefined);
-      }
-    };
-    const emptyUploadStarted = createDeferredPromise<void>(context.signal);
-    const markEmptyUploadStarted = (): void => {
-      if (!emptyUploadStarted.settled()) {
-        emptyUploadStarted.resolve(undefined);
-      }
-    };
-
-    let blockedEmptyPutCount = 0;
-    context.mocks.s3.send.mockImplementation((command: unknown) => {
-      if (
-        s3CommandName(command) === "PutObjectCommand" &&
-        s3CommandKey(command)?.includes("/artifact/memory/")
-      ) {
-        blockedEmptyPutCount += 1;
-        markEmptyUploadStarted();
-        return emptyUploadsGate.promise.then(() => {
-          return {};
-        });
-      }
-      return Promise.resolve({});
-    });
-
-    const staleInitializerRun = api.createDirectRun(actor, {
+    const initialRun = await api.createDirectRun(actor, {
       agentComposeVersionId: headVersionId,
-      prompt: "stale empty artifact initialization must not overwrite head",
+      prompt: "initial empty artifact creation should not block later commits",
     });
     onTestFinished(async () => {
-      releaseEmptyUploads();
-      const created = await staleInitializerRun.then(
-        (run) => {
-          return run;
-        },
-        () => {
-          return undefined;
-        },
-      );
-      if (created) {
-        await api.requestCancelRun(actor, created.runId, [200]);
-      }
+      await api.requestCancelRun(actor, initialRun.runId, [200]);
     });
-
-    const gateResult = await Promise.race([
-      emptyUploadStarted.promise.then(() => {
-        return "empty-upload-started" as const;
-      }),
-      staleInitializerRun.then(() => {
-        return "run-finished" as const;
-      }),
-    ]);
-    expect(gateResult).toBe("empty-upload-started");
+    const initialClaim = await api.claimRunnerJob(initialRun.runId);
+    const initialMemory = initialClaim.storageManifest?.artifacts.find(
+      (artifact) => {
+        return artifact.vasStorageName === "memory";
+      },
+    );
+    expect(initialMemory).toMatchObject({
+      empty: true,
+      archiveUrl: expect.any(String),
+      vasVersionId: expect.any(String),
+    });
 
     const artifactFile = storageTextFile(
       "artifact.txt",
@@ -1360,9 +1330,24 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       }),
     );
 
-    releaseEmptyUploads();
-    await staleInitializerRun;
-    expect(blockedEmptyPutCount).toBe(2);
+    const committedRun = await api.createDirectRun(actor, {
+      agentComposeVersionId: headVersionId,
+      prompt: "committed artifact head should stay non-empty",
+    });
+    onTestFinished(async () => {
+      await api.requestCancelRun(actor, committedRun.runId, [200]);
+    });
+    const committedClaim = await api.claimRunnerJob(committedRun.runId);
+    const committedMemory = committedClaim.storageManifest?.artifacts.find(
+      (artifact) => {
+        return artifact.vasStorageName === "memory";
+      },
+    );
+    expect(committedMemory).toMatchObject({
+      archiveUrl: expect.any(String),
+      vasVersionId: prepared.versionId,
+    });
+    expect(committedMemory?.empty).toBeUndefined();
     await expect(
       storages.downloadStorage(actor, {
         name: "memory",

--- a/turbo/apps/api/src/signals/routes/__tests__/storages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/storages.bdd.test.ts
@@ -365,6 +365,31 @@ describe("FILE-01 storage prepare, commit, list, and download", () => {
       size: volumeFile.size,
     });
 
+    const emptyVolumeName = `bdd-empty-volume-${randomUUID().slice(0, 8)}`;
+    const preparedEmptyVolume = await api.prepareStorage(actor, {
+      storageName: emptyVolumeName,
+      storageType: "volume",
+      files: [],
+    });
+    await api.commitStorage(actor, {
+      storageName: emptyVolumeName,
+      storageType: "volume",
+      versionId: preparedEmptyVolume.versionId,
+      files: [],
+    });
+    context.mocks.s3.send.mockClear();
+    api.mockStorageObjectMissingOnce();
+    const preparedMissingEmptyVolume = await api.prepareStorage(actor, {
+      storageName: emptyVolumeName,
+      storageType: "volume",
+      files: [],
+    });
+    expect(preparedMissingEmptyVolume).toMatchObject({
+      versionId: preparedEmptyVolume.versionId,
+      existing: false,
+    });
+    expect(preparedMissingEmptyVolume.uploads).toBeDefined();
+
     authOrg.mockClerkOrg(actor);
     const key = await authOrg.createApiKey(actor, {
       name: "BDD storages token",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-slack-connect.test.ts
@@ -393,7 +393,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
     expect(artifactStorage?.versionS3Key).toBe(
       `${fixture.orgId}/artifact/artifact/${artifactStorage?.versionId}`,
     );
-    expect(context.mocks.s3.send).toHaveBeenCalledWith(
+    expect(context.mocks.s3.send).not.toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           Bucket: "test-user-storages",
@@ -402,7 +402,7 @@ describe("POST /api/zero/integrations/slack/connect", () => {
         }),
       }),
     );
-    expect(context.mocks.s3.send).toHaveBeenCalledWith(
+    expect(context.mocks.s3.send).not.toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
           Bucket: "test-user-storages",

--- a/turbo/apps/api/src/signals/routes/test-memory-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-memory-state.ts
@@ -175,6 +175,7 @@ async function seedVersionForAction(
     id: body.version_id,
     storageId: body.storage_id,
     s3Key: body.s3_key,
+    fileCount: body.file_count ?? 0,
     createdBy: body.user_id,
     createdAt: new Date(body.created_at),
   });

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1,5 +1,3 @@
-import { gzipSync } from "node:zlib";
-
 import type { StorageManifest } from "@vm0/api-contracts/contracts/runners";
 import { expandVariablesInString } from "@vm0/core/variable-expander";
 import {
@@ -17,7 +15,7 @@ import { computed, type Computed } from "ccstate";
 import { and, eq, inArray, isNull, like } from "drizzle-orm";
 
 import { env } from "../../lib/env";
-import { generatePresignedGetUrl, putS3Object } from "../external/s3";
+import { generatePresignedGetUrl } from "../external/s3";
 import type { Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import { settle } from "../utils";
@@ -131,6 +129,7 @@ interface StorageResolution {
   readonly storageId: string;
   readonly versionId: string;
   readonly s3Key: string;
+  readonly fileCount: number;
   readonly resolvedOrgId: string;
 }
 
@@ -150,7 +149,11 @@ interface ArtifactStorageRow {
 interface StorageIndexEntry {
   readonly storageId: string;
   readonly headVersionId: string | null;
-  readonly headVersion: { readonly id: string; readonly s3Key: string } | null;
+  readonly headVersion: {
+    readonly id: string;
+    readonly s3Key: string;
+    readonly fileCount: number;
+  } | null;
 }
 
 interface StorageManifestInputs {
@@ -230,7 +233,6 @@ interface StorageManifestPhaseTimingWindow {
  */
 type StorageIndex = ReadonlyMap<string, StorageIndexEntry>;
 
-const EMPTY_TAR_GZ = gzipSync(Buffer.alloc(1024, 0));
 const DOWNLOAD_URL_TTL_SECONDS = 60 * 60;
 const STORAGE_MANIFEST_COUNT_BUCKET_DIMENSIONS = [
   "0",
@@ -254,7 +256,6 @@ const STORAGE_MANIFEST_ARTIFACT_ENSURE_ACTION_TYPES = [
   "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_storage",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_refetch_storage",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_skip_initialized",
-  "api_dispatch_prepare_storage_manifest_ensure_artifact_upload_empty_objects",
   "api_dispatch_prepare_storage_manifest_ensure_artifact_insert_initial_version",
 ] as const satisfies readonly ApiDispatchTimingActionType[];
 
@@ -1003,16 +1004,6 @@ function dedupArtifacts(
   return [...byName.values()];
 }
 
-function createEmptyStorageManifest(): string {
-  return JSON.stringify({
-    version: "1",
-    createdAt: nowDate().toISOString(),
-    totalSize: 0,
-    fileCount: 0,
-    files: [],
-  });
-}
-
 async function findStorage(
   db: Db,
   lookup: StorageLookup,
@@ -1060,6 +1051,7 @@ async function loadStorageIndex(
       headVersionId: storages.headVersionId,
       versionId: storageVersions.id,
       s3Key: storageVersions.s3Key,
+      fileCount: storageVersions.fileCount,
     })
     .from(storages)
     .leftJoin(storageVersions, eq(storages.headVersionId, storageVersions.id))
@@ -1071,8 +1063,8 @@ async function loadStorageIndex(
       storageId: row.storageId,
       headVersionId: row.headVersionId,
       headVersion:
-        row.versionId && row.s3Key
-          ? { id: row.versionId, s3Key: row.s3Key }
+        row.versionId && row.s3Key && row.fileCount !== null
+          ? { id: row.versionId, s3Key: row.s3Key, fileCount: row.fileCount }
           : null,
     });
   }
@@ -1155,37 +1147,6 @@ async function recordInitializedArtifactFastPath(
   );
 }
 
-async function uploadEmptyArtifactObjects(
-  get: ComputedGetter,
-  args: EnsureArtifactStorageArgs,
-  s3Key: string,
-): Promise<void> {
-  await measureStorageManifestArtifactEnsure(
-    args.timing,
-    "api_dispatch_prepare_storage_manifest_ensure_artifact_upload_empty_objects",
-    async () => {
-      await Promise.all([
-        get(
-          putS3Object(
-            args.bucket,
-            `${s3Key}/manifest.json`,
-            createEmptyStorageManifest(),
-            "application/json",
-          ),
-        ),
-        get(
-          putS3Object(
-            args.bucket,
-            `${s3Key}/archive.tar.gz`,
-            EMPTY_TAR_GZ,
-            "application/gzip",
-          ),
-        ),
-      ]);
-    },
-  );
-}
-
 async function insertInitialArtifactVersion(args: {
   readonly db: Db;
   readonly userId: string;
@@ -1233,14 +1194,12 @@ async function insertInitialArtifactVersion(args: {
 }
 
 async function initializeEmptyArtifactStorage(
-  get: ComputedGetter,
   args: EnsureArtifactStorageArgs,
   storage: ArtifactStorageRow,
 ): Promise<void> {
   args.stats?.recordArtifactEnsureMissingHeadVersion();
   const versionId = computeContentHashFromHashes(storage.id, []);
   const s3Key = `${storage.s3Prefix}/${versionId}`;
-  await uploadEmptyArtifactObjects(get, args, s3Key);
   const initializedHead = await insertInitialArtifactVersion({
     db: args.db,
     userId: args.userId,
@@ -1257,7 +1216,7 @@ async function initializeEmptyArtifactStorage(
 function ensureArtifactStorage(
   args: EnsureArtifactStorageArgs,
 ): Computed<Promise<void>> {
-  return computed(async (get): Promise<void> => {
+  return computed(async (): Promise<void> => {
     const lookup = {
       orgId: args.orgId,
       userId: args.userId,
@@ -1273,7 +1232,7 @@ function ensureArtifactStorage(
       return;
     }
 
-    await initializeEmptyArtifactStorage(get, args, storage);
+    await initializeEmptyArtifactStorage(args, storage);
   });
 }
 
@@ -1309,6 +1268,7 @@ function resolveLatestVersion(
     storageId: entry.storageId,
     versionId: entry.headVersion.id,
     s3Key: entry.headVersion.s3Key,
+    fileCount: entry.headVersion.fileCount,
     resolvedOrgId: lookup.orgId,
   };
 }
@@ -1327,7 +1287,11 @@ async function resolvePinnedVersion(
   }
 
   const [exactMatch] = await db
-    .select({ id: storageVersions.id, s3Key: storageVersions.s3Key })
+    .select({
+      id: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      fileCount: storageVersions.fileCount,
+    })
     .from(storageVersions)
     .where(
       and(
@@ -1341,6 +1305,7 @@ async function resolvePinnedVersion(
       storageId: storage.storageId,
       versionId: exactMatch.id,
       s3Key: exactMatch.s3Key,
+      fileCount: exactMatch.fileCount,
       resolvedOrgId: lookup.orgId,
     };
   }
@@ -1355,7 +1320,11 @@ async function resolvePinnedVersion(
   }
 
   const matches = await db
-    .select({ id: storageVersions.id, s3Key: storageVersions.s3Key })
+    .select({
+      id: storageVersions.id,
+      s3Key: storageVersions.s3Key,
+      fileCount: storageVersions.fileCount,
+    })
     .from(storageVersions)
     .where(
       and(
@@ -1381,6 +1350,7 @@ async function resolvePinnedVersion(
     storageId: storage.storageId,
     versionId: match.id,
     s3Key: match.s3Key,
+    fileCount: match.fileCount,
     resolvedOrgId: lookup.orgId,
   };
 }
@@ -1766,6 +1736,7 @@ async function buildArtifactEntryFromInput(
     vasStorageId: resolved.storageId,
     vasVersionId: resolved.versionId,
     archiveUrl,
+    ...(resolved.fileCount === 0 ? { empty: true } : {}),
     ...(artifact.missingRootPolicy
       ? { missingRootPolicy: artifact.missingRootPolicy }
       : {}),

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1076,7 +1076,6 @@ interface EnsureArtifactStorageArgs {
   readonly orgId: string;
   readonly userId: string;
   readonly name: string;
-  readonly bucket: string;
   readonly timing?: StorageManifestArtifactEnsureTiming;
   readonly stats?: StorageManifestBuildStats;
 }
@@ -1241,7 +1240,6 @@ export function ensureUserArtifactStorage(args: {
   readonly orgId: string;
   readonly userId: string;
   readonly name: string;
-  readonly bucket: string;
 }): Computed<Promise<void>> {
   return ensureArtifactStorage(args);
 }
@@ -1857,7 +1855,6 @@ async function ensureStorageManifestArtifacts(
     readonly db: Db;
     readonly runtimeOrgId: string;
     readonly userId: string;
-    readonly bucket: string;
     readonly artifacts: readonly ContextArtifact[];
     readonly timing?: ApiDispatchTimingCollector;
     readonly stats?: StorageManifestBuildStats;
@@ -1879,7 +1876,6 @@ async function ensureStorageManifestArtifacts(
               orgId: args.runtimeOrgId,
               userId: args.userId,
               name: artifact.name,
-              bucket: args.bucket,
               timing: artifactEnsureTiming,
               stats: args.stats,
             }),
@@ -2193,7 +2189,6 @@ export function prepareAgentRunStorageManifest(
       db: args.db,
       runtimeOrgId: args.runtimeOrgId,
       userId: args.userId,
-      bucket,
       artifacts,
       timing: args.timing,
       stats: args.stats,

--- a/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-summarize-memory.service.ts
@@ -19,6 +19,7 @@ import {
 import {
   computeMemoryChangeSet,
   type MemoryChangeSet,
+  type MemoryVersionSource,
 } from "./memory-activity-diff.service";
 import { generateMemoryDaySummary } from "./memory-activity-summarize.service";
 import { settle } from "../utils";
@@ -50,7 +51,12 @@ interface SummarizeUserMemoryOptions {
 interface MemoryVersionRow {
   readonly id: string;
   readonly s3Key: string;
+  readonly fileCount: number;
   readonly createdAt: Date;
+}
+
+function memoryVersionSource(version: MemoryVersionRow): MemoryVersionSource {
+  return { s3Key: version.s3Key, fileCount: version.fileCount };
 }
 
 function addDateLabelDays(dateLabel: string, days: number): string {
@@ -116,6 +122,7 @@ async function loadVersions(
     .select({
       id: storageVersions.id,
       s3Key: storageVersions.s3Key,
+      fileCount: storageVersions.fileCount,
       createdAt: storageVersions.createdAt,
     })
     .from(storageVersions)
@@ -284,7 +291,10 @@ function summarizeUserMemory(
         baseline?.id === toVersion.id
           ? { items: [], changed: false }
           : await get(
-              computeMemoryChangeSet(baseline?.s3Key ?? null, toVersion.s3Key),
+              computeMemoryChangeSet(
+                baseline ? memoryVersionSource(baseline) : null,
+                memoryVersionSource(toVersion),
+              ),
             );
       signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-activity-diff.service.ts
@@ -26,6 +26,11 @@ interface MemoryFileState {
 
 type MemoryFileMap = ReadonlyMap<string, MemoryFileState>;
 
+export interface MemoryVersionSource {
+  readonly s3Key: string;
+  readonly fileCount: number;
+}
+
 const MAX_DIFF_LINES = 300;
 const MAX_DIFF_LINE_CHARS = 500;
 const MAX_LCS_CELLS = 250_000;
@@ -337,16 +342,20 @@ function normalizePath(path: string): string {
 
 function loadVersionFiles(
   bucket: string,
-  s3Key: string,
+  version: MemoryVersionSource,
 ): Computed<Promise<MemoryFileMap>> {
   return computed(async (get): Promise<MemoryFileMap> => {
-    const manifest = await get(downloadManifest(bucket, s3Key));
+    if (version.fileCount === 0) {
+      return new Map();
+    }
+
+    const manifest = await get(downloadManifest(bucket, version.s3Key));
     const entries = manifest.files.map((file) => {
       return { path: normalizePath(file.path), hash: file.hash };
     });
 
     const archiveBuffer = await get(
-      downloadS3Buffer(bucket, `${s3Key}/archive.tar.gz`),
+      downloadS3Buffer(bucket, `${version.s3Key}/archive.tar.gz`),
     );
     const extracted = extractFilesFromTarGz(
       archiveBuffer,
@@ -376,21 +385,22 @@ function loadVersionFiles(
  * per-file hash from each version's manifest and the file bodies from its
  * archive, then delegates to the pure `computeChangeSet`.
  *
- * A null `fromS3Key` means there was no baseline version (the user's memory
+ * A null `fromVersion` means there was no baseline version (the user's memory
  * first appeared in the window), so the from-side is empty and every file in
- * `toS3Key` is treated as newly added.
+ * `toVersion` is treated as newly added. A zero-file version is also empty and
+ * does not require storage objects.
  */
 export function computeMemoryChangeSet(
-  fromS3Key: string | null,
-  toS3Key: string,
+  fromVersion: MemoryVersionSource | null,
+  toVersion: MemoryVersionSource,
 ): Computed<Promise<MemoryChangeSet>> {
   return computed(async (get): Promise<MemoryChangeSet> => {
     const bucket = env("R2_USER_STORAGES_BUCKET_NAME");
     const [fromFiles, toFiles] = await Promise.all([
-      fromS3Key === null
+      fromVersion === null
         ? Promise.resolve<MemoryFileMap>(new Map())
-        : get(loadVersionFiles(bucket, fromS3Key)),
-      get(loadVersionFiles(bucket, toS3Key)),
+        : get(loadVersionFiles(bucket, fromVersion)),
+      get(loadVersionFiles(bucket, toVersion)),
     ]);
     return computeChangeSet(fromFiles, toFiles);
   });

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -229,6 +229,10 @@ function mergeWithBaseVersion(args: {
       return args.files;
     }
 
+    if (baseVersionRecord.fileCount === 0) {
+      return args.files;
+    }
+
     const baseManifest = await get(
       downloadManifest(args.bucket, baseVersionRecord.s3Key),
     );

--- a/turbo/apps/api/src/signals/services/storage-write.service.ts
+++ b/turbo/apps/api/src/signals/services/storage-write.service.ts
@@ -362,6 +362,7 @@ function existingStorageVersionIsReusable(args: {
   readonly db: Db;
   readonly bucket: string;
   readonly storageId: string;
+  readonly storageType: StorageType;
   readonly versionId: string;
   readonly force: boolean | undefined;
   readonly signal: AbortSignal;
@@ -387,6 +388,9 @@ function existingStorageVersionIsReusable(args: {
         args.bucket,
         existingVersion.s3Key,
         existingVersion.fileCount,
+        {
+          allowMissingObjectsForEmptyVersion: args.storageType === "artifact",
+        },
       ),
     );
     args.signal.throwIfAborted();
@@ -470,6 +474,9 @@ function commitExistingStorageVersion(args: {
         args.bucket,
         args.version.s3Key,
         args.version.fileCount,
+        {
+          allowMissingObjectsForEmptyVersion: args.storage.type === "artifact",
+        },
       ),
     );
     args.signal.throwIfAborted();
@@ -724,6 +731,7 @@ export const prepareStorageUploadForAuth$ = command(
         db: writeDb,
         bucket,
         storageId: storage.id,
+        storageType: args.storageType,
         versionId,
         force: args.force,
         signal,

--- a/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-connect.service.ts
@@ -399,7 +399,6 @@ export const connectSlackWorkspace$ = command(
           orgId: args.orgId,
           userId: args.userId,
           name: "artifact",
-          bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
         }),
       );
       signal.throwIfAborted();
@@ -432,7 +431,6 @@ export const connectSlackWorkspace$ = command(
         orgId: args.orgId,
         userId: args.userId,
         name: "artifact",
-        bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
       }),
     );
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-teams-connect.service.ts
@@ -441,7 +441,6 @@ export const connectTeamsInstallation$ = command(
           orgId: args.orgId,
           userId: args.userId,
           name: "artifact",
-          bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
         }),
       );
       signal.throwIfAborted();
@@ -480,7 +479,6 @@ export const connectTeamsInstallation$ = command(
         orgId: args.orgId,
         userId: args.userId,
         name: "artifact",
-        bucket: env("R2_USER_STORAGES_BUCKET_NAME"),
       }),
     );
     signal.throwIfAborted();

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -87,6 +87,27 @@ describe("runner storage manifest contract", () => {
     });
   });
 
+  it("accepts explicit empty artifact entries while keeping archive urls required", () => {
+    const manifest = storageManifestSchema.parse({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/project",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          archiveUrl: "https://storage.example/artifact.tar.gz",
+          empty: true,
+        },
+      ],
+    });
+
+    expect(manifest.artifacts[0]).toMatchObject({
+      archiveUrl: "https://storage.example/artifact.tar.gz",
+      empty: true,
+    });
+  });
+
   it("rejects guest-download-only nullable archive urls", () => {
     const result = storageManifestSchema.safeParse({
       storages: [
@@ -99,6 +120,24 @@ describe("runner storage manifest contract", () => {
         },
       ],
       artifacts: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects nullable artifact archive urls even for explicit empty artifacts", () => {
+    const result = storageManifestSchema.safeParse({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/project",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          archiveUrl: null,
+          empty: true,
+        },
+      ],
     });
 
     expect(result.success).toBe(false);

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -203,6 +203,7 @@ export const artifactEntrySchema = z.object({
   vasStorageId: z.string(),
   vasVersionId: z.string(),
   archiveUrl: z.string(),
+  empty: z.boolean().optional(),
   missingRootPolicy: artifactMissingRootPolicySchema.optional(),
 });
 

--- a/turbo/packages/api-contracts/src/contracts/test-memory-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-memory-state.ts
@@ -64,6 +64,7 @@ export const testMemoryStateActionBodySchema = z.discriminatedUnion("action", [
     s3_key: z.string(),
     user_id: z.string(),
     created_at: z.string(),
+    file_count: z.number().optional(),
   }),
   z.object({
     action: z.literal("update-version-created-at"),

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -102,6 +102,9 @@ export const rustTypeBindings = [
           vasStorageId: ["VAS storage identifier for the artifact."],
           vasVersionId: ["VAS version identifier for the artifact contents."],
           archiveUrl: ["Presigned URL for downloading the artifact archive."],
+          empty: [
+            "Whether this artifact version is explicitly empty and can be prepared without downloading an archive.",
+          ],
           missingRootPolicy: [
             "Optional policy for a missing artifact root; absence behaves like `fail`.",
           ],


### PR DESCRIPTION
## Summary

- Add an optional artifact-only `empty` marker to the runner storage manifest while keeping `archiveUrl` required for old runner compatibility.
- Stop create-run storage preparation from uploading per-run empty `manifest.json` / `archive.tar.gz` objects; initial empty artifacts now use the deterministic zero-file storage version only.
- Teach the runner and guest-download to prepare explicit empty artifact mount directories without downloading an archive.
- Treat zero-file Memory Activity versions as empty without reading storage objects, so the new initial empty memory version does not break summary backfill.
- Treat zero-file base storage versions as empty during incremental prepare, avoiding failed S3 manifest reads after initial empty artifact creation.
- Treat zero-file storage versions as reusable during prepare/commit without requiring storage objects to exist in S3.
- Remove the now-unused bucket parameter from artifact ensure paths so ensure-only callers no longer appear to touch S3.

Closes #20429.

## Tests

- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts test`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/storages.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/cron-summarize-memory.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-connect.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-slack-connect.test.ts src/signals/routes/__tests__/zero-teams-connect.test.ts`
- `pnpm vitest run --project=api --shard=6/8`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage`
- `git diff --check`

## Notes

- No DB schema change. The persisted storage-version shape is unchanged; readers now use existing `file_count` to identify zero-file versions.
- Full `pnpm test` was attempted but interrupted after unrelated `@vm0/app` UI tests entered an `Invalid URL` retry loop; focused tests for this change passed.
