### PR TITLE
fix: warm background chat cache after follow-ups finish

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -110,11 +110,11 @@ export async function publishThreadListChanged(userId: string): Promise<void> {
   await publishUserSignal([userId], "threadListChanged");
 }
 
-export async function publishChatThreadRunFinished(args: {
+export async function publishChatThreadFollowupsFinished(args: {
   readonly userId: string;
   readonly threadId: string;
 }): Promise<void> {
-  await publishUserSignal([args.userId], "chatThreadRunFinished", {
+  await publishUserSignal([args.userId], "chatThreadFollowupsFinished", {
     threadId: args.threadId,
   });
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -490,11 +490,11 @@ function recommendedFollowupMessages(
   });
 }
 
-function publishedChatThreadRunFinished(threadId: string): boolean {
+function publishedChatThreadFollowupsFinished(threadId: string): boolean {
   return context.mocks.ably.publish.mock.calls.some((call) => {
     const payload = call[1];
     return (
-      call[0] === "chatThreadRunFinished" &&
+      call[0] === "chatThreadFollowupsFinished" &&
       payload !== null &&
       typeof payload === "object" &&
       "threadId" in payload &&
@@ -832,7 +832,7 @@ describe("CHAT-02: completed chat callback", () => {
     ]);
     await expect
       .poll(() => {
-        return publishedChatThreadRunFinished(first.threadId);
+        return publishedChatThreadFollowupsFinished(first.threadId);
       })
       .toBe(true);
 
@@ -997,6 +997,7 @@ describe("CHAT-02: completed chat callback", () => {
     chatCallbacks.mockChatOutputEvents([
       assistantEvent(0, "The final assistant answer"),
     ]);
+    context.mocks.ably.publish.mockClear();
     await completeChatRunOk(run.runId, sandboxHeaders, {
       lastEventSequence: 0,
     });
@@ -1009,6 +1010,7 @@ describe("CHAT-02: completed chat callback", () => {
       throw new Error("Expected a completed lifecycle marker");
     }
     expect(marker.recommendedFollowups).toBeUndefined();
+    expect(publishedChatThreadFollowupsFinished(run.threadId)).toBe(true);
   });
 
   it("auto-sends the queued message before completed-run LLM side effects finish", async () => {
@@ -2019,11 +2021,7 @@ describe("CHAT-02: failed chat callbacks", () => {
         `chatThreadRunCreated:${threadId}`,
         null,
       );
-      await expect
-        .poll(() => {
-          return publishedChatThreadRunFinished(run.threadId);
-        })
-        .toBe(true);
+      await waitForChatThreadMessageCreatedPublish(run.threadId);
     }
     const reportRunId = runIds[2];
     if (!threadId || !reportRunId) {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1010,7 +1010,7 @@ describe("CHAT-02: completed chat callback", () => {
       throw new Error("Expected a completed lifecycle marker");
     }
     expect(marker.recommendedFollowups).toBeUndefined();
-    expect(publishedChatThreadFollowupsFinished(run.threadId)).toBe(true);
+    expect(publishedChatThreadFollowupsFinished(run.threadId)).toBeTruthy();
   });
 
   it("auto-sends the queued message before completed-run LLM side effects finish", async () => {

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -35,8 +35,8 @@ import { waitUntil } from "../context/wait-until";
 import { getDatasetName, queryAxiomDirect } from "../external/axiom";
 import { writeDb$, type Db } from "../external/db";
 import {
+  publishChatThreadFollowupsFinished,
   publishChatThreadMessageCreatedSafely,
-  publishChatThreadRunFinished,
   publishThreadListChanged,
   publishUserSignal,
 } from "../external/realtime";
@@ -800,7 +800,6 @@ async function insertAssistantErrorMessage(args: {
   readonly runId: string;
   readonly threadId: string;
   readonly userId: string;
-  readonly publishRunFinished: boolean;
   readonly lifecycleEvent: "failed" | "cancelled";
   readonly getFormattedError: () => Promise<string>;
 }): Promise<FailedChatCallbackResult> {
@@ -842,12 +841,6 @@ async function insertAssistantErrorMessage(args: {
     `chatThreadMessageCreated:${args.threadId}`,
   );
   await publishThreadListChanged(args.userId);
-  if (args.publishRunFinished) {
-    await publishChatThreadRunFinished({
-      userId: args.userId,
-      threadId: args.threadId,
-    });
-  }
   return { displayErrorMessage, inserted: true };
 }
 
@@ -856,7 +849,6 @@ async function insertRunLifecycleMarker(args: {
   readonly runId: string;
   readonly threadId: string;
   readonly userId: string;
-  readonly publishRunFinished: boolean;
   readonly event: "completed" | "cancelled";
 }): Promise<boolean> {
   const markerCreatedAt = nowDate();
@@ -892,12 +884,6 @@ async function insertRunLifecycleMarker(args: {
     `chatThreadMessageCreated:${args.threadId}`,
   );
   await publishThreadListChanged(args.userId);
-  if (args.publishRunFinished) {
-    await publishChatThreadRunFinished({
-      userId: args.userId,
-      threadId: args.threadId,
-    });
-  }
   return true;
 }
 
@@ -1053,7 +1039,6 @@ async function handleCompletedChatCallback(args: {
         runId: args.runId,
         threadId: args.chatThread.chatThreadId,
         userId: args.chatThread.userId,
-        publishRunFinished: args.chatThread.triggerSource === "web",
         event: "completed",
       });
     },
@@ -1105,23 +1090,28 @@ async function runCompletedChatCallbackSideEffects(args: {
     currentAssistantReply: args.lastResultText ?? undefined,
   });
 
-  const lifecycleMarkerStep = (async () => {
+  const followupsStep = (async () => {
     const recommendedFollowups =
       await generateRecommendedFollowupsForCompletedRun({
         followupContext: args.followupContext,
         threadId: args.chatThread.chatThreadId,
         signal: args.signal,
       });
-    if (!recommendedFollowups) {
-      return;
+    if (recommendedFollowups) {
+      await insertRecommendedFollowupsMessage({
+        db: args.db,
+        runId: args.runId,
+        threadId: args.chatThread.chatThreadId,
+        userId: args.chatThread.userId,
+        recommendedFollowups,
+      });
     }
-    await insertRecommendedFollowupsMessage({
-      db: args.db,
-      runId: args.runId,
-      threadId: args.chatThread.chatThreadId,
-      userId: args.chatThread.userId,
-      recommendedFollowups,
-    });
+    if (args.chatThread.triggerSource === "web") {
+      await publishChatThreadFollowupsFinished({
+        userId: args.chatThread.userId,
+        threadId: args.chatThread.chatThreadId,
+      });
+    }
   })();
 
   const pushStep = (async () => {
@@ -1168,7 +1158,7 @@ async function runCompletedChatCallbackSideEffects(args: {
   const results = await Promise.allSettled([
     saveSummaryStep,
     titleStep,
-    lifecycleMarkerStep,
+    followupsStep,
     pushStep,
   ]);
   const errors = results.flatMap((result) => {
@@ -1202,7 +1192,6 @@ async function handleFailedChatCallback(args: {
     runId: args.runId,
     threadId: args.chatThread.chatThreadId,
     userId: args.chatThread.userId,
-    publishRunFinished: args.chatThread.triggerSource === "web",
     lifecycleEvent,
     getFormattedError: args.getFormattedError,
   });

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts
@@ -225,7 +225,7 @@ describe("createIdbCachedDataSource initial page cache", () => {
     );
   });
 
-  it("keeps warming later run-finished payloads after a stale thread payload", async () => {
+  it("keeps warming later followups-finished payloads after a stale thread payload", async () => {
     mockUser({ id: "user_1", fullName: "Test User" }, { token: "token" });
     mockOrganization({
       activeOrg: { id: "org_1", name: "Test Org" },
@@ -247,32 +247,34 @@ describe("createIdbCachedDataSource initial page cache", () => {
     });
 
     const { setupRealtime$ } = await import("../../realtime.ts");
-    const { subscribeBackgroundChatThreadRunFinished$ } =
+    const { subscribeBackgroundChatThreadFollowupsFinished$ } =
       await import("../background-chat-thread-cache.ts");
 
     await ctx.store.set(setupRealtime$, ctx.signal);
     const subscriptionPromise = ctx.store.set(
-      subscribeBackgroundChatThreadRunFinished$,
+      subscribeBackgroundChatThreadFollowupsFinished$,
       ctx.signal,
     );
     detach(subscriptionPromise, Reason.Daemon);
     await waitFor(() => {
       expect(
-        ctx.mocks.ably.hasSubscription("chatThreadRunFinished"),
+        ctx.mocks.ably.hasSubscription("chatThreadFollowupsFinished"),
       ).toBeTruthy();
     });
 
-    ctx.mocks.ably.trigger("chatThreadRunFinished", {
+    ctx.mocks.ably.trigger("chatThreadFollowupsFinished", {
       threadId: staleThreadId,
     });
     await waitFor(() => {
       expect(seenThreadIds).toContain(staleThreadId);
     });
 
-    ctx.mocks.ably.trigger("chatThreadRunFinished", {
+    ctx.mocks.ably.trigger("chatThreadFollowupsFinished", {
       threadId: "not-a-valid-thread-id",
     });
-    ctx.mocks.ably.trigger("chatThreadRunFinished", { threadId: liveThreadId });
+    ctx.mocks.ably.trigger("chatThreadFollowupsFinished", {
+      threadId: liveThreadId,
+    });
     await waitFor(() => {
       expect(seenThreadIds).toContain(liveThreadId);
       expect(seenThreadIds).not.toContain("not-a-valid-thread-id");

--- a/turbo/apps/platform/src/signals/chat-page/background-chat-thread-cache.ts
+++ b/turbo/apps/platform/src/signals/chat-page/background-chat-thread-cache.ts
@@ -8,11 +8,11 @@ import {
 import { warmLatestChatThreadMessages$ } from "./idb-cached-chat-thread-data-source.ts";
 
 const L = logger("BackgroundChatThreadCache");
-const CHAT_THREAD_RUN_FINISHED_TOPIC = "chatThreadRunFinished";
+const CHAT_THREAD_FOLLOWUPS_FINISHED_TOPIC = "chatThreadFollowupsFinished";
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function threadIdFromRunFinishedPayload(payload: unknown): string | null {
+function threadIdFromFollowupsFinishedPayload(payload: unknown): string | null {
   if (
     payload === null ||
     typeof payload !== "object" ||
@@ -27,18 +27,18 @@ function threadIdFromRunFinishedPayload(payload: unknown): string | null {
     : null;
 }
 
-const warmFinishedThread$ = command(
+const warmFollowupsFinishedThread$ = command(
   async ({ get, set }, payload: unknown, signal: AbortSignal) => {
-    const threadId = threadIdFromRunFinishedPayload(payload);
+    const threadId = threadIdFromFollowupsFinishedPayload(payload);
     if (!threadId) {
-      L.warn("runFinished:invalidPayload", { payload });
+      L.warn("followupsFinished:invalidPayload", { payload });
       return false;
     }
 
     const leftThreadId = get(currentLeftThread$)?.threadId;
     const rightThreadId = get(currentRightThread$)?.threadId;
     if (threadId === leftThreadId || threadId === rightThreadId) {
-      L.debug("runFinished:threadOpen", { threadId });
+      L.debug("followupsFinished:threadOpen", { threadId });
       return false;
     }
 
@@ -48,13 +48,13 @@ const warmFinishedThread$ = command(
   },
 );
 
-export const subscribeBackgroundChatThreadRunFinished$ = command(
+export const subscribeBackgroundChatThreadFollowupsFinished$ = command(
   async ({ set }, signal: AbortSignal) => {
     await set(
       setAblyPayloadLoop$,
       {
-        topic: CHAT_THREAD_RUN_FINISHED_TOPIC,
-        loopCommand$: warmFinishedThread$,
+        topic: CHAT_THREAD_FOLLOWUPS_FINISHED_TOPIC,
+        loopCommand$: warmFollowupsFinishedThread$,
       },
       signal,
     );

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -12,7 +12,7 @@ import {
   subscribeThreadListChanged$,
 } from "../signals/chat-thread-list-reload.ts";
 import { pollForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
-import { subscribeBackgroundChatThreadRunFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
+import { subscribeBackgroundChatThreadFollowupsFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
 import { subscribeEventDrivenChatThreads$ } from "../signals/chat-page/chat-thread-event-sourcing.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import { detach, Reason } from "../signals/utils.ts";
@@ -35,7 +35,7 @@ export const setupRouter = (
     Reason.Daemon,
   );
   detach(
-    store.set(subscribeBackgroundChatThreadRunFinished$, signal),
+    store.set(subscribeBackgroundChatThreadFollowupsFinished$, signal),
     Reason.Daemon,
   );
   detach(store.set(subscribeEventDrivenChatThreads$, signal), Reason.Daemon);


### PR DESCRIPTION
## Summary
- Replace the background chat cache subscription from the early `chatThreadRunFinished` signal to a new `chatThreadFollowupsFinished` signal.
- Publish `chatThreadFollowupsFinished` only after completed-run follow-up processing finishes, so cached background threads include recommended follow-up messages before the user opens them.
- Remove the unused `chatThreadRunFinished` publish path and update realtime/cache tests for the new topic.

## Verification
- `pnpm -F @vm0/app test src/signals/chat-page/__tests__/idb-cached-chat-thread-initial-page.test.ts`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `git diff --check`

## Notes
- Attempted `pnpm -F api test src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`; local setup failed before assertions because this fresh checkout has no test Postgres available (`ECONNREFUSED` during onboarding setup).
