### PR TITLE
fix(runner): skip zstd streaming usage decode

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -2,7 +2,7 @@
 
 Exports:
 
-- Bounded streaming usage decoding for gzip, deflate, zstd; one-shot
+- Bounded streaming usage decoding for gzip, deflate; one-shot
   decompression for gzip, deflate, br, zstd.
 - Request network-log capture decoding that hides opaque encoded bodies.
 - JSON usage decompression with diagnostic error classification.
@@ -30,14 +30,6 @@ from body_limits import (
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
-_ZSTD_STREAM_DECODE_MIN_INPUT_CHUNK_SIZE = 4
-# The streaming zstd API does not expose a per-call output limit. Keep the
-# adaptive ceiling small so a low-ratio prefix cannot make a later high-ratio
-# block materialise a multi-MB decoded ``bytes`` object before _feed_chunks().
-_ZSTD_STREAM_DECODE_MAX_INPUT_CHUNK_SIZE = 12
-_ZSTD_STREAM_DECODE_INPUT_GROWTH_FACTOR = 2
-_ZSTD_STREAM_DECODE_LOW_EXPANSION_RATIO = 2
-
 INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
 DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
@@ -86,33 +78,6 @@ def _feed_chunks(feed: _StreamDecodeFeed, data: bytes, max_decoded_chunk: int) -
 
 def _no_stream_decode_error() -> str | None:
     return None
-
-
-class _ZstdStreamDecodeInputSizer:
-    def __init__(self, *, max_decoded_chunk: int) -> None:
-        self._max_decoded_chunk = max_decoded_chunk
-        self._input_chunk_size = _ZSTD_STREAM_DECODE_MIN_INPUT_CHUNK_SIZE
-
-    @property
-    def input_chunk_size(self) -> int:
-        return self._input_chunk_size
-
-    def reset(self) -> None:
-        self._input_chunk_size = _ZSTD_STREAM_DECODE_MIN_INPUT_CHUNK_SIZE
-
-    def observe(self, source: bytes, decoded: bytes) -> None:
-        if not decoded:
-            return
-        if (
-            len(decoded) >= self._max_decoded_chunk
-            or len(decoded) > len(source) * _ZSTD_STREAM_DECODE_LOW_EXPANSION_RATIO
-        ):
-            self.reset()
-            return
-        self._input_chunk_size = min(
-            _ZSTD_STREAM_DECODE_MAX_INPUT_CHUNK_SIZE,
-            self._input_chunk_size * _ZSTD_STREAM_DECODE_INPUT_GROWTH_FACTOR,
-        )
 
 
 def _create_zlib_stream_decode_session(
@@ -165,62 +130,13 @@ def _create_zlib_stream_decode_session(
     return StreamDecodeSession(decode, finish_error)
 
 
-def _create_zstd_stream_decode_session(
-    feed: _StreamDecodeFeed, *, max_decoded_chunk: int
-) -> StreamDecodeSession:
-    obj = zstandard.ZstdDecompressor().decompressobj()
-    input_sizer = _ZstdStreamDecodeInputSizer(max_decoded_chunk=max_decoded_chunk)
-    decode_error: str | None = None
-    frame_in_progress = False
-    saw_input = False
-
-    def decode(chunk: bytes) -> None:
-        nonlocal decode_error, frame_in_progress, obj, saw_input
-        if decode_error is not None:
-            return
-        if chunk:
-            saw_input = True
-        data = chunk
-        while data:
-            input_chunk_size = input_sizer.input_chunk_size
-            source = data[:input_chunk_size]
-            remainder = data[input_chunk_size:]
-            frame_in_progress = True
-            try:
-                decoded = obj.decompress(source)
-            except zstandard.ZstdError as exc:
-                decode_error = INVALID_COMPRESSED_BODY
-                _log_streaming_decode_error("zstd", exc)
-                return
-            input_sizer.observe(source, decoded)
-            if decoded:
-                _feed_chunks(feed, decoded, max_decoded_chunk)
-            if obj.eof:
-                data = obj.unused_data + remainder
-                obj = zstandard.ZstdDecompressor().decompressobj()
-                input_sizer.reset()
-                frame_in_progress = False
-                continue
-            if obj.unconsumed_tail:
-                data = obj.unconsumed_tail + remainder
-                continue
-            data = remainder
-
-    def finish_error() -> str | None:
-        if decode_error is not None:
-            return decode_error
-        if saw_input and frame_in_progress:
-            return INCOMPLETE_COMPRESSED_BODY
-        return None
-
-    return StreamDecodeSession(decode, finish_error)
-
-
 def _stream_decode_skip_reason(encoding: str) -> str | None:
     if not encoding or encoding == "identity":
         return None
-    if encoding in ("gzip", "deflate", "zstd"):
+    if encoding in ("gzip", "deflate"):
         return None
+    if encoding == "zstd":
+        return "zstd streaming output cannot be hard-bounded"
     if encoding == "br":
         return "brotli streaming output cannot be bounded"
     return "unsupported content encoding"
@@ -246,10 +162,8 @@ def create_stream_decode_session(
 
     Usage parsers are bounded-state scanners and may need to inspect long
     responses, so this helper does not enforce a total decoded-byte cap. It
-    bounds each decoded chunk before parser entry. Codecs without a per-call
-    output cap still use small adaptive input slices as a best-effort guard
-    against high-ratio compressed input. Returns None when a content encoding
-    cannot be safely decoded incrementally.
+    bounds each decoded chunk before parser entry. Returns None when a content
+    encoding cannot be safely decoded incrementally.
 
     The returned session exposes ``finish_error()`` so billing paths can reject
     parser state from compressed streams that never reached a valid frame/member
@@ -268,8 +182,6 @@ def create_stream_decode_session(
             encoding=encoding,
             max_decoded_chunk=max_decoded_chunk,
         )
-    if encoding == "zstd":
-        return _create_zstd_stream_decode_session(feed, max_decoded_chunk=max_decoded_chunk)
     return None
 
 

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/response_parser.py
@@ -12,14 +12,14 @@ class ConnectorResponseParser(NamedTuple):
     connector usage extraction. The response streaming layer wires ``feed`` into
     the stream callback for that flow.
 
-    ``feed`` receives each streamed response-body chunk. For ``gzip``,
-    ``deflate``, and ``zstd``, the stream wrapper passes decompressed bytes to
-    ``feed``. With no encoding or ``identity``, the original chunk bytes are
-    passed through unchanged. Encodings that cannot be safely decoded with a
-    bounded incremental output, including ``br`` and unsupported values, skip
-    response-body parsing for that flow. Implementations must treat ``b""`` as
-    a no-op: incremental decompressors may produce no output for a source
-    chunk, and decompression failures intentionally suppress later parser input.
+    ``feed`` receives each streamed response-body chunk. For ``gzip`` and
+    ``deflate``, the stream wrapper passes decompressed bytes to ``feed``. With
+    no encoding or ``identity``, the original chunk bytes are passed through
+    unchanged. Encodings that cannot be safely decoded with a bounded
+    incremental output, including ``br``, ``zstd``, and unsupported values, skip
+    response-body parsing for that flow. Implementations must treat ``b""`` as a
+    no-op: incremental decompressors may produce no output for a source chunk,
+    and decompression failures intentionally suppress later parser input.
 
     ``finish`` is optional. When provided, normal completed-response
     finalization calls it once after streaming has fed all chunks and before

--- a/crates/runner/mitm-addon/tests/body_decode_helpers.py
+++ b/crates/runner/mitm-addon/tests/body_decode_helpers.py
@@ -1,19 +1,6 @@
 """Shared compression helpers for mitm-addon body decoding tests."""
 
-from dataclasses import dataclass, field
-
 import brotli
-import zstandard
-
-
-@dataclass
-class ZstdDecompressStats:
-    calls: int = 0
-    decompressobj_calls: int = 0
-    max_input: int = 0
-    max_output: int = 0
-    input_sizes: list[int] = field(default_factory=list, repr=False)
-    output_sizes: list[int] = field(default_factory=list, repr=False)
 
 
 def track_brotli_decompressor(monkeypatch):
@@ -35,51 +22,6 @@ def track_brotli_decompressor(monkeypatch):
             return self._inner.is_finished()
 
     monkeypatch.setattr("body_decoding.brotli.Decompressor", CountingDecompressor)
-    return stats
-
-
-def track_zstd_decompressor(monkeypatch) -> ZstdDecompressStats:
-    real_decompressor = zstandard.ZstdDecompressor
-    stats = ZstdDecompressStats()
-
-    class CountingDecompressionObj:
-        def __init__(self, inner):
-            self._inner = inner
-
-        def decompress(self, chunk: bytes) -> bytes:
-            stats.calls += 1
-            stats.input_sizes.append(len(chunk))
-            stats.max_input = max(stats.max_input, len(chunk))
-            try:
-                decoded = self._inner.decompress(chunk)
-            except zstandard.ZstdError:
-                stats.output_sizes.append(0)
-                raise
-            stats.output_sizes.append(len(decoded))
-            stats.max_output = max(stats.max_output, len(decoded))
-            return decoded
-
-        @property
-        def eof(self):
-            return self._inner.eof
-
-        @property
-        def unused_data(self):
-            return self._inner.unused_data
-
-        @property
-        def unconsumed_tail(self):
-            return self._inner.unconsumed_tail
-
-    class CountingZstdDecompressor:
-        def __init__(self, *args, **kwargs):
-            self._inner = real_decompressor(*args, **kwargs)
-
-        def decompressobj(self, *args, **kwargs):
-            stats.decompressobj_calls += 1
-            return CountingDecompressionObj(self._inner.decompressobj(*args, **kwargs))
-
-    monkeypatch.setattr("body_decoding.zstandard.ZstdDecompressor", CountingZstdDecompressor)
     return stats
 
 

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -1,7 +1,6 @@
 """Tests for shared HTTP body decoding helpers."""
 
 import gzip
-import hashlib
 import zlib
 
 import brotli
@@ -9,6 +8,7 @@ import pytest
 import zstandard
 
 from body_decoding import (
+    can_stream_decode_usage,
     create_stream_decode_feed,
     create_stream_decode_session,
     decode_request_body_for_network_log_capture,
@@ -18,17 +18,7 @@ from body_limits import DEFAULT_BODY_DECODE_LIMIT, STREAM_DECODE_CHUNK_LIMIT
 from tests.body_decode_helpers import (
     pseudo_random_ascii,
     track_brotli_decompressor,
-    track_zstd_decompressor,
 )
-
-
-def _deterministic_low_ratio_bytes(size: int) -> bytes:
-    data = bytearray()
-    counter = 0
-    while len(data) < size:
-        data.extend(hashlib.sha256(counter.to_bytes(8, "little")).digest())
-        counter += 1
-    return bytes(data[:size])
 
 
 def _compress_one_shot_body(encoding: str, body: bytes) -> bytes:
@@ -53,19 +43,11 @@ class TestStreamDecodeFeed:
         parse(gzip.compress(b"hello world"))
         assert b"".join(chunks) == b"hello world"
 
-    def test_zstd_happy_path(self, headers):
-        chunks: list[bytes] = []
-        parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert parse is not None
-        parse(zstandard.ZstdCompressor().compress(b"hello world"))
-        assert b"".join(chunks) == b"hello world"
-
     def test_supported_encodings_across_small_chunks(self, headers):
         plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
         compressed_by_encoding = {
             "gzip": gzip.compress(plaintext),
             "deflate": zlib.compress(plaintext),
-            "zstd": zstandard.ZstdCompressor().compress(plaintext),
         }
 
         for encoding, compressed in compressed_by_encoding.items():
@@ -91,17 +73,6 @@ class TestStreamDecodeFeed:
         session.feed(compressed[:-1])
 
         assert b"".join(chunks) == plaintext
-        assert session.finish_error() == "incomplete compressed body"
-
-    def test_zstd_session_reports_truncated_frame(self, headers):
-        plaintext = b'{"model":"claude-sonnet-4-6","usage":{"input_tokens":42}}'
-        compressed = zstandard.ZstdCompressor().compress(plaintext)
-        chunks: list[bytes] = []
-        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert session is not None
-
-        session.feed(compressed[:-1])
-
         assert session.finish_error() == "incomplete compressed body"
 
     @pytest.mark.parametrize("encoding", ["gzip", "deflate"])
@@ -164,105 +135,6 @@ class TestStreamDecodeFeed:
         assert len(chunks) > 1
         assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
 
-    def test_zstd_high_ratio_output_is_chunked(self, headers):
-        plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3 + 123)
-        chunks: list[bytes] = []
-        parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert parse is not None
-
-        parse(zstandard.ZstdCompressor().compress(plaintext))
-
-        assert b"".join(chunks) == plaintext
-        assert len(chunks) > 1
-        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
-
-    def test_zstd_large_low_ratio_input_ramps_up(self, headers, monkeypatch):
-        plaintext = _deterministic_low_ratio_bytes(512 * 1024)
-        compressed = zstandard.ZstdCompressor().compress(plaintext)
-        stats = track_zstd_decompressor(monkeypatch)
-        chunks: list[bytes] = []
-        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert session is not None
-
-        session.feed(compressed)
-
-        assert b"".join(chunks) == plaintext
-        assert session.finish_error() is None
-        assert stats.max_input > 4
-        assert stats.calls < len(compressed) // 8
-
-    def test_zstd_high_ratio_input_stays_small_before_large_output(self, headers, monkeypatch):
-        plaintext = b"A" * (STREAM_DECODE_CHUNK_LIMIT * 4 + 123)
-        compressed = zstandard.ZstdCompressor().compress(plaintext)
-        stats = track_zstd_decompressor(monkeypatch)
-        chunks: list[bytes] = []
-        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert session is not None
-
-        session.feed(compressed)
-
-        assert b"".join(chunks) == plaintext
-        assert session.finish_error() is None
-        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
-        assert stats.max_input <= 12
-
-    def test_zstd_mixed_ratio_input_keeps_transient_output_small(self, headers, monkeypatch):
-        plaintext = _deterministic_low_ratio_bytes(256 * 1024) + (
-            b"A" * (STREAM_DECODE_CHUNK_LIMIT * 64)
-        )
-        compressed = zstandard.ZstdCompressor().compress(plaintext)
-        stats = track_zstd_decompressor(monkeypatch)
-        chunks: list[bytes] = []
-        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert session is not None
-
-        session.feed(compressed)
-
-        assert b"".join(chunks) == plaintext
-        assert session.finish_error() is None
-        assert max(len(chunk) for chunk in chunks) <= STREAM_DECODE_CHUNK_LIMIT
-        assert stats.max_input <= 12
-        assert stats.max_output <= STREAM_DECODE_CHUNK_LIMIT * 4
-
-    def test_concatenated_zstd_frames_same_callback(self, headers):
-        first = zstandard.ZstdCompressor().compress(b"hello ")
-        second = zstandard.ZstdCompressor().compress(b"world")
-        chunks: list[bytes] = []
-        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert session is not None
-
-        session.feed(first + second)
-
-        assert b"".join(chunks) == b"hello world"
-        assert session.finish_error() is None
-
-    def test_zstd_streaming_uses_decompressobj_for_finalization(self, headers, monkeypatch):
-        real_decompressor = zstandard.ZstdDecompressor
-        stats = {"stream_writer": 0, "decompressobj": 0}
-
-        class CountingZstdDecompressor:
-            def __init__(self):
-                self._inner = real_decompressor()
-
-            def stream_writer(self, sink):
-                stats["stream_writer"] += 1
-                raise AssertionError("streaming usage decoder must not use stream_writer")
-
-            def decompressobj(self):
-                stats["decompressobj"] += 1
-                return self._inner.decompressobj()
-
-        monkeypatch.setattr("body_decoding.zstandard.ZstdDecompressor", CountingZstdDecompressor)
-        chunks: list[bytes] = []
-        parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
-        assert parse is not None
-
-        parse(zstandard.ZstdCompressor().compress(b"hello world"))
-
-        assert b"".join(chunks) == b"hello world"
-        assert stats["stream_writer"] == 0
-        assert stats["decompressobj"] >= 1
-
     def test_gzip_error_logs_once_and_short_circuits(self, headers, mitm_ctx):
         chunks: list[bytes] = []
         with mitm_ctx() as log:
@@ -287,18 +159,32 @@ class TestStreamDecodeFeed:
         assert "br" in log.debug.call_args[0][0]
         assert chunks == []
 
-    def test_zstd_error_logs_once_and_short_circuits(self, headers, mitm_ctx, monkeypatch):
-        stats = track_zstd_decompressor(monkeypatch)
+    def test_zstd_unsafe_encoding_logs_once_and_does_not_feed(self, headers, mitm_ctx):
         chunks: list[bytes] = []
         with mitm_ctx() as log:
             parse = create_stream_decode_feed(headers(("Content-Encoding", "zstd")), chunks.append)
-            assert parse is not None
-            parse(b"not zstd at all")
-            parse(b"more garbage")
+        assert parse is None
         assert log.debug.call_count == 1
-        assert "zstd" in log.debug.call_args[0][0]
-        assert stats.calls == 1
+        msg = log.debug.call_args[0][0]
+        assert "Streaming decompression skipped" in msg
+        assert "zstd" in msg
+        assert "hard-bounded" in msg
         assert chunks == []
+
+    def test_zstd_stream_decode_session_is_not_created(self, headers):
+        chunks: list[bytes] = []
+        session = create_stream_decode_session(headers(("Content-Encoding", "zstd")), chunks.append)
+        assert session is None
+        assert chunks == []
+
+    def test_zstd_can_stream_decode_usage_is_false(self, headers, mitm_ctx):
+        with mitm_ctx() as log:
+            assert can_stream_decode_usage(headers(("Content-Encoding", "zstd"))) is False
+        assert log.debug.call_count == 1
+        msg = log.debug.call_args[0][0]
+        assert "Streaming decompression skipped" in msg
+        assert "zstd" in msg
+        assert "hard-bounded" in msg
 
     def test_error_without_ctx_log_does_not_raise(self, headers):
         # No mitm_ctx patch — ctx.log is unavailable.  Guard must swallow.

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -34,9 +34,9 @@ def _deterministic_low_ratio_text(size: int) -> str:
     remaining = size
     while remaining > 0:
         seed = hashlib.sha256(seed).hexdigest().encode()
-        chunk = seed.decode()
-        chunks.append(chunk[:remaining])
-        remaining -= len(chunk)
+        fragment = seed.decode()[:remaining]
+        chunks.append(fragment)
+        remaining -= len(fragment)
     return "".join(chunks)
 
 
@@ -224,11 +224,7 @@ class TestModelProviderJsonStreaming:
             if entry.get("message") == "Model provider JSON usage extraction failed"
         ]
         assert len(usage_warnings) == 1
-        assert usage_warnings[0]["error"] in {
-            "decoded body limit exceeded",
-            "incomplete compressed body",
-            "invalid compressed body",
-        }
+        assert usage_warnings[0]["error"] == "incomplete compressed body"
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
     @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -1,6 +1,7 @@
 """Tests for model-provider JSON response streaming usage reporting."""
 
 import gzip
+import hashlib
 import json
 import zlib
 from pathlib import Path
@@ -12,7 +13,7 @@ from mitmproxy.test import tutils
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
-from body_limits import STREAM_BUFFER_LIMIT, STREAM_DECODE_CHUNK_LIMIT
+from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.model_provider_response_helpers import (
@@ -25,6 +26,18 @@ from tests.model_provider_response_helpers import (
     run_response,
     standard_success_payload,
 )
+
+
+def _deterministic_low_ratio_text(size: int) -> str:
+    chunks: list[str] = []
+    seed = b"vm0-zstd-json-streaming-test"
+    remaining = size
+    while remaining > 0:
+        seed = hashlib.sha256(seed).hexdigest().encode()
+        chunk = seed.decode()
+        chunks.append(chunk[:remaining])
+        remaining -= len(chunk)
+    return "".join(chunks)
 
 
 class TestModelProviderJsonStreaming:
@@ -133,7 +146,7 @@ class TestModelProviderJsonStreaming:
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == expected_event_quantities(provider_case)
 
-    def test_full_pipeline_zstd_model_json_scans_past_decode_chunk_limit(
+    def test_full_pipeline_small_zstd_model_json_uses_bounded_fallback(
         self,
         tmp_path,
         real_flow,
@@ -144,28 +157,78 @@ class TestModelProviderJsonStreaming:
             ANTHROPIC_JSON_CASE,
             proxy_log_path=tmp_path / "proxy.jsonl",
         )
-        payload = (
-            b'{"id":"msg_zstd","model":"claude-sonnet-4-6","content":[{"text":"'
-            + b"A" * (STREAM_DECODE_CHUNK_LIMIT * 3)
-            + b'"}],"usage":{"input_tokens":10,"output_tokens":20}}'
-        )
+        payload = standard_success_payload(ANTHROPIC_JSON_CASE)
+        compressed = zstandard.ZstdCompressor().compress(payload)
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map({"content-type": "application/json", "content-encoding": "zstd"}),
         )
 
         mitm_addon.responseheaders(flow)
-        response_stream(flow)(zstandard.ZstdCompressor().compress(payload))
+        assert "model_json_usage_finish" not in flow.metadata
+        response_stream(flow)(compressed)
 
         webhook = run_response(flow, self._usage_webhook_api)
 
         extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
-        assert extracted["message_id"] == "msg_zstd"
-        assert extracted["tokens.input"] == 10
-        assert extracted["tokens.output"] == 20
+        expected_usage = expected_model_usage(ANTHROPIC_JSON_CASE)
+        assert extracted["message_id"] == expected_usage["message_id"]
+        assert extracted["model"] == expected_usage["model"]
+        assert extracted["tokens.input"] == expected_usage["tokens.input"]
+        assert extracted["tokens.output"] == expected_usage["tokens.output"]
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
-        assert by_category == {"tokens.input": 10, "tokens.output": 20}
+        assert by_category == expected_event_quantities(ANTHROPIC_JSON_CASE)
+
+    def test_full_pipeline_large_zstd_model_json_does_not_parse_truncated_fallback(
+        self,
+        tmp_path,
+        real_flow,
+    ):
+        proxy_log_path = tmp_path / "proxy.jsonl"
+        flow = model_provider_flow(
+            real_flow,
+            tmp_path,
+            ANTHROPIC_JSON_CASE,
+            proxy_log_path=proxy_log_path,
+        )
+        payload = json.dumps(
+            {
+                "id": "msg_zstd_large",
+                "model": "claude-sonnet-4-6",
+                "content": [{"text": _deterministic_low_ratio_text(STREAM_BUFFER_LIMIT * 8)}],
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+            }
+        ).encode()
+        compressed = zstandard.ZstdCompressor().compress(payload)
+        assert len(compressed) > STREAM_BUFFER_LIMIT
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map({"content-type": "application/json", "content-encoding": "zstd"}),
+        )
+
+        mitm_addon.responseheaders(flow)
+        assert "model_json_usage_finish" not in flow.metadata
+        response_stream(flow)(compressed)
+        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+
+        webhook = run_response(flow, self._usage_webhook_api)
+
+        assert webhook.request_count == 0
+        assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
+        entries = read_jsonl_entries_after_flush(proxy_log_path)
+        usage_warnings = [
+            entry
+            for entry in entries
+            if entry.get("message") == "Model provider JSON usage extraction failed"
+        ]
+        assert len(usage_warnings) == 1
+        assert usage_warnings[0]["error"] in {
+            "decoded body limit exceeded",
+            "incomplete compressed body",
+            "invalid compressed body",
+        }
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate"])
     @pytest.mark.parametrize(

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -157,13 +157,7 @@ class TestXConnectorResponsePipeline:
         entry = lost_visibility_entries[0]
         assert entry["level"] == "error"
         assert entry["body_truncated"] is False
-        if encoding_case == "zstd":
-            assert entry["parse_error"] in {
-                "incomplete compressed body",
-                "invalid compressed body",
-            }
-        else:
-            assert entry["parse_error"] == "incomplete compressed body"
+        assert entry["parse_error"] == "incomplete compressed body"
         assert "connector_response_finish" not in flow.metadata
 
     def test_full_response_pipeline_x_data_object_bills_single_resource(

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import brotli
 import pytest
+import zstandard
 from mitmproxy.flow import Error
 
 import flow_metadata_keys as metadata_keys
@@ -22,6 +23,18 @@ from tests.x_flow_helpers import (
     make_x_pipeline_flow,
     make_x_stream_pipeline_flow,
 )
+
+
+def _compress_body(encoding: str, payload: bytes) -> bytes:
+    if encoding == "gzip":
+        return gzip.compress(payload)
+    if encoding == "deflate":
+        return zlib.compress(payload)
+    if encoding == "br":
+        return brotli.compress(payload)
+    if encoding == "zstd":
+        return zstandard.ZstdCompressor().compress(payload)
+    raise AssertionError(f"unsupported test encoding: {encoding}")
 
 
 class TestXConnectorResponsePipeline:
@@ -74,17 +87,17 @@ class TestXConnectorResponsePipeline:
         by_category = {event["category"]: event["quantity"] for event in events}
         assert by_category == {"posts.read": 1, "user.read": 1}
 
-    def test_full_response_pipeline_brotli_x_json_uses_bounded_fallback(
-        self, tmp_path, real_flow, mitm_ctx
+    @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
+    def test_full_response_pipeline_unsafe_compressed_x_json_uses_bounded_fallback(
+        self, tmp_path, real_flow, mitm_ctx, encoding_case
     ):
-        """Brotli streaming decode is skipped, but X JSON fallback remains active."""
-        flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding="br")
+        """Unsafe streaming encodings are skipped, but X JSON fallback remains active."""
+        flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding=encoding_case)
+        payload = b'{"data":[{"id":"1"}],"includes":{"users":[{"id":"u1"}]}}'
 
         with mitm_ctx() as log:
             mitm_addon.responseheaders(flow)
-        response_stream(flow)(
-            brotli.compress(b'{"data":[{"id":"1"}],"includes":{"users":[{"id":"u1"}]}}')
-        )
+        response_stream(flow)(_compress_body(encoding_case, payload))
 
         payloads = self._call_and_get_billing(flow)
 
@@ -93,14 +106,15 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert log.debug.call_count == 1
-        assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
+        assert f"Streaming decompression skipped ({encoding_case})" in log.debug.call_args[0][0]
 
-    def test_responseheaders_brotli_x_stream_does_not_leave_parser_state(
-        self, tmp_path, real_flow, mitm_ctx
+    @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
+    def test_responseheaders_unsafe_compressed_x_stream_does_not_leave_parser_state(
+        self, tmp_path, real_flow, mitm_ctx, encoding_case
     ):
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
         assert flow.response is not None
-        flow.response.headers["content-encoding"] = "br"
+        flow.response.headers["content-encoding"] = encoding_case
 
         with mitm_ctx() as log:
             mitm_addon.responseheaders(flow)
@@ -108,9 +122,9 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert log.debug.call_count == 1
-        assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
+        assert f"Streaming decompression skipped ({encoding_case})" in log.debug.call_args[0][0]
 
-    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate", "br"])
+    @pytest.mark.parametrize("encoding_case", ["gzip", "deflate", "br", "zstd"])
     def test_full_response_pipeline_truncated_compressed_x_json_does_not_bill(
         self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, encoding_case
     ):
@@ -124,12 +138,7 @@ class TestXConnectorResponsePipeline:
             content_encoding=encoding_case,
         )
         payload = b'{"data":[{"id":"1"}],"meta":{"result_count":1}}'
-        if encoding_case == "gzip":
-            compressed = gzip.compress(payload)[:-1]
-        elif encoding_case == "deflate":
-            compressed = zlib.compress(payload)[:-1]
-        else:
-            compressed = brotli.compress(payload)[:-1]
+        compressed = _compress_body(encoding_case, payload)[:-1]
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(compressed)
@@ -148,7 +157,13 @@ class TestXConnectorResponsePipeline:
         entry = lost_visibility_entries[0]
         assert entry["level"] == "error"
         assert entry["body_truncated"] is False
-        assert entry["parse_error"] == "incomplete compressed body"
+        if encoding_case == "zstd":
+            assert entry["parse_error"] in {
+                "incomplete compressed body",
+                "invalid compressed body",
+            }
+        else:
+            assert entry["parse_error"] == "incomplete compressed body"
         assert "connector_response_finish" not in flow.metadata
 
     def test_full_response_pipeline_x_data_object_bills_single_resource(


### PR DESCRIPTION
## Summary
- remove zstd from bounded streaming usage decoding because python-zstandard does not provide a hard per-call output cap for decompression objects
- keep one-shot zstd JSON/body decompression for bounded fallback paths
- update model-provider and X connector tests to cover zstd fallback and truncated-buffer fail-closed behavior

Closes #20441

## Tests
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests`
- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff format --check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff check src tests`
- `cd crates/runner/mitm-addon && .venv/bin/python -m basedpyright src tests`