### PR TITLE
feat: add platform client headers to runner requests

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -59,6 +59,24 @@ pub mod model_provider_env {
     }
 }
 
+/// Platform client request header contract constants shared by TypeScript and Rust.
+pub mod platform_client {
+    /// HTTP header names used to identify vm0 platform clients in API request logs.
+    pub mod headers {
+        /// HTTP header carrying the per-request vm0 client request identifier.
+        pub const PLATFORM_CLIENT_REQUEST_ID_HEADER: &str = "X-Client-Request-Id";
+
+        /// HTTP header carrying the sending vm0 client session identifier.
+        pub const PLATFORM_CLIENT_SESSION_ID_HEADER: &str = "X-Client-Session-Id";
+
+        /// HTTP header carrying the sending vm0 client component type.
+        pub const PLATFORM_CLIENT_TYPE_HEADER: &str = "X-Client-Type";
+
+        /// HTTP header carrying the sending vm0 client component version.
+        pub const PLATFORM_CLIENT_VERSION_HEADER: &str = "X-Client-Version";
+    }
+}
+
 /// Runner contract constants shared by TypeScript and Rust.
 pub mod runners {
     /// Maximum connector refs accepted by the runner network policy refresh endpoint.

--- a/crates/guest-agent/Cargo.toml
+++ b/crates/guest-agent/Cargo.toml
@@ -26,7 +26,7 @@ thiserror.workspace = true
 tar.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "process", "io-util", "fs", "sync", "net"] }
 tokio-util.workspace = true
-uuid = { workspace = true, features = ["v5"] }
+uuid = { workspace = true, features = ["v4", "v5"] }
 zstd.workspace = true
 
 [dev-dependencies]

