### PR TITLE
fix: configure minimax codex runtime provider

### DIFF
--- a/crates/guest-agent/src/cli/child_env.rs
+++ b/crates/guest-agent/src/cli/child_env.rs
@@ -28,9 +28,10 @@ const OPTIONAL_BASE_ENV_KEYS: &[&str] = &[
 ];
 
 pub(super) fn values_for_runtime(runtime: &CliRuntimeConfig<'_>) -> Vec<(String, String)> {
+    let user_env = runtime.child_user_env();
     values_with_inputs(
         runtime.home_dir.as_ref(),
-        runtime.user_env,
+        user_env.as_ref(),
         runtime.api_url.as_ref(),
     )
 }

--- a/crates/guest-agent/src/cli/codex_app_server.rs
+++ b/crates/guest-agent/src/cli/codex_app_server.rs
@@ -48,6 +48,7 @@ pub struct CodexAppServerConfig {
     codex_home: PathBuf,
     child_env: Option<CodexAppServerChildEnv>,
     extra_env: Vec<(String, String)>,
+    config_overrides: Vec<String>,
     current_dir: Option<PathBuf>,
     opt_out_notification_methods: Vec<String>,
 }
@@ -71,6 +72,7 @@ impl CodexAppServerConfig {
             codex_home: codex_home.into(),
             child_env: None,
             extra_env: Vec::new(),
+            config_overrides: Vec::new(),
             current_dir: None,
             opt_out_notification_methods: Vec::new(),
         }
@@ -113,6 +115,16 @@ impl CodexAppServerConfig {
     /// directory from Tokio's command builder.
     pub fn with_current_dir(mut self, current_dir: impl Into<PathBuf>) -> Self {
         self.current_dir = Some(current_dir.into());
+        self
+    }
+
+    /// Add Codex root `-c key=value` startup configuration overrides.
+    pub fn with_config_overrides<I, S>(mut self, overrides: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.config_overrides = overrides.into_iter().map(Into::into).collect();
         self
     }
 
@@ -330,17 +342,17 @@ impl CodexAppServerClient {
         ));
         child_env_values.retain(|(key, _)| key != "MOCK_CODEX_FIXTURE");
         let child_env_values = child_env::normalize_values(child_env_values);
-        let args = ["app-server", "--listen", "stdio://"];
+        let args = app_server_args(&config.config_overrides);
         let binary = config.binary.to_string_lossy();
         exec_boundary::validate_process_argv_env(
             "codex app-server argv/env too large",
             &binary,
-            args,
+            args.iter().map(String::as_str),
             &child_env_values,
         )
         .map_err(CodexAppServerError::Protocol)?;
         child_env::apply_values_to_tokio_command(&mut cmd, &child_env_values);
-        cmd.args(args)
+        cmd.args(&args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -999,6 +1011,18 @@ impl CodexAppServerClient {
     }
 }
 
