### PR TITLE
fix: add runner exit signal diagnostics

### DIFF
--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -28,6 +28,7 @@ use super::{
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
+use guest_contracts::diagnostics::CliObservedExitDiagnostic;
 
 const TURN_NOTIFICATION_LABEL: &str = "turn notification";
 
@@ -308,6 +309,7 @@ async fn run_codex_app_server(
 
         Ok::<CliExecutionResult, AgentError>(CliExecutionResult {
             exit_code,
+            cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(exit_code)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: None,

--- a/crates/guest-agent/src/cli/codex_app_server_backend.rs
+++ b/crates/guest-agent/src/cli/codex_app_server_backend.rs
@@ -28,7 +28,6 @@ use super::{
 };
 use crate::active_input::{ActiveInputFrame, ActiveInputWriter};
 use guest_common::{log_info, log_warn};
-use guest_contracts::diagnostics::CliObservedExitDiagnostic;
 
 const TURN_NOTIFICATION_LABEL: &str = "turn notification";
 
@@ -309,7 +308,9 @@ async fn run_codex_app_server(
 
         Ok::<CliExecutionResult, AgentError>(CliExecutionResult {
             exit_code,
-            cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(exit_code)),
+            // App-server terminal events report a protocol-level turn status,
+            // not the child process wait status.
+            cli_observed_exit: None,
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: None,

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -47,7 +47,9 @@ use event_delivery::{AckedEventPrefix, PreparedEvent};
 use framework::CliFrameworkBehavior;
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_info, log_warn};
-use guest_contracts::diagnostics::{CliTerminationDiagnostic, FailureDetailSource, FailureReason};
+use guest_contracts::diagnostics::{
+    CliObservedExitDiagnostic, CliTerminationDiagnostic, FailureDetailSource, FailureReason,
+};
 use process_group::ChildProcessGroup;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -180,6 +182,9 @@ pub struct CliExecutionResult {
     /// On Unix, signal termination is mapped to `128 + signal`, matching shell
     /// convention, so SIGKILL is reported as `137`.
     pub exit_code: i32,
+
+    /// Raw CLI process exit observation before signal exits are flattened.
+    pub cli_observed_exit: Option<CliObservedExitDiagnostic>,
 
     /// Best-effort, secret-masked stderr tail captured from the CLI.
     ///
@@ -1172,23 +1177,7 @@ async fn execute_cli_inner(
             None,
         );
     }
-    let exit_code = match status.code() {
-        Some(code) => code,
-        None => {
-            let mut code = 1;
-            #[cfg(unix)]
-            {
-                use std::os::unix::process::ExitStatusExt;
-                if let Some(sig) = status.signal() {
-                    log_warn!(LOG_TAG, "Process killed by signal {sig}");
-                    // Map signal to 128+signal (same convention as bash/vsock-guest)
-                    // so the runner can detect OOM kills (SIGKILL=9 → exit 137).
-                    code = 128 + sig;
-                }
-            }
-            code
-        }
-    };
+    let (exit_code, cli_observed_exit) = cli_exit_summary_from_status(&status);
 
     // Apply the same drain deadline to stderr — orphaned child processes
     // may hold the stderr fd open just like stdout.
@@ -1223,6 +1212,7 @@ async fn execute_cli_inner(
 
     Ok(CliExecutionResult {
         exit_code,
+        cli_observed_exit,
         stderr_lines: masked_stderr_lines,
         last_event_sequence,
         claude_result,
@@ -1231,6 +1221,24 @@ async fn execute_cli_inner(
         control_error,
         cli_termination,
     })
+}
+
+fn cli_exit_summary_from_status(status: &ExitStatus) -> (i32, Option<CliObservedExitDiagnostic>) {
+    if let Some(code) = status.code() {
+        return (code, Some(CliObservedExitDiagnostic::from_exit_code(code)));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(sig) = status.signal() {
+            log_warn!(LOG_TAG, "Process killed by signal {sig}");
+            let observed_exit = CliObservedExitDiagnostic::from_signal(sig);
+            return (observed_exit.mapped_exit_code, Some(observed_exit));
+        }
+    }
+
+    (1, None)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1369,9 +1377,9 @@ mod tests {
     use super::termination::{CliTerminationRuntime, PostResultCleanupPolicy};
     use super::{
         CliExitObservation, CliFailureDiagnostic, CliRuntimeConfig, child_env,
-        claude_initial_prompt_frame, codex_home_for_home_dir, codex_runtime_config, command,
-        exec_boundary, record_cli_exit, select_failure_diagnostic, set_cli_current_dir,
-        with_carried_failure_reason,
+        claude_initial_prompt_frame, cli_exit_summary_from_status, codex_home_for_home_dir,
+        codex_runtime_config, command, exec_boundary, record_cli_exit, select_failure_diagnostic,
+        set_cli_current_dir, with_carried_failure_reason,
     };
     use crate::active_input::ActiveInputRuntime;
     use crate::{constants, env};
@@ -1602,6 +1610,38 @@ mod tests {
             String::from_utf8_lossy(&output.stdout).trim(),
             dir.path().to_string_lossy()
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cli_exit_summary_preserves_normal_exit_137() {
+        let status = std::process::ExitStatus::from_raw(137 << 8);
+
+        let (exit_code, observed_exit) = cli_exit_summary_from_status(&status);
+
+        let observed_exit = observed_exit.expect("normal exit should be observed");
+        assert_eq!(exit_code, 137);
+        assert_eq!(
+            observed_exit,
+            guest_contracts::diagnostics::CliObservedExitDiagnostic::from_exit_code(137)
+        );
+        assert!(!observed_exit.is_sigkill());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cli_exit_summary_preserves_signal_exit_before_mapping() {
+        let status = std::process::ExitStatus::from_raw(libc::SIGKILL);
+
+        let (exit_code, observed_exit) = cli_exit_summary_from_status(&status);
+
+        let observed_exit = observed_exit.expect("signal exit should be observed");
+        assert_eq!(exit_code, 137);
+        assert_eq!(
+            observed_exit,
+            guest_contracts::diagnostics::CliObservedExitDiagnostic::from_signal(libc::SIGKILL)
+        );
+        assert!(observed_exit.is_sigkill());
     }
 
     #[cfg(unix)]

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -20,8 +20,9 @@ use guest_agent::telemetry::{Telemetry, UploadMode};
 use guest_common::telemetry::record_sandbox_op;
 use guest_common::{log_error, log_info, log_warn};
 use guest_contracts::diagnostics::{
-    AgentFramework, CliTerminationDiagnostic, CliTerminationReason, FailureClass,
-    FailureDetailSource, FailureDiagnostic, FailureReason, PromptMetadata, SessionHistoryStatus,
+    AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, CliTerminationReason,
+    FailureClass, FailureDetailSource, FailureDiagnostic, FailureReason, PromptMetadata,
+    SessionHistoryStatus,
 };
 use guest_contracts::session_history_identity::{
     FinalSessionHistoryIdentityExpectation, SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
@@ -355,6 +356,7 @@ async fn execute(
                     cli_exit_code,
                     cli_result.claude_result,
                 );
+                let diagnostic = with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit);
                 let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
                 (cli_exit_code, 1, msg, false, Some(diagnostic), false)
             } else if preserves_successful_post_result_cleanup(config.framework, &cli_result) {
@@ -373,6 +375,7 @@ async fn execute(
                     cli_result.claude_result,
                 )
                 .with_failure_detail_source(failure_message.source);
+                let diagnostic = with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit);
                 let diagnostic = with_cli_termination(diagnostic, cli_result.cli_termination);
                 let diagnostic = with_cli_failure_reason(diagnostic, &failure_message);
                 (
@@ -401,6 +404,11 @@ async fn execute(
                         FailureClass::ClaudeZeroTurnNoHistory,
                     )
                     .with_cli_exit_code(cli_exit_code)
+                    .with_cli_observed_exit(
+                        cli_result
+                            .cli_observed_exit
+                            .unwrap_or_else(|| CliObservedExitDiagnostic::from_exit_code(0)),
+                    )
                     .with_claude_num_turns(Some(0))
                     .with_session_history_status(session_history_status);
                     (
@@ -498,6 +506,17 @@ fn with_cli_termination(
 ) -> FailureDiagnostic {
     if let Some(cli_termination) = cli_termination {
         diagnostic.with_cli_termination(cli_termination)
+    } else {
+        diagnostic
+    }
+}
+
+fn with_cli_observed_exit(
+    diagnostic: FailureDiagnostic,
+    cli_observed_exit: Option<CliObservedExitDiagnostic>,
+) -> FailureDiagnostic {
+    if let Some(cli_observed_exit) = cli_observed_exit {
+        diagnostic.with_cli_observed_exit(cli_observed_exit)
     } else {
         diagnostic
     }
@@ -2700,9 +2719,34 @@ mod tests {
     }
 
     #[test]
+    fn cli_observed_exit_is_attached_without_changing_failure_reason() {
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("plain prompt"),
+        )
+        .with_cli_exit_code(137)
+        .with_failure_reason(FailureReason::ProviderOverloaded);
+        let observed_exit = CliObservedExitDiagnostic::from_signal(libc::SIGKILL);
+
+        let with_observed_exit =
+            with_cli_observed_exit(diagnostic.clone(), Some(observed_exit.clone()));
+        let unchanged = with_cli_observed_exit(diagnostic.clone(), None);
+
+        assert_eq!(with_observed_exit.failure_class, FailureClass::CliNonzero);
+        assert_eq!(
+            with_observed_exit.failure_reason,
+            Some(FailureReason::ProviderOverloaded)
+        );
+        assert_eq!(with_observed_exit.cli_observed_exit, Some(observed_exit));
+        assert_eq!(unchanged, diagnostic);
+    }
+
+    #[test]
     fn is_claude_zero_turn_result_requires_all_guards() {
         let zero_turn = cli::CliExecutionResult {
             exit_code: 0,
+            cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(0)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary {
@@ -2716,6 +2760,7 @@ mod tests {
         };
         let one_turn = cli::CliExecutionResult {
             exit_code: 0,
+            cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(0)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary {
@@ -2729,6 +2774,7 @@ mod tests {
         };
         let failed_zero_turn = cli::CliExecutionResult {
             exit_code: 1,
+            cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(1)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary {
@@ -2742,6 +2788,7 @@ mod tests {
         };
         let unknown_zero_turn = cli::CliExecutionResult {
             exit_code: 0,
+            cli_observed_exit: Some(CliObservedExitDiagnostic::from_exit_code(0)),
             stderr_lines: Vec::new(),
             last_event_sequence: None,
             claude_result: Some(cli::ClaudeResultSummary {
@@ -2790,6 +2837,7 @@ mod tests {
                 .with_observed_exit_code(143);
             cli::CliExecutionResult {
                 exit_code: 143,
+                cli_observed_exit: Some(CliObservedExitDiagnostic::from_signal(libc::SIGTERM)),
                 stderr_lines: Vec::new(),
                 last_event_sequence: None,
                 claude_result: Some(claude_result),

--- a/crates/guest-agent/src/main.rs
+++ b/crates/guest-agent/src/main.rs
@@ -404,13 +404,10 @@ async fn execute(
                         FailureClass::ClaudeZeroTurnNoHistory,
                     )
                     .with_cli_exit_code(cli_exit_code)
-                    .with_cli_observed_exit(
-                        cli_result
-                            .cli_observed_exit
-                            .unwrap_or_else(|| CliObservedExitDiagnostic::from_exit_code(0)),
-                    )
                     .with_claude_num_turns(Some(0))
                     .with_session_history_status(session_history_status);
+                    let diagnostic =
+                        with_cli_observed_exit(diagnostic, cli_result.cli_observed_exit);
                     (
                         cli_exit_code,
                         1,

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -12,6 +12,7 @@ const UNIX_SIGQUIT_SIGNAL_NUMBER: i32 = 3;
 const UNIX_SIGKILL_SIGNAL_NUMBER: i32 = 9;
 const UNIX_SIGTERM_SIGNAL_NUMBER: i32 = 15;
 const UNIX_SIGPIPE_SIGNAL_NUMBER: i32 = 13;
+const SHELL_SIGNAL_EXIT_CODE_OFFSET: i32 = 128;
 
 /// Structured information describing why a guest agent run failed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -166,7 +167,7 @@ impl CliObservedExitDiagnostic {
             exit_code: None,
             signal_number: Some(signal_number),
             signal_name: observed_signal_name(signal_number).map(String::from),
-            mapped_exit_code: 128 + signal_number,
+            mapped_exit_code: shell_signal_exit_code(signal_number),
         }
     }
 
@@ -219,6 +220,10 @@ fn observed_signal_name(signal_number: i32) -> Option<&'static str> {
         UNIX_SIGPIPE_SIGNAL_NUMBER => Some("sigpipe"),
         _ => None,
     }
+}
+
+const fn shell_signal_exit_code(signal_number: i32) -> i32 {
+    SHELL_SIGNAL_EXIT_CODE_OFFSET.saturating_add(signal_number)
 }
 
 /// Details about how the guest agent terminated a CLI process.
@@ -704,6 +709,18 @@ mod tests {
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
         assert!(round_trip.cli_observed_exit.unwrap().is_sigkill());
+    }
+
+    #[test]
+    fn observed_signal_exit_code_uses_shell_mapping_without_overflow() {
+        assert_eq!(
+            CliObservedExitDiagnostic::from_signal(UNIX_SIGKILL_SIGNAL_NUMBER).mapped_exit_code,
+            137
+        );
+        assert_eq!(
+            CliObservedExitDiagnostic::from_signal(i32::MAX).mapped_exit_code,
+            i32::MAX
+        );
     }
 
     #[test]

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -5,6 +5,14 @@ use serde::{Deserialize, Serialize};
 /// Current JSON schema version for failure diagnostics.
 pub const FAILURE_DIAGNOSTIC_SCHEMA_VERSION: u8 = 1;
 
+// These are stable Unix signal numbers in the serialized diagnostic contract.
+const UNIX_SIGHUP_SIGNAL_NUMBER: i32 = 1;
+const UNIX_SIGINT_SIGNAL_NUMBER: i32 = 2;
+const UNIX_SIGQUIT_SIGNAL_NUMBER: i32 = 3;
+const UNIX_SIGKILL_SIGNAL_NUMBER: i32 = 9;
+const UNIX_SIGTERM_SIGNAL_NUMBER: i32 = 15;
+const UNIX_SIGPIPE_SIGNAL_NUMBER: i32 = 13;
+
 /// Structured information describing why a guest agent run failed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -165,7 +173,8 @@ impl CliObservedExitDiagnostic {
     /// Return true when this observation is an observed SIGKILL.
     #[must_use]
     pub fn is_sigkill(&self) -> bool {
-        self.kind == CliObservedExitKind::Signal && self.signal_number == Some(libc::SIGKILL)
+        self.kind == CliObservedExitKind::Signal
+            && self.signal_number == Some(UNIX_SIGKILL_SIGNAL_NUMBER)
     }
 }
 
@@ -192,12 +201,12 @@ impl CliObservedExitKind {
 
 fn observed_signal_name(signal_number: i32) -> Option<&'static str> {
     match signal_number {
-        libc::SIGHUP => Some("sighup"),
-        libc::SIGINT => Some("sigint"),
-        libc::SIGQUIT => Some("sigquit"),
-        libc::SIGTERM => Some("sigterm"),
-        libc::SIGKILL => Some("sigkill"),
-        libc::SIGPIPE => Some("sigpipe"),
+        UNIX_SIGHUP_SIGNAL_NUMBER => Some("sighup"),
+        UNIX_SIGINT_SIGNAL_NUMBER => Some("sigint"),
+        UNIX_SIGQUIT_SIGNAL_NUMBER => Some("sigquit"),
+        UNIX_SIGTERM_SIGNAL_NUMBER => Some("sigterm"),
+        UNIX_SIGKILL_SIGNAL_NUMBER => Some("sigkill"),
+        UNIX_SIGPIPE_SIGNAL_NUMBER => Some("sigpipe"),
         _ => None,
     }
 }
@@ -662,7 +671,7 @@ mod tests {
 
     #[test]
     fn failure_diagnostic_serializes_observed_signal_exit() {
-        let observed_exit = CliObservedExitDiagnostic::from_signal(libc::SIGKILL);
+        let observed_exit = CliObservedExitDiagnostic::from_signal(UNIX_SIGKILL_SIGNAL_NUMBER);
         let diagnostic = FailureDiagnostic::new(
             FailureClass::CliNonzero,
             AgentFramework::ClaudeCode,

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -17,6 +17,8 @@ pub struct FailureDiagnostic {
     pub framework: AgentFramework,
     /// Exit code observed from the CLI process, when available.
     pub cli_exit_code: Option<i32>,
+    /// Raw CLI process exit observation before signal exits are flattened.
+    pub cli_observed_exit: Option<CliObservedExitDiagnostic>,
     /// Guest-agent termination details for the CLI process, when available.
     pub cli_termination: Option<CliTerminationDiagnostic>,
     /// Number of turns reported by Claude Code, when available.
@@ -48,6 +50,7 @@ impl FailureDiagnostic {
             failure_class,
             framework,
             cli_exit_code: None,
+            cli_observed_exit: None,
             cli_termination: None,
             claude_num_turns: None,
             failure_detail_source: None,
@@ -63,6 +66,13 @@ impl FailureDiagnostic {
     #[must_use]
     pub fn with_cli_exit_code(mut self, cli_exit_code: i32) -> Self {
         self.cli_exit_code = Some(cli_exit_code);
+        self
+    }
+
+    /// Attach the raw CLI process exit observation.
+    #[must_use]
+    pub fn with_cli_observed_exit(mut self, cli_observed_exit: CliObservedExitDiagnostic) -> Self {
+        self.cli_observed_exit = Some(cli_observed_exit);
         self
     }
 
@@ -105,6 +115,90 @@ impl FailureDiagnostic {
     ) -> Self {
         self.session_history_status = session_history_status;
         self
+    }
+}
+
+/// Raw CLI process exit observation before guest-agent maps it to a numeric exit code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliObservedExitDiagnostic {
+    /// Shape of the observed process exit.
+    pub kind: CliObservedExitKind,
+    /// Normal process exit code, when the process exited normally.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Unix signal number, when the process was killed by a signal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal_number: Option<i32>,
+    /// Stable snake_case signal name for common Unix signals, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal_name: Option<String>,
+    /// Existing shell-style mapped code used by `cliExitCode`.
+    pub mapped_exit_code: i32,
+}
+
+impl CliObservedExitDiagnostic {
+    /// Build a normal exit observation.
+    #[must_use]
+    pub const fn from_exit_code(exit_code: i32) -> Self {
+        Self {
+            kind: CliObservedExitKind::Exit,
+            exit_code: Some(exit_code),
+            signal_number: None,
+            signal_name: None,
+            mapped_exit_code: exit_code,
+        }
+    }
+
+    /// Build a Unix signal exit observation.
+    #[must_use]
+    pub fn from_signal(signal_number: i32) -> Self {
+        Self {
+            kind: CliObservedExitKind::Signal,
+            exit_code: None,
+            signal_number: Some(signal_number),
+            signal_name: observed_signal_name(signal_number).map(String::from),
+            mapped_exit_code: 128 + signal_number,
+        }
+    }
+
+    /// Return true when this observation is an observed SIGKILL.
+    #[must_use]
+    pub fn is_sigkill(&self) -> bool {
+        self.kind == CliObservedExitKind::Signal && self.signal_number == Some(libc::SIGKILL)
+    }
+}
+
+/// Shape of the raw CLI process exit observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CliObservedExitKind {
+    /// The process exited normally with an exit code.
+    Exit,
+    /// The process was killed by a Unix signal.
+    Signal,
+}
+
+impl CliObservedExitKind {
+    /// Return the stable snake_case string representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exit => "exit",
+            Self::Signal => "signal",
+        }
+    }
+}
+
+fn observed_signal_name(signal_number: i32) -> Option<&'static str> {
+    match signal_number {
+        libc::SIGHUP => Some("sighup"),
+        libc::SIGINT => Some("sigint"),
+        libc::SIGQUIT => Some("sigquit"),
+        libc::SIGTERM => Some("sigterm"),
+        libc::SIGKILL => Some("sigkill"),
+        libc::SIGPIPE => Some("sigpipe"),
+        _ => None,
     }
 }
 
@@ -564,6 +658,82 @@ mod tests {
 
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_observed_signal_exit() {
+        let observed_exit = CliObservedExitDiagnostic::from_signal(libc::SIGKILL);
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(137)
+        .with_cli_observed_exit(observed_exit);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(
+            json["cliObservedExit"],
+            serde_json::json!({
+                "kind": "signal",
+                "signalNumber": 9,
+                "signalName": "sigkill",
+                "mappedExitCode": 137
+            })
+        );
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+        assert!(round_trip.cli_observed_exit.unwrap().is_sigkill());
+    }
+
+    #[test]
+    fn failure_diagnostic_serializes_observed_normal_exit() {
+        let observed_exit = CliObservedExitDiagnostic::from_exit_code(137);
+        let diagnostic = FailureDiagnostic::new(
+            FailureClass::CliNonzero,
+            AgentFramework::ClaudeCode,
+            PromptMetadata::from_prompt("debug failure"),
+        )
+        .with_cli_exit_code(137)
+        .with_cli_observed_exit(observed_exit);
+
+        let json = serde_json::to_value(&diagnostic).unwrap();
+        assert_eq!(
+            json["cliObservedExit"],
+            serde_json::json!({
+                "kind": "exit",
+                "exitCode": 137,
+                "mappedExitCode": 137
+            })
+        );
+
+        let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, diagnostic);
+        assert!(!round_trip.cli_observed_exit.unwrap().is_sigkill());
+    }
+
+    #[test]
+    fn failure_diagnostic_deserializes_without_observed_exit() {
+        let json = serde_json::json!({
+            "schemaVersion": 1,
+            "failureClass": "cli_nonzero",
+            "framework": "claude_code",
+            "cliExitCode": 137,
+            "cliTermination": null,
+            "claudeNumTurns": null,
+            "failureDetailSource": "fallback_exit_code",
+            "failureReason": null,
+            "sessionHistoryStatus": "present",
+            "promptShape": "plain",
+            "promptBytes": 5,
+            "firstLineBytes": 5
+        });
+
+        let diagnostic: FailureDiagnostic = serde_json::from_value(json).unwrap();
+
+        assert_eq!(diagnostic.cli_exit_code, Some(137));
+        assert_eq!(diagnostic.cli_observed_exit, None);
     }
 
     #[test]

--- a/crates/guest-contracts/src/diagnostics.rs
+++ b/crates/guest-contracts/src/diagnostics.rs
@@ -170,6 +170,16 @@ impl CliObservedExitDiagnostic {
         }
     }
 
+    /// Return the stable signal name derived from the observed signal number.
+    #[must_use]
+    pub fn known_signal_name(&self) -> Option<&'static str> {
+        if self.kind != CliObservedExitKind::Signal {
+            return None;
+        }
+
+        self.signal_number.and_then(observed_signal_name)
+    }
+
     /// Return true when this observation is an observed SIGKILL.
     #[must_use]
     pub fn is_sigkill(&self) -> bool {
@@ -694,6 +704,14 @@ mod tests {
         let round_trip: FailureDiagnostic = serde_json::from_value(json).unwrap();
         assert_eq!(round_trip, diagnostic);
         assert!(round_trip.cli_observed_exit.unwrap().is_sigkill());
+    }
+
+    #[test]
+    fn observed_signal_name_is_derived_from_signal_number() {
+        let mut observed_exit = CliObservedExitDiagnostic::from_signal(UNIX_SIGKILL_SIGNAL_NUMBER);
+        observed_exit.signal_name = Some("tampered".to_string());
+
+        assert_eq!(observed_exit.known_signal_name(), Some("sigkill"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -10,8 +10,8 @@ use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use guest_contracts::diagnostics::{
-    CliObservedExitDiagnostic, CliTerminationDiagnostic, FailureClass, FailureDiagnostic,
-    FailureReason,
+    CliObservedExitDiagnostic, CliObservedExitKind, CliTerminationDiagnostic, FailureClass,
+    FailureDiagnostic, FailureReason,
 };
 use sandbox::SandboxId;
 use tokio::sync::mpsc;
@@ -904,11 +904,21 @@ impl From<Option<&CliTerminationDiagnostic>> for JobCliTerminationLogFields {
 
 impl From<Option<&CliObservedExitDiagnostic>> for JobCliObservedExitLogFields {
     fn from(diagnostic: Option<&CliObservedExitDiagnostic>) -> Self {
+        let is_exit =
+            diagnostic.is_some_and(|diagnostic| diagnostic.kind == CliObservedExitKind::Exit);
+        let is_signal =
+            diagnostic.is_some_and(|diagnostic| diagnostic.kind == CliObservedExitKind::Signal);
         Self {
             kind: diagnostic.map(|diagnostic| diagnostic.kind.as_str()),
-            exit_code: diagnostic.and_then(|diagnostic| diagnostic.exit_code),
-            signal_number: diagnostic.and_then(|diagnostic| diagnostic.signal_number),
-            signal_name: diagnostic.and_then(CliObservedExitDiagnostic::known_signal_name),
+            exit_code: is_exit
+                .then(|| diagnostic.and_then(|diagnostic| diagnostic.exit_code))
+                .flatten(),
+            signal_number: is_signal
+                .then(|| diagnostic.and_then(|diagnostic| diagnostic.signal_number))
+                .flatten(),
+            signal_name: is_signal
+                .then(|| diagnostic.and_then(CliObservedExitDiagnostic::known_signal_name))
+                .flatten(),
             mapped_exit_code: diagnostic.map(|diagnostic| diagnostic.mapped_exit_code),
         }
     }
@@ -1630,7 +1640,7 @@ mod tests {
             .with_cli_exit_code(137)
             .with_cli_observed_exit(CliObservedExitDiagnostic {
                 kind: CliObservedExitKind::Signal,
-                exit_code: None,
+                exit_code: Some(137),
                 signal_number: Some(libc::SIGKILL),
                 signal_name: Some("tampered".to_string()),
                 mapped_exit_code: 137,
@@ -1641,6 +1651,7 @@ mod tests {
         let event = capture_job_failure_log(&failure);
 
         assert_field_eq(&event, "cli_observed_signal_name", "sigkill");
+        assert!(!event.fields.contains_key("cli_observed_exit_code"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -879,11 +879,11 @@ struct JobCliTerminationLogFields {
     observed_exit_code: Option<i32>,
 }
 
-struct JobCliObservedExitLogFields<'a> {
+struct JobCliObservedExitLogFields {
     kind: Option<&'static str>,
     exit_code: Option<i32>,
     signal_number: Option<i32>,
-    signal_name: Option<&'a str>,
+    signal_name: Option<&'static str>,
     mapped_exit_code: Option<i32>,
 }
 
@@ -902,13 +902,13 @@ impl From<Option<&CliTerminationDiagnostic>> for JobCliTerminationLogFields {
     }
 }
 
-impl<'a> From<Option<&'a CliObservedExitDiagnostic>> for JobCliObservedExitLogFields<'a> {
-    fn from(diagnostic: Option<&'a CliObservedExitDiagnostic>) -> Self {
+impl From<Option<&CliObservedExitDiagnostic>> for JobCliObservedExitLogFields {
+    fn from(diagnostic: Option<&CliObservedExitDiagnostic>) -> Self {
         Self {
             kind: diagnostic.map(|diagnostic| diagnostic.kind.as_str()),
             exit_code: diagnostic.and_then(|diagnostic| diagnostic.exit_code),
             signal_number: diagnostic.and_then(|diagnostic| diagnostic.signal_number),
-            signal_name: diagnostic.and_then(|diagnostic| diagnostic.signal_name.as_deref()),
+            signal_name: diagnostic.and_then(CliObservedExitDiagnostic::known_signal_name),
             mapped_exit_code: diagnostic.map(|diagnostic| diagnostic.mapped_exit_code),
         }
     }
@@ -1013,8 +1013,9 @@ mod tests {
     use std::time::Duration;
 
     use guest_contracts::diagnostics::{
-        AgentFramework, CliTerminationDiagnostic, CliTerminationReason, CliTerminationSignal,
-        FailureClass, FailureDetailSource, PromptMetadata, SessionHistoryStatus,
+        AgentFramework, CliObservedExitKind, CliTerminationDiagnostic, CliTerminationReason,
+        CliTerminationSignal, FailureClass, FailureDetailSource, PromptMetadata,
+        SessionHistoryStatus,
     };
     use sandbox::SandboxId;
     use sandbox_mock::MockSandbox;
@@ -1621,6 +1622,25 @@ mod tests {
         assert_field_eq(&event, "cli_observed_signal_number", "9");
         assert_field_eq(&event, "cli_observed_signal_name", "sigkill");
         assert_field_eq(&event, "cli_observed_mapped_exit_code", "137");
+    }
+
+    #[test]
+    fn diagnostic_failure_logs_observed_signal_name_from_number() {
+        let diagnostic = job_failure_diagnostic(None)
+            .with_cli_exit_code(137)
+            .with_cli_observed_exit(CliObservedExitDiagnostic {
+                kind: CliObservedExitKind::Signal,
+                exit_code: None,
+                signal_number: Some(libc::SIGKILL),
+                signal_name: Some("tampered".to_string()),
+                mapped_exit_code: 137,
+            });
+        let failure =
+            executor::ExecutionFailure::new(137, "Agent exited with code 137", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_field_eq(&event, "cli_observed_signal_name", "sigkill");
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -10,7 +10,8 @@ use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
 use guest_contracts::diagnostics::{
-    CliTerminationDiagnostic, FailureClass, FailureDiagnostic, FailureReason,
+    CliObservedExitDiagnostic, CliTerminationDiagnostic, FailureClass, FailureDiagnostic,
+    FailureReason,
 };
 use sandbox::SandboxId;
 use tokio::sync::mpsc;
@@ -733,6 +734,8 @@ fn log_job_execution_failed(
             let failure_reason = diagnostic.failure_reason.map(|reason| reason.as_str());
             let cli_termination_fields =
                 JobCliTerminationLogFields::from(diagnostic.cli_termination.as_ref());
+            let cli_observed_exit_fields =
+                JobCliObservedExitLogFields::from(diagnostic.cli_observed_exit.as_ref());
             error!(
                 run_id = %run_id,
                 exit_code,
@@ -754,6 +757,11 @@ fn log_job_execution_failed(
                 cli_termination_signal_grace_ms = cli_termination_fields.signal_grace_ms,
                 cli_termination_escalated = cli_termination_fields.escalated,
                 cli_termination_observed_exit_code = cli_termination_fields.observed_exit_code,
+                cli_observed_exit_kind = cli_observed_exit_fields.kind,
+                cli_observed_exit_code = cli_observed_exit_fields.exit_code,
+                cli_observed_signal_number = cli_observed_exit_fields.signal_number,
+                cli_observed_signal_name = cli_observed_exit_fields.signal_name,
+                cli_observed_mapped_exit_code = cli_observed_exit_fields.mapped_exit_code,
                 session_history_status = diagnostic.session_history_status.as_str(),
                 prompt_shape = diagnostic.prompt_shape.as_str(),
                 prompt_bytes = diagnostic.prompt_bytes,
@@ -792,6 +800,8 @@ fn log_job_execution_failed(
         let failure_reason = diagnostic.failure_reason.map(|reason| reason.as_str());
         let cli_termination_fields =
             JobCliTerminationLogFields::from(diagnostic.cli_termination.as_ref());
+        let cli_observed_exit_fields =
+            JobCliObservedExitLogFields::from(diagnostic.cli_observed_exit.as_ref());
         macro_rules! log_with_diagnostic {
             ($level:ident) => {
                 $level!(
@@ -812,6 +822,11 @@ fn log_job_execution_failed(
                     cli_termination_signal_grace_ms = cli_termination_fields.signal_grace_ms,
                     cli_termination_escalated = cli_termination_fields.escalated,
                     cli_termination_observed_exit_code = cli_termination_fields.observed_exit_code,
+                    cli_observed_exit_kind = cli_observed_exit_fields.kind,
+                    cli_observed_exit_code = cli_observed_exit_fields.exit_code,
+                    cli_observed_signal_number = cli_observed_exit_fields.signal_number,
+                    cli_observed_signal_name = cli_observed_exit_fields.signal_name,
+                    cli_observed_mapped_exit_code = cli_observed_exit_fields.mapped_exit_code,
                     session_history_status = diagnostic.session_history_status.as_str(),
                     prompt_shape = diagnostic.prompt_shape.as_str(),
                     prompt_bytes = diagnostic.prompt_bytes,
@@ -864,6 +879,14 @@ struct JobCliTerminationLogFields {
     observed_exit_code: Option<i32>,
 }
 
+struct JobCliObservedExitLogFields<'a> {
+    kind: Option<&'static str>,
+    exit_code: Option<i32>,
+    signal_number: Option<i32>,
+    signal_name: Option<&'a str>,
+    mapped_exit_code: Option<i32>,
+}
+
 impl From<Option<&CliTerminationDiagnostic>> for JobCliTerminationLogFields {
     fn from(diagnostic: Option<&CliTerminationDiagnostic>) -> Self {
         Self {
@@ -875,6 +898,18 @@ impl From<Option<&CliTerminationDiagnostic>> for JobCliTerminationLogFields {
             signal_grace_ms: diagnostic.and_then(|diagnostic| diagnostic.signal_grace_ms),
             escalated: diagnostic.map(|diagnostic| diagnostic.escalated),
             observed_exit_code: diagnostic.and_then(|diagnostic| diagnostic.observed_exit_code),
+        }
+    }
+}
+
+impl<'a> From<Option<&'a CliObservedExitDiagnostic>> for JobCliObservedExitLogFields<'a> {
+    fn from(diagnostic: Option<&'a CliObservedExitDiagnostic>) -> Self {
+        Self {
+            kind: diagnostic.map(|diagnostic| diagnostic.kind.as_str()),
+            exit_code: diagnostic.and_then(|diagnostic| diagnostic.exit_code),
+            signal_number: diagnostic.and_then(|diagnostic| diagnostic.signal_number),
+            signal_name: diagnostic.and_then(|diagnostic| diagnostic.signal_name.as_deref()),
+            mapped_exit_code: diagnostic.map(|diagnostic| diagnostic.mapped_exit_code),
         }
     }
 }
@@ -1539,6 +1574,7 @@ mod tests {
         );
         assert!(!event.fields.contains_key("failure_reason"));
         assert!(!event.fields.contains_key("cli_termination_reason"));
+        assert!(!event.fields.contains_key("cli_observed_exit_kind"));
     }
 
     #[test]
@@ -1562,6 +1598,29 @@ mod tests {
         assert_field_eq(&event, "cli_termination_signal_grace_ms", "10000");
         assert_field_eq(&event, "cli_termination_escalated", "false");
         assert_field_eq(&event, "cli_termination_observed_exit_code", "143");
+    }
+
+    #[test]
+    fn diagnostic_failure_logs_cli_observed_exit_fields() {
+        let diagnostic = job_failure_diagnostic(None)
+            .with_cli_exit_code(137)
+            .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL));
+        let failure =
+            executor::ExecutionFailure::new(137, "Agent exited with code 137", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(
+            event.fields.get("message").map(String::as_str),
+            Some("job execution failed")
+        );
+        assert_field_eq(&event, "failure_cli_exit_code", "137");
+        assert_field_eq(&event, "cli_observed_exit_kind", "signal");
+        assert!(!event.fields.contains_key("cli_observed_exit_code"));
+        assert_field_eq(&event, "cli_observed_signal_number", "9");
+        assert_field_eq(&event, "cli_observed_signal_name", "sigkill");
+        assert_field_eq(&event, "cli_observed_mapped_exit_code", "137");
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -1635,6 +1635,23 @@ mod tests {
     }
 
     #[test]
+    fn diagnostic_failure_logs_cli_observed_normal_exit_fields() {
+        let diagnostic = job_failure_diagnostic(None)
+            .with_cli_exit_code(2)
+            .with_cli_observed_exit(CliObservedExitDiagnostic::from_exit_code(2));
+        let failure =
+            executor::ExecutionFailure::new(2, "Agent exited with code 2", Some(diagnostic));
+
+        let event = capture_job_failure_log(&failure);
+
+        assert_field_eq(&event, "cli_observed_exit_kind", "exit");
+        assert_field_eq(&event, "cli_observed_exit_code", "2");
+        assert!(!event.fields.contains_key("cli_observed_signal_number"));
+        assert!(!event.fields.contains_key("cli_observed_signal_name"));
+        assert_field_eq(&event, "cli_observed_mapped_exit_code", "2");
+    }
+
+    #[test]
     fn diagnostic_failure_logs_observed_signal_name_from_number() {
         let diagnostic = job_failure_diagnostic(None)
             .with_cli_exit_code(137)

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -1529,7 +1529,6 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 wait_cancelled,
                 &exit,
                 failure_diagnostic.as_ref(),
-                guest_error.as_deref(),
             );
         let should_collect_resource_diagnostics =
             should_collect_resource_diagnostics || should_collect_sigkill_resource_diagnostics;

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -27,6 +27,7 @@ use super::diagnostics::{
     log_agent_abnormal_exit_env_diagnostics, log_agent_bootstrap_abnormal_exit_diagnostics,
     log_agent_process_exit_summary, read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
+    should_collect_unattributed_sigkill_resource_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
 use super::effective_cli_framework;
@@ -1523,6 +1524,15 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             failure_diagnostic.as_ref(),
             guest_error.as_deref(),
         );
+        let should_collect_sigkill_resource_diagnostics =
+            should_collect_unattributed_sigkill_resource_diagnostics(
+                wait_cancelled,
+                &exit,
+                failure_diagnostic.as_ref(),
+                guest_error.as_deref(),
+            );
+        let should_collect_resource_diagnostics =
+            should_collect_resource_diagnostics || should_collect_sigkill_resource_diagnostics;
         let mut resource_diagnostics = None;
         if should_log_bootstrap_diagnostics || should_collect_resource_diagnostics {
             let env_key_diagnostics = build_agent_env_key_diagnostics(&env_pairs);

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -26,7 +26,9 @@ use std::io::{self, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use guest_contracts::diagnostics::{FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureDiagnostic};
+use guest_contracts::diagnostics::{
+    FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass, FailureDetailSource, FailureDiagnostic,
+};
 use sandbox::{
     CopyFileOptions, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessOutputReceiver,
     Sandbox,
@@ -196,6 +198,35 @@ pub(super) fn should_collect_agent_abnormal_exit_diagnostics(
         && stderr.is_empty()
         && failure_diagnostic.is_none()
         && guest_error.is_none()
+}
+
+pub(super) fn should_collect_unattributed_sigkill_resource_diagnostics(
+    wait_cancelled: bool,
+    exit: &sandbox::ProcessExit,
+    failure_diagnostic: Option<&FailureDiagnostic>,
+    guest_error: Option<&str>,
+) -> bool {
+    !wait_cancelled
+        && process_exited_nonzero(exit)
+        && guest_error.is_none()
+        && failure_diagnostic.is_some_and(unattributed_sigkill_cli_failure)
+}
+
+fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic) -> bool {
+    diagnostic.failure_class == FailureClass::CliNonzero
+        && diagnostic.cli_termination.is_none()
+        && matches!(
+            diagnostic.failure_detail_source,
+            None | Some(FailureDetailSource::FallbackExitCode)
+        )
+        && observed_or_compatible_sigkill(diagnostic)
+}
+
+fn observed_or_compatible_sigkill(diagnostic: &FailureDiagnostic) -> bool {
+    if let Some(observed_exit) = diagnostic.cli_observed_exit.as_ref() {
+        return observed_exit.is_sigkill();
+    }
+    diagnostic.cli_exit_code == Some(libc::SIGKILL + 128)
 }
 
 pub(super) fn should_log_agent_bootstrap_abnormal_exit_diagnostics(

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -220,10 +220,7 @@ fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic, exit_code: i
     diagnostic.failure_class == FailureClass::CliNonzero
         && diagnostic.cli_exit_code == Some(exit_code)
         && diagnostic.cli_termination.is_none()
-        && matches!(
-            diagnostic.failure_detail_source,
-            None | Some(FailureDetailSource::FallbackExitCode)
-        )
+        && diagnostic.failure_detail_source == Some(FailureDetailSource::FallbackExitCode)
         && diagnostic
             .cli_observed_exit
             .as_ref()

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -236,6 +236,7 @@ fn observed_sigkill_matches_exit_code(
     exit_code: i32,
 ) -> bool {
     observed_exit.is_sigkill()
+        && observed_exit.exit_code.is_none()
         && observed_exit.signal_number == Some(EXIT_SIGNAL_KILL)
         && observed_exit.mapped_exit_code == EXIT_SIGKILL
         && exit_code == EXIT_SIGKILL

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -218,14 +218,10 @@ fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic) -> bool {
             diagnostic.failure_detail_source,
             None | Some(FailureDetailSource::FallbackExitCode)
         )
-        && observed_or_compatible_sigkill(diagnostic)
-}
-
-fn observed_or_compatible_sigkill(diagnostic: &FailureDiagnostic) -> bool {
-    if let Some(observed_exit) = diagnostic.cli_observed_exit.as_ref() {
-        return observed_exit.is_sigkill();
-    }
-    diagnostic.cli_exit_code == Some(libc::SIGKILL + 128)
+        && diagnostic
+            .cli_observed_exit
+            .as_ref()
+            .is_some_and(|observed_exit| observed_exit.is_sigkill())
 }
 
 pub(super) fn should_log_agent_bootstrap_abnormal_exit_diagnostics(

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -204,11 +204,9 @@ pub(super) fn should_collect_unattributed_sigkill_resource_diagnostics(
     wait_cancelled: bool,
     exit: &sandbox::ProcessExit,
     failure_diagnostic: Option<&FailureDiagnostic>,
-    guest_error: Option<&str>,
 ) -> bool {
     !wait_cancelled
         && process_exited_nonzero(exit)
-        && guest_error.is_none()
         && failure_diagnostic.is_some_and(unattributed_sigkill_cli_failure)
 }
 

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -27,7 +27,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use guest_contracts::diagnostics::{
-    FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass, FailureDetailSource, FailureDiagnostic,
+    CliObservedExitDiagnostic, FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass,
+    FailureDetailSource, FailureDiagnostic,
 };
 use sandbox::{
     CopyFileOptions, EXEC_OUTPUT_LIMIT_64_KIB, ExecRequest, ExecTermination, ProcessOutputReceiver,
@@ -42,9 +43,10 @@ use super::session_restore::SessionRestoreDiagnostics;
 use super::{
     AGENT_ABNORMAL_EXIT_DIAGNOSTIC_SCRIPT, AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT,
     AGENT_ENV_KEY_DIAGNOSTIC_LIMIT, AGENT_ENV_KEY_MAX_CHARS, BOOTSTRAP_SENSITIVE_ENV_KEYS,
-    DEFAULT_EXEC_TIMEOUT, GUEST_LOG_COPY_MAX_BYTES, ResourceFailureDiagnostics,
-    ResourceFailureKind, SMALL_GUEST_FILE_MAX_BYTES, STDOUT_STREAM_LIMIT_MARKER,
-    STDOUT_STREAM_OVERFLOW_MARKER, SandboxReuseResult, guest_runtime_path,
+    DEFAULT_EXEC_TIMEOUT, EXIT_SIGKILL, EXIT_SIGNAL_KILL, GUEST_LOG_COPY_MAX_BYTES,
+    ResourceFailureDiagnostics, ResourceFailureKind, SMALL_GUEST_FILE_MAX_BYTES,
+    STDOUT_STREAM_LIMIT_MARKER, STDOUT_STREAM_OVERFLOW_MARKER, SandboxReuseResult,
+    guest_runtime_path,
 };
 use crate::helper_exec::{helper_exec_succeeded, helper_exec_termination_label};
 use crate::ids::RunId;
@@ -225,8 +227,18 @@ fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic, exit_code: i
             .cli_observed_exit
             .as_ref()
             .is_some_and(|observed_exit| {
-                observed_exit.is_sigkill() && observed_exit.mapped_exit_code == exit_code
+                observed_sigkill_matches_exit_code(observed_exit, exit_code)
             })
+}
+
+fn observed_sigkill_matches_exit_code(
+    observed_exit: &CliObservedExitDiagnostic,
+    exit_code: i32,
+) -> bool {
+    observed_exit.is_sigkill()
+        && observed_exit.signal_number == Some(EXIT_SIGNAL_KILL)
+        && observed_exit.mapped_exit_code == EXIT_SIGKILL
+        && exit_code == EXIT_SIGKILL
 }
 
 pub(super) fn should_log_agent_bootstrap_abnormal_exit_diagnostics(

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -207,6 +207,7 @@ pub(super) fn should_collect_unattributed_sigkill_resource_diagnostics(
 ) -> bool {
     !wait_cancelled
         && process_exited_nonzero(exit)
+        && exit.diagnostic.is_empty()
         && failure_diagnostic.is_some_and(unattributed_sigkill_cli_failure)
 }
 

--- a/crates/runner/src/executor/diagnostics.rs
+++ b/crates/runner/src/executor/diagnostics.rs
@@ -205,14 +205,20 @@ pub(super) fn should_collect_unattributed_sigkill_resource_diagnostics(
     exit: &sandbox::ProcessExit,
     failure_diagnostic: Option<&FailureDiagnostic>,
 ) -> bool {
+    let ExecTermination::Exited { exit_code } = exit.termination else {
+        return false;
+    };
+
     !wait_cancelled
-        && process_exited_nonzero(exit)
+        && exit_code != 0
         && exit.diagnostic.is_empty()
-        && failure_diagnostic.is_some_and(unattributed_sigkill_cli_failure)
+        && failure_diagnostic
+            .is_some_and(|diagnostic| unattributed_sigkill_cli_failure(diagnostic, exit_code))
 }
 
-fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic) -> bool {
+fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic, exit_code: i32) -> bool {
     diagnostic.failure_class == FailureClass::CliNonzero
+        && diagnostic.cli_exit_code == Some(exit_code)
         && diagnostic.cli_termination.is_none()
         && matches!(
             diagnostic.failure_detail_source,
@@ -221,7 +227,9 @@ fn unattributed_sigkill_cli_failure(diagnostic: &FailureDiagnostic) -> bool {
         && diagnostic
             .cli_observed_exit
             .as_ref()
-            .is_some_and(|observed_exit| observed_exit.is_sigkill())
+            .is_some_and(|observed_exit| {
+                observed_exit.is_sigkill() && observed_exit.mapped_exit_code == exit_code
+            })
 }
 
 pub(super) fn should_log_agent_bootstrap_abnormal_exit_diagnostics(

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -203,6 +203,19 @@ fn unattributed_sigkill_resource_diagnostics_require_observed_sigkill() {
 }
 
 #[test]
+fn unattributed_sigkill_resource_diagnostics_require_matching_exit_code() {
+    let exit = ProcessExit::new(1, 1, Vec::new(), Vec::new());
+    let diagnostic = fallback_cli_nonzero_diagnostic(137)
+        .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL));
+
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic)
+    ));
+}
+
+#[test]
 fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failure() {
     let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
     let exit_with_process_diagnostic = ProcessExit {

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use guest_contracts::diagnostics::{
-    AgentFramework, FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass, FailureDetailSource,
+    AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, CliTerminationReason,
+    CliTerminationSignal, FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass, FailureDetailSource,
     FailureDiagnostic, FailureReason, PromptMetadata, SessionHistoryStatus,
 };
 use sandbox::{ExecTermination, ProcessExit, ProcessOutputChunk};
@@ -17,6 +18,7 @@ use super::super::diagnostics::{
     host_dmesg_indicates_oom, parse_agent_abnormal_exit_resource_diagnostics,
     read_guest_cli_agent_session_id, read_guest_error_file, read_guest_failure_diagnostic_file,
     should_collect_agent_abnormal_exit_diagnostics,
+    should_collect_unattributed_sigkill_resource_diagnostics,
     should_log_agent_bootstrap_abnormal_exit_diagnostics,
 };
 use super::super::sandbox_run::post_job_cleanup;
@@ -149,6 +151,124 @@ fn bootstrap_abnormal_exit_diagnostics_allow_captured_stderr_without_resource_pr
         &timed_out_exit,
         None,
         None
+    ));
+}
+
+fn fallback_cli_nonzero_diagnostic(exit_code: i32) -> FailureDiagnostic {
+    FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("/help"),
+    )
+    .with_cli_exit_code(exit_code)
+    .with_failure_detail_source(FailureDetailSource::FallbackExitCode)
+}
+
+#[test]
+fn unattributed_sigkill_resource_diagnostics_match_observed_sigkill() {
+    let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
+    let diagnostic = fallback_cli_nonzero_diagnostic(137)
+        .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL));
+
+    assert!(should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic),
+        None
+    ));
+}
+
+#[test]
+fn unattributed_sigkill_resource_diagnostics_do_not_match_explicit_exit_137() {
+    let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
+    let diagnostic = fallback_cli_nonzero_diagnostic(137)
+        .with_cli_observed_exit(CliObservedExitDiagnostic::from_exit_code(137));
+
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic),
+        None
+    ));
+}
+
+#[test]
+fn unattributed_sigkill_resource_diagnostics_support_old_137_diagnostics() {
+    let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
+    let diagnostic = fallback_cli_nonzero_diagnostic(137);
+
+    assert!(should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic),
+        None
+    ));
+}
+
+#[test]
+fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failure() {
+    let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
+    let termination = CliTerminationDiagnostic::new(CliTerminationReason::StuckToolWatchdog)
+        .record_signal(CliTerminationSignal::Sigkill, Some(42), Some(1_000))
+        .with_observed_exit_code(137);
+    let attributed_diagnostic =
+        fallback_cli_nonzero_diagnostic(137).with_cli_termination(termination);
+    let specific_diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("/help"),
+    )
+    .with_cli_exit_code(137)
+    .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL))
+    .with_failure_detail_source(FailureDetailSource::ClaudeResult);
+    let non_cli_diagnostic = FailureDiagnostic::new(
+        FailureClass::CheckpointFailed,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("/help"),
+    )
+    .with_cli_exit_code(137)
+    .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL))
+    .with_failure_detail_source(FailureDetailSource::FallbackExitCode);
+    let timed_out_exit = ProcessExit {
+        termination: ExecTermination::TimedOut,
+        ..ProcessExit::new(1, 137, Vec::new(), Vec::new())
+    };
+
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&attributed_diagnostic),
+        None
+    ));
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&specific_diagnostic),
+        None
+    ));
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&non_cli_diagnostic),
+        None
+    ));
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &timed_out_exit,
+        Some(&fallback_cli_nonzero_diagnostic(137)),
+        None
+    ));
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        true,
+        &exit,
+        Some(&fallback_cli_nonzero_diagnostic(137)),
+        None
+    ));
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&fallback_cli_nonzero_diagnostic(137)),
+        Some("guest error")
     ));
 }
 

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -240,11 +240,14 @@ fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failu
         diagnostic: "wait failed inside provider".to_string(),
         ..ProcessExit::new(1, 137, Vec::new(), Vec::new())
     };
+    let observed_sigkill_diagnostic = fallback_cli_nonzero_diagnostic(137)
+        .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL));
     let termination = CliTerminationDiagnostic::new(CliTerminationReason::StuckToolWatchdog)
         .record_signal(CliTerminationSignal::Sigkill, Some(42), Some(1_000))
         .with_observed_exit_code(137);
-    let attributed_diagnostic =
-        fallback_cli_nonzero_diagnostic(137).with_cli_termination(termination);
+    let attributed_diagnostic = observed_sigkill_diagnostic
+        .clone()
+        .with_cli_termination(termination);
     let specific_diagnostic = FailureDiagnostic::new(
         FailureClass::CliNonzero,
         AgentFramework::ClaudeCode,
@@ -284,17 +287,17 @@ fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failu
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit_with_process_diagnostic,
-        Some(&fallback_cli_nonzero_diagnostic(137))
+        Some(&observed_sigkill_diagnostic)
     ));
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &timed_out_exit,
-        Some(&fallback_cli_nonzero_diagnostic(137))
+        Some(&observed_sigkill_diagnostic)
     ));
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         true,
         &exit,
-        Some(&fallback_cli_nonzero_diagnostic(137))
+        Some(&observed_sigkill_diagnostic)
     ));
 }
 

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -234,6 +234,20 @@ fn unattributed_sigkill_resource_diagnostics_require_matching_exit_code() {
 }
 
 #[test]
