### PR TITLE
refactor: accept empty artifact manifests without archive urls

### DIFF
--- a/crates/api-contracts/src/generated/types.rs
+++ b/crates/api-contracts/src/generated/types.rs
@@ -33,8 +33,9 @@ pub mod runners {
             pub vas_storage_id: String,
             /// VAS version identifier for the artifact contents.
             pub vas_version_id: String,
-            /// Presigned URL for downloading the artifact archive.
-            pub archive_url: String,
+            /// Optional presigned URL for downloading the artifact archive. Explicit empty artifacts may omit it.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub archive_url: Option<String>,
             /// Whether this artifact version is explicitly empty and can be prepared without downloading an archive.
             #[serde(default, skip_serializing_if = "Option::is_none")]
             pub empty: Option<bool>,

--- a/crates/api-contracts/tests/types.rs
+++ b/crates/api-contracts/tests/types.rs
@@ -212,6 +212,10 @@ fn generated_storage_manifest_ignores_legacy_artifact_manifest_url() {
         Some("AGENTS.md")
     );
     assert_eq!(manifest.artifacts[0].vas_storage_id, "storage-id-1");
+    assert_eq!(
+        manifest.artifacts[0].archive_url.as_deref(),
+        Some("https://storage.example/artifact.tar.gz")
+    );
     assert_eq!(manifest.artifacts[0].empty, None);
 }
 
@@ -231,7 +235,7 @@ fn generated_storage_manifest_serializes_claim_shape() {
             vas_storage_name: "memory".to_string(),
             vas_storage_id: "storage-id-1".to_string(),
             vas_version_id: "version-2".to_string(),
-            archive_url: "https://storage.example/artifact.tar.gz".to_string(),
+            archive_url: Some("https://storage.example/artifact.tar.gz".to_string()),
             empty: None,
             missing_root_policy: None,
         }],
