### PR TITLE
feat: enable playstation connector for all users

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -54,13 +54,10 @@ async function awsActor(): Promise<ApiTestUser> {
   return actor;
 }
 
-async function playstationActor(): Promise<ApiTestUser> {
+function playstationActor(): ApiTestUser {
   const bdd = createBddApi(context);
   const actor = bdd.user();
   context.mocks.ably.publish.mockResolvedValue(undefined);
-  await connectorsApi.updateFeatureSwitches(actor, {
-    [FeatureSwitchKey.PlaystationConnector]: true,
-  });
   return actor;
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -54,13 +54,6 @@ async function awsActor(): Promise<ApiTestUser> {
   return actor;
 }
 
-function playstationActor(): ApiTestUser {
-  const bdd = createBddApi(context);
-  const actor = bdd.user();
-  context.mocks.ably.publish.mockResolvedValue(undefined);
-  return actor;
-}
-
 function expectNoVisibleSecret(value: unknown, secret: string): void {
   expect(JSON.stringify(value)).not.toContain(secret);
 }
@@ -295,8 +288,10 @@ describe("CONN-02: external-code session lifecycle", () => {
   });
 
   it("returns generic external-code copy when the PlayStation NPSSO token is rejected", async () => {
-    const actor = await playstationActor();
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
     let authorizeRequestCount = 0;
+    context.mocks.ably.publish.mockResolvedValue(undefined);
     server.use(
       http.get(PLAYSTATION_AUTHORIZE_URL, ({ request }) => {
         authorizeRequestCount += 1;

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -409,12 +409,11 @@ describe("GET /api/zero/connector-catalog", () => {
     ).toStrictEqual(["api-token"]);
   });
 
-  it("returns PlayStation external-code catalog metadata when enabled", async () => {
+  it("returns PlayStation external-code catalog metadata", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;
     await enableConnectorFeatureSwitches(orgId, userId, {
       [FeatureSwitchKey.AwsConnector]: true,
-      [FeatureSwitchKey.PlaystationConnector]: true,
     });
 
     const client = setupApp({ context })(zeroConnectorCatalogContract);

--- a/turbo/packages/connectors/src/connectors/playstation.ts
+++ b/turbo/packages/connectors/src/connectors/playstation.ts
@@ -1,5 +1,4 @@
 import type { ConnectorConfig } from "../connector-config";
-import { FeatureSwitchKey } from "../feature-switch-key";
 
 export const playstation = {
   playstation: {
@@ -10,7 +9,6 @@ export const playstation = {
       "Connect your PlayStation Network account to access player profile, game, friends, presence, and trophy data.",
     authMethods: {
       api: {
-        featureFlag: FeatureSwitchKey.PlaystationConnector,
         label: "PlayStation sign-in",
         helpText:
           "First make sure you are signed in to PlayStation at [https://www.playstation.com/](https://www.playstation.com/).\nClick the button below, then copy the `npsso` value.",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -31,7 +31,6 @@ export enum FeatureSwitchKey {
   ResendConnector = "resendConnector",
   PexelsConnector = "pexelsConnector",
   SpotifyConnector = "spotifyConnector",
-  PlaystationConnector = "playstationConnector",
   ZeroDebug = "zeroDebug",
   Banking = "banking",
   Lab = "lab",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -177,12 +177,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description: "Enable the Spotify connector integration",
     enabled: false,
   },
-  [FeatureSwitchKey.PlaystationConnector]: {
-    maintainer: "liangyou@vm0.ai",
-    description: "Enable the PlayStation player connector integration",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.ZeroDebug]: {
     maintainer: "ethan@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- remove the PlayStation connector feature switch key and registry entry
- expose the PlayStation external-code auth method by default
- update API coverage so PlayStation no longer requires a feature-switch override

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
- pnpm -F @vm0/connectors check-types
- pnpm -F @vm0/core check-types
- pnpm -F api check-types
- pnpm -F @vm0/connectors lint
- pnpm -F @vm0/core lint
- pnpm -F api lint
- pnpm knip
- pnpm knip --cache
- pre-commit hook: prettier, knip, turbo check-types