### PR TITLE
perf: reuse codex zstd session history

### DIFF
--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -1647,6 +1647,103 @@ mod tests {
         checkpoint.assert_calls(1);
     }
 
+    #[tokio::test]
+    async fn checkpoint_falls_back_to_legacy_upload_when_prepare_rejects_reused_zstd() {
+        let server = MockServer::start();
+        let dir = tempfile::tempdir().unwrap();
+        let guest_paths = crate::paths::GuestPaths::from_runtime_dir(dir.path().join("runtime"));
+        let _files_guard = CheckpointFilesGuard::new(&guest_paths);
+        let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+        let history =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-02T10:00:00Z\"}}\n";
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        let history_hash = hex::encode(Sha256::digest(history));
+        let home_dir = dir.path().join("home");
+        let codex_day_dir = home_dir
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("07")
+            .join("02");
+        std::fs::create_dir_all(&codex_day_dir).unwrap();
+        std::fs::write(
+            codex_day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst"),
+            &compressed,
+        )
+        .unwrap();
+        crate::paths::write_private(guest_paths.session_id_file(), thread_id).unwrap();
+
+        let zstd_prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints/prepare-history")
+                .json_body(json!({
+                    "runId": "checkpoint-codex-zstd-legacy-fallback",
+                    "hash": history_hash,
+                    "rawSize": history.len() as u64,
+                    "encodedSize": compressed.len() as u64,
+                    "encoding": SESSION_HISTORY_ENCODING_ZSTD,
+                }));
+            then.status(400).json_body(json!({
+                "error": "unsupported encoding",
+            }));
+        });
+        let upload_url = server.url("/test/session-history-legacy-upload");
+        let legacy_prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints/prepare-history")
+                .json_body(json!({
+                    "runId": "checkpoint-codex-zstd-legacy-fallback",
+                    "hash": history_hash,
+                    "rawSize": history.len() as u64,
+                    "encodedSize": history.len() as u64,
+                    "encoding": SESSION_HISTORY_ENCODING_IDENTITY,
+                }));
+            then.status(200).json_body(json!({
+                "presignedUrl": upload_url,
+                "encoding": SESSION_HISTORY_ENCODING_IDENTITY,
+            }));
+        });
+        let upload = server.mock(|when, then| {
+            when.method(PUT).path("/test/session-history-legacy-upload");
+            then.respond_with(move |req| session_history_upload_response(req, history));
+        });
+        let checkpoint = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints")
+                .json_body(json!({
+                    "runId": "checkpoint-codex-zstd-legacy-fallback",
+                    "cliAgentType": "codex",
+                    "cliAgentSessionId": thread_id,
+                    "cliAgentSessionHistoryHash": history_hash,
+                }));
+            then.status(200)
+                .json_body(json!({"checkpointId": "checkpoint-codex-zstd-legacy"}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let home_dir = home_dir.to_string_lossy().into_owned();
+        let inputs = CheckpointInputs {
+            run_id: "checkpoint-codex-zstd-legacy-fallback",
+            framework: env::Framework::Codex,
+            home_dir: &home_dir,
+            artifact_entries: &[],
+            session_id_file: guest_paths.session_id_file().into(),
+            session_history_path_file: guest_paths.session_history_path_file().into(),
+            final_session_history_identity_file: guest_paths
+                .final_session_history_identity_file()
+                .into(),
+        };
+
+        create_checkpoint_impl(&http, CheckpointMode::Success, &inputs)
+            .await
+            .unwrap();
+
+        zstd_prepare.assert_calls(1);
+        legacy_prepare.assert_calls(1);
+        upload.assert_calls(1);
+        checkpoint.assert_calls(1);
+    }
+
     #[test]
     fn recoverable_session_history_accepts_valid_jsonl() {
         let history = r#"{"type":"system"}"#.to_string() + "\n" + r#"{"type":"assistant"}"#;

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -51,7 +51,27 @@ struct SessionHistoryUpload {
 struct PreparedSessionHistory {
     hash: String,
     raw_size: u64,
-    upload: SessionHistoryUpload,
+    upload_source: PreparedSessionHistoryUploadSource,
+}
+
+enum PreparedSessionHistoryUploadSource {
+    Raw(Vec<u8>),
+    ReusedCodexZstd(Vec<u8>),
+}
+
+impl PreparedSessionHistoryUploadSource {
+    fn into_upload(self, raw_size: u64) -> Result<SessionHistoryUpload, AgentError> {
+        match self {
+            Self::Raw(history_bytes) => build_session_history_upload(history_bytes),
+            Self::ReusedCodexZstd(zstd_bytes) => Ok(SessionHistoryUpload {
+                raw_size,
+                body: SessionHistoryUploadBody::Zstd {
+                    raw: None,
+                    zstd: zstd_bytes,
+                },
+            }),
+        }
+    }
 }
 
 struct DecodedSessionHistoryAnalysis {
@@ -483,8 +503,10 @@ async fn build_and_upload_session_history(
     http: &HttpClient,
     run_id: &str,
     history_hash: &str,
-    history_upload: SessionHistoryUpload,
+    history_size: u64,
+    upload_source: PreparedSessionHistoryUploadSource,
 ) -> Result<(), AgentError> {
+    let history_upload = upload_source.into_upload(history_size)?;
     match upload_session_history_candidate(http, run_id, history_hash, history_upload).await? {
         SessionHistoryUploadAttempt::Complete => Ok(()),
         SessionHistoryUploadAttempt::RetryLegacy(history_bytes) => {
@@ -771,11 +793,10 @@ fn prepare_raw_session_history(
         "Session history hash={}, size={history_size}",
         &history_hash[..8]
     );
-    let upload = build_session_history_upload(history_bytes)?;
     Ok(PreparedSessionHistory {
         hash: history_hash,
         raw_size: history_size,
-        upload,
+        upload_source: PreparedSessionHistoryUploadSource::Raw(history_bytes),
     })
 }
 
@@ -850,13 +871,7 @@ fn prepare_reused_zstd_session_history(
     Ok(PreparedSessionHistory {
         hash: analysis.sha256_hex,
         raw_size: analysis.raw_size,
-        upload: SessionHistoryUpload {
-            raw_size: analysis.raw_size,
-            body: SessionHistoryUploadBody::Zstd {
-                raw: None,
-                zstd: zstd_bytes,
-            },
-        },
+        upload_source: PreparedSessionHistoryUploadSource::ReusedCodexZstd(zstd_bytes),
     })
 }
 
@@ -1024,7 +1039,7 @@ async fn create_checkpoint_impl(
     let PreparedSessionHistory {
         hash: history_hash,
         raw_size: history_size,
-        upload: history_upload,
+        upload_source,
     } = prepared_history;
 
     // History upload and artifact snapshots are independent pre-requisites
@@ -1034,7 +1049,13 @@ async fn create_checkpoint_impl(
     // was longer plus the other; concurrent, it's just the longer one.
     let (artifact_snapshots, _) = tokio::try_join!(
         snapshot_artifact_entries(http, inputs.run_id, inputs.artifact_entries),
-        build_and_upload_session_history(http, inputs.run_id, &history_hash, history_upload,),
+        build_and_upload_session_history(
+            http,
+            inputs.run_id,
+            &history_hash,
+            history_size,
+            upload_source,
+        ),
     )?;
 
     // Build and send checkpoint payload (session history hash only, content uploaded to S3)

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -24,7 +24,7 @@ use guest_common::{log_error, log_info, log_warn};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::borrow::Cow;
-use std::io::{ErrorKind, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::time::Duration;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
@@ -40,12 +40,27 @@ enum CheckpointMode {
 enum SessionHistoryUploadBody {
     Identity(Vec<u8>),
     Gzip { raw: Vec<u8>, gzip: Vec<u8> },
-    Zstd { raw: Vec<u8>, zstd: Vec<u8> },
+    Zstd { raw: Option<Vec<u8>>, zstd: Vec<u8> },
 }
 
 struct SessionHistoryUpload {
     raw_size: u64,
     body: SessionHistoryUploadBody,
+}
+
+struct PreparedSessionHistory {
+    hash: String,
+    raw_size: u64,
+    upload: SessionHistoryUpload,
+}
+
+struct DecodedSessionHistoryAnalysis {
+    raw_size: u64,
+    sha256_hex: String,
+    line_count: Option<usize>,
+    invalid_utf8: Option<String>,
+    is_empty: bool,
+    recovery_validation_error: Option<String>,
 }
 
 impl SessionHistoryUpload {
@@ -65,27 +80,66 @@ impl SessionHistoryUpload {
         }
     }
 
-    fn into_raw(self) -> Vec<u8> {
+    fn into_raw(self) -> Result<Vec<u8>, AgentError> {
         match self.body {
             SessionHistoryUploadBody::Identity(raw)
             | SessionHistoryUploadBody::Gzip { raw, .. }
-            | SessionHistoryUploadBody::Zstd { raw, .. } => raw,
+            | SessionHistoryUploadBody::Zstd { raw: Some(raw), .. } => Ok(raw),
+            SessionHistoryUploadBody::Zstd { raw: None, zstd } => {
+                unzstd_session_history_upload_body(&zstd, self.raw_size)
+            }
         }
     }
 
-    fn into_server_accepted_bytes(self) -> (&'static str, Bytes) {
+    fn into_server_accepted_bytes(
+        self,
+        accepted_encoding: Option<&str>,
+    ) -> Result<SessionHistoryServerAcceptedBytes, AgentError> {
         match self.body {
             SessionHistoryUploadBody::Identity(raw) => {
-                (SESSION_HISTORY_ENCODING_IDENTITY, Bytes::from(raw))
+                Ok(SessionHistoryServerAcceptedBytes::Accepted {
+                    encoding: SESSION_HISTORY_ENCODING_IDENTITY,
+                    bytes: Bytes::from(raw),
+                })
             }
-            SessionHistoryUploadBody::Gzip { raw: _, gzip } => {
-                (SESSION_HISTORY_ENCODING_GZIP, Bytes::from(gzip))
+            SessionHistoryUploadBody::Gzip { raw: _, gzip }
+                if accepted_encoding == Some(SESSION_HISTORY_ENCODING_GZIP) =>
+            {
+                Ok(SessionHistoryServerAcceptedBytes::Accepted {
+                    encoding: SESSION_HISTORY_ENCODING_GZIP,
+                    bytes: Bytes::from(gzip),
+                })
             }
-            SessionHistoryUploadBody::Zstd { raw: _, zstd } => {
-                (SESSION_HISTORY_ENCODING_ZSTD, Bytes::from(zstd))
+            SessionHistoryUploadBody::Gzip { .. } => {
+                Err(compressed_encoding_not_acknowledged(SESSION_HISTORY_ENCODING_GZIP))
+            }
+            SessionHistoryUploadBody::Zstd { raw: _, zstd }
+                if accepted_encoding == Some(SESSION_HISTORY_ENCODING_ZSTD) =>
+            {
+                Ok(SessionHistoryServerAcceptedBytes::Accepted {
+                    encoding: SESSION_HISTORY_ENCODING_ZSTD,
+                    bytes: Bytes::from(zstd),
+                })
+            }
+            SessionHistoryUploadBody::Zstd { raw, zstd } => {
+                let raw = match raw {
+                    Some(raw) => raw,
+                    None => unzstd_session_history_upload_body(&zstd, self.raw_size)?,
+                };
+                Ok(SessionHistoryServerAcceptedBytes::UnsupportedZstd { raw })
             }
         }
     }
+}
+
+enum SessionHistoryServerAcceptedBytes {
+    Accepted {
+        encoding: &'static str,
+        bytes: Bytes,
+    },
+    UnsupportedZstd {
+        raw: Vec<u8>,
+    },
 }
 
 enum SessionHistoryUploadAttempt {
@@ -125,7 +179,7 @@ fn build_session_history_upload(
     Ok(SessionHistoryUpload {
         raw_size,
         body: SessionHistoryUploadBody::Zstd {
-            raw: history_bytes,
+            raw: Some(history_bytes),
             zstd: zstd_bytes,
         },
     })
@@ -173,6 +227,26 @@ fn compressed_encoding_not_acknowledged(requested_encoding: &'static str) -> Age
     AgentError::Checkpoint(format!(
         "Prepare-history response did not acknowledge {requested_encoding} session history"
     ))
+}
+
+fn unzstd_session_history_upload_body(
+    zstd_bytes: &[u8],
+    raw_size: u64,
+) -> Result<Vec<u8>, AgentError> {
+    let decoder = zstd::stream::read::Decoder::new(zstd_bytes)
+        .map_err(|error| AgentError::Checkpoint(format!("zstd session history: {error}")))?;
+    let mut reader = decoder.take(raw_size.saturating_add(1));
+    let mut bytes = Vec::new();
+    reader
+        .read_to_end(&mut bytes)
+        .map_err(|error| AgentError::Checkpoint(format!("zstd session history: {error}")))?;
+    if bytes.len() as u64 != raw_size {
+        return Err(AgentError::Checkpoint(format!(
+            "Decoded zstd session history size mismatch: expected {raw_size}, got {}",
+            bytes.len()
+        )));
+    }
+    Ok(bytes)
 }
 
 impl CheckpointMode {
@@ -323,7 +397,7 @@ async fn upload_session_history_candidate(
                     "Prepare-history rejected zstd session history; retrying legacy encoding"
                 );
                 return Ok(SessionHistoryUploadAttempt::RetryLegacy(
-                    history_upload.into_raw(),
+                    history_upload.into_raw()?,
                 ));
             }
             return Err(e);
@@ -343,7 +417,7 @@ async fn upload_session_history_candidate(
             "Prepare-history response did not acknowledge zstd; retrying legacy encoding"
         );
         return Ok(SessionHistoryUploadAttempt::RetryLegacy(
-            history_upload.into_raw(),
+            history_upload.into_raw()?,
         ));
     }
     if requested_encoding == SESSION_HISTORY_ENCODING_GZIP
@@ -370,7 +444,13 @@ async fn upload_session_history_candidate(
             AgentError::Checkpoint("No presignedUrl in prepare-history response".into())
         })?;
 
-    let (upload_encoding, upload_bytes) = history_upload.into_server_accepted_bytes();
+    let (upload_encoding, upload_bytes) =
+        match history_upload.into_server_accepted_bytes(response_encoding)? {
+            SessionHistoryServerAcceptedBytes::Accepted { encoding, bytes } => (encoding, bytes),
+            SessionHistoryServerAcceptedBytes::UnsupportedZstd { raw } => {
+                return Ok(SessionHistoryUploadAttempt::RetryLegacy(raw));
+            }
+        };
 
     log_info!(
         LOG_TAG,
@@ -403,9 +483,8 @@ async fn build_and_upload_session_history(
     http: &HttpClient,
     run_id: &str,
     history_hash: &str,
-    history_bytes: Vec<u8>,
+    history_upload: SessionHistoryUpload,
 ) -> Result<(), AgentError> {
-    let history_upload = build_session_history_upload(history_bytes)?;
     match upload_session_history_candidate(http, run_id, history_hash, history_upload).await? {
         SessionHistoryUploadAttempt::Complete => Ok(()),
         SessionHistoryUploadAttempt::RetryLegacy(history_bytes) => {
@@ -603,71 +682,16 @@ async fn create_recovery_checkpoint_with_inputs(
     result
 }
 
-async fn create_checkpoint_impl(
-    http: &HttpClient,
+fn prepare_session_history(
     mode: CheckpointMode,
-    inputs: &CheckpointInputs<'_>,
-) -> Result<(), AgentError> {
-    log_info!(LOG_TAG, "Creating {}...", mode.log_label());
-
-    // Read the CLI agent session id. Let `read_to_string` surface `NotFound`
-    // directly — an explicit `exists()` check would be a redundant stat plus a
-    // TOCTOU race between check and read.
-    let session_id_start = std::time::Instant::now();
-    let cli_agent_session_id = match std::fs::read_to_string(inputs.session_id_file.as_ref()) {
-        Ok(s) => s.trim().to_string(),
-        Err(e) if e.kind() == ErrorKind::NotFound => {
-            return Err(fail(
-                mode,
-                "session_id_read",
-                session_id_start,
-                "No session ID found",
-            ));
-        }
-        Err(e) => {
-            return Err(fail(
-                mode,
-                "session_id_read",
-                session_id_start,
-                format!("Failed to read session ID: {e}"),
-            ));
-        }
-    };
-    if cli_agent_session_id.is_empty() {
-        return Err(fail(
-            mode,
-            "session_id_read",
-            session_id_start,
-            "Session ID is empty",
-        ));
-    }
-    record_sandbox_op("session_id_read", session_id_start.elapsed(), true, None);
-
-    // Read session history. The persisted or derived marker payload is either
-    // a literal jsonl path (Claude) or a codex marker. `session_history`
-    // abstracts the difference and decompresses zstd-compressed codex sessions.
-    let history_read_start = std::time::Instant::now();
-    let history_marker_payload = match crate::session_metadata::resolve_history_marker_payload_from(
-        inputs.framework,
-        inputs.home_dir,
-        inputs.session_history_path_file.as_ref(),
-        &cli_agent_session_id,
-    ) {
-        Ok(payload) => payload,
-        Err(e) => {
-            return Err(fail(
-                mode,
-                "session_history_read",
-                history_read_start,
-                e.to_string(),
-            ));
-        }
-    };
-    let history_bytes = match session_history::read_session_history_from_payload_bounded(
-        &history_marker_payload,
+    history_marker_payload: &str,
+    history_read_start: std::time::Instant,
+) -> Result<PreparedSessionHistory, AgentError> {
+    let source = match session_history::read_session_history_checkpoint_source_from_payload_bounded(
+        history_marker_payload,
         RESUME_SESSION_HISTORY_MAX_BYTES,
     ) {
-        Ok(b) => b,
+        Ok(source) => source,
         Err(e) => {
             return Err(fail(
                 mode,
@@ -677,6 +701,21 @@ async fn create_checkpoint_impl(
             ));
         }
     };
+    match source {
+        session_history::SessionHistoryCheckpointSource::Decoded(history_bytes) => {
+            prepare_raw_session_history(mode, history_read_start, history_bytes)
+        }
+        session_history::SessionHistoryCheckpointSource::CodexZstd { encoded } => {
+            prepare_reused_zstd_session_history(mode, history_read_start, encoded)
+        }
+    }
+}
+
+fn prepare_raw_session_history(
+    mode: CheckpointMode,
+    history_read_start: std::time::Instant,
+    history_bytes: Vec<u8>,
+) -> Result<PreparedSessionHistory, AgentError> {
     let history_size = history_bytes.len() as u64;
 
     let session_history_text = match std::str::from_utf8(&history_bytes) {
@@ -726,13 +765,267 @@ async fn create_checkpoint_impl(
         None,
     );
 
-    // Compute SHA-256 hash of session history for presigned URL upload
     let history_hash = hex::encode(Sha256::digest(&history_bytes));
     log_info!(
         LOG_TAG,
         "Session history hash={}, size={history_size}",
         &history_hash[..8]
     );
+    let upload = build_session_history_upload(history_bytes)?;
+    Ok(PreparedSessionHistory {
+        hash: history_hash,
+        raw_size: history_size,
+        upload,
+    })
+}
+
+fn prepare_reused_zstd_session_history(
+    mode: CheckpointMode,
+    history_read_start: std::time::Instant,
+    zstd_bytes: Vec<u8>,
+) -> Result<PreparedSessionHistory, AgentError> {
+    let analysis = analyze_zstd_session_history(
+        &zstd_bytes,
+        RESUME_SESSION_HISTORY_MAX_BYTES,
+        mode.validate_history(),
+    )
+    .map_err(|e| {
+        fail(
+            mode,
+            "session_history_read",
+            history_read_start,
+            e.to_string(),
+        )
+    })?;
+
+    if let Some(msg) = &analysis.invalid_utf8 {
+        if mode.validate_history() {
+            return Err(fail(mode, "session_history_read", history_read_start, msg));
+        }
+        log_warn!(LOG_TAG, "{msg}; preserving session history for checkpoint");
+    }
+
+    if analysis.is_empty {
+        return Err(fail(
+            mode,
+            "session_history_read",
+            history_read_start,
+            "Session history is empty",
+        ));
+    }
+
+    if mode.validate_history()
+        && let Some(msg) = analysis.recovery_validation_error
+    {
+        return Err(fail(
+            mode,
+            "session_history_validate",
+            history_read_start,
+            msg,
+        ));
+    }
+
+    if let Some(line_count) = analysis.line_count {
+        log_info!(LOG_TAG, "Session history loaded ({line_count} lines)");
+    } else {
+        log_info!(
+            LOG_TAG,
+            "Session history loaded ({} raw bytes, invalid UTF-8)",
+            analysis.raw_size
+        );
+    }
+    record_sandbox_op(
+        "session_history_read",
+        history_read_start.elapsed(),
+        true,
+        None,
+    );
+
+    log_info!(
+        LOG_TAG,
+        "Session history hash={}, size={}",
+        &analysis.sha256_hex[..8],
+        analysis.raw_size
+    );
+    Ok(PreparedSessionHistory {
+        hash: analysis.sha256_hex,
+        raw_size: analysis.raw_size,
+        upload: SessionHistoryUpload {
+            raw_size: analysis.raw_size,
+            body: SessionHistoryUploadBody::Zstd {
+                raw: None,
+                zstd: zstd_bytes,
+            },
+        },
+    })
+}
+
+fn analyze_zstd_session_history(
+    zstd_bytes: &[u8],
+    max_bytes: u64,
+    validate_history: bool,
+) -> Result<DecodedSessionHistoryAnalysis, AgentError> {
+    let decoder = zstd::stream::read::Decoder::new(zstd_bytes).map_err(|error| {
+        AgentError::Checkpoint(format!(
+            "Failed to decompress zstd session history: {error}"
+        ))
+    })?;
+    analyze_decoded_session_history_reader(
+        BufReader::new(decoder.take(max_bytes.saturating_add(1))),
+        max_bytes,
+        validate_history,
+    )
+}
+
+fn analyze_decoded_session_history_reader(
+    mut reader: impl BufRead,
+    max_bytes: u64,
+    validate_history: bool,
+) -> Result<DecodedSessionHistoryAnalysis, AgentError> {
+    let mut hasher = Sha256::new();
+    let mut raw_size = 0u64;
+    let mut line_count = 0usize;
+    let mut all_bytes_ascii_whitespace = true;
+    let mut all_utf8_lines_trim_empty = true;
+    let mut invalid_utf8 = None;
+    let mut recovery_validation_error = None;
+    let mut line = Vec::new();
+
+    loop {
+        line.clear();
+        let bytes_read = reader.read_until(b'\n', &mut line).map_err(|error| {
+            AgentError::Checkpoint(format!(
+                "Failed to decompress zstd session history: {error}"
+            ))
+        })?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        raw_size = raw_size.checked_add(bytes_read as u64).ok_or_else(|| {
+            AgentError::Checkpoint(format!(
+                "Session history exceeds maximum size of {max_bytes} bytes"
+            ))
+        })?;
+        if raw_size > max_bytes {
+            return Err(AgentError::Checkpoint(format!(
+                "Session history exceeds maximum size of {max_bytes} bytes"
+            )));
+        }
+        hasher.update(&line);
+        if line.iter().any(|byte| !byte.is_ascii_whitespace()) {
+            all_bytes_ascii_whitespace = false;
+        }
+
+        let logical_line = strip_jsonl_line_ending(&line);
+        match std::str::from_utf8(logical_line) {
+            Ok(text) => {
+                line_count += 1;
+                if !text.trim().is_empty() {
+                    all_utf8_lines_trim_empty = false;
+                }
+                if validate_history
+                    && recovery_validation_error.is_none()
+                    && let Err(error) = validate_recoverable_session_history_line(line_count, text)
+                {
+                    recovery_validation_error = Some(error);
+                }
+            }
+            Err(error) => {
+                invalid_utf8
+                    .get_or_insert_with(|| format!("Session history is not valid UTF-8: {error}"));
+            }
+        }
+    }
+
+    let is_empty = if invalid_utf8.is_some() {
+        all_bytes_ascii_whitespace
+    } else {
+        all_utf8_lines_trim_empty
+    };
+    Ok(DecodedSessionHistoryAnalysis {
+        raw_size,
+        sha256_hex: hex::encode(hasher.finalize()),
+        line_count: invalid_utf8.is_none().then_some(line_count),
+        invalid_utf8,
+        is_empty,
+        recovery_validation_error,
+    })
+}
+
+fn strip_jsonl_line_ending(line: &[u8]) -> &[u8] {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    line.strip_suffix(b"\r").unwrap_or(line)
+}
+
+async fn create_checkpoint_impl(
+    http: &HttpClient,
+    mode: CheckpointMode,
+    inputs: &CheckpointInputs<'_>,
+) -> Result<(), AgentError> {
+    log_info!(LOG_TAG, "Creating {}...", mode.log_label());
+
+    // Read the CLI agent session id. Let `read_to_string` surface `NotFound`
+    // directly — an explicit `exists()` check would be a redundant stat plus a
+    // TOCTOU race between check and read.
+    let session_id_start = std::time::Instant::now();
+    let cli_agent_session_id = match std::fs::read_to_string(inputs.session_id_file.as_ref()) {
+        Ok(s) => s.trim().to_string(),
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            return Err(fail(
+                mode,
+                "session_id_read",
+                session_id_start,
+                "No session ID found",
+            ));
+        }
+        Err(e) => {
+            return Err(fail(
+                mode,
+                "session_id_read",
+                session_id_start,
+                format!("Failed to read session ID: {e}"),
+            ));
+        }
+    };
+    if cli_agent_session_id.is_empty() {
+        return Err(fail(
+            mode,
+            "session_id_read",
+            session_id_start,
+            "Session ID is empty",
+        ));
+    }
+    record_sandbox_op("session_id_read", session_id_start.elapsed(), true, None);
+
+    // Read session history. The persisted or derived marker payload is either
+    // a literal jsonl path (Claude) or a codex marker. `session_history`
+    // resolves Codex session files and preserves already-compressed zstd
+    // sources when possible.
+    let history_read_start = std::time::Instant::now();
+    let history_marker_payload = match crate::session_metadata::resolve_history_marker_payload_from(
+        inputs.framework,
+        inputs.home_dir,
+        inputs.session_history_path_file.as_ref(),
+        &cli_agent_session_id,
+    ) {
+        Ok(payload) => payload,
+        Err(e) => {
+            return Err(fail(
+                mode,
+                "session_history_read",
+                history_read_start,
+                e.to_string(),
+            ));
+        }
+    };
+    let prepared_history =
+        prepare_session_history(mode, &history_marker_payload, history_read_start)?;
+    let PreparedSessionHistory {
+        hash: history_hash,
+        raw_size: history_size,
+        upload: history_upload,
+    } = prepared_history;
 
     // History upload and artifact snapshots are independent pre-requisites
     // of the final checkpoint API call, so run them concurrently. The history
@@ -741,7 +1034,7 @@ async fn create_checkpoint_impl(
     // was longer plus the other; concurrent, it's just the longer one.
     let (artifact_snapshots, _) = tokio::try_join!(
         snapshot_artifact_entries(http, inputs.run_id, inputs.artifact_entries),
-        build_and_upload_session_history(http, inputs.run_id, &history_hash, history_bytes),
+        build_and_upload_session_history(http, inputs.run_id, &history_hash, history_upload,),
     )?;
 
     // Build and send checkpoint payload (session history hash only, content uploaded to S3)
@@ -879,18 +1172,7 @@ fn write_final_session_history_identity(
 fn validate_recoverable_session_history(session_history: &str) -> Result<(), String> {
     let mut line_count = 0usize;
     for (index, line) in session_history.lines().enumerate() {
-        if line.trim().is_empty() {
-            return Err(format!(
-                "Session history line {} is empty; recovery checkpoint skipped",
-                index + 1
-            ));
-        }
-        serde_json::from_str::<serde_json::Value>(line).map_err(|e| {
-            format!(
-                "Session history line {} is not valid JSON; recovery checkpoint skipped: {e}",
-                index + 1
-            )
-        })?;
+        validate_recoverable_session_history_line(index + 1, line)?;
         line_count += 1;
     }
 
@@ -898,6 +1180,18 @@ fn validate_recoverable_session_history(session_history: &str) -> Result<(), Str
         return Err("Session history has no JSONL entries; recovery checkpoint skipped".into());
     }
 
+    Ok(())
+}
+
+fn validate_recoverable_session_history_line(index: usize, line: &str) -> Result<(), String> {
+    if line.trim().is_empty() {
+        return Err(format!(
+            "Session history line {index} is empty; recovery checkpoint skipped"
+        ));
+    }
+    serde_json::from_str::<serde_json::Value>(line).map_err(|e| {
+        format!("Session history line {index} is not valid JSON; recovery checkpoint skipped: {e}")
+    })?;
     Ok(())
 }
 
@@ -930,6 +1224,29 @@ mod tests {
     fn cleanup_checkpoint_files(guest_paths: &crate::paths::GuestPaths) {
         let _ = std::fs::remove_file(guest_paths.session_id_file());
         let _ = std::fs::remove_file(guest_paths.session_history_path_file());
+    }
+
+    fn http_status(status: u16) -> HttpMockResponse {
+        HttpMockResponse::builder().status(status).build()
+    }
+
+    fn request_header_eq(req: &HttpMockRequest, name: &str, expected: &str) -> bool {
+        req.headers_vec()
+            .iter()
+            .any(|(key, value)| key.eq_ignore_ascii_case(name) && value == expected)
+    }
+
+    fn session_history_upload_response(
+        req: &HttpMockRequest,
+        expected_body: &[u8],
+    ) -> HttpMockResponse {
+        if request_header_eq(req, "content-type", "application/octet-stream")
+            && req.body_ref() == expected_body
+        {
+            http_status(200)
+        } else {
+            http_status(400)
+        }
     }
 
     #[test]
@@ -1245,6 +1562,89 @@ mod tests {
         prepare.assert_calls(0);
         commit.assert_calls(0);
         checkpoint.assert_calls(0);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_reuses_codex_zstd_session_history_upload_body() {
+        let server = MockServer::start();
+        let dir = tempfile::tempdir().unwrap();
+        let guest_paths = crate::paths::GuestPaths::from_runtime_dir(dir.path().join("runtime"));
+        let _files_guard = CheckpointFilesGuard::new(&guest_paths);
+        let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+        let history =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-02T10:00:00Z\"}}\n";
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        let history_hash = hex::encode(Sha256::digest(history));
+        let home_dir = dir.path().join("home");
+        let codex_day_dir = home_dir
+            .join(".codex")
+            .join("sessions")
+            .join("2026")
+            .join("07")
+            .join("02");
+        std::fs::create_dir_all(&codex_day_dir).unwrap();
+        std::fs::write(
+            codex_day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst"),
+            &compressed,
+        )
+        .unwrap();
+        crate::paths::write_private(guest_paths.session_id_file(), thread_id).unwrap();
+
+        let upload_url = server.url("/test/session-history-upload");
+        let prepare = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints/prepare-history")
+                .json_body(json!({
+                    "runId": "checkpoint-codex-zstd-reuse",
+                    "hash": history_hash,
+                    "rawSize": history.len() as u64,
+                    "encodedSize": compressed.len() as u64,
+                    "encoding": SESSION_HISTORY_ENCODING_ZSTD,
+                }));
+            then.status(200).json_body(json!({
+                "presignedUrl": upload_url,
+                "encoding": SESSION_HISTORY_ENCODING_ZSTD,
+            }));
+        });
+        let expected_upload = compressed.clone();
+        let upload = server.mock(|when, then| {
+            when.method(PUT).path("/test/session-history-upload");
+            then.respond_with(move |req| session_history_upload_response(req, &expected_upload));
+        });
+        let checkpoint = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/webhooks/agent/checkpoints")
+                .json_body(json!({
+                    "runId": "checkpoint-codex-zstd-reuse",
+                    "cliAgentType": "codex",
+                    "cliAgentSessionId": thread_id,
+                    "cliAgentSessionHistoryHash": history_hash,
+                }));
+            then.status(200)
+                .json_body(json!({"checkpointId": "checkpoint-codex-zstd"}));
+        });
+        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+            .unwrap();
+        let home_dir = home_dir.to_string_lossy().into_owned();
+        let inputs = CheckpointInputs {
+            run_id: "checkpoint-codex-zstd-reuse",
+            framework: env::Framework::Codex,
+            home_dir: &home_dir,
+            artifact_entries: &[],
+            session_id_file: guest_paths.session_id_file().into(),
+            session_history_path_file: guest_paths.session_history_path_file().into(),
+            final_session_history_identity_file: guest_paths
+                .final_session_history_identity_file()
+                .into(),
+        };
+
+        create_checkpoint_impl(&http, CheckpointMode::Success, &inputs)
+            .await
+            .unwrap();
+
+        prepare.assert_calls(1);
+        upload.assert_calls(1);
+        checkpoint.assert_calls(1);
     }
 
     #[test]

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -110,9 +110,9 @@ impl SessionHistoryUpload {
                     bytes: Bytes::from(gzip),
                 })
             }
-            SessionHistoryUploadBody::Gzip { .. } => {
-                Err(compressed_encoding_not_acknowledged(SESSION_HISTORY_ENCODING_GZIP))
-            }
+            SessionHistoryUploadBody::Gzip { .. } => Err(compressed_encoding_not_acknowledged(
+                SESSION_HISTORY_ENCODING_GZIP,
+            )),
             SessionHistoryUploadBody::Zstd { raw: _, zstd }
                 if accepted_encoding == Some(SESSION_HISTORY_ENCODING_ZSTD) =>
             {

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -101,6 +101,7 @@ pub(crate) fn read_session_history_from_payload(payload: &str) -> Result<Vec<u8>
 ///
 /// The implementation reads one extra decoded byte to detect over-limit
 /// histories without consuming an unbounded stream.
+#[cfg(test)]
 pub(crate) fn read_session_history_from_payload_bounded(
     payload: &str,
     max_bytes: u64,
@@ -117,6 +118,11 @@ fn session_history_exceeds_max_error(max_bytes: u64) -> AgentError {
 pub(crate) struct SessionHistoryDigest {
     pub(crate) size_bytes: u64,
     pub(crate) sha256_hex: String,
+}
+
+pub(crate) enum SessionHistoryCheckpointSource {
+    Decoded(Vec<u8>),
+    CodexZstd { encoded: Vec<u8> },
 }
 
 #[derive(Debug)]
@@ -137,6 +143,21 @@ pub(crate) fn digest_session_history_from_payload_bounded(
     max_bytes: u64,
 ) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
     resolve_session_history_source(payload)?.digest(max_bytes)
+}
+
+pub(crate) fn read_session_history_checkpoint_source_from_payload_bounded(
+    payload: &str,
+    max_bytes: u64,
+) -> Result<SessionHistoryCheckpointSource, AgentError> {
+    match resolve_session_history_source(payload)? {
+        ResolvedSessionHistorySource::Codex(session) if session.is_zstd() => {
+            let encoded = session.into_zstd_bytes(max_bytes)?;
+            Ok(SessionHistoryCheckpointSource::CodexZstd { encoded })
+        }
+        source => source
+            .read(Some(max_bytes))
+            .map(SessionHistoryCheckpointSource::Decoded),
+    }
 }
 
 fn read_session_history_from_payload_impl(
@@ -487,6 +508,10 @@ struct ResolvedCodexSession {
 }
 
 impl ResolvedCodexSession {
+    fn is_zstd(&self) -> bool {
+        is_zstd_session_history(&self.path)
+    }
+
     fn into_file(self) -> Result<(PathBuf, File), AgentError> {
         #[cfg(target_os = "linux")]
         {
@@ -498,6 +523,35 @@ impl ResolvedCodexSession {
             open_session_history_file(self.path)
         }
     }
+
+    fn into_zstd_bytes(self, max_encoded_bytes: u64) -> Result<Vec<u8>, AgentError> {
+        #[cfg(target_os = "linux")]
+        {
+            read_zstd_encoded_session_history(self.file, &self.path, max_encoded_bytes)
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            let file =
+                File::open(&self.path).map_err(|error| read_history_error(&self.path, error))?;
+            read_zstd_encoded_session_history(file, &self.path, max_encoded_bytes)
+        }
+    }
+}
+
+fn read_zstd_encoded_session_history(
+    file: File,
+    path: &Path,
+    max_encoded_bytes: u64,
+) -> Result<Vec<u8>, AgentError> {
+    let mut bytes = Vec::new();
+    file.take(max_encoded_bytes.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|error| read_history_error(path, error))?;
+    if bytes.len() as u64 > max_encoded_bytes {
+        return Err(session_history_exceeds_max_error(max_encoded_bytes));
+    }
+    Ok(bytes)
 }
 
 struct CodexSessionLookupBudget {

--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -151,8 +151,14 @@ pub(crate) fn read_session_history_checkpoint_source_from_payload_bounded(
 ) -> Result<SessionHistoryCheckpointSource, AgentError> {
     match resolve_session_history_source(payload)? {
         ResolvedSessionHistorySource::Codex(session) if session.is_zstd() => {
-            let encoded = session.into_zstd_bytes(max_bytes)?;
-            Ok(SessionHistoryCheckpointSource::CodexZstd { encoded })
+            if session.encoded_len()? <= max_bytes {
+                let encoded = session.into_zstd_bytes(max_bytes)?;
+                Ok(SessionHistoryCheckpointSource::CodexZstd { encoded })
+            } else {
+                ResolvedSessionHistorySource::Codex(session)
+                    .read(Some(max_bytes))
+                    .map(SessionHistoryCheckpointSource::Decoded)
+            }
         }
         source => source
             .read(Some(max_bytes))
@@ -524,6 +530,23 @@ impl ResolvedCodexSession {
         }
     }
 
+    fn encoded_len(&self) -> Result<u64, AgentError> {
+        #[cfg(target_os = "linux")]
+        {
+            self.file
+                .metadata()
+                .map(|metadata| metadata.len())
+                .map_err(|error| read_history_error(&self.path, error))
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            std::fs::metadata(&self.path)
+                .map(|metadata| metadata.len())
+                .map_err(|error| read_history_error(&self.path, error))
+        }
+    }
+
     fn into_zstd_bytes(self, max_encoded_bytes: u64) -> Result<Vec<u8>, AgentError> {
         #[cfg(target_os = "linux")]
         {
@@ -884,6 +907,37 @@ mod tests {
         assert_eq!(bytes, history);
         assert_eq!(digest.size_bytes, history.len() as u64);
         assert_eq!(digest.sha256_hex, hex::encode(Sha256::digest(history)));
+    }
+
+    #[test]
+    fn codex_zstd_checkpoint_source_falls_back_to_decoded_when_encoded_exceeds_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        let day_dir = sessions_dir.join("2026").join("07").join("02");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+        let history = b"a";
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        assert!(
+            compressed.len() > history.len(),
+            "fixture must be larger when encoded"
+        );
+        let path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
+        std::fs::write(path, compressed).unwrap();
+        let payload = codex_marker_payload(&sessions_dir, thread_id);
+
+        let source = read_session_history_checkpoint_source_from_payload_bounded(
+            &payload,
+            history.len() as u64,
+        )
+        .unwrap();
+
+        match source {
+            SessionHistoryCheckpointSource::Decoded(bytes) => assert_eq!(bytes, history),
+            SessionHistoryCheckpointSource::CodexZstd { .. } => {
+                panic!("oversized encoded body should fall back to decoded history")
+            }
+        }
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -23,7 +23,8 @@ use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
     RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializer,
-    SessionHistoryRestoreFallback, SessionHistoryRestorePlan, validate_resume_session_id,
+    SessionHistoryRestoreFallback, SessionHistoryRestorePlan, effective_cli_framework,
+    validate_resume_session_id,
 };
 use crate::http::HttpClient;
 use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
@@ -275,8 +276,12 @@ fn build_session_history_restore_plan(
     };
 
     let started_at = Instant::now();
-    let materializer =
-        SessionHistoryMaterializer::start_cancellable(http, Some(resume_session), cancel.token());
+    let materializer = SessionHistoryMaterializer::start_cancellable(
+        http,
+        Some(resume_session),
+        effective_cli_framework(&context.cli_agent_type),
+        cancel.token(),
+    );
     pre_spawn_timing.record_phase_elapsed(
         RunnerPreSpawnPhase::SessionHistoryMaterializerStart,
         started_at,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -29,6 +29,7 @@ use super::diagnostics::{
     should_collect_agent_abnormal_exit_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
+use super::effective_cli_framework;
 use super::env::{
     build_env_json_for_run, build_run_payload_for_run, build_user_env_json, write_run_payload_file,
     write_user_env_file,
@@ -926,6 +927,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     Some(SessionHistoryMaterializer::start_cancellable(
                         &config.http,
                         context.resume_session.as_ref(),
+                        effective_cli_framework(&context.cli_agent_type),
                         cancel.clone(),
                     ))
                 }
@@ -934,6 +936,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         SessionHistoryRestorePlan::Default => Some(SessionHistoryMaterializer::start_cancellable(
             &config.http,
             context.resume_session.as_ref(),
+            effective_cli_framework(&context.cli_agent_type),
             cancel.clone(),
         )),
         SessionHistoryRestorePlan::Prestarted {

--- a/crates/runner/src/executor/cli_framework.rs
+++ b/crates/runner/src/executor/cli_framework.rs
@@ -1,10 +1,10 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum EffectiveCliFramework {
+pub(crate) enum EffectiveCliFramework {
     ClaudeCode,
     Codex,
 }
 
-pub(super) fn effective_cli_framework(cli_agent_type: &str) -> EffectiveCliFramework {
+pub(crate) fn effective_cli_framework(cli_agent_type: &str) -> EffectiveCliFramework {
     if normalized_cli_agent_type(cli_agent_type) == "codex" {
         EffectiveCliFramework::Codex
     } else {

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -38,6 +38,7 @@ mod telemetry;
 
 pub(crate) use crate::restored_session_identity::RestoredSessionIdentity;
 pub(crate) use agent_run::{SessionHistoryRestoreFallback, SessionHistoryRestorePlan};
+pub(crate) use cli_framework::effective_cli_framework;
 pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
 pub(crate) use session_history_download::SessionHistoryMaterializer;
 

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -1087,6 +1087,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_materializer_rejects_zstd_hash_mismatch() {
+        let body =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-02T10:00:00Z\"}}\n";
+        let compressed = zstd_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let session = zstd_ref_session(
+            serve_once("200 OK", compressed, None).await,
+            "0".repeat(64),
+            body.len() as u64,
+            encoded_size,
+        );
+
+        let materializer =
+            start_materializer_with_framework(&session, EffectiveCliFramework::Codex);
+        let result = materializer.finish(&CancellationToken::new()).await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
+                assert!(
+                    error.to_string().contains("session history hash mismatch"),
+                    "unexpected error: {error}"
+                );
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_phase_failure(timings.hash_verification());
+            }
+            _ => panic!("expected failed materialization"),
+        }
+    }
+
+    #[tokio::test]
+    async fn codex_materializer_rejects_zstd_body_over_declared_raw_size() {
+        let body =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-02T10:00:00Z\"}}\n";
+        let compressed = zstd_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let hash = hex::encode(Sha256::digest(body));
+        let session = zstd_ref_session(
+            serve_once("200 OK", compressed, None).await,
+            hash,
+            1,
+            encoded_size,
+        );
+
+        let materializer =
+            start_materializer_with_framework(&session, EffectiveCliFramework::Codex);
+        let result = materializer.finish(&CancellationToken::new()).await;
+
+        match result {
+            SessionHistoryMaterialization::Failed { error, timings, .. } => {
+                assert!(
+                    error
+                        .to_string()
+                        .contains("session history is too large after decompression"),
+                    "unexpected error: {error}"
+                );
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+                assert_phase_failure(timings.hash_verification());
+            }
+            _ => panic!("expected failed materialization"),
+        }
+    }
+
+    #[tokio::test]
     async fn materializer_rejects_zstd_body_under_declared_encoded_size_without_content_length() {
         let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
         let compressed = zstd_bytes(body);

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -15,7 +15,7 @@
 //! downloaded bytes must satisfy the declared size, byte cap, and hash contract
 //! before they are restored into the sandbox.
 
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read};
 use std::time::{Duration, Instant};
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
@@ -24,7 +24,8 @@ use sha2::{Digest, Sha256};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use super::session_restore::MaterializedResumeSession;
+use super::cli_framework::EffectiveCliFramework;
+use super::session_restore::{MaterializedResumeSession, codex_session_meta_timestamp_line};
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::telemetry::SessionHistoryTelemetryMetadata;
@@ -165,6 +166,7 @@ impl SessionHistoryMaterializer {
     pub(crate) fn start_cancellable(
         http: &HttpClient,
         session: Option<&ResumeSession>,
+        framework: EffectiveCliFramework,
         cancel: CancellationToken,
     ) -> Self {
         let Some(session) = session else {
@@ -194,7 +196,7 @@ impl SessionHistoryMaterializer {
                         _ = cancel.cancelled() => {
                             SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
                         }
-                        result = download_resume_session_history_timed(http, session, metadata) => result,
+                        result = download_resume_session_history_timed(http, session, framework, metadata) => result,
                     }
                 })),
             },
@@ -327,11 +329,12 @@ impl Drop for SessionHistoryMaterializer {
 async fn download_resume_session_history_timed(
     http: HttpClient,
     session: ResumeSession,
+    framework: EffectiveCliFramework,
     metadata: SessionHistoryTelemetryMetadata,
 ) -> SessionHistoryDownloadTaskResult {
     let started_at = Instant::now();
     let mut timings = SessionHistoryDownloadTimings::for_metadata(metadata);
-    let result = download_resume_session_history(http, session, &mut timings).await;
+    let result = download_resume_session_history(http, session, framework, &mut timings).await;
     SessionHistoryDownloadTaskResult {
         elapsed: started_at.elapsed(),
         timings,
@@ -342,6 +345,7 @@ async fn download_resume_session_history_timed(
 async fn download_resume_session_history(
     http: HttpClient,
     session: ResumeSession,
+    framework: EffectiveCliFramework,
     timings: &mut SessionHistoryDownloadTimings,
 ) -> RunnerResult<MaterializedResumeSession<'static>> {
     // The history ref is treated as untrusted input. The request timeout and
@@ -396,6 +400,19 @@ async fn download_resume_session_history(
                 timings,
             )
             .await?;
+            if framework == EffectiveCliFramework::Codex {
+                let timestamp = verify_codex_zstd_session_history(
+                    &encoded_bytes,
+                    raw_size,
+                    &history_ref.hash,
+                    timings,
+                )?;
+                return Ok(MaterializedResumeSession::new_codex_zstd(
+                    session.cli_agent_session_id,
+                    encoded_bytes,
+                    timestamp,
+                ));
+            }
             let raw_bytes = unzstd_session_history(&encoded_bytes, raw_size)?;
             validate_decompressed_raw_size(raw_size, raw_bytes.len(), timings)?;
             raw_bytes
@@ -525,6 +542,62 @@ fn validate_decompressed_raw_size(
     }
     timings.add_validation(validation_started.elapsed(), true);
     Ok(())
+}
+
+fn verify_codex_zstd_session_history(
+    encoded_bytes: &[u8],
+    expected_raw_size: u64,
+    expected_hash: &str,
+    timings: &mut SessionHistoryDownloadTimings,
+) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
+    let decoder = zstd::stream::read::Decoder::new(encoded_bytes).map_err(|error| {
+        RunnerError::Internal(format!("decompress zstd session history: {error}"))
+    })?;
+    let mut reader = BufReader::new(decoder.take(expected_raw_size.saturating_add(1)));
+    let mut hasher = Sha256::new();
+    let mut decoded = 0u64;
+    let mut timestamp = None;
+    let mut line = Vec::new();
+    let hash_started = Instant::now();
+
+    loop {
+        line.clear();
+        let read = reader.read_until(b'\n', &mut line).map_err(|error| {
+            RunnerError::Internal(format!("decompress zstd session history: {error}"))
+        })?;
+        if read == 0 {
+            break;
+        }
+        decoded += read as u64;
+        if decoded > expected_raw_size {
+            timings.record_hash_verification(hash_started.elapsed(), false);
+            return Err(RunnerError::Internal(format!(
+                "session history is too large after decompression: {decoded} bytes exceeds {expected_raw_size} bytes"
+            )));
+        }
+        hasher.update(&line);
+        if timestamp.is_none()
+            && let Ok(line) = std::str::from_utf8(strip_jsonl_line_ending(&line))
+        {
+            timestamp = codex_session_meta_timestamp_line(line);
+        }
+    }
+
+    validate_decompressed_raw_size(expected_raw_size, decoded as usize, timings)?;
+    let actual_hash = hex::encode(hasher.finalize());
+    if actual_hash != expected_hash {
+        timings.record_hash_verification(hash_started.elapsed(), false);
+        return Err(RunnerError::Internal(
+            "session history hash mismatch".into(),
+        ));
+    }
+    timings.record_hash_verification(hash_started.elapsed(), true);
+    Ok(timestamp)
+}
+
+fn strip_jsonl_line_ending(line: &[u8]) -> &[u8] {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    line.strip_suffix(b"\r").unwrap_or(line)
 }
 
 fn gunzip_session_history(encoded_bytes: &[u8], max_raw_bytes: u64) -> RunnerResult<Vec<u8>> {
@@ -789,12 +862,20 @@ mod tests {
         zstd::encode_all(raw, 0).unwrap()
     }
 
-    fn start_materializer(session: &ResumeSession) -> SessionHistoryMaterializer {
+    fn start_materializer_with_framework(
+        session: &ResumeSession,
+        framework: EffectiveCliFramework,
+    ) -> SessionHistoryMaterializer {
         SessionHistoryMaterializer::start_cancellable(
             &http_client(),
             Some(session),
+            framework,
             CancellationToken::new(),
         )
+    }
+
+    fn start_materializer(session: &ResumeSession) -> SessionHistoryMaterializer {
+        start_materializer_with_framework(session, EffectiveCliFramework::ClaudeCode)
     }
 
     fn identity_metadata() -> SessionHistoryTelemetryMetadata {
@@ -955,6 +1036,47 @@ mod tests {
             } => {
                 assert_eq!(session.cli_agent_session_id(), "sess-123");
                 assert_eq!(session.history_bytes(), body);
+                assert_phase_success(timings.request_status());
+                assert_phase_success(timings.body_read());
+                assert_phase_success(timings.validation());
+                assert_phase_success(timings.hash_verification());
+            }
+            _ => panic!("expected downloaded session"),
+        }
+    }
+
+    #[tokio::test]
+    async fn codex_materializer_preserves_verified_zstd_history() {
+        let body =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-02T10:00:00Z\"}}\n";
+        let compressed = zstd_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let hash = hex::encode(Sha256::digest(body));
+        let session = zstd_ref_session(
+            serve_once("200 OK", compressed.clone(), None).await,
+            hash,
+            body.len() as u64,
+            encoded_size,
+        );
+
+        let materializer =
+            start_materializer_with_framework(&session, EffectiveCliFramework::Codex);
+        let result = materializer.finish(&CancellationToken::new()).await;
+
+        match result {
+            SessionHistoryMaterialization::Downloaded {
+                session, timings, ..
+            } => {
+                assert_eq!(session.cli_agent_session_id(), "sess-123");
+                assert_eq!(session.history_bytes(), compressed);
+                assert!(session.history_text().is_none());
+                let (_, timestamp) = session
+                    .codex_zstd_history()
+                    .expect("codex zstd history should be preserved");
+                assert_eq!(
+                    timestamp.map(|timestamp| timestamp.to_rfc3339()).as_deref(),
+                    Some("2026-07-02T10:00:00+00:00")
+                );
                 assert_phase_success(timings.request_status());
                 assert_phase_success(timings.body_read());
                 assert_phase_success(timings.validation());
@@ -1392,6 +1514,7 @@ mod tests {
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
             Some(&session),
+            EffectiveCliFramework::ClaudeCode,
             cancel.clone(),
         );
         tokio::time::timeout(Duration::from_secs(5), request_received_rx)
@@ -1436,6 +1559,7 @@ mod tests {
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
             Some(&session),
+            EffectiveCliFramework::ClaudeCode,
             cancel.clone(),
         );
         let result = materializer.finish(&cancel).await;

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -4,6 +4,7 @@ mod codex;
 
 use std::borrow::Cow;
 
+use chrono::{DateTime, Utc};
 use sandbox::Sandbox;
 use tracing::{info, warn};
 
@@ -53,6 +54,12 @@ fn restored_session_framework(framework: EffectiveCliFramework) -> RestoredSessi
     }
 }
 
+pub(super) fn codex_session_meta_timestamp_line(
+    line: &str,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    codex::codex_session_meta_timestamp_line(line)
+}
+
 #[derive(Debug)]
 pub(super) struct MaterializedResumeSession<'a> {
     cli_agent_session_id: Cow<'a, str>,
@@ -63,6 +70,10 @@ pub(super) struct MaterializedResumeSession<'a> {
 enum MaterializedResumeHistory<'a> {
     InlineText(&'a str),
     Bytes(Vec<u8>),
+    CodexZstd {
+        bytes: Vec<u8>,
+        timestamp: Option<DateTime<Utc>>,
+    },
 }
 
 impl MaterializedResumeSession<'static> {
@@ -70,6 +81,20 @@ impl MaterializedResumeSession<'static> {
         Self {
             cli_agent_session_id: Cow::Owned(cli_agent_session_id),
             history: MaterializedResumeHistory::Bytes(history_bytes),
+        }
+    }
+
+    pub(super) fn new_codex_zstd(
+        cli_agent_session_id: String,
+        history_bytes: Vec<u8>,
+        timestamp: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self {
+            cli_agent_session_id: Cow::Owned(cli_agent_session_id),
+            history: MaterializedResumeHistory::CodexZstd {
+                bytes: history_bytes,
+                timestamp,
+            },
         }
     }
 }
@@ -97,6 +122,7 @@ impl<'a> MaterializedResumeSession<'a> {
         match &self.history {
             MaterializedResumeHistory::InlineText(session_history) => session_history.as_bytes(),
             MaterializedResumeHistory::Bytes(history_bytes) => history_bytes,
+            MaterializedResumeHistory::CodexZstd { bytes, .. } => bytes,
         }
     }
 
@@ -106,6 +132,14 @@ impl<'a> MaterializedResumeSession<'a> {
             MaterializedResumeHistory::Bytes(history_bytes) => {
                 std::str::from_utf8(history_bytes).ok()
             }
+            MaterializedResumeHistory::CodexZstd { .. } => None,
+        }
+    }
+
+    pub(super) fn codex_zstd_history(&self) -> Option<(&[u8], Option<DateTime<Utc>>)> {
+        match &self.history {
+            MaterializedResumeHistory::CodexZstd { bytes, timestamp } => Some((bytes, *timestamp)),
+            MaterializedResumeHistory::InlineText(_) | MaterializedResumeHistory::Bytes(_) => None,
         }
     }
 }

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -15,14 +15,11 @@ const CODEX_SESSION_CLEANUP_SCRIPT: &str =
 
 fn codex_restore_rollout_path(
     session_id: &str,
-    session_history: Option<&str>,
-    fallback_timestamp: chrono::DateTime<chrono::Utc>,
+    timestamp: chrono::DateTime<chrono::Utc>,
+    extension: &str,
 ) -> String {
-    let timestamp = session_history
-        .and_then(codex_session_meta_timestamp)
-        .unwrap_or(fallback_timestamp);
     format!(
-        "{CODEX_HOME}/sessions/{}/{}/{}/rollout-{}-{session_id}.jsonl",
+        "{CODEX_HOME}/sessions/{}/{}/{}/rollout-{}-{session_id}{extension}",
         timestamp.format("%Y"),
         timestamp.format("%m"),
         timestamp.format("%d"),
@@ -30,39 +27,59 @@ fn codex_restore_rollout_path(
     )
 }
 
-fn codex_session_meta_timestamp(session_history: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+fn codex_restore_rollout_timestamp(
+    session: &MaterializedResumeSession<'_>,
+    fallback_timestamp: chrono::DateTime<chrono::Utc>,
+) -> chrono::DateTime<chrono::Utc> {
+    session
+        .codex_zstd_history()
+        .and_then(|(_, timestamp)| timestamp)
+        .or_else(|| {
+            session
+                .history_text()
+                .and_then(codex_session_meta_timestamp)
+        })
+        .unwrap_or(fallback_timestamp)
+}
+
+pub(super) fn codex_session_meta_timestamp(
+    session_history: &str,
+) -> Option<chrono::DateTime<chrono::Utc>> {
     for line in session_history.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
-            continue;
-        }
-
-        if let Some(timestamp) = value
-            .get("payload")
-            .and_then(|payload| payload.get("timestamp"))
-            .and_then(|timestamp| timestamp.as_str())
-            .and_then(parse_codex_rollout_timestamp)
-        {
-            return Some(timestamp);
-        }
-
-        if let Some(timestamp) = value
-            .get("timestamp")
-            .and_then(|timestamp| timestamp.as_str())
-            .and_then(parse_codex_rollout_timestamp)
-        {
+        if let Some(timestamp) = codex_session_meta_timestamp_line(line) {
             return Some(timestamp);
         }
     }
 
     None
+}
+
+pub(super) fn codex_session_meta_timestamp_line(
+    line: &str,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+        return None;
+    };
+    if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
+        return None;
+    }
+
+    value
+        .get("payload")
+        .and_then(|payload| payload.get("timestamp"))
+        .and_then(|timestamp| timestamp.as_str())
+        .and_then(parse_codex_rollout_timestamp)
+        .or_else(|| {
+            value
+                .get("timestamp")
+                .and_then(|timestamp| timestamp.as_str())
+                .and_then(parse_codex_rollout_timestamp)
+        })
 }
 
 fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
@@ -81,8 +98,9 @@ fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::U
         })
 }
 
-/// Write a Codex session history file as plain JSONL at
-/// `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-{thread_id}.jsonl`.
+/// Write a Codex session history file as canonical JSONL or zstd-compressed
+/// JSONL under
+/// `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-{thread_id}.jsonl[.zst]`.
 ///
 /// Codex 0.137 filters filesystem resume candidates through its canonical
 /// rollout filename parser, so a bare `{thread_id}.jsonl` is ignored.
@@ -91,15 +109,19 @@ pub(super) async fn restore_codex_session(
     context: &ExecutionContext,
     session: &MaterializedResumeSession<'_>,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
-    let session_history = session.history_bytes();
     let original_session_id = session.cli_agent_session_id();
     let thread_id = CodexThreadId::parse(original_session_id)
         .ok_or_else(|| RunnerError::Internal("invalid codex session_id".into()))?;
     let session_id = thread_id.as_str();
     let session_filename_key = thread_id.filename_key();
 
-    let session_path =
-        codex_restore_rollout_path(session_id, session.history_text(), chrono::Utc::now());
+    let timestamp = codex_restore_rollout_timestamp(session, chrono::Utc::now());
+    let (session_history, extension) = if let Some((bytes, _)) = session.codex_zstd_history() {
+        (bytes, ".jsonl.zst")
+    } else {
+        (session.history_bytes(), ".jsonl")
+    };
+    let session_path = codex_restore_rollout_path(session_id, timestamp, extension);
 
     cleanup_existing_codex_session_files(
         sandbox,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -34,6 +34,7 @@ use super::super::storage::guest_download_stdin_command;
 use super::super::{
     EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT, RestoredSessionIdentity,
     SessionHistoryMaterializer, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
+    effective_cli_framework,
 };
 use super::support::{
     CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_storage, create_overridden_sandbox,
@@ -960,6 +961,7 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
+        effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
     );
     tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, request_received_rx)
@@ -1086,6 +1088,7 @@ async fn run_in_sandbox_records_completed_prestarted_materializer_failure() {
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
+        effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
     );
     tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
@@ -1577,6 +1580,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
+        effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
     );
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -1662,6 +1666,7 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
+        effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
     );
     let mut telemetry = test_telemetry(&config, &ctx);
@@ -1751,6 +1756,7 @@ async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
         ctx.resume_session.as_ref(),
+        effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
     );
     let mut telemetry = test_telemetry(&config, &ctx);

--- a/crates/runner/src/executor/tests/session_restore_tests/codex.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/codex.rs
@@ -26,6 +26,34 @@ fn restore_session_writes_codex_session() {
 }
 
 #[test]
+fn restore_session_writes_codex_zstd_session() {
+    let sandbox = MockSandbox::new("test");
+    let ctx = codex_context();
+    let history = codex_session_meta_history(CODEX_SESSION_ID);
+    let compressed = zstd::encode_all(history.as_bytes(), 0).unwrap();
+    let timestamp = chrono::DateTime::parse_from_rfc3339("2026-06-04T07:18:08.000Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let session = materialized_codex_zstd_session(CODEX_SESSION_ID, &compressed, timestamp);
+
+    let diagnostics = run_restore_session(restore_session(&sandbox, &ctx, &session)).unwrap();
+
+    assert_codex_cleanup_call(&sandbox);
+
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert!(
+        writes[0]
+            .path
+            .ends_with(&format!("{CODEX_CANONICAL_ROLLOUT_SUFFIX}.zst")),
+        "codex zstd resume history must be restored as canonical rollout jsonl.zst, got {}",
+        writes[0].path
+    );
+    assert_eq!(writes[0].content, compressed);
+    assert_eq!(diagnostics.bytes_in, session.history_bytes().len());
+}
+
+#[test]
 fn restore_session_logs_codex_session_id() {
     let sandbox = MockSandbox::new("test");
     let ctx = codex_context();

--- a/crates/runner/src/executor/tests/session_restore_tests/mod.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/mod.rs
@@ -42,6 +42,14 @@ fn materialized_bytes_session(
     MaterializedResumeSession::new(session_id.into(), history.to_vec())
 }
 
+fn materialized_codex_zstd_session(
+    session_id: impl Into<String>,
+    history: &[u8],
+    timestamp: chrono::DateTime<chrono::Utc>,
+) -> MaterializedResumeSession<'static> {
+    MaterializedResumeSession::new_codex_zstd(session_id.into(), history.to_vec(), Some(timestamp))
+}
+
 fn history_ref(hash: impl Into<String>, raw_size: u64) -> ResumeSessionHistoryRef {
     ResumeSessionHistoryRef {
         kind: ResumeSessionHistoryRefKind::Blob,


### PR DESCRIPTION
## Summary
- reuse existing Codex `.jsonl.zst` session history bytes for checkpoint uploads while preserving raw hash/rawSize validation
- keep verified Codex zstd resume refs encoded through runner materialization and restore them as canonical `.jsonl.zst`
- keep non-Codex, gzip, identity, and deploy-compat fallback behavior unchanged

## Tests
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent checkpoint_reuses_codex_zstd_session_history_upload_body`
- `cargo test --manifest-path crates/Cargo.toml -p runner zstd`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent checkpoint`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent session_history`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_history_download`
- `cargo test --manifest-path crates/Cargo.toml -p runner session_restore`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- pre-commit: cargo fmt, cargo doc, cargo clippy

Closes #20431
