### PR TITLE
fix: add runner api transport diagnostics

### DIFF
--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -7,6 +7,9 @@ pub enum RunnerError {
     #[error("api error: {0}")]
     Api(String),
 
+    #[error("api error: {0}")]
+    ApiTransport(Box<ApiTransportError>),
+
     #[error("job already claimed by another runner")]
     AlreadyClaimed,
 
@@ -116,6 +119,55 @@ pub fn format_short_duration(d: Duration) -> String {
 }
 
 pub type RunnerResult<T> = Result<T, RunnerError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiRequestContext {
+    pub endpoint_label: &'static str,
+    pub method: String,
+    pub host: String,
+    pub path: String,
+    pub client_request_id: String,
+    pub client_session_id: String,
+    pub client_version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiFailureKind {
+    Timeout,
+    Connect,
+    Request,
+    Body,
+    Unknown,
+}
+
+impl ApiFailureKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Timeout => "timeout",
+            Self::Connect => "connect",
+            Self::Request => "request",
+            Self::Body => "body",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiTransportError {
+    pub request: ApiRequestContext,
+    pub failure_kind: ApiFailureKind,
+    pub summary: String,
+}
+
+impl std::fmt::Display for ApiTransportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}: send API request failed: {}",
+            self.request.endpoint_label, self.summary
+        )
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/runner/src/http.rs
+++ b/crates/runner/src/http.rs
@@ -13,12 +13,17 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::config::normalize_api_base_url;
-use crate::error::{RunnerError, RunnerResult};
+use crate::error::{
+    ApiFailureKind, ApiRequestContext, ApiTransportError, RunnerError, RunnerResult,
+};
 
 /// Default timeout for API requests (covers large claim payloads).
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
 const VERCEL_BYPASS_HEADER: &str = "x-vercel-protection-bypass";
 const RUNNER_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+const API_ERROR_SUMMARY_MAX_CHARS: usize = 512;
+const API_ERROR_SUMMARY_TRUNCATION_MARKER: &str = "...";
+const API_ERROR_SUMMARY_TRUNCATION_MARKER_CHARS: usize = 3;
 
 /// Configuration for the shared runner API HTTP client.
 pub struct HttpClientConfig {
@@ -46,6 +51,17 @@ struct ClientHeaders {
     client_type: HeaderValue,
     client_version: HeaderValue,
     client_session_id: HeaderValue,
+}
+
+struct AppliedClientHeaders {
+    client_version: String,
+    client_session_id: String,
+    client_request_id: String,
+}
+
+struct FinalizedApiRequest {
+    request: Request,
+    context: ApiRequestContext,
 }
 
 /// Request builder for generated vm0 API routes.
@@ -85,27 +101,38 @@ impl ApiRequestBuilder {
         }
     }
 
-    pub async fn send(self) -> RunnerResult<Response> {
+    pub async fn send(self, endpoint_label: &'static str) -> RunnerResult<Response> {
         let client = self.client.clone();
-        let request = self.finalize()?;
+        let finalized = self.finalize(endpoint_label)?;
+        let context = finalized.context;
         client
-            .execute(request)
+            .execute(finalized.request)
             .await
-            .map_err(|e| RunnerError::Api(format!("send API request: {e}")))
+            .map_err(|e| api_transport_error(context, e))
     }
 
     #[cfg(test)]
     pub fn build(self) -> RunnerResult<Request> {
-        self.finalize()
+        Ok(self.finalize("test")?.request)
     }
 
-    fn finalize(self) -> RunnerResult<Request> {
+    #[cfg(test)]
+    pub fn build_with_context_for_test(
+        self,
+        endpoint_label: &'static str,
+    ) -> RunnerResult<(Request, ApiRequestContext)> {
+        let finalized = self.finalize(endpoint_label)?;
+        Ok((finalized.request, finalized.context))
+    }
+
+    fn finalize(self, endpoint_label: &'static str) -> RunnerResult<FinalizedApiRequest> {
         let mut request = self
             .builder
             .build()
             .map_err(|e| RunnerError::Api(format!("build API request: {e}")))?;
-        self.client_headers.apply(request.headers_mut())?;
-        Ok(request)
+        let applied_headers = self.client_headers.apply(request.headers_mut())?;
+        let context = request_context(endpoint_label, &request, applied_headers);
+        Ok(FinalizedApiRequest { request, context })
     }
 
     #[cfg(test)]
@@ -135,7 +162,7 @@ impl ClientHeaders {
         })
     }
 
