### PR TITLE
test(platform): cover mac composer sidebar shortcut

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import {
+  chatThreadByIdContract,
+  chatThreadsContract,
+  type ChatThreadListItem,
+} from "@vm0/api-contracts/contracts/chat-threads";
+
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const THREAD_ID = "b0000000-0000-4000-a000-000000000001";
+const PLACEHOLDER = "Ask me to automate workflows, manage tasks...";
+
+type SidebarThread = ChatThreadListItem;
+
+const restoreNavigator = vi.hoisted(() => {
+  const macUserAgent =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+  const maxTouchPoints = Object.getOwnPropertyDescriptor(
+    navigator,
+    "maxTouchPoints",
+  );
+  const platform = Object.getOwnPropertyDescriptor(navigator, "platform");
+  const userAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+
+  function restoreProperty(
+    property: "maxTouchPoints" | "platform" | "userAgent",
+    descriptor: PropertyDescriptor | undefined,
+  ): void {
+    if (descriptor) {
+      Object.defineProperty(navigator, property, descriptor);
+    } else {
+      delete (navigator as Partial<Record<typeof property, unknown>>)[property];
+    }
+  }
+
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: macUserAgent,
+  });
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    value: "MacIntel",
+  });
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    configurable: true,
+    value: 0,
+  });
+
+  return () => {
+    restoreProperty("userAgent", userAgent);
+    restoreProperty("platform", platform);
+    restoreProperty("maxTouchPoints", maxTouchPoints);
+  };
+});
+
+function prepareDefaultAgent(): void {
+  context.mocks.data.team([
+    {
+      id: AGENT_ID,
+      ownerId: "test-user-123",
+      displayName: "Zero",
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      visibility: "public",
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ]);
+}
+
+function createThread(id: string, title: string): SidebarThread {
+  return {
+    id,
+    title,
+    agent: { id: AGENT_ID, avatarUrl: null },
+    createdAt: "2026-03-10T00:00:00Z",
+    updatedAt: "2026-03-10T00:00:00Z",
+    running: false,
+    pinnedAt: null,
+  };
+}
+
+function mockSidebarThreadStory(threads: readonly SidebarThread[]): void {
+  context.mocks.api(chatThreadsContract.snapshot, ({ respond }) => {
+    return respond(200, {
+      chatThreads: threads.map((thread, index) => {
+        return {
+          id: thread.id,
+          agentId: thread.agent.id,
+          title: thread.title,
+          sortAt: new Date(
+            Date.parse("2026-03-10T00:00:00Z") +
+              (threads.length - index) * 1000,
+          ).toISOString(),
+          createdAt: thread.createdAt,
+          updatedAt: thread.updatedAt,
+          pinnedAt: thread.pinnedAt ?? null,
+          renamedAt: thread.renamedAt ?? null,
+          selectedModel: null,
+        };
+      }),
+      latestEventId: null,
+    });
+  });
+  context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+    return respond(200, { events: [], hasMore: false });
+  });
+  context.mocks.api(chatThreadsContract.activeIds, ({ respond }) => {
+    return respond(200, { threadIds: [] });
+  });
+  context.mocks.api(chatThreadByIdContract.get, ({ respond }) => {
+    return respond(200, {
+      lastReadAt: null,
+      computerUseHostId: null,
+      codexServiceTier: null,
+    });
+  });
+}
+
+afterAll(() => {
+  restoreNavigator();
+  vi.resetModules();
+});
+
+describe("zero sidebar mac shortcuts", () => {
+  it("toggles the sidebar with cmd+b while the chat composer is focused", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([createThread(THREAD_ID, "Release plan")]);
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${THREAD_ID}`,
+    });
+
+    const composerRoot = await screen.findByPlaceholderText(PLACEHOLDER);
+    const composer = composerRoot.querySelector('[contenteditable="true"]');
+    if (!(composer instanceof HTMLElement)) {
+      throw new Error("Chat composer editor not found");
+    }
+    await waitFor(() => {
+      expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Expand sidebar")).not.toBeInTheDocument();
+    });
+
+    composer.focus();
+    expect(composer).toHaveFocus();
+    fireEvent.keyDown(composer, { key: "b", metaKey: true });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Expand sidebar")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -616,9 +616,11 @@ export function TiptapWorkflowComposer({
     ) {
       return true;
     }
-    // Defer to the parent for send / global shortcuts. If it consumes the event
-    // (e.g. Enter-to-send) it calls preventDefault; otherwise the editor handles
-    // the keystroke (e.g. Shift+Enter or mobile Enter inserts a newline).
+    // Defer to the parent for send / global shortcuts. Sidebar shortcuts such
+    // as Cmd+B are handled there before ProseMirror gets a chance to consume
+    // the keystroke. If the parent consumes the event (e.g. Enter-to-send) it
+    // calls preventDefault; otherwise the editor handles the keystroke (e.g.
+    // Shift+Enter or mobile Enter inserts a newline).
     onKeyDown(event);
     return event.defaultPrevented;
   }


### PR DESCRIPTION
## Summary
- Adds a focused Vitest for `/chats/:id` on a Mac-like navigator environment.
- Verifies `Cmd+B` on the TipTap contenteditable composer toggles the left sidebar from expanded to collapsed.
- Uses `vi.hoisted` so the Mac navigator is active before keyboard shortcut modules initialize.
- Touches an app composer source comment to force the PR app preview build without changing runtime behavior.

## Local verification
- `pnpm exec prettier --check apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx`
- `pnpm -F @vm0/app exec oxlint src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx`
- `pnpm -F @vm0/app exec eslint src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx --max-warnings 0`
- `pnpm vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar-mac-shortcut.test.tsx`

## Preview QA
- Preview: https://pr-20527-app.vm6.ai
- Test account: `test-1783420086+clerk_test@example.com`
- Browser flow: signed in on the PR preview, opened `/chats/224d0793-a07e-4d0d-b0e2-de778a854607`, used a Mac user agent session, focused the TipTap `[contenteditable="true"]` composer, and pressed `Meta+B`.
- PASS: before shortcut, the sidebar was visible and the toggle was `Collapse sidebar`: https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/e2cf7aa4-f4d7-4ea4-9397-48c7cb279f28/chat-before-cmd-b.png
- PASS: after first `Meta+B`, the sidebar collapsed and the toggle became `Expand sidebar`: https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/14a4a4aa-fd90-4ad2-a2c9-f906a935e79a/chat-after-cmd-b.png
- PASS: after second `Meta+B`, the sidebar expanded again and the toggle returned to `Collapse sidebar`: https://cdn.vm0.io/artifacts/user_35iyIuFrcCRvYzXGomnWn44jBoo/bcf61882-ae7f-4a66-b73e-207acaf308a0/chat-after-second-cmd-b.png

## CI
- CI is green after rerunning a transient `test-app` failure unrelated to this PR (`Image is not defined` from `zero-jobs-page.test.tsx` avatar preload).