### PR TITLE
fix: focus inside settings dialog on open

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -623,6 +623,18 @@ describe("zero sidebar account menu", () => {
       expect(screen.getByText("alex.rivera@example.test")).toBeInTheDocument();
     });
 
+    const openedSettingsDialog = screen.getByRole("dialog", {
+      name: "Settings",
+    });
+    await waitFor(() => {
+      const activeElement = document.activeElement;
+      expect(openedSettingsDialog).not.toHaveFocus();
+      expect(activeElement).toBeInstanceOf(HTMLElement);
+      expect(openedSettingsDialog).toContainElement(
+        activeElement as HTMLElement,
+      );
+    });
+
     click(buttonByText("Manage"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx
@@ -258,11 +258,6 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
     >
       <DialogContent
         className="zero-app flex flex-col w-[calc(100vw-2rem)] max-w-[1200px] h-[92dvh] sm:h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card"
-        onOpenAutoFocus={(event) => {
-          // Don't auto-focus the first nav item ("Preference") on open; it
-          // leaves an unwanted focus ring every time the dialog is opened.
-          event.preventDefault();
-        }}
         onInteractOutside={(event) => {
           if (isClerkModalTarget(event.target)) {
             event.preventDefault();
@@ -326,7 +321,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
                             handleSectionChange(item.id);
                           }}
                           className={cn(
-                            "flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200",
+                            "flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 focus-visible:bg-sidebar-accent focus-visible:outline-none",
                             isActive
                               ? "text-primary-foreground font-medium"
                               : "text-sidebar-foreground hover:bg-sidebar-accent",

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -45,7 +45,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          "zero-dialog-content fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] overflow-y-auto dialog-scrollable translate-x-[-50%] translate-y-[-50%] gap-4 border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg rounded-xl",
+          "zero-dialog-content fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] overflow-y-auto dialog-scrollable translate-x-[-50%] translate-y-[-50%] gap-4 border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg rounded-xl outline-none",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary

Fixes the Settings dialog opening with browser focus on the entire dialog container, which produced a blue outline around the full modal.

- Restores Radix's default dialog autofocus by removing the Settings-specific `onOpenAutoFocus.preventDefault()` override, so initial focus lands on an internal control instead of `DialogContent`.
- Adds `outline-none` to the shared dialog content primitive, matching shadcn's current DialogContent pattern and preventing native fallback outlines on the modal container.
- Adds a keyboard focus style to Settings sidebar items that matches the existing hover background.
- Extends the account menu page test to assert Settings opens with focus inside the dialog but not on the dialog root.

## Verification

- `pnpm exec prettier --write packages/ui/src/components/ui/dialog.tsx apps/platform/src/views/zero-page/components/settings/settings-dialog.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/ui check-types`
- `pnpm -F @vm0/ui lint`

Did not run a local dev server or full local vitest suite, per vm0 PR verification preference.
