### PR TITLE
feat: make steam connector generally available

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-openid.bdd.test.ts
@@ -6,9 +6,7 @@ import {
   zeroConnectorsByTypeContract,
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import { zeroConnectorCatalogContract } from "@vm0/api-contracts/contracts/zero-connector-catalog";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { zeroSteamPlayerContract } from "@vm0/api-contracts/contracts/zero-steam-player";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -45,21 +43,6 @@ function mockSession(actor: TestActor): void {
 function mockSteamRuntimeEnv(): void {
   mockEnv("VM0_API_URL", "https://api.vm0.ai");
   mockEnv("VM0_WEB_URL", "https://www.vm0.ai");
-}
-
-async function enableSteamConnector(actor: TestActor): Promise<void> {
-  mockSession(actor);
-  await accept(
-    setupApp({ context })(zeroFeatureSwitchesContract).update({
-      headers: authHeaders(),
-      body: {
-        switches: {
-          [FeatureSwitchKey.SteamConnector]: true,
-        },
-      },
-    }),
-    [200],
-  );
 }
 
 async function startSteamOpenId(actor: TestActor): Promise<URL> {
@@ -318,23 +301,11 @@ function mockSteamPlayerApis(args: { readonly privateOwnedGames?: boolean }) {
 }
 
 describe("Steam OpenID connector", () => {
-  it("hides Steam until the feature switch is enabled", async () => {
+  it("exposes Steam in the connector catalog by default", async () => {
     const actor = testActor();
     mockSession(actor);
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);
-    const hidden = await accept(
-      client.status({ headers: authHeaders() }),
-      [200],
-    );
-    expect(
-      hidden.body.connectors.some((connector) => {
-        return connector.connectorRef === "steam";
-      }),
-    ).toBeFalsy();
-
-    await enableSteamConnector(actor);
-    mockSession(actor);
     const visible = await accept(
       client.status({ headers: authHeaders() }),
       [200],
@@ -357,7 +328,6 @@ describe("Steam OpenID connector", () => {
   it("starts Steam OpenID auth and stores the verified SteamID on callback", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
-    await enableSteamConnector(actor);
 
     const authorizationUrl = await startSteamOpenId(actor);
     expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(
@@ -392,7 +362,6 @@ describe("Steam OpenID connector", () => {
   it("rejects invalid Steam OpenID verification without storing a connection", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
-    await enableSteamConnector(actor);
     const authorizationUrl = await startSteamOpenId(actor);
     mockSteamOpenIdVerification(false);
 
@@ -440,7 +409,6 @@ describe("Steam OpenID connector", () => {
   it("reads official Steam player data through the API-owned key", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
-    await enableSteamConnector(actor);
     await completeSteamOpenIdCallback(await startSteamOpenId(actor));
     mockSteamPlayerApis({ privateOwnedGames: false });
 
@@ -505,7 +473,6 @@ describe("Steam OpenID connector", () => {
   it("keeps private owned game data distinct from an empty library", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
-    await enableSteamConnector(actor);
     await completeSteamOpenIdCallback(await startSteamOpenId(actor));
     mockSteamPlayerApis({ privateOwnedGames: true });
 
@@ -526,7 +493,6 @@ describe("Steam OpenID connector", () => {
   it("returns provider unavailable when Steam returns malformed JSON", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
-    await enableSteamConnector(actor);
     await completeSteamOpenIdCallback(await startSteamOpenId(actor));
     mockSteamPlayerApis({ privateOwnedGames: false });
     server.use(
@@ -554,7 +520,6 @@ describe("Steam OpenID connector", () => {
   it("returns provider unavailable when Steam rejects the API key", async () => {
     const actor = testActor();
     mockSteamRuntimeEnv();
-    await enableSteamConnector(actor);
     await completeSteamOpenIdCallback(await startSteamOpenId(actor));
     mockSteamPlayerApis({ privateOwnedGames: false });
     server.use(

--- a/turbo/packages/connectors/src/connectors/steam.ts
+++ b/turbo/packages/connectors/src/connectors/steam.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connector-config";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const steam = {
   steam: {
@@ -9,7 +8,6 @@ export const steam = {
       "Connect your Steam account to access player profile, library, playtime, social, wishlist, and game stats data.",
     authMethods: {
       openid: {
-        featureFlag: FeatureSwitchKey.SteamConnector,
         label: "Steam sign-in",
         helpText: "Sign in with Steam to connect your player account.",
         storage: {

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -31,7 +31,6 @@ export enum FeatureSwitchKey {
   ResendConnector = "resendConnector",
   PexelsConnector = "pexelsConnector",
   SpotifyConnector = "spotifyConnector",
-  SteamConnector = "steamConnector",
   ZeroDebug = "zeroDebug",
   Banking = "banking",
   Lab = "lab",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -177,12 +177,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Spotify connector integration",
     enabled: false,
   },
-  [FeatureSwitchKey.SteamConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the Steam player connector integration",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ZeroDebug]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the Steam connector feature switch key and registry entry
- expose the Steam OpenID connector auth method by default
- update Steam OpenID coverage to assert default catalog visibility

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/connectors-openid.bdd.test.ts
- pnpm -F @vm0/connectors exec vitest run src/__tests__/steam-connector.test.ts src/__tests__/firewalls/steam.test.ts
- pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts
- pnpm -F api lint
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- pnpm -F api check-types
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types