### PR TITLE
refactor: clean up empty artifact compatibility

### DIFF
--- a/crates/guest-download/src/archive.rs
+++ b/crates/guest-download/src/archive.rs
@@ -149,7 +149,7 @@ fn archive_error(
 ) -> DownloadError {
     let message = format!("{}: {error}", message.into());
     if http_body_read_failure.failed() {
-        DownloadError::transport(message, true, None)
+        DownloadError::transport(message, true)
     } else {
         DownloadError::fatal(message)
     }

--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -16,19 +16,12 @@ const RETRY_DELAY: Duration = Duration::from_secs(1);
 const MAX_CONCURRENT: usize = 4;
 type TaskRunner = fn(DownloadTask) -> bool;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum NotFoundPolicy {
-    Fail,
-    Ignore404,
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct DownloadTask {
     label: String,
     op_name: &'static str,
     url: String,
     mount_path: String,
-    not_found_policy: NotFoundPolicy,
     kind: DownloadTaskKind,
 }
 
@@ -39,16 +32,8 @@ impl DownloadTask {
         op_name: &'static str,
         url: String,
         mount_path: String,
-        not_found_policy: NotFoundPolicy,
     ) -> Self {
-        Self::new_with_kind(
-            label,
-            op_name,
-            url,
-            mount_path,
-            not_found_policy,
-            DownloadTaskKind::Other,
-        )
+        Self::new_with_kind(label, op_name, url, mount_path, DownloadTaskKind::Other)
     }
 
     pub(crate) fn new_with_kind(
@@ -56,7 +41,6 @@ impl DownloadTask {
         op_name: &'static str,
         url: String,
         mount_path: String,
-        not_found_policy: NotFoundPolicy,
         kind: DownloadTaskKind,
     ) -> Self {
         Self {
@@ -64,7 +48,6 @@ impl DownloadTask {
             op_name,
             url,
             mount_path,
-            not_found_policy,
             kind,
         }
     }
@@ -669,13 +652,6 @@ fn run_download_task(task: DownloadTask) -> bool {
             );
             true
         }
-        Err(e)
-            if e.status_code == Some(404) && task.not_found_policy == NotFoundPolicy::Ignore404 =>
-        {
-            record_sandbox_op(task.op_name, start.elapsed(), true, None);
-            log_info!(LOG_TAG, "{} not found, skipping (first run)", task.label);
-            true
-        }
         Err(e) => {
             let failure_detail = task.failure_detail(&e);
             record_sandbox_op(task.op_name, start.elapsed(), false, Some(&failure_detail));
@@ -751,7 +727,6 @@ mod tests {
             "storage_download",
             "file:///tmp/archive.tar.gz".to_owned(),
             path.to_owned(),
-            NotFoundPolicy::Fail,
             kind,
         )
     }
@@ -939,14 +914,12 @@ mod tests {
                         "storage_download",
                         "panic".to_owned(),
                         "/tmp/panic".to_owned(),
-                        NotFoundPolicy::Fail,
                     ),
                     DownloadTask::new(
                         "success".to_owned(),
                         "storage_download",
                         "success".to_owned(),
                         "/tmp/success".to_owned(),
-                        NotFoundPolicy::Fail,
                     ),
                 ],
                 runner,
@@ -964,14 +937,12 @@ mod tests {
                 "storage_download",
                 "file:///tmp/archive.tar.gz".to_owned(),
                 "/tmp/mount/child".to_owned(),
-                NotFoundPolicy::Fail,
             ),
             DownloadTask::new(
                 "independent".to_owned(),
                 "artifact_download",
                 "https://example.com/archive.tar.gz".to_owned(),
                 "/tmp/other".to_owned(),
-                NotFoundPolicy::Fail,
             ),
         ]);
         let active = vec![ActiveDownload {
@@ -1128,7 +1099,6 @@ mod tests {
             "storage_download",
             "file:///tmp/archive.tar.gz".into(),
             "/workspace".into(),
-            NotFoundPolicy::Fail,
         );
         let error = DownloadError::fatal("Failed to read archive entries: invalid gzip header");
 

--- a/crates/guest-download/src/error.rs
+++ b/crates/guest-download/src/error.rs
@@ -1,7 +1,6 @@
 pub(crate) struct DownloadError {
     pub(crate) message: String,
     pub(crate) retriable: bool,
-    pub(crate) status_code: Option<u16>,
 }
 
 impl DownloadError {
@@ -9,19 +8,13 @@ impl DownloadError {
         Self {
             message: message.into(),
             retriable: false,
-            status_code: None,
         }
     }
 
-    pub(crate) fn transport(
-        message: impl Into<String>,
-        retriable: bool,
-        status_code: Option<u16>,
-    ) -> Self {
+    pub(crate) fn transport(message: impl Into<String>, retriable: bool) -> Self {
         Self {
             message: message.into(),
             retriable,
-            status_code,
         }
     }
 }

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -184,6 +184,26 @@ mod tests {
     }
 
     #[test]
+    fn run_manifest_prepares_explicit_empty_artifact_without_archive_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let mount = dir.path().join("memory");
+        let manifest = json!({
+            "storages": [],
+            "artifacts": [{
+                "mountPath": mount,
+                "empty": true,
+                "vasStorageName": "memory",
+                "vasVersionId": "empty-v1"
+            }]
+        });
+
+        let success = super::run_manifest_bytes(&serde_json::to_vec(&manifest).unwrap());
+
+        assert!(success);
+        assert!(mount.is_dir());
+    }
+
+    #[test]
     fn run_manifest_removes_created_staged_instruction_sources_when_precreate_fails() {
         let dir = tempfile::tempdir().unwrap();
         let first_extract_path = dir

--- a/crates/guest-download/src/plan.rs
+++ b/crates/guest-download/src/plan.rs
@@ -1,4 +1,4 @@
-use crate::download::{DownloadTask, NotFoundPolicy, classify_download_task_kind};
+use crate::download::{DownloadTask, classify_download_task_kind};
 use crate::instructions::{InstructionCleanup, InstructionNormalization};
 use crate::manifest::{Manifest, ManifestEntry};
 use std::path::Path;
@@ -36,13 +36,6 @@ impl ManifestEntryKind {
         match self {
             Self::Storage => "storage_download",
             Self::Artifact => "artifact_download",
-        }
-    }
-
-    fn not_found_policy(self) -> NotFoundPolicy {
-        match self {
-            Self::Storage => NotFoundPolicy::Fail,
-            Self::Artifact => NotFoundPolicy::Ignore404,
         }
     }
 
@@ -121,7 +114,8 @@ impl RunPlan {
             ManifestEntryKind::Storage,
         );
 
-        // Artifacts: 404 is non-fatal (may not exist on first run).
+        // Artifacts with archives must download successfully; explicit empty
+        // artifacts are prepared separately below and do not create tasks.
         append_download_tasks(
             &mut download_tasks,
             &manifest.artifacts,
@@ -176,7 +170,6 @@ fn append_download_tasks(
                 kind.op_name(),
                 url,
                 download_mount_path.to_string(),
-                kind.not_found_policy(),
                 task_kind,
             ));
         }
@@ -318,7 +311,6 @@ mod tests {
                 "storage_download",
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
-                NotFoundPolicy::Fail,
             )
         );
         assert_eq!(
@@ -328,7 +320,6 @@ mod tests {
                 "artifact_download",
                 "https://s3/a.tar.gz".into(),
                 "/workspace/a".into(),
-                NotFoundPolicy::Ignore404,
             )
         );
         assert_eq!(
@@ -338,7 +329,6 @@ mod tests {
                 "artifact_download",
                 "file:///tmp/vm0-storage-cache/b.tar.gz".into(),
                 "/workspace/b".into(),
-                NotFoundPolicy::Ignore404,
             )
         );
     }