@@ -276,10 +280,36 @@ fn generated_storage_manifest_accepts_explicit_empty_artifacts() {
     .unwrap();
 
     assert_eq!(manifest.artifacts[0].empty, Some(true));
+    assert_eq!(
+        manifest.artifacts[0].archive_url.as_deref(),
+        Some("https://storage.example/artifact.tar.gz")
+    );
 
     let value = serde_json::to_value(manifest).unwrap();
     assert_eq!(value["artifacts"][0]["empty"], true);
     assert!(value["artifacts"][0]["archiveUrl"].is_string());
+}
+
+#[test]
+fn generated_storage_manifest_accepts_explicit_empty_artifacts_without_archive_url() {
+    let manifest: runner_storage::StorageManifest = serde_json::from_value(json!({
+        "storages": [],
+        "artifacts": [{
+            "mountPath": "/home/user/.claude/projects/project",
+            "vasStorageName": "memory",
+            "vasStorageId": "storage-id-1",
+            "vasVersionId": "version-2",
+            "empty": true,
+        }],
+    }))
+    .unwrap();
+
+    assert_eq!(manifest.artifacts[0].empty, Some(true));
+    assert_eq!(manifest.artifacts[0].archive_url, None);
+
+    let value = serde_json::to_value(manifest).unwrap();
+    assert_eq!(value["artifacts"][0]["empty"], true);
+    assert!(value["artifacts"][0].get("archiveUrl").is_none());
 }
 
 #[test]

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -823,8 +823,23 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     // 3. Download storage manifest entries (skipping entries unchanged since the previous turn).
     if let Some(manifest) = &context.storage_manifest {
         let runtime_dir = guest_runtime_dir(context.run_id)?;
-        let guest_manifest =
-            GuestDownloadManifest::from_storage_manifest_for_run(manifest, runtime_dir.as_str());
+        let conversion_t = Instant::now();
+        let guest_manifest = match GuestDownloadManifest::from_storage_manifest_for_run(
+            manifest,
+            runtime_dir.as_str(),
+        ) {
+            Ok(guest_manifest) => guest_manifest,
+            Err(error) => {
+                let error_message = error.to_string();
+                telemetry.record(
+                    "runner_storage_manifest_apply",
+                    conversion_t.elapsed(),
+                    false,
+                    Some(&error_message),
+                );
+                return Err(error);
+            }
+        };
         let mut effective: GuestDownloadManifest = match start.prev_storage {
             Some(prev) => {
                 let t = Instant::now();

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -37,8 +37,8 @@ use super::super::{
     effective_cli_framework,
 };
 use super::support::{
-    CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_storage, create_overridden_sandbox,
-    minimal_context, sandbox_exec_error, spawn_run_in_sandbox_test,
+    CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_artifact, api_storage,
+    create_overridden_sandbox, minimal_context, sandbox_exec_error, spawn_run_in_sandbox_test,
     spawn_run_in_sandbox_test_with_timeouts, test_executor_config, test_telemetry,
 };
 use crate::active_input::ActiveInputSource;
@@ -681,6 +681,67 @@ async fn run_in_sandbox_records_storage_manifest_guest_download_failure_timing()
         apply_failures, 1,
         "top-level storage manifest apply failure should still be recorded once, got: {ops:?}"
     );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_rejects_non_empty_artifact_without_archive_url() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let mut ctx = minimal_context();
+    let mut artifact = api_artifact(
+        "memory",
+        "/home/user/.claude/projects/project",
+        "storage-id-1",
+        "version-2",
+        "https://storage.example/artifact.tar.gz",
+    );
+    artifact.archive_url = None;
+    ctx.storage_manifest = Some(StorageManifest {
+        storages: vec![],
+        artifacts: vec![artifact],
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await;
+
+    let error = match result {
+        Ok(_) => panic!("invalid storage manifest should fail"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("storage manifest artifact memory version version-2 is missing archiveUrl"),
+        "got: {error}"
+    );
+    let exec_calls = sandbox.exec_calls();
+    assert!(
+        exec_calls
+            .iter()
+            .all(|call| call.cmd != guest_download_stdin_command()),
+        "invalid storage manifest should fail before guest-download; calls: {exec_calls:?}"
+    );
+    let ops = telemetry.pending_ops_snapshot();
+    assert_failed_action_error_once(
+        &ops,
+        "runner_storage_manifest_apply",
+        "internal error: storage manifest artifact memory version version-2 is missing archiveUrl",
+    );
+    assert_no_action(&ops, "runner_storage_manifest_has_work");
+    assert_no_action(&ops, "runner_storage_manifest_guest_download");
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/support/manifest.rs
+++ b/crates/runner/src/executor/tests/support/manifest.rs
@@ -25,7 +25,7 @@ pub(in crate::executor::tests) fn api_artifact(
 ) -> ArtifactEntry {
     ArtifactEntry {
         mount_path: mount_path.into(),
-        archive_url: archive_url.into(),
+        archive_url: Some(archive_url.into()),
         vas_storage_name: name.into(),
         vas_storage_id: storage_id.into(),
         vas_version_id: version.into(),

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -9,6 +9,7 @@ use api_contracts::generated::types::runners::storage::{
     ArtifactEntryMissingRootPolicy, StorageManifest,
 };
 
+use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 
 pub(crate) const MAX_HELD_SESSION_STATES: usize = 1024;
@@ -294,22 +295,47 @@ pub struct GuestDownloadArtifactEntry {
     pub missing_root_policy: Option<ArtifactEntryMissingRootPolicy>,
 }
 
-impl From<&StorageManifest> for GuestDownloadManifest {
-    fn from(manifest: &StorageManifest) -> Self {
-        Self::from_storage_manifest(manifest, None)
-    }
-}
-
 impl GuestDownloadManifest {
     pub(crate) fn from_storage_manifest_for_run(
         manifest: &StorageManifest,
         runtime_dir: &str,
-    ) -> Self {
-        Self::from_storage_manifest(manifest, Some(runtime_dir))
+    ) -> RunnerResult<Self> {
+        Self::try_from_storage_manifest(manifest, Some(runtime_dir))
     }
 
-    fn from_storage_manifest(manifest: &StorageManifest, runtime_dir: Option<&str>) -> Self {
-        Self {
+    pub(crate) fn try_from_storage_manifest(
+        manifest: &StorageManifest,
+        runtime_dir: Option<&str>,
+    ) -> RunnerResult<Self> {
+        let artifacts = manifest
+            .artifacts
+            .iter()
+            .map(|artifact| {
+                let empty = artifact.empty.unwrap_or(false);
+                let archive_url = if empty {
+                    None
+                } else {
+                    Some(artifact.archive_url.clone().ok_or_else(|| {
+                        RunnerError::Internal(format!(
+                            "storage manifest artifact {} version {} is missing archiveUrl",
+                            artifact.vas_storage_name, artifact.vas_version_id
+                        ))
+                    })?)
+                };
+                Ok(GuestDownloadArtifactEntry {
+                    mount_path: artifact.mount_path.clone(),
+                    archive_url,
+                    empty,
+                    cached: false,
+                    vas_storage_name: artifact.vas_storage_name.clone(),
+                    vas_storage_id: artifact.vas_storage_id.clone(),
+                    vas_version_id: artifact.vas_version_id.clone(),
+                    missing_root_policy: artifact.missing_root_policy,
+                })
+            })
+            .collect::<RunnerResult<Vec<_>>>()?;
+
+        Ok(Self {
             storages: manifest
                 .storages
                 .iter()
@@ -330,27 +356,10 @@ impl GuestDownloadManifest {
                     }
                 })
                 .collect(),
-            artifacts: manifest
-                .artifacts
-                .iter()
-                .map(|artifact| GuestDownloadArtifactEntry {
-                    mount_path: artifact.mount_path.clone(),
-                    archive_url: if artifact.empty == Some(true) {
-                        None
-                    } else {
-                        Some(artifact.archive_url.clone())
-                    },
-                    empty: artifact.empty.unwrap_or(false),
-                    cached: false,
-                    vas_storage_name: artifact.vas_storage_name.clone(),
-                    vas_storage_id: artifact.vas_storage_id.clone(),
-                    vas_version_id: artifact.vas_version_id.clone(),
-                    missing_root_policy: artifact.missing_root_policy,
-                })
-                .collect(),
+            artifacts,
             cleanup_paths: Vec::new(),
             instruction_cleanups: Vec::new(),
-        }
+        })
     }
 }
 
@@ -1077,7 +1086,7 @@ mod tests {
             }],
             artifacts: vec![ArtifactEntry {
                 mount_path: "/artifacts".into(),
-                archive_url: "https://example.com/artifact.tar.gz".into(),
+                archive_url: Some("https://example.com/artifact.tar.gz".into()),
                 vas_storage_name: "memory".into(),
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
@@ -1086,7 +1095,8 @@ mod tests {
             }],
         };
 
-        let guest_manifest = GuestDownloadManifest::from(&manifest);
+        let guest_manifest =
+            GuestDownloadManifest::try_from_storage_manifest(&manifest, None).unwrap();
 
         assert!(guest_manifest.cleanup_paths.is_empty());
         assert!(guest_manifest.instruction_cleanups.is_empty());
@@ -1120,7 +1130,7 @@ mod tests {
             storages: vec![],
             artifacts: vec![ArtifactEntry {
                 mount_path: "/artifacts".into(),
-                archive_url: "https://example.com/compat-empty-artifact.tar.gz".into(),
+                archive_url: Some("https://example.com/compat-empty-artifact.tar.gz".into()),
                 vas_storage_name: "memory".into(),
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v-empty".into(),
@@ -1129,13 +1139,61 @@ mod tests {
             }],
         };
 
-        let guest_manifest = GuestDownloadManifest::from(&manifest);
+        let guest_manifest =
+            GuestDownloadManifest::try_from_storage_manifest(&manifest, None).unwrap();
 
         assert!(guest_manifest.artifacts[0].empty);
         assert!(guest_manifest.artifacts[0].archive_url.is_none());
         assert_eq!(
             guest_manifest.artifacts[0].missing_root_policy,
             Some(ArtifactEntryMissingRootPolicy::PreserveParentVersion)
+        );
+    }
+
+    #[test]
+    fn storage_manifest_conversion_accepts_empty_artifacts_without_archive_urls() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifacts: vec![ArtifactEntry {
+                mount_path: "/artifacts".into(),
+                archive_url: None,
+                vas_storage_name: "memory".into(),
+                vas_storage_id: "sid-1".into(),
+                vas_version_id: "v-empty".into(),
+                empty: Some(true),
+                missing_root_policy: None,
+            }],
+        };
+
+        let guest_manifest =
+            GuestDownloadManifest::try_from_storage_manifest(&manifest, None).unwrap();
+
+        assert!(guest_manifest.artifacts[0].empty);
+        assert!(guest_manifest.artifacts[0].archive_url.is_none());
+    }
+
+    #[test]
+    fn storage_manifest_conversion_rejects_non_empty_artifacts_without_archive_urls() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifacts: vec![ArtifactEntry {
+                mount_path: "/artifacts".into(),
+                archive_url: None,
+                vas_storage_name: "memory".into(),
+                vas_storage_id: "sid-1".into(),
+                vas_version_id: "v2".into(),
+                empty: None,
+                missing_root_policy: None,
+            }],
+        };
+
+        let error = GuestDownloadManifest::try_from_storage_manifest(&manifest, None).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("storage manifest artifact memory version v2 is missing archiveUrl"),
+            "got: {error}"
         );
     }
 
