### PR TITLE
fix: restore named tunnel token fallback

### DIFF
--- a/.github/scripts/tests/tunnel-test.sh
+++ b/.github/scripts/tests/tunnel-test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TUNNEL_SCRIPT="${REPO_ROOT}/scripts/tunnel.sh"
+TMPDIR="$(mktemp -d)"
+PORT=39991
+
+cleanup() {
+  local pid
+
+  pid="$(cat "/tmp/cloudflared-${PORT}.pid" 2>/dev/null || true)"
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+  fi
+
+  rm -f "/tmp/cloudflared-${PORT}.pid" "/tmp/cloudflared-${PORT}.log" "/tmp/cloudflared-${PORT}.check"
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+mkdir -p "${TMPDIR}/bin" "${TMPDIR}/home/.cloudflared"
+
+cat >"${TMPDIR}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+args=("$@")
+url=""
+output_file=""
+
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    http*)
+      url="${args[$i]}"
+      ;;
+    -o)
+      output_file="${args[$((i + 1))]}"
+      ;;
+  esac
+done
+
+printf '%s\n' "$*" >>"${CURL_LOG:?}"
+
+case "$url" in
+  *"/cfd_tunnel?name=test-tunnel"*)
+    printf '{"success":true,"result":[{"id":"test-tunnel-id"}]}'
+    ;;
+  *"/cfd_tunnel/test-tunnel-id/token"*)
+    printf '{"success":true,"result":"test-tunnel-token"}'
+    ;;
+  *"/zones?name=vm7.ai"*)
+    printf '{"success":true,"result":[{"id":"test-zone-id"}]}'
+    ;;
+  *"/dns_records?name=test-tunnel.vm7.ai&type=CNAME"*)
+    printf '{"success":true,"result":[]}'
+    ;;
+  *"/dns_records")
+    printf '{"success":true,"result":{"id":"test-record-id"}}'
+    ;;
+  "https://test-tunnel.vm7.ai/")
+    if [[ -n "$output_file" ]]; then
+      printf 'ok' >"$output_file"
+    fi
+    printf '204'
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 2
+    ;;
+esac
+SH
+chmod +x "${TMPDIR}/bin/curl"
+
+cat >"${TMPDIR}/bin/cloudflared" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${CLOUDFLARED_LOG:?}"
+if [[ "${TUNNEL_TOKEN:-}" == "test-tunnel-token" ]]; then
+  printf 'token-env=present\n' >>"${CLOUDFLARED_LOG:?}"
+fi
+
+printf 'Registered tunnel connection\n'
+sleep 30
+SH
+chmod +x "${TMPDIR}/bin/cloudflared"
+
+cat >"${TMPDIR}/bin/openssl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'test-secret\n'
+SH
+chmod +x "${TMPDIR}/bin/openssl"
+
+if ! output="$(
+  HOME="${TMPDIR}/home" \
+    PATH="${TMPDIR}/bin:$PATH" \
+    CURL_LOG="${TMPDIR}/curl.log" \
+    CLOUDFLARED_LOG="${TMPDIR}/cloudflared.log" \
+    CF_DNS_AND_TUNNEL_API_TOKEN=test-api-token \
+    CF_ACCOUNT_ID=test-account-id \
+    TUNNEL_HOSTNAME=test-tunnel.vm7.ai \
+    "$TUNNEL_SCRIPT" "$PORT" 2>"${TMPDIR}/tunnel.err"
+)"; then
+  cat "${TMPDIR}/tunnel.err" >&2
+  fail "expected named tunnel startup to succeed"
+fi
+
+[[ "$output" == "https://test-tunnel.vm7.ai" ]] || fail "expected named tunnel URL, got: $output"
+grep -q "Using API-fetched tunnel token instead." "${TMPDIR}/tunnel.err" || fail "expected token fallback log"
+grep -q "token-env=present" "${TMPDIR}/cloudflared.log" || fail "expected token fallback to start cloudflared"
+grep -q -- "--config /tmp/cloudflared-config-test-tunnel.yml --protocol http2 run" "${TMPDIR}/cloudflared.log" || fail "expected cloudflared config run"
+if grep -q "test-tunnel-token" "${TMPDIR}/cloudflared.log"; then
+  fail "tunnel token should not be passed through cloudflared argv"
+fi
+grep -q "https://test-tunnel.vm7.ai/" "${TMPDIR}/curl.log" || fail "expected named tunnel readiness check"
+
+echo "tunnel-test: ok"

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -181,17 +181,13 @@ if [[ "$MODE" == "named" ]]; then
     log "DNS route: ${FQDN} -> ${CNAME_TARGET}"
   fi
 
