### PR TITLE
fix(mitm-addon): detach auth base forwards from executor shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -154,6 +154,13 @@ def _cancel_pending_forward_request_futures() -> None:
         future.cancel()
 
 
+def _discard_pending_forward_request_future(
+    future: Future[tuple[int, bytes, http.Headers]],
+) -> None:
+    with _forward_request_pending_futures_lock:
+        _forward_request_pending_futures.discard(future)
+
+
 def _join_forward_request_workers() -> None:
     current_thread = threading.current_thread()
     while True:
@@ -800,10 +807,15 @@ def _run_forward_request_worker(
     body: bytes | None,
 ) -> None:
     try:
-        with _forward_request_pending_futures_lock:
-            _forward_request_pending_futures.discard(future)
-        if not future.set_running_or_notify_cancel():
-            return
+        with _forward_request_lifecycle_lock:
+            if not _forward_request_accepting:
+                future.cancel()
+                _discard_pending_forward_request_future(future)
+                return
+            if not future.set_running_or_notify_cancel():
+                _discard_pending_forward_request_future(future)
+                return
+            _discard_pending_forward_request_future(future)
         try:
             result = _forward_request_sync_in_context(context, url, method, headers, body)
         except BaseException as exc:

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -156,6 +156,21 @@ def _cancel_pending_forward_request_futures() -> None:
         future.cancel()
 
 
+def _wake_forward_request_admission_waiters(
+    state: tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None,
+) -> None:
+    if state is None:
+        return
+    loop, _max_workers, semaphore = state
+
+    def release_waiters() -> None:
+        for _ in range(MAX_ADMITTED_AUTH_BASE_FORWARDS):
+            semaphore.release()
+
+    with suppress(RuntimeError):
+        loop.call_soon_threadsafe(release_waiters)
+
+
 def _discard_pending_forward_request_future(
     future: Future[tuple[int, bytes, http.Headers]],
 ) -> None:
@@ -201,7 +216,9 @@ def shutdown_forward_request_workers(*, wait: bool) -> None:
 
     with _forward_request_lifecycle_lock:
         _forward_request_accepting = False
+        admission_state = _forward_request_admission_state
         _forward_request_admission_state = None
+    _wake_forward_request_admission_waiters(admission_state)
     _cancel_pending_forward_request_futures()
     _close_active_forward_request_closeables()
     if wait:

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -308,6 +308,11 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
             _untrack_active_closeable(closeable)
         self._tracked_closeables.clear()
 
