### PR TITLE
fix: restore clicks after closing settings dialog

### DIFF
--- a/turbo/apps/platform/src/lib/force-upgrade.ts
+++ b/turbo/apps/platform/src/lib/force-upgrade.ts
@@ -12,7 +12,7 @@ type ForceUpgradeResponse = {
   forceUpgrade?: unknown;
 };
 
-export type ForceUpgradeCheckOptions = {
+type ForceUpgradeCheckOptions = {
   apiBase?: string;
   fetcher?: ForceUpgradeFetch;
   version?: string | null;

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-emoji.ts
@@ -5,7 +5,7 @@ export interface ChatThreadEmojiItem {
   name: string;
 }
 
-export interface ChatThreadEmojiGroup {
+interface ChatThreadEmojiGroup {
   name: string;
   emojis: ChatThreadEmojiItem[];
 }

--- a/turbo/apps/platform/src/signals/force-upgrade.ts
+++ b/turbo/apps/platform/src/signals/force-upgrade.ts
@@ -9,7 +9,7 @@ const forceUpgradeDialogOpenState$ = state(false);
 
 export const forceUpgradeDialogOpen$ = forceUpgradeDialogOpenState$;
 
-export type ForceUpgradePollOptions = {
+type ForceUpgradePollOptions = {
   readonly check: () => Promise<boolean>;
   readonly onRequired: () => void;
   readonly pollIntervalMs?: number;

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -47,6 +47,7 @@ export function isAdminOnlySettingsSection(section: SettingsSection): boolean {
 
 const internalSettingsDialogOpen$ = state(false);
 const internalExternalProfileModalOpen$ = state(false);
+const pendingAccountMenuSettingsSection$ = state<SettingsSection | null>(null);
 
 export const settingsDialogOpen$ = computed((get) => {
   return get(internalSettingsDialogOpen$);
@@ -59,6 +60,20 @@ export const externalProfileModalOpen$ = computed((get) => {
 export const setExternalProfileModalOpen$ = command(
   ({ set }, open: boolean) => {
     set(internalExternalProfileModalOpen$, open);
+  },
+);
+
+export const setPendingAccountMenuSettingsSection$ = command(
+  ({ set }, section: SettingsSection | null) => {
+    set(pendingAccountMenuSettingsSection$, section);
+  },
+);
+
+export const consumePendingAccountMenuSettingsSection$ = command(
+  ({ get, set }) => {
+    const section = get(pendingAccountMenuSettingsSection$);
+    set(pendingAccountMenuSettingsSection$, null);
+    return section;
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-dialog.ts
@@ -47,7 +47,10 @@ export function isAdminOnlySettingsSection(section: SettingsSection): boolean {
 
 const internalSettingsDialogOpen$ = state(false);
 const internalExternalProfileModalOpen$ = state(false);
-const pendingAccountMenuSettingsSection$ = state<SettingsSection | null>(null);
+const pendingAccountMenuSettingsSection$ = state<{
+  readonly ownerId: string;
+  readonly section: SettingsSection;
+} | null>(null);
 
 export const settingsDialogOpen$ = computed((get) => {
   return get(internalSettingsDialogOpen$);
@@ -64,15 +67,25 @@ export const setExternalProfileModalOpen$ = command(
 );
 
 export const setPendingAccountMenuSettingsSection$ = command(
-  ({ set }, section: SettingsSection | null) => {
-    set(pendingAccountMenuSettingsSection$, section);
+  ({ get, set }, ownerId: string, section: SettingsSection | null) => {
+    if (section === null) {
+      const pending = get(pendingAccountMenuSettingsSection$);
+      if (pending?.ownerId === ownerId) {
+        set(pendingAccountMenuSettingsSection$, null);
+      }
+      return;
+    }
+    set(pendingAccountMenuSettingsSection$, { ownerId, section });
   },
 );
 
 export const consumePendingAccountMenuSettingsSection$ = command(
-  ({ get, set }) => {
-    const section = get(pendingAccountMenuSettingsSection$);
-    set(pendingAccountMenuSettingsSection$, null);
+  ({ get, set }, ownerId: string) => {
+    const pending = get(pendingAccountMenuSettingsSection$);
+    const section = pending?.ownerId === ownerId ? pending.section : null;
+    if (section !== null) {
+      set(pendingAccountMenuSettingsSection$, null);
+    }
     return section;
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -130,6 +130,16 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
+function buttonByLabel(label: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.getAttribute("aria-label") === label;
+  });
+  if (!button) {
+    throw new Error(`${label} button not found`);
+  }
+  return button;
+}
+
 async function openAccountMenu(): Promise<HTMLElement> {
   const accountName = await screen.findByText("Alex Rivera");
   const accountButton = accountName.closest("button");
@@ -610,6 +620,19 @@ describe("zero sidebar account menu", () => {
     await waitFor(() => {
       expect(screen.getByText("Disabled")).toBeInTheDocument();
     });
+
+    click(buttonByLabel("Close"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Settings" }),
+      ).not.toBeInTheDocument();
+      expect(document.querySelector(".zero-dialog-overlay")).toBeNull();
+    });
+    expect(document.body.style.pointerEvents).not.toBe("none");
+
+    const reopenedMenu = await openAccountMenu();
+    expect(within(reopenedMenu).getByText("Settings")).toBeInTheDocument();
   });
 
   it("shows account switching, add-account, and sign-out actions", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -130,8 +130,11 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
-function buttonByLabel(label: string): HTMLElement {
-  const button = queryAllByRoleFast("button").find((candidate) => {
+function buttonByLabel(
+  label: string,
+  container: ParentNode = document.body,
+): HTMLElement {
+  const button = queryAllByRoleFast("button", container).find((candidate) => {
     return candidate.getAttribute("aria-label") === label;
   });
   if (!button) {
@@ -621,7 +624,8 @@ describe("zero sidebar account menu", () => {
       expect(screen.getByText("Disabled")).toBeInTheDocument();
     });
 
-    click(buttonByLabel("Close"));
+    const settingsDialog = screen.getByRole("dialog", { name: "Settings" });
+    click(buttonByLabel("Close", settingsDialog));
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-shared.tsx
@@ -28,7 +28,10 @@ export function MinimalSidebarLayout({ children }: { children: ReactNode }) {
       <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
         <div className="flex-1" />
         <div className="p-2">
-          <AccountDropdown onAccountAction={onAccountAction} />
+          <AccountDropdown
+            onAccountAction={onAccountAction}
+            settingsOwnerId="minimal-sidebar"
+          />
         </div>
       </aside>
       <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -574,10 +574,12 @@ function SignOutItem({
 
 export function AccountDropdown({
   onAccountAction,
+  settingsOwnerId,
   collapsed = false,
   hidePreferences = false,
 }: {
   onAccountAction?: (action: ZeroAccountAction) => void;
+  settingsOwnerId: string;
   collapsed?: boolean;
   hidePreferences?: boolean;
 }) {
@@ -673,7 +675,7 @@ export function AccountDropdown({
 
   const queueSettingsOpen = (section: SettingsSection) => {
     setSidebarExpanded(false);
-    setPendingSettingsSection(section);
+    setPendingSettingsSection(settingsOwnerId, section);
   };
 
   const handleOpenSettings = () => {
@@ -708,7 +710,7 @@ export function AccountDropdown({
 
   const handleMenuOpenChange = (open: boolean) => {
     if (open) {
-      setPendingSettingsSection(null);
+      setPendingSettingsSection(settingsOwnerId, null);
     }
     if (!open || hidePreferences || !subscriptionsEnabled) {
       return;
@@ -735,7 +737,7 @@ export function AccountDropdown({
           className="w-[240px]"
           onCloseAutoFocus={(event) => {
             event.preventDefault();
-            const section = consumePendingSettingsSection();
+            const section = consumePendingSettingsSection(settingsOwnerId);
             if (section === null) {
               return;
             }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -736,11 +736,11 @@ export function AccountDropdown({
           sideOffset={8}
           className="w-[240px]"
           onCloseAutoFocus={(event) => {
-            event.preventDefault();
             const section = consumePendingSettingsSection(settingsOwnerId);
             if (section === null) {
               return;
             }
+            event.preventDefault();
             detach(openSettings(section, pageSignal), Reason.DomCallback);
           }}
         >

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -46,7 +46,12 @@ import {
   type ZeroAccountAction,
 } from "../../signals/zero-page/zero-nav.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { openSettingsDialogAt$ } from "../../signals/zero-page/settings/settings-dialog.ts";
+import {
+  consumePendingAccountMenuSettingsSection$,
+  openSettingsDialogAt$,
+  setPendingAccountMenuSettingsSection$,
+  type SettingsSection,
+} from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
@@ -587,6 +592,12 @@ export function AccountDropdown({
     features?.[FeatureSwitchKey.SidebarSubscriptionUsage] ?? false;
   const selectNav = useSet(handleZeroNavSelect$);
   const openSettings = useSet(openSettingsDialogAt$);
+  const setPendingSettingsSection = useSet(
+    setPendingAccountMenuSettingsSection$,
+  );
+  const consumePendingSettingsSection = useSet(
+    consumePendingAccountMenuSettingsSection$,
+  );
   const reloadSubscriptions = useSet(reloadAccountMenuSubscriptionUsageRows$);
   const resetCodexSubscriptionUsage = useSet(
     resetPersonalCodexSubscriptionUsage$,
@@ -660,14 +671,17 @@ export function AccountDropdown({
     setSidebarExpanded(false);
   };
 
-  const handleOpenSettings = () => {
+  const queueSettingsOpen = (section: SettingsSection) => {
     setSidebarExpanded(false);
-    detach(openSettings("preference", pageSignal), Reason.DomCallback);
+    setPendingSettingsSection(section);
+  };
+
+  const handleOpenSettings = () => {
+    queueSettingsOpen("preference");
   };
 
   const handleOpenCreditBalance = () => {
-    setSidebarExpanded(false);
-    detach(openSettings("usage", pageSignal), Reason.DomCallback);
+    queueSettingsOpen("usage");
   };
 
   const handleOpenCodexReset = (resetCredits: number | null) => {
@@ -693,6 +707,9 @@ export function AccountDropdown({
   };
 
   const handleMenuOpenChange = (open: boolean) => {
+    if (open) {
+      setPendingSettingsSection(null);
+    }
     if (!open || hidePreferences || !subscriptionsEnabled) {
       return;
     }
@@ -718,6 +735,11 @@ export function AccountDropdown({
           className="w-[240px]"
           onCloseAutoFocus={(event) => {
             event.preventDefault();
+            const section = consumePendingSettingsSection();
+            if (section === null) {
+              return;
+            }
+            detach(openSettings(section, pageSignal), Reason.DomCallback);
           }}
         >
           <CurrentAccountHeader

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -176,8 +176,13 @@ function AccountDropdownContainer({
   collapsed?: boolean;
 }) {
   const onAccountAction = useSet(handleZeroAccountAction$);
+  const settingsOwnerId = collapsed ? "sidebar-collapsed" : "sidebar-expanded";
   return (
-    <AccountDropdown onAccountAction={onAccountAction} collapsed={collapsed} />
+    <AccountDropdown
+      onAccountAction={onAccountAction}
+      settingsOwnerId={settingsOwnerId}
+      collapsed={collapsed}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary
- defer opening Settings from the account dropdown until the dropdown close lifecycle finishes
- add pending settings section state to avoid overlapping Radix dropdown/dialog pointer-events cleanup
- cover closing Settings and reopening the account menu in the account menu regression test
- remove stale exported internal types reported by knip during pre-commit

## Tests
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx --run
- pnpm -F @vm0/app run lint
- pnpm -F @vm0/app run check-types
- pnpm exec prettier --check apps/platform/src/signals/zero-page/settings/settings-dialog.ts apps/platform/src/views/zero-page/zero-sidebar-account.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
- git diff --check
- pnpm knip --cache