@@ -394,7 +384,6 @@ mod tests {
                 "storage_download",
                 "https://s3/storage.tar.gz".into(),
                 "/data".into(),
-                NotFoundPolicy::Fail,
             )]
         );
     }
@@ -464,7 +453,6 @@ mod tests {
                 "storage_download",
                 "https://s3/instructions.tar.gz".into(),
                 "/home/user/.vm0/guest-agent/runs/run-1/storage-instructions/0".into(),
-                NotFoundPolicy::Fail,
                 crate::download::DownloadTaskKind::FrameworkHomeInstructions,
             )
         );
@@ -492,7 +480,6 @@ mod tests {
                 "storage_download",
                 "https://s3/data.tar.gz".into(),
                 "/data".into(),
-                NotFoundPolicy::Fail,
                 crate::download::DownloadTaskKind::Other,
             )
         );
@@ -519,7 +506,6 @@ mod tests {
                 "artifact_download",
                 "https://s3/workspace.tar.gz".into(),
                 "/workspace".into(),
-                NotFoundPolicy::Ignore404,
                 crate::download::DownloadTaskKind::Other,
             )
         );
@@ -664,7 +650,6 @@ mod tests {
                 "storage_download",
                 "https://s3/storage.tar.gz".into(),
                 mount_path,
-                NotFoundPolicy::Fail,
             )],
         );
     }
