### PR TITLE
refactor: remove chat composer model picker popover experiment

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1638,44 +1638,6 @@ describe("chat composer models", () => {
     });
   });
 
-  it("uses the popover model picker behind the feature switch", async () => {
-    const user = userEvent.setup({ delay: null });
-    mockOrgModelRoutes("kimi-k2.7-code");
-    mockAgent();
-
-    detachedSetupPage({
-      context,
-      featureSwitches: {
-        [FeatureSwitchKey.ComposerModelPickerPopover]: true,
-      },
-      path: `/agents/${AGENT_ID}/chat`,
-    });
-
-    const trigger = await findComposerModel("Kimi K2.7 Code");
-    fireEvent.click(trigger);
-
-    await waitFor(() => {
-      const openTrigger = screen.getByRole("combobox", {
-        name: "Kimi K2.7 Code",
-      });
-      expect(openTrigger).toHaveAttribute("aria-expanded", "true");
-      expect(openTrigger).toHaveAttribute("data-state", "open");
-      expect(openTrigger).toHaveClass("data-[state=open]:bg-accent");
-      expect(openTrigger).not.toHaveClass("data-[state=open]:ring-2");
-    });
-    expect(screen.getByRole("listbox", { name: "Models" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("option", { name: /Kimi K2\.7 Code/ }),
-    ).toHaveAttribute("aria-selected", "true");
-
-    await user.click(
-      screen.getByRole("option", { name: /Claude Sonnet 4\.6/ }),
-    );
-
-    await expectComposerModel("Claude Sonnet 4.6");
-    expect(screen.queryByRole("listbox", { name: "Models" })).toBeNull();
-  });
-
   it("blocks routed model sends until the matching device login is opened", async () => {
     const user = userEvent.setup({ delay: null });
     const codexApproval = context.mocks.deferred<void>();

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -1,16 +1,7 @@
 import type { ReactNode, SyntheticEvent } from "react";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
+import { IconBolt, IconCheck, IconCpu } from "@tabler/icons-react";
 import {
-  IconBolt,
-  IconCheck,
-  IconChevronDown,
-  IconCpu,
-} from "@tabler/icons-react";
-import {
-  Popover,
-  PopoverClose,
-  PopoverContent,
-  PopoverTrigger,
   Select,
   SelectContent,
   SelectGroup,
@@ -93,8 +84,6 @@ interface ModelProviderPickerProps {
    * not user/workspace defaults.
    */
   resolveDefaultSelection?: boolean;
-  /** Controls which trigger/content primitive backs the model picker. */
-  pickerMode?: "select" | "popover";
 }
 
 // Radix Select reserves the empty string for "no value" and throws if a
@@ -474,40 +463,6 @@ function ModelFirstPolicyRow({
   );
 }
 
-function ModelFirstPolicyOption({
-  policy,
-  limitedFree1,
-  selected,
-  onSelect,
-}: {
-  policy: OrgModelPolicy;
-  limitedFree1: boolean;
-  selected: boolean;
-  onSelect: (model: string) => void;
-}) {
-  const disabled = policy.routeStatus !== "valid";
-  return (
-    <button
-      type="button"
-      role="option"
-      aria-selected={selected}
-      aria-disabled={disabled || undefined}
-      disabled={disabled}
-      className="relative flex w-full cursor-pointer select-none items-center rounded-md py-1.5 pl-2 pr-2 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
-      onClick={() => {
-        onSelect(policy.model);
-      }}
-    >
-      <ModelFirstPolicyRowContent
-        policy={policy}
-        limitedFree1={limitedFree1}
-        selected={selected}
-        showSelectedIndicator
-      />
-    </button>
-  );
-}
-
 function ModelFirstPolicyItems({
   policies,
   explicitSelectedModel,
@@ -725,133 +680,6 @@ function ModelFirstModelPickerContent({
   );
 }
 
-function ModelFirstModelPickerPopoverTrigger({
-  triggerAriaLabel,
-  selectedModel,
-  codexServiceTier,
-  placeholder,
-  mobileIconTrigger,
-  triggerClassName,
-  open,
-}: {
-  triggerAriaLabel: string;
-  selectedModel: string | null;
-  codexServiceTier: CodexServiceTier | undefined;
-  placeholder: string;
-  mobileIconTrigger: boolean;
-  triggerClassName: string | undefined;
-  open: boolean;
-}) {
-  return (
-    <PopoverTrigger asChild>
-      <button
-        type="button"
-        role="combobox"
-        aria-label={triggerAriaLabel}
-        aria-expanded={open}
-        aria-haspopup="listbox"
-        className={cn(
-          "flex h-9 w-full items-center justify-start gap-2 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:w-full [&>span]:text-left",
-          triggerClassName,
-        )}
-      >
-        <ModelFirstTriggerLabel
-          selectedModel={selectedModel}
-          codexServiceTier={codexServiceTier}
-          placeholder={placeholder}
-          mobileIcon={mobileIconTrigger}
-        />
-        <IconChevronDown className="h-4 w-4 shrink-0 opacity-50" />
-      </button>
-    </PopoverTrigger>
-  );
-}
-
-function ModelFirstModelPickerPopoverContent({
-  policies,
-  limitedFree1,
-  codexFastModeAvailable,
-  selectedModel,
-  codexServiceTier,
-  onSelectModel,
-  onChange,
-}: {
-  policies: OrgModelPolicy[];
-  limitedFree1: boolean;
-  codexFastModeAvailable: boolean;
-  selectedModel: string | null;
-  codexServiceTier: CodexServiceTier | undefined;
-  onSelectModel: (model: string) => void;
-  onChange: (value: ModelProviderSelection | null) => void;
-}) {
-  return (
-    <PopoverContent
-      align="end"
-      onOpenAutoFocus={(event) => {
-        event.preventDefault();
-      }}
-      onFocusOutside={(event) => {
-        event.preventDefault();
-      }}
-      onInteractOutside={(event) => {
-        const originalEvent = (event.detail as { originalEvent?: Event })
-          .originalEvent;
-        if (originalEvent instanceof FocusEvent) {
-          event.preventDefault();
-        }
-      }}
-      className={cn(
-        "max-h-[280px] overflow-hidden p-0",
-        codexFastModeAvailable ? "min-w-[372px]" : "min-w-[260px]",
-      )}
-    >
-      <div
-        className={cn(
-          "min-w-0",
-          codexFastModeAvailable && "grid grid-cols-[minmax(0,1fr)_132px]",
-        )}
-      >
-        <div
-          role="listbox"
-          aria-label="Models"
-          className="max-h-[280px] min-w-0 overflow-y-auto p-1"
-        >
-          {policies.length === 0 ? (
-            <div className="px-2 py-2 text-sm text-muted-foreground">
-              No configured models
-            </div>
-          ) : (
-            <>
-              <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
-                Models
-              </div>
-              {policies.map((policy) => {
-                return (
-                  <PopoverClose key={policy.id} asChild>
-                    <ModelFirstPolicyOption
-                      policy={policy}
-                      limitedFree1={limitedFree1}
-                      selected={selectedModel === policy.model}
-                      onSelect={onSelectModel}
-                    />
-                  </PopoverClose>
-                );
-              })}
-            </>
-          )}
-        </div>
-        {codexFastModeAvailable && selectedModel && (
-          <CodexFastModeSelectControl
-            selectedModel={selectedModel}
-            codexServiceTier={codexServiceTier}
-            onChange={onChange}
-          />
-        )}
-      </div>
-    </PopoverContent>
-  );
-}
-
 interface ModelFirstModelPickerState {
   policies: OrgModelPolicy[];
   selectablePolicies: OrgModelPolicy[];
@@ -969,58 +797,6 @@ function ModelFirstSelectPicker({
   );
 }
 
-function ModelFirstPopoverPicker({
-  state,
-  placeholder,
-  triggerClassName,
-  mobileIconTrigger,
-  limitedFree1,
-  open,
-  onOpenChange,
-  onValueChange,
-  onChange,
-}: {
-  state: ModelFirstModelPickerState;
-  placeholder: string;
-  triggerClassName: string | undefined;
-  mobileIconTrigger: boolean;
-  limitedFree1: boolean;
-  open: boolean | undefined;
-  onOpenChange: ((open: boolean) => void) | undefined;
-  onValueChange: (raw: string) => void;
-  onChange: (value: ModelProviderSelection | null) => void;
-}) {
-  const popoverOpen = open ?? false;
-  return (
-    <Popover open={open} onOpenChange={onOpenChange}>
-      <ModelFirstModelPickerPopoverTrigger
-        triggerAriaLabel={state.triggerAriaLabel}
-        selectedModel={state.selectedModel}
-        codexServiceTier={state.codexServiceTier}
-        placeholder={placeholder}
-        mobileIconTrigger={mobileIconTrigger}
-        triggerClassName={triggerClassName}
-        open={popoverOpen}
-      />
-      <ModelFirstModelPickerPopoverContent
-        policies={state.policies}
-        limitedFree1={limitedFree1}
-        codexFastModeAvailable={state.codexFastModeAvailable}
-        selectedModel={state.selectedModel}
-        codexServiceTier={state.codexServiceTier}
-        onSelectModel={(model) => {
-          onOpenChange?.(false);
-          if (model === state.selectValue) {
-            return;
-          }
-          onValueChange(model);
-        }}
-        onChange={onChange}
-      />
-    </Popover>
-  );
-}
-
 function ModelFirstModelPicker({
   value,
   onChange,
@@ -1034,7 +810,6 @@ function ModelFirstModelPicker({
   disabled,
   userPreference,
   resolveDefaultSelection,
-  pickerMode = "select",
 }: ModelProviderPickerProps & {
   placeholder: string;
   compactTrigger: boolean;
@@ -1101,22 +876,6 @@ function ModelFirstModelPicker({
     );
   };
 
-  if (pickerMode === "popover") {
-    return (
-      <ModelFirstPopoverPicker
-        state={state}
-        placeholder={placeholder}
-        triggerClassName={triggerClassName}
-        mobileIconTrigger={mobileIconTrigger}
-        limitedFree1={limitedFree1}
-        open={open}
-        onOpenChange={onOpenChange}
-        onValueChange={handleRawValueChange}
-        onChange={onChange}
-      />
-    );
-  }
-
   return (
     <ModelFirstSelectPicker
       state={state}
@@ -1161,7 +920,6 @@ export function ModelProviderPicker({
   onOpenChange,
   disabled = false,
   resolveDefaultSelection = true,
-  pickerMode = "select",
 }: ModelProviderPickerProps) {
   const props = {
     value,
@@ -1174,7 +932,6 @@ export function ModelProviderPicker({
     open,
     onOpenChange,
     disabled,
-    pickerMode,
   };
   if (resolveDefaultSelection) {
     return <ModelFirstModelPickerWithDefaultSelection {...props} />;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7092,7 +7092,6 @@ function ComposerModelPickerSlot({
   modelPickerLoading,
   submitBlocker,
   codexFastModeEnabled,
-  popoverModelPickerEnabled,
   modelPickerOpen,
   onModelPickerChange,
   onModelPickerOpenChange,
@@ -7101,7 +7100,6 @@ function ComposerModelPickerSlot({
   modelPickerLoading: boolean;
   submitBlocker: ZeroChatComposerProps["submitBlocker"];
   codexFastModeEnabled: boolean;
-  popoverModelPickerEnabled: boolean;
   modelPickerOpen: boolean;
   onModelPickerChange: (value: ModelProviderSelection | null) => void;
   onModelPickerOpenChange: (open: boolean) => void;
@@ -7128,7 +7126,6 @@ function ComposerModelPickerSlot({
           )}
           compactTrigger
           mobileIconTrigger
-          pickerMode={popoverModelPickerEnabled ? "popover" : "select"}
           codexFastModeEnabled={codexFastModeEnabled}
           open={modelPickerOpen}
           onOpenChange={onModelPickerOpenChange}
@@ -7147,11 +7144,6 @@ function ComposerModelPickerSlot({
 function useCodexFastModeEnabled(): boolean {
   const features = useLastResolved(featureSwitch$);
   return features?.[FeatureSwitchKey.CodexFastMode] ?? false;
-}
-
-function usePopoverModelPickerEnabled(): boolean {
-  const features = useLastResolved(featureSwitch$);
-  return features?.[FeatureSwitchKey.ComposerModelPickerPopover] ?? false;
 }
 
 function useUploadPopoverEnabled(): boolean {
@@ -7196,7 +7188,6 @@ export function ZeroChatComposer({
   const setModelPickerOpen = useSet(setModelPickerOpen$);
   const openGoalDialog = useSet(openChatThreadGoalDialog$);
   const codexFastModeEnabled = useCodexFastModeEnabled();
-  const popoverModelPickerEnabled = usePopoverModelPickerEnabled();
   const uploadPopoverEnabled = useUploadPopoverEnabled();
 
   const resolved = useResolvedComposerSignals(
@@ -7666,7 +7657,6 @@ export function ZeroChatComposer({
                     modelPickerLoading={modelPickerLoading}
                     submitBlocker={submitBlocker}
                     codexFastModeEnabled={codexFastModeEnabled}
-                    popoverModelPickerEnabled={popoverModelPickerEnabled}
                     modelPickerOpen={modelPickerOpen}
                     onModelPickerChange={handleModelPickerChange}
                     onModelPickerOpenChange={setModelPickerOpen}

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -45,7 +45,6 @@ export enum FeatureSwitchKey {
   ApiKeys = "apiKeys",
   CodexFrameworkForMinimax = "codexFrameworkForMinimax",
   CodexFastMode = "codexFastMode",
-  ComposerModelPickerPopover = "composerModelPickerPopover",
   ComposerUploadPopover = "composerUploadPopover",
 
   ZapierConnector = "zapierConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -265,13 +265,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ComposerModelPickerPopover]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Use the Popover-based chat composer model picker instead of Radix Select.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ComposerUploadPopover]: {
     maintainer: "bingjie@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Remove the `composerModelPickerPopover` feature switch from the shared key enum and core feature-switch registry.
- Remove the chat composer switch lookup so the model picker always uses the existing Radix Select path.
- Delete the unused Popover-backed model picker implementation and its feature-switch-only test.

## Verification
- `pnpm exec prettier --write apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx apps/platform/src/views/zero-page/components/model-provider-picker.tsx apps/platform/src/views/zero-page/zero-chat-composer.tsx packages/connectors/src/feature-switch-key.ts packages/core/src/feature-switch.ts`
- `git diff --check HEAD~1 HEAD`
- `pnpm --filter @vm0/connectors --filter @vm0/core --filter @vm0/app lint`
- `pnpm --filter @vm0/connectors --filter @vm0/core --filter @vm0/app check-types` passed for `@vm0/connectors` and `@vm0/core`; `@vm0/app` hit Node heap OOM under the default limit
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`

## Notes
- Targeted local Vitest attempts for `chat-composer-models-and-templates.test.tsx` did not complete in a reasonable time and were interrupted; PR CI should cover the test suite.