### PR TITLE
fix: add builtin firewall fallback telemetry

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -27,6 +27,12 @@ class BuiltinFirewallCatalogCacheError(ValueError):
     """Builtin firewall catalog cache is unavailable or malformed."""
 
 
+class _CatalogCacheOpenError(OSError):
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
 @dataclass(frozen=True)
 class BuiltinFirewallCatalog:
     identity: CatalogIdentity
@@ -149,6 +155,8 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
 
 
 def _open_error_fallback_reason(exc: OSError) -> str:
+    if isinstance(exc, _CatalogCacheOpenError):
+        return exc.reason
     if isinstance(exc, FileNotFoundError):
         return "cache_file_missing"
     if isinstance(exc, PermissionError):
@@ -168,10 +176,16 @@ def _open_cache_for_read(path: Path) -> tuple[int, os.stat_result]:
         raise
     if not stat.S_ISREG(st.st_mode):
         os.close(fd)
-        raise OSError(f"builtin firewall catalog cache is not a regular file: {path}")
+        raise _CatalogCacheOpenError(
+            "cache_not_regular",
+            f"builtin firewall catalog cache is not a regular file: {path}",
+        )
     if not _cache_file_stat_is_trusted(st):
         os.close(fd)
-        raise OSError(f"builtin firewall catalog cache is not trusted: {path}")
+        raise _CatalogCacheOpenError(
+            "cache_untrusted",
+            f"builtin firewall catalog cache is not trusted: {path}",
+        )
     return fd, st
 
 

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -37,6 +37,8 @@ class BuiltinFirewallCatalog:
 class BuiltinFirewallCatalogSnapshot:
     dependency_file_key: CatalogFileKey | None
     catalog: BuiltinFirewallCatalog | None
+    cache_path: str | None = None
+    fallback_reason: str | None = None
 
 
 @dataclass
@@ -44,12 +46,14 @@ class _CatalogCacheState:
     path_key: str | None = None
     loaded_key: CatalogFileKey | None = None
     failed_key: CatalogFileKey | None = None
+    failed_reason: str | None = None
     catalog: BuiltinFirewallCatalog | None = None
 
     def reset(self, path_key: str | None = None) -> None:
         self.path_key = path_key
         self.loaded_key = None
         self.failed_key = None
+        self.failed_reason = None
         self.catalog = None
 
 
@@ -88,7 +92,11 @@ def catalog_file_key(cache_path: str | None) -> CatalogFileKey | None:
 def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnapshot:
     """Load one catalog cache state for a single registry reload."""
     if not cache_path:
-        return BuiltinFirewallCatalogSnapshot(None, None)
+        return BuiltinFirewallCatalogSnapshot(
+            None,
+            None,
+            fallback_reason="cache_path_missing",
+        )
 
     path = Path(cache_path)
     path_key = _path_key(path)
@@ -96,31 +104,56 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
 
     try:
         fd, st = _open_cache_for_read(path)
-    except OSError:
+    except OSError as exc:
         state.reset(path_key)
-        return BuiltinFirewallCatalogSnapshot(None, None)
+        return BuiltinFirewallCatalogSnapshot(
+            None,
+            None,
+            cache_path=path_key,
+            fallback_reason=_open_error_fallback_reason(exc),
+        )
 
     try:
         key = (path_key, st.st_dev, st.st_ino, st.st_mtime_ns, st.st_size)
         if key == state.loaded_key:
-            return BuiltinFirewallCatalogSnapshot(key, state.catalog)
+            return BuiltinFirewallCatalogSnapshot(key, state.catalog, cache_path=path_key)
         if key == state.failed_key:
-            return BuiltinFirewallCatalogSnapshot(key, None)
+            return BuiltinFirewallCatalogSnapshot(
+                key,
+                None,
+                cache_path=path_key,
+                fallback_reason=state.failed_reason or "cache_invalid",
+            )
         try:
             catalog = _read_catalog(fd, path, st.st_size, key)
         except (BuiltinFirewallCatalogCacheError, OSError, ValueError, RecursionError) as exc:
             state.failed_key = key