-    fn apply(&self, headers: &mut HeaderMap) -> RunnerResult<()> {
+    fn apply(&self, headers: &mut HeaderMap) -> RunnerResult<AppliedClientHeaders> {
         let request_id = Uuid::new_v4().to_string();
         let request_id = match HeaderValue::from_str(&request_id) {
             Ok(value) => value,
@@ -148,9 +175,20 @@ impl ClientHeaders {
         headers.insert(CLIENT_VERSION_HEADER, self.client_version.clone());
         headers.insert(CLIENT_TYPE_HEADER, self.client_type.clone());
         headers.insert(CLIENT_SESSION_ID_HEADER, self.client_session_id.clone());
-        headers.insert(CLIENT_REQUEST_ID_HEADER, request_id);
-        Ok(())
+        headers.insert(CLIENT_REQUEST_ID_HEADER, request_id.clone());
+        Ok(AppliedClientHeaders {
+            client_version: header_value_string(&self.client_version, "client version")?,
+            client_session_id: header_value_string(&self.client_session_id, "client session id")?,
+            client_request_id: header_value_string(&request_id, "client request id")?,
+        })
     }
+}
+
+fn header_value_string(value: &HeaderValue, label: &str) -> RunnerResult<String> {
+    value
+        .to_str()
+        .map(str::to_string)
+        .map_err(|e| RunnerError::Internal(format!("invalid {label}: {e}")))
 }
 
 impl HttpClient {
@@ -244,10 +282,91 @@ fn reqwest_method(method: Method) -> reqwest::Method {
     }
 }
 
+fn request_context(
+    endpoint_label: &'static str,
+    request: &Request,
+    headers: AppliedClientHeaders,
+) -> ApiRequestContext {
+    let url = request.url();
+    let host = match (url.host_str(), url.port()) {
+        (Some(host), Some(port)) if host.contains(':') && !host.starts_with('[') => {
+            format!("[{host}]:{port}")
+        }
+        (Some(host), Some(port)) => format!("{host}:{port}"),
+        (Some(host), None) => host.to_string(),
+        (None, _) => String::new(),
+    };
+    ApiRequestContext {
+        endpoint_label,
+        method: request.method().as_str().to_string(),
+        host,
+        path: url.path().to_string(),
+        client_request_id: headers.client_request_id,
+        client_session_id: headers.client_session_id,
+        client_version: headers.client_version,
+    }
+}
+
+fn api_transport_error(context: ApiRequestContext, error: reqwest::Error) -> RunnerError {
+    let failure_kind = api_failure_kind(&error);
+    let summary = sanitize_api_error_summary(error.without_url().to_string());
+    RunnerError::ApiTransport(Box::new(ApiTransportError {
+        request: context,
+        failure_kind,
+        summary,
+    }))
+}
+
+fn api_failure_kind(error: &reqwest::Error) -> ApiFailureKind {
+    if error.is_timeout() {
+        ApiFailureKind::Timeout
+    } else if error.is_connect() {
+        ApiFailureKind::Connect
+    } else if error.is_body() {
+        ApiFailureKind::Body
+    } else if error.is_request() {
+        ApiFailureKind::Request
+    } else {
+        ApiFailureKind::Unknown
+    }
+}
+
+fn sanitize_api_error_summary(summary: String) -> String {
+    let mut sanitized = String::with_capacity(summary.len().min(API_ERROR_SUMMARY_MAX_CHARS));
+    let mut previous_was_whitespace = false;
+    let mut emitted = 0;
+    let max_body_chars =
+        API_ERROR_SUMMARY_MAX_CHARS.saturating_sub(API_ERROR_SUMMARY_TRUNCATION_MARKER_CHARS);
+    let mut truncated = false;
+    for ch in summary.chars() {
+        if emitted >= max_body_chars {
+            truncated = true;
+            break;
+        }
+        if ch.is_control() || ch.is_whitespace() {
+            if !previous_was_whitespace {
+                sanitized.push(' ');
+                emitted += 1;
+                previous_was_whitespace = true;
+            }
+            continue;
+        }
+        sanitized.push(ch);
+        emitted += 1;
+        previous_was_whitespace = false;
+    }
+    let mut sanitized = sanitized.trim().to_string();
+    if truncated {
+        sanitized.push_str(API_ERROR_SUMMARY_TRUNCATION_MARKER);
+    }
+    sanitized
+}
+
 #[cfg(test)]
 mod tests {
     use api_contracts::generated::routes;
     use reqwest::header::AUTHORIZATION;
+    use tokio::net::TcpListener;
 
     use super::*;
 
@@ -268,6 +387,13 @@ mod tests {
             .to_str()
             .unwrap()
             .to_string()
+    }
+
+    fn api_transport_error(error: RunnerError) -> ApiTransportError {
+        match error {
+            RunnerError::ApiTransport(error) => *error,
+            other => panic!("expected RunnerError::ApiTransport, got {other:?}"),
+        }
     }
 
     #[test]
@@ -413,6 +539,110 @@ mod tests {
             "runner-session-test"
         );
         Uuid::parse_str(&header_value(&request, CLIENT_REQUEST_ID_HEADER)).unwrap();
+    }
+
+    #[test]
+    fn build_with_context_matches_generated_headers_and_excludes_sensitive_request_data() {
+        let http = http_client("https://api.vm0.dev/");
+
+        let (request, context) = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .json(&serde_json::json!({"secret": "body-secret"}))
+            .build_with_context_for_test("telemetry")
+            .unwrap();
+
+        assert_eq!(context.endpoint_label, "telemetry");
+        assert_eq!(context.method, "POST");
+        assert_eq!(context.host, "api.vm0.dev");
+        assert_eq!(context.path, "/api/webhooks/agent/telemetry");
+        assert_eq!(
+            context.client_request_id,
+            header_value(&request, CLIENT_REQUEST_ID_HEADER)
+        );
+        assert_eq!(context.client_session_id, "runner-session-test");
+        assert_eq!(context.client_version, RUNNER_CLIENT_VERSION);
+
+        let context_debug = format!("{context:?}");
+        assert!(
+            !context_debug.contains("sandbox-token"),
+            "context should not include authorization token: {context_debug}"
+        );
+        assert!(
+            !context_debug.contains("body-secret"),
+            "context should not include request body: {context_debug}"
+        );
+        assert!(
+            !context.path.contains('?'),
+            "context path should exclude query strings"
+        );
+    }
+
+    #[test]
+    fn build_with_context_formats_ipv6_host_with_port_as_authority() {
+        let http = http_client("http://[::1]:8080/base/");
+
+        let (_, context) = http
+            .request_route(routes::webhooks::agent::telemetry::SEND, "sandbox-token")
+            .build_with_context_for_test("telemetry")
+            .unwrap();
+
+        assert_eq!(context.host, "[::1]:8080");
+        assert_eq!(context.path, "/base/api/webhooks/agent/telemetry");
+    }
+
+    #[tokio::test]
+    async fn send_timeout_returns_structured_api_transport_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let server_task = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let error = http_client(&api_url)
+            .request_route(routes::runners::heartbeat::HEARTBEAT, "runner-token")
+            .timeout(Duration::from_millis(10))
+            .json(&serde_json::json!({"token": "body-token"}))
+            .send("heartbeat")
+            .await
+            .unwrap_err();
+        server_task.abort();
+        let _ = server_task.await;
+        let error = api_transport_error(error);
+
+        assert_eq!(error.request.endpoint_label, "heartbeat");
+        assert_eq!(error.request.method, "POST");
+        assert_eq!(
+            error.request.path,
+            routes::runners::heartbeat::HEARTBEAT.path
+        );
+        assert_eq!(error.failure_kind, ApiFailureKind::Timeout);
+        assert_eq!(error.failure_kind.as_str(), "timeout");
+        assert!(
+            !error.summary.contains(&api_url),
+            "summary should not include full URL: {}",
+            error.summary
+        );
+        assert!(
+            !error.summary.contains("body-token") && !error.summary.contains("runner-token"),
+            "summary should not include token or body: {}",
+            error.summary
+        );
+    }
+
+    #[test]
+    fn sanitize_api_error_summary_collapses_whitespace_and_caps_output() {
+        let summary = format!(
+            "connect\nfailed\t{}",
+            "x".repeat(API_ERROR_SUMMARY_MAX_CHARS * 2)
+        );
+
+        let sanitized = sanitize_api_error_summary(summary);
+
+        assert!(sanitized.starts_with("connect failed "));
+        assert!(sanitized.ends_with(API_ERROR_SUMMARY_TRUNCATION_MARKER));
+        assert!(sanitized.chars().count() <= API_ERROR_SUMMARY_MAX_CHARS);
+        assert!(!sanitized.contains('\n'));
+        assert!(!sanitized.contains('\t'));
     }
 
     #[test]

--- a/crates/runner/src/network_logs.rs
+++ b/crates/runner/src/network_logs.rs
@@ -202,7 +202,7 @@ impl<'a> NetworkLogBatchUploader<'a> {
             .http
             .request_route(routes::webhooks::agent::telemetry::SEND, self.sandbox_token)
             .json(&payload)
-            .send()
+            .send("network_logs")
             .await;
 
         match result {

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -391,7 +391,7 @@ impl JobProvider for ApiProvider {
 
     async fn heartbeat(&self, state: &HeartbeatState) {
         if let Err(e) = self.api.heartbeat(state).await {
-            warn!(error = %e, "heartbeat failed");
+            log_heartbeat_failure(state, &e);
         }
     }
 
@@ -450,6 +450,44 @@ impl JobProvider for ApiProvider {
             }
         }
     }
+}
+
+fn log_heartbeat_failure(state: &HeartbeatState, error: &RunnerError) {
+    let sessions = state.held_session_states.len();
+    if let RunnerError::ApiTransport(api_error) = error {
+        let request = &api_error.request;
+        warn!(
+            error = %error,
+            endpoint = request.endpoint_label,
+            method = %request.method,
+            host = %request.host,
+            path = %request.path,
+            client_request_id = %request.client_request_id,
+            client_session_id = %request.client_session_id,
+            client_version = %request.client_version,
+            failure_kind = api_error.failure_kind.as_str(),
+            error_summary = %api_error.summary,
+            runner_id = %state.runner_id,
+            runner_name = %state.runner_name,
+            runner_group = %state.group,
+            mode = %state.mode,
+            running = state.running_count,
+            sessions,
+            "heartbeat failed"
+        );
+        return;
+    }
+
+    warn!(
+        error = %error,
+        runner_id = %state.runner_id,
+        runner_name = %state.runner_name,
+        runner_group = %state.group,
+        mode = %state.mode,
+        running = state.running_count,
+        sessions,
+        "heartbeat failed"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -745,8 +783,8 @@ fn poll_reason_value(reason: PollReason) -> &'static str {
     }
 }
 
-async fn send_api(req: ApiRequestBuilder, label: &str) -> RunnerResult<Response> {
-    match req.send().await {
+async fn send_api(req: ApiRequestBuilder, label: &'static str) -> RunnerResult<Response> {
+    match req.send(label).await {
         Ok(resp) => Ok(resp),
         Err(RunnerError::Api(message)) => Err(RunnerError::Api(format!("{label}: {message}"))),
         Err(error) => Err(error),
@@ -1028,6 +1066,10 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
     use tokio::task::JoinHandle;
+    use tracing::Level;
+    use tracing_subscriber::prelude::*;
+    use tracing_test_support::{CapturedEvent, CapturedEvents};
+    use uuid::Uuid;
 
     use crate::http::HttpClientConfig;
 
@@ -1224,6 +1266,59 @@ mod tests {
         })
     }
 
+    async fn capture_api_provider_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
+    where
+        F: std::future::Future,
+    {
+        let captured = CapturedEvents::default();
+        let subscriber = tracing_subscriber::registry().with(captured.clone());
+        let guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+        let output = future.await;
+        drop(guard);
+        (output, captured.entries())
+    }
+
+    fn captured_event<'a>(events: &'a [CapturedEvent], message: &str) -> &'a CapturedEvent {
+        events
+            .iter()
+            .find(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|actual| actual == message)
+            })
+            .unwrap_or_else(|| panic!("missing event {message}; events={events:#?}"))
+    }
+
+    fn event_field<'a>(event: &'a CapturedEvent, field: &str) -> &'a str {
+        event
+            .fields
+            .get(field)
+            .map(String::as_str)
+            .unwrap_or_else(|| panic!("missing field {field}; event={event:#?}"))
+    }
+
+    fn heartbeat_state_for_test() -> HeartbeatState {
+        HeartbeatState {
+            runner_id: "runner-heartbeat-test".to_string(),
+            runner_name: "runner test".to_string(),
+            group: "vm0/test".to_string(),
+            total_vcpu: 8,
+            total_memory_mb: 32768,
+            max_concurrent: 4,
+            allocated_vcpu: 2,
+            allocated_memory_mb: 4096,
+            running_count: 1,
+            admittable_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
+            held_session_states: vec![crate::types::HeldSessionState {
+                session_id: "held-session-test".to_string(),
+                last_completed_at: "2026-07-08T00:00:00.000Z".to_string(),
+            }],
+            mode: "running".to_string(),
+        }
+    }
+
     async fn push_direct_candidate_for_test(provider: &ApiProvider, candidate: DirectJobCandidate) {
         provider.direct_candidates.push(candidate).await;
     }
