### PR TITLE
fix(runner): prevent service drain restarts

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1528,7 +1528,7 @@ jobs:
             SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
               "$RUNNER_DIR/status.json" 2>/dev/null)
             if [ -n "$RUN_ID" ] && [ -n "$SANDBOX_ID" ] \
-              && sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- test -p /tmp/vm0-drain-release-a 2>/dev/null; then
+              && sudo timeout 10 "$BIN_DIR/runner" exec --timeout 5 --sandbox "$SANDBOX_ID" -- test -p /tmp/vm0-drain-release-a 2>/dev/null; then
               RELEASE_FIFO_READY=1
               break
             fi
@@ -1626,7 +1626,7 @@ jobs:
           # Test 6: the long-running A that straddled drain+resume finishes
           # normally (exit 0) — drain must not cancel in-flight jobs.
           echo "--- Test: A completes normally through drain+resume ---"
-          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- timeout 10 sh -c 'printf release > /tmp/vm0-drain-release-a' \
+          sudo timeout 20 "$BIN_DIR/runner" exec --timeout 15 --sandbox "$SANDBOX_ID" -- timeout 10 sh -c 'printf release > /tmp/vm0-drain-release-a' \
             || fail "failed to release A after drain+resume"
           wait "$SUBMIT_A_PID"
           SUBMIT_A_EXIT=$?

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1514,8 +1514,9 @@ jobs:
           # Unit must still be active — the in-flight job keeps it alive.
           sudo systemctl is-active --quiet "$UNIT" \
             || fail "unit should still be active during Draining"
-          [ "$(restart_policy)" = "no" ] \
-            || fail "expected Restart=no during drain, got '$(restart_policy)'"
+          RESTART_POLICY=$(restart_policy)
+          [ "$RESTART_POLICY" = "no" ] \
+            || fail "expected Restart=no during drain, got '$RESTART_POLICY'"
           [ -f "$DRAIN_DROP_IN" ] \
             || fail "expected drain drop-in at $DRAIN_DROP_IN"
           echo "PASS: Restart=no applied during drain"
@@ -1554,8 +1555,9 @@ jobs:
           [ "$(status_mode)" = "running" ] \
             || fail "expected mode=running after resume, got '$(status_mode)'"
           echo "PASS: mode=running after resume"
-          [ "$(restart_policy)" = "on-failure" ] \
-            || fail "expected Restart=on-failure after resume, got '$(restart_policy)'"
+          RESTART_POLICY=$(restart_policy)
+          [ "$RESTART_POLICY" = "on-failure" ] \
+            || fail "expected Restart=on-failure after resume, got '$RESTART_POLICY'"
           [ ! -e "$DRAIN_DROP_IN" ] \
             || fail "drain drop-in remained after resume at $DRAIN_DROP_IN"
           echo "PASS: Restart policy restored after resume"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1513,12 +1513,11 @@ jobs:
           sudo "$BIN_DIR/runner" service start --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true --env USE_MOCK_CODEX=true
 
-          # Submit a long-running job in background so we can drain mid-flight.
-          # Duration must exceed the drain+verify+resume+verify window below
-          # so the job survives the round trip — otherwise jobs.is_empty()
-          # would auto-Stop the runner before resume can take effect.
+          # Submit a host-released job in background so we can drain mid-flight.
+          # A fixed sleep would force CI to wait for the whole duration even
+          # after the drain/resume assertions finish.
           echo "--- Submitting long-running job ---"
-          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 45 && echo done' &
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'rm -f /tmp/vm0-drain-release-a && mkfifo /tmp/vm0-drain-release-a && cat /tmp/vm0-drain-release-a >/dev/null && echo done' &
           SUBMIT_A_PID=$!
 
           # Wait for sandbox to appear in status.json.
@@ -1526,11 +1525,14 @@ jobs:
           for i in $(seq 1 60); do
             RUN_ID=$(sudo jq -r '.active_runs[0].run_id // empty' \
               "$RUNNER_DIR/status.json" 2>/dev/null)
-            [ -n "$RUN_ID" ] && break
+            SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
+              "$RUNNER_DIR/status.json" 2>/dev/null)
+            [ -n "$RUN_ID" ] && [ -n "$SANDBOX_ID" ] && break
             sleep 1
           done
           [ -z "$RUN_ID" ] && fail "sandbox not found after 60s"
-          echo "Found run $RUN_ID"
+          [ -z "$SANDBOX_ID" ] && fail "sandbox id not found after 60s"
+          echo "Found run $RUN_ID (sandbox $SANDBOX_ID)"
 
           # Test 1: drain while the job is in-flight → mode=draining.
           echo "--- Test: service drain (mid-flight) ---"
@@ -1619,6 +1621,8 @@ jobs:
           # Test 6: the long-running A that straddled drain+resume finishes
           # normally (exit 0) — drain must not cancel in-flight jobs.
           echo "--- Test: A completes normally through drain+resume ---"
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- timeout 10 sh -c 'printf release > /tmp/vm0-drain-release-a' \
+            || fail "failed to release A after drain+resume"
           wait "$SUBMIT_A_PID"
           SUBMIT_A_EXIT=$?
           SUBMIT_A_PID=""

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1455,11 +1455,15 @@ jobs:
           RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-drain"
           SVC="${JOB_REF}-drain"
           UNIT="vm0-runner-${SVC}.service"
+          DRAIN_DROP_IN="/run/systemd/system/${UNIT}.d/50-vm0-drain.conf"
           GROUP="vm0/drain-${JOB_REF}"
 
           fail() { echo "FAIL: $1"; exit 1; }
           status_mode() {
             sudo jq -r '.mode // empty' "$RUNNER_DIR/status.json" 2>/dev/null
+          }
+          restart_policy() {
+            sudo systemctl show "$UNIT" --property=Restart --value 2>/dev/null
           }
 
           cleanup() {
@@ -1510,6 +1514,11 @@ jobs:
           # Unit must still be active — the in-flight job keeps it alive.
           sudo systemctl is-active --quiet "$UNIT" \
             || fail "unit should still be active during Draining"
+          [ "$(restart_policy)" = "no" ] \
+            || fail "expected Restart=no during drain, got '$(restart_policy)'"
+          [ -f "$DRAIN_DROP_IN" ] \
+            || fail "expected drain drop-in at $DRAIN_DROP_IN"
+          echo "PASS: Restart=no applied during drain"
 
           # Test 2: a job submitted *during* Draining must stay pending —
           # the Draining arm does not poll discover, so the queued file
@@ -1545,6 +1554,11 @@ jobs:
           [ "$(status_mode)" = "running" ] \
             || fail "expected mode=running after resume, got '$(status_mode)'"
           echo "PASS: mode=running after resume"
+          [ "$(restart_policy)" = "on-failure" ] \
+            || fail "expected Restart=on-failure after resume, got '$(restart_policy)'"
+          [ ! -e "$DRAIN_DROP_IN" ] \
+            || fail "drain drop-in remained after resume at $DRAIN_DROP_IN"
+          echo "PASS: Restart policy restored after resume"
 
           # Test 4: the pending B is picked up after resume and completes.
           echo "--- Test: drain-era submit executes after resume ---"
@@ -1589,6 +1603,11 @@ jobs:
             fail "unit still active 30s after drain on idle runner"
           fi
           echo "PASS: unit stopped via auto-Stop"
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" --force \
+            || fail "stop after idle drain failed"
+          [ ! -e "$DRAIN_DROP_IN" ] \
+            || fail "drain drop-in remained after stop at $DRAIN_DROP_IN"
+          echo "PASS: stop cleaned drain drop-in"
 
           # Test 8: resume refused on an inactive unit (is_unit_active guard).
           echo "--- Test: resume refused after stop ---"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1481,6 +1481,7 @@ jobs:
           GROUP="vm0/drain-${JOB_REF}"
           SUBMIT_A_PID=""
           SUBMIT_B_PID=""
+          RELEASE_FIFO_READY=""
 
           fail() { echo "FAIL: $1"; exit 1; }
           status_mode() {
@@ -1528,7 +1529,7 @@ jobs:
             SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
               "$RUNNER_DIR/status.json" 2>/dev/null)
             if [ -n "$RUN_ID" ] && [ -n "$SANDBOX_ID" ] \
-              && sudo timeout 10 "$BIN_DIR/runner" exec --timeout 5 --sandbox "$SANDBOX_ID" -- test -p /tmp/vm0-drain-release-a 2>/dev/null; then
+              && sudo timeout 3 "$BIN_DIR/runner" exec --timeout 2 --sandbox "$SANDBOX_ID" -- test -p /tmp/vm0-drain-release-a 2>/dev/null; then
               RELEASE_FIFO_READY=1
               break
             fi

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1053,12 +1053,21 @@ jobs:
           RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-exec"
           SVC="${JOB_REF}-exec"
           GROUP="vm0/exec-${JOB_REF}"
+          SUBMIT_PID=""
 
           fail() { echo "FAIL: $1"; exit 1; }
+
+          cleanup_submit_pid() {
+            local pid=$1
+            [ -n "$pid" ] || return 0
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+          }
 
           cleanup() {
             echo "--- Cleanup ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            cleanup_submit_pid "$SUBMIT_PID"
           }
           trap cleanup EXIT
 
@@ -1074,6 +1083,7 @@ jobs:
           # Submit a long-running job in background (keeps sandbox alive during tests)
           echo "--- Submitting long-running job ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
+          SUBMIT_PID=$!
 
           # Wait for OUR runner's sandbox to have a control socket.
           # Read the sandbox_id from our runner's status.json (not from
@@ -1293,6 +1303,8 @@ jobs:
 
           # Stop transient service (kills sandbox, submit terminates naturally)
           sudo "$BIN_DIR/runner" service stop --name "$SVC" --force
+          cleanup_submit_pid "$SUBMIT_PID"
+          SUBMIT_PID=""
           trap - EXIT
 
           echo "=== Exec test passed ==="
@@ -1343,12 +1355,21 @@ jobs:
           RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-cancel"
           SVC="${JOB_REF}-cancel"
           GROUP="vm0/cancel-${JOB_REF}"
+          SUBMIT_PID=""
 
           fail() { echo "FAIL: $1"; exit 1; }
+
+          cleanup_submit_pid() {
+            local pid=$1
+            [ -n "$pid" ] || return 0
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+          }
 
           cleanup() {
             echo "--- Cleanup ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            cleanup_submit_pid "$SUBMIT_PID"
           }
           trap cleanup EXIT
 
@@ -1395,6 +1416,7 @@ jobs:
           SECONDS=0
           wait "$SUBMIT_PID"
           SUBMIT_EXIT=$?
+          SUBMIT_PID=""
           ELAPSED=$SECONDS
           echo "Submit exited with code $SUBMIT_EXIT in ${ELAPSED}s"
           # Cancel should kill the job within 30s, not after the 300s submit timeout
@@ -1457,6 +1479,8 @@ jobs:
           UNIT="vm0-runner-${SVC}.service"
           DRAIN_DROP_IN="/run/systemd/system/${UNIT}.d/50-vm0-drain.conf"
           GROUP="vm0/drain-${JOB_REF}"
+          SUBMIT_A_PID=""
+          SUBMIT_B_PID=""
 
           fail() { echo "FAIL: $1"; exit 1; }
           status_mode() {
@@ -1466,9 +1490,18 @@ jobs:
             sudo systemctl show "$UNIT" --property=Restart --value 2>/dev/null
           }
 
+          cleanup_submit_pid() {
+            local pid=$1
+            [ -n "$pid" ] || return 0
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+          }
+
           cleanup() {
             echo "--- Cleanup ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            cleanup_submit_pid "$SUBMIT_B_PID"
+            cleanup_submit_pid "$SUBMIT_A_PID"
           }
           trap cleanup EXIT
 
@@ -1567,6 +1600,7 @@ jobs:
           SECONDS=0
           wait "$SUBMIT_B_PID"
           SUBMIT_B_EXIT=$?
+          SUBMIT_B_PID=""
           B_ELAPSED=$SECONDS
           echo "B exited with code $SUBMIT_B_EXIT in ${B_ELAPSED}s"
           [ "$SUBMIT_B_EXIT" -eq 0 ] \
@@ -1587,6 +1621,7 @@ jobs:
           echo "--- Test: A completes normally through drain+resume ---"
           wait "$SUBMIT_A_PID"
           SUBMIT_A_EXIT=$?
+          SUBMIT_A_PID=""
           [ "$SUBMIT_A_EXIT" -eq 0 ] \
             || fail "A expected exit 0, got $SUBMIT_A_EXIT — job was killed"
           echo "PASS: A completed normally through drain+resume"
@@ -1942,9 +1977,18 @@ jobs:
           RUNNER_DIR_B="/var/lib/vm0-runner/runners/${JOB_REF}-upgrade-b"
           SVC_A="${JOB_REF}-upgrade-a"
           SVC_B="${JOB_REF}-upgrade-b"
+          SUBMIT1_PID=""
+          SUBMIT2_PID=""
 
           FAILED=0
           fail() { FAILED=1; echo "FAIL: $1"; exit 1; }
+
+          cleanup_submit_pid() {
+            local pid=$1
+            [ -n "$pid" ] || return 0
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+          }
 
           # Poll `systemctl is-active` with a bounded budget; fail if the unit
           # is still active afterward so the EXIT trap dumps journalctl at the
@@ -1971,6 +2015,8 @@ jobs:
             echo "--- Cleanup: uninstalling services ---"
             sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" --force 2>/dev/null || true
             sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" --force 2>/dev/null || true
+            cleanup_submit_pid "$SUBMIT2_PID"
+            cleanup_submit_pid "$SUBMIT1_PID"
             if [ "$FAILED" -ne 0 ]; then
               echo "--- Cleanup: dumping logs (test failed) ---"
               journalctl --unit "vm0-runner-${SVC_A}" --lines 50 --no-pager 2>/dev/null || true
@@ -2009,9 +2055,11 @@ jobs:
 
           # 6. Verify both jobs complete despite drain
           echo "--- Waiting for job 1 ---"
-          wait $SUBMIT1_PID || fail "Job 1 failed"
+          wait "$SUBMIT1_PID" || fail "Job 1 failed"
+          SUBMIT1_PID=""
           echo "--- Waiting for job 2 ---"
-          wait $SUBMIT2_PID || fail "Job 2 failed"
+          wait "$SUBMIT2_PID" || fail "Job 2 failed"
+          SUBMIT2_PID=""
 
           # 7. Wait for A to exit after drain, then verify drain still disables
           # an inactive-but-enabled installed unit.

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1527,11 +1527,16 @@ jobs:
               "$RUNNER_DIR/status.json" 2>/dev/null)
             SANDBOX_ID=$(sudo jq -r '.active_runs[0].sandbox_id // empty' \
               "$RUNNER_DIR/status.json" 2>/dev/null)