--- a/crates/guest-agent/src/artifact/mod.rs
+++ b/crates/guest-agent/src/artifact/mod.rs
@@ -511,7 +511,13 @@ mod tests {
     }
 
     fn test_http_client(server: &httpmock::MockServer) -> Result<HttpClient, AgentError> {
-        HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
+        HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
     }
 
     fn file_json_values(files: &[FileEntry]) -> Vec<serde_json::Value> {

--- a/crates/guest-agent/src/checkpoint.rs
+++ b/crates/guest-agent/src/checkpoint.rs
@@ -1316,8 +1316,14 @@ mod tests {
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let dir = tempfile::tempdir().unwrap();
         let missing_mount = dir.path().join("missing");
         let entries = vec![env::ArtifactEnv {
@@ -1353,8 +1359,14 @@ mod tests {
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let dir = tempfile::tempdir().unwrap();
         let missing_mount = dir.path().join("missing");
         let entries = vec![env::ArtifactEnv {
@@ -1390,8 +1402,14 @@ mod tests {
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let dir = tempfile::tempdir().unwrap();
         let valid_mount = dir.path().join("valid");
         std::fs::create_dir(&valid_mount).unwrap();
@@ -1439,8 +1457,14 @@ mod tests {
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let dir = tempfile::tempdir().unwrap();
         let missing_mount = dir.path().join("memory");
         let entries = vec![env::ArtifactEnv {
@@ -1484,8 +1508,14 @@ mod tests {
                 .path("/api/webhooks/agent/storages/commit");
             then.status(200).json_body(json!({"unreachable": true}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let dir = tempfile::tempdir().unwrap();
         let file_mount = dir.path().join("memory");
         std::fs::write(&file_mount, "not a directory").unwrap();
@@ -1549,8 +1579,14 @@ mod tests {
             then.status(200)
                 .json_body(json!({"checkpointId": "unreachable"}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let missing_mount = dir.path().join("missing");
         let entries = vec![env::ArtifactEnv {
             name: "workspace".to_string(),
@@ -1644,8 +1680,14 @@ mod tests {
             then.status(200)
                 .json_body(json!({"checkpointId": "checkpoint-codex-zstd"}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let home_dir = home_dir.to_string_lossy().into_owned();
         let inputs = CheckpointInputs {
             run_id: "checkpoint-codex-zstd-reuse",
@@ -1740,8 +1782,14 @@ mod tests {
             then.status(200)
                 .json_body(json!({"checkpointId": "checkpoint-codex-zstd-legacy"}));
         });
-        let http = HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO)
-            .unwrap();
+        let http = HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap();
         let home_dir = home_dir.to_string_lossy().into_owned();
         let inputs = CheckpointInputs {
             run_id: "checkpoint-codex-zstd-legacy-fallback",

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -4,6 +4,10 @@ use crate::constants;
 use crate::env;
 use crate::error::AgentError;
 use crate::urls;
+use api_contracts::generated::constants::platform_client::headers::{
+    PLATFORM_CLIENT_REQUEST_ID_HEADER, PLATFORM_CLIENT_SESSION_ID_HEADER,
+    PLATFORM_CLIENT_TYPE_HEADER, PLATFORM_CLIENT_VERSION_HEADER,
+};
 use bytes::{Bytes, BytesMut};
 use guest_common::log_warn;
 use http_body::{Frame, SizeHint};
@@ -18,10 +22,13 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncSeekExt, ReadBuf};
+use uuid::Uuid;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
 const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(1);
+const GUEST_AGENT_CLIENT_TYPE: &str = "GuestAgent";
+const GUEST_AGENT_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn format_reqwest_error(error: reqwest::Error) -> String {
     error.without_url().to_string()
@@ -45,6 +52,7 @@ struct ApiHttpConfig {
     urls: ApiUrls,
     token: String,
     vercel_bypass: String,
+    client_session_id: String,
 }
 
 #[derive(Clone)]
@@ -88,6 +96,7 @@ impl HttpClient {
         base_url: impl Into<String>,
         token: impl Into<String>,
         vercel_bypass: impl Into<String>,
+        client_session_id: impl Into<String>,
         retry_delay: Duration,
     ) -> Result<Self, AgentError> {
         Self::build(
@@ -95,6 +104,7 @@ impl HttpClient {
                 base_url.into(),
                 token.into(),
                 vercel_bypass.into(),
+                client_session_id.into(),
             )?),
             retry_delay,
         )
@@ -122,6 +132,7 @@ impl HttpClient {
             &config.api_url,
             &config.api_token,
             &config.vercel_bypass,
+            &config.run_id,
         )?
         else {
             return Ok(Self {
@@ -160,6 +171,7 @@ impl HttpClient {
         base_url: &str,
         token: &str,
         vercel_bypass: &str,
+        client_session_id: &str,
     ) -> Result<Option<ApiHttpConfig>, AgentError> {
         if token.is_empty() {
             return Ok(None);
@@ -169,6 +181,7 @@ impl HttpClient {
             base_url.to_string(),
             token.to_string(),
             vercel_bypass.to_string(),
+            client_session_id.to_string(),
         )?))
     }
 
@@ -206,7 +219,12 @@ impl HttpClient {
 }
 
 impl ApiHttpConfig {
-    fn new(base_url: String, token: String, vercel_bypass: String) -> Result<Self, AgentError> {
+    fn new(
+        base_url: String,
+        token: String,
+        vercel_bypass: String,
+        client_session_id: String,
+    ) -> Result<Self, AgentError> {
         if base_url.is_empty() {
             return Err(AgentError::Http(
                 "VM0_API_URL is required when VM0_API_TOKEN is set".into(),
@@ -221,6 +239,7 @@ impl ApiHttpConfig {
             urls: ApiUrls::new(&base_url),
             token,
             vercel_bypass,
+            client_session_id,
         })
     }
 }
@@ -305,6 +324,7 @@ impl HttpClient {
             self.retry_delay,
             format!("POST failed after {max_retries} attempts to {url}"),
             || {
+                let request_id = Uuid::new_v4().to_string();
                 let mut req = client
                     .post(url)
                     .header("Authorization", format!("Bearer {}", api.token))
@@ -313,6 +333,15 @@ impl HttpClient {
                 if !api.vercel_bypass.is_empty() {
                     req = req.header("x-vercel-protection-bypass", &api.vercel_bypass);
                 }
+
+                req = req
+                    .header(PLATFORM_CLIENT_VERSION_HEADER, GUEST_AGENT_CLIENT_VERSION)
+                    .header(PLATFORM_CLIENT_TYPE_HEADER, GUEST_AGENT_CLIENT_TYPE)
+                    .header(
+                        PLATFORM_CLIENT_SESSION_ID_HEADER,
+                        api.client_session_id.as_str(),
+                    )
+                    .header(PLATFORM_CLIENT_REQUEST_ID_HEADER, request_id);
 
                 std::future::ready(Ok(req))
             },

--- a/crates/guest-agent/src/http.rs
+++ b/crates/guest-agent/src/http.rs
@@ -235,6 +235,8 @@ impl ApiHttpConfig {
                 "VM0_API_TOKEN is required for enabled API HTTP config".into(),
             ));
         }
+        reqwest::header::HeaderValue::from_str(&client_session_id)
+            .map_err(|e| AgentError::Http(format!("invalid client session id: {e}")))?;
         Ok(Self {
             urls: ApiUrls::new(&base_url),
             token,

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -1276,7 +1276,14 @@ mod tests {
     }
 
     fn test_http_client(server: &MockServer) -> HttpClient {
-        HttpClient::with_api_config(server.base_url(), "test-token", "", Duration::ZERO).unwrap()
+        HttpClient::with_api_config(
+            server.base_url(),
+            "test-token",
+            "",
+            "test-run-001",
+            Duration::ZERO,
+        )
+        .unwrap()
     }
 
     fn test_guest_config(server: &MockServer, prompt: Option<&str>) -> env::GuestConfig {

--- a/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
+++ b/crates/guest-agent/tests/artifact_checkpoint_content_hash.rs
@@ -102,7 +102,8 @@ fn test_runtime(
         guest_runtime_dir: Some(runtime_dir),
         ..GuestConfigRaw::default()
     })?;
-    let http = HttpClient::with_api_config(api_url, "test-token", "", Duration::ZERO)?;
+    let http =
+        HttpClient::with_api_config(api_url, "test-token", "", "test-run-001", Duration::ZERO)?;
     Ok(GuestRuntime {
         config,
         paths,

--- a/crates/guest-agent/tests/codex_session_resume.rs
+++ b/crates/guest-agent/tests/codex_session_resume.rs
@@ -132,6 +132,7 @@ fn checkpoint_http_client(
         server.base_url(),
         "test-token",
         "",
+        "test-run-001",
         Duration::ZERO,
     )
 }

--- a/crates/guest-agent/tests/integration/http_client.rs
+++ b/crates/guest-agent/tests/integration/http_client.rs
@@ -1,9 +1,15 @@
 use crate::support::*;
+use api_contracts::generated::constants::platform_client::headers::{
+    PLATFORM_CLIENT_REQUEST_ID_HEADER, PLATFORM_CLIENT_SESSION_ID_HEADER,
+    PLATFORM_CLIENT_TYPE_HEADER, PLATFORM_CLIENT_VERSION_HEADER,
+};
 use guest_agent::error::AgentError;
 use guest_agent::masker::SecretMasker;
 use httpmock::prelude::*;
 use serde_json::json;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use uuid::Uuid;
 
 // =========================================================================
 // post_json core
@@ -259,12 +265,66 @@ async fn post_json_sends_vercel_bypass_header() {
 }
 
 #[tokio::test]
+async fn post_json_sends_platform_client_headers() {
+    let api = SharedApiMock::new().await;
+    let server = api.server();
+    let request_ids = Arc::new(Mutex::new(Vec::new()));
+    let request_ids_for_mock = Arc::clone(&request_ids);
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/test/client-headers");
+        then.respond_with(move |req| {
+            let request_id = req
+                .headers_vec()
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case(PLATFORM_CLIENT_REQUEST_ID_HEADER))
+                .map(|(_, value)| value.as_str());
+            let Some(request_id) = request_id else {
+                return http_status(400);
+            };
+            if Uuid::parse_str(request_id).is_err() {
+                return http_status(400);
+            }
+            if !request_header_eq(
+                req,
+                PLATFORM_CLIENT_VERSION_HEADER,
+                env!("CARGO_PKG_VERSION"),
+            ) || !request_header_eq(req, PLATFORM_CLIENT_TYPE_HEADER, "GuestAgent")
+                || !request_header_eq(req, PLATFORM_CLIENT_SESSION_ID_HEADER, TEST_RUN_ID)
+            {
+                return http_status(400);
+            }
+
+            request_ids_for_mock
+                .lock()
+                .expect("request ids lock should not be poisoned")
+                .push(request_id.to_string());
+            http_status(200)
+        });
+    });
+
+    let url = api.url("/test/client-headers");
+    let first = http_client!().post_json(&url, &json!({}), 1).await;
+    let second = http_client!().post_json(&url, &json!({}), 1).await;
+
+    mock.assert_calls_async(2).await;
+    assert!(first.is_ok());
+    assert!(second.is_ok());
+    let request_ids = request_ids
+        .lock()
+        .expect("request ids lock should not be poisoned");
+    assert_eq!(request_ids.len(), 2);
+    assert_ne!(request_ids[0], request_ids[1]);
+}
+
+#[tokio::test]
 async fn post_json_uses_explicit_api_config_without_env_api_url() {
     let server = MockServer::start();
     let http = guest_agent::http::HttpClient::with_api_config(
         server.base_url(),
         "explicit-token",
         "explicit-bypass",
+        "explicit-run",
         Duration::ZERO,
     )
     .expect("build explicit API client");
@@ -314,6 +374,7 @@ async fn send_event_uses_explicit_api_config_route_instead_of_env_route()
         explicit_server.base_url(),
         "explicit-token",
         "",
+        "explicit-run",
         Duration::ZERO,
     )?;
     let config = shared_guest_config()?;

--- a/crates/guest-agent/tests/integration/http_client.rs
+++ b/crates/guest-agent/tests/integration/http_client.rs
@@ -317,6 +317,22 @@ async fn post_json_sends_platform_client_headers() {
     assert_ne!(request_ids[0], request_ids[1]);
 }
 
+#[test]
+fn with_api_config_rejects_invalid_client_session_header() {
+    let result = guest_agent::http::HttpClient::with_api_config(
+        "http://127.0.0.1",
+        "test-token",
+        "",
+        "bad\nrun",
+        Duration::ZERO,
+    );
+
+    let Err(AgentError::Http(message)) = result else {
+        panic!("expected invalid client session id error");
+    };
+    assert!(message.contains("invalid client session id"));
+}
+
 #[tokio::test]
 async fn post_json_uses_explicit_api_config_without_env_api_url() {
     let server = MockServer::start();

--- a/crates/guest-agent/tests/integration/presigned_upload.rs
+++ b/crates/guest-agent/tests/integration/presigned_upload.rs
@@ -1,4 +1,8 @@
 use crate::support::*;
+use api_contracts::generated::constants::platform_client::headers::{
+    PLATFORM_CLIENT_REQUEST_ID_HEADER, PLATFORM_CLIENT_SESSION_ID_HEADER,
+    PLATFORM_CLIENT_TYPE_HEADER, PLATFORM_CLIENT_VERSION_HEADER,
+};
 use bytes::Bytes;
 use httpmock::prelude::*;
 use std::sync::{
@@ -65,6 +69,10 @@ async fn put_presigned_does_not_send_api_headers() {
         then.respond_with(|req| {
             if request_header_absent(req, "authorization")
                 && request_header_absent(req, "x-vercel-protection-bypass")
+                && request_header_absent(req, PLATFORM_CLIENT_VERSION_HEADER)
+                && request_header_absent(req, PLATFORM_CLIENT_TYPE_HEADER)
+                && request_header_absent(req, PLATFORM_CLIENT_SESSION_ID_HEADER)
+                && request_header_absent(req, PLATFORM_CLIENT_REQUEST_ID_HEADER)
             {
                 http_status(200)
             } else {

--- a/crates/guest-agent/tests/integration/support.rs
+++ b/crates/guest-agent/tests/integration/support.rs
@@ -130,6 +130,7 @@ pub(crate) fn test_http_client(retry_delay: Duration) -> guest_agent::http::Http
         server.base_url(),
         "test-token-abc123",
         "test-bypass-value",
+        TEST_RUN_ID,
         retry_delay,
     )
     .expect("build test http client")

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -55,6 +55,7 @@ import http_local_responses
 import http_network_log
 import matching
 import network_log_sanitization
+import platform_api
 import public_destination
 import registry
 import request_streaming
@@ -408,6 +409,11 @@ def load(loader: Loader) -> None:
 
 
 def configure(updated: set[str]) -> None:
+    if "vm0_client_session_id" in updated or "vm0_client_version" in updated:
+        platform_api.configure_client_headers(
+            client_session_id=ctx.options.vm0_client_session_id,
+            client_version=ctx.options.vm0_client_version,
+        )
     if "vm0_usage_flush_interval_seconds" in updated:
         usage.configure_usage_buffer(
             flush_interval_seconds=ctx.options.vm0_usage_flush_interval_seconds

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -394,6 +394,12 @@ def load(loader: Loader) -> None:
         help="Runner-generated client session id for platform API requests",
     )
     loader.add_option(
+        name="vm0_client_version",
+        typespec=str,
+        default="",
+        help="Runner package version for platform API request attribution",
+    )
+    loader.add_option(
         name="vm0_usage_flush_interval_seconds",
         typespec=float,
         default=usage.DEFAULT_FLUSH_INTERVAL_SECONDS,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -409,11 +409,10 @@ def load(loader: Loader) -> None:
 
 
 def configure(updated: set[str]) -> None:
-    if "vm0_client_session_id" in updated or "vm0_client_version" in updated:
-        platform_api.configure_client_headers(
-            client_session_id=ctx.options.vm0_client_session_id,
-            client_version=ctx.options.vm0_client_version,
-        )
+    platform_api.configure_client_headers(
+        client_session_id=ctx.options.vm0_client_session_id,
+        client_version=ctx.options.vm0_client_version,
+    )
     if "vm0_usage_flush_interval_seconds" in updated:
         usage.configure_usage_buffer(
             flush_interval_seconds=ctx.options.vm0_usage_flush_interval_seconds

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -388,6 +388,12 @@ def load(loader: Loader) -> None:
         help="Runner-generated usage-pending state id",
     )
     loader.add_option(
+        name="vm0_client_session_id",
+        typespec=str,
+        default="",
+        help="Runner-generated client session id for platform API requests",
+    )
+    loader.add_option(
         name="vm0_usage_flush_interval_seconds",
         typespec=float,
         default=usage.DEFAULT_FLUSH_INTERVAL_SECONDS,

--- a/crates/runner/mitm-addon/src/mitm_addon_version.py
+++ b/crates/runner/mitm-addon/src/mitm_addon_version.py
@@ -1,3 +1,0 @@
-"""mitm-addon package version used for platform client headers."""
-
-MITM_ADDON_VERSION = "0.1.0"

--- a/crates/runner/mitm-addon/src/mitm_addon_version.py
+++ b/crates/runner/mitm-addon/src/mitm_addon_version.py
@@ -1,0 +1,3 @@
+"""mitm-addon package version used for platform client headers."""
+
+MITM_ADDON_VERSION = "0.1.0"

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -7,8 +7,6 @@ import uuid
 
 from mitmproxy import ctx
 
-from mitm_addon_version import MITM_ADDON_VERSION
-
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
 PLATFORM_CLIENT_VERSION_HEADER = "X-Client-Version"
@@ -43,7 +41,7 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
             "Content-Type": "application/json",
             "Authorization": f"Bearer {sandbox_token}",
             "User-Agent": "vm0-mitm-addon/1.0",
-            PLATFORM_CLIENT_VERSION_HEADER: MITM_ADDON_VERSION,
+            PLATFORM_CLIENT_VERSION_HEADER: ctx.options.vm0_client_version,
             PLATFORM_CLIENT_TYPE_HEADER: MITM_ADDON_CLIENT_TYPE,
             PLATFORM_CLIENT_SESSION_ID_HEADER: ctx.options.vm0_client_session_id,
             PLATFORM_CLIENT_REQUEST_ID_HEADER: str(uuid.uuid4()),

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -14,6 +14,13 @@ PLATFORM_CLIENT_TYPE_HEADER = "X-Client-Type"
 PLATFORM_CLIENT_SESSION_ID_HEADER = "X-Client-Session-Id"
 PLATFORM_CLIENT_REQUEST_ID_HEADER = "X-Client-Request-Id"
 MITM_ADDON_CLIENT_TYPE = "MitmAddon"
+_CLIENT_HEADERS = ("", "")
+
+
+def configure_client_headers(*, client_session_id: str, client_version: str) -> None:
+    """Snapshot runner-provided client header values for worker-thread requests."""
+    global _CLIENT_HEADERS
+    _CLIENT_HEADERS = (client_session_id, client_version)
 
 
 def get_api_url() -> str:
@@ -30,6 +37,7 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
     parsed_url = urllib.parse.urlsplit(url)
     if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
         raise ValueError("Platform API URL must be an absolute http(s) URL")
+    client_session_id, client_version = _CLIENT_HEADERS
 
     # S310 (suspicious-url-open-usage): callers build `url` from the
     # operator-configured platform API URL, and the scheme is validated above
@@ -41,9 +49,9 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
             "Content-Type": "application/json",
             "Authorization": f"Bearer {sandbox_token}",
             "User-Agent": "vm0-mitm-addon/1.0",
-            PLATFORM_CLIENT_VERSION_HEADER: ctx.options.vm0_client_version,
+            PLATFORM_CLIENT_VERSION_HEADER: client_version,
             PLATFORM_CLIENT_TYPE_HEADER: MITM_ADDON_CLIENT_TYPE,
-            PLATFORM_CLIENT_SESSION_ID_HEADER: ctx.options.vm0_client_session_id,
+            PLATFORM_CLIENT_SESSION_ID_HEADER: client_session_id,
             PLATFORM_CLIENT_REQUEST_ID_HEADER: str(uuid.uuid4()),
         },
     )

--- a/crates/runner/mitm-addon/src/platform_api.py
+++ b/crates/runner/mitm-addon/src/platform_api.py
@@ -3,11 +3,19 @@
 import os
 import urllib.parse
 import urllib.request
+import uuid
 
 from mitmproxy import ctx
 
+from mitm_addon_version import MITM_ADDON_VERSION
+
 # Vercel bypass secret (still from environment as it's a secret)
 VERCEL_BYPASS = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
+PLATFORM_CLIENT_VERSION_HEADER = "X-Client-Version"
+PLATFORM_CLIENT_TYPE_HEADER = "X-Client-Type"
+PLATFORM_CLIENT_SESSION_ID_HEADER = "X-Client-Session-Id"
+PLATFORM_CLIENT_REQUEST_ID_HEADER = "X-Client-Request-Id"
+MITM_ADDON_CLIENT_TYPE = "MitmAddon"
 
 
 def get_api_url() -> str:
@@ -35,6 +43,10 @@ def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.reques
             "Content-Type": "application/json",
             "Authorization": f"Bearer {sandbox_token}",
             "User-Agent": "vm0-mitm-addon/1.0",
+            PLATFORM_CLIENT_VERSION_HEADER: MITM_ADDON_VERSION,
+            PLATFORM_CLIENT_TYPE_HEADER: MITM_ADDON_CLIENT_TYPE,
+            PLATFORM_CLIENT_SESSION_ID_HEADER: ctx.options.vm0_client_session_id,
+            PLATFORM_CLIENT_REQUEST_ID_HEADER: str(uuid.uuid4()),
         },
     )
     if VERCEL_BYPASS:

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -313,11 +313,13 @@ class _StubOptions:
         api_url: str,
         builtin_firewall_catalog_cache_path: str,
         client_session_id: str,
+        client_version: str,
     ) -> None:
         self.vm0_proxy_registry_path = registry_path
         self.vm0_api_url = api_url
         self.vm0_builtin_firewall_catalog_cache_path = builtin_firewall_catalog_cache_path
         self.vm0_client_session_id = client_session_id
+        self.vm0_client_version = client_version
         self.vm0_usage_flush_interval_seconds = usage.DEFAULT_FLUSH_INTERVAL_SECONDS
 
 
@@ -349,6 +351,7 @@ def mitm_ctx(tmp_path):
         api_url: str = "https://api.vm0.ai",
         builtin_firewall_catalog_cache_path: str | None = None,
         client_session_id: str = "runner-session-test",
+        client_version: str = "runner-version-test",
     ) -> Iterator[MagicMock]:
         if registry_path is None:
             registry_path = default_registry_path
@@ -359,6 +362,7 @@ def mitm_ctx(tmp_path):
             api_url=api_url,
             builtin_firewall_catalog_cache_path=builtin_firewall_catalog_cache_path,
             client_session_id=client_session_id,
+            client_version=client_version,
         )
         log = MagicMock()
         with (

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -30,6 +30,7 @@ import auth_base_forwarder
 import builtin_connector_diagnostics
 import logging_utils
 import mitm_addon
+import platform_api
 import registry
 import upstream_destination_binding
 import usage
@@ -57,6 +58,7 @@ def _reset_module_state() -> Iterator[None]:
     mitm_addon.reset_upstream_destination_resolution_cache_for_tests()
     mitm_addon.reset_runner_usage_flush_state_for_tests()
     mitm_addon.reset_tls_admission_state_for_tests()
+    platform_api.configure_client_headers(client_session_id="", client_version="")
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
     usage.counters.reset_for_tests()
@@ -72,6 +74,7 @@ def _reset_module_state() -> Iterator[None]:
     upstream_destination_binding.reset_for_tests()
     mitm_addon.reset_upstream_destination_resolution_cache_for_tests()
     mitm_addon.reset_tls_admission_state_for_tests()
+    platform_api.configure_client_headers(client_session_id="", client_version="")
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.counters.reset_for_tests()
 
@@ -369,7 +372,17 @@ def mitm_ctx(tmp_path):
             patch.object(mitm_addon.ctx, "options", options, create=True),
             patch.object(mitm_addon.ctx, "log", log, create=True),
         ):
-            yield log
+            platform_api.configure_client_headers(
+                client_session_id=client_session_id,
+                client_version=client_version,
+            )
+            try:
+                yield log
+            finally:
+                platform_api.configure_client_headers(
+                    client_session_id="",
+                    client_version="",
+                )
 
     return _stub
 

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -312,10 +312,12 @@ class _StubOptions:
         registry_path: str,
         api_url: str,
         builtin_firewall_catalog_cache_path: str,
+        client_session_id: str,
     ) -> None:
         self.vm0_proxy_registry_path = registry_path
         self.vm0_api_url = api_url
         self.vm0_builtin_firewall_catalog_cache_path = builtin_firewall_catalog_cache_path
+        self.vm0_client_session_id = client_session_id
         self.vm0_usage_flush_interval_seconds = usage.DEFAULT_FLUSH_INTERVAL_SECONDS
 
 
@@ -346,6 +348,7 @@ def mitm_ctx(tmp_path):
         registry_path: str | None = None,
         api_url: str = "https://api.vm0.ai",
         builtin_firewall_catalog_cache_path: str | None = None,
+        client_session_id: str = "runner-session-test",
     ) -> Iterator[MagicMock]:
         if registry_path is None:
             registry_path = default_registry_path
@@ -355,6 +358,7 @@ def mitm_ctx(tmp_path):
             registry_path=registry_path,
             api_url=api_url,
             builtin_firewall_catalog_cache_path=builtin_firewall_catalog_cache_path,
+            client_session_id=client_session_id,
         )
         log = MagicMock()
         with (

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from mitmproxy.addonmanager import Loader
 
 import mitm_addon
+import mitm_addon_version
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
@@ -105,12 +106,21 @@ class TestAddonConfiguration:
 
         option_names = [option.name for option in master.options.added]
         assert "vm0_usage_state_id" in option_names
+        assert "vm0_client_session_id" in option_names
         assert "vm0_usage_flush_interval_seconds" in option_names
         assert not pending_path.exists()
         signal_handler.assert_called_once_with(
             mitm_addon._RUNNER_USAGE_FLUSH_SIGNAL,
             mitm_addon._handle_runner_usage_flush_signal,
         )
+
+    def test_mitm_addon_version_matches_pyproject(self):
+        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        version_line = next(
+            line for line in pyproject.read_text().splitlines() if line.startswith("version = ")
+        )
+        pyproject_version = version_line.split("=", 1)[1].strip().strip('"')
+        assert pyproject_version == mitm_addon_version.MITM_ADDON_VERSION
 
     def test_configure_writes_pending_state_with_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from mitmproxy.addonmanager import Loader
 
 import mitm_addon
+import platform_api
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
@@ -58,9 +59,13 @@ class _Options:
         *,
         usage_state_id: str = "runner-usage-state-id",
         flush_interval_seconds: float = usage.DEFAULT_FLUSH_INTERVAL_SECONDS,
+        client_session_id: str = "runner-session-test",
+        client_version: str = "runner-version-test",
     ) -> None:
         self.vm0_usage_state_id = usage_state_id
         self.vm0_usage_flush_interval_seconds = flush_interval_seconds
+        self.vm0_client_session_id = client_session_id
+        self.vm0_client_version = client_version
 
 
 def _addon_file_path(tmp_path: Path) -> str:
@@ -155,6 +160,23 @@ class TestAddonConfiguration:
             mitm_addon.configure({"vm0_api_url"})
 
         assert not pending_path.exists()
+
+    def test_configure_snapshots_platform_client_headers(self):
+        with patch.object(
+            mitm_addon.ctx,
+            "options",
+            _Options(
+                client_session_id="runner-session-configured",
+                client_version="runner-version-configured",
+            ),
+            create=True,
+        ):
+            mitm_addon.configure({"vm0_client_session_id", "vm0_client_version"})
+
+        req = platform_api.make_api_request("https://api.vm0.ai/webhook", b"{}", "tok")
+        normalized_headers = {name.lower(): value for name, value in req.header_items()}
+        assert normalized_headers["x-client-session-id"] == "runner-session-configured"
+        assert normalized_headers["x-client-version"] == "runner-version-configured"
 
     def test_configure_updates_usage_flush_interval(self, tmp_path):
         timers = install_recording_usage_timer()

--- a/crates/runner/mitm-addon/tests/test_addon_configuration.py
+++ b/crates/runner/mitm-addon/tests/test_addon_configuration.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 from mitmproxy.addonmanager import Loader
 
 import mitm_addon
-import mitm_addon_version
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_pending
@@ -107,20 +106,13 @@ class TestAddonConfiguration:
         option_names = [option.name for option in master.options.added]
         assert "vm0_usage_state_id" in option_names
         assert "vm0_client_session_id" in option_names
+        assert "vm0_client_version" in option_names
         assert "vm0_usage_flush_interval_seconds" in option_names
         assert not pending_path.exists()
         signal_handler.assert_called_once_with(
             mitm_addon._RUNNER_USAGE_FLUSH_SIGNAL,
             mitm_addon._handle_runner_usage_flush_signal,
         )
-
-    def test_mitm_addon_version_matches_pyproject(self):
-        pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
-        version_line = next(
-            line for line in pyproject.read_text().splitlines() if line.startswith("version = ")
-        )
-        pyproject_version = version_line.split("=", 1)[1].strip().strip('"')
-        assert pyproject_version == mitm_addon_version.MITM_ADDON_VERSION
 
     def test_configure_writes_pending_state_with_usage_state_id(self, tmp_path):
         pending_path = tmp_path / "usage-pending"

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -5,6 +5,7 @@ import io
 import json
 import time
 import urllib.error
+import uuid
 from email.message import Message
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -16,6 +17,7 @@ import firewall_auth_cache as auth_cache
 import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import matching
+import mitm_addon_version
 import platform_api
 from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
@@ -1672,8 +1674,11 @@ class TestHandleFirewallRequest:
 
 
 class TestMakeApiRequest:
-    def test_builds_platform_api_request_with_standard_headers(self):
-        with patch.object(platform_api, "VERCEL_BYPASS", ""):
+    def test_builds_platform_api_request_with_standard_headers(self, mitm_ctx):
+        with (
+            mitm_ctx(client_session_id="runner-session-direct"),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+        ):
             req = platform_api.make_api_request(
                 "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
                 b"{}",
@@ -1686,6 +1691,11 @@ class TestMakeApiRequest:
         assert headers["Content-type"] == "application/json"
         assert headers["Authorization"] == "Bearer tok-xyz"
         assert headers["User-agent"] == "vm0-mitm-addon/1.0"
+        normalized_headers = {name.lower(): value for name, value in headers.items()}
+        assert normalized_headers["x-client-version"] == mitm_addon_version.MITM_ADDON_VERSION
+        assert normalized_headers["x-client-type"] == "MitmAddon"
+        assert normalized_headers["x-client-session-id"] == "runner-session-direct"
+        uuid.UUID(normalized_headers["x-client-request-id"])
 
     @pytest.mark.parametrize(
         "url",
@@ -1731,6 +1741,10 @@ class TestFetchFirewallHeaders:
         assert request.headers["authorization"] == "Bearer tok-xyz"
         assert request.headers["content-type"] == "application/json"
         assert request.headers["user-agent"] == "vm0-mitm-addon/1.0"
+        assert request.headers["x-client-version"] == mitm_addon_version.MITM_ADDON_VERSION
+        assert request.headers["x-client-type"] == "MitmAddon"
+        assert request.headers["x-client-session-id"] == "runner-session-test"
+        uuid.UUID(request.headers["x-client-request-id"])
         assert "x-vercel-protection-bypass" not in request.headers
         assert request.json_body() == {
             "encryptedSecrets": "iv:tag:data",

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -17,7 +17,6 @@ import firewall_auth_cache as auth_cache
 import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import matching
-import mitm_addon_version
 import platform_api
 from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
@@ -1676,7 +1675,10 @@ class TestHandleFirewallRequest:
 class TestMakeApiRequest:
     def test_builds_platform_api_request_with_standard_headers(self, mitm_ctx):
         with (
-            mitm_ctx(client_session_id="runner-session-direct"),
+            mitm_ctx(
+                client_session_id="runner-session-direct",
+                client_version="runner-version-direct",
+            ),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
             req = platform_api.make_api_request(
@@ -1692,7 +1694,7 @@ class TestMakeApiRequest:
         assert headers["Authorization"] == "Bearer tok-xyz"
         assert headers["User-agent"] == "vm0-mitm-addon/1.0"
         normalized_headers = {name.lower(): value for name, value in headers.items()}
-        assert normalized_headers["x-client-version"] == mitm_addon_version.MITM_ADDON_VERSION
+        assert normalized_headers["x-client-version"] == "runner-version-direct"
         assert normalized_headers["x-client-type"] == "MitmAddon"
         assert normalized_headers["x-client-session-id"] == "runner-session-direct"
         uuid.UUID(normalized_headers["x-client-request-id"])
@@ -1741,7 +1743,7 @@ class TestFetchFirewallHeaders:
         assert request.headers["authorization"] == "Bearer tok-xyz"
         assert request.headers["content-type"] == "application/json"
         assert request.headers["user-agent"] == "vm0-mitm-addon/1.0"
-        assert request.headers["x-client-version"] == mitm_addon_version.MITM_ADDON_VERSION
+        assert request.headers["x-client-version"] == "runner-version-test"
         assert request.headers["x-client-type"] == "MitmAddon"
         assert request.headers["x-client-session-id"] == "runner-session-test"
         uuid.UUID(request.headers["x-client-request-id"])
@@ -2240,13 +2242,14 @@ class TestFirewallAuthResponseBodyReader:
 
 
 class TestFetchFirewallHeadersResourceBoundary:
-    def test_closes_response_on_success(self):
+    def test_closes_response_on_success(self, mitm_ctx):
         """Success path must close the urlopen response — FD leak guard (#10475)."""
         mock_resp = MagicMock()
         mock_resp.__enter__.return_value = mock_resp
         mock_resp.read.return_value = json.dumps({"headers": {}}).encode()
 
         with (
+            mitm_ctx(),
             patch("platform_api.urllib.request.Request"),
             patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
@@ -2255,7 +2258,7 @@ class TestFetchFirewallHeadersResourceBoundary:
 
         mock_resp.__exit__.assert_called_once()  # urllib external boundary (#9991)
 
-    def test_closes_http_error_response_when_body_is_unreadable(self):
+    def test_closes_http_error_response_when_body_is_unreadable(self, mitm_ctx):
         http_error = urllib.error.HTTPError(
             "https://api.vm0.ai/api/webhooks/agent/firewall/auth",
             400,
@@ -2266,6 +2269,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         http_error.close = MagicMock()
 
         with (
+            mitm_ctx(),
             patch("platform_api.urllib.request.Request"),
             patch("firewall_auth_client.urllib.request.urlopen", side_effect=http_error),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
@@ -2276,7 +2280,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         assert exc_info.value is http_error
         http_error.close.assert_called_once()
 
-    def test_closes_http_error_response_when_body_is_too_large(self):
+    def test_closes_http_error_response_when_body_is_too_large(self, mitm_ctx):
         error_body = json.dumps(
             {
                 "error": {
@@ -2294,6 +2298,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         http_error.close = MagicMock()
 
         with (
+            mitm_ctx(),
             patch.object(
                 auth_client,
                 "MAX_FIREWALL_AUTH_RESPONSE_BODY_BYTES",
@@ -2329,7 +2334,10 @@ class TestFetchFirewallHeadersResourceBoundary:
         ],
     )
     def test_closes_http_error_response(
-        self, error_body: bytes, expected_exception: type[Exception]
+        self,
+        mitm_ctx,
+        error_body: bytes,
+        expected_exception: type[Exception],
     ):
         """HTTPError path must close the underlying socket — FD leak guard (#10475)."""
         http_error = _http_error(
@@ -2341,6 +2349,7 @@ class TestFetchFirewallHeadersResourceBoundary:
         http_error.close = MagicMock()
 
         with (
+            mitm_ctx(),
             patch("platform_api.urllib.request.Request"),
             patch("firewall_auth_client.urllib.request.urlopen", side_effect=http_error),
             patch.object(platform_api, "VERCEL_BYPASS", ""),

--- a/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
+++ b/crates/runner/mitm-addon/tests/test_fresh_usage_executor.py
@@ -69,7 +69,7 @@ def test_fresh_usage_executor_restores_and_shuts_down_after_flush_failure(tmp_pa
         executors[0].submit(lambda: None)
 
 
-def test_fresh_usage_executor_uses_owned_executor_when_global_changes(tmp_path):
+def test_fresh_usage_executor_uses_owned_executor_when_global_changes(tmp_path, mitm_ctx):
     original = usage.webhook.usage_executor
     replacement = _RecordingExecutor()
     executors: list[ThreadPoolExecutor] = []
@@ -77,6 +77,7 @@ def test_fresh_usage_executor_uses_owned_executor_when_global_changes(tmp_path):
 
     with (
         server.run(),
+        mitm_ctx(),
         patch.object(usage, "flush_usage_events", wraps=usage.flush_usage_events) as flush,
         fresh_usage_executor_context() as executor,
     ):

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -696,6 +696,7 @@ class TestRunnerUsageFlushSignal:
         self,
         runner_usage_flush_files: RunnerUsageFlushFiles,
         sync_usage_executor,
+        mitm_ctx,
         usage_webhook_server,
     ):
         del sync_usage_executor
@@ -712,7 +713,7 @@ class TestRunnerUsageFlushSignal:
         try:
             usage_webhook_server.queue_response(500)
             usage_webhook_server.queue_response(500)
-            with patch.object(usage.webhook.time, "sleep"):
+            with mitm_ctx(), patch.object(usage.webhook.time, "sleep"):
                 mitm_addon._handle_runner_usage_flush_signal(0, None)
                 wait_for_usage_flush_worker_to_stop()
 
@@ -727,8 +728,9 @@ class TestRunnerUsageFlushSignal:
             )
 
             usage_webhook_server.queue_response(204)
-            mitm_addon._handle_runner_usage_flush_signal(0, None)
-            wait_for_usage_flush_worker_to_stop()
+            with mitm_ctx():
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                wait_for_usage_flush_worker_to_stop()
 
             assert usage_webhook_server.request_count == 3
             retry_key = usage_webhook_server.requests[2].json_body()["events"][0]["idempotencyKey"]

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_flush_failures.py
@@ -572,6 +572,7 @@ def test_flush_preserves_events_buffered_during_enqueue(tmp_path):
 def test_retryable_delivery_failure_retains_flush_and_retries_with_same_key(
     tmp_path,
     sync_usage_executor,
+    mitm_ctx,
     usage_webhook_server,
 ):
     del sync_usage_executor
@@ -589,7 +590,7 @@ def test_retryable_delivery_failure_retains_flush_and_retries_with_same_key(
     usage_webhook_server.queue_response(500)
     usage_webhook_server.queue_response(500)
 
-    with patch.object(usage.webhook.time, "sleep"):
+    with mitm_ctx(), patch.object(usage.webhook.time, "sleep"):
         assert usage.flush_usage_events(trigger="test") == 1
 
     assert usage_webhook_server.request_count == 2
@@ -598,7 +599,8 @@ def test_retryable_delivery_failure_retains_flush_and_retries_with_same_key(
     assert_pending(pending_path, flows=0, buffered=1, reports=0, flush_request_id="request-1")
 
     usage_webhook_server.queue_response(204)
-    assert usage.flush_usage_events(trigger="test") == 1
+    with mitm_ctx():
+        assert usage.flush_usage_events(trigger="test") == 1
 
     assert usage_webhook_server.request_count == 3
     retry_body = usage_webhook_server.requests[2].json_body()
@@ -608,13 +610,15 @@ def test_retryable_delivery_failure_retains_flush_and_retries_with_same_key(
     usage.write_pending_snapshot(flush_request_id="request-2")
     assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-2")
     drained_request_count = usage_webhook_server.request_count
-    assert usage.flush_usage_events(trigger="test") == 0
+    with mitm_ctx():
+        assert usage.flush_usage_events(trigger="test") == 0
     assert usage_webhook_server.request_count == drained_request_count
 
 
 def test_partial_delivery_failure_retains_only_failed_batch_with_same_key(
     tmp_path,
     sync_usage_executor,
+    mitm_ctx,
     usage_webhook_server,
 ):
     del sync_usage_executor
@@ -633,7 +637,7 @@ def test_partial_delivery_failure_retains_only_failed_batch_with_same_key(
     usage_webhook_server.queue_response(204)
     usage_webhook_server.queue_response(500)
     usage_webhook_server.queue_response(500)
-    with patch.object(usage.webhook.time, "sleep"):
+    with mitm_ctx(), patch.object(usage.webhook.time, "sleep"):
         assert usage.flush_usage_events(trigger="test") == 2
 
     first_attempts = [
@@ -650,7 +654,8 @@ def test_partial_delivery_failure_retains_only_failed_batch_with_same_key(
     )
 
     usage_webhook_server.queue_response(204)
-    assert usage.flush_usage_events(trigger="test") == 1
+    with mitm_ctx():
+        assert usage.flush_usage_events(trigger="test") == 1
 
     retry_body = usage_webhook_server.requests[3].json_body()
     assert retry_body["runId"] == "run-b"
@@ -967,6 +972,7 @@ def test_permanent_sync_fallback_failure_does_not_requeue(tmp_path, fresh_usage_
 def test_permanent_http_delivery_failure_completes_flush(
     tmp_path,
     sync_usage_executor,
+    mitm_ctx,
     usage_webhook_server,
 ):
     del sync_usage_executor
@@ -983,11 +989,13 @@ def test_permanent_http_delivery_failure_completes_flush(
     )
     usage_webhook_server.queue_response(400)
 
-    assert usage.flush_usage_events(trigger="test") == 1
+    with mitm_ctx():
+        assert usage.flush_usage_events(trigger="test") == 1
 
     assert usage_webhook_server.request_count == 1
     usage.write_pending_snapshot(flush_request_id="request-1")
     assert_pending(pending_path, flows=0, buffered=0, reports=0, flush_request_id="request-1")
     drained_request_count = usage_webhook_server.request_count
-    assert usage.flush_usage_events(trigger="test") == 0
+    with mitm_ctx():
+        assert usage.flush_usage_events(trigger="test") == 0
     assert usage_webhook_server.request_count == drained_request_count

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 import pytest
 
 import flow_metadata_keys as metadata_keys
-import mitm_addon_version
 import platform_api
 import usage
 from tests.jsonl_log_helpers import (
@@ -71,7 +70,7 @@ def _assert_sensitive_webhook_url_parts_absent(entry: dict) -> None:
 
 
 def _assert_platform_client_headers(request, *, session_id: str = "runner-session-test") -> None:
-    assert request.header("x-client-version") == mitm_addon_version.MITM_ADDON_VERSION
+    assert request.header("x-client-version") == "runner-version-test"
     assert request.header("x-client-type") == "MitmAddon"
     assert request.header("x-client-session-id") == session_id
     uuid.UUID(request.header("x-client-request-id"))

--- a/crates/runner/mitm-addon/tests/test_webhook.py
+++ b/crates/runner/mitm-addon/tests/test_webhook.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 import flow_metadata_keys as metadata_keys
+import mitm_addon_version
 import platform_api
 import usage
 from tests.jsonl_log_helpers import (
@@ -69,6 +70,13 @@ def _assert_sensitive_webhook_url_parts_absent(entry: dict) -> None:
     assert "pass@api.vm0.ai" not in serialized
 
 
+def _assert_platform_client_headers(request, *, session_id: str = "runner-session-test") -> None:
+    assert request.header("x-client-version") == mitm_addon_version.MITM_ADDON_VERSION
+    assert request.header("x-client-type") == "MitmAddon"
+    assert request.header("x-client-session-id") == session_id
+    uuid.UUID(request.header("x-client-request-id"))
+
+
 class TestUsageWebhookDelivery:
     """Webhook delivery behavior observed through the HTTP boundary."""
 
@@ -82,13 +90,13 @@ class TestUsageWebhookDelivery:
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {"tokens.input": 100}
         return flow
 
-    def test_post_webhook_does_not_follow_redirects(self, usage_webhook_server):
+    def test_post_webhook_does_not_follow_redirects(self, mitm_ctx, usage_webhook_server):
         usage_webhook_server.queue_response(
             302,
             headers=(("Location", usage_webhook_server.url("/redirected")),),
         )
 
-        with pytest.raises(urllib.error.HTTPError) as exc:
+        with mitm_ctx(), pytest.raises(urllib.error.HTTPError) as exc:
             usage.webhook._post_webhook(
                 usage_webhook_server.url("/webhook"),
                 "tok",
@@ -132,6 +140,7 @@ class TestUsageWebhookDelivery:
         assert request.header("content-type") == "application/json"
         assert request.header("authorization") == "Bearer tok"
         assert request.header("user-agent") == "vm0-mitm-addon/1.0"
+        _assert_platform_client_headers(request)
         body = request.json_body()
         assert body["runId"] == "run-1"
         assert set(body) == {"runId", "events"}
@@ -163,11 +172,12 @@ class TestUsageWebhookDelivery:
                 payload_bytes=None if "enqueued" in entry["message"] else payload_bytes,
             )
 
-    def test_closes_http_error_response(self, usage_webhook_server):
+    def test_closes_http_error_response(self, mitm_ctx, usage_webhook_server):
         """HTTPError sockets must be closed to avoid leaking."""
         usage_webhook_server.queue_response(500)
 
         with (
+            mitm_ctx(),
             patch.object(urllib.error.HTTPError, "close", autospec=True) as close_mock,
             pytest.raises(urllib.error.HTTPError),
         ):
@@ -211,7 +221,7 @@ class TestUsageWebhookDelivery:
         mock_sleep.assert_called_once_with(0.5)
 
     def test_retry_with_payload_collision_logs_body_free_summary(
-        self, tmp_path, usage_webhook_server
+        self, mitm_ctx, tmp_path, usage_webhook_server
     ):
         proxy_log = tmp_path / "proxy.jsonl"
         usage_webhook_server.queue_response(500)
@@ -219,7 +229,7 @@ class TestUsageWebhookDelivery:
         payload = {"url": "payload-url", "type": "payload-type", "runId": "run-1", "events": []}
         payload_bytes = len(json.dumps(payload).encode())
 
-        with patch.object(usage.webhook.time, "sleep") as mock_sleep:
+        with mitm_ctx(), patch.object(usage.webhook.time, "sleep") as mock_sleep:
             usage.webhook._do_post_webhook_attempts(
                 usage_webhook_server.url("/x"),
                 "tok",
@@ -268,21 +278,22 @@ class TestUsageWebhookDelivery:
         assert all(entry["level"] != "error" for entry in entries)
 
     def test_give_up_with_payload_collision_logs_body_free_summary(
-        self, tmp_path, usage_webhook_server
+        self, mitm_ctx, tmp_path, usage_webhook_server
     ):
         proxy_log = tmp_path / "proxy.jsonl"
         usage_webhook_server.queue_response(500)
         payload = {"error": "payload-error", "attempt": 99, "runId": "run-1", "events": []}
         payload_bytes = len(json.dumps(payload).encode())
 
-        outcome = usage.webhook._do_post_webhook_attempts(
-            usage_webhook_server.url("/x"),
-            "tok",
-            payload,
-            str(proxy_log),
-            "usage",
-            max_retries=0,
-        )
+        with mitm_ctx():
+            outcome = usage.webhook._do_post_webhook_attempts(
+                usage_webhook_server.url("/x"),
+                "tok",
+                payload,
+                str(proxy_log),
+                "usage",
+                max_retries=0,
+            )
 
         assert outcome == "retryable_failure"
         [entry] = read_jsonl_entries_after_flush(proxy_log)
@@ -297,12 +308,12 @@ class TestUsageWebhookDelivery:
             payload_bytes=payload_bytes,
         )
 
-    def test_http_429_is_retryable(self, tmp_path, usage_webhook_server):
+    def test_http_429_is_retryable(self, mitm_ctx, tmp_path, usage_webhook_server):
         proxy_log = tmp_path / "proxy.jsonl"
         usage_webhook_server.queue_response(429)
         usage_webhook_server.queue_response(429)
 
-        with patch.object(usage.webhook.time, "sleep") as mock_sleep:
+        with mitm_ctx(), patch.object(usage.webhook.time, "sleep") as mock_sleep:
             outcome = usage.webhook._do_post_webhook_attempts(
                 usage_webhook_server.url("/x"),
                 "tok",
@@ -319,12 +330,13 @@ class TestUsageWebhookDelivery:
         assert [entry["level"] for entry in entries] == ["info", "info"]
         assert entries[-1]["delivery_outcome"] == "retryable_failure"
 
-    def test_url_error_is_retryable(self, tmp_path):
+    def test_url_error_is_retryable(self, mitm_ctx, tmp_path):
         proxy_log = tmp_path / "proxy.jsonl"
         payload = {"runId": "run-1", "events": []}
         payload_bytes = len(json.dumps(payload).encode())
 
         with (
+            mitm_ctx(),
             patch.object(
                 usage.webhook._opener,
                 "open",
@@ -356,16 +368,22 @@ class TestUsageWebhookDelivery:
                 payload_bytes=payload_bytes,
             )
 
-    def test_retry_failure_sanitizes_sensitive_webhook_url_in_message_and_error(self, tmp_path):
+    def test_retry_failure_sanitizes_sensitive_webhook_url_in_message_and_error(
+        self, mitm_ctx, tmp_path
+    ):
         proxy_log = tmp_path / "proxy.jsonl"
         payload = {"runId": "run-1", "events": []}
         payload_bytes = len(json.dumps(payload).encode())
+        url_without_fragment = SENSITIVE_WEBHOOK_URL.removesuffix("#frag")
 
-        with patch.object(
-            usage.webhook._opener,
-            "open",
-            side_effect=urllib.error.URLError(
-                f"failed {SENSITIVE_WEBHOOK_URL} and {SENSITIVE_WEBHOOK_URL.removesuffix('#frag')}"
+        with (
+            mitm_ctx(),
+            patch.object(
+                usage.webhook._opener,
+                "open",
+                side_effect=urllib.error.URLError(
+                    f"failed {SENSITIVE_WEBHOOK_URL} and {url_without_fragment}"
+                ),
             ),
         ):
             outcome = usage.webhook._do_post_webhook_attempts(
@@ -391,18 +409,19 @@ class TestUsageWebhookDelivery:
         )
         _assert_sensitive_webhook_url_parts_absent(entry)
 
-    def test_http_400_is_permanent(self, tmp_path, usage_webhook_server):
+    def test_http_400_is_permanent(self, mitm_ctx, tmp_path, usage_webhook_server):
         proxy_log = tmp_path / "proxy.jsonl"
         usage_webhook_server.queue_response(400)
 
-        outcome = usage.webhook._do_post_webhook_attempts(
-            usage_webhook_server.url("/x"),
-            "tok",
-            {"runId": "run-1", "events": []},
-            str(proxy_log),
-            "usage",
-            max_retries=1,
-        )
+        with mitm_ctx():
+            outcome = usage.webhook._do_post_webhook_attempts(
+                usage_webhook_server.url("/x"),
+                "tok",
+                {"runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage",
+                max_retries=1,
+            )
 
         assert outcome == "permanent_failure"
         assert usage_webhook_server.request_count == 1
@@ -710,20 +729,21 @@ class TestUsageWebhookDelivery:
         assert "secret-payload" not in json.dumps(saturated_entry)
 
     def test_delivery_capacity_released_after_success(
-        self, tmp_path, sync_usage_executor, usage_webhook_server
+        self, mitm_ctx, tmp_path, sync_usage_executor, usage_webhook_server
     ):
         proxy_log = tmp_path / "proxy.jsonl"
         pending_path = tmp_path / "usage-pending"
         usage.set_pending_path(str(pending_path))
         usage_webhook_server.queue_response(204)
 
-        assert usage.webhook._enqueue_webhook(
-            usage_webhook_server.url("/usage"),
-            "tok",
-            {"runId": "run-1", "events": []},
-            str(proxy_log),
-            "usage_event",
-        )
+        with mitm_ctx():
+            assert usage.webhook._enqueue_webhook(
+                usage_webhook_server.url("/usage"),
+                "tok",
+                {"runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage_event",
+            )
 
         assert usage_webhook_server.request_count == 1
         assert usage.webhook._pending_delivery_payload_count_for_tests() == 0
@@ -736,7 +756,7 @@ class TestUsageWebhookDelivery:
         )
 
     def test_delivery_capacity_released_when_outcome_callback_fails(
-        self, tmp_path, sync_usage_executor, usage_webhook_server
+        self, mitm_ctx, tmp_path, sync_usage_executor, usage_webhook_server
     ):
         proxy_log = tmp_path / "proxy.jsonl"
         pending_path = tmp_path / "usage-pending"
@@ -746,14 +766,15 @@ class TestUsageWebhookDelivery:
         def fail_callback(_outcome: usage.webhook.WebhookDeliveryOutcome) -> None:
             raise RuntimeError("callback failed")
 
-        assert usage.webhook._enqueue_webhook(
-            usage_webhook_server.url("/usage"),
-            "tok",
-            {"runId": "run-1", "events": []},
-            str(proxy_log),
-            "usage_event",
-            delivery_outcome_callback=fail_callback,
-        )
+        with mitm_ctx():
+            assert usage.webhook._enqueue_webhook(
+                usage_webhook_server.url("/usage"),
+                "tok",
+                {"runId": "run-1", "events": []},
+                str(proxy_log),
+                "usage_event",
+                delivery_outcome_callback=fail_callback,
+            )
 
         with pytest.raises(RuntimeError, match="callback failed"):
             sync_usage_executor.shutdown(wait=True)
@@ -769,7 +790,7 @@ class TestUsageWebhookDelivery:
         )
 
     def test_delivery_capacity_released_after_retry_exhaustion(
-        self, tmp_path, sync_usage_executor, usage_webhook_server
+        self, mitm_ctx, tmp_path, sync_usage_executor, usage_webhook_server
     ):
         proxy_log = tmp_path / "proxy.jsonl"
         pending_path = tmp_path / "usage-pending"
@@ -777,7 +798,7 @@ class TestUsageWebhookDelivery:
         usage_webhook_server.queue_response(500)
         usage_webhook_server.queue_response(500)
 
-        with patch.object(usage.webhook.time, "sleep"):
+        with mitm_ctx(), patch.object(usage.webhook.time, "sleep"):
             assert usage.webhook._enqueue_webhook(
                 usage_webhook_server.url("/usage"),
                 "tok",

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -141,6 +141,7 @@ pub async fn run_benchmark(
         registry_lock_path: runner_paths.proxy_registry_lock(),
         builtin_firewall_catalog_cache_path: runner_paths.builtin_firewall_catalog_cache(),
         api_url: runner_config.server.as_ref().map(|s| s.url.clone()),
+        client_session_id: uuid::Uuid::new_v4().to_string(),
     })
     .await?;
     mitm.start().await?;

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -701,6 +701,7 @@ mod tests {
         HttpClient::new(HttpClientConfig {
             api_url: "http://localhost".into(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap()
     }

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1074,6 +1074,7 @@ mod tests {
         HttpClient::new(HttpClientConfig {
             api_url: "http://localhost".into(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap()
     }

--- a/crates/runner/src/cmd/start/mitm_restart.rs
+++ b/crates/runner/src/cmd/start/mitm_restart.rs
@@ -134,6 +134,7 @@ mod tests {
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
             api_url: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .await
         .unwrap();

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -38,6 +38,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 use crate::duration::duration_ms as saturated_duration_ms;
 use crate::ids::RunId;
@@ -366,9 +367,11 @@ async fn run_start_with_home(
     // checks can fail due to config/filesystem state and should not leave
     // runtime-owned pools behind.
     let cancel = CancellationToken::new();
+    let runner_client_session_id = Uuid::new_v4().to_string();
     let http = HttpClient::new(HttpClientConfig {
         api_url: server.url.clone(),
         vercel_bypass: std::env::var("VERCEL_AUTOMATION_BYPASS_SECRET").ok(),
+        client_session_id: runner_client_session_id.clone(),
     })?;
     let name = runner_config.name;
     let group = runner_config.group;
@@ -419,6 +422,7 @@ async fn run_start_with_home(
         registry_lock_path: paths.proxy_registry_lock(),
         builtin_firewall_catalog_cache_path: paths.builtin_firewall_catalog_cache(),
         api_url: Some(server.url.clone()),
+        client_session_id: runner_client_session_id,
     })
     .await?;
     mitm.start().await?;

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -246,6 +246,7 @@ fn build_mock_run_config_with_runtime(
             http: crate::http::HttpClient::new(crate::http::HttpClientConfig {
                 api_url: api_url.to_string(),
                 vercel_bypass: None,
+                client_session_id: "runner-session-test".to_string(),
             })
             .unwrap(),
             log_paths: crate::paths::LogPaths::new(log_dir),

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -1065,6 +1065,7 @@ mod tests {
         HttpClient::new(HttpClientConfig {
             api_url: "http://api.test".to_string(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap()
     }

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -29,6 +29,7 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
         http: crate::http::HttpClient::new(HttpClientConfig {
             api_url: "http://localhost:9999".into(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap(),
         log_paths: LogPaths::new(log_dir),

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -49,6 +49,7 @@ fn new_telemetry() -> JobTelemetry {
     let http = HttpClient::new(HttpClientConfig {
         api_url: "http://localhost".to_string(),
         vercel_bypass: None,
+        client_session_id: "runner-session-test".to_string(),
     })
     .unwrap();
     JobTelemetry::new(http, RunId::nil(), "tok".to_string())

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -1,9 +1,16 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use api_contracts::generated::constants::platform_client::headers::{
+    PLATFORM_CLIENT_REQUEST_ID_HEADER, PLATFORM_CLIENT_SESSION_ID_HEADER,
+    PLATFORM_CLIENT_TYPE_HEADER, PLATFORM_CLIENT_VERSION_HEADER,
+};
 use api_contracts::{Method, ResolvedRoute, Route};
-use reqwest::Client;
+use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::{Client, Request, Response};
+use serde::Serialize;
 use tracing::info;
+use uuid::Uuid;
 
 use crate::config::normalize_api_base_url;
 use crate::error::{RunnerError, RunnerResult};
@@ -11,11 +18,14 @@ use crate::error::{RunnerError, RunnerResult};
 /// Default timeout for API requests (covers large claim payloads).
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const VERCEL_BYPASS_HEADER: &str = "x-vercel-protection-bypass";
+const RUNNER_CLIENT_TYPE: &str = "Runner";
+const RUNNER_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Configuration for the shared runner API HTTP client.
 pub struct HttpClientConfig {
     pub api_url: String,
     pub vercel_bypass: Option<String>,
+    pub client_session_id: String,
 }
 
 /// Shared HTTP client for the vm0 API. Owns the connection pool, base URL,
@@ -29,6 +39,122 @@ struct Inner {
     client: Client,
     api_url: String,
     vercel_bypass: Option<String>,
+    client_headers: ClientHeaders,
+}
+
+#[derive(Clone)]
+struct ClientHeaders {
+    client_type: HeaderValue,
+    client_version: HeaderValue,
+    client_session_id: HeaderValue,
+}
+
+/// Request builder for generated vm0 API routes.
+///
+/// Generated client headers are finalized in `send`/`build` so caller-side
+/// request customization cannot accidentally override them.
+pub struct ApiRequestBuilder {
+    client: Client,
+    builder: reqwest::RequestBuilder,
+    client_headers: ClientHeaders,
+}
+
+impl ApiRequestBuilder {
+    pub fn json<T: Serialize + ?Sized>(self, json: &T) -> Self {
+        let Self {
+            client,
+            builder,
+            client_headers,
+        } = self;
+        Self {
+            client,
+            builder: builder.json(json),
+            client_headers,
+        }
+    }
+
+    pub fn timeout(self, timeout: Duration) -> Self {
+        let Self {
+            client,
+            builder,
+            client_headers,
+        } = self;
+        Self {
+            client,
+            builder: builder.timeout(timeout),
+            client_headers,
+        }
+    }
+
+    pub async fn send(self) -> RunnerResult<Response> {
+        let client = self.client.clone();
+        let request = self.finalize()?;
+        client
+            .execute(request)
+            .await
+            .map_err(|e| RunnerError::Api(format!("send API request: {e}")))
+    }
+
+    #[cfg(test)]
+    pub fn build(self) -> RunnerResult<Request> {
+        self.finalize()
+    }
+
+    fn finalize(self) -> RunnerResult<Request> {
+        let mut request = self
+            .builder
+            .build()
+            .map_err(|e| RunnerError::Api(format!("build API request: {e}")))?;
+        self.client_headers.apply(request.headers_mut())?;
+        Ok(request)
+    }
+
+    #[cfg(test)]
+    fn header_for_test(self, name: &'static str, value: &'static str) -> Self {
+        let Self {
+            client,
+            builder,
+            client_headers,
+        } = self;
+        Self {
+            client,
+            builder: builder.header(name, value),
+            client_headers,
+        }
+    }
+}
+
+impl ClientHeaders {
+    fn new(client_session_id: String) -> RunnerResult<Self> {
+        let client_session_id = HeaderValue::from_str(&client_session_id)
+            .map_err(|e| RunnerError::Internal(format!("invalid client session id: {e}")))?;
+
+        Ok(Self {
+            client_type: HeaderValue::from_static(RUNNER_CLIENT_TYPE),
+            client_version: HeaderValue::from_static(RUNNER_CLIENT_VERSION),
+            client_session_id,
+        })
+    }
+
+    fn apply(&self, headers: &mut HeaderMap) -> RunnerResult<()> {
+        let request_id = Uuid::new_v4().to_string();
+        let request_id = match HeaderValue::from_str(&request_id) {
+            Ok(value) => value,
+            Err(error) => {
+                return Err(RunnerError::Internal(format!(
+                    "invalid client request id: {error}"
+                )));
+            }
+        };
+        headers.insert(PLATFORM_CLIENT_VERSION_HEADER, self.client_version.clone());
+        headers.insert(PLATFORM_CLIENT_TYPE_HEADER, self.client_type.clone());
+        headers.insert(
+            PLATFORM_CLIENT_SESSION_ID_HEADER,
+            self.client_session_id.clone(),
+        );
+        headers.insert(PLATFORM_CLIENT_REQUEST_ID_HEADER, request_id);
+        Ok(())
+    }
 }
 
 impl HttpClient {
@@ -43,6 +169,7 @@ impl HttpClient {
         let HttpClientConfig {
             api_url: raw_api_url,
             vercel_bypass,
+            client_session_id,
         } = config;
         let api_url = normalize_api_base_url(&raw_api_url)?;
 
@@ -62,12 +189,13 @@ impl HttpClient {
                 client,
                 api_url,
                 vercel_bypass,
+                client_headers: ClientHeaders::new(client_session_id)?,
             }),
         })
     }
 
     /// Build an authenticated request from a generated API route.
-    pub fn request_route(&self, route: Route, token: &str) -> reqwest::RequestBuilder {
+    pub fn request_route(&self, route: Route, token: &str) -> ApiRequestBuilder {
         self.authenticated_request(
             reqwest_method(route.method),
             route.url(&self.inner.api_url),
@@ -76,11 +204,7 @@ impl HttpClient {
     }
 
     /// Build an authenticated request from a generated route with params applied.
-    pub fn request_resolved_route(
-        &self,
-        route: ResolvedRoute,
-        token: &str,
-    ) -> reqwest::RequestBuilder {
+    pub fn request_resolved_route(&self, route: ResolvedRoute, token: &str) -> ApiRequestBuilder {
         self.authenticated_request(
             reqwest_method(route.method),
             route.url(&self.inner.api_url),
@@ -97,14 +221,18 @@ impl HttpClient {
         method: reqwest::Method,
         url: String,
         token: &str,
-    ) -> reqwest::RequestBuilder {
+    ) -> ApiRequestBuilder {
         let mut req = self.inner.client.request(method, url).bearer_auth(token);
 
         if let Some(bypass) = &self.inner.vercel_bypass {
             req = req.header(VERCEL_BYPASS_HEADER, bypass);
         }
 
-        req
+        ApiRequestBuilder {
+            client: self.inner.client.clone(),
+            builder: req,
+            client_headers: self.inner.client_headers.clone(),
+        }
     }
 }
 
@@ -131,8 +259,19 @@ mod tests {
         HttpClient::new(HttpClientConfig {
             api_url: api_url.to_string(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap()
+    }
+
+    fn header_value(request: &reqwest::Request, name: &str) -> String {
+        request
+            .headers()
+            .get(name)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
     }
 
     #[test]
@@ -180,6 +319,7 @@ mod tests {
         let result = HttpClient::new(HttpClientConfig {
             api_url: "https://user:pass@api.vm0.dev?token=secret".to_string(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         });
         let error = match result {
             Ok(_) => panic!("expected invalid API URL to be rejected"),
@@ -223,6 +363,7 @@ mod tests {
         let http = HttpClient::new(HttpClientConfig {
             api_url: "https://api.vm0.dev/".to_string(),
             vercel_bypass: Some("bypass-secret".to_string()),
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap();
 
@@ -252,5 +393,110 @@ mod tests {
             .unwrap();
 
         assert!(request.headers().get(VERCEL_BYPASS_HEADER).is_none());
+    }
+
+    #[test]
+    fn request_includes_platform_client_headers() {
+        let http = http_client("https://api.vm0.dev/");
+
+        let request = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            header_value(&request, PLATFORM_CLIENT_VERSION_HEADER),
+            RUNNER_CLIENT_VERSION
+        );
+        assert_eq!(
+            header_value(&request, PLATFORM_CLIENT_TYPE_HEADER),
+            RUNNER_CLIENT_TYPE
+        );
+        assert_eq!(
+            header_value(&request, PLATFORM_CLIENT_SESSION_ID_HEADER),
+            "runner-session-test"
+        );
+        Uuid::parse_str(&header_value(&request, PLATFORM_CLIENT_REQUEST_ID_HEADER)).unwrap();
+    }
+
+    #[test]
+    fn request_reuses_session_id_and_generates_fresh_request_id() {
+        let http = http_client("https://api.vm0.dev/");
+
+        let first = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build()
+            .unwrap();
+        let second = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            header_value(&first, PLATFORM_CLIENT_SESSION_ID_HEADER),
+            header_value(&second, PLATFORM_CLIENT_SESSION_ID_HEADER)
+        );
+        assert_ne!(
+            header_value(&first, PLATFORM_CLIENT_REQUEST_ID_HEADER),
+            header_value(&second, PLATFORM_CLIENT_REQUEST_ID_HEADER)
+        );
+    }
+
+    #[test]
+    fn generated_platform_client_headers_override_caller_headers() {
+        let http = http_client("https://api.vm0.dev/");
+
+        let request = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .header_for_test(PLATFORM_CLIENT_VERSION_HEADER, "caller-version")
+            .header_for_test(PLATFORM_CLIENT_TYPE_HEADER, "caller-type")
+            .header_for_test(PLATFORM_CLIENT_SESSION_ID_HEADER, "caller-session")
+            .header_for_test(PLATFORM_CLIENT_REQUEST_ID_HEADER, "caller-request")
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            header_value(&request, PLATFORM_CLIENT_VERSION_HEADER),
+            RUNNER_CLIENT_VERSION
+        );
+        assert_eq!(
+            header_value(&request, PLATFORM_CLIENT_TYPE_HEADER),
+            RUNNER_CLIENT_TYPE
+        );
+        assert_eq!(
+            header_value(&request, PLATFORM_CLIENT_SESSION_ID_HEADER),
+            "runner-session-test"
+        );
+        assert_ne!(
+            header_value(&request, PLATFORM_CLIENT_REQUEST_ID_HEADER),
+            "caller-request"
+        );
+    }
+
+    #[test]
+    fn external_get_excludes_platform_client_headers() {
+        let http = http_client("https://api.vm0.dev/");
+
+        let request = http.get("https://blob.example/history").build().unwrap();
+
+        assert!(
+            request
+                .headers()
+                .get(PLATFORM_CLIENT_VERSION_HEADER)
+                .is_none()
+        );
+        assert!(request.headers().get(PLATFORM_CLIENT_TYPE_HEADER).is_none());
+        assert!(
+            request
+                .headers()
+                .get(PLATFORM_CLIENT_SESSION_ID_HEADER)
+                .is_none()
+        );
+        assert!(
+            request
+                .headers()
+                .get(PLATFORM_CLIENT_REQUEST_ID_HEADER)
+                .is_none()
+        );
     }
 }

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -326,6 +326,7 @@ mod tests {
         HttpClient::new(HttpClientConfig {
             api_url: server.base_url(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap()
     }
@@ -840,6 +841,7 @@ mod tests {
         let http = HttpClient::new(HttpClientConfig {
             api_url,
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap();
         upload_network_logs(&http, RunId::nil(), SANDBOX_TOKEN, &path).await;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use api_contracts::generated::routes;
-use reqwest::{RequestBuilder, Response, StatusCode};
+use reqwest::{Response, StatusCode};
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::api_ably_supervisor::{
@@ -24,7 +24,7 @@ use super::{
 };
 use crate::duration::duration_ms;
 use crate::error::{RunnerError, RunnerResult};
-use crate::http::HttpClient;
+use crate::http::{ApiRequestBuilder, HttpClient};
 use crate::ids::RunId;
 use crate::run_cancellation::SharedRunCancellationMap;
 use crate::types::{
@@ -569,7 +569,7 @@ impl ApiClient {
         &self,
         run_id: &str,
         connector_refs: &[String],
-    ) -> RequestBuilder {
+    ) -> ApiRequestBuilder {
         self.http
             .request_resolved_route(
                 routes::runners::runs::by_run_id::network_policy_refresh::route(
@@ -659,10 +659,12 @@ fn poll_reason_value(reason: PollReason) -> &'static str {
     }
 }
 
-async fn send_api(req: RequestBuilder, label: &str) -> RunnerResult<Response> {
-    req.send()
-        .await
-        .map_err(|e| RunnerError::Api(format!("{label}: {e}")))
+async fn send_api(req: ApiRequestBuilder, label: &str) -> RunnerResult<Response> {
+    match req.send().await {
+        Ok(resp) => Ok(resp),
+        Err(RunnerError::Api(message)) => Err(RunnerError::Api(format!("{label}: {message}"))),
+        Err(error) => Err(error),
+    }
 }
 
 async fn check_api_status(resp: Response, label: &str) -> RunnerResult<Response> {
@@ -948,6 +950,7 @@ mod tests {
             HttpClient::new(HttpClientConfig {
                 api_url: server.base_url(),
                 vercel_bypass: None,
+                client_session_id: "runner-session-test".to_string(),
             })
             .unwrap(),
             "runner-token".to_string(),
@@ -1114,6 +1117,7 @@ mod tests {
             HttpClient::new(HttpClientConfig {
                 api_url,
                 vercel_bypass: None,
+                client_session_id: "runner-session-test".to_string(),
             })
             .unwrap(),
             "runner-token".to_string(),

--- a/crates/runner/src/provider/network_policy_refresh.rs
+++ b/crates/runner/src/provider/network_policy_refresh.rs
@@ -778,6 +778,7 @@ mod tests {
             HttpClient::new(HttpClientConfig {
                 api_url: server.base_url(),
                 vercel_bypass: None,
+                client_session_id: "runner-session-test".to_string(),
             })
             .expect("test API URL should be valid"),
             "runner-token".to_string(),

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -25,6 +25,7 @@ const READY_TIMEOUT: Duration = Duration::from_secs(10);
 /// installed/replaced mitmdump binary is still observed as writable.
 const TEXT_BUSY_SPAWN_RETRY_DELAY: Duration = Duration::from_millis(20);
 const TEXT_BUSY_SPAWN_MAX_RETRIES: usize = 5;
+const RUNNER_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Timeout for graceful shutdown before SIGKILL.
 ///
@@ -529,6 +530,8 @@ pub(crate) async fn spawn_mitmdump(
             "vm0_client_session_id={}",
             config.client_session_id
         ))
+        .arg("--set")
+        .arg(format!("vm0_client_version={RUNNER_CLIENT_VERSION}"))
         .arg("--scripts")
         .arg(config.addon_dir.join("mitm_addon.py"))
         .arg("--set")
@@ -1116,6 +1119,11 @@ PY
             args.lines()
                 .any(|arg| arg == "vm0_client_session_id=runner-session-test"),
             "mitmdump args should include vm0_client_session_id option; got:\n{args}",
+        );
+        assert!(
+            args.lines()
+                .any(|arg| arg == format!("vm0_client_version={RUNNER_CLIENT_VERSION}")),
+            "mitmdump args should include vm0_client_version option; got:\n{args}",
         );
         assert!(
             args.lines().all(|arg| arg != "connection_strategy=lazy"),

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -49,6 +49,8 @@ pub struct ProxyConfig {
     pub builtin_firewall_catalog_cache_path: PathBuf,
     /// VM0 API URL passed to the addon (optional).
     pub api_url: Option<String>,
+    /// Runner-runtime client session id passed to the addon for vm0 API requests.
+    pub client_session_id: String,
 }
 
 /// Manages the mitmdump process lifecycle and proxy registry.
@@ -431,6 +433,7 @@ impl MitmProxy {
                     registry_lock_path: std::path::PathBuf::new(),
                     builtin_firewall_catalog_cache_path: std::path::PathBuf::new(),
                     api_url: None,
+                    client_session_id: "runner-session-test".to_string(),
                 },
                 child: None,
                 crash_tx,
@@ -520,6 +523,11 @@ pub(crate) async fn spawn_mitmdump(
         .arg(format!(
             "vm0_builtin_firewall_catalog_cache_path={}",
             config.builtin_firewall_catalog_cache_path.display()
+        ))
+        .arg("--set")
+        .arg(format!(
+            "vm0_client_session_id={}",
+            config.client_session_id
         ))
         .arg("--scripts")
         .arg(config.addon_dir.join("mitm_addon.py"))
@@ -967,6 +975,7 @@ PY
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
             api_url: None,
+            client_session_id: "runner-session-test".to_string(),
         };
 
         let result = MitmProxy::new(config).await;
@@ -997,6 +1006,7 @@ PY
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
             api_url: None,
+            client_session_id: "runner-session-test".to_string(),
         };
 
         let (_proxy, _crash_rx) = MitmProxy::new(config).await.unwrap();
@@ -1075,6 +1085,7 @@ PY
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
             builtin_firewall_catalog_cache_path: builtin_firewall_catalog_cache_path.clone(),
             api_url: None,
+            client_session_id: "runner-session-test".to_string(),
         };
         let (crash_tx, _crash_rx) = mpsc::channel(1);
         let stopping = Arc::new(AtomicBool::new(false));
@@ -1102,6 +1113,11 @@ PY
             "mitmdump args should include vm0_builtin_firewall_catalog_cache_path option; got:\n{args}",
         );
         assert!(
+            args.lines()
+                .any(|arg| arg == "vm0_client_session_id=runner-session-test"),
+            "mitmdump args should include vm0_client_session_id option; got:\n{args}",
+        );
+        assert!(
             args.lines().all(|arg| arg != "connection_strategy=lazy"),
             "mitmdump args must not use global lazy upstream connections because server-first TCP protocols must keep working; got:\n{args}",
         );
@@ -1123,6 +1139,7 @@ PY
                 .path()
                 .join("builtin-firewall-catalog-cache.json"),
             api_url: None,
+            client_session_id: "runner-session-test".to_string(),
         };
         let (crash_tx, _crash_rx) = mpsc::channel(1);
         let stopping = Arc::new(AtomicBool::new(false));

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -2439,6 +2439,7 @@ mod tests {
         let http = HttpClient::new(HttpClientConfig {
             api_url: api_url.to_string(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap();
         JobTelemetry::new(http, RunId::nil(), "test-token".to_string())

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -524,6 +524,7 @@ mod tests {
         HttpClient::new(HttpClientConfig {
             api_url: api_url.to_string(),
             vercel_bypass: None,
+            client_session_id: "runner-session-test".to_string(),
         })
         .unwrap()
     }

--- a/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/__tests__/constants.test.ts
@@ -14,6 +14,12 @@ import {
   MODEL_PROVIDER_FIREWALL_CONFIGS,
 } from "../../contracts/model-providers";
 import {
+  PLATFORM_CLIENT_REQUEST_ID_HEADER,
+  PLATFORM_CLIENT_SESSION_ID_HEADER,
+  PLATFORM_CLIENT_TYPE_HEADER,
+  PLATFORM_CLIENT_VERSION_HEADER,
+} from "../../contracts/platform-client-headers";
+import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
   NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX,
@@ -61,6 +67,18 @@ const sessionHistoryGzipMinBytesDoc = [
   "Minimum raw resume session history size before the guest attempts gzip upload negotiation.",
   "Smaller histories stay identity-encoded to avoid gzip work when it cannot materially reduce transport size.",
 ] as const;
+const platformClientVersionHeaderDoc = [
+  "HTTP header carrying the sending vm0 client component version.",
+] as const;
+const platformClientTypeHeaderDoc = [
+  "HTTP header carrying the sending vm0 client component type.",
+] as const;
+const platformClientSessionIdHeaderDoc = [
+  "HTTP header carrying the sending vm0 client session identifier.",
+] as const;
+const platformClientRequestIdHeaderDoc = [
+  "HTTP header carrying the per-request vm0 client request identifier.",
+] as const;
 
 function rustString(value: string): RustConstantValue {
   return { kind: "string", value };
@@ -78,6 +96,30 @@ function placeholderRustDoc(name: string): readonly string[] {
 }
 
 const expectedBindings = [
+  {
+    rustModulePath: ["platform_client", "headers"],
+    rustConstName: "PLATFORM_CLIENT_VERSION_HEADER",
+    value: rustString(PLATFORM_CLIENT_VERSION_HEADER),
+    rustDoc: platformClientVersionHeaderDoc,
+  },
+  {
+    rustModulePath: ["platform_client", "headers"],
+    rustConstName: "PLATFORM_CLIENT_TYPE_HEADER",
+    value: rustString(PLATFORM_CLIENT_TYPE_HEADER),
+    rustDoc: platformClientTypeHeaderDoc,
+  },
+  {
+    rustModulePath: ["platform_client", "headers"],
+    rustConstName: "PLATFORM_CLIENT_SESSION_ID_HEADER",
+    value: rustString(PLATFORM_CLIENT_SESSION_ID_HEADER),
+    rustDoc: platformClientSessionIdHeaderDoc,
+  },
+  {
+    rustModulePath: ["platform_client", "headers"],
+    rustConstName: "PLATFORM_CLIENT_REQUEST_ID_HEADER",
+    value: rustString(PLATFORM_CLIENT_REQUEST_ID_HEADER),
+    rustDoc: platformClientRequestIdHeaderDoc,
+  },
   {
     rustModulePath: ["runners"],
     rustConstName: "NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX",
@@ -251,8 +293,10 @@ describe("Rust constant bindings", () => {
     expect(secondRender).toBe(firstRender);
     expect(firstRender).toContain("pub mod codex_oauth_token {");
     expect(firstRender).toContain("pub mod model_provider_env {");
+    expect(firstRender).toContain("pub mod platform_client {");
     expect(firstRender).toContain("pub mod runners {");
     expect(firstRender).toContain("pub mod placeholders {");
+    expect(firstRender).toContain("pub mod headers {");
     expect(firstRender).toContain(
       "//! Generated Rust constants for `@vm0/api-contracts`.",
     );
@@ -300,6 +344,18 @@ describe("Rust constant bindings", () => {
     );
     expect(firstRender).toContain(
       `pub const SESSION_HISTORY_GZIP_MIN_BYTES: u64 = ${SESSION_HISTORY_GZIP_MIN_BYTES};`,
+    );
+    expect(firstRender).toContain(
+      `pub const PLATFORM_CLIENT_VERSION_HEADER: &str = "${PLATFORM_CLIENT_VERSION_HEADER}";`,
+    );
+    expect(firstRender).toContain(
+      `pub const PLATFORM_CLIENT_TYPE_HEADER: &str = "${PLATFORM_CLIENT_TYPE_HEADER}";`,
+    );
+    expect(firstRender).toContain(
+      `pub const PLATFORM_CLIENT_SESSION_ID_HEADER: &str = "${PLATFORM_CLIENT_SESSION_ID_HEADER}";`,
+    );
+    expect(firstRender).toContain(
+      `pub const PLATFORM_CLIENT_REQUEST_ID_HEADER: &str = "${PLATFORM_CLIENT_REQUEST_ID_HEADER}";`,
     );
     expect(firstRender).toContain(
       `pub const CHATGPT_ACCOUNT_ID: &str = "${codexOauthPlaceholders.CHATGPT_ACCOUNT_ID}";`,

--- a/turbo/packages/api-contracts/src/rust-bindings/constants.ts
+++ b/turbo/packages/api-contracts/src/rust-bindings/constants.ts
@@ -3,6 +3,12 @@ import {
   MODEL_PROVIDER_FIREWALL_CONFIGS,
 } from "../contracts/model-providers";
 import {
+  PLATFORM_CLIENT_REQUEST_ID_HEADER,
+  PLATFORM_CLIENT_SESSION_ID_HEADER,
+  PLATFORM_CLIENT_TYPE_HEADER,
+  PLATFORM_CLIENT_VERSION_HEADER,
+} from "../contracts/platform-client-headers";
+import {
   CANONICAL_GUEST_HOME_DIR,
   CANONICAL_WORKING_DIR,
   NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX,
@@ -65,6 +71,7 @@ const modelProviderEnvPlaceholderModule = [
   "model_provider_env",
   "placeholders",
 ] as const;
+const platformClientHeadersModule = ["platform_client", "headers"] as const;
 const runnerPathsModule = ["runners", "paths"] as const;
 
 export const rustConstantRootDoc = [
@@ -99,6 +106,18 @@ export const rustConstantModuleDocs = [
     rustDoc: [
       "Fake model-provider environment placeholder marker values.",
       "These values are not secrets and are not usable credentials.",
+    ],
+  },
+  {
+    rustModulePath: ["platform_client"],
+    rustDoc: [
+      "Platform client request header contract constants shared by TypeScript and Rust.",
+    ],
+  },
+  {
+    rustModulePath: platformClientHeadersModule,
+    rustDoc: [
+      "HTTP header names used to identify vm0 platform clients in API request logs.",
     ],
   },
   {
@@ -153,6 +172,34 @@ function rustU64(value: number): RustConstantValue {
 }
 
 export const rustConstantBindings = [
+  {
+    rustModulePath: platformClientHeadersModule,
+    rustConstName: "PLATFORM_CLIENT_VERSION_HEADER",
+    value: rustString(PLATFORM_CLIENT_VERSION_HEADER),
+    rustDoc: ["HTTP header carrying the sending vm0 client component version."],
+  },
+  {
+    rustModulePath: platformClientHeadersModule,
+    rustConstName: "PLATFORM_CLIENT_TYPE_HEADER",
+    value: rustString(PLATFORM_CLIENT_TYPE_HEADER),
+    rustDoc: ["HTTP header carrying the sending vm0 client component type."],
+  },
+  {
+    rustModulePath: platformClientHeadersModule,
+    rustConstName: "PLATFORM_CLIENT_SESSION_ID_HEADER",
+    value: rustString(PLATFORM_CLIENT_SESSION_ID_HEADER),
+    rustDoc: [
+      "HTTP header carrying the sending vm0 client session identifier.",
+    ],
+  },
+  {
+    rustModulePath: platformClientHeadersModule,
+    rustConstName: "PLATFORM_CLIENT_REQUEST_ID_HEADER",
+    value: rustString(PLATFORM_CLIENT_REQUEST_ID_HEADER),
+    rustDoc: [
+      "HTTP header carrying the per-request vm0 client request identifier.",
+    ],
+  },
   {
     rustModulePath: ["runners"],
     rustConstName: "NETWORK_POLICY_REFRESH_CONNECTOR_REFS_MAX",


### PR DESCRIPTION
## Summary
- Export the existing platform client header contract into Rust constants.
- Add `X-Client-Version`, `X-Client-Type`, `X-Client-Session-Id`, and `X-Client-Request-Id` to runner API route requests, guest-agent API JSON posts, and mitm-addon platform API requests.
- Use one runner-process session id for the host runner and mitm-addon, use the run id for guest-agent, and generate a fresh request id per platform API request.
- Keep external downloads and presigned uploads free of platform client headers.

Closes #20546

## Tests
- `pnpm -F @vm0/api-contracts exec vitest run src/rust-bindings/__tests__/constants.test.ts`
- `ruff format src tests && ruff check src tests`
- `pytest tests/test_firewall_auth.py::TestMakeApiRequest tests/test_firewall_auth.py::TestFetchFirewallHeaders::test_sends_request_and_maps_basic_success tests/test_webhook.py::TestUsageWebhookDelivery::test_succeeds_on_first_attempt tests/test_webhook.py::TestUsageWebhookDelivery::test_post_webhook_does_not_follow_redirects tests/test_webhook.py::TestUsageWebhookDelivery::test_retry_with_payload_collision_logs_body_free_summary tests/test_webhook.py::TestUsageWebhookDelivery::test_http_400_is_permanent tests/test_addon_configuration.py::TestAddonConfiguration`
- `cargo test --manifest-path crates/Cargo.toml -p runner http::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner proxy::process::tests::spawn_mitmdump_passes_usage_state_id_option`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration post_json_sends_platform_client_headers`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test integration put_presigned_does_not_send_api_headers`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --lib with_api_config`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --bin guest-agent with_api_config`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`