### PR TITLE
refactor(mitm-addon): extract upstream admission owner

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -460,9 +460,9 @@ def _prebind_requestheaders_upstream_destination(
 
 
 def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) -> None:
-    api_url = getattr(getattr(ctx, "options", None), "vm0_api_url", None)
-    if not isinstance(api_url, str):
+    if getattr(ctx, "options", None) is None:
         return
+    api_url = get_api_url()
     metadata_snapshot = {
         key: flow.metadata[key]
         for key in _request_headers_probe_metadata_keys()

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -14,21 +14,17 @@ This addon runs on the runner HOST (not inside VMs) and:
 import asyncio
 import base64
 import binascii
-import functools
-import ipaddress
 import json
 import os
 import signal
-import socket
 import tempfile
 import threading
 import time
-import urllib.parse
 from collections.abc import Awaitable
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Literal
+from typing import Literal
 
 from mitmproxy import connection, ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
@@ -36,20 +32,18 @@ from mitmproxy.addonmanager import Loader
 # --- Sub-module imports ---
 #
 # auth_base_forwarder/body_capture/connector_diagnostics/matching/registry/
-# response_encoding_negotiation/response_streaming/terminal_usage/usage are
-# imported by module (not selective `from X import ...`)
-# so that:
+# response_encoding_negotiation/response_streaming/terminal_usage/upstream_admission/
+# usage are imported by module (not selective `from X import ...`) so that:
 #   1. Cross-module calls read as ``auth_base_forwarder.X(...)`` /
 #      ``body_capture.X(...)`` / ``connector_diagnostics.X(...)`` /
 #      ``matching.X(...)`` / ``registry.X(...)`` / ``response_streaming.X(...)`` /
-#      ``terminal_usage.X(...)`` / ``usage.X(...)``,
+#      ``terminal_usage.X(...)`` / ``upstream_admission.X(...)`` / ``usage.X(...)``,
 #      making the module boundary visible at call sites.
 #   2. Tests can patch names on the owning module object and affect all
 #      callers — no mock-placement pitfalls from copied function bindings.
 import auth_base_forwarder
 import body_capture
 import builtin_host_policy
-import connection_endpoints
 import connector_diagnostics
 import flow_metadata
 import flow_metadata_keys as metadata_keys
@@ -65,6 +59,7 @@ import response_encoding_negotiation
 import response_streaming
 import tcp_logging
 import terminal_usage
+import upstream_admission
 import upstream_destination_binding
 import usage
 from auth import (
@@ -95,14 +90,13 @@ from logging_utils import (
     log_proxy_entry,
     shutdown_log_writer,
 )
-from url_utils import AuthorityValidationError, get_trusted_authority, normalize_trusted_hostname
+from url_utils import AuthorityValidationError, get_trusted_authority
 
 # HTTP status boundaries used in response-phase classification.
 _HTTP_STATUS_UNAUTHORIZED = 401
 _HTTP_STATUS_BAD_GATEWAY = 502
 _HTTP_STATUS_ERROR_MIN = 400  # inclusive: start of 4xx/5xx error range
 _HTTP_OWS_CHARS = " \t"
-_TEST_ENDPOINT_BYPASS_HEADER: Final = "x-vm0-test-endpoint-bypass"
 
 # Request-header phase state.
 # Creator: requestheaders() and header-phase stream/auth helpers.
@@ -115,36 +109,7 @@ _FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS = "_firewall_auth_applied_in_requesthea
 _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 _WEBSOCKET_KEY_BYTES = 16
-_TLS_ADMISSION_VALID_REGISTRY_VM: Final = "valid_registry_vm"
-_TLS_ADMISSION_INVALID_REGISTRY_VM: Final = "invalid_registry_vm"
-_TLS_ADMISSION_REGISTRY_UNAVAILABLE: Final = "registry_unavailable"
-
-# Upstream binding diagnostics state.
-# Creator: _block_upstream_destination_unbound().
-# Consumer: _http_network_log_entry().
-# Release: no explicit pop before flow completion.
-# Follow-up owner: #20510 TLS upstream admission extraction.
-_UPSTREAM_BINDING_DIAGNOSTICS = "_upstream_binding_diagnostics"
-_TRUSTED_HOST_ADDRESS_CACHE_TTL_SECONDS: Final = 60.0
-_TRUSTED_HOST_ADDRESS_NEGATIVE_CACHE_TTL_SECONDS: Final = 5.0
-_TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES: Final = 512
-
-_TlsAdmissionKind = Literal[
-    "valid_registry_vm",
-    "invalid_registry_vm",
-    "registry_unavailable",
-]
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
-_trusted_host_address_cache: dict[tuple[str, int], tuple[float, frozenset[str]]] = {}
-_trusted_host_address_lookup_tasks: dict[tuple[str, int], asyncio.Task[frozenset[str]]] = {}
-
-
-@dataclass(frozen=True)
-class _TlsAdmission:
-    client_ip: str
-    kind: _TlsAdmissionKind
-    run_id: str | None = None
-    sni: str | None = None
 
 
 @dataclass(frozen=True)
@@ -153,8 +118,6 @@ class _AuthBaseBodyCheck:
     observed_size: int = 0
     reason: str = ""
 
-
-_tls_admissions: dict[str, _TlsAdmission] = {}
 
 # Runner-triggered flush protocols:
 # - Rust writes `usage-flush-request` with the active usageStateId and a fresh
@@ -456,7 +419,7 @@ def _classify_request_for_flow(
         flow,
         registry_path=get_registry_path(),
         api_url=get_api_url(),
-        tls_admission=_tls_admission_for_client(flow.client_conn),
+        tls_admission=upstream_admission.tls_admission_for_client(flow.client_conn),
         defer_unresolved_public_destination=defer_unresolved_public_destination,
     )
 
@@ -468,7 +431,7 @@ def _request_classification_for_flow(
         flow,
         registry_path=get_registry_path(),
         api_url=get_api_url(),
-        tls_admission=_tls_admission_for_client(flow.client_conn),
+        tls_admission=upstream_admission.tls_admission_for_client(flow.client_conn),
     )
 
 
@@ -478,17 +441,29 @@ def _prebind_requestheaders_upstream_destination(
 ) -> None:
     """Bind privileged upstreams while requestheaders can still retarget."""
     if classification.kind == "api_allow":
-        _ensure_bound_upstream_destination(flow, kind="api_allow")
+        upstream_admission.ensure_bound_destination(
+            flow,
+            kind="api_allow",
+            api_url=get_api_url(),
+        )
         return
     if classification.kind != "firewall_allow":
         return
     allow = classification.firewall_allow
     if allow is None or not _firewall_allow_injects_ordinary_upstream_credentials(allow):
         return
-    _ensure_bound_upstream_destination(flow, kind="connector_auth")
+    upstream_admission.ensure_bound_destination(
+        flow,
+        kind="connector_auth",
+        api_url=get_api_url(),
+    )
 
 
 def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) -> None:
+    try:
+        api_url = get_api_url()
+    except AttributeError:
+        return
     metadata_snapshot = {
         key: flow.metadata[key]
         for key in _request_headers_probe_metadata_keys()
@@ -500,17 +475,22 @@ def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) ->
         except AuthorityValidationError:
             return
         flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = trusted_authority.host
-        if _api_hostname_matches(trusted_authority.host) and not flow.request.path.startswith(
-            "/api/test/"
-        ):
+        if upstream_admission.api_hostname_matches(
+            api_url,
+            trusted_authority.host,
+        ) and not flow.request.path.startswith("/api/test/"):
             classification = _classify_request_for_flow(
                 flow,
                 defer_unresolved_public_destination=True,
             )
             if classification.kind == "api_allow":
-                _ensure_bound_upstream_destination(flow, kind="api_allow")
+                upstream_admission.ensure_bound_destination(
+                    flow,
+                    kind="api_allow",
+                    api_url=api_url,
+                )
             return
-        if _has_bound_upstream_destination(
+        if upstream_admission.has_bound_destination(
             flow,
             allowed_kinds=frozenset(("connector_auth",)),
         ):
@@ -572,113 +552,6 @@ def _builtin_host_policy_error_for_firewall_allow(
     except builtin_host_policy.BuiltinRuntimeHostPolicyError as e:
         return e
     return None
-
-
-def _has_bound_upstream_destination(
-    flow: http.HTTPFlow,
-    *,
-    allowed_kinds: frozenset[upstream_destination_binding.BindingKind],
-) -> bool:
-    return upstream_destination_binding.flow_matches_bound_destination(
-        flow,
-        allowed_kinds=allowed_kinds,
-    )
-
-
-def _bind_flow_upstream_destination(
-    flow: http.HTTPFlow,
-    *,
-    kind: upstream_destination_binding.BindingKind,
-) -> bool:
-    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
-    if not trusted_host:
-        return False
-    try:
-        normalized_host = normalize_trusted_hostname(trusted_host)
-    except (UnicodeError, ValueError):
-        return False
-
-    original_address = connection_endpoints.server_address(flow.server_conn)
-    has_server_binding = upstream_destination_binding.has_server_binding(flow.server_conn)
-    if _requires_platform_connector_auth_bypass(
-        kind=kind,
-        normalized_host=normalized_host,
-    ) and not _request_allows_platform_connector_auth(flow):
-        return False
-
-    if has_server_binding:
-        if upstream_destination_binding.add_server_binding_kind_if_matching(
-            flow.server_conn,
-            client=flow.client_conn,
-            host=normalized_host,
-            port=flow.request.port,
-            kind=kind,
-        ):
-            return True
-        if flow.server_conn.connected:
-            connected_address = _connected_verified_tls_destination_endpoint(
-                flow.server_conn,
-                host=normalized_host,
-                port=flow.request.port,
-                extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
-            )
-            if connected_address is None:
-                return False
-            return (
-                upstream_destination_binding.refresh_server_binding_connected_address_if_matching(
-                    flow.server_conn,
-                    client=flow.client_conn,
-                    host=normalized_host,
-                    port=flow.request.port,
-                    kind=kind,
-                    connected_address=connected_address,
-                )
-            )
-        return False
-
-    if flow.server_conn.connected:
-        connected_address = _connected_verified_tls_destination_endpoint(
-            flow.server_conn,
-            host=normalized_host,
-            port=flow.request.port,
-            extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
-        )
-        if connected_address is None:
-            return False
-        original_address = connected_address
-    else:
-        flow.server_conn.address = (normalized_host, flow.request.port)
-
-    upstream_destination_binding.record_server_binding(
-        flow.server_conn,
-        client=flow.client_conn,
-        host=normalized_host,
-        port=flow.request.port,
-        kinds=frozenset((kind,)),
-        original_address=original_address,
-    )
-    return True
-
-
-def _ensure_bound_upstream_destination(
-    flow: http.HTTPFlow,
-    *,
-    kind: upstream_destination_binding.BindingKind,
-) -> bool:
-    if _flow_requires_platform_connector_auth_bypass(
-        flow,
-        kind=kind,
-    ) and not _request_allows_platform_connector_auth(flow):
-        return False
-
-    allowed_kinds = frozenset((kind,))
-    has_bound_destination = _has_bound_upstream_destination(flow, allowed_kinds=allowed_kinds)
-    if has_bound_destination and upstream_destination_binding.has_server_binding(flow.server_conn):
-        return True
-    # If has_bound_destination is true here, it is only an unconnected address
-    # or prior-client match. That is retargetable, not durable proof for later
-    # keepalive reuse, and connected flows still need current upstream TLS proof.
-    return _bind_flow_upstream_destination(flow, kind=kind)
 
 
 def _auth_base_body_header_check(flow: http.HTTPFlow) -> _AuthBaseBodyCheck:
@@ -792,11 +665,7 @@ def _http_network_log_entry(
     firewall_error = flow_metadata.firewall_error(flow.metadata)
     if firewall_error is not None:
         entry["firewall_error"] = firewall_error
-    upstream_binding_diagnostics = flow.metadata.get(_UPSTREAM_BINDING_DIAGNOSTICS)
-    if isinstance(upstream_binding_diagnostics, dict):
-        for key, value in upstream_binding_diagnostics.items():
-            if isinstance(value, (str, int, bool)):
-                entry[f"upstream_binding_{key}"] = value
+    entry.update(upstream_admission.upstream_binding_log_fields(flow))
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
         entry["browser_user_agent"] = True
     return entry
@@ -830,8 +699,7 @@ def _block_upstream_destination_unbound(
     reason: upstream_destination_binding.BindingKind,
 ) -> None:
     server_address = getattr(flow.server_conn, "address", None)
-    diagnostics = _upstream_binding_diagnostics(flow, reason=reason)
-    flow.metadata[_UPSTREAM_BINDING_DIAGNOSTICS] = diagnostics
+    diagnostics = upstream_admission.record_unbound_diagnostics(flow, reason=reason)
     http_local_responses.block_upstream_destination_unbound(
         flow,
         reason=reason,
@@ -865,473 +733,20 @@ def _endpoint_text(address: tuple[str, int] | None) -> str:
     return f"{host}:{port}"
 
 
-def _upstream_binding_diagnostics(
-    flow: http.HTTPFlow,
-    *,
-    reason: upstream_destination_binding.BindingKind,
-) -> dict[str, object]:
-    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
-    diagnostics = upstream_destination_binding.diagnostic_snapshot_for_flow(
-        flow,
-        allowed_kinds=frozenset((reason,)),
-    )
-    diagnostics.update(
-        {
-            "reason": reason,
-            "trusted_host": trusted_host,
-            "request_host": flow.request.host,
-            "request_port": flow.request.port,
-            "server_connected": bool(getattr(flow.server_conn, "connected", False)),
-            "server_address": _endpoint_text(connection_endpoints.server_address(flow.server_conn)),
-            "server_peername": _endpoint_text(
-                connection_endpoints.server_peername(flow.server_conn)
-            ),
-            "server_sockname": _endpoint_text(
-                connection_endpoints.connection_sockname(flow.server_conn)
-            ),
-            "client_sockname": _endpoint_text(
-                connection_endpoints.connection_sockname(flow.client_conn)
-            ),
-        }
-    )
-    return diagnostics
-
-
-def _client_connection_id(client: object) -> str | None:
-    client_id = getattr(client, "id", None)
-    if isinstance(client_id, str) and client_id:
-        return client_id
-    return None
-
-
-def _record_tls_admission(client: object, admission: _TlsAdmission) -> None:
-    client_id = _client_connection_id(client)
-    if client_id is not None:
-        _tls_admissions[client_id] = admission
-
-
-def _tls_admission_for_client(client: object) -> _TlsAdmission | None:
-    client_id = _client_connection_id(client)
-    if client_id is None:
-        return None
-    return _tls_admissions.get(client_id)
-
-
-def _forget_tls_admission(client: object) -> None:
-    client_id = _client_connection_id(client)
-    if client_id is not None:
-        _tls_admissions.pop(client_id, None)
-
-
-def reset_tls_admission_state_for_tests() -> None:
-    _tls_admissions.clear()
-
-
-def _ip_address_text(host: str) -> str | None:
-    try:
-        address = ipaddress.ip_address(host)
-    except ValueError:
-        return None
-    return str(address)
-
-
-def _trusted_host_address_cache_time() -> float:
-    return time.monotonic()
-
-
-def _cached_trusted_host_addresses(
-    cache_key: tuple[str, int],
-    *,
-    now: float,
-) -> frozenset[str] | None:
-    cached = _trusted_host_address_cache.get(cache_key)
-    if cached is not None:
-        expires_at, cached_addresses = cached
-        if expires_at > now:
-            return cached_addresses
-        _trusted_host_address_cache.pop(cache_key, None)
-    return None
-
-
-def _cache_trusted_host_addresses(
-    cache_key: tuple[str, int],
-    addresses: frozenset[str],
-    *,
-    now: float,
-) -> None:
-    if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
-        expired_keys = [
-            key
-            for key, (expires_at, _addresses) in _trusted_host_address_cache.items()
-            if expires_at <= now
-        ]
-        for key in expired_keys:
-            _trusted_host_address_cache.pop(key, None)
-        if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
-            _trusted_host_address_cache.pop(next(iter(_trusted_host_address_cache)), None)
-
-    ttl = (
-        _TRUSTED_HOST_ADDRESS_CACHE_TTL_SECONDS
-        if addresses
-        else _TRUSTED_HOST_ADDRESS_NEGATIVE_CACHE_TTL_SECONDS
-    )
-    _trusted_host_address_cache[cache_key] = (now + ttl, addresses)
-
-
-def _resolve_trusted_host_addresses_sync(host: str, port: int) -> frozenset[str]:
-    try:
-        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
-    except OSError:
-        return frozenset()
-
-    address_set: set[str] = set()
-    for info in infos:
-        sockaddr = info[4]
-        if not sockaddr:
-            continue
-        sockaddr_host = sockaddr[0]
-        if not isinstance(sockaddr_host, str):
-            continue
-        resolved_ip = _ip_address_text(sockaddr_host)
-        if resolved_ip is not None:
-            address_set.add(resolved_ip)
-
-    return frozenset(address_set)
-
-
-def _complete_trusted_host_address_lookup(
-    cache_key: tuple[str, int],
-    task: asyncio.Task[frozenset[str]],
-) -> None:
-    if _trusted_host_address_lookup_tasks.get(cache_key) is not task:
-        return
-    _trusted_host_address_lookup_tasks.pop(cache_key, None)
-    if task.cancelled():
-        return
-    resolved_addresses = task.result()
-    _cache_trusted_host_addresses(
-        cache_key,
-        resolved_addresses,
-        now=_trusted_host_address_cache_time(),
-    )
-
-
-async def _resolved_trusted_host_addresses(host: str, port: int) -> frozenset[str]:
-    cache_key = (host, port)
-    cached = _cached_trusted_host_addresses(cache_key, now=_trusted_host_address_cache_time())
-    if cached is not None:
-        return cached
-
-    lookup_task = _trusted_host_address_lookup_tasks.get(cache_key)
-    if lookup_task is None:
-        lookup_task = asyncio.create_task(
-            asyncio.to_thread(_resolve_trusted_host_addresses_sync, host, port)
-        )
-        _trusted_host_address_lookup_tasks[cache_key] = lookup_task
-        lookup_task.add_done_callback(
-            functools.partial(_complete_trusted_host_address_lookup, cache_key)
-        )
-
-    return await asyncio.shield(lookup_task)
-
-
-def _connected_verified_tls_destination_endpoint(
-    server: object,
-    *,
-    host: str,
-    port: int,
-    extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
-) -> tuple[str, int] | None:
-    if bool(getattr(getattr(ctx, "options", object()), "ssl_insecure", False)):
-        return None
-    if not bool(getattr(server, "tls_established", False)):
-        return None
-    if getattr(server, "error", None):
-        return None
-    server_sni = getattr(server, "sni", None)
-    if not isinstance(server_sni, str):
-        return None
-    try:
-        normalized_sni = normalize_trusted_hostname(server_sni)
-    except (UnicodeError, ValueError):
-        return None
-    if normalized_sni != host:
-        return None
-    if not getattr(server, "certificate_list", ()):
-        return None
-
-    # mitmproxy verifies the upstream certificate against server.sni when
-    # ssl_insecure is false. At this point the connected IP is authenticated as
-    # the same host we plan to bind, so CDN/Anycast DNS drift does not matter.
-    return connection_endpoints.connected_ip_destination_endpoint(
-        server,
-        port=port,
-        extra_endpoints=extra_endpoints,
-    )
-
-
-def _request_has_platform_test_endpoint_bypass(flow: http.HTTPFlow) -> bool:
-    if not flow.request.path.startswith("/api/test/"):
-        return False
-    expected_bypass = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
-    if not expected_bypass:
-        return False
-    return flow.request.headers.get(_TEST_ENDPOINT_BYPASS_HEADER) == expected_bypass
-
-
-def _request_allows_platform_connector_auth(flow: http.HTTPFlow) -> bool:
-    # Synthetic test providers live on the platform API preview host but
-    # intentionally exercise connector auth injection instead of API auto-allow.
-    # Keep this path limited to test endpoints gated by the same internal
-    # bypass secret that the API route validates.
-    return _request_has_platform_test_endpoint_bypass(flow)
-
-
-def _requires_platform_connector_auth_bypass(
-    *,
-    kind: upstream_destination_binding.BindingKind,
-    normalized_host: str,
-) -> bool:
-    return kind == "connector_auth" and _api_hostname_matches(normalized_host)
-
-
-def _flow_requires_platform_connector_auth_bypass(
-    flow: http.HTTPFlow,
-    *,
-    kind: upstream_destination_binding.BindingKind,
-) -> bool:
-    if kind != "connector_auth":
-        return False
-    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
-    if not trusted_host:
-        return False
-    try:
-        normalized_host = normalize_trusted_hostname(trusted_host)
-    except (UnicodeError, ValueError):
-        return False
-    return _requires_platform_connector_auth_bypass(
-        kind=kind,
-        normalized_host=normalized_host,
-    )
-
-
-def reset_upstream_destination_resolution_cache_for_tests() -> None:
-    _trusted_host_address_cache.clear()
-    _trusted_host_address_lookup_tasks.clear()
-
-
-def _api_hostname_matches(hostname: str) -> bool:
-    api_destination = _api_destination()
-    if api_destination is None:
-        return False
-    api_hostname, _api_port = api_destination
-    return hostname == api_hostname or hostname.endswith(f".{api_hostname}")
-
-
-def _api_destination() -> tuple[str, int] | None:
-    try:
-        api_url = get_api_url()
-    except AttributeError:
-        return None
-    if not api_url:
-        return None
-    parsed_api = urllib.parse.urlparse(api_url)
-    if not parsed_api.hostname:
-        return None
-    try:
-        api_hostname = normalize_trusted_hostname(parsed_api.hostname)
-    except (UnicodeError, ValueError):
-        return None
-    if parsed_api.port is not None:
-        api_port = parsed_api.port
-    elif parsed_api.scheme.lower() == "http":
-        api_port = 80
-    else:
-        api_port = 443
-    return api_hostname, api_port
-
-
-async def _address_resolves_to_trusted_host(
-    address: tuple[str, int] | None,
-    *,
-    host: str,
-    port: int,
-) -> bool:
-    if address is None:
-        return False
-    address_host, address_port = address
-    if address_port != port:
-        return False
-    address_ip = _ip_address_text(address_host)
-    if address_ip is None:
-        return False
-    return address_ip in await _resolved_trusted_host_addresses(host, port)
-
-
-async def _bind_api_upstream_destination_from_original_address(
-    *,
-    client: object,
-    server: connection.Server,
-) -> bool:
-    if bool(getattr(server, "connected", False)):
-        return False
-
-    api_destination = _api_destination()
-    if api_destination is None:
-        return False
-    api_hostname, api_port = api_destination
-
-    original_address = None
-    for candidate_address in (
-        connection_endpoints.server_address(server),
-        connection_endpoints.connection_sockname(client),
-    ):
-        if await _address_resolves_to_trusted_host(
-            candidate_address,
-            host=api_hostname,
-            port=api_port,
-        ):
-            original_address = candidate_address
-            break
-    if original_address is None:
-        return False
-
-    server.address = (api_hostname, api_port)
-    upstream_destination_binding.record_server_binding(
-        server,
-        client=client,
-        host=api_hostname,
-        port=api_port,
-        kinds=frozenset(("api_allow",)),
-        original_address=original_address,
-    )
-    return True
-
-
-def _server_connect_binding_kinds(
-    *,
-    hostname: str,
-    port: int,
-    compiled_firewalls: matching.CompiledFirewallSet | None,
-) -> frozenset[upstream_destination_binding.BindingKind]:
-    kinds: set[upstream_destination_binding.BindingKind] = set()
-    is_api_host = _api_hostname_matches(hostname)
-    if is_api_host:
-        kinds.add("api_allow")
-    if (
-        not is_api_host
-        and compiled_firewalls is not None
-        and compiled_firewalls.matches_ordinary_credential_authority(
-            hostname,
-            port,
-        )
-    ):
-        kinds.add("connector_auth")
-    return frozenset(kinds)
-
-
-def _bind_privileged_upstream_destination(
-    *,
-    client: object,
-    server: connection.Server,
-    raw_sni: object,
-    registry_state: registry.RegistryState,
-    client_ip: str,
-    run_id: str,
-) -> None:
-    if isinstance(registry_state, registry.RegistryUnavailable):
-        return
-
-    tls_admission = _tls_admission_for_client(client)
-    if tls_admission is not None and (
-        tls_admission.client_ip != client_ip
-        or tls_admission.kind != _TLS_ADMISSION_VALID_REGISTRY_VM
-        or (tls_admission.run_id is not None and tls_admission.run_id != run_id)
-    ):
-        return
-
-    if not isinstance(raw_sni, str) or not raw_sni.strip():
-        return
-    try:
-        hostname = normalize_trusted_hostname(raw_sni.strip())
-    except (UnicodeError, ValueError):
-        return
-
-    address = connection_endpoints.server_address(server)
-    if address is None:
-        return
-    _original_host, port = address
-
-    kinds = _server_connect_binding_kinds(
-        hostname=hostname,
-        port=port,
-        compiled_firewalls=registry_state.compiled_firewalls.get(client_ip),
-    )
-    if not kinds:
-        return
-
-    if bool(getattr(server, "connected", False)):
-        return
-
-    server.address = (hostname, port)
-
-    upstream_destination_binding.record_server_binding(
-        server,
-        client=client,
-        host=hostname,
-        port=port,
-        kinds=kinds,
-        original_address=address,
-    )
-
-
 async def server_connect(data: object) -> None:
-    """Bind privileged HTTPS upstream connections to their trusted SNI host."""
-    client = getattr(data, "client", None)
-    server = getattr(data, "server", None)
-    if client is None or server is None:
-        return
-
-    client_ip = client.peername[0] if getattr(client, "peername", None) else None
-    if not client_ip:
-        return
-
-    registry_state = registry.load_registry_state(get_registry_path())
-    if isinstance(registry_state, registry.RegistryUnavailable):
-        return
-
-    vm_info = registry_state.vms.get(client_ip)
-    if vm_info is None:
-        return
-
-    run_id = vm_info.get("runId", "")
-    tls_admission = _tls_admission_for_client(client)
-    raw_sni = getattr(client, "sni", None)
-    if not raw_sni and tls_admission is not None:
-        raw_sni = tls_admission.sni
-    if not raw_sni and await _bind_api_upstream_destination_from_original_address(
-        client=client,
-        server=server,
-    ):
-        return
-    _bind_privileged_upstream_destination(
-        client=client,
-        server=server,
-        raw_sni=raw_sni,
-        registry_state=registry_state,
-        client_ip=client_ip,
-        run_id=run_id,
+    await upstream_admission.handle_server_connect(
+        data,
+        registry_path=get_registry_path(),
+        api_url=get_api_url(),
     )
 
 
 def server_disconnected(data: object) -> None:
-    server = getattr(data, "server", data)
-    upstream_destination_binding.forget_server_binding(server)
+    upstream_admission.forget_server_binding_from_event(data)
 
 
 def server_connect_error(data: object) -> None:
-    server = getattr(data, "server", data)
-    upstream_destination_binding.forget_server_binding(server)
+    upstream_admission.forget_server_binding_from_event(data)
 
 
 # ============================================================================
@@ -1340,68 +755,15 @@ def server_connect_error(data: object) -> None:
 
 
 def tls_clienthello(data: tls.ClientHelloData) -> None:
-    """
-    Handle TLS ClientHello — decide whether to MITM intercept.
-    All registered VMs use MITM mode for HTTP-level filtering and logging.
-    Unregistered IPs are passed through without interception.
-    """
-    client_ip = data.context.client.peername[0] if data.context.client.peername else None
-    if not client_ip:
-        return
-
-    registry_state = registry.load_registry_state(get_registry_path())
-    if isinstance(registry_state, registry.RegistryUnavailable):
-        _record_tls_admission(
-            data.context.client,
-            _TlsAdmission(
-                client_ip=client_ip,
-                kind=_TLS_ADMISSION_REGISTRY_UNAVAILABLE,
-            ),
-        )
-        return
-
-    vm_info = registry_state.vms.get(client_ip)
-    if vm_info is not None:
-        run_id = vm_info.get("runId", "")
-        raw_sni = data.client_hello.sni
-        _record_tls_admission(
-            data.context.client,
-            _TlsAdmission(
-                client_ip=client_ip,
-                kind=_TLS_ADMISSION_VALID_REGISTRY_VM,
-                run_id=run_id,
-                sni=raw_sni if isinstance(raw_sni, str) else None,
-            ),
-        )
-        _bind_privileged_upstream_destination(
-            client=data.context.client,
-            server=data.context.server,
-            raw_sni=raw_sni,
-            registry_state=registry_state,
-            client_ip=client_ip,
-            run_id=run_id,
-        )
-        return
-
-    if client_ip in registry_state.invalid_vms:
-        _record_tls_admission(
-            data.context.client,
-            _TlsAdmission(
-                client_ip=client_ip,
-                kind=_TLS_ADMISSION_INVALID_REGISTRY_VM,
-            ),
-        )
-        return
-
-    # Not a registered VM - pass through without MITM interception.
-    # This is critical for CIDR-based rules where all VM traffic is redirected.
-    _forget_tls_admission(data.context.client)
-    data.ignore_connection = True
+    upstream_admission.handle_tls_clienthello(
+        data,
+        registry_path=get_registry_path(),
+        api_url=get_api_url(),
+    )
 
 
 def client_disconnected(client: connection.Client) -> None:
-    _forget_tls_admission(client)
-    upstream_destination_binding.forget_client_bindings(client)
+    upstream_admission.forget_client(client)
 
 
 # ============================================================================
@@ -1441,13 +803,13 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
                 send_response=False,
             )
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-            upstream_destination_binding.forget_server_binding(flow.server_conn)
+            upstream_admission.forget_server_binding(flow.server_conn)
             flow.kill()
         return None
 
     if connector_diagnostics.maybe_make_firewall_allow_local_response(flow, classification):
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-        upstream_destination_binding.forget_server_binding(flow.server_conn)
+        upstream_admission.forget_server_binding(flow.server_conn)
         return None
 
     _prebind_requestheaders_upstream_destination(flow, classification)
@@ -1478,7 +840,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             )
         request_classification.pop_cached_classification(flow)
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-        upstream_destination_binding.forget_server_binding(flow.server_conn)
+        upstream_admission.forget_server_binding(flow.server_conn)
         flow.kill()
         return None
 
@@ -1508,7 +870,7 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             )
             request_classification.pop_cached_classification(flow)
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-            upstream_destination_binding.forget_server_binding(flow.server_conn)
+            upstream_admission.forget_server_binding(flow.server_conn)
             flow.kill()
             return None
         try:
@@ -1520,9 +882,10 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         return None
 
     if request_classification.should_stream_capture_request(classification):
-        if classification.kind == "api_allow" and not _ensure_bound_upstream_destination(
+        if classification.kind == "api_allow" and not upstream_admission.ensure_bound_destination(
             flow,
             kind="api_allow",
+            api_url=get_api_url(),
         ):
             _restore_request_headers_probe_metadata(flow, metadata_snapshot)
             return None
@@ -1556,7 +919,11 @@ async def _try_firewall_request_stream_capture_from_headers(
         return
     if _firewall_allow_injects_ordinary_upstream_credentials(
         allow
-    ) and not _ensure_bound_upstream_destination(flow, kind="connector_auth"):
+    ) and not upstream_admission.ensure_bound_destination(
+        flow,
+        kind="connector_auth",
+        api_url=get_api_url(),
+    ):
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
         return
     if _builtin_host_policy_error_for_firewall_allow(flow, allow) is not None:
@@ -1569,7 +936,7 @@ async def _try_firewall_request_stream_capture_from_headers(
         result = await try_apply_stream_safe_firewall_auth_for_requestheaders(flow, allow, vm_info)
     except (asyncio.CancelledError, Exception):
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
-        upstream_destination_binding.forget_server_binding(flow.server_conn)
+        upstream_admission.forget_server_binding(flow.server_conn)
         raise
     if result is not FirewallHeaderPhaseAuthResult.APPLIED:
         _restore_request_headers_probe_metadata(flow, metadata_snapshot)
@@ -1619,13 +986,13 @@ async def request(flow: http.HTTPFlow) -> None:
 
     if flow.metadata.get(_REQUEST_HEADERS_TERMINATED):
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
-        upstream_destination_binding.forget_server_binding(flow.server_conn)
+        upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
         return
 
     if flow.response is not None or flow.error is not None:
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
-        upstream_destination_binding.forget_server_binding(flow.server_conn)
+        upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
         return
 
@@ -1662,7 +1029,11 @@ async def request(flow: http.HTTPFlow) -> None:
                 _block_authority_validation_error(flow, authority_error)
             return
         if classification.kind == "api_allow":
-            if not _ensure_bound_upstream_destination(flow, kind="api_allow"):
+            if not upstream_admission.ensure_bound_destination(
+                flow,
+                kind="api_allow",
+                api_url=get_api_url(),
+            ):
                 _block_upstream_destination_unbound(flow, reason="api_allow")
                 return
             flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
@@ -1709,7 +1080,11 @@ async def request(flow: http.HTTPFlow) -> None:
                 return
             if _firewall_allow_injects_ordinary_upstream_credentials(
                 allow
-            ) and not _ensure_bound_upstream_destination(flow, kind="connector_auth"):
+            ) and not upstream_admission.ensure_bound_destination(
+                flow,
+                kind="connector_auth",
+                api_url=get_api_url(),
+            ):
                 prepare_firewall_metadata(flow, allow, vm_info)
                 _block_upstream_destination_unbound(flow, reason="connector_auth")
                 return
@@ -1752,12 +1127,12 @@ async def request(flow: http.HTTPFlow) -> None:
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)
-        upstream_destination_binding.forget_server_binding(flow.server_conn)
+        upstream_admission.forget_server_binding(flow.server_conn)
         terminal_usage.release_tracked_flow(flow)
         raise
     finally:
         if flow.response is not None or flow.error is not None:
-            upstream_destination_binding.forget_server_binding(flow.server_conn)
+            upstream_admission.forget_server_binding(flow.server_conn)
         request_classification.pop_cached_classification(flow)
 
 
@@ -1952,7 +1327,7 @@ def _release_terminal_flow_state(
     response_streaming.release_response_stream_state(flow)
     auth_base_forwarder.release_forward_request_admission_from_flow(flow)
     if flow.error is not None:
-        upstream_destination_binding.forget_server_binding(flow.server_conn)
+        upstream_admission.forget_server_binding(flow.server_conn)
     if release_tracking:
         terminal_usage.release_tracked_flow(flow)
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -460,9 +460,8 @@ def _prebind_requestheaders_upstream_destination(
 
 
 def _prebind_bounded_requestheaders_upstream_destination(flow: http.HTTPFlow) -> None:
-    try:
-        api_url = get_api_url()
-    except AttributeError:
+    api_url = getattr(getattr(ctx, "options", None), "vm0_api_url", None)
+    if not isinstance(api_url, str):
         return
     metadata_snapshot = {
         key: flow.metadata[key]

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -1,0 +1,734 @@
+"""TLS and upstream destination admission lifecycle owner."""
+
+import asyncio
+import functools
+import ipaddress
+import os
+import socket
+import time
+import urllib.parse
+from dataclasses import dataclass
+from typing import Final, Literal
+
+from mitmproxy import connection, ctx, http, tls
+
+import connection_endpoints
+import flow_metadata
+import matching
+import registry
+import upstream_destination_binding
+from url_utils import normalize_trusted_hostname
+
+TLS_ADMISSION_VALID_REGISTRY_VM: Final = "valid_registry_vm"
+TLS_ADMISSION_INVALID_REGISTRY_VM: Final = "invalid_registry_vm"
+TLS_ADMISSION_REGISTRY_UNAVAILABLE: Final = "registry_unavailable"
+
+_TEST_ENDPOINT_BYPASS_HEADER: Final = "x-vm0-test-endpoint-bypass"
+_UPSTREAM_BINDING_DIAGNOSTICS = "_upstream_binding_diagnostics"
+_TRUSTED_HOST_ADDRESS_CACHE_TTL_SECONDS: Final = 60.0
+_TRUSTED_HOST_ADDRESS_NEGATIVE_CACHE_TTL_SECONDS: Final = 5.0
+_TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES: Final = 512
+
+TlsAdmissionKind = Literal[
+    "valid_registry_vm",
+    "invalid_registry_vm",
+    "registry_unavailable",
+]
+
+_trusted_host_address_cache: dict[tuple[str, int], tuple[float, frozenset[str]]] = {}
+_trusted_host_address_lookup_tasks: dict[tuple[str, int], asyncio.Task[frozenset[str]]] = {}
+_tls_admissions: dict[str, "TlsAdmission"] = {}
+
+
+@dataclass(frozen=True)
+class TlsAdmission:
+    client_ip: str
+    kind: TlsAdmissionKind
+    run_id: str | None = None
+    sni: str | None = None
+
+
+def _client_connection_id(client: object) -> str | None:
+    client_id = getattr(client, "id", None)
+    if isinstance(client_id, str) and client_id:
+        return client_id
+    return None
+
+
+def record_tls_admission(client: object, admission: TlsAdmission) -> None:
+    client_id = _client_connection_id(client)
+    if client_id is not None:
+        _tls_admissions[client_id] = admission
+
+
+def tls_admission_for_client(client: object) -> TlsAdmission | None:
+    client_id = _client_connection_id(client)
+    if client_id is None:
+        return None
+    return _tls_admissions.get(client_id)
+
+
+def forget_tls_admission(client: object) -> None:
+    client_id = _client_connection_id(client)
+    if client_id is not None:
+        _tls_admissions.pop(client_id, None)
+
+
+def reset_tls_admission_state_for_tests() -> None:
+    _tls_admissions.clear()
+
+
+def _ip_address_text(host: str) -> str | None:
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return None
+    return str(address)
+
+
+def trusted_host_address_cache_time() -> float:
+    return time.monotonic()
+
+
+def _cached_trusted_host_addresses(
+    cache_key: tuple[str, int],
+    *,
+    now: float,
+) -> frozenset[str] | None:
+    cached = _trusted_host_address_cache.get(cache_key)
+    if cached is not None:
+        expires_at, cached_addresses = cached
+        if expires_at > now:
+            return cached_addresses
+        _trusted_host_address_cache.pop(cache_key, None)
+    return None
+
+
+def _cache_trusted_host_addresses(
+    cache_key: tuple[str, int],
+    addresses: frozenset[str],
+    *,
+    now: float,
+) -> None:
+    if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
+        expired_keys = [
+            key
+            for key, (expires_at, _addresses) in _trusted_host_address_cache.items()
+            if expires_at <= now
+        ]
+        for key in expired_keys:
+            _trusted_host_address_cache.pop(key, None)
+        if len(_trusted_host_address_cache) >= _TRUSTED_HOST_ADDRESS_CACHE_MAX_ENTRIES:
+            _trusted_host_address_cache.pop(next(iter(_trusted_host_address_cache)), None)
+
+    ttl = (
+        _TRUSTED_HOST_ADDRESS_CACHE_TTL_SECONDS
+        if addresses
+        else _TRUSTED_HOST_ADDRESS_NEGATIVE_CACHE_TTL_SECONDS
+    )
+    _trusted_host_address_cache[cache_key] = (now + ttl, addresses)
+
+
+def _resolve_trusted_host_addresses_sync(host: str, port: int) -> frozenset[str]:
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except OSError:
+        return frozenset()
+
+    address_set: set[str] = set()
+    for info in infos:
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        sockaddr_host = sockaddr[0]
+        if not isinstance(sockaddr_host, str):
+            continue
+        resolved_ip = _ip_address_text(sockaddr_host)
+        if resolved_ip is not None:
+            address_set.add(resolved_ip)
+
+    return frozenset(address_set)
+
+
+def _complete_trusted_host_address_lookup(
+    cache_key: tuple[str, int],
+    task: asyncio.Task[frozenset[str]],
+) -> None:
+    if _trusted_host_address_lookup_tasks.get(cache_key) is not task:
+        return
+    _trusted_host_address_lookup_tasks.pop(cache_key, None)
+    if task.cancelled():
+        return
+    resolved_addresses = task.result()
+    _cache_trusted_host_addresses(
+        cache_key,
+        resolved_addresses,
+        now=trusted_host_address_cache_time(),
+    )
+
+
+async def resolved_trusted_host_addresses(host: str, port: int) -> frozenset[str]:
+    cache_key = (host, port)
+    cached = _cached_trusted_host_addresses(cache_key, now=trusted_host_address_cache_time())
+    if cached is not None:
+        return cached
+
+    lookup_task = _trusted_host_address_lookup_tasks.get(cache_key)
+    if lookup_task is None:
+        lookup_task = asyncio.create_task(
+            asyncio.to_thread(_resolve_trusted_host_addresses_sync, host, port)
+        )
+        _trusted_host_address_lookup_tasks[cache_key] = lookup_task
+        lookup_task.add_done_callback(
+            functools.partial(_complete_trusted_host_address_lookup, cache_key)
+        )
+
+    return await asyncio.shield(lookup_task)
+
+
+def reset_upstream_destination_resolution_cache_for_tests() -> None:
+    _trusted_host_address_cache.clear()
+    _trusted_host_address_lookup_tasks.clear()
+
+
+def _connected_verified_tls_destination_endpoint(
+    server: object,
+    *,
+    host: str,
+    port: int,
+    extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
+) -> tuple[str, int] | None:
+    if bool(getattr(getattr(ctx, "options", object()), "ssl_insecure", False)):
+        return None
+    if not bool(getattr(server, "tls_established", False)):
+        return None
+    if getattr(server, "error", None):
+        return None
+    server_sni = getattr(server, "sni", None)
+    if not isinstance(server_sni, str):
+        return None
+    try:
+        normalized_sni = normalize_trusted_hostname(server_sni)
+    except (UnicodeError, ValueError):
+        return None
+    if normalized_sni != host:
+        return None
+    if not getattr(server, "certificate_list", ()):
+        return None
+
+    # mitmproxy verifies the upstream certificate against server.sni when
+    # ssl_insecure is false. At this point the connected IP is authenticated as
+    # the same host we plan to bind, so CDN/Anycast DNS drift does not matter.
+    return connection_endpoints.connected_ip_destination_endpoint(
+        server,
+        port=port,
+        extra_endpoints=extra_endpoints,
+    )
+
+
+def _request_has_platform_test_endpoint_bypass(flow: http.HTTPFlow) -> bool:
+    if not flow.request.path.startswith("/api/test/"):
+        return False
+    expected_bypass = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
+    if not expected_bypass:
+        return False
+    return flow.request.headers.get(_TEST_ENDPOINT_BYPASS_HEADER) == expected_bypass
+
+
+def _request_allows_platform_connector_auth(flow: http.HTTPFlow) -> bool:
+    # Synthetic test providers live on the platform API preview host but
+    # intentionally exercise connector auth injection instead of API auto-allow.
+    # Keep this path limited to test endpoints gated by the same internal
+    # bypass secret that the API route validates.
+    return _request_has_platform_test_endpoint_bypass(flow)
+
+
+def _requires_platform_connector_auth_bypass(
+    *,
+    kind: upstream_destination_binding.BindingKind,
+    normalized_host: str,
+    api_url: str,
+) -> bool:
+    return kind == "connector_auth" and api_hostname_matches(api_url, normalized_host)
+
+
+def _flow_requires_platform_connector_auth_bypass(
+    flow: http.HTTPFlow,
+    *,
+    kind: upstream_destination_binding.BindingKind,
+    api_url: str,
+) -> bool:
+    if kind != "connector_auth":
+        return False
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
+        return False
+    try:
+        normalized_host = normalize_trusted_hostname(trusted_host)
+    except (UnicodeError, ValueError):
+        return False
+    return _requires_platform_connector_auth_bypass(
+        kind=kind,
+        normalized_host=normalized_host,
+        api_url=api_url,
+    )
+
+
+def api_hostname_matches(api_url: str, hostname: str) -> bool:
+    api_destination = _api_destination(api_url)
+    if api_destination is None:
+        return False
+    api_hostname, _api_port = api_destination
+    return hostname == api_hostname or hostname.endswith(f".{api_hostname}")
+
+
+def _api_destination(api_url: str) -> tuple[str, int] | None:
+    if not api_url:
+        return None
+    parsed_api = urllib.parse.urlparse(api_url)
+    if not parsed_api.hostname:
+        return None
+    try:
+        api_hostname = normalize_trusted_hostname(parsed_api.hostname)
+    except (UnicodeError, ValueError):
+        return None
+    if parsed_api.port is not None:
+        api_port = parsed_api.port
+    elif parsed_api.scheme.lower() == "http":
+        api_port = 80
+    else:
+        api_port = 443
+    return api_hostname, api_port
+
+
+async def _address_resolves_to_trusted_host(
+    address: tuple[str, int] | None,
+    *,
+    host: str,
+    port: int,
+) -> bool:
+    if address is None:
+        return False
+    address_host, address_port = address
+    if address_port != port:
+        return False
+    address_ip = _ip_address_text(address_host)
+    if address_ip is None:
+        return False
+    return address_ip in await resolved_trusted_host_addresses(host, port)
+
+
+async def _bind_api_upstream_destination_from_original_address(
+    *,
+    client: object,
+    server: connection.Server,
+    api_url: str,
+) -> bool:
+    if bool(getattr(server, "connected", False)):
+        return False
+
+    api_destination = _api_destination(api_url)
+    if api_destination is None:
+        return False
+    api_hostname, api_port = api_destination
+
+    original_address = None
+    for candidate_address in (
+        connection_endpoints.server_address(server),
+        connection_endpoints.connection_sockname(client),
+    ):
+        if await _address_resolves_to_trusted_host(
+            candidate_address,
+            host=api_hostname,
+            port=api_port,
+        ):
+            original_address = candidate_address
+            break
+    if original_address is None:
+        return False
+
+    server.address = (api_hostname, api_port)
+    upstream_destination_binding.record_server_binding(
+        server,
+        client=client,
+        host=api_hostname,
+        port=api_port,
+        kinds=frozenset(("api_allow",)),
+        original_address=original_address,
+    )
+    return True
+
+
+def _server_connect_binding_kinds(
+    *,
+    hostname: str,
+    port: int,
+    compiled_firewalls: matching.CompiledFirewallSet | None,
+    api_url: str,
+) -> frozenset[upstream_destination_binding.BindingKind]:
+    kinds: set[upstream_destination_binding.BindingKind] = set()
+    is_api_host = api_hostname_matches(api_url, hostname)
+    if is_api_host:
+        kinds.add("api_allow")
+    if (
+        not is_api_host
+        and compiled_firewalls is not None
+        and compiled_firewalls.matches_ordinary_credential_authority(
+            hostname,
+            port,
+        )
+    ):
+        kinds.add("connector_auth")
+    return frozenset(kinds)
+
+
+def _bind_privileged_upstream_destination(
+    *,
+    client: object,
+    server: connection.Server,
+    raw_sni: object,
+    registry_state: registry.RegistryState,
+    client_ip: str,
+    run_id: str,
+    api_url: str,
+) -> None:
+    if isinstance(registry_state, registry.RegistryUnavailable):
+        return
+
+    tls_admission = tls_admission_for_client(client)
+    if tls_admission is not None and (
+        tls_admission.client_ip != client_ip
+        or tls_admission.kind != TLS_ADMISSION_VALID_REGISTRY_VM
+        or (tls_admission.run_id is not None and tls_admission.run_id != run_id)
+    ):
+        return
+
+    if not isinstance(raw_sni, str) or not raw_sni.strip():
+        return
+    try:
+        hostname = normalize_trusted_hostname(raw_sni.strip())
+    except (UnicodeError, ValueError):
+        return
+
+    address = connection_endpoints.server_address(server)
+    if address is None:
+        return
+    _original_host, port = address
+
+    kinds = _server_connect_binding_kinds(
+        hostname=hostname,
+        port=port,
+        compiled_firewalls=registry_state.compiled_firewalls.get(client_ip),
+        api_url=api_url,
+    )
+    if not kinds:
+        return
+
+    if bool(getattr(server, "connected", False)):
+        return
+
+    server.address = (hostname, port)
+
+    upstream_destination_binding.record_server_binding(
+        server,
+        client=client,
+        host=hostname,
+        port=port,
+        kinds=kinds,
+        original_address=address,
+    )
+
+
+async def handle_server_connect(
+    data: object,
+    *,
+    registry_path: str,
+    api_url: str,
+) -> None:
+    """Bind privileged HTTPS upstream connections to their trusted SNI host."""
+    client = getattr(data, "client", None)
+    server = getattr(data, "server", None)
+    if client is None or server is None:
+        return
+
+    client_ip = client.peername[0] if getattr(client, "peername", None) else None
+    if not client_ip:
+        return
+
+    registry_state = registry.load_registry_state(registry_path)
+    if isinstance(registry_state, registry.RegistryUnavailable):
+        return
+
+    vm_info = registry_state.vms.get(client_ip)
+    if vm_info is None:
+        return
+
+    run_id = vm_info.get("runId", "")
+    tls_admission = tls_admission_for_client(client)
+    raw_sni = getattr(client, "sni", None)
+    if not raw_sni and tls_admission is not None:
+        raw_sni = tls_admission.sni
+    if not raw_sni and await _bind_api_upstream_destination_from_original_address(
+        client=client,
+        server=server,
+        api_url=api_url,
+    ):
+        return
+    _bind_privileged_upstream_destination(
+        client=client,
+        server=server,
+        raw_sni=raw_sni,
+        registry_state=registry_state,
+        client_ip=client_ip,
+        run_id=run_id,
+        api_url=api_url,
+    )
+
+
+def handle_tls_clienthello(
+    data: tls.ClientHelloData,
+    *,
+    registry_path: str,
+    api_url: str,
+) -> None:
+    """
+    Handle TLS ClientHello — decide whether to MITM intercept.
+    All registered VMs use MITM mode for HTTP-level filtering and logging.
+    Unregistered IPs are passed through without interception.
+    """
+    client_ip = data.context.client.peername[0] if data.context.client.peername else None
+    if not client_ip:
+        return
+
+    registry_state = registry.load_registry_state(registry_path)
+    if isinstance(registry_state, registry.RegistryUnavailable):
+        record_tls_admission(
+            data.context.client,
+            TlsAdmission(
+                client_ip=client_ip,
+                kind=TLS_ADMISSION_REGISTRY_UNAVAILABLE,
+            ),
+        )
+        return
+
+    vm_info = registry_state.vms.get(client_ip)
+    if vm_info is not None:
+        run_id = vm_info.get("runId", "")
+        raw_sni = data.client_hello.sni
+        record_tls_admission(
+            data.context.client,
+            TlsAdmission(
+                client_ip=client_ip,
+                kind=TLS_ADMISSION_VALID_REGISTRY_VM,
+                run_id=run_id,
+                sni=raw_sni if isinstance(raw_sni, str) else None,
+            ),
+        )
+        _bind_privileged_upstream_destination(
+            client=data.context.client,
+            server=data.context.server,
+            raw_sni=raw_sni,
+            registry_state=registry_state,
+            client_ip=client_ip,
+            run_id=run_id,
+            api_url=api_url,
+        )
+        return
+
+    if client_ip in registry_state.invalid_vms:
+        record_tls_admission(
+            data.context.client,
+            TlsAdmission(
+                client_ip=client_ip,
+                kind=TLS_ADMISSION_INVALID_REGISTRY_VM,
+            ),
+        )
+        return
+
+    # Not a registered VM - pass through without MITM interception.
+    # This is critical for CIDR-based rules where all VM traffic is redirected.
+    forget_tls_admission(data.context.client)
+    data.ignore_connection = True
+
+
+def has_bound_destination(
+    flow: http.HTTPFlow,
+    *,
+    allowed_kinds: frozenset[upstream_destination_binding.BindingKind],
+) -> bool:
+    return upstream_destination_binding.flow_matches_bound_destination(
+        flow,
+        allowed_kinds=allowed_kinds,
+    )
+
+
+def _bind_flow_upstream_destination(
+    flow: http.HTTPFlow,
+    *,
+    kind: upstream_destination_binding.BindingKind,
+    api_url: str,
+) -> bool:
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    if not trusted_host:
+        return False
+    try:
+        normalized_host = normalize_trusted_hostname(trusted_host)
+    except (UnicodeError, ValueError):
+        return False
+
+    original_address = connection_endpoints.server_address(flow.server_conn)
+    has_server_binding = upstream_destination_binding.has_server_binding(flow.server_conn)
+    if _requires_platform_connector_auth_bypass(
+        kind=kind,
+        normalized_host=normalized_host,
+        api_url=api_url,
+    ) and not _request_allows_platform_connector_auth(flow):
+        return False
+
+    if has_server_binding:
+        if upstream_destination_binding.add_server_binding_kind_if_matching(
+            flow.server_conn,
+            client=flow.client_conn,
+            host=normalized_host,
+            port=flow.request.port,
+            kind=kind,
+        ):
+            return True
+        if flow.server_conn.connected:
+            connected_address = _connected_verified_tls_destination_endpoint(
+                flow.server_conn,
+                host=normalized_host,
+                port=flow.request.port,
+                extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
+            )
+            if connected_address is None:
+                return False
+            return (
+                upstream_destination_binding.refresh_server_binding_connected_address_if_matching(
+                    flow.server_conn,
+                    client=flow.client_conn,
+                    host=normalized_host,
+                    port=flow.request.port,
+                    kind=kind,
+                    connected_address=connected_address,
+                )
+            )
+        return False
+
+    if flow.server_conn.connected:
+        connected_address = _connected_verified_tls_destination_endpoint(
+            flow.server_conn,
+            host=normalized_host,
+            port=flow.request.port,
+            extra_endpoints=(connection_endpoints.connection_sockname(flow.client_conn),),
+        )
+        if connected_address is None:
+            return False
+        original_address = connected_address
+    else:
+        flow.server_conn.address = (normalized_host, flow.request.port)
+
+    upstream_destination_binding.record_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        host=normalized_host,
+        port=flow.request.port,
+        kinds=frozenset((kind,)),
+        original_address=original_address,
+    )
+    return True
+
+
+def ensure_bound_destination(
+    flow: http.HTTPFlow,
+    *,
+    kind: upstream_destination_binding.BindingKind,
+    api_url: str,
+) -> bool:
+    if _flow_requires_platform_connector_auth_bypass(
+        flow,
+        kind=kind,
+        api_url=api_url,
+    ) and not _request_allows_platform_connector_auth(flow):
+        return False
+
+    allowed_kinds = frozenset((kind,))
+    has_bound = has_bound_destination(flow, allowed_kinds=allowed_kinds)
+    if has_bound and upstream_destination_binding.has_server_binding(flow.server_conn):
+        return True
+    # If has_bound is true here, it is only an unconnected address or
+    # prior-client match. That is retargetable, not durable proof for later
+    # keepalive reuse, and connected flows still need current upstream TLS proof.
+    return _bind_flow_upstream_destination(flow, kind=kind, api_url=api_url)
+
+
+def forget_server_binding(server: object) -> None:
+    upstream_destination_binding.forget_server_binding(server)
+
+
+def forget_server_binding_from_event(data: object) -> None:
+    server = getattr(data, "server", data)
+    forget_server_binding(server)
+
+
+def forget_client(client: object) -> None:
+    forget_tls_admission(client)
+    upstream_destination_binding.forget_client_bindings(client)
+
+
+def _endpoint_text(address: tuple[str, int] | None) -> str:
+    if address is None:
+        return ""
+    host, port = address
+    return f"{host}:{port}"
+
+
+def record_unbound_diagnostics(
+    flow: http.HTTPFlow,
+    *,
+    reason: upstream_destination_binding.BindingKind,
+) -> dict[str, object]:
+    trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
+    diagnostics = upstream_destination_binding.diagnostic_snapshot_for_flow(
+        flow,
+        allowed_kinds=frozenset((reason,)),
+    )
+    diagnostics.update(
+        {
+            "reason": reason,
+            "trusted_host": trusted_host,
+            "request_host": flow.request.host,
+            "request_port": flow.request.port,
+            "server_connected": bool(getattr(flow.server_conn, "connected", False)),
+            "server_address": _endpoint_text(connection_endpoints.server_address(flow.server_conn)),
+            "server_peername": _endpoint_text(
+                connection_endpoints.server_peername(flow.server_conn)
+            ),
+            "server_sockname": _endpoint_text(
+                connection_endpoints.connection_sockname(flow.server_conn)
+            ),
+            "client_sockname": _endpoint_text(
+                connection_endpoints.connection_sockname(flow.client_conn)
+            ),
+        }
+    )
+    flow.metadata[_UPSTREAM_BINDING_DIAGNOSTICS] = diagnostics
+    return diagnostics
+
+
+def upstream_binding_log_fields(flow: http.HTTPFlow) -> dict[str, str | int | bool]:
+    diagnostics = flow.metadata.get(_UPSTREAM_BINDING_DIAGNOSTICS)
+    if not isinstance(diagnostics, dict):
+        return {}
+    return {
+        f"upstream_binding_{key}": value
+        for key, value in diagnostics.items()
+        if isinstance(value, (str, int, bool))
+    }
+
+
+def upstream_binding_diagnostics_for_tests(flow: http.HTTPFlow) -> dict[str, object]:
+    diagnostics = flow.metadata.get(_UPSTREAM_BINDING_DIAGNOSTICS)
+    if not isinstance(diagnostics, dict):
+        return {}
+    return diagnostics

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -346,6 +346,13 @@ async def _bind_api_upstream_destination_from_original_address(
             break
     if original_address is None:
         return False
+    if bool(getattr(server, "connected", False)) or getattr(server, "error", None):
+        return False
+    if original_address not in (
+        connection_endpoints.server_address(server),
+        connection_endpoints.connection_sockname(client),
+    ):
+        return False
 
     server.address = (api_hostname, api_port)
     upstream_destination_binding.record_server_binding(

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -456,16 +456,18 @@ def _bind_privileged_upstream_destination(
     if not kinds:
         return
 
-    if all(
-        upstream_destination_binding.add_server_binding_kind_if_matching(
-            server,
-            client=client,
-            host=hostname,
-            port=port,
-            kind=kind,
-        )
-        for kind in kinds
-    ):
+    if upstream_destination_binding.has_server_binding(server):
+        if all(
+            upstream_destination_binding.add_server_binding_kind_if_matching(
+                server,
+                client=client,
+                host=hostname,
+                port=port,
+                kind=kind,
+            )
+            for kind in kinds
+        ):
+            return
         return
 
     if bool(getattr(server, "connected", False)):

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -456,6 +456,18 @@ def _bind_privileged_upstream_destination(
     if not kinds:
         return
 
+    if all(
+        upstream_destination_binding.add_server_binding_kind_if_matching(
+            server,
+            client=client,
+            host=hostname,
+            port=port,
+            kind=kind,
+        )
+        for kind in kinds
+    ):
+        return
+
     if bool(getattr(server, "connected", False)):
         return
 

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -34,6 +34,7 @@ TlsAdmissionKind = Literal[
     "invalid_registry_vm",
     "registry_unavailable",
 ]
+_ApiOriginalAddressSource = Literal["server_address", "client_sockname"]
 
 _trusted_host_address_cache: dict[tuple[str, int], tuple[float, frozenset[str]]] = {}
 _trusted_host_address_lookup_tasks: dict[tuple[str, int], asyncio.Task[frozenset[str]]] = {}
@@ -324,7 +325,7 @@ async def _bind_api_upstream_destination_from_original_address(
     server: connection.Server,
     api_url: str,
 ) -> bool:
-    if bool(getattr(server, "connected", False)):
+    if bool(getattr(server, "connected", False)) or getattr(server, "error", None):
         return False
 
     api_destination = _api_destination(api_url)
@@ -332,25 +333,33 @@ async def _bind_api_upstream_destination_from_original_address(
         return False
     api_hostname, api_port = api_destination
 
-    original_address = None
-    for candidate_address in (
-        connection_endpoints.server_address(server),
-        connection_endpoints.connection_sockname(client),
-    ):
+    original_address: tuple[str, int] | None = None
+    original_address_source: _ApiOriginalAddressSource | None = None
+    candidate_addresses: tuple[
+        tuple[_ApiOriginalAddressSource, tuple[str, int] | None],
+        ...,
+    ] = (
+        ("server_address", connection_endpoints.server_address(server)),
+        ("client_sockname", connection_endpoints.connection_sockname(client)),
+    )
+    for candidate_source, candidate_address in candidate_addresses:
         if await _address_resolves_to_trusted_host(
             candidate_address,
             host=api_hostname,
             port=api_port,
         ):
             original_address = candidate_address
+            original_address_source = candidate_source
             break
-    if original_address is None:
+    if original_address is None or original_address_source is None:
         return False
     if bool(getattr(server, "connected", False)) or getattr(server, "error", None):
         return False
-    if original_address not in (
-        connection_endpoints.server_address(server),
-        connection_endpoints.connection_sockname(client),
+    if not _original_address_source_still_matches(
+        client=client,
+        server=server,
+        original_address=original_address,
+        source=original_address_source,
     ):
         return False
 
@@ -364,6 +373,18 @@ async def _bind_api_upstream_destination_from_original_address(
         original_address=original_address,
     )
     return True
+
+
+def _original_address_source_still_matches(
+    *,
+    client: object,
+    server: object,
+    original_address: tuple[str, int],
+    source: _ApiOriginalAddressSource,
+) -> bool:
+    if source == "server_address":
+        return connection_endpoints.server_address(server) == original_address
+    return connection_endpoints.connection_sockname(client) == original_address
 
 
 def _server_connect_binding_kinds(

--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -333,14 +333,16 @@ async def _bind_api_upstream_destination_from_original_address(
         return False
     api_hostname, api_port = api_destination
 
+    starting_server_address = connection_endpoints.server_address(server)
+    starting_client_sockname = connection_endpoints.connection_sockname(client)
     original_address: tuple[str, int] | None = None
     original_address_source: _ApiOriginalAddressSource | None = None
     candidate_addresses: tuple[
         tuple[_ApiOriginalAddressSource, tuple[str, int] | None],
         ...,
     ] = (
-        ("server_address", connection_endpoints.server_address(server)),
-        ("client_sockname", connection_endpoints.connection_sockname(client)),
+        ("server_address", starting_server_address),
+        ("client_sockname", starting_client_sockname),
     )
     for candidate_source, candidate_address in candidate_addresses:
         if await _address_resolves_to_trusted_host(
@@ -354,6 +356,8 @@ async def _bind_api_upstream_destination_from_original_address(
     if original_address is None or original_address_source is None:
         return False
     if bool(getattr(server, "connected", False)) or getattr(server, "error", None):
+        return False
+    if connection_endpoints.server_address(server) != starting_server_address:
         return False
     if not _original_address_source_still_matches(
         client=client,

--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -32,6 +32,7 @@ import logging_utils
 import mitm_addon
 import platform_api
 import registry
+import upstream_admission
 import upstream_destination_binding
 import usage
 from tests.auth_state_helpers import clear_auth_state
@@ -55,9 +56,9 @@ def _reset_module_state() -> Iterator[None]:
     builtin_connector_diagnostics.reset_cache_for_tests()
     registry.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
-    mitm_addon.reset_upstream_destination_resolution_cache_for_tests()
+    upstream_admission.reset_upstream_destination_resolution_cache_for_tests()
     mitm_addon.reset_runner_usage_flush_state_for_tests()
-    mitm_addon.reset_tls_admission_state_for_tests()
+    upstream_admission.reset_tls_admission_state_for_tests()
     platform_api.configure_client_headers(client_session_id="", client_version="")
     clear_auth_state()
     _usage_connectors._unregistered_handler_warned.clear()
@@ -72,8 +73,8 @@ def _reset_module_state() -> Iterator[None]:
     auth_base_forwarder.reset_forward_request_state_for_tests()
     builtin_connector_diagnostics.reset_cache_for_tests()
     upstream_destination_binding.reset_for_tests()
-    mitm_addon.reset_upstream_destination_resolution_cache_for_tests()
-    mitm_addon.reset_tls_admission_state_for_tests()
+    upstream_admission.reset_upstream_destination_resolution_cache_for_tests()
+    upstream_admission.reset_tls_admission_state_for_tests()
     platform_api.configure_client_headers(client_session_id="", client_version="")
     usage.webhook.reset_delivery_capacity_for_tests()
     usage.counters.reset_for_tests()

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -9,6 +9,7 @@ from mitmproxy import connection
 import builtin_host_policy
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import upstream_admission
 import upstream_destination_binding
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
@@ -188,7 +189,7 @@ async def test_runtime_host_policy_blocks_public_destination_hostname_without_ip
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("runtime host policy must not use DNS"),
         ),
@@ -629,7 +630,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_without_veri
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified connected connector must not use fresh DNS"),
         ),
@@ -663,7 +664,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_when_upstrea
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("mismatched upstream TLS must not use fresh DNS"),
         ),
@@ -698,7 +699,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_when_upstrea
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("failed upstream TLS must not use fresh DNS"),
         ),
@@ -739,7 +740,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_with_early_b
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("bound connector request must not use fresh DNS"),
         ),
@@ -782,7 +783,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_after_retarg
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified retargeted binding must not use fresh DNS"),
         ),
@@ -828,7 +829,7 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_with_verifie
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified retargeted binding must not use fresh DNS"),
         ),
@@ -871,7 +872,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_without_endp
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified direct binding must not use fresh DNS"),
         ),
@@ -915,7 +916,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_loopbac
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified loopback endpoint must not use fresh DNS"),
         ),
@@ -956,7 +957,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_stale_b
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("stale direct binding must not use fresh DNS"),
         ),
@@ -1103,7 +1104,7 @@ async def test_matching_sni_and_host_blocks_connected_vm0_api_edge_when_unbound(
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified connected API edge must not use fresh DNS"),
         ),
@@ -1139,7 +1140,7 @@ async def test_matching_sni_and_host_allows_authenticated_connected_vm0_api_edge
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified connected API edge must not use fresh DNS"),
         ),
@@ -1178,7 +1179,7 @@ async def test_matching_sni_and_host_allows_test_connector_on_authenticated_api_
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified connected test connector must not use fresh DNS"),
         ),
@@ -1225,7 +1226,7 @@ async def test_test_connector_extends_existing_api_allow_binding(
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("existing binding should not use fresh DNS"),
         ),
@@ -1271,7 +1272,7 @@ async def test_test_connector_without_bypass_does_not_extend_existing_api_allow_
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unbypassed existing binding must not use fresh DNS"),
         ),
@@ -1348,7 +1349,7 @@ async def test_test_connector_without_bypass_does_not_reuse_connector_auth_bindi
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unbypassed connector auth binding must not use DNS"),
         ),
@@ -1466,7 +1467,7 @@ async def test_matching_sni_and_host_blocks_test_connector_api_edge_without_bypa
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers() as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unbypassed test connector must not use fresh DNS"),
         ),

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -13,6 +13,7 @@ import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
+import upstream_admission
 import upstream_destination_binding
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.request_handler_helpers import (
@@ -136,7 +137,7 @@ async def test_capture_enabled_api_allow_blocks_connected_unbound_edge_upstream(
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified connected edge must not use fresh DNS"),
         ),
@@ -179,7 +180,7 @@ async def test_capture_enabled_api_allow_uses_authenticated_connected_edge_upstr
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified connected edge must not use fresh DNS"),
         ),
@@ -224,7 +225,7 @@ async def test_capture_enabled_api_allow_uses_connected_upstream_address_when_tl
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified connected edge must not use fresh DNS"),
         ),
