### PR TITLE
fix(api): refresh API release marker comment

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker to exercise the full release pipeline)
+// (no-op API release marker refreshed for the production release pipeline)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary
- Refreshes the no-op API release marker comment in `turbo/apps/api/src/index.ts`.
- Intentionally comment-only; this exists to trigger a release-please API release.

## Verification
- Verified the diff is limited to a TypeScript comment under `turbo/apps/api`.
- Per manual release trigger workflow, no full local Vitest run or local dev server was started.