### PR TITLE
feat: serve web client compatibility from api

### DIFF
--- a/turbo/apps/api/src/lib/web-client-compatibility.json
+++ b/turbo/apps/api/src/lib/web-client-compatibility.json
@@ -1,0 +1,3 @@
+{
+  "minimumSupportedVersion": "0.0.0"
+}

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -1,5 +1,6 @@
 import { buildInfoContract } from "@vm0/api-contracts/contracts/build-info";
 import { healthContract } from "@vm0/api-contracts/contracts/health";
+import { webClientCompatibilityContract } from "@vm0/api-contracts/contracts/web-client-compatibility";
 
 import { agentCheckpointsRoutes } from "./routes/agent-checkpoints-id";
 import { agentComposesByIdRoutes } from "./routes/agent-composes-id";
@@ -40,6 +41,7 @@ import { desktopUpdateRoutes } from "./routes/desktop-updates";
 import { emailUnsubscribeRoutes } from "./routes/email-unsubscribe";
 import { apiHealth$ } from "./routes/health";
 import { apiBuildInfo$ } from "./routes/build-info";
+import { webClientCompatibility$ } from "./routes/web-client-compatibility";
 import { healthAuthProbeRoutes } from "./routes/health-auth-probe";
 import { githubOauthRoutes } from "./routes/github-oauth";
 import { legacyFileRoutes } from "./routes/legacy-file";
