### PR TITLE
fix(mitm-addon): define json prefix probe contract

### DIFF
--- a/crates/runner/mitm-addon/src/usage/json_probe.py
+++ b/crates/runner/mitm-addon/src/usage/json_probe.py
@@ -28,9 +28,9 @@ class TopLevelStringFieldProbeResult:
 
     - ``found``: the first matching top-level member has a complete string value.
     - ``not_found``: a complete top-level object ended before a matching member.
-    - ``incomplete``: the prefix may become valid if more bytes arrive.
+    - ``incomplete``: more bytes are needed before the probe can decide.
     - ``invalid``: the prefix already violates the JSON structure accepted here.
-    - ``non_string``: the matching member's value starts as a JSON non-string.
+    - ``non_string``: the matching member's value starts with a non-string token.
     - ``bound_exceeded``: a configured key, string, or depth bound stopped probing.
 
     ``field_seen`` is true only after the first matching top-level member's

--- a/crates/runner/mitm-addon/src/usage/json_probe.py
+++ b/crates/runner/mitm-addon/src/usage/json_probe.py
@@ -22,7 +22,23 @@ _UTF8_SURROGATE_MAX = 0xDFFF
 
 @dataclass(frozen=True)
 class TopLevelStringFieldProbeResult:
-    """Result of probing a JSON object for a top-level string field."""
+    """Result of probing a JSON object prefix for a top-level string member.
+
+    Status values form the caller-visible contract:
+
+    - ``found``: the first matching top-level member has a complete string value.
+    - ``not_found``: a complete top-level object ended before a matching member.
+    - ``incomplete``: the prefix may become valid if more bytes arrive.
+    - ``invalid``: the prefix already violates the JSON structure accepted here.
+    - ``non_string``: the matching member's value starts as a JSON non-string.
+    - ``bound_exceeded``: a configured key, string, or depth bound stopped probing.
+
+    ``field_seen`` is true only after the first matching top-level member's
+    key-colon boundary has been recognized, so the status describes that
+    member's value. A bare matching key token without a colon is not seen.
+    Matching is top-level only, nested members are skipped, the first duplicate
+    wins, and skipped values can still stop probing with ``bound_exceeded``.
+    """
 
     status: TopLevelStringFieldProbeStatus
     value: str | None = None
@@ -81,10 +97,9 @@ def probe_top_level_string_field(
         if body[i] != ord(":"):
             return TopLevelStringFieldProbeResult("invalid")
         i = _skip_json_whitespace(body, i + 1)
-        if i >= len(body):
-            return TopLevelStringFieldProbeResult("incomplete")
-
         if key == field_name:
+            if i >= len(body):
+                return TopLevelStringFieldProbeResult("incomplete", field_seen=True)
             if body[i] != ord('"'):
                 return TopLevelStringFieldProbeResult(
                     "non_string" if _is_json_value_start(body[i]) else "invalid",
@@ -94,6 +109,9 @@ def probe_top_level_string_field(
             if value_result.status != "ok":
                 return TopLevelStringFieldProbeResult(value_result.status, field_seen=True)
             return TopLevelStringFieldProbeResult("found", value_result.value, field_seen=True)
+
+        if i >= len(body):
+            return TopLevelStringFieldProbeResult("incomplete")
 
         skip_result = _skip_json_value(
             body,

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -10,6 +10,7 @@ def test_probe_finds_top_level_string_field_without_scanning_rest():
 
     assert result.status == "found"
     assert result.value == "response.completed"
+    assert result.field_seen
 
 
 def test_probe_ignores_nested_fields_with_same_name():
@@ -19,6 +20,7 @@ def test_probe_ignores_nested_fields_with_same_name():
 
     assert result.status == "found"
     assert result.value == "top_level"
+    assert result.field_seen
 
 
 def test_probe_ignores_field_name_inside_string_payload():
@@ -29,6 +31,7 @@ def test_probe_ignores_field_name_inside_string_payload():
 
     assert result.status == "found"
     assert result.value == "response.output_text.delta"
+    assert result.field_seen
 
 
 def test_probe_uses_first_duplicate_top_level_field():
@@ -38,6 +41,7 @@ def test_probe_uses_first_duplicate_top_level_field():
 
     assert result.status == "found"
     assert result.value == "response.output_text.delta"
+    assert result.field_seen
 
 
 def test_probe_reports_incomplete_prefix_before_field_value_completes():
@@ -77,6 +81,7 @@ def test_probe_reports_not_found_when_complete_object_has_no_field():
 
     assert result.status == "not_found"
     assert result.value is None
+    assert not result.field_seen
 
 
 def test_probe_reports_non_string_field_value():
@@ -100,6 +105,7 @@ def test_probe_reports_invalid_utf8_in_skipped_string():
 
     assert result.status == "invalid"
     assert result.value is None
+    assert not result.field_seen
 
 
 def test_probe_reports_bound_exceeded_for_oversized_value():
@@ -129,6 +135,7 @@ def test_probe_reports_bound_exceeded_for_depth_limit():
 
     assert result.status == "bound_exceeded"
     assert result.value is None
+    assert not result.field_seen
 
 
 def test_probe_supports_custom_field_name():
@@ -136,3 +143,4 @@ def test_probe_supports_custom_field_name():
 
     assert result.status == "found"
     assert result.value == "target"
+    assert result.field_seen

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -45,6 +45,23 @@ def test_probe_reports_incomplete_prefix_before_field_value_completes():
 
     assert result.status == "incomplete"
     assert result.value is None
+    assert result.field_seen
+
+
+def test_probe_reports_incomplete_after_target_member_boundary():
+    result = probe_top_level_string_field(b'{"type":')
+
+    assert result.status == "incomplete"
+    assert result.value is None
+    assert result.field_seen
+
+
+def test_probe_reports_invalid_after_target_member_boundary():
+    result = probe_top_level_string_field(b'{"type":?}')
+
+    assert result.status == "invalid"
+    assert result.value is None
+    assert result.field_seen
 
 
 def test_probe_reports_not_found_when_complete_object_has_no_field():

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -92,6 +92,14 @@ def test_probe_reports_non_string_field_value():
     assert result.field_seen
 
 
+def test_probe_reports_non_string_once_target_value_token_starts():
+    result = probe_top_level_string_field(b'{"type":t')
+
+    assert result.status == "non_string"
+    assert result.value is None
+    assert result.field_seen
+
+
 def test_probe_reports_invalid_json_prefix():
     result = probe_top_level_string_field(b'{"type" "response.completed"}')
 

--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -56,6 +56,14 @@ def test_probe_reports_incomplete_after_target_member_boundary():
     assert result.field_seen
 
 
+def test_probe_reports_incomplete_before_target_member_boundary():
+    result = probe_top_level_string_field(b'{"padding":')
+
+    assert result.status == "incomplete"
+    assert result.value is None
+    assert not result.field_seen
+
+
 def test_probe_reports_invalid_after_target_member_boundary():
     result = probe_top_level_string_field(b'{"type":?}')
 


### PR DESCRIPTION
## Summary

- document the `probe_top_level_string_field()` result contract
- normalize `field_seen` after the target top-level key-colon member boundary is recognized
- add focused contract tests for incomplete and invalid target member values

## Testing

- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_json_probe.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_openai_responses_event_json.py tests/test_openai_responses_sse.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff check src/usage/json_probe.py tests/test_json_probe.py`

No feature switch is needed because this is an internal parser contract fix, not a user-facing feature or new deployable API surface.

Closes #20460