-            [ -n "$RUN_ID" ] && [ -n "$SANDBOX_ID" ] && break
+            if [ -n "$RUN_ID" ] && [ -n "$SANDBOX_ID" ] \
+              && sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- test -p /tmp/vm0-drain-release-a 2>/dev/null; then
+              RELEASE_FIFO_READY=1
+              break
+            fi
             sleep 1
           done
           [ -z "$RUN_ID" ] && fail "sandbox not found after 60s"
           [ -z "$SANDBOX_ID" ] && fail "sandbox id not found after 60s"
+          [ -z "$RELEASE_FIFO_READY" ] && fail "release FIFO not ready after 60s"
           echo "Found run $RUN_ID (sandbox $SANDBOX_ID)"
 
           # Test 1: drain while the job is in-flight → mode=draining.

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -1,8 +1,10 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsString;
+use std::future::Future;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::time::{Duration, SystemTime};
 
 use clap::Args;
@@ -206,6 +208,12 @@ struct GcCandidate {
 }
 
 type ProtectedImageRefs = HashMap<String, HashSet<String>>;
+type ServiceUninstallFuture<'a> = Pin<Box<dyn Future<Output = RunnerResult<()>> + 'a>>;
+type ServiceUninstallFn = for<'a> fn(&'a service::RunnerServiceUnit) -> ServiceUninstallFuture<'a>;
+
+fn real_uninstall_service_unit(unit: &service::RunnerServiceUnit) -> ServiceUninstallFuture<'_> {
+    Box::pin(service::uninstall_service_unit(unit))
+}
 
 #[derive(serde::Deserialize)]
 struct ConfigImageRefs {
@@ -1609,6 +1617,20 @@ async fn version_retention_reason(
 }
 
 #[cfg(test)]
+fn successful_fake_uninstall_service_unit(
+    _unit: &service::RunnerServiceUnit,
+) -> ServiceUninstallFuture<'_> {
+    Box::pin(async { Ok(()) })
+}
+
+#[cfg(test)]
+fn failing_fake_uninstall_service_unit(
+    _unit: &service::RunnerServiceUnit,
+) -> ServiceUninstallFuture<'_> {
+    Box::pin(async { Err(RunnerError::Internal("fake uninstall failed".to_string())) })
+}
+
+#[cfg(test)]
 async fn gc_versions(
     home: &HomePaths,
     dry_run: bool,
@@ -1616,7 +1638,13 @@ async fn gc_versions(
     keep_latest: Option<usize>,
 ) -> RunnerResult<Vec<String>> {
     let analysis = analyze_version_gc(home, protect, keep_latest).await?;
-    gc_versions_with_analysis(home, dry_run, analysis).await
+    gc_versions_with_analysis_and_uninstall(
+        home,
+        dry_run,
+        analysis,
+        successful_fake_uninstall_service_unit,
+    )
+    .await
 }
 
 /// Remove old deployment version directories that are not actively running.
@@ -1639,6 +1667,16 @@ async fn gc_versions_with_analysis(
     home: &HomePaths,
     dry_run: bool,
     analysis: VersionGcAnalysis,
+) -> RunnerResult<Vec<String>> {
+    gc_versions_with_analysis_and_uninstall(home, dry_run, analysis, real_uninstall_service_unit)
+        .await
+}
+
+async fn gc_versions_with_analysis_and_uninstall(
+    home: &HomePaths,
+    dry_run: bool,
+    analysis: VersionGcAnalysis,
+    uninstall_service: ServiceUninstallFn,
 ) -> RunnerResult<Vec<String>> {
     let bin_dir = home.bin_dir();
     let mut removed: Vec<String> = Vec::new();
@@ -1723,10 +1761,9 @@ async fn gc_versions_with_analysis(
             }
             Ok(false) => {}
             Err(e) => {
-                // systemctl unavailable (e.g. in tests or broken PATH).
-                // Log and treat as inactive — the version dir will still be
-                // removed, which is preferable to silently accumulating stale
-                // versions when systemd units are already gone.
+                // systemctl may be unavailable on non-systemd hosts. Continue
+                // to the uninstall step; it will refuse deletion if it cannot
+                // prove the service is stopped.
                 warn!("version {name}: cannot check unit status ({e}), assuming inactive");
             }
         }
@@ -1738,8 +1775,14 @@ async fn gc_versions_with_analysis(
                 warn!("version {name}: service lock missing before delete, skipping");
                 continue;
             };
-            // Best-effort uninstall the systemd service (may not exist).
-            let _ = service::uninstall_service_unit(&unit).await;
+            // Uninstall is best-effort for missing/inactive units, but it
+            // returns an error when it cannot prove the service is stopped.
+            // In that case the version may still be backing a live runner, so
+            // keep the bin/config directories for the next GC pass.
+            if let Err(e) = uninstall_service(&unit).await {
+                warn!("version {name}: cannot uninstall service safely ({e}), skipping");
+                continue;
+            }
 
             // Remove bin directory.
             if let Err(e) = tokio::fs::remove_dir_all(&version_bin).await
@@ -3818,7 +3861,6 @@ server:
         std::fs::create_dir_all(runners_dir.join("v1.0.0")).unwrap();
         age_versions_past_gc_min_age(&home, &["v1.0.0", "v2.0.0"]);
 
-        // systemctl will fail in test env, so versions are treated as inactive
         let mut removed = gc_versions(&home, false, None, None).await.unwrap();
         removed.sort();
         assert_eq!(removed, ["v1.0.0", "v2.0.0"]);
@@ -3829,6 +3871,39 @@ server:
             "non-semver should be untouched"
         );
         assert!(!runners_dir.join("v1.0.0").exists());
