### PR TITLE
fix: show full workflow template card description instead of truncating to two lines

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1387,7 +1387,7 @@ function WorkflowTemplateCard({
       )}
     >
       <p className="text-sm font-semibold text-foreground">{item.title}</p>
-      <p className="mt-1.5 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+      <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
         {item.description}
       </p>
       <div className="mt-auto flex items-center gap-2 pt-3.5">


### PR DESCRIPTION
## What & why

In the **Create with template → Workflow** picker, each template card's description was clamped to two lines with an ellipsis (`line-clamp-2`). For several templates the sentence was cut off mid-way (e.g. *"Pull product and engineering signals each morning, create a…"*), so users couldn't tell what the template actually does before clicking **Use**.

## Change

Removed `line-clamp-2` from the description paragraph in `WorkflowTemplateCard` so the full description renders.

- `turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx` — dropped the `line-clamp-2` class from the card description `<p>`.

## User-visible impact

The complete template description is now shown. Layout stays intact: the card grid uses equal-height rows and the connector-icons + **Use** footer is pinned to the bottom via `mt-auto`, so cards simply grow to fit their text and their footers stay aligned.

## Notes

- Descriptions are already short (one, occasionally two sentences), so cards grow only slightly.
- Only the Workflow tab used `line-clamp-2`; the other template tabs are unaffected.

## Verification

Visual before/after confirmed with a faithful HTML replica of the card row. Relying on the PR pipeline for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)