@@ -706,7 +691,6 @@ mod tests {
                 "artifact_download",
                 "https://s3/artifact.tar.gz".into(),
                 mount_path,
-                NotFoundPolicy::Ignore404,
             )],
         );
     }

--- a/crates/guest-download/src/source.rs
+++ b/crates/guest-download/src/source.rs
@@ -38,16 +38,14 @@ pub(crate) fn open_archive(url: &str) -> Result<ArchiveSource, DownloadError> {
     }
 
     let response = HTTP_AGENT.get(url).call().map_err(|e| {
-        let (retriable, status_code, message) = match &e {
+        let (retriable, message) = match &e {
             // Retry on server errors (5xx) and rate limiting (429)
-            ureq::Error::StatusCode(code) => (
-                *code >= 500 || *code == 429,
-                Some(*code),
-                format!("HTTP status {code}"),
-            ),
-            _ => (true, None, "HTTP transport error".to_string()), // network/timeout errors are retriable
+            ureq::Error::StatusCode(code) => {
+                (*code >= 500 || *code == 429, format!("HTTP status {code}"))
+            }
+            _ => (true, "HTTP transport error".to_string()), // network/timeout errors are retriable
         };
-        DownloadError::transport(message, retriable, status_code)
+        DownloadError::transport(message, retriable)
     })?;
     Ok(ArchiveSource::http(response.into_body().into_reader()))
 }

--- a/crates/guest-download/tests/integration/binary_logging.rs
+++ b/crates/guest-download/tests/integration/binary_logging.rs
@@ -772,6 +772,79 @@ fn binary_does_not_log_http_archive_url_on_fatal_status() {
 }
 
 #[test]