-  # Write ingress config. Prefer local tunnel credentials over --token so the
-  # local ingress rules are honored for this named tunnel.
+  # Write ingress config. Prefer local tunnel credentials, but fall back to the
+  # API-fetched tunnel token so devcontainers do not need per-tunnel files.
   CONFIG_FILE="/tmp/cloudflared-config-${TUNNEL_NAME}.yml"
   CREDENTIALS_FILE="${HOME}/.cloudflared/${TUNNEL_ID}.json"
-  if [[ ! -f "$CREDENTIALS_FILE" ]]; then
-    log "Error: credentials file not found for ${TUNNEL_NAME}: ${CREDENTIALS_FILE}"
-    log "Run 'cloudflared tunnel login' or sync the tunnel credentials before starting this tunnel."
-    exit 1
-  fi
 
-  cat > "$CONFIG_FILE" <<EOF
+  if [[ -f "$CREDENTIALS_FILE" ]]; then
+    cat > "$CONFIG_FILE" <<EOF
 tunnel: ${TUNNEL_ID}
 credentials-file: ${CREDENTIALS_FILE}
 ingress:
@@ -199,11 +195,32 @@ ingress:
     service: http://localhost:${PORT}
   - service: http_status:404
 EOF
+    TUNNEL_AUTH_ARGS=(env -u CF_DNS_AND_TUNNEL_API_TOKEN -u CF_ACCOUNT_ID -u TUNNEL_TOKEN)
+    USE_TUNNEL_TOKEN=0
+    log "Using local tunnel credentials: ${CREDENTIALS_FILE}"
+  else
+    cat > "$CONFIG_FILE" <<EOF
+ingress:
+  - hostname: ${FQDN}
+    service: http://localhost:${PORT}
+  - service: http_status:404
+EOF
+    TUNNEL_AUTH_ARGS=(env -u CF_DNS_AND_TUNNEL_API_TOKEN -u CF_ACCOUNT_ID)
+    USE_TUNNEL_TOKEN=1
+    log "Credentials file not found for ${TUNNEL_NAME}: ${CREDENTIALS_FILE}"
+    log "Using API-fetched tunnel token instead."
+  fi
 
   # QUIC fails in devcontainer environment, must use HTTP/2
   stop_existing_tunnel
-  start_cloudflared env -u CF_DNS_AND_TUNNEL_API_TOKEN -u CF_ACCOUNT_ID \
+  if [[ "$USE_TUNNEL_TOKEN" == "1" ]]; then
+    export TUNNEL_TOKEN
+  fi
+  start_cloudflared "${TUNNEL_AUTH_ARGS[@]}" \
     cloudflared tunnel --config "$CONFIG_FILE" --protocol http2 run
+  if [[ "$USE_TUNNEL_TOKEN" == "1" ]]; then
+    unset TUNNEL_TOKEN
+  fi
 
 else
   log "Anonymous tunnel: localhost:${PORT}"


### PR DESCRIPTION
## Summary
- keep named dev tunnels on the stable vm7.ai URL when local cloudflared credentials are missing
- fall back to the Cloudflare API-fetched tunnel token instead of failing or requiring a git email workaround
- add a shell regression test for the token fallback path

## Testing
- bash -n scripts/tunnel.sh .github/scripts/tests/tunnel-test.sh
- bash .github/scripts/tests/tunnel-test.sh
- git diff --check
- for test_script in .github/scripts/tests/*.sh; do bash "$test_script"; done

Closes #20696