### PR TITLE
test: bound ignored child test waits

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -7039,10 +7039,15 @@ server:
             unsafe {
                 let rc = nix::libc::setrlimit(nix::libc::RLIMIT_NOFILE, &self.original);
                 if rc != 0 {
-                    eprintln!(
+                    let message = format!(
                         "restore RLIMIT_NOFILE failed: {}",
                         std::io::Error::last_os_error()
                     );
+                    if std::thread::panicking() {
+                        eprintln!("{message}");
+                    } else {
+                        panic!("{message}");
+                    }
                 }
             }
         }

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -2778,6 +2778,7 @@ fn human_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::run_ignored_child_test;
     use clap::Parser;
 
     /// `--r2-keep-days 0` would wipe even just-uploaded images. Verify the
@@ -6980,29 +6981,14 @@ server:
 
     const LOW_FD_STORAGE_GC_CHILD_ENV: &str = "VM0_RUNNER_LOW_FD_STORAGE_GC_CHILD";
 
-    #[test]
-    fn gc_storage_cache_many_candidates_does_not_exhaust_lock_fds() {
-        let output = std::process::Command::new(std::env::current_exe().unwrap())
-            .env(LOW_FD_STORAGE_GC_CHILD_ENV, "1")
-            .arg("gc_storage_cache_many_candidates_low_fd_child")
-            .arg("--ignored")
-            .arg("--nocapture")
-            .output()
-            .unwrap();
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-
-        assert!(
-            output.status.success(),
-            "low-fd storage GC child failed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
-            output.status,
-            stdout,
-            stderr
-        );
-        assert!(
-            stdout.contains("gc_storage_cache_many_candidates_low_fd_child"),
-            "low-fd storage GC child did not run\nstdout:\n{stdout}\nstderr:\n{stderr}"
-        );
+    #[tokio::test]
+    async fn gc_storage_cache_many_candidates_does_not_exhaust_lock_fds() {
+        run_ignored_child_test(
+            "cmd::gc::tests::gc_storage_cache_many_candidates_low_fd_child",
+            &[(LOW_FD_STORAGE_GC_CHILD_ENV, "1")],
+            Duration::from_secs(60),
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -2778,7 +2778,7 @@ fn human_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_fixtures::run_ignored_child_test;
+    use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
     use clap::Parser;
 
     /// `--r2-keep-days 0` would wipe even just-uploaded images. Verify the
@@ -6985,7 +6985,7 @@ server:
     async fn gc_storage_cache_many_candidates_does_not_exhaust_lock_fds() {
         run_ignored_child_test(
             "cmd::gc::tests::gc_storage_cache_many_candidates_low_fd_child",
-            &[(LOW_FD_STORAGE_GC_CHILD_ENV, "1")],
+            (LOW_FD_STORAGE_GC_CHILD_ENV, "1"),
             Duration::from_secs(60),
         )
         .await;
@@ -6994,7 +6994,7 @@ server:
     #[tokio::test]
     #[ignore = "spawned by gc_storage_cache_many_candidates_does_not_exhaust_lock_fds"]
     async fn gc_storage_cache_many_candidates_low_fd_child() {
-        if std::env::var_os(LOW_FD_STORAGE_GC_CHILD_ENV).is_none() {
+        if !ignored_child_test_env_guard_enabled(LOW_FD_STORAGE_GC_CHILD_ENV) {
             return;
         }
 

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -6994,7 +6994,7 @@ server:
     #[tokio::test]
     #[ignore = "spawned by gc_storage_cache_many_candidates_does_not_exhaust_lock_fds"]
     async fn gc_storage_cache_many_candidates_low_fd_child() {
-        if !ignored_child_test_env_guard_enabled(LOW_FD_STORAGE_GC_CHILD_ENV) {
+        if !ignored_child_test_env_guard_enabled((LOW_FD_STORAGE_GC_CHILD_ENV, "1")) {
             return;
         }
 

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -7018,7 +7018,7 @@ server:
             "test storage entries must consume disk blocks"
         );
 
-        set_soft_nofile_limit_for_child(128);
+        let _nofile_limit = set_soft_nofile_limit_for_child(128);
 
         let cap = entry_size * keep_count as u64;
         let freed = gc_storage_cache_with_cap(&home, cap, false).await.unwrap();
@@ -7030,9 +7030,25 @@ server:
         );
     }
 
-    fn set_soft_nofile_limit_for_child(limit: u64) {
-        // This helper runs only in the spawned child process, so lowering the
-        // process-wide fd limit cannot leak into the parent test runner.
+    struct SoftNofileLimitGuard {
+        original: nix::libc::rlimit,
+    }
+
+    impl Drop for SoftNofileLimitGuard {
+        fn drop(&mut self) {
+            unsafe {
+                let rc = nix::libc::setrlimit(nix::libc::RLIMIT_NOFILE, &self.original);
+                if rc != 0 {
+                    eprintln!(
+                        "restore RLIMIT_NOFILE failed: {}",
+                        std::io::Error::last_os_error()
+                    );
+                }
+            }
+        }
+    }
+
+    fn set_soft_nofile_limit_for_child(limit: u64) -> SoftNofileLimitGuard {
         unsafe {
             let mut current = std::mem::MaybeUninit::<nix::libc::rlimit>::uninit();
             let rc = nix::libc::getrlimit(nix::libc::RLIMIT_NOFILE, current.as_mut_ptr());
@@ -7060,6 +7076,7 @@ server:
                 "setrlimit(RLIMIT_NOFILE) failed: {}",
                 std::io::Error::last_os_error()
             );
+            SoftNofileLimitGuard { original: current }
         }
     }
 

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -599,30 +599,23 @@ fn wrap_io(error: io::Error, context: String) -> io::Error {
 mod tests {
     use std::io;
     use std::os::unix::fs::{PermissionsExt, symlink};
-    use std::process::Command;
+    use std::time::Duration;
 
     use super::*;
+    use crate::test_fixtures::run_ignored_child_test;
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
-    #[test]
-    fn ensure_dir_handles_restrictive_umask() {
-        let output = Command::new(std::env::current_exe().unwrap())
-            .env("VM0_RUN_RESTRICTIVE_UMASK_TEST", "1")
-            .arg("--exact")
-            .arg("host_file::tests::ensure_dir_handles_restrictive_umask_child")
-            .arg("--ignored")
-            .output()
-            .unwrap();
-
-        assert!(
-            output.status.success(),
-            "child failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
+    #[tokio::test]
+    async fn ensure_dir_handles_restrictive_umask() {
+        run_ignored_child_test(
+            "host_file::tests::ensure_dir_handles_restrictive_umask_child",
+            &[("VM0_RUN_RESTRICTIVE_UMASK_TEST", "1")],
+            Duration::from_secs(60),
+        )
+        .await;
     }
 
     #[test]

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -602,7 +602,9 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::test_fixtures::run_ignored_child_test;
+    use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+
+    const RESTRICTIVE_UMASK_CHILD_ENV: &str = "VM0_RUN_RESTRICTIVE_UMASK_TEST";
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
@@ -612,7 +614,7 @@ mod tests {
     async fn ensure_dir_handles_restrictive_umask() {
         run_ignored_child_test(
             "host_file::tests::ensure_dir_handles_restrictive_umask_child",
-            &[("VM0_RUN_RESTRICTIVE_UMASK_TEST", "1")],
+            (RESTRICTIVE_UMASK_CHILD_ENV, "1"),
             Duration::from_secs(60),
         )
         .await;
@@ -621,7 +623,7 @@ mod tests {
     #[test]
     #[ignore]
     fn ensure_dir_handles_restrictive_umask_child() {
-        if std::env::var_os("VM0_RUN_RESTRICTIVE_UMASK_TEST").is_none() {
+        if !ignored_child_test_env_guard_enabled(RESTRICTIVE_UMASK_CHILD_ENV) {
             return;
         }
 

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     #[ignore]
     fn ensure_dir_handles_restrictive_umask_child() {
-        if !ignored_child_test_env_guard_enabled(RESTRICTIVE_UMASK_CHILD_ENV) {
+        if !ignored_child_test_env_guard_enabled((RESTRICTIVE_UMASK_CHILD_ENV, "1")) {
             return;
         }
 

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -629,13 +629,30 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("base").join("child");
-        let old_umask = nix::sys::stat::umask(Mode::from_bits_truncate(0o777));
+        let _umask = UmaskGuard::set(Mode::from_bits_truncate(0o777));
         let result = ensure_dir(&path, DirMode::SharedTrustedParent, "test directory");
-        nix::sys::stat::umask(old_umask);
 
         result.unwrap();
         assert_eq!(mode(&dir.path().join("base")), SHARED_TRUSTED_DIR_MODE);
         assert_eq!(mode(&path), SHARED_TRUSTED_DIR_MODE);
+    }
+
+    struct UmaskGuard {
+        original: Mode,
+    }
+
+    impl UmaskGuard {
+        fn set(mask: Mode) -> Self {
+            Self {
+                original: nix::sys::stat::umask(mask),
+            }
+        }
+    }
+
+    impl Drop for UmaskGuard {
+        fn drop(&mut self) {
+            nix::sys::stat::umask(self.original);
+        }
     }
 
     #[test]

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -304,8 +304,9 @@ fn kill_wait_error(kill_error: Option<std::io::Error>, wait_error: String) -> St
     }
 }
 
-pub(crate) fn ignored_child_test_env_guard_enabled(env_guard_key: &str) -> bool {
-    if std::env::var_os(env_guard_key).is_none() {
+pub(crate) fn ignored_child_test_env_guard_enabled(env_guard: (&str, &str)) -> bool {
+    let (env_guard_key, env_guard_value) = env_guard;
+    if std::env::var_os(env_guard_key).as_deref() != Some(OsStr::new(env_guard_value)) {
         return false;
     }
 
@@ -398,7 +399,7 @@ mod tests {
     #[test]
     #[ignore]
     fn run_ignored_child_test_timeout_child() {
-        if !ignored_child_test_env_guard_enabled(TIMEOUT_CHILD_ENV) {
+        if !ignored_child_test_env_guard_enabled((TIMEOUT_CHILD_ENV, "1")) {
             return;
         }
 

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -14,6 +14,8 @@ use crate::types::ExecutionContext;
 
 const RAW_HTTP_FIXTURE_TIMEOUT: Duration = Duration::from_secs(5);
 const CHILD_OUTPUT_TIMEOUT: Duration = Duration::from_secs(5);
+const CHILD_KILL_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+const CHILD_ENV_GUARD_ACTIVE_PREFIX: &str = "vm0 ignored child env guard active: ";
 
 pub(crate) struct OneShotSessionHistoryServer {
     url: String,
@@ -175,14 +177,22 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
 
 pub(crate) async fn run_ignored_child_test(
     child_test_name: &str,
-    env: &[(&str, &str)],
+    env_guard: (&str, &str),
     timeout: Duration,
 ) {
+    let (env_guard_key, env_guard_value) = env_guard;
     assert!(
         !child_test_name.is_empty(),
         "ignored child test name must not be empty"
     );
-    assert!(!env.is_empty(), "ignored child test must have an env guard");
+    assert!(
+        !env_guard_key.is_empty(),
+        "ignored child test env guard key must not be empty"
+    );
+    assert!(
+        !env_guard_value.is_empty(),
+        "ignored child test env guard value must not be empty"
+    );
     assert!(
         !timeout.is_zero(),
         "ignored child test timeout must not be zero"
@@ -198,9 +208,7 @@ pub(crate) async fn run_ignored_child_test(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
-    for (key, value) in env {
-        command.env(key, value);
-    }
+    command.env(env_guard_key, env_guard_value);
 
     let mut child = command.spawn().expect("spawn ignored child test");
     let stdout = child
@@ -217,16 +225,19 @@ pub(crate) async fn run_ignored_child_test(
     let status = match tokio::time::timeout(timeout, child.wait()).await {
         Ok(Ok(status)) => status,
         Ok(Err(error)) => {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
+            let kill_error = kill_ignored_child(&mut child).await.err();
             let (stdout, stderr) = collect_child_output(stdout_task, stderr_task).await;
-            panic!(
-                "ignored child test {child_test_name} wait failed: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}"
-            );
+            match kill_error {
+                Some(kill_error) => panic!(
+                    "ignored child test {child_test_name} wait failed: {error}; {kill_error}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                ),
+                None => panic!(
+                    "ignored child test {child_test_name} wait failed: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                ),
+            }
         }
         Err(_) => {
-            let _ = child.start_kill();
-            let killed_status = child.wait().await;
+            let killed_status = kill_ignored_child(&mut child).await;
             let (stdout, stderr) = collect_child_output(stdout_task, stderr_task).await;
             let timeout_ms = timeout.as_millis();
             match killed_status {
@@ -249,6 +260,48 @@ pub(crate) async fn run_ignored_child_test(
         stdout.contains(child_test_name),
         "ignored child test {child_test_name} did not run\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
+    assert!(
+        stdout.contains(&format!("{CHILD_ENV_GUARD_ACTIVE_PREFIX}{env_guard_key}")),
+        "ignored child test {child_test_name} did not activate env guard {env_guard_key}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+async fn kill_ignored_child(
+    child: &mut tokio::process::Child,
+) -> Result<std::process::ExitStatus, String> {
+    let kill_error = child.start_kill().err();
+    let wait_result = tokio::time::timeout(CHILD_KILL_WAIT_TIMEOUT, child.wait()).await;
+
+    match wait_result {
+        Ok(Ok(status)) => Ok(status),
+        Ok(Err(error)) => Err(kill_wait_error(
+            kill_error,
+            format!("wait after kill failed: {error}"),
+        )),
+        Err(_) => Err(kill_wait_error(
+            kill_error,
+            format!(
+                "wait after kill timed out after {}ms",
+                CHILD_KILL_WAIT_TIMEOUT.as_millis()
+            ),
+        )),
+    }
+}
+
+fn kill_wait_error(kill_error: Option<std::io::Error>, wait_error: String) -> String {
+    match kill_error {
+        Some(kill_error) => format!("start kill failed: {kill_error}; {wait_error}"),
+        None => wait_error,
+    }
+}
+
+pub(crate) fn ignored_child_test_env_guard_enabled(env_guard_key: &str) -> bool {
+    if std::env::var_os(env_guard_key).is_none() {
+        return false;
+    }
+
+    println!("{CHILD_ENV_GUARD_ACTIVE_PREFIX}{env_guard_key}");
+    true
 }
 
 async fn read_child_output<R>(mut output: R) -> io::Result<Vec<u8>>
@@ -325,7 +378,7 @@ mod tests {
     async fn run_ignored_child_test_times_out() {
         run_ignored_child_test(
             "test_fixtures::tests::run_ignored_child_test_timeout_child",
-            &[(TIMEOUT_CHILD_ENV, "1")],
+            (TIMEOUT_CHILD_ENV, "1"),
             Duration::from_millis(10),
         )
         .await;
@@ -334,7 +387,7 @@ mod tests {
     #[test]
     #[ignore]
     fn run_ignored_child_test_timeout_child() {
-        if std::env::var_os(TIMEOUT_CHILD_ENV).is_none() {
+        if !ignored_child_test_env_guard_enabled(TIMEOUT_CHILD_ENV) {
             return;
         }
 

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -177,6 +177,16 @@ pub(crate) async fn run_ignored_child_test(
     env: &[(&str, &str)],
     timeout: Duration,
 ) {
+    assert!(
+        !child_test_name.is_empty(),
+        "ignored child test name must not be empty"
+    );
+    assert!(!env.is_empty(), "ignored child test must have an env guard");
+    assert!(
+        !timeout.is_zero(),
+        "ignored child test timeout must not be zero"
+    );
+
     let mut command =
         tokio::process::Command::new(std::env::current_exe().expect("resolve current test binary"));
     command

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -319,7 +319,9 @@ mod tests {
     const TIMEOUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_TIMEOUT_TEST";
 
     #[tokio::test]
-    #[should_panic(expected = "timed out")]
+    #[should_panic(
+        expected = "ignored child test test_fixtures::tests::run_ignored_child_test_timeout_child timed out after"
+    )]
     async fn run_ignored_child_test_times_out() {
         run_ignored_child_test(
             "test_fixtures::tests::run_ignored_child_test_timeout_child",

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -1,8 +1,10 @@
+use std::ffi::OsStr;
 use std::io;
+use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::{Notify, oneshot};
 use tokio::task::JoinHandle;
@@ -167,5 +169,130 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
         feature_flags: None,
         billable_firewalls: vec![],
         model_usage_provider: None,
+    }
+}
+
+pub(crate) async fn run_ignored_child_test(
+    child_test_name: &str,
+    env: &[(&str, &str)],
+    timeout: Duration,
+) {
+    let mut command =
+        tokio::process::Command::new(std::env::current_exe().expect("resolve current test binary"));
+    command
+        .arg("--exact")
+        .arg(child_test_name)
+        .arg("--ignored")
+        .arg("--nocapture")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    let mut child = command.spawn().expect("spawn ignored child test");
+    let stdout = child
+        .stdout
+        .take()
+        .expect("ignored child test stdout must be piped");
+    let stderr = child
+        .stderr
+        .take()
+        .expect("ignored child test stderr must be piped");
+    let stdout_task = tokio::spawn(read_child_output(stdout));
+    let stderr_task = tokio::spawn(read_child_output(stderr));
+
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(error)) => {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            let (stdout, stderr) = collect_child_output(stdout_task, stderr_task).await;
+            panic!(
+                "ignored child test {child_test_name} wait failed: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            );
+        }
+        Err(_) => {
+            let _ = child.start_kill();
+            let killed_status = child.wait().await;
+            let (stdout, stderr) = collect_child_output(stdout_task, stderr_task).await;
+            let timeout_ms = timeout.as_millis();
+            match killed_status {
+                Ok(status) => panic!(
+                    "ignored child test {child_test_name} timed out after {timeout_ms}ms; killed child status: {status}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                ),
+                Err(error) => panic!(
+                    "ignored child test {child_test_name} timed out after {timeout_ms}ms; wait after kill failed: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                ),
+            }
+        }
+    };
+
+    let (stdout, stderr) = collect_child_output(stdout_task, stderr_task).await;
+    assert!(
+        status.success(),
+        "ignored child test {child_test_name} failed\nstatus: {status}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains(child_test_name),
+        "ignored child test {child_test_name} did not run\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+async fn read_child_output<R>(mut output: R) -> io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = Vec::new();
+    output.read_to_end(&mut buffer).await?;
+    Ok(buffer)
+}
+
+async fn collect_child_output(
+    stdout_task: JoinHandle<io::Result<Vec<u8>>>,
+    stderr_task: JoinHandle<io::Result<Vec<u8>>>,
+) -> (String, String) {
+    let stdout = join_child_output("stdout", stdout_task).await;
+    let stderr = join_child_output("stderr", stderr_task).await;
+    (
+        String::from_utf8_lossy(&stdout).into_owned(),
+        String::from_utf8_lossy(&stderr).into_owned(),
+    )
+}
+
+async fn join_child_output(stream_name: &str, task: JoinHandle<io::Result<Vec<u8>>>) -> Vec<u8> {
+    match task.await {
+        Ok(Ok(output)) => output,
+        Ok(Err(error)) => panic!("read ignored child test {stream_name}: {error}"),
+        Err(error) => panic!("join ignored child test {stream_name} reader: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TIMEOUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_TIMEOUT_TEST";
+
+    #[tokio::test]
+    #[should_panic(expected = "timed out")]
+    async fn run_ignored_child_test_times_out() {
+        run_ignored_child_test(
+            "test_fixtures::tests::run_ignored_child_test_timeout_child",
+            &[(TIMEOUT_CHILD_ENV, "1")],
+            Duration::from_millis(10),
+        )
+        .await;
+    }
+
+    #[test]
+    #[ignore]
+    fn run_ignored_child_test_timeout_child() {
+        if std::env::var_os(TIMEOUT_CHILD_ENV).is_none() {
+            return;
+        }
+
+        std::thread::sleep(Duration::from_secs(60));
     }
 }

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -15,11 +15,20 @@ use crate::types::ExecutionContext;
 const RAW_HTTP_FIXTURE_TIMEOUT: Duration = Duration::from_secs(5);
 const CHILD_OUTPUT_TIMEOUT: Duration = Duration::from_secs(5);
 const CHILD_KILL_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+const CHILD_OUTPUT_HEAD_BYTES: usize = 8 * 1024;
+const CHILD_OUTPUT_TAIL_BYTES: usize = 8 * 1024;
+const CHILD_OUTPUT_READ_CHUNK_BYTES: usize = 8 * 1024;
 const CHILD_ENV_GUARD_ACTIVE_PREFIX: &str = "vm0 ignored child env guard active: ";
 
 pub(crate) struct OneShotSessionHistoryServer {
     url: String,
     task: Option<JoinHandle<io::Result<()>>>,
+}
+
+struct ChildOutput {
+    head: Vec<u8>,
+    tail: Vec<u8>,
+    truncated_bytes: usize,
 }
 
 impl OneShotSessionHistoryServer {
@@ -314,18 +323,46 @@ pub(crate) fn ignored_child_test_env_guard_enabled(env_guard: (&str, &str)) -> b
     true
 }
 
-async fn read_child_output<R>(mut output: R) -> io::Result<Vec<u8>>
+async fn read_child_output<R>(mut output: R) -> io::Result<ChildOutput>
 where
     R: AsyncRead + Unpin,
 {
-    let mut buffer = Vec::new();
-    output.read_to_end(&mut buffer).await?;
-    Ok(buffer)
+    let mut head = Vec::new();
+    let mut tail = Vec::new();
+    let mut total_bytes = 0usize;
+    let mut chunk = [0u8; CHILD_OUTPUT_READ_CHUNK_BYTES];
+
+    loop {
+        let read = output.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+
+        total_bytes = total_bytes.saturating_add(read);
+        let remaining = CHILD_OUTPUT_HEAD_BYTES.saturating_sub(head.len());
+        let keep = remaining.min(read);
+        if keep > 0 {
+            head.extend_from_slice(&chunk[..keep]);
+        }
+
+        if keep < read {
+            tail.extend_from_slice(&chunk[keep..read]);
+            if tail.len() > CHILD_OUTPUT_TAIL_BYTES {
+                tail.drain(..tail.len() - CHILD_OUTPUT_TAIL_BYTES);
+            }
+        }
+    }
+
+    Ok(ChildOutput {
+        truncated_bytes: total_bytes.saturating_sub(head.len() + tail.len()),
+        head,
+        tail,
+    })
 }
 
 async fn collect_child_output(
-    mut stdout_task: JoinHandle<io::Result<Vec<u8>>>,
-    mut stderr_task: JoinHandle<io::Result<Vec<u8>>>,
+    mut stdout_task: JoinHandle<io::Result<ChildOutput>>,
+    mut stderr_task: JoinHandle<io::Result<ChildOutput>>,
 ) -> (String, String) {
     let timeout = tokio::time::sleep(CHILD_OUTPUT_TIMEOUT);
     tokio::pin!(timeout);
@@ -361,15 +398,15 @@ async fn collect_child_output(
     let stdout = stdout.expect("stdout reader result must be set");
     let stderr = stderr.expect("stderr reader result must be set");
     (
-        String::from_utf8_lossy(&stdout).into_owned(),
-        String::from_utf8_lossy(&stderr).into_owned(),
+        format_child_output("stdout", stdout),
+        format_child_output("stderr", stderr),
     )
 }
 
 fn child_output(
     stream_name: &str,
-    result: Result<io::Result<Vec<u8>>, tokio::task::JoinError>,
-) -> Vec<u8> {
+    result: Result<io::Result<ChildOutput>, tokio::task::JoinError>,
+) -> ChildOutput {
     match result {
         Ok(Ok(output)) => output,
         Ok(Err(error)) => panic!("read ignored child test {stream_name}: {error}"),
@@ -377,11 +414,80 @@ fn child_output(
     }
 }
 
+fn format_child_output(stream_name: &str, output: ChildOutput) -> String {
+    let mut bytes = output.head;
+    if output.truncated_bytes > 0 {
+        bytes.extend_from_slice(
+            format!(
+                "\n[truncated {} bytes from ignored child test {stream_name}]\n",
+                output.truncated_bytes
+            )
+            .as_bytes(),
+        );
+    }
+    bytes.extend_from_slice(&output.tail);
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const LARGE_SUCCESS_OUTPUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_LARGE_SUCCESS_OUTPUT_TEST";
+    const LARGE_OUTPUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_LARGE_OUTPUT_TEST";
     const TIMEOUT_CHILD_ENV: &str = "VM0_RUN_IGNORED_CHILD_TIMEOUT_TEST";
+
+    #[tokio::test]
+    async fn run_ignored_child_test_preserves_tail_after_large_output() {
+        run_ignored_child_test(
+            "test_fixtures::tests::run_ignored_child_test_large_success_output_child",
+            (LARGE_SUCCESS_OUTPUT_CHILD_ENV, "1"),
+            Duration::from_secs(5),
+        )
+        .await;
+    }
+
+    #[test]
+    #[ignore]
+    fn run_ignored_child_test_large_success_output_child() {
+        if !ignored_child_test_env_guard_enabled((LARGE_SUCCESS_OUTPUT_CHILD_ENV, "1")) {
+            return;
+        }
+
+        write_large_ignored_child_stdout();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "[truncated ")]
+    async fn run_ignored_child_test_truncates_large_output() {
+        run_ignored_child_test(
+            "test_fixtures::tests::run_ignored_child_test_large_output_child",
+            (LARGE_OUTPUT_CHILD_ENV, "1"),
+            Duration::from_secs(5),
+        )
+        .await;
+    }
+
+    #[test]
+    #[ignore]
+    fn run_ignored_child_test_large_output_child() {
+        if !ignored_child_test_env_guard_enabled((LARGE_OUTPUT_CHILD_ENV, "1")) {
+            return;
+        }
+
+        write_large_ignored_child_stdout();
+        panic!("large output child failed intentionally");
+    }
+
+    fn write_large_ignored_child_stdout() {
+        let output =
+            vec![
+                b'x';
+                CHILD_OUTPUT_HEAD_BYTES + CHILD_OUTPUT_TAIL_BYTES + CHILD_OUTPUT_READ_CHUNK_BYTES
+            ];
+        std::io::Write::write_all(&mut std::io::stdout().lock(), &output)
+            .expect("write large ignored child stdout");
+    }
 
     #[tokio::test]
     #[should_panic(

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -270,21 +270,30 @@ async fn kill_ignored_child(
     child: &mut tokio::process::Child,
 ) -> Result<std::process::ExitStatus, String> {
     let kill_error = child.start_kill().err();
-    let wait_result = tokio::time::timeout(CHILD_KILL_WAIT_TIMEOUT, child.wait()).await;
+    let timeout = tokio::time::sleep(CHILD_KILL_WAIT_TIMEOUT);
+    tokio::pin!(timeout);
 
-    match wait_result {
-        Ok(Ok(status)) => Ok(status),
-        Ok(Err(error)) => Err(kill_wait_error(
-            kill_error,
-            format!("wait after kill failed: {error}"),
-        )),
-        Err(_) => Err(kill_wait_error(
-            kill_error,
-            format!(
-                "wait after kill timed out after {}ms",
-                CHILD_KILL_WAIT_TIMEOUT.as_millis()
-            ),
-        )),
+    tokio::select! {
+        biased;
+
+        wait_result = child.wait() => {
+            match wait_result {
+                Ok(status) => Ok(status),
+                Err(error) => Err(kill_wait_error(
+                    kill_error,
+                    format!("wait after kill failed: {error}"),
+                )),
+            }
+        }
+        _ = &mut timeout => {
+            Err(kill_wait_error(
+                kill_error,
+                format!(
+                    "wait after kill timed out after {}ms",
+                    CHILD_KILL_WAIT_TIMEOUT.as_millis()
+                ),
+            ))
+        }
     }
 }
 
@@ -325,6 +334,8 @@ async fn collect_child_output(
 
     loop {
         tokio::select! {
+            biased;
+
             result = &mut stdout_task, if stdout.is_none() => {
                 stdout = Some(child_output("stdout", result));
             }

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -13,6 +13,7 @@ use crate::ids::RunId;
 use crate::types::ExecutionContext;
 
 const RAW_HTTP_FIXTURE_TIMEOUT: Duration = Duration::from_secs(5);
+const CHILD_OUTPUT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) struct OneShotSessionHistoryServer {
     url: String,
@@ -260,19 +261,51 @@ where
 }
 
 async fn collect_child_output(
-    stdout_task: JoinHandle<io::Result<Vec<u8>>>,
-    stderr_task: JoinHandle<io::Result<Vec<u8>>>,
+    mut stdout_task: JoinHandle<io::Result<Vec<u8>>>,
+    mut stderr_task: JoinHandle<io::Result<Vec<u8>>>,
 ) -> (String, String) {
-    let stdout = join_child_output("stdout", stdout_task).await;
-    let stderr = join_child_output("stderr", stderr_task).await;
+    let timeout = tokio::time::sleep(CHILD_OUTPUT_TIMEOUT);
+    tokio::pin!(timeout);
+
+    let mut stdout = None;
+    let mut stderr = None;
+
+    loop {
+        tokio::select! {
+            result = &mut stdout_task, if stdout.is_none() => {
+                stdout = Some(child_output("stdout", result));
+            }
+            result = &mut stderr_task, if stderr.is_none() => {
+                stderr = Some(child_output("stderr", result));
+            }
+            _ = &mut timeout => {
+                stdout_task.abort();
+                stderr_task.abort();
+                panic!(
+                    "collect ignored child test output timed out after {}ms",
+                    CHILD_OUTPUT_TIMEOUT.as_millis()
+                );
+            }
+        }
+
+        if stdout.is_some() && stderr.is_some() {
+            break;
+        }
+    }
+
+    let stdout = stdout.expect("stdout reader result must be set");
+    let stderr = stderr.expect("stderr reader result must be set");
     (
         String::from_utf8_lossy(&stdout).into_owned(),
         String::from_utf8_lossy(&stderr).into_owned(),
     )
 }
 
-async fn join_child_output(stream_name: &str, task: JoinHandle<io::Result<Vec<u8>>>) -> Vec<u8> {
-    match task.await {
+fn child_output(
+    stream_name: &str,
+    result: Result<io::Result<Vec<u8>>, tokio::task::JoinError>,
+) -> Vec<u8> {
+    match result {
         Ok(Ok(output)) => output,
         Ok(Err(error)) => panic!("read ignored child test {stream_name}: {error}"),
         Err(error) => panic!("join ignored child test {stream_name} reader: {error}"),


### PR DESCRIPTION
## Summary

- Add a runner test fixture for running ignored child tests in the current test binary with a bounded wait.
- Drain child stdout/stderr concurrently, kill and reap on timeout, and include captured output in failures.
- Use the helper for the storage GC low-fd regression test and the restrictive umask child test.
- Add a helper regression test that verifies the timeout path kills the child and fails locally.

Fixes #20442

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p runner run_ignored_child_test_times_out -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner gc_storage_cache_many_candidates_does_not_exhaust_lock_fds -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner ensure_dir_handles_restrictive_umask -- --nocapture`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --tests -- -D warnings`
