### PR TITLE
fix: keep mobile unread shortcuts personal

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts
@@ -191,7 +191,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeUndefined();
   });
 
-  it("stores org-scoped feature switch overrides", async () => {
+  it("stores org-scoped feature switch overrides separately from personal overrides", async () => {
     const orgId = `org_${randomUUID()}`;
     const owner = api.user({ orgId });
     const peer = api.user({ orgId });
@@ -205,6 +205,7 @@ describe("OPS-01: feature switches and report-error routes", () => {
             [FeatureSwitchKey.RelationshipMemory]: true,
             [FeatureSwitchKey.AgentUnreadIndicators]: true,
             [FeatureSwitchKey.ChatThreadUnifiedSearch]: true,
+            [FeatureSwitchKey.MobileUnreadChatThreadShortcuts]: true,
             [FeatureSwitchKey.Dummy]: false,
           },
         },
@@ -219,6 +220,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeTruthy();
     expect(
       ownerUpdate.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
+    ).toBeTruthy();
+    expect(
+      ownerUpdate.body.switches[
+        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
+      ],
     ).toBeTruthy();
     expect(ownerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeFalsy();
 
@@ -235,6 +241,9 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       peerRead.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeTruthy();
+    expect(
+      peerRead.body.switches[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
+    ).toBeUndefined();
     expect(peerRead.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const outsiderRead = await accept(
@@ -249,6 +258,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
     ).toBeUndefined();
     expect(
       outsiderRead.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
+    ).toBeUndefined();
+    expect(
+      outsiderRead.body.switches[
+        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
+      ],
     ).toBeUndefined();
 
     const peerUpdate = await accept(
@@ -273,6 +287,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       peerUpdate.body.switches[FeatureSwitchKey.ChatThreadUnifiedSearch],
     ).toBeFalsy();
+    expect(
+      peerUpdate.body.switches[
+        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
+      ],
+    ).toBeUndefined();
     expect(peerUpdate.body.switches[FeatureSwitchKey.Dummy]).toBeUndefined();
 
     const ownerReadAfterPeerUpdate = await accept(
@@ -294,6 +313,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
         FeatureSwitchKey.ChatThreadUnifiedSearch
       ],
     ).toBeFalsy();
+    expect(
+      ownerReadAfterPeerUpdate.body.switches[
+        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
+      ],
+    ).toBeTruthy();
     expect(
       ownerReadAfterPeerUpdate.body.switches[FeatureSwitchKey.Dummy],
     ).toBeFalsy();
@@ -317,6 +341,11 @@ describe("OPS-01: feature switches and report-error routes", () => {
     expect(
       peerReadAfterDelete.body.switches[
         FeatureSwitchKey.ChatThreadUnifiedSearch
+      ],
+    ).toBeUndefined();
+    expect(
+      peerReadAfterDelete.body.switches[
+        FeatureSwitchKey.MobileUnreadChatThreadShortcuts
       ],
     ).toBeUndefined();
     expect(

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -138,7 +138,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.AgentUnreadIndicators]).toBe(true);
     expect(
       staffOrgStates[FeatureSwitchKey.MobileUnreadChatThreadShortcuts],
-    ).toBe(true);
+    ).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       true,
     );

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -346,7 +346,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Show unread chat thread shortcuts between the mobile agent chat composer and suggested prompt cards.",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ChatThreadUnifiedSearch]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Stop enabling `MobileUnreadChatThreadShortcuts` by default for staff orgs.
- Keep the mobile unread thread shortcut feature available only through a personal feature-switch override.
- Extend the feature-switch route test to verify org-scoped overrides still propagate across an org while this mobile shortcut override remains user-scoped.

## Verification
- `pnpm exec prettier --write --ignore-unknown packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts apps/api/src/signals/routes/__tests__/hooks-ops.bdd.test.ts`
- `pnpm -F @vm0/core exec vitest run src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/core check-types`
- `pnpm -F api lint`
- `git diff --check`

## Local limits
- `pnpm -F api exec vitest run src/signals/routes/__tests__/hooks-ops.bdd.test.ts` was attempted but local Postgres was not running (`ECONNREFUSED`).
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types` was attempted but the local process was killed by the runtime (exit 137). CI should cover the full API route test/type-check path.