### PR TITLE
fix: render blockquotes in inline-feedback and user messages instead of literal ">"

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -76,6 +76,24 @@ describe("assistant markdown", () => {
     expect(container.querySelector(".wmde-markdown span")).toBeNull();
   });
 
+  it("keeps blockquotes rendering when html is escaped", () => {
+    const { container } = render(
+      <StoreProvider value={context.store}>
+        <Markdown
+          source={"Feedback on this part of your reply:\n\n> quoted passage"}
+          escapeHtml
+        />
+      </StoreProvider>,
+    );
+
+    const blockquote = container.querySelector(".wmde-markdown blockquote");
+    expect(blockquote).not.toBeNull();
+    expect(blockquote?.textContent).toContain("quoted passage");
+    // The leading `>` must be consumed as the blockquote marker, not shown as
+    // literal text alongside the passage.
+    expect(blockquote?.textContent).not.toContain(">");
+  });
+
   it("renders formatted text and follows theme changes", async () => {
     mockThread("**bold text**");
 

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -360,10 +360,12 @@ const MEDIA_MARKDOWN_COMPONENTS = {
   img: MediaImageRenderer,
 } as const;
 
+// Neutralize raw HTML by escaping only `<`: a tag cannot start without it, so
+// escaping `<` alone stops tag injection. Leaving `>` intact preserves Markdown
+// block syntax that relies on a leading `>` — most importantly blockquotes,
+// which otherwise collapse into a literal `>` paragraph once escaped.
 function escapeHtmlTags(source: string): string {
-  return source.replace(/[<>]/g, (char) => {
-    return char === "<" ? "&lt;" : "&gt;";
-  });
+  return source.replace(/</g, "&lt;");
 }
 
 export function Markdown({


### PR DESCRIPTION
## Problem

Inline feedback quotes the selected passage with a leading `> `, but in the chat the quote rendered as literal `> text` with no blockquote styling. The same happened to any user-typed blockquote.


## Root cause

User messages (`PagedUserMessage`/`GoalUserMessage`) and the composer preview render markdown with `escapeHtml` on. `escapeHtmlTags` in `markdown.tsx` escaped **both** `<` and `>` to `&lt;`/`&gt;`. Escaping the leading `>` of a blockquote turns it into `&gt;`, which markdown no longer parses as a blockquote marker — it renders as a plain paragraph starting with a literal `>`.

The feedback prompt builder (`chat-feedback.ts`) already emits a correct `> ${line}` (with the space); the breakage was purely in rendering.

## Fix

Escape only `<`. An HTML tag cannot start without `<`, so escaping `<` alone still neutralizes tag/script injection, while leaving `>` intact so blockquote syntax survives. Verified against the CommonMark parser (micromark, the engine behind the app's `@uiw/react-markdown-preview`): the blockquote renders as `<blockquote>` and an injected `<img onerror=…>` is still neutralized to `&lt;img …`.

## Scope & compatibility

- Only affects the `escapeHtml=true` path: user message bubbles and the composer preview. Assistant messages don't escape and were never affected.
- No API, schema, or persisted-state change.

## Verification

- Added a regression test in `markdown.test.tsx` asserting a blockquote still renders as a `<blockquote>` element (marker consumed, not shown as literal `>`) under `escapeHtml`.
- Existing `escapes html-like source` test still holds: `<span> 123 </span>` renders as literal text with no `span` element, since `<` is still escaped.
- Relying on the PR pipeline for lint/type/test per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)