@@ -325,7 +326,7 @@ async def test_api_allow_prior_client_binding_endpoint_mismatch_blocks(
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))],
         ),
@@ -339,7 +340,9 @@ async def test_api_allow_prior_client_binding_endpoint_mismatch_blocks(
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert (
-        flow.metadata[mitm_addon._UPSTREAM_BINDING_DIAGNOSTICS]["client_binding_endpoint_match"]
+        upstream_admission.upstream_binding_diagnostics_for_tests(flow)[
+            "client_binding_endpoint_match"
+        ]
         is False
     )
 
@@ -438,7 +441,7 @@ async def test_firewall_allow_current_server_binding_address_mismatch_blocks(
     assert flow.response is not None
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
-    diagnostics = flow.metadata[mitm_addon._UPSTREAM_BINDING_DIAGNOSTICS]
+    diagnostics = upstream_admission.upstream_binding_diagnostics_for_tests(flow)
     assert diagnostics["direct_binding_present"] is True
     assert diagnostics["server_connected"] is False
     assert diagnostics["server_address"] == "203.0.113.99:443"
@@ -1031,7 +1034,7 @@ async def test_firewall_allow_header_auth_requestheaders_falls_back_when_upstrea
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("198.18.20.34", 443))],
         ),
@@ -1134,7 +1137,7 @@ async def test_firewall_allow_header_auth_uses_connected_upstream_when_tls_verif
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified connected connector must not use fresh DNS"),
         ),