@@ -1321,6 +1416,61 @@ mod tests {
                 .lines()
                 .any(|line| line.eq_ignore_ascii_case(&expected)),
             "completion request should use sandbox auth; request was:\n{request}",
+        );
+    }
+
+    #[tokio::test]
+    async fn heartbeat_send_failure_logs_transport_and_state_context_without_secrets() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let provider = api_provider_for_test(
+            api_url.clone(),
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+        let state = heartbeat_state_for_test();
+
+        let (_, events) = capture_api_provider_events(provider.heartbeat(&state)).await;
+        let event = captured_event(&events, "heartbeat failed");
+
+        assert_eq!(event.level, Level::WARN);
+        assert_eq!(event_field(event, "runner_id"), "runner-heartbeat-test");
+        assert_eq!(event_field(event, "runner_name"), "runner test");
+        assert_eq!(event_field(event, "runner_group"), "vm0/test");
+        assert_eq!(event_field(event, "mode"), "running");
+        assert_eq!(event_field(event, "running"), "1");
+        assert_eq!(event_field(event, "sessions"), "1");
+        assert_eq!(event_field(event, "endpoint"), "heartbeat");
+        assert_eq!(event_field(event, "method"), "POST");
+        assert_eq!(
+            event_field(event, "path"),
+            routes::runners::heartbeat::HEARTBEAT.path
+        );
+        assert_eq!(
+            event_field(event, "client_session_id"),
+            "runner-session-test"
+        );
+        assert_eq!(
+            event_field(event, "client_version"),
+            env!("CARGO_PKG_VERSION")
+        );
+        assert_eq!(event_field(event, "failure_kind"), "connect");
+        assert!(
+            event_field(event, "host").starts_with("127.0.0.1:"),
+            "host should include only host and port; event={event:#?}"
+        );
+        Uuid::parse_str(event_field(event, "client_request_id"))
+            .expect("client_request_id should be a UUID");
+
+        let event_debug = format!("{event:#?}");
+        assert!(
+            !event_debug.contains(&api_url),
+            "event should not include full URL: {event_debug}"
+        );
+        assert!(
+            !event_debug.contains("runner-token") && !event_debug.contains("held-session-test"),
+            "event should not include bearer token or heartbeat body: {event_debug}"
         );
     }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -1423,7 +1423,9 @@ mod tests {
     async fn heartbeat_send_failure_logs_transport_and_state_context_without_secrets() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let api_url = format!("http://{}", listener.local_addr().unwrap());
-        drop(listener);
+        let server_task = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+        });
         let provider = api_provider_for_test(
             api_url.clone(),
             CancellationToken::new(),
@@ -1432,6 +1434,8 @@ mod tests {
         let state = heartbeat_state_for_test();
 
         let (_, events) = capture_api_provider_events(provider.heartbeat(&state)).await;
+        server_task.abort();
+        let _ = server_task.await;
         let event = captured_event(&events, "heartbeat failed");
 
         assert_eq!(event.level, Level::WARN);
@@ -1455,7 +1459,7 @@ mod tests {
             event_field(event, "client_version"),
             env!("CARGO_PKG_VERSION")
         );
-        assert_eq!(event_field(event, "failure_kind"), "connect");
+        assert!(!event_field(event, "failure_kind").is_empty());
         assert!(
             event_field(event, "host").starts_with("127.0.0.1:"),
             "host should include only host and port; event={event:#?}"

--- a/crates/runner/src/telemetry.rs
+++ b/crates/runner/src/telemetry.rs
@@ -641,7 +641,7 @@ async fn send_telemetry(
         .timeout(TELEMETRY_TIMEOUT)
         .json(&payload);
 
-    match req.send().await {
+    match req.send("telemetry").await {
         Ok(resp) if !resp.status().is_success() => {
             warn!(run_id = %run_id, status = %resp.status(), "telemetry flush rejected");
         }


### PR DESCRIPTION
## Summary

- add structured runner API transport errors with endpoint, method, host, path, client request id, session id, version, failure kind, and sanitized summary
- log heartbeat failure context with runner identity, group, mode, running count, and held-session count
- keep heartbeat retry, timeout, API handler, stale threshold, and alert severity behavior unchanged

Closes #20593

## Testing

- `cargo test --manifest-path crates/Cargo.toml -p runner http::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api::tests`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`