### PR TITLE
refactor: route platform polling through shared loop helper

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/force-upgrade.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/force-upgrade.test.ts
@@ -1,15 +1,9 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { pollForceUpgradeRequirement } from "../force-upgrade.ts";
 
 describe("force upgrade polling", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("checks immediately and then polls every 60 seconds until an upgrade is required", async () => {
-    vi.useFakeTimers();
-
+  it("checks through the shared loop until an upgrade is required", async () => {
     const check = vi
       .fn<() => Promise<boolean>>()
       .mockResolvedValueOnce(false)
@@ -20,20 +14,10 @@ describe("force upgrade polling", () => {
     const poll = pollForceUpgradeRequirement({
       check,
       onRequired,
-      pollIntervalMs: 60_000,
+      pollIntervalMs: 0,
       signal: AbortSignal.any([]),
     });
 
-    await vi.waitFor(() => {
-      expect(check).toHaveBeenCalledTimes(1);
-    });
-    expect(onRequired).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(check).toHaveBeenCalledTimes(2);
-    expect(onRequired).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(60_000);
     await poll;
 
     expect(check).toHaveBeenCalledTimes(3);

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -10,6 +10,7 @@ import {
   chatIdbReadOr,
   chatIdbWriteBestEffort,
 } from "../external/chat-idb-safe.ts";
+import { setLoop } from "../utils.ts";
 import { createIdbMessageStores } from "../external/idb-message-store.ts";
 import { logger } from "../log.ts";
 import { createRemoteChatThreadDataSource } from "./remote-chat-thread-data-source.ts";
@@ -124,43 +125,48 @@ export async function readCachedMessagesBeforeUntilMiss(
   const messagePages: PagedChatMessage[][] = [];
   const seenIds = new Set<string>([beforeId]);
 
-  while (true) {
-    const page = await chatIdbReadOr(
-      "cachedDataSource:readBefore",
-      () => {
-        return readStore.readBefore(
-          threadId,
-          cursorId,
-          MESSAGE_PAGE_SIZE,
-          signal,
-        );
-      },
-      [],
-      signal,
-    );
-    signal.throwIfAborted();
+  await setLoop(
+    async (loopSignal) => {
+      const page = await chatIdbReadOr(
+        "cachedDataSource:readBefore",
+        () => {
+          return readStore.readBefore(
+            threadId,
+            cursorId,
+            MESSAGE_PAGE_SIZE,
+            loopSignal,
+          );
+        },
+        [],
+        loopSignal,
+      );
+      loopSignal.throwIfAborted();
 
-    const newMessages = page.filter((message) => {
-      return !seenIds.has(message.id);
-    });
-    if (newMessages.length === 0) {
-      break;
-    }
+      const newMessages = page.filter((message) => {
+        return !seenIds.has(message.id);
+      });
+      if (newMessages.length === 0) {
+        return true;
+      }
 
-    for (const message of newMessages) {
-      seenIds.add(message.id);
-    }
-    messagePages.unshift(newMessages);
+      for (const message of newMessages) {
+        seenIds.add(message.id);
+      }
+      messagePages.unshift(newMessages);
 
-    if (
-      reachedStart(newMessages, startMessageId) ||
-      page.length < MESSAGE_PAGE_SIZE
-    ) {
-      break;
-    }
+      if (
+        reachedStart(newMessages, startMessageId) ||
+        page.length < MESSAGE_PAGE_SIZE
+      ) {
+        return true;
+      }
 
-    cursorId = newMessages[0]!.id;
-  }
+      cursorId = newMessages[0]!.id;
+      return false;
+    },
+    0,
+    signal,
+  );
 
   const messages = messagePages.flat();
   return {
@@ -394,50 +400,55 @@ export const warmLatestChatThreadMessages$ = command(
 
     let sinceId = latest[0]?.id;
     let pages = 0;
-    while (!signal.aborted) {
-      const result = await set(
-        warmListMessagesAfter$,
-        { threadId, sinceId },
-        signal,
-      );
-      signal.throwIfAborted();
-      if (result === null) {
-        return;
-      }
-      pages += 1;
-
-      L.debug("warmLatest:page", {
-        threadId,
-        sinceId: sinceId ?? null,
-        count: result.messages.length,
-        reachedEnd: result.reachedEnd,
-        pages,
-      });
-
-      if (result.messages.length > 0) {
-        await chatIdbWriteBestEffort(
-          "cachedDataSource:warmUpsert",
-          () => {
-            return stores.writeStore.upsertMessages(
-              threadId,
-              result.messages,
-              signal,
-            );
-          },
-          signal,
+    await setLoop(
+      async (loopSignal) => {
+        const result = await set(
+          warmListMessagesAfter$,
+          { threadId, sinceId },
+          loopSignal,
         );
-        signal.throwIfAborted();
-        const nextSinceId = result.messages[result.messages.length - 1]!.id;
-        if (nextSinceId === sinceId) {
-          break;
+        loopSignal.throwIfAborted();
+        if (result === null) {
+          return true;
         }
-        sinceId = nextSinceId;
-      }
+        pages += 1;
 
-      if (result.reachedEnd) {
-        break;
-      }
-    }
+        L.debug("warmLatest:page", {
+          threadId,
+          sinceId: sinceId ?? null,
+          count: result.messages.length,
+          reachedEnd: result.reachedEnd,
+          pages,
+        });
+
+        if (result.messages.length > 0) {
+          await chatIdbWriteBestEffort(
+            "cachedDataSource:warmUpsert",
+            () => {
+              return stores.writeStore.upsertMessages(
+                threadId,
+                result.messages,
+                loopSignal,
+              );
+            },
+            loopSignal,
+          );
+          loopSignal.throwIfAborted();
+          const nextSinceId = result.messages[result.messages.length - 1]!.id;
+          if (nextSinceId === sinceId) {
+            return true;
+          }
+          sinceId = nextSinceId;
+        }
+
+        if (result.reachedEnd) {
+          return true;
+        }
+        return false;
+      },
+      0,
+      signal,
+    );
   },
 );
 

--- a/turbo/apps/platform/src/signals/force-upgrade.ts
+++ b/turbo/apps/platform/src/signals/force-upgrade.ts
@@ -1,7 +1,7 @@
 import { command, state } from "ccstate";
-import { delay } from "signal-timers";
 
 import { checkForceUpgrade } from "../lib/force-upgrade.ts";
+import { setLoop } from "./utils.ts";
 
 const FORCE_UPGRADE_POLL_INTERVAL_MS = 60_000;
 
@@ -22,15 +22,18 @@ export async function pollForceUpgradeRequirement({
   pollIntervalMs = FORCE_UPGRADE_POLL_INTERVAL_MS,
   signal,
 }: ForceUpgradePollOptions): Promise<void> {
-  while (!signal.aborted) {
-    signal.throwIfAborted();
-    const required = await check();
-    if (required) {
-      onRequired();
-      return;
-    }
-    await delay(pollIntervalMs, { signal });
-  }
+  await setLoop(
+    async (loopSignal) => {
+      const required = await check();
+      loopSignal.throwIfAborted();
+      if (required) {
+        onRequired();
+      }
+      return required;
+    },
+    pollIntervalMs,
+    signal,
+  );
 }
 
 export const pollForceUpgradeDialog$ = command(

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -6,7 +6,7 @@ import { IN_VITEST } from "../env.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { clerk$ } from "./auth.ts";
 import { createAblyAuthCallback } from "../lib/ably-auth.ts";
-import { createDeferredPromise, throwIfAbort } from "./utils.ts";
+import { createDeferredPromise, setLoop, throwIfAbort } from "./utils.ts";
 import { logger } from "./log.ts";
 
 const L = logger("Realtime");
@@ -182,31 +182,36 @@ const runWithChannel$ = command(
       }
       L.debug("subscribed to topic: " + topic);
 
-      while (!signal.aborted) {
-        await deferred.promise;
-        signal.throwIfAborted();
-        deferred = createDeferredPromise(signal);
-        poked = false;
+      await setLoop(
+        async (loopSignal) => {
+          await deferred.promise;
+          loopSignal.throwIfAborted();
+          deferred = createDeferredPromise(loopSignal);
+          poked = false;
 
-        // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry with backoff
-        try {
-          const done = await set(loopCommand$, signal);
-          signal.throwIfAborted();
-          transientRetryCount = 0;
-          if (done) {
-            cleanup();
-            return;
+          // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry with backoff
+          try {
+            const done = await set(loopCommand$, loopSignal);
+            loopSignal.throwIfAborted();
+            transientRetryCount = 0;
+            if (done) {
+              cleanup();
+              return true;
+            }
+          } catch (error) {
+            loopSignal.throwIfAborted();
+            throwIfAbort(error);
+            L.warn(`transient error in ably notification`, error);
+            await waitForTransientRetry(loopSignal, transientRetryCount);
+            loopSignal.throwIfAborted();
+            transientRetryCount++;
+            pokeLoop();
           }
-        } catch (error) {
-          signal.throwIfAborted();
-          throwIfAbort(error);
-          L.warn(`transient error in ably notification`, error);
-          await waitForTransientRetry(signal, transientRetryCount);
-          signal.throwIfAborted();
-          transientRetryCount++;
-          pokeLoop();
-        }
-      }
+          return false;
+        },
+        0,
+        signal,
+      );
     } catch (error) {
       signal.throwIfAborted();
       throwIfAbort(error);
@@ -297,37 +302,47 @@ const runWithChannelPayload$ = command(
       options?.onSubscribed?.();
       L.debug("subscribed to payload topic: " + topic);
 
-      while (!signal.aborted) {
-        await deferred.promise;
-        signal.throwIfAborted();
-        deferred = createDeferredPromise(signal);
-        poked = false;
+      await setLoop(
+        async (loopSignal) => {
+          await deferred.promise;
+          loopSignal.throwIfAborted();
+          deferred = createDeferredPromise(loopSignal);
+          poked = false;
 
-        while (pendingPayloads.length > 0) {
           const payload = pendingPayloads[0];
+          if (payload === undefined) {
+            return false;
+          }
+
           let done = false;
           // eslint-disable-next-line no-restricted-syntax -- payload notifications must retry transient handler failures without dropping the payload
           try {
-            done = await set(loopCommand$, payload, signal);
-            signal.throwIfAborted();
+            done = await set(loopCommand$, payload, loopSignal);
+            loopSignal.throwIfAborted();
           } catch (error) {
-            signal.throwIfAborted();
+            loopSignal.throwIfAborted();
             throwIfAbort(error);
             L.warn(`transient error in ably payload notification`, error);
-            await waitForTransientRetry(signal, transientRetryCount);
-            signal.throwIfAborted();
+            await waitForTransientRetry(loopSignal, transientRetryCount);
+            loopSignal.throwIfAborted();
             transientRetryCount++;
             pokeLoop();
-            break;
+            return false;
           }
           pendingPayloads.shift();
           transientRetryCount = 0;
           if (done) {
             cleanup();
-            return;
+            return true;
           }
-        }
-      }
+          if (pendingPayloads.length > 0) {
+            pokeLoop();
+          }
+          return false;
+        },
+        0,
+        signal,
+      );
     } catch (error) {
       signal.throwIfAborted();
       throwIfAbort(error);

--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -336,11 +336,8 @@ function runRetriedLoad<T>(load: () => Promise<T>): Promise<T> {
  * network or chunk-loading errors. Do not wrap mutations: `load` may run more
  * than once.
  */
-export async function retryTransientLoad<T>(
-  load: () => Promise<T>,
-): Promise<T> {
-  let attempt = 0;
-  while (true) {
+export function retryTransientLoad<T>(load: () => Promise<T>): Promise<T> {
+  async function attemptLoad(attempt: number): Promise<T> {
     const result = await settle(runRetriedLoad(load));
     if (result.ok) {
       return result.value;
@@ -349,9 +346,11 @@ export async function retryTransientLoad<T>(
     if (delayMs === undefined || !isRetryableError(result.error)) {
       throw result.error;
     }
-    attempt += 1;
     await delay(IN_VITEST ? 0 : delayMs);
+    return attemptLoad(attempt + 1);
   }
+
+  return attemptLoad(0);
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/view-component-state.ts
+++ b/turbo/apps/platform/src/signals/view-component-state.ts
@@ -1,6 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { reloadTelegramConnectLinkStatus$ } from "./zero-page/telegram-connect-signals.ts";
-import { onRef, throwIfAbort } from "./utils.ts";
+import { onRef, setLoop, throwIfAbort } from "./utils.ts";
 import { fetchPreviewText } from "./chat-page/parse-body-blocks.ts";
 
 type ImageLoadStatus = "loading" | "loaded" | "error";
@@ -164,7 +164,7 @@ const setTypewriterDisplayed$ = command(
 );
 
 const startTypewriterOnRef$ = command(
-  ({ set }, el: HTMLElement, signal: AbortSignal) => {
+  async ({ set }, el: HTMLElement, signal: AbortSignal) => {
     const key = el.dataset.typewriterKey;
     const text = el.dataset.typewriterText ?? "";
     const parsedSpeed = Number.parseInt(el.dataset.typewriterSpeed ?? "40", 10);
@@ -176,20 +176,14 @@ const startTypewriterOnRef$ = command(
 
     set(resetTypewriterDisplayed$, key);
     let index = 0;
-    const timer = window.setInterval(() => {
-      index += 1;
-      set(setTypewriterDisplayed$, key, text.slice(0, index));
-      if (index >= text.length) {
-        window.clearInterval(timer);
-      }
-    }, speed);
-
-    signal.addEventListener(
-      "abort",
+    await setLoop(
       () => {
-        window.clearInterval(timer);
+        index += 1;
+        set(setTypewriterDisplayed$, key, text.slice(0, index));
+        return index >= text.length;
       },
-      { once: true },
+      speed,
+      signal,
     );
   },
 );
@@ -209,17 +203,19 @@ const openTelegramOnRef$ = command(
 export const telegramAutoOpenRef$ = onRef(openTelegramOnRef$);
 
 const pollTelegramDomainStatusOnRef$ = command(
-  ({ set }, _el: HTMLElement, signal: AbortSignal) => {
-    const intervalId = window.setInterval(() => {
-      set(reloadTelegramConnectLinkStatus$);
-    }, 3000);
-
-    signal.addEventListener(
-      "abort",
+  async ({ set }, _el: HTMLElement, signal: AbortSignal) => {
+    let first = true;
+    await setLoop(
       () => {
-        window.clearInterval(intervalId);
+        if (first) {
+          first = false;
+          return false;
+        }
+        set(reloadTelegramConnectLinkStatus$);
+        return false;
       },
-      { once: true },
+      3000,
+      signal,
     );
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -191,11 +191,9 @@ function nextEventPageRequest(
 
 function createRunPagedEvents(runId: string) {
   const initialPagedEventsList$ = computed(async (get) => {
-    const pages = [
-      createEventPageComputed(runId, INITIAL_AGENT_EVENTS_PAGE_LIMIT),
-    ];
-
-    while (true) {
+    async function resolvePages(
+      pages: Computed<Promise<PagedRunEvents>>[],
+    ): Promise<Computed<Promise<PagedRunEvents>>[]> {
       const lastPage = await get(pages[pages.length - 1]);
       if (!lastPage.hasMore) {
         return pages;
@@ -210,14 +208,20 @@ function createRunPagedEvents(runId: string) {
       if (!request) {
         return pages;
       }
-      pages.push(
+
+      return resolvePages([
+        ...pages,
         createEventPageComputed(
           runId,
           INITIAL_AGENT_EVENTS_PAGE_LIMIT,
           request,
         ),
-      );
+      ]);
     }
+
+    return await resolvePages([
+      createEventPageComputed(runId, INITIAL_AGENT_EVENTS_PAGE_LIMIT),
+    ]);
   });
 
   return { pagedEventsList$: initialPagedEventsList$ };

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -1950,60 +1950,30 @@ export function isStandaloneMode(): boolean {
 
 const OAUTH_AUTH_CODE_POPUP_CLOSED_POLL_MS = IN_VITEST ? 10 : 250;
 
-function waitForOAuthAuthCodePopupClosed(
+async function waitForOAuthAuthCodePopupClosed(
   authWindow: Pick<Window, "closed">,
   signal: AbortSignal,
 ): Promise<"popupClosed"> {
   signal.throwIfAborted();
 
-  const deferred = Promise.withResolvers<"popupClosed">();
-  let settled = false;
-  let intervalId: number | undefined;
-
-  function cleanup() {
-    if (intervalId !== undefined) {
-      window.clearInterval(intervalId);
-      intervalId = undefined;
-    }
-    signal.removeEventListener("abort", onAbort);
-  }
-
-  function resolveClosed() {
-    if (settled) {
-      return;
-    }
-    settled = true;
-    cleanup();
-    deferred.resolve("popupClosed");
-  }
-
-  function rejectAborted() {
-    if (settled) {
-      return;
-    }
-    settled = true;
-    cleanup();
-    deferred.reject(signal.reason);
-  }
-
-  function onAbort() {
-    rejectAborted();
-  }
-
-  function checkClosed() {
-    if (authWindow.closed) {
-      resolveClosed();
-    }
-  }
-
-  intervalId = window.setInterval(
-    checkClosed,
+  let closed = false;
+  await setLoop(
+    () => {
+      if (authWindow.closed) {
+        closed = true;
+        return true;
+      }
+      return false;
+    },
     OAUTH_AUTH_CODE_POPUP_CLOSED_POLL_MS,
+    signal,
   );
-  signal.addEventListener("abort", onAbort, { once: true });
-  checkClosed();
 
-  return deferred.promise;
+  signal.throwIfAborted();
+  if (!closed) {
+    throw new Error("OAuth auth code popup wait ended before popup closed");
+  }
+  return "popupClosed";
 }
 
 const resetOAuthAuthCodeConnectorLoopSignal$ = resetSignal();

--- a/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
@@ -1,5 +1,4 @@
 import { command, computed, state } from "ccstate";
-import { delay } from "signal-timers";
 import { zeroImageIoGenerateContract } from "@vm0/api-contracts/contracts/zero-image-io-generate";
 import {
   zeroBuiltInGenerationContract,
@@ -9,8 +8,9 @@ import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { searchParams$, updateSearchParams$ } from "../route.ts";
 import { accept } from "../../lib/accept.ts";
+import { now } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
-import { tapError, withCleanup } from "../utils.ts";
+import { setLoop, tapError, withCleanup } from "../utils.ts";
 import { publicAttachmentUrl } from "../../views/zero-page/zero-attachment-url.ts";
 import {
   ARTIFACT_FULLSCREEN_PARAM,
@@ -310,36 +310,45 @@ async function pollImageEditResultUrl({
   createClient,
   generationId,
   signal,
-  timeoutSignal,
 }: {
   createClient: ZeroClientFactory;
   generationId: string;
   signal: AbortSignal;
-  timeoutSignal: AbortSignal;
 }) {
   const generationClient = createClient(zeroBuiltInGenerationContract, {
     apiBase: "api",
   });
+  const expiresAt = now() + POLL_TIMEOUT_MS;
+  let resultUrl: string | null = null;
 
-  while (!timeoutSignal.aborted) {
-    const polled = await accept(
-      generationClient.get({
-        params: { generationId },
-        fetchOptions: { signal },
-      }),
-      [200],
-    );
-    signal.throwIfAborted();
+  await setLoop(
+    async (loopSignal) => {
+      if (now() >= expiresAt) {
+        return true;
+      }
 
-    const resultUrl = readPollResultUrl(polled.body);
-    if (resultUrl !== undefined) {
-      return resultUrl;
-    }
+      const polled = await accept(
+        generationClient.get({
+          params: { generationId },
+          fetchOptions: { signal: loopSignal },
+        }),
+        [200],
+      );
+      loopSignal.throwIfAborted();
 
-    await delay(POLL_INTERVAL_MS, { signal });
-  }
+      const polledResultUrl = readPollResultUrl(polled.body);
+      if (polledResultUrl !== undefined) {
+        resultUrl = polledResultUrl;
+        return true;
+      }
 
-  return null;
+      return now() >= expiresAt;
+    },
+    POLL_INTERVAL_MS,
+    signal,
+  );
+
+  return resultUrl;
 }
 
 async function waitForImageEditResultUrl({
@@ -351,13 +360,10 @@ async function waitForImageEditResultUrl({
   generationId: string;
   signal: AbortSignal;
 }) {
-  const timeoutSignal = AbortSignal.timeout(POLL_TIMEOUT_MS);
-
   return await pollImageEditResultUrl({
     createClient,
     generationId,
     signal,
-    timeoutSignal,
   });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/utils/highlight-text.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/utils/highlight-text.tsx
@@ -33,16 +33,9 @@ export function highlightText(
   const elements: ReactNode[] = [];
   let matchCount = 0;
   let cursor = 0;
+  let idx = lowered.indexOf(target, cursor);
 
-  for (;;) {
-    const idx = lowered.indexOf(target, cursor);
-    if (idx === -1) {
-      if (cursor < text.length) {
-        elements.push(text.slice(cursor));
-      }
-      break;
-    }
-
+  while (idx !== -1) {
     if (idx > cursor) {
       elements.push(text.slice(cursor, idx));
     }
@@ -68,6 +61,11 @@ export function highlightText(
 
     matchCount++;
     cursor = idx + target.length;
+    idx = lowered.indexOf(target, cursor);
+  }
+
+  if (cursor < text.length) {
+    elements.push(text.slice(cursor));
   }
 
   return {


### PR DESCRIPTION
## Summary
- Routes platform polling and deferred realtime loops through the shared `setLoop` helper instead of custom `while`/`setInterval` implementations.
- Updates force-upgrade, image edit polling, OAuth popup waiting, Telegram/domain/typewriter timers, realtime subscriptions, and chat IDB cache loops to use the shared loop/AbortSignal behavior.
- Removes the remaining non-helper infinite loop pattern from platform highlighter code so the only remaining platform custom loop scan hit is `setLoop` itself.

## Verification
- `pnpm exec prettier --write ...changed files...`
- `pnpm exec oxlint ...changed files...`
- `rg -n "while \(!.*\.aborted\)|while \(true\)|for \(;;\)|setInterval\(" turbo/apps/platform/src -g "!**/__tests__/**" -g "!**/*.test.*"`
- `pnpm exec vitest run src/signals/__tests__/force-upgrade.test.ts src/signals/__tests__/realtime.test.ts src/signals/chat-page/__tests__/idb-cached-chat-thread-data-source.test.ts src/views/zero-page/__tests__/zero-image-edit.test.tsx src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx src/views/zero-page/__tests__/zero-connectors-page.test.tsx src/views/zero-page/__tests__/zero-telegram-connect-page.test.tsx --reporter=verbose --testTimeout=15000 --hookTimeout=15000`
- `pnpm exec tsc -p tsconfig.production.json --noEmit`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm exec tsc -p tsconfig.tests.json --noEmit`