### PR TITLE
fix: focus current main chat in sidebar thread list

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1109,6 +1109,32 @@ describe("zero sidebar", () => {
     expect(link).toHaveClass("focus-visible:ring-ring");
   });
 
+  it("focuses the current main chat when the thread list receives focus", async () => {
+    prepareDefaultAgent();
+    mockSidebarThreadStory([
+      createThread(INCIDENT_THREAD_ID, "Incident notes"),
+      createThread(EXISTING_THREAD_ID, "Release plan"),
+      createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+    ]);
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(within(sidebar()).getByText("Incident notes")).toBeInTheDocument();
+      expect(within(sidebar()).getByText("Release plan")).toBeInTheDocument();
+    });
+
+    screen.getByTestId("sidebar-scroll-area").focus();
+
+    await waitFor(() => {
+      expect(threadLinkByTitle("Release plan")).toHaveFocus();
+    });
+    expect(threadLinkByTitle("Incident notes")).not.toHaveFocus();
+  });
+
   it("keeps pinned agents and the chat title outside the thread list scroll area", async () => {
     prepareAgentTeam();
     context.mocks.data.userPreferences({

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -96,6 +96,7 @@ import {
   setChatThreadVirtualListElement$,
   getChatThreadVirtualListScrollMargin,
   CHAT_THREAD_VIRTUAL_ROW_HEIGHT,
+  scrollChatThreadVirtualListToIndex$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { Link } from "../router/link.tsx";
 import { OverlayScrollArea } from "./zero-sidebar-scroll.tsx";
@@ -517,6 +518,7 @@ function ChatThreadItemLink({
       pathname="/chats/:threadId"
       options={{ pathParams: { threadId: session.id } }}
       aria-current={state.isCurrentPage ? "page" : undefined}
+      data-sidebar-chat-thread-id={session.id}
       onClick={(e) => {
         handleChatThreadClick(e, {
           closeSidebarOnSelect,
@@ -982,6 +984,59 @@ function ChatThreadsContent() {
   const collapsed = useGet(sessionListCollapsed$);
   const isScrolled = useGet(isScrolled$);
   const setIsScrolledFn = useSet(setIsScrolled$);
+  const pathParams = useGet(pathParams$);
+  const currentMainThreadId =
+    typeof pathParams?.threadId === "string" ? pathParams.threadId : null;
+  const scrollVirtualListToIndex = useSet(scrollChatThreadVirtualListToIndex$);
+  const focusThreadLink = (
+    viewport: HTMLElement,
+    threadId: string,
+  ): boolean => {
+    const link = Array.from(
+      viewport.querySelectorAll<HTMLAnchorElement>(
+        "[data-sidebar-chat-thread-id]",
+      ),
+    ).find((candidate) => {
+      return candidate.dataset.sidebarChatThreadId === threadId;
+    });
+    if (!link?.isConnected) {
+      return false;
+    }
+    link.focus({ preventScroll: true });
+    return true;
+  };
+  const focusThreadLinkOnNextFrame = (
+    viewport: HTMLElement,
+    threadId: string,
+  ) => {
+    const win = viewport.ownerDocument.defaultView;
+    const focus = () => {
+      focusThreadLink(viewport, threadId);
+    };
+    if (win?.requestAnimationFrame) {
+      win.requestAnimationFrame(focus);
+    } else {
+      queueMicrotask(focus);
+    }
+  };
+  const focusCurrentMainThreadLink = (viewport: HTMLElement) => {
+    if (
+      !currentMainThreadId ||
+      focusThreadLink(viewport, currentMainThreadId)
+    ) {
+      return;
+    }
+
+    const currentIndex = chatThreads.findIndex((thread) => {
+      return thread.id === currentMainThreadId;
+    });
+    if (currentIndex === -1) {
+      return;
+    }
+
+    scrollVirtualListToIndex(currentIndex, "top");
+    focusThreadLinkOnNextFrame(viewport, currentMainThreadId);
+  };
 
   if (collapsed) {
     return null;
@@ -1000,7 +1055,15 @@ function ChatThreadsContent() {
   return (
     <OverlayScrollArea
       className="mt-1 min-h-0 flex-1"
+      aria-label="Chat threads"
       data-testid="sidebar-scroll-area"
+      tabIndex={currentMainThreadId ? 0 : undefined}
+      onFocus={(event) => {
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+        focusCurrentMainThreadLink(event.currentTarget);
+      }}
       onScroll={(e) => {
         return setIsScrolledFn(e.currentTarget.scrollTop > 0);
       }}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-scroll.tsx
@@ -1,4 +1,9 @@
-import type { CSSProperties, ReactNode, UIEvent } from "react";
+import type {
+  CSSProperties,
+  FocusEventHandler,
+  ReactNode,
+  UIEvent,
+} from "react";
 import { useGet, useSet } from "ccstate-react";
 import {
   thumbStyle$,
@@ -11,17 +16,23 @@ import {
 
 /** Overlay scroll area: hides native scrollbar, renders a custom thin indicator. */
 export function OverlayScrollArea({
+  "aria-label": ariaLabel,
   className,
   children,
+  onFocus,
   onScroll,
   style,
   "data-testid": dataTestId,
+  tabIndex,
 }: {
+  "aria-label"?: string;
   className?: string;
   children: ReactNode;
+  onFocus?: FocusEventHandler<HTMLDivElement>;
   onScroll?: (e: UIEvent<HTMLDivElement>) => void;
   style?: CSSProperties;
   "data-testid"?: string;
+  tabIndex?: number;
 }) {
   const thumbStyleValue = useGet(thumbStyle$);
   const setThumbStyleFn = useSet(setThumbStyle$);
@@ -66,7 +77,10 @@ export function OverlayScrollArea({
         ref={setViewportRef}
         className="h-full overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={style}
+        onFocus={onFocus}
         onScroll={handleScroll}
+        tabIndex={tabIndex}
+        aria-label={ariaLabel}
         data-testid={dataTestId}
       >
         {children}


### PR DESCRIPTION
## Summary
- Makes the chat thread list scroll area a stable keyboard focus entry only on chat pages.
- When that list receives focus, it now prioritizes the current main thread link instead of whichever virtualized row happens to be first in the DOM.
- If the current main thread row is outside the virtualized window, the list scrolls to it before focusing.

## Verification
- `pnpm exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx --reporter dot`
- `pnpm exec prettier --check src/views/zero-page/sidebar-threads.tsx src/views/zero-page/zero-sidebar-scroll.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx`
- `pnpm exec eslint src/views/zero-page/sidebar-threads.tsx src/views/zero-page/zero-sidebar-scroll.tsx src/views/zero-page/__tests__/zero-sidebar.test.tsx --max-warnings 0`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F @vm0/app check-types`
