### PR TITLE
docs: document runner state file contract

### DIFF
--- a/crates/runner/src/proxy/mod.rs
+++ b/crates/runner/src/proxy/mod.rs
@@ -20,11 +20,12 @@
 //!   upload. The addon acknowledges in `jsonl-flush-state` after accepted
 //!   writes for that path are visible.
 //!
-//! Registry writes are atomic so the addon never consumes partial JSON. Flush
-//! acknowledgements must match the active usage state and request id; missing,
-//! stale, invalid, or mismatched addon state is treated as "not ready" until
-//! the bounded wait times out. Usage drain is a shutdown path for billing and
-//! usage reports, while JSONL flush is a per-upload network-log path.
+//! On supported Unix runner hosts, registry writes are target-path atomic so
+//! the addon never consumes partial JSON. Flush acknowledgements must match the
+//! active usage state and request id; missing, stale, invalid, or mismatched
+//! addon state is treated as "not ready" until the bounded wait times out.
+//! Usage drain is a shutdown path for billing and usage reports, while JSONL
+//! flush is a per-upload network-log path.
 //!
 //! `MitmProxy::new` prepares addon files, an empty registry, crash channel, and
 //! initial usage state. `start` spawns `mitmdump` and monitor tasks. Unexpected

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -70,9 +70,10 @@ async fn read_registry(path: &std::path::Path) -> RunnerResult<ProxyRegistry> {
         .map_err(|e| RunnerError::Internal(format!("parse registry: {e}")))
 }
 
-/// Write the proxy registry JSON file atomically (write tmp + rename).
+/// Write the proxy registry JSON file with target-path atomic replacement on Unix.
 ///
