### PR TITLE
fix(core): disable minimax codex staff rollout

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -130,7 +130,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.WorkflowWebhookTriggers]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
-      true,
+      false,
     );
     expect(staffOrgStates[FeatureSwitchKey.ChatThreadEmoji]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.RelationshipMemory]).toBe(true);

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -257,7 +257,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Expose the experimental MiniMax Codex framework provider route for Responses API compatibility testing.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.CodexFastMode]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary
- Keep the MiniMax Codex framework switch disabled by default without VM0 staff org rollout.
- Update the core feature-switch rollout matrix test so staff orgs also see `codexFrameworkForMinimax` as disabled unless explicitly overridden.

## Verification
- `pnpm exec prettier --write packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts`
- `pnpm --filter @vm0/core lint`
- `pnpm --filter @vm0/core check-types`
- `pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`

Did not run full local vitest or start a dev server per vm0 PR verification preference.