@@ -1166,7 +1224,8 @@ mod tests {
         let guest_manifest = GuestDownloadManifest::from_storage_manifest_for_run(
             &manifest,
             "/home/user/.vm0/guest-agent/runs/run-1",
-        );
+        )
+        .unwrap();
 
         assert_eq!(guest_manifest.storages[0].mount_path, "/home/user/.codex");
         assert_eq!(
@@ -1193,7 +1252,7 @@ mod tests {
             }],
             artifacts: vec![ArtifactEntry {
                 mount_path: "/artifacts".into(),
-                archive_url: "https://example.com/artifact.tar.gz".into(),
+                archive_url: Some("https://example.com/artifact.tar.gz".into()),
                 vas_storage_name: "memory".into(),
                 vas_storage_id: "sid-1".into(),
                 vas_version_id: "v2".into(),
@@ -1202,7 +1261,10 @@ mod tests {
             }],
         };
 
-        let value = serde_json::to_value(GuestDownloadManifest::from(&manifest)).unwrap();
+        let value = serde_json::to_value(
+            GuestDownloadManifest::try_from_storage_manifest(&manifest, None).unwrap(),
+        )
+        .unwrap();
 
         assert!(value["cleanupPaths"].is_array());
         assert!(value.get("instructionCleanups").is_none());

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1190,8 +1190,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       vasVersionId: expect.any(String),
       missingRootPolicy: "preserveParentVersion",
     });