+    }
+
+    #[tokio::test]
+    async fn gc_versions_keeps_version_when_service_uninstall_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = test_home(dir.path());
+        let bin_dir = home.bin_dir();
+        let runners_dir = home.runners_dir();
+        let version = "v1.0.0";
+
+        std::fs::create_dir_all(bin_dir.join(version)).unwrap();
+        std::fs::create_dir_all(runners_dir.join(version)).unwrap();
+        age_version_past_gc_min_age(&home, version);
+
+        let analysis = analyze_version_gc(&home, None, None).await.unwrap();
+        let removed = gc_versions_with_analysis_and_uninstall(
+            &home,
+            false,
+            analysis,
+            failing_fake_uninstall_service_unit,
+        )
+        .await
+        .unwrap();
+
+        assert!(removed.is_empty());
+        assert!(
+            bin_dir.join(version).exists(),
+            "failed service uninstall must keep version bin dir"
+        );
+        assert!(
+            runners_dir.join(version).exists(),
+            "failed service uninstall must keep version config dir"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/drain_override.rs
+++ b/crates/runner/src/cmd/service/drain_override.rs
@@ -1,0 +1,164 @@
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use crate::error::{RunnerError, RunnerResult};
+
+use super::target::RunnerServiceUnit;
+use super::unit_file::{cleanup_unit_staging_files, write_unit_file};
+
+const RUNTIME_SYSTEMD_SYSTEM_DIR: &str = "/run/systemd/system";
+const DRAIN_DROP_IN_FILE_NAME: &str = "50-vm0-drain.conf";
+const DRAIN_DROP_IN_CONTENT: &str = "[Service]\nRestart=no\n";
+
+pub(super) fn write_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerResult<()> {
+    write_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
+}
+
+pub(super) fn remove_drain_restart_override(unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+    remove_drain_restart_override_at(Path::new(RUNTIME_SYSTEMD_SYSTEM_DIR), unit)
+}
+
+fn drain_restart_override_dir_at(root: &Path, unit: &RunnerServiceUnit) -> PathBuf {
+    root.join(format!("{}.d", unit.service_name()))
+}
+
+fn drain_restart_override_path_at(root: &Path, unit: &RunnerServiceUnit) -> PathBuf {
+    drain_restart_override_dir_at(root, unit).join(DRAIN_DROP_IN_FILE_NAME)
+}
+
+fn write_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> RunnerResult<()> {
+    let dir = drain_restart_override_dir_at(root, unit);
+    std::fs::create_dir_all(&dir).map_err(|e| {
+        RunnerError::Internal(format!(
+            "create drain restart override directory {}: {e}",
+            dir.display()
+        ))
+    })?;
+    let path = drain_restart_override_path_at(root, unit);
+    cleanup_unit_staging_files(&path)?;
+    write_unit_file(&path, DRAIN_DROP_IN_CONTENT)
+}
+
+fn remove_drain_restart_override_at(root: &Path, unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+    let path = drain_restart_override_path_at(root, unit);
+    cleanup_unit_staging_files(&path)?;
+
+    let mut changed = match std::fs::remove_file(&path) {
+        Ok(()) => true,
+        Err(e) if e.kind() == ErrorKind::NotFound => false,
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "remove drain restart override {}: {e}",
+                path.display()
+            )));
+        }
+    };
+
+    let dir = drain_restart_override_dir_at(root, unit);
+    match std::fs::remove_dir(&dir) {
+        Ok(()) => changed = true,
+        Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty) => {}
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "remove empty drain restart override directory {}: {e}",
+                dir.display()
+            )));
+        }
+    }
+
+    Ok(changed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service_unit() -> RunnerServiceUnit {
+        RunnerServiceUnit::from_suffix("test").unwrap()
+    }
+
+    #[test]
+    fn override_path_is_derived_from_service_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = RunnerServiceUnit::from_suffix("v1.2.3").unwrap();
+
+        assert_eq!(
+            drain_restart_override_path_at(dir.path(), &unit),
+            dir.path()
+                .join("vm0-runner-v1.2.3.service.d")
+                .join(DRAIN_DROP_IN_FILE_NAME)
+        );
+    }
+
+    #[test]
+    fn write_creates_fixed_drop_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = service_unit();
+        let path = drain_restart_override_path_at(dir.path(), &unit);
+
+        write_drain_restart_override_at(dir.path(), &unit).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            DRAIN_DROP_IN_CONTENT
+        );
+    }
+
+    #[test]
+    fn repeated_writes_overwrite_same_drop_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = service_unit();
+        let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
+        let path = drain_restart_override_path_at(dir.path(), &unit);
+
+        write_drain_restart_override_at(dir.path(), &unit).unwrap();
+        std::fs::write(&path, "old content").unwrap();
+        write_drain_restart_override_at(dir.path(), &unit).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            DRAIN_DROP_IN_CONTENT
+        );
+        let entries: Vec<_> = std::fs::read_dir(&drop_in_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(entries, vec![DRAIN_DROP_IN_FILE_NAME]);
+    }
+
+    #[test]
+    fn remove_ignores_missing_drop_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = service_unit();
+
+        assert!(!remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+    }
+
+    #[test]
+    fn remove_deletes_empty_drop_in_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = service_unit();
+        let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
+
+        write_drain_restart_override_at(dir.path(), &unit).unwrap();
+        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+
+        assert!(!drop_in_dir.exists());
+    }
+
+    #[test]
+    fn remove_preserves_nonempty_drop_in_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let unit = service_unit();
+        let drop_in_dir = drain_restart_override_dir_at(dir.path(), &unit);
+        let other = drop_in_dir.join("90-operator.conf");
+
+        write_drain_restart_override_at(dir.path(), &unit).unwrap();
+        std::fs::write(&other, "[Service]\nEnvironment=EXTRA=1\n").unwrap();
+        assert!(remove_drain_restart_override_at(dir.path(), &unit).unwrap());
+
+        assert!(drop_in_dir.exists());
+        assert!(other.exists());
+        assert!(!drain_restart_override_path_at(dir.path(), &unit).exists());
+    }
+}

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -396,6 +396,24 @@ fn removed_drain_override_reload_error(
     ))
 }
 
+fn ensure_resume_mode_is_draining(unit: &RunnerServiceUnit, mode: &str) -> RunnerResult<()> {
+    match mode {
+        "draining" => Ok(()),
+        "stopping" | "stopped" => Err(RunnerError::Internal(format!(
+            "{} is already shutting down (mode={mode}) — cannot resume",
+            unit.unit_name()
+        ))),
+        "running" => Err(RunnerError::Internal(format!(
+            "{} is running, not draining — cannot resume",
+            unit.unit_name()
+        ))),
+        _ => Err(RunnerError::Internal(format!(
+            "{} is in unknown mode {mode:?} — cannot resume",
+            unit.unit_name()
+        ))),
+    }
+}
+
 async fn remove_drain_restart_override_before_resume(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceResumeOps,
@@ -875,9 +893,10 @@ async fn drain(args: ServiceDrainArgs) -> RunnerResult<()> {
 ///
 /// Reverses a prior `service drain` while the runner is still `Draining`.
 /// If the runner has already transitioned to `Stopping` (teardown in
-/// progress) or exited, resume is refused. SIGUSR2 on an already-`Running`
-/// runner is a no-op on the runner side (the state guard rejects the
-/// transition).
+/// progress), is still `Running`, or exited, resume is refused when status is
+/// readable. SIGUSR2 on an already-`Running` runner is a no-op on the runner
+/// side, so the CLI must not restore Restart=on-failure until the runner has
+/// actually entered `Draining`.
 async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
     let home = HomePaths::new()?;
@@ -890,19 +909,14 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
         )));
     }
 
-    // Preflight: if status.json shows the runner is already past the
-    // resumable point (Stopping = teardown in progress, Stopped = exited),
-    // SIGUSR2 is too late.
+    // Preflight: only remove Restart=no once status.json confirms the runner
+    // has processed SIGUSR1 and entered Draining. A too-early resume while
+    // status is still Running can race with the pending SIGUSR1: SIGUSR2 is a
+    // no-op in Running, but removing the restart override would let a later
+    // Draining runner regain restart behavior.
     if let Some(base_dir) = runner_base_dir(&unit) {
         match read_runner_status(&base_dir).await {
-            Ok(status) if matches!(status.mode.as_str(), "stopping" | "stopped") => {
-                return Err(RunnerError::Internal(format!(
-                    "{} is already shutting down (mode={}) — cannot resume",
-                    unit.unit_name(),
-                    status.mode
-                )));
-            }
-            Ok(_) => {}
+            Ok(status) => ensure_resume_mode_is_draining(&unit, &status.mode)?,
             Err(e) => {
                 warn!(
                     unit = %unit.unit_name(),
@@ -1587,6 +1601,22 @@ profiles:
             .unwrap();
 
         assert_eq!(ops.events, ["signal_resume"]);
+    }
+
+    #[test]
+    fn resume_preflight_allows_only_draining_mode() {
+        let unit = service_unit();
+
+        ensure_resume_mode_is_draining(&unit, "draining").unwrap();
+
+        let running = ensure_resume_mode_is_draining(&unit, "running").unwrap_err();
+        assert!(running.to_string().contains("running, not draining"));
+
+        let stopping = ensure_resume_mode_is_draining(&unit, "stopping").unwrap_err();
+        assert!(stopping.to_string().contains("already shutting down"));
+
+        let unknown = ensure_resume_mode_is_draining(&unit, "paused").unwrap_err();
+        assert!(unknown.to_string().contains("unknown mode"));
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -205,6 +205,7 @@ type ServiceFuture<'a, T> = Pin<Box<dyn Future<Output = RunnerResult<T>> + 'a>>;
 trait ServiceDrainOps {
     fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
+    fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
     fn daemon_reload(&mut self) -> ServiceFuture<'_, ()>;
     fn restart_policy<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, String>;
     fn signal_drain<'a>(
@@ -223,6 +224,10 @@ impl ServiceDrainOps for RealServiceDrainOps {
 
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
         write_drain_restart_override(unit)
+    }
+
+    fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+        remove_drain_restart_override(unit)
     }
 
     fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
@@ -245,6 +250,34 @@ impl ServiceDrainOps for RealServiceDrainOps {
     }
 }
 
+async fn rollback_drain_restart_override(
+    unit: &RunnerServiceUnit,
+    ops: &mut impl ServiceDrainOps,
+    context: &str,
+) {
+    match ops.remove_restart_override(unit) {
+        Ok(true) => {
+            if let Err(e) = ops.daemon_reload().await {
+                warn!(
+                    unit = %unit.unit_name(),
+                    context,
+                    error = %e,
+                    "failed to reload systemd after removing drain restart override"
+                );
+            }
+        }
+        Ok(false) => {}
+        Err(e) => {
+            warn!(
+                unit = %unit.unit_name(),
+                context,
+                error = %e,
+                "failed to remove drain restart override after drain failure"
+            );
+        }
+    }
+}
+
 async fn drain_with_ops(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceDrainOps,
@@ -256,13 +289,20 @@ async fn drain_with_ops(
 
     if should_signal {
         ops.write_restart_override(unit)?;
-        ops.daemon_reload().await?;
+        if let Err(e) = ops.daemon_reload().await {
+            rollback_drain_restart_override(unit, ops, "daemon_reload").await;
+            return Err(e);
+        }
         match ops.restart_policy(unit).await {
             Ok(restart_policy) => {
-                ensure_drain_restart_policy_applied(unit, &restart_policy)?;
+                if let Err(e) = ensure_drain_restart_policy_applied(unit, &restart_policy) {
+                    rollback_drain_restart_override(unit, ops, "restart_policy").await;
+                    return Err(e);
+                }
             }
             Err(e) => {
                 if ops.is_active(unit).await? {
+                    rollback_drain_restart_override(unit, ops, "restart_policy").await;
                     return Err(e);
                 }
                 info!(
@@ -280,11 +320,15 @@ async fn drain_with_ops(
         // Both outcomes ("live, signal delivered" and "already gone") must still
         // run `systemctl disable` below so the unit does not auto-start at the
         // next boot.
-        match ops.signal_drain(unit).await? {
-            ServiceSignalOutcome::Sent { pid } => {
+        match ops.signal_drain(unit).await {
+            Err(e) => {
+                rollback_drain_restart_override(unit, ops, "signal_drain").await;
+                return Err(e);
+            }
+            Ok(ServiceSignalOutcome::Sent { pid }) => {
                 info!(unit = %unit.unit_name(), pid, "sent SIGUSR1 (drain)");
             }
-            ServiceSignalOutcome::AlreadyGone => {
+            Ok(ServiceSignalOutcome::AlreadyGone) => {
                 info!(unit = %unit.unit_name(), "runner already exited; drain signal not needed");
             }
         }
@@ -913,9 +957,11 @@ profiles:
         events: Vec<&'static str>,
         active_results: VecDeque<bool>,
         write_error: bool,
+        remove_error: bool,
         reload_error: bool,
         restart_policy_error: bool,
         restart_policy: String,
+        signal_error: bool,
         signal_outcome: ServiceSignalOutcome,
         disable_error: bool,
     }
@@ -926,9 +972,11 @@ profiles:
                 events: Vec::new(),
                 active_results: VecDeque::from([true]),
                 write_error: false,
+                remove_error: false,
                 reload_error: false,
                 restart_policy_error: false,
                 restart_policy: "no".to_string(),
+                signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
                 disable_error: false,
             }
@@ -954,6 +1002,15 @@ profiles:
                 Err(fake_error("write failed"))
             } else {
                 Ok(())
+            }
+        }
+
+        fn remove_restart_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+            self.events.push("remove_restart_override");
+            if self.remove_error {
+                Err(fake_error("remove failed"))
+            } else {
+                Ok(true)
             }
         }
 
@@ -983,7 +1040,11 @@ profiles:
             _unit: &'a RunnerServiceUnit,
         ) -> ServiceFuture<'a, ServiceSignalOutcome> {
             self.events.push("signal_drain");
-            Box::pin(std::future::ready(Ok(self.signal_outcome)))
+            Box::pin(std::future::ready(if self.signal_error {
+                Err(fake_error("signal failed"))
+            } else {
+                Ok(self.signal_outcome)
+            }))
         }
 
         fn disable<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
@@ -1044,7 +1105,7 @@ profiles:
     }
 
     #[tokio::test]
-    async fn drain_daemon_reload_failure_aborts_before_signal() {
+    async fn drain_daemon_reload_failure_rolls_back_before_signal() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
             reload_error: true,
@@ -1056,7 +1117,13 @@ profiles:
         assert!(err.to_string().contains("reload failed"));
         assert_eq!(
             ops.events,
-            ["is_active", "write_restart_override", "daemon_reload"]
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "remove_restart_override",
+                "daemon_reload",
+            ]
         );
     }
 
@@ -1078,6 +1145,8 @@ profiles:
                 "write_restart_override",
                 "daemon_reload",
                 "restart_policy",
+                "remove_restart_override",
+                "daemon_reload",
             ]
         );
     }
@@ -1102,6 +1171,8 @@ profiles:
                 "daemon_reload",
                 "restart_policy",
                 "is_active",
+                "remove_restart_override",
+                "daemon_reload",
             ]
         );
     }
