### PR TITLE
fix(runner): diagnose workspace mount cleanup failures

### DIFF
--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -78,8 +78,8 @@ is_workspace_ref() {
 }
 
 is_workspace_child_mountpoint() {
-  mount_point=$1
-  case "$mount_point" in
+  workspace_child_mount_point=$1
+  case "$workspace_child_mount_point" in
     "$workspace_dir"/*) return 0 ;;
   esac
 
@@ -89,11 +89,35 @@ is_workspace_child_mountpoint() {
 decode_mountinfo_path() {
   awk 'BEGIN {
     value = ARGV[1]
-    gsub(/\\040/, " ", value)
-    gsub(/\\011/, "\t", value)
-    gsub(/\\012/, "\n", value)
-    gsub(/\\134/, "\\", value)
-    printf "%s", value
+    decoded = ""
+    for (i = 1; i <= length(value); i++) {
+      char = substr(value, i, 1)
+      if (char == "\\" && i + 3 <= length(value)) {
+        escape = substr(value, i + 1, 3)
+        if (escape == "040") {
+          decoded = decoded " "
+          i += 3
+          continue
+        }
+        if (escape == "011") {
+          decoded = decoded sprintf("%c", 9)
+          i += 3
+          continue
+        }
+        if (escape == "012") {
+          decoded = decoded sprintf("%c", 10)
+          i += 3
+          continue
+        }
+        if (escape == "134") {
+          decoded = decoded "\\"
+          i += 3
+          continue
+        }
+      }
+      decoded = decoded char
+    }
+    printf "%s", decoded
     exit
   }' "$1"
 }

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -165,7 +165,7 @@ proc_comm() {
 }
 
 sanitize_log_value() {
-  value="$(printf '%s' "$1" | tr '\n\t' '  ')"
+  value="$(printf '%s' "$1" | tr '[:cntrl:]' ' ')"
   if [ "${#value}" -gt "$WORKSPACE_HOLDER_VALUE_LIMIT" ]; then
     value="$(printf '%s' "$value" | cut -c 1-"$WORKSPACE_HOLDER_VALUE_LIMIT")..."
   fi
@@ -473,16 +473,16 @@ cleanup_workspace_child_mounts() {
     child_mount_log="$(sanitize_log_value "$child_mount")"
     if ! is_safe_workspace_child_mountpoint_path "$child_mount"; then
       failed_status=64
-      echo "workspace mount cleanup: child unmount skipped unsafe path mount=$child_mount_log" >&2
+      printf 'workspace mount cleanup: child unmount skipped unsafe path mount=%s\n' "$child_mount_log" >&2
       continue
     fi
-    echo "workspace mount cleanup: child unmount started mount=$child_mount_log" >&2
+    printf 'workspace mount cleanup: child unmount started mount=%s\n' "$child_mount_log" >&2
     if umount -- "$child_mount"; then
-      echo "workspace mount cleanup: child unmount succeeded mount=$child_mount_log" >&2
+      printf 'workspace mount cleanup: child unmount succeeded mount=%s\n' "$child_mount_log" >&2
     else
       status=$?
       failed_status=$status
-      echo "workspace mount cleanup: child unmount failed exit_code=$status mount=$child_mount_log" >&2
+      printf 'workspace mount cleanup: child unmount failed exit_code=%s mount=%s\n' "$status" "$child_mount_log" >&2
     fi
   done < "$child_mount_records"
 

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -87,7 +87,15 @@ is_workspace_child_mountpoint() {
 }
 
 decode_mountinfo_path() {
-  printf '%b' "$1"
+  awk 'BEGIN {
+    value = ARGV[1]
+    gsub(/\\040/, " ", value)
+    gsub(/\\011/, "\t", value)
+    gsub(/\\012/, "\n", value)
+    gsub(/\\134/, "\\", value)
+    printf "%s", value
+    exit
+  }' "$1"
 }
 
 proc_uid() {

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -86,6 +86,10 @@ is_workspace_child_mountpoint() {
   return 1
 }
 
+decode_mountinfo_path() {
+  printf '%b' "$1"
+}
+
 proc_uid() {
   stat -c %u "/proc/$1" 2>/dev/null || true
 }
@@ -162,10 +166,11 @@ scan_workspace_mountinfo_refs() {
 
   while IFS=' ' read -r mount_id parent_id mount_dev mount_root mount_point mount_options _rest; do
     [ -n "$mount_point" ] || continue
+    decoded_mount_point="$(decode_mountinfo_path "$mount_point")"
     category=
-    if [ "$mount_point" = "$workspace_dir" ]; then
+    if [ "$decoded_mount_point" = "$workspace_dir" ]; then
       category=workspace
-    elif is_workspace_child_mountpoint "$mount_point"; then
+    elif is_workspace_child_mountpoint "$decoded_mount_point"; then
       category=child
     elif [ -n "$workspace_dev" ] && [ "$mount_dev" = "$workspace_dev" ]; then
       category=same-device
@@ -181,8 +186,9 @@ scan_workspace_child_mountpoints() {
 
   while IFS=' ' read -r _mount_id _parent_id _mount_dev _mount_root mount_point _mount_options _rest; do
     [ -n "$mount_point" ] || continue
-    is_workspace_child_mountpoint "$mount_point" || continue
-    depth="$(printf '%s' "$mount_point" | tr -cd '/' | wc -c | tr -d ' ')"
+    decoded_mount_point="$(decode_mountinfo_path "$mount_point")"
+    is_workspace_child_mountpoint "$decoded_mount_point" || continue
+    depth="$(printf '%s' "$decoded_mount_point" | tr -cd '/' | wc -c | tr -d ' ')"
     [ -n "$depth" ] || depth=0
     printf '%s\t%s\n' "$depth" "$mount_point"
   done < "$workspace_mountinfo_path" | sort -rn -k1,1 | cut -f2-
@@ -371,8 +377,8 @@ log_workspace_mount_diagnostics() {
   while IFS="$tab" read -r category mount_id parent_id mount_dev mount_root mount_point mount_options; do
     count=$((count + 1))
     if [ "$count" -le "$WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT" ]; then
-      mount_root="$(sanitize_log_value "$mount_root")"
-      mount_point="$(sanitize_log_value "$mount_point")"
+      mount_root="$(sanitize_log_value "$(decode_mountinfo_path "$mount_root")")"
+      mount_point="$(sanitize_log_value "$(decode_mountinfo_path "$mount_point")")"
       mount_options="$(sanitize_log_value "$mount_options")"
       printf 'workspace mount: category=%s id=%s parent=%s dev=%s root=%s mount=%s options=%s\n' \
         "$category" "$mount_id" "$parent_id" "$mount_dev" "$mount_root" "$mount_point" "$mount_options" >&2
@@ -389,9 +395,10 @@ cleanup_workspace_child_mounts() {
 
   count=0
   failed_status=0
-  while IFS= read -r child_mount; do
-    [ -n "$child_mount" ] || continue
+  while IFS= read -r encoded_child_mount; do
+    [ -n "$encoded_child_mount" ] || continue
     count=$((count + 1))
+    child_mount="$(decode_mountinfo_path "$encoded_child_mount")"
     child_mount_log="$(sanitize_log_value "$child_mount")"
     echo "workspace mount cleanup: child unmount started mount=$child_mount_log" >&2
     if umount -- "$child_mount"; then

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -42,6 +42,8 @@ WORKSPACE_HOLDER_MAPS_LINE_LIMIT=4096
 WORKSPACE_HOLDER_VALUE_LIMIT=240
 WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1
 WORKSPACE_HOLDER_TERM_GRACE_SECONDS=1
+WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT=40
+workspace_mountinfo_path=${workspace_mountinfo_path:-/proc/self/mountinfo}
 
 holder_record_dir="$(mktemp -d)"
 direct_holder_records="$holder_record_dir/direct"
@@ -49,6 +51,8 @@ remaining_direct_holder_records="$holder_record_dir/direct-remaining"
 fd_holder_records="$holder_record_dir/fd"
 remaining_fd_holder_records="$holder_record_dir/fd-remaining"
 maps_holder_records="$holder_record_dir/maps"
+child_mount_records="$holder_record_dir/child-mounts"
+mount_diagnostic_records="$holder_record_dir/mount-diagnostics"
 cleanup_workspace_holder_records() {
   rm -rf -- "$holder_record_dir"
 }
@@ -68,6 +72,15 @@ is_workspace_ref() {
         "$workspace_dir"/*) return 0 ;;
       esac
       ;;
+  esac
+
+  return 1
+}
+
+is_workspace_child_mountpoint() {
+  mount_point=$1
+  case "$mount_point" in
+    "$workspace_dir"/*) return 0 ;;
   esac
 
   return 1
@@ -142,6 +155,37 @@ scan_proc_maps() {
   fi
 
   return 0
+}
+
+scan_workspace_mountinfo_refs() {
+  [ -r "$workspace_mountinfo_path" ] || return 0
+
+  while IFS=' ' read -r mount_id parent_id mount_dev mount_root mount_point mount_options _rest; do
+    [ -n "$mount_point" ] || continue
+    category=
+    if [ "$mount_point" = "$workspace_dir" ]; then
+      category=workspace
+    elif is_workspace_child_mountpoint "$mount_point"; then
+      category=child
+    elif [ -n "$workspace_dev" ] && [ "$mount_dev" = "$workspace_dev" ]; then
+      category=same-device
+    fi
+    [ -n "$category" ] || continue
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$category" "$mount_id" "$parent_id" "$mount_dev" "$mount_root" "$mount_point" "$mount_options"
+  done < "$workspace_mountinfo_path"
+}
+
+scan_workspace_child_mountpoints() {
+  [ -r "$workspace_mountinfo_path" ] || return 0
+
+  while IFS=' ' read -r _mount_id _parent_id _mount_dev _mount_root mount_point _mount_options _rest; do
+    [ -n "$mount_point" ] || continue
+    is_workspace_child_mountpoint "$mount_point" || continue
+    depth="$(printf '%s' "$mount_point" | tr -cd '/' | wc -c | tr -d ' ')"
+    [ -n "$depth" ] || depth=0
+    printf '%s\t%s\n' "$depth" "$mount_point"
+  done < "$workspace_mountinfo_path" | sort -rn -k1,1 | cut -f2-
 }
 
 is_scannable_holder_pid() {
@@ -318,6 +362,58 @@ collect_and_log_workspace_holders() {
   echo "workspace holder cleanup: $label scan completed holder_ref_count=$count" >&2
 }
 
+log_workspace_mount_diagnostics() {
+  echo "workspace mount diagnostics: mountinfo scan started" >&2
+  : > "$mount_diagnostic_records"
+  scan_workspace_mountinfo_refs > "$mount_diagnostic_records" || true
+  count=0
+  tab="$(printf '\t')"
+  while IFS="$tab" read -r category mount_id parent_id mount_dev mount_root mount_point mount_options; do
+    count=$((count + 1))
+    if [ "$count" -le "$WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT" ]; then
+      mount_root="$(sanitize_log_value "$mount_root")"
+      mount_point="$(sanitize_log_value "$mount_point")"
+      mount_options="$(sanitize_log_value "$mount_options")"
+      printf 'workspace mount: category=%s id=%s parent=%s dev=%s root=%s mount=%s options=%s\n' \
+        "$category" "$mount_id" "$parent_id" "$mount_dev" "$mount_root" "$mount_point" "$mount_options" >&2
+    elif [ "$count" -eq "$((WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT + 1))" ]; then
+      echo "workspace mount diagnostics truncated after $WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT entries" >&2
+    fi
+  done < "$mount_diagnostic_records"
+  echo "workspace mount diagnostics: mountinfo scan completed mount_ref_count=$count" >&2
+}
+
+cleanup_workspace_child_mounts() {
+  : > "$child_mount_records"
+  scan_workspace_child_mountpoints > "$child_mount_records" || true
+
+  count=0
+  failed_status=0
+  while IFS= read -r child_mount; do
+    [ -n "$child_mount" ] || continue
+    count=$((count + 1))
+    child_mount_log="$(sanitize_log_value "$child_mount")"
+    echo "workspace mount cleanup: child unmount started mount=$child_mount_log" >&2
+    if umount -- "$child_mount"; then
+      echo "workspace mount cleanup: child unmount succeeded mount=$child_mount_log" >&2
+    else
+      status=$?
+      failed_status=$status
+      echo "workspace mount cleanup: child unmount failed exit_code=$status mount=$child_mount_log" >&2
+    fi
+  done < "$child_mount_records"
+
+  echo "workspace mount cleanup: child scan completed mount_count=$count" >&2
+  if [ "$count" -eq 0 ]; then
+    echo "no workspace child mounts found" >&2
+  fi
+
+  if [ "$failed_status" -eq 0 ]; then
+    return 0
+  fi
+  return "$failed_status"
+}
+
 holder_record_pids() {
   sed -n '/^[0-9][0-9]*$/p' "$1" | sort -u
 }
@@ -471,4 +567,20 @@ else
   echo "no workspace maps holder processes found" >&2
 fi
 
-retry_workspace_unmount "slow maps diagnostics"
+echo "workspace mount cleanup: child scan started" >&2
+if cleanup_workspace_child_mounts; then
+  child_mount_cleanup_status=0
+else
+  child_mount_cleanup_status=$?
+fi
+
+if retry_workspace_unmount "child mount cleanup"; then
+  if [ "$child_mount_cleanup_status" -ne 0 ]; then
+    echo "workspace mount cleanup: parent unmount succeeded after child cleanup failure" >&2
+  fi
+  exit 0
+else
+  final_unmount_status=$?
+fi
+log_workspace_mount_diagnostics || true
+exit "$final_unmount_status"

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -145,6 +145,17 @@ decode_mountinfo_path() {
   }' "$1"
 }
 
+decode_mountinfo_path_to_result() {
+  decoded_mountinfo_path_result="$(
+    set +e
+    decode_mountinfo_path "$1"
+    decode_mountinfo_status=$?
+    printf .
+    exit "$decode_mountinfo_status"
+  )"
+  decoded_mountinfo_path_result=${decoded_mountinfo_path_result%.}
+}
+
 proc_uid() {
   stat -c %u "/proc/$1" 2>/dev/null || true
 }
@@ -221,7 +232,8 @@ scan_workspace_mountinfo_refs() {
 
   while IFS=' ' read -r mount_id parent_id mount_dev mount_root mount_point mount_options _rest; do
     [ -n "$mount_point" ] || continue
-    decoded_mount_point="$(decode_mountinfo_path "$mount_point")"
+    decode_mountinfo_path_to_result "$mount_point"
+    decoded_mount_point=$decoded_mountinfo_path_result
     category=
     if [ "$decoded_mount_point" = "$workspace_dir" ]; then
       category=workspace
@@ -241,7 +253,8 @@ scan_workspace_child_mountpoints() {
 
   while IFS=' ' read -r _mount_id _parent_id _mount_dev _mount_root mount_point _mount_options _rest; do
     [ -n "$mount_point" ] || continue
-    decoded_mount_point="$(decode_mountinfo_path "$mount_point")"
+    decode_mountinfo_path_to_result "$mount_point"
+    decoded_mount_point=$decoded_mountinfo_path_result
     is_workspace_child_mountpoint "$decoded_mount_point" || continue
     depth="$(printf '%s' "$decoded_mount_point" | tr -cd '/' | wc -c | tr -d ' ')"
     [ -n "$depth" ] || depth=0
@@ -432,8 +445,10 @@ log_workspace_mount_diagnostics() {
   while IFS="$tab" read -r category mount_id parent_id mount_dev mount_root mount_point mount_options; do
     count=$((count + 1))
     if [ "$count" -le "$WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT" ]; then
-      mount_root="$(sanitize_log_value "$(decode_mountinfo_path "$mount_root")")"
-      mount_point="$(sanitize_log_value "$(decode_mountinfo_path "$mount_point")")"
+      decode_mountinfo_path_to_result "$mount_root"
+      mount_root="$(sanitize_log_value "$decoded_mountinfo_path_result")"
+      decode_mountinfo_path_to_result "$mount_point"
+      mount_point="$(sanitize_log_value "$decoded_mountinfo_path_result")"
       mount_options="$(sanitize_log_value "$mount_options")"
       printf 'workspace mount: category=%s id=%s parent=%s dev=%s root=%s mount=%s options=%s\n' \
         "$category" "$mount_id" "$parent_id" "$mount_dev" "$mount_root" "$mount_point" "$mount_options" >&2
@@ -453,7 +468,8 @@ cleanup_workspace_child_mounts() {
   while IFS= read -r encoded_child_mount; do
     [ -n "$encoded_child_mount" ] || continue
     count=$((count + 1))
-    child_mount="$(decode_mountinfo_path "$encoded_child_mount")"
+    decode_mountinfo_path_to_result "$encoded_child_mount"
+    child_mount=$decoded_mountinfo_path_result
     child_mount_log="$(sanitize_log_value "$child_mount")"
     if ! is_safe_workspace_child_mountpoint_path "$child_mount"; then
       failed_status=64

--- a/crates/runner/scripts/unmount-workspace-drive.sh
+++ b/crates/runner/scripts/unmount-workspace-drive.sh
@@ -86,6 +86,29 @@ is_workspace_child_mountpoint() {
   return 1
 }
 
+is_safe_workspace_child_mountpoint_path() {
+  workspace_child_mount_point=$1
+  is_workspace_child_mountpoint "$workspace_child_mount_point" || return 1
+
+  workspace_child_relative_path=${workspace_child_mount_point#"$workspace_dir"/}
+  check_path=$workspace_dir
+  while [ -n "$workspace_child_relative_path" ]; do
+    component=${workspace_child_relative_path%%/*}
+    if [ "$workspace_child_relative_path" = "$component" ]; then
+      workspace_child_relative_path=
+    else
+      workspace_child_relative_path=${workspace_child_relative_path#*/}
+    fi
+    case "$component" in
+      ""|"."|"..") return 1 ;;
+    esac
+    check_path="$check_path/$component"
+    [ ! -L "$check_path" ] || return 1
+  done
+
+  return 0
+}
+
 decode_mountinfo_path() {
   awk 'BEGIN {
     value = ARGV[1]
@@ -432,6 +455,11 @@ cleanup_workspace_child_mounts() {
     count=$((count + 1))
     child_mount="$(decode_mountinfo_path "$encoded_child_mount")"
     child_mount_log="$(sanitize_log_value "$child_mount")"
+    if ! is_safe_workspace_child_mountpoint_path "$child_mount"; then
+      failed_status=64
+      echo "workspace mount cleanup: child unmount skipped unsafe path mount=$child_mount_log" >&2
+      continue
+    fi
     echo "workspace mount cleanup: child unmount started mount=$child_mount_log" >&2
     if umount -- "$child_mount"; then
       echo "workspace mount cleanup: child unmount succeeded mount=$child_mount_log" >&2

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -1026,6 +1026,55 @@ exit 0
 
     #[test]
     #[cfg(target_os = "linux")]
+    fn unmount_script_sanitizes_control_characters_in_mount_logs() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let child_mount = workspace_dir.join("child\r\u{1b}\\c");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        let mountinfo_path = temp.path().join("mountinfo");
+        fs::create_dir_all(&child_mount).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_child_mount_cleanup_fake_umount(&fake_bin, &workspace_dir, &log_path, &count_path);
+        write_mountinfo(
+            &mountinfo_path,
+            &[
+                mountinfo_line(100, 1, "123", "/", &workspace_dir),
+                mountinfo_line(101, 100, "456", "/", &child_mount),
+            ],
+        );
+
+        let output = run_unmount_script_with_mountinfo(
+            &workspace_dir,
+            &workspace_device,
+            &fake_bin,
+            Some(&mountinfo_path),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let expected_log_path = format!("mount={}/child  \\c", workspace_dir.display());
+
+        assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+        assert!(
+            !stderr.contains('\r'),
+            "stderr should sanitize CR: {stderr:?}"
+        );
+        assert!(
+            !stderr.contains('\u{1b}'),
+            "stderr should sanitize ESC: {stderr:?}"
+        );
+        assert!(
+            stderr.contains(&expected_log_path),
+            "stderr should preserve printable backslashes without echo truncation: {stderr:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
     fn unmount_script_skips_child_mounts_with_symlink_components() {
         let temp = tempfile::tempdir().unwrap();
         let workspace_dir = temp.path().join("workspace");

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -16,7 +16,8 @@
 //! processes. A clean unmount is attempted first. If that fails, diagnostics and
 //! cleanup stay targeted to processes that still reference the workspace:
 //! direct cwd/root/exe holder cleanup, fd holder cleanup, a slower maps scan,
-//! and final retry diagnostics. Holder diagnostics are bounded and truncated.
+//! workspace child mount cleanup, and final mount-topology diagnostics. Holder
+//! and mount diagnostics are bounded and truncated.
 //!
 //! Keep this as a high-level contract. The included shell helpers and their
 //! tests remain the source of truth for exact command behavior and limits.
@@ -277,13 +278,118 @@ exit 32
         );
     }
 
+    fn write_child_mount_cleanup_fake_umount(
+        fake_bin: &Path,
+        workspace_dir: &Path,
+        log_path: &Path,
+        count_path: &Path,
+    ) {
+        let workspace_dir = quote_shell_arg(workspace_dir.to_str().unwrap());
+        let log_path = quote_shell_arg(log_path.to_str().unwrap());
+        let count_path = quote_shell_arg(count_path.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("umount"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+workspace_dir={workspace_dir}
+target=$2
+printf 'umount target=%s args=%s\n' "$target" "$*" >> {log_path}
+if [ "$target" != "$workspace_dir" ]; then
+  exit 0
+fi
+count=0
+if [ -f {count_path} ]; then
+  count="$(cat {count_path})"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > {count_path}
+if [ "$count" -lt 4 ]; then
+  echo "target is busy" >&2
+  exit 32
+fi
+exit 0
+"#
+            ),
+        );
+    }
+
+    fn write_child_mount_failure_parent_success_fake_umount(
+        fake_bin: &Path,
+        workspace_dir: &Path,
+        log_path: &Path,
+        count_path: &Path,
+    ) {
+        let workspace_dir = quote_shell_arg(workspace_dir.to_str().unwrap());
+        let log_path = quote_shell_arg(log_path.to_str().unwrap());
+        let count_path = quote_shell_arg(count_path.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("umount"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+workspace_dir={workspace_dir}
+target=$2
+printf 'umount target=%s args=%s\n' "$target" "$*" >> {log_path}
+if [ "$target" != "$workspace_dir" ]; then
+  echo "child mount is already gone" >&2
+  exit 32
+fi
+count=0
+if [ -f {count_path} ]; then
+  count="$(cat {count_path})"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > {count_path}
+if [ "$count" -lt 4 ]; then
+  echo "target is busy" >&2
+  exit 32
+fi
+exit 0
+"#
+            ),
+        );
+    }
+
+    fn write_mountinfo(path: &Path, lines: &[String]) {
+        fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
+    }
+
+    fn mountinfo_line(
+        mount_id: u32,
+        parent_id: u32,
+        mount_dev: &str,
+        mount_root: &str,
+        mount_point: &Path,
+    ) -> String {
+        format!(
+            "{mount_id} {parent_id} {mount_dev} {mount_root} {} rw,relatime - ext4 /dev/vdb rw",
+            mount_point.display()
+        )
+    }
+
     fn run_unmount_script(
         workspace_dir: &Path,
         workspace_device: &Path,
         fake_bin: &Path,
     ) -> Output {
+        run_unmount_script_with_mountinfo(workspace_dir, workspace_device, fake_bin, None)
+    }
+
+    fn run_unmount_script_with_mountinfo(
+        workspace_dir: &Path,
+        workspace_device: &Path,
+        fake_bin: &Path,
+        mountinfo_path: Option<&Path>,
+    ) -> Output {
+        let mountinfo_assignment = mountinfo_path.map_or(String::new(), |path| {
+            format!(
+                "workspace_mountinfo_path={}\n",
+                quote_shell_arg(path.to_str().unwrap())
+            )
+        });
         let cmd = format!(
-            "workspace_dir={}\nworkspace_device={}\n{}",
+            "workspace_dir={}\nworkspace_device={}\n{mountinfo_assignment}{}",
             quote_shell_arg(workspace_dir.to_str().unwrap()),
             quote_shell_arg(workspace_device.to_str().unwrap()),
             WORKSPACE_UNMOUNT_SCRIPT
@@ -476,13 +582,15 @@ exit 32
         write_successful_fake_umount(&fake_bin, &log_path);
 
         let output = run_unmount_script(&workspace_dir, &workspace_device, &fake_bin);
+        let stderr = String::from_utf8_lossy(&output.stderr);
 
         assert!(
             output.status.success(),
             "stderr={} stdout={}",
-            String::from_utf8_lossy(&output.stderr),
+            stderr,
             String::from_utf8_lossy(&output.stdout)
         );
+        assert!(!stderr.contains("workspace mount diagnostics"));
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("sync cwd=/ args=-f --"));
         assert!(log.contains("umount cwd=/ args=--"));
@@ -536,6 +644,7 @@ exit 32
                 .contains("workspace holder cleanup: retry umount after direct cleanup succeeded")
         );
         assert!(!stderr.contains("workspace holder cleanup: fd scan started"));
+        assert!(!stderr.contains("workspace mount diagnostics"));
         let log = fs::read_to_string(log_path).unwrap();
         assert_eq!(log.matches("umount call=").count(), 2);
         assert!(log.contains("umount call=1 cwd=/ args=--"));
@@ -590,6 +699,7 @@ exit 32
         assert!(
             stderr.contains("workspace holder cleanup: retry umount after fd cleanup succeeded")
         );
+        assert!(!stderr.contains("workspace mount diagnostics"));
         let log = fs::read_to_string(log_path).unwrap();
         assert_eq!(log.matches("umount call=").count(), 3);
         assert!(log.contains("umount call=1 cwd=/ args=--"));
@@ -677,13 +787,169 @@ exit 32
         assert!(stderr.contains("workspace holder cleanup: retry umount after fd cleanup failed"));
         assert!(stderr.contains("workspace holder cleanup: slow maps scan started"));
         assert!(stderr.contains("no workspace maps holder processes found"));
+        assert!(stderr.contains("workspace mount cleanup: child scan started"));
+        assert!(stderr.contains("no workspace child mounts found"));
         assert!(
             stderr.contains(
-                "workspace holder cleanup: retry umount after slow maps diagnostics failed"
+                "workspace holder cleanup: retry umount after child mount cleanup failed"
             )
         );
+        assert!(stderr.contains("workspace mount diagnostics: mountinfo scan started"));
         let log = fs::read_to_string(log_path).unwrap();
         assert_eq!(log.matches("umount call=").count(), 4);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn unmount_script_reports_mount_topology_when_process_holders_are_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let child_mount = workspace_dir.join("nested");
+        let sibling_mount = temp.path().join("same-device");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        let mountinfo_path = temp.path().join("mountinfo");
+        fs::create_dir_all(&child_mount).unwrap();
+        fs::create_dir(&sibling_mount).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_always_busy_fake_umount(&fake_bin, &log_path, &count_path);
+        write_mountinfo(
+            &mountinfo_path,
+            &[
+                mountinfo_line(100, 1, "123", "/", &workspace_dir),
+                mountinfo_line(101, 100, "456", "/", &child_mount),
+                mountinfo_line(102, 1, "123", "/", &sibling_mount),
+            ],
+        );
+
+        let output = run_unmount_script_with_mountinfo(
+            &workspace_dir,
+            &workspace_device,
+            &fake_bin,
+            Some(&mountinfo_path),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(!output.status.success(), "stderr={stderr}");
+        assert!(stderr.contains("workspace holder cleanup: direct scan holder_pid_count=0"));
+        assert!(stderr.contains("workspace holder cleanup: fd scan holder_pid_count=0"));
+        assert!(stderr.contains("workspace holder cleanup: slow maps scan holder_pid_count=0"));
+        assert!(stderr.contains("workspace mount cleanup: child unmount started"));
+        assert!(stderr.contains("workspace mount diagnostics: mountinfo scan started"));
+        assert!(stderr.contains("workspace mount: category=workspace id=100"));
+        assert!(stderr.contains("workspace mount: category=child id=101"));
+        assert!(stderr.contains("workspace mount: category=same-device id=102"));
+        assert!(stderr.contains("workspace mount diagnostics: mountinfo scan completed"));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn unmount_script_unmounts_workspace_child_mounts_before_parent_retry() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let shallow_child = workspace_dir.join("child");
+        let deep_child = shallow_child.join("grandchild");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        let mountinfo_path = temp.path().join("mountinfo");
+        fs::create_dir_all(&deep_child).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_child_mount_cleanup_fake_umount(&fake_bin, &workspace_dir, &log_path, &count_path);
+        write_mountinfo(
+            &mountinfo_path,
+            &[
+                mountinfo_line(100, 1, "123", "/", &workspace_dir),
+                mountinfo_line(101, 100, "456", "/", &shallow_child),
+                mountinfo_line(102, 101, "789", "/", &deep_child),
+            ],
+        );
+
+        let output = run_unmount_script_with_mountinfo(
+            &workspace_dir,
+            &workspace_device,
+            &fake_bin,
+            Some(&mountinfo_path),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+        assert!(stderr.contains("workspace mount cleanup: child scan started"));
+        assert!(stderr.contains("workspace mount cleanup: child unmount succeeded"));
+        assert!(!stderr.contains("workspace mount diagnostics"));
+
+        let log = fs::read_to_string(log_path).unwrap();
+        let deep_unmount = log
+            .find(&format!("umount target={} ", deep_child.display()))
+            .expect("deep child unmount");
+        let shallow_unmount = log
+            .find(&format!("umount target={} ", shallow_child.display()))
+            .expect("shallow child unmount");
+        let final_parent_unmount = log
+            .rfind(&format!("umount target={} ", workspace_dir.display()))
+            .expect("final parent unmount");
+        assert!(
+            deep_unmount < shallow_unmount,
+            "deeper child mount should unmount before shallower child: {log}"
+        );
+        assert!(
+            shallow_unmount < final_parent_unmount,
+            "child mounts should unmount before final parent retry: {log}"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn unmount_script_succeeds_when_child_cleanup_races_with_parent_unmount() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let child_mount = workspace_dir.join("child");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        let mountinfo_path = temp.path().join("mountinfo");
+        fs::create_dir_all(&child_mount).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_child_mount_failure_parent_success_fake_umount(
+            &fake_bin,
+            &workspace_dir,
+            &log_path,
+            &count_path,
+        );
+        write_mountinfo(
+            &mountinfo_path,
+            &[
+                mountinfo_line(100, 1, "123", "/", &workspace_dir),
+                mountinfo_line(101, 100, "456", "/", &child_mount),
+            ],
+        );
+
+        let output = run_unmount_script_with_mountinfo(
+            &workspace_dir,
+            &workspace_device,
+            &fake_bin,
+            Some(&mountinfo_path),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+        assert!(stderr.contains("workspace mount cleanup: child unmount failed exit_code=32"));
+        assert!(stderr.contains(
+            "workspace mount cleanup: parent unmount succeeded after child cleanup failure"
+        ));
+        assert!(!stderr.contains("workspace mount diagnostics"));
     }
 
     #[test]
@@ -766,6 +1032,10 @@ exit 32
         assert!(cmd.contains("scan_workspace_direct_holder_refs()"));
         assert!(cmd.contains("scan_workspace_fd_holder_refs()"));
         assert!(cmd.contains("scan_workspace_maps_holder_refs()"));
+        assert!(cmd.contains("scan_workspace_mountinfo_refs()"));
+        assert!(cmd.contains("scan_workspace_child_mountpoints()"));
+        assert!(cmd.contains("cleanup_workspace_child_mounts()"));
+        assert!(cmd.contains("log_workspace_mount_diagnostics()"));
         assert!(cmd.contains("scan_proc_ref \"$pid\" cwd \"$proc_dir/cwd\""));
         assert!(cmd.contains("scan_proc_ref \"$pid\" root \"$proc_dir/root\""));
         assert!(cmd.contains("scan_proc_ref \"$pid\" exe \"$proc_dir/exe\""));
@@ -784,9 +1054,16 @@ exit 32
         assert!(cmd.contains("WORKSPACE_HOLDER_MAPS_LINE_LIMIT=4096"));
         assert!(cmd.contains("WORKSPACE_HOLDER_VALUE_LIMIT=240"));
         assert!(cmd.contains("WORKSPACE_HOLDER_KILL_GRACE_SECONDS=1"));
+        assert!(cmd.contains("WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT=40"));
+        assert!(cmd.contains(
+            "workspace_mountinfo_path=${workspace_mountinfo_path:-/proc/self/mountinfo}"
+        ));
         assert!(cmd.contains("wait_for_workspace_holder_records_to_clear()"));
         assert!(cmd.contains("holder_records_have_workspace_ref()"));
         assert!(cmd.contains("diagnostics truncated after $WORKSPACE_HOLDER_DIAGNOSTIC_LIMIT"));
+        assert!(cmd.contains(
+            "workspace mount diagnostics truncated after $WORKSPACE_MOUNT_DIAGNOSTIC_LIMIT"
+        ));
         assert!(cmd.contains("workspace holder cleanup: direct scan started"));
         assert!(cmd.contains("workspace holder cleanup: direct TERM started"));
         assert!(cmd.contains("workspace holder cleanup: direct KILL started"));
@@ -795,7 +1072,13 @@ exit 32
         assert!(cmd.contains("workspace holder cleanup: fd KILL started"));
         assert!(cmd.contains("workspace holder cleanup: slow maps scan started"));
         assert!(cmd.contains("workspace holder cleanup: maps KILL started"));
+        assert!(cmd.contains("workspace mount cleanup: child scan started"));
+        assert!(cmd.contains("workspace mount cleanup: child unmount started"));
+        assert!(cmd.contains("workspace mount diagnostics: mountinfo scan started"));
         assert!(cmd.contains("pid=%s uid=%s comm=%s ref=%s path=%s"));
+        assert!(cmd.contains(
+            "workspace mount: category=%s id=%s parent=%s dev=%s root=%s mount=%s options=%s"
+        ));
         assert!(cmd.contains("comm=\"$(sanitize_log_value \"$comm\")\""));
         assert!(cmd.contains("target=\"$(sanitize_log_value \"$target\")\""));
         assert!(cmd.contains("pid_has_cleanup_workspace_ref \"$pid\" \"$ref_mode\" || continue"));
@@ -889,11 +1172,18 @@ exit 32
             "wait_for_workspace_holder_records_to_clear \"$maps_holder_records\" maps \"$WORKSPACE_HOLDER_KILL_GRACE_SECONDS\"",
             maps_kill,
         );
-        let maps_retry = find_after(
+        let child_scan = find_after(
             &cmd,
-            "retry_workspace_unmount \"slow maps diagnostics\"",
+            "echo \"workspace mount cleanup: child scan started\"",
             maps_wait,
         );
+        let child_cleanup = find_after(&cmd, "cleanup_workspace_child_mounts", child_scan);
+        let child_retry = find_after(
+            &cmd,
+            "retry_workspace_unmount \"child mount cleanup\"",
+            child_cleanup,
+        );
+        let mount_diagnostics = find_after(&cmd, "log_workspace_mount_diagnostics", child_retry);
 
         assert!(
             clean_unmount < direct_scan,
@@ -968,8 +1258,20 @@ exit 32
             "maps KILL must wait for maps refs to clear"
         );
         assert!(
-            maps_wait < maps_retry,
-            "maps wait must happen before final retry unmount"
+            maps_wait < child_scan,
+            "maps wait must happen before child mount cleanup"
+        );
+        assert!(
+            child_scan < child_cleanup,
+            "child mount cleanup must start after the maps cleanup phase"
+        );
+        assert!(
+            child_cleanup < child_retry,
+            "child mounts must be cleaned before the final parent retry"
+        );
+        assert!(
+            child_retry < mount_diagnostics,
+            "mount diagnostics should only run after the final parent retry fails"
         );
     }
 
@@ -978,6 +1280,7 @@ exit 32
         let cmd = workspace_unmount_command();
 
         assert!(!cmd.contains("umount -l"));
+        assert!(!cmd.contains("umount -f"));
         assert!(!cmd.contains("pkill"));
         assert!(!cmd.contains("killall"));
         assert!(!cmd.contains("cmdline"));

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -315,6 +315,53 @@ exit 0
         );
     }
 
+    fn write_trailing_newline_child_mount_fake_umount(
+        fake_bin: &Path,
+        workspace_dir: &Path,
+        expected_child_mount: &Path,
+        log_path: &Path,
+        count_path: &Path,
+        child_unmounted_marker_path: &Path,
+    ) {
+        let workspace_dir = quote_shell_arg(workspace_dir.to_str().unwrap());
+        let expected_child_mount = quote_shell_arg(expected_child_mount.to_str().unwrap());
+        let log_path = quote_shell_arg(log_path.to_str().unwrap());
+        let count_path = quote_shell_arg(count_path.to_str().unwrap());
+        let child_unmounted_marker_path =
+            quote_shell_arg(child_unmounted_marker_path.to_str().unwrap());
+        write_executable(
+            &fake_bin.join("umount"),
+            &format!(
+                r#"#!/bin/sh
+set -eu
+workspace_dir={workspace_dir}
+expected_child_mount={expected_child_mount}
+target=$2
+printf 'umount target=%s args=%s\n' "$target" "$*" >> {log_path}
+if [ "$target" = "$expected_child_mount" ]; then
+  printf unmounted > {child_unmounted_marker_path}
+  exit 0
+fi
+if [ "$target" != "$workspace_dir" ]; then
+  echo "unexpected child mount target" >&2
+  exit 33
+fi
+count=0
+if [ -f {count_path} ]; then
+  count="$(cat {count_path})"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > {count_path}
+if [ -f {child_unmounted_marker_path} ] && [ "$count" -ge 2 ]; then
+  exit 0
+fi
+echo "target is busy" >&2
+exit 32
+"#
+            ),
+        );
+    }
+
     fn write_child_mount_failure_parent_success_fake_umount(
         fake_bin: &Path,
         workspace_dir: &Path,
@@ -929,6 +976,56 @@ exit 0
 
     #[test]
     #[cfg(target_os = "linux")]
+    fn unmount_script_preserves_trailing_newline_in_mountinfo_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let child_mount = workspace_dir.join("child\n");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        let mountinfo_path = temp.path().join("mountinfo");
+        let child_unmounted_marker_path = temp.path().join("child-unmounted");
+        fs::create_dir_all(&child_mount).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_trailing_newline_child_mount_fake_umount(
+            &fake_bin,
+            &workspace_dir,
+            &child_mount,
+            &log_path,
+            &count_path,
+            &child_unmounted_marker_path,
+        );
+        write_mountinfo(
+            &mountinfo_path,
+            &[
+                mountinfo_line(100, 1, "123", "/", &workspace_dir),
+                mountinfo_line(101, 100, "456", "/", &child_mount),
+            ],
+        );
+
+        let output = run_unmount_script_with_mountinfo(
+            &workspace_dir,
+            &workspace_device,
+            &fake_bin,
+            Some(&mountinfo_path),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        assert!(output.status.success(), "stderr={stderr} stdout={stdout}");
+        assert_eq!(
+            fs::read_to_string(child_unmounted_marker_path).unwrap(),
+            "unmounted"
+        );
+        assert!(!stderr.contains("unexpected child mount target"));
+        assert!(!stderr.contains("workspace mount diagnostics"));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
     fn unmount_script_skips_child_mounts_with_symlink_components() {
         let temp = tempfile::tempdir().unwrap();
         let workspace_dir = temp.path().join("workspace");
@@ -1100,6 +1197,7 @@ exit 0
         assert!(cmd.contains("scan_workspace_mountinfo_refs()"));
         assert!(cmd.contains("scan_workspace_child_mountpoints()"));
         assert!(cmd.contains("decode_mountinfo_path()"));
+        assert!(cmd.contains("decode_mountinfo_path_to_result()"));
         assert!(cmd.contains("is_safe_workspace_child_mountpoint_path()"));
         assert!(cmd.contains("\"\"|\".\"|\"..\") return 1 ;;"));
         assert!(cmd.contains("cleanup_workspace_child_mounts()"));

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -111,8 +111,9 @@ fn workspace_mount_command() -> String {
 fn workspace_unmount_command() -> String {
     let workspace_dir = quote_shell_arg(CANONICAL_WORKING_DIR);
     let workspace_device = quote_shell_arg(WORKSPACE_DEVICE);
+    let workspace_mountinfo_path = quote_shell_arg("/proc/self/mountinfo");
     format!(
-        "workspace_dir={workspace_dir}\nworkspace_device={workspace_device}\n{WORKSPACE_UNMOUNT_SCRIPT}"
+        "workspace_dir={workspace_dir}\nworkspace_device={workspace_device}\nworkspace_mountinfo_path={workspace_mountinfo_path}\n{WORKSPACE_UNMOUNT_SCRIPT}"
     )
 }
 
@@ -382,16 +383,17 @@ exit 0
         fake_bin: &Path,
         mountinfo_path: Option<&Path>,
     ) -> Output {
-        let mountinfo_assignment = mountinfo_path.map_or(String::new(), |path| {
-            format!(
-                "workspace_mountinfo_path={}\n",
-                quote_shell_arg(path.to_str().unwrap())
-            )
-        });
+        let workspace_mountinfo_path = quote_shell_arg(
+            mountinfo_path
+                .unwrap_or(Path::new("/proc/self/mountinfo"))
+                .to_str()
+                .unwrap(),
+        );
         let cmd = format!(
-            "workspace_dir={}\nworkspace_device={}\n{mountinfo_assignment}{}",
+            "workspace_dir={}\nworkspace_device={}\nworkspace_mountinfo_path={}\n{}",
             quote_shell_arg(workspace_dir.to_str().unwrap()),
             quote_shell_arg(workspace_device.to_str().unwrap()),
+            workspace_mountinfo_path,
             WORKSPACE_UNMOUNT_SCRIPT
         );
         Command::new("sh")
@@ -563,6 +565,7 @@ exit 0
 
         assert!(cmd.contains("workspace_dir='/home/user/workspace'"));
         assert!(cmd.contains("workspace_device='/dev/vdb'"));
+        assert!(cmd.contains("workspace_mountinfo_path='/proc/self/mountinfo'"));
         assert!(cmd.contains("sync -f -- \"$workspace_dir\""));
         assert!(cmd.contains("umount -- \"$workspace_dir\""));
         assert_eq!(cmd.matches("umount -- \"$workspace_dir\"").count(), 2);

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -856,6 +856,9 @@ exit 0
         assert!(stderr.contains("workspace mount: category=child id=101"));
         assert!(stderr.contains("workspace mount: category=same-device id=102"));
         assert!(stderr.contains("workspace mount diagnostics: mountinfo scan completed"));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains(&child_mount.display().to_string()));
+        assert!(!log.contains(&sibling_mount.display().to_string()));
     }
 
     #[test]

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -929,6 +929,50 @@ exit 0
 
     #[test]
     #[cfg(target_os = "linux")]
+    fn unmount_script_skips_child_mounts_with_symlink_components() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_dir = temp.path().join("workspace");
+        let outside_dir = temp.path().join("outside");
+        let symlink_path = workspace_dir.join("redirect");
+        let unsafe_child_mount = symlink_path.join("child");
+        let workspace_device = temp.path().join("vdb");
+        let fake_bin = temp.path().join("bin");
+        let log_path = temp.path().join("calls.log");
+        let count_path = temp.path().join("umount-count");
+        let mountinfo_path = temp.path().join("mountinfo");
+        fs::create_dir(&workspace_dir).unwrap();
+        fs::create_dir(&outside_dir).unwrap();
+        fs::create_dir(outside_dir.join("child")).unwrap();
+        std::os::unix::fs::symlink(&outside_dir, &symlink_path).unwrap();
+        fs::create_dir(&fake_bin).unwrap();
+        write_fake_mountpoint(&fake_bin, &workspace_dir, &workspace_device);
+        write_fake_sync(&fake_bin, &log_path);
+        write_always_busy_fake_umount(&fake_bin, &log_path, &count_path);
+        write_mountinfo(
+            &mountinfo_path,
+            &[
+                mountinfo_line(100, 1, "123", "/", &workspace_dir),
+                mountinfo_line(101, 100, "456", "/", &unsafe_child_mount),
+            ],
+        );
+
+        let output = run_unmount_script_with_mountinfo(
+            &workspace_dir,
+            &workspace_device,
+            &fake_bin,
+            Some(&mountinfo_path),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(!output.status.success(), "stderr={stderr}");
+        assert!(stderr.contains("workspace mount cleanup: child unmount skipped unsafe path"));
+        assert!(!stderr.contains("workspace mount cleanup: child unmount started"));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(!log.contains(&unsafe_child_mount.display().to_string()));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
     fn unmount_script_succeeds_when_child_cleanup_races_with_parent_unmount() {
         let temp = tempfile::tempdir().unwrap();
         let workspace_dir = temp.path().join("workspace");
@@ -1056,6 +1100,8 @@ exit 0
         assert!(cmd.contains("scan_workspace_mountinfo_refs()"));
         assert!(cmd.contains("scan_workspace_child_mountpoints()"));
         assert!(cmd.contains("decode_mountinfo_path()"));
+        assert!(cmd.contains("is_safe_workspace_child_mountpoint_path()"));
+        assert!(cmd.contains("\"\"|\".\"|\"..\") return 1 ;;"));
         assert!(cmd.contains("cleanup_workspace_child_mounts()"));
         assert!(cmd.contains("log_workspace_mount_diagnostics()"));
         assert!(cmd.contains("scan_proc_ref \"$pid\" cwd \"$proc_dir/cwd\""));
@@ -1096,6 +1142,7 @@ exit 0
         assert!(cmd.contains("workspace holder cleanup: maps KILL started"));
         assert!(cmd.contains("workspace mount cleanup: child scan started"));
         assert!(cmd.contains("workspace mount cleanup: child unmount started"));
+        assert!(cmd.contains("workspace mount cleanup: child unmount skipped unsafe path"));
         assert!(cmd.contains("workspace mount diagnostics: mountinfo scan started"));
         assert!(cmd.contains("pid=%s uid=%s comm=%s ref=%s path=%s"));
         assert!(cmd.contains(

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -363,10 +363,19 @@ exit 0
         mount_root: &str,
         mount_point: &Path,
     ) -> String {
+        let mount_point = encode_mountinfo_path_for_test(mount_point);
         format!(
-            "{mount_id} {parent_id} {mount_dev} {mount_root} {} rw,relatime - ext4 /dev/vdb rw",
-            mount_point.display()
+            "{mount_id} {parent_id} {mount_dev} {mount_root} {mount_point} rw,relatime - ext4 /dev/vdb rw"
         )
+    }
+
+    fn encode_mountinfo_path_for_test(path: &Path) -> String {
+        path.display()
+            .to_string()
+            .replace('\\', "\\134")
+            .replace(' ', "\\040")
+            .replace('\t', "\\011")
+            .replace('\n', "\\012")
     }
 
     fn run_unmount_script(
@@ -854,7 +863,7 @@ exit 0
     fn unmount_script_unmounts_workspace_child_mounts_before_parent_retry() {
         let temp = tempfile::tempdir().unwrap();
         let workspace_dir = temp.path().join("workspace");
-        let shallow_child = workspace_dir.join("child");
+        let shallow_child = workspace_dir.join("child with space");
         let deep_child = shallow_child.join("grandchild");
         let workspace_device = temp.path().join("vdb");
         let fake_bin = temp.path().join("bin");
@@ -1037,6 +1046,7 @@ exit 0
         assert!(cmd.contains("scan_workspace_maps_holder_refs()"));
         assert!(cmd.contains("scan_workspace_mountinfo_refs()"));
         assert!(cmd.contains("scan_workspace_child_mountpoints()"));
+        assert!(cmd.contains("decode_mountinfo_path()"));
         assert!(cmd.contains("cleanup_workspace_child_mounts()"));
         assert!(cmd.contains("log_workspace_mount_diagnostics()"));
         assert!(cmd.contains("scan_proc_ref \"$pid\" cwd \"$proc_dir/cwd\""));

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -863,7 +863,7 @@ exit 0
     fn unmount_script_unmounts_workspace_child_mounts_before_parent_retry() {
         let temp = tempfile::tempdir().unwrap();
         let workspace_dir = temp.path().join("workspace");
-        let shallow_child = workspace_dir.join("child with space");
+        let shallow_child = workspace_dir.join("child with space\\backslash");
         let deep_child = shallow_child.join("grandchild");
         let workspace_device = temp.path().join("vdb");
         let fake_bin = temp.path().join("bin");

--- a/crates/runner/src/workspace_mount.rs
+++ b/crates/runner/src/workspace_mount.rs
@@ -863,7 +863,7 @@ exit 0
     fn unmount_script_unmounts_workspace_child_mounts_before_parent_retry() {
         let temp = tempfile::tempdir().unwrap();
         let workspace_dir = temp.path().join("workspace");
-        let shallow_child = workspace_dir.join("child with space\\backslash");
+        let shallow_child = workspace_dir.join("child with space\\040literal\\backslash");
         let deep_child = shallow_child.join("grandchild");
         let workspace_device = temp.path().join("vdb");
         let fake_bin = temp.path().join("bin");
@@ -899,9 +899,15 @@ exit 0
         assert!(!stderr.contains("workspace mount diagnostics"));
 
         let log = fs::read_to_string(log_path).unwrap();
+        let mountinfo = fs::read_to_string(&mountinfo_path).unwrap();
         let deep_unmount = log
             .find(&format!("umount target={} ", deep_child.display()))
-            .expect("deep child unmount");
+            .unwrap_or_else(|| {
+                panic!(
+                    "deep child unmount missing: expected={} mountinfo={mountinfo} log={log}",
+                    deep_child.display()
+                )
+            });
         let shallow_unmount = log
             .find(&format!("umount target={} ", shallow_child.display()))
             .expect("shallow child unmount");


### PR DESCRIPTION
## Summary
- add bounded mountinfo diagnostics when workspace unmount still fails after process-holder cleanup
- clean nested workspace child mounts deepest-first with normal unmounts before the final parent retry
- cover mount-topology diagnostics, child mount cleanup ordering, and child-cleanup race behavior in runner tests

Closes #20597

## Tests
- `sh -n crates/runner/scripts/unmount-workspace-drive.sh`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner workspace_mount`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- pre-commit hook: crates cargo-fmt, cargo-doc, cargo-clippy
