### PR TITLE
chore(rust): update sentry dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2869,9 +2869,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "sentry"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1975064d9f3d9d87a7c8f0371f7fac10d876906ca3e39faad72e61c263ff9b87"
+checksum = "82719d9cd9d2686541dc49875f7944ab71348edfcc6a5686414b22ea0b6d9b29"
 dependencies = [
  "cfg_aliases",
  "sentry-core",
@@ -2880,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f552b6b147f77aeee46ece875d67a8bfc1d56fe3860d78446ed4c25bb5f9f"
+checksum = "317271b821fcca9fc661f66aa8afe93058578d05cca4bd09615fe28a16c8b4cb"
 dependencies = [
  "backtrace",
  "regex",
@@ -2891,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cff96247f4dc36867511d108709e703eb354143e7893319d763d2dd1edb4f48"
+checksum = "b8c44ee52fa3d30581f951b57aec754ef9cd70186df5fb788367804360c48097"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
@@ -2904,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de3f4a1fc77d4c57e8bacd8ef064c26aaa88ea5b2541a761d37c7c3703b9a9"
+checksum = "d47aa64170cf609b948fe8f47d2690541bde11e465daa836cf81ad6e62bb3240"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -2914,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7e78132ccfb4a1c777b959fb2944d1f6d5145bffe6be2a98ee6b25d244f72c"
+checksum = "1be93ef0435a5ab91f88178fb7681249437e875d004f996ecb35be94dc99a0e0"
 dependencies = [
  "debugid",
  "hex",


### PR DESCRIPTION
## Summary

Updated the Rust workspace lockfile in `crates/Cargo.lock`.

Resolved dependency updates:
- `sentry` `0.48.3 -> 0.48.4`
- `sentry-backtrace` `0.48.3 -> 0.48.4`
- `sentry-core` `0.48.3 -> 0.48.4`
- `sentry-panic` `0.48.3 -> 0.48.4`
- `sentry-types` `0.48.3 -> 0.48.4`

## Dependencies Not Updated

- `generic-array` remains at `0.14.7` while `0.14.9` is available. This is blocked by transitive `crypto-common v0.1.7`, which requires `generic-array = "=0.14.7"` through the `digest v0.10.7` dependency path. There is no direct workspace `Cargo.toml` dependency to safely bump for this package.

## Manual Version Bumps

None. No `Cargo.toml` files were changed.

## Verification

Passed:
- `cargo fmt --check`
- `umask 0022 && CARGO_TARGET_DIR=/home/user/workspace/vm0-rust-target-2026-07-08 TMPDIR=/home/user/workspace/t CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --workspace`

The test command uses a workspace-backed target directory and short `TMPDIR` to fit this runner's disk, memory, and Unix socket path-length constraints. It does not change the tested workspace behavior.