+fn binary_records_artifact_404_as_fatal_status() {
+    let server = MockServer::start();
+
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/failing-artifact-object/archive.tar.gz");
+        then.status(404);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("artifact-mount");
+    let url = server.url(
+        "/failing-artifact-object/archive.tar.gz?X-Amz-Signature=artifact-secret-token&X-Amz-Credential=artifact-credential",
+    );
+    let manifest = write_manifest(&dir, &[], Some((mount.to_str().unwrap(), Some(&url)))).unwrap();
+    let run_id = unique_run_id("artifact-secret-url-fatal");
+    let logs = RuntimeLogPaths::new(&dir);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_guest-download"))
+        .arg(&manifest)
+        .env("VM0_RUN_ID", &run_id)
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            &logs.runtime_dir,
+        )
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    mock.assert_calls(1);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let system_log_content = std::fs::read_to_string(&logs.system_log).unwrap();
+    let ops_log_content = std::fs::read_to_string(&logs.ops_log).unwrap();
+    let forbidden = [
+        url.as_str(),
+        "failing-artifact-object",
+        "X-Amz-Signature",
+        "artifact-secret-token",
+        "X-Amz-Credential",
+        "artifact-credential",
+    ];
+    assert_does_not_contain_any("stderr", &stderr, &forbidden);
+    assert_does_not_contain_any("system log", &system_log_content, &forbidden);
+    assert_does_not_contain_any("sandbox ops log", &ops_log_content, &forbidden);
+    assert!(
+        stderr.contains("HTTP status 404"),
+        "unexpected stderr: {stderr}"
+    );
+
+    let ops: Vec<serde_json::Value> = ops_log_content
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert!(
+        ops.iter()
+            .any(|entry| entry["action_type"] == "artifact_download"
+                && entry["success"] == false
+                && entry["error"]
+                    .as_str()
+                    .is_some_and(|error| error.contains("HTTP status 404")
+                        && error.contains("mountPath=")
+                        && error.contains("urlScheme=http"))),
+        "missing failed artifact_download entry: {ops_log_content}"
+    );
+    assert!(
+        ops.iter()
+            .any(|entry| entry["action_type"] == "download_total" && entry["success"] == false),
+        "missing failed download_total entry: {ops_log_content}"
+    );
+}
+
+#[test]
 fn binary_does_not_log_file_archive_path_on_missing_local_file() {
     let dir = tempfile::tempdir().unwrap();
     let missing = dir.path().join("secret-staged-archive.tar.gz");

--- a/crates/guest-download/tests/integration/download.rs
+++ b/crates/guest-download/tests/integration/download.rs
@@ -355,15 +355,17 @@ fn artifact_download_success() {
 }
 
 #[test]
-fn artifact_404_non_fatal() {
+fn artifact_404_fatal() {
     let server = MockServer::start();
-    mock_status(&server, ARTIFACT_ARCHIVE_PATH, 404);
+    let mock = mock_status(&server, ARTIFACT_ARCHIVE_PATH, 404);
 
     let dir = tempfile::tempdir().unwrap();
     let mount = dir.path().join("artifact_mount");
     let url = server.url(ARTIFACT_ARCHIVE_PATH);
     let result = run_artifact_download(&dir, &mount, Some(&url)).unwrap();
-    assert!(result);
+
+    assert!(!result);
+    mock.assert_calls(1);
 }
 
 #[test]

--- a/crates/guest-download/tests/integration/file_scheme.rs
+++ b/crates/guest-download/tests/integration/file_scheme.rs
@@ -179,7 +179,7 @@ fn file_scheme_preexisting_symlink_ancestor_blocks_nested_entry() {
 
 // Storage with a missing file:// target fails the run. The runner only rewrites
 // archive_url to file:// after vsock-staging succeeds, so a missing file means a
-// broken runner contract — fatal, no retry (status_code is None, retriable false).
+// broken runner contract: fatal and not retriable.
 #[test]
 fn file_scheme_missing_storage_fatal() {
     let dir = tempfile::tempdir().unwrap();
@@ -194,10 +194,8 @@ fn file_scheme_missing_storage_fatal() {
     assert!(!result);
 }
 
-// Artifacts treat HTTP 404 as non-fatal ("may not exist on first run"), but the
-// file:// path has no status_code, so a missing local file is fatal for artifacts
-// too. Same reasoning as storages: the runner only stages + rewrites after the
-// file lands, so a missing file signals a broken contract, not an absent artifact.
+// Artifact downloads require a real archive. Explicit empty artifacts use the
+// empty marker instead of a file:// archive, so a missing staged file is fatal.
 #[test]
 fn file_scheme_missing_artifact_fatal() {
     let dir = tempfile::tempdir().unwrap();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1050,7 +1050,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         storage_manifest_final_storage_count_bucket: "1",
         storage_manifest_final_artifact_count_bucket: "1",
         storage_manifest_dropped_compose_count_bucket: "1",
-        storage_manifest_planned_presign_count_bucket: "2_4",
+        storage_manifest_planned_presign_count_bucket: "1",
         storage_manifest_duplicate_presign_candidate_count_bucket: "0",
         storage_manifest_source_compose_volume_resolved_count_bucket: "1",
         storage_manifest_source_compose_volume_planned_presign_count_bucket:
@@ -1064,8 +1064,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         storage_manifest_source_request_additional_volume_non_system_presign_count_bucket:
           "1",
         storage_manifest_source_artifact_resolved_count_bucket: "1",
-        storage_manifest_source_artifact_planned_presign_count_bucket: "1",
-        storage_manifest_source_artifact_non_system_presign_count_bucket: "1",
+        storage_manifest_source_artifact_planned_presign_count_bucket: "0",
+        storage_manifest_source_artifact_non_system_presign_count_bucket: "0",
         storage_manifest_artifact_ensure_already_initialized_count_bucket: "0",
         storage_manifest_artifact_ensure_missing_storage_count_bucket: "1",
         storage_manifest_artifact_ensure_created_storage_count_bucket: "1",
@@ -1101,7 +1101,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         storage_manifest_resolved_compose_count_bucket: "1",
         storage_manifest_resolved_additional_count_bucket: "1",
         storage_manifest_resolved_artifact_count_bucket: "1",
-        storage_manifest_planned_presign_count_bucket: "2_4",
+        storage_manifest_planned_presign_count_bucket: "1",
         storage_manifest_duplicate_presign_candidate_count_bucket: "0",
         storage_manifest_source_compose_volume_resolved_count_bucket: "1",
         storage_manifest_source_request_additional_volume_resolved_count_bucket:
@@ -1111,8 +1111,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           "1",
         storage_manifest_source_request_additional_volume_non_system_presign_count_bucket:
           "1",
-        storage_manifest_source_artifact_planned_presign_count_bucket: "1",
-        storage_manifest_source_artifact_non_system_presign_count_bucket: "1",
+        storage_manifest_source_artifact_planned_presign_count_bucket: "0",
+        storage_manifest_source_artifact_non_system_presign_count_bucket: "0",
       }),
     );
     expect(
@@ -1151,9 +1151,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       ),
     ).toStrictEqual(
       expect.objectContaining({
-        storage_manifest_artifact_planned_presign_count_bucket: "1",
-        storage_manifest_source_artifact_planned_presign_count_bucket: "1",
-        storage_manifest_source_artifact_non_system_presign_count_bucket: "1",
+        storage_manifest_artifact_planned_presign_count_bucket: "0",
+        storage_manifest_source_artifact_planned_presign_count_bucket: "0",
+        storage_manifest_source_artifact_non_system_presign_count_bucket: "0",
         storage_manifest_source_request_additional_volume_planned_presign_count_bucket:
           "0",
       }),
@@ -1184,19 +1184,16 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       return artifact.vasStorageName === "memory";
     });
     expect(memoryArtifact).toMatchObject({
-      archiveUrl: expect.any(String),
       empty: true,
       vasStorageId: expect.any(String),
       vasVersionId: expect.any(String),
       missingRootPolicy: "preserveParentVersion",
     });
