### PR TITLE
feat: order everyone first and drop general in workflow template picker

### DIFF
--- a/turbo/packages/core/src/workflow-template-items.ts
+++ b/turbo/packages/core/src/workflow-template-items.ts
@@ -12,10 +12,10 @@ export interface WorkflowTemplateItem {
   readonly promptGuidance: string;
 }
 
-// Ordered persona groups for the template picker. "General" holds the generic
-// starter template; the rest mirror the onboarding personas.
+// Ordered persona groups for the template picker. "Everyone" leads and holds the
+// generic starter template; the rest mirror the onboarding personas.
 export const WORKFLOW_TEMPLATE_CATEGORIES: readonly string[] = [
-  "General",
+  "Everyone",
   "Engineering",
   "Product",
   "Data",
@@ -24,7 +24,6 @@ export const WORKFLOW_TEMPLATE_CATEGORIES: readonly string[] = [
   "Support",
   "CEO",
   "Operations",
-  "Everyone",
 ];
 
 // Built-in workflow templates. Each entry compiles into promptGuidance that
@@ -66,7 +65,7 @@ function defineWorkflowTemplate(args: {
 export const WORKFLOW_TEMPLATE_ITEMS: readonly WorkflowTemplateItem[] = [
   defineWorkflowTemplate({
     id: "workflow-template:auto-inbox-label",
-    category: "General",
+    category: "Everyone",
     title: "Auto-inbox label",
     description:
       "Create a workflow that runs when a Gmail label is applied and handles the labeled inbox item.",


### PR DESCRIPTION
## What changed

Reorders the workflow template picker's persona pills and re-homes the generic starter template.

- **Auto-inbox label** (the generic starter workflow template) moves from the `General` category into `Everyone`.
- **Everyone** is promoted to the first pill after **All** in `WORKFLOW_TEMPLATE_CATEGORIES`.
- The now-empty **General** category is removed from the pill list.

## User-visible impact

In the composer's Workflow template picker, the pill row changes from `All · General · Engineering · … · Everyone` to `All · Everyone · Engineering · Product · Data · Marketing · Sales · Support · CEO · Operations`. The Auto-inbox label starter now appears under **Everyone**.

Because `resolveWorkflowCatalog` uses `WORKFLOW_TEMPLATE_CATEGORIES[0]` as the collapsed-view default group, the collapsed picker now surfaces the **Everyone** templates (which include the Auto-inbox starter) instead of a lone General item.

## Implementation notes

- Single source of truth touched: `turbo/packages/core/src/workflow-template-items.ts`. `General` was used by exactly one item (Auto-inbox label), which is re-categorized, so no items are orphaned.
- Comment updated to reflect that `Everyone` now leads and holds the generic starter.

## Verification

Relying on the PR pipeline for lint/type/test. The existing composer template test selects `WORKFLOW_TEMPLATE_ITEMS[0]` by search term (unchanged array position), so it remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)