@@ -1185,7 +1188,7 @@ async def test_firewall_allow_header_auth_blocks_without_verified_connected_tls(
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified connected connector must not use fresh DNS"),
         ),
@@ -1254,7 +1257,9 @@ async def test_firewall_allow_prior_client_binding_endpoint_mismatch_blocks(
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert (
-        flow.metadata[mitm_addon._UPSTREAM_BINDING_DIAGNOSTICS]["client_binding_endpoint_match"]
+        upstream_admission.upstream_binding_diagnostics_for_tests(flow)[
+            "client_binding_endpoint_match"
+        ]
         is False
     )
 
@@ -1295,7 +1300,7 @@ async def test_firewall_allow_prior_client_binding_endpoint_match_still_requires
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified connected connector must not use fresh DNS"),
         ),
@@ -1312,7 +1317,9 @@ async def test_firewall_allow_prior_client_binding_endpoint_match_still_requires
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert (
-        flow.metadata[mitm_addon._UPSTREAM_BINDING_DIAGNOSTICS]["client_binding_endpoint_match"]
+        upstream_admission.upstream_binding_diagnostics_for_tests(flow)[
+            "client_binding_endpoint_match"
+        ]
         is True
     )
     assert flow.server_conn.id not in upstream_destination_binding.binding_snapshot_for_tests()
