### PR TITLE
perf: build vsock frames outside writer lock

### DIFF
--- a/crates/vsock-host/src/exec_operation/tests.rs
+++ b/crates/vsock-host/src/exec_operation/tests.rs
@@ -430,6 +430,7 @@ fn shared_with_logged_operation(
     let (_read_half, write_half) = write_stream.into_split();
     let shared = Arc::new(Shared {
         writer: tokio::sync::Mutex::new(write_half),
+        frame_builder: tokio::sync::Mutex::new(()),
         fd,
         seq: AtomicU32::new(2),
         state: std::sync::Mutex::new(ConnectionState::Connected {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -422,19 +422,6 @@ impl CompositeNormalOperation {
             })
     }
 
-    fn mark_possible_guest_write_started(&mut self) -> io::Result<()> {
-        let normal_operation = self.normal_operation.as_mut().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "composite normal operation already completed",
-            )
-        })?;
-        normal_operation
-            .mark_possible_guest_write_started()
-            .map_err(normal_operation_transition_error)?;
-        Ok(())
-    }
-
     fn complete(mut self) -> io::Result<()> {
         let normal_operation = self.normal_operation.take().ok_or_else(|| {
             io::Error::new(
@@ -781,7 +768,7 @@ async fn request_on_shared_with_composite_operation_and_observer_frame_builder(
         build_frame,
         timeout,
         || {
-            normal_operation.mark_possible_guest_write_started()?;
+            mark_pending_normal_operation_possible_guest_write(shared, seq, |_| Ok(()))?;
             write_observer.record_write_start()
         },
         rx,

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -214,6 +214,9 @@ enum ConnectionState {
 struct Shared {
     /// Serialises writes to the stream.
     writer: tokio::sync::Mutex<tokio::net::unix::OwnedWriteHalf>,
+    /// Serialises memory-heavy encoded frame construction without blocking
+    /// ordinary writer-lock users such as lifecycle and control frames.
+    frame_builder: tokio::sync::Mutex<()>,
     /// Raw fd of the underlying socket, used to poison a corrupted stream.
     fd: RawFd,
     /// Monotonically increasing sequence number (starts at 2, skips 0).
@@ -596,6 +599,7 @@ async fn write_request_frame_with_builder(
     before_write: impl FnOnce() -> io::Result<()>,
 ) -> io::Result<()> {
     let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
+    let frame_builder_guard = shared.frame_builder.lock().await;
     let mut frame = Vec::new();
     build_frame(seq, &mut frame)?;
     let mut writer = shared.writer.lock().await;
@@ -607,10 +611,12 @@ async fn write_request_frame_with_builder(
         shared.poison_connection();
         drop(writer);
         drop(frame);
+        drop(frame_builder_guard);
         return Err(error);
     }
     drop(writer);
     drop(frame);
+    drop(frame_builder_guard);
     write_guard.mark_returned();
     Ok(())
 }
@@ -944,6 +950,7 @@ impl VsockHost {
 
         let shared = Arc::new(Shared {
             writer: tokio::sync::Mutex::new(write_half),
+            frame_builder: tokio::sync::Mutex::new(()),
             fd,
             seq: AtomicU32::new(2),
             state: std::sync::Mutex::new(ConnectionState::Connected {

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -596,9 +596,9 @@ async fn write_request_frame_with_builder(
     before_write: impl FnOnce() -> io::Result<()>,
 ) -> io::Result<()> {
     let mut write_guard = RequestWriteGuard::new(Arc::clone(shared));
-    let mut writer = shared.writer.lock().await;
     let mut frame = Vec::new();
     build_frame(seq, &mut frame)?;
+    let mut writer = shared.writer.lock().await;
     before_write()?;
     write_guard.mark_started();
     let result = writer.write_all(&frame).await;

--- a/crates/vsock-host/src/lib.rs
+++ b/crates/vsock-host/src/lib.rs
@@ -602,12 +602,15 @@ async fn write_request_frame_with_builder(
     before_write()?;
     write_guard.mark_started();
     let result = writer.write_all(&frame).await;
-    drop(frame);
     if let Err(error) = result {
         write_guard.mark_returned();
         shared.poison_connection();
+        drop(writer);
+        drop(frame);
         return Err(error);
     }
+    drop(writer);
+    drop(frame);
     write_guard.mark_returned();
     Ok(())
 }

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -4,7 +4,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
-use vsock_proto::{MSG_EXEC_START, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
+use vsock_proto::{
+    MSG_ERROR, MSG_EXEC_START, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK, MSG_WRITE_FILE_RESULT,
+};
 
 use super::super::support::{
     MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
@@ -586,6 +588,80 @@ async fn write_file_connection_close_while_waiting_for_frame_builder_keeps_track
     let err = tokio::time::timeout(Duration::from_secs(5), write_task)
         .await
         .expect("write_file should return after the frame builder is released")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+}
+
+#[tokio::test]
+async fn write_file_connection_close_while_waiting_for_writer_keeps_tracker_closed() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let writer_guard = host.shared.writer.lock().await;
+    let (frame_built_tx, frame_built_rx) = tokio::sync::oneshot::channel();
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            crate::normal_request_on_shared_with_write_observer_frame_builder(
+                &host.shared,
+                &[MSG_ERROR, MSG_WRITE_FILE_RESULT],
+                Duration::from_secs(5),
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+                move |seq, frame| {
+                    vsock_proto::encode_write_file_frame_into(
+                        frame,
+                        seq,
+                        "/tmp/waiting-writer-closed.txt",
+                        b"hello",
+                        false,
+                        false,
+                    )
+                    .map_err(|error| {
+                        io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
+                    })?;
+                    frame_built_tx.send(()).unwrap();
+                    Ok(())
+                },
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), frame_built_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    drop(guest);
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+
+    drop(writer_guard);
+    let err = tokio::time::timeout(Duration::from_secs(5), write_task)
+        .await
+        .expect("write_file should return after the writer is released")
         .unwrap()
         .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -495,6 +495,51 @@ async fn lifecycle_request_writes_while_file_frame_builder_waits() {
 }
 
 #[tokio::test]
+async fn write_file_cancelled_while_waiting_for_frame_builder_does_not_poison_or_send_frame() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let frame_builder_guard = host.shared.frame_builder.lock().await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                "/tmp/waiting-builder-cancelled.txt",
+                b"hello",
+                false,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while normal_operation_readiness(&host) != NormalOperationReadiness::Busy {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    write_task.abort();
+    let _ = write_task.await;
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Idle
+    );
+
+    drop(frame_builder_guard);
+    assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
 async fn write_file_rejects_invalid_path_before_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -382,13 +382,12 @@ async fn write_file_rejects_protocol_path_too_long_before_waiting_for_writer() {
 async fn write_file_frame_builder_runs_before_waiting_for_writer_lock() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);
-    let frame_built_count = Arc::new(AtomicUsize::new(0));
+    let (frame_built_tx, frame_built_rx) = tokio::sync::oneshot::channel();
     let before_write_count = Arc::new(AtomicUsize::new(0));
     let writer_guard = host.shared.writer.lock().await;
 
     let write_task = {
         let host = Arc::clone(&host);
-        let frame_built_count = Arc::clone(&frame_built_count);
         let before_write_count = Arc::clone(&before_write_count);
         tokio::spawn(async move {
             crate::write_request_frame_with_builder(
@@ -406,7 +405,7 @@ async fn write_file_frame_builder_runs_before_waiting_for_writer_lock() {
                     .map_err(|error| {
                         io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
                     })?;
-                    frame_built_count.fetch_add(1, Ordering::SeqCst);
+                    frame_built_tx.send(()).unwrap();
                     Ok(())
                 },
                 move || {
@@ -418,13 +417,10 @@ async fn write_file_frame_builder_runs_before_waiting_for_writer_lock() {
         })
     };
 
-    tokio::time::timeout(Duration::from_secs(5), async {
-        while frame_built_count.load(Ordering::SeqCst) != 1 {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .unwrap();
+    tokio::time::timeout(Duration::from_secs(5), frame_built_rx)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(before_write_count.load(Ordering::SeqCst), 0);
     match guest.try_read(&mut [0u8; 1]) {
         Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -540,6 +540,63 @@ async fn write_file_cancelled_while_waiting_for_frame_builder_does_not_poison_or
 }
 
 #[tokio::test]
+async fn write_file_connection_close_while_waiting_for_frame_builder_keeps_tracker_closed() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let frame_builder_guard = host.shared.frame_builder.lock().await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                "/tmp/waiting-builder-closed.txt",
+                b"hello",
+                false,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while normal_operation_readiness(&host) != NormalOperationReadiness::Busy {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    drop(guest);
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+
+    drop(frame_builder_guard);
+    let err = tokio::time::timeout(Duration::from_secs(5), write_task)
+        .await
+        .expect("write_file should return after the frame builder is released")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+}
+
+#[tokio::test]
 async fn write_file_rejects_invalid_path_before_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -4,11 +4,12 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use tokio::io::AsyncWriteExt;
-use vsock_proto::MSG_EXEC_START;
+use vsock_proto::{MSG_EXEC_START, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK};
 
 use super::super::support::{
     MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
     make_pair, normal_operation_readiness, pending_request_count, setup_host_and_guest,
+    setup_host_and_mock_guest,
 };
 use super::support::{
     expect_write_file, expect_write_files, send_guest_error, send_write_file_failure,
@@ -438,6 +439,59 @@ async fn write_file_frame_builder_runs_before_waiting_for_writer_lock() {
     assert!(!write.private);
     write_task.await.unwrap().unwrap();
     assert_eq!(before_write_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn lifecycle_request_writes_while_file_frame_builder_waits() {
+    let (host, mut guest) = setup_host_and_mock_guest().await;
+    let host = Arc::new(host);
+    let frame_builder_guard = host.shared.frame_builder.lock().await;
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            host.write_file_with_write_observer(
+                "/tmp/waiting-builder.txt",
+                b"hello",
+                false,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while normal_operation_readiness(&host) != NormalOperationReadiness::Busy {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+
+    let shutdown_task = {
+        let host = Arc::clone(&host);
+        tokio::spawn(async move { host.shutdown(Duration::from_secs(5)).await })
+    };
+    let shutdown = guest.expect_message(MSG_SHUTDOWN).await;
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    guest
+        .send_empty_response(MSG_SHUTDOWN_ACK, shutdown.seq)
+        .await;
+    assert!(shutdown_task.await.unwrap());
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+
+    drop(frame_builder_guard);
+    let write = expect_write_file(guest.stream_mut()).await;
+    assert_eq!(write.path, "/tmp/waiting-builder.txt");
+    assert_eq!(write.content, b"hello");
+    send_write_file_success(guest.stream_mut(), write.seq()).await;
+    write_task.await.unwrap().unwrap();
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/crates/vsock-host/src/tests/file/write.rs
+++ b/crates/vsock-host/src/tests/file/write.rs
@@ -379,6 +379,72 @@ async fn write_file_rejects_protocol_path_too_long_before_waiting_for_writer() {
 }
 
 #[tokio::test]
+async fn write_file_frame_builder_runs_before_waiting_for_writer_lock() {
+    let (host, mut guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let frame_built_count = Arc::new(AtomicUsize::new(0));
+    let before_write_count = Arc::new(AtomicUsize::new(0));
+    let writer_guard = host.shared.writer.lock().await;
+
+    let write_task = {
+        let host = Arc::clone(&host);
+        let frame_built_count = Arc::clone(&frame_built_count);
+        let before_write_count = Arc::clone(&before_write_count);
+        tokio::spawn(async move {
+            crate::write_request_frame_with_builder(
+                &host.shared,
+                123,
+                move |seq, frame| {
+                    vsock_proto::encode_write_file_frame_into(
+                        frame,
+                        seq,
+                        "/tmp/built-before-lock.txt",
+                        b"hello",
+                        false,
+                        false,
+                    )
+                    .map_err(|error| {
+                        io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
+                    })?;
+                    frame_built_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                move || {
+                    before_write_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while frame_built_count.load(Ordering::SeqCst) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(before_write_count.load(Ordering::SeqCst), 0);
+    match guest.try_read(&mut [0u8; 1]) {
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+        Ok(n) => panic!("frame must not be sent before writer lock is released; read {n} bytes"),
+        Err(err) => panic!("unexpected read error before writer lock is released: {err}"),
+    }
+
+    drop(writer_guard);
+    let write = expect_write_file(&mut guest).await;
+    assert_eq!(write.seq(), 123);
+    assert_eq!(write.path, "/tmp/built-before-lock.txt");
+    assert_eq!(write.content, b"hello");
+    assert!(!write.sudo);
+    assert!(!write.append);
+    assert!(!write.private);
+    write_task.await.unwrap().unwrap();
+    assert_eq!(before_write_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn write_file_rejects_invalid_path_before_sending_frame() {
     let (host, mut guest) = setup_host_and_guest().await;
     let host = Arc::new(host);

--- a/crates/vsock-host/src/tests/file/write_chunked.rs
+++ b/crates/vsock-host/src/tests/file/write_chunked.rs
@@ -9,7 +9,10 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::UnixStream;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use vsock_proto::{ExecOutputPolicy, ExecTermination, MSG_EXEC_START, MSG_WRITE_FILE};
+use vsock_proto::{
+    ExecOutputPolicy, ExecTermination, MSG_ERROR, MSG_EXEC_START, MSG_WRITE_FILE,
+    MSG_WRITE_FILE_RESULT,
+};
 
 use super::super::support::{
     MockGuest, assert_connection_accepts_exec_operation, await_mock_guest, host_from_stream,
@@ -184,6 +187,83 @@ async fn write_file_chunked_cancelled_before_first_frame_write_does_not_cleanup(
 
     drop(writer_guard);
     assert_connection_accepts_exec_operation(&host, &mut guest).await;
+}
+
+#[tokio::test]
+async fn write_file_chunked_connection_close_while_waiting_for_writer_returns_connection_reset() {
+    let (host, guest) = setup_host_and_guest().await;
+    let host = Arc::new(host);
+    let writer_guard = host.shared.writer.lock().await;
+    let (frame_built_tx, frame_built_rx) = oneshot::channel();
+    let write_start_count = Arc::new(AtomicUsize::new(0));
+
+    let write_task = {
+        let host = Arc::clone(&host);
+        let write_start_count = Arc::clone(&write_start_count);
+        tokio::spawn(async move {
+            let mut normal_operation = crate::CompositeNormalOperation::reserve(&host.shared)?;
+            crate::request_on_shared_with_composite_operation_and_observer_frame_builder(
+                &host.shared,
+                &[MSG_ERROR, MSG_WRITE_FILE_RESULT],
+                Duration::from_secs(5),
+                &mut normal_operation,
+                FrameWriteObserver::new(move || {
+                    write_start_count.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }),
+                move |seq, frame| {
+                    vsock_proto::encode_write_file_frame_into(
+                        frame,
+                        seq,
+                        "/tmp/chunked-waiting-writer-closed.txt",
+                        b"hello",
+                        false,
+                        false,
+                    )
+                    .map_err(|error| {
+                        io::Error::new(io::ErrorKind::InvalidInput, error.to_string())
+                    })?;
+                    frame_built_tx.send(()).unwrap();
+                    Ok(())
+                },
+            )
+            .await?;
+            normal_operation.complete()
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(5), frame_built_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Busy
+    );
+
+    drop(guest);
+    host.wait_until_closed(Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(pending_request_count(&host), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
+
+    drop(writer_guard);
+    let err = tokio::time::timeout(Duration::from_secs(5), write_task)
+        .await
+        .expect("chunked write should return after the writer is released")
+        .unwrap()
+        .unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    assert_eq!(write_start_count.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        normal_operation_readiness(&host),
+        NormalOperationReadiness::Closed
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- build builder-backed vsock request frames before acquiring the shared writer lock
- keep `before_write()`, `RequestWriteGuard::mark_started()`, and `write_all()` in the same guest-write-boundary order
- add focused coverage proving frame construction does not wait for the writer lock and `before_write()` does not run early

Closes #20461

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p vsock-host write_file_frame_builder_runs_before_waiting_for_writer_lock`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::write`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host file::write_chunked`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p vsock-host`