+fn unattributed_sigkill_resource_diagnostics_require_standard_sigkill_mapping() {
+    let exit = ProcessExit::new(1, 99, Vec::new(), Vec::new());
+    let mut observed_exit = CliObservedExitDiagnostic::from_signal(libc::SIGKILL);
+    observed_exit.mapped_exit_code = 99;
+    let diagnostic = fallback_cli_nonzero_diagnostic(99).with_cli_observed_exit(observed_exit);
+
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic)
+    ));
+}
+
+#[test]
 fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failure() {
     let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
     let exit_with_process_diagnostic = ProcessExit {

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -205,6 +205,10 @@ fn unattributed_sigkill_resource_diagnostics_support_old_137_diagnostics() {
 #[test]
 fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failure() {
     let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
+    let exit_with_process_diagnostic = ProcessExit {
+        diagnostic: "wait failed inside provider".to_string(),
+        ..ProcessExit::new(1, 137, Vec::new(), Vec::new())
+    };
     let termination = CliTerminationDiagnostic::new(CliTerminationReason::StuckToolWatchdog)
         .record_signal(CliTerminationSignal::Sigkill, Some(42), Some(1_000))
         .with_observed_exit_code(137);
@@ -245,6 +249,11 @@ fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failu
         false,
         &exit,
         Some(&non_cli_diagnostic)
+    ));
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit_with_process_diagnostic,
+        Some(&fallback_cli_nonzero_diagnostic(137))
     ));
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -173,8 +173,7 @@ fn unattributed_sigkill_resource_diagnostics_match_observed_sigkill() {
     assert!(should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit,
-        Some(&diagnostic),
-        None
+        Some(&diagnostic)
     ));
 }
 
