### PR TITLE
feat: add memory source detail view

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-relationships.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-relationships.test.ts
@@ -1003,6 +1003,35 @@ describe("GET /api/zero/relationships/*", () => {
     });
     expect(sources.body.sources[0]?.contentHash).toMatch(/^[a-f0-9]{64}$/);
 
+    const sourceId = sources.body.sources[0]?.id;
+    expect(sourceId).toBeDefined();
+    const sourceDetail = await accept(
+      memoryClient().source({
+        headers: authHeaders(),
+        params: { sourceId: sourceId ?? randomUUID() },
+      }),
+      [200],
+    );
+    expect(sourceDetail.body).toMatchObject({
+      id: sourceId,
+      provider: "slack",
+      sourceType: "slack_message",
+      externalId: "T-memory-backfill:C-memory:1780000000.000100",
+      connectorId: null,
+      title: "Slack channel message",
+      occurredAt: "2026-05-28T20:26:40.000Z",
+      metadata: {
+        workspaceId: "T-memory-backfill",
+        channelId: "C-memory",
+        channelType: "channel",
+        threadId: null,
+        messageTs: "1780000000.000100",
+        senderId: "U-memory-user",
+        participantIds: ["U-memory-user"],
+        fileIds: [],
+      },
+    });
+
     const relationships = await accept(
       relationshipsClient().search({
         headers: authHeaders(),

--- a/turbo/apps/api/src/signals/routes/zero-memory.ts
+++ b/turbo/apps/api/src/signals/routes/zero-memory.ts
@@ -5,12 +5,16 @@ import { isFeatureEnabled } from "@vm0/core/feature-switch";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
-import { bodyResultOf, queryOf } from "../context/request";
+import { notFound } from "../../lib/error";
+import { bodyResultOf, pathParamsOf, queryOf } from "../context/request";
 import type { RouteEntry } from "../route-entry";
 import { zeroMemoryDetail } from "../services/zero-memory-detail.service";
 import { db$, writeDb$, type ReadonlyDb } from "../external/db";
 import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
-import { listMemorySources } from "../services/memory-substrate.service";
+import {
+  getMemorySourceDetail,
+  listMemorySources,
+} from "../services/memory-substrate.service";
 import {
   getSlackMemoryStatus,
   restartSlackMemoryBackfill,
@@ -51,6 +55,7 @@ const getMemoryInner$ = computed(async (get): Promise<unknown> => {
 });
 
 const memorySourcesQuery$ = queryOf(zeroMemoryContract.sources);
+const memorySourceParams$ = pathParamsOf(zeroMemoryContract.source);
 const slackBackfillBody$ = bodyResultOf(zeroMemoryContract.slackBackfill);
 
 const memorySourcesInner$ = computed(async (get): Promise<unknown> => {
@@ -72,6 +77,26 @@ const memorySourcesInner$ = computed(async (get): Promise<unknown> => {
     status: 200 as const,
     body: result,
   };
+});
+
+const memorySourceInner$ = computed(async (get): Promise<unknown> => {
+  const auth = get(organizationAuthContext$);
+  if (!(await isMemorySourceEnabled(get(db$), auth.orgId, auth.userId))) {
+    return memorySourceDisabled;
+  }
+
+  const params = get(memorySourceParams$);
+  const result = await getMemorySourceDetail(get(db$), {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    sourceId: params.sourceId,
+  });
+
+  if (!result) {
+    return notFound("Memory source not found");
+  }
+
+  return { status: 200 as const, body: result };
 });
 
 const slackStatusInner$ = computed(async (get): Promise<unknown> => {
@@ -164,6 +189,10 @@ export const zeroMemoryRoutes: readonly RouteEntry[] = [
   {
     route: zeroMemoryContract.sources,
     handler: authRoute(memoryAuthOptions, memorySourcesInner$),
+  },
+  {
+    route: zeroMemoryContract.source,
+    handler: authRoute(memoryAuthOptions, memorySourceInner$),
   },
   {
     route: zeroMemoryContract.slackStatus,

--- a/turbo/apps/api/src/signals/services/memory-substrate.service.ts
+++ b/turbo/apps/api/src/signals/services/memory-substrate.service.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import type {
+  MemorySourceDetailResponse,
   MemorySourceListResponse,
   MemorySourceProvider,
 } from "@vm0/api-contracts/contracts/zero-memory";
@@ -114,6 +115,68 @@ function compactMemorySourceMetadata(
     ...(metadata.mailboxEmail ? { mailboxEmail: metadata.mailboxEmail } : {}),
     ...(metadata.direction ? { direction: metadata.direction } : {}),
   };
+}
+
+function serializeMemorySourceMetadata(
+  metadata: MemorySourceMetadata,
+): MemorySourceDetailResponse["metadata"] {
+  return {
+    workspaceId: metadata.workspaceId,
+    channelId: metadata.channelId,
+    channelType: metadata.channelType,
+    threadId: metadata.threadId,
+    messageId: metadata.messageId,
+    messageTs: metadata.messageTs,
+    senderId: metadata.senderId,
+    participantIds: metadata.participantIds
+      ? [...metadata.participantIds]
+      : undefined,
+    fileIds: metadata.fileIds ? [...metadata.fileIds] : undefined,
+    mailboxEmail: metadata.mailboxEmail,
+    historyId: metadata.historyId,
+    direction: metadata.direction,
+    from: metadata.from,
+    to: metadata.to ? [...metadata.to] : undefined,
+    cc: metadata.cc ? [...metadata.cc] : undefined,
+    reason: metadata.reason,
+  };
+}
+
+function serializeMemorySourceDetail(
+  row: typeof memorySources.$inferSelect,
+): MemorySourceDetailResponse {
+  return {
+    id: row.id,
+    provider: row.provider,
+    sourceType: row.sourceType,
+    title: row.title,
+    occurredAt: serializeDate(row.occurredAt),
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    externalId: row.externalId,
+    connectorId: row.connectorId,
+    contentHash: row.contentHash,
+    metadata: serializeMemorySourceMetadata(row.metadata),
+  };
+}
+
+export async function getMemorySourceDetail(
+  db: ReadonlyDb,
+  args: MemoryScope & { readonly sourceId: string },
+): Promise<MemorySourceDetailResponse | null> {
+  const [row] = await db
+    .select()
+    .from(memorySources)
+    .where(
+      and(
+        eq(memorySources.orgId, args.orgId),
+        eq(memorySources.userId, args.userId),
+        eq(memorySources.id, args.sourceId),
+      ),
+    )
+    .limit(1);
+
+  return row ? serializeMemorySourceDetail(row) : null;
 }
 
 export async function listMemorySources(

--- a/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
+++ b/turbo/apps/platform/src/signals/memory-page/memory-signals.ts
@@ -2,6 +2,7 @@ import { command, computed, state } from "ccstate";
 import {
   zeroMemoryContract,
   type MemoryDetailResponse,
+  type MemorySourceDetailResponse,
   type MemorySourceListResponse,
   type MemorySourceProvider,
   type SlackMemoryBackfillRequest,
@@ -246,6 +247,7 @@ const internalMemorySourceProviderFilter$ =
 const internalMemorySourcePage$ = state(1);
 const internalMemorySourceLimit$ = state(50);
 const internalMemorySourcesReload$ = state(0);
+const internalSelectedMemorySourceId$ = state<string | null>(null);
 const internalSlackMemoryStatusReload$ = state(0);
 const internalSlackMemoryBackfillDialogOpen$ = state(false);
 const internalSlackMemoryBackfillRequest$ = state<SlackMemoryBackfillRequest>(
@@ -255,6 +257,16 @@ const internalSlackMemoryBackfillRequest$ = state<SlackMemoryBackfillRequest>(
 export const memorySourceProviderFilter$ = computed((get) => {
   return get(internalMemorySourceProviderFilter$);
 });
+
+export const selectedMemorySourceId$ = computed((get) => {
+  return get(internalSelectedMemorySourceId$);
+});
+
+export const setSelectedMemorySourceId$ = command(
+  ({ set }, sourceId: string | null) => {
+    set(internalSelectedMemorySourceId$, sourceId);
+  },
+);
 
 export const setMemorySourceProviderFilter$ = command(
   ({ set }, filter: MemorySourceProviderFilter) => {
@@ -411,6 +423,19 @@ export const memorySources$ = computed(
       }),
       [200],
     );
+    return result.body;
+  },
+);
+
+export const selectedMemorySourceDetail$ = computed(
+  async (get): Promise<MemorySourceDetailResponse | null> => {
+    const sourceId = get(selectedMemorySourceId$);
+    if (!sourceId) {
+      return null;
+    }
+
+    const client = get(zeroClient$)(zeroMemoryContract);
+    const result = await accept(client.source({ params: { sourceId } }), [200]);
     return result.body;
   },
 );

--- a/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
+++ b/turbo/apps/platform/src/views/memory-page/__tests__/memory-page.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import {
   zeroMemoryContract,
   type MemoryDetailResponse,
+  type MemorySourceDetailResponse,
   type MemorySourceListResponse,
   type SlackMemoryStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-memory";
@@ -195,6 +196,31 @@ function memorySourceListPage(
       total: sources.length,
       totalPages: 1,
       hasMore: false,
+    },
+  };
+}
+
+function memorySourceDetail(sourceId: string): MemorySourceDetailResponse {
+  return {
+    id: sourceId,
+    provider: "slack",
+    sourceType: "slack_message",
+    title: "Slack channel message",
+    occurredAt: `${localDateDaysAgo(0)}T10:00:00Z`,
+    createdAt: `${localDateDaysAgo(0)}T10:01:00Z`,
+    updatedAt: `${localDateDaysAgo(0)}T10:02:00Z`,
+    externalId: "T-memory:C-memory:1780000000.000100",
+    connectorId: null,
+    contentHash: "a".repeat(64),
+    metadata: {
+      workspaceId: "T-memory",
+      channelId: "C-memory",
+      channelType: "channel",
+      threadId: null,
+      messageTs: "1780000000.000100",
+      senderId: "U-memory-user",
+      participantIds: ["U-memory-user"],
+      fileIds: [],
     },
   };
 }
@@ -768,6 +794,10 @@ describe("memory page", () => {
       sourceQueries.push(query.provider);
       return respond(200, memorySourceListPage(query.provider));
     });
+    context.mocks.api(zeroMemoryContract.source, ({ params, respond }) => {
+      expect(params.sourceId).toBe("00000000-0000-4000-8000-000000000301");
+      return respond(200, memorySourceDetail(params.sourceId));
+    });
 
     let status = slackMemoryStatus();
     context.mocks.api(zeroMemoryContract.slackStatus, ({ respond }) => {
@@ -837,6 +867,16 @@ describe("memory page", () => {
         screen.getByText("Backfilling Slack - 0 scanned, 0 recorded"),
       ).toBeInTheDocument();
     });
+
+    click(getButtonWithText("Details"));
+    await waitFor(() => {
+      expect(screen.getByText("Source details")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("T-memory:C-memory:1780000000.000100"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Participants")).toBeInTheDocument();
+    expect(screen.getAllByText("U-memory-user").length).toBeGreaterThan(0);
   });
 
   it("moves through relationship pages from the relationships tab", async () => {

--- a/turbo/apps/platform/src/views/memory-page/memory-sources.tsx
+++ b/turbo/apps/platform/src/views/memory-page/memory-sources.tsx
@@ -3,12 +3,14 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconBrandSlack,
   IconDatabase,
+  IconInfoCircle,
   IconLoader2,
   IconMail,
   IconPlayerStop,
   IconRefresh,
 } from "@tabler/icons-react";
 import type {
+  MemorySourceDetailResponse,
   MemorySourceListResponse,
   SlackMemoryBackfillRequest,
   SlackMemoryStatusResponse,
@@ -43,8 +45,11 @@ import {
   memorySources$,
   reloadMemorySources$,
   reloadSlackMemoryStatus$,
+  selectedMemorySourceDetail$,
+  selectedMemorySourceId$,
   setMemorySourceProviderFilter$,
   setMemorySourceRowsPerPage$,
+  setSelectedMemorySourceId$,
   setSlackMemoryBackfillDialogOpen$,
   slackMemoryBackfillDialogOpen$,
   slackMemoryBackfillRequest$,
@@ -75,6 +80,25 @@ const SLACK_BACKFILL_DAY_OPTIONS = [
 ] as const;
 
 type MemorySource = MemorySourceListResponse["sources"][number];
+
+const SOURCE_DETAIL_METADATA_ORDER: readonly string[] = [
+  "workspaceId",
+  "channelId",
+  "channelType",
+  "threadId",
+  "messageId",
+  "messageTs",
+  "senderId",
+  "participantIds",
+  "fileIds",
+  "mailboxEmail",
+  "historyId",
+  "direction",
+  "from",
+  "to",
+  "cc",
+  "reason",
+];
 
 function formatDateTime(value: string | null): string {
   if (!value) {
@@ -142,6 +166,212 @@ function sourceCountLabel(
   const start = (pagination.page - 1) * pagination.pageSize + 1;
   const end = Math.min(start + visibleCount - 1, pagination.total);
   return `${start}-${end} of ${pagination.total}`;
+}
+
+function detailMetadataLabel(key: string): string {
+  if (key === "workspaceId") {
+    return "Workspace ID";
+  }
+  if (key === "channelId") {
+    return "Channel ID";
+  }
+  if (key === "channelType") {
+    return "Channel type";
+  }
+  if (key === "threadId") {
+    return "Thread ID";
+  }
+  if (key === "messageId") {
+    return "Message ID";
+  }
+  if (key === "messageTs") {
+    return "Message timestamp";
+  }
+  if (key === "senderId") {
+    return "Sender ID";
+  }
+  if (key === "participantIds") {
+    return "Participants";
+  }
+  if (key === "fileIds") {
+    return "Files";
+  }
+  if (key === "mailboxEmail") {
+    return "Mailbox";
+  }
+  if (key === "historyId") {
+    return "History ID";
+  }
+  if (key === "direction") {
+    return "Direction";
+  }
+  if (key === "from") {
+    return "From";
+  }
+  if (key === "to") {
+    return "To";
+  }
+  if (key === "cc") {
+    return "Cc";
+  }
+  if (key === "reason") {
+    return "Reason";
+  }
+  return key;
+}
+
+function detailMetadataEntries(
+  metadata: MemorySourceDetailResponse["metadata"],
+): [string, unknown][] {
+  return Object.entries(metadata).sort(([left], [right]) => {
+    const leftIndex = SOURCE_DETAIL_METADATA_ORDER.indexOf(left);
+    const rightIndex = SOURCE_DETAIL_METADATA_ORDER.indexOf(right);
+    if (leftIndex === -1 && rightIndex === -1) {
+      return left.localeCompare(right);
+    }
+    if (leftIndex === -1) {
+      return 1;
+    }
+    if (rightIndex === -1) {
+      return -1;
+    }
+    return leftIndex - rightIndex;
+  });
+}
+
+function detailValueText(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "None";
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.join(", ") : "None";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function SourceDetailField({
+  label,
+  mono = false,
+  value,
+}: {
+  readonly label: string;
+  readonly mono?: boolean;
+  readonly value: unknown;
+}) {
+  return (
+    <div className="grid gap-1 border-b border-border/60 py-2 last:border-b-0 sm:grid-cols-[9rem_1fr] sm:gap-3">
+      <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
+      <dd
+        className={cn(
+          "min-w-0 break-words text-sm text-foreground",
+          mono ? "font-mono text-xs leading-5" : null,
+        )}
+      >
+        {detailValueText(value)}
+      </dd>
+    </div>
+  );
+}
+
+function SourceDetailDialog() {
+  const selectedSourceId = useGet(selectedMemorySourceId$);
+  const setSelectedSourceId = useSet(setSelectedMemorySourceId$);
+  const detailLoadable = useLoadable(selectedMemorySourceDetail$);
+  const open = selectedSourceId !== null;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          setSelectedSourceId(null);
+        }
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Source details</DialogTitle>
+          <DialogDescription>
+            Review the identifiers and metadata recorded for this source.
+          </DialogDescription>
+        </DialogHeader>
+        {detailLoadable.state === "loading" ? (
+          <div className="flex min-h-40 items-center justify-center gap-2 text-sm text-muted-foreground">
+            <IconLoader2 className="h-4 w-4 animate-spin" />
+            <span>Loading source details</span>
+          </div>
+        ) : detailLoadable.state === "hasError" ? (
+          <div className="flex min-h-40 items-center justify-center px-6 text-center text-sm text-muted-foreground">
+            Source details are unavailable.
+          </div>
+        ) : detailLoadable.data ? (
+          <div className="max-h-[70vh] overflow-y-auto pr-1">
+            <dl className="rounded-lg border border-border/70 px-3">
+              <SourceDetailField
+                label="Title"
+                value={detailLoadable.data.title}
+              />
+              <SourceDetailField
+                label="Provider"
+                value={providerLabel(detailLoadable.data.provider)}
+              />
+              <SourceDetailField
+                label="Source type"
+                value={sourceTypeLabel(detailLoadable.data)}
+              />
+              <SourceDetailField
+                label="Occurred"
+                value={formatDateTime(detailLoadable.data.occurredAt)}
+              />
+              <SourceDetailField
+                label="Created"
+                value={formatDateTime(detailLoadable.data.createdAt)}
+              />
+              <SourceDetailField
+                label="Updated"
+                value={formatDateTime(detailLoadable.data.updatedAt)}
+              />
+              <SourceDetailField
+                label="External ID"
+                mono
+                value={detailLoadable.data.externalId}
+              />
+              <SourceDetailField
+                label="Connector ID"
+                mono
+                value={detailLoadable.data.connectorId}
+              />
+              <SourceDetailField
+                label="Content hash"
+                mono
+                value={detailLoadable.data.contentHash}
+              />
+            </dl>
+            <div className="mt-4">
+              <p className="text-sm font-medium text-foreground">Metadata</p>
+              <dl className="mt-2 rounded-lg border border-border/70 px-3">
+                {detailMetadataEntries(detailLoadable.data.metadata).map(
+                  ([key, value]) => {
+                    return (
+                      <SourceDetailField
+                        key={key}
+                        label={detailMetadataLabel(key)}
+                        mono={Array.isArray(value) || key.endsWith("Id")}
+                        value={value}
+                      />
+                    );
+                  },
+                )}
+              </dl>
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 function backfillProgressText(
@@ -544,6 +774,7 @@ function SourcesToolbar({
 function SourceRow({ source }: { readonly source: MemorySource }) {
   const Icon = providerIcon(source);
   const metadataParts = sourceMetadataParts(source);
+  const setSelectedSourceId = useSet(setSelectedMemorySourceId$);
 
   return (
     <article className="flex min-w-0 gap-3 border-b border-border/70 px-4 py-3 last:border-b-0">
@@ -576,6 +807,18 @@ function SourceRow({ source }: { readonly source: MemorySource }) {
           </p>
         ) : null}
       </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 shrink-0 gap-1.5 px-2.5 text-xs"
+        onClick={() => {
+          setSelectedSourceId(source.id);
+        }}
+      >
+        <IconInfoCircle className="h-3.5 w-3.5" />
+        <span>Details</span>
+      </Button>
     </article>
   );
 }
@@ -680,6 +923,7 @@ export function MemorySources() {
           onRowsPerPageChange={setRowsPerPage}
         />
       </div>
+      <SourceDetailDialog />
     </section>
   );
 }

--- a/turbo/packages/api-contracts/src/contracts/zero-memory.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-memory.ts
@@ -15,8 +15,38 @@ const memoryFileContentSchema = z.object({
 });
 
 const memorySourceProviderSchema = z.enum(["gmail", "slack"]);
+const memorySourceDirectionSchema = z.enum([
+  "sent",
+  "received",
+  "mixed",
+  "unknown",
+]);
 
-const memorySourceSchema = z.object({
+const memorySourceCompactMetadataSchema = z.object({
+  workspaceId: z.string().optional(),
+  channelId: z.string().optional(),
+  channelType: z.string().optional(),
+  threadId: z.string().nullable().optional(),
+  messageTs: z.string().optional(),
+  senderId: z.string().optional(),
+  mailboxEmail: z.string().optional(),
+  direction: memorySourceDirectionSchema.optional(),
+});
+
+const memorySourceMetadataSchema = memorySourceCompactMetadataSchema
+  .extend({
+    messageId: z.string().nullable().optional(),
+    participantIds: z.array(z.string()).optional(),
+    fileIds: z.array(z.string()).optional(),
+    historyId: z.string().optional(),
+    from: z.string().nullable().optional(),
+    to: z.array(z.string()).optional(),
+    cc: z.array(z.string()).optional(),
+    reason: z.string().optional(),
+  })
+  .passthrough();
+
+const memorySourceBaseSchema = z.object({
   id: z.string().uuid(),
   provider: memorySourceProviderSchema,
   sourceType: z.enum(["gmail_message", "slack_message"]),
@@ -24,16 +54,17 @@ const memorySourceSchema = z.object({
   occurredAt: z.string().nullable(),
   createdAt: z.string(),
   contentHash: z.string().nullable(),
-  metadata: z.object({
-    workspaceId: z.string().optional(),
-    channelId: z.string().optional(),
-    channelType: z.string().optional(),
-    threadId: z.string().nullable().optional(),
-    messageTs: z.string().optional(),
-    senderId: z.string().optional(),
-    mailboxEmail: z.string().optional(),
-    direction: z.enum(["sent", "received", "mixed", "unknown"]).optional(),
-  }),
+});
+
+const memorySourceSchema = memorySourceBaseSchema.extend({
+  metadata: memorySourceCompactMetadataSchema,
+});
+
+const memorySourceDetailResponseSchema = memorySourceBaseSchema.extend({
+  externalId: z.string(),
+  connectorId: z.string().uuid().nullable(),
+  updatedAt: z.string(),
+  metadata: memorySourceMetadataSchema,
 });
 
 export const memorySourceListResponseSchema = z.object({
@@ -102,6 +133,9 @@ export type MemorySourceProvider = z.infer<typeof memorySourceProviderSchema>;
 export type MemorySourceListResponse = z.infer<
   typeof memorySourceListResponseSchema
 >;
+export type MemorySourceDetailResponse = z.infer<
+  typeof memorySourceDetailResponseSchema
+>;
 export type SlackMemoryStatusResponse = z.infer<
   typeof slackMemoryStatusResponseSchema
 >;
@@ -142,6 +176,22 @@ export const zeroMemoryContract = c.router({
       500: apiErrorSchema,
     },
     summary: "List structured memory sources for the current user",
+  },
+  source: {
+    method: "GET",
+    path: "/api/zero/memory/sources/:sourceId",
+    pathParams: z.object({
+      sourceId: z.string().uuid(),
+    }),
+    headers: authHeadersSchema,
+    responses: {
+      200: memorySourceDetailResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get structured memory source details for the current user",
   },
   slackStatus: {
     method: "GET",


### PR DESCRIPTION
## Summary
- Adds a dedicated memory source detail endpoint scoped to the current org and user.
- Shows a Details action on Memory > Sources rows and opens a dialog with source identifiers, timestamps, content hash, and provider metadata.
- Extends API and platform tests to cover Slack source detail retrieval and rendering.

## Verification
- pnpm format
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pnpm -F @vm0/app lint
- pnpm -F @vm0/api-contracts check-types
- NODE_OPTIONS='--max-old-space-size=4096' pnpm -F api check-types
- NODE_OPTIONS='--max-old-space-size=4096' pnpm -F @vm0/app check-types
- DATABASE_URL='postgresql://postgres@localhost:5432/vm0_test' pnpm -F api exec vitest run src/signals/routes/__tests__/zero-relationships.test.ts
- pnpm -F @vm0/app exec vitest run src/views/memory-page/__tests__/memory-page.test.tsx
