### PR TITLE
refactor(mitm-addon): add flow metadata boundaries

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -919,9 +919,7 @@ def _finalize_firewall_auth_success(
     """Record successful auth metadata and proxy log after auth application."""
     _record_firewall_auth_success_metadata(flow, token_meta)
 
-    trusted_host = (
-        flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST) or flow.request.pretty_host
-    )
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata) or flow.request.pretty_host
     log_proxy_entry(
         context.proxy_log_path,
         "info",

--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -14,6 +14,7 @@ from enum import Enum
 
 from mitmproxy import http
 
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import matching
 from auth_base_forwarder import (
@@ -125,7 +126,7 @@ def _build_firewall_auth_context(
     auth_config = api_entry.get("auth", {})
     firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
     api_id = flow.metadata[metadata_keys.FIREWALL_API_ID]
-    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+    run_id = flow_metadata.run_id(flow.metadata)
     auth_request = FirewallAuthRequest(
         sandbox_token=vm_info.get("sandboxToken", ""),
         encrypted_secrets=vm_info.get("encryptedSecrets") or "",
@@ -151,7 +152,7 @@ def _build_firewall_auth_context(
     return _FirewallAuthContext(
         allow=allow,
         firewall_base=firewall_base,
-        proxy_log_path=flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
+        proxy_log_path=flow_metadata.proxy_log_path(flow.metadata),
         auth_request=auth_request,
         auth_cache_key=auth_cache_key,
     )
@@ -234,8 +235,7 @@ def _mark_matched_firewall_failure(
     action: str,
     error_code: str,
 ) -> None:
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = action
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = error_code
+    flow_metadata.set_firewall_decision(flow.metadata, action, error=error_code)
 
 
 def _merge_auth_headers(
@@ -257,7 +257,7 @@ def _merge_auth_headers(
 
 
 def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict) -> None:
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
     flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] = token_meta.get("resolved_secrets", [])
     flow.metadata[metadata_keys.AUTH_REFRESHED_CONNECTORS] = token_meta.get(
         "refreshed_connectors", []

--- a/crates/runner/mitm-addon/src/flow_metadata.py
+++ b/crates/runner/mitm-addon/src/flow_metadata.py
@@ -1,10 +1,96 @@
-"""Firewall metadata access helpers."""
+"""Shared flow metadata access helpers.
 
-from collections.abc import Mapping
+This module owns only stable shape/default helpers for cross-module metadata
+reads plus narrow shared state transitions. Domain-specific lifecycle state
+stays with the module that creates and releases it.
+"""
+
+from collections.abc import Mapping, MutableMapping
 
 import flow_metadata_keys as metadata_keys
 
 
-def get_firewall_name_metadata(meta: Mapping[str, object]) -> str:
-    value = meta.get(metadata_keys.FIREWALL_NAME)
-    return value if isinstance(value, str) else ""
+def _metadata_str(meta: Mapping[str, object], key: str, default: str = "") -> str:
+    value = meta.get(key)
+    return value if isinstance(value, str) else default
+
+
+def _metadata_optional_str(meta: Mapping[str, object], key: str) -> str | None:
+    value = meta.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _metadata_bool(meta: Mapping[str, object], key: str, default: bool = False) -> bool:
+    value = meta.get(key)
+    return value if isinstance(value, bool) else default
+
+
+def run_id(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.VM_RUN_ID)
+
+
+def network_log_path(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.VM_NETWORK_LOG_PATH)
+
+
+def proxy_log_path(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.VM_PROXY_LOG_PATH)
+
+
+def sandbox_auth_key(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.VM_SANDBOX_AUTH_KEY)
+
+
+def cli_agent_type(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.CLI_AGENT_TYPE)
+
+
+def original_url(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.ORIGINAL_URL)
+
+
+def trusted_authority_host(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.TRUSTED_AUTHORITY_HOST)
+
+
+def firewall_base(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.FIREWALL_BASE)
+
+
+def firewall_name(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.FIREWALL_NAME)
+
+
+def firewall_permission(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.FIREWALL_PERMISSION)
+
+
+def firewall_action(meta: Mapping[str, object], default: str = "ALLOW") -> str:
+    return _metadata_str(meta, metadata_keys.FIREWALL_ACTION, default)
+
+
+def firewall_error(meta: Mapping[str, object]) -> str | None:
+    return _metadata_optional_str(meta, metadata_keys.FIREWALL_ERROR)
+
+
+def is_firewall_billable(meta: Mapping[str, object]) -> bool:
+    return _metadata_bool(meta, metadata_keys.FIREWALL_BILLABLE)
+
+
+def should_capture_body(meta: Mapping[str, object]) -> bool:
+    return _metadata_bool(meta, metadata_keys.CAPTURE_BODY)
+
+
+def model_usage_provider(meta: Mapping[str, object]) -> str:
+    return _metadata_str(meta, metadata_keys.MODEL_USAGE_PROVIDER)
+
+
+def set_firewall_decision(
+    meta: MutableMapping[str, object],
+    action: str,
+    *,
+    error: str | None = None,
+) -> None:
+    meta[metadata_keys.FIREWALL_ACTION] = action
+    if error is not None:
+        meta[metadata_keys.FIREWALL_ERROR] = error

--- a/crates/runner/mitm-addon/src/http_local_responses.py
+++ b/crates/runner/mitm-addon/src/http_local_responses.py
@@ -7,6 +7,7 @@ from typing import Final
 from mitmproxy import http
 
 import builtin_host_policy
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import http_network_log
 import matching
@@ -23,11 +24,10 @@ def block_authority_validation_error(
     flow: http.HTTPFlow,
     error: AuthorityValidationError,
 ) -> None:
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
     flow.metadata[metadata_keys.ORIGINAL_URL] = error.fallback_url
     http_network_log.set_target_from_url(flow, error.fallback_url)
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = error.reason
+    flow_metadata.set_firewall_decision(flow.metadata, "DENY", error=error.reason)
 
     log_proxy_entry(
         proxy_log_path,
@@ -61,8 +61,11 @@ def block_registry_unavailable(
     flow: http.HTTPFlow,
     unavailable: registry.RegistryUnavailable,
 ) -> None:
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = "registry_unavailable"
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error="registry_unavailable",
+    )
     flow.response = http.Response.make(
         503,
         json.dumps(
@@ -80,8 +83,11 @@ def block_invalid_registry_vm(
     flow: http.HTTPFlow,
     invalid_vm: registry.InvalidVmEntry,
 ) -> None:
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = "invalid_registry_vm"
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error="invalid_registry_vm",
+    )
     flow.response = http.Response.make(
         503,
         json.dumps(
@@ -96,8 +102,11 @@ def block_invalid_registry_vm(
 
 
 def block_stale_tls_admission(flow: http.HTTPFlow, *, reason: str) -> None:
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = _STALE_TLS_ADMISSION_ERROR
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error=_STALE_TLS_ADMISSION_ERROR,
+    )
     flow.response = http.Response.make(
         503,
         json.dumps(
@@ -121,8 +130,8 @@ def block_upstream_destination_unbound(
     server_address: object,
     diagnostics: dict[str, object],
 ) -> None:
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
     log_proxy_entry(
         proxy_log_path,
         "warn",
@@ -135,8 +144,11 @@ def block_upstream_destination_unbound(
         server_address=server_address,
         diagnostics=diagnostics,
     )
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = _UPSTREAM_DESTINATION_UNBOUND_ERROR
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error=_UPSTREAM_DESTINATION_UNBOUND_ERROR,
+    )
     body: dict[str, object] = {
         "error": _UPSTREAM_DESTINATION_UNBOUND_ERROR,
         "message": "Request blocked: upstream destination is not bound to trusted authority",
@@ -145,8 +157,8 @@ def block_upstream_destination_unbound(
         "request_host": flow.request.host,
         "request_port": flow.request.port,
     }
-    firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
-    if isinstance(firewall_base, str):
+    firewall_base = flow_metadata.firewall_base(flow.metadata)
+    if firewall_base:
         body["base"] = firewall_base
     flow.response = http.Response.make(
         403,
@@ -162,8 +174,8 @@ def block_builtin_host_policy_denied(
     error: builtin_host_policy.BuiltinRuntimeHostPolicyError,
     upstream_endpoint: str,
 ) -> None:
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST, "")
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
     log_proxy_entry(
         proxy_log_path,
         "warn",
@@ -175,8 +187,11 @@ def block_builtin_host_policy_denied(
         request_port=flow.request.port,
         upstream_endpoint=upstream_endpoint,
     )
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "BLOCK"
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = _BUILTIN_HOST_POLICY_DENIED_ERROR
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "BLOCK",
+        error=_BUILTIN_HOST_POLICY_DENIED_ERROR,
+    )
     body: dict[str, object] = {
         "error": _BUILTIN_HOST_POLICY_DENIED_ERROR,
         "message": "Request blocked: builtin firewall host policy rejected credential injection",
@@ -185,8 +200,8 @@ def block_builtin_host_policy_denied(
         "trusted_host": trusted_host,
         "request_port": flow.request.port,
     }
-    firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
-    if isinstance(firewall_base, str):
+    firewall_base = flow_metadata.firewall_base(flow.metadata)
+    if firewall_base:
         body["base"] = firewall_base
     flow.response = http.Response.make(
         403,
@@ -196,7 +211,7 @@ def block_builtin_host_policy_denied(
 
 
 def set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBlock) -> None:
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
     if result.reason == "malformed_network_policy":
         block_message = "malformed network policy"
         response_message = "Request blocked: malformed network policy"
@@ -214,7 +229,7 @@ def set_firewall_block_response(flow: http.HTTPFlow, result: matching.FirewallBl
         name=result.name,
         reason=result.reason,
     )
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
+    flow_metadata.set_firewall_decision(flow.metadata, "DENY")
     flow.metadata[metadata_keys.FIREWALL_BASE] = result.base
     flow.metadata[metadata_keys.FIREWALL_NAME] = result.name
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
@@ -252,10 +267,13 @@ def block_public_destination_denied(
     reason: str,
     send_response: bool = True,
 ) -> None:
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
     flow.request.stream = False
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "DENY"
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = "unsafe_public_destination"
+    flow_metadata.set_firewall_decision(
+        flow.metadata,
+        "DENY",
+        error="unsafe_public_destination",
+    )
     flow.metadata[metadata_keys.FIREWALL_BASE] = base
     flow.metadata[metadata_keys.FIREWALL_NAME] = name
 

--- a/crates/runner/mitm-addon/src/logging_utils.py
+++ b/crates/runner/mitm-addon/src/logging_utils.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 
 from mitmproxy import ctx, http
 
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import jsonl_writer
 import network_log_sanitization
@@ -126,11 +127,6 @@ def _metadata_optional_str(meta: Mapping[str, object], key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
-def _metadata_bool(meta: Mapping[str, object], key: str, default: bool = False) -> bool:
-    value = meta.get(key)
-    return value if isinstance(value, bool) else default
-
-
 def _metadata_optional_bool(meta: Mapping[str, object], key: str) -> bool | None:
     value = meta.get(key)
     return value if isinstance(value, bool) else None
@@ -164,16 +160,16 @@ def add_firewall_metadata(flow: http.HTTPFlow, log_entry: dict) -> None:
     """Copy firewall and auth metadata from flow into a log entry."""
     # [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
     meta = flow.metadata
-    log_entry["firewall_base"] = _metadata_str(meta, metadata_keys.FIREWALL_BASE)
-    log_entry["firewall_name"] = _metadata_str(meta, metadata_keys.FIREWALL_NAME)
-    log_entry["firewall_permission"] = _metadata_str(meta, metadata_keys.FIREWALL_PERMISSION)
+    log_entry["firewall_base"] = flow_metadata.firewall_base(meta)
+    log_entry["firewall_name"] = flow_metadata.firewall_name(meta)
+    log_entry["firewall_permission"] = flow_metadata.firewall_permission(meta)
     log_entry["firewall_rule_match"] = _metadata_str(meta, metadata_keys.FIREWALL_RULE_MATCH)
-    log_entry["firewall_billable"] = _metadata_bool(meta, metadata_keys.FIREWALL_BILLABLE)
+    log_entry["firewall_billable"] = flow_metadata.is_firewall_billable(meta)
 
     # Optional fields — only include when present with the network-log schema type.
     for log_key, value in (
         ("firewall_params", _metadata_str_record(meta, metadata_keys.FIREWALL_PARAMS)),
-        ("firewall_error", _metadata_optional_str(meta, metadata_keys.FIREWALL_ERROR)),
+        ("firewall_error", flow_metadata.firewall_error(meta)),
         (
             "connector_diagnostic_type",
             _metadata_optional_str(meta, metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE),

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -49,6 +49,7 @@ import body_capture
 import builtin_connector_diagnostics
 import builtin_host_policy
 import deferred_callbacks
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import http_local_responses
 import http_network_log
@@ -822,8 +823,8 @@ def _current_public_destination_denial(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
 ) -> _PublicDestinationDenial | None:
-    trusted_authority_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
-    if not isinstance(trusted_authority_host, str) or not trusted_authority_host:
+    trusted_authority_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_authority_host:
         try:
             trusted_authority_host = get_trusted_authority(flow).host
         except AuthorityValidationError:
@@ -1080,8 +1081,8 @@ def _builtin_host_policy_error_for_firewall_allow(
         return None
     if not _firewall_allow_injects_ordinary_upstream_credentials(allow):
         return None
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
-    if not isinstance(trusted_host, str) or not trusted_host:
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
         return builtin_host_policy.BuiltinRuntimeHostPolicyError(
             reason="trusted_authority_unavailable",
             message="trusted request authority is unavailable",
@@ -1120,8 +1121,8 @@ def _bind_flow_upstream_destination(
     *,
     kind: upstream_destination_binding.BindingKind,
 ) -> bool:
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
-    if not isinstance(trusted_host, str) or not trusted_host:
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
         return False
     try:
         normalized_host = normalize_trusted_hostname(trusted_host)
@@ -1562,7 +1563,7 @@ def _log_connector_diagnostic_proxy_entry(
     if isinstance(ownership_hint_status, str) and ownership_hint_status:
         extra["ownership_hint_status"] = ownership_hint_status
     log_proxy_entry(
-        flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
+        flow_metadata.proxy_log_path(flow.metadata),
         "warn",
         f"{candidate.connector_type} is not configured for this run: {safe_url}",
         type="connector_diagnostic",
@@ -1592,7 +1593,7 @@ def _maybe_make_connector_diagnostic_local_response(
 
     _start_request_timing(flow)
     _set_connector_diagnostic_failure_metadata(flow, candidate)
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
     flow.response = http.Response.make(
         _HTTP_STATUS_FAILED_DEPENDENCY,
         _connector_diagnostic_response_body(candidate, upstream_status=0),
@@ -1626,8 +1627,8 @@ def _maybe_make_firewall_allow_connector_diagnostic_local_response(
     if allow is None or vm_info is None or not _firewall_allow_is_unknown_endpoint(allow):
         return False
 
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(original_url, str) or not original_url:
+    original_url = flow_metadata.original_url(flow.metadata)
+    if not original_url:
         return False
 
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
@@ -1649,7 +1650,7 @@ def _maybe_make_firewall_allow_connector_diagnostic_local_response(
     flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON] = resolution.reason
     flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES] = resolution.candidate_connector_types
     flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS] = resolution.hint_status
-    flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
     flow.response = http.Response.make(
         _HTTP_STATUS_FAILED_DEPENDENCY,
         _connector_diagnostic_response_body(candidate, upstream_status=0),
@@ -1830,8 +1831,8 @@ def _http_network_log_entry(
         "request_size": request_size,
         "response_size": response_size,
     }
-    firewall_error = flow.metadata.get(metadata_keys.FIREWALL_ERROR)
-    if isinstance(firewall_error, str):
+    firewall_error = flow_metadata.firewall_error(flow.metadata)
+    if firewall_error is not None:
         entry["firewall_error"] = firewall_error
     upstream_binding_diagnostics = flow.metadata.get(_UPSTREAM_BINDING_DIAGNOSTICS)
     if isinstance(upstream_binding_diagnostics, dict):
@@ -1911,9 +1912,7 @@ def _upstream_binding_diagnostics(
     *,
     reason: upstream_destination_binding.BindingKind,
 ) -> dict[str, object]:
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST, "")
-    if not isinstance(trusted_host, str):
-        trusted_host = ""
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
     diagnostics = upstream_destination_binding.diagnostic_snapshot_for_flow(
         flow,
         allowed_kinds=frozenset((reason,)),
@@ -2210,8 +2209,8 @@ def _flow_requires_platform_connector_auth_bypass(
 ) -> bool:
     if kind != "connector_auth":
         return False
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
-    if not isinstance(trusted_host, str) or not trusted_host:
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
         return False
     try:
         normalized_host = normalize_trusted_hostname(trusted_host)
@@ -2565,7 +2564,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     ):
         _start_request_timing(flow)
         prepare_firewall_metadata(flow, allow, vm_info)
-        proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+        proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
         firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
         if body_check.kind == "too_large":
             mark_auth_base_request_too_large(
@@ -2604,7 +2603,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         ):
             _start_request_timing(flow)
             prepare_firewall_metadata(flow, allow, vm_info)
-            proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+            proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
             firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
             mark_auth_base_forwarding_saturated(
                 flow,
@@ -2770,13 +2769,13 @@ async def request(flow: http.HTTPFlow) -> None:
             if not _ensure_bound_upstream_destination(flow, kind="api_allow"):
                 _block_upstream_destination_unbound(flow, reason="api_allow")
                 return
-            flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+            flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
             return
         if classification.kind == "browser_allow":
             # Browser-originated traffic intentionally bypasses connector
             # firewall handling. User-Agent is the short-term heuristic for that
             # business passthrough, not trusted provenance.
-            flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+            flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
             flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
             return
         if classification.kind == "firewall_block":
@@ -2850,7 +2849,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 original_url=original_url,
             ):
                 return
-        flow.metadata[metadata_keys.FIREWALL_ACTION] = "ALLOW"
+        flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
@@ -2991,7 +2990,7 @@ def websocket_message(flow: http.HTTPFlow) -> None:
     """Feed server-side WebSocket frames into model-provider usage parsers."""
     if not flow.websocket or not flow.websocket.messages:
         return
-    if not flow.metadata.get(metadata_keys.VM_RUN_ID, ""):
+    if not flow_metadata.run_id(flow.metadata):
         return
     if not response_streaming.is_model_websocket_usage_enabled(flow):
         return
@@ -3139,7 +3138,7 @@ def _track_response_usage_flow(fn):
 @_track_usage_flow
 def websocket_end(flow: http.HTTPFlow) -> None:
     """Report model-provider usage extracted from a WebSocket-upgraded response."""
-    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+    run_id = flow_metadata.run_id(flow.metadata)
     if run_id:
         _report_model_provider_usage_once(flow, run_id)
 
@@ -3152,7 +3151,7 @@ def response(flow: http.HTTPFlow) -> None:
     # Pop before any early return so tracked flows consume timing exactly once.
     start_time = flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
 
-    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+    run_id = flow_metadata.run_id(flow.metadata)
     if not run_id:
         # Unregistered VM: the request handler returned before populating
         # metadata, so none of this handler's work applies.
@@ -3160,7 +3159,7 @@ def response(flow: http.HTTPFlow) -> None:
 
     latency_ms = elapsed_ms(start_time)
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-    firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
+    firewall_action = flow_metadata.firewall_action(flow.metadata)
 
     _maybe_replace_connector_diagnostic_response(flow, original_url=original_url)
 
@@ -3171,8 +3170,8 @@ def response(flow: http.HTTPFlow) -> None:
     # Log HTTP network entry for this run. DNS/kmsg rows are produced by the
     # Rust runner; api-contracts is the shared network-log schema boundary.
     # [NETWORK_LOG_FIELDS]
-    network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    network_log_path = flow_metadata.network_log_path(flow.metadata)
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
     if network_log_path:
         response_size = _response_size(flow)
         log_entry = _http_network_log_entry(
@@ -3186,12 +3185,12 @@ def response(flow: http.HTTPFlow) -> None:
         )
 
         # Add firewall match info if this was a firewall request
-        firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
+        firewall_base = flow_metadata.firewall_base(flow.metadata)
         if firewall_base:
             add_firewall_metadata(flow, log_entry)
 
         # Add captured header names, selected safe header values, and bodies when enabled
-        if flow.metadata.get(metadata_keys.CAPTURE_BODY):
+        if flow_metadata.should_capture_body(flow.metadata):
             body_capture.add_capture_fields(flow, log_entry)
 
         log_network_entry(network_log_path, log_entry)
@@ -3244,7 +3243,7 @@ def response(flow: http.HTTPFlow) -> None:
     if (
         flow.response
         and flow.response.status_code == _HTTP_STATUS_UNAUTHORIZED
-        and flow.metadata.get(metadata_keys.FIREWALL_BASE)
+        and flow_metadata.firewall_base(flow.metadata)
     ):
         cache_key = flow.metadata.get(metadata_keys.FIREWALL_AUTH_CACHE_KEY)
         if isinstance(cache_key, FirewallAuthCacheKey):
@@ -3271,16 +3270,16 @@ def error(flow: http.HTTPFlow) -> None:
     """
     start_time = flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
 
-    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
-    network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    run_id = flow_metadata.run_id(flow.metadata)
+    network_log_path = flow_metadata.network_log_path(flow.metadata)
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
 
     if not run_id or not network_log_path:
         return
 
     latency_ms = elapsed_ms(start_time)
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
-    firewall_action = flow.metadata.get(metadata_keys.FIREWALL_ACTION, "ALLOW")
+    firewall_action = flow_metadata.firewall_action(flow.metadata)
 
     _maybe_make_connector_diagnostic_error_response(flow, original_url=original_url)
 
@@ -3300,7 +3299,7 @@ def error(flow: http.HTTPFlow) -> None:
     log_entry["error"] = error_msg
 
     # Add firewall context if available
-    firewall_base = flow.metadata.get(metadata_keys.FIREWALL_BASE)
+    firewall_base = flow_metadata.firewall_base(flow.metadata)
     if firewall_base:
         add_firewall_metadata(flow, log_entry)
 

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -22,6 +22,7 @@ from typing import NamedTuple
 from mitmproxy import http
 
 import body_decoding
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
@@ -48,10 +49,10 @@ def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
     """Return whether a flow should use OpenAI Responses usage parsing.
 
     Read-only predicate used from parser setup and response fallback extraction.
-    Reads ``metadata_keys.CLI_AGENT_TYPE``; Codex flows use the OpenAI Responses
+    Codex flows use the OpenAI Responses
     usage protocol, while other model-provider flows use the Anthropic protocol.
     """
-    return flow.metadata.get(metadata_keys.CLI_AGENT_TYPE) == "codex"
+    return flow_metadata.cli_agent_type(flow.metadata) == "codex"
 
 
 def is_model_websocket_usage_enabled(flow: http.HTTPFlow) -> bool:
@@ -77,7 +78,7 @@ def _make_model_sse_parse_error_logger(
     *,
     usage_protocol: str,
 ) -> _SseUsageParseErrorLogger:
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
 
     def log_parse_error(event: str, error: str) -> None:
         log_proxy_entry(
@@ -104,7 +105,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
     # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
     # and the incremental response parsers used for connector billing payload
     # extraction. Model-provider usage reporting is gated separately.
-    is_billable_flow = flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False)
+    is_billable_flow = flow_metadata.is_firewall_billable(flow.metadata)
     is_observable_model_provider = usage.is_model_provider_usage_observable(flow)
     if (
         is_observable_model_provider
@@ -362,7 +363,7 @@ def feed_model_websocket_usage(flow: http.HTTPFlow, content: bytes | str) -> Non
             usage_target = {}
             usage_sources[message_id] = usage_target
         usage.merge_openai_responses_usage_result(usage_target, usage_result)
-        run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
+        run_id = flow_metadata.run_id(flow.metadata)
         usage.report_model_provider_usage_source(
             flow,
             run_id,

--- a/crates/runner/mitm-addon/src/tcp_logging.py
+++ b/crates/runner/mitm-addon/src/tcp_logging.py
@@ -5,6 +5,7 @@ import time
 from mitmproxy import tcp
 
 import deferred_callbacks
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import logging_utils
 import registry
@@ -58,8 +59,7 @@ def error(flow: tcp.TCPFlow) -> None:
 
 def _is_registered_tcp_log_flow(flow: tcp.TCPFlow) -> bool:
     return bool(
-        flow.metadata.get(metadata_keys.VM_RUN_ID, "")
-        and flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
+        flow_metadata.run_id(flow.metadata) and flow_metadata.network_log_path(flow.metadata)
     )
 
 
@@ -137,8 +137,8 @@ def _tcp_log_sizes(flow: tcp.TCPFlow) -> tuple[int, int]:
 
 
 def _log_tcp(flow: tcp.TCPFlow) -> None:
-    run_id = flow.metadata.get(metadata_keys.VM_RUN_ID, "")
-    network_log_path = flow.metadata.get(metadata_keys.VM_NETWORK_LOG_PATH, "")
+    run_id = flow_metadata.run_id(flow.metadata)
+    network_log_path = flow_metadata.network_log_path(flow.metadata)
     if not run_id or not network_log_path:
         return
 

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -19,7 +19,7 @@ from typing import Literal
 
 from mitmproxy import http
 
-import flow_metadata_keys as metadata_keys
+import flow_metadata
 from url_utils import normalize_trusted_hostname
 
 # Public API used by mitm_addon hooks and tests. Private helpers encode the
@@ -410,9 +410,9 @@ def diagnostic_snapshot_for_flow(
         for bound_server_id in client_server_ids
         if (binding := _bindings_by_server_id.get(bound_server_id)) is not None
     ]
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
     normalized_host = None
-    if isinstance(trusted_host, str):
+    if trusted_host:
         try:
             normalized_host = normalize_trusted_hostname(trusted_host)
         except (UnicodeError, ValueError):
@@ -465,8 +465,8 @@ def flow_matches_bound_destination(
     the same client may be used as fallback, but connected flows still require
     authoritative endpoint evidence matching the bound concrete endpoint.
     """
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
-    if not isinstance(trusted_host, str) or not trusted_host:
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
         return False
     try:
         normalized_host = normalize_trusted_hostname(trusted_host)
@@ -511,8 +511,8 @@ def bound_destination_endpoint_for_flow(
     Host-policy checks use this endpoint as connection evidence. A connected
     fallback match returns the live authoritative endpoint, not a DNS result.
     """
-    trusted_host = flow.metadata.get(metadata_keys.TRUSTED_AUTHORITY_HOST)
-    if not isinstance(trusted_host, str) or not trusted_host:
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
         return None
     try:
         normalized_host = normalize_trusted_hostname(trusted_host)

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -21,7 +21,6 @@ from collections.abc import Callable
 from mitmproxy import http
 
 import flow_metadata
-import flow_metadata_keys as metadata_keys
 
 from ...underbilling import log_usage_underbilling
 from . import x
@@ -57,8 +56,8 @@ _unregistered_handler_warned: set[str] = set()
 
 
 def _require_original_url(flow: http.HTTPFlow) -> str:
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(original_url, str) or not original_url:
+    original_url = flow_metadata.original_url(flow.metadata)
+    if not original_url:
         raise ValueError("registered billable connector flow is missing original_url")
     return original_url
 
@@ -80,9 +79,9 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
     """
     if not run_id:
         return
-    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
+    if not flow_metadata.is_firewall_billable(flow.metadata):
         return
-    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+    firewall_name = flow_metadata.firewall_name(flow.metadata)
     if firewall_name.startswith("model-provider:"):
         return
     handler = _HANDLERS.get(firewall_name)
@@ -90,7 +89,7 @@ def report_connector_usage(flow: http.HTTPFlow, run_id: str) -> None:
         if firewall_name and firewall_name not in _unregistered_handler_warned:
             _unregistered_handler_warned.add(firewall_name)
             log_usage_underbilling(
-                flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, ""),
+                flow_metadata.proxy_log_path(flow.metadata),
                 f"Billable firewall {firewall_name!r} has no registered handler — "
                 "billing records for this firewall will be dropped.  Check that "
                 "BILLABLE_FIREWALL_CONNECTOR_TYPES and _HANDLERS here are in sync.",
@@ -115,9 +114,9 @@ def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponsePa
     connector-owned ``flow.metadata`` state for ``report_connector_usage``.
     Non-billable flows never need connector billing parser state.
     """
-    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
+    if not flow_metadata.is_firewall_billable(flow.metadata):
         return None
-    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+    firewall_name = flow_metadata.firewall_name(flow.metadata)
     factory = _RESPONSE_PARSER_FACTORIES.get(firewall_name)
     if factory is None:
         return None

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -14,6 +14,7 @@ from mitmproxy import http
 
 import billing_body
 import body_decoding
+import flow_metadata
 import flow_metadata_keys as metadata_keys
 import matching
 import request_streaming
@@ -941,12 +942,12 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     - ``firewall_permission`` is not mapped to an X billing bucket
       (e.g. the ``"app-only"`` scope for BearerToken-only endpoints)
     """
-    firewall_name = flow.metadata.get(metadata_keys.FIREWALL_NAME, "")
+    firewall_name = flow_metadata.firewall_name(flow.metadata)
     if not flow.response or not (
         _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
     ):
         return
-    permission = flow.metadata.get(metadata_keys.FIREWALL_PERMISSION, "")
+    permission = flow_metadata.firewall_permission(flow.metadata)
     if not permission:
         return
     # mitmproxy's ``flow.request.path`` is the raw request-target — it
@@ -984,7 +985,7 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
         )
         else _empty_request_query_fallback_hints()
     )
-    proxy_log_path = flow.metadata.get(metadata_keys.VM_PROXY_LOG_PATH, "")
+    proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
 
     # Structured context common to every billing-side proxy log entry
     # for this flow — threaded into the helper so the log firing at the

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -51,10 +51,10 @@ def is_model_provider_usage_observable(flow: http.HTTPFlow) -> bool:
     be observable when the run context supplies a non-empty
     ``MODEL_USAGE_PROVIDER``.
     """
-    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+    firewall_name = flow_metadata.firewall_name(flow.metadata)
     if not firewall_name.startswith("model-provider:"):
         return False
-    return bool(_string_or_none(flow.metadata.get(metadata_keys.MODEL_USAGE_PROVIDER)))
+    return bool(flow_metadata.model_usage_provider(flow.metadata))
 
 
 def has_positive_model_provider_usage(source_usage: dict) -> bool:
@@ -81,10 +81,10 @@ def report_model_provider_usage(flow: http.HTTPFlow, run_id: str) -> bool:
     """
     if not run_id:
         return False
-    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+    firewall_name = flow_metadata.firewall_name(flow.metadata)
     if not firewall_name.startswith("model-provider:"):
         return False
-    if not flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False):
+    if not flow_metadata.is_firewall_billable(flow.metadata):
         return False
     events = _build_model_provider_usage_events(flow, run_id, USAGE_EVENT_NAMESPACE_MODEL)
     if not events:
@@ -169,7 +169,7 @@ def report_model_provider_usage_source(
     context = usage_reporting_context(flow)
     if not context.is_complete:
         if usage_events:
-            firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+            firewall_name = flow_metadata.firewall_name(flow.metadata)
             _log_usage_reporting_context_missing(context, run_id, firewall_name)
         if observation_events:
             _log_model_usage_observation_context_missing(context)
@@ -323,7 +323,7 @@ def _build_usage_events(
 
 def _reported_model(flow: http.HTTPFlow, usage: dict) -> str:
     return (
-        _string_or_none(flow.metadata.get(metadata_keys.MODEL_USAGE_PROVIDER))
+        flow_metadata.model_usage_provider(flow.metadata)
         or _string_or_none(usage.get("model"))
         or "unknown"
     )
@@ -342,7 +342,7 @@ def _string_or_none(value: object) -> str | None:
 def _is_billable_model_provider(flow: http.HTTPFlow, run_id: str) -> bool:
     if not run_id:
         return False
-    firewall_name = flow_metadata.get_firewall_name_metadata(flow.metadata)
+    firewall_name = flow_metadata.firewall_name(flow.metadata)
     if not firewall_name.startswith("model-provider:"):
         return False
-    return bool(flow.metadata.get(metadata_keys.FIREWALL_BILLABLE, False))
+    return flow_metadata.is_firewall_billable(flow.metadata)

--- a/crates/runner/mitm-addon/src/usage/reporting_context.py
+++ b/crates/runner/mitm-addon/src/usage/reporting_context.py
@@ -2,7 +2,7 @@
 
 from mitmproxy import http
 
-import flow_metadata_keys as metadata_keys
+import flow_metadata
 from platform_api import get_api_url
 
 USAGE_EVENT_WEBHOOK_PATH = "/api/webhooks/agent/usage-event"
@@ -43,12 +43,7 @@ class UsageReportingContext:
 
 def usage_reporting_context(flow: http.HTTPFlow) -> UsageReportingContext:
     return UsageReportingContext(
-        sandbox_token=_metadata_string(flow, metadata_keys.VM_SANDBOX_AUTH_KEY),
+        sandbox_token=flow_metadata.sandbox_auth_key(flow.metadata),
         api_url=get_api_url(),
-        proxy_log_path=_metadata_string(flow, metadata_keys.VM_PROXY_LOG_PATH),
+        proxy_log_path=flow_metadata.proxy_log_path(flow.metadata),
     )
-
-
-def _metadata_string(flow: http.HTTPFlow, key: str) -> str:
-    value = flow.metadata.get(key, "")
-    return value if isinstance(value, str) else ""


### PR DESCRIPTION
## Summary
- add semantic helpers for shared request/run and firewall flow metadata
- migrate cross-domain consumers in auth, logging, usage, response, TCP, and upstream binding paths
- keep stream buffers, connector parser state, and hook-private lifecycle metadata in their owning modules

## Tests
- `/tmp/mitm-addon-venv/bin/ruff check src tests/test_flow_metadata_key_contract.py`
- `/tmp/mitm-addon-venv/bin/ruff format --check src tests/test_flow_metadata_key_contract.py`
- `/tmp/mitm-addon-venv/bin/pytest tests/test_flow_metadata_key_contract.py tests/test_logging_utils.py tests/test_firewall_auth.py tests/test_firewall_rewrite_success.py tests/test_request_handler_passthrough.py tests/test_request_handler_authority_validation.py tests/test_response_handler.py tests/test_error_handler.py tests/test_model_provider_usage.py tests/test_connector_usage.py`
- `/tmp/mitm-addon-venv/bin/pytest tests/test_request_headers_handler.py tests/test_request_handler_firewall_dispatch.py tests/test_response_streaming.py tests/test_model_provider_websocket_metadata.py tests/test_model_provider_websocket_usage.py tests/test_tcp_hooks.py tests/test_tls_clienthello_hook.py tests/test_server_connect_hook.py`
- `/tmp/mitm-addon-venv/bin/pytest tests/`
- `/tmp/mitm-addon-venv/bin/basedpyright --pythonpath /tmp/mitm-addon-venv/bin/python src scripts tests`

Closes #20540