@@ -187,8 +186,7 @@ fn unattributed_sigkill_resource_diagnostics_do_not_match_explicit_exit_137() {
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit,
-        Some(&diagnostic),
-        None
+        Some(&diagnostic)
     ));
 }
 
@@ -200,8 +198,7 @@ fn unattributed_sigkill_resource_diagnostics_support_old_137_diagnostics() {
     assert!(should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit,
-        Some(&diagnostic),
-        None
+        Some(&diagnostic)
     ));
 }
 
@@ -237,38 +234,27 @@ fn unattributed_sigkill_resource_diagnostics_require_unattributed_fallback_failu
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit,
-        Some(&attributed_diagnostic),
-        None
+        Some(&attributed_diagnostic)
     ));
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit,
-        Some(&specific_diagnostic),
-        None
+        Some(&specific_diagnostic)
     ));
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit,
-        Some(&non_cli_diagnostic),
-        None
+        Some(&non_cli_diagnostic)
     ));
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &timed_out_exit,
-        Some(&fallback_cli_nonzero_diagnostic(137)),
-        None
+        Some(&fallback_cli_nonzero_diagnostic(137))
     ));
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         true,
         &exit,
-        Some(&fallback_cli_nonzero_diagnostic(137)),
-        None
-    ));
-    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
-        false,
-        &exit,
-        Some(&fallback_cli_nonzero_diagnostic(137)),
-        Some("guest error")
+        Some(&fallback_cli_nonzero_diagnostic(137))
     ));
 }
 

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -191,11 +191,11 @@ fn unattributed_sigkill_resource_diagnostics_do_not_match_explicit_exit_137() {
 }
 
 #[test]
