### PR TITLE
fix: prune stale runner direct candidates

### DIFF
--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -14,7 +14,10 @@ use serde::{Serialize, de::DeserializeOwned};
 use super::api_ably_supervisor::{
     AblySupervisor, AblySupervisorConfig, PollDue, PollOutcome, PollReason, PollWakeups,
 };
-use super::api_direct_candidates::{DirectCandidateInbox, DirectJobCandidate};
+use super::api_direct_candidates::{
+    DIRECT_CANDIDATE_STALE_AFTER, DirectCandidateInbox, DirectCandidatePruneSnapshot,
+    DirectJobCandidate,
+};
 use super::builtin_firewall_catalog::{
     BuiltinFirewallCatalog, BuiltinFirewallCatalogRefreshHandle,
 };
@@ -149,7 +152,10 @@ impl ApiProvider {
         )
         .await;
         let poll_wakeups = Arc::new(PollWakeups::new(false));
-        let direct_candidates = DirectCandidateInbox::new(DIRECT_CANDIDATE_INBOX_CAPACITY);
+        let direct_candidates = DirectCandidateInbox::new(
+            DIRECT_CANDIDATE_INBOX_CAPACITY,
+            DIRECT_CANDIDATE_STALE_AFTER,
+        );
         let ably_supervisor = AblySupervisor::spawn(AblySupervisorConfig {
             api: api.clone(),
             group: group.clone(),
@@ -179,11 +185,41 @@ impl ApiProvider {
     }
 
     async fn try_recv_direct_candidate(&self) -> Option<DirectJobCandidate> {
-        self.direct_candidates.try_pop().await
+        let outcome = self.direct_candidates.try_pop_with_prune().await;
+        if let Some(pruned) = outcome.pruned {
+            Self::log_direct_candidate_pruned("pop", pruned);
+            if outcome.candidate.is_none() {
+                self.poll_wakeups.request_immediate_poll().await;
+            }
+        }
+        outcome.candidate
     }
 
     async fn wait_for_direct_candidate(&self) -> Option<DirectJobCandidate> {
-        self.direct_candidates.wait_pop(&self.cancel).await
+        loop {
+            if let Some(candidate) = self.try_recv_direct_candidate().await {
+                return Some(candidate);
+            }
+            if !self
+                .direct_candidates
+                .wait_for_notification(&self.cancel)
+                .await
+            {
+                return None;
+            }
+        }
+    }
+
+    fn log_direct_candidate_pruned(source: &'static str, pruned: DirectCandidatePruneSnapshot) {
+        info!(
+            source,
+            pruned_count = pruned.pruned_count,
+            depth = pruned.depth,
+            capacity = pruned.capacity,
+            stale_after_ms = duration_ms(pruned.stale_after),
+            oldest_pruned_wait_ms = duration_ms(pruned.oldest_pruned_wait_elapsed),
+            "ably: stale direct candidates pruned"
+        );
     }
 
     async fn wait_for_discovery_wakeup(&self) -> Option<DiscoveryWakeup> {
@@ -1179,7 +1215,10 @@ mod tests {
             group: "default".to_string(),
             supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             poll_wakeups,
-            direct_candidates: DirectCandidateInbox::new(DIRECT_CANDIDATE_INBOX_CAPACITY),
+            direct_candidates: DirectCandidateInbox::new(
+                DIRECT_CANDIDATE_INBOX_CAPACITY,
+                DIRECT_CANDIDATE_STALE_AFTER,
+            ),
             ably_supervisor: AblySupervisor::disabled(),
             cancel,
         })
@@ -1679,6 +1718,68 @@ mod tests {
         );
         assert!(provider.try_discover_ready().await.is_none());
         poll_mock.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn discover_prunes_stale_direct_candidate_and_polls_immediately() {
+        let server = MockServer::start_async().await;
+        let stale_run_id: RunId = "00000000-0000-0000-0000-000000000017".parse().unwrap();
+        let poll_run_id: RunId = "00000000-0000-0000-0000-000000000018".parse().unwrap();
+        let poll_mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path(routes::runners::poll::POLL.path)
+                    .json_body(serde_json::json!({
+                        "group": "default",
+                        "supportedProfiles": [crate::profile::DEFAULT_PROFILE],
+                        "telemetry": {
+                            "pollReason": "immediate"
+                        }
+                    }));
+                then.status(200).json_body(serde_json::json!({
+                    "job": {
+                        "runId": poll_run_id,
+                        "experimentalProfile": crate::profile::DEFAULT_PROFILE
+                    }
+                }));
+            })
+            .await;
+        let wakeups = Arc::new(PollWakeups::new(true));
+        let initial_poll = wakeups
+            .wait_for_poll_due(&CancellationToken::new(), POLL_SLOW, POLL_FAST)
+            .await
+            .unwrap();
+        wakeups
+            .record_poll_result(initial_poll, PollOutcome::Empty, POLL_WAKEUP_RETRY)
+            .await;
+        let provider = api_provider_for_test(
+            server.base_url(),
+            CancellationToken::new(),
+            Arc::clone(&wakeups),
+        );
+        let stale_enqueued_at = Instant::now() - Duration::from_secs(120);
+        push_direct_candidate_for_test(
+            &provider,
+            DirectJobCandidate::new_with_enqueued_at(
+                stale_run_id,
+                crate::profile::DEFAULT_PROFILE.to_string(),
+                stale_enqueued_at,
+                stale_enqueued_at,
+            ),
+        )
+        .await;
+
+        let discovered = tokio::time::timeout(Duration::from_secs(1), provider.discover())
+            .await
+            .expect("stale direct pruning should wake immediate poll")
+            .unwrap();
+
+        assert_eq!(discovered.run_id(), poll_run_id);
+        assert_eq!(
+            discovered.discovery_source(),
+            Some(JobDiscoverySource::Poll)
+        );
+        poll_mock.assert_async().await;
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -24,9 +24,11 @@ use tracing::{error, info, warn};
 
 use super::api::ApiClient;
 use super::api_direct_candidates::{
-    DirectCandidateInbox, DirectCandidateInsertOutcome, DirectJobCandidate,
+    DirectCandidateInbox, DirectCandidateInsertOutcome, DirectCandidatePruneSnapshot,
+    DirectJobCandidate,
 };
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
+use crate::duration::duration_ms;
 use crate::ids::RunId;
 use crate::retry::{RetryState, recv_retry, sleep_until_retry};
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
@@ -740,12 +742,18 @@ async fn enqueue_direct_candidate(
 ) {
     let run_id = candidate.run_id();
     let profile = candidate.profile_name().to_owned();
-    match direct_candidates.push(candidate).await {
-        DirectCandidateInsertOutcome::Inserted(_) | DirectCandidateInsertOutcome::Updated(_) => {}
+    let outcome = direct_candidates.push(candidate).await;
+    if let Some(pruned) = outcome.pruned() {
+        log_direct_candidate_pruned(&profile, "push", pruned);
+    }
+    match outcome {
+        DirectCandidateInsertOutcome::Inserted { .. }
+        | DirectCandidateInsertOutcome::Updated { .. } => {}
         DirectCandidateInsertOutcome::Overflow {
             snapshot,
             coalesced_count,
             should_wake_poll,
+            ..
         } => {
             if !should_wake_poll {
                 return;
@@ -762,6 +770,23 @@ async fn enqueue_direct_candidate(
             poll_wakeups.request_immediate_poll().await;
         }
     }
+}
+
+fn log_direct_candidate_pruned(
+    profile: &str,
+    source: &'static str,
+    pruned: DirectCandidatePruneSnapshot,
+) {
+    info!(
+        profile,
+        source,
+        pruned_count = pruned.pruned_count,
+        depth = pruned.depth,
+        capacity = pruned.capacity,
+        stale_after_ms = duration_ms(pruned.stale_after),
+        oldest_pruned_wait_ms = duration_ms(pruned.oldest_pruned_wait_elapsed),
+        "ably: stale direct candidates pruned"
+    );
 }
 
 fn parse_cancel_notification(msg: &ably_subscriber::Message) -> Option<RunId> {
@@ -1019,7 +1044,17 @@ mod tests {
     }
 
     fn direct_candidate_inbox_with_capacity(capacity: usize) -> Arc<DirectCandidateInbox> {
-        DirectCandidateInbox::new(capacity)
+        direct_candidate_inbox_with_stale_after(
+            capacity,
+            crate::provider::api_direct_candidates::DIRECT_CANDIDATE_STALE_AFTER,
+        )
+    }
+
+    fn direct_candidate_inbox_with_stale_after(
+        capacity: usize,
+        stale_after: Duration,
+    ) -> Arc<DirectCandidateInbox> {
+        DirectCandidateInbox::new(capacity, stale_after)
     }
 
     async fn pop_direct_candidate(inbox: &DirectCandidateInbox) -> DirectJobCandidate {
@@ -1891,6 +1926,50 @@ mod tests {
         let candidate = pop_direct_candidate(&direct_candidates).await;
         assert_eq!(candidate.profile_name(), "vm0/default");
         assert!(wakeups.snapshot().await.poll_now);
+    }
+
+    #[tokio::test]
+    async fn stale_full_direct_candidate_queue_prunes_before_enqueueing() {
+        let tokens = Mutex::new(HashMap::new());
+        let wakeups = PollWakeups::new(true);
+        let stale_after = Duration::from_secs(60);
+        let direct_candidates = direct_candidate_inbox_with_stale_after(1, stale_after);
+        let profiles = default_profiles();
+        let _ = wakeups
+            .wait_for_poll_due(
+                &CancellationToken::new(),
+                Duration::from_secs(30),
+                Duration::from_secs(5),
+            )
+            .await;
+        let stale_enqueued_at = StdInstant::now() - Duration::from_secs(120);
+        let stale_run_id: RunId = "00000000-0000-0000-0000-000000000001".parse().unwrap();
+        let _ = direct_candidates
+            .push(DirectJobCandidate::new_with_enqueued_at(
+                stale_run_id,
+                "vm0/default".to_string(),
+                stale_enqueued_at,
+                stale_enqueued_at,
+            ))
+            .await;
+        let msg = make_message(
+            Some("job"),
+            serde_json::json!({
+                "runId": "00000000-0000-0000-0000-000000000002",
+                "profile": "vm0/default"
+            }),
+        );
+
+        handle_ably_message(&msg, &profiles, &wakeups, &direct_candidates, &tokens).await;
+
+        let candidate = pop_direct_candidate(&direct_candidates).await;
+        assert_eq!(
+            candidate.run_id(),
+            "00000000-0000-0000-0000-000000000002"
+                .parse::<RunId>()
+                .unwrap()
+        );
+        assert!(!wakeups.snapshot().await.poll_now);
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::Instant as StdInstant;
+use std::time::{Duration, Instant as StdInstant};
 
 use tokio::sync::{Mutex, Notify};
 use tokio_util::sync::CancellationToken;
@@ -8,6 +8,8 @@ use tracing::warn;
 
 use super::{JobCandidate, JobDiscoverySource};
 use crate::ids::RunId;
+
+pub(super) const DIRECT_CANDIDATE_STALE_AFTER: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 pub(super) struct DirectJobCandidate {
@@ -32,6 +34,19 @@ impl DirectJobCandidate {
         discovered_at: StdInstant,
     ) -> Self {
         Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None)
+    }
+
+    #[cfg(test)]
+    pub(super) fn new_with_enqueued_at(
+        run_id: RunId,
+        profile_name: String,
+        discovered_at: StdInstant,
+        enqueued_at: StdInstant,
+    ) -> Self {
+        let mut candidate =
+            Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None);
+        candidate.enqueued_at = Some(enqueued_at);
+        candidate
     }
 
     pub(super) fn new_with_affinity_metadata(
@@ -69,9 +84,9 @@ impl DirectJobCandidate {
         self.enqueued_at
     }
 
-    fn mark_enqueued(&mut self) {
+    fn mark_enqueued_at(&mut self, enqueued_at: StdInstant) {
         if self.enqueued_at.is_none() {
-            self.enqueued_at = Some(StdInstant::now());
+            self.enqueued_at = Some(enqueued_at);
         }
     }
 
@@ -110,12 +125,19 @@ impl DirectJobCandidate {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DirectCandidateInsertOutcome {
-    Inserted(DirectCandidateInboxSnapshot),
-    Updated(DirectCandidateInboxSnapshot),
+    Inserted {
+        snapshot: DirectCandidateInboxSnapshot,
+        pruned: Option<DirectCandidatePruneSnapshot>,
+    },
+    Updated {
+        snapshot: DirectCandidateInboxSnapshot,
+        pruned: Option<DirectCandidatePruneSnapshot>,
+    },
     Overflow {
         snapshot: DirectCandidateInboxSnapshot,
         coalesced_count: u64,
         should_wake_poll: bool,
+        pruned: Option<DirectCandidatePruneSnapshot>,
     },
 }
 
@@ -123,8 +145,16 @@ impl DirectCandidateInsertOutcome {
     #[cfg(test)]
     pub(super) fn snapshot(self) -> DirectCandidateInboxSnapshot {
         match self {
-            Self::Inserted(snapshot) | Self::Updated(snapshot) => snapshot,
+            Self::Inserted { snapshot, .. } | Self::Updated { snapshot, .. } => snapshot,
             Self::Overflow { snapshot, .. } => snapshot,
+        }
+    }
+
+    pub(super) fn pruned(self) -> Option<DirectCandidatePruneSnapshot> {
+        match self {
+            Self::Inserted { pruned, .. }
+            | Self::Updated { pruned, .. }
+            | Self::Overflow { pruned, .. } => pruned,
         }
     }
 }
@@ -133,6 +163,21 @@ impl DirectCandidateInsertOutcome {
 pub(super) struct DirectCandidateInboxSnapshot {
     pub(super) depth: usize,
     pub(super) capacity: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DirectCandidatePruneSnapshot {
+    pub(super) pruned_count: usize,
+    pub(super) depth: usize,
+    pub(super) capacity: usize,
+    pub(super) stale_after: Duration,
+    pub(super) oldest_pruned_wait_elapsed: Duration,
+}
+
+#[derive(Debug)]
+pub(super) struct DirectCandidatePopOutcome {
+    pub(super) candidate: Option<DirectJobCandidate>,
+    pub(super) pruned: Option<DirectCandidatePruneSnapshot>,
 }
 
 #[derive(Debug)]
@@ -146,14 +191,16 @@ struct DirectCandidateInboxInner {
 #[derive(Debug)]
 pub(super) struct DirectCandidateInbox {
     capacity: usize,
+    stale_after: Duration,
     inner: Mutex<DirectCandidateInboxInner>,
     notify: Notify,
 }
 
 impl DirectCandidateInbox {
-    pub(super) fn new(capacity: usize) -> Arc<Self> {
+    pub(super) fn new(capacity: usize, stale_after: Duration) -> Arc<Self> {
         Arc::new(Self {
             capacity,
+            stale_after,
             inner: Mutex::new(DirectCandidateInboxInner {
                 order: VecDeque::new(),
                 candidates: HashMap::new(),
@@ -166,13 +213,15 @@ impl DirectCandidateInbox {
 
     pub(super) async fn push(&self, candidate: DirectJobCandidate) -> DirectCandidateInsertOutcome {
         let mut inner = self.inner.lock().await;
+        let now = StdInstant::now();
+        let pruned = prune_stale_candidates(&mut inner, now, self.capacity, self.stale_after);
         let run_id = candidate.run_id();
         if let Some(existing) = inner.candidates.get_mut(&run_id) {
             existing.merge_metadata_from(candidate);
-            return DirectCandidateInsertOutcome::Updated(snapshot(
-                inner.order.len(),
-                self.capacity,
-            ));
+            return DirectCandidateInsertOutcome::Updated {
+                snapshot: snapshot(inner.order.len(), self.capacity),
+                pruned,
+            };
         }
 
         if inner.order.len() >= self.capacity {
@@ -183,29 +232,42 @@ impl DirectCandidateInbox {
                 snapshot: snapshot(inner.order.len(), self.capacity),
                 coalesced_count: inner.overflow_count,
                 should_wake_poll,
+                pruned,
             };
         }
 
         let mut candidate = candidate;
-        candidate.mark_enqueued();
+        candidate.mark_enqueued_at(now);
         inner.order.push_back(run_id);
         inner.candidates.insert(run_id, candidate);
         let snapshot = snapshot(inner.order.len(), self.capacity);
         drop(inner);
         self.notify.notify_one();
-        DirectCandidateInsertOutcome::Inserted(snapshot)
+        DirectCandidateInsertOutcome::Inserted { snapshot, pruned }
     }
 
+    #[cfg(test)]
     pub(super) async fn try_pop(&self) -> Option<DirectJobCandidate> {
+        self.try_pop_with_prune().await.candidate
+    }
+
+    pub(super) async fn try_pop_with_prune(&self) -> DirectCandidatePopOutcome {
         let mut inner = self.inner.lock().await;
+        let pruned = prune_stale_candidates(
+            &mut inner,
+            StdInstant::now(),
+            self.capacity,
+            self.stale_after,
+        );
         let candidate = pop_candidate(&mut inner);
-        if candidate.is_some() && inner.order.len() < self.capacity {
+        if (candidate.is_some() || pruned.is_some()) && inner.order.len() < self.capacity {
             inner.overflow_active = false;
             inner.overflow_count = 0;
         }
-        candidate
+        DirectCandidatePopOutcome { candidate, pruned }
     }
 
+    #[cfg(test)]
     pub(super) async fn wait_pop(&self, cancel: &CancellationToken) -> Option<DirectJobCandidate> {
         loop {
             if let Some(candidate) = self.try_pop().await {
@@ -219,6 +281,60 @@ impl DirectCandidateInbox {
             }
         }
     }
+
+    pub(super) async fn wait_for_notification(&self, cancel: &CancellationToken) -> bool {
+        let notified = self.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => false,
+            () = &mut notified => true,
+        }
+    }
+}
+
+fn prune_stale_candidates(
+    inner: &mut DirectCandidateInboxInner,
+    now: StdInstant,
+    capacity: usize,
+    stale_after: Duration,
+) -> Option<DirectCandidatePruneSnapshot> {
+    let mut pruned_count = 0;
+    let mut oldest_pruned_wait_elapsed = Duration::ZERO;
+
+    while let Some(run_id) = inner.order.front().copied() {
+        let Some(candidate) = inner.candidates.get(&run_id) else {
+            inner.order.pop_front();
+            continue;
+        };
+        let queued_at = candidate.enqueued_at.unwrap_or(candidate.discovered_at);
+        let wait_elapsed = now.saturating_duration_since(queued_at);
+        if wait_elapsed < stale_after {
+            break;
+        }
+
+        inner.order.pop_front();
+        inner.candidates.remove(&run_id);
+        pruned_count += 1;
+        oldest_pruned_wait_elapsed = oldest_pruned_wait_elapsed.max(wait_elapsed);
+    }
+
+    if pruned_count == 0 {
+        return None;
+    }
+    if inner.order.len() < capacity {
+        inner.overflow_active = false;
+        inner.overflow_count = 0;
+    }
+    Some(DirectCandidatePruneSnapshot {
+        pruned_count,
+        depth: inner.order.len(),
+        capacity,
+        stale_after,
+        oldest_pruned_wait_elapsed,
+    })
 }
 
 fn pop_candidate(inner: &mut DirectCandidateInboxInner) -> Option<DirectJobCandidate> {
@@ -244,9 +360,30 @@ mod tests {
         RunId::from(uuid::Uuid::from_u128(value))
     }
 
+    fn direct_candidate_inbox(capacity: usize) -> Arc<DirectCandidateInbox> {
+        DirectCandidateInbox::new(capacity, DIRECT_CANDIDATE_STALE_AFTER)
+    }
+
+    fn direct_candidate_inbox_with_stale_after(
+        capacity: usize,
+        stale_after: Duration,
+    ) -> Arc<DirectCandidateInbox> {
+        DirectCandidateInbox::new(capacity, stale_after)
+    }
+
+    fn candidate_with_enqueued_at(run_id: RunId, enqueued_at: StdInstant) -> DirectJobCandidate {
+        let mut candidate = DirectJobCandidate::new_with_discovered_at(
+            run_id,
+            "vm0/default".to_string(),
+            enqueued_at,
+        );
+        candidate.enqueued_at = Some(enqueued_at);
+        candidate
+    }
+
     #[tokio::test]
     async fn duplicate_run_id_occupies_one_slot_and_preserves_first_discovery_time() {
-        let inbox = DirectCandidateInbox::new(4);
+        let inbox = direct_candidate_inbox(4);
         let first_discovered_at = StdInstant::now() - Duration::from_secs(5);
         let second_discovered_at = StdInstant::now();
         let run_id = run_id(1);
@@ -279,10 +416,13 @@ mod tests {
             .await;
         assert!(matches!(
             updated,
-            DirectCandidateInsertOutcome::Updated(DirectCandidateInboxSnapshot {
-                depth: 1,
-                capacity: 4,
-            })
+            DirectCandidateInsertOutcome::Updated {
+                snapshot: DirectCandidateInboxSnapshot {
+                    depth: 1,
+                    capacity: 4,
+                },
+                pruned: None,
+            }
         ));
 
         let candidate = inbox.try_pop().await.expect("direct candidate");
@@ -302,7 +442,7 @@ mod tests {
 
     #[tokio::test]
     async fn overflow_is_coalesced_until_capacity_makes_progress() {
-        let inbox = DirectCandidateInbox::new(1);
+        let inbox = direct_candidate_inbox(1);
         let _ = inbox
             .push(DirectJobCandidate::new(
                 run_id(1),
@@ -325,6 +465,7 @@ mod tests {
                 },
                 coalesced_count: 1,
                 should_wake_poll: true,
+                pruned: None,
             }
         ));
 
@@ -343,6 +484,7 @@ mod tests {
                 },
                 coalesced_count: 2,
                 should_wake_poll: false,
+                pruned: None,
             }
         ));
 
@@ -367,14 +509,116 @@ mod tests {
             DirectCandidateInsertOutcome::Overflow {
                 coalesced_count: 1,
                 should_wake_poll: true,
+                pruned: None,
                 ..
             }
         ));
     }
 
     #[tokio::test]
+    async fn stale_candidates_are_pruned_before_push_and_reset_overflow_state() {
+        let stale_after = Duration::from_secs(60);
+        let inbox = direct_candidate_inbox_with_stale_after(1, stale_after);
+        let stale_enqueued_at = StdInstant::now() - Duration::from_secs(120);
+        let _ = inbox
+            .push(candidate_with_enqueued_at(run_id(1), stale_enqueued_at))
+            .await;
+
+        let inserted_after_prune = inbox
+            .push(DirectJobCandidate::new(
+                run_id(2),
+                "vm0/default".to_string(),
+            ))
+            .await;
+
+        assert!(matches!(
+            inserted_after_prune,
+            DirectCandidateInsertOutcome::Inserted {
+                snapshot: DirectCandidateInboxSnapshot {
+                    depth: 1,
+                    capacity: 1,
+                },
+                pruned: Some(DirectCandidatePruneSnapshot {
+                    pruned_count: 1,
+                    depth: 0,
+                    capacity: 1,
+                    stale_after: pruned_stale_after,
+                    oldest_pruned_wait_elapsed,
+                }),
+            } if pruned_stale_after == stale_after
+                && oldest_pruned_wait_elapsed >= stale_after
+        ));
+
+        let overflow_after_prune = inbox
+            .push(DirectJobCandidate::new(
+                run_id(3),
+                "vm0/default".to_string(),
+            ))
+            .await;
+        assert!(matches!(
+            overflow_after_prune,
+            DirectCandidateInsertOutcome::Overflow {
+                coalesced_count: 1,
+                should_wake_poll: true,
+                pruned: None,
+                ..
+            }
+        ));
+        assert_eq!(
+            inbox.try_pop().await.expect("fresh candidate").run_id(),
+            run_id(2)
+        );
+        assert!(inbox.try_pop().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_candidates_are_pruned_before_pop() {
+        let stale_after = Duration::from_secs(60);
+        let inbox = direct_candidate_inbox_with_stale_after(1, stale_after);
+        let stale_enqueued_at = StdInstant::now() - Duration::from_secs(120);
+        let _ = inbox
+            .push(candidate_with_enqueued_at(run_id(1), stale_enqueued_at))
+            .await;
+
+        let outcome = inbox.try_pop_with_prune().await;
+
+        assert!(outcome.candidate.is_none());
+        assert!(matches!(
+            outcome.pruned,
+            Some(DirectCandidatePruneSnapshot {
+                pruned_count: 1,
+                depth: 0,
+                capacity: 1,
+                stale_after: pruned_stale_after,
+                oldest_pruned_wait_elapsed,
+            }) if pruned_stale_after == stale_after
+                && oldest_pruned_wait_elapsed >= stale_after
+        ));
+        assert!(inbox.try_pop().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn fresh_candidates_are_preserved_before_pop() {
+        let stale_after = Duration::from_secs(60);
+        let inbox = direct_candidate_inbox_with_stale_after(1, stale_after);
+        let fresh_enqueued_at = StdInstant::now() - Duration::from_secs(5);
+        let _ = inbox
+            .push(candidate_with_enqueued_at(run_id(1), fresh_enqueued_at))
+            .await;
+
+        let outcome = inbox.try_pop_with_prune().await;
+
+        assert!(outcome.pruned.is_none());
+        assert_eq!(
+            outcome.candidate.expect("fresh candidate").run_id(),
+            run_id(1)
+        );
+        assert!(inbox.try_pop().await.is_none());
+    }
+
+    #[tokio::test]
     async fn wait_pop_exits_on_cancel() {
-        let inbox = DirectCandidateInbox::new(1);
+        let inbox = direct_candidate_inbox(1);
         let cancel = CancellationToken::new();
         cancel.cancel();
 


### PR DESCRIPTION
## Summary

- prune stale Ably direct candidates in the runner inbox before enqueue and dequeue
- wake immediate HTTP polling when stale-only pruning clears the local direct inbox
- keep fresh-full overflow fallback behavior unchanged and log aggregate prune stats

## Tests

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api_direct_candidates`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api_ably_supervisor`
- `cargo test --manifest-path crates/Cargo.toml -p runner provider::api`
- pre-commit hooks: cargo-doc and cargo-clippy

Closes #20594