### PR TITLE
fix: keep add automation trigger cards fixed-height and match rail icon stroke

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -2511,7 +2511,7 @@ function TriggerCreateCategoryButton({
           : "text-sidebar-foreground hover:bg-gray-50",
       )}
     >
-      <Icon size={16} className="shrink-0" />
+      <Icon size={16} stroke={1.5} className="shrink-0" />
       <span className="truncate">{category.label}</span>
     </button>
   );
@@ -2618,7 +2618,7 @@ function TriggerCreateMenu({
               );
             })}
           </nav>
-          <div className="grid min-w-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="grid min-w-0 flex-1 auto-rows-min grid-cols-1 content-start gap-4 sm:grid-cols-2">
             {activeCategory?.options.map((option) => {
               return (
                 <TriggerCreateOptionCard


### PR DESCRIPTION
## Problem

In the **Add automation** trigger picker dialog (`workflow-detail-page.tsx`), two visual issues:

1. **Cards stretch vertically.** The trigger option cards (e.g. *Gmail new message*) stretched to fill the dialog's `sm:min-h-[20rem]` height instead of keeping their content height. This happens because the options grid is a `flex-1` flex child stretched to full row height, and CSS Grid's default `align-content: stretch` then stretches the single auto row (and its cards) to fill it.

2. **Rail icon weight/color inconsistent.** The left category-rail icons (Schedule / Email / Calendar / Integrations) used the default Tabler stroke width (`2`), making them read heavier and darker than every other icon in the app. This rail icon was the **only** icon in the file not using `stroke={1.5}` — the option-card icons right beside it, and the rest of the file's icons, all use `1.5`.

## Fix

- Add `content-start auto-rows-min` to the options grid so rows size to their content and sit at the top, leaving the reserved min-height as empty space below rather than inflating the cards. Cards keep their `min-h-[8rem]` fixed height.
- Add `stroke={1.5}` to the rail category icon to match the app-wide icon convention.

## Visual impact

- Trigger cards now stay a consistent, content-sized height regardless of how many options a category has.
- Rail icons match the stroke weight/appearance of the option-card icons and other app icons.

## Verification

Prettier clean; no logic changes. Relying on the PR pipeline for lint/type/test.