### PR TITLE
fix: remove stray focus ring on member/workspace dropdowns after selecting

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -450,7 +450,13 @@ function SelfDemoteAction({ email }: { email: string }) {
             <IconDots size={15} stroke={1.5} />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuContent
+          align="end"
+          className="w-48"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+          }}
+        >
           <DialogTrigger asChild>
             <DropdownMenuItem>Switch to member</DropdownMenuItem>
           </DialogTrigger>
@@ -524,7 +530,13 @@ function MemberActions({ member }: { member: OrgMember }) {
             <IconDots size={15} stroke={1.5} />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuContent
+          align="end"
+          className="w-48"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+          }}
+        >
           <DropdownMenuItem
             onClick={() => {
               return detach(
@@ -633,7 +645,13 @@ function PendingInvitationRow({
                   <IconDots size={15} stroke={1.5} />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuContent
+                align="end"
+                className="w-48"
+                onCloseAutoFocus={(event) => {
+                  event.preventDefault();
+                }}
+              >
                 <DialogTrigger asChild>
                   <DropdownMenuItem className="text-destructive focus:text-destructive">
                     Revoke invitation

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -545,7 +545,13 @@ function PermissionAllowDurationDropdown({
           <IconChevronDown size={12} stroke={2.5} className="shrink-0" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-40">
+      <DropdownMenuContent
+        align="start"
+        className="w-40"
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+        }}
+      >
         {ALLOW_DURATION_MENU_OPTIONS.map((option) => {
           return (
             <DropdownMenuItem

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -227,6 +227,9 @@ function OrgDropdownContent() {
     <DropdownMenuContent
       align="start"
       className="flex max-h-[min(420px,var(--radix-dropdown-menu-content-available-height))] w-72 flex-col overflow-hidden"
+      onCloseAutoFocus={(event) => {
+        event.preventDefault();
+      }}
     >
       <div className="flex min-w-0 shrink-0 items-center gap-3 px-2 py-1.5">
         <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} size="lg" />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -716,6 +716,9 @@ export function AccountDropdown({
           align="start"
           sideOffset={8}
           className="w-[240px]"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+          }}
         >
           <CurrentAccountHeader
             display={accountDisplay}


### PR DESCRIPTION
## Problem

Several dropdown menus in the platform left a stray focus outline/ring on their trigger button **after** the user made a selection — most visibly the member-management "⋯" menus in **Settings → People**. Picking a person/action, switching workspaces, or choosing a permission duration would leave a keyboard-style focus ring on the trigger even though the menu was dismissed with the mouse.

## Root cause

Radix `DropdownMenu` restores focus to its trigger when the menu closes. Because the trigger is programmatically re-focused, the browser's `:focus-visible` heuristic matches and paints the focus ring (a 2px `ring-ring` for `<Button>` triggers, or the native UA outline for plain `<button>` triggers) — even when the close was pointer-initiated. None of the affected member/workspace pickers opted out of this focus restoration.

## Fix

Add `onCloseAutoFocus={(event) => event.preventDefault()}` to the affected `DropdownMenuContent` instances so focus is no longer forced back onto the trigger on close. This is the same pattern already used by `zero-artifact-actions.tsx` and `zero-chat-feedback-selection.tsx`, so it is consistent with existing house style. Keyboard users can still Tab to the trigger and see the focus ring normally; only the post-close focus restoration is suppressed.

Applied to:
- `org-members-tab.tsx` — `MemberActions` (change/remove role), `SelfDemoteAction` (switch to member), `PendingInvitationRow` (revoke invitation)
- `zero-org-switcher.tsx` — workspace / organization switcher menu
- `zero-sidebar-account.tsx` — account menu
- `permissions-dialog.tsx` — per-user permission "allow duration" picker

## Scope notes

Radix `Select` triggers (e.g. the role select inside the invite dialog) are unaffected — `SelectTrigger` has no `focus-visible:` ring, so no change was needed there. Dialog-close focus rings (e.g. the "Add member" button after the invite dialog closes) were left out of this PR to keep it scoped to the reported dropdown behavior.

## Verification

Relying on the PR CI pipeline for lint/type-check/format/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)