@@ -1126,6 +1197,31 @@ profiles:
                 "restart_policy",
                 "is_active",
                 "disable",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_signal_failure_rolls_back_restart_override() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            signal_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(err.to_string().contains("signal failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "restart_policy",
+                "signal_drain",
+                "remove_restart_override",
+                "daemon_reload",
             ]
         );
     }

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -218,6 +218,7 @@ trait ServiceDrainOps {
 
 trait ServiceResumeOps {
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
+    fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool>;
     fn daemon_reload(&mut self) -> ServiceFuture<'_, ()>;
     fn signal_resume<'a>(
         &'a mut self,
@@ -264,6 +265,10 @@ impl ServiceDrainOps for RealServiceDrainOps {
 impl ServiceResumeOps for RealServiceResumeOps {
     fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
         write_drain_restart_override(unit)
+    }
+
+    fn remove_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+        remove_drain_restart_override(unit)
     }
 
     fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
@@ -335,6 +340,42 @@ fn resume_error_with_restore_failure(
         "resume failed for {}: {resume_error}; additionally failed to restore drain restart override: {restore_error}",
         unit.unit_name()
     ))
+}
+
+fn removed_drain_override_reload_error(
+    unit: &RunnerServiceUnit,
+    reload_error: RunnerError,
+    restore_error: RunnerError,
+) -> RunnerError {
+    RunnerError::Internal(format!(
+        "failed to reload systemd after removing drain restart override for {} before resume: {reload_error}; additionally failed to restore drain restart override: {restore_error}",
+        unit.unit_name()
+    ))
+}
+
+async fn remove_drain_restart_override_before_resume(
+    unit: &RunnerServiceUnit,
+    ops: &mut impl ServiceResumeOps,
+) -> RunnerResult<bool> {
+    let removed = ops.remove_restart_override(unit)?;
+    if !removed {
+        return Ok(false);
+    }
+
+    if let Err(reload_error) = ops.daemon_reload().await {
+        if let Err(restore_error) =
+            restore_drain_restart_override_after_failed_resume(unit, ops, "remove_reload").await
+        {
+            return Err(removed_drain_override_reload_error(
+                unit,
+                reload_error,
+                restore_error,
+            ));
+        }
+        return Err(reload_error);
+    }
+
+    Ok(true)
 }
 
 async fn signal_resume_after_restart_policy_restored(
@@ -682,7 +723,14 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
             );
             cleanup_unit_staging_files(&upath)?;
             write_unit_file(&upath, &unit_content)?;
-            remove_drain_restart_override(&unit_for_activation)?;
+            if is_unit_active(&unit_for_activation).await? {
+                warn!(
+                    unit = %unit_for_activation.unit_name(),
+                    "skipping drain restart override cleanup while service is active"
+                );
+            } else {
+                remove_drain_restart_override(&unit_for_activation)?;
+            }
 
             run_systemctl(&["daemon-reload"]).await?;
             run_systemctl(&["enable", "--now", unit_for_activation.service_name()]).await?;
@@ -702,7 +750,10 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
 /// Callers that can race with install/uninstall/GC must hold the service lock.
 pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerResult<()> {
     // Best-effort stop + disable (may already be stopped/disabled).
-    let _ = run_systemctl(&["stop", unit.service_name()]).await;
+    let stop_result = run_systemctl(&["stop", unit.service_name()]).await;
+    if let Err(e) = &stop_result {
+        warn!(unit = %unit.unit_name(), error = %e, "failed to stop service during uninstall");
+    }
     let _ = run_systemctl(&["disable", unit.service_name()]).await;
 
     // Remove the unit file if it exists.
@@ -713,7 +764,28 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
     if let Err(e) = remove_unit_file_if_exists(upath) {
         warn!(unit = %unit.unit_name(), error = %e, "failed to remove unit file");
     }
-    if let Err(e) = remove_drain_restart_override(unit) {
+    let should_remove_drain_override = match stop_result {
+        Ok(()) => true,
+        Err(_) => match is_unit_active(unit).await {
+            Ok(false) => true,
+            Ok(true) => {
+                warn!(
+                    unit = %unit.unit_name(),
+                    "skipping drain restart override cleanup because service is still active after failed stop"
+                );
+                false
+            }
+            Err(e) => {
+                warn!(
+                    unit = %unit.unit_name(),
+                    error = %e,
+                    "skipping drain restart override cleanup because service activity could not be verified after failed stop"
+                );
+                false
+            }
+        },
+    };
+    if should_remove_drain_override && let Err(e) = remove_drain_restart_override(unit) {
         warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override");
     }
 
@@ -787,8 +859,9 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
         }
     }
 
+    let mut resume_ops = RealServiceResumeOps;
     let removed_drain_restart_override =
-        reload_systemd_if_drain_restart_override_removed(&unit).await?;
+        remove_drain_restart_override_before_resume(&unit, &mut resume_ops).await?;
 
     // Same race as in `drain`: the runner can exit after the preflight
     // `is_unit_active` check but before we deliver SIGUSR2. If resume does not
@@ -797,7 +870,7 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
     signal_resume_after_restart_policy_restored(
         &unit,
         removed_drain_restart_override,
-        &mut RealServiceResumeOps,
+        &mut resume_ops,
     )
     .await?;
 
@@ -1078,7 +1151,9 @@ profiles:
     struct FakeResumeOps {
         events: Vec<&'static str>,
         write_error: bool,
-        reload_error: bool,
+        remove_error: bool,
+        removed_restart_override: bool,
+        reload_errors: VecDeque<bool>,
         signal_error: bool,
         signal_outcome: ServiceSignalOutcome,
     }
@@ -1105,7 +1180,9 @@ profiles:
             Self {
                 events: Vec::new(),
                 write_error: false,
-                reload_error: false,
+                remove_error: false,
+                removed_restart_override: true,
+                reload_errors: VecDeque::new(),
                 signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
             }
@@ -1195,9 +1272,19 @@ profiles:
             }
         }
 
+        fn remove_restart_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<bool> {
+            self.events.push("remove_restart_override");
+            if self.remove_error {
+                Err(fake_error("remove failed"))
+            } else {
+                Ok(self.removed_restart_override)
+            }
+        }
+
         fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
             self.events.push("daemon_reload");
