### PR TITLE
fix(platform): tighten user bubble emoji-to-text word-spacing

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -725,6 +725,13 @@ body {
   margin-bottom: 8px;
 }
 
+.zero-chat-bubble-user .wmde-markdown {
+  /* Pull the ASCII space after a leading emoji closer so the emoji doesn't
+     read as detached from the rest of the user-typed text. word-spacing only
+     affects space-separated runs; CJK characters are unaffected. */
+  word-spacing: -0.15em;
+}
+
 .wmde-markdown h1,
 .wmde-markdown h2,
 .wmde-markdown h3,


### PR DESCRIPTION
用户在用户气泡里输入 `😊 UI界面…` 时，emoji 看起来跟正文脱节，间距偏大、不和谐。

根因是 color emoji（Apple Color Emoji / Noto Color Emoji）字形本身带明显 right-side bearing，再加上 `emoji + 一个 ASCII 空格 + 正文` 的组合，前后两个空白加起来视觉上比正常 word-spacing 宽一档。CJK 字符不被 `word-spacing` 影响，所以这个收紧只作用于 space 分隔的运行，对纯中文无副作用。

改动是 `turbo/apps/platform/src/views/css/index.css` 一条规则，仅作用于 `.zero-chat-bubble-user .wmde-markdown`，不会影响 assistant 气泡或任何其它 markdown 表面：

```css
.zero-chat-bubble-user .wmde-markdown {
  word-spacing: -0.15em;
}
```

不修改任何用户输入内容、CJK 字符间距、列表/表格布局。

Verification status: 未本地起 dev server；CSS 单文件改动已提交到 `fix/user-bubble-emoji-spacing`，等 CI。