@@ -221,6 +223,10 @@ export const ROUTES: readonly RouteEntry[] = [
   {
     route: buildInfoContract.get,
     handler: apiBuildInfo$,
+  },
+  {
+    route: webClientCompatibilityContract.get,
+    handler: webClientCompatibility$,
   },
   ...authMeRoutes,
   ...cliAuthRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/web-client-compatibility.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/web-client-compatibility.test.ts
@@ -1,0 +1,35 @@
+import { webClientCompatibilityContract } from "@vm0/api-contracts/contracts/web-client-compatibility";
+import { describe, expect, it } from "vitest";
+
+import { setupAppWithRoutes } from "../../../__tests__/test-app";
+import { accept, testContext } from "../../../__tests__/test-context";
+import { webClientCompatibility$ } from "../web-client-compatibility";
+
+const context = testContext();
+
+function webClientCompatibilityClient() {
+  return setupAppWithRoutes({
+    context,
+    routes: [
+      {
+        route: webClientCompatibilityContract.get,
+        handler: webClientCompatibility$,
+      },
+    ],
+  })(webClientCompatibilityContract);
+}
+
+describe("web client compatibility", () => {
+  it("checks public web client compatibility from repo config", async () => {
+    const response = await accept(
+      webClientCompatibilityClient().get({ query: { version: "0.0.0" } }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      minimumSupportedVersion: "0.0.0",
+      supported: true,
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/turbo/apps/api/src/signals/routes/web-client-compatibility.ts
+++ b/turbo/apps/api/src/signals/routes/web-client-compatibility.ts
@@ -1,0 +1,123 @@
+import { command } from "ccstate";
+import { z } from "zod";
+import {
+  appVersionSchema,
+  webClientCompatibilityContract,
+  type WebClientCompatibilityRouteResponse,
+} from "@vm0/api-contracts/contracts";
+
+import compatibilityConfig from "../../lib/web-client-compatibility.json";
+import { setResHeader$ } from "../context/hono";
+import { queryOf } from "../context/request";
+
+type AppVersion = {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly prerelease: readonly string[];
+};
+
+const APP_VERSION_PATTERN =
+  /^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>[0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/u;
+
+const webClientCompatibilityConfigSchema = z.object({
+  minimumSupportedVersion: appVersionSchema,
+});
+
+const { minimumSupportedVersion } =
+  webClientCompatibilityConfigSchema.parse(compatibilityConfig);
+const webClientCompatibilityQuery$ = queryOf(
+  webClientCompatibilityContract.get,
+);
+
+function parseAppVersion(version: string): AppVersion {
+  const match = APP_VERSION_PATTERN.exec(version);
+  if (!match?.groups) {
+    throw new Error(`Invalid app version: ${version}`);
+  }
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    prerelease: match.groups.prerelease?.split(".") ?? [],
+  };
+}
+
+function compareIdentifiers(left: string, right: string): number {
+  const leftNumeric = /^\d+$/u.test(left);
+  const rightNumeric = /^\d+$/u.test(right);
+
+  if (leftNumeric && rightNumeric) {
+    return Number(left) - Number(right);
+  }
+  if (leftNumeric) {
+    return -1;
+  }
+  if (rightNumeric) {
+    return 1;
+  }
+  return left.localeCompare(right);
+}
+
+function compareAppVersions(left: string, right: string): number {
+  const parsedLeft = parseAppVersion(left);
+  const parsedRight = parseAppVersion(right);
+
+  const releaseComparison =
+    parsedLeft.major - parsedRight.major ||
+    parsedLeft.minor - parsedRight.minor ||
+    parsedLeft.patch - parsedRight.patch;
+  if (releaseComparison !== 0) {
+    return releaseComparison;
+  }
+
+  if (parsedLeft.prerelease.length === 0) {
+    return parsedRight.prerelease.length === 0 ? 0 : 1;
+  }
+  if (parsedRight.prerelease.length === 0) {
+    return -1;
+  }
+
+  const length = Math.max(
+    parsedLeft.prerelease.length,
+    parsedRight.prerelease.length,
+  );
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = parsedLeft.prerelease[index];
+    const rightIdentifier = parsedRight.prerelease[index];
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const comparison = compareIdentifiers(leftIdentifier, rightIdentifier);
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+function isSupportedWebClientVersion(version: string): boolean {
+  return compareAppVersions(version, minimumSupportedVersion) >= 0;
+}
+
+export const webClientCompatibility$ = command(
+  ({ get, set }, _signal: AbortSignal): WebClientCompatibilityRouteResponse => {
+    const query = get(webClientCompatibilityQuery$);
+
+    set(setResHeader$, "Cache-Control", "no-store");
+
+    return {
+      status: 200,
+      body: {
+        minimumSupportedVersion,
+        supported: isSupportedWebClientVersion(query.version),
+      },
+    };
+  },
+);

--- a/turbo/apps/platform/.env.local.tpl
+++ b/turbo/apps/platform/.env.local.tpl
@@ -4,7 +4,6 @@ VITE_CLERK_PUBLISHABLE_KEY=op://Development/clerk/CLERK_PUBLISHABLE_KEY
 VITE_API_URL=http://localhost:3000
 PUBLIC_ARTIFACTS_BASE_URL=https://cdn.vm7.io
 VITE_ZERO_HOST_DOMAIN=sites.vm7.io
-ATOM_URL=https://atom-api.vm7.ai:8442
 
 # Web Push (VAPID public key for push subscription)
 VITE_VAPID_PUBLIC_KEY=op://Development/vapid/VAPID_PUBLIC_KEY

--- a/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
@@ -16,26 +16,26 @@ function jsonResponse(body: unknown, ok = true) {
 }
 
 describe("force upgrade", () => {
-  it("builds the Atom force-upgrade URL with the current version", () => {
-    expect(buildForceUpgradeUrl("0.540.0", "https://atom.example.test/")).toBe(
-      "https://atom.example.test/api/client/force-upgrade?version=0.540.0",
+  it("builds the web client compatibility URL with the current version", () => {
+    expect(buildForceUpgradeUrl("0.540.0", "https://api.example.test/")).toBe(
+      "https://api.example.test/api/client/compatibility?version=0.540.0",
     );
   });
 
-  it("returns true only when Atom explicitly requires a force upgrade", async () => {
+  it("returns true only when the API marks the client unsupported", async () => {
     const fetcher = vi.fn(() => {
-      return Promise.resolve(jsonResponse({ forceUpgrade: true }));
+      return Promise.resolve(jsonResponse({ supported: false }));
     });
 
     await expect(
       shouldForceUpgrade("0.540.0", {
-        apiBase: "https://atom.example.test",
+        apiBase: "https://api.example.test",
         fetcher,
       }),
     ).resolves.toBeTruthy();
 
     expect(fetcher).toHaveBeenCalledWith(
-      "https://atom.example.test/api/client/force-upgrade?version=0.540.0",
+      "https://api.example.test/api/client/compatibility?version=0.540.0",
       {
         cache: "no-store",
         credentials: "omit",
@@ -44,67 +44,24 @@ describe("force upgrade", () => {
     );
   });
 
-  it("uses ATOM_URL when no API base override is provided", async () => {
-    const previousAtomUrl = import.meta.env.ATOM_URL as string | undefined;
-    vi.stubEnv("ATOM_URL", "https://atom.example.test/");
-    const fetcher = vi.fn(() => {
-      return Promise.resolve(jsonResponse({ forceUpgrade: true }));
-    });
-
-    try {
-      await expect(
-        shouldForceUpgrade("0.540.0", { fetcher }),
-      ).resolves.toBeTruthy();
-
-      expect(fetcher).toHaveBeenCalledWith(
-        "https://atom.example.test/api/client/force-upgrade?version=0.540.0",
-        {
-          cache: "no-store",
-          credentials: "omit",
-          method: "GET",
-        },
-      );
-    } finally {
-      vi.stubEnv("ATOM_URL", previousAtomUrl);
-    }
-  });
-
-  it("skips the request when ATOM_URL is not configured", async () => {
-    const previousAtomUrl = import.meta.env.ATOM_URL as string | undefined;
-    vi.stubEnv("ATOM_URL", "");
-    const fetcher = vi.fn(() => {
-      return Promise.resolve(jsonResponse({ forceUpgrade: true }));
-    });
-
-    try {
-      await expect(
-        shouldForceUpgrade("0.540.0", { fetcher }),
-      ).resolves.toBeFalsy();
-
-      expect(fetcher).not.toHaveBeenCalled();
-    } finally {
-      vi.stubEnv("ATOM_URL", previousAtomUrl);
-    }
-  });
-
-  it("returns false when Atom does not require a force upgrade", async () => {
+  it("returns false when the API marks the client supported", async () => {
     await expect(
       checkForceUpgrade({
-        apiBase: "https://atom.example.test",
+        apiBase: "https://api.example.test",
         fetcher: vi.fn(() => {
-          return Promise.resolve(jsonResponse({ forceUpgrade: false }));
+          return Promise.resolve(jsonResponse({ supported: true }));
         }),
         version: "0.540.0",
       }),
     ).resolves.toBeFalsy();
   });
 
-  it("returns true when Atom requires a force upgrade", async () => {
+  it("returns true when the API marks the client unsupported", async () => {
     await expect(
       checkForceUpgrade({
-        apiBase: "https://atom.example.test",
+        apiBase: "https://api.example.test",
         fetcher: vi.fn(() => {
-          return Promise.resolve(jsonResponse({ forceUpgrade: true }));
+          return Promise.resolve(jsonResponse({ supported: false }));
         }),
         version: "0.540.0",
       }),
@@ -114,9 +71,9 @@ describe("force upgrade", () => {
   it("returns false when the response is not OK", async () => {
     await expect(
       checkForceUpgrade({
-        apiBase: "https://atom.example.test",
+        apiBase: "https://api.example.test",
         fetcher: vi.fn(() => {
-          return Promise.resolve(jsonResponse({ forceUpgrade: true }, false));
+          return Promise.resolve(jsonResponse({ supported: false }, false));
         }),
         version: "0.540.0",
       }),
@@ -141,7 +98,7 @@ describe("force upgrade", () => {
   it("returns false when the force-upgrade request fails", async () => {
     await expect(
       checkForceUpgrade({
-        apiBase: "https://atom.example.test",
+        apiBase: "https://api.example.test",
         fetcher: vi.fn(() => {
           return Promise.reject(new Error("network unavailable"));
         }),

--- a/turbo/apps/platform/src/lib/force-upgrade.ts
+++ b/turbo/apps/platform/src/lib/force-upgrade.ts
@@ -1,7 +1,8 @@
 import { getBuildVersion } from "./build-info.ts";
+import { resolveApiBase } from "../signals/api-base.ts";
 import { settle } from "../signals/utils.ts";
 
-const FORCE_UPGRADE_PATH = "api/client/force-upgrade";
+const WEB_CLIENT_COMPATIBILITY_PATH = "api/client/compatibility";
 
 type ForceUpgradeFetch = (
   input: string,
@@ -9,7 +10,7 @@ type ForceUpgradeFetch = (
 ) => Promise<Pick<Response, "json" | "ok">>;
 
 type ForceUpgradeResponse = {
-  forceUpgrade?: unknown;
+  supported?: unknown;
 };
 
 export type ForceUpgradeCheckOptions = {
@@ -30,8 +31,7 @@ function normalizeForceUpgradeApiBase(
 }
 
 function resolveForceUpgradeApiBase(): string | null {
-  const configured = import.meta.env.ATOM_URL as string | undefined;
-  return normalizeForceUpgradeApiBase(configured);
+  return normalizeForceUpgradeApiBase(resolveApiBase());
 }
 
 function isForceUpgradeResponse(value: unknown): value is ForceUpgradeResponse {
@@ -39,7 +39,10 @@ function isForceUpgradeResponse(value: unknown): value is ForceUpgradeResponse {
 }
 
 export function buildForceUpgradeUrl(version: string, apiBase: string): string {
-  const url = new URL(FORCE_UPGRADE_PATH, `${trimTrailingSlash(apiBase)}/`);
+  const url = new URL(
+    WEB_CLIENT_COMPATIBILITY_PATH,
+    `${trimTrailingSlash(apiBase)}/`,
+  );
   url.searchParams.set("version", version);
   return url.toString();
 }
@@ -68,7 +71,7 @@ export async function shouldForceUpgrade(
   }
 
   const body: unknown = await response.json();
-  return isForceUpgradeResponse(body) && body.forceUpgrade === true;
+  return isForceUpgradeResponse(body) && body.supported === false;
 }
 
 export async function checkForceUpgrade(

--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -144,7 +144,7 @@ function devArtifactFetchProxy(): PluginOption {
 
 export default defineConfig({
   base: process.env.VITE_BASE_URL || "/",
-  envPrefix: ["VITE_", "PUBLIC_", "ATOM_URL"],
+  envPrefix: ["VITE_", "PUBLIC_"],
   plugins: [
     tailwindcss(),
     react(),

--- a/turbo/packages/api-contracts/src/contracts/__tests__/web-client-compatibility.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/web-client-compatibility.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  appVersionSchema,
+  webClientCompatibilityContract,
+  webClientCompatibilityQuerySchema,
+  webClientCompatibilityResponseSchema,
+} from "../web-client-compatibility";
+
+describe("web client compatibility contract", () => {
+  it("defines the web client compatibility endpoint", () => {
+    expect(webClientCompatibilityContract.get.method).toBe("GET");
+    expect(webClientCompatibilityContract.get.path).toBe(
+      "/api/client/compatibility",
+    );
+  });
+
+  it("accepts app-style versions", () => {
+    expect(appVersionSchema.parse("1.229.0")).toBe("1.229.0");
+    expect(appVersionSchema.parse("1.229.0-beta.1")).toBe("1.229.0-beta.1");
+    expect(appVersionSchema.parse("1.229.0+build.1")).toBe("1.229.0+build.1");
+  });
+
+  it("rejects malformed app versions", () => {
+    expect(appVersionSchema.safeParse("").success).toBe(false);
+    expect(appVersionSchema.safeParse("v1.229.0").success).toBe(false);
+    expect(appVersionSchema.safeParse("1.229").success).toBe(false);
+  });
+
+  it("validates query and response bodies", () => {
+    expect(
+      webClientCompatibilityQuerySchema.parse({ version: "1.229.0" }),
+    ).toStrictEqual({ version: "1.229.0" });
+    expect(
+      webClientCompatibilityResponseSchema.parse({
+        minimumSupportedVersion: "1.229.0",
+        supported: true,
+      }),
+    ).toStrictEqual({
+      minimumSupportedVersion: "1.229.0",
+      supported: true,
+    });
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -14,6 +14,15 @@ export {
   type BuildInfoRouteResponse,
 } from "./build-info";
 export {
+  appVersionSchema,
+  webClientCompatibilityContract,
+  webClientCompatibilityQuerySchema,
+  webClientCompatibilityResponseSchema,
+  type WebClientCompatibilityContract,
+  type WebClientCompatibilityResponse,
+  type WebClientCompatibilityRouteResponse,
+} from "./web-client-compatibility";
+export {
   healthAuthContract,
   healthContract,
   healthResponseSchema,

--- a/turbo/packages/api-contracts/src/contracts/web-client-compatibility.ts
+++ b/turbo/packages/api-contracts/src/contracts/web-client-compatibility.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { initContract } from "./base";
+
+const c = initContract();
+
+export const appVersionSchema = z
+  .string()
+  .regex(
+    /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u,
+    "Expected an app version like 1.229.0",
+  );
+
+export const webClientCompatibilityQuerySchema = z.object({
+  version: appVersionSchema,
+});
+
+export const webClientCompatibilityResponseSchema = z.object({
+  minimumSupportedVersion: appVersionSchema,
+  supported: z.boolean(),
+});
+
+export const webClientCompatibilityContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/client/compatibility",
+    query: webClientCompatibilityQuerySchema,
+    responses: {
+      200: webClientCompatibilityResponseSchema,
+    },
+    summary: "Check web client version compatibility",
+  },
+});
+
+export type WebClientCompatibilityContract =
+  typeof webClientCompatibilityContract;
+export type WebClientCompatibilityResponse = z.infer<
+  typeof webClientCompatibilityResponseSchema
+>;
+export type WebClientCompatibilityRouteResponse = {
+  readonly status: 200;
+  readonly body: WebClientCompatibilityResponse;
+};


### PR DESCRIPTION
## Summary
- add a repo-owned web client compatibility JSON config under the API app
- expose GET /api/client/compatibility?version=... with app-version validation and no-store responses
- switch the platform force-upgrade polling request from Atom to the vm0 API compatibility endpoint

## Validation
- pnpm --dir turbo/apps/platform exec vitest run src/lib/__tests__/force-upgrade.test.ts src/signals/__tests__/force-upgrade.test.ts src/views/components/__tests__/force-upgrade-dialog.test.tsx
- pnpm --dir turbo/packages/api-contracts exec vitest run src/contracts/__tests__/web-client-compatibility.test.ts src/contracts/__tests__/build-info.test.ts
- pnpm --dir turbo/apps/api exec vitest run src/signals/routes/__tests__/web-client-compatibility.test.ts
- pnpm --dir turbo/apps/platform exec eslint src/lib/force-upgrade.ts src/lib/__tests__/force-upgrade.test.ts src/signals/force-upgrade.ts src/signals/__tests__/force-upgrade.test.ts src/views/components/force-upgrade-dialog.tsx src/views/components/__tests__/force-upgrade-dialog.test.tsx src/views/main.tsx --max-warnings 0
- pnpm --dir turbo/apps/api exec eslint src/signals/routes/web-client-compatibility.ts src/signals/routes/__tests__/web-client-compatibility.test.ts src/signals/route.ts --max-warnings 0
- pnpm --dir turbo/packages/api-contracts exec eslint src/contracts/web-client-compatibility.ts src/contracts/__tests__/web-client-compatibility.test.ts src/contracts/index.ts --max-warnings 0
- pnpm --dir turbo/apps/platform exec oxlint src/lib/force-upgrade.ts src/lib/__tests__/force-upgrade.test.ts src/signals/force-upgrade.ts src/signals/__tests__/force-upgrade.test.ts src/views/components/force-upgrade-dialog.tsx src/views/components/__tests__/force-upgrade-dialog.test.tsx src/views/main.tsx
- pnpm --dir turbo/apps/api exec oxlint src/signals/routes/web-client-compatibility.ts src/signals/routes/__tests__/web-client-compatibility.test.ts src/signals/route.ts
- pnpm --dir turbo/packages/api-contracts exec oxlint src/contracts/web-client-compatibility.ts src/contracts/__tests__/web-client-compatibility.test.ts src/contracts/index.ts
- pnpm --filter @vm0/api-contracts check-types
- pnpm --filter @vm0/app check-types
- CI: lint-format, lint-knip, lint-types, lint-types-apps, lint-eslint, test-api, test-app, deploy-api all passed