@@ -1452,7 +1459,7 @@ async def test_firewall_allow_small_bounded_body_uses_connected_upstream_when_tl
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("verified connected connector must not use fresh DNS"),
         ),
@@ -1498,7 +1505,7 @@ async def test_firewall_allow_small_bounded_body_blocks_without_verified_connect
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         fake_firewall_headers(headers={"Authorization": "Bearer resolved"}) as auth_fetch,
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("unverified connected connector must not use fresh DNS"),
         ),

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -31,6 +31,7 @@ class _Server:
         self.address = address
         self.peername = peername
         self.connected = connected
+        self.error: str | None = None
 
 
 class _Client:
@@ -471,3 +472,29 @@ async def test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup
     assert calls == [("pr-test-api.vm6.ai", 443)]
     assert cancelled.server.address == ("198.18.20.34", 443)
     assert completed.server.address == ("pr-test-api.vm6.ai", 443)
+
+
+async def test_server_connect_does_not_bind_after_connect_error_during_dns(registry_file, mitm_ctx):
+    data = _data(client_ip="10.200.0.1", sni="", address=("198.18.20.34", 443))
+    lookup_started = threading.Event()
+    release_lookup = threading.Event()
+
+    def getaddrinfo(host: str, port: int, *args, **kwargs):
+        lookup_started.set()
+        if not release_lookup.wait(timeout=5):
+            raise AssertionError("timed out waiting to release DNS lookup")
+        return _API_ADDRINFO
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(upstream_admission.socket, "getaddrinfo", side_effect=getaddrinfo),
+    ):
+        connect_task = asyncio.create_task(mitm_addon.server_connect(data))
+        assert await asyncio.to_thread(lookup_started.wait, 5)
+        data.server.error = "connect failed"
+        mitm_addon.server_connect_error(data)
+        release_lookup.set()
+        await connect_task
+
+    assert data.server.address == ("198.18.20.34", 443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -530,3 +530,35 @@ async def test_server_connect_does_not_bind_when_source_endpoint_changes_during_
 
     assert data.server.address == ("203.0.113.99", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_server_connect_does_not_bind_sockname_source_after_server_address_changes(
+    registry_file, mitm_ctx
+):
+    data = _data(
+        client_ip="10.200.0.1",
+        sni="",
+        address=("127.0.0.1", 8080),
+        client_sockname=("198.18.20.34", 443),
+    )
+    lookup_started = threading.Event()
+    release_lookup = threading.Event()
+
+    def getaddrinfo(host: str, port: int, *args, **kwargs):
+        lookup_started.set()
+        if not release_lookup.wait(timeout=5):
+            raise AssertionError("timed out waiting to release DNS lookup")
+        return _API_ADDRINFO
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(upstream_admission.socket, "getaddrinfo", side_effect=getaddrinfo),
+    ):
+        connect_task = asyncio.create_task(mitm_addon.server_connect(data))
+        assert await asyncio.to_thread(lookup_started.wait, 5)
+        data.server.address = ("203.0.113.99", 443)
+        release_lookup.set()
+        await connect_task
+
+    assert data.server.address == ("203.0.113.99", 443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -498,3 +498,35 @@ async def test_server_connect_does_not_bind_after_connect_error_during_dns(regis
 
     assert data.server.address == ("198.18.20.34", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
+
+
+async def test_server_connect_does_not_bind_when_source_endpoint_changes_during_dns(
+    registry_file, mitm_ctx
+):
+    data = _data(
+        client_ip="10.200.0.1",
+        sni="",
+        address=("198.18.20.34", 443),
+        client_sockname=("198.18.20.34", 443),
+    )
+    lookup_started = threading.Event()
+    release_lookup = threading.Event()
+
+    def getaddrinfo(host: str, port: int, *args, **kwargs):
+        lookup_started.set()
+        if not release_lookup.wait(timeout=5):
+            raise AssertionError("timed out waiting to release DNS lookup")
+        return _API_ADDRINFO
+
+    with (
+        mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
+        patch.object(upstream_admission.socket, "getaddrinfo", side_effect=getaddrinfo),
+    ):
+        connect_task = asyncio.create_task(mitm_addon.server_connect(data))
+        assert await asyncio.to_thread(lookup_started.wait, 5)
+        data.server.address = ("203.0.113.99", 443)
+        release_lookup.set()
+        await connect_task
+
+    assert data.server.address == ("203.0.113.99", 443)
+    assert upstream_destination_binding.binding_snapshot_for_tests() == {}

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -48,7 +48,7 @@ class _Client:
 
 
 class _ServerConnectData:
-    def __init__(self, *, client: _Client, server: _Server) -> None:
+    def __init__(self, *, client: object, server: _Server) -> None:
         self.client = client
         self.server = server
 
@@ -83,20 +83,22 @@ async def test_server_connect_retargets_credentialed_connector_host(tmp_path, mi
     assert binding.original_address == ("203.0.113.10", 443)
 
 
-async def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(tmp_path, mitm_ctx):
+async def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(
+    tmp_path,
+    mitm_ctx,
+    make_tls_data,
+):
     reg_path = _write_github_firewall_registry(tmp_path)
-    data = _data(sni="")
-    upstream_admission.record_tls_admission(
-        data.client,
-        upstream_admission.TlsAdmission(
-            client_ip="10.200.0.5",
-            kind=upstream_admission.TLS_ADMISSION_VALID_REGISTRY_VM,
-            run_id="run-conn-1",
-            sni="api.github.com",
-        ),
+    tls_data = make_tls_data(
+        client_ip="10.200.0.5",
+        client_sni="",
+        sni="api.github.com",
+        server_connected=True,
     )
+    data = _ServerConnectData(client=tls_data.context.client, server=_Server())
 
     with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
         await mitm_addon.server_connect(data)
 
     assert data.server.address == ("api.github.com", 443)

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -108,6 +108,29 @@ async def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(
     assert binding.kinds == frozenset(("connector_auth",))
 
 
+async def test_server_connect_preserves_clienthello_original_address(
+    tmp_path,
+    mitm_ctx,
+    make_tls_data,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    tls_data = make_tls_data(
+        client_ip="10.200.0.5",
+        client_sni="",
+        sni="api.github.com",
+    )
+    data = _ServerConnectData(client=tls_data.context.client, server=tls_data.context.server)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        await mitm_addon.server_connect(data)
+
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert binding.host == "api.github.com"
+    assert binding.kinds == frozenset(("connector_auth",))
+    assert binding.original_address == ("203.0.113.10", 443)
+
+
 async def test_server_connect_retargets_api_allow_host(registry_file, mitm_ctx):
     data = _data(client_ip="10.200.0.1", sni="api.vm0.ai")
 

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -131,6 +131,31 @@ async def test_server_connect_preserves_clienthello_original_address(
     assert binding.original_address == ("203.0.113.10", 443)
 
 
+async def test_server_connect_does_not_overwrite_clienthello_binding_after_address_changes(
+    tmp_path,
+    mitm_ctx,
+    make_tls_data,
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    tls_data = make_tls_data(
+        client_ip="10.200.0.5",
+        client_sni="",
+        sni="api.github.com",
+    )
+    data = _ServerConnectData(client=tls_data.context.client, server=tls_data.context.server)
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        mitm_addon.tls_clienthello(tls_data)
+        data.server.address = ("203.0.113.99", 443)
+        await mitm_addon.server_connect(data)
+
+    binding = upstream_destination_binding.binding_snapshot_for_tests()[data.server.id]
+    assert data.server.address == ("203.0.113.99", 443)
+    assert binding.host == "api.github.com"
+    assert binding.kinds == frozenset(("connector_auth",))
+    assert binding.original_address == ("203.0.113.10", 443)
+
+
 async def test_server_connect_retargets_api_allow_host(registry_file, mitm_ctx):
     data = _data(client_ip="10.200.0.1", sni="api.vm0.ai")
 

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -7,6 +7,7 @@ import uuid
 from unittest.mock import patch
 
 import mitm_addon
+import upstream_admission
 import upstream_destination_binding
 from tests.request_handler_helpers import (
     _single_firewall_vm,
@@ -85,11 +86,11 @@ async def test_server_connect_retargets_credentialed_connector_host(tmp_path, mi
 async def test_server_connect_uses_tls_clienthello_sni_when_client_sni_is_empty(tmp_path, mitm_ctx):
     reg_path = _write_github_firewall_registry(tmp_path)
     data = _data(sni="")
-    mitm_addon._record_tls_admission(
+    upstream_admission.record_tls_admission(
         data.client,
-        mitm_addon._TlsAdmission(
+        upstream_admission.TlsAdmission(
             client_ip="10.200.0.5",
-            kind=mitm_addon._TLS_ADMISSION_VALID_REGISTRY_VM,
+            kind=upstream_admission.TLS_ADMISSION_VALID_REGISTRY_VM,
             run_id="run-conn-1",
             sni="api.github.com",
         ),
@@ -153,7 +154,7 @@ async def test_server_connect_does_not_bind_connected_api_edge_from_sni_only(
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("66.33.60.34", 443))],
         ),
@@ -176,7 +177,7 @@ async def test_server_connect_does_not_bind_connected_connector_from_sni_only(tm
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=AssertionError("connector binding must not use fresh DNS"),
         ),
@@ -192,7 +193,7 @@ async def test_server_connect_binds_api_host_from_original_address(registry_file
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
+        patch.object(upstream_admission.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
         await mitm_addon.server_connect(data)
 
@@ -216,7 +217,7 @@ async def test_server_connect_does_not_bind_connected_api_host_from_original_add
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
+        patch.object(upstream_admission.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
         await mitm_addon.server_connect(data)
 
@@ -234,7 +235,7 @@ async def test_server_connect_binds_api_host_from_transparent_sockname(registry_
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
+        patch.object(upstream_admission.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
         await mitm_addon.server_connect(data)
 
@@ -252,7 +253,7 @@ async def test_server_connect_does_not_bind_api_host_when_original_address_misse
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO),
+        patch.object(upstream_admission.socket, "getaddrinfo", return_value=_API_ADDRINFO),
     ):
         await mitm_addon.server_connect(data)
 
@@ -328,8 +329,12 @@ async def test_server_connect_negative_caches_dns_errors(registry_file, mitm_ctx
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon, "_trusted_host_address_cache_time", return_value=10.0),
-        patch.object(mitm_addon.socket, "getaddrinfo", side_effect=OSError("dns down")) as dns,
+        patch.object(upstream_admission, "trusted_host_address_cache_time", return_value=10.0),
+        patch.object(
+            upstream_admission.socket,
+            "getaddrinfo",
+            side_effect=OSError("dns down"),
+        ) as dns,
     ):
         await mitm_addon.server_connect(first)
         await mitm_addon.server_connect(second)
@@ -346,8 +351,8 @@ async def test_server_connect_negative_caches_empty_dns_results(registry_file, m
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon, "_trusted_host_address_cache_time", return_value=10.0),
-        patch.object(mitm_addon.socket, "getaddrinfo", return_value=[]) as dns,
+        patch.object(upstream_admission, "trusted_host_address_cache_time", return_value=10.0),
+        patch.object(upstream_admission.socket, "getaddrinfo", return_value=[]) as dns,
     ):
         await mitm_addon.server_connect(first)
         await mitm_addon.server_connect(second)
@@ -366,12 +371,12 @@ async def test_server_connect_retries_after_negative_dns_cache_expires(registry_
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
         patch.object(
-            mitm_addon,
-            "_trusted_host_address_cache_time",
+            upstream_admission,
+            "trusted_host_address_cache_time",
             side_effect=monotonic_values,
         ),
         patch.object(
-            mitm_addon.socket,
+            upstream_admission.socket,
             "getaddrinfo",
             side_effect=[OSError("dns down"), _API_ADDRINFO],
         ) as dns,
@@ -391,8 +396,8 @@ async def test_server_connect_positive_caches_dns_results(registry_file, mitm_ct
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon, "_trusted_host_address_cache_time", return_value=10.0),
-        patch.object(mitm_addon.socket, "getaddrinfo", return_value=_API_ADDRINFO) as dns,
+        patch.object(upstream_admission, "trusted_host_address_cache_time", return_value=10.0),
+        patch.object(upstream_admission.socket, "getaddrinfo", return_value=_API_ADDRINFO) as dns,
     ):
         await mitm_addon.server_connect(first)
         await mitm_addon.server_connect(second)
@@ -418,7 +423,7 @@ async def test_server_connect_coalesces_concurrent_dns_resolution(registry_file,
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon.socket, "getaddrinfo", side_effect=getaddrinfo),
+        patch.object(upstream_admission.socket, "getaddrinfo", side_effect=getaddrinfo),
     ):
         first_task = asyncio.create_task(mitm_addon.server_connect(first))
         assert await asyncio.to_thread(lookup_started.wait, 5)
@@ -450,7 +455,7 @@ async def test_server_connect_cancelled_waiter_does_not_cancel_shared_dns_lookup
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://pr-test-api.vm6.ai"),
-        patch.object(mitm_addon.socket, "getaddrinfo", side_effect=getaddrinfo),
+        patch.object(upstream_admission.socket, "getaddrinfo", side_effect=getaddrinfo),
     ):
         cancelled_task = asyncio.create_task(mitm_addon.server_connect(cancelled))
         assert await asyncio.to_thread(lookup_started.wait, 5)

--- a/crates/runner/mitm-addon/tests/test_server_connect_hook.py
+++ b/crates/runner/mitm-addon/tests/test_server_connect_hook.py
@@ -542,7 +542,7 @@ async def test_server_connect_does_not_bind_after_connect_error_during_dns(regis
         data.server.error = "connect failed"
         mitm_addon.server_connect_error(data)
         release_lookup.set()
-        await connect_task
+        _ = await connect_task
 
     assert data.server.address == ("198.18.20.34", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
@@ -574,7 +574,7 @@ async def test_server_connect_does_not_bind_when_source_endpoint_changes_during_
         assert await asyncio.to_thread(lookup_started.wait, 5)
         data.server.address = ("203.0.113.99", 443)
         release_lookup.set()
-        await connect_task
+        _ = await connect_task
 
     assert data.server.address == ("203.0.113.99", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
@@ -606,7 +606,7 @@ async def test_server_connect_does_not_bind_sockname_source_after_server_address
         assert await asyncio.to_thread(lookup_started.wait, 5)
         data.server.address = ("203.0.113.99", 443)
         release_lookup.set()
-        await connect_task
+        _ = await connect_task
 
     assert data.server.address == ("203.0.113.99", 443)
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}

--- a/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
+++ b/crates/runner/mitm-addon/tests/test_tls_clienthello_hook.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import mitm_addon
 import registry
+import upstream_admission
 import upstream_destination_binding
 from tests.request_handler_helpers import _write_github_firewall_registry
 
@@ -88,7 +89,7 @@ class TestTlsClienthello:
                 api_url="https://pr-test-api.vm6.ai",
             ),
             patch.object(
-                mitm_addon.socket,
+                upstream_admission.socket,
                 "getaddrinfo",
                 return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("66.33.60.34", 443))],
             ),
@@ -137,7 +138,7 @@ class TestTlsClienthello:
         with (
             mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
             patch.object(
-                mitm_addon.socket,
+                upstream_admission.socket,
                 "getaddrinfo",
                 return_value=[(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("140.82.112.5", 443))],
             ),
@@ -162,7 +163,7 @@ class TestTlsClienthello:
         with (
             mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
             patch.object(
-                mitm_addon.socket,
+                upstream_admission.socket,
                 "getaddrinfo",
                 side_effect=AssertionError("connector binding must not use fresh DNS"),
             ),

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -904,6 +904,7 @@ PY
             "registry.py",
             "response_streaming.py",
             "terminal_usage.py",
+            "upstream_admission.py",
             "url_utils.py",
             "logging_utils.py",
             "usage/__init__.py",


### PR DESCRIPTION
## Summary
- extract TLS admission, DNS trusted-host cache, upstream destination binding, and diagnostics ownership into `upstream_admission.py`
- keep mitmproxy public hooks in `mitm_addon.py` as thin delegates
- update tests to patch the new owner module and add the module to the runner addon bundle smoke test

Closes #20510

## Tests
- `PATH="/tmp/mitm-addon-venv/bin:$PATH" ruff check src tests`
- `PATH="/tmp/mitm-addon-venv/bin:$PATH" basedpyright src tests`
- `python3 -m py_compile src/mitm_addon.py src/upstream_admission.py src/upstream_destination_binding.py src/request_classification.py`
- `PATH="/tmp/mitm-addon-venv/bin:$PATH" pytest tests`
- `cargo test -p runner addon_scripts_are_embedded`
- pre-commit hook: ruff, cargo fmt/doc/clippy, commitlint