### PR TITLE
perf: add fresh sandbox factory stage telemetry

### DIFF
--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -396,7 +396,7 @@ async fn create_started_sandbox(
     let create_result = {
         let mut observer = FreshSandboxFactoryCreateObserver { telemetry };
         factory
-            .create_with_observer(sandbox_config, Some(&mut observer))
+            .create_with_observer(sandbox_config, &mut observer)
             .await
     };
     let mut sandbox = match create_result {

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -5,7 +5,9 @@ use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
-use sandbox::{Sandbox, SandboxConfig, SandboxFactory, SandboxId};
+use sandbox::{
+    Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxId,
+};
 use tracing::{info, warn};
 
 use super::agent_run::{AgentExecutionResult, RunControls, RunStart, run_in_sandbox};
@@ -41,6 +43,24 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 const SLOW_PROXY_REGISTER_THRESHOLD: Duration = Duration::from_secs(3);
 const RUNNER_FRESH_WORKSPACE_IMAGE_PREPARE: &str = "runner_fresh_workspace_image_prepare";
 const RUNNER_FRESH_SANDBOX_FACTORY_CREATE: &str = "runner_fresh_sandbox_factory_create";
+const RUNNER_FRESH_SANDBOX_FACTORY_COW_POOL_ACQUIRE: &str =
+    "runner_fresh_sandbox_factory_cow_pool_acquire";
+const RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_DIR_RENAME: &str =
+    "runner_fresh_sandbox_factory_workspace_dir_rename";
+// `workspace_drive_prepare` contains the seed-copy/fresh-format child stages;
+// downstream queries should not sum the parent and child durations together.
+const RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_DRIVE_PREPARE: &str =
+    "runner_fresh_sandbox_factory_workspace_drive_prepare";
+const RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_SEED_SPARSE_COPY: &str =
+    "runner_fresh_sandbox_factory_workspace_seed_sparse_copy";
+const RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_FRESH_FORMAT: &str =
+    "runner_fresh_sandbox_factory_workspace_fresh_format";
+const RUNNER_FRESH_SANDBOX_FACTORY_SOCK_DIR_PREPARE: &str =
+    "runner_fresh_sandbox_factory_sock_dir_prepare";
+const RUNNER_FRESH_SANDBOX_FACTORY_NETNS_ACQUIRE: &str =
+    "runner_fresh_sandbox_factory_netns_acquire";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_CREATE: &str =
+    "runner_fresh_sandbox_factory_nbd_cow_create";
 const RUNNER_FRESH_SANDBOX_PROXY_REGISTER: &str = "runner_fresh_sandbox_proxy_register";
 const RUNNER_FRESH_SANDBOX_START: &str = "runner_fresh_sandbox_start";
 const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE: &str =
@@ -52,8 +72,48 @@ const WORKSPACE_IMAGE_PREPARE_LOCK_BUSY: &str = "workspace_image_prepare_lock_bu
 const WORKSPACE_IMAGE_PREPARE_INVALID_METADATA: &str = "workspace_image_prepare_invalid_metadata";
 const WORKSPACE_IMAGE_PREPARE_DISK_PRESSURE: &str = "workspace_image_prepare_disk_pressure";
 const SANDBOX_FACTORY_CREATE_FAILED: &str = "sandbox_factory_create_failed";
+const SANDBOX_FACTORY_CREATE_STAGE_FAILED: &str = "sandbox_factory_create_stage_failed";
 const SANDBOX_PROXY_REGISTER_FAILED: &str = "sandbox_proxy_register_failed";
 const SANDBOX_START_FAILED: &str = "sandbox_start_failed";
+
+struct FreshSandboxFactoryCreateObserver<'a> {
+    telemetry: &'a mut JobTelemetry,
+}
+
+impl SandboxCreateObserver for FreshSandboxFactoryCreateObserver<'_> {
+    fn record_stage(&mut self, stage: SandboxCreateStage, duration: Duration, success: bool) {
+        let error = if success {
+            None
+        } else {
+            Some(SANDBOX_FACTORY_CREATE_STAGE_FAILED)
+        };
+        self.telemetry.record(
+            fresh_sandbox_factory_stage_action(stage),
+            duration,
+            success,
+            error,
+        );
+    }
+}
+
+fn fresh_sandbox_factory_stage_action(stage: SandboxCreateStage) -> &'static str {
+    match stage {
+        SandboxCreateStage::CowPoolAcquire => RUNNER_FRESH_SANDBOX_FACTORY_COW_POOL_ACQUIRE,
+        SandboxCreateStage::WorkspaceDirRename => RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_DIR_RENAME,
+        SandboxCreateStage::WorkspaceDrivePrepare => {
+            RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_DRIVE_PREPARE
+        }
+        SandboxCreateStage::WorkspaceSeedSparseCopy => {
+            RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_SEED_SPARSE_COPY
+        }
+        SandboxCreateStage::WorkspaceFreshFormat => {
+            RUNNER_FRESH_SANDBOX_FACTORY_WORKSPACE_FRESH_FORMAT
+        }
+        SandboxCreateStage::SockDirPrepare => RUNNER_FRESH_SANDBOX_FACTORY_SOCK_DIR_PREPARE,
+        SandboxCreateStage::NetnsAcquire => RUNNER_FRESH_SANDBOX_FACTORY_NETNS_ACQUIRE,
+        SandboxCreateStage::NbdCowCreate => RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_CREATE,
+    }
+}
 
 #[cfg(test)]
 pub(super) async fn execute_new_sandbox(
@@ -333,7 +393,13 @@ async fn create_started_sandbox(
     info!(run_id = %context.run_id, sandbox_id = %sandbox_id, "creating sandbox");
     let t = Instant::now();
     let factory_create_started = Instant::now();
-    let mut sandbox = match factory.create(sandbox_config).await {
+    let create_result = {
+        let mut observer = FreshSandboxFactoryCreateObserver { telemetry };
+        factory
+            .create_with_observer(sandbox_config, Some(&mut observer))
+            .await
+    };
+    let mut sandbox = match create_result {
         Ok(s) => {
             telemetry.record(
                 RUNNER_FRESH_SANDBOX_FACTORY_CREATE,

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -136,22 +136,18 @@ impl SandboxFactory for ObservedMockSandboxFactory {
     async fn create_with_observer(
         &self,
         config: SandboxConfig,
-        observer: Option<&mut dyn SandboxCreateObserver>,
+        observer: &mut dyn SandboxCreateObserver,
     ) -> sandbox::Result<Box<dyn Sandbox>> {
         if let Some(stage) = self.failed_stage {
-            if let Some(observer) = observer {
-                observer.record_stage(stage, Duration::from_millis(1), false);
-            }
+            observer.record_stage(stage, Duration::from_millis(1), false);
             return Err(SandboxError::Initialization {
                 phase: SandboxInitializationPhase::SandboxAllocation,
                 message: "observed mock create failure".to_string(),
             });
         }
 
-        if let Some(observer) = observer {
-            for (index, stage) in SandboxCreateStage::ALL.iter().copied().enumerate() {
-                observer.record_stage(stage, Duration::from_millis(index as u64 + 1), true);
-            }
+        for (index, stage) in SandboxCreateStage::ALL.iter().copied().enumerate() {
+            observer.record_stage(stage, Duration::from_millis(index as u64 + 1), true);
         }
         self.inner.create(config).await
     }

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -357,7 +357,7 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         assert_has_action(&telemetry, action);
     }
     for action in FRESH_SANDBOX_FACTORY_STAGE_ACTIONS {
-        assert_has_action(&telemetry, action);
+        assert_action_success(&telemetry, action, true);
     }
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use sandbox::{
     ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxCreateObserver,
-    SandboxCreateStage, SandboxFactory, SandboxId,
+    SandboxCreateStage, SandboxError, SandboxFactory, SandboxId, SandboxInitializationPhase,
 };
 use sandbox_mock::MockSandboxFactory;
 
@@ -83,14 +83,38 @@ fn assert_action_success(telemetry: &JobTelemetry, action: &str, success: bool) 
     assert_eq!(op.1, success, "{action} success flag");
 }
 
+fn assert_action_outcome(
+    telemetry: &JobTelemetry,
+    action: &str,
+    success: bool,
+    error: Option<&str>,
+) {
+    let ops = telemetry.pending_ops_snapshot();
+    let op = ops
+        .iter()
+        .find(|op| op.0 == action)
+        .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {ops:?}"));
+    assert_eq!(op.1, success, "{action} success flag");
+    assert_eq!(op.2.as_deref(), error, "{action} error");
+}
+
 struct ObservedMockSandboxFactory {
     inner: MockSandboxFactory,
+    failed_stage: Option<SandboxCreateStage>,
 }
 
 impl ObservedMockSandboxFactory {
     fn new() -> Self {
         Self {
             inner: MockSandboxFactory::new(),
+            failed_stage: None,
+        }
+    }
+
+    fn with_failed_stage(stage: SandboxCreateStage) -> Self {
+        Self {
+            inner: MockSandboxFactory::new(),
+            failed_stage: Some(stage),
         }
     }
 }
@@ -114,6 +138,16 @@ impl SandboxFactory for ObservedMockSandboxFactory {
         config: SandboxConfig,
         observer: Option<&mut dyn SandboxCreateObserver>,
     ) -> sandbox::Result<Box<dyn Sandbox>> {
+        if let Some(stage) = self.failed_stage {
+            if let Some(observer) = observer {
+                observer.record_stage(stage, Duration::from_millis(1), false);
+            }
+            return Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: "observed mock create failure".to_string(),
+            });
+        }
+
         if let Some(observer) = observer {
             for (index, stage) in SandboxCreateStage::ALL.iter().copied().enumerate() {
                 observer.record_stage(stage, Duration::from_millis(index as u64 + 1), true);
@@ -333,6 +367,42 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_workspace_image_prepare");
     assert_lacks_action(&telemetry, "runner_guest_state_restore");
+}
+
+#[tokio::test]
+async fn execute_job_records_failed_fresh_sandbox_factory_stage_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = ObservedMockSandboxFactory::with_failed_stage(SandboxCreateStage::NbdCowCreate);
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, telemetry) = execute_job(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        cancel,
+    )
+    .await;
+
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_factory_nbd_cow_create",
+        false,
+        Some("sandbox_factory_create_stage_failed"),
+    );
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_factory_create",
+        false,
+        Some("sandbox_factory_create_failed"),
+    );
+    assert_action_success(&telemetry, "vm_create", false);
+    assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
-use sandbox::SandboxId;
-use sandbox::{ProcessOutputChunk, ProcessOutputMode};
+use async_trait::async_trait;
+use sandbox::{
+    ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxCreateObserver,
+    SandboxCreateStage, SandboxFactory, SandboxId,
+};
 use sandbox_mock::MockSandboxFactory;
 
 use super::super::telemetry::{
@@ -79,6 +82,76 @@ fn assert_action_success(telemetry: &JobTelemetry, action: &str, success: bool) 
         .unwrap_or_else(|| panic!("expected telemetry action {action}, got: {ops:?}"));
     assert_eq!(op.1, success, "{action} success flag");
 }
+
+struct ObservedMockSandboxFactory {
+    inner: MockSandboxFactory,
+}
+
+impl ObservedMockSandboxFactory {
+    fn new() -> Self {
+        Self {
+            inner: MockSandboxFactory::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl SandboxFactory for ObservedMockSandboxFactory {
+    fn name(&self) -> &str {
+        "observed-mock"
+    }
+
+    fn config_hash(&self) -> String {
+        self.inner.config_hash()
+    }
+
+    async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
+        self.inner.create(config).await
+    }
+
+    async fn create_with_observer(
+        &self,
+        config: SandboxConfig,
+        observer: Option<&mut dyn SandboxCreateObserver>,
+    ) -> sandbox::Result<Box<dyn Sandbox>> {
+        if let Some(observer) = observer {
+            for (index, stage) in SANDBOX_CREATE_STAGES.iter().copied().enumerate() {
+                observer.record_stage(stage, Duration::from_millis(index as u64 + 1), true);
+            }
+        }
+        self.inner.create(config).await
+    }
+
+    async fn destroy(&self, sandbox: Box<dyn Sandbox>) {
+        self.inner.destroy(sandbox).await;
+    }
+
+    async fn shutdown(&mut self) {
+        self.inner.shutdown().await;
+    }
+}
+
+const SANDBOX_CREATE_STAGES: &[SandboxCreateStage] = &[
+    SandboxCreateStage::CowPoolAcquire,
+    SandboxCreateStage::WorkspaceDirRename,
+    SandboxCreateStage::WorkspaceDrivePrepare,
+    SandboxCreateStage::WorkspaceSeedSparseCopy,
+    SandboxCreateStage::WorkspaceFreshFormat,
+    SandboxCreateStage::SockDirPrepare,
+    SandboxCreateStage::NetnsAcquire,
+    SandboxCreateStage::NbdCowCreate,
+];
+
+const FRESH_SANDBOX_FACTORY_STAGE_ACTIONS: &[&str] = &[
+    "runner_fresh_sandbox_factory_cow_pool_acquire",
+    "runner_fresh_sandbox_factory_workspace_dir_rename",
+    "runner_fresh_sandbox_factory_workspace_drive_prepare",
+    "runner_fresh_sandbox_factory_workspace_seed_sparse_copy",
+    "runner_fresh_sandbox_factory_workspace_fresh_format",
+    "runner_fresh_sandbox_factory_sock_dir_prepare",
+    "runner_fresh_sandbox_factory_netns_acquire",
+    "runner_fresh_sandbox_factory_nbd_cow_create",
+];
 
 const RUNNER_PRE_SPAWN_PHASE_ACTIONS: &[&str] = &[
     "runner_claim_resume_session_validation",
@@ -223,7 +296,7 @@ async fn execute_job_reuse_records_sandbox_reuse_hit_in_telemetry() {
 async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let factory = MockSandboxFactory::new();
+    let factory = ObservedMockSandboxFactory::new();
 
     let cancel = tokio_util::sync::CancellationToken::new();
     let (_outcome, telemetry) = execute_job_with_prepared_notifier(
@@ -262,6 +335,9 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
         "workspace_drive_mount",
         "agent_execute",
     ] {
+        assert_has_action(&telemetry, action);
+    }
+    for action in FRESH_SANDBOX_FACTORY_STAGE_ACTIONS {
         assert_has_action(&telemetry, action);
     }
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
@@ -327,6 +403,9 @@ async fn execute_job_reuse_records_runner_pre_spawn_and_reuse_path_timing() {
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_factory_create");
+    for action in FRESH_SANDBOX_FACTORY_STAGE_ACTIONS {
+        assert_lacks_action(&telemetry, action);
+    }
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_proxy_register");
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
     assert_lacks_action(&telemetry, "runner_guest_timezone_sync");

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -115,7 +115,7 @@ impl SandboxFactory for ObservedMockSandboxFactory {
         observer: Option<&mut dyn SandboxCreateObserver>,
     ) -> sandbox::Result<Box<dyn Sandbox>> {
         if let Some(observer) = observer {
-            for (index, stage) in SANDBOX_CREATE_STAGES.iter().copied().enumerate() {
+            for (index, stage) in SandboxCreateStage::ALL.iter().copied().enumerate() {
                 observer.record_stage(stage, Duration::from_millis(index as u64 + 1), true);
             }
         }
@@ -130,17 +130,6 @@ impl SandboxFactory for ObservedMockSandboxFactory {
         self.inner.shutdown().await;
     }
 }
-
-const SANDBOX_CREATE_STAGES: &[SandboxCreateStage] = &[
-    SandboxCreateStage::CowPoolAcquire,
-    SandboxCreateStage::WorkspaceDirRename,
-    SandboxCreateStage::WorkspaceDrivePrepare,
-    SandboxCreateStage::WorkspaceSeedSparseCopy,
-    SandboxCreateStage::WorkspaceFreshFormat,
-    SandboxCreateStage::SockDirPrepare,
-    SandboxCreateStage::NetnsAcquire,
-    SandboxCreateStage::NbdCowCreate,
-];
 
 const FRESH_SANDBOX_FACTORY_STAGE_ACTIONS: &[&str] = &[
     "runner_fresh_sandbox_factory_cow_pool_acquire",

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -39,18 +39,7 @@ macro_rules! emit_success_summary_event {
     };
 }
 
-const SANDBOX_CREATE_STAGES: [SandboxCreateStage; 8] = [
-    SandboxCreateStage::CowPoolAcquire,
-    SandboxCreateStage::WorkspaceDirRename,
-    SandboxCreateStage::WorkspaceDrivePrepare,
-    SandboxCreateStage::WorkspaceSeedSparseCopy,
-    SandboxCreateStage::WorkspaceFreshFormat,
-    SandboxCreateStage::SockDirPrepare,
-    SandboxCreateStage::NetnsAcquire,
-    SandboxCreateStage::NbdCowCreate,
-];
-
-const SANDBOX_CREATE_STAGE_COUNT: usize = SANDBOX_CREATE_STAGES.len();
+const SANDBOX_CREATE_STAGE_COUNT: usize = SandboxCreateStage::ALL.len();
 
 fn sandbox_create_stage_name(stage: SandboxCreateStage) -> &'static str {
     match stage {
@@ -474,7 +463,7 @@ mod tests {
             .collect();
 
         assert_eq!(stage_fields.len(), SANDBOX_CREATE_STAGE_COUNT);
-        for stage in SANDBOX_CREATE_STAGES {
+        for stage in SandboxCreateStage::ALL {
             let Some((_, field)) = SUCCESS_SUMMARY_STAGE_FIELDS
                 .iter()
                 .find(|(candidate, _)| *candidate == stage)
@@ -621,7 +610,7 @@ mod tests {
                 "vm0/default".into(),
                 Some(&mut observer),
             );
-            for stage in SANDBOX_CREATE_STAGES {
+            for stage in SandboxCreateStage::ALL {
                 timing
                     .record_stage_result(stage, Instant::now(), Ok::<(), &str>(()))
                     .unwrap();

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -160,23 +160,29 @@ impl SandboxCreateStageDurations {
     }
 }
 
-pub(crate) struct SandboxCreateTiming {
+pub(crate) struct SandboxCreateTiming<'a> {
     sandbox_id: String,
     profile: String,
     started_at: Instant,
     durations: SandboxCreateStageDurations,
+    observer: Option<&'a mut dyn sandbox::SandboxCreateObserver>,
     workspace_drive_present: bool,
     workspace_seed_image_used: bool,
     failure_logged: bool,
 }
 
-impl SandboxCreateTiming {
-    pub(super) fn new(sandbox_id: String, profile: String) -> Self {
+impl<'a> SandboxCreateTiming<'a> {
+    pub(super) fn new(
+        sandbox_id: String,
+        profile: String,
+        observer: Option<&'a mut dyn sandbox::SandboxCreateObserver>,
+    ) -> Self {
         Self {
             sandbox_id,
             profile,
             started_at: Instant::now(),
             durations: SandboxCreateStageDurations::default(),
+            observer,
             workspace_drive_present: false,
             workspace_seed_image_used: false,
             failure_logged: false,
@@ -203,8 +209,12 @@ impl SandboxCreateTiming {
         let elapsed = started_at.elapsed();
         self.record_stage_duration(stage, elapsed);
         match result {
-            Ok(value) => Ok(value),
+            Ok(value) => {
+                self.record_observer_stage(stage, elapsed, true);
+                Ok(value)
+            }
             Err(error) => {
+                self.record_observer_stage(stage, elapsed, false);
                 let message = error.to_string();
                 self.emit_stage_failure(stage, elapsed, &message);
                 Err(error)
@@ -223,6 +233,18 @@ impl SandboxCreateTiming {
 
     fn record_stage_duration(&mut self, stage: SandboxCreateStage, duration: Duration) {
         self.durations.set(stage, duration);
+    }
+
+    fn record_observer_stage(
+        &mut self,
+        stage: SandboxCreateStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        let Some(observer) = self.observer.as_deref_mut() else {
+            return;
+        };
+        observer.record_stage(stage.into(), duration, success);
     }
 
     fn stage_duration_ms(&self, stage: SandboxCreateStage) -> u64 {
@@ -255,7 +277,22 @@ impl SandboxCreateTiming {
     }
 }
 
-impl WorkspaceDriveImagePrepareObserver for SandboxCreateTiming {
+impl From<SandboxCreateStage> for sandbox::SandboxCreateStage {
+    fn from(stage: SandboxCreateStage) -> Self {
+        match stage {
+            SandboxCreateStage::CowPoolAcquire => Self::CowPoolAcquire,
+            SandboxCreateStage::WorkspaceDirRename => Self::WorkspaceDirRename,
+            SandboxCreateStage::WorkspaceDrivePrepare => Self::WorkspaceDrivePrepare,
+            SandboxCreateStage::WorkspaceSeedSparseCopy => Self::WorkspaceSeedSparseCopy,
+            SandboxCreateStage::WorkspaceFreshFormat => Self::WorkspaceFreshFormat,
+            SandboxCreateStage::SockDirPrepare => Self::SockDirPrepare,
+            SandboxCreateStage::NetnsAcquire => Self::NetnsAcquire,
+            SandboxCreateStage::NbdCowCreate => Self::NbdCowCreate,
+        }
+    }
+}
+
+impl WorkspaceDriveImagePrepareObserver for SandboxCreateTiming<'_> {
     fn mark_workspace_drive_present(&mut self) {
         SandboxCreateTiming::mark_workspace_drive_present(self);
     }
@@ -337,6 +374,22 @@ mod tests {
     use tracing_test_support::{CapturedEvent, CapturedEvents};
 
     use super::*;
+
+    #[derive(Default)]
+    struct RecordingCreateObserver {
+        records: Vec<(sandbox::SandboxCreateStage, Duration, bool)>,
+    }
+
+    impl sandbox::SandboxCreateObserver for RecordingCreateObserver {
+        fn record_stage(
+            &mut self,
+            stage: sandbox::SandboxCreateStage,
+            duration: Duration,
+            success: bool,
+        ) {
+            self.records.push((stage, duration, success));
+        }
+    }
 
     const SUCCESS_SUMMARY_FIELD_NAMES: &[&str] = &[
         "cow_pool_acquire_ms",
@@ -466,7 +519,7 @@ mod tests {
 
     #[test]
     fn fast_success_emits_info_summary() {
-        let timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        let timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into(), None);
 
         let event = capture_success_summary_event(&timing, SLOW_SANDBOX_CREATE_THRESHOLD / 2);
 
@@ -494,8 +547,8 @@ mod tests {
 
     #[test]
     fn success_summary_fast_and_slow_field_sets_match() {
-        let fast_timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
-        let slow_timing = SandboxCreateTiming::new("sandbox-2".into(), "vm0/default".into());
+        let fast_timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into(), None);
+        let slow_timing = SandboxCreateTiming::new("sandbox-2".into(), "vm0/default".into(), None);
 
         let fast_event =
             capture_success_summary_event(&fast_timing, SLOW_SANDBOX_CREATE_THRESHOLD / 2);
@@ -510,7 +563,7 @@ mod tests {
 
     #[test]
     fn slow_success_emits_summary_with_stable_fields() {
-        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into(), None);
         timing.mark_workspace_drive_present();
         timing.mark_workspace_seed_image_used();
         for (index, (stage, _)) in SUCCESS_SUMMARY_STAGE_FIELDS.iter().copied().enumerate() {
@@ -540,7 +593,7 @@ mod tests {
 
     #[test]
     fn success_summary_saturates_large_durations() {
-        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into(), None);
         timing.record_stage_duration(SandboxCreateStage::CowPoolAcquire, Duration::MAX);
 
         let event = capture_success_summary_event(&timing, Duration::MAX);
@@ -554,7 +607,7 @@ mod tests {
 
     #[test]
     fn workspace_drive_image_observer_maps_to_sandbox_create_timing() {
-        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into(), None);
 
         WorkspaceDriveImagePrepareObserver::mark_workspace_drive_present(&mut timing);
         WorkspaceDriveImagePrepareObserver::mark_workspace_seed_image_used(&mut timing);
@@ -588,8 +641,64 @@ mod tests {
     }
 
     #[test]
+    fn stage_results_forward_to_external_observer() {
+        let mut observer = RecordingCreateObserver::default();
+        {
+            let mut timing = SandboxCreateTiming::new(
+                "sandbox-1".into(),
+                "vm0/default".into(),
+                Some(&mut observer),
+            );
+            for stage in SandboxCreateStage::ALL {
+                timing
+                    .record_stage_result(stage, Instant::now(), Ok::<(), &str>(()))
+                    .unwrap();
+            }
+        }
+
+        let stages: Vec<_> = observer.records.iter().map(|record| record.0).collect();
+        assert_eq!(
+            stages,
+            vec![
+                sandbox::SandboxCreateStage::CowPoolAcquire,
+                sandbox::SandboxCreateStage::WorkspaceDirRename,
+                sandbox::SandboxCreateStage::WorkspaceDrivePrepare,
+                sandbox::SandboxCreateStage::WorkspaceSeedSparseCopy,
+                sandbox::SandboxCreateStage::WorkspaceFreshFormat,
+                sandbox::SandboxCreateStage::SockDirPrepare,
+                sandbox::SandboxCreateStage::NetnsAcquire,
+                sandbox::SandboxCreateStage::NbdCowCreate,
+            ]
+        );
+        assert!(observer.records.iter().all(|record| record.2));
+    }
+
+    #[test]
+    fn failed_stage_result_forwards_failure_to_external_observer() {
+        let mut observer = RecordingCreateObserver::default();
+        {
+            let mut timing = SandboxCreateTiming::new(
+                "sandbox-1".into(),
+                "vm0/default".into(),
+                Some(&mut observer),
+            );
+            let result =
+                timing.record_stage_result(SandboxCreateStage::NbdCowCreate, Instant::now(), {
+                    Err::<(), _>("nbd failed")
+                });
+            assert!(result.is_err());
+        }
+
+        let [(stage, _duration, success)] = observer.records.as_slice() else {
+            panic!("expected one observer record, got {:?}", observer.records);
+        };
+        assert_eq!(*stage, sandbox::SandboxCreateStage::NbdCowCreate);
+        assert!(!success);
+    }
+
+    #[test]
     fn stage_failure_emits_warning_once() {
-        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into(), None);
 
         let events = capture_events(|| {
             timing.emit_stage_failure(
@@ -618,7 +727,7 @@ mod tests {
 
     #[test]
     fn stage_failure_redacts_paths_and_command_argv() {
-        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into());
+        let mut timing = SandboxCreateTiming::new("sandbox-1".into(), "vm0/default".into(), None);
 
         let events = capture_events(|| {
             timing.emit_stage_failure(

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::time::{Duration, Instant};
 
+use sandbox::SandboxCreateStage;
 use tracing::{info, warn};
 
 use crate::duration::duration_ms;
@@ -38,68 +39,54 @@ macro_rules! emit_success_summary_event {
     };
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum SandboxCreateStage {
-    CowPoolAcquire,
-    WorkspaceDirRename,
-    WorkspaceDrivePrepare,
-    WorkspaceSeedSparseCopy,
-    WorkspaceFreshFormat,
-    SockDirPrepare,
-    NetnsAcquire,
-    NbdCowCreate,
+const SANDBOX_CREATE_STAGES: [SandboxCreateStage; 8] = [
+    SandboxCreateStage::CowPoolAcquire,
+    SandboxCreateStage::WorkspaceDirRename,
+    SandboxCreateStage::WorkspaceDrivePrepare,
+    SandboxCreateStage::WorkspaceSeedSparseCopy,
+    SandboxCreateStage::WorkspaceFreshFormat,
+    SandboxCreateStage::SockDirPrepare,
+    SandboxCreateStage::NetnsAcquire,
+    SandboxCreateStage::NbdCowCreate,
+];
+
+const SANDBOX_CREATE_STAGE_COUNT: usize = SANDBOX_CREATE_STAGES.len();
+
+fn sandbox_create_stage_name(stage: SandboxCreateStage) -> &'static str {
+    match stage {
+        SandboxCreateStage::CowPoolAcquire => "cow_pool_acquire",
+        SandboxCreateStage::WorkspaceDirRename => "workspace_dir_rename",
+        SandboxCreateStage::WorkspaceDrivePrepare => "workspace_drive_prepare",
+        SandboxCreateStage::WorkspaceSeedSparseCopy => "workspace_seed_sparse_copy",
+        SandboxCreateStage::WorkspaceFreshFormat => "workspace_fresh_format",
+        SandboxCreateStage::SockDirPrepare => "sock_dir_prepare",
+        SandboxCreateStage::NetnsAcquire => "netns_acquire",
+        SandboxCreateStage::NbdCowCreate => "nbd_cow_create",
+    }
 }
 
-impl SandboxCreateStage {
-    const ALL: [Self; 8] = [
-        Self::CowPoolAcquire,
-        Self::WorkspaceDirRename,
-        Self::WorkspaceDrivePrepare,
-        Self::WorkspaceSeedSparseCopy,
-        Self::WorkspaceFreshFormat,
-        Self::SockDirPrepare,
-        Self::NetnsAcquire,
-        Self::NbdCowCreate,
-    ];
-
-    const COUNT: usize = Self::ALL.len();
-
-    pub(super) fn as_str(self) -> &'static str {
-        match self {
-            Self::CowPoolAcquire => "cow_pool_acquire",
-            Self::WorkspaceDirRename => "workspace_dir_rename",
-            Self::WorkspaceDrivePrepare => "workspace_drive_prepare",
-            Self::WorkspaceSeedSparseCopy => "workspace_seed_sparse_copy",
-            Self::WorkspaceFreshFormat => "workspace_fresh_format",
-            Self::SockDirPrepare => "sock_dir_prepare",
-            Self::NetnsAcquire => "netns_acquire",
-            Self::NbdCowCreate => "nbd_cow_create",
-        }
-    }
-
-    #[cfg(test)]
-    fn summary_field_name(self) -> &'static str {
-        match self {
-            Self::CowPoolAcquire => "cow_pool_acquire_ms",
-            Self::WorkspaceDirRename => "workspace_dir_rename_ms",
-            Self::WorkspaceDrivePrepare => "workspace_drive_prepare_ms",
-            Self::WorkspaceSeedSparseCopy => "workspace_seed_sparse_copy_ms",
-            Self::WorkspaceFreshFormat => "workspace_fresh_format_ms",
-            Self::SockDirPrepare => "sock_dir_prepare_ms",
-            Self::NetnsAcquire => "netns_acquire_ms",
-            Self::NbdCowCreate => "nbd_cow_create_ms",
-        }
+#[cfg(test)]
+fn sandbox_create_stage_summary_field_name(stage: SandboxCreateStage) -> &'static str {
+    match stage {
+        SandboxCreateStage::CowPoolAcquire => "cow_pool_acquire_ms",
+        SandboxCreateStage::WorkspaceDirRename => "workspace_dir_rename_ms",
+        SandboxCreateStage::WorkspaceDrivePrepare => "workspace_drive_prepare_ms",
+        SandboxCreateStage::WorkspaceSeedSparseCopy => "workspace_seed_sparse_copy_ms",
+        SandboxCreateStage::WorkspaceFreshFormat => "workspace_fresh_format_ms",
+        SandboxCreateStage::SockDirPrepare => "sock_dir_prepare_ms",
+        SandboxCreateStage::NetnsAcquire => "netns_acquire_ms",
+        SandboxCreateStage::NbdCowCreate => "nbd_cow_create_ms",
     }
 }
 
 struct SandboxCreateStageDurations {
-    values: [Option<Duration>; SandboxCreateStage::COUNT],
+    values: [Option<Duration>; SANDBOX_CREATE_STAGE_COUNT],
 }
 
 impl Default for SandboxCreateStageDurations {
     fn default() -> Self {
         Self {
-            values: [None; SandboxCreateStage::COUNT],
+            values: [None; SANDBOX_CREATE_STAGE_COUNT],
         }
     }
 }
@@ -244,7 +231,7 @@ impl<'a> SandboxCreateTiming<'a> {
         let Some(observer) = self.observer.as_deref_mut() else {
             return;
         };
-        observer.record_stage(stage.into(), duration, success);
+        observer.record_stage(stage, duration, success);
     }
 
     fn stage_duration_ms(&self, stage: SandboxCreateStage) -> u64 {
@@ -258,7 +245,7 @@ impl<'a> SandboxCreateTiming<'a> {
         self.failure_logged = true;
         let safe_error = sanitize_error_for_timing(error);
         warn!(
-            stage = stage.as_str(),
+            stage = sandbox_create_stage_name(stage),
             elapsed_ms = duration_ms(elapsed),
             success = false,
             sandbox_id = self.sandbox_id.as_str(),
@@ -274,21 +261,6 @@ impl<'a> SandboxCreateTiming<'a> {
             return;
         }
         emit_success_summary_event!(warn, self, total_elapsed, "slow sandbox create");
-    }
-}
-
-impl From<SandboxCreateStage> for sandbox::SandboxCreateStage {
-    fn from(stage: SandboxCreateStage) -> Self {
-        match stage {
-            SandboxCreateStage::CowPoolAcquire => Self::CowPoolAcquire,
-            SandboxCreateStage::WorkspaceDirRename => Self::WorkspaceDirRename,
-            SandboxCreateStage::WorkspaceDrivePrepare => Self::WorkspaceDrivePrepare,
-            SandboxCreateStage::WorkspaceSeedSparseCopy => Self::WorkspaceSeedSparseCopy,
-            SandboxCreateStage::WorkspaceFreshFormat => Self::WorkspaceFreshFormat,
-            SandboxCreateStage::SockDirPrepare => Self::SockDirPrepare,
-            SandboxCreateStage::NetnsAcquire => Self::NetnsAcquire,
-            SandboxCreateStage::NbdCowCreate => Self::NbdCowCreate,
-        }
     }
 }
 
@@ -494,22 +466,22 @@ mod tests {
     fn success_summary_contract_includes_every_stage_field() {
         assert_eq!(
             SUCCESS_SUMMARY_STAGE_FIELDS.len(),
-            SandboxCreateStage::COUNT
+            SANDBOX_CREATE_STAGE_COUNT
         );
         let stage_fields: BTreeSet<&str> = SUCCESS_SUMMARY_STAGE_FIELDS
             .iter()
             .map(|(_, field)| *field)
             .collect();
 
-        assert_eq!(stage_fields.len(), SandboxCreateStage::COUNT);
-        for stage in SandboxCreateStage::ALL {
+        assert_eq!(stage_fields.len(), SANDBOX_CREATE_STAGE_COUNT);
+        for stage in SANDBOX_CREATE_STAGES {
             let Some((_, field)) = SUCCESS_SUMMARY_STAGE_FIELDS
                 .iter()
                 .find(|(candidate, _)| *candidate == stage)
             else {
                 panic!("missing success summary field contract for {stage:?}");
             };
-            assert_eq!(stage.summary_field_name(), *field);
+            assert_eq!(sandbox_create_stage_summary_field_name(stage), *field);
             assert!(
                 SUCCESS_SUMMARY_FIELD_NAMES.contains(field),
                 "missing success summary field for {stage:?}"
@@ -649,7 +621,7 @@ mod tests {
                 "vm0/default".into(),
                 Some(&mut observer),
             );
-            for stage in SandboxCreateStage::ALL {
+            for stage in SANDBOX_CREATE_STAGES {
                 timing
                     .record_stage_result(stage, Instant::now(), Ok::<(), &str>(()))
                     .unwrap();

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -10,8 +10,8 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use sandbox::{
-    Sandbox, SandboxConfig, SandboxError, SandboxFactory, SandboxInitializationPhase,
-    SandboxInvalidStateContext,
+    Sandbox, SandboxConfig, SandboxCreateObserver, SandboxError, SandboxFactory,
+    SandboxInitializationPhase, SandboxInvalidStateContext,
 };
 use tracing::{info, warn};
 
@@ -223,11 +223,20 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
+        self.create_with_observer(config, None).await
+    }
+
+    async fn create_with_observer(
+        &self,
+        config: SandboxConfig,
+        observer: Option<&mut dyn SandboxCreateObserver>,
+    ) -> sandbox::Result<Box<dyn Sandbox>> {
         let resources = self.resources()?;
         let device_rate_limits = convert_device_rate_limits(config.device_rate_limits.as_ref())?;
         let leak_tx = resources.leak_cleaner.sender();
         let id = config.id.to_string();
-        let mut timing = SandboxCreateTiming::new(id.clone(), self.config.profile.clone());
+        let mut timing =
+            SandboxCreateTiming::new(id.clone(), self.config.profile.clone(), observer);
         let rollback_cleanup = FactoryCreateRollbackCleanup {
             id: id.clone(),
             netns_pool: resources.netns_pool.clone(),

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -10,8 +10,8 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use sandbox::{
-    Sandbox, SandboxConfig, SandboxCreateObserver, SandboxError, SandboxFactory,
-    SandboxInitializationPhase, SandboxInvalidStateContext,
+    Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxError,
+    SandboxFactory, SandboxInitializationPhase, SandboxInvalidStateContext,
 };
 use tracing::{info, warn};
 
@@ -20,7 +20,7 @@ use crate::cow_cleanup::CowCleanupOutcome;
 use crate::duration::duration_ms;
 use crate::factory::cleanup_group::{FactoryCleanupGroup, FactoryCleanupTaskKind};
 use crate::factory::cow_cleanup::destroy_cow_device_with_retries;
-use crate::factory::create_timing::{SandboxCreateStage, SandboxCreateTiming};
+use crate::factory::create_timing::SandboxCreateTiming;
 use crate::factory::create_transaction::{
     FactoryCreateRollbackCleanup, SandboxCreateResources, SandboxCreateTransaction,
     rollback_create_transaction,

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -6,7 +6,7 @@ mod invariant;
 mod leak_cleaner;
 
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use async_trait::async_trait;
 use sandbox::{
@@ -56,12 +56,6 @@ struct StartedFactoryResources {
     cow_pool: crate::cow_pool::CowPoolHandle,
     /// Owns the channel/task that drains leaked sandbox resources from Drop.
     leak_cleaner: LeakCleaner,
-}
-
-struct NoopSandboxCreateObserver;
-
-impl SandboxCreateObserver for NoopSandboxCreateObserver {
-    fn record_stage(&mut self, _stage: SandboxCreateStage, _duration: Duration, _success: bool) {}
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -216,34 +210,18 @@ impl FirecrackerFactory {
             },
         }
     }
-}
 
-#[async_trait]
-impl SandboxFactory for FirecrackerFactory {
-    fn name(&self) -> &str {
-        "firecracker"
-    }
-
-    fn config_hash(&self) -> String {
-        config_hash()
-    }
-
-    async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
-        let mut observer = NoopSandboxCreateObserver;
-        self.create_with_observer(config, &mut observer).await
-    }
-
-    async fn create_with_observer(
+    async fn create_inner(
         &self,
         config: SandboxConfig,
-        observer: &mut dyn SandboxCreateObserver,
+        observer: Option<&mut dyn SandboxCreateObserver>,
     ) -> sandbox::Result<Box<dyn Sandbox>> {
         let resources = self.resources()?;
         let device_rate_limits = convert_device_rate_limits(config.device_rate_limits.as_ref())?;
         let leak_tx = resources.leak_cleaner.sender();
         let id = config.id.to_string();
         let mut timing =
-            SandboxCreateTiming::new(id.clone(), self.config.profile.clone(), Some(observer));
+            SandboxCreateTiming::new(id.clone(), self.config.profile.clone(), observer);
         let rollback_cleanup = FactoryCreateRollbackCleanup {
             id: id.clone(),
             netns_pool: resources.netns_pool.clone(),
@@ -405,6 +383,29 @@ impl SandboxFactory for FirecrackerFactory {
             leak_tx,
         });
         Ok(Box::new(sandbox))
+    }
+}
+
+#[async_trait]
+impl SandboxFactory for FirecrackerFactory {
+    fn name(&self) -> &str {
+        "firecracker"
+    }
+
+    fn config_hash(&self) -> String {
+        config_hash()
+    }
+
+    async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
+        self.create_inner(config, None).await
+    }
+
+    async fn create_with_observer(
+        &self,
+        config: SandboxConfig,
+        observer: &mut dyn SandboxCreateObserver,
+    ) -> sandbox::Result<Box<dyn Sandbox>> {
+        self.create_inner(config, Some(observer)).await
     }
 
     async fn destroy(&self, sandbox: Box<dyn Sandbox>) {

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -6,7 +6,7 @@ mod invariant;
 mod leak_cleaner;
 
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use sandbox::{
@@ -56,6 +56,12 @@ struct StartedFactoryResources {
     cow_pool: crate::cow_pool::CowPoolHandle,
     /// Owns the channel/task that drains leaked sandbox resources from Drop.
     leak_cleaner: LeakCleaner,
+}
+
+struct NoopSandboxCreateObserver;
+
+impl SandboxCreateObserver for NoopSandboxCreateObserver {
+    fn record_stage(&mut self, _stage: SandboxCreateStage, _duration: Duration, _success: bool) {}
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -223,20 +229,21 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn create(&self, config: SandboxConfig) -> sandbox::Result<Box<dyn Sandbox>> {
-        self.create_with_observer(config, None).await
+        let mut observer = NoopSandboxCreateObserver;
+        self.create_with_observer(config, &mut observer).await
     }
 
     async fn create_with_observer(
         &self,
         config: SandboxConfig,
-        observer: Option<&mut dyn SandboxCreateObserver>,
+        observer: &mut dyn SandboxCreateObserver,
     ) -> sandbox::Result<Box<dyn Sandbox>> {
         let resources = self.resources()?;
         let device_rate_limits = convert_device_rate_limits(config.device_rate_limits.as_ref())?;
         let leak_tx = resources.leak_cleaner.sender();
         let id = config.id.to_string();
         let mut timing =
-            SandboxCreateTiming::new(id.clone(), self.config.profile.clone(), observer);
+            SandboxCreateTiming::new(id.clone(), self.config.profile.clone(), Some(observer));
         let rollback_cleanup = FactoryCreateRollbackCleanup {
             id: id.clone(),
             netns_pool: resources.netns_pool.clone(),

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -5,10 +5,11 @@ use crate::config::SandboxConfig;
 use crate::error::Result;
 use crate::sandbox::Sandbox;
 
-/// Provider-neutral stages inside sandbox factory creation.
+/// Low-cardinality stages inside sandbox factory creation.
 ///
-/// These stages are optional observations for attribution. Providers that do
-/// not expose a matching internal boundary can ignore the observer.
+/// The current stage set matches the factory boundaries that runner telemetry
+/// needs to attribute. Providers that do not expose a matching internal
+/// boundary can ignore the observer.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SandboxCreateStage {
     CowPoolAcquire,
@@ -68,7 +69,7 @@ pub trait SandboxFactory: Send + Sync {
     /// The returned sandbox belongs to this factory's lifecycle and should be
     /// released through [`destroy`](Self::destroy) on the normal teardown path.
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
-    /// Create a sandbox while optionally reporting provider-neutral stage timings.
+    /// Create a sandbox while optionally reporting create-stage timings.
     ///
     /// The default implementation preserves existing factory behavior for
     /// providers that do not expose internal create-stage attribution.

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -1,8 +1,30 @@
 use async_trait::async_trait;
+use std::time::Duration;
 
 use crate::config::SandboxConfig;
 use crate::error::Result;
 use crate::sandbox::Sandbox;
+
+/// Provider-neutral stages inside sandbox factory creation.
+///
+/// These stages are optional observations for attribution. Providers that do
+/// not expose a matching internal boundary can ignore the observer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxCreateStage {
+    CowPoolAcquire,
+    WorkspaceDirRename,
+    WorkspaceDrivePrepare,
+    WorkspaceSeedSparseCopy,
+    WorkspaceFreshFormat,
+    SockDirPrepare,
+    NetnsAcquire,
+    NbdCowCreate,
+}
+
+/// Receives low-cardinality sandbox factory create stage timings.
+pub trait SandboxCreateObserver: Send {
+    fn record_stage(&mut self, stage: SandboxCreateStage, duration: Duration, success: bool);
+}
 
 /// Creates and owns the normal teardown path for sandboxes in one profile.
 ///
@@ -46,6 +68,18 @@ pub trait SandboxFactory: Send + Sync {
     /// The returned sandbox belongs to this factory's lifecycle and should be
     /// released through [`destroy`](Self::destroy) on the normal teardown path.
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
+    /// Create a sandbox while optionally reporting provider-neutral stage timings.
+    ///
+    /// The default implementation preserves existing factory behavior for
+    /// providers that do not expose internal create-stage attribution.
+    async fn create_with_observer(
+        &self,
+        config: SandboxConfig,
+        _observer: Option<&mut dyn SandboxCreateObserver>,
+    ) -> Result<Box<dyn Sandbox>> {
+        self.create(config).await
+    }
+
     /// Explicitly tear down a sandbox created by this factory.
     ///
     /// This is the normal resource-release path for sandbox-owned provider

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -83,14 +83,14 @@ pub trait SandboxFactory: Send + Sync {
     /// The returned sandbox belongs to this factory's lifecycle and should be
     /// released through [`destroy`](Self::destroy) on the normal teardown path.
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>>;
-    /// Create a sandbox while optionally reporting create-stage timings.
+    /// Create a sandbox while reporting create-stage timings to `observer`.
     ///
     /// The default implementation preserves existing factory behavior for
     /// providers that do not expose internal create-stage attribution.
     async fn create_with_observer(
         &self,
         config: SandboxConfig,
-        _observer: Option<&mut dyn SandboxCreateObserver>,
+        _observer: &mut dyn SandboxCreateObserver,
     ) -> Result<Box<dyn Sandbox>> {
         self.create(config).await
     }

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -22,6 +22,20 @@ pub enum SandboxCreateStage {
     NbdCowCreate,
 }
 
+impl SandboxCreateStage {
+    /// All create stages in the stable order used by telemetry tests.
+    pub const ALL: [Self; 8] = [
+        Self::CowPoolAcquire,
+        Self::WorkspaceDirRename,
+        Self::WorkspaceDrivePrepare,
+        Self::WorkspaceSeedSparseCopy,
+        Self::WorkspaceFreshFormat,
+        Self::SockDirPrepare,
+        Self::NetnsAcquire,
+        Self::NbdCowCreate,
+    ];
+}
+
 /// Receives low-cardinality sandbox factory create stage timings.
 pub trait SandboxCreateObserver: Send {
     fn record_stage(&mut self, stage: SandboxCreateStage, duration: Duration, success: bool);

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -36,7 +36,7 @@ pub use error::{
     Result, SandboxError, SandboxIdleTransition, SandboxInitializationPhase,
     SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
 };
-pub use factory::SandboxFactory;
+pub use factory::{SandboxCreateObserver, SandboxCreateStage, SandboxFactory};
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::Sandbox;
 pub use snapshot::{


### PR DESCRIPTION
## Summary
- add an optional sandbox factory create observer API for low-cardinality stage attribution
- forward Firecracker sandbox create stages into runner JobTelemetry as `runner_fresh_sandbox_factory_*` actions
- keep existing create summary telemetry and avoid emitting these stage actions on reuse paths

## Testing
- `cargo test --manifest-path crates/Cargo.toml -p runner executor::tests::telemetry_tests`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc factory::create_timing`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox -p sandbox-fc -p sandbox-mock -p runner --all-targets -- -D warnings`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `git diff --check`

Closes #20681