### PR TITLE
feat(cli): split image prompt generation modes

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -2905,8 +2905,9 @@ describe("CHAT-02: generation templates and attachments", () => {
       .appendSystemPrompt;
     expect(firstPrompt).toContain("# Artifact Template Context");
     expect(firstPrompt).toContain(
-      `zero generate image --provider built-in --style ${style.illustrationStyleId}`,
+      `zero generate image --provider built-in --style ${style.illustrationStyleId} --prompt "<user request>" --compile`,
     );
+    expect(firstPrompt).toContain("--compiled-prompt");
     expect(firstPrompt).toContain(style.illustrationStyleId);
 
     const firstClaim = await claimChatRun(runnerGroup, first.runId);
@@ -2972,7 +2973,7 @@ describe("CHAT-02: generation templates and attachments", () => {
     // to this message, and prior/incomplete context no longer repeats template
     // selections.
     expect(thirdPrompt).not.toContain(
-      `zero generate image --provider built-in --style ${style.illustrationStyleId}`,
+      `zero generate image --provider built-in --style ${style.illustrationStyleId} --prompt "<user request>" --compile`,
     );
     expect(thirdPrompt).not.toContain(style.illustrationStyleId);
     await cancelChatRun(actor, third.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts
@@ -97,8 +97,9 @@ describe("buildGenerationTemplatePrompt", () => {
     // agent does not re-ask for an already-selected style (vm0-ai/vm0#17525).
     expect(result.prompt).toContain(item.illustrationStyleId);
     expect(result.prompt).toContain(
-      `zero generate image --provider built-in --style ${item.illustrationStyleId}`,
+      `zero generate image --provider built-in --style ${item.illustrationStyleId} --prompt "<user request>" --compile`,
     );
+    expect(result.prompt).toContain("--compiled-prompt");
   });
 
   it("builds video template preset guidance", () => {

--- a/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
+++ b/turbo/apps/api/src/signals/routes/generation-template-prompt.ts
@@ -267,7 +267,8 @@ function buildIllustrationGenerationTemplatePrompt(
       `- Style description: ${imageStyle.description}`,
       "",
       "When you produce an illustration or image from the user's request:",
-      `- Run: zero generate image --provider built-in --style ${imageStyle.id} --prompt "<user request>"`,
+      `- Run: zero generate image --provider built-in --style ${imageStyle.id} --prompt "<user request>" --compile`,
+      '- Compile the returned packet into a final image prompt, then run `zero generate image --provider built-in --compiled-prompt "<compiled prompt>"` with any reference image URLs and requested generation parameters from the packet.',
       "- If a flag above no longer applies, run `zero generate image -h` to discover the current flags, models, providers, and styles.",
     ].join("\n"),
   };

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/image.test.ts
@@ -79,8 +79,7 @@ describe("zero generate image command", () => {
       "node",
       "cli",
       "image",
-      "--skip-style",
-      "--prompt",
+      "--raw-prompt",
       "A watercolor fox",
       "--quality",
       "auto",
@@ -141,11 +140,10 @@ describe("zero generate image command", () => {
       "node",
       "cli",
       "image",
-      "--skip-style",
+      "--raw-prompt",
+      "A product hero shot",
       "--model",
       "flux-pro-1.1",
-      "--prompt",
-      "A product hero shot",
       "--format",
       "jpeg",
       "--seed",
@@ -195,11 +193,10 @@ describe("zero generate image command", () => {
       "node",
       "cli",
       "image",
-      "--skip-style",
+      "--compiled-prompt",
+      "Turn this mockup into a polished product shot",
       "--model",
       "flux-pro-1.1",
-      "--prompt",
-      "Turn this mockup into a polished product shot",
       "--image-url",
       "https://example.com/mockup.png",
       "--image-prompt-strength",
@@ -248,11 +245,10 @@ describe("zero generate image command", () => {
       "node",
       "cli",
       "image",
-      "--skip-style",
+      "--compiled-prompt",
+      "Combine these references into a campaign image",
       "--model",
       "nano-banana-2",
-      "--prompt",
-      "Combine these references into a campaign image",
       "--image-url",
       "https://example.com/reference-1.png",
       "--image-url",
@@ -285,7 +281,7 @@ describe("zero generate image command", () => {
     expect(stdout).toContain("Provider: fal");
   });
 
-  it("should print styled image resource selection instructions with --style", async () => {
+  it("should print styled image prompt compilation instructions with --style and --compile", async () => {
     await generateCommand.parseAsync([
       "node",
       "cli",
@@ -294,22 +290,24 @@ describe("zero generate image command", () => {
       "image-style:notion-illustration",
       "--prompt",
       "Notion illustration of a product manager mapping a launch plan",
+      "--compile",
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(
-      "# Zero generate image --style image-style:notion-illustration",
+      "# Zero generate image prompt compile image-style:notion-illustration",
     );
-    expect(stdout).toContain("federated generation source-selection packet");
+    expect(stdout).toContain("image prompt-compilation packet");
     expect(stdout).toContain("## Selected Image Style");
     expect(stdout).toContain("image-style:notion-illustration");
-    expect(stdout).toContain("## Candidate Registry Slice");
+    expect(stdout).toContain("## Style Source");
     expect(stdout).toContain("vm0-ai/vm0-skills");
     expect(stdout).toContain("notion-illustration");
-    expect(stdout).toContain("## Stage 3: Generate Image");
+    expect(stdout).toContain("## Prompt Compiler Task");
+    expect(stdout).toContain("--compiled-prompt");
   });
 
-  it("should fail with style listing when neither --style nor --skip-style is provided", async () => {
+  it("should fail with mode guidance when no image prompt mode is selected", async () => {
     await expect(async () => {
       await generateCommand.parseAsync([
         "node",
@@ -321,9 +319,29 @@ describe("zero generate image command", () => {
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
-    expect(stderr).toContain("--style <id> or --skip-style is required");
+    expect(stderr).toContain("Choose one image prompt mode");
+    expect(stderr).toContain("--compiled-prompt");
+    expect(stderr).toContain("--raw-prompt");
     expect(stderr).toContain("image-style:notion-illustration");
     expect(stderr).toContain("image-style:vm0-illustration");
+  });
+
+  it("should reject compile mode without a prompt", async () => {
+    await expect(async () => {
+      await generateCommand.parseAsync([
+        "node",
+        "cli",
+        "image",
+        "--style",
+        "image-style:notion-illustration",
+        "--compile",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const stderr = mockConsoleError.mock.calls.flat().join("\n");
+    expect(stderr).toContain(
+      "--compile requires --prompt <text> or piped stdin",
+    );
   });
 
   it("should fail with style listing when --style id is unknown", async () => {
@@ -336,6 +354,7 @@ describe("zero generate image command", () => {
         "image-style:does-not-exist",
         "--prompt",
         "Anything",
+        "--compile",
       ]);
     }).rejects.toThrow("process.exit called");
 
@@ -344,7 +363,7 @@ describe("zero generate image command", () => {
     expect(stderr).toContain("image-style:notion-illustration");
   });
 
-  it("should reject combining --style with --skip-style", async () => {
+  it("should reject --style without --compile", async () => {
     await expect(async () => {
       await generateCommand.parseAsync([
         "node",
@@ -352,14 +371,13 @@ describe("zero generate image command", () => {
         "image",
         "--style",
         "image-style:notion-illustration",
-        "--skip-style",
         "--prompt",
         "Anything",
       ]);
     }).rejects.toThrow("process.exit called");
 
     const stderr = mockConsoleError.mock.calls.flat().join("\n");
-    expect(stderr).toContain("--style and --skip-style cannot be combined");
+    expect(stderr).toContain("--style can only be used with --compile");
   });
 
   it("should wait for an accepted async generation result", async () => {
@@ -406,8 +424,7 @@ describe("zero generate image command", () => {
       "node",
       "cli",
       "image",
-      "--skip-style",
-      "--prompt",
+      "--raw-prompt",
       "Async please",
     ]);
 
@@ -444,7 +461,10 @@ describe("zero generate image command", () => {
     expect(helpOutput).toContain("--image-prompt-strength");
     expect(helpOutput).toContain("Nano Banana 2 accepts up to 14");
     expect(helpOutput).toContain("--style <id>");
-    expect(helpOutput).toContain("--skip-style");
+    expect(helpOutput).toContain("--compile");
+    expect(helpOutput).toContain("--compiled-prompt");
+    expect(helpOutput).toContain("--raw-prompt");
+    expect(helpOutput).not.toContain("--skip-style");
     expect(helpOutput).not.toContain("--json");
     expect(helpOutput).not.toContain("--styled ");
     expect(helpOutput).toContain("provider");
@@ -479,8 +499,7 @@ describe("zero generate image command", () => {
         "node",
         "cli",
         "image",
-        "--skip-style",
-        "--prompt",
+        "--raw-prompt",
         "hello",
       ]);
     }).rejects.toThrow("process.exit called");

--- a/turbo/apps/cli/src/commands/zero/generate/image.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/image.ts
@@ -4,13 +4,14 @@ export const imageCommand = createImageGenerateCommand({
   name: "image",
   generationType: "image",
   usageCommand: "zero generate image",
-  examples: `  Styled image:          zero generate image --style vm0:image-style:notion-illustration --prompt "A product manager mapping a launch plan"
-  Skip style:            zero generate image --skip-style --prompt "A watercolor fox"
-  Pipe prompt:           cat prompt.txt | zero generate image --skip-style
-  GPT Image model:       zero generate image --skip-style --model gpt-image-1.5 --prompt "A poster" --size 1024x1536 --quality high
-  Flux model:            zero generate image --skip-style --model flux-pro-1.1 --prompt "A product hero shot" --seed 42
-  Nano Banana 2:         zero generate image --skip-style --model nano-banana-2 --prompt "A crisp launch poster with readable typography"
-  Image-to-image:        zero generate image --skip-style --model flux-pro-1.1 --image-url https://example.com/mockup.png --prompt "Turn this mockup into a polished product shot"
+  examples: `  Compile styled prompt: zero generate image --style image-style:notion-illustration --prompt "A product manager mapping a launch plan" --compile
+  Generate compiled:     zero generate image --compiled-prompt "A Notion-style brush-pen illustration..."
+  Generate raw:          zero generate image --raw-prompt "A watercolor fox"
+  Pipe compile prompt:   cat prompt.txt | zero generate image --style image-style:notion-illustration --compile
+  GPT Image model:       zero generate image --compiled-prompt "A poster" --model gpt-image-1.5 --size 1024x1536 --quality high
+  Flux model:            zero generate image --raw-prompt "A product hero shot" --model flux-pro-1.1 --seed 42
+  Nano Banana 2:         zero generate image --compiled-prompt "A crisp launch poster with readable typography" --model nano-banana-2
+  Image-to-image:        zero generate image --compiled-prompt "Turn this mockup into a polished product shot" --model flux-pro-1.1 --image-url https://example.com/mockup.png
   List providers:        zero generate image
   Use a connector:       zero generate image --provider replicate`,
 });

--- a/turbo/apps/cli/src/commands/zero/generate/index.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/index.ts
@@ -40,7 +40,7 @@ const documentCommand = createListerOnlyCommand({
 
 function buildGenerateHelpText(): string {
   const examples = [
-    '  Generate image:        zero generate image --prompt "A watercolor fox"',
+    '  Generate image:        zero generate image --raw-prompt "A watercolor fox"',
     '  Generate deck:         zero generate presentation --prompt "A product roadmap"',
     '  Generate report:       zero generate report --prompt "A Q2 usage report"',
     '  Generate docs:         zero generate docs-design --prompt "A setup guide"',
@@ -53,7 +53,7 @@ function buildGenerateHelpText(): string {
     "  Show image choices:    zero generate image",
     "  Show report choices:   zero generate report",
     "  Use a connector:       zero generate video --provider heygen",
-    "  Force built-in:        zero generate image --provider built-in --model gpt-image-1.5 --prompt ...",
+    "  Force built-in:        zero generate image --provider built-in --model gpt-image-1.5 --raw-prompt ...",
   ];
 
   return `\nExamples:\n${examples.join("\n")}\n\nNotes:\n  - Run "zero generate <type>" with no --prompt to list generation choices for that type.

--- a/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/lib/dispatch.ts
@@ -7,6 +7,8 @@ interface DispatchOptions {
   readonly provider?: string;
   readonly prompt?: string;
   readonly all?: boolean;
+  readonly listOnMissingPrompt?: boolean;
+  readonly missingPromptError?: string;
 }
 
 /**
@@ -32,6 +34,9 @@ export async function dispatchGenerate(
   const resolvedPrompt = resolvePrompt(options.prompt);
 
   if (resolvedPrompt === null) {
+    if (options.listOnMissingPrompt === false) {
+      throw new Error(options.missingPromptError ?? "Prompt is required");
+    }
     await runLister(options.generationType, {
       all: options.all,
     });

--- a/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-generate.ts
@@ -2,7 +2,7 @@ import { Command, InvalidArgumentError } from "commander";
 import chalk from "chalk";
 import { generateWebImage } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-import { createStyledImageAuthoringPacket } from "./image-style-authoring";
+import { createStyledImageCompilationPacket } from "./image-style-authoring";
 import { findImageStyle, listImageStyles } from "./resource-registry";
 import { formatRegistryListing } from "./resource-listing";
 import { dispatchGenerate } from "../generate/lib/dispatch";
@@ -10,6 +10,8 @@ import type { GenerationType } from "../generate/lib/lister";
 
 interface ImageOptions {
   prompt?: string;
+  compiledPrompt?: string;
+  rawPrompt?: string;
   provider?: string;
   model: string;
   size: string;
@@ -26,7 +28,7 @@ interface ImageOptions {
   inputFidelity?: string;
   imagePromptStrength?: string;
   style?: string;
-  skipStyle?: boolean;
+  compile?: boolean;
   all?: boolean;
 }
 
@@ -37,17 +39,20 @@ interface ImageGenerateCommandConfig {
   examples: string;
 }
 
-function requireStyleError(usageCommand: string): Error {
+type ImagePromptMode = "compile" | "compiled" | "raw";
+
+function requireImageModeError(usageCommand: string): Error {
   const styles = listImageStyles();
   const message = [
-    "--style <id> or --skip-style is required",
+    "Choose one image prompt mode",
+    "",
+    "Modes:",
+    `  Compile styled prompt: ${usageCommand} --style ${styles[0]?.id ?? "<style-id>"} --prompt "..." --compile`,
+    `  Generate compiled prompt: ${usageCommand} --compiled-prompt "..."`,
+    `  Generate raw prompt: ${usageCommand} --raw-prompt "..."`,
     "",
     "Available styles:",
     formatRegistryListing(styles, "image styles"),
-    "",
-    `Examples:`,
-    `  ${usageCommand} --style ${styles[0]?.id ?? "<style-id>"} --prompt "..."`,
-    `  ${usageCommand} --skip-style --prompt "..."`,
   ].join("\n");
   return new Error(message);
 }
@@ -61,7 +66,7 @@ function unknownStyleError(id: string, usageCommand: string): Error {
     formatRegistryListing(styles, "image styles"),
     "",
     `Example:`,
-    `  ${usageCommand} --style ${styles[0]?.id ?? "<style-id>"} --prompt "..."`,
+    `  ${usageCommand} --style ${styles[0]?.id ?? "<style-id>"} --prompt "..." --compile`,
   ].join("\n");
   return new Error(message);
 }
@@ -114,13 +119,73 @@ function parseImagePromptStrength(
   return strength;
 }
 
+function resolvePromptInput(options: ImageOptions): string | undefined {
+  return options.compiledPrompt ?? options.rawPrompt ?? options.prompt;
+}
+
+function hasImagePromptModeRequest(options: ImageOptions): boolean {
+  return (
+    options.style !== undefined ||
+    options.compile === true ||
+    options.prompt !== undefined ||
+    options.compiledPrompt !== undefined ||
+    options.rawPrompt !== undefined
+  );
+}
+
+function resolveImagePromptMode(
+  options: ImageOptions,
+  usageCommand: string,
+): ImagePromptMode {
+  const hasCompiledPrompt = options.compiledPrompt !== undefined;
+  const hasRawPrompt = options.rawPrompt !== undefined;
+  const compile = options.compile === true;
+
+  if (!compile && options.style) {
+    throw new Error("--style can only be used with --compile");
+  }
+
+  if ([compile, hasCompiledPrompt, hasRawPrompt].filter(Boolean).length !== 1) {
+    throw requireImageModeError(usageCommand);
+  }
+
+  if (compile && !options.style) {
+    throw new Error("--compile requires --style <id>");
+  }
+
+  if (!compile && options.prompt !== undefined) {
+    throw new Error(
+      "--prompt can only be used with --style <id> --compile; use --compiled-prompt or --raw-prompt to generate",
+    );
+  }
+
+  if (compile) {
+    return "compile";
+  }
+  if (hasCompiledPrompt) {
+    return "compiled";
+  }
+  return "raw";
+}
+
 export function createImageGenerateCommand(
   config: ImageGenerateCommandConfig,
 ): Command {
   return new Command()
     .name(config.name)
     .description("Generate a billed image file from a prompt")
-    .option("--prompt <text>", "Image prompt; can also be piped via stdin")
+    .option(
+      "--prompt <text>",
+      "User prompt to compile with --style and --compile; can also be piped via stdin",
+    )
+    .option(
+      "--compiled-prompt <text>",
+      "Final image prompt produced from a prompt-compilation packet",
+    )
+    .option(
+      "--raw-prompt <text>",
+      "Final image prompt for unstyled/model-native generation",
+    )
     .option(
       "--provider <name>",
       "Provider: 'built-in' to run vm0's pipeline, or a connector name to get its skill-invocation guidance",
@@ -179,11 +244,11 @@ export function createImageGenerateCommand(
     )
     .option(
       "--style <id>",
-      "Image style id from the registry (see Image Styles below)",
+      "Image style id to compile from the registry (see Image Styles below)",
     )
     .option(
-      "--skip-style",
-      "Opt out of styled image generation for this invocation",
+      "--compile",
+      "Resolve the selected style and print a prompt-compilation packet",
     )
     .addHelpText("after", () => {
       const styles = listImageStyles();
@@ -192,9 +257,9 @@ Examples:
 ${config.examples}
 
 Output:
-  Prints the generated /f/ image file URL and metadata. With --style <id>,
-  prints a source-selection packet for the current agent
-  with the selected style locked in.
+  Prints the generated /f/ image file URL and metadata with --compiled-prompt
+  or --raw-prompt. With --style <id> --prompt "..." --compile, prints a
+  prompt-compilation packet for the current agent.
 
 Notes:
   - Authenticates via ZERO_TOKEN (requires file:write capability)
@@ -210,9 +275,10 @@ Models:
     megapixel, depending on the model.
 
 Options:
-  - Prompt: required, up to 32,000 characters; stdin is supported.
-  - Style: required. Pass --style <id> to generate in a registered style
-    or --skip-style to bypass styled generation entirely.
+  - Prompt modes: choose exactly one mode. Use --style <id> --prompt "..."
+    --compile to prepare a styled prompt-compilation packet, --compiled-prompt
+    to generate from an agent-compiled prompt, or --raw-prompt to generate
+    without a style. stdin is supported for --prompt in compile mode.
   - Size: gpt-image-2 accepts auto or WIDTHxHEIGHT. Popular sizes include
     1024x1024,
     1536x1024, 1024x1536, 2048x2048, 2048x1152, 3840x2160,
@@ -241,26 +307,30 @@ ${formatRegistryListing(styles, "image styles")}`;
         const dispatch = await dispatchGenerate({
           generationType: config.generationType,
           provider: options.provider,
-          prompt: options.prompt,
+          prompt: resolvePromptInput(options),
           all: options.all,
+          listOnMissingPrompt: !hasImagePromptModeRequest(options),
+          missingPromptError:
+            options.compile || options.style
+              ? "--compile requires --prompt <text> or piped stdin"
+              : undefined,
         });
         if (dispatch.outcome === "handled") return;
-        const prompt = dispatch.prompt;
+        const resolvedPrompt = dispatch.prompt;
+        const mode = resolveImagePromptMode(options, config.usageCommand);
 
-        if (options.style && options.skipStyle) {
-          throw new Error("--style and --skip-style cannot be combined");
-        }
-        if (!options.style && !options.skipStyle) {
-          throw requireStyleError(config.usageCommand);
-        }
-        if (options.style) {
-          const style = findImageStyle(options.style);
+        if (mode === "compile") {
+          const styleId = options.style;
+          if (!styleId) {
+            throw new Error("--compile requires --style <id>");
+          }
+          const style = findImageStyle(styleId);
           if (!style) {
-            throw unknownStyleError(options.style, config.usageCommand);
+            throw unknownStyleError(styleId, config.usageCommand);
           }
 
-          const packet = createStyledImageAuthoringPacket({
-            prompt,
+          const packet = createStyledImageCompilationPacket({
+            prompt: resolvedPrompt,
             style,
             details: [
               `Model preference if direct image generation is used: ${options.model}`,
@@ -292,7 +362,7 @@ ${formatRegistryListing(styles, "image styles")}`;
             ? "auto"
             : options.size;
         const result = await generateWebImage({
-          prompt,
+          prompt: resolvedPrompt,
           model: options.model,
           size,
           quality: options.quality,

--- a/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/image-style-authoring.ts
@@ -1,21 +1,18 @@
 import {
   type GenerationOutputKind,
-  type ResourceCandidateSlice,
   type RegistryEntry,
-  selectResourceCandidates,
 } from "./resource-registry";
 
-interface StyledImageAuthoringOptions {
+interface StyledImageCompilationOptions {
   readonly prompt: string;
   readonly details: readonly string[];
   readonly style: RegistryEntry;
 }
 
-interface StyledImageAuthoringPacket {
-  readonly type: "generation-source-selection";
+interface StyledImageCompilationPacket {
+  readonly type: "image-prompt-compilation";
   readonly kind: "image";
   readonly prompt: string;
-  readonly registryVersion: string;
   readonly artifact: {
     readonly outputMode: "primary-image";
     readonly primaryArtifact: {
@@ -30,14 +27,6 @@ interface StyledImageAuthoringPacket {
     readonly previewKind: "image";
     readonly outputDir: string;
   };
-  readonly selection: {
-    readonly candidates: ResourceCandidateSlice["candidates"];
-    readonly outputSchema: {
-      readonly imageStyle: "string";
-      readonly skills: "string[]";
-      readonly rationale: "string";
-    };
-  };
   readonly authoring: {
     readonly details: readonly string[];
     readonly artifactRules: readonly string[];
@@ -46,38 +35,26 @@ interface StyledImageAuthoringPacket {
   readonly instructions: string;
 }
 
-function formatCandidateSource(
-  source: ResourceCandidateSlice["sources"][number],
-): string {
+function formatStyleSource(source: RegistryEntry["source"]): readonly string[] {
   if ("repo" in source) {
-    return `- \`${source.repo}@${source.ref}\``;
+    return [
+      `- Repository: \`${source.repo}@${source.ref}\``,
+      `- Path: \`${source.path}\``,
+    ];
   }
-  return `- ${source.description}`;
+  return [`- Path: \`${source.path}\``];
 }
 
 const outputDir = "./generated/images";
 const artifactRules = [
-  "Resolve the selected style source before generating the image.",
-  "Use the style skill's referenced assets and generation path when it provides one.",
-  "Produce a single final image file and keep any temporary metadata under the output directory.",
+  "Compile the user prompt into a final image prompt before generating.",
+  "Use the style source, referenced assets, and generation path when they are available.",
+  "Generate with `--compiled-prompt`; do not pass `--style` during final image generation.",
 ] as const;
 
-export function createStyledImageAuthoringPacket(
-  options: StyledImageAuthoringOptions,
-): StyledImageAuthoringPacket {
-  const baseSlice = selectResourceCandidates();
-  const candidateSlice: ResourceCandidateSlice = {
-    ...baseSlice,
-    candidates: {
-      ...baseSlice.candidates,
-      imageStyles: [options.style],
-    },
-  };
-  const selectionSchema = {
-    imageStyle: "string",
-    skills: "string[]",
-    rationale: "string",
-  } as const;
+export function createStyledImageCompilationPacket(
+  options: StyledImageCompilationOptions,
+): StyledImageCompilationPacket {
   const artifact = {
     outputMode: "primary-image",
     primaryArtifact: {
@@ -95,47 +72,27 @@ export function createStyledImageAuthoringPacket(
     outputDir,
   } as const;
   const instructions = [
-    `# Zero generate image --style ${options.style.id}`,
+    `# Zero generate image prompt compile ${options.style.id}`,
     "",
-    "This is a federated generation source-selection packet for the current agent.",
-    "Zero is not generating this image on the server yet. The image style has already been selected by the caller — resolve it and generate the styled image.",
+    "This is an image prompt-compilation packet for the current agent.",
+    "Zero is not generating this image yet. The image style has already been selected — compile the user prompt into a final image prompt, then generate with `--compiled-prompt`.",
     "",
     "## User Prompt",
     options.prompt,
     "",
     "## Selected Image Style",
     `- \`${options.style.id}\` — ${options.style.name}`,
+    `- ${options.style.description}`,
     "",
-    "## Stage 1: Supporting Resource Selection",
-    "- The image style is locked. Optionally pick supporting skills/templates from the candidate slice below.",
-    "- Choose only IDs present in this packet; do not invent registry IDs.",
-    "- Treat the selection JSON as internal working state, then continue to generation.",
+    "## Style Source",
+    ...formatStyleSource(options.style.source),
     "",
-    "## Selection Output Schema",
-    "```json",
-    JSON.stringify(selectionSchema, null, 2),
-    "```",
-    "",
-    "## Candidate Registry Slice",
-    `Registry: \`${candidateSlice.registryVersion}\``,
-    "Sources:",
-    ...candidateSlice.sources.map(formatCandidateSource),
-    "",
-    "```json",
-    JSON.stringify(candidateSlice.candidates, null, 2),
-    "```",
-    "",
-    "## Stage 2: Resolve Selected Resources",
-    "- Fetch or read the selected resource source before generation.",
-    "- Each candidate carries a `source` object with `path` and optional `repo`/`ref`; when `repo`/`ref` are omitted, fall back to the registry-level source above.",
-    "- If `source.archive` is present, pull the private R2 archive with `zero resource pull <resource-id> --dir ./generated/resources`; the CLI requests an authenticated short-lived download URL, verifies the digest, and then extracts `source.path`.",
-    "- For directory refs, inspect the most relevant files such as `SKILL.md`, references, examples, and templates.",
-    "- If a source file cannot be fetched, state that limitation and fall back to the registry metadata for that resource.",
-    "",
-    "## Stage 3: Generate Image",
-    "- Generate one production-quality image using the selected style.",
-    "- Follow the selected style skill's generation path when it defines one.",
-    "- If the style skill delegates to a model or connector, use that flow directly instead of restating the style text manually.",
+    "## Prompt Compiler Task",
+    "- Read the selected style source when available, especially `SKILL.md`, references, examples, and templates.",
+    "- Rewrite the user prompt into one final image-generation prompt that obeys the selected style.",
+    "- Include style-specific composition, medium, palette, subject handling, reference usage, and must-avoid constraints in the final prompt.",
+    "- Keep user intent intact; expand only the visual details needed to satisfy the style.",
+    "- Return only the compiled prompt text when preparing the next command.",
     "",
     "## Artifact Output Model",
     `- Primary artifact: \`${artifact.primaryArtifact.kind}\` under \`${artifact.primaryArtifact.path}\`.`,
@@ -152,6 +109,11 @@ export function createStyledImageAuthoringPacket(
       return `- ${rule}`;
     }),
     "",
+    "## Next Command Template",
+    "```bash",
+    'zero generate image --compiled-prompt "<compiled prompt>"',
+    "```",
+    "",
     "## Verification",
     "- Verify the final image exists and is nonblank.",
     "- Check that the selected style's required reference anchors or source assets were used when applicable.",
@@ -159,15 +121,10 @@ export function createStyledImageAuthoringPacket(
   ].join("\n");
 
   return {
-    type: "generation-source-selection",
+    type: "image-prompt-compilation",
     kind: "image",
     prompt: options.prompt,
-    registryVersion: candidateSlice.registryVersion,
     artifact,
-    selection: {
-      candidates: candidateSlice.candidates,
-      outputSchema: selectionSchema,
-    },
     authoring: {
       details: options.details,
       artifactRules,

--- a/turbo/apps/cli/src/commands/zero/shared/sprite-authoring.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/sprite-authoring.ts
@@ -126,7 +126,7 @@ export function createSpriteAuthoringPacket(
     `- Output name: ${plan.name}`,
     "",
     "## Recommended Model",
-    `- Use \`${plan.model}\` for every raw sheet via built-in image generation (\`zero generate image --provider built-in --model ${plan.model} --skip-style --prompt "..."\`, or the in-context image tool).`,
+    `- Use \`${plan.model}\` for every raw sheet via built-in image generation (\`zero generate image --provider built-in --model ${plan.model} --raw-prompt "..."\`, or the in-context image tool).`,
     "- gpt-image-2 is recommended for sprite sheets: it accepts flexible WIDTHxHEIGHT sizes and high quality for crisp, evenly-spaced grids. It does not emit transparent backgrounds, which is expected here — the solid magenta background is chroma-keyed by the local processor.",
     "- Pick a sheet-friendly square or grid-aligned size (for example 1024x1024 for 2x2/3x3/4x4) so each cell stays evenly spaced.",
     "",

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -402,7 +402,7 @@ export function buildZeroHelpText(
       ? []
       : ['  Rename this chat?     zero chat rename "New title"']),
     "  List generators?       zero generate --help",
-    '  Generate image?        zero generate image --prompt "..."',
+    '  Generate image?        zero generate image --raw-prompt "..."',
     '  Generate website?      zero generate website --prompt "..."',
     '  Generate voice?        zero generate voice --prompt "..."',
     ...(canWriteHost


### PR DESCRIPTION
## Summary

- Replace the image CLI's ambiguous style/skip-style routing with explicit prompt modes: `--compile`, `--compiled-prompt`, and `--raw-prompt`.
- Convert styled image requests into a compact prompt-compilation packet that tells the agent how to compile the user prompt and which final command to run.
- Update image generation help, artifact template guidance, sprite guidance, and focused tests for the new command language.

## Verification

- `pnpm format`
- `pnpm --filter @vm0/cli lint`
- `pnpm --filter @vm0/cli check-types`
- `pnpm exec vitest run apps/cli/src/commands/zero/generate/__tests__/image.test.ts`
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/generation-template-prompt.test.ts`
- `pnpm --filter api lint`
- `git diff --check`

## Local limitations

- `pnpm --filter api check-types` exhausted local memory once with V8 OOM and once with exit 137 after retrying with `NODE_OPTIONS=--max-old-space-size=4096`.
- `pnpm exec vitest run apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts -t "generation templates"` could not complete locally because the temporary Postgres database was not migrated (`org_metadata` / `zero_agents` missing).
