### PR TITLE
feat: default limited-free workspaces to sonnet 4.6

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -891,7 +891,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       agentId,
       modelSelection: {
         modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
-        selectedModel: "MiniMax-M3",
+        selectedModel: "claude-sonnet-4-6",
       },
       title: "limited free model pin",
     });
@@ -899,7 +899,6 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
-      "claude-sonnet-4-6",
       "claude-sonnet-5",
     ] as const) {
       const restrictedSelection = await chat.requestUpdateThreadModelSelection(

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-callbacks.bdd.test.ts
@@ -1,5 +1,6 @@
 import { createHash, randomInt, randomUUID } from "node:crypto";
 
+import { LIMITED_FREE1_DEFAULT_RUN_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import { RESUME_SESSION_HISTORY_MAX_BYTES } from "@vm0/api-contracts/contracts/runners";
 import { MAX_FILE_SIZE_BYTES } from "@vm0/api-contracts/contracts/storages";
 import { HttpResponse, http } from "msw";
@@ -470,6 +471,12 @@ describe("WHCB-01: third-party webhook verification boundaries", () => {
       remaining: 3000,
     });
     expectExpiresAboutThirtyDaysFromNow(onboardingCreditGrant?.expiresAt);
+    const limitedFreeProviders = await runs.listOrgModelProviders(admin);
+    expect(
+      limitedFreeProviders.find((provider) => {
+        return provider.type === "vm0";
+      })?.selectedModel,
+    ).toBe(LIMITED_FREE1_DEFAULT_RUN_MODEL);
 
     api.verifyNextClerkWebhook({
       type: "organizationMembership.created",

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
+  LIMITED_FREE1_DEFAULT_RUN_MODEL,
   type ModelProviderType,
   type OrgModelPoliciesResponse,
   type UpdateOrgModelPolicy,
@@ -232,8 +233,13 @@ describe("GET/PUT /api/zero/model-policies", () => {
       }),
     ).toStrictEqual(DEFAULT_ORG_MODEL_POLICY_MODELS);
     expect(response.body.workspaceDefaultModel).toBe(
-      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+      LIMITED_FREE1_DEFAULT_RUN_MODEL,
     );
+    expect(
+      response.body.policies.find((policy) => {
+        return policy.isDefault;
+      })?.model,
+    ).toBe(LIMITED_FREE1_DEFAULT_RUN_MODEL);
   });
 
   it("allows members to read policy controls", async () => {
@@ -412,6 +418,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
       "claude-opus-4-8",
       "claude-opus-4-6",
       "claude-sonnet-5",
+      "claude-sonnet-4-6",
       "MiniMax-M3",
     ]);
   });
@@ -446,7 +453,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
       },
     });
     expect(afterRejected.body.workspaceDefaultModel).toBe(
-      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+      LIMITED_FREE1_DEFAULT_RUN_MODEL,
     );
     expect(
       afterRejected.body.policies
@@ -456,7 +463,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
         .map((policy) => {
           return policy.model;
         }),
-    ).toStrictEqual([DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL]);
+    ).toStrictEqual([LIMITED_FREE1_DEFAULT_RUN_MODEL]);
   });
 
   it("rejects BYOK policy writes for limited-free-1 workspaces", async () => {

--- a/turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts
+++ b/turbo/apps/api/src/signals/services/org-limited-free-bootstrap.service.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL } from "@vm0/api-contracts/contracts/model-providers";
+import { LIMITED_FREE1_DEFAULT_RUN_MODEL } from "@vm0/api-contracts/contracts/model-providers";
 import { SEED_INSTRUCTIONS } from "@vm0/core/zero-seed-instructions";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -257,7 +257,7 @@ export const ensureOrgLimitedFreeBootstrap$ = command(
       {
         orgId: args.orgId,
         type: "vm0",
-        selectedModel: DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+        selectedModel: LIMITED_FREE1_DEFAULT_RUN_MODEL,
       },
       signal,
     );

--- a/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { and, eq, inArray, notInArray } from "drizzle-orm";
 import {
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+  LIMITED_FREE1_DEFAULT_RUN_MODEL,
   MODEL_PROVIDER_TYPES,
   SUPPORTED_RUN_MODELS,
   getCanonicalModelDisplayName,
@@ -123,34 +124,127 @@ function sortRowsByCatalog(rows: OrgModelPolicyRow[]): OrgModelPolicyRow[] {
   });
 }
 
