### PR TITLE
refactor(mitm-addon): extract connector diagnostic owner

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -1,0 +1,640 @@
+"""Connector diagnostic hook lifecycle owner."""
+
+import json
+import urllib.parse
+from typing import Final
+
+from mitmproxy import http
+
+import builtin_connector_diagnostics
+import flow_metadata
+import flow_metadata_keys as metadata_keys
+import matching
+import network_log_sanitization
+import request_classification
+from logging_utils import log_proxy_entry
+
+_HTTP_STATUS_UNAUTHORIZED = 401
+_HTTP_STATUS_FORBIDDEN = 403
+_HTTP_STATUS_FAILED_DEPENDENCY = 424
+
+_CONNECTOR_INTENT_HEADER: Final = "X-VM0-Connector-Intent"
+_CONNECTOR_INTENT_VALUE = "_connector_intent_value"
+_CONNECTOR_INTENT_STATUS = "_connector_intent_status"
+
+REQUEST_HEADERS_PROBE_METADATA_KEYS = (
+    _CONNECTOR_INTENT_VALUE,
+    _CONNECTOR_INTENT_STATUS,
+)
+
+_CONNECTOR_DIAGNOSTIC_ELIGIBLE = "_connector_diagnostic_eligible"
+_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES = "_connector_diagnostic_active_firewall_names"
+_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE = "_connector_diagnostic_lookup_done"
+_CONNECTOR_DIAGNOSTIC_CANDIDATE = "_connector_diagnostic_candidate"
+_CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES = "_connector_diagnostic_auth_header_names"
+_CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES = "_connector_diagnostic_auth_query_param_names"
+_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS = (
+    "_connector_diagnostic_response_replaced_in_headers"
+)
+_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY = "_connector_diagnostic_response_body"
+_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT = "_connector_diagnostic_response_stream_body_sent"
+_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK = "_connector_diagnostic_response_stream_callback"
+_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED = "_connector_diagnostic_proxy_entry_logged"
+_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON = "_connector_diagnostic_ownership_reason"
+_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES = "_connector_diagnostic_ownership_candidates"
+_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS = "_connector_diagnostic_ownership_hint_status"
+
+_EMPTY_RESPONSE_STREAM_CHUNKS: tuple[bytes, ...] = ()
+_GENERIC_AUTH_HEADER_NAMES = frozenset(
+    (
+        "authorization",
+        "x-api-key",
+        "api-key",
+    )
+)
+_GENERIC_AUTH_QUERY_PARAM_NAMES = frozenset(
+    (
+        "access_token",
+        "api_key",
+        "apikey",
+        "app_key",
+        "auth",
+        "authorization",
+        "key",
+        "token",
+    )
+)
+_AUTH_SCHEMES_REQUIRING_CREDENTIAL = frozenset(
+    (
+        "api-key",
+        "apikey",
+        "basic",
+        "bearer",
+        "digest",
+        "key",
+        "oauth",
+        "oauth2",
+        "token",
+    )
+)
+
+
+def capture_and_strip_connector_intent_header(flow: http.HTTPFlow) -> None:
+    if _CONNECTOR_INTENT_STATUS not in flow.metadata:
+        values = flow.request.headers.get_all(_CONNECTOR_INTENT_HEADER)
+        if not values:
+            flow.metadata[_CONNECTOR_INTENT_STATUS] = "absent"
+        elif len(values) != 1:
+            flow.metadata[_CONNECTOR_INTENT_STATUS] = "malformed"
+        else:
+            value = values[0].strip()
+            if value == "" or "," in value:
+                flow.metadata[_CONNECTOR_INTENT_STATUS] = "malformed"
+            else:
+                flow.metadata[_CONNECTOR_INTENT_STATUS] = "present"
+                flow.metadata[_CONNECTOR_INTENT_VALUE] = value
+
+    if _CONNECTOR_INTENT_HEADER in flow.request.headers:
+        del flow.request.headers[_CONNECTOR_INTENT_HEADER]
+
+
+def record_allow_context(
+    flow: http.HTTPFlow,
+    classification: request_classification.RequestClassification,
+) -> None:
+    if classification.kind != "allow":
+        return
+    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
+        return
+    if metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE in flow.metadata:
+        return
+
+    vm_info = classification.vm_info
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if vm_info is None or not isinstance(original_url, str):
+        return
+
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_ELIGIBLE] = True
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = tuple(
+        sorted(_active_firewall_names(vm_info))
+    )
+
+
+def maybe_make_local_response(
+    flow: http.HTTPFlow,
+    *,
+    original_url: str,
+) -> bool:
+    if _is_browser_diagnostic_skip(flow):
+        return False
+    candidate = _resolve_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return False
+    if _request_has_auth_material(flow, candidate, original_url):
+        return False
+
+    flow_metadata.start_request_timing(flow.metadata)
+    _set_failure_metadata(flow, candidate)
+    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
+    flow.response = http.Response.make(
+        _HTTP_STATUS_FAILED_DEPENDENCY,
+        _response_body(candidate, upstream_status=0),
+        {"Content-Type": "application/json"},
+    )
+    _log_proxy_entry(
+        flow,
+        original_url=original_url,
+        upstream_status=0,
+    )
+    return True
+
+
+def maybe_make_firewall_allow_local_response(
+    flow: http.HTTPFlow,
+    classification: request_classification.RequestClassification,
+) -> bool:
+    if classification.kind != "firewall_allow":
+        return False
+    if _is_browser_diagnostic_skip(flow):
+        return False
+
+    allow = classification.firewall_allow
+    vm_info = classification.vm_info
+    if allow is None or vm_info is None or not _firewall_allow_is_unknown_endpoint(allow):
+        return False
+
+    original_url = flow_metadata.original_url(flow.metadata)
+    if not original_url:
+        return False
+
+    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        original_url,
+        flow.request.method,
+        active_firewall_names=_active_firewall_names(vm_info),
+        matched_firewall_name=allow.name,
+        connector_intent=_connector_intent_from_flow(flow),
+    )
+    if resolution is None or resolution.candidate is None:
+        return False
+
+    candidate = resolution.candidate
+    if _request_has_auth_material(flow, candidate, original_url):
+        return False
+
+    flow_metadata.start_request_timing(flow.metadata)
+    _set_failure_metadata(flow, candidate)
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON] = resolution.reason
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES] = resolution.candidate_connector_types
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS] = resolution.hint_status
+    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
+    flow.response = http.Response.make(
+        _HTTP_STATUS_FAILED_DEPENDENCY,
+        _response_body(candidate, upstream_status=0),
+        {"Content-Type": "application/json"},
+    )
+    _log_proxy_entry(
+        flow,
+        original_url=original_url,
+        upstream_status=0,
+    )
+    return True
+
+
+def install_response_stream_if_needed(flow: http.HTTPFlow) -> bool:
+    if not _should_stream_response(flow):
+        return False
+    return _install_response_stream(flow)
+
+
+def maybe_replace_response(
+    flow: http.HTTPFlow,
+    *,
+    original_url: str,
+) -> None:
+    if flow.response is None:
+        return
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
+        flow.response.trailers = None
+        body = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY)
+        if isinstance(body, bytes) and not flow.metadata.get(
+            _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT
+        ):
+            flow.response.content = body
+            flow.response.headers["Content-Type"] = "application/json"
+            flow.response.headers["Content-Length"] = str(len(body))
+        _log_proxy_entry(
+            flow,
+            original_url=original_url,
+            upstream_status=flow.response.status_code,
+        )
+        return
+    if flow.response.status_code not in (
+        _HTTP_STATUS_UNAUTHORIZED,
+        _HTTP_STATUS_FORBIDDEN,
+    ):
+        return
+    if _is_browser_diagnostic_skip(flow):
+        return
+
+    candidate = _resolve_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return
+    upstream_status = flow.response.status_code
+    if _request_has_auth_material(flow, candidate, original_url):
+        return
+
+    _set_failure_metadata(flow, candidate)
+    _replace_response_content(
+        flow,
+        candidate,
+        upstream_status=upstream_status,
+    )
+    _log_proxy_entry(
+        flow,
+        original_url=original_url,
+        upstream_status=upstream_status,
+    )
+
+
+def maybe_make_error_response(
+    flow: http.HTTPFlow,
+    *,
+    original_url: str,
+) -> None:
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
+        if flow.response is not None:
+            flow.response.trailers = None
+        return
+    if _is_browser_diagnostic_skip(flow):
+        return
+    candidate = _resolve_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return
+    if _request_has_auth_material(flow, candidate, original_url):
+        return
+    _set_failure_metadata(flow, candidate)
+    flow.response = http.Response.make(
+        _HTTP_STATUS_FAILED_DEPENDENCY,
+        _response_body(candidate, upstream_status=0),
+        {"Content-Type": "application/json"},
+    )
+    _log_proxy_entry(
+        flow,
+        original_url=original_url,
+        upstream_status=0,
+    )
+
+
+def release_response_stream_state(flow: http.HTTPFlow) -> None:
+    stream_callback = flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED, None)
+    if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
+        flow.response.stream = False
+
+
+def _connector_intent_from_flow(flow: http.HTTPFlow) -> str | None:
+    value = flow.metadata.get(_CONNECTOR_INTENT_VALUE)
+    return value if isinstance(value, str) else None
+
+
+def _active_firewall_names(vm_info: dict) -> set[str]:
+    raw_firewalls = vm_info.get("firewalls")
+    if not isinstance(raw_firewalls, list):
+        return set()
+
+    names: set[str] = set()
+    for firewall in raw_firewalls:
+        if not isinstance(firewall, dict):
+            continue
+        name = firewall.get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
+
+
+def _candidate_from_flow(
+    flow: http.HTTPFlow,
+) -> builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None:
+    meta = flow.metadata
+    connector_type = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE)
+    reason = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_REASON)
+    base = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_BASE)
+    if not (
+        isinstance(connector_type, str)
+        and connector_type
+        and isinstance(reason, str)
+        and reason
+        and isinstance(base, str)
+        and base
+    ):
+        return None
+
+    env_names = _metadata_str_tuple(meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES))
+    auth_header_names = _metadata_str_tuple(meta.get(_CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES))
+    auth_query_param_names = _metadata_str_tuple(
+        meta.get(_CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES)
+    )
+    return builtin_connector_diagnostics.ConnectorDiagnosticCandidate(
+        connector_type=connector_type,
+        reason=reason,
+        env_names=env_names,
+        base=base,
+        auth_header_names=auth_header_names,
+        auth_query_param_names=auth_query_param_names,
+    )
+
+
+def _cached_candidate_from_flow(
+    flow: http.HTTPFlow,
+) -> builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None:
+    candidate = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_CANDIDATE)
+    if isinstance(candidate, builtin_connector_diagnostics.ConnectorDiagnosticCandidate):
+        return candidate
+    return None
+
+
+def _resolve_candidate(
+    flow: http.HTTPFlow,
+    *,
+    original_url: str,
+) -> builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None:
+    candidate = _cached_candidate_from_flow(flow)
+    if candidate is not None:
+        return candidate
+    candidate = _candidate_from_flow(flow)
+    if candidate is not None:
+        return candidate
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE):
+        return None
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_ELIGIBLE) is not True:
+        return None
+    if not original_url:
+        return None
+    if _is_browser_diagnostic_skip(flow):
+        return None
+
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE] = True
+    candidate = builtin_connector_diagnostics.find_candidate(
+        original_url,
+        flow.request.method,
+        active_firewall_names=set(
+            _metadata_str_tuple(flow.metadata.get(_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES))
+        ),
+    )
+    if candidate is not None:
+        flow.metadata[_CONNECTOR_DIAGNOSTIC_CANDIDATE] = candidate
+    return candidate
+
+
+def _metadata_str_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            return ()
+        result.append(item)
+    return tuple(result)
+
+
+def _set_failure_metadata(
+    flow: http.HTTPFlow,
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
+) -> None:
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_CANDIDATE] = candidate
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES] = candidate.auth_header_names
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES] = candidate.auth_query_param_names
+    flow.metadata[metadata_keys.FIREWALL_BASE] = candidate.base
+    flow.metadata[metadata_keys.FIREWALL_NAME] = candidate.connector_type
+    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = ""
+    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = ""
+    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
+    flow.metadata[metadata_keys.FIREWALL_ERROR] = "connector_not_configured_for_run"
+    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] = candidate.connector_type
+    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_REASON] = candidate.reason
+    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES] = list(candidate.env_names)
+    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_BASE] = candidate.base
+
+
+def _response_body(
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
+    *,
+    upstream_status: int,
+) -> bytes:
+    body = {
+        "error": "connector_not_configured_for_run",
+        "connector": candidate.connector_type,
+        "reason": candidate.reason,
+        "message": _message(candidate),
+        "envNames": list(candidate.env_names),
+        "base": candidate.base,
+        "upstreamStatus": upstream_status,
+    }
+    return json.dumps(body, separators=(",", ":")).encode()
+
+
+def _message(
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
+) -> str:
+    if not candidate.env_names:
+        return (
+            f"{candidate.connector_type} is not configured for this run. "
+            "Credentials cannot be injected."
+        )
+    env_names = ", ".join(candidate.env_names)
+    verb = "is" if len(candidate.env_names) == 1 else "are"
+    return (
+        f"{candidate.connector_type} is not configured for this run. "
+        f"{env_names} {verb} unavailable, so credentials cannot be injected."
+    )
+
+
+def _request_has_auth_material(
+    flow: http.HTTPFlow,
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
+    original_url: str,
+) -> bool:
+    configured_headers = {name.lower() for name in candidate.auth_header_names}
+    auth_headers = configured_headers | _GENERIC_AUTH_HEADER_NAMES
+    for name in auth_headers:
+        if _request_header_has_auth_material(flow, name):
+            return True
+
+    configured_query_params = set(candidate.auth_query_param_names)
+    normalized_configured_query_params = {name.lower() for name in candidate.auth_query_param_names}
+    try:
+        parsed = urllib.parse.urlparse(original_url)
+    except ValueError:
+        return False
+    for name, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True):
+        normalized_name = name.lower()
+        is_auth_param = (
+            name in configured_query_params
+            or normalized_name in normalized_configured_query_params
+            or normalized_name in _GENERIC_AUTH_QUERY_PARAM_NAMES
+        )
+        if is_auth_param and _query_param_has_auth_material(value):
+            return True
+    return False
+
+
+def _request_header_has_auth_material(flow: http.HTTPFlow, name: str) -> bool:
+    return any(
+        _header_value_has_auth_material(name, value) for value in flow.request.headers.get_all(name)
+    )
+
+
+def _header_value_has_auth_material(name: str, value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if name.lower() not in ("authorization", "proxy-authorization"):
+        return True
+
+    return _scheme_auth_value_has_credential(stripped)
+
+
+def _scheme_auth_value_has_credential(stripped: str) -> bool:
+    parts = stripped.split(None, 1)
+    if len(parts) == 1:
+        return parts[0].lower() not in _AUTH_SCHEMES_REQUIRING_CREDENTIAL
+    return bool(parts[1].strip())
+
+
+def _query_param_has_auth_material(value: str) -> bool:
+    return bool(value.strip())
+
+
+def _replace_response_content(
+    flow: http.HTTPFlow,
+    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
+    *,
+    upstream_status: int,
+) -> bytes | None:
+    if flow.response is None:
+        return None
+    flow.metadata.pop(metadata_keys.STREAM_BUFFER, None)
+    flow.metadata.pop(metadata_keys.STREAM_BUFFER_STATE, None)
+    for header in ("content-encoding", "content-length", "transfer-encoding"):
+        if header in flow.response.headers:
+            del flow.response.headers[header]
+    flow.response.trailers = None
+    body = _response_body(
+        candidate,
+        upstream_status=upstream_status,
+    )
+    flow.response.content = body
+    flow.response.headers["Content-Type"] = "application/json"
+    flow.response.headers["Content-Length"] = str(len(body))
+    return body
+
+
+def _log_proxy_entry(
+    flow: http.HTTPFlow,
+    *,
+    original_url: str,
+    upstream_status: int,
+) -> None:
+    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED):
+        return
+    candidate = _candidate_from_flow(flow)
+    if candidate is None:
+        return
+    safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
+    extra: dict[str, object] = {}
+    ownership_reason = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON)
+    if isinstance(ownership_reason, str) and ownership_reason:
+        extra["ownership_reason"] = ownership_reason
+    ownership_candidates = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES)
+    if isinstance(ownership_candidates, tuple) and all(
+        isinstance(candidate, str) for candidate in ownership_candidates
+    ):
+        extra["ownership_candidates"] = list(ownership_candidates)
+    ownership_hint_status = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS)
+    if isinstance(ownership_hint_status, str) and ownership_hint_status:
+        extra["ownership_hint_status"] = ownership_hint_status
+    log_proxy_entry(
+        flow_metadata.proxy_log_path(flow.metadata),
+        "warn",
+        f"{candidate.connector_type} is not configured for this run: {safe_url}",
+        type="connector_diagnostic",
+        connector=candidate.connector_type,
+        reason=candidate.reason,
+        upstream_status=upstream_status,
+        url=original_url,
+        **extra,
+    )
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED] = True
+
+
+def _firewall_allow_is_unknown_endpoint(allow: matching.FirewallAllow) -> bool:
+    return allow.permission is None and allow.rule is None
+
+
+def _should_stream_response(flow: http.HTTPFlow) -> bool:
+    if flow.response is None:
+        return False
+    if flow.response.status_code not in (
+        _HTTP_STATUS_UNAUTHORIZED,
+        _HTTP_STATUS_FORBIDDEN,
+    ):
+        return False
+    if _is_browser_diagnostic_skip(flow):
+        return False
+
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(original_url, str):
+        return False
+    candidate = _resolve_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return False
+    return not _request_has_auth_material(flow, candidate, original_url)
+
+
+def _install_response_stream(flow: http.HTTPFlow) -> bool:
+    if flow.response is None:
+        return False
+    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+    if not isinstance(original_url, str):
+        return False
+    candidate = _resolve_candidate(flow, original_url=original_url)
+    if candidate is None:
+        return False
+    if _request_has_auth_material(flow, candidate, original_url):
+        return False
+
+    upstream_status = flow.response.status_code
+    _set_failure_metadata(flow, candidate)
+    body = _replace_response_content(
+        flow,
+        candidate,
+        upstream_status=upstream_status,
+    )
+    if body is None:
+        return False
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY] = body
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
+
+    def stream_connector_diagnostic_response(chunk: bytes) -> bytes | tuple[bytes, ...]:
+        if chunk:
+            return _EMPTY_RESPONSE_STREAM_CHUNKS
+        if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT):
+            return _EMPTY_RESPONSE_STREAM_CHUNKS
+        flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT] = True
+        return body
+
+    flow.response.stream = stream_connector_diagnostic_response
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK] = (
+        stream_connector_diagnostic_response
+    )
+    return True
+
+
+def _is_browser_diagnostic_skip(flow: http.HTTPFlow) -> bool:
+    return bool(
+        flow.metadata.get(metadata_keys.BROWSER_USER_AGENT)
+        or request_classification.is_browser_passthrough_heuristic(flow)
+    )

