### PR TITLE
fix: normalize desktop x-client-type casing

### DIFF
--- a/crates/api-contracts/src/generated/constants.rs
+++ b/crates/api-contracts/src/generated/constants.rs
@@ -26,7 +26,7 @@ pub mod client {
         pub const CLIENT_TYPE_APP: &str = "App";
 
         /// Client type value for the desktop client.
-        pub const CLIENT_TYPE_DESKTOP: &str = "desktop";
+        pub const CLIENT_TYPE_DESKTOP: &str = "Desktop";
 
         /// Client type value for the guest agent.
         pub const CLIENT_TYPE_GUEST_AGENT: &str = "GuestAgent";

--- a/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIENT_HEADER_NAMES,
+  CLIENT_REQUEST_ID_HEADER,
+  CLIENT_SESSION_ID_HEADER,
+  CLIENT_TYPE_APP,
+  CLIENT_TYPE_DESKTOP,
+  CLIENT_TYPE_GUEST_AGENT,
+  CLIENT_TYPE_HEADER,
+  CLIENT_TYPE_MITM_ADDON,
+  CLIENT_TYPE_RUNNER,
+  CLIENT_VERSION_HEADER,
+} from "./client-headers";
+
+describe("client header contract", () => {
+  it("documents the canonical X-Client-Type wire values", () => {
+    expect({
+      app: CLIENT_TYPE_APP,
+      desktop: CLIENT_TYPE_DESKTOP,
+      guestAgent: CLIENT_TYPE_GUEST_AGENT,
+      mitmAddon: CLIENT_TYPE_MITM_ADDON,
+      runner: CLIENT_TYPE_RUNNER,
+    }).toStrictEqual({
+      app: "App",
+      desktop: "Desktop",
+      guestAgent: "GuestAgent",
+      mitmAddon: "MitmAddon",
+      runner: "Runner",
+    });
+  });
+
+  it("keeps client header names stable for CORS and request logs", () => {
+    expect(CLIENT_HEADER_NAMES).toStrictEqual([
+      CLIENT_VERSION_HEADER,
+      CLIENT_TYPE_HEADER,
+      CLIENT_SESSION_ID_HEADER,
+      CLIENT_REQUEST_ID_HEADER,
+    ]);
+    expect(CLIENT_HEADER_NAMES).toStrictEqual([
+      "X-Client-Version",
+      "X-Client-Type",
+      "X-Client-Session-Id",
+      "X-Client-Request-Id",
+    ]);
+  });
+});

--- a/turbo/packages/api-contracts/src/contracts/client-headers.ts
+++ b/turbo/packages/api-contracts/src/contracts/client-headers.ts
@@ -3,8 +3,9 @@ export const CLIENT_TYPE_HEADER = "X-Client-Type";
 export const CLIENT_SESSION_ID_HEADER = "X-Client-Session-Id";
 export const CLIENT_REQUEST_ID_HEADER = "X-Client-Request-Id";
 
+// Canonical X-Client-Type wire values emitted by first-party clients.
 export const CLIENT_TYPE_APP = "App";
-export const CLIENT_TYPE_DESKTOP = "desktop";
+export const CLIENT_TYPE_DESKTOP = "Desktop";
 export const CLIENT_TYPE_GUEST_AGENT = "GuestAgent";
 export const CLIENT_TYPE_MITM_ADDON = "MitmAddon";
 export const CLIENT_TYPE_RUNNER = "Runner";


### PR DESCRIPTION
## Summary
- Normalize the canonical desktop `X-Client-Type` wire value from `desktop` to `Desktop` while keeping `App`, `Runner`, `GuestAgent`, and `MitmAddon` unchanged.
- Regenerate the shared Rust `api-contracts` constants from the TypeScript contract.
- Add contract tests that pin the client type literals and the header names used by CORS and request logging.

## Compatibility
- Desktop request injection continues to read the shared `CLIENT_TYPE_DESKTOP` constant, so desktop callers now emit `Desktop`.
- API request logging and CORS behavior remain header-name based; `X-Client-Type` is still allowed and `x_client_type` is still logged as the received value.
- Repository search found no tracked dashboard, log-query, alert, or analytics config hardcoding the old `desktop` value. A read-only Axiom config check was attempted for dashboards, monitors, starred queries, and saved views, but the active connector token returned 403 for those config APIs, so no external Axiom config changes were made.

## Verification
- `pnpm -F @vm0/api-contracts generate:rust`
- `pnpm -F @vm0/api-contracts test src/contracts/client-headers.test.ts src/rust-bindings/__tests__/constants.test.ts`
- `pnpm -F @vm0/desktop test src/desktop-client-headers.test.ts src/desktop-computer-use-api.test.ts src/computer-use-host.test.ts src/desktop-auth-session.test.ts`
- `pnpm -F api test src/__tests__/app-factory.test.ts`
- `pnpm exec prettier --write --ignore-unknown packages/api-contracts/src/contracts/client-headers.ts packages/api-contracts/src/contracts/client-headers.test.ts ../crates/api-contracts/src/generated/constants.rs`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `cargo test -p api-contracts`

Closes #20666