### PR TITLE
feat: simplify lab maintainer filter toolbar

### DIFF
--- a/turbo/apps/platform/src/signals/lab-page/lab-page-ui.ts
+++ b/turbo/apps/platform/src/signals/lab-page/lab-page-ui.ts
@@ -1,23 +1,13 @@
 import { command, computed, state } from "ccstate";
 
-export type LabSort = "name" | "maintainer" | "enabled";
 export const LAB_ALL_MAINTAINERS = "__all__";
 export type LabMaintainerFilter = string;
 
-const internalLabSort$ = state<LabSort>("name");
 const internalLabMaintainerFilter$ =
   state<LabMaintainerFilter>(LAB_ALL_MAINTAINERS);
 
-export const labSort$ = computed((get): LabSort => {
-  return get(internalLabSort$);
-});
-
 export const labMaintainerFilter$ = computed((get): LabMaintainerFilter => {
   return get(internalLabMaintainerFilter$);
-});
-
-export const setLabSort$ = command(({ set }, sort: LabSort) => {
-  set(internalLabSort$, sort);
 });
 
 export const setLabMaintainerFilter$ = command(

--- a/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
+++ b/turbo/apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
@@ -104,7 +104,7 @@ describe("lab page", () => {
     });
   });
 
-  it("sorts feature switches by maintainer", async () => {
+  it("shows feature switches in name order without sort controls", async () => {
     context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
       return respond(200, { switches: {}, effectiveSwitches: {} });
     });
@@ -120,15 +120,9 @@ describe("lab page", () => {
       featureSwitchRow(FeatureSwitchKey.ApiKeys),
     );
 
-    click(screen.getByRole("combobox", { name: "Sort features" }));
-    click(await screen.findByRole("option", { name: "Maintainer" }));
-
-    await waitFor(() => {
-      expectBefore(
-        featureSwitchRow(FeatureSwitchKey.ApiKeys),
-        featureSwitchRow(FeatureSwitchKey.AgentsPageRedesign),
-      );
-    });
+    expect(
+      screen.queryByRole("combobox", { name: "Sort features" }),
+    ).not.toBeInTheDocument();
   });
 
   it("filters feature switches by maintainer", async () => {

--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -6,16 +6,7 @@ import {
   type FeatureSwitchMetadata,
 } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import {
-  Switch,
-  Button,
-  cn,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@vm0/ui";
+import { Switch, Button, cn } from "@vm0/ui";
 import {
   featureSwitch$,
   setFeatureSwitch$,
@@ -26,11 +17,8 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   LAB_ALL_MAINTAINERS,
   labMaintainerFilter$,
-  labSort$,
   setLabMaintainerFilter$,
-  setLabSort$,
   type LabMaintainerFilter,
-  type LabSort,
 } from "../../signals/lab-page/lab-page-ui.ts";
 
 type FeatureSwitchStates = Record<FeatureSwitchKey, boolean> | undefined;
@@ -38,12 +26,6 @@ type FeatureSwitchMetadataByKey = Record<
   FeatureSwitchKey,
   FeatureSwitchMetadata
 >;
-
-const SORT_OPTIONS: readonly { value: LabSort; label: string }[] = [
-  { value: "name", label: "Name" },
-  { value: "maintainer", label: "Maintainer" },
-  { value: "enabled", label: "Enabled first" },
-];
 
 interface MaintainerFilterOption {
   readonly value: LabMaintainerFilter;
@@ -55,42 +37,8 @@ function compareByName(a: FeatureSwitchKey, b: FeatureSwitchKey): number {
   return a.localeCompare(b, undefined, { sensitivity: "base" });
 }
 
-function compareFeatureSwitches(params: {
-  readonly a: FeatureSwitchKey;
-  readonly b: FeatureSwitchKey;
-  readonly sort: LabSort;
-  readonly features: FeatureSwitchStates;
-  readonly metadata: FeatureSwitchMetadataByKey;
-}): number {
-  const { a, b, sort, features, metadata } = params;
-  if (sort === "enabled") {
-    const enabledComparison =
-      Number(features?.[b] ?? false) - Number(features?.[a] ?? false);
-    if (enabledComparison !== 0) {
-      return enabledComparison;
-    }
-  }
-  if (sort === "maintainer") {
-    const maintainerComparison = metadata[a].maintainer.localeCompare(
-      metadata[b].maintainer,
-      undefined,
-      { sensitivity: "base" },
-    );
-    if (maintainerComparison !== 0) {
-      return maintainerComparison;
-    }
-  }
-  return compareByName(a, b);
-}
-
-function sortedFeatureSwitchKeys(params: {
-  readonly sort: LabSort;
-  readonly features: FeatureSwitchStates;
-  readonly metadata: FeatureSwitchMetadataByKey;
-}): FeatureSwitchKey[] {
-  return [...getUserOverridableFeatureSwitchKeys()].sort((a, b) => {
-    return compareFeatureSwitches({ a, b, ...params });
-  });
+function sortedFeatureSwitchKeys(): FeatureSwitchKey[] {
+  return [...getUserOverridableFeatureSwitchKeys()].sort(compareByName);
 }
 
 function maintainerLabel(email: string): string {
@@ -196,13 +144,11 @@ function MaintainerFilterPills(props: {
 }
 
 function LabFilterBar(props: {
-  readonly sort: LabSort;
   readonly maintainerFilter: LabMaintainerFilter;
   readonly maintainerOptions: readonly MaintainerFilterOption[];
   readonly totalCount: number;
   readonly busy: boolean;
   readonly resetting: boolean;
-  readonly onSortChange: (sort: LabSort) => void;
   readonly onMaintainerFilterChange: (filter: LabMaintainerFilter) => void;
   readonly onReset: () => void;
 }) {
@@ -215,28 +161,6 @@ function LabFilterBar(props: {
         onChange={props.onMaintainerFilterChange}
       />
       <div className="ml-auto flex items-center gap-1.5">
-        <Select
-          value={props.sort}
-          onValueChange={(value) => {
-            props.onSortChange(value as LabSort);
-          }}
-        >
-          <SelectTrigger
-            aria-label="Sort features"
-            className="zero-btn-morandi h-9 w-[160px] gap-1.5 rounded-lg px-3.5 text-sm font-medium"
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {SORT_OPTIONS.map((option) => {
-              return (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              );
-            })}
-          </SelectContent>
-        </Select>
         <Button
           variant="outline"
           size="sm"
@@ -314,16 +238,14 @@ export function LabPage() {
   const features = useLastResolved(featureSwitch$);
   const [toggleLoadable, setFeature] = useLoadableSet(setFeatureSwitch$);
   const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitches$);
-  const sort = useGet(labSort$);
   const maintainerFilter = useGet(labMaintainerFilter$);
-  const setSort = useSet(setLabSort$);
   const setMaintainerFilter = useSet(setLabMaintainerFilter$);
   const resetting = resetLoadable.state === "loading";
   const toggling = toggleLoadable.state === "loading";
   const busy = resetting || toggling;
   const pageSignal = useGet(pageSignal$);
   const metadata = getFeatureSwitchMetadata();
-  const sorted = sortedFeatureSwitchKeys({ sort, features, metadata });
+  const sorted = sortedFeatureSwitchKeys();
   const allKeys = getUserOverridableFeatureSwitchKeys();
   const maintainerOptions = maintainerFilterOptions({
     keys: allKeys,
@@ -360,13 +282,11 @@ export function LabPage() {
       <div className="flex-1 overflow-y-auto px-4 sm:px-6 pb-10">
         <div className="mx-auto max-w-[900px] space-y-4">
           <LabFilterBar
-            sort={sort}
             maintainerFilter={maintainerFilter}
             maintainerOptions={maintainerOptions}
             totalCount={allKeys.length}
             busy={busy}
             resetting={resetting}
-            onSortChange={setSort}
             onMaintainerFilterChange={setMaintainerFilter}
             onReset={handleReset}
           />


### PR DESCRIPTION
Summary:
- Remove the Lab sort dropdown so maintainer filter pills and Reset all can stay on one toolbar row.
- Keep feature switches in the existing default name order instead of exposing sort state.
- Update Lab page tests to assert name ordering, maintainer filtering, and absence of the sort combobox.

Verification:
- pnpm exec prettier --write apps/platform/src/signals/lab-page/lab-page-ui.ts apps/platform/src/views/lab-page/lab-page.tsx apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
- pnpm exec vitest run apps/platform/src/views/lab-page/__tests__/lab-page.test.tsx
- NODE_OPTIONS=--max-old-space-size=6144 pnpm -F @vm0/app check-types

Notes:
- Local pre-commit hook was installed and attempted. Its full turbo check-types step exceeded the hook timeout; a hook-external full check-types attempt then passed @vm0/app and was later killed in unrelated api#check-types with exit 137. The PR pipeline should run the authoritative full checks.