+            state.failed_reason = "cache_invalid"
             state.loaded_key = None
             state.catalog = None
             _warn(f"Failed to read builtin firewall catalog cache: {exc}")
-            return BuiltinFirewallCatalogSnapshot(key, None)
+            return BuiltinFirewallCatalogSnapshot(
+                key,
+                None,
+                cache_path=path_key,
+                fallback_reason=state.failed_reason,
+            )
     finally:
         os.close(fd)
 
     state.loaded_key = key
     state.failed_key = None
+    state.failed_reason = None
     state.catalog = catalog
-    return BuiltinFirewallCatalogSnapshot(key, catalog)
+    return BuiltinFirewallCatalogSnapshot(key, catalog, cache_path=path_key)
+
+
+def _open_error_fallback_reason(exc: OSError) -> str:
+    if isinstance(exc, FileNotFoundError):
+        return "cache_file_missing"
+    if isinstance(exc, PermissionError):
+        return "cache_permission_denied"
+    return "cache_unavailable"
 
 
 def _open_cache_for_read(path: Path) -> tuple[int, os.stat_result]:

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -131,12 +131,13 @@ def _warn_bundled_fallback(
     catalog_version = None
     if cached_catalog is not None:
         _, catalog_digest, catalog_version, _ = cached_catalog.identity
+    warning_file_key = None if cached_catalog is not None else catalog_snapshot.dependency_file_key
 
     warning_key = (
         raw_name,
         reason,
         catalog_snapshot.cache_path,
-        catalog_snapshot.dependency_file_key,
+        warning_file_key,
         catalog_digest,
         catalog_version,
     )
@@ -155,8 +156,8 @@ def _warn_bundled_fallback(
         fields.append(f"catalog_digest={catalog_digest}")
     if catalog_version is not None:
         fields.append(f"catalog_version={catalog_version}")
-    if catalog_snapshot.dependency_file_key is not None:
-        fields.append(f"cache_file_key={catalog_snapshot.dependency_file_key!r}")
+    if warning_file_key is not None:
+        fields.append(f"cache_file_key={warning_file_key!r}")
 
     with suppress(Exception):
         ctx.log.warn(" ".join(fields))

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -1,7 +1,10 @@
 """Registry VM firewall entry resolution."""
 
 import copy
+from contextlib import suppress
 from dataclasses import dataclass
+
+from mitmproxy import ctx
 
 import builtin_base_url
 import builtin_firewall_cache
@@ -35,9 +38,22 @@ class _ResolvedBuiltinFirewallEntry:
     cache_key: BuiltinFirewallCoreCacheKey
 
 
+_bundled_fallback_warnings: set[
+    tuple[
+        str,
+        str,
+        str | None,
+        BuiltinFirewallCatalogFileKey | None,
+        str | None,
+        str | None,
+    ]
+] = set()
+
+
 def reset_cache_for_tests() -> None:
     """Reset builtin firewall resolver cache state between tests."""
     builtin_firewall_cache.reset_cache_for_tests()
+    _bundled_fallback_warnings.clear()
 
 
 def catalog_file_key(
@@ -90,9 +106,60 @@ def _catalog_source_for_name(
         catalog_firewall = cached_catalog.firewalls.get(raw_name)
         if catalog_firewall is not None:
             return catalog_firewall, cached_catalog.identity
+        fallback_reason = "cache_missing_firewall"
+    else:
+        fallback_reason = catalog_snapshot.fallback_reason or "cache_unavailable"
 
     catalog_firewall = BUILTIN_FIREWALLS.get(raw_name)
+    if catalog_firewall is not None:
+        _warn_bundled_fallback(
+            raw_name=raw_name,
+            reason=fallback_reason,
+            catalog_snapshot=catalog_snapshot,
+        )
     return catalog_firewall, ("bundled", raw_name, str(id(catalog_firewall)))
+
+
+def _warn_bundled_fallback(
+    *,
+    raw_name: str,
+    reason: str,
+    catalog_snapshot: BuiltinFirewallCatalogSnapshot,
+) -> None:
+    cached_catalog = catalog_snapshot.catalog
+    catalog_digest = None
+    catalog_version = None
+    if cached_catalog is not None:
+        _, catalog_digest, catalog_version, _ = cached_catalog.identity
+
+    warning_key = (
+        raw_name,
+        reason,
+        catalog_snapshot.cache_path,
+        catalog_snapshot.dependency_file_key,
+        catalog_digest,
+        catalog_version,
+    )
+    if warning_key in _bundled_fallback_warnings:
+        return
+    _bundled_fallback_warnings.add(warning_key)
+
+    fields = [
+        "Using bundled builtin firewall fallback",
+        f"reason={reason}",
+        f"firewall_name={raw_name}",
+    ]
+    if catalog_snapshot.cache_path is not None:
+        fields.append(f"cache_path={catalog_snapshot.cache_path}")
+    if catalog_digest is not None:
+        fields.append(f"catalog_digest={catalog_digest}")
+    if catalog_version is not None:
+        fields.append(f"catalog_version={catalog_version}")
+    if catalog_snapshot.dependency_file_key is not None:
+        fields.append(f"cache_file_key={catalog_snapshot.dependency_file_key!r}")
+
+    with suppress(Exception):
+        ctx.log.warn(" ".join(fields))
 
 
 def _resolve_builtin_firewall_entry(

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -376,6 +376,98 @@ class TestRegistryBuiltinCache:
         assert second_compiled is not None
         assert second_vm_info["firewalls"][0]["apis"][0]["base"] == "https://cache.example.com"
 
+    def test_missing_runner_catalog_cache_logs_bundled_fallback_once(
+        self, tmp_path, monkeypatch, mitm_ctx
+    ):
+        cache_path = tmp_path / "missing-builtin-firewall-catalog-cache.json"
+        monkeypatch.setattr(
+            registry_firewalls,
+            "BUILTIN_FIREWALLS",
+            {
+                "fallback": {
+                    "name": "fallback",
+                    "apis": [
+                        {
+                            "base": "https://bundled.example.com",
+                            "auth": {"headers": {}},
+                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+                        }
+                    ],
+                }
+            },
+        )
+        snapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
+            dependency_file_key=None,
+            catalog=None,
+            cache_path=str(cache_path),
+            fallback_reason="cache_file_missing",
+        )
+
+        with mitm_ctx() as log:
+            for _ in range(2):
+                resolved = registry_firewalls.resolve_firewall_entries(
+                    builtin_vm("run-fallback", "fallback"),
+                    builtin_firewall_catalog_snapshot=snapshot,
+                )
+                assert resolved.firewalls is not None
+                assert resolved.firewalls[0]["apis"][0]["base"] == "https://bundled.example.com"
+
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert "Using bundled builtin firewall fallback" in warning
+        assert "reason=cache_file_missing" in warning
+        assert "firewall_name=fallback" in warning
+        assert f"cache_path={cache_path}" in warning
+
+    def test_runner_catalog_cache_missing_firewall_logs_bundled_fallback(
+        self, monkeypatch, mitm_ctx
+    ):
+        monkeypatch.setattr(
+            registry_firewalls,
+            "BUILTIN_FIREWALLS",
+            {
+                "fallback": {
+                    "name": "fallback",
+                    "apis": [
+                        {
+                            "base": "https://bundled.example.com",
+                            "auth": {"headers": {}},
+                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+                        }
+                    ],
+                }
+            },
+        )
+        snapshot = _catalog_snapshot(
+            digest_char="a",
+            version="catalog-a",
+            firewalls={
+                "other": _cache_firewall(
+                    "other",
+                    "https://cache.example.com",
+                )
+            },
+        )
+
+        with mitm_ctx() as log:
+            resolved = registry_firewalls.resolve_firewall_entries(
+                builtin_vm("run-fallback", "fallback"),
+                builtin_firewall_catalog_snapshot=snapshot,
+            )
+
+        assert resolved.firewalls is not None
+        assert resolved.firewalls[0]["apis"][0]["base"] == "https://bundled.example.com"
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert "Using bundled builtin firewall fallback" in warning
+        assert "reason=cache_missing_firewall" in warning
+        assert "firewall_name=fallback" in warning
+        assert (
+            "catalog_digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            in warning
+        )
+        assert "catalog_version=catalog-a" in warning
+
     def test_registry_reload_pins_one_catalog_snapshot_for_builtin_entries(
         self, tmp_path, monkeypatch, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -448,15 +448,20 @@ class TestRegistryBuiltinCache:
                 )
             },
         )
+        rewritten_snapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
+            dependency_file_key=("catalog-cache/catalog-a.json", 1, 2, 3, 4),
+            catalog=snapshot.catalog,
+        )
 
         with mitm_ctx() as log:
-            resolved = registry_firewalls.resolve_firewall_entries(
-                builtin_vm("run-fallback", "fallback"),
-                builtin_firewall_catalog_snapshot=snapshot,
-            )
+            for current_snapshot in (snapshot, rewritten_snapshot):
+                resolved = registry_firewalls.resolve_firewall_entries(
+                    builtin_vm("run-fallback", "fallback"),
+                    builtin_firewall_catalog_snapshot=current_snapshot,
+                )
+                assert resolved.firewalls is not None
+                assert resolved.firewalls[0]["apis"][0]["base"] == "https://bundled.example.com"
 
-        assert resolved.firewalls is not None
-        assert resolved.firewalls[0]["apis"][0]["base"] == "https://bundled.example.com"
         log.warn.assert_called_once()
         warning = log.warn.call_args.args[0]
         assert "Using bundled builtin firewall fallback" in warning
@@ -467,6 +472,7 @@ class TestRegistryBuiltinCache:
             in warning
         )
         assert "catalog_version=catalog-a" in warning