-            Box::pin(std::future::ready(if self.reload_error {
+            let reload_error = self.reload_errors.pop_front().unwrap_or(false);
+            Box::pin(std::future::ready(if reload_error {
                 Err(fake_error("reload failed"))
             } else {
                 Ok(())
@@ -1448,6 +1535,100 @@ profiles:
     }
 
     #[tokio::test]
+    async fn resume_remove_missing_override_skips_reload() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            removed_restart_override: false,
+            ..FakeResumeOps::default()
+        };
+
+        let removed = remove_drain_restart_override_before_resume(&unit, &mut ops)
+            .await
+            .unwrap();
+
+        assert!(!removed);
+        assert_eq!(ops.events, ["remove_restart_override"]);
+    }
+
+    #[tokio::test]
+    async fn resume_remove_reload_failure_restores_removed_drain_override() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            reload_errors: VecDeque::from([true, false]),
+            ..FakeResumeOps::default()
+        };
+
+        let err = remove_drain_restart_override_before_resume(&unit, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("reload failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "remove_restart_override",
+                "daemon_reload",
+                "write_restart_override",
+                "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_remove_reload_failure_reports_restore_write_failure() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            write_error: true,
+            reload_errors: VecDeque::from([true]),
+            ..FakeResumeOps::default()
+        };
+
+        let err = remove_drain_restart_override_before_resume(&unit, &mut ops)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("failed to reload systemd after removing drain restart override"));
+        assert!(message.contains("additionally failed to restore drain restart override"));
+        assert!(message.contains("write failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "remove_restart_override",
+                "daemon_reload",
+                "write_restart_override",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_remove_reload_failure_reports_restore_reload_failure() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            reload_errors: VecDeque::from([true, true]),
+            ..FakeResumeOps::default()
+        };
+
+        let err = remove_drain_restart_override_before_resume(&unit, &mut ops)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("failed to reload systemd after removing drain restart override"));
+        assert!(message.contains("additionally failed to restore drain restart override"));
+        assert!(message.contains("reload failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "remove_restart_override",
+                "daemon_reload",
+                "write_restart_override",
+                "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn resume_signal_failure_restores_removed_drain_override() {
         let unit = service_unit();
         let mut ops = FakeResumeOps {
@@ -1490,7 +1671,7 @@ profiles:
     async fn resume_signal_failure_reports_restore_reload_failure() {
         let unit = service_unit();
         let mut ops = FakeResumeOps {
-            reload_error: true,
+            reload_errors: VecDeque::from([true]),
             signal_error: true,
             ..FakeResumeOps::default()
         };

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -180,11 +180,12 @@ fn systemd_run_limit_nofile_property_arg() -> String {
 
 async fn reload_systemd_if_drain_restart_override_removed(
     unit: &RunnerServiceUnit,
-) -> RunnerResult<()> {
+) -> RunnerResult<bool> {
     if remove_drain_restart_override(unit)? {
         run_systemctl(&["daemon-reload"]).await?;
+        return Ok(true);
     }
-    Ok(())
+    Ok(false)
 }
 
 fn ensure_drain_restart_policy_applied(
@@ -215,7 +216,17 @@ trait ServiceDrainOps {
     fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
 }
 
+trait ServiceResumeOps {
+    fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
+    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()>;
+    fn signal_resume<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, ServiceSignalOutcome>;
+}
+
 struct RealServiceDrainOps;
+struct RealServiceResumeOps;
 
 impl ServiceDrainOps for RealServiceDrainOps {
     fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
@@ -250,6 +261,23 @@ impl ServiceDrainOps for RealServiceDrainOps {
     }
 }
 
+impl ServiceResumeOps for RealServiceResumeOps {
+    fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
+        write_drain_restart_override(unit)
+    }
+
+    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+        Box::pin(async { run_systemctl(&["daemon-reload"]).await })
+    }
+
+    fn signal_resume<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, ServiceSignalOutcome> {
+        Box::pin(async move { signal_service_main(unit, nix::sys::signal::Signal::SIGUSR2).await })
+    }
+}
+
 async fn rollback_drain_restart_override(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceDrainOps,
@@ -274,6 +302,68 @@ async fn rollback_drain_restart_override(
                 error = %e,
                 "failed to remove drain restart override after drain failure"
             );
+        }
+    }
+}
+
+async fn restore_drain_restart_override_after_failed_resume(
+    unit: &RunnerServiceUnit,
+    ops: &mut impl ServiceResumeOps,
+    context: &str,
+) {
+    if let Err(e) = ops.write_restart_override(unit) {
+        warn!(
+            unit = %unit.unit_name(),
+            context,
+            error = %e,
+            "failed to restore drain restart override after resume failure"
+        );
+        return;
+    }
+    if let Err(e) = ops.daemon_reload().await {
+        warn!(
+            unit = %unit.unit_name(),
+            context,
+            error = %e,
+            "failed to reload systemd after restoring drain restart override"
+        );
+    }
+}
+
+async fn signal_resume_after_restart_policy_restored(
+    unit: &RunnerServiceUnit,
+    removed_drain_restart_override: bool,
+    ops: &mut impl ServiceResumeOps,
+) -> RunnerResult<()> {
+    match ops.signal_resume(unit).await {
+        Ok(ServiceSignalOutcome::Sent { pid }) => {
+            info!(unit = %unit.unit_name(), pid, "sent SIGUSR2 (resume)");
+            Ok(())
+        }
+        Ok(ServiceSignalOutcome::AlreadyGone) => {
+            if removed_drain_restart_override {
+                restore_drain_restart_override_after_failed_resume(unit, ops, "signal_resume_gone")
+                    .await;
+            }
+            info!(
+                unit = %unit.unit_name(),
+                "runner exited between preflight and signal; refusing resume",
+            );
+            Err(RunnerError::Internal(format!(
+                "{} is not active — cannot resume an inactive runner",
+                unit.unit_name()
+            )))
+        }
+        Err(e) => {
+            if removed_drain_restart_override {
+                restore_drain_restart_override_after_failed_resume(
+                    unit,
+                    ops,
+                    "signal_resume_error",
+                )
+                .await;
+            }
+            Err(e)
         }
     }
 }
@@ -677,28 +767,19 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
         }
     }
 
-    reload_systemd_if_drain_restart_override_removed(&unit).await?;
+    let removed_drain_restart_override =
+        reload_systemd_if_drain_restart_override_removed(&unit).await?;
 
     // Same race as in `drain`: the runner can exit after the preflight
-    // `is_unit_active` check but before we deliver SIGUSR2. Unlike drain,
-    // there is no useful cleanup left once the runner is gone — resume is
-    // meaningless — so surface the same "not active" error the preflight
-    // branch above already returns.
-    match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR2).await? {
-        ServiceSignalOutcome::Sent { pid } => {
-            info!(unit = %unit.unit_name(), pid, "sent SIGUSR2 (resume)");
-        }
-        ServiceSignalOutcome::AlreadyGone => {
-            info!(
-                unit = %unit.unit_name(),
-                "runner exited between preflight and signal; refusing resume",
-            );
-            return Err(RunnerError::Internal(format!(
-                "{} is not active — cannot resume an inactive runner",
-                unit.unit_name()
-            )));
-        }
-    }
+    // `is_unit_active` check but before we deliver SIGUSR2. If resume does not
+    // deliver SIGUSR2 after restoring Restart=on-failure, put the drain override
+    // back so a still-draining old runner does not regain restart behavior.
+    signal_resume_after_restart_policy_restored(
+        &unit,
+        removed_drain_restart_override,
+        &mut RealServiceResumeOps,
+    )
+    .await?;
 
     // Re-enable so the unit restarts on reboot (undoes the disable from drain).
     // Use `enable` (not `--now`) — the service is already running. SIGUSR2
@@ -974,6 +1055,14 @@ profiles:
         disable_error: bool,
     }
 
+    struct FakeResumeOps {
+        events: Vec<&'static str>,
+        write_error: bool,
+        reload_error: bool,
+        signal_error: bool,
+        signal_outcome: ServiceSignalOutcome,
+    }
+
     impl Default for FakeDrainOps {
         fn default() -> Self {
             Self {
@@ -987,6 +1076,18 @@ profiles:
                 signal_error: false,
                 signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
                 disable_error: false,
+            }
+        }
+    }
+
+    impl Default for FakeResumeOps {
+        fn default() -> Self {
+            Self {
+                events: Vec::new(),
+                write_error: false,
+                reload_error: false,
+                signal_error: false,
+                signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
             }
         }
     }
