### PR TITLE
fix: defer settings dialog from account menu

### DIFF
--- a/turbo/apps/platform/src/lib/force-upgrade.ts
+++ b/turbo/apps/platform/src/lib/force-upgrade.ts
@@ -12,7 +12,7 @@ type ForceUpgradeResponse = {
   forceUpgrade?: unknown;
 };
 
-export type ForceUpgradeCheckOptions = {
+type ForceUpgradeCheckOptions = {
   apiBase?: string;
   fetcher?: ForceUpgradeFetch;
   version?: string | null;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
@@ -5,7 +5,7 @@ export interface ChatThreadEmojiItem {
   name: string;
 }
 
-export interface ChatThreadEmojiGroup {
+interface ChatThreadEmojiGroup {
   name: string;
   emojis: ChatThreadEmojiItem[];
 }

--- a/turbo/apps/platform/src/signals/force-upgrade.ts
+++ b/turbo/apps/platform/src/signals/force-upgrade.ts
@@ -9,7 +9,7 @@ const forceUpgradeDialogOpenState$ = state(false);
 
 export const forceUpgradeDialogOpen$ = forceUpgradeDialogOpenState$;
 
-export type ForceUpgradePollOptions = {
+type ForceUpgradePollOptions = {
   readonly check: () => Promise<boolean>;
   readonly onRequired: () => void;
   readonly pollIntervalMs?: number;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -610,6 +610,16 @@ describe("zero sidebar account menu", () => {
     await waitFor(() => {
       expect(screen.getByText("Disabled")).toBeInTheDocument();
     });
+
+    const dialog = screen.getByRole("dialog", { name: "Settings" });
+    click(within(dialog).getByLabelText("Close"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Settings" }),
+      ).not.toBeInTheDocument();
+      expect(document.body.style.pointerEvents).not.toBe("none");
+    });
   });
 
   it("shows account switching, add-account, and sign-out actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -57,6 +57,7 @@ import {
   setAccountMenuCodexResetDialog$,
 } from "../../signals/zero-page/settings/personal-model-providers.ts";
 import { CodexResetUsageDialog } from "./components/preferences/codex-reset-usage-dialog.tsx";
+import { runAfterDropdownMenuClose } from "../components/dropdown-menu-modal-action.ts";
 import {
   AccountMenuSubscriptionsPanel,
   useSubscriptionUsageRows,
@@ -662,16 +663,22 @@ export function AccountDropdown({
 
   const handleOpenSettings = () => {
     setSidebarExpanded(false);
-    detach(openSettings("preference", pageSignal), Reason.DomCallback);
+    runAfterDropdownMenuClose(() => {
+      detach(openSettings("preference", pageSignal), Reason.DomCallback);
+    });
   };
 
   const handleOpenCreditBalance = () => {
     setSidebarExpanded(false);
-    detach(openSettings("usage", pageSignal), Reason.DomCallback);
+    runAfterDropdownMenuClose(() => {
+      detach(openSettings("usage", pageSignal), Reason.DomCallback);
+    });
   };
 
   const handleOpenCodexReset = (resetCredits: number | null) => {
-    setResetDialog({ open: true, resetCredits });
+    runAfterDropdownMenuClose(() => {
+      setResetDialog({ open: true, resetCredits });
+    });
   };
 
   const handleConfirmCodexReset = () => {


### PR DESCRIPTION
## Summary
- defer account-menu modal launches until after the Radix dropdown finishes closing
- cover the Settings close path so body pointer events are not left disabled
- clean up unused internal type exports that blocked knip on latest main

## Tests
- pnpm -C turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
- pnpm -C turbo -F @vm0/app check-types
- pnpm -C turbo -F @vm0/app lint
- pnpm -C turbo knip --cache

## Notes
- Ran pnpm -C turbo install to sync the local workspace dependency set after pulling main; no tracked install output changed.