--- a/crates/runner/mitm-addon/src/flow_metadata.py
+++ b/crates/runner/mitm-addon/src/flow_metadata.py
@@ -5,6 +5,7 @@ reads plus narrow shared state transitions. Domain-specific lifecycle state
 stays with the module that creates and releases it.
 """
 
+import time
 from collections.abc import Mapping, MutableMapping
 
 import flow_metadata_keys as metadata_keys
@@ -83,6 +84,11 @@ def should_capture_body(meta: Mapping[str, object]) -> bool:
 
 def model_usage_provider(meta: Mapping[str, object]) -> str:
     return _metadata_str(meta, metadata_keys.MODEL_USAGE_PROVIDER)
+
+
+def start_request_timing(meta: MutableMapping[str, object]) -> None:
+    if metadata_keys.HTTP_REQUEST_START_MONOTONIC not in meta:
+        meta[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
 
 
 def set_firewall_decision(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -35,22 +35,22 @@ from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports ---
 #
-# auth_base_forwarder/body_capture/matching/registry/response_encoding_negotiation/
-# response_streaming/usage are imported by module
+# auth_base_forwarder/body_capture/connector_diagnostics/matching/registry/
+# response_encoding_negotiation/response_streaming/usage are imported by module
 # (not selective `from X import ...`)
 # so that:
 #   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
-#      ``body_capture.X(...)`` / ``builtin_connector_diagnostics.X(...)`` /
-#      ``matching.X(...)`` / ``registry.X(...)`` /
-#      ``response_streaming.X(...)`` / ``usage.X(...)``,
+#      ``body_capture.X(...)`` / ``connector_diagnostics.X(...)`` /
+#      ``matching.X(...)`` / ``registry.X(...)`` / ``response_streaming.X(...)`` /
+#      ``usage.X(...)``,
 #      making the module boundary visible at call sites.
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import auth_base_forwarder
 import body_capture
-import builtin_connector_diagnostics
 import builtin_host_policy
 import connection_endpoints
+import connector_diagnostics
 import deferred_callbacks
 import flow_metadata
 import flow_metadata_keys as metadata_keys
@@ -99,27 +99,10 @@ from url_utils import AuthorityValidationError, get_trusted_authority, normalize
 
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
-_HTTP_STATUS_FORBIDDEN = 403
-_HTTP_STATUS_FAILED_DEPENDENCY = 424
 _HTTP_STATUS_BAD_GATEWAY = 502
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _HTTP_OWS_CHARS = " \t"
 _TEST_ENDPOINT_BYPASS_HEADER: Final = "x-vm0-test-endpoint-bypass"
-
-# Hook-private lifecycle state constants. Keep flow.metadata marker strings in
-# this block out of flow_metadata_keys.py unless they become public cross-module
-# contracts.
-
-_CONNECTOR_INTENT_HEADER: Final = "X-VM0-Connector-Intent"
-
-# Connector intent metadata state.
-# Creator: _capture_and_strip_connector_intent_header().
-# Consumer: _connector_intent_from_flow() and request-header probe restore.
-# Release: restored on probe rollback, otherwise no explicit pop before flow
-# completion.
-# Follow-up owner: #20508 connector diagnostics extraction.
-_CONNECTOR_INTENT_VALUE = "_connector_intent_value"
-_CONNECTOR_INTENT_STATUS = "_connector_intent_status"
 
 # Request-header phase state.
 # Creator: requestheaders() and header-phase stream/auth helpers.
@@ -128,55 +111,6 @@ _CONNECTOR_INTENT_STATUS = "_connector_intent_status"
 # _REQUEST_HEADERS_TERMINATED is a flow-local sentinel for request() early exit.
 _REQUEST_HEADERS_TERMINATED = "_request_headers_terminated"
 _FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requestheaders"
-
-# Request-header probe rollback keys for state still owned by this module.
-# Creator: static key set for requestheaders() snapshots.
-# Consumer: _restore_request_headers_probe_metadata().
-# Release: n/a; the helper restores or removes the listed metadata values.
-_REQUEST_HEADERS_PROBE_METADATA_KEYS = (
-    _CONNECTOR_INTENT_VALUE,
-    _CONNECTOR_INTENT_STATUS,
-)
-
-# Connector diagnostic candidate state.
-# Creator: allow-path diagnostic probes and diagnostic metadata helpers.
-# Consumer: request(), response(), and error() diagnostic response helpers.
-# Release: no explicit pop before flow completion.
-# Follow-up owner: #20508 connector diagnostics extraction.
-_CONNECTOR_DIAGNOSTIC_ELIGIBLE = "_connector_diagnostic_eligible"
-_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES = "_connector_diagnostic_active_firewall_names"
-_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE = "_connector_diagnostic_lookup_done"
-_CONNECTOR_DIAGNOSTIC_CANDIDATE = "_connector_diagnostic_candidate"
-_CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES = "_connector_diagnostic_auth_header_names"
-_CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES = "_connector_diagnostic_auth_query_param_names"
-
-# Connector diagnostic response-stream state.
-# Creator: _install_connector_diagnostic_response_stream().
-# Consumer: response replacement, stream callback, and terminal cleanup.
-# Release: _release_connector_diagnostic_response_stream_state().
-# Follow-up owner: #20508 connector diagnostics extraction.
-_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS = (
-    "_connector_diagnostic_response_replaced_in_headers"
-)
-_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY = "_connector_diagnostic_response_body"
-_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT = "_connector_diagnostic_response_stream_body_sent"
-_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK = "_connector_diagnostic_response_stream_callback"
-
-# Connector diagnostic proxy-log state.
-# Creator: _log_connector_diagnostic_proxy_entry().
-# Consumer: _log_connector_diagnostic_proxy_entry() duplicate guard.
-# Release: _release_connector_diagnostic_response_stream_state().
-# Follow-up owner: #20508 connector diagnostics extraction.
-_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED = "_connector_diagnostic_proxy_entry_logged"
-
-# Connector diagnostic ownership state.
-# Creator: shared-base connector diagnostic resolution.
-# Consumer: connector diagnostic proxy-log emission.
-# Release: no explicit pop before flow completion.
-# Follow-up owner: #20508 connector diagnostics extraction.
-_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON = "_connector_diagnostic_ownership_reason"
-_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES = "_connector_diagnostic_ownership_candidates"
-_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS = "_connector_diagnostic_ownership_hint_status"
 
 # Usage tracking state.
 # Creator: _maybe_track_usage_flow() and _report_model_provider_usage_once().
@@ -194,39 +128,6 @@ _MODEL_PROVIDER_USAGE_REPORTED = "_model_provider_usage_reported"
 # Follow-up owner: #20509 terminal flow lifecycle extraction.
 _MODEL_WEBSOCKET_MESSAGE_TRIM_SCHEDULED = "_model_websocket_message_trim_scheduled"
 
-_EMPTY_RESPONSE_STREAM_CHUNKS: tuple[bytes, ...] = ()
-_GENERIC_AUTH_HEADER_NAMES = frozenset(
-    (
-        "authorization",
-        "x-api-key",
-        "api-key",
-    )
-)
-_GENERIC_AUTH_QUERY_PARAM_NAMES = frozenset(
-    (
-        "access_token",
-        "api_key",
-        "apikey",
-        "app_key",
-        "auth",
-        "authorization",
-        "key",
-        "token",
-    )
-)
-_AUTH_SCHEMES_REQUIRING_CREDENTIAL = frozenset(
-    (
-        "api-key",
-        "apikey",
-        "basic",
-        "bearer",
-        "digest",
-        "key",
-        "oauth",
-        "oauth2",
-        "token",
-    )
-)
 _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 _WEBSOCKET_KEY_BYTES = 16
@@ -555,49 +456,10 @@ def get_registry_path() -> str:
     return ctx.options.vm0_proxy_registry_path
 
 
-def _capture_and_strip_connector_intent_header(flow: http.HTTPFlow) -> None:
-    if _CONNECTOR_INTENT_STATUS not in flow.metadata:
-        values = flow.request.headers.get_all(_CONNECTOR_INTENT_HEADER)
-        if not values:
-            flow.metadata[_CONNECTOR_INTENT_STATUS] = "absent"
-        elif len(values) != 1:
-            flow.metadata[_CONNECTOR_INTENT_STATUS] = "malformed"
-        else:
-            value = values[0].strip()
-            if value == "" or "," in value:
-                flow.metadata[_CONNECTOR_INTENT_STATUS] = "malformed"
-            else:
-                flow.metadata[_CONNECTOR_INTENT_STATUS] = "present"
-                flow.metadata[_CONNECTOR_INTENT_VALUE] = value
-
-    if _CONNECTOR_INTENT_HEADER in flow.request.headers:
-        del flow.request.headers[_CONNECTOR_INTENT_HEADER]
-
-
-def _connector_intent_from_flow(flow: http.HTTPFlow) -> str | None:
-    value = flow.metadata.get(_CONNECTOR_INTENT_VALUE)
-    return value if isinstance(value, str) else None
-
-
-def _active_firewall_names(vm_info: dict) -> set[str]:
-    raw_firewalls = vm_info.get("firewalls")
-    if not isinstance(raw_firewalls, list):
-        return set()
-
-    names: set[str] = set()
-    for firewall in raw_firewalls:
-        if not isinstance(firewall, dict):
-            continue
-        name = firewall.get("name")
-        if isinstance(name, str) and name:
-            names.add(name)
-    return names
-
-
 def _request_headers_probe_metadata_keys() -> tuple[str, ...]:
     return (
         *request_classification.REQUEST_HEADERS_PROBE_METADATA_KEYS,
-        *_REQUEST_HEADERS_PROBE_METADATA_KEYS,
+        *connector_diagnostics.REQUEST_HEADERS_PROBE_METADATA_KEYS,
     )
 
 
@@ -681,8 +543,7 @@ def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) ->
 
 
 def _start_request_timing(flow: http.HTTPFlow) -> None:
-    if metadata_keys.HTTP_REQUEST_START_MONOTONIC not in flow.metadata:
-        flow.metadata[metadata_keys.HTTP_REQUEST_START_MONOTONIC] = time.monotonic()
+    flow_metadata.start_request_timing(flow.metadata)
 
 
 def _firewall_allow_auth_base(allow: matching.FirewallAllow) -> str | None:
@@ -917,519 +778,8 @@ def _restore_request_headers_probe_metadata(
     request_classification.restore_request_headers_probe_metadata(
         flow,
         snapshot,
-        extra_keys=_REQUEST_HEADERS_PROBE_METADATA_KEYS,
+        extra_keys=connector_diagnostics.REQUEST_HEADERS_PROBE_METADATA_KEYS,
     )
-
-
-def _connector_diagnostic_candidate_from_flow(
-    flow: http.HTTPFlow,
-) -> builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None:
-    meta = flow.metadata
-    connector_type = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE)
-    reason = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_REASON)
-    base = meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_BASE)
-    if not (
-        isinstance(connector_type, str)
-        and connector_type
-        and isinstance(reason, str)
-        and reason
-        and isinstance(base, str)
-        and base
-    ):
-        return None
-
-    env_names = _metadata_str_tuple(meta.get(metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES))
-    auth_header_names = _metadata_str_tuple(meta.get(_CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES))
-    auth_query_param_names = _metadata_str_tuple(
-        meta.get(_CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES)
-    )
-    return builtin_connector_diagnostics.ConnectorDiagnosticCandidate(
-        connector_type=connector_type,
-        reason=reason,
-        env_names=env_names,
-        base=base,
-        auth_header_names=auth_header_names,
-        auth_query_param_names=auth_query_param_names,
-    )
-
-
-def _cached_connector_diagnostic_candidate_from_flow(
-    flow: http.HTTPFlow,
-) -> builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None:
-    candidate = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_CANDIDATE)
-    if isinstance(candidate, builtin_connector_diagnostics.ConnectorDiagnosticCandidate):
-        return candidate
-    return None
-
-
-def _maybe_record_allow_connector_diagnostic_context(
-    flow: http.HTTPFlow,
-    classification: request_classification.RequestClassification,
-) -> None:
-    if classification.kind != "allow":
-        return
-    if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-        return
-    if metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE in flow.metadata:
-        return
-
-    vm_info = classification.vm_info
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if vm_info is None or not isinstance(original_url, str):
-        return
-
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_ELIGIBLE] = True
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = tuple(
-        sorted(_active_firewall_names(vm_info))
-    )
-
-
-def _resolve_connector_diagnostic_candidate(
-    flow: http.HTTPFlow,
-    *,
-    original_url: str,
-) -> builtin_connector_diagnostics.ConnectorDiagnosticCandidate | None:
-    candidate = _cached_connector_diagnostic_candidate_from_flow(flow)
-    if candidate is not None:
-        return candidate
-    candidate = _connector_diagnostic_candidate_from_flow(flow)
-    if candidate is not None:
-        return candidate
-    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE):
-        return None
-    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_ELIGIBLE) is not True:
-        return None
-    if not original_url:
-        return None
-    if flow.metadata.get(
-        metadata_keys.BROWSER_USER_AGENT
-    ) or request_classification.is_browser_passthrough_heuristic(flow):
-        return None
-
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE] = True
-    candidate = builtin_connector_diagnostics.find_candidate(
-        original_url,
-        flow.request.method,
-        active_firewall_names=set(
-            _metadata_str_tuple(flow.metadata.get(_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES))
-        ),
-    )
-    if candidate is not None:
-        flow.metadata[_CONNECTOR_DIAGNOSTIC_CANDIDATE] = candidate
-    return candidate
-
-
-def _metadata_str_tuple(value: object) -> tuple[str, ...]:
-    if not isinstance(value, (list, tuple)):
-        return ()
-    result: list[str] = []
-    for item in value:
-        if not isinstance(item, str):
-            return ()
-        result.append(item)
-    return tuple(result)
-
-
-def _set_connector_diagnostic_failure_metadata(
-    flow: http.HTTPFlow,
-    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
-) -> None:
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_CANDIDATE] = candidate
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES] = candidate.auth_header_names
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES] = candidate.auth_query_param_names
-    flow.metadata[metadata_keys.FIREWALL_BASE] = candidate.base
-    flow.metadata[metadata_keys.FIREWALL_NAME] = candidate.connector_type
-    flow.metadata[metadata_keys.FIREWALL_PERMISSION] = ""
-    flow.metadata[metadata_keys.FIREWALL_RULE_MATCH] = ""
-    flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
-    flow.metadata[metadata_keys.FIREWALL_ERROR] = "connector_not_configured_for_run"
-    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE] = candidate.connector_type
-    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_REASON] = candidate.reason
-    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_ENV_NAMES] = list(candidate.env_names)
-    flow.metadata[metadata_keys.CONNECTOR_DIAGNOSTIC_BASE] = candidate.base
-
-
-def _connector_diagnostic_response_body(
-    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
-    *,
-    upstream_status: int,
-) -> bytes:
-    body = {
-        "error": "connector_not_configured_for_run",
-        "connector": candidate.connector_type,
-        "reason": candidate.reason,
-        "message": _connector_diagnostic_message(candidate),
-        "envNames": list(candidate.env_names),
-        "base": candidate.base,
-        "upstreamStatus": upstream_status,
-    }
-    return json.dumps(body, separators=(",", ":")).encode()
-
-
-def _connector_diagnostic_message(
-    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
-) -> str:
-    if not candidate.env_names:
-        return (
-            f"{candidate.connector_type} is not configured for this run. "
-            "Credentials cannot be injected."
-        )
-    env_names = ", ".join(candidate.env_names)
-    verb = "is" if len(candidate.env_names) == 1 else "are"
-    return (
-        f"{candidate.connector_type} is not configured for this run. "
-        f"{env_names} {verb} unavailable, so credentials cannot be injected."
-    )
-
-
-def _request_has_connector_auth_material(
-    flow: http.HTTPFlow,
-    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
-    original_url: str,
-) -> bool:
-    configured_headers = {name.lower() for name in candidate.auth_header_names}
-    auth_headers = configured_headers | _GENERIC_AUTH_HEADER_NAMES
-    for name in auth_headers:
-        if _request_header_has_auth_material(flow, name):
-            return True
-
-    configured_query_params = set(candidate.auth_query_param_names)
-    normalized_configured_query_params = {name.lower() for name in candidate.auth_query_param_names}
-    try:
-        parsed = urllib.parse.urlparse(original_url)
-    except ValueError:
-        return False
-    for name, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True):
-        normalized_name = name.lower()
-        is_auth_param = (
-            name in configured_query_params
-            or normalized_name in normalized_configured_query_params
-            or normalized_name in _GENERIC_AUTH_QUERY_PARAM_NAMES
-        )
-        if is_auth_param and _query_param_has_auth_material(value):
-            return True
-    return False
-
-
-def _request_header_has_auth_material(flow: http.HTTPFlow, name: str) -> bool:
-    return any(
-        _header_value_has_auth_material(name, value) for value in flow.request.headers.get_all(name)
-    )
-
-
-def _header_value_has_auth_material(name: str, value: str) -> bool:
-    stripped = value.strip()
-    if not stripped:
-        return False
-    if name.lower() not in ("authorization", "proxy-authorization"):
-        return True
-
-    return _scheme_auth_value_has_credential(stripped)
-
-
-def _scheme_auth_value_has_credential(stripped: str) -> bool:
-    parts = stripped.split(None, 1)
-    if len(parts) == 1:
-        return parts[0].lower() not in _AUTH_SCHEMES_REQUIRING_CREDENTIAL
-    return bool(parts[1].strip())
-
-
-def _query_param_has_auth_material(value: str) -> bool:
-    return bool(value.strip())
-
-
-def _replace_connector_diagnostic_response_content(
-    flow: http.HTTPFlow,
-    candidate: builtin_connector_diagnostics.ConnectorDiagnosticCandidate,
-    *,
-    upstream_status: int,
-) -> bytes | None:
-    if flow.response is None:
-        return None
-    flow.metadata.pop(metadata_keys.STREAM_BUFFER, None)
-    flow.metadata.pop(metadata_keys.STREAM_BUFFER_STATE, None)
-    for header in ("content-encoding", "content-length", "transfer-encoding"):
-        if header in flow.response.headers:
-            del flow.response.headers[header]
-    flow.response.trailers = None
-    body = _connector_diagnostic_response_body(
-        candidate,
-        upstream_status=upstream_status,
-    )
-    flow.response.content = body
-    flow.response.headers["Content-Type"] = "application/json"
-    flow.response.headers["Content-Length"] = str(len(body))
-    return body
-
-
-def _log_connector_diagnostic_proxy_entry(
-    flow: http.HTTPFlow,
-    *,
-    original_url: str,
-    upstream_status: int,
-) -> None:
-    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED):
-        return
-    candidate = _connector_diagnostic_candidate_from_flow(flow)
-    if candidate is None:
-        return
-    safe_url = network_log_sanitization.sanitize_url_for_network_log(original_url)
-    extra: dict[str, object] = {}
-    ownership_reason = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON)
-    if isinstance(ownership_reason, str) and ownership_reason:
-        extra["ownership_reason"] = ownership_reason
-    ownership_candidates = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES)
-    if isinstance(ownership_candidates, tuple) and all(
-        isinstance(candidate, str) for candidate in ownership_candidates
-    ):
-        extra["ownership_candidates"] = list(ownership_candidates)
-    ownership_hint_status = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS)
-    if isinstance(ownership_hint_status, str) and ownership_hint_status:
-        extra["ownership_hint_status"] = ownership_hint_status
-    log_proxy_entry(
-        flow_metadata.proxy_log_path(flow.metadata),
-        "warn",
-        f"{candidate.connector_type} is not configured for this run: {safe_url}",
-        type="connector_diagnostic",
-        connector=candidate.connector_type,
-        reason=candidate.reason,
-        upstream_status=upstream_status,
-        url=original_url,
-        **extra,
-    )
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED] = True
-
-
-def _maybe_make_connector_diagnostic_local_response(
-    flow: http.HTTPFlow,
-    *,
-    original_url: str,
-) -> bool:
-    if flow.metadata.get(
-        metadata_keys.BROWSER_USER_AGENT
-    ) or request_classification.is_browser_passthrough_heuristic(flow):
-        return False
-    candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return False
-    if _request_has_connector_auth_material(flow, candidate, original_url):
-        return False
-
-    _start_request_timing(flow)
-    _set_connector_diagnostic_failure_metadata(flow, candidate)
-    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
-    flow.response = http.Response.make(
-        _HTTP_STATUS_FAILED_DEPENDENCY,
-        _connector_diagnostic_response_body(candidate, upstream_status=0),
-        {"Content-Type": "application/json"},
-    )
-    _log_connector_diagnostic_proxy_entry(
-        flow,
-        original_url=original_url,
-        upstream_status=0,
-    )
-    return True
-
-
-def _firewall_allow_is_unknown_endpoint(allow: matching.FirewallAllow) -> bool:
-    return allow.permission is None and allow.rule is None
-
-
-def _maybe_make_firewall_allow_connector_diagnostic_local_response(
-    flow: http.HTTPFlow,
-    classification: request_classification.RequestClassification,
-) -> bool:
-    if classification.kind != "firewall_allow":
-        return False
-    if flow.metadata.get(
-        metadata_keys.BROWSER_USER_AGENT
-    ) or request_classification.is_browser_passthrough_heuristic(flow):
-        return False
-
-    allow = classification.firewall_allow
-    vm_info = classification.vm_info
-    if allow is None or vm_info is None or not _firewall_allow_is_unknown_endpoint(allow):
-        return False
-
-    original_url = flow_metadata.original_url(flow.metadata)
-    if not original_url:
-        return False
-
-    resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
-        original_url,
-        flow.request.method,
-        active_firewall_names=_active_firewall_names(vm_info),
-        matched_firewall_name=allow.name,
-        connector_intent=_connector_intent_from_flow(flow),
-    )
-    if resolution is None or resolution.candidate is None:
-        return False
-
-    candidate = resolution.candidate
-    if _request_has_connector_auth_material(flow, candidate, original_url):
-        return False
-
-    _start_request_timing(flow)
-    _set_connector_diagnostic_failure_metadata(flow, candidate)
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON] = resolution.reason
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES] = resolution.candidate_connector_types
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS] = resolution.hint_status
-    flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
-    flow.response = http.Response.make(
-        _HTTP_STATUS_FAILED_DEPENDENCY,
-        _connector_diagnostic_response_body(candidate, upstream_status=0),
-        {"Content-Type": "application/json"},
-    )
-    _log_connector_diagnostic_proxy_entry(
-        flow,
-        original_url=original_url,
-        upstream_status=0,
-    )
-    return True
-
-
-def _maybe_replace_connector_diagnostic_response(
-    flow: http.HTTPFlow,
-    *,
-    original_url: str,
-) -> None:
-    if flow.response is None:
-        return
-    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
-        flow.response.trailers = None
-        body = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY)
-        if isinstance(body, bytes) and not flow.metadata.get(
-            _CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT
-        ):
-            flow.response.content = body
-            flow.response.headers["Content-Type"] = "application/json"
-            flow.response.headers["Content-Length"] = str(len(body))
-        _log_connector_diagnostic_proxy_entry(
-            flow,
-            original_url=original_url,
-            upstream_status=flow.response.status_code,
-        )
-        return
-    if flow.response.status_code not in (
-        _HTTP_STATUS_UNAUTHORIZED,
-        _HTTP_STATUS_FORBIDDEN,
-    ):
-        return
-    if flow.metadata.get(
-        metadata_keys.BROWSER_USER_AGENT
-    ) or request_classification.is_browser_passthrough_heuristic(flow):
-        return
-
-    candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return
-    upstream_status = flow.response.status_code
-    if _request_has_connector_auth_material(flow, candidate, original_url):
-        return
-
-    _set_connector_diagnostic_failure_metadata(flow, candidate)
-    _replace_connector_diagnostic_response_content(
-        flow,
-        candidate,
-        upstream_status=upstream_status,
-    )
-    _log_connector_diagnostic_proxy_entry(
-        flow,
-        original_url=original_url,
-        upstream_status=upstream_status,
-    )
-
-
-def _maybe_make_connector_diagnostic_error_response(
-    flow: http.HTTPFlow,
-    *,
-    original_url: str,
-) -> None:
-    if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS):
-        if flow.response is not None:
-            flow.response.trailers = None
-        return
-    if flow.metadata.get(
-        metadata_keys.BROWSER_USER_AGENT
-    ) or request_classification.is_browser_passthrough_heuristic(flow):
-        return
-    candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return
-    if _request_has_connector_auth_material(flow, candidate, original_url):
-        return
-    _set_connector_diagnostic_failure_metadata(flow, candidate)
-    flow.response = http.Response.make(
-        _HTTP_STATUS_FAILED_DEPENDENCY,
-        _connector_diagnostic_response_body(candidate, upstream_status=0),
-        {"Content-Type": "application/json"},
-    )
-    _log_connector_diagnostic_proxy_entry(
-        flow,
-        original_url=original_url,
-        upstream_status=0,
-    )
-
-
-def _should_stream_connector_diagnostic_response(flow: http.HTTPFlow) -> bool:
-    if flow.response is None:
-        return False
-    if flow.response.status_code not in (
-        _HTTP_STATUS_UNAUTHORIZED,
-        _HTTP_STATUS_FORBIDDEN,
-    ):
-        return False
-    if flow.metadata.get(
-        metadata_keys.BROWSER_USER_AGENT
-    ) or request_classification.is_browser_passthrough_heuristic(flow):
-        return False
-
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(original_url, str):
-        return False
-    candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return False
-    return not _request_has_connector_auth_material(flow, candidate, original_url)
-
-
-def _install_connector_diagnostic_response_stream(flow: http.HTTPFlow) -> bool:
-    if flow.response is None:
-        return False
-    original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if not isinstance(original_url, str):
-        return False
-    candidate = _resolve_connector_diagnostic_candidate(flow, original_url=original_url)
-    if candidate is None:
-        return False
-    if _request_has_connector_auth_material(flow, candidate, original_url):
-        return False
-
-    upstream_status = flow.response.status_code
-    _set_connector_diagnostic_failure_metadata(flow, candidate)
-    body = _replace_connector_diagnostic_response_content(
-        flow,
-        candidate,
-        upstream_status=upstream_status,
-    )
-    if body is None:
-        return False
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY] = body
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS] = True
-
-    def stream_connector_diagnostic_response(chunk: bytes) -> bytes | tuple[bytes, ...]:
-        if chunk:
-            return _EMPTY_RESPONSE_STREAM_CHUNKS
-        if flow.metadata.get(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT):
-            return _EMPTY_RESPONSE_STREAM_CHUNKS
-        flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT] = True
-        return body
-
-    flow.response.stream = stream_connector_diagnostic_response
-    flow.metadata[_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK] = (
-        stream_connector_diagnostic_response
-    )
-    return True
 
 
 def _http_network_log_entry(
@@ -2077,7 +1427,7 @@ def client_disconnected(client: connection.Client) -> None:
 
 def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
     """Handle request-header-only decisions before mitmproxy buffers bodies."""
-    _capture_and_strip_connector_intent_header(flow)
+    connector_diagnostics.capture_and_strip_connector_intent_header(flow)
 
     body_check = _auth_base_body_header_check(flow)
     body_fits_stream_buffer = body_check.kind == "ok" and _request_body_fits_stream_buffer(flow)
@@ -2111,7 +1461,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             flow.kill()
         return None
 
-    if _maybe_make_firewall_allow_connector_diagnostic_local_response(flow, classification):
+    if connector_diagnostics.maybe_make_firewall_allow_local_response(flow, classification):
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         upstream_destination_binding.forget_server_binding(flow.server_conn)
         return None
@@ -2192,7 +1542,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         ):
             _restore_request_headers_probe_metadata(flow, metadata_snapshot)
             return None
-        _maybe_record_allow_connector_diagnostic_context(flow, classification)
+        connector_diagnostics.record_allow_context(flow, classification)
         request_classification.cache_classification(flow, classification)
         _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
@@ -2281,7 +1631,7 @@ async def request(flow: http.HTTPFlow) -> None:
     2. VM0 API auto-allow (agent must always reach the platform)
     3. Firewall match (inject auth headers for allowed requests)
     """
