### PR TITLE
feat: support full runner builtin firewall catalog resolve

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@vm0/connectors/firewall-metadata/runner-runtime";
 import { describe, expect, it } from "vitest";
 
+import { createAppWithRoutes } from "../../../app-factory-core";
 import { setupAppWithRoutes } from "../../../__tests__/test-app";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { runnersRoutes } from "../runners";
@@ -29,6 +30,10 @@ function client() {
   return setupAppWithRoutes({ context, routes: runnersRoutes })(
     runnersBuiltinFirewallsResolveContract,
   );
+}
+
+function rawApp() {
+  return createAppWithRoutes({ signal: context.signal, routes: runnersRoutes });
 }
 
 describe("runner builtin firewall resolver", () => {
@@ -56,6 +61,22 @@ describe("runner builtin firewall resolver", () => {
     expect(response.body.error.message).toBe(
       "Unknown builtin firewall: not-a-builtin-firewall",
     );
+  });
+
+  it("rejects misspelled full-catalog request fields", async () => {
+    const response = await rawApp().request(
+      "/api/runners/builtin-firewalls/resolve",
+      {
+        method: "POST",
+        headers: {
+          authorization: OFFICIAL_RUNNER_AUTHORIZATION,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ name: ["github"] }),
+      },
+    );
+
+    expect(response.status).toBe(400);
   });
 
   it("resolves connector and model-provider builtin firewalls", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -127,6 +127,11 @@ describe("runner builtin firewall resolver", () => {
 
     expect(body.catalogDigest).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST);
     expect(body.catalogVersion).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.responses[200].safeParse(
+        body,
+      ).success,
+    ).toBeTruthy();
     expect(Object.keys(body.firewalls).sort(compareStrings)).toStrictEqual([
       ...RUNNER_RUNTIME_FIREWALL_NAMES,
     ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -90,6 +90,31 @@ describe("runner builtin firewall resolver", () => {
     });
   });
 
+  it("handles concurrent full generated builtin firewall catalog resolves", async () => {
+    const responses = await Promise.all(
+      Array.from({ length: 3 }, () => {
+        return accept(
+          client().resolve({
+            headers: { authorization: OFFICIAL_RUNNER_AUTHORIZATION },
+            body: {},
+          }),
+          [200],
+        );
+      }),
+    );
+
+    for (const response of responses) {
+      const body: RunnerBuiltinFirewallsResolveResponse = response.body;
+      expect(body.catalogDigest).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST);
+      expect(body.catalogVersion).toBe(
+        RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
+      );
+      expect(Object.keys(body.firewalls).sort(compareStrings)).toStrictEqual([
+        ...RUNNER_RUNTIME_FIREWALL_NAMES,
+      ]);
+    }
+  });
+
   it("resolves the full generated builtin firewall catalog when names are omitted", async () => {
     const response = await accept(
       client().resolve({

--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -79,6 +79,26 @@ describe("runner builtin firewall resolver", () => {
     expect(response.status).toBe(400);
   });
 
+  it.each([
+    { body: "not-json", label: "invalid JSON" },
+    { body: "null", label: "null JSON" },
+    { body: "[]", label: "array JSON" },
+  ])("rejects $label full-catalog request bodies", async ({ body }) => {
+    const response = await rawApp().request(
+      "/api/runners/builtin-firewalls/resolve",
+      {
+        method: "POST",
+        headers: {
+          authorization: OFFICIAL_RUNNER_AUTHORIZATION,
+          "content-type": "application/json",
+        },
+        body,
+      },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
   it("resolves connector and model-provider builtin firewalls", async () => {
     const response = await accept(
       client().resolve({

--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -21,6 +21,10 @@ const OPENAI_API_KEY_AUTH_HEADER = [
   "{{ secrets.OPENAI_API_KEY }}",
 ].join("");
 
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 function client() {
   return setupAppWithRoutes({ context, routes: runnersRoutes })(
     runnersBuiltinFirewallsResolveContract,
@@ -98,7 +102,7 @@ describe("runner builtin firewall resolver", () => {
 
     expect(body.catalogDigest).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST);
     expect(body.catalogVersion).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION);
-    expect(Object.keys(body.firewalls).sort()).toStrictEqual([
+    expect(Object.keys(body.firewalls).sort(compareStrings)).toStrictEqual([
       ...RUNNER_RUNTIME_FIREWALL_NAMES,
     ]);
     expect(body.firewalls.github?.name).toBe("github");

--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -4,6 +4,7 @@ import {
 } from "@vm0/api-contracts/contracts/runners";
 import {
   RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_NAMES,
   RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
 } from "@vm0/connectors/firewall-metadata/runner-runtime";
 import { describe, expect, it } from "vitest";
@@ -70,6 +71,35 @@ describe("runner builtin firewall resolver", () => {
     expect(Object.keys(body.firewalls).sort()).toStrictEqual([
       "github",
       "model-provider:openai-api-key",
+    ]);
+    expect(body.firewalls.github?.name).toBe("github");
+    expect(
+      body.firewalls["model-provider:openai-api-key"]?.apis[0],
+    ).toStrictEqual({
+      base: "https://api.openai.com/v1/responses",
+      auth: {
+        headers: {
+          Authorization: OPENAI_API_KEY_AUTH_HEADER,
+        },
+      },
+      permissions: [],
+    });
+  });
+
+  it("resolves the full generated builtin firewall catalog when names are omitted", async () => {
+    const response = await accept(
+      client().resolve({
+        headers: { authorization: OFFICIAL_RUNNER_AUTHORIZATION },
+        body: {},
+      }),
+      [200],
+    );
+    const body: RunnerBuiltinFirewallsResolveResponse = response.body;
+
+    expect(body.catalogDigest).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST);
+    expect(body.catalogVersion).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION);
+    expect(Object.keys(body.firewalls).sort()).toStrictEqual([
+      ...RUNNER_RUNTIME_FIREWALL_NAMES,
     ]);
     expect(body.firewalls.github?.name).toBe("github");
     expect(

--- a/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/runners-builtin-firewalls.test.ts
@@ -147,9 +147,7 @@ describe("runner builtin firewall resolver", () => {
     for (const response of responses) {
       const body: RunnerBuiltinFirewallsResolveResponse = response.body;
       expect(body.catalogDigest).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST);
-      expect(body.catalogVersion).toBe(
-        RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
-      );
+      expect(body.catalogVersion).toBe(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION);
       expect(Object.keys(body.firewalls).sort(compareStrings)).toStrictEqual([
         ...RUNNER_RUNTIME_FIREWALL_NAMES,
       ]);

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -16,6 +16,7 @@ import {
   RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
   RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
   hasRunnerRuntimeFirewall,
+  loadAllRunnerRuntimeFirewalls,
   loadRunnerRuntimeFirewalls,
 } from "@vm0/connectors/firewall-metadata/runner-runtime";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
@@ -1946,17 +1947,21 @@ const builtinFirewallsResolveInner$ = command(
       return body.response;
     }
 
-    const names = [...new Set(body.data.names)];
-    const missingNames = names.filter((name) => {
-      return !hasRunnerRuntimeFirewall(name);
-    });
-    if (missingNames.length > 0) {
-      return badRequestMessage(
-        `Unknown builtin firewall: ${missingNames.join(", ")}`,
-      );
+    let firewalls: Awaited<ReturnType<typeof loadRunnerRuntimeFirewalls>>;
+    if (body.data.names === undefined) {
+      firewalls = await loadAllRunnerRuntimeFirewalls();
+    } else {
+      const names = [...new Set(body.data.names)];
+      const missingNames = names.filter((name) => {
+        return !hasRunnerRuntimeFirewall(name);
+      });
+      if (missingNames.length > 0) {
+        return badRequestMessage(
+          `Unknown builtin firewall: ${missingNames.join(", ")}`,
+        );
+      }
+      firewalls = await loadRunnerRuntimeFirewalls(names);
     }
-
-    const firewalls = await loadRunnerRuntimeFirewalls(names);
     signal.throwIfAborted();
 
     return {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -362,6 +362,13 @@ describe("runner claim capability contract", () => {
 });
 
 describe("runner builtin firewall resolve contract", () => {
+  it("accepts omitted names for full catalog resolution", () => {
+    const result =
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({});
+
+    expect(result.success).toBe(true);
+  });
+
   it("accepts connector and model-provider names", () => {
     const result =
       runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
@@ -380,6 +387,11 @@ describe("runner builtin firewall resolve contract", () => {
     expect(
       runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
         names: ["model-provider:"],
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: [],
       }).success,
     ).toBe(false);
     expect(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -380,6 +380,13 @@ describe("runner builtin firewall resolve contract", () => {
 
   it("rejects malformed and oversized requests", () => {
     expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse(null)
+        .success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse([]).success,
+    ).toBe(false);
+    expect(
       runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
         names: ["ModelProvider:openai-api-key"],
       }).success,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -411,6 +411,17 @@ describe("runner builtin firewall resolve contract", () => {
     ).toBe(false);
     expect(
       runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        name: ["github"],
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: ["github"],
+        extra: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
         names: Array.from(
           { length: RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX + 1 },
           (_, index) => {

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -396,6 +396,21 @@ describe("runner builtin firewall resolve contract", () => {
     ).toBe(false);
     expect(
       runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: null,
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: "github",
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
+        names: [""],
+      }).success,
+    ).toBe(false);
+    expect(
+      runnersBuiltinFirewallsResolveContract.resolve.body.safeParse({
         names: Array.from(
           { length: RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX + 1 },
           (_, index) => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -96,7 +96,7 @@ const runnerBuiltinFirewallsResolveBodySchema = z.object({
     .min(1)
     .max(RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX)
     .optional(),
-});
+}).strict();
 const runnerBuiltinFirewallsResolveResponseSchema = z.object({
   catalogDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
   catalogVersion: z.string().min(1),

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -90,13 +90,15 @@ const runnerBuiltinFirewallNameSchema = z
   .min(1)
   .max(128)
   .regex(/^(?:[a-z0-9][a-z0-9-]*|model-provider:[a-z0-9][a-z0-9-]*)$/);
-const runnerBuiltinFirewallsResolveBodySchema = z.object({
-  names: z
-    .array(runnerBuiltinFirewallNameSchema)
-    .min(1)
-    .max(RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX)
-    .optional(),
-}).strict();
+const runnerBuiltinFirewallsResolveBodySchema = z
+  .object({
+    names: z
+      .array(runnerBuiltinFirewallNameSchema)
+      .min(1)
+      .max(RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX)
+      .optional(),
+  })
+  .strict();
 const runnerBuiltinFirewallsResolveResponseSchema = z.object({
   catalogDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),
   catalogVersion: z.string().min(1),

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -94,7 +94,8 @@ const runnerBuiltinFirewallsResolveBodySchema = z.object({
   names: z
     .array(runnerBuiltinFirewallNameSchema)
     .min(1)
-    .max(RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX),
+    .max(RUNNER_BUILTIN_FIREWALL_RESOLVE_NAMES_MAX)
+    .optional(),
 });
 const runnerBuiltinFirewallsResolveResponseSchema = z.object({
   catalogDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/),

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -412,6 +412,7 @@ describe("firewall runtime surface", () => {
     expect(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION).toMatch(
       /^sha256-[a-f0-9]{12}$/,
     );
+    expect(Object.isFrozen(RUNNER_RUNTIME_FIREWALL_NAMES)).toBe(true);
     expect(RUNNER_RUNTIME_FIREWALL_NAMES).toContain("github");
     expect(RUNNER_RUNTIME_FIREWALL_NAMES).toContain(
       "model-provider:openai-api-key",

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_NAMES,
   RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
   hasRunnerRuntimeFirewall,
+  loadAllRunnerRuntimeFirewalls,
   loadRunnerRuntimeFirewall,
 } from "../firewall-metadata/runner-runtime";
 
@@ -410,6 +412,13 @@ describe("firewall runtime surface", () => {
     expect(RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION).toMatch(
       /^sha256-[a-f0-9]{12}$/,
     );
+    expect(RUNNER_RUNTIME_FIREWALL_NAMES).toContain("github");
+    expect(RUNNER_RUNTIME_FIREWALL_NAMES).toContain(
+      "model-provider:openai-api-key",
+    );
+    expect([...RUNNER_RUNTIME_FIREWALL_NAMES].sort(compareStrings)).toEqual([
+      ...RUNNER_RUNTIME_FIREWALL_NAMES,
+    ]);
     expect(hasRunnerRuntimeFirewall("github")).toBe(true);
     expect(hasRunnerRuntimeFirewall("model-provider:openai-api-key")).toBe(
       true,
@@ -438,6 +447,24 @@ describe("firewall runtime surface", () => {
       ],
     });
     expect(missing).toBeNull();
+  });
+
+  it("loads the full runner runtime firewall catalog from generated names", async () => {
+    const firewalls = await loadAllRunnerRuntimeFirewalls();
+
+    expect(Object.keys(firewalls).sort(compareStrings)).toStrictEqual([
+      ...RUNNER_RUNTIME_FIREWALL_NAMES,
+    ]);
+    expect(firewalls.github?.name).toBe("github");
+    expect(firewalls["model-provider:openai-api-key"]?.apis[0]).toStrictEqual({
+      base: "https://api.openai.com/v1/responses",
+      auth: {
+        headers: {
+          Authorization: "Bearer ${{ secrets.OPENAI_API_KEY }}",
+        },
+      },
+      permissions: [],
+    });
   });
 
   it("does not statically import the eager registry or connector runtime modules", () => {

--- a/turbo/packages/connectors/src/firewall-metadata/runner-runtime.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/runner-runtime.ts
@@ -1,6 +1,7 @@
 import type { Firewall } from "../firewall-types";
 import {
   RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_NAMES,
   RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
   hasGeneratedRunnerRuntimeFirewall,
   loadGeneratedRunnerRuntimeFirewall,
@@ -8,6 +9,7 @@ import {
 
 export {
   RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST,
+  RUNNER_RUNTIME_FIREWALL_NAMES,
   RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION,
 };
 
@@ -34,4 +36,10 @@ export async function loadRunnerRuntimeFirewalls(
     }),
   );
   return Object.fromEntries(entries);
+}
+
+export async function loadAllRunnerRuntimeFirewalls(): Promise<
+  Record<string, Firewall>
+> {
+  return await loadRunnerRuntimeFirewalls(RUNNER_RUNTIME_FIREWALL_NAMES);
 }

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -816,6 +816,9 @@ describe("firewall metadata generator", () => {
       expect(loaderSource).toContain('["model-provider:openai-api-key"]');
       expect(loaderSource).toContain("RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST");
       expect(loaderSource).toContain("RUNNER_RUNTIME_FIREWALL_NAMES");
+      expect(loaderSource).toContain(
+        "export const RUNNER_RUNTIME_FIREWALL_NAMES = Object.freeze(",
+      );
 
       const googleDriveRuntimeSource = fs.readFileSync(
         path.resolve(

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -815,6 +815,7 @@ describe("firewall metadata generator", () => {
       );
       expect(loaderSource).toContain('["model-provider:openai-api-key"]');
       expect(loaderSource).toContain("RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST");
+      expect(loaderSource).toContain("RUNNER_RUNTIME_FIREWALL_NAMES");
 
       const googleDriveRuntimeSource = fs.readFileSync(
         path.resolve(

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -792,7 +792,7 @@ function renderRunnerRuntimeLoaderFile(args: {
 
 export const RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST = ${JSON.stringify(args.catalogDigest)};
 export const RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION = ${JSON.stringify(args.catalogVersion)};
-export const RUNNER_RUNTIME_FIREWALL_NAMES = ${stableJson(args.entries.map((entry) => entry.name))} as const;
+export const RUNNER_RUNTIME_FIREWALL_NAMES = Object.freeze(${stableJson(args.entries.map((entry) => entry.name))});
 
 ${renderLazyLoaderRecord({
   constName: "RUNNER_RUNTIME_FIREWALL_LOADERS",

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -792,6 +792,7 @@ function renderRunnerRuntimeLoaderFile(args: {
 
 export const RUNNER_RUNTIME_FIREWALL_CATALOG_DIGEST = ${JSON.stringify(args.catalogDigest)};
 export const RUNNER_RUNTIME_FIREWALL_CATALOG_VERSION = ${JSON.stringify(args.catalogVersion)};
+export const RUNNER_RUNTIME_FIREWALL_NAMES = ${stableJson(args.entries.map((entry) => entry.name))} as const;
 
 ${renderLazyLoaderRecord({
   constName: "RUNNER_RUNTIME_FIREWALL_LOADERS",


### PR DESCRIPTION
## Summary
- Allow runner builtin firewall resolve requests to omit `names` and return the full generated runner runtime catalog.
- Expose generated runner runtime firewall names through the runner runtime metadata wrapper.
- Preserve selected-name resolve behavior and unknown-name rejection for existing runners.

Closes #20354

## Tests
- `pnpm -F @vm0/firewalls-generator generate`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/metadata.test.ts`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-runtime-loader.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/runners-builtin-firewalls.test.ts`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F api lint`
- `pnpm format`
- `git diff --check`

## Notes
- `@vm0/firewalls-generator` does not define a `lint` script.
- Generated runner runtime metadata remains generated/ignored; generation is still run by postinstall and CI.