### PR TITLE
feat: show model usage reset countdown

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/personal-providers-tab.test.tsx
@@ -2,7 +2,7 @@ import { zeroClaudeCodeDeviceAuthContract } from "@vm0/api-contracts/contracts/z
 import { zeroCodexDeviceAuthContract } from "@vm0/api-contracts/contracts/zero-codex-device-auth";
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { screen, waitFor, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   click,
@@ -10,9 +10,14 @@ import {
   fill,
   queryAllByRoleFast,
 } from "../../../__tests__/page-helper.ts";
+import { clearMockNow, mockNow } from "../../../lib/time.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 
 const context = testContext();
+
+afterEach(() => {
+  clearMockNow();
+});
 
 function stalePersonalCodexProvider(): ModelProviderResponse {
   return {
@@ -305,6 +310,7 @@ describe("personal model providers settings", () => {
 
   it("shows available subscription details in the connected status", async () => {
     mockBrowserTimeZone("America/New_York");
+    mockNow(new Date("2030-01-01T00:48:00.000Z"));
     context.mocks.data.org({
       id: "org_1",
       slug: "test-org",
@@ -329,8 +335,10 @@ describe("personal model providers settings", () => {
     ).not.toBeInTheDocument();
     expect(within(claudeCodeRow).getByText("5h")).toBeInTheDocument();
     expect(within(claudeCodeRow).getByText("88% left")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("in 4h 12m")).toBeInTheDocument();
     expect(within(claudeCodeRow).getByText("Week")).toBeInTheDocument();
     expect(within(claudeCodeRow).getByText("76% left")).toBeInTheDocument();
+    expect(within(claudeCodeRow).getByText("in 5d 23h")).toBeInTheDocument();
     expect(
       within(claudeCodeRow).getByText(
         formatResetInTimeZone("2030-01-01T05:00:00.000Z", "America/New_York"),
@@ -349,7 +357,9 @@ describe("personal model providers settings", () => {
       within(codexRow).queryByText(/codex\.user@example\.com/),
     ).not.toBeInTheDocument();
     expect(within(codexRow).getByText("82% left")).toBeInTheDocument();
+    expect(within(codexRow).getByText("in 4h 12m")).toBeInTheDocument();
     expect(within(codexRow).getByText("55% left")).toBeInTheDocument();
+    expect(within(codexRow).getByText("in 5d 23h")).toBeInTheDocument();
     expect(
       within(codexRow).queryByText(/Account:|Plan:|Reset:|Connected .*resets/),
     ).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ModelProviderResponse } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroBillingStatusContract } from "@vm0/api-contracts/contracts/zero-billing";
@@ -143,6 +143,39 @@ function buttonByLabel(
   return button;
 }
 
+function formatResetInTimeZone(resetAt: string, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone,
+    timeZoneName: "short",
+  }).format(new Date(resetAt));
+}
+
+function mockBrowserTimeZone(timeZone: string): void {
+  const resolvedOptions = new Intl.DateTimeFormat().resolvedOptions();
+  vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+    ...resolvedOptions,
+    timeZone,
+  });
+}
+
+function expectVisibleText(text: string): void {
+  const matches = screen.getAllByText(text);
+  const visibleMatch = matches.find((element) => {
+    try {
+      expect(element).toBeVisible();
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  expect(visibleMatch).toBeDefined();
+}
+
 async function openAccountMenu(): Promise<HTMLElement> {
   const accountName = await screen.findByText("Alex Rivera");
   const accountButton = accountName.closest("button");
@@ -271,6 +304,8 @@ describe("zero sidebar account menu", () => {
   });
 
   it("shows subscription usage grouped below credits in the account menu", async () => {
+    mockBrowserTimeZone("America/New_York");
+    mockNow(new Date("2030-01-01T00:48:00.000Z"));
     mockAdminAccountSidebar();
     context.mocks.data.personalModelProviders([
       connectedPersonalCodexProvider(),
@@ -308,6 +343,7 @@ describe("zero sidebar account menu", () => {
     expect(within(panel).getByText("88%")).toBeInTheDocument();
     expect(within(panel).getByText("76%")).toBeInTheDocument();
     expect(within(panel).getByText("2 resets left")).toBeInTheDocument();
+    expect(within(panel).queryByText(/^resets /)).not.toBeInTheDocument();
     expect(
       within(panel).queryByText(/codex\.user@example\.com/),
     ).not.toBeInTheDocument();
@@ -316,6 +352,14 @@ describe("zero sidebar account menu", () => {
       name: "Codex 5h remaining",
     });
     expect(codexFiveHour).toHaveAttribute("aria-valuenow", "82");
+    fireEvent.focus(codexFiveHour);
+
+    await waitFor(() => {
+      expectVisibleText("Resets in 4h 12m");
+      expectVisibleText(
+        formatResetInTimeZone("2030-01-01T05:00:00.000Z", "America/New_York"),
+      );
+    });
 
     const credits = within(menu).getByText("12,500 credits");
     const codex = within(panel).getByRole("heading", { name: "Codex" });

--- a/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/preferences/personal-providers-tab.tsx
@@ -29,6 +29,7 @@ import { PersonalClaudeCodeDeviceAuthDialog } from "../settings/claude-code-devi
 import { PersonalCodexDeviceAuthDialog } from "../settings/codex-device-auth-dialog.tsx";
 import { SettingsSectionHeading } from "../settings/settings-section-heading.tsx";
 import { runAfterDropdownMenuClose } from "../../../components/dropdown-menu-modal-action.ts";
+import { formatSubscriptionUsageReset } from "../../subscription-usage-format.ts";
 import {
   CodexResetUsageDialog,
   formatCodexResetCredits,
@@ -331,30 +332,6 @@ function formatUsagePercent(value: number | null): string | null {
   return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
 }
 
-function formatUsageReset(resetAt: string | null): string | null {
-  const text = resetAt?.trim();
-  if (!text) {
-    return null;
-  }
-  const date = new Date(text);
-  if (Number.isNaN(date.getTime())) {
-    return `resets ${text}`;
-  }
-  const options: Intl.DateTimeFormatOptions = {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    timeZoneName: "short",
-  };
-  const browserTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
-  if (browserTimeZone) {
-    options.timeZone = browserTimeZone;
-  }
-  return `resets ${date.toLocaleDateString("en-US", options)}`;
-}
-
 function fallbackSubscriptionUsage(
   provider: ModelProviderResponse,
 ): SubscriptionUsage | null {
@@ -439,7 +416,7 @@ function SubscriptionUsageMeter({
             window.remainingPercent ??
             (window.usedPercent === null ? null : 100 - window.usedPercent);
           const displayPercent = formatUsagePercent(remainingPercent);
-          const resetText = formatUsageReset(window.resetAt);
+          const reset = formatSubscriptionUsageReset(window.resetAt);
           const tone = usageTone(remainingPercent);
           return (
             <div key={label} className="space-y-1">
@@ -464,10 +441,21 @@ function SubscriptionUsageMeter({
                   }}
                 />
               </div>
-              {resetText ? (
-                <div className="truncate text-[10px] leading-none text-muted-foreground">
-                  {resetText}
-                </div>
+              {reset !== null ? (
+                "fallbackText" in reset ? (
+                  <div className="truncate text-[10px] leading-none text-muted-foreground">
+                    {reset.fallbackText}
+                  </div>
+                ) : (
+                  <div className="flex min-w-0 items-center justify-between gap-2 text-[10px] leading-none text-muted-foreground">
+                    <span className="min-w-0 truncate">
+                      {reset.absoluteResetText}
+                    </span>
+                    <span className="shrink-0 rounded bg-background/70 px-1.5 py-0.5 font-medium text-muted-foreground shadow-[inset_0_0_0_1px_hsl(var(--border)/0.6)]">
+                      {reset.relativeText}
+                    </span>
+                  </div>
+                )
               ) : null}
             </div>
           );

--- a/turbo/apps/platform/src/views/zero-page/subscription-usage-format.ts
+++ b/turbo/apps/platform/src/views/zero-page/subscription-usage-format.ts
@@ -1,0 +1,92 @@
+import { now } from "../../lib/time.ts";
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+interface SubscriptionUsageResetFormat {
+  readonly absoluteResetText: string;
+  readonly absoluteText: string;
+  readonly relativeText: string;
+  readonly tooltipTitle: string;
+}
+
+interface InvalidSubscriptionUsageResetFormat {
+  readonly fallbackText: string;
+}
+
+type SubscriptionUsageResetDisplay =
+  | InvalidSubscriptionUsageResetFormat
+  | SubscriptionUsageResetFormat;
+
+export function formatSubscriptionUsageReset(
+  resetAt: string | null,
+): SubscriptionUsageResetDisplay | null {
+  const text = resetAt?.trim();
+  if (!text) {
+    return null;
+  }
+
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) {
+    return { fallbackText: `resets ${text}` };
+  }
+
+  const absoluteText = formatAbsoluteResetDate(date);
+  const relativeText = formatRelativeResetTime(date.getTime() - now());
+
+  return {
+    absoluteResetText: `resets ${absoluteText}`,
+    absoluteText,
+    relativeText,
+    tooltipTitle:
+      relativeText === "reset time passed"
+        ? "Reset time passed"
+        : `Resets ${relativeText}`,
+  };
+}
+
+function formatAbsoluteResetDate(date: Date): string {
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  };
+  const browserTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (browserTimeZone) {
+    options.timeZone = browserTimeZone;
+  }
+  return date.toLocaleDateString("en-US", options);
+}
+
+function formatRelativeResetTime(remainingMs: number): string {
+  if (remainingMs <= 0) {
+    return "reset time passed";
+  }
+  if (remainingMs < MINUTE_MS) {
+    return "in <1m";
+  }
+
+  const totalMinutes = Math.floor(remainingMs / MINUTE_MS);
+  if (remainingMs < HOUR_MS) {
+    return `in ${totalMinutes}m`;
+  }
+
+  const totalHours = Math.floor(remainingMs / HOUR_MS);
+  if (remainingMs < DAY_MS) {
+    const minutes = Math.floor((remainingMs % HOUR_MS) / MINUTE_MS);
+    return minutes > 0 ? `in ${totalHours}h ${minutes}m` : `in ${totalHours}h`;
+  }
+
+  const totalDays = Math.floor(remainingMs / DAY_MS);
+  if (remainingMs < WEEK_MS) {
+    const hours = Math.floor((remainingMs % DAY_MS) / HOUR_MS);
+    return hours > 0 ? `in ${totalDays}d ${hours}h` : `in ${totalDays}d`;
+  }
+
+  return `in ${totalDays}d`;
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-subscriptions.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../signals/zero-page/account-menu-subscriptions.ts";
 import { runAfterDropdownMenuClose } from "../components/dropdown-menu-modal-action.ts";
 import { formatCodexResetCredits } from "./components/preferences/codex-reset-usage-dialog.tsx";
+import { formatSubscriptionUsageReset } from "./subscription-usage-format.ts";
 
 type SubscriptionUsage = AccountMenuSubscriptionUsage;
 type SubscriptionUsageWindow = AccountMenuSubscriptionUsageWindow;
@@ -187,7 +188,7 @@ function AccountMenuSubscriptionUsageBar({
       ? rawRemainingPercent
       : null;
   const displayPercent = formatUsagePercent(remainingPercent);
-  const resetText = formatUsageReset(window.resetAt);
+  const reset = formatSubscriptionUsageReset(window.resetAt);
   const tone = usageTone(remainingPercent);
   const width =
     remainingPercent === null
@@ -216,8 +217,19 @@ function AccountMenuSubscriptionUsageBar({
             />
           </span>
         </TooltipTrigger>
-        <TooltipContent side="right" align="center">
-          <p className="text-xs">{resetText ?? "Reset time unavailable"}</p>
+        <TooltipContent side="right" align="center" className="max-w-56">
+          {reset === null ? (
+            <p className="text-xs">Reset time unavailable</p>
+          ) : "fallbackText" in reset ? (
+            <p className="text-xs">{reset.fallbackText}</p>
+          ) : (
+            <div className="space-y-0.5">
+              <p className="text-xs font-medium">{reset.tooltipTitle}</p>
+              <p className="text-[10px] text-muted-foreground">
+                {reset.absoluteText}
+              </p>
+            </div>
+          )}
         </TooltipContent>
       </Tooltip>
       <span
@@ -235,30 +247,6 @@ function formatUsagePercent(value: number | null): string | null {
   }
   const rounded = Math.round(value * 10) / 10;
   return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
-}
-
-function formatUsageReset(resetAt: string | null): string | null {
-  const text = resetAt?.trim();
-  if (!text) {
-    return null;
-  }
-  const date = new Date(text);
-  if (Number.isNaN(date.getTime())) {
-    return `resets ${text}`;
-  }
-  const options: Intl.DateTimeFormatOptions = {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    timeZoneName: "short",
-  };
-  const browserTimeZone = new Intl.DateTimeFormat().resolvedOptions().timeZone;
-  if (browserTimeZone) {
-    options.timeZone = browserTimeZone;
-  }
-  return `resets ${date.toLocaleDateString("en-US", options)}`;
 }
 
 function usageTone(remainingPercent: number | null): {


### PR DESCRIPTION
## Summary
- add shared subscription usage reset formatting with absolute and relative reset labels
- show reset countdowns inline in model settings while keeping the account menu compact
- add account menu tooltip coverage for reset countdown details

## Tests
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/personal-providers-tab.test.tsx --run
- pnpm -F @vm0/app exec vitest src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx --run
- pnpm -F @vm0/app run lint
- pnpm -F @vm0/app run check-types
- pre-commit: pnpm knip --cache, turbo run check-types --concurrency=1

Closes #20526