-    _capture_and_strip_connector_intent_header(flow)
+    connector_diagnostics.capture_and_strip_connector_intent_header(flow)
 
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
@@ -2366,7 +1716,7 @@ async def request(flow: http.HTTPFlow) -> None:
                 return
             if flow.metadata.get(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS):
                 return
-            if _maybe_make_firewall_allow_connector_diagnostic_local_response(
+            if connector_diagnostics.maybe_make_firewall_allow_local_response(
                 flow,
                 classification,
             ):
@@ -2406,10 +1756,10 @@ async def request(flow: http.HTTPFlow) -> None:
         vm_info = classification.vm_info
         if vm_info is None:
             return
-        _maybe_record_allow_connector_diagnostic_context(flow, classification)
+        connector_diagnostics.record_allow_context(flow, classification)
         if request_streaming.streamed_request_size(flow) is None:
             original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-            if isinstance(original_url, str) and _maybe_make_connector_diagnostic_local_response(
+            if isinstance(original_url, str) and connector_diagnostics.maybe_make_local_response(
                 flow,
                 original_url=original_url,
             ):
@@ -2572,8 +1922,7 @@ def _schedule_model_websocket_message_trim(flow: http.HTTPFlow) -> None:
 
 def responseheaders(flow: http.HTTPFlow) -> None:
     """Install response stream buffering and incremental body parsers."""
-    should_stream_diagnostic = _should_stream_connector_diagnostic_response(flow)
-    if should_stream_diagnostic and _install_connector_diagnostic_response_stream(flow):
+    if connector_diagnostics.install_response_stream_if_needed(flow):
         return
     response_streaming.configure_response_stream(flow)
 
@@ -2677,23 +2026,13 @@ def _release_terminal_flow_state(
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     flow.metadata.pop(metadata_keys.WEBSOCKET_UPGRADE_REQUEST, None)
     request_streaming.release_request_stream_state(flow)
-    _release_connector_diagnostic_response_stream_state(flow)
+    connector_diagnostics.release_response_stream_state(flow)
     response_streaming.release_response_stream_state(flow)
     auth_base_forwarder.release_forward_request_admission_from_flow(flow)
     if flow.error is not None:
         upstream_destination_binding.forget_server_binding(flow.server_conn)
     if release_tracking:
         _release_tracked_usage_flow(flow)
-
-
-def _release_connector_diagnostic_response_stream_state(flow: http.HTTPFlow) -> None:
-    stream_callback = flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK, None)
-    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY, None)
-    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT, None)
-    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_REPLACED_IN_HEADERS, None)
-    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_PROXY_ENTRY_LOGGED, None)
-    if stream_callback is not None and flow.response and flow.response.stream is stream_callback:
-        flow.response.stream = False
 
 
 def _track_usage_flow(fn):
