### PR TITLE
feat: warn about member data loss before destructive agent and workflow actions

### DIFF
--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -184,6 +184,7 @@ const internalWorkflowDetailActiveTab$ =
 
 const internalSelectedFilePath$ = state<string | null>(null);
 const internalWorkflowActionDialog$ = state<WorkflowDetailActionDialog>(null);
+const internalWorkflowDemoteConfirmOpen$ = state<boolean>(false);
 const internalWorkflowCopyForm$ = state<WorkflowCopyFormState>(
   defaultWorkflowCopyForm(),
 );
@@ -214,6 +215,16 @@ const internalEditingScheduleCronFields$ = state<WorkflowCronFields>(
 export const workflowActionDialog$ = computed((get) => {
   return get(internalWorkflowActionDialog$);
 });
+
+export const workflowDemoteConfirmOpen$ = computed((get) => {
+  return get(internalWorkflowDemoteConfirmOpen$);
+});
+
+export const setWorkflowDemoteConfirmOpen$ = command(
+  ({ set }, open: boolean) => {
+    set(internalWorkflowDemoteConfirmOpen$, open);
+  },
+);
 
 export const workflowCopyForm$ = computed((get) => {
   return get(internalWorkflowCopyForm$);

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-tab.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-tab.ts
@@ -165,3 +165,16 @@ export const deleteAgent$ = command(
     await deleteFn();
   },
 );
+
+// ---------------------------------------------------------------------------
+// Destructive-action confirmation state
+// ---------------------------------------------------------------------------
+
+/** Whether the public → private confirmation dialog is open. */
+const internalDemoteConfirmOpen$ = state<boolean>(false);
+export const agentDemoteConfirmOpen$ = computed((get) => {
+  return get(internalDemoteConfirmOpen$);
+});
+export const setAgentDemoteConfirmOpen$ = command(({ set }, open: boolean) => {
+  set(internalDemoteConfirmOpen$, open);
+});

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -914,7 +914,7 @@ describe("team page navigation", () => {
     const deleteDialog = await screen.findByRole("dialog");
     expect(
       within(deleteDialog).getByText(
-        /instructions, automations, and all associated data/u,
+        /including automations and chats other people created/u,
       ),
     ).toBeInTheDocument();
 

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import {
   zeroWorkflowsCollectionContract,
   zeroWorkflowsDetailContract,
+  zeroWorkflowVisibilityContract,
   zeroWorkflowTriggersContract,
   type ZeroWorkflowTriggerCreateRequest,
   type ZeroWorkflowTriggerUpdateRequest,
@@ -1420,6 +1421,55 @@ describe("workflow detail page", () => {
     expect(pageText.indexOf("Copy workflow")).toBeLessThan(
       pageText.indexOf("Delete workflow"),
     );
+  });
+
+  it("confirms before making a public workflow private", async () => {
+    const demotedIds: string[] = [];
+    mockWorkflowApis([salesResearch()]);
+    context.mocks.api(
+      zeroWorkflowVisibilityContract.demote,
+      ({ params, respond }) => {
+        demotedIds.push(params.workflowId);
+        return respond(
+          200,
+          summary({ ...salesResearch(), visibility: "private" }),
+        );
+      },
+    );
+
+    detachedSetupWorkflowDetailPage(workflowDetailPath("info"));
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Make workflow public",
+    });
+    expect(toggle).toBeEnabled();
+    fireEvent.click(toggle);
+
+    // Demoting a public workflow now requires an explicit confirmation.
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByText("Make this workflow private?"),
+    ).toBeInTheDocument();
+    expect(demotedIds).toStrictEqual([]);
+
+    // Cancelling leaves the workflow public and fires no request.
+    click(buttonByText("Cancel", dialog));
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Make this workflow private?"),
+      ).not.toBeInTheDocument();
+    });
+    expect(demotedIds).toStrictEqual([]);
+
+    // Reopening and confirming demotes the workflow.
+    fireEvent.click(
+      await screen.findByRole("switch", { name: "Make workflow public" }),
+    );
+    const confirmDialog = await screen.findByRole("dialog");
+    click(buttonByText("Make private", confirmDialog));
+    await waitFor(() => {
+      expect(demotedIds).toStrictEqual([SALES_WORKFLOW_ID]);
+    });
   });
 
   it("copies a workflow to another agent from the info tab", async () => {

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1047,10 +1047,14 @@ function WorkflowPublicToggle({
               automations other members built on it stop running.
             </DialogDescription>
           </DialogHeader>
-          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            {workflowTitle(detail)} will be hidden from other members and their
-            automations will stop.
-          </div>
+          <Alert variant="destructive">
+            <IconAlertTriangle size={16} stroke={1.5} />
+            <AlertTitle>Automations will stop</AlertTitle>
+            <AlertDescription>
+              {workflowTitle(detail)} will be hidden from other members and
+              their automations will stop.
+            </AlertDescription>
+          </Alert>
           <DialogFooter>
             <Button
               type="button"

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -2,7 +2,6 @@
 // (SKILL.md is never shown), automations, visibility controls, metadata
 // editing, slash use, copy, and delete.
 import type { FormEvent, ReactNode } from "react";
-import { useState } from "react";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type {
@@ -127,6 +126,8 @@ import {
   updateWorkflowScheduleTrigger$,
   updateWorkflow$,
   workflowActionDialog$,
+  workflowDemoteConfirmOpen$,
+  setWorkflowDemoteConfirmOpen$,
   setWorkflowTriggerPickerCategory$,
   setWorkflowTriggerPickerOpen$,
   workflowCopyForm$,
@@ -973,7 +974,8 @@ function WorkflowPublicToggle({
   const [changeLoadable, changeVisibility] = useLoadableSet(
     changeWorkflowVisibility$,
   );
-  const [demoteConfirmOpen, setDemoteConfirmOpen] = useState(false);
+  const demoteConfirmOpen = useGet(workflowDemoteConfirmOpen$);
+  const setDemoteConfirmOpen = useSet(setWorkflowDemoteConfirmOpen$);
   const busy = changeLoadable.state === "loading";
   const isPublic = detail.visibility === "public";
   const statusLabel = isPublic ? "Public" : "Private";
@@ -1069,9 +1071,7 @@ function WorkflowPublicToggle({
                 submitVisibilityAction("demote");
               }}
             >
-              {busy ? (
-                <IconLoader2 size={14} className="animate-spin" />
-              ) : null}
+              {busy ? <IconLoader2 size={14} className="animate-spin" /> : null}
               Make private
             </Button>
           </DialogFooter>

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -2,6 +2,7 @@
 // (SKILL.md is never shown), automations, visibility controls, metadata
 // editing, slash use, copy, and delete.
 import type { FormEvent, ReactNode } from "react";
+import { useState } from "react";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import type {
@@ -972,6 +973,7 @@ function WorkflowPublicToggle({
   const [changeLoadable, changeVisibility] = useLoadableSet(
     changeWorkflowVisibility$,
   );
+  const [demoteConfirmOpen, setDemoteConfirmOpen] = useState(false);
   const busy = changeLoadable.state === "loading";
   const isPublic = detail.visibility === "public";
   const statusLabel = isPublic ? "Public" : "Private";
@@ -1010,9 +1012,14 @@ function WorkflowPublicToggle({
             busy || !toggleAction ? "cursor-not-allowed opacity-60" : "",
           )}
           onClick={() => {
-            if (toggleAction) {
-              submitVisibilityAction(toggleAction);
+            if (!toggleAction) {
+              return;
             }
+            if (toggleAction === "demote") {
+              setDemoteConfirmOpen(true);
+              return;
+            }
+            submitVisibilityAction(toggleAction);
           }}
         >
           <span
@@ -1029,6 +1036,47 @@ function WorkflowPublicToggle({
           permissions.
         </p>
       ) : null}
+      <Dialog open={demoteConfirmOpen} onOpenChange={setDemoteConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Make this workflow private?</DialogTitle>
+            <DialogDescription>
+              This is a dangerous operation. While this workflow is private,
+              automations other members built on it stop running.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {workflowTitle(detail)} will be hidden from other members and their
+            automations will stop.
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busy}
+              onClick={() => {
+                setDemoteConfirmOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={busy}
+              onClick={() => {
+                setDemoteConfirmOpen(false);
+                submitVisibilityAction("demote");
+              }}
+            >
+              {busy ? (
+                <IconLoader2 size={14} className="animate-spin" />
+              ) : null}
+              Make private
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -379,6 +379,14 @@ describe("zero settings tab", () => {
 
     click(screen.getByText("Save"));
 
+    // Demoting the agent from public to private now requires confirmation.
+    await waitFor(() => {
+      expect(
+        screen.getByText("Make Research Agent private?"),
+      ).toBeInTheDocument();
+    });
+    click(screen.getByText("Make private"));
+
     await waitFor(() => {
       expect(
         screen.queryByText("You have unsaved changes"),
@@ -413,7 +421,9 @@ describe("zero settings tab", () => {
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(
-        screen.getByText(/instructions, automations, and all associated data/u),
+        screen.getByText(
+          /including automations and chats other people created/u,
+        ),
       ).toBeInTheDocument();
     });
 
@@ -422,7 +432,7 @@ describe("zero settings tab", () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          /instructions, automations, and all associated data/u,
+          /including automations and chats other people created/u,
         ),
       ).not.toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -19,7 +19,12 @@ import {
   Switch,
   cn,
 } from "@vm0/ui";
-import { IconTrash } from "@tabler/icons-react";
+import { IconAlertTriangle, IconTrash } from "@tabler/icons-react";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@vm0/ui/components/ui/alert";
 import {
   type Tone,
   TONE_OPTIONS,
@@ -368,11 +373,15 @@ export function ZeroSettingsTab({
                           This action cannot be undone.
                         </DialogDescription>
                       </DialogHeader>
-                      <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                        {resolvedAgentName} and every member&apos;s workflows,
-                        automations, and chat history under it will be
-                        permanently deleted.
-                      </div>
+                      <Alert variant="destructive">
+                        <IconAlertTriangle size={16} stroke={1.5} />
+                        <AlertTitle>This can&apos;t be undone</AlertTitle>
+                        <AlertDescription>
+                          {resolvedAgentName} and every member&apos;s workflows,
+                          automations, and chat history under it will be
+                          permanently deleted.
+                        </AlertDescription>
+                      </Alert>
                       <DialogFooter>
                         <DialogClose asChild>
                           <Button variant="outline" size="sm">
@@ -415,10 +424,14 @@ export function ZeroSettingsTab({
               again.
             </DialogDescription>
           </DialogHeader>
-          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            Other members will no longer see {resolvedAgentName} or their chats
-            under it.
-          </div>
+          <Alert variant="destructive">
+            <IconAlertTriangle size={16} stroke={1.5} />
+            <AlertTitle>Members lose access</AlertTitle>
+            <AlertDescription>
+              Other members will no longer see {resolvedAgentName} or their
+              chats under it.
+            </AlertDescription>
+          </Alert>
           <DialogFooter>
             <Button
               variant="outline"

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -2,7 +2,6 @@
 // oxlint-disable max-lines-per-function
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { useState } from "react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   Button,
@@ -53,6 +52,8 @@ import {
   deleteAgent$,
   settingsVisibility$,
   setSettingsVisibility$,
+  agentDemoteConfirmOpen$,
+  setAgentDemoteConfirmOpen$,
 } from "../../signals/zero-page/settings/settings-tab.ts";
 
 interface ZeroSettingsTabProps {
@@ -129,7 +130,8 @@ export function ZeroSettingsTab({
 
   const pageSignal = useGet(pageSignal$);
 
-  const [demoteConfirmOpen, setDemoteConfirmOpen] = useState(false);
+  const demoteConfirmOpen = useGet(agentDemoteConfirmOpen$);
+  const setDemoteConfirmOpen = useSet(setAgentDemoteConfirmOpen$);
   const willDemoteVisibility =
     initialVisibility === "public" && visibility === "private";
 
@@ -359,11 +361,11 @@ export function ZeroSettingsTab({
                       <DialogHeader>
                         <DialogTitle>Delete {resolvedAgentName}?</DialogTitle>
                         <DialogDescription>
-                          This is a dangerous operation. Deleting this agent also
-                          permanently deletes every workflow bound to it and
-                          every member&apos;s chat history under it, including
-                          automations and chats other people created. This action
-                          cannot be undone.
+                          This is a dangerous operation. Deleting this agent
+                          also permanently deletes every workflow bound to it
+                          and every member&apos;s chat history under it,
+                          including automations and chats other people created.
+                          This action cannot be undone.
                         </DialogDescription>
                       </DialogHeader>
                       <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -2,6 +2,7 @@
 // oxlint-disable max-lines-per-function
 import { useGet, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
+import { useState } from "react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   Button,
@@ -128,7 +129,11 @@ export function ZeroSettingsTab({
 
   const pageSignal = useGet(pageSignal$);
 
-  const handleSaveSettings = () => {
+  const [demoteConfirmOpen, setDemoteConfirmOpen] = useState(false);
+  const willDemoteVisibility =
+    initialVisibility === "public" && visibility === "private";
+
+  const runSaveSettings = () => {
     detach(
       (async () => {
         await triggerUpdateSettings(
@@ -146,6 +151,14 @@ export function ZeroSettingsTab({
       })(),
       Reason.DomCallback,
     );
+  };
+
+  const handleSaveSettings = () => {
+    if (willDemoteVisibility) {
+      setDemoteConfirmOpen(true);
+      return;
+    }
+    runSaveSettings();
   };
 
   const handleDelete = () => {
@@ -346,11 +359,18 @@ export function ZeroSettingsTab({
                       <DialogHeader>
                         <DialogTitle>Delete {resolvedAgentName}?</DialogTitle>
                         <DialogDescription>
-                          This will permanently delete the agent, its
-                          instructions, automations, and all associated data.
-                          This action cannot be undone.
+                          This is a dangerous operation. Deleting this agent also
+                          permanently deletes every workflow bound to it and
+                          every member&apos;s chat history under it, including
+                          automations and chats other people created. This action
+                          cannot be undone.
                         </DialogDescription>
                       </DialogHeader>
+                      <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                        {resolvedAgentName} and every member&apos;s workflows,
+                        automations, and chat history under it will be
+                        permanently deleted.
+                      </div>
                       <DialogFooter>
                         <DialogClose asChild>
                           <Button variant="outline" size="sm">
@@ -382,6 +402,46 @@ export function ZeroSettingsTab({
           saving={saving}
         />
       )}
+
+      <Dialog open={demoteConfirmOpen} onOpenChange={setDemoteConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Make {resolvedAgentName} private?</DialogTitle>
+            <DialogDescription>
+              While this agent is private, other members lose access to their
+              chat history under it. They regain access if you make it public
+              again.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            Other members will no longer see {resolvedAgentName} or their chats
+            under it.
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={saving}
+              onClick={() => {
+                setDemoteConfirmOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={saving}
+              onClick={() => {
+                setDemoteConfirmOpen(false);
+                runSaveSettings();
+              }}
+            >
+              {saving ? "Saving…" : "Make private"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
Addresses #20400 (warning half), #20401, #20402.

## What & why

Three destructive actions silently destroyed or cut off **other members'** data with no warning. This adds an explicit warning + confirmation to each, reusing the codebase's hand-built destructive-confirm dialog pattern (no new shared primitive, no API/contract change).

### #20400 — Deleting an agent
The agent-delete confirmation only said "automations, and all associated data". By DB cascade, deleting an agent also removes **every workflow bound to it** and **every member's chat threads/automations** under it. The dialog now states this explicitly and adds a red impact banner.

*Deferred:* the issue's reconcile step (choose **delete** vs **migrate to another agent** per bound workflow) is **not** included — there is no backend capability to transfer a workflow's `agentId` today (only Copy, which forks a new private workflow owned by the caller). That needs a new transfer endpoint and is best tracked as its own change. This PR covers the data-loss **warning** half of #20400.

### #20401 — Switching an agent from public to private
Previously no confirmation. Going private removes other members' **access** to their chat history under the agent (data is retained; access returns if made public again). Saving a public→private change now opens a confirmation first; other profile edits save without friction.

### #20402 — Making a workflow private
Previously the visibility toggle demoted immediately. Making a workflow private stops **automations other members built on it**. The toggle now opens a confirmation before demoting. (Workflow **delete** already warned about other users' automations — left as-is for consistency.)

## Implementation
- `zero-settings-tab.tsx`: strengthened delete-dialog copy + red banner; intercept `handleSaveSettings` when `public → private` to confirm via a controlled dialog before running the real save.
- `workflow-detail-page.tsx` (`WorkflowPublicToggle`): gate the `demote` action behind a confirm dialog mirroring `WorkflowDeleteDialog`; `publish` stays immediate.
- Copy stays accurate (going private is reversible, so worded as "lose access", not "unrecoverable").

## Verification
- New test: workflow demote requires confirmation, Cancel fires no request, confirming calls `demote` (`workflows-page.test.tsx`).
- Updated `zero-settings-tab.test.tsx`: public→private save now routes through the confirm dialog; delete-dialog copy assertion updated.
- Updated `team-navigation.test.tsx` delete-dialog copy assertion.
- Relying on the PR pipeline for full lint/type-check/test per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)