-/// This ensures the Python mitm-addon never reads a partially-written file.
+/// On supported Unix runner hosts, this ensures the Python mitm-addon never
+/// reads a partially-written file.
 async fn write_registry(path: &std::path::Path, value: &ProxyRegistry) -> RunnerResult<()> {
     let content = serde_json::to_string(value)
         .map_err(|e| RunnerError::Internal(format!("serialize registry: {e}")))?;

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -3,8 +3,8 @@
 //! State files handled here are local runner coordination files such as the
 //! proxy registry, mitm-addon flush state, live runner instance records,
 //! workspace cache metadata reads, and diagnostic config reads. The helper
-//! centralizes size-bounded reads and the filesystem checks that make those
-//! reads safe when paths come from local process or runner state.
+//! centralizes size-bounded reads and filesystem checks for paths that come
+//! from local process or runner state.
 //!
 //! On Unix, reads open files with `O_NOFOLLOW`, `O_CLOEXEC`, and
 //! `O_NONBLOCK`, then validate the opened descriptor with `fstat` before
@@ -16,8 +16,8 @@
 //!
 //! Unix writes create a private same-directory temporary file, write and flush
 //! its contents, then rename it over the target. This avoids exposing partial
-//! contents to readers, but it does not fsync the parent directory and should
-//! not be treated as a full crash-durability guarantee.
+//! contents through the target path, but it does not fsync the parent directory
+//! and should not be treated as a full crash-durability guarantee.
 
 use std::path::Path;
 
@@ -205,7 +205,7 @@ fn validate_open_state_file<Fd: std::os::fd::AsRawFd>(
     Ok(())
 }
 
-/// Write a state file without exposing partial contents to readers.
+/// Write a state file without exposing partial contents through the target path.
 ///
 /// On Unix, this writes to a hidden same-directory temporary file created with
 /// private `0600` permissions, flushes the file, renames it over the target,

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -206,13 +206,14 @@ fn validate_open_state_file<Fd: std::os::fd::AsRawFd>(
     Ok(())
 }
 
-/// Write a state file without exposing partial contents through the target path.
+/// Write a state file, using target-path atomic replacement on Unix.
 ///
 /// On Unix, this writes to a hidden same-directory temporary file created with
 /// private `0600` permissions, flushes the file, renames it over the target,
-/// and removes the temporary file on errors as best-effort cleanup. The parent
-/// directory is not fsynced, so this does not provide a full crash-durability
-/// guarantee. Non-Unix builds use `tokio::fs::write` as a weaker fallback.
+/// and removes the temporary file on errors as best-effort cleanup. This avoids
+/// exposing partial contents through the target path. The parent directory is
+/// not fsynced, so this does not provide a full crash-durability guarantee.
+/// Non-Unix builds use `tokio::fs::write` as a weaker fallback.
 pub(crate) async fn write_private_atomic(path: &Path, content: &[u8]) -> RunnerResult<()> {
     #[cfg(unix)]
     {

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -2,7 +2,7 @@
 //!
 //! State files handled here are local runner coordination files such as the
 //! proxy registry, mitm-addon flush state, live runner instance records,
-//! workspace cache metadata, and diagnostic config reads. The helper
+//! workspace cache metadata reads, and diagnostic config reads. The helper
 //! centralizes size-bounded reads and the filesystem checks that make those
 //! reads safe when paths come from local process or runner state.
 //!

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -49,7 +49,8 @@ pub(crate) enum OwnerCheck {
 /// Read an optional UTF-8 state file with a caller-supplied byte limit.
 ///
 /// Missing files return `Ok(None)`. Existing files must be valid UTF-8 after
-/// the bounded read and platform-specific state-file validation complete.
+/// the configured byte limit and any platform-specific state-file validation
+/// are applied.
 pub(crate) async fn read_to_string(
     path: &Path,
     max_bytes: u64,
@@ -65,8 +66,8 @@ pub(crate) async fn read_to_string(
 
 /// Read a required state file as bytes with a caller-supplied byte limit.
 ///
-/// Missing files are returned as `NotFound` errors. Existing files are read
-/// only after the platform-specific state-file validation completes.
+/// Missing files are returned as `NotFound` errors. Existing files use the
+/// same bounded, platform-specific read path as [`read_to_string`].
 pub(crate) async fn read_to_bytes_required(
     path: &Path,
     max_bytes: u64,

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -1,3 +1,24 @@
+//! Bounded, hardened I/O helpers for small runner state files.
+//!
+//! State files handled here are local runner coordination files such as the
+//! proxy registry, mitm-addon flush state, live runner instance records,
+//! workspace cache metadata, and diagnostic config reads. The helper
+//! centralizes size-bounded reads and the filesystem checks that make those
+//! reads safe when paths come from local process or runner state.
+//!
+//! On Unix, reads open files with `O_NOFOLLOW`, `O_CLOEXEC`, and
+//! `O_NONBLOCK`, then validate the opened descriptor with `fstat` before
+//! reading. The post-open check rejects non-regular files and can optionally
+//! require ownership by the current effective uid through [`OwnerCheck`].
+//! Non-Unix builds use a weaker fallback that keeps the byte limit but does
+//! not provide the Unix-specific open flags, file-type validation, or owner
+//! validation.
+//!
+//! Unix writes create a private same-directory temporary file, write and flush
+//! its contents, then rename it over the target. This avoids exposing partial
+//! contents to readers, but it does not fsync the parent directory and should
+//! not be treated as a full crash-durability guarantee.
+
 use std::path::Path;
 
 use crate::error::{RunnerError, RunnerResult};
@@ -8,12 +29,27 @@ pub(crate) const WORKSPACE_METADATA_MAX_BYTES: u64 = 1024 * 1024;
 
 const PRIVATE_FILE_MODE: u32 = 0o600;
 
+/// Ownership policy for reading a runner state file.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum OwnerCheck {
+    /// Skip owner validation.
+    ///
+    /// Use this for files that may legitimately be produced by another
+    /// runner-adjacent process or uid. On Unix, this still keeps the helper's
+    /// bounded read, nofollow open, nonblocking open, and regular-file checks;
+    /// it only skips the current-euid ownership check.
     None,
+    /// Require the opened file to be owned by the runner process effective uid.
+    ///
+    /// Use this for runner-owned files discovered from local process or state
+    /// paths, where accepting a file owned by another uid would be suspicious.
     CurrentEuid,
 }
 
+/// Read an optional UTF-8 state file with a caller-supplied byte limit.
+///
+/// Missing files return `Ok(None)`. Existing files must be valid UTF-8 after
+/// the bounded read and platform-specific state-file validation complete.
 pub(crate) async fn read_to_string(
     path: &Path,
     max_bytes: u64,
@@ -27,6 +63,10 @@ pub(crate) async fn read_to_string(
     })
 }
 
+/// Read a required state file as bytes with a caller-supplied byte limit.
+///
+/// Missing files are returned as `NotFound` errors. Existing files are read
+/// only after the platform-specific state-file validation completes.
 pub(crate) async fn read_to_bytes_required(
     path: &Path,
     max_bytes: u64,
@@ -165,6 +205,13 @@ fn validate_open_state_file<Fd: std::os::fd::AsRawFd>(
     Ok(())
 }
 
+/// Write a state file without exposing partial contents to readers.
+///
+/// On Unix, this writes to a hidden same-directory temporary file created with
+/// private `0600` permissions, flushes the file, renames it over the target,
+/// and removes the temporary file on errors as best-effort cleanup. The parent
+/// directory is not fsynced, so this does not provide a full crash-durability
+/// guarantee. Non-Unix builds use `tokio::fs::write` as a weaker fallback.
 pub(crate) async fn write_private_atomic(path: &Path, content: &[u8]) -> RunnerResult<()> {
     #[cfg(unix)]
     {

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -16,8 +16,8 @@
 //!
 //! Unix writes create a private same-directory temporary file, write and flush
 //! its contents, then rename it over the target. This avoids exposing partial
-//! contents through the target path, but it does not fsync the parent directory
-//! and should not be treated as a full crash-durability guarantee.
+//! contents through the target path, but it does not fsync the file or parent
+//! directory and should not be treated as a crash-durability guarantee.
 
 use std::path::Path;
 
@@ -211,9 +211,9 @@ fn validate_open_state_file<Fd: std::os::fd::AsRawFd>(
 /// On Unix, this writes to a hidden same-directory temporary file created with
 /// private `0600` permissions, flushes the file, renames it over the target,
 /// and removes the temporary file on errors as best-effort cleanup. This avoids
-/// exposing partial contents through the target path. The parent directory is
-/// not fsynced, so this does not provide a full crash-durability guarantee.
-/// Non-Unix builds use `tokio::fs::write` as a weaker fallback.
+/// exposing partial contents through the target path. The file and parent
+/// directory are not fsynced, so this does not provide a crash-durability
+/// guarantee. Non-Unix builds use `tokio::fs::write` as a weaker fallback.
 pub(crate) async fn write_private_atomic(path: &Path, content: &[u8]) -> RunnerResult<()> {
     #[cfg(unix)]
     {


### PR DESCRIPTION
## Summary

- document the runner state-file helper safety contract
- clarify `OwnerCheck::CurrentEuid` versus `OwnerCheck::None`
- document Unix write behavior and the lack of parent-directory fsync durability

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner state_file`

Closes #20440