### PR TITLE
fix: allow limited-free-1 to use Claude Sonnet 4.6

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -899,7 +899,7 @@ describe("CHAT-01 thread detail, create, and delete cascades", () => {
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
-      "claude-sonnet-4-6",
+      "claude-fable-5",
       "claude-sonnet-5",
     ] as const) {
       const restrictedSelection = await chat.requestUpdateThreadModelSelection(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -142,10 +142,10 @@ describe("model-first canonical catalog", () => {
     expect(isLimitedFree1RestrictedRunModel("anthropic/claude-sonnet-5")).toBe(
       true,
     );
-    expect(isLimitedFree1RestrictedRunModel("claude-sonnet-4-6")).toBe(true);
+    expect(isLimitedFree1RestrictedRunModel("claude-sonnet-4-6")).toBe(false);
     expect(
       isLimitedFree1RestrictedRunModel("anthropic/claude-sonnet-4.6"),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isLimitedFree1RestrictedRunModel("anthropic/claude-sonnet-4.5"),
     ).toBe(true);

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -335,6 +335,10 @@ export const VM0_MODEL_ALIAS_TO_MODEL = {
 const VM0_MODEL_ALIAS_LOOKUP: Readonly<Record<string, string>> =
   VM0_MODEL_ALIAS_TO_MODEL;
 
+const LIMITED_FREE_1_ALLOWED_RUN_MODELS: ReadonlySet<string> = new Set([
+  "claude-sonnet-4-6",
+]);
+
 export function normalizeVm0ModelId(model: string): string {
   return VM0_MODEL_ALIAS_LOOKUP[model] ?? model;
 }
@@ -347,6 +351,9 @@ export function isLimitedFree1RestrictedRunModel(
   }
   const normalized = model.trim().toLowerCase();
   const canonicalModel = normalizeVm0ModelId(normalized);
+  if (LIMITED_FREE_1_ALLOWED_RUN_MODELS.has(canonicalModel)) {
+    return false;
+  }
   const vendor = VM0_MODEL_TO_PROVIDER[canonicalModel]?.vendor;
 
   return (


### PR DESCRIPTION
## Summary
- Allows `claude-sonnet-4-6` to bypass the broad limited-free-1 Anthropic/OpenAI restriction, matching the availability behavior of `MiniMax-M3`.
- Keeps the existing broad restrictions for other Anthropic/OpenAI models, including Sonnet 5 and Fable 5.
- Updates contract coverage for both canonical `claude-sonnet-4-6` and alias `anthropic/claude-sonnet-4.6`, and adjusts the API restricted-model test sample to use `claude-fable-5` instead.

## Verification
- `pnpm -F @vm0/api-contracts exec prettier --write src/contracts/model-providers.ts src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F api exec prettier --write src/signals/routes/__tests__/chat-threads.bdd.test.ts`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F api lint`
- `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm -F @vm0/db db:migrate`
- `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t "rejects restricted model pins for limited-free-1 workspaces"`

## Local Verification Notes
- `pnpm -F api check-types` failed locally due Node heap/system memory limits: first `FATAL ERROR: Ineffective mark-compacts near heap limit`, then `NODE_OPTIONS=--max-old-space-size=4096` was killed with exit 137.
- Full `chat-threads.bdd.test.ts` runs locally after DB migration but has one unrelated existing failure: `returns chat thread snapshot and lifecycle events with cursor expiry` expects 2 events and receives 1. The directly affected limited-free-1 test passes when run by name.