-fn unattributed_sigkill_resource_diagnostics_support_old_137_diagnostics() {
+fn unattributed_sigkill_resource_diagnostics_require_observed_sigkill() {
     let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
     let diagnostic = fallback_cli_nonzero_diagnostic(137);
 
-    assert!(should_collect_unattributed_sigkill_resource_diagnostics(
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,
         &exit,
         Some(&diagnostic)

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use guest_contracts::diagnostics::{
-    AgentFramework, CliObservedExitDiagnostic, CliTerminationDiagnostic, CliTerminationReason,
-    CliTerminationSignal, FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass, FailureDetailSource,
-    FailureDiagnostic, FailureReason, PromptMetadata, SessionHistoryStatus,
+    AgentFramework, CliObservedExitDiagnostic, CliObservedExitKind, CliTerminationDiagnostic,
+    CliTerminationReason, CliTerminationSignal, FAILURE_DIAGNOSTIC_SCHEMA_VERSION, FailureClass,
+    FailureDetailSource, FailureDiagnostic, FailureReason, PromptMetadata, SessionHistoryStatus,
 };
 use sandbox::{ExecTermination, ProcessExit, ProcessOutputChunk};
 use sandbox_mock::MockSandbox;
@@ -239,6 +239,25 @@ fn unattributed_sigkill_resource_diagnostics_require_standard_sigkill_mapping() 
     let mut observed_exit = CliObservedExitDiagnostic::from_signal(libc::SIGKILL);
     observed_exit.mapped_exit_code = 99;
     let diagnostic = fallback_cli_nonzero_diagnostic(99).with_cli_observed_exit(observed_exit);
+
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic)
+    ));
+}
+
+#[test]
+fn unattributed_sigkill_resource_diagnostics_require_signal_exit_shape() {
+    let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
+    let diagnostic =
+        fallback_cli_nonzero_diagnostic(137).with_cli_observed_exit(CliObservedExitDiagnostic {
+            kind: CliObservedExitKind::Signal,
+            exit_code: Some(137),
+            signal_number: Some(libc::SIGKILL),
+            signal_name: Some("sigkill".to_string()),
+            mapped_exit_code: 137,
+        });
 
     assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
         false,

--- a/crates/runner/src/executor/tests/diagnostics_tests.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests.rs
@@ -203,6 +203,24 @@ fn unattributed_sigkill_resource_diagnostics_require_observed_sigkill() {
 }
 
 #[test]
+fn unattributed_sigkill_resource_diagnostics_require_fallback_detail_source() {
+    let exit = ProcessExit::new(1, 137, Vec::new(), Vec::new());
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("/help"),
+    )
+    .with_cli_exit_code(137)
+    .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL));
+
+    assert!(!should_collect_unattributed_sigkill_resource_diagnostics(
+        false,
+        &exit,
+        Some(&diagnostic)
+    ));
+}
+
+#[test]
 fn unattributed_sigkill_resource_diagnostics_require_matching_exit_code() {
     let exit = ProcessExit::new(1, 1, Vec::new(), Vec::new());
     let diagnostic = fallback_cli_nonzero_diagnostic(137)

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -835,6 +835,58 @@ async fn execute_inner_nonzero_with_failure_diagnostic_skips_abnormal_exit_diagn
 }
 
 #[tokio::test]
