### PR TITLE
fix: default vm0 managed orgs to sonnet 4.6

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
@@ -124,6 +124,14 @@ function sortRowsByCatalog(rows: OrgModelPolicyRow[]): OrgModelPolicyRow[] {
   });
 }
 
+function isLimitedFreeReplaceableStandardDefaultModel(model: string): boolean {
+  // MiniMax-M3 was the previous VM0-managed default; limited-free orgs seeded
+  // before this change still need to converge to the built-in Sonnet 4.6 route.
+  return (
+    model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL || model === "MiniMax-M3"
+  );
+}
+
 function getSeedDefaultModelForTier(limitedFree1: boolean): SupportedRunModel {
   return limitedFree1
     ? LIMITED_FREE1_DEFAULT_RUN_MODEL
@@ -137,11 +145,18 @@ function shouldReplaceExistingDefaultForTier(
   if (!limitedFree1) {
     return existingDefault === undefined;
   }
+  if (existingDefault === undefined) {
+    return true;
+  }
+  const shouldReplaceModel =
+    existingDefault.model !== LIMITED_FREE1_DEFAULT_RUN_MODEL &&
+    (isLimitedFreeReplaceableStandardDefaultModel(existingDefault.model) ||
+      isLimitedFree1RestrictedRunModel(existingDefault.model));
   return (
-    existingDefault === undefined ||
-    existingDefault.model === DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL ||
+    shouldReplaceModel ||
     existingDefault.defaultProviderType !== "vm0" ||
-    isLimitedFree1RestrictedRunModel(existingDefault.model)
+    existingDefault.credentialScope !== "org" ||
+    existingDefault.modelProviderId !== null
   );
 }
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -381,7 +381,7 @@ describe("model-first canonical catalog", () => {
       "claude-sonnet-4-6",
       "MiniMax-M3",
     ]);
-    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("MiniMax-M3");
+    expect(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL).toBe("claude-sonnet-4-6");
     expect(LIMITED_FREE1_DEFAULT_RUN_MODEL).toBe("claude-sonnet-4-6");
     expect(getDefaultModel("vm0")).toBe(DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL);
     expect(getDefaultOrgModelPolicySeed()).toEqual(

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -155,7 +155,7 @@ export const DEFAULT_ORG_MODEL_POLICY_MODELS = [
 ] as const satisfies readonly SupportedRunModel[];
 
 export const DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL =
-  "MiniMax-M3" as const satisfies SupportedRunModel;
+  "claude-sonnet-4-6" as const satisfies SupportedRunModel;
 
 export const LIMITED_FREE1_DEFAULT_RUN_MODEL =
   "claude-sonnet-4-6" as const satisfies SupportedRunModel;


### PR DESCRIPTION
## Summary
- Set the VM0 Managed default org model policy to `claude-sonnet-4-6` for newly seeded org defaults.
- Keep `limited-free-1` defaults on Sonnet 4.6 without repeatedly rewriting already-correct Sonnet 4.6 defaults.
- Preserve convergence for limited-free workspaces previously seeded with the old `MiniMax-M3` VM0-managed default or a non-built-in route.

## Verification
- `pnpm exec prettier --check packages/api-contracts/src/contracts/model-providers.ts packages/api-contracts/src/contracts/__tests__/model-providers.test.ts apps/api/src/signals/services/zero-model-policy.service.ts`
- `pnpm --filter @vm0/api-contracts lint`
- `pnpm --filter api lint`
- `pnpm --filter @vm0/api-contracts check-types`
- `NODE_OPTIONS=--max-old-space-size=3584 pnpm --filter api check-types`
- `pnpm exec vitest run packages/api-contracts/src/contracts/__tests__/model-providers.test.ts`
- `DATABASE_URL=postgresql://postgres@localhost:5432/vm0_test pnpm exec vitest run apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts`
