### PR TITLE
fix: match private agents empty state to the canonical workflow card style

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -236,17 +236,13 @@ function AgentTabsView({
           showCreator={activeTab !== "private"}
         />
       ) : activeTab === "private" ? (
-        <PrivateEmptyState
-          onCreate={() => {
-            return onCreate("private");
-          }}
-        />
+        <PrivateEmptyState />
       ) : null}
     </div>
   );
 }
 
-function PrivateEmptyState({ onCreate }: { onCreate: () => void }) {
+function PrivateEmptyState() {
   return (
     <div className="zero-card flex min-h-[20rem] flex-col items-center justify-center px-6 text-center">
       <img
@@ -261,14 +257,6 @@ function PrivateEmptyState({ onCreate }: { onCreate: () => void }) {
       <p className="mt-1 max-w-[340px] text-sm text-muted-foreground">
         Create an agent only you can see and use. Private agents are unlimited.
       </p>
-      <Button
-        variant="outline"
-        size="sm"
-        className="zero-btn-morandi mt-4 h-8 rounded-lg border"
-        onClick={onCreate}
-      >
-        Create agent
-      </Button>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page-tabs.tsx
@@ -248,17 +248,17 @@ function AgentTabsView({
 
 function PrivateEmptyState({ onCreate }: { onCreate: () => void }) {
   return (
-    <div className="flex flex-col items-center gap-1.5 py-14 text-center">
+    <div className="zero-card flex min-h-[20rem] flex-col items-center justify-center px-6 text-center">
       <img
         src={platformEmptyPrivateAgentsImg}
         alt=""
         aria-hidden="true"
-        className="mb-2 h-40 w-40 object-contain"
+        className="h-24 w-24 object-contain opacity-80"
       />
-      <p className="text-base font-semibold text-foreground">
+      <p className="mt-3 text-sm font-medium text-foreground">
         No private agents yet
       </p>
-      <p className="max-w-[340px] text-sm text-muted-foreground">
+      <p className="mt-1 max-w-[340px] text-sm text-muted-foreground">
         Create an agent only you can see and use. Private agents are unlimited.
       </p>
       <Button


### PR DESCRIPTION
## What & why

The **private agents** empty state (`No private agents yet`) didn't match the empty-state card used everywhere else in the platform (workflows list, workflow-detail automations, lab, memory). Ming flagged two inconsistencies: the outer container + illustration size, and the CTA treatment.

Root causes:
1. `PrivateEmptyState` was a bare centered `py-14` block — no card frame — with an oversized 160px illustration and a larger title, while the canonical empty state is a bordered `zero-card` with a 96px illustration.
2. It was the only empty state in the app with an **in-card CTA button** ("Create agent"), which was also **redundant** with the page header's "New agent" button (on the Private tab both call `onCreate("private")`). Every other empty state keeps its CTA in the page header only.

## Changes (`agents-page-tabs.tsx` → `PrivateEmptyState`)

- **Container**: bare `py-14` block → `zero-card flex min-h-[20rem] flex-col items-center justify-center px-6` — adds the card border/radius/surface and matches the workflows card height + vertical centering.
- **Illustration**: `h-40 w-40` (160px) → `h-24 w-24` (96px) + `opacity-80`, identical to the workflows empty state.
- **Title**: `text-base font-semibold` → `mt-3 text-sm font-medium`.
- **Description**: added `mt-1` for consistent spacing.
- **CTA**: removed the redundant in-card "Create agent" button (and its now-unused `onCreate` prop). Creating a private agent is still one click away via the header "New agent" button, mirroring the workflows page whose only CTA is the header "Create in chat".

## User-visible impact

The private-agents empty state now renders inside the same bordered card, at the same size and typography, as every other empty state — and no longer shows a duplicate CTA. Only the illustration artwork (plant vs puzzle) differs.

## Verification

Walked through the real per-PR preview (`pr-20511-app.vm6.ai`, HEAD): the Agents · Private empty state now matches the Workflows empty state on container, height, 96px illustration, and typography. `Button` and `onCreate` remain used by the header button (no unused imports/vars). The existing `agents-page-tabs.test.tsx` asserts only the copy (`No private agents yet`), which is unchanged. Relying on the PR pipeline for lint/type/test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