+function getSeedDefaultModelForTier(limitedFree1: boolean): SupportedRunModel {
+  return limitedFree1
+    ? LIMITED_FREE1_DEFAULT_RUN_MODEL
+    : DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
+}
+
+function shouldReplaceExistingDefaultForTier(
+  existingDefault: OrgModelPolicyRow | undefined,
+  limitedFree1: boolean,
+): boolean {
+  if (!limitedFree1) {
+    return existingDefault === undefined;
+  }
+  return (
+    existingDefault === undefined ||
+    existingDefault.model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL ||
+    isLimitedFree1RestrictedRunModel(existingDefault.model)
+  );
+}
+
+async function ensureModelPolicy(
+  db: Db,
+  orgId: string,
+  userId: string,
+  model: SupportedRunModel,
+): Promise<void> {
+  const now = nowDate();
+  await db
+    .insert(orgModelPolicies)
+    .values({
+      model,
+      isDefault: false,
+      defaultProviderType: "vm0",
+      credentialScope: "org",
+      modelProviderId: null,
+      orgId,
+      createdByUserId: userId,
+      updatedByUserId: userId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing({
+      target: [orgModelPolicies.orgId, orgModelPolicies.model],
+    });
+}
+
+async function setDefaultModelPolicy(
+  db: Db,
+  orgId: string,
+  userId: string,
+  model: SupportedRunModel,
+  options?: { readonly resetRouteToBuiltIn?: boolean },
+): Promise<void> {
+  await ensureModelPolicy(db, orgId, userId, model);
+  const now = nowDate();
+  await db
+    .update(orgModelPolicies)
+    .set({
+      isDefault: false,
+      updatedByUserId: userId,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(orgModelPolicies.orgId, orgId),
+        eq(orgModelPolicies.isDefault, true),
+      ),
+    );
+  await db
+    .update(orgModelPolicies)
+    .set({
+      isDefault: true,
+      ...(options?.resetRouteToBuiltIn === true
+        ? {
+            defaultProviderType: "vm0",
+            credentialScope: "org",
+            modelProviderId: null,
+          }
+        : {}),
+      updatedByUserId: userId,
+      updatedAt: now,
+    })
+    .where(
+      and(eq(orgModelPolicies.orgId, orgId), eq(orgModelPolicies.model, model)),
+    );
+}
+
 export async function ensureOrgModelPolicies(
   db: Db,
   orgId: string,
   userId: string,
 ): Promise<OrgModelPolicyRow[]> {
+  const limitedFree1 = await orgHasLimitedFree1Restrictions(db, orgId);
+  const seedDefaultModel = getSeedDefaultModelForTier(limitedFree1);
   const existing = await loadRows(db, orgId);
   if (existing.length > 0) {
-    if (
-      existing.some((policy) => {
-        return policy.isDefault;
-      })
-    ) {
+    const existingDefault = existing.find((policy) => {
+      return policy.isDefault;
+    });
+    if (!shouldReplaceExistingDefaultForTier(existingDefault, limitedFree1)) {
       return sortRowsByCatalog(existing);
+    }
+
+    if (limitedFree1) {
+      await setDefaultModelPolicy(db, orgId, userId, seedDefaultModel, {
+        resetRouteToBuiltIn: true,
+      });
+      return sortRowsByCatalog(await loadRows(db, orgId));
     }
 
     const fallbackDefault =
       existing.find((policy) => {
-        return policy.model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
+        return policy.model === seedDefaultModel;
       }) ?? sortRowsByCatalog(existing)[0];
     if (fallbackDefault) {
-      await db
-        .update(orgModelPolicies)
-        .set({
-          isDefault: true,
-          updatedByUserId: userId,
-          updatedAt: nowDate(),
-        })
-        .where(eq(orgModelPolicies.id, fallbackDefault.id));
+      await setDefaultModelPolicy(
+        db,
+        orgId,
+        userId,
+        parseSupportedModel(fallbackDefault.model) ?? seedDefaultModel,
+      );
       return sortRowsByCatalog(await loadRows(db, orgId));
     }
     return sortRowsByCatalog(existing);
@@ -161,7 +255,7 @@ export async function ensureOrgModelPolicies(
       return policy.model;
     }),
   );
-  const missing = getDefaultOrgModelPolicySeed()
+  const missing = getDefaultOrgModelPolicySeed(seedDefaultModel)
     .filter((seed) => {
       return !existingModels.has(seed.model);
     })

--- a/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
@@ -140,6 +140,7 @@ function shouldReplaceExistingDefaultForTier(
   return (
     existingDefault === undefined ||
     existingDefault.model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL ||
+    existingDefault.defaultProviderType !== "vm0" ||
     isLimitedFree1RestrictedRunModel(existingDefault.model)
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -29,6 +29,7 @@ import {
   modelProviderCredentialScopeSchema,
   supportedRunModelSchema,
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+  LIMITED_FREE1_DEFAULT_RUN_MODEL,
   SUPPORTED_RUN_MODELS,
   VM0_MODEL_PRICE_TIER,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
@@ -142,10 +143,10 @@ describe("model-first canonical catalog", () => {
     expect(isLimitedFree1RestrictedRunModel("anthropic/claude-sonnet-5")).toBe(
       true,
     );
-    expect(isLimitedFree1RestrictedRunModel("claude-sonnet-4-6")).toBe(true);
+    expect(isLimitedFree1RestrictedRunModel("claude-sonnet-4-6")).toBe(false);
     expect(
       isLimitedFree1RestrictedRunModel("anthropic/claude-sonnet-4.6"),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isLimitedFree1RestrictedRunModel("anthropic/claude-sonnet-4.5"),
     ).toBe(true);
@@ -377,9 +378,11 @@ describe("model-first canonical catalog", () => {
       "gpt-5.5",
       "claude-opus-4-8",
       "claude-sonnet-5",
+      "claude-sonnet-4-6",
       "MiniMax-M3",
     ]);
     expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("MiniMax-M3");
+    expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("claude-sonnet-4-6");
     expect(getDefaultModel("vm0")).toBe(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL);
     expect(getDefaultOrgModelPolicySeed()).toEqual(
       DEFAULT_ORG_MODEL_POLICY_MODELS.map((model) => {
@@ -392,6 +395,13 @@ describe("model-first canonical catalog", () => {
         };
       }),
     );
+    expect(
+      getDefaultOrgModelPolicySeed(LIMITED_FREE1_DEFAULT_RUN_MODEL).find(
+        (seed) => {
+          return seed.isDefault;
+        },
+      )?.model,
+    ).toBe(LIMITED_FREE1_DEFAULT_RUN_MODEL);
   });
 
   it("exposes VM0 price tiers for built-in reasoning models", () => {

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -634,6 +634,7 @@ export {
   VM0_MODEL_PRICE_TIER_LABEL,
   DEFAULT_ORG_MODEL_POLICY_MODELS,
   DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+  LIMITED_FREE1_DEFAULT_RUN_MODEL,
   getFrameworkForType,
   getSecretNameForType,
   getModelProviderEnvBindings,

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -150,11 +150,15 @@ export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
   "gpt-5.5",
   "claude-opus-4-8",
   "claude-sonnet-5",
+  "claude-sonnet-4-6",
   "MiniMax-M3",
 ] as const satisfies readonly SupportedRunModel[];
 
 export const DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL =
   "MiniMax-M3" as const satisfies SupportedRunModel;
+
+export const LIMITED_FREE1_DEFAULT_RUN_MODEL =
+  "claude-sonnet-4-6" as const satisfies SupportedRunModel;
 
 export const supportedRunModelSchema = z.enum(SUPPORTED_RUN_MODELS);
 
@@ -215,11 +219,13 @@ export function getCanonicalModelDisplayName(model: string): string {
   return isSupportedRunModel(model) ? SUPPORTED_RUN_MODEL_LABELS[model] : model;
 }
 
-export function getDefaultOrgModelPolicySeed(): DefaultOrgModelPolicySeed[] {
+export function getDefaultOrgModelPolicySeed(
+  defaultModel: SupportedRunModel = DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+): DefaultOrgModelPolicySeed[] {
   return DEFAULT_ORG_MODEL_POLICY_MODELS.map((model) => {
     return {
       model,
-      isDefault: model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+      isDefault: model === defaultModel,
       defaultProviderType: "vm0",
       credentialScope: "org",
       modelProviderId: null,
@@ -347,6 +353,9 @@ export function isLimitedFree1RestrictedRunModel(
   }
   const normalized = model.trim().toLowerCase();
   const canonicalModel = normalizeVm0ModelId(normalized);
+  if (canonicalModel === LIMITED_FREE1_DEFAULT_RUN_MODEL) {
+    return false;
+  }
   const vendor = VM0_MODEL_TO_PROVIDER[canonicalModel]?.vendor;
 
   return (


### PR DESCRIPTION
## Summary

- Allows `limited-free-1` workspaces to select Claude Sonnet 4.6 by exempting `claude-sonnet-4-6` and its Anthropic alias from the limited-free restricted model check.
- Adds Sonnet 4.6 to the default org model policy seed and introduces `LIMITED_FREE1_DEFAULT_RUN_MODEL` for tier-specific defaults.
- Defaults new limited-free bootstraps to Sonnet 4.6 and migrates existing limited-free seeded/default-restricted policies to built-in Sonnet 4.6 when model policies are ensured.

## Verification

- `pnpm -F api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api exec tsc --noEmit --pretty false --skipLibCheck --incremental false`
- `pnpm -F api-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api lint`
- `git diff --check`

Not fully runnable in this local runtime:

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-model-policies.test.ts` fails before assertions because local Postgres at `localhost:5432` is unavailable (`ECONNREFUSED`), and this runtime has no Docker to start the test DB.
