### PR TITLE
feat(api): log platform client headers on request logs

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -29,6 +29,19 @@ vi.mock("../lib/log", async () => {
 
 const c = initContract();
 
+function axiomRequestLogEvents(
+  context: ReturnType<typeof testContext>,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.ingest.mock.calls.flatMap(([dataset, events]) => {
+    if (dataset !== "request-log" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return typeof event === "object" && event !== null;
+    });
+  });
+}
+
 const errorTestContract = c.router({
   boom: {
     method: "GET",
@@ -641,6 +654,65 @@ describe("createApp", () => {
       expect(response.headers.get("access-control-allow-origin")).toBe(
         "https://www.vm7.ai:3042",
       );
+    });
+  });
+
+  describe("axiom request log", () => {
+    it("records platform client headers on request log events", async () => {
+      context.mocks.axiom.flush.mockResolvedValue(undefined);
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("https://api.vm0.test/health", {
+        method: "GET",
+        headers: {
+          "user-agent": "zero-test-agent",
+          "x-forwarded-for": "203.0.113.10, 198.51.100.5",
+          "x-client-version": "0.569.1",
+          "x-client-type": "App",
+          "x-client-session-id": "session-test",
+          "x-client-request-id": "request-test",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await flushWaitUntilForTest();
+
+      const [event] = axiomRequestLogEvents(context);
+      expect(event).toMatchObject({
+        method: "GET",
+        status: 200,
+        host: "api.vm0.test",
+        path_template: "/health",
+        remote_addr: "203.0.113.10",
+        user_agent: "zero-test-agent",
+        x_client_version: "0.569.1",
+        x_client_type: "App",
+        x_client_session_id: "session-test",
+        x_client_request_id: "request-test",
+      });
+      expect(event?._time).toStrictEqual(expect.any(String));
+      expect(event?.request_time_ms).toStrictEqual(expect.any(Number));
+      expect(context.mocks.axiom.flush).toHaveBeenCalledWith({
+        client: "telemetry",
+      });
+    });
+
+    it("omits platform client header fields when they are absent", async () => {
+      const app = createApp({ signal: context.signal });
+      const response = await app.request("/health", { method: "GET" });
+
+      expect(response.status).toBe(200);
+      await flushWaitUntilForTest();
+
+      const [event] = axiomRequestLogEvents(context);
+      expect(event).toMatchObject({
+        method: "GET",
+        status: 200,
+        path_template: "/health",
+      });
+      expect(event).not.toHaveProperty("x_client_version");
+      expect(event).not.toHaveProperty("x_client_type");
+      expect(event).not.toHaveProperty("x_client_session_id");
+      expect(event).not.toHaveProperty("x_client_request_id");
     });
   });
 

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -1,5 +1,11 @@
 import { httpInstrumentationMiddleware } from "@hono/otel";
 import * as Sentry from "@sentry/node";
+import {
+  PLATFORM_CLIENT_REQUEST_ID_HEADER,
+  PLATFORM_CLIENT_SESSION_ID_HEADER,
+  PLATFORM_CLIENT_TYPE_HEADER,
+  PLATFORM_CLIENT_VERSION_HEADER,
+} from "@vm0/api-contracts/contracts/platform-client-headers";
 import { serializeError } from "@vm0/core/log-utils";
 // oxlint-disable-next-line no-restricted-imports -- app factory owns the Hono instance, confirmed by ethan@vm0.ai
 import { Hono, type Context } from "hono";
@@ -9,15 +15,27 @@ import { matchedRoutes } from "hono/route";
 import { corsMiddleware } from "./lib/cors";
 import { env } from "./lib/env";
 import { flushLogs, logger } from "./lib/log";
+import { now } from "./lib/time";
 import { waitUntil } from "./signals/context/wait-until";
 import { honoSignalHandler } from "./signals/context/route";
+import {
+  flushAxiom,
+  getDatasetName,
+  ingestToAxiom,
+} from "./signals/external/axiom";
 import type { RouteEntry } from "./signals/route-entry";
-import { isAbortError, normalizeThrown, safeSync } from "./signals/utils";
+import {
+  isAbortError,
+  normalizeThrown,
+  safeSync,
+  safeUrlParse,
+} from "./signals/utils";
 
 const L = logger("App");
 
 const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
 const UNHANDLED_REQUEST_ERROR_TYPE = "unhandled_request_error" as const;
+const REQUEST_LOG_DATASET = "request-log";
 const ERROR_CHAIN_MAX_DEPTH = 32;
 const ERROR_SUMMARY_MAX_LENGTH = 240;
 const ERROR_SUMMARY_SOURCE_MAX_LENGTH = 4096;
@@ -29,6 +47,26 @@ interface UnhandledRequestErrorLogFields {
   readonly route?: string;
   readonly errorCode?: string;
   readonly error: Record<string, unknown>;
+}
+
+interface PlatformClientHeaderLogFields {
+  readonly x_client_version?: string;
+  readonly x_client_type?: string;
+  readonly x_client_session_id?: string;
+  readonly x_client_request_id?: string;
+}
+
+interface AxiomRequestLogEvent
+  extends PlatformClientHeaderLogFields, Record<string, unknown> {
+  readonly _time: string;
+  readonly method: string;
+  readonly status: number;
+  readonly host: string;
+  readonly path_template: string;
+  readonly request_time_ms: number;
+  readonly body_bytes_sent?: number;
+  readonly remote_addr?: string;
+  readonly user_agent?: string;
 }
 
 type ErrorWithCode = Error & { readonly code?: unknown };
@@ -238,6 +276,112 @@ function requestRouteTemplate(context: Context): string | undefined {
   return undefined;
 }
 
+function presentHeaderValue(value: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function requestHeader(context: Context, name: string): string | undefined {
+  return presentHeaderValue(context.req.raw.headers.get(name));
+}
+
+function platformClientHeaderLogFields(
+  context: Context,
+): PlatformClientHeaderLogFields {
+  const clientVersion = requestHeader(context, PLATFORM_CLIENT_VERSION_HEADER);
+  const clientType = requestHeader(context, PLATFORM_CLIENT_TYPE_HEADER);
+  const clientSessionId = requestHeader(
+    context,
+    PLATFORM_CLIENT_SESSION_ID_HEADER,
+  );
+  const clientRequestId = requestHeader(
+    context,
+    PLATFORM_CLIENT_REQUEST_ID_HEADER,
+  );
+
+  return {
+    ...(clientVersion ? { x_client_version: clientVersion } : {}),
+    ...(clientType ? { x_client_type: clientType } : {}),
+    ...(clientSessionId ? { x_client_session_id: clientSessionId } : {}),
+    ...(clientRequestId ? { x_client_request_id: clientRequestId } : {}),
+  };
+}
+
+function requestPathname(context: Context): string {
+  const url = safeUrlParse(context.req.url);
+  return url?.pathname ?? context.req.path;
+}
+
+function requestHost(context: Context): string {
+  const headerHost = requestHeader(context, "host");
+  if (headerHost) {
+    return headerHost;
+  }
+  return safeUrlParse(context.req.url)?.host ?? "";
+}
+
+function firstForwardedAddress(value: string | undefined): string | undefined {
+  return presentHeaderValue(value?.split(",")[0] ?? null);
+}
+
+function requestRemoteAddress(context: Context): string | undefined {
+  return (
+    firstForwardedAddress(requestHeader(context, "x-forwarded-for")) ??
+    requestHeader(context, "x-real-ip") ??
+    requestHeader(context, "cf-connecting-ip")
+  );
+}
+
+function responseBodyBytes(response: Response): number | undefined {
+  const raw = response.headers.get("content-length");
+  if (!raw) {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function axiomRequestLogEvent(
+  context: Context,
+  startedAt: number,
+): AxiomRequestLogEvent {
+  const response = context.res;
+  const bodyBytes = responseBodyBytes(response);
+  const remoteAddress = requestRemoteAddress(context);
+  const userAgent = requestHeader(context, "user-agent");
+
+  return {
+    _time: new Date(startedAt).toISOString(),
+    method: context.req.method,
+    status: response.status,
+    host: requestHost(context),
+    path_template: requestRouteTemplate(context) ?? requestPathname(context),
+    request_time_ms: Math.max(0, now() - startedAt),
+    ...(bodyBytes !== undefined ? { body_bytes_sent: bodyBytes } : {}),
+    ...(remoteAddress ? { remote_addr: remoteAddress } : {}),
+    ...(userAgent ? { user_agent: userAgent } : {}),
+    ...platformClientHeaderLogFields(context),
+  };
+}
+
+function scheduleAxiomRequestLog(context: Context, startedAt: number): void {
+  const ingested = safeSync(() => {
+    return ingestToAxiom(getDatasetName(REQUEST_LOG_DATASET), [
+      axiomRequestLogEvent(context, startedAt),
+    ]);
+  });
+  if (!("ok" in ingested) || !ingested.ok) {
+    return;
+  }
+
+  const flushed = safeSync(() => {
+    return flushAxiom({ client: "telemetry" });
+  });
+  if ("ok" in flushed) {
+    waitUntil(Promise.resolve(flushed.ok));
+  }
+}
+
 function unhandledRequestErrorLogFields(
   error: unknown,
   context: Context,
@@ -250,6 +394,7 @@ function unhandledRequestErrorLogFields(
     method: context.req.method,
     ...(route ? { route } : {}),
     ...(errorCode ? { errorCode } : {}),
+    ...platformClientHeaderLogFields(context),
     error: serializeError(error),
   };
 }
@@ -292,6 +437,13 @@ export function createAppWithRoutes({
   // propagation; correlate them to a route by their `trace_id`, not by
   // copying `http.route` onto each child span.
   app.use("*", httpInstrumentationMiddleware({ serviceName: "vm0-api" }));
+
+  app.use("*", async (c, next) => {
+    const startedAt = now();
+    await next();
+    scheduleAxiomRequestLog(c, startedAt);
+  });
+
   // Browser cross-origin requests (e.g. https://app.vm0.ai -> api.vm0.ai). Must
   // run before the route handlers so OPTIONS preflight short-circuits without
   // matching a registered method, and so registered route responses receive


### PR DESCRIPTION
## Summary
- Follow-up to #20518: write API request-log events to the `request-log` Axiom dataset from the app factory boundary.
- Include the four platform client headers as query-friendly fields: `x_client_version`, `x_client_type`, `x_client_session_id`, and `x_client_request_id`.
- Reuse the same header extraction for structured unhandled request error logs, and keep missing headers omitted rather than writing empty fields.

## Verification
- `pnpm exec prettier --write apps/api/src/app-factory-core.ts apps/api/src/__tests__/app-factory.test.ts`
- `pnpm exec vitest run src/__tests__/app-factory.test.ts` from `turbo/apps/api`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