@@ -1060,6 +1161,38 @@ profiles:
                 Err(fake_error("disable failed"))
             } else {
                 Ok(())
+            }))
+        }
+    }
+
+    impl ServiceResumeOps for FakeResumeOps {
+        fn write_restart_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<()> {
+            self.events.push("write_restart_override");
+            if self.write_error {
+                Err(fake_error("write failed"))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+            self.events.push("daemon_reload");
+            Box::pin(std::future::ready(if self.reload_error {
+                Err(fake_error("reload failed"))
+            } else {
+                Ok(())
+            }))
+        }
+
+        fn signal_resume<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, ServiceSignalOutcome> {
+            self.events.push("signal_resume");
+            Box::pin(std::future::ready(if self.signal_error {
+                Err(fake_error("signal failed"))
+            } else {
+                Ok(self.signal_outcome)
             }))
         }
     }
@@ -1280,6 +1413,72 @@ profiles:
                 "disable",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn resume_signal_sent_keeps_restored_restart_policy() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps::default();
+
+        signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
+            .await
+            .unwrap();
+
+        assert_eq!(ops.events, ["signal_resume"]);
+    }
+
+    #[tokio::test]
+    async fn resume_signal_failure_restores_removed_drain_override() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            signal_error: true,
+            ..FakeResumeOps::default()
+        };
+
+        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("signal failed"));
+        assert_eq!(
+            ops.events,
+            ["signal_resume", "write_restart_override", "daemon_reload"]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_already_gone_restores_removed_drain_override() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            signal_outcome: ServiceSignalOutcome::AlreadyGone,
+            ..FakeResumeOps::default()
+        };
+
+        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("cannot resume an inactive runner"));
+        assert_eq!(
+            ops.events,
+            ["signal_resume", "write_restart_override", "daemon_reload"]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_signal_failure_without_removed_override_does_not_write_override() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            signal_error: true,
+            ..FakeResumeOps::default()
+        };
+
+        let err = signal_resume_after_restart_policy_restored(&unit, false, &mut ops)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("signal failed"));
+        assert_eq!(ops.events, ["signal_resume"]);
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -249,12 +249,32 @@ async fn drain_with_ops(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceDrainOps,
 ) -> RunnerResult<()> {
-    if ops.is_active(unit).await? {
+    let mut should_signal = ops.is_active(unit).await?;
+    if !should_signal {
+        info!(unit = %unit.unit_name(), "no active service found; drain signal not needed");
+    }
+
+    if should_signal {
         ops.write_restart_override(unit)?;
         ops.daemon_reload().await?;
-        let restart_policy = ops.restart_policy(unit).await?;
-        ensure_drain_restart_policy_applied(unit, &restart_policy)?;
+        match ops.restart_policy(unit).await {
+            Ok(restart_policy) => {
+                ensure_drain_restart_policy_applied(unit, &restart_policy)?;
+            }
+            Err(e) => {
+                if ops.is_active(unit).await? {
+                    return Err(e);
+                }
+                info!(
+                    unit = %unit.unit_name(),
+                    "runner exited before restart policy verification; drain signal not needed"
+                );
+                should_signal = false;
+            }
+        }
+    }
 
+    if should_signal {
         // `is_unit_active` above can race against the runner exiting on its own:
         // by the time we read MainPID or call `kill`, the process may be gone.
         // Both outcomes ("live, signal delivered" and "already gone") must still
@@ -268,8 +288,6 @@ async fn drain_with_ops(
                 info!(unit = %unit.unit_name(), "runner already exited; drain signal not needed");
             }
         }
-    } else {
-        info!(unit = %unit.unit_name(), "no active service found; drain signal not needed");
     }
 
     // Disable so it won't restart on reboot. Disabling is boot enablement
@@ -675,6 +693,8 @@ async fn logs(args: ServiceLogsArgs) -> RunnerResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use super::*;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -881,9 +901,10 @@ profiles:
 
     struct FakeDrainOps {
         events: Vec<&'static str>,
-        active: bool,
+        active_results: VecDeque<bool>,
         write_error: bool,
         reload_error: bool,
+        restart_policy_error: bool,
         restart_policy: String,
         signal_outcome: ServiceSignalOutcome,
         disable_error: bool,
@@ -893,9 +914,10 @@ profiles:
         fn default() -> Self {
             Self {
                 events: Vec::new(),
-                active: true,
+                active_results: VecDeque::from([true]),
                 write_error: false,
                 reload_error: false,
+                restart_policy_error: false,
                 restart_policy: "no".to_string(),
                 signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
                 disable_error: false,
@@ -910,7 +932,10 @@ profiles:
     impl ServiceDrainOps for FakeDrainOps {
         fn is_active<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
             self.events.push("is_active");
-            Box::pin(std::future::ready(Ok(self.active)))
+            Box::pin(std::future::ready(Ok(self
+                .active_results
+                .pop_front()
+                .unwrap_or(false))))
         }
 
         fn write_restart_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<()> {
@@ -936,7 +961,11 @@ profiles:
             _unit: &'a RunnerServiceUnit,
         ) -> ServiceFuture<'a, String> {
             self.events.push("restart_policy");
-            Box::pin(std::future::ready(Ok(self.restart_policy.clone())))
+            Box::pin(std::future::ready(if self.restart_policy_error {
+                Err(fake_error("restart policy failed"))
+            } else {
+                Ok(self.restart_policy.clone())
+            }))
         }
 
         fn signal_drain<'a>(
@@ -981,7 +1010,7 @@ profiles:
     async fn drain_inactive_service_skips_restart_override_and_signal() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active: false,
+            active_results: VecDeque::from([false]),
             ..FakeDrainOps::default()
         };
 
@@ -1039,6 +1068,54 @@ profiles:
                 "write_restart_override",
                 "daemon_reload",
                 "restart_policy",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_restart_policy_error_for_still_active_service_aborts_before_signal() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            active_results: VecDeque::from([true, true]),
+            restart_policy_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(err.to_string().contains("restart policy failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "restart_policy",
+                "is_active",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_restart_policy_error_for_exited_service_still_disables_unit() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            active_results: VecDeque::from([true, false]),
+            restart_policy_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        drain_with_ops(&unit, &mut ops).await.unwrap();
+
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "restart_policy",
+                "is_active",
+                "disable",
             ]
         );
     }

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -301,9 +301,17 @@ async fn drain_with_ops(
                 }
             }
             Err(e) => {
-                if ops.is_active(unit).await? {
-                    rollback_drain_restart_override(unit, ops, "restart_policy").await;
-                    return Err(e);
+                match ops.is_active(unit).await {
+                    Ok(true) => {
+                        rollback_drain_restart_override(unit, ops, "restart_policy").await;
+                        return Err(e);
+                    }
+                    Ok(false) => {}
+                    Err(active_err) => {
+                        rollback_drain_restart_override(unit, ops, "restart_policy_active_check")
+                            .await;
+                        return Err(active_err);
+                    }
                 }
                 info!(
                     unit = %unit.unit_name(),
@@ -955,7 +963,7 @@ profiles:
 
     struct FakeDrainOps {
         events: Vec<&'static str>,
-        active_results: VecDeque<bool>,
+        active_results: VecDeque<RunnerResult<bool>>,
         write_error: bool,
         remove_error: bool,
         reload_error: bool,
@@ -970,7 +978,7 @@ profiles:
         fn default() -> Self {
             Self {
                 events: Vec::new(),
-                active_results: VecDeque::from([true]),
+                active_results: VecDeque::from([Ok(true)]),
                 write_error: false,
                 remove_error: false,
                 reload_error: false,
@@ -990,10 +998,9 @@ profiles:
     impl ServiceDrainOps for FakeDrainOps {
         fn is_active<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
             self.events.push("is_active");
-            Box::pin(std::future::ready(Ok(self
-                .active_results
-                .pop_front()
-                .unwrap_or(false))))
+            Box::pin(std::future::ready(
+                self.active_results.pop_front().unwrap_or(Ok(false)),
+            ))
         }
 
         fn write_restart_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<()> {
@@ -1081,7 +1088,7 @@ profiles:
     async fn drain_inactive_service_skips_restart_override_and_signal() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active_results: VecDeque::from([false]),
+            active_results: VecDeque::from([Ok(false)]),
             ..FakeDrainOps::default()
         };
 
@@ -1155,7 +1162,7 @@ profiles:
     async fn drain_restart_policy_error_for_still_active_service_aborts_before_signal() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active_results: VecDeque::from([true, true]),
+            active_results: VecDeque::from([Ok(true), Ok(true)]),
             restart_policy_error: true,
             ..FakeDrainOps::default()
         };
@@ -1178,10 +1185,36 @@ profiles:
     }
 
     #[tokio::test]
+    async fn drain_restart_policy_error_with_failed_active_recheck_rolls_back() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            active_results: VecDeque::from([Ok(true), Err(fake_error("active recheck failed"))]),
+            restart_policy_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(err.to_string().contains("active recheck failed"));
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "restart_policy",
+                "is_active",
+                "remove_restart_override",
+                "daemon_reload",
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn drain_restart_policy_error_for_exited_service_still_disables_unit() {
         let unit = service_unit();
         let mut ops = FakeDrainOps {
-            active_results: VecDeque::from([true, false]),
+            active_results: VecDeque::from([Ok(true), Ok(false)]),
             restart_policy_error: true,
             ..FakeDrainOps::default()
         };

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -310,24 +310,31 @@ async fn restore_drain_restart_override_after_failed_resume(
     unit: &RunnerServiceUnit,
     ops: &mut impl ServiceResumeOps,
     context: &str,
-) {
+) -> RunnerResult<()> {
     if let Err(e) = ops.write_restart_override(unit) {
-        warn!(
-            unit = %unit.unit_name(),
-            context,
-            error = %e,
-            "failed to restore drain restart override after resume failure"
-        );
-        return;
+        return Err(RunnerError::Internal(format!(
+            "failed to restore drain restart override for {} after resume failure ({context}): {e}",
+            unit.unit_name()
+        )));
     }
     if let Err(e) = ops.daemon_reload().await {
-        warn!(
-            unit = %unit.unit_name(),
-            context,
-            error = %e,
-            "failed to reload systemd after restoring drain restart override"
-        );
+        return Err(RunnerError::Internal(format!(
+            "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
+            unit.unit_name()
+        )));
     }
+    Ok(())
+}
+
+fn resume_error_with_restore_failure(
+    unit: &RunnerServiceUnit,
+    resume_error: RunnerError,
+    restore_error: RunnerError,
+) -> RunnerError {
+    RunnerError::Internal(format!(
+        "resume failed for {}: {resume_error}; additionally failed to restore drain restart override: {restore_error}",
+        unit.unit_name()
+    ))
 }
 
 async fn signal_resume_after_restart_policy_restored(
@@ -341,27 +348,40 @@ async fn signal_resume_after_restart_policy_restored(
             Ok(())
         }
         Ok(ServiceSignalOutcome::AlreadyGone) => {
-            if removed_drain_restart_override {
-                restore_drain_restart_override_after_failed_resume(unit, ops, "signal_resume_gone")
-                    .await;
+            let resume_error = RunnerError::Internal(format!(
+                "{} is not active — cannot resume an inactive runner",
+                unit.unit_name()
+            ));
+            if removed_drain_restart_override
+                && let Err(restore_error) = restore_drain_restart_override_after_failed_resume(
+                    unit,
+                    ops,
+                    "signal_resume_gone",
+                )
+                .await
+            {
+                return Err(resume_error_with_restore_failure(
+                    unit,
+                    resume_error,
+                    restore_error,
+                ));
             }
             info!(
                 unit = %unit.unit_name(),
                 "runner exited between preflight and signal; refusing resume",
             );
-            Err(RunnerError::Internal(format!(
-                "{} is not active — cannot resume an inactive runner",
-                unit.unit_name()
-            )))
+            Err(resume_error)
         }
         Err(e) => {
-            if removed_drain_restart_override {
-                restore_drain_restart_override_after_failed_resume(
+            if removed_drain_restart_override
+                && let Err(restore_error) = restore_drain_restart_override_after_failed_resume(
                     unit,
                     ops,
                     "signal_resume_error",
                 )
-                .await;
+                .await
+            {
+                return Err(resume_error_with_restore_failure(unit, e, restore_error));
             }
             Err(e)
         }
@@ -1440,6 +1460,49 @@ profiles:
             .unwrap_err();
 
         assert!(err.to_string().contains("signal failed"));
+        assert_eq!(
+            ops.events,
+            ["signal_resume", "write_restart_override", "daemon_reload"]
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_signal_failure_reports_restore_write_failure() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            write_error: true,
+            signal_error: true,
+            ..FakeResumeOps::default()
+        };
+
+        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("signal failed"));
+        assert!(message.contains("additionally failed to restore drain restart override"));
+        assert!(message.contains("write failed"));
+        assert_eq!(ops.events, ["signal_resume", "write_restart_override"]);
+    }
+
+    #[tokio::test]
+    async fn resume_signal_failure_reports_restore_reload_failure() {
+        let unit = service_unit();
+        let mut ops = FakeResumeOps {
+            reload_error: true,
+            signal_error: true,
+            ..FakeResumeOps::default()
+        };
+
+        let err = signal_resume_after_restart_policy_restored(&unit, true, &mut ops)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("signal failed"));
+        assert!(message.contains("additionally failed to restore drain restart override"));
+        assert!(message.contains("reload failed"));
         assert_eq!(
             ops.events,
             ["signal_resume", "write_restart_override", "daemon_reload"]

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -1,5 +1,6 @@
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::paths::{HomePaths, touch_mtime};
@@ -8,6 +9,7 @@ use sha2::{Digest, Sha256};
 use tracing::{info, warn};
 
 mod diagnostic;
+mod drain_override;
 mod gate;
 mod signal;
 mod systemctl;
@@ -19,9 +21,10 @@ pub(crate) use systemctl::{is_unit_active, is_unit_enabled};
 pub(crate) use target::RunnerServiceUnit;
 pub(crate) use unit_config::read_unit_config_path;
 
+use drain_override::{remove_drain_restart_override, write_drain_restart_override};
 use gate::{check_active_jobs_gate, read_runner_status, runner_base_dir};
 use signal::{ServiceSignalOutcome, signal_service_main};
-use systemctl::{journalctl_logs_status, run_systemctl};
+use systemctl::{get_service_restart_policy, journalctl_logs_status, run_systemctl};
 use unit_file::{
     RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE, cleanup_unit_staging_files, generate_unit_file,
     remove_unit_file_if_exists, resolve_config_path, validate_current_exe_path, validate_env_vars,
@@ -175,6 +178,117 @@ fn systemd_run_limit_nofile_property_arg() -> String {
     format!("--property={RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE}")
 }
 
+async fn reload_systemd_if_drain_restart_override_removed(
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<()> {
+    if remove_drain_restart_override(unit)? {
+        run_systemctl(&["daemon-reload"]).await?;
+    }
+    Ok(())
+}
+
+fn ensure_drain_restart_policy_applied(
+    unit: &RunnerServiceUnit,
+    restart_policy: &str,
+) -> RunnerResult<()> {
+    if restart_policy == "no" {
+        return Ok(());
+    }
+    Err(RunnerError::Internal(format!(
+        "effective Restart={restart_policy:?} for {} after drain override; expected Restart=no",
+        unit.service_name()
+    )))
+}
+
+type ServiceFuture<'a, T> = Pin<Box<dyn Future<Output = RunnerResult<T>> + 'a>>;
+
+trait ServiceDrainOps {
+    fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool>;
+    fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()>;
+    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()>;
+    fn restart_policy<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, String>;
+    fn signal_drain<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, ServiceSignalOutcome>;
+    fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()>;
+}
+
+struct RealServiceDrainOps;
+
+impl ServiceDrainOps for RealServiceDrainOps {
+    fn is_active<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+        Box::pin(async move { is_unit_active(unit).await })
+    }
+
+    fn write_restart_override(&mut self, unit: &RunnerServiceUnit) -> RunnerResult<()> {
+        write_drain_restart_override(unit)
+    }
+
+    fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+        Box::pin(async { run_systemctl(&["daemon-reload"]).await })
+    }
+
+    fn restart_policy<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, String> {
+        Box::pin(async move { get_service_restart_policy(unit).await })
+    }
+
+    fn signal_drain<'a>(
+        &'a mut self,
+        unit: &'a RunnerServiceUnit,
+    ) -> ServiceFuture<'a, ServiceSignalOutcome> {
+        Box::pin(async move { signal_service_main(unit, nix::sys::signal::Signal::SIGUSR1).await })
+    }
+
+    fn disable<'a>(&'a mut self, unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+        Box::pin(async move { run_systemctl(&["disable", unit.service_name()]).await })
+    }
+}
+
+async fn drain_with_ops(
+    unit: &RunnerServiceUnit,
+    ops: &mut impl ServiceDrainOps,
+) -> RunnerResult<()> {
+    if ops.is_active(unit).await? {
+        ops.write_restart_override(unit)?;
+        ops.daemon_reload().await?;
+        let restart_policy = ops.restart_policy(unit).await?;
+        ensure_drain_restart_policy_applied(unit, &restart_policy)?;
+
+        // `is_unit_active` above can race against the runner exiting on its own:
+        // by the time we read MainPID or call `kill`, the process may be gone.
+        // Both outcomes ("live, signal delivered" and "already gone") must still
+        // run `systemctl disable` below so the unit does not auto-start at the
+        // next boot.
+        match ops.signal_drain(unit).await? {
+            ServiceSignalOutcome::Sent { pid } => {
+                info!(unit = %unit.unit_name(), pid, "sent SIGUSR1 (drain)");
+            }
+            ServiceSignalOutcome::AlreadyGone => {
+                info!(unit = %unit.unit_name(), "runner already exited; drain signal not needed");
+            }
+        }
+    } else {
+        info!(unit = %unit.unit_name(), "no active service found; drain signal not needed");
+    }
+
+    // Disable so it won't restart on reboot. Disabling is boot enablement
+    // cleanup only; active-unit restart prevention is handled by the runtime
+    // Restart=no override above.
+    if let Err(e) = ops.disable(unit).await {
+        warn!(unit = %unit.unit_name(), error = %e, "failed to disable unit");
+        eprintln!(
+            "WARNING: drain could not disable {}: {e}. \
+             Run it manually to prevent the unit from restarting on reboot.",
+            unit.service_name()
+        );
+    } else {
+        info!(unit = %unit.unit_name(), "disabled (won't restart on reboot)");
+    }
+
+    Ok(())
+}
+
 async fn prepare_service_activation_config(
     unit: &RunnerServiceUnit,
     config_path: &Path,
@@ -261,6 +375,7 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     )?;
     validate_systemd_path("current executable path", &exe_path)?;
     validate_systemd_path("config path", &config_path)?;
+    reload_systemd_if_drain_restart_override_removed(&unit).await?;
 
     let unit_arg = format!("--unit={}", unit.unit_name());
     let desc_arg = format!("--description=VM0 Runner ({})", unit.unit_name());
@@ -377,6 +492,7 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
             );
             cleanup_unit_staging_files(&upath)?;
             write_unit_file(&upath, &unit_content)?;
+            remove_drain_restart_override(&unit_for_activation)?;
 
             run_systemctl(&["daemon-reload"]).await?;
             run_systemctl(&["enable", "--now", unit_for_activation.service_name()]).await?;
@@ -407,6 +523,9 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
     if let Err(e) = remove_unit_file_if_exists(upath) {
         warn!(unit = %unit.unit_name(), error = %e, "failed to remove unit file");
     }
+    if let Err(e) = remove_drain_restart_override(unit) {
+        warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override");
+    }
 
     if let Err(e) = run_systemctl(&["daemon-reload"]).await {
         warn!(unit = %unit.unit_name(), error = %e, "failed to reload systemd daemon");
@@ -430,40 +549,9 @@ async fn uninstall(args: ServiceUninstallArgs) -> RunnerResult<()> {
 /// `service drain` — send SIGUSR1, disable unit, return immediately.
 async fn drain(args: ServiceDrainArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
-    if is_unit_active(&unit).await? {
-        // `is_unit_active` above can race against the runner exiting on its own:
-        // by the time we read MainPID or call `kill`, the process may be gone.
-        // Both outcomes ("live, signal delivered" and "already gone") must still
-        // run `systemctl disable` below so the unit does not auto-start at the
-        // next boot.
-        match signal_service_main(&unit, nix::sys::signal::Signal::SIGUSR1).await? {
-            ServiceSignalOutcome::Sent { pid } => {
-                info!(unit = %unit.unit_name(), pid, "sent SIGUSR1 (drain)");
-            }
-            ServiceSignalOutcome::AlreadyGone => {
-                info!(unit = %unit.unit_name(), "runner already exited; drain signal not needed");
-            }
-        }
-    } else {
-        info!(unit = %unit.unit_name(), "no active service found; drain signal not needed");
-    }
-
-    // Disable so it won't restart on reboot. At this point the runner either
-    // saw SIGUSR1, already exited, or was inactive, so disabling is the
-    // remaining retirement step. Surface the hint on stderr in addition to
-    // the structured log so CLI users don't miss it.
-    if let Err(e) = run_systemctl(&["disable", unit.service_name()]).await {
-        warn!(unit = %unit.unit_name(), error = %e, "failed to disable unit");
-        eprintln!(
-            "WARNING: drain could not disable {}: {e}. \
-             Run it manually to prevent the unit from restarting on reboot.",
-            unit.service_name()
-        );
-    } else {
-        info!(unit = %unit.unit_name(), "disabled (won't restart on reboot)");
-    }
-
-    Ok(())
+    let home = HomePaths::new()?;
+    let _service_lock = acquire_service_lock(&unit, &home).await?;
+    drain_with_ops(&unit, &mut RealServiceDrainOps).await
 }
 
 /// `service resume` — send SIGUSR2, re-enable unit.
@@ -475,6 +563,9 @@ async fn drain(args: ServiceDrainArgs) -> RunnerResult<()> {
 /// transition).
 async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
+    let home = HomePaths::new()?;
+    let _service_lock = acquire_service_lock(&unit, &home).await?;
+
     if !is_unit_active(&unit).await? {
         return Err(RunnerError::Internal(format!(
             "{} is not active — cannot resume an inactive runner",
@@ -505,6 +596,8 @@ async fn resume(args: ServiceResumeArgs) -> RunnerResult<()> {
             }
         }
     }
+
+    reload_systemd_if_drain_restart_override_removed(&unit).await?;
 
     // Same race as in `drain`: the runner can exit after the preflight
     // `is_unit_active` check but before we deliver SIGUSR2. Unlike drain,
@@ -784,6 +877,193 @@ profiles:
 
     fn service_unit() -> RunnerServiceUnit {
         RunnerServiceUnit::from_suffix("test").unwrap()
+    }
+
+    struct FakeDrainOps {
+        events: Vec<&'static str>,
+        active: bool,
+        write_error: bool,
+        reload_error: bool,
+        restart_policy: String,
+        signal_outcome: ServiceSignalOutcome,
+        disable_error: bool,
+    }
+
+    impl Default for FakeDrainOps {
+        fn default() -> Self {
+            Self {
+                events: Vec::new(),
+                active: true,
+                write_error: false,
+                reload_error: false,
+                restart_policy: "no".to_string(),
+                signal_outcome: ServiceSignalOutcome::Sent { pid: 123 },
+                disable_error: false,
+            }
+        }
+    }
+
+    fn fake_error(message: &str) -> RunnerError {
+        RunnerError::Internal(message.to_string())
+    }
+
+    impl ServiceDrainOps for FakeDrainOps {
+        fn is_active<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, bool> {
+            self.events.push("is_active");
+            Box::pin(std::future::ready(Ok(self.active)))
+        }
+
+        fn write_restart_override(&mut self, _unit: &RunnerServiceUnit) -> RunnerResult<()> {
+            self.events.push("write_restart_override");
+            if self.write_error {
+                Err(fake_error("write failed"))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn daemon_reload(&mut self) -> ServiceFuture<'_, ()> {
+            self.events.push("daemon_reload");
+            Box::pin(std::future::ready(if self.reload_error {
+                Err(fake_error("reload failed"))
+            } else {
+                Ok(())
+            }))
+        }
+
+        fn restart_policy<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, String> {
+            self.events.push("restart_policy");
+            Box::pin(std::future::ready(Ok(self.restart_policy.clone())))
+        }
+
+        fn signal_drain<'a>(
+            &'a mut self,
+            _unit: &'a RunnerServiceUnit,
+        ) -> ServiceFuture<'a, ServiceSignalOutcome> {
+            self.events.push("signal_drain");
+            Box::pin(std::future::ready(Ok(self.signal_outcome)))
+        }
+
+        fn disable<'a>(&'a mut self, _unit: &'a RunnerServiceUnit) -> ServiceFuture<'a, ()> {
+            self.events.push("disable");
+            Box::pin(std::future::ready(if self.disable_error {
+                Err(fake_error("disable failed"))
+            } else {
+                Ok(())
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_active_service_disables_restart_before_signal() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps::default();
+
+        drain_with_ops(&unit, &mut ops).await.unwrap();
+
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "restart_policy",
+                "signal_drain",
+                "disable",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_inactive_service_skips_restart_override_and_signal() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            active: false,
+            ..FakeDrainOps::default()
+        };
+
+        drain_with_ops(&unit, &mut ops).await.unwrap();
+
+        assert_eq!(ops.events, ["is_active", "disable"]);
+    }
+
+    #[tokio::test]
+    async fn drain_write_failure_aborts_before_signal() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            write_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(err.to_string().contains("write failed"));
+        assert_eq!(ops.events, ["is_active", "write_restart_override"]);
+    }
+
+    #[tokio::test]
+    async fn drain_daemon_reload_failure_aborts_before_signal() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            reload_error: true,
+            ..FakeDrainOps::default()
+        };
+
+        let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(err.to_string().contains("reload failed"));
+        assert_eq!(
+            ops.events,
+            ["is_active", "write_restart_override", "daemon_reload"]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_restart_policy_mismatch_aborts_before_signal() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            restart_policy: "on-failure".to_string(),
+            ..FakeDrainOps::default()
+        };
+
+        let err = drain_with_ops(&unit, &mut ops).await.unwrap_err();
+
+        assert!(err.to_string().contains("Restart=\"on-failure\""));
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "restart_policy",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_already_gone_still_disables_unit() {
+        let unit = service_unit();
+        let mut ops = FakeDrainOps {
+            signal_outcome: ServiceSignalOutcome::AlreadyGone,
+            ..FakeDrainOps::default()
+        };
+
+        drain_with_ops(&unit, &mut ops).await.unwrap();
+
+        assert_eq!(
+            ops.events,
+            [
+                "is_active",
+                "write_restart_override",
+                "daemon_reload",
+                "restart_policy",
+                "signal_drain",
+                "disable",
+            ]
+        );
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -178,16 +178,6 @@ fn systemd_run_limit_nofile_property_arg() -> String {
     format!("--property={RUNNER_SERVICE_NOFILE_LIMIT_DIRECTIVE}")
 }
 
-async fn reload_systemd_if_drain_restart_override_removed(
-    unit: &RunnerServiceUnit,
-) -> RunnerResult<bool> {
-    if remove_drain_restart_override(unit)? {
-        run_systemctl(&["daemon-reload"]).await?;
-        return Ok(true);
-    }
-    Ok(false)
-}
-
 fn ensure_drain_restart_policy_applied(
     unit: &RunnerServiceUnit,
     restart_policy: &str,
@@ -281,6 +271,59 @@ impl ServiceResumeOps for RealServiceResumeOps {
     ) -> ServiceFuture<'a, ServiceSignalOutcome> {
         Box::pin(async move { signal_service_main(unit, nix::sys::signal::Signal::SIGUSR2).await })
     }
+}
+
+fn drain_override_cleanup_reload_error(
+    unit: &RunnerServiceUnit,
+    reload_error: RunnerError,
+    restore_error: RunnerError,
+) -> RunnerError {
+    RunnerError::Internal(format!(
+        "failed to reload systemd after removing drain restart override for {}: {reload_error}; additionally failed to restore drain restart override: {restore_error}",
+        unit.unit_name()
+    ))
+}
+
+async fn restore_drain_restart_override_after_failed_cleanup(
+    unit: &RunnerServiceUnit,
+    context: &str,
+) -> RunnerResult<()> {
+    if let Err(e) = write_drain_restart_override(unit) {
+        return Err(RunnerError::Internal(format!(
+            "failed to restore drain restart override for {} after cleanup reload failure ({context}): {e}",
+            unit.unit_name()
+        )));
+    }
+    if let Err(e) = run_systemctl(&["daemon-reload"]).await {
+        return Err(RunnerError::Internal(format!(
+            "failed to reload systemd after restoring drain restart override for {} ({context}): {e}",
+            unit.unit_name()
+        )));
+    }
+    Ok(())
+}
+
+async fn reload_systemd_if_drain_restart_override_removed(
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<bool> {
+    if !remove_drain_restart_override(unit)? {
+        return Ok(false);
+    }
+
+    if let Err(reload_error) = run_systemctl(&["daemon-reload"]).await {
+        if let Err(restore_error) =
+            restore_drain_restart_override_after_failed_cleanup(unit, "remove_reload").await
+        {
+            return Err(drain_override_cleanup_reload_error(
+                unit,
+                reload_error,
+                restore_error,
+            ));
+        }
+        return Err(reload_error);
+    }
+
+    Ok(true)
 }
 
 async fn rollback_drain_restart_override(
@@ -721,16 +764,16 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
                 &args.env,
                 args.local,
             );
-            cleanup_unit_staging_files(&upath)?;
-            write_unit_file(&upath, &unit_content)?;
             if is_unit_active(&unit_for_activation).await? {
                 warn!(
                     unit = %unit_for_activation.unit_name(),
                     "skipping drain restart override cleanup while service is active"
                 );
             } else {
-                remove_drain_restart_override(&unit_for_activation)?;
+                reload_systemd_if_drain_restart_override_removed(&unit_for_activation).await?;
             }
+            cleanup_unit_staging_files(&upath)?;
+            write_unit_file(&upath, &unit_content)?;
 
             run_systemctl(&["daemon-reload"]).await?;
             run_systemctl(&["enable", "--now", unit_for_activation.service_name()]).await?;
@@ -745,7 +788,8 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
 
 /// Stop + disable + remove the unit file for the given service unit.
 ///
-/// Best-effort: does not fail if the service is already stopped or missing.
+/// Best-effort for already-stopped or missing services, but refuses to remove
+/// unit files when `systemctl stop` fails and the service still appears active.
 ///
 /// Callers that can race with install/uninstall/GC must hold the service lock.
 pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerResult<()> {
@@ -754,6 +798,25 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
     if let Err(e) = &stop_result {
         warn!(unit = %unit.unit_name(), error = %e, "failed to stop service during uninstall");
     }
+    match stop_result {
+        Ok(()) => {}
+        Err(_) => match is_unit_active(unit).await {
+            Ok(false) => {}
+            Ok(true) => {
+                return Err(RunnerError::Internal(format!(
+                    "failed to stop active service {}; refusing to remove unit files",
+                    unit.unit_name()
+                )));
+            }
+            Err(e) => {
+                return Err(RunnerError::Internal(format!(
+                    "failed to stop service {} and could not verify it is inactive; refusing to remove unit files: {e}",
+                    unit.unit_name()
+                )));
+            }
+        },
+    };
+
     let _ = run_systemctl(&["disable", unit.service_name()]).await;
 
     // Remove the unit file if it exists.
@@ -764,29 +827,21 @@ pub(crate) async fn uninstall_service_unit(unit: &RunnerServiceUnit) -> RunnerRe
     if let Err(e) = remove_unit_file_if_exists(upath) {
         warn!(unit = %unit.unit_name(), error = %e, "failed to remove unit file");
     }
-    let should_remove_drain_override = match stop_result {
-        Ok(()) => true,
-        Err(_) => match is_unit_active(unit).await {
-            Ok(false) => true,
-            Ok(true) => {
-                warn!(
-                    unit = %unit.unit_name(),
-                    "skipping drain restart override cleanup because service is still active after failed stop"
-                );
-                false
-            }
-            Err(e) => {
-                warn!(
-                    unit = %unit.unit_name(),
-                    error = %e,
-                    "skipping drain restart override cleanup because service activity could not be verified after failed stop"
-                );
-                false
-            }
-        },
+    let drain_override_cleanup_reloaded = match reload_systemd_if_drain_restart_override_removed(
+        unit,
+    )
+    .await
+    {
+        Ok(removed) => removed,
+        Err(e) => {
+            warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override");
+            false
+        }
     };
-    if should_remove_drain_override && let Err(e) = remove_drain_restart_override(unit) {
-        warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override");
+
+    if drain_override_cleanup_reloaded {
+        info!(unit = %unit.unit_name(), "service uninstalled");
+        return Ok(());
     }
 
     if let Err(e) = run_systemctl(&["daemon-reload"]).await {

--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -456,6 +456,9 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
 /// See [`check_active_jobs_gate`] for the policy.
 async fn stop(args: ServiceStopArgs) -> RunnerResult<()> {
     let unit = RunnerServiceUnit::from_suffix(&args.name)?;
+    let home = HomePaths::new()?;
+    let _service_lock = acquire_service_lock(&unit, &home).await?;
+
     check_active_jobs_gate(&unit, args.force, "stop").await?;
     let svc = unit.service_name();
 
@@ -475,6 +478,13 @@ async fn stop(args: ServiceStopArgs) -> RunnerResult<()> {
     // Clear "failed" latch so systemd fully unloads the transient unit.
     // (stop alone does not clear the failed state.)
     let _ = run_systemctl(&["reset-failed", svc]).await;
+    if let Err(e) = reload_systemd_if_drain_restart_override_removed(&unit).await {
+        warn!(unit = %unit.unit_name(), error = %e, "failed to remove drain restart override after stop");
+        eprintln!(
+            "WARNING: stop could not remove the drain restart override for {}: {e}.",
+            unit.service_name()
+        );
+    }
     Ok(())
 }
 

--- a/crates/runner/src/cmd/service/signal.rs
+++ b/crates/runner/src/cmd/service/signal.rs
@@ -21,6 +21,7 @@ use super::target::RunnerServiceUnit;
 /// the runner is no longer around to receive it. `Sent` carries the PID
 /// so callers can keep the pre-refactor `info!(…, pid, …)` structured
 /// field in their journald logs.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ServiceSignalOutcome {
     Sent { pid: u32 },
     AlreadyGone,

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -71,6 +71,21 @@ pub(super) async fn get_service_pid(unit: &RunnerServiceUnit) -> RunnerResult<Op
     service_pid_from_systemctl_show(svc, &properties, &output.status, &values, &output.stderr)
 }
 
+/// Get the effective systemd Restart policy of a service unit.
+pub(super) async fn get_service_restart_policy(unit: &RunnerServiceUnit) -> RunnerResult<String> {
+    let svc = unit.service_name();
+    let properties = ["Restart"];
+    let output = run_systemctl_show(svc, &properties).await?;
+    let values = parse_systemctl_show_output(svc, &properties, &output)?;
+    service_restart_policy_from_systemctl_show(
+        svc,
+        &properties,
+        &output.status,
+        &values,
+        &output.stderr,
+    )
+}
+
 async fn run_systemctl_show(svc: &str, properties: &[&str]) -> RunnerResult<Output> {
     let mut cmd = tokio::process::Command::new("systemctl");
     cmd.args(["show", svc]);
@@ -218,6 +233,18 @@ fn parse_main_pid(svc: &str, value: &str) -> RunnerResult<Option<u32>> {
         ))
     })?;
     if pid == 0 { Ok(None) } else { Ok(Some(pid)) }
+}
+
+fn service_restart_policy_from_systemctl_show(
+    svc: &str,
+    properties: &[&str],
+    status: &ExitStatus,
+    values: &BTreeMap<String, String>,
+    stderr: &[u8],
+) -> RunnerResult<String> {
+    let restart = required_systemctl_property(svc, values, "Restart")?.to_string();
+    ensure_systemctl_show_status(svc, properties, status, stderr, false)?;
+    Ok(restart)
 }
 
 fn unit_enabled_from_systemctl_is_enabled(
@@ -688,6 +715,84 @@ mod tests {
             .unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn service_restart_policy_from_systemctl_show_returns_restart_value() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["Restart"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"Restart=no\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0);
+
+        assert_eq!(
+            service_restart_policy_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"",
+            )
+            .unwrap(),
+            "no"
+        );
+    }
+
+    #[test]
+    fn service_restart_policy_from_systemctl_show_exposes_non_no_policy() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["Restart"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"Restart=on-failure\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0);
+
+        assert_eq!(
+            service_restart_policy_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"",
+            )
+            .unwrap(),
+            "on-failure"
+        );
+    }
+
+    #[test]
+    fn service_restart_policy_from_systemctl_show_rejects_failed_status() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["Restart"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"Restart=no\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+        let err = service_restart_policy_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"Failed to connect to bus\n",
+        )
+        .unwrap_err();
+        let message = err.to_string();
+
+        assert!(message.contains("systemctl show vm0-runner-test.service --property=Restart"));
+        assert!(message.contains("Failed to connect to bus"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a runtime systemd drop-in that forces runner services to use Restart=no before drain sends SIGUSR1
- verify the effective Restart policy before signaling so systemd cannot restart a drained runner after a MainPID exit
- clean the vm0-owned drain drop-in on resume/start/install/uninstall paths and cover the sequencing with tests

Fixes #20483

## Tests
- cargo fmt --manifest-path crates/Cargo.toml --all
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::service
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings
- cargo test --manifest-path crates/Cargo.toml -p runner --bin runner
- git diff --cached --check