### PR TITLE
fix(platform): show inline feedback toolbar after double-click selection

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -60,6 +60,39 @@ describe("inline feedback thread scoping", () => {
     expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(1);
   });
 
+  it("anchors the toolbar with visible client rects when the range bounds are empty", () => {
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    const range = document.createRange();
+    range.selectNodeContents(bubble);
+    Object.defineProperty(range, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        return new DOMRect(0, 0, 0, 0);
+      },
+    });
+    Object.defineProperty(range, "getClientRects", {
+      configurable: true,
+      value: () => {
+        return [
+          new DOMRect(0, 0, 0, 0),
+          new DOMRect(24, 32, 180, 20),
+        ] as unknown as DOMRectList;
+      },
+    });
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    ctx.store.set(captureFeedbackSelection$);
+
+    expect(ctx.store.get(feedbackSelectionValue$)?.rect).toStrictEqual({
+      top: 32,
+      left: 24,
+      width: 180,
+      height: 20,
+    });
+  });
+
   it("starts a fresh stack when feedback moves to another thread", () => {
     const bubbleA = mountThreadBubble("thread-a", "Reply from thread A");
     selectContents(bubbleA);

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -170,6 +170,48 @@ function readAssistantSelection(): {
   return { text, range, bubble };
 }
 
+function hasVisibleArea(rect: DOMRectReadOnly): boolean {
+  return rect.width > 0 && rect.height > 0;
+}
+
+function rectFromRange(range: Range): FeedbackSelectionRect {
+  const rects = Array.from(range.getClientRects()).filter(hasVisibleArea);
+  if (rects.length === 0) {
+    const rect = range.getBoundingClientRect();
+    return {
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  const top = Math.min(...rects.map((rect) => rect.top));
+  const left = Math.min(...rects.map((rect) => rect.left));
+  const right = Math.max(...rects.map((rect) => rect.right));
+  const bottom = Math.max(...rects.map((rect) => rect.bottom));
+  return {
+    top,
+    left,
+    width: right - left,
+    height: bottom - top,
+  };
+}
+
+function readFeedbackSelection(): FeedbackSelection | null {
+  const found = readAssistantSelection();
+  if (!found) {
+    return null;
+  }
+  const rect = rectFromRange(found.range);
+  return {
+    text: found.text,
+    threadId: resolveSelectionThreadId(found.bubble),
+    range: found.range.cloneRange(),
+    rect,
+  };
+}
+
 // Compose every noted fragment into a single follow-up turn, each passage
 // quoted above the note that belongs to it.
 function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
@@ -199,25 +241,25 @@ export const closeFeedbackSelectionToolbar$ = command(({ set }) => {
 // shows whether or not the tray is open — selecting another passage and
 // clicking "Provide feedback" again is how a further fragment is added.
 export const captureFeedbackSelection$ = command(({ get, set }) => {
-  const found = readAssistantSelection();
-  if (!found) {
+  const selection = readFeedbackSelection();
+  if (!selection) {
     if (get(feedbackSelection$) !== null) {
       set(closeFeedbackSelectionToolbar$);
     }
     return;
   }
-  const rect = found.range.getBoundingClientRect();
-  set(feedbackSelection$, {
-    text: found.text,
-    threadId: resolveSelectionThreadId(found.bubble),
-    range: found.range.cloneRange(),
-    rect: {
-      top: rect.top,
-      left: rect.left,
-      width: rect.width,
-      height: rect.height,
-    },
-  });
+  set(feedbackSelection$, selection);
+});
+
+// Selectionchange can arrive after mouseup for double-click/line selections in
+// Chromium. Use it only as an additive capture path so toolbar button clicks are
+// not interrupted when focusing a button clears the native selection.
+export const captureFeedbackSelectionIfPresent$ = command(({ set }) => {
+  const selection = readFeedbackSelection();
+  if (!selection) {
+    return;
+  }
+  set(feedbackSelection$, selection);
 });
 
 // "Provide feedback" on a passage: append it as a new fragment. The newest
@@ -381,20 +423,64 @@ export const setFeedbackSelectionListenersRef$ = onRef(
   command(({ set }, el: HTMLElement, signal: AbortSignal) => {
     const doc = el.ownerDocument;
     let captureTimerId: number | null = null;
+    let pendingDismissWhenEmpty = false;
+    let mouseIsDown = false;
     const capture = () => {
       set(captureFeedbackSelection$);
     };
-    const captureDeferred = () => {
+    const captureIfPresent = () => {
+      set(captureFeedbackSelectionIfPresent$);
+    };
+    const captureDeferred = (dismissWhenEmpty: boolean) => {
+      pendingDismissWhenEmpty ||= dismissWhenEmpty;
       if (captureTimerId !== null) {
         window.clearTimeout(captureTimerId);
       }
       captureTimerId = window.setTimeout(() => {
+        const shouldDismissWhenEmpty = pendingDismissWhenEmpty;
         captureTimerId = null;
-        capture();
+        pendingDismissWhenEmpty = false;
+        if (shouldDismissWhenEmpty) {
+          capture();
+          return;
+        }
+        captureIfPresent();
       }, 0);
     };
 
-    doc.addEventListener("mouseup", captureDeferred, { signal });
+    doc.addEventListener(
+      "mousedown",
+      () => {
+        mouseIsDown = true;
+      },
+      { capture: true, signal },
+    );
+    doc.addEventListener(
+      "mouseup",
+      () => {
+        mouseIsDown = false;
+        captureDeferred(true);
+      },
+      { signal },
+    );
+    doc.addEventListener(
+      "dblclick",
+      () => {
+        mouseIsDown = false;
+        captureDeferred(false);
+      },
+      { signal },
+    );
+    doc.addEventListener(
+      "selectionchange",
+      () => {
+        if (mouseIsDown) {
+          return;
+        }
+        captureDeferred(false);
+      },
+      { signal },
+    );
     doc.addEventListener("keyup", capture, { signal });
     doc.addEventListener(
       "scroll",

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -186,10 +186,26 @@ function rectFromRange(range: Range): FeedbackSelectionRect {
     };
   }
 
-  const top = Math.min(...rects.map((rect) => rect.top));
-  const left = Math.min(...rects.map((rect) => rect.left));
-  const right = Math.max(...rects.map((rect) => rect.right));
-  const bottom = Math.max(...rects.map((rect) => rect.bottom));
+  const top = Math.min(
+    ...rects.map((rect) => {
+      return rect.top;
+    }),
+  );
+  const left = Math.min(
+    ...rects.map((rect) => {
+      return rect.left;
+    }),
+  );
+  const right = Math.max(
+    ...rects.map((rect) => {
+      return rect.right;
+    }),
+  );
+  const bottom = Math.max(
+    ...rects.map((rect) => {
+      return rect.bottom;
+    }),
+  );
   return {
     top,
     left,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -8,6 +8,7 @@ import type {
 import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 import {
   detachedSetupPage,
   fill,
@@ -58,9 +59,13 @@ function selectTextForInlineFeedback(element: HTMLElement): void {
 }
 
 function waitForDeferredSelectionCapture(): Promise<void> {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, 0);
+  const deferred = createDeferredPromise<void>(context.signal);
+  window.setTimeout(() => {
+    if (!deferred.settled()) {
+      deferred.resolve(undefined);
+    }
   });
+  return deferred.promise;
 }
 
 function selectTextAcrossElementsForInlineFeedback(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -34,7 +34,7 @@ interface RunCreateCapture {
   clientMessageId?: string;
 }
 
-function selectTextForInlineFeedback(element: HTMLElement): void {
+function selectTextRangeForInlineFeedback(element: HTMLElement): void {
   const range = document.createRange();
   range.selectNodeContents(element);
   Object.defineProperty(range, "getBoundingClientRect", {
@@ -50,7 +50,17 @@ function selectTextForInlineFeedback(element: HTMLElement): void {
   }
   selection.removeAllRanges();
   selection.addRange(range);
+}
+
+function selectTextForInlineFeedback(element: HTMLElement): void {
+  selectTextRangeForInlineFeedback(element);
   document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
+function waitForDeferredSelectionCapture(): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, 0);
+  });
 }
 
 function selectTextAcrossElementsForInlineFeedback(
@@ -202,6 +212,49 @@ describe("chat inline feedback", () => {
     expect(
       screen.queryByPlaceholderText("What should change about this?"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the inline feedback toolbar when double-click selection settles after mouseup", async () => {
+    const assistantReply = "The rollout dates are unclear in this summary.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-late-selection-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-late-selection",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-late-selection-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-late-selection",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+
+    document.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    await waitForDeferredSelectionCapture();
+
+    selectTextRangeForInlineFeedback(assistantReplyElement);
+    document.dispatchEvent(new Event("selectionchange"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
   });
 
   it("focuses the inline feedback composer when started from the keyboard shortcut", async () => {


### PR DESCRIPTION
## Summary
- Keeps the inline feedback toolbar reliable when Chrome commits a double-click or full-line selection after the existing mouseup capture has already run.
- Adds an additive selectionchange/dblclick capture path that only opens the toolbar for valid assistant selections, while preserving the mouseup path that dismisses the toolbar when a click clears selection.
- Uses visible range client rects before falling back to getBoundingClientRect so the toolbar can anchor correctly for whole-line and multiline selections.

## Verification
- `corepack pnpm -F @vm0/app exec vitest run src/signals/__tests__/chat-feedback.test.ts src/views/zero-page/__tests__/chat-inline-feedback.test.tsx`
- `corepack pnpm exec prettier --check apps/platform/src/signals/zero-page/chat-feedback.ts apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx apps/platform/src/signals/__tests__/chat-feedback.test.ts`
- `corepack pnpm -F @vm0/app exec oxlint src/signals/zero-page/chat-feedback.ts src/views/zero-page/__tests__/chat-inline-feedback.test.tsx src/signals/__tests__/chat-feedback.test.ts`
- `NODE_OPTIONS=--max-old-space-size=4096 corepack pnpm -F @vm0/app check-types`