### PR TITLE
feat: make emoji shortcut keys discoverable and widen picker to 9 columns

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -761,9 +761,7 @@ function ChatThreadEmojiGrid({
           <button
             key={`${item.name}-${item.emoji}`}
             type="button"
-            aria-label={
-              shortcutLabel ? `${item.name} (${shortcutLabel})` : item.name
-            }
+            aria-label={item.name}
             title={shortcutLabel}
             className="relative flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-accent"
             onClick={() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -56,6 +56,8 @@ import {
 } from "@tabler/icons-react";
 import {
   cn,
+  getShortcutLabel,
+  getShortcutParts,
   Button,
   Input,
   Skeleton,
@@ -698,11 +700,24 @@ function ChatThreadEmojiSection({
   onSelect: (emoji: string) => void;
   showShortcutDigits?: boolean;
 }) {
+  // Ctrl+Shift is a shared prefix for every digit shortcut, so surface it once
+  // as a quiet hint next to the label rather than repeating it on each emoji.
+  // getShortcutParts keeps the modifiers OS-aware (⌃⇧ on Mac, Ctrl+Shift else).
+  const shortcutHint = showShortcutDigits
+    ? `${formatModifierPrefix(getShortcutParts("ctrl+shift"))} + number`
+    : null;
   return (
     <div>
-      <p className="px-1 pb-1 pt-2 text-xs font-medium text-muted-foreground">
-        {label}
-      </p>
+      <div className="flex items-baseline justify-between gap-2 px-1 pb-1 pt-2">
+        <span className="text-xs font-medium text-muted-foreground">
+          {label}
+        </span>
+        {shortcutHint && (
+          <span className="text-[11px] text-muted-foreground/70">
+            {shortcutHint}
+          </span>
+        )}
+      </div>
       <ChatThreadEmojiGrid
         items={items}
         onSelect={onSelect}
@@ -710,6 +725,13 @@ function ChatThreadEmojiSection({
       />
     </div>
   );
+}
+
+// Join modifier keycap labels the way each platform reads them: Mac symbols
+// run together (⌃⇧), word labels are joined with "+" (Ctrl+Shift).
+function formatModifierPrefix(modifiers: string[]): string {
+  const usesWords = /[A-Za-z]/.test(modifiers[0] ?? "");
+  return modifiers.join(usesWords ? "+" : "");
 }
 
 function ChatThreadEmojiGrid({
@@ -721,18 +743,28 @@ function ChatThreadEmojiGrid({
   onSelect: (emoji: string) => void;
   showShortcutDigits?: boolean;
 }) {
+  // Nine columns so the nine frequently-used digit shortcuts sit on a single
+  // row; every other emoji group uses the same width to stay aligned.
   return (
-    <div className="grid grid-cols-8 gap-0.5">
+    <div className="grid grid-cols-9 gap-0.5">
       {items.map((item, index) => {
-        // Ctrl+Shift+1-9 set the first nine "frequently used" icons; surface a
-        // faint digit so the shortcut is discoverable without adding clutter.
+        // Ctrl+Shift+1-9 set the first nine "frequently used" icons. Keep a
+        // faint digit in the corner and reveal the full combo on hover so the
+        // shortcut is discoverable without cluttering the grid.
         const shortcutDigit =
           showShortcutDigits && index < 9 ? index + 1 : null;
+        const shortcutLabel =
+          shortcutDigit !== null
+            ? getShortcutLabel(`ctrl+shift+${shortcutDigit}`)
+            : undefined;
         return (
           <button
             key={`${item.name}-${item.emoji}`}
             type="button"
-            aria-label={item.name}
+            aria-label={
+              shortcutLabel ? `${item.name} (${shortcutLabel})` : item.name
+            }
+            title={shortcutLabel}
             className="relative flex aspect-square items-center justify-center rounded-md text-xl leading-none transition-colors hover:bg-accent"
             onClick={() => {
               onSelect(item.emoji);
@@ -742,7 +774,7 @@ function ChatThreadEmojiGrid({
             {shortcutDigit !== null && (
               <span
                 aria-hidden="true"
-                className="absolute bottom-0 right-0.5 text-[9px] leading-none text-muted-foreground/60"
+                className="pointer-events-none absolute bottom-0 right-0.5 text-[9px] leading-none text-muted-foreground/60"
               >
                 {shortcutDigit}
               </span>


### PR DESCRIPTION
## What & why

The chat thread icon picker already binds **Ctrl+Shift+1–9** to the first nine *Frequently used* emoji, but the only on-screen hint was a bare corner digit that reads like an ordinal ("item #1"), not a keystroke. Users had no way to discover the shortcut. This makes it legible without cluttering the grid.

## User-visible changes

- **Shortcut hint next to the label** — an OS-aware `⌃⇧ + number` sits at the right of the *Frequently used* header (`Ctrl+Shift + number` on Windows/Linux), built from `getShortcutParts("ctrl+shift")`.
- **Hover reveals the exact combo** — each frequently-used emoji now has a `title` (and enriched `aria-label`, e.g. `Done (⌃⇧1)`) via `getShortcutLabel`, so pointer, keyboard, and screen-reader users all perceive the shortcut. Mac shows `⌃⇧1`, Windows shows `Ctrl+Shift+1`.
- **Corner digit kept** — the faint bottom-right number stays as the at-a-glance position marker.
- **One row of nine** — the grid moves from `grid-cols-8` to `grid-cols-9` so all nine shortcuts sit on a single row (the ninth no longer wraps), and every emoji group shares the same 9-column width so columns stay aligned top to bottom.

## Landed result

![picker](https://cdn.vm0.io/artifacts/user_36PnTFtD4dBQ9zg5jj6E5r918aV/70f661a1-eb12-4b44-9d6c-19b92c0f2d7c/full9_v2.png)

## Implementation notes

- All rendering changes live in `ChatThreadEmojiSection` / `ChatThreadEmojiGrid` in `turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx`; no new component or shortcut binding — reuses the existing `@vm0/ui` shortcut helpers so labels match the shortcut help dialog.
- `formatModifierPrefix` joins Mac modifier symbols together (`⌃⇧`) and word labels with `+` (`Ctrl+Shift`).

## Verification

Not run locally (dependencies not installed in this environment) — relying on the PR pipeline for lint / type-check / tests. Existing Ctrl+Shift+1–9 behavior tests in `chat-lifecycle.test.tsx` are keyboard-event based and unaffected by the label/markup changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)