+async fn execute_inner_unattributed_sigkill_failure_collects_resource_diagnostics() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_wait_process_exit(ProcessExit::new(1, 137, Vec::new(), Vec::new()));
+    let diagnostic = FailureDiagnostic::new(
+        FailureClass::CliNonzero,
+        AgentFramework::ClaudeCode,
+        PromptMetadata::from_prompt("/help"),
+    )
+    .with_cli_exit_code(137)
+    .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL))
+    .with_failure_detail_source(FailureDetailSource::FallbackExitCode);
+    overrides.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
+    overrides.push_read_file_result(Ok(None));
+    overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+        pattern: "guest-agent-binary".to_string(),
+        exit_code: 0,
+        stdout: b"/dev/root       7.8G  7.4G   20K 100% /\nMem:            3934        3310         255           0         552         624\n".to_vec(),
+        stderr: Vec::new(),
+    });
+    let factory = sandbox_mock::MockSandboxFactory::with_overrides(Arc::clone(&overrides));
+
+    let outcome = run_new_sandbox_outcome(&factory, &minimal_context(), &config, &default_params())
+        .await
+        .unwrap();
+
+    let failure = outcome.failure.as_ref().expect("expected failure");
+    assert_eq!(failure.exit_code, 137);
+    assert_eq!(failure.error.as_str(), "Agent exited with code 137");
+    let resource_diagnostics = failure
+        .resource_diagnostics
+        .expect("expected resource diagnostics");
+    assert_eq!(
+        resource_diagnostics.failure_kind,
+        Some(ResourceFailureKind::GuestRootFilesystemFull)
+    );
+    assert_eq!(resource_diagnostics.guest_root_fs_used_percent, Some(100));
+    assert_eq!(resource_diagnostics.guest_memory_available_mb, Some(624));
+    let diagnostic_calls: Vec<sandbox_mock::ExecCall> = overrides
+        .exec_calls()
+        .into_iter()
+        .filter(|call| call.cmd.contains("guest-agent-binary"))
+        .collect();
+    assert_eq!(diagnostic_calls.len(), 1);
+    assert_eq!(
+        diagnostic_calls[0].timeout,
+        AGENT_ABNORMAL_EXIT_DIAGNOSTIC_TIMEOUT
+    );
+}
+
+#[tokio::test]
 async fn execute_inner_nonzero_records_agent_execute_error() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;