+    def _close_and_untrack_after_connect_failure(self, closeable: _Closeable) -> None:
+        with suppress(Exception):
+            closeable.close()
+        self._untrack_closeables()
+
     def connect(self) -> None:
         raw_sock = _connect_to_validated_addresses(self._validated_addresses)(
             (self.host, self.port),
@@ -319,8 +324,7 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
             raw_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except OSError as exc:
             if exc.errno != errno.ENOPROTOOPT:
-                raw_sock.close()
-                self._untrack_closeables()
+                self._close_and_untrack_after_connect_failure(raw_sock)
                 raise
         try:
             wrapped_sock = self._context.wrap_socket(raw_sock, server_hostname=self.host)
@@ -328,8 +332,7 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
                 self._track_closeable(wrapped_sock)
             self.sock = wrapped_sock
         except Exception:
-            raw_sock.close()
-            self._untrack_closeables()
+            self._close_and_untrack_after_connect_failure(raw_sock)
             raise
 
     def close(self) -> None:

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -130,8 +130,13 @@ class _Closeable(Protocol):
 
 
 def _track_active_closeable(closeable: _Closeable) -> None:
-    with _forward_request_active_closeables_lock:
-        _forward_request_active_closeables.add(closeable)
+    with _forward_request_lifecycle_lock:
+        close_after_track = not _forward_request_accepting
+        with _forward_request_active_closeables_lock:
+            _forward_request_active_closeables.add(closeable)
+    if close_after_track:
+        with suppress(Exception):
+            closeable.close()
 
 
 def _untrack_active_closeable(closeable: _Closeable) -> None:
@@ -150,6 +155,7 @@ def _close_active_forward_request_closeables() -> None:
 def _cancel_pending_forward_request_futures() -> None:
     with _forward_request_pending_futures_lock:
         futures = tuple(_forward_request_pending_futures)
+        _forward_request_pending_futures.clear()
     for future in futures:
         future.cancel()
 

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -111,6 +111,7 @@ _forward_request_admission_state: (
     tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None
 ) = None
 _forward_request_accepting = True
+_forward_request_lifecycle_lock = threading.Lock()
 _forward_request_workers: set[threading.Thread] = set()
 _forward_request_workers_lock = threading.Lock()
 _forward_request_pending_futures: set[Future[tuple[int, bytes, http.Headers]]] = set()
@@ -189,8 +190,9 @@ def shutdown_forward_request_executor(*, wait: bool) -> None:
     global _forward_request_admission_state
     global _forward_request_accepting
 
-    _forward_request_accepting = False
-    _forward_request_admission_state = None
+    with _forward_request_lifecycle_lock:
+        _forward_request_accepting = False
+        _forward_request_admission_state = None
     _cancel_pending_forward_request_futures()
     _close_active_forward_request_closeables()
     if wait:
@@ -733,29 +735,31 @@ def _forward_request_sync(
 def _get_forward_request_admission_semaphore() -> asyncio.Semaphore:
     global _forward_request_admission_state
 
-    if not _forward_request_accepting:
-        raise RuntimeError("auth.base forwarding workers are shut down")
-    loop = asyncio.get_running_loop()
-    max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
-    if (
-        _forward_request_admission_state is None
-        or _forward_request_admission_state[0] is not loop
-        or _forward_request_admission_state[1] != max_workers
-    ):
-        _forward_request_admission_state = (
-            loop,
-            max_workers,
-            asyncio.Semaphore(max_workers),
-        )
-    return _forward_request_admission_state[2]
+    with _forward_request_lifecycle_lock:
+        if not _forward_request_accepting:
+            raise RuntimeError("auth.base forwarding workers are shut down")
+        loop = asyncio.get_running_loop()
+        max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
+        if (
+            _forward_request_admission_state is None
+            or _forward_request_admission_state[0] is not loop
+            or _forward_request_admission_state[1] != max_workers
+        ):
+            _forward_request_admission_state = (
+                loop,
+                max_workers,
+                asyncio.Semaphore(max_workers),
+            )
+        return _forward_request_admission_state[2]
 
 
 def _can_submit_forward_request(semaphore: asyncio.Semaphore) -> bool:
-    return (
-        _forward_request_accepting
-        and _forward_request_admission_state is not None
-        and _forward_request_admission_state[2] is semaphore
-    )
+    with _forward_request_lifecycle_lock:
+        return (
+            _forward_request_accepting
+            and _forward_request_admission_state is not None
+            and _forward_request_admission_state[2] is semaphore
+        )
 
 
 def _release_forward_request_resources(
@@ -826,19 +830,22 @@ def _start_forward_request_worker(
         name="auth-base-forward",
         daemon=True,
     )
-    with _forward_request_pending_futures_lock:
-        _forward_request_pending_futures.add(future)
-    with _forward_request_workers_lock:
-        _forward_request_workers.add(worker)
-    try:
-        worker.start()
-    except BaseException:
+    with _forward_request_lifecycle_lock:
+        if not _forward_request_accepting:
+            raise RuntimeError("auth.base forwarding workers are shut down")
         with _forward_request_pending_futures_lock:
-            _forward_request_pending_futures.discard(future)
+            _forward_request_pending_futures.add(future)
         with _forward_request_workers_lock:
-            _forward_request_workers.discard(worker)
-        future.cancel()
-        raise
+            _forward_request_workers.add(worker)
+        try:
+            worker.start()
+        except BaseException:
+            with _forward_request_pending_futures_lock:
+                _forward_request_pending_futures.discard(future)
+            with _forward_request_workers_lock:
+                _forward_request_workers.discard(worker)
+            future.cancel()
+            raise
     return future
 
 

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -587,21 +587,23 @@ def reserve_forward_request_admission(body_bytes: int) -> AuthBaseForwardingAdmi
 
     if body_bytes < 0:
         raise ValueError("auth.base forwarding body size cannot be negative")
-    if not _forward_request_accepting:
-        raise RuntimeError("auth.base forwarding workers are shut down")
 
-    with _forward_request_budget_lock:
-        if _forward_request_admitted_count + 1 > MAX_ADMITTED_AUTH_BASE_FORWARDS:
-            raise AuthBaseForwardingSaturatedError("auth.base forwarding admission is full")
-        if (
-            _forward_request_admitted_body_bytes + body_bytes
-            > MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES
-        ):
-            raise AuthBaseForwardingSaturatedError("auth.base forwarding body budget is full")
+    with _forward_request_lifecycle_lock:
+        if not _forward_request_accepting:
+            raise RuntimeError("auth.base forwarding workers are shut down")
 
-        _forward_request_admitted_count += 1
-        _forward_request_admitted_body_bytes += body_bytes
-        return AuthBaseForwardingAdmission(body_bytes)
+        with _forward_request_budget_lock:
+            if _forward_request_admitted_count + 1 > MAX_ADMITTED_AUTH_BASE_FORWARDS:
+                raise AuthBaseForwardingSaturatedError("auth.base forwarding admission is full")
+            if (
+                _forward_request_admitted_body_bytes + body_bytes
+                > MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES
+            ):
+                raise AuthBaseForwardingSaturatedError("auth.base forwarding body budget is full")
+
+            _forward_request_admitted_count += 1
+            _forward_request_admitted_body_bytes += body_bytes
+            return AuthBaseForwardingAdmission(body_bytes)
 
 
 def adjust_forward_request_admission(

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -107,9 +107,6 @@ MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
 MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
 _PERCENT_DECODED_UPSTREAM_HOST_SYNTAX_CHARS = frozenset("{}*.\u3002\uff0e\uff61,")
 _UPSTREAM_HOST_FORBIDDEN_CHARS = frozenset("{}*")
-_forward_request_admission_state: (
-    tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None
-) = None
 _forward_request_accepting = True
 _forward_request_lifecycle_lock = threading.Lock()
 _forward_request_workers: set[threading.Thread] = set()
@@ -127,6 +124,16 @@ _https_context_lock = threading.Lock()
 
 class _Closeable(Protocol):
     def close(self) -> object: ...
+
+
+class _ForwardRequestAdmissionState(NamedTuple):
+    loop: asyncio.AbstractEventLoop
+    max_workers: int
+    admission_limit: int
+    semaphore: asyncio.Semaphore
+
+
+_forward_request_admission_state: _ForwardRequestAdmissionState | None = None
 
 
 def _track_active_closeable(closeable: _Closeable) -> None:
@@ -157,18 +164,17 @@ def _cancel_pending_forward_request_futures() -> None:
 
 
 def _wake_forward_request_admission_waiters(
-    state: tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None,
+    state: _ForwardRequestAdmissionState | None,
 ) -> None:
     if state is None:
         return
-    loop, _max_workers, semaphore = state
 
     def release_waiters() -> None:
-        for _ in range(MAX_ADMITTED_AUTH_BASE_FORWARDS):
-            semaphore.release()
+        for _ in range(state.admission_limit):
+            state.semaphore.release()
 
     with suppress(RuntimeError):
-        loop.call_soon_threadsafe(release_waiters)
+        state.loop.call_soon_threadsafe(release_waiters)
 
 
 def _discard_pending_forward_request_future(
@@ -771,17 +777,26 @@ def _get_forward_request_admission_semaphore() -> asyncio.Semaphore:
             raise RuntimeError("auth.base forwarding workers are shut down")
         loop = asyncio.get_running_loop()
         max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
+        admission_limit = MAX_ADMITTED_AUTH_BASE_FORWARDS
         if (
             _forward_request_admission_state is None
-            or _forward_request_admission_state[0] is not loop
-            or _forward_request_admission_state[1] != max_workers
+            or _forward_request_admission_state.loop is not loop
+            or _forward_request_admission_state.max_workers != max_workers
         ):
-            _forward_request_admission_state = (
-                loop,
-                max_workers,
-                asyncio.Semaphore(max_workers),
+            _forward_request_admission_state = _ForwardRequestAdmissionState(
+                loop=loop,
+                max_workers=max_workers,
+                admission_limit=admission_limit,
+                semaphore=asyncio.Semaphore(max_workers),
             )
-        return _forward_request_admission_state[2]
+        elif admission_limit > _forward_request_admission_state.admission_limit:
+            _forward_request_admission_state = _ForwardRequestAdmissionState(
+                loop=_forward_request_admission_state.loop,
+                max_workers=_forward_request_admission_state.max_workers,
+                admission_limit=admission_limit,
+                semaphore=_forward_request_admission_state.semaphore,
+            )
+        return _forward_request_admission_state.semaphore
 
 
 def _can_submit_forward_request(semaphore: asyncio.Semaphore) -> bool:
@@ -789,7 +804,7 @@ def _can_submit_forward_request(semaphore: asyncio.Semaphore) -> bool:
         return (
             _forward_request_accepting
             and _forward_request_admission_state is not None
-            and _forward_request_admission_state[2] is semaphore
+            and _forward_request_admission_state.semaphore is semaphore
         )
 
 

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -170,6 +170,8 @@ def _wake_forward_request_admission_waiters(
         return
 
     def release_waiters() -> None:
+        # Wake every admitted waiter. Shutdown has already disabled submission, so
+        # these extra permits only let waiters observe the closed lifecycle state.
         for _ in range(state.admission_limit):
             state.semaphore.release()
 
@@ -790,6 +792,8 @@ def _get_forward_request_admission_semaphore() -> asyncio.Semaphore:
                 semaphore=asyncio.Semaphore(max_workers),
             )
         elif admission_limit > _forward_request_admission_state.admission_limit:
+            # Keep the same semaphore so a capacity change cannot reset the
+            # active concurrency limit while forwards are already running.
             _forward_request_admission_state = _ForwardRequestAdmissionState(
                 loop=_forward_request_admission_state.loop,
                 max_workers=_forward_request_admission_state.max_workers,

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -136,9 +136,12 @@ class _ForwardRequestAdmissionState(NamedTuple):
 _forward_request_admission_state: _ForwardRequestAdmissionState | None = None
 
 
-def _track_active_closeable(closeable: _Closeable) -> None:
+def _track_active_closeable(closeable: _Closeable) -> bool:
     with _forward_request_lifecycle_lock, _forward_request_active_closeables_lock:
+        if not _forward_request_accepting:
+            return False
         _forward_request_active_closeables.add(closeable)
+        return True
 
 
 def _untrack_active_closeable(closeable: _Closeable) -> None:
@@ -327,8 +330,11 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
         self._tracked_closeables: list[_Closeable] = []
 
     def _track_closeable(self, closeable: _Closeable) -> None:
+        if not _track_active_closeable(closeable):
+            with suppress(Exception):
+                closeable.close()
+            raise RuntimeError("auth.base forwarding workers are shut down")
         self._tracked_closeables.append(closeable)
-        _track_active_closeable(closeable)
 
     def _untrack_closeables(self) -> None:
         for closeable in self._tracked_closeables:

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -176,7 +176,7 @@ def reset_forward_request_state_for_tests() -> None:
     global _forward_request_admitted_count
     global _https_context
 
-    shutdown_forward_request_executor(wait=True)
+    shutdown_forward_request_workers(wait=True)
     with _forward_request_budget_lock:
         _forward_request_admitted_count = 0
         _forward_request_admitted_body_bytes = 0
@@ -185,7 +185,7 @@ def reset_forward_request_state_for_tests() -> None:
     _forward_request_accepting = True
 
 
-def shutdown_forward_request_executor(*, wait: bool) -> None:
+def shutdown_forward_request_workers(*, wait: bool) -> None:
     """Shut down auth.base forwarding workers."""
     global _forward_request_admission_state
     global _forward_request_accepting

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -130,13 +130,8 @@ class _Closeable(Protocol):
 
 
 def _track_active_closeable(closeable: _Closeable) -> None:
-    with _forward_request_lifecycle_lock:
-        close_after_track = not _forward_request_accepting
-        with _forward_request_active_closeables_lock:
-            _forward_request_active_closeables.add(closeable)
-    if close_after_track:
-        with suppress(Exception):
-            closeable.close()
+    with _forward_request_lifecycle_lock, _forward_request_active_closeables_lock:
+        _forward_request_active_closeables.add(closeable)
 
 
 def _untrack_active_closeable(closeable: _Closeable) -> None:
@@ -147,6 +142,7 @@ def _untrack_active_closeable(closeable: _Closeable) -> None:
 def _close_active_forward_request_closeables() -> None:
     with _forward_request_active_closeables_lock:
         closeables = tuple(_forward_request_active_closeables)
+        _forward_request_active_closeables.clear()
     for closeable in closeables:
         with suppress(Exception):
             closeable.close()

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -12,6 +12,7 @@ import http.client as http_client
 import ipaddress
 import socket
 import ssl
+import sys
 import threading
 import urllib.parse
 from concurrent.futures import Future, InvalidStateError
@@ -105,6 +106,13 @@ MAX_AUTH_BASE_RESPONSE_BODY_BYTES = 32 * 1024 * 1024
 MAX_CONCURRENT_AUTH_BASE_FORWARDS = 4
 MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
 MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
+_FORWARD_REQUEST_CLEANUP_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    Exception,
+    asyncio.CancelledError,
+    KeyboardInterrupt,
+    SystemExit,
+    GeneratorExit,
+)
 _PERCENT_DECODED_UPSTREAM_HOST_SYNTAX_CHARS = frozenset("{}*.\u3002\uff0e\uff61,")
 _UPSTREAM_HOST_FORBIDDEN_CHARS = frozenset("{}*")
 _forward_request_accepting = True
@@ -123,7 +131,8 @@ _https_context_lock = threading.Lock()
 
 
 class _Closeable(Protocol):
-    def close(self) -> object: ...
+    def close(self) -> object:
+        raise NotImplementedError
 
 
 class _ForwardRequestAdmissionState(NamedTuple):
@@ -867,12 +876,17 @@ def _run_forward_request_worker(
             _discard_pending_forward_request_future(future)
         try:
             result = _forward_request_sync_in_context(context, url, method, headers, body)
-        except BaseException as exc:
+        except Exception as exc:
             _set_forward_request_future_exception(future, exc)
         else:
             with suppress(InvalidStateError):
                 future.set_result(result)
     finally:
+        if sys.exc_info()[1] is not None and future.running():
+            _set_forward_request_future_exception(
+                future,
+                RuntimeError("auth.base forwarding worker exited without completing future"),
+            )
         with _forward_request_workers_lock:
             _forward_request_workers.discard(threading.current_thread())
 
@@ -900,7 +914,7 @@ def _start_forward_request_worker(
             _forward_request_workers.add(worker)
         try:
             worker.start()
-        except BaseException:
+        except _FORWARD_REQUEST_CLEANUP_EXCEPTIONS:
             with _forward_request_pending_futures_lock:
                 _forward_request_pending_futures.discard(future)
             with _forward_request_workers_lock:
@@ -922,7 +936,7 @@ async def forward_request(
     body_bytes = _request_body_size(body)
     try:
         _validate_request_body_size(body)
-    except BaseException:
+    except _FORWARD_REQUEST_CLEANUP_EXCEPTIONS:
         if admission is not None:
             release_forward_request_admission(admission)
         raise
@@ -931,7 +945,7 @@ async def forward_request(
     else:
         try:
             adjust_forward_request_admission(admission, body_bytes)
-        except BaseException:
+        except _FORWARD_REQUEST_CLEANUP_EXCEPTIONS:
             release_forward_request_admission(admission)
             raise
 
@@ -952,7 +966,7 @@ async def forward_request(
                 headers,
                 body,
             )
-        except BaseException:
+        except _FORWARD_REQUEST_CLEANUP_EXCEPTIONS:
             semaphore.release()
             raise
         future.add_done_callback(

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -14,9 +14,9 @@ import socket
 import ssl
 import threading
 import urllib.parse
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, InvalidStateError
 from contextlib import suppress
-from typing import NamedTuple
+from typing import NamedTuple, Protocol
 
 from mitmproxy import http
 
@@ -107,16 +107,65 @@ MAX_ADMITTED_AUTH_BASE_FORWARDS = 16
 MAX_ADMITTED_AUTH_BASE_REQUEST_BODY_BYTES = 128 * 1024 * 1024
 _PERCENT_DECODED_UPSTREAM_HOST_SYNTAX_CHARS = frozenset("{}*.\u3002\uff0e\uff61,")
 _UPSTREAM_HOST_FORBIDDEN_CHARS = frozenset("{}*")
-_forward_request_executor_state: tuple[int, ThreadPoolExecutor] | None = None
 _forward_request_admission_state: (
     tuple[asyncio.AbstractEventLoop, int, asyncio.Semaphore] | None
 ) = None
 _forward_request_accepting = True
+_forward_request_workers: set[threading.Thread] = set()
+_forward_request_workers_lock = threading.Lock()
+_forward_request_pending_futures: set[Future[tuple[int, bytes, http.Headers]]] = set()
+_forward_request_pending_futures_lock = threading.Lock()
 _forward_request_budget_lock = threading.Lock()
 _forward_request_admitted_count = 0
 _forward_request_admitted_body_bytes = 0
+_forward_request_active_closeables: set["_Closeable"] = set()
+_forward_request_active_closeables_lock = threading.Lock()
 _https_context: ssl.SSLContext | None = None
 _https_context_lock = threading.Lock()
+
+
+class _Closeable(Protocol):
+    def close(self) -> object: ...
+
+
+def _track_active_closeable(closeable: _Closeable) -> None:
+    with _forward_request_active_closeables_lock:
+        _forward_request_active_closeables.add(closeable)
+
+
+def _untrack_active_closeable(closeable: _Closeable) -> None:
+    with _forward_request_active_closeables_lock:
+        _forward_request_active_closeables.discard(closeable)
+
+
+def _close_active_forward_request_closeables() -> None:
+    with _forward_request_active_closeables_lock:
+        closeables = tuple(_forward_request_active_closeables)
+    for closeable in closeables:
+        with suppress(Exception):
+            closeable.close()
+
+
+def _cancel_pending_forward_request_futures() -> None:
+    with _forward_request_pending_futures_lock:
+        futures = tuple(_forward_request_pending_futures)
+    for future in futures:
+        future.cancel()
+
+
+def _join_forward_request_workers() -> None:
+    current_thread = threading.current_thread()
+    while True:
+        with _forward_request_workers_lock:
+            workers = tuple(
+                worker
+                for worker in _forward_request_workers
+                if worker is not current_thread and worker.is_alive()
+            )
+        if not workers:
+            return
+        for worker in workers:
+            worker.join()
 
 
 def reset_forward_request_state_for_tests() -> None:
@@ -137,16 +186,15 @@ def reset_forward_request_state_for_tests() -> None:
 
 def shutdown_forward_request_executor(*, wait: bool) -> None:
     """Shut down auth.base forwarding workers."""
-    global _forward_request_executor_state
     global _forward_request_admission_state
     global _forward_request_accepting
 
     _forward_request_accepting = False
     _forward_request_admission_state = None
-    state = _forward_request_executor_state
-    _forward_request_executor_state = None
-    if state is not None:
-        state[1].shutdown(wait=wait, cancel_futures=True)
+    _cancel_pending_forward_request_futures()
+    _close_active_forward_request_closeables()
+    if wait:
+        _join_forward_request_workers()
 
 
 class ForwardedResponseTooLargeError(Exception):
@@ -240,6 +288,16 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
         super().__init__(host, port=port, timeout=timeout)
         self._validated_addresses = validated_addresses
         self._context = _get_https_context()
+        self._tracked_closeables: list[_Closeable] = []
+
+    def _track_closeable(self, closeable: _Closeable) -> None:
+        self._tracked_closeables.append(closeable)
+        _track_active_closeable(closeable)
+
+    def _untrack_closeables(self) -> None:
+        for closeable in self._tracked_closeables:
+            _untrack_active_closeable(closeable)
+        self._tracked_closeables.clear()
 
     def connect(self) -> None:
         raw_sock = _connect_to_validated_addresses(self._validated_addresses)(
@@ -247,17 +305,29 @@ class _ValidatedTLSConnection(http_client.HTTPConnection):
             self.timeout,
             None,
         )
+        self._track_closeable(raw_sock)
         try:
             raw_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except OSError as exc:
             if exc.errno != errno.ENOPROTOOPT:
                 raw_sock.close()
+                self._untrack_closeables()
                 raise
         try:
-            self.sock = self._context.wrap_socket(raw_sock, server_hostname=self.host)
+            wrapped_sock = self._context.wrap_socket(raw_sock, server_hostname=self.host)
+            if wrapped_sock is not raw_sock:
+                self._track_closeable(wrapped_sock)
+            self.sock = wrapped_sock
         except Exception:
             raw_sock.close()
+            self._untrack_closeables()
             raise
+
+    def close(self) -> None:
+        try:
+            super().close()
+        finally:
+            self._untrack_closeables()
 
 
 def _make_validated_https_connection(
@@ -509,7 +579,7 @@ def reserve_forward_request_admission(body_bytes: int) -> AuthBaseForwardingAdmi
     if body_bytes < 0:
         raise ValueError("auth.base forwarding body size cannot be negative")
     if not _forward_request_accepting:
-        raise RuntimeError("auth.base forwarding executor is shut down")
+        raise RuntimeError("auth.base forwarding workers are shut down")
 
     with _forward_request_budget_lock:
         if _forward_request_admitted_count + 1 > MAX_ADMITTED_AUTH_BASE_FORWARDS:
@@ -660,31 +730,11 @@ def _forward_request_sync(
         conn.close()
 
 
-def _get_forward_request_executor() -> ThreadPoolExecutor:
-    global _forward_request_executor_state
-
-    if not _forward_request_accepting:
-        raise RuntimeError("auth.base forwarding executor is shut down")
-    max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
-    if _forward_request_executor_state is None or _forward_request_executor_state[0] != max_workers:
-        state = _forward_request_executor_state
-        _forward_request_executor_state = (
-            max_workers,
-            ThreadPoolExecutor(
-                max_workers=max_workers,
-                thread_name_prefix="auth-base-forward",
-            ),
-        )
-        if state is not None:
-            state[1].shutdown(wait=True, cancel_futures=True)
-    return _forward_request_executor_state[1]
-
-
 def _get_forward_request_admission_semaphore() -> asyncio.Semaphore:
     global _forward_request_admission_state
 
     if not _forward_request_accepting:
-        raise RuntimeError("auth.base forwarding executor is shut down")
+        raise RuntimeError("auth.base forwarding workers are shut down")
     loop = asyncio.get_running_loop()
     max_workers = MAX_CONCURRENT_AUTH_BASE_FORWARDS
     if (
@@ -729,6 +779,69 @@ def _forward_request_sync_in_context(
     return context.run(_forward_request_sync, url, method, headers, body)
 
 
+def _set_forward_request_future_exception(
+    future: Future[tuple[int, bytes, http.Headers]],
+    exc: BaseException,
+) -> None:
+    with suppress(InvalidStateError):
+        future.set_exception(exc)
+
+
+def _run_forward_request_worker(
+    future: Future[tuple[int, bytes, http.Headers]],
+    context: contextvars.Context,
+    url: str,
+    method: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+) -> None:
+    try:
+        with _forward_request_pending_futures_lock:
+            _forward_request_pending_futures.discard(future)
+        if not future.set_running_or_notify_cancel():
+            return
+        try:
+            result = _forward_request_sync_in_context(context, url, method, headers, body)
+        except BaseException as exc:
+            _set_forward_request_future_exception(future, exc)
+        else:
+            with suppress(InvalidStateError):
+                future.set_result(result)
+    finally:
+        with _forward_request_workers_lock:
+            _forward_request_workers.discard(threading.current_thread())
+
+
+def _start_forward_request_worker(
+    context: contextvars.Context,
+    url: str,
+    method: str,
+    headers: list[tuple[str, str]],
+    body: bytes | None,
+) -> Future[tuple[int, bytes, http.Headers]]:
+    future: Future[tuple[int, bytes, http.Headers]] = Future()
+    worker = threading.Thread(
+        target=_run_forward_request_worker,
+        args=(future, context, url, method, headers, body),
+        name="auth-base-forward",
+        daemon=True,
+    )
+    with _forward_request_pending_futures_lock:
+        _forward_request_pending_futures.add(future)
+    with _forward_request_workers_lock:
+        _forward_request_workers.add(worker)
+    try:
+        worker.start()
+    except BaseException:
+        with _forward_request_pending_futures_lock:
+            _forward_request_pending_futures.discard(future)
+        with _forward_request_workers_lock:
+            _forward_request_workers.discard(worker)
+        future.cancel()
+        raise
+    return future
+
+
 async def forward_request(
     url: str,
     method: str,
@@ -762,10 +875,9 @@ async def forward_request(
         await semaphore.acquire()
         if not _can_submit_forward_request(semaphore):
             semaphore.release()
-            raise RuntimeError("auth.base forwarding executor is shut down")
+            raise RuntimeError("auth.base forwarding workers are shut down")
         try:
-            future = _get_forward_request_executor().submit(
-                _forward_request_sync_in_context,
+            future = _start_forward_request_worker(
                 context,
                 url,
                 method,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -3533,7 +3533,7 @@ def done():
             usage.webhook.usage_executor.shutdown(wait=True)
         finally:
             try:
-                auth_base_forwarder.shutdown_forward_request_executor(wait=False)
+                auth_base_forwarder.shutdown_forward_request_workers(wait=False)
             finally:
                 shutdown_log_writer()
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -3519,8 +3519,9 @@ def done():
     executor while a SIGUSR1 worker is still converting buffered usage into
     webhook reports. After that, ``shutdown(wait=True)`` drains submitted
     webhook futures during graceful stop. Auth.base forwarding does not need
-    to finish queued work during shutdown, so its executor cancels queued
-    futures without waiting for slow upstream responses.
+    to finish running work during shutdown, so its worker shutdown stops new
+    forwards and best-effort closes active upstream sockets without waiting for
+    slow upstream responses.
     """
     try:
         # Wait for any in-flight runner-triggered flush before closing the

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -456,36 +456,6 @@ class TestAuthBaseForwarderTransportSecurity:
         with forwarder._forward_request_active_closeables_lock:
             assert raw_sock not in forwarder._forward_request_active_closeables
 
-    def test_validated_connection_closes_socket_tracked_after_shutdown(self):
-        class CloseAwareSocket(FakeSocket):
-            def setsockopt(self, level: int, optname: int, value: int) -> None:
-                super().setsockopt(level, optname, value)
-                if self.closed:
-                    raise OSError(errno.EBADF, "closed during shutdown")
-
-        raw_sock = CloseAwareSocket(http_response())
-        context = MagicMock()
-        conn = forwarder._make_validated_https_connection(
-            "hooks.example.com",
-            port=None,
-            timeout=30,
-            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
-        )
-        vars(conn)["_context"] = context
-
-        forwarder.shutdown_forward_request_workers(wait=False)
-        with (
-            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
-            pytest.raises(OSError, match="closed during shutdown"),
-        ):
-            conn.connect()
-
-        assert raw_sock.closed
-        assert raw_sock.close_count >= 1
-        context.wrap_socket.assert_not_called()
-        with forwarder._forward_request_active_closeables_lock:
-            assert raw_sock not in forwarder._forward_request_active_closeables
-
 
 class TestAuthBaseForwarderRequestBehavior:
     async def test_returns_redirect_response_without_following(self):
@@ -1299,6 +1269,8 @@ class TestForwardRequestAsyncWrapper:
                 assert await asyncio.to_thread(setsockopt_entered.wait, 2)
                 forwarder.shutdown_forward_request_workers(wait=False)
                 assert await asyncio.to_thread(socket_closed.wait, 2)
+                with forwarder._forward_request_active_closeables_lock:
+                    assert socket not in forwarder._forward_request_active_closeables
             finally:
                 release_setsockopt.set()
                 await asyncio.gather(task, return_exceptions=True)

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1188,6 +1188,76 @@ class TestForwardRequestAsyncWrapper:
         assert started == 2
         assert max_active == 1
 
+    async def test_admission_limit_change_does_not_reset_concurrency_limit(self):
+        active = 0
+        max_active = 0
+        started = 0
+        lock = threading.Lock()
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            nonlocal active
+            nonlocal max_active
+            nonlocal started
+
+            with lock:
+                active += 1
+                started += 1
+                current = started
+                max_active = max(max_active, active)
+                if current == 1:
+                    first_entered.set()
+                elif current == 2:
+                    second_entered.set()
+            try:
+                if current == 1 and not release_first.wait(timeout=5):
+                    raise TimeoutError("test did not release first forward")
+                return FakeSocket(http_response())
+            finally:
+                with lock:
+                    active -= 1
+
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 2),
+            fake_forwarder_upstream(create_connection=create_connection),
+        ):
+            first_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            second_task = None
+            try:
+                first_started = await asyncio.to_thread(first_entered.wait, 2)
+                assert first_started
+                assert started == 1
+
+                with patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 3):
+                    second_task = asyncio.create_task(
+                        forwarder.forward_request("https://example.com", "GET", [], None)
+                    )
+                    await _run_ready_tasks()
+
+                assert not second_entered.is_set()
+
+                release_first.set()
+                second_started_after_release = await asyncio.to_thread(second_entered.wait, 2)
+                assert second_started_after_release
+
+                status, body, headers = await asyncio.wait_for(second_task, timeout=2)
+            finally:
+                release_first.set()
+                await asyncio.gather(first_task, return_exceptions=True)
+                if second_task is not None:
+                    await asyncio.gather(second_task, return_exceptions=True)
+
+        assert status == 200
+        assert body == b"ok"
+        assert list(headers.items(multi=True)) == []
+        assert started == 2
+        assert max_active == 1
+
     async def test_shutdown_rejects_waiting_forward_without_starting_next_forward(self):
         started = 0
         lock = threading.Lock()
@@ -1262,6 +1332,7 @@ class TestForwardRequestAsyncWrapper:
 
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 2),
             fake_forwarder_upstream(create_connection=create_connection),
         ):
             first_task = asyncio.create_task(
@@ -1274,7 +1345,8 @@ class TestForwardRequestAsyncWrapper:
                 first_started = await asyncio.to_thread(first_entered.wait, 2)
                 assert first_started
 
-                forwarder.shutdown_forward_request_workers(wait=False)
+                with patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 0):
+                    forwarder.shutdown_forward_request_workers(wait=False)
 
                 with pytest.raises(RuntimeError, match="workers are shut down"):
                     await asyncio.wait_for(waiting_task, timeout=2)

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -2,9 +2,13 @@
 
 import asyncio
 import errno
+import os
 import ssl
+import subprocess
+import sys
+import textwrap
 import threading
-from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -12,23 +16,8 @@ import pytest
 import auth_base_forwarder as forwarder
 from tests.auth_base_forwarder_helpers import FakeSocket, fake_forwarder_upstream, http_response
 
-
-class _SubmitRecordingThreadPoolExecutor(ThreadPoolExecutor):
-    def __init__(self, *args, **kwargs) -> None:
-        self._submit_count = 0
-        self._submit_lock = threading.Lock()
-        super().__init__(*args, **kwargs)
-
-    def submit(self, fn, /, *args, **kwargs):
-        future = super().submit(fn, *args, **kwargs)
-        with self._submit_lock:
-            self._submit_count += 1
-        return future
-
-    @property
-    def submit_count(self) -> int:
-        with self._submit_lock:
-            return self._submit_count
+_ADDON_ROOT = Path(__file__).resolve().parents[1]
+_SUBPROCESS_TIMEOUT_SECONDS = 5
 
 
 async def _run_ready_tasks() -> None:
@@ -785,6 +774,64 @@ class TestAuthBaseForwarderResourceCleanup:
 
 
 class TestForwardRequestAsyncWrapper:
+    def test_shutdown_wait_false_does_not_keep_process_alive_with_blocked_forward(self):
+        script = textwrap.dedent(
+            """
+            import asyncio
+            import threading
+
+            import auth_base_forwarder as forwarder
+            from tests.auth_base_forwarder_helpers import (
+                FakeSocket,
+                fake_forwarder_upstream,
+                http_response,
+            )
+
+
+            async def main():
+                forward_started = threading.Event()
+                never_release = threading.Event()
+
+                def create_connection(_address, _timeout, _source_address):
+                    forward_started.set()
+                    never_release.wait()
+                    return FakeSocket(http_response())
+
+                with fake_forwarder_upstream(create_connection=create_connection):
+                    task = asyncio.create_task(
+                        forwarder.forward_request("https://example.com", "GET", [], None)
+                    )
+                    try:
+                        if not await asyncio.to_thread(forward_started.wait, 2):
+                            raise RuntimeError("auth.base forward did not start")
+                        forwarder.shutdown_forward_request_executor(wait=False)
+                    finally:
+                        task.cancel()
+
+
+            asyncio.run(main())
+            """
+        )
+        env = os.environ.copy()
+        python_paths = [
+            str(_ADDON_ROOT / "src"),
+            str(_ADDON_ROOT),
+        ]
+        if env.get("PYTHONPATH"):
+            python_paths.append(env["PYTHONPATH"])
+        env["PYTHONPATH"] = os.pathsep.join(python_paths)
+
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-c", script],
+            capture_output=True,
+            check=False,
+            env=env,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+
+        assert result.returncode == 0, result.stderr
+
     async def test_rejects_body_over_limit_before_forwarding(self):
         with (
             patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),
@@ -974,17 +1021,9 @@ class TestForwardRequestAsyncWrapper:
                 with lock:
                     active -= 1
 
-        executors: list[_SubmitRecordingThreadPoolExecutor] = []
-
-        def create_executor(*args, **kwargs):
-            executor = _SubmitRecordingThreadPoolExecutor(*args, **kwargs)
-            executors.append(executor)
-            return executor
-
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
             patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 1),
-            patch.object(forwarder, "ThreadPoolExecutor", new=create_executor),
             fake_forwarder_upstream(create_connection=create_connection),
         ):
             first_task = asyncio.create_task(
@@ -993,9 +1032,7 @@ class TestForwardRequestAsyncWrapper:
             try:
                 first_started = await asyncio.to_thread(first_entered.wait, 2)
                 assert first_started
-                assert len(executors) == 1
-                executor = executors[0]
-                assert executor.submit_count == 1
+                assert started == 1
 
                 first_task.cancel()
                 with pytest.raises(asyncio.CancelledError):
@@ -1005,7 +1042,7 @@ class TestForwardRequestAsyncWrapper:
 
                 with pytest.raises(forwarder.AuthBaseForwardingSaturatedError):
                     await forwarder.forward_request("https://example.com", "GET", [], None)
-                assert executor.submit_count == 1
+                assert started == 1
 
                 release_first.set()
             finally:
@@ -1047,17 +1084,9 @@ class TestForwardRequestAsyncWrapper:
                     active -= 1
 
         third_task = None
-        executors: list[_SubmitRecordingThreadPoolExecutor] = []
-
-        def create_executor(*args, **kwargs):
-            executor = _SubmitRecordingThreadPoolExecutor(*args, **kwargs)
-            executors.append(executor)
-            return executor
-
         with (
             patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
             patch.object(forwarder, "MAX_ADMITTED_AUTH_BASE_FORWARDS", 2),
-            patch.object(forwarder, "ThreadPoolExecutor", new=create_executor),
             fake_forwarder_upstream(create_connection=create_connection),
         ):
             first_task = asyncio.create_task(
@@ -1069,9 +1098,7 @@ class TestForwardRequestAsyncWrapper:
             try:
                 first_started = await asyncio.to_thread(first_entered.wait, 2)
                 assert first_started
-                assert len(executors) == 1
-                executor = executors[0]
-                assert executor.submit_count == 1
+                assert started == 1
 
                 waiting_task.cancel()
                 with pytest.raises(asyncio.CancelledError):
@@ -1081,7 +1108,7 @@ class TestForwardRequestAsyncWrapper:
                     forwarder.forward_request("https://example.com", "GET", [], None)
                 )
                 await _run_ready_tasks()
-                assert executor.submit_count == 1
+                assert started == 1
                 assert not second_entered.is_set()
 
                 release_first.set()
@@ -1101,7 +1128,7 @@ class TestForwardRequestAsyncWrapper:
         assert started == 2
         assert max_active == 1
 
-    async def test_shutdown_rejects_waiting_forward_without_restarting_executor(self):
+    async def test_shutdown_rejects_waiting_forward_without_starting_next_forward(self):
         started = 0
         lock = threading.Lock()
         first_entered = threading.Event()
@@ -1140,7 +1167,7 @@ class TestForwardRequestAsyncWrapper:
                 release_first.set()
 
                 status, body, headers = await asyncio.wait_for(first_task, timeout=2)
-                with pytest.raises(RuntimeError, match="executor is shut down"):
+                with pytest.raises(RuntimeError, match="workers are shut down"):
                     await asyncio.wait_for(waiting_task, timeout=2)
             finally:
                 release_first.set()
@@ -1151,6 +1178,42 @@ class TestForwardRequestAsyncWrapper:
         assert list(headers.items(multi=True)) == []
         assert not second_entered.is_set()
         assert started == 1
+
+    async def test_shutdown_closes_active_forward_socket(self):
+        setsockopt_entered = threading.Event()
+        socket_closed = threading.Event()
+        release_setsockopt = threading.Event()
+
+        class BlockingSetsockoptSocket(FakeSocket):
+            def setsockopt(self, level: int, optname: int, value: int) -> None:
+                self.setsockopt_calls.append((level, optname, value))
+                setsockopt_entered.set()
+                if not release_setsockopt.wait(timeout=5):
+                    raise TimeoutError("test did not release setsockopt")
+
+            def close(self) -> None:
+                super().close()
+                socket_closed.set()
+                release_setsockopt.set()
+
+        socket = BlockingSetsockoptSocket(http_response())
+
+        def create_connection(_address, _timeout, _source_address):
+            return socket
+
+        with fake_forwarder_upstream(create_connection=create_connection):
+            task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                assert await asyncio.to_thread(setsockopt_entered.wait, 2)
+                forwarder.shutdown_forward_request_executor(wait=False)
+                assert await asyncio.to_thread(socket_closed.wait, 2)
+            finally:
+                release_setsockopt.set()
+                await asyncio.gather(task, return_exceptions=True)
+
+        assert socket.closed
 
     async def test_offloads_request_work_from_event_loop_thread(self):
         event_loop_thread_id = threading.get_ident()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -835,6 +835,14 @@ class TestForwardRequestAsyncWrapper:
         with forwarder._forward_request_pending_futures_lock:
             assert future not in forwarder._forward_request_pending_futures
 
+    def test_shutdown_rejects_new_forward_admission(self):
+        forwarder.shutdown_forward_request_workers(wait=False)
+
+        with pytest.raises(RuntimeError, match="workers are shut down"):
+            forwarder.reserve_forward_request_admission(0)
+
+        assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
     async def test_rejects_body_over_limit_before_forwarding(self):
         with (
             patch.object(forwarder, "MAX_AUTH_BASE_REQUEST_BODY_BYTES", 4),

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -38,7 +38,7 @@ def _run_blocked_forward_then_shutdown_wait_false() -> None:
             try:
                 if not await asyncio.to_thread(forward_started.wait, 2):
                     raise RuntimeError("auth.base forward did not start")
-                forwarder.shutdown_forward_request_executor(wait=False)
+                forwarder.shutdown_forward_request_workers(wait=False)
             finally:
                 task.cancel()
 
@@ -1141,7 +1141,7 @@ class TestForwardRequestAsyncWrapper:
                 first_started = await asyncio.to_thread(first_entered.wait, 2)
                 assert first_started
 
-                forwarder.shutdown_forward_request_executor(wait=False)
+                forwarder.shutdown_forward_request_workers(wait=False)
                 release_first.set()
 
                 status, body, headers = await asyncio.wait_for(first_task, timeout=2)
@@ -1185,7 +1185,7 @@ class TestForwardRequestAsyncWrapper:
             )
             try:
                 assert await asyncio.to_thread(setsockopt_entered.wait, 2)
-                forwarder.shutdown_forward_request_executor(wait=False)
+                forwarder.shutdown_forward_request_workers(wait=False)
                 assert await asyncio.to_thread(socket_closed.wait, 2)
             finally:
                 release_setsockopt.set()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -389,6 +389,30 @@ class TestAuthBaseForwarderTransportSecurity:
         context.wrap_socket.assert_called_once_with(raw_sock, server_hostname="hooks.example.com")
         assert conn.sock is wrapped_sock
 
+    def test_validated_connection_untracks_raw_socket_when_setsockopt_cleanup_close_fails(self):
+        raw_sock = MagicMock()
+        raw_sock.setsockopt.side_effect = OSError(errno.EINVAL, "setsockopt failed")
+        raw_sock.close.side_effect = OSError("close failed")
+        context = MagicMock()
+        conn = forwarder._make_validated_https_connection(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+        )
+        vars(conn)["_context"] = context
+
+        with (
+            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
+            pytest.raises(OSError, match="setsockopt failed"),
+        ):
+            conn.connect()
+
+        raw_sock.close.assert_called_once_with()
+        context.wrap_socket.assert_not_called()
+        with forwarder._forward_request_active_closeables_lock:
+            assert raw_sock not in forwarder._forward_request_active_closeables
+
     def test_validated_connection_closes_raw_socket_when_tls_wrap_fails(self):
         raw_sock = MagicMock()
         context = MagicMock()
@@ -408,6 +432,29 @@ class TestAuthBaseForwarderTransportSecurity:
             conn.connect()
 
         raw_sock.close.assert_called_once_with()
+
+    def test_validated_connection_untracks_raw_socket_when_tls_cleanup_close_fails(self):
+        raw_sock = MagicMock()
+        raw_sock.close.side_effect = OSError("close failed")
+        context = MagicMock()
+        context.wrap_socket.side_effect = OSError("tls failed")
+        conn = forwarder._make_validated_https_connection(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+        )
+        vars(conn)["_context"] = context
+
+        with (
+            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
+            pytest.raises(OSError, match="tls failed"),
+        ):
+            conn.connect()
+
+        raw_sock.close.assert_called_once_with()
+        with forwarder._forward_request_active_closeables_lock:
+            assert raw_sock not in forwarder._forward_request_active_closeables
 
 
 class TestAuthBaseForwarderRequestBehavior:

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1258,7 +1258,7 @@ class TestForwardRequestAsyncWrapper:
         assert started == 2
         assert max_active == 1
 
-    async def test_shutdown_rejects_waiting_forward_without_starting_next_forward(self):
+    async def test_shutdown_rejects_untracked_running_forward_and_waiting_forward(self):
         started = 0
         lock = threading.Lock()
         first_entered = threading.Event()
@@ -1296,16 +1296,14 @@ class TestForwardRequestAsyncWrapper:
                 forwarder.shutdown_forward_request_workers(wait=False)
                 release_first.set()
 
-                status, body, headers = await asyncio.wait_for(first_task, timeout=2)
+                with pytest.raises(RuntimeError, match="workers are shut down"):
+                    await asyncio.wait_for(first_task, timeout=2)
                 with pytest.raises(RuntimeError, match="workers are shut down"):
                     await asyncio.wait_for(waiting_task, timeout=2)
             finally:
                 release_first.set()
                 await asyncio.gather(first_task, waiting_task, return_exceptions=True)
 
-        assert status == 200
-        assert body == b"ok"
-        assert list(headers.items(multi=True)) == []
         assert not second_entered.is_set()
         assert started == 1
 
@@ -1394,6 +1392,38 @@ class TestForwardRequestAsyncWrapper:
                 await asyncio.gather(task, return_exceptions=True)
 
         assert socket.closed
+
+    async def test_shutdown_closes_socket_created_after_active_close_snapshot(self):
+        connect_entered = threading.Event()
+        release_connect = threading.Event()
+        socket = FakeSocket(http_response())
+
+        def create_connection(_address, _timeout, _source_address):
+            connect_entered.set()
+            if not release_connect.wait(timeout=5):
+                raise TimeoutError("test did not release connect")
+            return socket
+
+        with fake_forwarder_upstream(create_connection=create_connection):
+            task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                assert await asyncio.to_thread(connect_entered.wait, 2)
+                forwarder.shutdown_forward_request_workers(wait=False)
+                release_connect.set()
+
+                with pytest.raises(RuntimeError, match="workers are shut down"):
+                    await asyncio.wait_for(task, timeout=2)
+            finally:
+                release_connect.set()
+                await asyncio.gather(task, return_exceptions=True)
+
+        assert socket.closed
+        assert not socket.setsockopt_calls
+        with forwarder._forward_request_active_closeables_lock:
+            assert socket not in forwarder._forward_request_active_closeables
+        assert forwarder.forward_request_admission_state_for_tests() == (0, 0)
 
     async def test_offloads_request_work_from_event_loop_thread(self):
         event_loop_thread_id = threading.get_ident()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -456,6 +456,36 @@ class TestAuthBaseForwarderTransportSecurity:
         with forwarder._forward_request_active_closeables_lock:
             assert raw_sock not in forwarder._forward_request_active_closeables
 
+    def test_validated_connection_closes_socket_tracked_after_shutdown(self):
+        class CloseAwareSocket(FakeSocket):
+            def setsockopt(self, level: int, optname: int, value: int) -> None:
+                super().setsockopt(level, optname, value)
+                if self.closed:
+                    raise OSError(errno.EBADF, "closed during shutdown")
+
+        raw_sock = CloseAwareSocket(http_response())
+        context = MagicMock()
+        conn = forwarder._make_validated_https_connection(
+            "hooks.example.com",
+            port=None,
+            timeout=30,
+            validated_addresses=(forwarder._ValidatedAddress("93.184.216.34", 443),),
+        )
+        vars(conn)["_context"] = context
+
+        forwarder.shutdown_forward_request_workers(wait=False)
+        with (
+            patch.object(forwarder.socket, "create_connection", return_value=raw_sock),
+            pytest.raises(OSError, match="closed during shutdown"),
+        ):
+            conn.connect()
+
+        assert raw_sock.closed
+        assert raw_sock.close_count >= 1
+        context.wrap_socket.assert_not_called()
+        with forwarder._forward_request_active_closeables_lock:
+            assert raw_sock not in forwarder._forward_request_active_closeables
+
 
 class TestAuthBaseForwarderRequestBehavior:
     async def test_returns_redirect_response_without_following(self):
@@ -867,6 +897,10 @@ class TestForwardRequestAsyncWrapper:
 
         forwarder.shutdown_forward_request_workers(wait=False)
 
+        assert future.cancelled()
+        with forwarder._forward_request_pending_futures_lock:
+            assert future not in forwarder._forward_request_pending_futures
+
         with patch.object(forwarder, "_forward_request_sync_in_context") as forward_sync:
             forwarder._run_forward_request_worker(
                 future,
@@ -879,8 +913,6 @@ class TestForwardRequestAsyncWrapper:
 
         forward_sync.assert_not_called()
         assert future.cancelled()
-        with forwarder._forward_request_pending_futures_lock:
-            assert future not in forwarder._forward_request_pending_futures
 
     def test_shutdown_rejects_new_forward_admission(self):
         forwarder.shutdown_forward_request_workers(wait=False)

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1239,6 +1239,52 @@ class TestForwardRequestAsyncWrapper:
         assert not second_entered.is_set()
         assert started == 1
 
+    async def test_shutdown_wakes_waiting_forward_when_running_forward_is_blocked(self):
+        started = 0
+        lock = threading.Lock()
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        release_first = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            nonlocal started
+
+            with lock:
+                started += 1
+                current = started
+                if current == 1:
+                    first_entered.set()
+                elif current == 2:
+                    second_entered.set()
+            if current == 1 and not release_first.wait(timeout=5):
+                raise TimeoutError("test did not release first forward")
+            return FakeSocket(http_response())
+
+        with (
+            patch.object(forwarder, "MAX_CONCURRENT_AUTH_BASE_FORWARDS", 1),
+            fake_forwarder_upstream(create_connection=create_connection),
+        ):
+            first_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            waiting_task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                first_started = await asyncio.to_thread(first_entered.wait, 2)
+                assert first_started
+
+                forwarder.shutdown_forward_request_workers(wait=False)
+
+                with pytest.raises(RuntimeError, match="workers are shut down"):
+                    await asyncio.wait_for(waiting_task, timeout=2)
+            finally:
+                release_first.set()
+                await asyncio.gather(first_task, waiting_task, return_exceptions=True)
+
+        assert not second_entered.is_set()
+        assert started == 1
+
     async def test_shutdown_closes_active_forward_socket(self):
         setsockopt_entered = threading.Event()
         socket_closed = threading.Event()

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1099,10 +1099,12 @@ class TestForwardRequestAsyncWrapper:
                     await asyncio.wait_for(first_task, timeout=1)
                 with lock:
                     assert active == 1
+                    started_before_second_attempt = started
 
                 with pytest.raises(forwarder.AuthBaseForwardingSaturatedError):
                     await forwarder.forward_request("https://example.com", "GET", [], None)
-                assert started == 1
+                with lock:
+                    assert started == started_before_second_attempt
 
                 release_first.set()
             finally:
@@ -1168,7 +1170,6 @@ class TestForwardRequestAsyncWrapper:
                     forwarder.forward_request("https://example.com", "GET", [], None)
                 )
                 await _run_ready_tasks()
-                assert started == 1
                 assert not second_entered.is_set()
 
                 release_first.set()
@@ -1257,6 +1258,34 @@ class TestForwardRequestAsyncWrapper:
         assert list(headers.items(multi=True)) == []
         assert started == 2
         assert max_active == 1
+
+    def test_worker_base_exception_completes_future_before_propagating(self):
+        future: Future[tuple[int, bytes, http.Headers]] = Future()
+        with forwarder._forward_request_pending_futures_lock:
+            forwarder._forward_request_pending_futures.add(future)
+
+        with (
+            patch.object(
+                forwarder,
+                "_forward_request_sync_in_context",
+                side_effect=SystemExit("worker stopped"),
+            ),
+            pytest.raises(SystemExit, match="worker stopped"),
+        ):
+            forwarder._run_forward_request_worker(
+                future,
+                contextvars.copy_context(),
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        assert future.done()
+        with pytest.raises(RuntimeError, match="worker exited without completing future"):
+            future.result()
+        with forwarder._forward_request_pending_futures_lock:
+            assert future not in forwarder._forward_request_pending_futures
 
     async def test_shutdown_rejects_untracked_running_forward_and_waiting_forward(self):
         started = 0

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -2,13 +2,9 @@
 
 import asyncio
 import errno
-import os
+import multiprocessing
 import ssl
-import subprocess
-import sys
-import textwrap
 import threading
-from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -16,14 +12,37 @@ import pytest
 import auth_base_forwarder as forwarder
 from tests.auth_base_forwarder_helpers import FakeSocket, fake_forwarder_upstream, http_response
 
-_ADDON_ROOT = Path(__file__).resolve().parents[1]
-_SUBPROCESS_TIMEOUT_SECONDS = 5
+_PROCESS_EXIT_TIMEOUT_SECONDS = 2
 
 
 async def _run_ready_tasks() -> None:
     ready = asyncio.Event()
     asyncio.get_running_loop().call_soon(ready.set)
     await ready.wait()
+
+
+def _run_blocked_forward_then_shutdown_wait_false() -> None:
+    async def main():
+        forward_started = threading.Event()
+        never_release = threading.Event()
+
+        def create_connection(_address, _timeout, _source_address):
+            forward_started.set()
+            never_release.wait()
+            return FakeSocket(http_response())
+
+        with fake_forwarder_upstream(create_connection=create_connection):
+            task = asyncio.create_task(
+                forwarder.forward_request("https://example.com", "GET", [], None)
+            )
+            try:
+                if not await asyncio.to_thread(forward_started.wait, 2):
+                    raise RuntimeError("auth.base forward did not start")
+                forwarder.shutdown_forward_request_executor(wait=False)
+            finally:
+                task.cancel()
+
+    asyncio.run(main())
 
 
 class TestAuthBaseForwarderSecurity:
@@ -775,62 +794,21 @@ class TestAuthBaseForwarderResourceCleanup:
 
 class TestForwardRequestAsyncWrapper:
     def test_shutdown_wait_false_does_not_keep_process_alive_with_blocked_forward(self):
-        script = textwrap.dedent(
-            """
-            import asyncio
-            import threading
-
-            import auth_base_forwarder as forwarder
-            from tests.auth_base_forwarder_helpers import (
-                FakeSocket,
-                fake_forwarder_upstream,
-                http_response,
-            )
-
-
-            async def main():
-                forward_started = threading.Event()
-                never_release = threading.Event()
-
-                def create_connection(_address, _timeout, _source_address):
-                    forward_started.set()
-                    never_release.wait()
-                    return FakeSocket(http_response())
-
-                with fake_forwarder_upstream(create_connection=create_connection):
-                    task = asyncio.create_task(
-                        forwarder.forward_request("https://example.com", "GET", [], None)
-                    )
-                    try:
-                        if not await asyncio.to_thread(forward_started.wait, 2):
-                            raise RuntimeError("auth.base forward did not start")
-                        forwarder.shutdown_forward_request_executor(wait=False)
-                    finally:
-                        task.cancel()
-
-
-            asyncio.run(main())
-            """
+        process = multiprocessing.Process(
+            target=_run_blocked_forward_then_shutdown_wait_false,
+            name="auth-base-shutdown-regression",
         )
-        env = os.environ.copy()
-        python_paths = [
-            str(_ADDON_ROOT / "src"),
-            str(_ADDON_ROOT),
-        ]
-        if env.get("PYTHONPATH"):
-            python_paths.append(env["PYTHONPATH"])
-        env["PYTHONPATH"] = os.pathsep.join(python_paths)
+        process.start()
+        try:
+            process.join(timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
+            assert not process.is_alive()
+            assert process.exitcode == 0
+        finally:
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
 
-        result = subprocess.run(  # noqa: S603
-            [sys.executable, "-c", script],
-            capture_output=True,
-            check=False,
-            env=env,
-            text=True,
-            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
-        )
-
-        assert result.returncode == 0, result.stderr
+        assert process.exitcode == 0
 
     async def test_rejects_body_over_limit_before_forwarding(self):
         with (

--- a/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/tests/test_auth_base_forwarder.py
@@ -1,18 +1,21 @@
 """Tests for auth.base HTTPS forwarding behavior."""
 
 import asyncio
+import contextvars
 import errno
 import multiprocessing
 import ssl
 import threading
+from concurrent.futures import Future
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from mitmproxy import http
 
 import auth_base_forwarder as forwarder
 from tests.auth_base_forwarder_helpers import FakeSocket, fake_forwarder_upstream, http_response
 
-_PROCESS_EXIT_TIMEOUT_SECONDS = 2
+_PROCESS_EXIT_TIMEOUT_SECONDS = 5
 
 
 async def _run_ready_tasks() -> None:
@@ -794,7 +797,7 @@ class TestAuthBaseForwarderResourceCleanup:
 
 class TestForwardRequestAsyncWrapper:
     def test_shutdown_wait_false_does_not_keep_process_alive_with_blocked_forward(self):
-        process = multiprocessing.Process(
+        process = multiprocessing.get_context("spawn").Process(
             target=_run_blocked_forward_then_shutdown_wait_false,
             name="auth-base-shutdown-regression",
         )
@@ -809,6 +812,28 @@ class TestForwardRequestAsyncWrapper:
                 process.join(timeout=_PROCESS_EXIT_TIMEOUT_SECONDS)
 
         assert process.exitcode == 0
+
+    def test_shutdown_before_worker_start_cancels_pending_forward(self):
+        future: Future[tuple[int, bytes, http.Headers]] = Future()
+        with forwarder._forward_request_pending_futures_lock:
+            forwarder._forward_request_pending_futures.add(future)
+
+        forwarder.shutdown_forward_request_workers(wait=False)
+
+        with patch.object(forwarder, "_forward_request_sync_in_context") as forward_sync:
+            forwarder._run_forward_request_worker(
+                future,
+                contextvars.copy_context(),
+                "https://example.com",
+                "GET",
+                [],
+                None,
+            )
+
+        forward_sync.assert_not_called()
+        assert future.cancelled()
+        with forwarder._forward_request_pending_futures_lock:
+            assert future not in forwarder._forward_request_pending_futures
 
     async def test_rejects_body_over_limit_before_forwarding(self):
         with (

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -21,15 +21,15 @@ class TestDoneHook:
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
-                "shutdown_forward_request_executor",
-            ) as shutdown_forward_request_executor,
+                "shutdown_forward_request_workers",
+            ) as shutdown_forward_request_workers,
             patch.object(mitm_addon, "shutdown_log_writer") as shutdown_log_writer,
         ):
             mitm_addon.done()
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         # concurrent.futures boundary: done() must gracefully shut down the pool (#9991).
         mock_executor.shutdown.assert_called_once_with(wait=True)
-        shutdown_forward_request_executor.assert_called_once_with(wait=False)
+        shutdown_forward_request_workers.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()
 
     def test_done_waits_for_runner_flush_before_executor_shutdown(self):
@@ -83,7 +83,7 @@ class TestDoneHook:
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
-                "shutdown_forward_request_executor",
+                "shutdown_forward_request_workers",
                 lambda *, wait: calls.append(f"auth-base:shutdown:{wait}"),
             ),
             patch.object(mitm_addon, "shutdown_log_writer", lambda: calls.append("jsonl:shutdown")),
@@ -129,8 +129,8 @@ class TestDoneHook:
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
-                "shutdown_forward_request_executor",
-            ) as shutdown_forward_request_executor,
+                "shutdown_forward_request_workers",
+            ) as shutdown_forward_request_workers,
             patch.object(mitm_addon, "shutdown_log_writer") as shutdown_log_writer,
             pytest.raises(RuntimeError, match="flush failed"),
         ):
@@ -138,5 +138,5 @@ class TestDoneHook:
 
         flush_usage_events.assert_called_once_with(trigger="shutdown")
         mock_executor.shutdown.assert_called_once_with(wait=True)
-        shutdown_forward_request_executor.assert_called_once_with(wait=False)
+        shutdown_forward_request_workers.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()


### PR DESCRIPTION
## Summary

- replace auth.base `ThreadPoolExecutor` ownership with bounded daemon forwarding threads backed by the existing semaphore
- best-effort close active auth.base upstream sockets during shutdown
- add a subprocess lifecycle regression test proving `shutdown(wait=False)` does not keep mitm-addon alive when a forward blocks

Fixes #20470

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/test_auth_base_forwarder.py tests/test_done_hook.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src/auth_base_forwarder.py src/mitm_addon.py tests/test_auth_base_forwarder.py tests/test_done_hook.py`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
