### PR TITLE
fix: fit artifact image previews to viewport

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -589,6 +589,48 @@ function mockIntersectionObserver(): { triggerAll: () => void } {
   };
 }
 
+function mockElementBox(
+  element: HTMLElement,
+  { height, width }: { height: number; width: number },
+) {
+  Object.defineProperties(element, {
+    clientHeight: {
+      configurable: true,
+      value: height,
+    },
+    clientWidth: {
+      configurable: true,
+      value: width,
+    },
+    offsetHeight: {
+      configurable: true,
+      value: height,
+    },
+    offsetWidth: {
+      configurable: true,
+      value: width,
+    },
+  });
+  Object.defineProperty(element, "getBoundingClientRect", {
+    configurable: true,
+    value: () => {
+      return {
+        bottom: height,
+        height,
+        left: 0,
+        right: width,
+        toJSON: () => {
+          return {};
+        },
+        top: 0,
+        width,
+        x: 0,
+        y: 0,
+      };
+    },
+  });
+}
+
 describe("zero artifact sidebar", () => {
   it("opens document previews from chat, moves them into split view, and closes the pane", async () => {
     const user = userEvent.setup({ delay: null });
@@ -1427,6 +1469,52 @@ describe("zero artifact sidebar", () => {
         "alt",
         "first.png",
       );
+    });
+  });
+
+  it("fits tall image artifacts inside the preview when opened", async () => {
+    const posterUrl =
+      "https://cdn.vm7.io/artifacts/test/sidebar-fit-tall-image/poster.png";
+    setupChatThread({
+      artifactFiles: [
+        artifactFile(posterUrl, {
+          id: "artifact-sidebar-tall-image",
+          filename: "poster.png",
+          contentType: "image/png",
+          size: 2048,
+        }),
+      ],
+      content: "Image artifact is ready.",
+      path: `${THREAD_PATH}?artifact=${encodeURIComponent(posterUrl)}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveAttribute(
+        "alt",
+        "poster.png",
+      );
+    });
+
+    const zoomStage = screen.getByTestId("zoomable-image-canvas");
+    const image = screen.getByTestId("artifact-sidebar-body-image");
+    mockElementBox(zoomStage, { height: 600, width: 800 });
+    Object.defineProperties(image, {
+      naturalHeight: {
+        configurable: true,
+        value: 3200,
+      },
+      naturalWidth: {
+        configurable: true,
+        value: 1600,
+      },
+    });
+    fireEvent.load(image);
+
+    await waitFor(() => {
+      expect(image).toHaveStyle({ width: "300px" });
+      expect(
+        screen.getByTestId("artifact-sidebar-image-zoom-level"),
+      ).toHaveTextContent("100%");
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-zoomable-image-canvas.tsx
@@ -98,7 +98,12 @@ function controlsFromTransformState({
   };
 }
 
-function calculateImageFitWidth(image: HTMLImageElement) {
+function cssPixelValue(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function calculateImageFitWidth(image: HTMLImageElement): number | null {
   const content = image.parentElement;
   const scrollContainer = image.closest<HTMLElement>(
     "[data-zoomable-image-canvas='true']",
@@ -108,13 +113,23 @@ function calculateImageFitWidth(image: HTMLImageElement) {
   }
 
   const contentStyle = getComputedStyle(content);
-  const paddingLeft = Number.parseFloat(contentStyle.paddingLeft);
-  const paddingRight = Number.parseFloat(contentStyle.paddingRight);
-  const horizontalPadding =
-    (Number.isFinite(paddingLeft) ? paddingLeft : 0) +
-    (Number.isFinite(paddingRight) ? paddingRight : 0);
+  const paddingLeft = cssPixelValue(contentStyle.paddingLeft);
+  const paddingRight = cssPixelValue(contentStyle.paddingRight);
+  const paddingTop = cssPixelValue(contentStyle.paddingTop);
+  const paddingBottom = cssPixelValue(contentStyle.paddingBottom);
+  const horizontalPadding = paddingLeft + paddingRight;
+  const verticalPadding = paddingTop + paddingBottom;
   const availableWidth = scrollContainer.clientWidth - horizontalPadding;
+  const availableHeight = scrollContainer.clientHeight - verticalPadding;
   const naturalWidth = image.naturalWidth;
+  const naturalHeight = image.naturalHeight;
+
+  if (naturalWidth > 0 && naturalHeight > 0) {
+    const widthScale = availableWidth > 0 ? availableWidth / naturalWidth : 1;
+    const heightScale =
+      availableHeight > 0 ? availableHeight / naturalHeight : 1;
+    return naturalWidth * Math.min(1, widthScale, heightScale);
+  }
 
   if (naturalWidth > 0 && availableWidth > 0) {
     return Math.min(naturalWidth, availableWidth);


### PR DESCRIPTION
## Summary
- Fit zoomable artifact images against both preview width and height on load.
- Keep the zoom level at 100% while shrinking the rendered image dimensions so tall images open fully visible.
- Add a page-level artifact sidebar test for a tall image opened from an artifact deep link.

## Root cause
The initial image fit calculation only constrained by available width, so tall images could open at a width that made their height overflow the preview area.

## Validation
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types