-    if (!memoryArtifact || typeof memoryArtifact.archiveUrl !== "string") {
-      throw new Error(
-        "Expected the claim manifest to include memory with an archive URL",
-      );
+    if (!memoryArtifact) {
+      throw new Error("Expected the claim manifest to include memory");
     }
+    expect(memoryArtifact.archiveUrl).toBeUndefined();
     expectApiDispatchTimingEventsNotToLeak(timingEvents, [
-      memoryArtifact.archiveUrl,
       memoryArtifact.vasStorageId,
       memoryArtifact.vasVersionId,
     ]);
@@ -1301,9 +1298,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     );
     expect(initialMemory).toMatchObject({
       empty: true,
-      archiveUrl: expect.any(String),
       vasVersionId: expect.any(String),
     });
+    expect(initialMemory?.archiveUrl).toBeUndefined();
     const initialMemoryVersionId = initialMemory?.vasVersionId;
     if (!initialMemoryVersionId) {
       throw new Error("Expected initial memory artifact version id");

--- a/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-reads.bdd.test.ts
@@ -766,7 +766,8 @@ describe("RUN-04: session and checkpoint reads", () => {
     if (!outArtifact) {
       throw new Error("Expected the claim manifest to mount bdd-out");
     }
-    expect(outArtifact.archiveUrl).toStrictEqual(expect.any(String));
+    expect(outArtifact.empty).toBeTruthy();
+    expect(outArtifact.archiveUrl).toBeUndefined();
     expect(outArtifact.vasStorageId).toStrictEqual(expect.any(String));
     expect(outArtifact.vasVersionId).toStrictEqual(expect.any(String));
     expect("manifestUrl" in outArtifact).toBeFalsy();
@@ -1407,7 +1408,7 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     });
     expect(memory1).toMatchObject({
       mountPath: CANONICAL_CLAUDE_MEMORY_MOUNT_PATH,
-      archiveUrl: expect.any(String),
+      empty: true,
       vasStorageId: expect.any(String),
       vasVersionId: expect.any(String),
       missingRootPolicy: "preserveParentVersion",
@@ -1415,6 +1416,7 @@ describe("RUN-01/RUN-02: checkpoint resume, memory policies, and volume pinning"
     if (!memory1) {
       throw new Error("Expected the claim manifest to mount memory");
     }
+    expect(memory1.archiveUrl).toBeUndefined();
     expect("manifestUrl" in memory1).toBeFalsy();
     expect(
       hasManifestPresign(presignedUrlKeysSince(presignCallsBeforeRun)),

--- a/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-storage.service.ts
@@ -1709,6 +1709,22 @@ async function buildArtifactEntryFromInput(
   },
 ): Promise<ManifestArtifact> {
   const { artifact, resolved } = args.input;
+  const entryBase = {
+    mountPath: artifact.mountPath,
+    vasStorageName: artifact.name,
+    vasStorageId: resolved.storageId,
+    vasVersionId: resolved.versionId,
+    ...(artifact.missingRootPolicy
+      ? { missingRootPolicy: artifact.missingRootPolicy }
+      : {}),
+  };
+  if (resolved.fileCount === 0) {
+    return {
+      ...entryBase,
+      empty: true,
+    };
+  }
+
   const archiveKey = `${resolved.s3Key}/archive.tar.gz`;
   args.stats?.recordPresignCandidate("artifact", args.input.source, {
     bucket: args.bucket,
@@ -1729,15 +1745,8 @@ async function buildArtifactEntryFromInput(
   );
 
   return {
-    mountPath: artifact.mountPath,
-    vasStorageName: artifact.name,
-    vasStorageId: resolved.storageId,
-    vasVersionId: resolved.versionId,
+    ...entryBase,
     archiveUrl,
-    ...(resolved.fileCount === 0 ? { empty: true } : {}),
-    ...(artifact.missingRootPolicy
-      ? { missingRootPolicy: artifact.missingRootPolicy }
-      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- stop emitting and presigning `archiveUrl` for explicit empty artifact manifest entries
- make non-empty artifact archive download failures, including 404, fatal in guest-download
- keep contract/runner reader tolerance for compatibility empty artifact payloads

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo test --manifest-path crates/Cargo.toml -p runner storage_manifest_conversion -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner guest_download_has_work -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p api-contracts generated_storage_manifest -- --nocapture`
- `pnpm -F @vm0/api-contracts test -- src/contracts/__tests__/runners.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-reads.bdd.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets -- -D warnings`
- pre-commit: `pnpm knip`, `pnpm check-types`, cargo fmt/doc/clippy

Closes #20430