### PR TITLE
fix: add codex web image upload prompt

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1743,6 +1743,10 @@ describe("CHAT-02: explicit provider pins", () => {
     const { claim } = await claimChatRun(runnerGroup, run.runId);
     const appendSystemPrompt = claim.appendSystemPrompt ?? "";
     expect(claim.cliAgentType).toBe("codex");
+    expect(appendSystemPrompt).toContain(
+      "You are currently running inside: Web",
+    );
+    expect(appendSystemPrompt).toContain("zero web upload-file -h");
     expect(appendSystemPrompt).toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);
     expect(appendSystemPrompt).not.toContain("When running in Codex");
     await cancelChatRun(actor, run.runId);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -72,6 +72,7 @@ const misc = createMiscRoutesApi(context);
 const routeMocks = createZeroRouteMocks(context);
 const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
+const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_ZERO_WEB_CHAT_PRE_CREATE_ACTION_TYPES = [
   "api_dispatch_pre_create_zero_web_chat_prepare_normal_send",
   "api_dispatch_pre_create_zero_web_chat_resolve_client_message",
@@ -1708,6 +1709,45 @@ describe("CHAT-02: admission without spendable credits", () => {
 });
 
 describe("CHAT-02: explicit provider pins", () => {
+  it("adds Codex image upload guidance for web chat Codex sends", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    await misc.upsertPersonalModelProvider(
+      actor,
+      {
+        type: "codex-oauth-token",
+        authMethod: "auth_json",
+        secrets: { CODEX_AUTH_JSON: codexAuthJson() },
+      },
+      [200, 201],
+    );
+    await api.updateOrgModelPolicies(actor, [
+      {
+        model: "gpt-5.4",
+        isDefault: true,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+        modelProviderId: null,
+      },
+    ]);
+
+    const run = await sendChatRun(actor, {
+      agentId,
+      prompt: "generate an image in web chat",
+      modelSelection: {
+        modelProviderId: MODEL_FIRST_SELECTION_PROVIDER_ID,
+        selectedModel: "gpt-5.4",
+      },
+    });
+    const { claim } = await claimChatRun(runnerGroup, run.runId);
+    const appendSystemPrompt = claim.appendSystemPrompt ?? "";
+    expect(claim.cliAgentType).toBe("codex");
+    expect(appendSystemPrompt).toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);
+    expect(appendSystemPrompt).not.toContain("When running in Codex");
+    await cancelChatRun(actor, run.runId);
+  });
+
   it("routes explicit provider pins into the runner claim", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     chatCallbacks.failIfChatCallbackRouteIsFetched();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2983,7 +2983,7 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("adds Codex image upload guidance only to web Codex runs", async () => {
+  it("does not add Codex image upload guidance outside web chat Codex runs", async () => {
     const api = createRunsAutomationsApi(context);
     const fw = createFirewallApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -2998,14 +2998,14 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
 
     const codexWebRun = await api.createRun(actor, {
       agentId,
-      prompt: "generate an image with codex",
+      prompt: "generate an image with codex without a chat thread",
       modelProvider: "codex-oauth-token",
     });
     await api.heartbeatRunner(runnerGroup);
     const codexWebClaim = await api.claimRunnerJob(codexWebRun.runId);
     const codexWebPrompt = codexWebClaim.appendSystemPrompt ?? "";
     expect(codexWebClaim.cliAgentType).toBe("codex");
-    expect(codexWebPrompt).toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);
+    expect(codexWebPrompt).not.toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);
     expect(codexWebPrompt).not.toContain("When running in Codex");
     await api.requestCancelRun(actor, codexWebRun.runId, [200]);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -74,6 +74,7 @@ const TEST_DATA_KEY = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
 // value the chat composer sends when picking a model instead of a provider).
 const MODEL_FIRST_SELECTION_PROVIDER_ID =
   "00000000-0000-4000-8000-000000000000";
+const CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET = "zero web upload-file -f <path>";
 const API_DISPATCH_QUEUE_PERSISTENCE_ACTION_TYPES = [
   "api_dispatch_persist_custom_connector_auth_refs",
   "api_dispatch_insert_runner_job_queue",
@@ -2980,6 +2981,62 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("adds Codex image upload guidance only to web Codex runs", async () => {
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await fw.seedOrgCodexProvider(actor, {
+      accessToken: "chatgpt-access-image-guidance",
+      refreshToken: "chatgpt-refresh-image-guidance",
+      accountId: "workspace-id-image-guidance",
+      idToken: "chatgpt-id-token-image-guidance",
+      expiresIn: 3600,
+    });
+
+    const codexWebRun = await api.createRun(actor, {
+      agentId,
+      prompt: "generate an image with codex",
+      modelProvider: "codex-oauth-token",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const codexWebClaim = await api.claimRunnerJob(codexWebRun.runId);
+    const codexWebPrompt = codexWebClaim.appendSystemPrompt ?? "";
+    expect(codexWebClaim.cliAgentType).toBe("codex");
+    expect(codexWebPrompt).toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);
+    expect(codexWebPrompt).not.toContain("When running in Codex");
+    await api.requestCancelRun(actor, codexWebRun.runId, [200]);
+
+    const claudeWebRun = await api.createRun(actor, {
+      agentId,
+      prompt: "generate an image with claude",
+      modelProvider: "anthropic-api-key",
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const claudeWebClaim = await api.claimRunnerJob(claudeWebRun.runId);
+    expect(claudeWebClaim.cliAgentType).toBe("claude-code");
+    expect(claudeWebClaim.appendSystemPrompt ?? "").not.toContain(
+      CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET,
+    );
+    await api.requestCancelRun(actor, claudeWebRun.runId, [200]);
+
+    const codexSlackRun = await api.createDirectRun(actor, {
+      agentComposeId: agentId,
+      prompt: "generate an image from slack",
+      modelProviderType: "codex-oauth-token",
+      triggerSource: "slack",
+      vars: { ZERO_AGENT_ID: agentId },
+      secrets: { ZERO_TOKEN: "bdd-zero-direct-token" },
+    });
+    await api.heartbeatRunner(runnerGroup);
+    const codexSlackClaim = await api.claimRunnerJob(codexSlackRun.runId);
+    expect(codexSlackClaim.cliAgentType).toBe("codex");
+    expect(codexSlackClaim.appendSystemPrompt ?? "").not.toContain(
+      CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET,
+    );
+    await api.requestCancelRun(actor, codexSlackRun.runId, [200]);
   });
 
   it("claims MiniMax Codex runs with structured runtime config", async () => {

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -246,7 +246,7 @@ type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 type RunAdmissionDb = Pick<Db, "select">;
 
 const CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT =
-  "If you use the built-in image generation tool and it saves one or more image files to local paths, upload each saved file with `zero web upload-file -f <path>` before telling the web chat user the image is available. Quote the path when needed. Do not provide only sandbox-local paths, because users cannot open local files.";
+  "If you use the built-in image generation tool and it saves generated output image file(s) to local paths, upload each output file you intend to show with `zero web upload-file -f <path>` before telling the web chat user the image is available. Quote the path when needed. Do not provide only sandbox-local paths, because users cannot open local files.";
 
 function withZeroTokenSecret(
   body: CreateRunBody,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -245,6 +245,9 @@ type CreateRunBody = z.infer<typeof unifiedRunRequestSchema>;
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 type RunAdmissionDb = Pick<Db, "select">;
 
+const CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT =
+  "If you use the built-in image generation tool and it saves an image to a local path, upload the saved image with `zero web upload-file -f <path>` before telling the web chat user the image is available. Do not provide only a sandbox-local path, because users cannot open local files.";
+
 function withZeroTokenSecret(
   body: CreateRunBody,
   zeroToken: string,
@@ -260,6 +263,27 @@ function withZeroTokenSecret(
 
 function withPendingZeroTokenSecret(body: CreateRunBody): CreateRunBody {
   return withZeroTokenSecret(body, "__pending_zero_token__");
+}
+
+function withFinalFrameworkAppendSystemPrompt(
+  body: CreateRunBody,
+  framework: SupportedFramework,
+): CreateRunBody {
+  if (framework !== "codex" || body.triggerSource !== "web") {
+    return body;
+  }
+
+  return {
+    ...body,
+    appendSystemPrompt: [
+      body.appendSystemPrompt,
+      CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT,
+    ]
+      .filter((part): part is string => {
+        return Boolean(part);
+      })
+      .join("\n\n"),
+  };
 }
 
 interface ContextArtifact {
@@ -6656,6 +6680,10 @@ function prepareRunContext(
       if (isRouteError(runtimeContext)) {
         return runtimeContext;
       }
+      const body = withFinalFrameworkAppendSystemPrompt(
+        bodyContext.body,
+        runtimeContext.framework,
+      );
 
       const validation = await timing.measure(
         "api_dispatch_prepare_context_validate_environment",
@@ -6664,7 +6692,7 @@ function prepareRunContext(
           return await Promise.resolve(
             validateRunEnvironmentReferences({
               resolved: bodyContext.resolved,
-              body: bodyContext.body,
+              body,
               modelProvider: runtimeContext.modelProvider,
               connectorContext: runtimeContext.connectorContext,
               customConnectorContext: runtimeContext.customConnectorContext,
@@ -6697,7 +6725,7 @@ function prepareRunContext(
               connectorScope: bodyContext.connectorScope,
               framework: runtimeContext.framework,
               featureSwitchContext: bodyContext.featureSwitchContext,
-              body: bodyContext.body,
+              body,
               resolved: bodyContext.resolved,
             }),
           );
@@ -6705,7 +6733,7 @@ function prepareRunContext(
       );
 
       return {
-        body: bodyContext.body,
+        body,
         resolved: bodyContext.resolved,
         framework: runtimeContext.framework,
         modelProvider: runtimeContext.modelProvider,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -246,7 +246,7 @@ type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 type RunAdmissionDb = Pick<Db, "select">;
 
 const CODEX_WEB_IMAGE_GENERATION_UPLOAD_PROMPT =
-  "If you use the built-in image generation tool and it saves an image to a local path, upload the saved image with `zero web upload-file -f <path>` before telling the web chat user the image is available. Do not provide only a sandbox-local path, because users cannot open local files.";
+  "If you use the built-in image generation tool and it saves one or more image files to local paths, upload each saved file with `zero web upload-file -f <path>` before telling the web chat user the image is available. Quote the path when needed. Do not provide only sandbox-local paths, because users cannot open local files.";
 
 function withZeroTokenSecret(
   body: CreateRunBody,
@@ -268,8 +268,9 @@ function withPendingZeroTokenSecret(body: CreateRunBody): CreateRunBody {
 function withFinalFrameworkAppendSystemPrompt(
   body: CreateRunBody,
   framework: SupportedFramework,
+  chatThreadId: string | undefined,
 ): CreateRunBody {
-  if (framework !== "codex" || body.triggerSource !== "web") {
+  if (framework !== "codex" || body.triggerSource !== "web" || !chatThreadId) {
     return body;
   }
 
@@ -6683,6 +6684,7 @@ function prepareRunContext(
       const body = withFinalFrameworkAppendSystemPrompt(
         bodyContext.body,
         runtimeContext.framework,
+        args.chatThreadId,
       );
 
       const validation = await timing.measure(


### PR DESCRIPTION
## Summary
- append Codex-specific web chat guidance after final framework resolution so Codex image generation outputs are uploaded with `zero web upload-file -f <path>`
- keep the guidance scoped to web-triggered Codex runs only
- add integration coverage for Codex web injection plus Claude web and Codex Slack non-injection

Closes #20619

## Tests
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "adds Codex image upload guidance"`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --workspace api`