### PR TITLE
fix(workflows): prevent content shift when the list scrolls

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -984,7 +984,7 @@ export function WorkflowsPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6">
+      <main className="flex-1 overflow-auto px-4 pb-8 pt-3 [scrollbar-gutter:stable] sm:px-6">
         <div className="mx-auto flex max-w-[900px] flex-col gap-4">
           <WorkflowFilterBar
             filter={filter}


### PR DESCRIPTION
## Summary

The workflows page main container used `overflow-auto`, so the native vertical scrollbar appeared or disappeared based on the rendered list height. Switching between tabs (e.g. `Automated` with many rows vs a short `Manual` list) caused the scrollbar to toggle and the list content to horizontally jump by the scrollbar width.

Add `scrollbar-gutter: stable` to reserve the gutter so the layout width stays constant regardless of whether the scrollbar is currently visible. This matches the convention already used in other views such as `zero-usage-page`, `api-keys-page`, and `zero-account-page`.

## Changes

- `turbo/apps/platform/src/views/workflows-page/workflows-page.tsx`: add `[scrollbar-gutter:stable]` utility class to the `<main>` container.

## Verification

- `prettier@3.8.1 --check` clean
- `oxlint` clean (no warnings, no errors)
- No other files touched