--- a/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/execution_diagnostics.rs
@@ -849,7 +849,7 @@ async fn execute_inner_unattributed_sigkill_failure_collects_resource_diagnostic
     .with_cli_observed_exit(CliObservedExitDiagnostic::from_signal(libc::SIGKILL))
     .with_failure_detail_source(FailureDetailSource::FallbackExitCode);
     overrides.push_read_file_result(Ok(Some(serde_json::to_vec(&diagnostic).unwrap())));
-    overrides.push_read_file_result(Ok(None));
+    overrides.push_read_file_result(Ok(Some(b"Agent exited with code 137".to_vec())));
     overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
         pattern: "guest-agent-binary".to_string(),
         exit_code: 0,

--- a/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/mod.rs
@@ -8,7 +8,8 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use api_contracts::generated::types::runners::storage::StorageManifest;
 use futures_util::FutureExt;
 use guest_contracts::diagnostics::{
-    AgentFramework, FailureClass, FailureDiagnostic, PromptMetadata,
+    AgentFramework, CliObservedExitDiagnostic, FailureClass, FailureDetailSource,
+    FailureDiagnostic, PromptMetadata,
 };
 use sandbox::{
     EXEC_OUTPUT_LIMIT_64_KIB, ExecResult, ExecTermination, ProcessControlMode, ProcessExit,


### PR DESCRIPTION
## Summary
- add optional cliObservedExit diagnostics to preserve raw CLI child exit status before signal exits are flattened
- attach observed exit data from guest-agent and expose cli_observed_* terminal runner log fields
- collect bounded resource diagnostics for unattributed SIGKILL-shaped CLI failures while preserving evidence-based OOM/resource classification

Fixes #20599

## Tests
- cargo test -p guest-contracts diagnostics
- cargo test -p guest-agent cli
- cargo test -p runner diagnostics
- cargo test -p runner job_spawn
- pre-commit lefthook: cargo-fmt, cargo-doc, cargo-clippy