### PR TITLE
fix: clear slack pre-run status on dispatch failure

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -625,16 +625,19 @@ describe("POST /api/test/slack-dispatch-probe", () => {
         );
       }),
     ).toBeUndefined();
+    expect(context.mocks.slack.assistant.threads.setStatus).toHaveBeenCalledTimes(
+      2,
+    );
     expect(
       context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledWith({
+    ).toHaveBeenNthCalledWith(1, {
       channel_id: "C-test",
       thread_ts: "1710000003.000000",
       status: "is thinking...",
     });
     expect(
       context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledWith({
+    ).toHaveBeenNthCalledWith(2, {
       channel_id: "C-test",
       thread_ts: "1710000003.000000",
       status: "",
@@ -677,16 +680,19 @@ describe("POST /api/test/slack-dispatch-probe", () => {
         code: "slack_history_failed",
       },
     });
+    expect(context.mocks.slack.assistant.threads.setStatus).toHaveBeenCalledTimes(
+      2,
+    );
     expect(
       context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledWith({
+    ).toHaveBeenNthCalledWith(1, {
       channel_id: "C-test",
       thread_ts: "1710000004.000000",
       status: "is thinking...",
     });
     expect(
       context.mocks.slack.assistant.threads.setStatus,
-    ).toHaveBeenCalledWith({
+    ).toHaveBeenNthCalledWith(2, {
       channel_id: "C-test",
       thread_ts: "1710000004.000000",
       status: "",

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -680,6 +680,15 @@ describe("POST /api/test/slack-dispatch-probe", () => {
         code: "slack_history_failed",
       },
     });
+    const state = await readSlackState(fixture);
+    expect(
+      state.recent_runs.find((run) => {
+        return (
+          run.triggerSource === "slack" &&
+          run.promptPreview === "trigger cleanup failure"
+        );
+      }),
+    ).toBeUndefined();
     expect(context.mocks.slack.assistant.threads.setStatus).toHaveBeenCalledTimes(
       2,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -582,4 +582,114 @@ describe("POST /api/test/slack-dispatch-probe", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("clears thread status when pre-create fails after status succeeds", async () => {
+    const fixture = await track(
+      seedSlackProbeFixture({ withConnection: true, withDefaultAgent: true }),
+    );
+    const historyError = Object.assign(
+      new Error("conversation history failed"),
+      {
+        code: "slack_history_failed",
+      },
+    );
+    context.mocks.slack.conversations.history.mockRejectedValueOnce(
+      historyError,
+    );
+
+    const response = await postProbe({
+      team_id: fixture.slackWorkspaceId,
+      channel_id: "C-test",
+      user_id: fixture.slackUserId,
+      message_text: "trigger a context error",
+      message_ts: "1710000003.000000",
+      channel_type: "channel",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TestSlackDispatchProbeResponse>(response);
+    expect(body).toMatchObject({
+      ok: false,
+      error: {
+        name: "Error",
+        message: "conversation history failed",
+        code: "slack_history_failed",
+      },
+    });
+    const state = await readSlackState(fixture);
+    expect(
+      state.recent_runs.find((run) => {
+        return (
+          run.triggerSource === "slack" &&
+          run.promptPreview === "trigger a context error"
+        );
+      }),
+    ).toBeUndefined();
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith({
+      channel_id: "C-test",
+      thread_ts: "1710000003.000000",
+      status: "is thinking...",
+    });
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith({
+      channel_id: "C-test",
+      thread_ts: "1710000003.000000",
+      status: "",
+    });
+  });
+
+  it("preserves the pre-create error when status cleanup fails", async () => {
+    const fixture = await track(
+      seedSlackProbeFixture({ withConnection: true, withDefaultAgent: true }),
+    );
+    context.mocks.slack.assistant.threads.setStatus
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error("status cleanup failed"));
+    const historyError = Object.assign(
+      new Error("conversation history still failed"),
+      {
+        code: "slack_history_failed",
+      },
+    );
+    context.mocks.slack.conversations.history.mockRejectedValueOnce(
+      historyError,
+    );
+
+    const response = await postProbe({
+      team_id: fixture.slackWorkspaceId,
+      channel_id: "C-test",
+      user_id: fixture.slackUserId,
+      message_text: "trigger cleanup failure",
+      message_ts: "1710000004.000000",
+      channel_type: "channel",
+    });
+
+    expect(response.status).toBe(200);
+    const body = await readJson<TestSlackDispatchProbeResponse>(response);
+    expect(body).toMatchObject({
+      ok: false,
+      error: {
+        name: "Error",
+        message: "conversation history still failed",
+        code: "slack_history_failed",
+      },
+    });
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith({
+      channel_id: "C-test",
+      thread_ts: "1710000004.000000",
+      status: "is thinking...",
+    });
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith({
+      channel_id: "C-test",
+      thread_ts: "1710000004.000000",
+      status: "",
+    });
+  });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -625,9 +625,9 @@ describe("POST /api/test/slack-dispatch-probe", () => {
         );
       }),
     ).toBeUndefined();
-    expect(context.mocks.slack.assistant.threads.setStatus).toHaveBeenCalledTimes(
-      2,
-    );
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledTimes(2);
     expect(
       context.mocks.slack.assistant.threads.setStatus,
     ).toHaveBeenNthCalledWith(1, {
@@ -689,9 +689,9 @@ describe("POST /api/test/slack-dispatch-probe", () => {
         );
       }),
     ).toBeUndefined();
-    expect(context.mocks.slack.assistant.threads.setStatus).toHaveBeenCalledTimes(
-      2,
-    );
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledTimes(2);
     expect(
       context.mocks.slack.assistant.threads.setStatus,
     ).toHaveBeenNthCalledWith(1, {

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1384,6 +1384,20 @@ function settledValue<T>(result: PromiseSettledResult<T>): T {
   return result.value;
 }
 
+async function clearSlackThreadStatusBestEffort(args: {
+  readonly client: ReturnType<typeof createSlackClient>;
+  readonly channelId: string;
+  readonly threadTs: string;
+  readonly failureMessage: string;
+}): Promise<void> {
+  const [result] = await Promise.allSettled([
+    setThreadStatus(args.client, args.channelId, args.threadTs, ""),
+  ]);
+  if (result.status === "rejected") {
+    L.warn(args.failureMessage, { error: result.reason });
+  }
+}
+
 async function loadSlackRunParamBundle(args: {
   readonly timing: ApiDispatchTimingCollector;
   readonly db: Db;
@@ -1837,31 +1851,32 @@ const handleSlackRunResult$ = command(
         ],
       });
     } else if (result.status === "failed") {
+      let errorReplyResult: PromiseSettledResult<void> | undefined;
       if (!result.runId) {
-        await set(postPreDispatchErrorReply$, {
-          db: message.db,
-          client: resolved.client,
-          channelId: message.channelId,
-          threadTs: resolved.threadTs,
-          errorText:
-            result.response ?? "Sorry, an error occurred. Please try again.",
-          orgId: resolved.installation.orgId,
-          vm0UserId: resolved.connection.vm0UserId,
-          composeId: resolved.composeId,
-          agentLabel: resolved.agent.displayName ?? resolved.agent.name,
-        });
+        [errorReplyResult] = await Promise.allSettled([
+          set(postPreDispatchErrorReply$, {
+            db: message.db,
+            client: resolved.client,
+            channelId: message.channelId,
+            threadTs: resolved.threadTs,
+            errorText:
+              result.response ?? "Sorry, an error occurred. Please try again.",
+            orgId: resolved.installation.orgId,
+            vm0UserId: resolved.connection.vm0UserId,
+            composeId: resolved.composeId,
+            agentLabel: resolved.agent.displayName ?? resolved.agent.name,
+          }),
+        ]);
       }
-      await tapError(
-        setThreadStatus(
-          resolved.client,
-          message.channelId,
-          resolved.threadTs,
-          "",
-        ),
-        (error) => {
-          L.warn("Failed to clear thread status", { error });
-        },
-      );
+      await clearSlackThreadStatusBestEffort({
+        client: resolved.client,
+        channelId: message.channelId,
+        threadTs: resolved.threadTs,
+        failureMessage: "Failed to clear thread status",
+      });
+      if (errorReplyResult?.status === "rejected") {
+        throw errorReplyResult.reason;
+      }
     }
   },
 );
@@ -1937,9 +1952,26 @@ const handleSlackAgentMessage$ = command(
       ),
     ]);
     settledValue(statusResult);
-    const runParams = settledValue(runParamsResult);
-    const result = await set(runAgentForSlackOrg$, runParams, args.signal);
-    await set(handleSlackRunResult$, { message: args, resolved, result });
+    const [runResult] = await Promise.allSettled([
+      (async () => {
+        const runParams = settledValue(runParamsResult);
+        return await set(runAgentForSlackOrg$, runParams, args.signal);
+      })(),
+    ]);
+    if (runResult.status === "rejected") {
+      await clearSlackThreadStatusBestEffort({
+        client: resolved.client,
+        channelId: args.channelId,
+        threadTs: resolved.threadTs,
+        failureMessage: "Failed to clear pre-run thread status",
+      });
+      throw runResult.reason;
+    }
+    await set(handleSlackRunResult$, {
+      message: args,
+      resolved,
+      result: runResult.value,
+    });
   },
 );
 

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1854,19 +1854,21 @@ const handleSlackRunResult$ = command(
       const errorReplyResultPromise = result.runId
         ? undefined
         : Promise.allSettled([
-            set(postPreDispatchErrorReply$, {
-              db: message.db,
-              client: resolved.client,
-              channelId: message.channelId,
-              threadTs: resolved.threadTs,
-              errorText:
-                result.response ??
-                "Sorry, an error occurred. Please try again.",
-              orgId: resolved.installation.orgId,
-              vm0UserId: resolved.connection.vm0UserId,
-              composeId: resolved.composeId,
-              agentLabel: resolved.agent.displayName ?? resolved.agent.name,
-            }),
+            (async () => {
+              await set(postPreDispatchErrorReply$, {
+                db: message.db,
+                client: resolved.client,
+                channelId: message.channelId,
+                threadTs: resolved.threadTs,
+                errorText:
+                  result.response ??
+                  "Sorry, an error occurred. Please try again.",
+                orgId: resolved.installation.orgId,
+                vm0UserId: resolved.connection.vm0UserId,
+                composeId: resolved.composeId,
+                agentLabel: resolved.agent.displayName ?? resolved.agent.name,
+              });
+            })(),
           ]);
       await clearSlackThreadStatusBestEffort({
         client: resolved.client,

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1851,29 +1851,32 @@ const handleSlackRunResult$ = command(
         ],
       });
     } else if (result.status === "failed") {
-      let errorReplyResult: PromiseSettledResult<void> | undefined;
-      if (!result.runId) {
-        [errorReplyResult] = await Promise.allSettled([
-          set(postPreDispatchErrorReply$, {
-            db: message.db,
-            client: resolved.client,
-            channelId: message.channelId,
-            threadTs: resolved.threadTs,
-            errorText:
-              result.response ?? "Sorry, an error occurred. Please try again.",
-            orgId: resolved.installation.orgId,
-            vm0UserId: resolved.connection.vm0UserId,
-            composeId: resolved.composeId,
-            agentLabel: resolved.agent.displayName ?? resolved.agent.name,
-          }),
-        ]);
-      }
+      const errorReplyResultPromise = result.runId
+        ? undefined
+        : Promise.allSettled([
+            set(postPreDispatchErrorReply$, {
+              db: message.db,
+              client: resolved.client,
+              channelId: message.channelId,
+              threadTs: resolved.threadTs,
+              errorText:
+                result.response ??
+                "Sorry, an error occurred. Please try again.",
+              orgId: resolved.installation.orgId,
+              vm0UserId: resolved.connection.vm0UserId,
+              composeId: resolved.composeId,
+              agentLabel: resolved.agent.displayName ?? resolved.agent.name,
+            }),
+          ]);
       await clearSlackThreadStatusBestEffort({
         client: resolved.client,
         channelId: message.channelId,
         threadTs: resolved.threadTs,
         failureMessage: "Failed to clear thread status",
       });
+      const [errorReplyResult] = errorReplyResultPromise
+        ? await errorReplyResultPromise
+        : [];
       if (errorReplyResult?.status === "rejected") {
         throw errorReplyResult.reason;
       }


### PR DESCRIPTION
## Summary

- clear Slack `is thinking...` status when pre-run dispatch fails after status was set
- keep status update failures as hard failures before run creation
- make failed run-result status cleanup run even if the pre-dispatch error reply fails
- add Slack dispatch probe regression coverage for status-success/pre-create-failure and cleanup-failure behavior

Closes #20623

## Tests

- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts`
- `pnpm knip --workspace apps/api`
- `git diff --check`

Note: the local pre-commit hook's full `pnpm knip --cache` run is currently blocked by unrelated unused platform exports (`isProductionHostname`, `createIdbArtifactItemStores`). This PR validates the affected API workspace with `pnpm knip --workspace apps/api`.