### PR TITLE
ci: remove atom web client recording from app promotion

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1490,55 +1490,6 @@ jobs:
           vercel-project-id: ${{ vars.VERCEL_PROJECT_ID_APP }}
           deployment-url: ${{ needs.build-app-production.outputs.deployment_url }}
 
-      - name: Record Atom web client version
-        shell: bash
-        env:
-          ATOM_API_URL: ${{ vars.ATOM_API_URL || 'https://atom-api.vm6.ai' }}
-          ATOM_DEPLOY_TOKEN: ${{ secrets.ATOM_DEPLOY_TOKEN }}
-          DEPLOYMENT_URL: ${{ needs.build-app-production.outputs.deployment_url }}
-          GIT_SHA: ${{ needs.build-app-production.outputs.git_sha }}
-          VERSION: ${{ needs.release-please.outputs.app_version }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "$ATOM_DEPLOY_TOKEN" ]; then
-            echo "::error::ATOM_DEPLOY_TOKEN is required to record web client versions in Atom"
-            exit 1
-          fi
-          if [ -z "$VERSION" ]; then
-            echo "::error::App version is missing"
-            exit 1
-          fi
-          if [ -z "$GIT_SHA" ]; then
-            echo "::error::Git SHA is missing"
-            exit 1
-          fi
-
-          payload="$(jq -n \
-            --arg version "$VERSION" \
-            --arg gitSha "$GIT_SHA" \
-            --arg releaseTag "platform-v$VERSION" \
-            --arg deploymentUrl "$DEPLOYMENT_URL" \
-            '{
-              version: $version,
-              gitSha: $gitSha,
-              releaseTag: $releaseTag,
-              deploymentUrl: $deploymentUrl
-            }')"
-
-          curl --fail --show-error --silent \
-            --retry 5 \
-            --retry-delay 2 \
-            --retry-max-time 60 \
-            --retry-all-errors \
-            --max-time 30 \
-            --request POST \
-            --url "${ATOM_API_URL%/}/api/deployments/web-client-versions" \
-            --header "Authorization: Bearer ${ATOM_DEPLOY_TOKEN}" \
-            --header "Content-Type: application/json" \
-            --data "$payload" \
-            >/dev/null
-
       - name: Resolve Vercel dashboard URL
         id: vercel-dashboard
         if: ${{ needs.build-app-production.outputs.deployment_url != '' }}


### PR DESCRIPTION
## Summary
- Remove the `Record Atom web client version` step from the `promote-app-production` release job.
- Leave app promotion, GitHub deployment finalization, Vercel dashboard URL resolution, and Slack notifications unchanged.

## Verification
- `git diff --check`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/release-please.yml")'`
- `npx -y prettier@3.8.1 --check .github/workflows/release-please.yml`

Not run: full local vitest or local dev server; this is a CI workflow-only change.
