### PR TITLE
chore: temporarily log notion webhook verification tokens

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts
@@ -39,6 +39,7 @@ const NOTION_DATABASE_URL =
 const NOTION_DATA_SOURCE_URL =
   "https://www.notion.so/Bug-Bash-88888888888848888888888888888888";
 const NOTION_WEBHOOK_TOKEN = "notion-webhook-verification-token";
+const NOTION_REPLACEMENT_WEBHOOK_TOKEN = "notion-webhook-resend-token";
 const NOTION_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
 const NOTION_SUBSCRIPTION_ID = "44444444-4444-4444-8444-444444444444";
 const NOTION_INTEGRATION_ID = "55555555-5555-4555-8555-555555555555";
@@ -270,10 +271,11 @@ function configureNotionDatabaseMock(): void {
   );
 }
 
-function notionSignature(rawBody: string): string {
-  return `sha256=${createHmac("sha256", NOTION_WEBHOOK_TOKEN)
-    .update(rawBody)
-    .digest("hex")}`;
+function notionSignature(
+  rawBody: string,
+  token: string = NOTION_WEBHOOK_TOKEN,
+): string {
+  return `sha256=${createHmac("sha256", token).update(rawBody).digest("hex")}`;
 }
 
 function notionPageEvent(args: {
@@ -442,16 +444,27 @@ describe("POST /api/webhooks/notion", () => {
     expect(secretState.secrets).toHaveLength(1);
 
     const replacement = await postNotionWebhook({
-      rawBody: JSON.stringify({ verification_token: "attacker-token" }),
+      rawBody: JSON.stringify({
+        verification_token: NOTION_REPLACEMENT_WEBHOOK_TOKEN,
+      }),
     });
     expect(replacement).toStrictEqual({
-      status: 401,
-      body: { error: "Unauthorized" },
+      status: 200,
+      body: {
+        success: true,
+        kind: "verification",
+        pending: 0,
+        refreshed: 0,
+        duplicates: 0,
+      },
     });
-    const unchangedSecretState = await workflowTriggerStateAction({
+    const replacedSecretState = await workflowTriggerStateAction({
       action: "get-notion-webhook-secret",
     });
-    expect(unchangedSecretState.secrets).toHaveLength(1);
+    expect(replacedSecretState.secrets).toStrictEqual([
+      expect.objectContaining({ active: false }),
+      expect.objectContaining({ active: true }),
+    ]);
 
     const createdRaw = JSON.stringify(
       notionPageEvent({
@@ -462,7 +475,7 @@ describe("POST /api/webhooks/notion", () => {
     );
     const first = await postNotionWebhook({
       rawBody: createdRaw,
-      signature: notionSignature(createdRaw),
+      signature: notionSignature(createdRaw, NOTION_REPLACEMENT_WEBHOOK_TOKEN),
     });
     expect(first).toStrictEqual({
       status: 200,
@@ -502,7 +515,7 @@ describe("POST /api/webhooks/notion", () => {
     );
     const update = await postNotionWebhook({
       rawBody: updateRaw,
-      signature: notionSignature(updateRaw),
+      signature: notionSignature(updateRaw, NOTION_REPLACEMENT_WEBHOOK_TOKEN),
     });
     expect(update).toStrictEqual({
       status: 200,
@@ -529,7 +542,7 @@ describe("POST /api/webhooks/notion", () => {
 
     const duplicate = await postNotionWebhook({
       rawBody: updateRaw,
-      signature: notionSignature(updateRaw),
+      signature: notionSignature(updateRaw, NOTION_REPLACEMENT_WEBHOOK_TOKEN),
     });
     expect(duplicate).toStrictEqual({
       status: 200,

--- a/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
+++ b/turbo/apps/api/src/signals/services/notion-workflow-event.service.ts
@@ -33,6 +33,7 @@ import { command } from "ccstate";
 import { and, asc, desc, eq, inArray, lte, sql } from "drizzle-orm";
 import { z } from "zod";
 
+import { logger } from "../../lib/log";
 import { optionalEnv } from "../../lib/env";
 import { writeDb$, type Db, type ReadonlyDb } from "../external/db";
 import { now, nowDate } from "../external/time";
@@ -60,6 +61,7 @@ const NOTION_CHILD_PAGE_SETTLE_MS = 15 * 60 * 1000;
 const NOTION_PENDING_RETRY_MS = 5 * 60 * 1000;
 const NOTION_PENDING_MAX_ATTEMPTS = 8;
 const NOTION_PENDING_BATCH_SIZE = 25;
+const log = logger("api:notion-workflow-event");
 const NOTION_CHILD_PAGE_MOVED_SKIP_REASON =
   "Notion page is no longer a direct child of the configured parent";
 const NOTION_DATABASE_ITEM_MOVED_SKIP_REASON =
@@ -1059,19 +1061,6 @@ async function storeVerificationToken(args: {
   args.signal.throwIfAborted();
 }
 
-async function activeVerificationTokenExists(args: {
-  readonly db: ReadonlyDb;
-  readonly signal: AbortSignal;
-}): Promise<boolean> {
-  const rows = await args.db
-    .select({ id: notionWebhookSecrets.id })
-    .from(notionWebhookSecrets)
-    .where(eq(notionWebhookSecrets.active, true))
-    .limit(1);
-  args.signal.throwIfAborted();
-  return rows.length > 0;
-}
-
 async function loadActiveVerificationTokens(args: {
   readonly db: ReadonlyDb;
   readonly signal: AbortSignal;
@@ -1610,9 +1599,9 @@ export const dispatchNotionWebhook$ = command(
     const verification = notionWebhookVerificationSchema.safeParse(rawJson);
     const db = set(writeDb$);
     if (verification.success) {
-      if (await activeVerificationTokenExists({ db, signal })) {
-        return { kind: "unauthorized" };
-      }
+      log.warn("TEMP_NOTION_WEBHOOK_VERIFICATION_TOKEN", {
+        verificationToken: verification.data.verification_token,
+      });
       await storeVerificationToken({
         db,
         token: verification.data.verification_token,


### PR DESCRIPTION
## Summary
- temporarily logs Notion webhook verification payload tokens with marker `TEMP_NOTION_WEBHOOK_VERIFICATION_TOKEN` before KMS encryption so we can complete the Notion developer subscription verification
- lets a verification resend replace the active Notion webhook token so the token entered in Notion and the token used for future signature checks stay aligned
- updates the Notion webhook route test to cover replacement-token signing after a resend

## Operational notes
- This is intentionally temporary while Notion workflow triggers are still in development.
- After the Notion subscription is verified, this PR should be reverted immediately to remove plaintext token logging and restore the stricter verification flow.
- Do not paste the token into the PR or chat; query it from Axiom only for the verification step.

## Verification
- `pnpm exec prettier --check apps/api/src/signals/services/notion-workflow-event.service.ts apps/api/src/signals/routes/__tests__/webhooks-notion.test.ts`
- `pnpm -F api exec eslint src/signals/services/notion-workflow-event.service.ts src/signals/routes/__tests__/webhooks-notion.test.ts --max-warnings 0`
- `pnpm -F api exec oxlint src/signals/services/notion-workflow-event.service.ts src/signals/routes/__tests__/webhooks-notion.test.ts`
- `DATABASE_URL=postgresql://user@localhost:5432/vm0_test pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-notion.test.ts`

## Local check limitation
- Full pre-commit `turbo run check-types --concurrency=1` reached the local 120s hook timeout; direct `pnpm -F api check-types` also exceeded this runner memory limit. CI should run the full check suite.