+        assert "cache_file_key=" not in warning
 
     def test_registry_reload_pins_one_catalog_snapshot_for_builtin_entries(
         self, tmp_path, monkeypatch, mitm_ctx
@@ -904,6 +910,56 @@ class TestRegistryBuiltinCache:
             firewall,
             cache_mode=0o666,
         )
+
+    def test_world_writable_runner_catalog_cache_logs_untrusted_fallback(
+        self, tmp_path, monkeypatch, mitm_ctx
+    ):
+        registry_path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        monkeypatch.setattr(
+            registry_firewalls,
+            "BUILTIN_FIREWALLS",
+            {
+                "fallback": {
+                    "name": "fallback",
+                    "apis": [
+                        {
+                            "base": "https://bundled.example.com",
+                            "auth": {"headers": {}},
+                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
+                        }
+                    ],
+                }
+            },
+        )
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"fallback": _cache_firewall("fallback", "https://cache.example.com")},
+        )
+        cache_path.chmod(0o666)
+        write_multi_vm_registry(
+            registry_path,
+            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
+        )
+
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ) as log:
+            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
+        log.warn.assert_called_once()
+        warning = log.warn.call_args.args[0]
+        assert "Using bundled builtin firewall fallback" in warning
+        assert "reason=cache_untrusted" in warning
+        assert "firewall_name=fallback" in warning
+        assert f"cache_path={cache_path}" in warning
 
     def test_malformed_aws_sigv4_runner_catalog_cache_falls_back_to_bundled(
         self, tmp_path, monkeypatch, mitm_ctx


### PR DESCRIPTION
## Summary
- add fallback metadata to builtin firewall catalog cache snapshots
- warn when mitm-addon actually resolves a builtin firewall from the bundled fallback catalog
- dedupe fallback warnings by reason, firewall, cache path, cache file key, and catalog identity

## Tests
- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff check src/builtin_firewall_cache.py src/registry_firewalls.py tests/test_registry_builtin_cache.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff format --check src/builtin_firewall_cache.py src/registry_firewalls.py tests/test_registry_builtin_cache.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_registry_builtin_cache.py tests/test_registry_context.py tests/test_registry_context_state.py tests/test_registry_loading.py`