@@ -2755,7 +2094,7 @@ def response(flow: http.HTTPFlow) -> None:
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     firewall_action = flow_metadata.firewall_action(flow.metadata)
 
-    _maybe_replace_connector_diagnostic_response(flow, original_url=original_url)
+    connector_diagnostics.maybe_replace_response(flow, original_url=original_url)
 
     request_size = _request_size(flow)
     stream_buf = flow.metadata.get(metadata_keys.STREAM_BUFFER)
@@ -2875,7 +2214,7 @@ def error(flow: http.HTTPFlow) -> None:
     original_url = flow.metadata[metadata_keys.ORIGINAL_URL]
     firewall_action = flow_metadata.firewall_action(flow.metadata)
 
-    _maybe_make_connector_diagnostic_error_response(flow, original_url=original_url)
+    connector_diagnostics.maybe_make_error_response(flow, original_url=original_url)
 
     request_size = _request_size(flow)
     error_msg = flow.error.msg if flow.error else "unknown error"


### PR DESCRIPTION
## Summary

- Add `connector_diagnostics.py` as the owner for connector diagnostic intent, candidate lookup, auth-material checks, response replacement, proxy logging, and diagnostic stream cleanup.
- Keep `mitm_addon.py` as hook orchestration and move request timing into a neutral `flow_metadata.start_request_timing` helper.
- Preserve diagnostic response body/status/log metadata and requestheaders probe rollback behavior.

Closes #20508

## Testing

- `PYTHONPATH=src:scripts /tmp/mitm-addon-venv/bin/python scripts/check-flow-metadata-keys.py`
- `/tmp/mitm-addon-venv/bin/ruff check .`
- `/tmp/mitm-addon-venv/bin/ruff format --check .`
- `/tmp/mitm-addon-venv/bin/basedpyright --pythonpath /tmp/mitm-addon-venv/bin/python`
- `/tmp/mitm-addon-venv/bin/pytest tests/test_builtin_connector_diagnostics.py tests/test_request_handler_firewall_dispatch.py tests/test_response_handler.py tests/test_error_handler.py tests/test_request_headers_handler.py tests/test_flow_metadata_key_contract.py`
- `/tmp/mitm-addon-venv/bin/pytest tests/`