-    if (!memoryArtifact) {
-      throw new Error("Expected the claim manifest to include memory");
+    if (!memoryArtifact || typeof memoryArtifact.archiveUrl !== "string") {
+      throw new Error(
+        "Expected the claim manifest to include memory with an archive URL",
+      );
     }
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
       memoryArtifact.archiveUrl,

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -87,7 +87,7 @@ describe("runner storage manifest contract", () => {
     });
   });
 
-  it("accepts explicit empty artifact entries while keeping archive urls required", () => {
+  it("accepts explicit empty artifact entries with compatibility archive urls", () => {
     const manifest = storageManifestSchema.parse({
       storages: [],
       artifacts: [
@@ -106,6 +106,42 @@ describe("runner storage manifest contract", () => {
       archiveUrl: "https://storage.example/artifact.tar.gz",
       empty: true,
     });
+  });
+
+  it("accepts explicit empty artifact entries without archive urls", () => {
+    const manifest = storageManifestSchema.parse({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/project",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+          empty: true,
+        },
+      ],
+    });
+
+    expect(manifest.artifacts[0]).toMatchObject({
+      empty: true,
+    });
+    expect(manifest.artifacts[0]?.archiveUrl).toBeUndefined();
+  });
+
+  it("rejects non-empty artifact entries without archive urls", () => {
+    const result = storageManifestSchema.safeParse({
+      storages: [],
+      artifacts: [
+        {
+          mountPath: "/home/user/.claude/projects/project",
+          vasStorageName: "memory",
+          vasStorageId: "storage-id-1",
+          vasVersionId: "version-2",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it("rejects guest-download-only nullable archive urls", () => {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -200,15 +200,27 @@ export const artifactMissingRootPolicySchema = z.enum([
   "preserveParentVersion",
 ]);
 
-export const artifactEntrySchema = z.object({
-  mountPath: z.string(),
-  vasStorageName: z.string(),
-  vasStorageId: z.string(),
-  vasVersionId: z.string(),
-  archiveUrl: z.string(),
-  empty: z.boolean().optional(),
-  missingRootPolicy: artifactMissingRootPolicySchema.optional(),
-});
+export const artifactEntrySchema = z
+  .object({
+    mountPath: z.string(),
+    vasStorageName: z.string(),
+    vasStorageId: z.string(),
+    vasVersionId: z.string(),
+    archiveUrl: z.string().optional(),
+    empty: z.boolean().optional(),
+    missingRootPolicy: artifactMissingRootPolicySchema.optional(),
+  })
+  .superRefine((artifact, ctx) => {
+    if (artifact.empty === true || artifact.archiveUrl !== undefined) {
+      return;
+    }
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["archiveUrl"],
+      message: "archiveUrl is required unless empty is true",
+    });
+  });
 
 /**
  * Storage manifest with presigned URLs for download

--- a/turbo/packages/api-contracts/src/rust-bindings/types.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/types.ts
@@ -101,7 +101,9 @@ export const rustTypeBindings = [
           ],
           vasStorageId: ["VAS storage identifier for the artifact."],
           vasVersionId: ["VAS version identifier for the artifact contents."],
-          archiveUrl: ["Presigned URL for downloading the artifact archive."],
+          archiveUrl: [
+            "Optional presigned URL for downloading the artifact archive. Explicit empty artifacts may omit it.",
+          ],
           empty: [
             "Whether this artifact version is explicitly empty and can be prepared without downloading an archive.",
           ],


### PR DESCRIPTION
Refs #20430

## Summary

This is the first cleanup step for empty artifact compatibility after the #20429 runner rollout.

- Relax the runner storage manifest contract so artifact `archiveUrl` may be omitted only when `empty: true` is present.
- Regenerate Rust API-contract bindings so runner DTOs can deserialize explicit empty artifacts without an archive URL.
- Convert runner storage manifest handling from an infallible conversion to a fallible conversion: explicit empty artifacts omit guest `archiveUrl`, while non-empty artifacts missing `archiveUrl` fail before guest-download.
- Keep storage entries requiring `archiveUrl` and keep current API emission behavior unchanged in this PR.

## Deployment compatibility

The API still emits compatibility `archiveUrl` values today. This PR only prepares new runners and generated contracts for the later PR that stops emitting compatibility URLs for explicit empty artifacts.

## Tests

- `pnpm -F @vm0/api-contracts generate:rust`
- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts generated_storage_manifest`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_manifest_conversion -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_rejects_non_empty_artifact_without_archive_url -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner run_in_sandbox_records_storage_manifest -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_manifest_for_run -- --nocapture`
- `pnpm -F @vm0/api-contracts test -- src/contracts/__tests__/runners.test.ts`
- `pnpm -F @vm0/api-contracts check-types`

## Notes

The local pre-commit hook's full `knip --cache` check reports unrelated existing unused platform exports that are unchanged from `origin/main`; those files are not part of this PR.
