### PR TITLE
fix: render chat thread emoji picker glyphs in color

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -18,6 +18,12 @@
     Roboto, sans-serif;
   --font-family-mono:
     "JetBrains Mono", ui-monospace, "SF Mono", Monaco, Consolas, monospace;
+  /* Color-emoji fonts must come first so dual-presentation codepoints (e.g. the
+     "squared CJK" buttons 🈶🈯🈹) resolve to their color glyph instead of the
+     text glyph a CJK text font would otherwise supply. */
+  --font-family-emoji:
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji", sans-serif;
 
   /* Sidebar colors - using tokens for dark mode support */
   --color-sidebar: hsl(var(--gray-0));
@@ -322,6 +328,13 @@ body {
 }
 
 /* Reusable 0.7px border utilities — replaces inline style={{ border: "0.7px solid ..." }} */
+/* Force the color-emoji font ahead of the inherited CJK/text stack so emoji
+   glyphs render in color. Without this, dual-presentation codepoints fall back
+   to a CJK text font and appear as flat black outlines. */
+.zero-emoji {
+  font-family: var(--font-family-emoji);
+}
+
 .zero-border {
   border: 0.7px solid hsl(var(--gray-400));
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -576,7 +576,10 @@ function ChatThreadEmojiMenuButton({
                 className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
               >
                 {emoji ? (
-                  <span aria-hidden="true" className="text-base leading-none">
+                  <span
+                    aria-hidden="true"
+                    className="zero-emoji text-base leading-none"
+                  >
                     {emoji}
                   </span>
                 ) : (
@@ -770,7 +773,9 @@ function ChatThreadEmojiGrid({
               onSelect(item.emoji);
             }}
           >
-            <span aria-hidden="true">{item.emoji}</span>
+            <span aria-hidden="true" className="zero-emoji">
+              {item.emoji}
+            </span>
             {shortcutDigit !== null && (
               <span
                 aria-hidden="true"


### PR DESCRIPTION
## Problem

In the chat thread icon (emoji) picker, several emoji rendered as flat black-outline characters instead of color glyphs, while their neighbors rendered normally — an inconsistent, broken-looking grid.

The affected glyphs are the enclosed-ideograph **"squared CJK" buttons**: 🈶 🈯 🈹 🈚 🈲 🉑 🈸 🈴 🈳 🈵 (reported via a picker screenshot).

## Root cause

The picker rendered each emoji in a bare `<span>{emoji}</span>` that inherited the app's `--font-family-sans` stack (`"Noto Sans", system-ui, …`). Those codepoints are **dual-presentation** (they have both a text and an emoji form). With no color-emoji font ahead of the inherited text stack, the browser resolved them from a CJK text font first and drew the flat text glyph. Neighboring emoji (e.g. 🆙 🆚) aren't in that CJK font, so they fell through to the color-emoji font and looked fine — hence the inconsistency.

## Fix

- Add a `--font-family-emoji` theme variable that lists color-emoji fonts first (`"Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", sans-serif`) and a reusable `.zero-emoji` utility class.
- Apply `.zero-emoji` to the two emoji render sites in the thread picker: the grid cells and the selected-icon trigger button.

Because color-emoji fonts contain no Latin/CJK letter glyphs, forcing them first only affects emoji codepoints — regular text still falls through to the sans stack.

## Verification

- Focused CSS + `className` change; no logic paths touched. Relying on the PR pipeline for lint/type/test.
- Manual visual check recommended on the preview: open the chat thread icon picker and confirm the squared-CJK row renders in color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)