+fn app_server_args(config_overrides: &[String]) -> Vec<String> {
+    let mut args = Vec::with_capacity((config_overrides.len() * 2) + 3);
+    for override_value in config_overrides {
+        args.push("-c".to_string());
+        args.push(override_value.clone());
+    }
+    args.push("app-server".to_string());
+    args.push("--listen".to_string());
+    args.push("stdio://".to_string());
+    args
+}
+
 impl Drop for CodexAppServerClient {
     fn drop(&mut self) {
         if !self.closed {
@@ -1238,5 +1262,31 @@ fn bounded_error_message(message: &str) -> String {
         format!("{bounded}...")
     } else {
         bounded
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::app_server_args;
+
+    #[test]
+    fn app_server_args_put_root_config_overrides_before_subcommand() {
+        let args = app_server_args(&[
+            r#"model_provider="minimax""#.to_string(),
+            r#"model_providers.minimax.supports_websockets=false"#.to_string(),
+        ]);
+
+        let expected = [
+            "-c",
+            r#"model_provider="minimax""#,
+            "-c",
+            r#"model_providers.minimax.supports_websockets=false"#,
+            "app-server",
+            "--listen",
+            "stdio://",
+        ]
+        .map(String::from)
+        .to_vec();
+        assert_eq!(args, expected);
     }
 }

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -362,6 +362,7 @@ fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConf
             runtime.user_env,
             runtime.api_url.as_ref(),
         )
+        .with_config_overrides(runtime.codex_startup_config_overrides())
         .with_current_dir(paths::CANONICAL_WORKING_DIR)
         .with_opt_out_notification_methods(IGNORED_NOTIFICATION_METHODS.iter().copied());
     if runtime.use_mock_codex

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -437,6 +437,12 @@ fn thread_param_fields(runtime: &CliRuntimeConfig<'_>) -> Map<String, Value> {
             Value::String(runtime.openai_model.to_string()),
         );
     }
+    if let Some(provider_id) = runtime.codex_model_provider_id() {
+        params.insert(
+            "modelProvider".to_string(),
+            Value::String(provider_id.to_string()),
+        );
+    }
     if !runtime.append_system_prompt.is_empty() {
         params.insert(
             "developerInstructions".to_string(),

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -356,10 +356,11 @@ fn codex_app_server_config(runtime: &CliRuntimeConfig<'_>) -> CodexAppServerConf
         PathBuf::from("codex")
     };
     let codex_home = PathBuf::from(runtime.codex_home());
+    let child_user_env = runtime.child_user_env();
     let mut config = CodexAppServerConfig::new(binary, codex_home)
         .with_child_env(
             runtime.home_dir.as_ref(),
-            runtime.user_env,
+            child_user_env.as_ref(),
             runtime.api_url.as_ref(),
         )
         .with_config_overrides(runtime.codex_startup_config_overrides())

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -1,0 +1,236 @@
+//! Codex runtime provider configuration owned by vm0.
+//!
+//! The API resolves provider capability metadata before dispatch. The guest
+//! only translates that structured payload into Codex startup configuration.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::AgentError;
+
+const MODEL_CATALOG_FILENAME: &str = "vm0-model-catalog.json";
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct CodexRuntimeConfig {
+    pub provider_id: String,
+    pub name: String,
+    pub base_url: String,
+    pub env_key: String,
+    pub wire_api: String,
+    pub supports_websockets: bool,
+    #[serde(default)]
+    pub model_catalog: Option<serde_json::Value>,
+}
+
+pub(super) fn parse_raw(raw: &str) -> Result<Option<CodexRuntimeConfig>, AgentError> {
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    let config: CodexRuntimeConfig = serde_json::from_str(raw)?;
+    validate_config(&config)?;
+    Ok(Some(config))
+}
+
+fn validate_config(config: &CodexRuntimeConfig) -> Result<(), AgentError> {
+    if !is_codex_config_key_segment(&config.provider_id) {
+        return Err(AgentError::Execution(
+            "invalid Codex runtime provider id".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_codex_config_key_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+}
+
+pub(super) fn write_model_catalog_from_raw(home_dir: &str, raw: &str) -> Result<(), AgentError> {
+    let Some(config) = parse_raw(raw)? else {
+        return Ok(());
+    };
+    write_model_catalog(
+        &crate::codex_auth::codex_home_path(Path::new(home_dir)),
+        &config,
+    )
+}
+
+pub(super) fn model_catalog_path(codex_home: &Path) -> PathBuf {
+    codex_home.join(MODEL_CATALOG_FILENAME)
+}
+
+pub(super) fn write_model_catalog(
+    codex_home: &Path,
+    config: &CodexRuntimeConfig,
+) -> Result<(), AgentError> {
+    let Some(model_catalog) = &config.model_catalog else {
+        return Ok(());
+    };
+    std::fs::create_dir_all(codex_home)?;
+    let path = model_catalog_path(codex_home);
+    std::fs::write(path, serde_json::to_vec(model_catalog)?)?;
+    Ok(())
+}
+
+pub(super) fn startup_config_overrides(
+    config: Option<&CodexRuntimeConfig>,
+    codex_home: &Path,
+) -> Vec<String> {
+    let Some(config) = config else {
+        return Vec::new();
+    };
+    let provider_prefix = format!("model_providers.{}", config.provider_id);
+    let mut overrides = vec![
+        format!(
+            "model_provider={}",
+            quote_toml_basic_string(&config.provider_id)
+        ),
+        format!(
+            "{provider_prefix}.name={}",
+            quote_toml_basic_string(&config.name)
+        ),
+        format!(
+            "{provider_prefix}.base_url={}",
+            quote_toml_basic_string(&config.base_url)
+        ),
+        format!(
+            "{provider_prefix}.env_key={}",
+            quote_toml_basic_string(&config.env_key)
+        ),
+        format!(
+            "{provider_prefix}.wire_api={}",
+            quote_toml_basic_string(&config.wire_api)
+        ),
+        format!(
+            "{provider_prefix}.supports_websockets={}",
+            config.supports_websockets
+        ),
+    ];
+    if config.model_catalog.is_some() {
+        overrides.push(format!(
+            "model_catalog_json={}",
+            quote_toml_basic_string(&model_catalog_path(codex_home).to_string_lossy())
+        ));
+    }
+    overrides
+}
+
+pub(super) fn quote_toml_basic_string(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => quoted.push_str("\\\""),
+            '\\' => quoted.push_str("\\\\"),
+            '\n' => quoted.push_str("\\n"),
+            '\t' => quoted.push_str("\\t"),
+            '\u{08}' => quoted.push_str("\\b"),
+            '\u{0C}' => quoted.push_str("\\f"),
+            '\r' => quoted.push_str("\\r"),
+            ch if ch.is_control() => quoted.push_str(&format!("\\u{:04X}", u32::from(ch))),
+            ch => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    quoted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn startup_config_overrides_include_provider_and_catalog_path() {
+        let codex_home = Path::new("/tmp/codex-home");
+        let config = CodexRuntimeConfig {
+            provider_id: "minimax".to_string(),
+            name: "MiniMax".to_string(),
+            base_url: "https://api.minimax.io/v1".to_string(),
+            env_key: "OPENAI_API_KEY".to_string(),
+            wire_api: "responses".to_string(),
+            supports_websockets: false,
+            model_catalog: Some(json!({ "models": [{ "slug": "MiniMax-M3" }] })),
+        };
+
+        let overrides = startup_config_overrides(Some(&config), codex_home);
+
+        assert_eq!(overrides[0], r#"model_provider="minimax""#);
+        assert!(overrides.contains(&r#"model_providers.minimax.name="MiniMax""#.to_string()));
+        assert!(overrides.contains(
+            &r#"model_providers.minimax.base_url="https://api.minimax.io/v1""#.to_string()
+        ));
+        assert!(
+            overrides.contains(&r#"model_providers.minimax.env_key="OPENAI_API_KEY""#.to_string())
+        );
+        assert!(overrides.contains(&r#"model_providers.minimax.wire_api="responses""#.to_string()));
+        assert!(
+            overrides.contains(&r#"model_providers.minimax.supports_websockets=false"#.to_string())
+        );
+        assert!(overrides.contains(
+            &r#"model_catalog_json="/tmp/codex-home/vm0-model-catalog.json""#.to_string()
+        ));
+    }
+
+    #[test]
+    fn parse_raw_rejects_unsafe_provider_key_segments() {
+        let raw = r#"{
+            "providerId": "provider.with.dot",
+            "name": "Provider",
+            "baseUrl": "https://example.test/v1",
+            "envKey": "OPENAI_API_KEY",
+            "wireApi": "responses",
+            "supportsWebsockets": false
+        }"#;
+
+        let error = parse_raw(raw).unwrap_err().to_string();
+
+        assert!(error.contains("invalid Codex runtime provider id"));
+        assert!(!error.contains("provider.with.dot"));
+    }
+
+    #[test]
+    fn startup_config_overrides_use_codex_dotted_path_segments() {
+        let config = CodexRuntimeConfig {
+            provider_id: "provider-with-dash".to_string(),
+            name: "Provider".to_string(),
+            base_url: "https://example.test/v1".to_string(),
+            env_key: "OPENAI_API_KEY".to_string(),
+            wire_api: "responses".to_string(),
+            supports_websockets: false,
+            model_catalog: None,
+        };
+
+        let overrides = startup_config_overrides(Some(&config), Path::new("/tmp/codex-home"));
+
+        assert!(overrides.contains(
+            &r#"model_providers.provider-with-dash.base_url="https://example.test/v1""#.to_string()
+        ));
+        assert!(
+            !overrides
+                .iter()
+                .any(|override_value| override_value.starts_with("model_catalog_json="))
+        );
+    }
+
+    #[test]
+    fn write_model_catalog_writes_json_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = CodexRuntimeConfig {
+            provider_id: "minimax".to_string(),
+            name: "MiniMax".to_string(),
+            base_url: "https://api.minimax.io/v1".to_string(),
+            env_key: "OPENAI_API_KEY".to_string(),
+            wire_api: "responses".to_string(),
+            supports_websockets: false,
+            model_catalog: Some(json!({ "models": [{ "slug": "MiniMax-M3" }] })),
+        };
+
+        write_model_catalog(tmp.path(), &config).unwrap();
+
+        let written = std::fs::read_to_string(model_catalog_path(tmp.path())).unwrap();
+        assert_eq!(written, r#"{"models":[{"slug":"MiniMax-M3"}]}"#);
+    }
+}

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -85,7 +85,30 @@ pub(super) fn write_model_catalog(
     };
     std::fs::create_dir_all(codex_home)?;
     let path = model_catalog_path(codex_home);
-    std::fs::write(path, serde_json::to_vec(model_catalog)?)?;
+    write_model_catalog_json_atomic(codex_home, &path, &serde_json::to_vec(model_catalog)?)?;
+    Ok(())
+}
+
+fn write_model_catalog_json_atomic(
+    codex_home: &Path,
+    path: &Path,
+    serialized: &[u8],
+) -> Result<(), AgentError> {
+    use std::io::Write as _;
+
+    let mut temp = tempfile::NamedTempFile::new_in(codex_home)?;
+    temp.as_file_mut().write_all(serialized)?;
+    temp.as_file_mut().flush()?;
+    temp.persist(path).map_err(|error| {
+        AgentError::Io(std::io::Error::new(
+            error.error.kind(),
+            format!(
+                "failed to replace {} atomically: {}",
+                path.display(),
+                error.error
+            ),
+        ))
+    })?;
     Ok(())
 }
 
@@ -263,6 +286,45 @@ mod tests {
         write_model_catalog(tmp.path(), &config).unwrap();
 
         let written = std::fs::read_to_string(model_catalog_path(tmp.path())).unwrap();
+        assert_eq!(written, r#"{"models":[{"slug":"MiniMax-M3"}]}"#);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_model_catalog_replaces_existing_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_home = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_home).unwrap();
+        let symlink_target = tmp.path().join("target-catalog.json");
+        std::fs::write(&symlink_target, b"TARGET_CONTENT_MUST_SURVIVE").unwrap();
+        symlink(&symlink_target, model_catalog_path(&codex_home)).unwrap();
+        let config = CodexRuntimeConfig {
+            provider_id: "minimax".to_string(),
+            name: "MiniMax".to_string(),
+            base_url: "https://api.minimax.io/v1".to_string(),
+            env_key: "OPENAI_API_KEY".to_string(),
+            wire_api: "responses".to_string(),
+            supports_websockets: false,
+            model_catalog: Some(json!({ "models": [{ "slug": "MiniMax-M3" }] })),
+        };
+
+        write_model_catalog(&codex_home, &config).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(&symlink_target).unwrap(),
+            "TARGET_CONTENT_MUST_SURVIVE",
+            "model catalog replacement must not write through an existing symlink"
+        );
+        assert!(
+            !std::fs::symlink_metadata(model_catalog_path(&codex_home))
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "model catalog path should be a regular replacement file, not the old symlink"
+        );
+        let written = std::fs::read_to_string(model_catalog_path(&codex_home)).unwrap();
         assert_eq!(written, r#"{"models":[{"slug":"MiniMax-M3"}]}"#);
     }
 }

--- a/crates/guest-agent/src/cli/codex_runtime_config.rs
+++ b/crates/guest-agent/src/cli/codex_runtime_config.rs
@@ -37,6 +37,11 @@ fn validate_config(config: &CodexRuntimeConfig) -> Result<(), AgentError> {
             "invalid Codex runtime provider id".to_string(),
         ));
     }
+    if !is_env_var_name(&config.env_key) {
+        return Err(AgentError::Execution(
+            "invalid Codex runtime auth env key".to_string(),
+        ));
+    }
     Ok(())
 }
 
@@ -45,6 +50,16 @@ fn is_codex_config_key_segment(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+}
+
+fn is_env_var_name(value: &str) -> bool {
+    let Some(first) = value.bytes().next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == b'_')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
 }
 
 pub(super) fn write_model_catalog_from_raw(home_dir: &str, raw: &str) -> Result<(), AgentError> {
@@ -189,6 +204,23 @@ mod tests {
 
         assert!(error.contains("invalid Codex runtime provider id"));
         assert!(!error.contains("provider.with.dot"));
+    }
+
+    #[test]
+    fn parse_raw_rejects_invalid_auth_env_keys() {
+        let raw = r#"{
+            "providerId": "provider",
+            "name": "Provider",
+            "baseUrl": "https://example.test/v1",
+            "envKey": "OPENAI-API-KEY",
+            "wireApi": "responses",
+            "supportsWebsockets": false
+        }"#;
+
+        let error = parse_raw(raw).unwrap_err().to_string();
+
+        assert!(error.contains("invalid Codex runtime auth env key"));
+        assert!(!error.contains("OPENAI-API-KEY"));
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -1,8 +1,8 @@
-//! Codex auth setup boundary.
+//! Codex setup boundary.
 //!
-//! This module owns the guest-side setup wrapper that runs before
-//! `codex exec`. Auth-state file construction lives in `codex_auth`;
-//! command construction stays in `cli::command`.
+//! This module owns the guest-side setup wrapper that runs before Codex starts.
+//! Auth-state file construction lives in `codex_auth`; command construction
+//! stays in `cli::command`.
 
 use std::time::Instant;
 
@@ -14,9 +14,15 @@ use crate::env;
 use crate::error::AgentError;
 use crate::masker::SecretMasker;
 
+use super::codex_runtime_config;
+
 const LOG_TAG: &str = "sandbox:guest-agent";
 
-/// Reconcile Codex auth using the config captured during guest-agent bootstrap.
+/// Reconcile Codex runtime files using the config captured during bootstrap.
+///
+/// API-owned runtime provider metadata may write a model catalog before auth
+/// reconciliation so both `codex exec` and `codex app-server` observe the same
+/// startup config.
 ///
 /// Three mutually-exclusive states are supported:
 ///
@@ -34,6 +40,10 @@ pub async fn setup_codex_for_config(
     _masker: &SecretMasker,
     config: &env::GuestConfig,
 ) -> Result<(), AgentError> {
+    codex_runtime_config::write_model_catalog_from_raw(
+        &config.home_dir,
+        &config.codex_runtime_config,
+    )?;
     let codex_oauth_mode = config
         .user_env
         .get("CHATGPT_ACCOUNT_ID")

--- a/crates/guest-agent/src/cli/codex_setup.rs
+++ b/crates/guest-agent/src/cli/codex_setup.rs
@@ -20,9 +20,10 @@ const LOG_TAG: &str = "sandbox:guest-agent";
 
 /// Reconcile Codex runtime files using the config captured during bootstrap.
 ///
-/// API-owned runtime provider metadata may write a model catalog before auth
-/// reconciliation so both `codex exec` and `codex app-server` observe the same
-/// startup config.
+/// Auth reconciliation owns `CODEX_HOME` validation and permissions. API-owned
+/// runtime provider metadata writes the model catalog only after that boundary
+/// succeeds, before `codex exec` or `codex app-server` can observe startup
+/// config.
 ///
 /// Three mutually-exclusive states are supported:
 ///
@@ -40,10 +41,6 @@ pub async fn setup_codex_for_config(
     _masker: &SecretMasker,
     config: &env::GuestConfig,
 ) -> Result<(), AgentError> {
-    codex_runtime_config::write_model_catalog_from_raw(
-        &config.home_dir,
-        &config.codex_runtime_config,
-    )?;
     let codex_oauth_mode = config
         .user_env
         .get("CHATGPT_ACCOUNT_ID")
@@ -53,7 +50,11 @@ pub async fn setup_codex_for_config(
         .get("OPENAI_API_KEY")
         .map(String::as_str)
         .unwrap_or("");
-    setup_codex_with_values(codex_oauth_mode, &config.home_dir, api_key)
+    setup_codex_with_values(codex_oauth_mode, &config.home_dir, api_key)?;
+    codex_runtime_config::write_model_catalog_from_raw(
+        &config.home_dir,
+        &config.codex_runtime_config,
+    )
 }
 
 fn setup_codex_with_values(

--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -8,7 +8,7 @@ use crate::error::AgentError;
 use crate::{env, paths};
 use guest_common::log_info;
 
-use super::{CliRuntimeConfig, LOG_TAG};
+use super::{CliRuntimeConfig, LOG_TAG, codex_runtime_config};
 
 pub(super) fn build_cli_command_for_runtime(
     runtime: &CliRuntimeConfig<'_>,
@@ -28,18 +28,22 @@ pub(super) fn build_cli_command_for_runtime(
                 replay_user_messages,
             },
         )),
-        env::Framework::Codex => Ok(build_codex_command_with_config(
-            runtime.use_mock_codex,
-            runtime.mock_codex_path.as_ref(),
-            CodexArgsConfig {
-                model: runtime.openai_model.as_ref(),
-                openai_base_url: runtime.openai_base_url.as_ref(),
-                fast_mode: runtime.codex_fast_mode,
-                resume_id: runtime.resume_session_id.as_ref(),
-                append_system_prompt: runtime.append_system_prompt.as_ref(),
-                prompt: runtime.prompt.as_ref(),
-            },
-        )),
+        env::Framework::Codex => {
+            let startup_config_overrides = runtime.codex_startup_config_overrides();
+            Ok(build_codex_command_with_config(
+                runtime.use_mock_codex,
+                runtime.mock_codex_path.as_ref(),
+                CodexArgsConfig {
+                    model: runtime.openai_model.as_ref(),
+                    openai_base_url: runtime.openai_base_url.as_ref(),
+                    startup_config_overrides: &startup_config_overrides,
+                    fast_mode: runtime.codex_fast_mode,
+                    resume_id: runtime.resume_session_id.as_ref(),
+                    append_system_prompt: runtime.append_system_prompt.as_ref(),
+                    prompt: runtime.prompt.as_ref(),
+                },
+            ))
+        }
     }
 }
 
@@ -147,28 +151,8 @@ fn build_claude_command_with_config(
 /// Resume is a positional sub-subcommand (`codex exec resume <id> <prompt>`),
 /// not a `--resume <id>` flag. Use `--` before the prompt so user text that
 /// starts with `-` is not parsed as another codex option.
-fn quote_toml_basic_string(value: &str) -> String {
-    let mut quoted = String::with_capacity(value.len() + 2);
-    quoted.push('"');
-    for ch in value.chars() {
-        match ch {
-            '"' => quoted.push_str("\\\""),
-            '\\' => quoted.push_str("\\\\"),
-            '\u{08}' => quoted.push_str("\\b"),
-            '\t' => quoted.push_str("\\t"),
-            '\n' => quoted.push_str("\\n"),
-            '\u{0C}' => quoted.push_str("\\f"),
-            '\r' => quoted.push_str("\\r"),
-            ch if ch.is_control() => quoted.push_str(&format!("\\u{:04X}", u32::from(ch))),
-            ch => quoted.push(ch),
-        }
-    }
-    quoted.push('"');
-    quoted
-}
-
 fn build_codex_developer_instructions_config(append_system_prompt: &str) -> String {
-    let value = quote_toml_basic_string(append_system_prompt);
+    let value = codex_runtime_config::quote_toml_basic_string(append_system_prompt);
     format!("developer_instructions={value}")
 }
 
@@ -177,8 +161,15 @@ fn build_codex_memories_config() -> String {
 }
 
 fn build_codex_openai_base_url_config(openai_base_url: &str) -> String {
-    let value = quote_toml_basic_string(openai_base_url);
+    let value = codex_runtime_config::quote_toml_basic_string(openai_base_url);
     format!("openai_base_url={value}")
+}
+
+fn push_codex_config_overrides(args: &mut Vec<String>, overrides: &[String]) {
+    for override_value in overrides {
+        args.push("-c".to_string());
+        args.push(override_value.clone());
+    }
 }
 
 fn push_codex_fast_mode_configs(args: &mut Vec<String>) {
@@ -202,6 +193,7 @@ pub(super) fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'
 struct CodexArgsConfig<'a> {
     model: &'a str,
     openai_base_url: &'a str,
+    startup_config_overrides: &'a [String],
     fast_mode: bool,
     resume_id: &'a str,
     append_system_prompt: &'a str,
@@ -211,6 +203,7 @@ struct CodexArgsConfig<'a> {
 fn build_codex_args(
     model: &str,
     openai_base_url: &str,
+    startup_config_overrides: &[String],
     fast_mode: bool,
     resume_id: &str,
     append_system_prompt: &str,
@@ -229,10 +222,11 @@ fn build_codex_args(
     args.push("-c".to_string());
     args.push(build_codex_memories_config());
 
-    if !openai_base_url.is_empty() {
+    if startup_config_overrides.is_empty() && !openai_base_url.is_empty() {
         args.push("-c".to_string());
         args.push(build_codex_openai_base_url_config(openai_base_url));
     }
+    push_codex_config_overrides(&mut args, startup_config_overrides);
 
     if fast_mode {
         push_codex_fast_mode_configs(&mut args);
@@ -286,6 +280,7 @@ fn build_codex_command_with_config(
     cmd.extend(build_codex_args(
         config.model,
         config.openai_base_url,
+        config.startup_config_overrides,
         config.fast_mode,
         config.resume_id,
         config.append_system_prompt,
@@ -477,13 +472,13 @@ mod tests {
     fn build_codex_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, "", false, resume_id, "", prompt)
+        build_codex_args(model, "", &[], false, resume_id, "", prompt)
     }
 
     fn build_codex_fast_args_for_test(model: &str, resume_id: &str, prompt: &str) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, "", true, resume_id, "", prompt)
+        build_codex_args(model, "", &[], true, resume_id, "", prompt)
     }
 
     fn build_codex_args_with_base_url_for_test(
@@ -494,7 +489,17 @@ mod tests {
     ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, openai_base_url, false, resume_id, "", prompt)
+        build_codex_args(model, openai_base_url, &[], false, resume_id, "", prompt)
+    }
+
+    fn build_codex_args_with_startup_config_for_test(
+        model: &str,
+        startup_config_overrides: &[String],
+        prompt: &str,
+    ) -> Vec<String> {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
+        disable_system_log();
+        build_codex_args(model, "", startup_config_overrides, false, "", "", prompt)
     }
 
     fn build_codex_args_with_append_for_test(
@@ -505,7 +510,15 @@ mod tests {
     ) -> Vec<String> {
         let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
         disable_system_log();
-        build_codex_args(model, "", false, resume_id, append_system_prompt, prompt)
+        build_codex_args(
+            model,
+            "",
+            &[],
+            false,
+            resume_id,
+            append_system_prompt,
+            prompt,
+        )
     }
 
     fn codex_args_have_config(args: &[String], config: &str) -> bool {
@@ -526,6 +539,7 @@ mod tests {
             CodexArgsConfig {
                 model: "",
                 openai_base_url: "",
+                startup_config_overrides: &[],
                 fast_mode: false,
                 resume_id: "",
                 append_system_prompt: "",
@@ -541,7 +555,7 @@ mod tests {
         let system_log_path = tmp.path().join("system.log");
         guest_common::log::set_system_log_file(system_log_path.to_string_lossy().as_ref());
 
-        let args = build_codex_args("", "", false, "thread-secret-123", "", "prompt");
+        let args = build_codex_args("", "", &[], false, "thread-secret-123", "", "prompt");
         guest_common::log::clear_system_log_file();
         let system_log = std::fs::read_to_string(system_log_path).unwrap();
 
@@ -598,6 +612,39 @@ mod tests {
             &args,
             r#"openai_base_url="https://api.minimax.io/v1""#
         ));
+    }
+
+    #[test]
+    fn build_codex_args_with_structured_runtime_config() {
+        let overrides = vec![
+            r#"model_provider="minimax""#.to_string(),
+            r#"model_providers.minimax.supports_websockets=false"#.to_string(),
+            r#"model_catalog_json="/home/user/.codex/vm0-model-catalog.json""#.to_string(),
+        ];
+        let args = build_codex_args_with_startup_config_for_test("MiniMax-M3", &overrides, "p");
+
+        for override_value in overrides {
+            assert!(codex_args_have_config(&args, &override_value));
+        }
+        assert!(!args.iter().any(|arg| arg.starts_with("openai_base_url=")));
+    }
+
+    #[test]
+    fn build_codex_args_prefers_structured_runtime_config_over_openai_base_url() {
+        let _guard = SYSTEM_LOG_TEST_MUTEX.lock().unwrap();
+        disable_system_log();
+        let args = build_codex_args(
+            "MiniMax-M3",
+            "https://api.minimax.io/v1",
+            &[r#"model_provider="minimax""#.to_string()],
+            false,
+            "",
+            "",
+            "p",
+        );
+
+        assert!(codex_args_have_config(&args, r#"model_provider="minimax""#));
+        assert!(!args.iter().any(|arg| arg.starts_with("openai_base_url=")));
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -63,6 +63,7 @@ use tokio::sync::oneshot;
 use tokio::time::Sleep;
 
 const LOG_TAG: &str = "sandbox:guest-agent";
+const OPENAI_BASE_URL_ENV_KEY: &str = "OPENAI_BASE_URL";
 
 #[derive(serde::Serialize)]
 struct ClaudeUserFrame<'a> {
@@ -321,7 +322,10 @@ impl<'a> CliRuntimeConfig<'a> {
             api_start_time: Cow::Borrowed(&config.api_start_time),
             anthropic_model: Cow::Borrowed(user_env_value(&config.user_env, "ANTHROPIC_MODEL")),
             openai_model: Cow::Borrowed(user_env_value(&config.user_env, "OPENAI_MODEL")),
-            openai_base_url: Cow::Borrowed(user_env_value(&config.user_env, "OPENAI_BASE_URL")),
+            openai_base_url: Cow::Borrowed(user_env_value(
+                &config.user_env,
+                OPENAI_BASE_URL_ENV_KEY,
+            )),
             codex_runtime_config,
             codex_oauth_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty(),
             codex_fast_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty()
@@ -356,6 +360,17 @@ impl<'a> CliRuntimeConfig<'a> {
         self.codex_runtime_config
             .as_ref()
             .map(|config| config.provider_id.as_str())
+    }
+
+    fn child_user_env(&self) -> Cow<'_, HashMap<String, String>> {
+        if self.codex_runtime_config.is_none()
+            || !self.user_env.contains_key(OPENAI_BASE_URL_ENV_KEY)
+        {
+            return Cow::Borrowed(self.user_env);
+        }
+        let mut user_env = self.user_env.clone();
+        user_env.remove(OPENAI_BASE_URL_ENV_KEY);
+        Cow::Owned(user_env)
     }
 }
 
@@ -1354,8 +1369,8 @@ mod tests {
     use super::termination::{CliTerminationRuntime, PostResultCleanupPolicy};
     use super::{
         CliExitObservation, CliFailureDiagnostic, CliRuntimeConfig, child_env,
-        claude_initial_prompt_frame, codex_home_for_home_dir, command, exec_boundary,
-        record_cli_exit, select_failure_diagnostic, set_cli_current_dir,
+        claude_initial_prompt_frame, codex_home_for_home_dir, codex_runtime_config, command,
+        exec_boundary, record_cli_exit, select_failure_diagnostic, set_cli_current_dir,
         with_carried_failure_reason,
     };
     use crate::active_input::ActiveInputRuntime;
@@ -1474,6 +1489,63 @@ mod tests {
             &env_values,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn legacy_codex_child_env_keeps_openai_base_url_without_structured_runtime_config() {
+        let user_env = HashMap::from([
+            ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
+            ("OPENAI_MODEL".to_string(), "gpt-5".to_string()),
+            (
+                "OPENAI_BASE_URL".to_string(),
+                "https://api.legacy-provider.test/v1".to_string(),
+            ),
+        ]);
+        let runtime =
+            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
+
+        let env_values = child_env::values_for_runtime(&runtime);
+
+        assert!(env_values.iter().any(|(key, value)| {
+            key == "OPENAI_BASE_URL" && value == "https://api.legacy-provider.test/v1"
+        }));
+    }
+
+    #[test]
+    fn structured_codex_runtime_config_omits_legacy_openai_base_url_from_child_env() {
+        let user_env = HashMap::from([
+            ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
+            ("OPENAI_MODEL".to_string(), "MiniMax-M3".to_string()),
+            (
+                "OPENAI_BASE_URL".to_string(),
+                "https://api.should-not-win.test/v1".to_string(),
+            ),
+        ]);
+        let mut runtime =
+            runtime_for_exec_boundary_test(env::Framework::Codex, "prompt", "", false, &user_env);
+        runtime.codex_runtime_config = Some(codex_runtime_config::CodexRuntimeConfig {
+            provider_id: "minimax".to_string(),
+            name: "MiniMax".to_string(),
+            base_url: "https://api.minimax.io/v1".to_string(),
+            env_key: "OPENAI_API_KEY".to_string(),
+            wire_api: "responses".to_string(),
+            supports_websockets: false,
+            model_catalog: None,
+        });
+
+        let env_values = child_env::values_for_runtime(&runtime);
+
+        assert!(
+            env_values
+                .iter()
+                .any(|(key, value)| { key == "OPENAI_API_KEY" && value == "sk-test" })
+        );
+        assert!(
+            env_values
+                .iter()
+                .any(|(key, value)| { key == "OPENAI_MODEL" && value == "MiniMax-M3" })
+        );
+        assert!(!env_values.iter().any(|(key, _)| key == "OPENAI_BASE_URL"));
     }
 
     #[test]

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -351,6 +351,12 @@ impl<'a> CliRuntimeConfig<'a> {
             Path::new(&codex_home),
         )
     }
+
+    fn codex_model_provider_id(&self) -> Option<&str> {
+        self.codex_runtime_config
+            .as_ref()
+            .map(|config| config.provider_id.as_str())
+    }
 }
 
 fn codex_home_for_home_dir(home_dir: &str) -> String {

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -21,6 +21,7 @@ mod child_env;
 pub mod codex_app_server;
 mod codex_app_server_backend;
 mod codex_app_server_events;
+mod codex_runtime_config;
 mod codex_setup;
 mod command;
 mod diagnostics;
@@ -279,6 +280,7 @@ pub(super) struct CliRuntimeConfig<'a> {
     anthropic_model: Cow<'a, str>,
     openai_model: Cow<'a, str>,
     openai_base_url: Cow<'a, str>,
+    codex_runtime_config: Option<codex_runtime_config::CodexRuntimeConfig>,
     codex_oauth_mode: bool,
     codex_fast_mode: bool,
     stuck_tool_timeout_secs: u64,
@@ -291,8 +293,16 @@ pub(super) struct CliRuntimeConfig<'a> {
 }
 
 impl<'a> CliRuntimeConfig<'a> {
-    fn from_config(config: &'a env::GuestConfig, paths: &'a paths::GuestPaths) -> Self {
-        Self {
+    fn from_config(
+        config: &'a env::GuestConfig,
+        paths: &'a paths::GuestPaths,
+    ) -> Result<Self, AgentError> {
+        let codex_runtime_config = if matches!(config.framework, env::Framework::Codex) {
+            codex_runtime_config::parse_raw(&config.codex_runtime_config)?
+        } else {
+            None
+        };
+        Ok(Self {
             framework: config.framework,
             run_id: Cow::Borrowed(&config.run_id),
             prompt: Cow::Borrowed(&config.prompt),
@@ -312,6 +322,7 @@ impl<'a> CliRuntimeConfig<'a> {
             anthropic_model: Cow::Borrowed(user_env_value(&config.user_env, "ANTHROPIC_MODEL")),
             openai_model: Cow::Borrowed(user_env_value(&config.user_env, "OPENAI_MODEL")),
             openai_base_url: Cow::Borrowed(user_env_value(&config.user_env, "OPENAI_BASE_URL")),
+            codex_runtime_config,
             codex_oauth_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty(),
             codex_fast_mode: !user_env_value(&config.user_env, "CHATGPT_ACCOUNT_ID").is_empty()
                 && user_env_value(&config.user_env, "VM0_CODEX_SERVICE_TIER") == "fast",
@@ -326,11 +337,19 @@ impl<'a> CliRuntimeConfig<'a> {
             session_history_path_file: Cow::Borrowed(paths.session_history_path_file()),
             event_error_flag: Cow::Borrowed(paths.event_error_flag()),
             user_env: &config.user_env,
-        }
+        })
     }
 
     fn codex_home(&self) -> String {
         codex_home_for_home_dir(self.home_dir.as_ref())
+    }
+
+    fn codex_startup_config_overrides(&self) -> Vec<String> {
+        let codex_home = self.codex_home();
+        codex_runtime_config::startup_config_overrides(
+            self.codex_runtime_config.as_ref(),
+            Path::new(&codex_home),
+        )
     }
 }
 
@@ -481,7 +500,7 @@ pub async fn execute_cli_with_active_input_for_config(
     config: &env::GuestConfig,
     paths: &paths::GuestPaths,
 ) -> Result<CliExecutionResult, AgentError> {
-    let runtime = CliRuntimeConfig::from_config(config, paths);
+    let runtime = CliRuntimeConfig::from_config(config, paths)?;
     execute_cli_inner(masker, heartbeat_monitor, http, active_input, &runtime).await
 }
 
@@ -1369,6 +1388,7 @@ mod tests {
             anthropic_model: Cow::Borrowed(""),
             openai_model: Cow::Borrowed(""),
             openai_base_url: Cow::Borrowed(""),
+            codex_runtime_config: None,
             codex_oauth_mode: false,
             codex_fast_mode: false,
             stuck_tool_timeout_secs: constants::STUCK_TOOL_TIMEOUT_SECS,

--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -242,6 +242,7 @@ pub struct GuestConfig {
     pub home_dir: String,
     pub artifacts: Vec<ArtifactEnv>,
     pub feature_flags: String,
+    pub codex_runtime_config: String,
     pub stuck_tool_timeout_secs: u64,
     pub post_result_sigterm_grace: Duration,
     pub post_result_total_cap: Duration,
@@ -306,6 +307,7 @@ impl GuestConfig {
             home_dir,
             artifacts,
             feature_flags: payload.feature_flags,
+            codex_runtime_config: payload.codex_runtime_config,
             stuck_tool_timeout_secs: u64_value_or(
                 guest_contracts::env::STUCK_TOOL_TIMEOUT_SECS_ENV,
                 non_empty(&raw.stuck_tool_timeout_secs),
@@ -832,6 +834,7 @@ mod tests {
                 r#"[{"name":"artifact","mountPath":"/mnt/a","storageId":"storage","versionId":"v1"}]"#
                     .to_string(),
             feature_flags: r#"{"flag":true}"#.to_string(),
+            codex_runtime_config: r#"{"providerId":"minimax"}"#.to_string(),
         };
         let path = write_run_payload_fixture(&runtime_dir, &payload);
         let parent = path.parent().unwrap().to_path_buf();
@@ -852,6 +855,7 @@ mod tests {
         assert_eq!(config.settings, "{}");
         assert_eq!(config.artifacts.len(), 1);
         assert_eq!(config.feature_flags, r#"{"flag":true}"#);
+        assert_eq!(config.codex_runtime_config, r#"{"providerId":"minimax"}"#);
         assert!(!path.exists());
         assert!(!parent.exists());
     }

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -295,16 +295,13 @@ async fn execute(
     }
     record_sandbox_op("working_dir_setup", wd_start.elapsed(), true, None);
 
-    // Codex auth reconciliation must complete before the CLI starts. On reused
-    // sandboxes, continuing after a setup failure can inherit stale auth state
+    // Codex setup must complete before the CLI starts. On reused sandboxes,
+    // continuing after a setup failure can inherit stale auth or runtime state
     // from an earlier run.
     if matches!(config.framework, env::Framework::Codex)
         && let Err(e) = cli::setup_codex_for_config(masker, config).await
     {
-        let msg = format!(
-            "Codex auth setup failed: {}",
-            masker.mask_string(&e.to_string())
-        );
+        let msg = format!("Codex setup failed: {}", masker.mask_string(&e.to_string()));
         log_error!(LOG_TAG, "{msg}");
         write_guest_error_file(runtime_paths.checkpoint_error_file(), &msg);
         write_guest_failure_diagnostic(

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -7,6 +7,7 @@ mod common;
 
 use guest_agent::masker::SecretMasker;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::time::Duration;
 
 #[tokio::test]
@@ -14,17 +15,48 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
 -> Result<(), Box<dyn std::error::Error>> {
     let mock = common::build_and_locate_mock_codex()?;
     let tmp = tempfile::tempdir()?;
+    let run_id = "codex-app-server-backend-test";
+    let prompt = "drive the app-server backend";
 
     unsafe {
         common::setup_codex_app_server_env(
             &mock,
             tmp.path(),
             common::CodexAppServerEnvConfig {
-                run_id: "codex-app-server-backend-test",
-                prompt: "drive the app-server backend",
+                run_id,
+                prompt,
                 scenario: Some("runtime-turn-complete-without-thread-started"),
                 resume_session_id: None,
             },
+        )?;
+        let runtime_dir = guest_contracts::runtime_paths::run_dir_for_home(tmp.path(), run_id)
+            .map_err(|error| format!("resolve runtime dir: {error}"))?;
+        common::set_run_payload_file_env_for_test(
+            &runtime_dir,
+            &guest_contracts::env::RunPayload {
+                prompt: prompt.to_string(),
+                codex_runtime_config: r#"{
+                    "providerId": "minimax",
+                    "name": "MiniMax",
+                    "baseUrl": "https://api.minimax.io/v1",
+                    "envKey": "OPENAI_API_KEY",
+                    "wireApi": "responses",
+                    "supportsWebsockets": false
+                }"#
+                .to_string(),
+                ..guest_contracts::env::RunPayload::default()
+            },
+        )?;
+        common::set_user_env_file_env_for_test(
+            &runtime_dir,
+            &HashMap::from([
+                ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
+                ("OPENAI_MODEL".to_string(), "MiniMax-M3".to_string()),
+                (
+                    "OPENAI_BASE_URL".to_string(),
+                    "https://api.should-not-win.test/v1".to_string(),
+                ),
+            ]),
         )?;
     }
     let runtime = common::guest_runtime_from_process_env()?;
@@ -74,6 +106,18 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
             .get("thread_request_has_runtime_workspace_roots")
             .and_then(Value::as_bool),
         Some(false)
+    );
+    assert_eq!(
+        input_event
+            .get("thread_request_model")
+            .and_then(Value::as_str),
+        Some("MiniMax-M3")
+    );
+    assert_eq!(
+        input_event
+            .get("thread_request_model_provider")
+            .and_then(Value::as_str),
+        Some("minimax")
     );
     assert_eq!(
         input_event

--- a/crates/guest-agent/tests/codex_app_server_backend.rs
+++ b/crates/guest-agent/tests/codex_app_server_backend.rs
@@ -119,6 +119,11 @@ async fn codex_app_server_backend_runs_initial_turn_and_synthesizes_thread_start
             .and_then(Value::as_str),
         Some("minimax")
     );
+    assert!(
+        input_event
+            .get("child_env_openai_base_url")
+            .is_some_and(Value::is_null)
+    );
     assert_eq!(
         input_event
             .get("turn_request_has_runtime_workspace_roots")

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -8,7 +8,7 @@ mod common;
 use guest_contracts::diagnostics::{FailureClass, FailureDiagnostic};
 use shell_quote::quote_shell_arg;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Output};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
@@ -31,24 +31,13 @@ fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
         },
     )?;
 
-    let guest_agent = env!("CARGO_BIN_EXE_guest-agent");
-    let output = Command::new(guest_agent)
-        .env_clear()
-        .env("CLI_AGENT_TYPE", "codex")
-        .env("USE_MOCK_CODEX", "true")
-        .env("VM0_MOCK_CODEX_PATH", &fake_codex)
-        .env("VM0_RUN_ID", "codex-auth-setup-fail-closed")
-        .env(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, run_payload_path)
-        .env("VM0_API_URL", "http://127.0.0.1:1")
-        .env("VM0_API_TOKEN", "")
-        .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")
-        .env("VM0_SANDBOX_REUSE_RESULT", "reused")
-        .env(
-            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
-            &runtime_dir,
-        )
-        .env("HOME", tmp.path())
-        .output()?;
+    let output = run_guest_agent(GuestAgentInvocation {
+        fake_codex: &fake_codex,
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-auth-setup-fail-closed",
+    })?;
 
     assert!(
         !output.status.success(),
@@ -72,6 +61,103 @@ fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
     assert_eq!(diagnostic.failure_class, FailureClass::CliExecutionError);
 
     Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_setup_rejects_symlinked_home_before_model_catalog_write() -> TestResult {
+    common::ensure_canonical_workspace_for_test()?;
+
+    let tmp = tempfile::tempdir()?;
+    let fake_codex = tmp.path().join("codex");
+    let invoked_marker = tmp.path().join("codex-invoked");
+    let runtime_dir = tmp.path().join("runtime");
+    let target_codex_home = tmp.path().join("target-codex-home");
+    std::fs::create_dir_all(&target_codex_home)?;
+    std::os::unix::fs::symlink(&target_codex_home, tmp.path().join(".codex"))?;
+    write_fake_codex(&fake_codex, &invoked_marker)?;
+    let run_payload_path = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "should not reach codex".to_string(),
+            codex_runtime_config: serde_json::json!({
+                "providerId": "minimax",
+                "name": "MiniMax",
+                "baseUrl": "https://api.minimax.io/v1",
+                "envKey": "OPENAI_API_KEY",
+                "wireApi": "responses",
+                "supportsWebsockets": false,
+                "modelCatalog": {
+                    "models": [{ "slug": "MiniMax-M3" }],
+                },
+            })
+            .to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )?;
+
+    let output = run_guest_agent(GuestAgentInvocation {
+        fake_codex: &fake_codex,
+        runtime_dir: &runtime_dir,
+        run_payload_path: &run_payload_path,
+        home: tmp.path(),
+        run_id: "codex-auth-setup-symlink-fail-closed",
+    })?;
+
+    assert!(
+        !output.status.success(),
+        "guest-agent should fail when Codex setup rejects symlinked CODEX_HOME"
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        !invoked_marker.exists(),
+        "guest-agent must not launch Codex after setup fails"
+    );
+    assert!(
+        !target_codex_home.join("vm0-model-catalog.json").exists(),
+        "Codex setup must not write model catalog through symlinked CODEX_HOME"
+    );
+
+    let error_path = guest_contracts::runtime_paths::checkpoint_error_file(&runtime_dir);
+    let error = std::fs::read_to_string(error_path)?;
+    assert!(
+        error.contains("Codex setup failed"),
+        "guest error should describe Codex setup failure: {error}"
+    );
+
+    Ok(())
+}
+
+struct GuestAgentInvocation<'a> {
+    fake_codex: &'a Path,
+    runtime_dir: &'a Path,
+    run_payload_path: &'a Path,
+    home: &'a Path,
+    run_id: &'a str,
+}
+
+fn run_guest_agent(args: GuestAgentInvocation<'_>) -> Result<Output, std::io::Error> {
+    let guest_agent = env!("CARGO_BIN_EXE_guest-agent");
+    Command::new(guest_agent)
+        .env_clear()
+        .env("CLI_AGENT_TYPE", "codex")
+        .env("USE_MOCK_CODEX", "true")
+        .env("VM0_MOCK_CODEX_PATH", args.fake_codex)
+        .env("VM0_RUN_ID", args.run_id)
+        .env(
+            guest_contracts::env::RUN_PAYLOAD_FILE_ENV,
+            args.run_payload_path,
+        )
+        .env("VM0_API_URL", "http://127.0.0.1:1")
+        .env("VM0_API_TOKEN", "")
+        .env("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc")
+        .env("VM0_SANDBOX_REUSE_RESULT", "reused")
+        .env(
+            guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
+            args.runtime_dir,
+        )
+        .env("HOME", args.home)
+        .output()
 }
 
 fn write_fake_codex(path: &Path, marker: &Path) -> TestResult {

--- a/crates/guest-agent/tests/codex_setup_fail_closed.rs
+++ b/crates/guest-agent/tests/codex_setup_fail_closed.rs
@@ -1,4 +1,4 @@
-//! Codex auth setup failures should stop before launching the CLI.
+//! Codex setup failures should stop before launching the CLI.
 //!
 //! This test uses the real guest-agent binary because the fail-closed boundary
 //! lives in `main.rs`, not in the public `cli::setup_codex` helper.
@@ -13,7 +13,7 @@ use std::process::Command;
 type TestResult = Result<(), Box<dyn std::error::Error>>;
 
 #[test]
-fn codex_auth_setup_failure_exits_before_cli_spawn() -> TestResult {
+fn codex_setup_failure_exits_before_cli_spawn() -> TestResult {
     common::ensure_canonical_workspace_for_test()?;
 
     let tmp = tempfile::tempdir()?;
@@ -52,19 +52,19 @@ fn codex_auth_setup_failure_exits_before_cli_spawn() -> TestResult {
 
     assert!(
         !output.status.success(),
-        "guest-agent should fail when Codex auth setup cannot reconcile"
+        "guest-agent should fail when Codex setup cannot reconcile"
     );
     assert_eq!(output.status.code(), Some(1));
     assert!(
         !invoked_marker.exists(),
-        "guest-agent must not launch Codex after auth setup fails"
+        "guest-agent must not launch Codex after setup fails"
     );
 
     let error_path = guest_contracts::runtime_paths::checkpoint_error_file(&runtime_dir);
     let error = std::fs::read_to_string(error_path)?;
     assert!(
-        error.contains("Codex auth setup failed"),
-        "guest error should describe Codex auth setup failure: {error}"
+        error.contains("Codex setup failed"),
+        "guest error should describe Codex setup failure: {error}"
     );
 
     let diagnostic_path = guest_contracts::runtime_paths::failure_diagnostic_file(&runtime_dir);

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -21,6 +21,7 @@ mod system_log;
 
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::io;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
@@ -530,6 +531,26 @@ pub unsafe fn set_run_payload_file_env_for_test(
     let path = write_run_payload_file_for_test(runtime_dir, payload)?;
     unsafe {
         std::env::set_var(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, path);
+    }
+    Ok(())
+}
+
+/// Write model-provider/user environment and expose it through process env.
+///
+/// # Safety
+/// Call before any other test thread reads process environment.
+pub unsafe fn set_user_env_file_env_for_test(
+    runtime_dir: &Path,
+    user_env: &HashMap<String, String>,
+) -> Result<(), String> {
+    let dir = runtime_dir.join("user-env");
+    std::fs::create_dir_all(&dir).map_err(|error| format!("create user env dir: {error}"))?;
+    let path = dir.join("env.json");
+    let bytes =
+        serde_json::to_vec(user_env).map_err(|error| format!("serialize user env: {error}"))?;
+    std::fs::write(&path, bytes).map_err(|error| format!("write user env: {error}"))?;
+    unsafe {
+        std::env::set_var(guest_contracts::env::USER_ENV_FILE_ENV, path);
     }
     Ok(())
 }

--- a/crates/guest-contracts/src/env.rs
+++ b/crates/guest-contracts/src/env.rs
@@ -139,6 +139,9 @@ pub const ARTIFACTS_ENV: &str = "VM0_ARTIFACTS";
 /// Unset or empty means there are no feature flags.
 pub const FEATURE_FLAGS_ENV: &str = "VM0_FEATURE_FLAGS";
 
+/// Logical run-payload field name for API-owned Codex runtime metadata.
+pub const CODEX_RUNTIME_CONFIG_ENV: &str = "VM0_CODEX_RUNTIME_CONFIG";
+
 /// Runner-owned variable-length run payload sent through
 /// [`RUN_PAYLOAD_FILE_ENV`].
 ///
@@ -169,6 +172,9 @@ pub struct RunPayload {
     /// JSON map of feature flag names to enabled states.
     #[serde(default)]
     pub feature_flags: String,
+    /// JSON object describing API-owned Codex provider/runtime metadata.
+    #[serde(default)]
+    pub codex_runtime_config: String,
 }
 
 /// Borrowed logical string field from [`RunPayload`].
@@ -182,7 +188,7 @@ pub struct RunPayloadField<'a> {
 
 impl RunPayload {
     /// Return all logical string fields carried by this run payload.
-    pub fn fields(&self) -> [RunPayloadField<'_>; 8] {
+    pub fn fields(&self) -> [RunPayloadField<'_>; 9] {
         let Self {
             prompt,
             append_system_prompt,
@@ -192,6 +198,7 @@ impl RunPayload {
             settings,
             artifacts,
             feature_flags,
+            codex_runtime_config,
         } = self;
 
         [
@@ -226,6 +233,10 @@ impl RunPayload {
             RunPayloadField {
                 name: FEATURE_FLAGS_ENV,
                 value: feature_flags,
+            },
+            RunPayloadField {
+                name: CODEX_RUNTIME_CONFIG_ENV,
+                value: codex_runtime_config,
             },
         ]
     }
@@ -408,6 +419,7 @@ mod tests {
             settings: "{}".to_string(),
             artifacts: "[]".to_string(),
             feature_flags: r#"{"flag":true}"#.to_string(),
+            codex_runtime_config: r#"{"providerId":"minimax"}"#.to_string(),
         };
 
         let json = serde_json::to_value(&payload).unwrap();
@@ -417,6 +429,7 @@ mod tests {
         assert_eq!(json["secretValues"], "secret");
         assert_eq!(json["disallowedTools"], "WebFetch");
         assert_eq!(json["featureFlags"], r#"{"flag":true}"#);
+        assert_eq!(json["codexRuntimeConfig"], r#"{"providerId":"minimax"}"#);
     }
 
     #[test]
@@ -430,6 +443,7 @@ mod tests {
             settings: "{}".to_string(),
             artifacts: "[]".to_string(),
             feature_flags: r#"{"flag":true}"#.to_string(),
+            codex_runtime_config: r#"{"providerId":"minimax"}"#.to_string(),
         };
 
         let fields = payload.fields();
@@ -469,6 +483,10 @@ mod tests {
                     name: FEATURE_FLAGS_ENV,
                     value: r#"{"flag":true}"#
                 },
+                RunPayloadField {
+                    name: CODEX_RUNTIME_CONFIG_ENV,
+                    value: r#"{"providerId":"minimax"}"#
+                },
             ]
         );
     }
@@ -494,6 +512,7 @@ mod tests {
             settings: "{}".to_string(),
             artifacts: "[]".to_string(),
             feature_flags: r#"{"flag":true}"#.to_string(),
+            codex_runtime_config: r#"{"providerId":"minimax"}"#.to_string(),
         };
 
         assert_eq!(payload.first_nul_field(), None);

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -996,6 +996,7 @@ fn persist_input_events(context: &InputEventContext<'_>, inputs: &[String]) -> i
                 "child_env_api_url": std::env::var("VM0_API_URL").ok(),
                 "child_env_custom_user_env": std::env::var("CUSTOM_USER_ENV").ok(),
                 "child_env_openai_model": std::env::var("OPENAI_MODEL").ok(),
+                "child_env_openai_base_url": std::env::var("OPENAI_BASE_URL").ok(),
             })
         })
         .collect::<Vec<_>>();

--- a/crates/guest-mock-codex/src/app_server.rs
+++ b/crates/guest-mock-codex/src/app_server.rs
@@ -161,6 +161,8 @@ struct AppServerThread {
     artifact_thread_id: String,
     active_turn_id: Option<String>,
     thread_request_has_runtime_workspace_roots: bool,
+    thread_request_model: Option<String>,
+    thread_request_model_provider: Option<String>,
 }
 
 impl AppServerState {
@@ -293,6 +295,8 @@ impl AppServerState {
                 self.set_current_thread(
                     thread_id.clone(),
                     params.get("runtimeWorkspaceRoots").is_some(),
+                    string_param(params, "model").map(str::to_string),
+                    string_param(params, "modelProvider").map(str::to_string),
                 );
                 let response_thread_id = if self.scenario == Scenario::ThreadStartInvalidThreadId {
                     "not-a-valid-codex-thread-id"
@@ -388,6 +392,8 @@ impl AppServerState {
                 self.set_current_thread(
                     thread_id.to_string(),
                     params.get("runtimeWorkspaceRoots").is_some(),
+                    string_param(params, "model").map(str::to_string),
+                    string_param(params, "modelProvider").map(str::to_string),
                 );
                 let response_thread_id = if self.scenario == Scenario::ResumeDifferentThreadId {
                     "0193abcd-ef01-7234-89ab-cdef01234568"
@@ -426,6 +432,9 @@ impl AppServerState {
                 let artifact_thread_id = current_thread.artifact_thread_id.clone();
                 let thread_request_has_runtime_workspace_roots =
                     current_thread.thread_request_has_runtime_workspace_roots;
+                let thread_request_model = current_thread.thread_request_model.clone();
+                let thread_request_model_provider =
+                    current_thread.thread_request_model_provider.clone();
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -444,13 +453,17 @@ impl AppServerState {
                 }
                 self.initial_inputs.extend(inputs.iter().cloned());
                 persist_input_events(
-                    &artifact_thread_id,
-                    &thread_id,
-                    &turn_id,
-                    "initial",
+                    &InputEventContext {
+                        artifact_thread_id: &artifact_thread_id,
+                        thread_id: &thread_id,
+                        turn_id: &turn_id,
+                        kind: "initial",
+                        thread_request_has_runtime_workspace_roots,
+                        thread_request_model: thread_request_model.as_deref(),
+                        thread_request_model_provider: thread_request_model_provider.as_deref(),
+                        turn_params: params,
+                    },
                     &inputs,
-                    thread_request_has_runtime_workspace_roots,
-                    params,
                 )?;
                 write_success(output, id, json!({ "turn": turn(&turn_id) }))?;
                 if self.scenario == Scenario::UnexpectedThreadTurnCompleted {
@@ -522,6 +535,9 @@ impl AppServerState {
                 let artifact_thread_id = current_thread.artifact_thread_id.clone();
                 let thread_request_has_runtime_workspace_roots =
                     current_thread.thread_request_has_runtime_workspace_roots;
+                let thread_request_model = current_thread.thread_request_model.clone();
+                let thread_request_model_provider =
+                    current_thread.thread_request_model_provider.clone();
                 let inputs = match text_inputs(params) {
                     Ok(inputs) => inputs,
                     Err(message) => {
@@ -531,13 +547,17 @@ impl AppServerState {
                 };
                 self.steered_inputs.extend(inputs.iter().cloned());
                 persist_input_events(
-                    &artifact_thread_id,
-                    &thread_id,
-                    &active_turn_id,
-                    "steered",
+                    &InputEventContext {
+                        artifact_thread_id: &artifact_thread_id,
+                        thread_id: &thread_id,
+                        turn_id: &active_turn_id,
+                        kind: "steered",
+                        thread_request_has_runtime_workspace_roots,
+                        thread_request_model: thread_request_model.as_deref(),
+                        thread_request_model_provider: thread_request_model_provider.as_deref(),
+                        turn_params: params,
+                    },
                     &inputs,
-                    thread_request_has_runtime_workspace_roots,
-                    params,
                 )?;
                 if self.scenario == Scenario::RuntimeTurnCompleteBeforeSteerResponse {
                     write_turn_completion_notifications(output, &thread_id, &active_turn_id)?;
@@ -638,6 +658,8 @@ impl AppServerState {
         &mut self,
         thread_id: String,
         thread_request_has_runtime_workspace_roots: bool,
+        thread_request_model: Option<String>,
+        thread_request_model_provider: Option<String>,
     ) {
         let artifact_thread_id = self
             .session_artifact_thread_ids
@@ -649,6 +671,8 @@ impl AppServerState {
             artifact_thread_id,
             active_turn_id: None,
             thread_request_has_runtime_workspace_roots,
+            thread_request_model,
+            thread_request_model_provider,
         });
     }
 
@@ -938,31 +962,36 @@ fn text_inputs(params: &Value) -> Result<Vec<String>, String> {
     Ok(inputs)
 }
 
-fn persist_input_events(
-    artifact_thread_id: &str,
-    thread_id: &str,
-    turn_id: &str,
-    kind: &str,
-    inputs: &[String],
+struct InputEventContext<'a> {
+    artifact_thread_id: &'a str,
+    thread_id: &'a str,
+    turn_id: &'a str,
+    kind: &'a str,
     thread_request_has_runtime_workspace_roots: bool,
-    turn_params: &Value,
-) -> io::Result<()> {
+    thread_request_model: Option<&'a str>,
+    thread_request_model_provider: Option<&'a str>,
+    turn_params: &'a Value,
+}
+
+fn persist_input_events(context: &InputEventContext<'_>, inputs: &[String]) -> io::Result<()> {
     let events = inputs
         .iter()
         .map(|text| {
             json!({
                 "type": "mock.app_server.input",
-                "kind": kind,
-                "thread_id": thread_id,
-                "turn_id": turn_id,
+                "kind": context.kind,
+                "thread_id": context.thread_id,
+                "turn_id": context.turn_id,
                 "text": text,
-                "thread_request_has_runtime_workspace_roots": thread_request_has_runtime_workspace_roots,
-                "turn_request_has_runtime_workspace_roots": turn_params.get("runtimeWorkspaceRoots").is_some(),
-                "turn_request_cwd": turn_params.get("cwd"),
-                "turn_request_approval_policy": turn_params.get("approvalPolicy"),
-                "turn_request_approvals_reviewer": turn_params.get("approvalsReviewer"),
-                "turn_request_sandbox_policy": turn_params.get("sandboxPolicy"),
-                "turn_request_client_user_message_id": turn_params.get("clientUserMessageId"),
+                "thread_request_has_runtime_workspace_roots": context.thread_request_has_runtime_workspace_roots,
+                "thread_request_model": context.thread_request_model,
+                "thread_request_model_provider": context.thread_request_model_provider,
+                "turn_request_has_runtime_workspace_roots": context.turn_params.get("runtimeWorkspaceRoots").is_some(),
+                "turn_request_cwd": context.turn_params.get("cwd"),
+                "turn_request_approval_policy": context.turn_params.get("approvalPolicy"),
+                "turn_request_approvals_reviewer": context.turn_params.get("approvalsReviewer"),
+                "turn_request_sandbox_policy": context.turn_params.get("sandboxPolicy"),
+                "turn_request_client_user_message_id": context.turn_params.get("clientUserMessageId"),
                 "child_env_home": std::env::var("HOME").ok(),
                 "child_env_api_url": std::env::var("VM0_API_URL").ok(),
                 "child_env_custom_user_env": std::env::var("CUSTOM_USER_ENV").ok(),
@@ -971,7 +1000,12 @@ fn persist_input_events(
         })
         .collect::<Vec<_>>();
     let home = session::codex_home();
-    session::persist_resume_session(&home, Utc::now().date_naive(), artifact_thread_id, &events)
+    session::persist_resume_session(
+        &home,
+        Utc::now().date_naive(),
+        context.artifact_thread_id,
+        &events,
+    )
 }
 
 fn session_artifact_thread_id(thread_id: &str) -> String {

--- a/crates/guest-mock-codex/src/main.rs
+++ b/crates/guest-mock-codex/src/main.rs
@@ -15,13 +15,13 @@
 //!
 //! Usage (mirrors real Codex CLI):
 //! ```text
-//!   guest-mock-codex exec [--json] [--sandbox <mode>] [--skip-git-repo-check]
-//!                          [-C <dir>] [-m <model>] [-c <config>]
+//!   guest-mock-codex [-c <config>] exec [--json] [--sandbox <mode>] [--skip-git-repo-check]
+//!                          [-C <dir>] [-m <model>]
 //!                          [--append-system-prompt <s>] [--last]
 //!                          [-- <prompt>]
-//!   guest-mock-codex exec resume <canonical-uuid-thread-id> [-- <prompt>]
-//!   guest-mock-codex app-server --listen stdio:// [-c <config>]
-//!   guest-mock-codex app-server --stdio [-c <config>]
+//!   guest-mock-codex [-c <config>] exec resume <canonical-uuid-thread-id> [-- <prompt>]
+//!   guest-mock-codex [-c <config>] app-server --listen stdio://
+//!   guest-mock-codex [-c <config>] app-server --stdio
 //! ```
 //!
 //! Fixture mode: when `MOCK_CODEX_FIXTURE=<name>` is set in the env, the
@@ -46,6 +46,10 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(name = "guest-mock-codex", version)]
 struct Cli {
+    /// Codex config override (accepted, ignored).
+    #[arg(short = 'c', long = "config", global = true)]
+    config: Vec<String>,
+
     #[command(subcommand)]
     command: Cmd,
 }
@@ -84,10 +88,6 @@ struct ExecArgs {
     #[arg(short = 'm', long)]
     model: Option<String>,
 
-    /// Codex config override (accepted, ignored).
-    #[arg(short = 'c', long = "config")]
-    config: Vec<String>,
-
     /// Append-system-prompt (accepted, ignored).
     #[arg(long = "append-system-prompt")]
     append_system_prompt: Option<String>,
@@ -123,21 +123,13 @@ struct AppServerArgs {
     /// Use stdio transport.
     #[arg(long)]
     stdio: bool,
-
-    /// Codex config override (accepted, ignored).
-    #[arg(short = 'c', long = "config")]
-    config: Vec<String>,
 }
 
 fn main() -> io::Result<()> {
-    let cli = Cli::parse();
+    let Cli { command, config: _ } = Cli::parse();
 
-    match cli.command {
-        Cmd::AppServer(AppServerArgs {
-            listen,
-            stdio: _,
-            config: _,
-        }) => run_app_server(&listen),
+    match command {
+        Cmd::AppServer(AppServerArgs { listen, stdio: _ }) => run_app_server(&listen),
         Cmd::Exec(ExecArgs {
             sub: Some(ExecSub::Resume { thread_id, prompt }),
             ..

--- a/crates/runner/src/executor/env.rs
+++ b/crates/runner/src/executor/env.rs
@@ -12,7 +12,7 @@ use super::{
     guest_runtime_path,
 };
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, SandboxReuseResult};
+use crate::types::{CodexRuntimeConfig, ExecutionContext, SandboxReuseResult};
 
 pub(super) struct ProtectedModelProviderEnvKey {
     name: &'static str,
@@ -172,6 +172,10 @@ fn validate_run_payload_fields_before_sandbox(context: &ExecutionContext) -> Res
         validate_run_payload_field(guest_contracts::env::SETTINGS_ENV, settings)?;
     }
 
+    if let Some(config) = &context.codex_runtime_config {
+        validate_codex_runtime_config_field(config)?;
+    }
+
     Ok(())
 }
 
@@ -180,6 +184,38 @@ fn validate_run_payload_field(name: &str, value: &str) -> Result<(), String> {
         return Err(format!("run payload contains NUL byte for {name}"));
     }
     Ok(())
+}
+
+fn validate_codex_runtime_config_field(config: &CodexRuntimeConfig) -> Result<(), String> {
+    for value in [
+        config.provider_id.as_str(),
+        config.name.as_str(),
+        config.base_url.as_str(),
+        config.env_key.as_str(),
+        config.wire_api.as_str(),
+    ] {
+        validate_run_payload_field(guest_contracts::env::CODEX_RUNTIME_CONFIG_ENV, value)?;
+    }
+    if let Some(model_catalog) = &config.model_catalog
+        && json_value_contains_nul_string(model_catalog)
+    {
+        return Err(format!(
+            "run payload contains NUL byte for {}",
+            guest_contracts::env::CODEX_RUNTIME_CONFIG_ENV
+        ));
+    }
+    Ok(())
+}
+
+fn json_value_contains_nul_string(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::String(value) => value.contains('\0'),
+        serde_json::Value::Array(values) => values.iter().any(json_value_contains_nul_string),
+        serde_json::Value::Object(values) => values.values().any(json_value_contains_nul_string),
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {
+            false
+        }
+    }
 }
 
 fn validate_bootstrap_environment_for_guest(
@@ -445,6 +481,7 @@ pub(super) fn build_run_payload_for_run(
         secret_values: serialize_secret_values(context),
         artifacts: serialize_artifacts_payload(context)?,
         feature_flags: serialize_feature_flags_payload(context)?,
+        codex_runtime_config: serialize_codex_runtime_config_payload(context)?,
         ..guest_contracts::env::RunPayload::default()
     };
 
@@ -526,6 +563,14 @@ fn serialize_feature_flags_payload(context: &ExecutionContext) -> RunnerResult<S
     }
     serde_json::to_string(flags)
         .map_err(|e| RunnerError::Internal(format!("serialize feature flags payload: {e}")))
+}
+
+fn serialize_codex_runtime_config_payload(context: &ExecutionContext) -> RunnerResult<String> {
+    let Some(config) = &context.codex_runtime_config else {
+        return Ok(String::new());
+    };
+    serde_json::to_string(config)
+        .map_err(|e| RunnerError::Internal(format!("serialize Codex runtime config: {e}")))
 }
 
 fn validate_run_payload_for_guest(

--- a/crates/runner/src/executor/tests/env_tests.rs
+++ b/crates/runner/src/executor/tests/env_tests.rs
@@ -6,6 +6,7 @@ use api_contracts::generated::types::runners::storage::{
 };
 use sandbox::SandboxId;
 use sandbox_mock::MockSandbox;
+use serde_json::json;
 
 use super::super::cli_framework::{
     EffectiveCliFramework, effective_cli_framework, normalized_cli_agent_type,
@@ -28,7 +29,7 @@ use crate::host_env::{
     RUNNER_NET_RX_MIB_PER_SEC_ENV, RUNNER_NET_TX_MIB_PER_SEC_ENV,
 };
 use crate::ids::RunId;
-use crate::types::{ExecutionContext, ResumeSession, SandboxReuseResult};
+use crate::types::{CodexRuntimeConfig, ExecutionContext, ResumeSession, SandboxReuseResult};
 
 fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
     let sandbox_id = SandboxId::new_v4().to_string();
@@ -38,6 +39,18 @@ fn validate_context_for_test(ctx: &ExecutionContext) -> Result<(), String> {
         &sandbox_id,
         SandboxReuseResult::Reused,
     )
+}
+
+fn codex_runtime_config_for_test(model_catalog: Option<serde_json::Value>) -> CodexRuntimeConfig {
+    CodexRuntimeConfig {
+        provider_id: "minimax".into(),
+        name: "MiniMax".into(),
+        base_url: "https://api.minimax.io/v1".into(),
+        env_key: "OPENAI_API_KEY".into(),
+        wire_api: "responses".into(),
+        supports_websockets: false,
+        model_catalog,
+    }
 }
 
 #[test]
@@ -1209,6 +1222,65 @@ fn build_run_payload_for_run_rejects_prompt_nul() {
     assert!(error.contains("run payload"));
     assert!(error.contains("NUL byte"));
     assert!(error.contains("VM0_PROMPT"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn build_run_payload_for_run_serializes_codex_runtime_config() {
+    let mut ctx = minimal_context();
+    ctx.codex_runtime_config = Some(codex_runtime_config_for_test(Some(json!({
+        "models": [{ "slug": "MiniMax-M3" }],
+    }))));
+
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&payload.codex_runtime_config).unwrap();
+
+    assert_eq!(value["providerId"], "minimax");
+    assert_eq!(value["baseUrl"], "https://api.minimax.io/v1");
+    assert_eq!(value["envKey"], "OPENAI_API_KEY");
+    assert_eq!(value["wireApi"], "responses");
+    assert_eq!(value["supportsWebsockets"], false);
+    assert_eq!(value["modelCatalog"]["models"][0]["slug"], "MiniMax-M3");
+}
+
+#[test]
+fn build_run_payload_for_run_omits_absent_codex_runtime_config() {
+    let ctx = minimal_context();
+
+    let payload = build_run_payload_for_run(&ctx).unwrap();
+
+    assert!(payload.codex_runtime_config.is_empty());
+}
+
+#[test]
+fn execution_context_validation_rejects_codex_runtime_config_nul() {
+    let secret = "Mini\0Max";
+    let mut ctx = minimal_context();
+    let mut config = codex_runtime_config_for_test(None);
+    config.name = secret.into();
+    ctx.codex_runtime_config = Some(config);
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("run payload"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_CODEX_RUNTIME_CONFIG"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
+fn execution_context_validation_rejects_codex_runtime_config_catalog_nul() {
+    let secret = "MiniMax\0M3";
+    let mut ctx = minimal_context();
+    ctx.codex_runtime_config = Some(codex_runtime_config_for_test(Some(json!({
+        "models": [{ "slug": secret }],
+    }))));
+
+    let error = validate_context_for_test(&ctx).unwrap_err();
+
+    assert!(error.contains("run payload"));
+    assert!(error.contains("NUL byte"));
+    assert!(error.contains("VM0_CODEX_RUNTIME_CONFIG"));
     assert!(!error.contains(secret));
 }
 

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -202,6 +202,7 @@ impl JobProvider for LocalProvider {
             feature_flags: req.feature_flags,
             billable_firewalls: vec![],
             model_usage_provider: None,
+            codex_runtime_config: None,
         };
         let active_input_source = req.active_input.unwrap_or(false).then(|| {
             crate::active_input::ActiveInputSource::local_queue(self.queue.clone(), run_id)

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -181,6 +181,7 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
         feature_flags: None,
         billable_firewalls: vec![],
         model_usage_provider: None,
+        codex_runtime_config: None,
     }
 }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -124,6 +124,21 @@ pub struct ExecutionContext {
     pub billable_firewalls: Vec<String>,
     #[serde(default)]
     pub model_usage_provider: Option<String>,
+    #[serde(default)]
+    pub codex_runtime_config: Option<CodexRuntimeConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CodexRuntimeConfig {
+    pub provider_id: String,
+    pub name: String,
+    pub base_url: String,
+    pub env_key: String,
+    pub wire_api: String,
+    pub supports_websockets: bool,
+    #[serde(default)]
+    pub model_catalog: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -1131,6 +1131,34 @@ export function createBddIntegrationApi(context: TestContext) {
       );
     },
 
+    async configureSlackMiniMaxModelPolicy(actor: ApiTestUser): Promise<void> {
+      const providers = setupApp({ context })(zeroModelProvidersMainContract);
+      const minimax = await accept(
+        providers.upsert({
+          headers: authenticate(context, routeMocks, actor),
+          body: { type: "minimax-api-key", secret: "bdd-minimax-key" },
+        }),
+        [200, 201],
+      );
+      await accept(
+        setupApp({ context })(zeroModelPoliciesMainContract).update({
+          headers: authenticate(context, routeMocks, actor),
+          body: {
+            policies: [
+              {
+                model: "MiniMax-M3",
+                isDefault: true,
+                defaultProviderType: "minimax-api-key",
+                credentialScope: "org",
+                modelProviderId: minimax.body.provider.id,
+              },
+            ],
+          },
+        }),
+        [200],
+      );
+    },
+
     mockSlackRunResultOutput(text: string): void {
       context.mocks.axiom.query.mockResolvedValueOnce([
         { eventType: "result", eventData: { result: text } },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
@@ -75,6 +75,20 @@ export async function seedVm0ManagedDefaultModelKey(
   return response.selected_model;
 }
 
+export async function seedVm0ManagedModelKey(
+  context: TestContext,
+  selectedModel: string,
+): Promise<string> {
+  const response = await postAction(context, {
+    action: "seed-vm0-managed-model-key",
+    selected_model: selectedModel,
+  });
+  if (!response.selected_model) {
+    throw new Error("seedVm0ManagedModelKey missing selected_model");
+  }
+  return response.selected_model;
+}
+
 export async function deleteVm0ManagedDefaultModelKey(
   context: TestContext,
 ): Promise<void> {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac, randomInt, randomUUID } from "node:crypto";
 
 import { OFFICIAL_TELEGRAM_BOT_ID } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -18,6 +19,7 @@ import {
 } from "./helpers/api-bdd-integrations";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 
 /*
 helper gap:
@@ -1347,6 +1349,73 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     const run5 = await runs.readRun(actor, run5Id);
     expect(run5.result?.agentSessionId).not.toBe(session4);
+  });
+
+  it("starts a new Slack session when MiniMax switches framework", async () => {
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("MiniMax framework switch test requires an org");
+    }
+
+    runs.acceptStorageDownloads();
+    integrations.configureSlackAppMocks();
+    integrations.acceptSlackSessionHistoryDownloads();
+    const runnerGroup = runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await integrations.configureSlackMiniMaxModelPolicy(actor);
+    const slackUserId = uniqueSlackUserId();
+    const { teamId } = await integrations.installSlackWorkspace(actor, {
+      installerSlackUserId: slackUserId,
+    });
+    integrations.clearSlackCallHistory();
+
+    const channelId = "C_BDD_MINIMAX_FRAMEWORK";
+    const threadTs = "3300.000100";
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUserId,
+      text: "start on minimax claude",
+      ts: threadTs,
+      channel: channelId,
+    });
+    const run1Id = await pollSlackRun(runnerGroup);
+    const claim1 = await runs.claimRunnerJob(run1Id);
+    expect(claim1.cliAgentType).toBe("claude-code");
+    expect(claim1.resumeSession).toBeNull();
+    await completeSlackTriggeredRun({
+      runId: run1Id,
+      sandboxToken: claim1.sandboxToken,
+      cliAgentType: "claude-code",
+    });
+    const run1 = await runs.readRun(actor, run1Id);
+    expect(run1.result?.agentSessionId).toStrictEqual(expect.any(String));
+
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
+      {
+        [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
+      },
+    );
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUserId,
+      text: "continue after minimax codex switch",
+      ts: "3300.000200",
+      thread_ts: threadTs,
+      channel: channelId,
+    });
+    const run2Id = await pollSlackRun(runnerGroup);
+    const claim2 = await runs.claimRunnerJob(run2Id);
+    expect(claim2.cliAgentType).toBe("codex");
+    expect(claim2.resumeSession).toBeNull();
+    expect(claim2.codexRuntimeConfig).toMatchObject({
+      providerId: "minimax",
+      supportsWebsockets: false,
+    });
+
+    await runs.requestCancelRun(actor, run2Id, [200]);
   });
 
   it("prompts disconnected Slack users and filters non-actionable messages", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -51,6 +51,7 @@ import {
   readAutomationsFakeKmsDecryptCallCount,
   resetAutomationsFakeKms,
   seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState,
+  seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
 } from "./helpers/automations";
 import {
   setSecretKmsClientForTests,
@@ -378,6 +379,13 @@ async function seedVm0ManagedDefaultModelKey(): Promise<string> {
     await deleteVm0ManagedDefaultModelKey(context);
   });
   return await seedVm0ManagedDefaultModelKeyState(context);
+}
+
+async function seedVm0ManagedModelKey(selectedModel: string): Promise<string> {
+  onTestFinished(async () => {
+    await deleteVm0ManagedDefaultModelKey(context);
+  });
+  return await seedVm0ManagedModelKeyState(context, selectedModel);
 }
 
 function useSecretKmsClientForTests(args: {
@@ -2946,6 +2954,76 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     ).toContain("model-provider:minimax-api-key");
 
     await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("claims vm0-managed MiniMax Codex runs with structured runtime config", async () => {
+    const api = createRunsAutomationsApi(context);
+    const chat = createChatFilesBddApi(context);
+    const selectedModel = await seedVm0ManagedModelKey("MiniMax-M3");
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("MiniMax Codex feature switch test requires an org");
+    }
+
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
+      {
+        [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
+      },
+    );
+
+    const sent = await chat.requestSendMessage(
+      actor,
+      {
+        agentId,
+        prompt: "vm0 managed minimax codex provider",
+        modelProvider: "vm0",
+        modelSelection: {
+          modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+          selectedModel,
+        },
+      },
+      [201],
+    );
+    if (sent.status !== 201 || sent.body.runId === null) {
+      throw new Error("Expected the MiniMax chat send to create a run");
+    }
+
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(sent.body.runId);
+    const minimaxApiKeyPlaceholder = getModelProviderFirewall(
+      "minimax-api-key",
+      {
+        [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
+      },
+    )?.placeholders?.MINIMAX_API_KEY;
+    if (!minimaxApiKeyPlaceholder) {
+      throw new Error("Missing MiniMax Codex API key placeholder");
+    }
+
+    expect(claim.cliAgentType).toBe("codex");
+    expect(claim.environment).toMatchObject({
+      OPENAI_API_KEY: minimaxApiKeyPlaceholder,
+      OPENAI_BASE_URL: "https://api.minimax.io/v1",
+      OPENAI_MODEL: "MiniMax-M3",
+    });
+    expect(claim.codexRuntimeConfig).toMatchObject({
+      providerId: "minimax",
+      name: "MiniMax",
+      baseUrl: "https://api.minimax.io/v1",
+      envKey: "OPENAI_API_KEY",
+      wireApi: "responses",
+      supportsWebsockets: false,
+    });
+    expect(claim.modelUsageProvider).toBe("MiniMax-M3");
+    expect(
+      claim.firewalls?.map((firewall) => {
+        return firewallEntryName(firewall);
+      }),
+    ).toContain("model-provider:minimax-api-key");
+
+    await api.requestCancelRun(actor, sent.body.runId, [200]);
   });
 
   it("uses the requested provider instead of the caller's personal default", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2925,9 +2925,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(claim.cliAgentType).toBe("codex");
     expect(claim.environment).toMatchObject({
       OPENAI_API_KEY: minimaxApiKeyPlaceholder,
+      OPENAI_BASE_URL: "https://api.minimax.io/v1",
       OPENAI_MODEL: "MiniMax-M3",
     });
-    expect(claim.environment).not.toHaveProperty("OPENAI_BASE_URL");
     expect(claim.codexRuntimeConfig).toMatchObject({
       providerId: "minimax",
       name: "MiniMax",

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -43,6 +43,7 @@ import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { storageTextFile } from "./helpers/api-bdd-storage-files";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import {
   deleteVm0ManagedDefaultModelKey,
   enableAutomationsFakeKms,
@@ -2883,6 +2884,68 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("claims MiniMax Codex runs with structured runtime config", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("MiniMax Codex feature switch test requires an org");
+    }
+
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
+      {
+        [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
+      },
+    );
+    await api.createOrgModelProvider(actor, {
+      type: "minimax-api-key",
+      secret: "sk-minimax-bdd",
+    });
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "minimax codex provider",
+      modelProvider: "minimax-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claim = await api.claimRunnerJob(run.runId);
+    const minimaxApiKeyPlaceholder = getModelProviderFirewall(
+      "minimax-api-key",
+      {
+        [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
+      },
+    )?.placeholders?.MINIMAX_API_KEY;
+    if (!minimaxApiKeyPlaceholder) {
+      throw new Error("Missing MiniMax Codex API key placeholder");
+    }
+
+    expect(claim.cliAgentType).toBe("codex");
+    expect(claim.environment).toMatchObject({
+      OPENAI_API_KEY: minimaxApiKeyPlaceholder,
+      OPENAI_MODEL: "MiniMax-M3",
+    });
+    expect(claim.environment).not.toHaveProperty("OPENAI_BASE_URL");
+    expect(claim.codexRuntimeConfig).toMatchObject({
+      providerId: "minimax",
+      name: "MiniMax",
+      baseUrl: "https://api.minimax.io/v1",
+      envKey: "OPENAI_API_KEY",
+      wireApi: "responses",
+      supportsWebsockets: false,
+    });
+    expect(claim.codexRuntimeConfig?.modelCatalog).toMatchObject({
+      models: [expect.objectContaining({ slug: "MiniMax-M3" })],
+    });
+    expect(
+      claim.firewalls?.map((firewall) => {
+        return firewallEntryName(firewall);
+      }),
+    ).toContain("model-provider:minimax-api-key");
+
+    await api.requestCancelRun(actor, run.runId, [200]);
   });
 
   it("uses the requested provider instead of the caller's personal default", async () => {

--- a/turbo/apps/api/src/signals/routes/test-automations-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-automations-state.ts
@@ -109,6 +109,14 @@ async function seedVm0ManagedDefaultModelKey(
   if (!selectedModel) {
     throw new Error("Expected vm0 to define a default model");
   }
+  return await seedVm0ManagedModelKey(db, selectedModel, signal);
+}
+
+async function seedVm0ManagedModelKey(
+  db: Db,
+  selectedModel: string,
+  signal: AbortSignal,
+): Promise<string> {
   await db
     .delete(vm0ApiKeys)
     .where(eq(vm0ApiKeys.apiKey, RUN_LIFECYCLE_TEST_VM0_MANAGED_API_KEY));
@@ -179,6 +187,19 @@ const postAutomationsStateAction$ = command(
           body: {
             ok: true as const,
             selected_model: await seedVm0ManagedDefaultModelKey(db, signal),
+          },
+        };
+      }
+      case "seed-vm0-managed-model-key": {
+        return {
+          status: 200 as const,
+          body: {
+            ok: true as const,
+            selected_model: await seedVm0ManagedModelKey(
+              db,
+              body.selected_model,
+              signal,
+            ),
           },
         };
       }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -12,6 +12,7 @@ import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs"
 import {
   getDefaultModel,
   getModelProviderFirewall,
+  getModelProviderCodexRuntimeConfig,
   getModelProviderEnvBindings,
   getFrameworkForType,
   getProviderRuntimeModel,
@@ -25,6 +26,7 @@ import {
   MODEL_PROVIDER_TYPES,
   normalizeRunModelId,
   shouldInlineModelProviderFirewall,
+  type ModelProviderCodexRuntimeConfig,
   type ModelProviderEnvBindings,
   type ModelProviderCredentialScope,
   type ModelProviderFeatureStates,
@@ -478,6 +480,7 @@ interface ResolvedModelProviderEnvironment {
   readonly inlineFirewall?: boolean;
   readonly secretConnectorMap?: Record<string, string>;
   readonly secretConnectorMetadataMap?: Record<string, SecretConnectorMetadata>;
+  readonly codexRuntimeConfig?: ModelProviderCodexRuntimeConfig;
 }
 
 interface PermissionManifest {
@@ -1471,6 +1474,10 @@ function modelProviderEnvironment(args: {
       ? {}
       : { [args.config.secretName]: args.secretValue ?? "" },
     selectedModel: model,
+    codexRuntimeConfig: getModelProviderCodexRuntimeConfig(
+      args.type,
+      args.featureStates,
+    ),
     firewall,
     inlineFirewall: shouldInlineModelProviderFirewall(
       args.type,
@@ -4784,6 +4791,7 @@ async function buildStoredExecutionContext(args: {
       featureFlags: getAllFeatureStates(args.featureSwitchContext),
       billableFirewalls: [...args.billableFirewalls],
       modelUsageProvider: args.modelUsageProvider,
+      codexRuntimeConfig: args.modelProvider?.codexRuntimeConfig ?? null,
     },
     secretNames,
     secretValues,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -1715,6 +1715,10 @@ async function multiAuthModelProviderEnvironment(
     ),
     secrets: hasFirewallAuth ? {} : forwardableSecrets,
     selectedModel,
+    codexRuntimeConfig: getModelProviderCodexRuntimeConfig(
+      args.type,
+      featureStates,
+    ),
     firewall,
     inlineFirewall: shouldInlineModelProviderFirewall(args.type, featureStates),
     secretConnectorMap: authMaps?.secretConnectorMap,
@@ -1766,6 +1770,10 @@ async function vm0ModelProviderEnvironment(
     ),
     secrets: { [secretName]: apiKey },
     selectedModel,
+    codexRuntimeConfig: getModelProviderCodexRuntimeConfig(
+      concreteType,
+      featureStates,
+    ),
     firewall: getModelProviderFirewall(concreteType, featureStates),
     inlineFirewall: shouldInlineModelProviderFirewall(
       concreteType,

--- a/turbo/apps/api/src/signals/services/integration-model-route.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-model-route.service.ts
@@ -1,14 +1,22 @@
 import { command } from "ccstate";
-import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
+import {
+  getFrameworkForType,
+  getVm0ConcreteProviderType,
+  type ModelProviderCredentialScope,
+} from "@vm0/api-contracts/contracts/model-providers";
+import { getAllFeatureStates } from "@vm0/core/feature-switch";
+import type { SupportedFramework } from "@vm0/core/frameworks";
 
 import { listOrgModelPolicies$ } from "./zero-model-policy.service";
 import { userModelPreference } from "./zero-user-data.service";
+import { userFeatureSwitchContext } from "./feature-switches.service";
 
 export interface IntegrationModelRoutePin {
   readonly modelProviderType: string;
   readonly modelProviderId: string | null;
   readonly modelProviderCredentialScope: ModelProviderCredentialScope;
   readonly selectedModel: string;
+  readonly cliAgentType: SupportedFramework;
 }
 
 export const resolveIntegrationModelRouteForUser$ = command(
@@ -30,6 +38,11 @@ export const resolveIntegrationModelRouteForUser$ = command(
       { orgId: args.orgId, userId: args.userId },
       signal,
     );
+    const featureSwitchContext = await get(
+      userFeatureSwitchContext(args.orgId, args.userId),
+    );
+    signal.throwIfAborted();
+    const featureStates = getAllFeatureStates(featureSwitchContext);
 
     const preferredPolicy = preference.selectedModel
       ? policies.policies.find((policy) => {
@@ -54,6 +67,12 @@ export const resolveIntegrationModelRouteForUser$ = command(
       modelProviderId: routePolicy.modelProviderId,
       modelProviderCredentialScope: routePolicy.credentialScope,
       selectedModel: routePolicy.model,
+      cliAgentType: getFrameworkForType(
+        routePolicy.defaultProviderType === "vm0"
+          ? getVm0ConcreteProviderType(routePolicy.model)
+          : routePolicy.defaultProviderType,
+        featureStates,
+      ),
     };
   },
 );

--- a/turbo/apps/api/src/signals/services/integration-session-model-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-session-model-compatibility.service.ts
@@ -7,14 +7,14 @@ import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentSessions } from "@vm0/db/schema/agent-session";
 import { conversations } from "@vm0/db/schema/conversation";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 import type { Db, ReadonlyDb } from "../external/db";
 
 interface IntegrationSessionModelSignature {
   readonly modelProvider: string | null;
   readonly selectedModel: string | null;
-  readonly cliAgentType: string;
+  readonly cliAgentType: string | null;
 }
 
 interface IntegrationRunModelRoute {
@@ -37,7 +37,10 @@ function areIntegrationSessionModelsCompatible(
   previous: IntegrationSessionModelSignature,
   current: IntegrationRunModelRoute,
 ): boolean {
-  if (previous.cliAgentType !== current.cliAgentType) {
+  if (
+    previous.cliAgentType !== null &&
+    previous.cliAgentType !== current.cliAgentType
+  ) {
     return false;
   }
 
@@ -56,7 +59,7 @@ function areIntegrationSessionModelsCompatible(
   );
 }
 
-async function currentIntegrationSessionModelSignature(
+async function latestIntegrationSessionModelSignature(
   db: Db | ReadonlyDb,
   sessionId: string,
 ): Promise<IntegrationSessionModelSignature | null> {
@@ -66,14 +69,12 @@ async function currentIntegrationSessionModelSignature(
       selectedModel: zeroRuns.selectedModel,
       cliAgentType: conversations.cliAgentType,
     })
-    .from(agentSessions)
-    .innerJoin(
-      conversations,
-      eq(conversations.id, agentSessions.conversationId),
-    )
-    .innerJoin(agentRuns, eq(agentRuns.id, conversations.runId))
+    .from(agentRuns)
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-    .where(eq(agentSessions.id, sessionId))
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
+    .leftJoin(conversations, eq(conversations.id, agentSessions.conversationId))
+    .where(eq(agentRuns.sessionId, sessionId))
+    .orderBy(desc(agentRuns.createdAt))
     .limit(1);
 
   return previousRun ?? null;
@@ -88,7 +89,7 @@ export async function canReuseIntegrationSessionForModelRoute(args: {
     return true;
   }
 
-  const previous = await currentIntegrationSessionModelSignature(
+  const previous = await latestIntegrationSessionModelSignature(
     args.db,
     args.sessionId,
   );

--- a/turbo/apps/api/src/signals/services/integration-session-model-compatibility.service.ts
+++ b/turbo/apps/api/src/signals/services/integration-session-model-compatibility.service.ts
@@ -4,19 +4,23 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
+import { conversations } from "@vm0/db/schema/conversation";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import { desc, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 import type { Db, ReadonlyDb } from "../external/db";
 
 interface IntegrationSessionModelSignature {
   readonly modelProvider: string | null;
   readonly selectedModel: string | null;
+  readonly cliAgentType: string;
 }
 
 interface IntegrationRunModelRoute {
   readonly modelProviderType: string | null | undefined;
   readonly selectedModel: string | null | undefined;
+  readonly cliAgentType: string;
 }
 
 function isKnownModelProvider(
@@ -33,6 +37,10 @@ function areIntegrationSessionModelsCompatible(
   previous: IntegrationSessionModelSignature,
   current: IntegrationRunModelRoute,
 ): boolean {
+  if (previous.cliAgentType !== current.cliAgentType) {
+    return false;
+  }
+
   if (
     isKnownModelProvider(previous.modelProvider) &&
     isKnownModelProvider(current.modelProviderType) &&
@@ -48,7 +56,7 @@ function areIntegrationSessionModelsCompatible(
   );
 }
 
-async function latestIntegrationSessionModelSignature(
+async function currentIntegrationSessionModelSignature(
   db: Db | ReadonlyDb,
   sessionId: string,
 ): Promise<IntegrationSessionModelSignature | null> {
@@ -56,11 +64,16 @@ async function latestIntegrationSessionModelSignature(
     .select({
       modelProvider: zeroRuns.modelProvider,
       selectedModel: zeroRuns.selectedModel,
+      cliAgentType: conversations.cliAgentType,
     })
-    .from(agentRuns)
+    .from(agentSessions)
+    .innerJoin(
+      conversations,
+      eq(conversations.id, agentSessions.conversationId),
+    )
+    .innerJoin(agentRuns, eq(agentRuns.id, conversations.runId))
     .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
-    .where(eq(agentRuns.sessionId, sessionId))
-    .orderBy(desc(agentRuns.createdAt))
+    .where(eq(agentSessions.id, sessionId))
     .limit(1);
 
   return previousRun ?? null;
@@ -75,7 +88,7 @@ export async function canReuseIntegrationSessionForModelRoute(args: {
     return true;
   }
 
-  const previous = await latestIntegrationSessionModelSignature(
+  const previous = await currentIntegrationSessionModelSignature(
     args.db,
     args.sessionId,
   );

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -741,13 +741,13 @@ describe("minimax-api-key provider", () => {
     expect(getSecretNameForType("minimax-api-key")).toBe("MINIMAX_API_KEY");
   });
 
-  it("maps Codex env bindings without provider metadata when the feature flag is enabled", () => {
+  it("maps Codex env bindings with old-runner base URL compatibility", () => {
     const envBindings = getModelProviderEnvBindings("minimax-api-key", {
       [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
     });
     expect(envBindings).toBeDefined();
     expect(envBindings!["OPENAI_API_KEY"]).toBe("$secret");
-    expect(envBindings!["OPENAI_BASE_URL"]).toBeUndefined();
+    expect(envBindings!["OPENAI_BASE_URL"]).toBe("https://api.minimax.io/v1");
     expect(envBindings!["OPENAI_MODEL"]).toBe("$model");
   });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -6,6 +6,7 @@ import {
   getModels,
   getDefaultModel,
   getModelProviderEnvBindings,
+  getModelProviderCodexRuntimeConfig,
   getModelProviderFirewall,
   getFrameworkForType,
   getVm0VisibleModels,
@@ -470,7 +471,7 @@ describe("getProviderBaseUrl", () => {
     },
   );
 
-  it("returns MiniMax OpenAI base URL when Codex framework switch is enabled", () => {
+  it("returns MiniMax Codex runtime base URL when the framework switch is enabled", () => {
     expect(
       getProviderBaseUrl("minimax-api-key", {
         [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
@@ -740,14 +741,38 @@ describe("minimax-api-key provider", () => {
     expect(getSecretNameForType("minimax-api-key")).toBe("MINIMAX_API_KEY");
   });
 
-  it("maps OpenAI-style Codex env bindings when the feature flag is enabled", () => {
+  it("maps Codex env bindings without provider metadata when the feature flag is enabled", () => {
     const envBindings = getModelProviderEnvBindings("minimax-api-key", {
       [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
     });
     expect(envBindings).toBeDefined();
     expect(envBindings!["OPENAI_API_KEY"]).toBe("$secret");
-    expect(envBindings!["OPENAI_BASE_URL"]).toBe("https://api.minimax.io/v1");
+    expect(envBindings!["OPENAI_BASE_URL"]).toBeUndefined();
     expect(envBindings!["OPENAI_MODEL"]).toBe("$model");
+  });
+
+  it("declares MiniMax Codex runtime config when the feature flag is enabled", () => {
+    const config = getModelProviderCodexRuntimeConfig("minimax-api-key", {
+      [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
+    });
+
+    expect(config).toMatchObject({
+      providerId: "minimax",
+      name: "MiniMax",
+      baseUrl: "https://api.minimax.io/v1",
+      envKey: "OPENAI_API_KEY",
+      wireApi: "responses",
+      supportsWebsockets: false,
+    });
+    expect(config?.modelCatalog).toMatchObject({
+      models: [expect.objectContaining({ slug: "MiniMax-M3" })],
+    });
+  });
+
+  it("omits MiniMax Codex runtime config when the feature flag is disabled", () => {
+    expect(
+      getModelProviderCodexRuntimeConfig("minimax-api-key"),
+    ).toBeUndefined();
   });
 
   it("does not add a second selectable provider when the feature switch is enabled", () => {

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -95,7 +95,9 @@ const MINIMAX_CODEX_ENV_BINDINGS = {
   OPENAI_API_KEY: "$secret",
   // Deployment compatibility: old runners ignore codexRuntimeConfig and still
   // need the legacy base URL. New guest-agent code ignores OPENAI_BASE_URL
-  // whenever structured Codex runtime config is present.
+  // whenever structured Codex runtime config is present. Remove this after the
+  // first runner version with codexRuntimeConfig support is fully deployed and
+  // older runners have drained.
   OPENAI_BASE_URL: MINIMAX_CODEX_BASE_URL,
   OPENAI_MODEL: "$model",
 } as const satisfies ModelProviderEnvBindings;

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -1370,7 +1370,7 @@ export function getProviderBaseUrl(
 
 /**
  * Check if two model providers are compatible for session continuation.
- * Providers are compatible if they resolve to the same ANTHROPIC_BASE_URL.
+ * Providers are compatible if they resolve to the same upstream base URL.
  */
 export function areProvidersCompatible(
   a: ModelProviderType,

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -75,11 +75,79 @@ export type ModelProviderFeatureStates = Partial<
   Record<FeatureSwitchKey, boolean>
 >;
 
+export const modelProviderCodexRuntimeConfigSchema = z.object({
+  providerId: z.string().regex(/^[A-Za-z0-9_-]+$/),
+  name: z.string().min(1),
+  baseUrl: z.url(),
+  envKey: z.string().min(1),
+  wireApi: z.literal("responses"),
+  supportsWebsockets: z.boolean(),
+  modelCatalog: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type ModelProviderCodexRuntimeConfig = z.infer<
+  typeof modelProviderCodexRuntimeConfigSchema
+>;
+
 const MINIMAX_CODEX_ENV_BINDINGS = {
   OPENAI_API_KEY: "$secret",
-  OPENAI_BASE_URL: "https://api.minimax.io/v1",
   OPENAI_MODEL: "$model",
 } as const satisfies ModelProviderEnvBindings;
+
+const MINIMAX_CODEX_BASE_URL = "https://api.minimax.io/v1";
+
+const MINIMAX_CODEX_RUNTIME_CONFIG = {
+  providerId: "minimax",
+  name: "MiniMax",
+  baseUrl: MINIMAX_CODEX_BASE_URL,
+  envKey: "OPENAI_API_KEY",
+  wireApi: "responses",
+  supportsWebsockets: false,
+  modelCatalog: {
+    models: [
+      {
+        slug: "MiniMax-M3",
+        display_name: "MiniMax M3",
+        description: "MiniMax M3",
+        default_reasoning_level: null,
+        supported_reasoning_levels: [],
+        shell_type: "shell_command",
+        visibility: "list",
+        supported_in_api: true,
+        priority: 0,
+        additional_speed_tiers: [],
+        service_tiers: [],
+        default_service_tier: null,
+        availability_nux: null,
+        upgrade: null,
+        base_instructions: "",
+        model_messages: null,
+        include_skills_usage_instructions: false,
+        supports_reasoning_summaries: false,
+        default_reasoning_summary: "auto",
+        support_verbosity: false,
+        default_verbosity: null,
+        apply_patch_tool_type: null,
+        web_search_tool_type: "text",
+        truncation_policy: { mode: "bytes", limit: 10_000 },
+        supports_parallel_tool_calls: false,
+        supports_image_detail_original: false,
+        context_window: 1_000_000,
+        max_context_window: null,
+        auto_compact_token_limit: null,
+        comp_hash: null,
+        effective_context_window_percent: 95,
+        experimental_supported_tools: [],
+        input_modalities: ["text", "image"],
+        supports_search_tool: false,
+        use_responses_lite: false,
+        auto_review_model_override: null,
+        tool_mode: null,
+        multi_agent_version: null,
+      },
+    ],
+  },
+} as const satisfies ModelProviderCodexRuntimeConfig;
 
 const GATED_MODEL_PROVIDER_FEATURE_SWITCHES: Partial<
   Record<ModelProviderType, FeatureSwitchKey>
@@ -1243,12 +1311,26 @@ export function getModelProviderEnvBindings(
   return "envBindings" in config ? config.envBindings : undefined;
 }
 
+export function getModelProviderCodexRuntimeConfig(
+  type: ModelProviderType,
+  featureStates?: ModelProviderFeatureStates,
+): ModelProviderCodexRuntimeConfig | undefined {
+  if (
+    type === "minimax-api-key" &&
+    isModelProviderFrameworkSwitchEnabled(type, featureStates)
+  ) {
+    return MINIMAX_CODEX_RUNTIME_CONFIG;
+  }
+  return undefined;
+}
+
 /**
  * Get the upstream base URL for a model provider type.
  *
- * Returns the framework-appropriate base URL override from
- * envBindings — ANTHROPIC_BASE_URL for claude-code, OPENAI_BASE_URL
- * for codex. Returns null when the provider relies on the SDK's default
+ * Returns the framework-appropriate upstream base URL. Codex custom-provider
+ * runtime config is authoritative when present; otherwise this falls back to
+ * envBindings — ANTHROPIC_BASE_URL for claude-code, OPENAI_BASE_URL for codex.
+ * Returns null when the provider relies on the SDK's default
  * (Anthropic-native providers, OpenAI direct).
  *
  * Used by areProvidersCompatible to detect session-continuation safety
@@ -1260,6 +1342,14 @@ export function getProviderBaseUrl(
   type: ModelProviderType,
   featureStates?: ModelProviderFeatureStates,
 ): string | null {
+  const codexRuntimeConfig = getModelProviderCodexRuntimeConfig(
+    type,
+    featureStates,
+  );
+  if (codexRuntimeConfig) {
+    return codexRuntimeConfig.baseUrl;
+  }
+
   const envBindings = getModelProviderEnvBindings(type, featureStates);
   if (!envBindings) {
     return null;

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -79,7 +79,7 @@ export const modelProviderCodexRuntimeConfigSchema = z.object({
   providerId: z.string().regex(/^[A-Za-z0-9_-]+$/),
   name: z.string().min(1),
   baseUrl: z.url(),
-  envKey: z.string().min(1),
+  envKey: z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/),
   wireApi: z.literal("responses"),
   supportsWebsockets: z.boolean(),
   modelCatalog: z.record(z.string(), z.unknown()).optional(),

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -89,12 +89,16 @@ export type ModelProviderCodexRuntimeConfig = z.infer<
   typeof modelProviderCodexRuntimeConfigSchema
 >;
 
+const MINIMAX_CODEX_BASE_URL = "https://api.minimax.io/v1";
+
 const MINIMAX_CODEX_ENV_BINDINGS = {
   OPENAI_API_KEY: "$secret",
+  // Deployment compatibility: old runners ignore codexRuntimeConfig and still
+  // need the legacy base URL. New guest-agent code ignores OPENAI_BASE_URL
+  // whenever structured Codex runtime config is present.
+  OPENAI_BASE_URL: MINIMAX_CODEX_BASE_URL,
   OPENAI_MODEL: "$model",
 } as const satisfies ModelProviderEnvBindings;
-
-const MINIMAX_CODEX_BASE_URL = "https://api.minimax.io/v1";
 
 const MINIMAX_CODEX_RUNTIME_CONFIG = {
   providerId: "minimax",

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -7,6 +7,7 @@ import {
   networkPoliciesSchema,
 } from "@vm0/connectors/firewall-types";
 import { apiErrorSchema } from "./errors";
+import { modelProviderCodexRuntimeConfigSchema } from "./model-providers";
 
 const c = initContract();
 
@@ -379,6 +380,10 @@ export const storedExecutionContextSchema = z.object({
   // this model id for built-in billing rows and model usage observations;
   // billing eligibility is decided from API-owned run context.
   modelUsageProvider: z.string().optional(),
+  // API-owned Codex provider/runtime metadata forwarded through the runner.
+  codexRuntimeConfig: modelProviderCodexRuntimeConfigSchema
+    .nullable()
+    .optional(),
 });
 
 /**
@@ -448,6 +453,10 @@ export const executionContextSchema = z.object({
   // this model id for built-in billing rows and model usage observations;
   // billing eligibility is decided from API-owned run context.
   modelUsageProvider: z.string().optional(),
+  // API-owned Codex provider/runtime metadata forwarded through the runner.
+  codexRuntimeConfig: modelProviderCodexRuntimeConfigSchema
+    .nullable()
+    .optional(),
 });
 
 /**

--- a/turbo/packages/api-contracts/src/contracts/test-automations-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-automations-state.ts
@@ -29,6 +29,10 @@ export const testAutomationsStateActionBodySchema = z.discriminatedUnion(
       action: z.literal("seed-vm0-managed-default-model-key"),
     }),
     z.object({
+      action: z.literal("seed-vm0-managed-model-key"),
+      selected_model: z.string(),
+    }),
+    z.object({
       action: z.literal("delete-vm0-managed-default-model-key"),
     }),
     z.object({


### PR DESCRIPTION
## Summary

- add API-owned `codexRuntimeConfig` for Codex custom provider metadata and forward it through the runner run payload
- configure MiniMax Codex as a custom `minimax` provider with `supports_websockets=false` and startup model catalog metadata for `MiniMax-M3`
- apply the same Codex runtime config to direct MiniMax API keys, multi-auth providers, and vm0-managed MiniMax model selection
- apply the same Codex startup config to both `codex exec` and `codex app-server`, while preserving the legacy `OPENAI_BASE_URL` env binding for old runners during drain
- pass the structured Codex provider id through app-server `thread/start` / `thread/resume` requests so app-server threads do not depend on the default OpenAI provider
- validate Codex runtime provider ids and auth env keys before turning API-owned metadata into Codex `-c` overrides

Closes #20555

## Verification

- `cd turbo && pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "claims MiniMax Codex runs with structured runtime config"`
- `cd turbo && pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "claims vm0-managed MiniMax Codex runs with structured runtime config"`
- `cd turbo && pnpm -F @vm0/api-contracts check-types`
- `cd turbo && pnpm -F @vm0/api-contracts lint`
- `cd turbo && pnpm -F api check-types`
- `cd turbo && pnpm -F api lint`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_setup_fail_closed -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent codex_runtime_config -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent app_server_args_put_root_config_overrides_before_subcommand -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p runner codex_runtime_config -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts run_payload -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-mock-codex -- --nocapture`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent -p runner -p guest-contracts -p guest-mock-codex --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `git diff --check`
- `codex doctor --json ...` with the generated MiniMax provider overrides reports `Responses WebSocket is not enabled for the active provider`
- `codex doctor --json ...` with both structured MiniMax provider overrides and `OPENAI_BASE_URL` env still reports provider `minimax` and WebSocket disabled
- `codex debug models ...` with the generated model catalog loads `MiniMax-M3` metadata
