### PR TITLE
perf(api): lazily emit connector platform secret metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3775,11 +3775,14 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("withholds platform secrets from the sandbox environment", async () => {
+  it("emits lazy platform-secret metadata without snapshotting platform secrets", async () => {
     const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
-    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "developer-token-bdd");
+    mockOptionalEnv(
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+      "developer-token-before-claim",
+    );
 
     await fw.seedTestConnector(actor, {
       connectorName: "google-ads",
@@ -3800,6 +3803,102 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(claim.environment).not.toHaveProperty("GOOGLE_ADS_DEVELOPER_TOKEN");
     expect(claim.secretConnectorMap).toMatchObject({
       GOOGLE_ADS_TOKEN: "google-ads",
+      GOOGLE_ADS_DEVELOPER_TOKEN: "google-ads",
+    });
+    expect(claim.secretConnectorMetadataMap).toMatchObject({
+      GOOGLE_ADS_DEVELOPER_TOKEN: { sourceType: "platform-secret" },
+    });
+    expect(
+      claim.firewalls?.map((firewall) => {
+        return firewallEntryName(firewall);
+      }),
+    ).toContain("google-ads");
+    if (!claim.encryptedSecrets) {
+      throw new Error(
+        "Expected the google ads claim to carry encrypted secrets",
+      );
+    }
+
+    mockOptionalEnv(
+      "GOOGLE_ADS_DEVELOPER_TOKEN",
+      "developer-token-after-claim",
+    );
+    const resolved = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          Authorization: `Bearer \${{ secrets.GOOGLE_ADS_TOKEN }}`,
+          "developer-token": `\${{ secrets.GOOGLE_ADS_DEVELOPER_TOKEN }}`,
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error("Expected google ads firewall auth to resolve");
+    }
+    expect(resolved.body.headers).toStrictEqual({
+      Authorization: "Bearer google-ads-bdd-access",
+      "developer-token": "developer-token-after-claim",
+    });
+
+    const missingWithoutMetadata = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          "developer-token": `\${{ secrets.GOOGLE_ADS_DEVELOPER_TOKEN }}`,
+        },
+      },
+      [424],
+    );
+    if (missingWithoutMetadata.status !== 424) {
+      throw new Error(
+        "Expected google ads platform secret to require lazy metadata",
+      );
+    }
+    expect(missingWithoutMetadata.body.error.code).toBe(
+      "CONNECTOR_NOT_CONFIGURED",
+    );
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+    const cancelled = await api.readRun(actor, run.runId);
+    expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("filters platform-secret metadata when request secrets override the alias", async () => {
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    mockOptionalEnv("GOOGLE_ADS_DEVELOPER_TOKEN", "platform-developer-token");
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "google-ads",
+      authMethod: "oauth",
+      accessToken: "google-ads-bdd-access",
+      refreshToken: "google-ads-bdd-refresh",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["google-ads"]);
+
+    const run = await api.createDirectRun(actor, {
+      ...zeroBackedDirectRunBody({
+        agentId,
+        prompt: "use google ads with explicit developer token",
+      }),
+      secrets: {
+        ZERO_TOKEN: "bdd-zero-direct-token",
+        GOOGLE_ADS_DEVELOPER_TOKEN: "body-developer-token",
+      },
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+
+    expect(claim.environment).not.toHaveProperty("GOOGLE_ADS_DEVELOPER_TOKEN");
+    expect(claim.secretConnectorMap).toMatchObject({
+      GOOGLE_ADS_TOKEN: "google-ads",
     });
     expect(claim.secretConnectorMap ?? {}).not.toHaveProperty(
       "GOOGLE_ADS_DEVELOPER_TOKEN",
@@ -3807,11 +3906,33 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(claim.secretConnectorMetadataMap ?? {}).not.toHaveProperty(
       "GOOGLE_ADS_DEVELOPER_TOKEN",
     );
-    expect(
-      claim.firewalls?.map((firewall) => {
-        return firewallEntryName(firewall);
-      }),
-    ).toContain("google-ads");
+    if (!claim.encryptedSecrets) {
+      throw new Error(
+        "Expected the google ads claim to carry encrypted secrets",
+      );
+    }
+
+    const resolved = await fw.requestFirewallAuth(
+      { authorization: `Bearer ${claim.sandboxToken}` },
+      {
+        encryptedSecrets: claim.encryptedSecrets,
+        authHeaders: {
+          "developer-token": `\${{ secrets.GOOGLE_ADS_DEVELOPER_TOKEN }}`,
+        },
+        secretConnectorMap: claim.secretConnectorMap ?? undefined,
+        secretConnectorMetadataMap:
+          claim.secretConnectorMetadataMap ?? undefined,
+      },
+      [200],
+    );
+    if (resolved.status !== 200) {
+      throw new Error(
+        "Expected explicit google ads developer token to resolve",
+      );
+    }
+    expect(resolved.body.headers).toStrictEqual({
+      "developer-token": "body-developer-token",
+    });
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -587,6 +587,9 @@ interface ConnectorRuntimeContext {
   readonly secrets: Record<string, string> | undefined;
   readonly vars: Record<string, string> | undefined;
   readonly secretConnectorMap: Record<string, string> | undefined;
+  readonly secretConnectorMetadataMap:
+    | Record<string, SecretConnectorMetadata>
+    | undefined;
   readonly connectorTypes: readonly ConnectorType[];
   readonly storedEnvironment: Record<string, string> | undefined;
 }
@@ -2190,6 +2193,7 @@ interface ResolvedStoredConnectorState {
   readonly secrets: Record<string, string>;
   readonly vars: Record<string, string>;
   readonly secretConnectorMap: Record<string, string>;
+  readonly secretConnectorMetadataMap: Record<string, SecretConnectorMetadata>;
   readonly environment: Record<string, string>;
 }
 
@@ -2198,6 +2202,7 @@ function emptyConnectorRuntimeContext(): ConnectorRuntimeContext {
     secrets: undefined,
     vars: undefined,
     secretConnectorMap: undefined,
+    secretConnectorMetadataMap: undefined,
     connectorTypes: [],
     storedEnvironment: undefined,
   };
@@ -2583,6 +2588,8 @@ function resolveStoredConnectorState(
   const secrets: Record<string, string> = {};
   const vars: Record<string, string> = {};
   const secretConnectorMap: Record<string, string> = {};
+  const secretConnectorMetadataMap: Record<string, SecretConnectorMetadata> =
+    {};
   const environment: Record<string, string> = {};
 
   for (const { connectorType, runtimeBindings } of bindingSets) {
@@ -2613,10 +2620,6 @@ function resolveStoredConnectorState(
           break;
         }
         case "platform-secret": {
-          const secretValue = optionalEnv(source.name);
-          if (secretValue) {
-            secrets[envName] = secretValue;
-          }
           break;
         }
       }
@@ -2628,6 +2631,9 @@ function resolveStoredConnectorState(
     for (const { envName, source } of runtimeBindings) {
       if (source.kind === "connector-secret") {
         secretConnectorMap[envName] = connectorType;
+      } else if (source.kind === "platform-secret") {
+        secretConnectorMap[envName] = connectorType;
+        secretConnectorMetadataMap[envName] = { sourceType: "platform-secret" };
       }
     }
   }
@@ -2636,6 +2642,7 @@ function resolveStoredConnectorState(
     secrets,
     vars,
     secretConnectorMap,
+    secretConnectorMetadataMap,
     environment,
   };
 }
@@ -2655,6 +2662,7 @@ function storedConnectorContextFromSnapshot(
       ),
     ),
     secretConnectorMap: undefined,
+    secretConnectorMetadataMap: undefined,
     connectorTypes: snapshot.allowedConnectorRows.map((row) => {
       return row.connectorType;
     }),
@@ -2734,6 +2742,9 @@ async function materializeStoredConnectorContext(
         secrets: compactRecord(resolved.secrets),
         vars: compactRecord(resolved.vars),
         secretConnectorMap: compactRecord(resolved.secretConnectorMap),
+        secretConnectorMetadataMap: compactRecord(
+          resolved.secretConnectorMetadataMap,
+        ),
         connectorTypes: snapshot.allowedConnectorRows.map((row) => {
           return row.connectorType;
         }),
@@ -4954,12 +4965,22 @@ function buildStoredExecutionSecrets(args: {
       args.customConnectorContext.reservedSecretAliases,
     ],
   });
+  const filteredConnectorMetadataMap = filterSecretConnectorMetadataMap({
+    secretConnectorMetadataMap:
+      args.connectorContext.secretConnectorMetadataMap,
+    secretConnectorMap: filteredConnectorMap,
+  });
   const filteredModelProviderMetadataMap = filterSecretConnectorMetadataMap({
     secretConnectorMetadataMap: args.modelProvider?.secretConnectorMetadataMap,
     secretConnectorMap: filteredModelProviderMap,
   });
   const secretConnectorMap =
     mergeRecords(filteredConnectorMap, filteredModelProviderMap) ?? null;
+  const secretConnectorMetadataMap =
+    mergeRecords(
+      filteredConnectorMetadataMap,
+      filteredModelProviderMetadataMap,
+    ) ?? null;
   const secrets = mergeRecords(
     args.connectorContext.secrets,
     args.modelProvider?.secrets,
@@ -4972,7 +4993,7 @@ function buildStoredExecutionSecrets(args: {
   return {
     secrets: secrets ?? (secretConnectorMap ? {} : undefined),
     secretConnectorMap,
-    secretConnectorMetadataMap: filteredModelProviderMetadataMap ?? null,
+    secretConnectorMetadataMap,
   };
 }
 


### PR DESCRIPTION
Closes #20412.

## Summary

- Stop resolving connector `platform-secret` runtime bindings during run creation.
- Emit platform-owned connector aliases through the existing `secretConnectorMap` plus `secretConnectorMetadataMap` channel with `sourceType: "platform-secret"`.
- Filter connector metadata through the final connector map so explicit request/model/custom overrides drop stale platform metadata.
- Extend Google Ads run lifecycle coverage for lazy metadata, auth-time env rotation, no new encrypted platform secret snapshot, and request-secret override behavior.

## Deployment note

Do not merge until #20411 / #20415 reader support has been deployed to every API reader. New writer payloads include `sourceType: "platform-secret"`; old readers reject that source type. No new runner or mitm protocol field is introduced.

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --testNamePattern "platform-secret|platform secrets|GOOGLE_ADS_DEVELOPER_TOKEN"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts --testNamePattern "platform connector secrets"`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- pre-commit: `prettier`, `knip --cache`, full `turbo run check-types --concurrency=1`
