### PR TITLE
fix: require visible chat output before callback delivery

### DIFF
--- a/turbo/apps/api/src/lib/agent-event-visibility.ts
+++ b/turbo/apps/api/src/lib/agent-event-visibility.ts
@@ -53,6 +53,10 @@ interface AgentEventVisibilityResult {
   readonly error?: unknown;
 }
 
+type RunEventWatermarkVisibilityResult =
+  | { readonly kind: "not_requested" }
+  | ({ readonly kind: "checked" } & AgentEventVisibilityResult);
+
 /**
  * Decide which sequence number a paged read needs to wait for, given the
  * caller's `since` cursor (exclusive), the page `limit`, and the run's known
@@ -214,34 +218,10 @@ async function waitForAgentEventPrefixVisible(
   };
 }
 
-/**
- * Best-effort barrier for code that reads run events back from Axiom after
- * the terminal webhook. Callers always supply `knownTargetSequence` from
- * their own DB read (the api side never falls back to the per-runId lookup
- * web has — that branch is dead code in api context).
- *
- * Returns the target sequence on success / `not_configured` (so the caller
- * can stamp it into a watermark column if desired); returns `undefined`
- * when no wait was attempted (target is null).
- */
-export async function waitForRunEventWatermarkVisible(
+function logIncompleteVisibility(
   runId: string,
-  knownTargetSequence: number | null,
-  options: WaitOptions = {},
-): Promise<number | undefined> {
-  if (knownTargetSequence === null) {
-    return undefined;
-  }
-
-  const visibility = await waitForAgentEventPrefixVisible(
-    runId,
-    knownTargetSequence,
-    options,
-  );
-  if (visibility.visible) {
-    return knownTargetSequence;
-  }
-
+  visibility: AgentEventVisibilityResult,
+): void {
   log.warn("Reading run Axiom events before terminal watermark is visible", {
     runId,
     targetSequence: visibility.targetSequence,
@@ -251,5 +231,50 @@ export async function waitForRunEventWatermarkVisible(
     reason: visibility.reason,
     error: visibility.error,
   });
-  return knownTargetSequence;
+}
+
+/**
+ * Best-effort barrier for code that reads run events back from Axiom after
+ * the terminal webhook. Callers always supply `knownTargetSequence` from
+ * their own DB read (the api side never falls back to the per-runId lookup
+ * web has — that branch is dead code in api context).
+ *
+ * Returns a structured visibility result when a target sequence is known;
+ * returns `not_requested` when no wait was attempted (target is null).
+ */
+export async function waitForRunEventWatermarkVisibility(
+  runId: string,
+  knownTargetSequence: number | null,
+  options: WaitOptions = {},
+): Promise<RunEventWatermarkVisibilityResult> {
+  if (knownTargetSequence === null) {
+    return { kind: "not_requested" };
+  }
+
+  const visibility = await waitForAgentEventPrefixVisible(
+    runId,
+    knownTargetSequence,
+    options,
+  );
+  if (!visibility.visible) {
+    logIncompleteVisibility(runId, visibility);
+  }
+
+  return { kind: "checked", ...visibility };
+}
+
+export async function waitForRunEventWatermarkVisible(
+  runId: string,
+  knownTargetSequence: number | null,
+  options: WaitOptions = {},
+): Promise<number | undefined> {
+  const visibility = await waitForRunEventWatermarkVisibility(
+    runId,
+    knownTargetSequence,
+    options,
+  );
+  if (visibility.kind === "not_requested") {
+    return undefined;
+  }
+  return visibility.targetSequence;
 }

--- a/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, http } from "msw";
+import { HttpResponse, delay as mswDelay, http } from "msw";
 import { describe, expect, it, vi } from "vitest";
 
 import { getApiTestMocks } from "../../../__tests__/mocks";
@@ -143,5 +143,25 @@ describe("queryAxiomDirect", () => {
         log: "abortable query",
       },
     ]);
+  });
+
+  it("reports direct fetch timeout as a query error", async () => {
+    const { queryAxiomDirect } =
+      await vi.importActual<typeof import("../axiom")>("../axiom");
+    const apl = "['vm0-agent-run-events-dev'] | limit 1";
+
+    server.use(
+      http.post("https://api.axiom.co/v1/datasets/_apl", async () => {
+        await mswDelay(100);
+        return HttpResponse.json({ matches: [] });
+      }),
+    );
+
+    await expect(
+      queryAxiomDirect(apl, {
+        noCache: true,
+        timeoutMs: 1,
+      }),
+    ).rejects.toThrow("Axiom query timed out after 1ms");
   });
 });

--- a/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
+++ b/turbo/apps/api/src/signals/external/__tests__/axiom.test.ts
@@ -92,4 +92,56 @@ describe("queryAxiomDirect", () => {
       },
     ]);
   });
+
+  it("uses direct fetch when a cancellation signal is supplied", async () => {
+    const { queryAxiomDirect } =
+      await vi.importActual<typeof import("../axiom")>("../axiom");
+    const mocks = getApiTestMocks();
+    const apl = "['vm0-agent-run-events-dev'] | limit 1";
+    const requests: {
+      readonly body: unknown;
+      readonly url: string;
+    }[] = [];
+
+    server.use(
+      http.post(
+        "https://api.axiom.co/v1/datasets/_apl",
+        async ({ request }) => {
+          requests.push({
+            body: await request.json(),
+            url: request.url,
+          });
+
+          return HttpResponse.json({
+            matches: [
+              {
+                _time: "2026-06-10T12:30:00Z",
+                data: { log: "abortable query" },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    const rows = await queryAxiomDirect(apl, {
+      noCache: true,
+      signal: new AbortController().signal,
+      timeoutMs: 1000,
+    });
+
+    expect(mocks.axiom.query).not.toHaveBeenCalled();
+    expect(requests).toStrictEqual([
+      {
+        body: { apl },
+        url: "https://api.axiom.co/v1/datasets/_apl?format=legacy&nocache=true",
+      },
+    ]);
+    expect(rows).toStrictEqual([
+      {
+        _time: "2026-06-10T12:30:00Z",
+        log: "abortable query",
+      },
+    ]);
+  });
 });

--- a/turbo/apps/api/src/signals/external/agentphone-client.ts
+++ b/turbo/apps/api/src/signals/external/agentphone-client.ts
@@ -1,7 +1,9 @@
 import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
+import { createNativeAbortSignalWithTimeout } from "../utils";
 
 const log = logger("api:agentphone");
+const AGENTPHONE_API_TIMEOUT_MS = 15_000;
 
 interface AgentPhoneSentMessage {
   readonly id: string;
@@ -45,6 +47,18 @@ function makeAgentPhoneApiError(
   });
 }
 
+function createAgentPhoneRequestAbort(signal?: AbortSignal): {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+} {
+  return createNativeAbortSignalWithTimeout({
+    signal,
+    timeoutMs: AGENTPHONE_API_TIMEOUT_MS,
+    timeoutMessage: `AgentPhone API request timed out after ${AGENTPHONE_API_TIMEOUT_MS}ms`,
+    description: "agentphone api request timeout",
+  });
+}
+
 export function isAgentPhoneApiError(
   error: unknown,
 ): error is AgentPhoneApiError {
@@ -67,82 +81,95 @@ export async function sendAgentPhoneMessage(
   },
   signal?: AbortSignal,
 ): Promise<AgentPhoneSentMessage> {
-  const response = await fetch(`${agentPhoneApiBase()}/v1/messages`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${agentPhoneApiKey()}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      agent_id: opts.agentphoneAgentId,
-      ...(opts.toNumber ? { to_number: opts.toNumber } : {}),
-      ...(opts.conversationId ? { conversation_id: opts.conversationId } : {}),
-      ...(opts.replyToMessageId
-        ? { reply_to_message_id: opts.replyToMessageId }
-        : {}),
-      body: opts.body,
-      ...(opts.mediaUrl ? { media_url: opts.mediaUrl } : {}),
-      ...(opts.mediaUrls?.length ? { media_urls: opts.mediaUrls } : {}),
-    }),
-    signal,
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    log.error("AgentPhone send message failed", {
-      status: response.status,
-      body: text,
+  const abort = createAgentPhoneRequestAbort(signal);
+  return await (async () => {
+    const response = await fetch(`${agentPhoneApiBase()}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${agentPhoneApiKey()}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agent_id: opts.agentphoneAgentId,
+        ...(opts.toNumber ? { to_number: opts.toNumber } : {}),
+        ...(opts.conversationId
+          ? { conversation_id: opts.conversationId }
+          : {}),
+        ...(opts.replyToMessageId
+          ? { reply_to_message_id: opts.replyToMessageId }
+          : {}),
+        body: opts.body,
+        ...(opts.mediaUrl ? { media_url: opts.mediaUrl } : {}),
+        ...(opts.mediaUrls?.length ? { media_urls: opts.mediaUrls } : {}),
+      }),
+      signal: abort.signal,
     });
-    throw makeAgentPhoneApiError(response.status, text);
-  }
 
-  const result = (await response.json()) as Record<string, unknown>;
-  const mediaUrls = Array.isArray(result.media_urls)
-    ? result.media_urls.filter((item): item is string => {
-        return typeof item === "string";
-      })
-    : [];
+    if (!response.ok) {
+      const text = await response.text();
+      abort.signal.throwIfAborted();
+      log.error("AgentPhone send message failed", {
+        status: response.status,
+        body: text,
+      });
+      throw makeAgentPhoneApiError(response.status, text);
+    }
 
-  return {
-    id: typeof result.id === "string" ? result.id : "unknown",
-    status: typeof result.status === "string" ? result.status : "sent",
-    channel: typeof result.channel === "string" ? result.channel : null,
-    fromNumber:
-      typeof result.from_number === "string" ? result.from_number : null,
-    toNumber:
-      typeof result.to_number === "string"
-        ? result.to_number
-        : (opts.toNumber ?? null),
-    mediaUrls,
-  };
+    const result = (await response.json()) as Record<string, unknown>;
+    abort.signal.throwIfAborted();
+    const mediaUrls = Array.isArray(result.media_urls)
+      ? result.media_urls.filter((item): item is string => {
+          return typeof item === "string";
+        })
+      : [];
+
+    return {
+      id: typeof result.id === "string" ? result.id : "unknown",
+      status: typeof result.status === "string" ? result.status : "sent",
+      channel: typeof result.channel === "string" ? result.channel : null,
+      fromNumber:
+        typeof result.from_number === "string" ? result.from_number : null,
+      toNumber:
+        typeof result.to_number === "string"
+          ? result.to_number
+          : (opts.toNumber ?? null),
+      mediaUrls,
+    };
+  })().finally(abort.cleanup);
 }
 
 export async function sendAgentPhoneTypingIndicator(
   opts: { readonly conversationId: string },
   signal?: AbortSignal,
 ): Promise<void> {
-  const response = await fetch(
-    `${agentPhoneApiBase()}/v1/conversations/${encodeURIComponent(
-      opts.conversationId,
-    )}/typing`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${agentPhoneApiKey()}`,
-        "Content-Type": "application/json",
+  const abort = createAgentPhoneRequestAbort(signal);
+  await (async () => {
+    const response = await fetch(
+      `${agentPhoneApiBase()}/v1/conversations/${encodeURIComponent(
+        opts.conversationId,
+      )}/typing`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${agentPhoneApiKey()}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+        signal: abort.signal,
       },
-      body: JSON.stringify({}),
-      signal,
-    },
-  );
+    );
 
-  if (!response.ok) {
-    const text = await response.text();
-    log.debug("AgentPhone typing indicator failed", {
-      conversationId: opts.conversationId,
-      status: response.status,
-      body: text,
-    });
-    throw makeAgentPhoneApiError(response.status, text);
-  }
+    if (!response.ok) {
+      const text = await response.text();
+      abort.signal.throwIfAborted();
+      log.debug("AgentPhone typing indicator failed", {
+        conversationId: opts.conversationId,
+        status: response.status,
+        body: text,
+      });
+      throw makeAgentPhoneApiError(response.status, text);
+    }
+    await response.text();
+    abort.signal.throwIfAborted();
+  })().finally(abort.cleanup);
 }

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -1,9 +1,8 @@
 import { computed, type Computed } from "ccstate";
 import { Axiom } from "@axiomhq/js";
-import { delay } from "signal-timers";
 import { env, optionalEnv } from "../../lib/env";
 import { singleton } from "../../lib/singleton";
-import { detach, Mechanism } from "../utils";
+import { createAbortSignalWithTimeout } from "../utils";
 import {
   getAxiomTokenEnvNameForApl,
   getAxiomTokenEnvNameForDataset,
@@ -173,42 +172,17 @@ function queryAxiomDirectWithCursor<T>(
   return queryAxiomDirectFetch<T>(apl, options);
 }
 
-function axiomQueryAbort(args: { readonly options: QueryAxiomOptions }): {
+function axiomQueryAbort(options: QueryAxiomOptions): {
   readonly signal: AbortSignal;
   readonly cleanup: () => void;
 } {
-  const controller = new AbortController();
-  const timeoutController = new AbortController();
-  detach(
-    (async () => {
-      await delay(args.options.timeoutMs ?? AXIOM_QUERY_TIMEOUT_MS, {
-        signal: timeoutController.signal,
-      });
-      controller.abort();
-    })(),
-    Mechanism.BestEffortCleanup,
-    "axiom query timeout",
-  );
-
-  const callerSignal = args.options.signal;
-  const abortFromCaller = (): void => {
-    controller.abort(callerSignal?.reason);
-  };
-  if (callerSignal) {
-    if (callerSignal.aborted) {
-      abortFromCaller();
-    } else {
-      callerSignal.addEventListener("abort", abortFromCaller, { once: true });
-    }
-  }
-
-  return {
-    signal: controller.signal,
-    cleanup: () => {
-      timeoutController.abort();
-      callerSignal?.removeEventListener("abort", abortFromCaller);
-    },
-  };
+  const timeoutMs = options.timeoutMs ?? AXIOM_QUERY_TIMEOUT_MS;
+  return createAbortSignalWithTimeout({
+    signal: options.signal,
+    timeoutMs,
+    timeoutMessage: `Axiom query timed out after ${timeoutMs}ms`,
+    description: "axiom query timeout",
+  });
 }
 
 function axiomQueryErrorMessage(status: number, body: string): string {
@@ -226,7 +200,7 @@ async function queryAxiomDirectFetch<T>(
   apl: string,
   options: QueryAxiomOptions,
 ): Promise<readonly T[]> {
-  const abort = axiomQueryAbort({ options });
+  const abort = axiomQueryAbort(options);
   return await (async () => {
     const response = await fetch(axiomAplQueryUrl(options), {
       method: "POST",

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -1,7 +1,9 @@
 import { computed, type Computed } from "ccstate";
 import { Axiom } from "@axiomhq/js";
+import { delay } from "signal-timers";
 import { env, optionalEnv } from "../../lib/env";
 import { singleton } from "../../lib/singleton";
+import { detach, Mechanism } from "../utils";
 import {
   getAxiomTokenEnvNameForApl,
   getAxiomTokenEnvNameForDataset,
@@ -171,13 +173,42 @@ function queryAxiomDirectWithCursor<T>(
   return queryAxiomDirectFetch<T>(apl, options);
 }
 
-function axiomQuerySignal(options: QueryAxiomOptions): AbortSignal {
-  const timeoutSignal = AbortSignal.timeout(
-    options.timeoutMs ?? AXIOM_QUERY_TIMEOUT_MS,
+function axiomQueryAbort(args: { readonly options: QueryAxiomOptions }): {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timeoutController = new AbortController();
+  detach(
+    (async () => {
+      await delay(args.options.timeoutMs ?? AXIOM_QUERY_TIMEOUT_MS, {
+        signal: timeoutController.signal,
+      });
+      controller.abort();
+    })(),
+    Mechanism.BestEffortCleanup,
+    "axiom query timeout",
   );
-  return options.signal
-    ? AbortSignal.any([options.signal, timeoutSignal])
-    : timeoutSignal;
+
+  const callerSignal = args.options.signal;
+  const abortFromCaller = (): void => {
+    controller.abort(callerSignal?.reason);
+  };
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      abortFromCaller();
+    } else {
+      callerSignal.addEventListener("abort", abortFromCaller, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      timeoutController.abort();
+      callerSignal?.removeEventListener("abort", abortFromCaller);
+    },
+  };
 }
 
 function axiomQueryErrorMessage(status: number, body: string): string {
@@ -195,32 +226,35 @@ async function queryAxiomDirectFetch<T>(
   apl: string,
   options: QueryAxiomOptions,
 ): Promise<readonly T[]> {
-  const response = await fetch(axiomAplQueryUrl(options), {
-    method: "POST",
-    headers: {
-      accept: "application/json",
-      authorization: `Bearer ${env(getAxiomTokenEnvNameForApl(apl))}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      apl,
-      ...(options.cursor === undefined ? {} : { cursor: options.cursor }),
-    }),
-    signal: axiomQuerySignal(options),
-  });
+  const abort = axiomQueryAbort({ options });
+  return await (async () => {
+    const response = await fetch(axiomAplQueryUrl(options), {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${env(getAxiomTokenEnvNameForApl(apl))}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        apl,
+        ...(options.cursor === undefined ? {} : { cursor: options.cursor }),
+      }),
+      signal: abort.signal,
+    });
 
-  if (!response.ok) {
-    throw new Error(
-      axiomQueryErrorMessage(response.status, await response.text()),
-    );
-  }
+    if (!response.ok) {
+      throw new Error(
+        axiomQueryErrorMessage(response.status, await response.text()),
+      );
+    }
 
-  const payload: unknown = await response.json();
-  if (!isAxiomQueryResult(payload)) {
-    throw new Error("Axiom query returned an unexpected response shape");
-  }
+    const payload: unknown = await response.json();
+    if (!isAxiomQueryResult(payload)) {
+      throw new Error("Axiom query returned an unexpected response shape");
+    }
 
-  return mapAxiomMatches<T>(payload);
+    return mapAxiomMatches<T>(payload);
+  })().finally(abort.cleanup);
 }
 
 export async function queryAxiomDirect<T = Record<string, unknown>>(

--- a/turbo/apps/api/src/signals/external/axiom.ts
+++ b/turbo/apps/api/src/signals/external/axiom.ts
@@ -9,6 +9,7 @@ import {
 
 const AXIOM_API_ORIGIN = "https://api.axiom.co";
 const AXIOM_QUERY_TIMEOUT_MS = 120_000;
+const AXIOM_ERROR_BODY_MAX_LENGTH = 500;
 
 const sessionsAxiomClient = singleton(() => {
   return new Axiom({ token: env("AXIOM_TOKEN_SESSIONS") });
@@ -105,12 +106,13 @@ export async function flushAxiom(
 
 // Minimal options surface. `noCache` is used by the agent-event watermark wait
 // to bypass Axiom's per-request cache for freshly-completed runs; `cursor` is
-// used for Axiom-managed time pagination. Other options from web's queryAxiom
-// (maxRetries, streamingDuration, timeoutMs) intentionally NOT ported — see
-// leader guidance on issue #12424; add them when a caller actually needs them.
+// used for Axiom-managed time pagination. `signal`/`timeoutMs` force the
+// direct fetch path for callers that must bound background work.
 export interface QueryAxiomOptions {
   readonly noCache?: boolean;
   readonly cursor?: string;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
 }
 
 interface AxiomQueryMatch {
@@ -162,9 +164,36 @@ function mapAxiomMatches<T>(result: AxiomQueryResult): readonly T[] {
   );
 }
 
-async function queryAxiomDirectWithCursor<T>(
+function queryAxiomDirectWithCursor<T>(
   apl: string,
   options: QueryAxiomOptions & { readonly cursor: string },
+): Promise<readonly T[]> {
+  return queryAxiomDirectFetch<T>(apl, options);
+}
+
+function axiomQuerySignal(options: QueryAxiomOptions): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(
+    options.timeoutMs ?? AXIOM_QUERY_TIMEOUT_MS,
+  );
+  return options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+}
+
+function axiomQueryErrorMessage(status: number, body: string): string {
+  if (!body) {
+    return `Axiom query failed with status ${status}`;
+  }
+  const suffix =
+    body.length <= AXIOM_ERROR_BODY_MAX_LENGTH
+      ? body
+      : `${body.slice(0, AXIOM_ERROR_BODY_MAX_LENGTH)}...`;
+  return `Axiom query failed with status ${status}: ${suffix}`;
+}
+
+async function queryAxiomDirectFetch<T>(
+  apl: string,
+  options: QueryAxiomOptions,
 ): Promise<readonly T[]> {
   const response = await fetch(axiomAplQueryUrl(options), {
     method: "POST",
@@ -175,13 +204,15 @@ async function queryAxiomDirectWithCursor<T>(
     },
     body: JSON.stringify({
       apl,
-      cursor: options.cursor,
+      ...(options.cursor === undefined ? {} : { cursor: options.cursor }),
     }),
-    signal: AbortSignal.timeout(AXIOM_QUERY_TIMEOUT_MS),
+    signal: axiomQuerySignal(options),
   });
 
   if (!response.ok) {
-    throw new Error(`Axiom query failed with status ${response.status}`);
+    throw new Error(
+      axiomQueryErrorMessage(response.status, await response.text()),
+    );
   }
 
   const payload: unknown = await response.json();
@@ -201,6 +232,9 @@ export async function queryAxiomDirect<T = Record<string, unknown>>(
       ...options,
       cursor: options.cursor,
     });
+  }
+  if (options?.signal !== undefined || options?.timeoutMs !== undefined) {
+    return queryAxiomDirectFetch<T>(apl, options);
   }
 
   const client = axiomClientForApl(apl);

--- a/turbo/apps/api/src/signals/external/slack-message-client.ts
+++ b/turbo/apps/api/src/signals/external/slack-message-client.ts
@@ -8,6 +8,9 @@ import {
 import { optionalEnv } from "../../lib/env";
 import { settle } from "../utils";
 
+const SLACK_API_TIMEOUT_MS = 15_000;
+const SLACK_API_RETRIES = 1;
+
 type OpenDmResult =
   | { readonly kind: "ok"; readonly channelId: string }
   | { readonly kind: "slack_error"; readonly error: string };
@@ -48,8 +51,12 @@ function resolveSlackApiUrl(): string | undefined {
 
 export function createSlackClient(token: string): WebClient {
   const slackApiUrl = resolveSlackApiUrl();
+  const clientOptions = {
+    retryConfig: { retries: SLACK_API_RETRIES },
+    timeout: SLACK_API_TIMEOUT_MS,
+  };
   if (!slackApiUrl) {
-    return new WebClient(token);
+    return new WebClient(token, clientOptions);
   }
 
   const bypass = optionalEnv("VERCEL_AUTOMATION_BYPASS_SECRET");
@@ -61,10 +68,9 @@ export function createSlackClient(token: string): WebClient {
     : {};
 
   return new WebClient(token, {
+    ...clientOptions,
     slackApiUrl,
     headers,
-    retryConfig: { retries: 1 },
-    timeout: 5000,
   });
 }
 

--- a/turbo/apps/api/src/signals/external/teams-bot-client.ts
+++ b/turbo/apps/api/src/signals/external/teams-bot-client.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
 
 import { env, optionalEnv } from "../../lib/env";
-import { safeJsonParse, safeUrlParse, settle } from "../utils";
+import {
+  createNativeAbortSignalWithTimeout,
+  safeJsonParse,
+  safeUrlParse,
+  settle,
+} from "../utils";
 
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default";
 const MICROSOFT_GRAPH_SCOPE = "https://graph.microsoft.com/.default";
 const MICROSOFT_GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0";
+const TEAMS_API_TIMEOUT_MS = 15_000;
 
 const teamsTokenResponseSchema = z
   .object({
@@ -151,6 +157,18 @@ function teamsApiError(status: number, error: string): TeamsApiErrorResult {
   return { kind: "teams-error", status, error };
 }
 
+function createTeamsRequestAbort(signal: AbortSignal): {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+} {
+  return createNativeAbortSignalWithTimeout({
+    signal,
+    timeoutMs: TEAMS_API_TIMEOUT_MS,
+    timeoutMessage: `Microsoft Teams API request timed out after ${TEAMS_API_TIMEOUT_MS}ms`,
+    description: "microsoft teams api request timeout",
+  });
+}
+
 async function fetchClientCredentialsAccessToken(args: {
   readonly tokenUrl: string;
   readonly scope: string;
@@ -173,35 +191,35 @@ async function fetchClientCredentialsAccessToken(args: {
     scope: args.scope,
   });
 
+  const abort = createTeamsRequestAbort(args.signal);
   const responseResult = await settle(
-    fetch(args.tokenUrl, {
-      method: "POST",
-      headers: {
-        "content-type": "application/x-www-form-urlencoded",
-      },
-      body,
-      signal: args.signal,
-    }),
-    args.signal,
+    (async () => {
+      const response = await fetch(args.tokenUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body,
+        signal: abort.signal,
+      });
+      const text = await response.text();
+      abort.signal.throwIfAborted();
+      return { response, text };
+    })().finally(abort.cleanup),
   );
   if (!responseResult.ok) {
     return teamsApiError(502, networkErrorMessage(responseResult.error));
   }
 
-  const response = responseResult.value;
+  const { response, text } = responseResult.value;
   if (!response.ok) {
-    const text = await response.text();
-    args.signal.throwIfAborted();
     return teamsApiError(
       502,
       text || `OAuth token request failed with HTTP ${response.status}`,
     );
   }
 
-  const parsed = teamsTokenResponseSchema.safeParse(
-    safeJsonParse(await response.text()),
-  );
-  args.signal.throwIfAborted();
+  const parsed = teamsTokenResponseSchema.safeParse(safeJsonParse(text));
   if (!parsed.success) {
     return teamsApiError(502, "Invalid OAuth token response");
   }
@@ -292,23 +310,26 @@ async function fetchTeamsGraphJson<T>(args: {
     return accessToken;
   }
 
+  const abort = createTeamsRequestAbort(args.signal);
   const responseResult = await settle(
-    fetch(args.url, {
-      method: "GET",
-      headers: {
-        authorization: `Bearer ${accessToken.accessToken}`,
-      },
-      signal: args.signal,
-    }),
-    args.signal,
+    (async () => {
+      const response = await fetch(args.url, {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${accessToken.accessToken}`,
+        },
+        signal: abort.signal,
+      });
+      const text = await response.text();
+      abort.signal.throwIfAborted();
+      return { response, text };
+    })().finally(abort.cleanup),
   );
   if (!responseResult.ok) {
     return teamsApiError(502, networkErrorMessage(responseResult.error));
   }
 
-  const response = responseResult.value;
-  const responseText = await response.text();
-  args.signal.throwIfAborted();
+  const { response, text: responseText } = responseResult.value;
   if (!response.ok) {
     return teamsApiError(
       response.status,
@@ -348,25 +369,28 @@ async function postTeamsActivity(args: {
     return teamsApiError(400, "Invalid Microsoft Teams serviceUrl");
   }
 
+  const abort = createTeamsRequestAbort(args.signal);
   const responseResult = await settle(
-    fetch(url, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${accessToken.accessToken}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify(args.activity),
-      signal: args.signal,
-    }),
-    args.signal,
+    (async () => {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken.accessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(args.activity),
+        signal: abort.signal,
+      });
+      const text = await response.text();
+      abort.signal.throwIfAborted();
+      return { response, text };
+    })().finally(abort.cleanup),
   );
   if (!responseResult.ok) {
     return teamsApiError(502, networkErrorMessage(responseResult.error));
   }
 
-  const response = responseResult.value;
-  const responseText = await response.text();
-  args.signal.throwIfAborted();
+  const { response, text: responseText } = responseResult.value;
   if (!response.ok) {
     return teamsApiError(
       response.status,

--- a/turbo/apps/api/src/signals/external/telegram-client.ts
+++ b/turbo/apps/api/src/signals/external/telegram-client.ts
@@ -1,6 +1,8 @@
 import { optionalEnv } from "../../lib/env";
+import { createNativeAbortSignalWithTimeout } from "../utils";
 
 const DEFAULT_TELEGRAM_API_BASE = "https://api.telegram.org/bot";
+const TELEGRAM_API_TIMEOUT_MS = 15_000;
 
 interface TelegramApiErrorPayload {
   readonly ok: false;
@@ -22,6 +24,10 @@ function isTelegramApiErrorPayload(
 interface TelegramApiErrorShape {
   readonly status: number;
   readonly description: string | undefined;
+}
+
+interface TelegramRequestOptions {
+  readonly signal?: AbortSignal;
 }
 
 class TelegramApiError extends Error implements TelegramApiErrorShape {
@@ -87,24 +93,86 @@ function buildTelegramApiHeaders(): Record<string, string> {
   return headers;
 }
 
+function createTelegramRequestAbort(signal?: AbortSignal): {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+} {
+  return createNativeAbortSignalWithTimeout({
+    signal,
+    timeoutMs: TELEGRAM_API_TIMEOUT_MS,
+    timeoutMessage: `Telegram API request timed out after ${TELEGRAM_API_TIMEOUT_MS}ms`,
+    description: "telegram api request timeout",
+  });
+}
+
+async function readTelegramResponseJson(
+  response: Response,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const text = await response.text();
+  signal.throwIfAborted();
+  return JSON.parse(text) as unknown;
+}
+
+function telegramErrorDescription(data: unknown): string | undefined {
+  if (isTelegramApiErrorPayload(data)) {
+    return data.description;
+  }
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    "description" in data &&
+    typeof (data as { readonly description: unknown }).description === "string"
+  ) {
+    return (data as { readonly description: string }).description;
+  }
+  return undefined;
+}
+
+async function fetchTelegramApiJson(args: {
+  readonly token: string;
+  readonly method: string;
+  readonly params?: Record<string, string>;
+  readonly body?: Record<string, unknown>;
+  readonly forcePost?: boolean;
+  readonly signal?: AbortSignal;
+}): Promise<{ readonly response: Response; readonly data: unknown }> {
+  const url = buildTelegramApiUrl(args.token, args.method);
+  const abort = createTelegramRequestAbort(args.signal);
+  return await (async () => {
+    const usePost = args.forcePost === true || isE2eTelegramMockEnabled();
+    const response = usePost
+      ? await fetch(url, {
+          method: "POST",
+          headers: buildTelegramApiHeaders(),
+          body: JSON.stringify(args.body ?? args.params ?? {}),
+          signal: abort.signal,
+        })
+      : await fetch(
+          `${url}${
+            args.params ? `?${new URLSearchParams(args.params).toString()}` : ""
+          }`,
+          { headers: buildTelegramApiHeaders(), signal: abort.signal },
+        );
+    return {
+      response,
+      data: await readTelegramResponseJson(response, abort.signal),
+    };
+  })().finally(abort.cleanup);
+}
+
 async function callTelegramApi<T>(
   token: string,
   method: string,
   params?: Record<string, string>,
+  options: TelegramRequestOptions = {},
 ): Promise<T> {
-  const url = buildTelegramApiUrl(token, method);
-  const response = isE2eTelegramMockEnabled()
-    ? await fetch(url, {
-        method: "POST",
-        headers: buildTelegramApiHeaders(),
-        body: JSON.stringify(params ?? {}),
-      })
-    : await fetch(
-        `${url}${params ? `?${new URLSearchParams(params).toString()}` : ""}`,
-        { headers: buildTelegramApiHeaders() },
-      );
-
-  const data: unknown = await response.json();
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method,
+    params,
+    signal: options.signal,
+  });
 
   const errorPayload = isTelegramApiErrorPayload(data) ? data : null;
 
@@ -155,10 +223,15 @@ export function buildFileDownloadUrl(token: string, filePath: string): string {
   return `https://api.telegram.org/file/bot${token}/${filePath}`;
 }
 
-export async function deleteWebhook(token: string): Promise<void> {
-  const response = await fetch(buildTelegramApiUrl(token, "deleteWebhook"), {
-    method: "POST",
-    headers: buildTelegramApiHeaders(),
+export async function deleteWebhook(
+  token: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method: "deleteWebhook",
+    forcePost: true,
+    signal,
   });
 
   if (!response.ok) {
@@ -167,7 +240,6 @@ export async function deleteWebhook(token: string): Promise<void> {
     );
   }
 
-  const data: unknown = await response.json();
   if (isTelegramApiErrorPayload(data)) {
     throw new Error(`Telegram API error: ${data.description}`);
   }
@@ -177,15 +249,18 @@ export async function setWebhook(
   token: string,
   url: string,
   secretToken: string,
+  signal?: AbortSignal,
 ): Promise<void> {
-  const response = await fetch(buildTelegramApiUrl(token, "setWebhook"), {
-    method: "POST",
-    headers: buildTelegramApiHeaders(),
-    body: JSON.stringify({
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method: "setWebhook",
+    body: {
       url,
       secret_token: secretToken,
       allowed_updates: ["message"],
-    }),
+    },
+    forcePost: true,
+    signal,
   });
 
   if (!response.ok) {
@@ -194,7 +269,6 @@ export async function setWebhook(
     );
   }
 
-  const data: unknown = await response.json();
   if (isTelegramApiErrorPayload(data)) {
     throw new Error(`Telegram API error: ${data.description}`);
   }
@@ -206,11 +280,14 @@ export async function setMyCommands(
     readonly command: string;
     readonly description: string;
   }[],
+  signal?: AbortSignal,
 ): Promise<void> {
-  const response = await fetch(buildTelegramApiUrl(token, "setMyCommands"), {
-    method: "POST",
-    headers: buildTelegramApiHeaders(),
-    body: JSON.stringify({ commands }),
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method: "setMyCommands",
+    body: { commands },
+    forcePost: true,
+    signal,
   });
 
   if (!response.ok) {
@@ -219,7 +296,6 @@ export async function setMyCommands(
     );
   }
 
-  const data: unknown = await response.json();
   if (isTelegramApiErrorPayload(data)) {
     throw new Error(`Telegram API error: ${data.description}`);
   }
@@ -262,18 +338,20 @@ export async function sendChatAction(
   token: string,
   chatId: string,
   action: string,
+  signal?: AbortSignal,
 ): Promise<void> {
-  const response = await fetch(buildTelegramApiUrl(token, "sendChatAction"), {
-    method: "POST",
-    headers: buildTelegramApiHeaders(),
-    body: JSON.stringify({ chat_id: chatId, action }),
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method: "sendChatAction",
+    body: { chat_id: chatId, action },
+    forcePost: true,
+    signal,
   });
   if (!response.ok) {
     throw new Error(
       `Telegram API error: ${response.status} ${response.statusText}`,
     );
   }
-  const data: unknown = await response.json();
   if (isTelegramApiErrorPayload(data)) {
     throw new Error(`Telegram API error: ${data.description}`);
   }
@@ -289,18 +367,20 @@ export async function deleteMessage(
   token: string,
   chatId: string,
   messageId: number,
+  signal?: AbortSignal,
 ): Promise<void> {
-  const response = await fetch(buildTelegramApiUrl(token, "deleteMessage"), {
-    method: "POST",
-    headers: buildTelegramApiHeaders(),
-    body: JSON.stringify({ chat_id: chatId, message_id: messageId }),
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method: "deleteMessage",
+    body: { chat_id: chatId, message_id: messageId },
+    forcePost: true,
+    signal,
   });
   if (!response.ok) {
     throw new Error(
       `Telegram API error: ${response.status} ${response.statusText}`,
     );
   }
-  const data: unknown = await response.json();
   if (isTelegramApiErrorPayload(data)) {
     throw new Error(`Telegram API error: ${data.description}`);
   }
@@ -344,6 +424,7 @@ export async function sendMessage(
     readonly replyToMessageId?: number;
     readonly messageThreadId?: number;
     readonly replyMarkup?: TelegramReplyMarkup;
+    readonly signal?: AbortSignal;
   } = {},
 ): Promise<SendTelegramMessageResult> {
   const payload: Record<string, unknown> = {
@@ -361,25 +442,19 @@ export async function sendMessage(
     payload.reply_markup = options.replyMarkup;
   }
 
-  const response = await fetch(buildTelegramApiUrl(token, "sendMessage"), {
-    method: "POST",
-    headers: buildTelegramApiHeaders(),
-    body: JSON.stringify(payload),
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method: "sendMessage",
+    body: payload,
+    forcePost: true,
+    signal: options.signal,
   });
 
-  const data: unknown = await response.json();
-
   if (!response.ok) {
-    const description =
-      data && typeof data === "object" && "description" in data
-        ? typeof (data as { description: unknown }).description === "string"
-          ? ((data as { description: string }).description as string)
-          : undefined
-        : undefined;
     return {
       kind: "telegram-error",
       status: response.status,
-      description,
+      description: telegramErrorDescription(data),
     };
   }
 
@@ -442,6 +517,7 @@ export async function sendDocument(
   options: {
     readonly caption?: string;
     readonly messageThreadId?: number;
+    readonly signal?: AbortSignal;
   } = {},
 ): Promise<SendTelegramDocumentResult> {
   const payload: Record<string, unknown> = {
@@ -455,25 +531,19 @@ export async function sendDocument(
     payload.message_thread_id = options.messageThreadId;
   }
 
-  const response = await fetch(buildTelegramApiUrl(token, "sendDocument"), {
-    method: "POST",
-    headers: buildTelegramApiHeaders(),
-    body: JSON.stringify(payload),
+  const { response, data } = await fetchTelegramApiJson({
+    token,
+    method: "sendDocument",
+    body: payload,
+    forcePost: true,
+    signal: options.signal,
   });
 
-  const data: unknown = await response.json();
-
   if (!response.ok) {
-    const description =
-      data && typeof data === "object" && "description" in data
-        ? typeof (data as { description: unknown }).description === "string"
-          ? ((data as { description: string }).description as string)
-          : undefined
-        : undefined;
     return {
       kind: "telegram-error",
       status: response.status,
-      description,
+      description: telegramErrorDescription(data),
     };
   }
 

--- a/turbo/apps/api/src/signals/external/telegram-client.ts
+++ b/turbo/apps/api/src/signals/external/telegram-client.ts
@@ -1,5 +1,5 @@
 import { optionalEnv } from "../../lib/env";
-import { createNativeAbortSignalWithTimeout } from "../utils";
+import { createNativeAbortSignalWithTimeout, safeJsonParse } from "../utils";
 
 const DEFAULT_TELEGRAM_API_BASE = "https://api.telegram.org/bot";
 const TELEGRAM_API_TIMEOUT_MS = 15_000;
@@ -105,13 +105,17 @@ function createTelegramRequestAbort(signal?: AbortSignal): {
   });
 }
 
-async function readTelegramResponseJson(
+async function readTelegramResponseData(
   response: Response,
   signal: AbortSignal,
 ): Promise<unknown> {
   const text = await response.text();
   signal.throwIfAborted();
-  return JSON.parse(text) as unknown;
+  const data = safeJsonParse(text);
+  if (data === undefined && response.ok) {
+    throw new Error("Telegram API returned invalid JSON");
+  }
+  return data;
 }
 
 function telegramErrorDescription(data: unknown): string | undefined {
@@ -156,7 +160,7 @@ async function fetchTelegramApiJson(args: {
         );
     return {
       response,
-      data: await readTelegramResponseJson(response, abort.signal),
+      data: await readTelegramResponseData(response, abort.signal),
     };
   })().finally(abort.cleanup);
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -151,7 +151,12 @@ async function completeSandboxRun(
     );
   }
   await webhooks.requestAgentComplete(
-    { runId, exitCode, ...(error === undefined ? {} : { error }) },
+    {
+      runId,
+      exitCode,
+      ...(exitCode === 0 ? { lastEventSequence: 0 } : {}),
+      ...(error === undefined ? {} : { error }),
+    },
     sandboxHeaders,
     [200],
   );

--- a/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/agentphone.bdd.test.ts
@@ -368,8 +368,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     expect(run2.appendSystemPrompt).toContain("SENDER: {id: BOT}");
 
     const beforeRun2Completion = sends.messages.length;
+    ap.mockCompletionRunOutput("Task completed successfully.");
     await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
     await waitForSendCount(sends, beforeRun2Completion + 1);
+    ap.restoreCompletionRunOutput();
     expect(lastSend(sends).body).toBe("Task completed successfully.");
     await waitForRunSessionId(actor, run2.runId, session1);
 
@@ -394,7 +396,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       isGroup: false,
     });
     const run3 = await claimDispatchedRun(runnerGroup);
+    ap.mockCompletionRunOutput("Task completed successfully.");
     await completeSandboxRun(run3.sandboxToken, run3.runId, 0);
+    ap.restoreCompletionRunOutput();
     const session3 = await waitForRunSessionIdPresent(actor, run3.runId);
     expect(session3).not.toBe(session1);
 
@@ -439,8 +443,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       ].join("\n\n"),
     );
     const beforeRun1Completion = sends.messages.length;
+    ap.mockCompletionRunOutput("Task completed successfully.");
     await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
     await waitForSendCount(sends, beforeRun1Completion + 1);
+    ap.restoreCompletionRunOutput();
     const mediaSession = await waitForRunSessionIdPresent(actor, run1.runId);
 
     // Provider-sent recent history wins over stored context: full entries
@@ -479,8 +485,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     // Session continuity: the second DM reuses the session saved by the
     // first completion.
     const beforeRun2Completion = sends.messages.length;
+    ap.mockCompletionRunOutput("Task completed successfully.");
     await completeSandboxRun(run2.sandboxToken, run2.runId, 0);
     await waitForSendCount(sends, beforeRun2Completion + 1);
+    ap.restoreCompletionRunOutput();
     await waitForRunSessionId(actor, run2.runId, mediaSession);
 
     // Re-pointing the default model policy at an incompatible provider
@@ -492,7 +500,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
       body: "after provider switch",
     });
     const run3 = await claimDispatchedRun(runnerGroup);
+    ap.mockCompletionRunOutput("Task completed successfully.");
     await completeSandboxRun(run3.sandboxToken, run3.runId, 0);
+    ap.restoreCompletionRunOutput();
     await expect(ap.readRunSessionId(actor, run3.runId)).resolves.not.toBe(
       mediaSession,
     );
@@ -613,8 +623,10 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
 
     // The completion replies into the conversation, not to a number.
     const beforeGroupCompletion = sends.messages.length;
+    ap.mockCompletionRunOutput("Task completed successfully.");
     await completeSandboxRun(run1.sandboxToken, run1.runId, 0);
     await waitForSendCount(sends, beforeGroupCompletion + 1);
+    ap.restoreCompletionRunOutput();
     const groupReply = lastSend(sends);
     expect(groupReply.conversationId).toBe(conversationId);
     expect(groupReply.replyToMessageId).toBe(groupMessageId);
@@ -841,7 +853,9 @@ describe("INT-03: AgentPhone linked-run lifecycle through public APIs", () => {
     );
     expectApiError(unauthorized.body);
 
+    ap.mockCompletionRunOutput("Task completed successfully.");
     await completeSandboxRun(claim.sandboxToken, run.runId, 0);
+    ap.restoreCompletionRunOutput();
   });
 
   it("guards startLink against foreign-owner handles and provider network failures", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2572,4 +2572,53 @@ describe("CHAT-02: push notification gating", () => {
     });
     expect(context.mocks.webpush.sendNotification).toHaveBeenCalledTimes(1);
   }, 60_000);
+
+  it("bounds push fan-out without serializing every subscription", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    chatCallbacks.enableVapid();
+
+    for (let index = 0; index < 6; index += 1) {
+      await chatCallbacks.registerPushSubscription(actor);
+    }
+
+    const pushGate = deferredGate();
+    let activePushes = 0;
+    let maxActivePushes = 0;
+    context.mocks.webpush.sendNotification.mockImplementation(async () => {
+      activePushes += 1;
+      maxActivePushes = Math.max(maxActivePushes, activePushes);
+      await pushGate.wait().finally(() => {
+        activePushes -= 1;
+      });
+    });
+
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "bounded push fan-out",
+    });
+    const headers = await claimChatRun(runnerGroup, run.runId);
+    await completeChatRunOk(run.runId, headers);
+
+    await expect
+      .poll(() => {
+        return context.mocks.webpush.sendNotification.mock.calls.length;
+      })
+      .toBe(5);
+    expect(activePushes).toBe(5);
+    expect(maxActivePushes).toBe(5);
+
+    pushGate.release();
+    await flushWaitUntilForTest();
+
+    expect(context.mocks.webpush.sendNotification).toHaveBeenCalledTimes(6);
+    expect(maxActivePushes).toBe(5);
+    expect(
+      pushPayload(context.mocks.webpush.sendNotification.mock.calls[5]),
+    ).toMatchObject({
+      title: "bounded push fan-out",
+      body: "Your task is complete",
+      url: `/chats/${run.threadId}`,
+    });
+  }, 60_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -543,6 +543,10 @@ function pushPayload(call: readonly unknown[] | undefined): unknown {
   return JSON.parse(typeof raw === "string" ? raw : "{}");
 }
 
+function pushOptions(call: readonly unknown[] | undefined): unknown {
+  return call?.[2];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -2549,6 +2553,9 @@ describe("CHAT-02: push notification gating", () => {
       body: "Your task is complete",
       url: `/chats/${first.threadId}`,
     });
+    expect(
+      pushOptions(context.mocks.webpush.sendNotification.mock.calls[0]),
+    ).toMatchObject({ timeout: 10_000 });
     await flushWaitUntilForTest();
 
     const third = await startChatRun(actor, {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-agentphone.ts
@@ -263,7 +263,13 @@ export function createAgentPhoneBddApi(context: TestContext) {
         const apl = typeof args[0] === "string" ? args[0] : "";
         return Promise.resolve(
           apl.includes("agent-run-events")
-            ? [{ eventType: "result", eventData: { result: text } }]
+            ? [
+                {
+                  eventType: "result",
+                  sequenceNumber: 0,
+                  eventData: { result: text },
+                },
+              ]
             : [],
         );
       });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -75,6 +75,42 @@ interface AuthHeaders {
   readonly authorization?: string;
 }
 
+function axiomApl(args: readonly unknown[]): string {
+  return typeof args[0] === "string" ? args[0] : "";
+}
+
+function isRunEventVisibilityQuery(apl: string): boolean {
+  return (
+    apl.includes("agent-run-events") && apl.includes("| project sequenceNumber")
+  );
+}
+
+function isCompletedOutputQuery(apl: string): boolean {
+  return (
+    apl.includes("agent-run-events") &&
+    apl.includes("order by sequenceNumber") &&
+    (apl.includes('eventType == "assistant"') ||
+      apl.includes('eventType == "result"') ||
+      apl.includes('eventType == "item.completed"'))
+  );
+}
+
+function mockSlackRunOutput(
+  context: TestContext,
+  event: Record<string, unknown>,
+): void {
+  context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+    const apl = axiomApl(args);
+    if (isRunEventVisibilityQuery(apl)) {
+      return Promise.resolve([{ sequenceNumber: 0 }]);
+    }
+    if (isCompletedOutputQuery(apl)) {
+      return Promise.resolve([event]);
+    }
+    return Promise.resolve([]);
+  });
+}
+
 interface ClerkUserProfile {
   readonly id: string;
   readonly emailAddresses: readonly {
@@ -1160,19 +1196,19 @@ export function createBddIntegrationApi(context: TestContext) {
     },
 
     mockSlackRunResultOutput(text: string): void {
-      context.mocks.axiom.query.mockResolvedValueOnce([
-        { eventType: "result", sequenceNumber: 0, eventData: { result: text } },
-      ]);
+      mockSlackRunOutput(context, {
+        eventType: "result",
+        sequenceNumber: 0,
+        eventData: { result: text },
+      });
     },
 
     mockSlackRunAgentMessageOutput(text: string): void {
-      context.mocks.axiom.query.mockResolvedValueOnce([
-        {
-          eventType: "item.completed",
-          sequenceNumber: 0,
-          eventData: { item: { type: "agent_message", text } },
-        },
-      ]);
+      mockSlackRunOutput(context, {
+        eventType: "item.completed",
+        sequenceNumber: 0,
+        eventData: { item: { type: "agent_message", text } },
+      });
     },
 
     async enableAuditLinkSwitch(actor: ApiTestUser): Promise<void> {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-integrations.ts
@@ -1161,7 +1161,7 @@ export function createBddIntegrationApi(context: TestContext) {
 
     mockSlackRunResultOutput(text: string): void {
       context.mocks.axiom.query.mockResolvedValueOnce([
-        { eventType: "result", eventData: { result: text } },
+        { eventType: "result", sequenceNumber: 0, eventData: { result: text } },
       ]);
     },
 
@@ -1169,6 +1169,7 @@ export function createBddIntegrationApi(context: TestContext) {
       context.mocks.axiom.query.mockResolvedValueOnce([
         {
           eventType: "item.completed",
+          sequenceNumber: 0,
           eventData: { item: { type: "agent_message", text } },
         },
       ]);

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2760,7 +2760,8 @@ describe("INT-01: Slack app deep webhook flows", () => {
     let legacyRunId = "";
     let legacySandboxToken = "";
     let legacyWatermarkInjected = false;
-    let legacyOutputQueryCount = 0;
+    let legacyUnwatermarkedOutputQueries = 0;
+    let legacyWatermarkedOutputQueries = 0;
     let legacyVisibilityQuerySeen = false;
     context.mocks.axiom.query.mockImplementation(async (...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
@@ -2769,8 +2770,11 @@ describe("INT-01: Slack app deep webhook flows", () => {
         return [{ sequenceNumber: 0 }];
       }
       if (apl.includes('eventType == "assistant"')) {
-        legacyOutputQueryCount++;
-        if (!legacyWatermarkInjected) {
+        if (!apl.includes("| where sequenceNumber <= 0")) {
+          legacyUnwatermarkedOutputQueries++;
+          if (legacyUnwatermarkedOutputQueries < 4) {
+            return [];
+          }
           legacyWatermarkInjected = true;
           await webhooks.requestAgentComplete(
             {
@@ -2783,15 +2787,14 @@ describe("INT-01: Slack app deep webhook flows", () => {
           );
           return [];
         }
-        return apl.includes("| where sequenceNumber <= 0")
-          ? [
-              {
-                eventType: "result",
-                sequenceNumber: 0,
-                eventData: { result: legacyCompleteText },
-              },
-            ]
-          : [];
+        legacyWatermarkedOutputQueries++;
+        return [
+          {
+            eventType: "result",
+            sequenceNumber: 0,
+            eventData: { result: legacyCompleteText },
+          },
+        ];
       }
       return [];
     });
@@ -2822,7 +2825,9 @@ describe("INT-01: Slack app deep webhook flows", () => {
         }),
       );
     });
-    expect(legacyOutputQueryCount).toBe(2);
+    expect(legacyWatermarkInjected).toBeTruthy();
+    expect(legacyUnwatermarkedOutputQueries).toBe(4);
+    expect(legacyWatermarkedOutputQueries).toBe(1);
     expect(legacyVisibilityQuerySeen).toBeTruthy();
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2691,6 +2691,71 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     expect(outputQueryCount).toBe(2);
 
+    const finalLongRunText = "Final answer after many intermediate events";
+    let latestOutputQuerySeen = false;
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (apl.includes("| project sequenceNumber")) {
+        return Promise.resolve([{ sequenceNumber: 250 }]);
+      }
+      if (apl.includes('eventType == "assistant"')) {
+        latestOutputQuerySeen = apl.includes("| order by sequenceNumber desc");
+        if (latestOutputQuerySeen) {
+          return Promise.resolve([
+            {
+              eventType: "result",
+              sequenceNumber: 250,
+              eventData: { result: finalLongRunText },
+            },
+          ]);
+        }
+        return Promise.resolve(
+          Array.from({ length: 200 }, (_, sequenceNumber) => {
+            return {
+              eventType: "assistant",
+              sequenceNumber,
+              eventData: {
+                message: {
+                  content: [
+                    { type: "text", text: `Old output ${sequenceNumber}` },
+                  ],
+                },
+              },
+            };
+          }),
+        );
+      }
+      return Promise.resolve([]);
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "use the final output from a long run",
+      ts: "4050.000150",
+      channel: channelId,
+    });
+    const longRunId = await pollSlackRun(runnerGroup);
+    const longRunClaim = await runs.claimRunnerJob(longRunId);
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: longRunId,
+      sandboxToken: longRunClaim.sandboxToken,
+      cliAgentType: "claude-code",
+      lastEventSequence: 250,
+    });
+
+    await waitForExpectation(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: "4050.000150",
+          text: finalLongRunText,
+        }),
+      );
+    });
+    expect(latestOutputQuerySeen).toBeTruthy();
+
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
       if (apl.includes("| project sequenceNumber")) {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2757,29 +2757,43 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(latestOutputQuerySeen).toBeTruthy();
 
     const legacyCompleteText = "Delayed output without a terminal watermark";
+    let legacyRunId = "";
+    let legacySandboxToken = "";
+    let legacyWatermarkInjected = false;
     let legacyOutputQueryCount = 0;
     let legacyVisibilityQuerySeen = false;
-    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+    context.mocks.axiom.query.mockImplementation(async (...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
       if (apl.includes("| project sequenceNumber")) {
         legacyVisibilityQuerySeen = true;
-        return Promise.resolve([]);
+        return [{ sequenceNumber: 0 }];
       }
       if (apl.includes('eventType == "assistant"')) {
         legacyOutputQueryCount++;
-        return Promise.resolve(
-          legacyOutputQueryCount < 4
-            ? []
-            : [
-                {
-                  eventType: "result",
-                  sequenceNumber: 0,
-                  eventData: { result: legacyCompleteText },
-                },
-              ],
-        );
+        if (!legacyWatermarkInjected) {
+          legacyWatermarkInjected = true;
+          await webhooks.requestAgentComplete(
+            {
+              runId: legacyRunId,
+              exitCode: 0,
+              lastEventSequence: 0,
+            },
+            { authorization: `Bearer ${legacySandboxToken}` },
+            [200],
+          );
+          return [];
+        }
+        return apl.includes("| where sequenceNumber <= 0")
+          ? [
+              {
+                eventType: "result",
+                sequenceNumber: 0,
+                eventData: { result: legacyCompleteText },
+              },
+            ]
+          : [];
       }
-      return Promise.resolve([]);
+      return [];
     });
 
     await integrations.postSlackEvent(teamId, {
@@ -2789,8 +2803,9 @@ describe("INT-01: Slack app deep webhook flows", () => {
       ts: "4050.000175",
       channel: channelId,
     });
-    const legacyRunId = await pollSlackRun(runnerGroup);
+    legacyRunId = await pollSlackRun(runnerGroup);
     const legacyClaim = await runs.claimRunnerJob(legacyRunId);
+    legacySandboxToken = legacyClaim.sandboxToken;
     context.mocks.slack.chat.postMessage.mockClear();
     await completeSlackTriggeredRun({
       runId: legacyRunId,
@@ -2807,8 +2822,8 @@ describe("INT-01: Slack app deep webhook flows", () => {
         }),
       );
     });
-    expect(legacyOutputQueryCount).toBe(4);
-    expect(legacyVisibilityQuerySeen).toBeFalsy();
+    expect(legacyOutputQueryCount).toBe(2);
+    expect(legacyVisibilityQuerySeen).toBeTruthy();
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2845,13 +2845,74 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     expect(legacyWatermarkInjected).toBeTruthy();
     expect(legacyMissingWatermarkDelays).toBe(3);
-    expect(legacyUnwatermarkedTerminalResultQueries).toBe(3);
+    expect(legacyUnwatermarkedTerminalResultQueries).toBe(0);
     expect(legacyUnwatermarkedOutputQueries).toBe(0);
     expect(legacyWatermarkedOutputQueries).toBe(1);
     expect(legacyVisibilityQuerySeen).toBeTruthy();
     expect(slackPostMessageCallsJson()).not.toContain("STALE_UNBOUNDED_OUTPUT");
 
     context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+    const legacyTerminalOnlyText = "Legacy terminal result output";
+    let legacyTerminalOnlyQueries = 0;
+    let legacyTerminalOnlyUnboundedOutputQueries = 0;
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (
+        apl.includes('| where eventType == "result"') &&
+        !apl.includes("| where sequenceNumber <=")
+      ) {
+        legacyTerminalOnlyQueries++;
+        return Promise.resolve([
+          {
+            eventType: "result",
+            sequenceNumber: 0,
+            eventData: { result: legacyTerminalOnlyText },
+          },
+        ]);
+      }
+      if (apl.includes('eventType == "assistant"')) {
+        legacyTerminalOnlyUnboundedOutputQueries++;
+        return Promise.resolve([
+          {
+            eventType: "result",
+            sequenceNumber: 0,
+            eventData: { result: "STALE_LEGACY_OUTPUT" },
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "handle old runner terminal result output",
+      ts: "4050.000190",
+      channel: channelId,
+    });
+    const legacyTerminalOnlyRunId = await pollSlackRun(runnerGroup);
+    const legacyTerminalOnlyClaim = await runs.claimRunnerJob(
+      legacyTerminalOnlyRunId,
+    );
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: legacyTerminalOnlyRunId,
+      sandboxToken: legacyTerminalOnlyClaim.sandboxToken,
+      cliAgentType: "claude-code",
+    });
+    await waitForExpectation(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: "4050.000190",
+          text: legacyTerminalOnlyText,
+        }),
+      );
+    });
+    expect(legacyTerminalOnlyQueries).toBe(1);
+    expect(legacyTerminalOnlyUnboundedOutputQueries).toBe(0);
+    expect(slackPostMessageCallsJson()).not.toContain("STALE_LEGACY_OUTPUT");
+
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
       if (apl.includes("| project sequenceNumber")) {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2691,6 +2691,57 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     expect(outputQueryCount).toBe(2);
 
+    const transientAxiomText = "Recovered after a transient Axiom error";
+    let transientAxiomOutputQueries = 0;
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (apl.includes("| project sequenceNumber")) {
+        return Promise.resolve([{ sequenceNumber: 0 }]);
+      }
+      if (apl.includes('eventType == "assistant"')) {
+        transientAxiomOutputQueries++;
+        if (transientAxiomOutputQueries === 1) {
+          return Promise.reject(new Error("temporary Axiom query failure"));
+        }
+        return Promise.resolve([
+          {
+            eventType: "result",
+            sequenceNumber: 0,
+            eventData: { result: transientAxiomText },
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "retry a transient completed output query failure",
+      ts: "4050.000125",
+      channel: channelId,
+    });
+    const transientRunId = await pollSlackRun(runnerGroup);
+    const transientClaim = await runs.claimRunnerJob(transientRunId);
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: transientRunId,
+      sandboxToken: transientClaim.sandboxToken,
+      cliAgentType: "claude-code",
+      lastEventSequence: 0,
+    });
+
+    await waitForExpectation(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: "4050.000125",
+          text: transientAxiomText,
+        }),
+      );
+    });
+    expect(transientAxiomOutputQueries).toBe(2);
+
     const finalLongRunText = "Final answer after many intermediate events";
     let latestOutputQuerySeen = false;
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2756,6 +2756,60 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     expect(latestOutputQuerySeen).toBeTruthy();
 
+    const legacyCompleteText = "Delayed output without a terminal watermark";
+    let legacyOutputQueryCount = 0;
+    let legacyVisibilityQuerySeen = false;
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (apl.includes("| project sequenceNumber")) {
+        legacyVisibilityQuerySeen = true;
+        return Promise.resolve([]);
+      }
+      if (apl.includes('eventType == "assistant"')) {
+        legacyOutputQueryCount++;
+        return Promise.resolve(
+          legacyOutputQueryCount < 4
+            ? []
+            : [
+                {
+                  eventType: "result",
+                  sequenceNumber: 0,
+                  eventData: { result: legacyCompleteText },
+                },
+              ],
+        );
+      }
+      return Promise.resolve([]);
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "handle legacy completion without lastEventSequence",
+      ts: "4050.000175",
+      channel: channelId,
+    });
+    const legacyRunId = await pollSlackRun(runnerGroup);
+    const legacyClaim = await runs.claimRunnerJob(legacyRunId);
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: legacyRunId,
+      sandboxToken: legacyClaim.sandboxToken,
+      cliAgentType: "claude-code",
+    });
+
+    await waitForExpectation(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: "4050.000175",
+          text: legacyCompleteText,
+        }),
+      );
+    });
+    expect(legacyOutputQueryCount).toBe(4);
+    expect(legacyVisibilityQuerySeen).toBeFalsy();
+
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
       if (apl.includes("| project sequenceNumber")) {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2756,6 +2756,83 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     expect(latestOutputQuerySeen).toBeTruthy();
 
+    const refreshedWatermarkText = "Final answer after refreshed watermark";
+    let refreshedRunId = "";
+    let refreshedSandboxToken = "";
+    let refreshedWatermarkInjected = false;
+    let refreshedLowWatermarkQueries = 0;
+    let refreshedHighWatermarkQueries = 0;
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (apl.includes("| project sequenceNumber")) {
+        return Promise.resolve([{ sequenceNumber: 0 }]);
+      }
+      if (apl.includes('eventType == "assistant"')) {
+        if (apl.includes("| where sequenceNumber <= 0")) {
+          refreshedLowWatermarkQueries++;
+          if (!refreshedWatermarkInjected) {
+            refreshedWatermarkInjected = true;
+            return webhooks
+              .requestAgentComplete(
+                {
+                  runId: refreshedRunId,
+                  exitCode: 0,
+                  lastEventSequence: 250,
+                },
+                { authorization: `Bearer ${refreshedSandboxToken}` },
+                [200],
+              )
+              .then(() => {
+                return [];
+              });
+          }
+          return Promise.resolve([]);
+        }
+        if (apl.includes("| where sequenceNumber <= 250")) {
+          refreshedHighWatermarkQueries++;
+          return Promise.resolve([
+            {
+              eventType: "result",
+              sequenceNumber: 250,
+              eventData: { result: refreshedWatermarkText },
+            },
+          ]);
+        }
+      }
+      return Promise.resolve([]);
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "handle a refreshed completion watermark",
+      ts: "4050.000165",
+      channel: channelId,
+    });
+    refreshedRunId = await pollSlackRun(runnerGroup);
+    const refreshedClaim = await runs.claimRunnerJob(refreshedRunId);
+    refreshedSandboxToken = refreshedClaim.sandboxToken;
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: refreshedRunId,
+      sandboxToken: refreshedClaim.sandboxToken,
+      cliAgentType: "claude-code",
+      lastEventSequence: 0,
+    });
+
+    await waitForExpectation(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: "4050.000165",
+          text: refreshedWatermarkText,
+        }),
+      );
+    });
+    expect(refreshedWatermarkInjected).toBeTruthy();
+    expect(refreshedLowWatermarkQueries).toBe(1);
+    expect(refreshedHighWatermarkQueries).toBe(1);
+
     const legacyCompleteText = "Delayed output without a terminal watermark";
     let legacyRunId = "";
     let legacySandboxToken = "";

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2761,6 +2761,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     let legacySandboxToken = "";
     let legacyWatermarkInjected = false;
     let legacyMissingWatermarkDelays = 0;
+    let legacyUnwatermarkedTerminalResultQueries = 0;
     let legacyUnwatermarkedOutputQueries = 0;
     let legacyWatermarkedOutputQueries = 0;
     let legacyVisibilityQuerySeen = false;
@@ -2785,6 +2786,13 @@ describe("INT-01: Slack app deep webhook flows", () => {
       if (apl.includes("| project sequenceNumber")) {
         legacyVisibilityQuerySeen = true;
         return Promise.resolve([{ sequenceNumber: 0 }]);
+      }
+      if (
+        apl.includes('| where eventType == "result"') &&
+        !apl.includes("| where sequenceNumber <= 0")
+      ) {
+        legacyUnwatermarkedTerminalResultQueries++;
+        return Promise.resolve([]);
       }
       if (apl.includes('eventType == "assistant"')) {
         if (!apl.includes("| where sequenceNumber <= 0")) {
@@ -2837,6 +2845,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     expect(legacyWatermarkInjected).toBeTruthy();
     expect(legacyMissingWatermarkDelays).toBe(3);
+    expect(legacyUnwatermarkedTerminalResultQueries).toBe(3);
     expect(legacyUnwatermarkedOutputQueries).toBe(0);
     expect(legacyWatermarkedOutputQueries).toBe(1);
     expect(legacyVisibilityQuerySeen).toBeTruthy();

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2760,43 +2760,53 @@ describe("INT-01: Slack app deep webhook flows", () => {
     let legacyRunId = "";
     let legacySandboxToken = "";
     let legacyWatermarkInjected = false;
+    let legacyMissingWatermarkDelays = 0;
     let legacyUnwatermarkedOutputQueries = 0;
     let legacyWatermarkedOutputQueries = 0;
     let legacyVisibilityQuerySeen = false;
-    context.mocks.axiom.query.mockImplementation(async (...args: unknown[]) => {
+    context.mocks.signalTimers.delay.mockImplementation(async () => {
+      legacyMissingWatermarkDelays++;
+      if (legacyMissingWatermarkDelays < 3 || legacyWatermarkInjected) {
+        return;
+      }
+      legacyWatermarkInjected = true;
+      await webhooks.requestAgentComplete(
+        {
+          runId: legacyRunId,
+          exitCode: 0,
+          lastEventSequence: 0,
+        },
+        { authorization: `Bearer ${legacySandboxToken}` },
+        [200],
+      );
+    });
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
       if (apl.includes("| project sequenceNumber")) {
         legacyVisibilityQuerySeen = true;
-        return [{ sequenceNumber: 0 }];
+        return Promise.resolve([{ sequenceNumber: 0 }]);
       }
       if (apl.includes('eventType == "assistant"')) {
         if (!apl.includes("| where sequenceNumber <= 0")) {
           legacyUnwatermarkedOutputQueries++;
-          if (legacyUnwatermarkedOutputQueries < 4) {
-            return [];
-          }
-          legacyWatermarkInjected = true;
-          await webhooks.requestAgentComplete(
+          return Promise.resolve([
             {
-              runId: legacyRunId,
-              exitCode: 0,
-              lastEventSequence: 0,
+              eventType: "result",
+              sequenceNumber: 0,
+              eventData: { result: "STALE_UNBOUNDED_OUTPUT" },
             },
-            { authorization: `Bearer ${legacySandboxToken}` },
-            [200],
-          );
-          return [];
+          ]);
         }
         legacyWatermarkedOutputQueries++;
-        return [
+        return Promise.resolve([
           {
             eventType: "result",
             sequenceNumber: 0,
             eventData: { result: legacyCompleteText },
           },
-        ];
+        ]);
       }
-      return [];
+      return Promise.resolve([]);
     });
 
     await integrations.postSlackEvent(teamId, {
@@ -2826,10 +2836,13 @@ describe("INT-01: Slack app deep webhook flows", () => {
       );
     });
     expect(legacyWatermarkInjected).toBeTruthy();
-    expect(legacyUnwatermarkedOutputQueries).toBe(4);
+    expect(legacyMissingWatermarkDelays).toBe(3);
+    expect(legacyUnwatermarkedOutputQueries).toBe(0);
     expect(legacyWatermarkedOutputQueries).toBe(1);
     expect(legacyVisibilityQuerySeen).toBeTruthy();
+    expect(slackPostMessageCallsJson()).not.toContain("STALE_UNBOUNDED_OUTPUT");
 
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";
       if (apl.includes("| project sequenceNumber")) {

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2709,6 +2709,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const unresolvedRunId = await pollSlackRun(runnerGroup);
     const unresolvedClaim = await runs.claimRunnerJob(unresolvedRunId);
     context.mocks.slack.chat.postMessage.mockClear();
+    context.mocks.slack.assistant.threads.setStatus.mockClear();
     await completeSlackTriggeredRun({
       runId: unresolvedRunId,
       sandboxToken: unresolvedClaim.sandboxToken,
@@ -2720,6 +2721,15 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(context.mocks.slack.chat.postMessage).not.toHaveBeenCalled();
     expect(slackPostMessageCallsJson()).not.toContain(
       "Task completed successfully.",
+    );
+    expect(
+      context.mocks.slack.assistant.threads.setStatus,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel_id: channelId,
+        thread_ts: "4050.000200",
+        status: "",
+      }),
     );
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -220,6 +220,7 @@ async function completeSlackTriggeredRun(args: {
   readonly sandboxToken: string;
   readonly cliAgentType: string;
   readonly lastEventSequence?: number;
+  readonly omitLastEventSequence?: boolean;
 }): Promise<void> {
   const sandboxHeaders = {
     authorization: `Bearer ${args.sandboxToken}`,
@@ -240,9 +241,9 @@ async function completeSlackTriggeredRun(args: {
     {
       runId: args.runId,
       exitCode: 0,
-      ...(args.lastEventSequence === undefined
+      ...(args.omitLastEventSequence === true
         ? {}
-        : { lastEventSequence: args.lastEventSequence }),
+        : { lastEventSequence: args.lastEventSequence ?? 0 }),
     },
     sandboxHeaders,
     [200],
@@ -2960,6 +2961,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       runId: legacyRunId,
       sandboxToken: legacyClaim.sandboxToken,
       cliAgentType: "claude-code",
+      omitLastEventSequence: true,
     });
 
     await waitForExpectation(() => {
@@ -3027,6 +3029,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       runId: legacyTerminalOnlyRunId,
       sandboxToken: legacyTerminalOnlyClaim.sandboxToken,
       cliAgentType: "claude-code",
+      omitLastEventSequence: true,
     });
     await waitForExpectation(() => {
       expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
@@ -3040,6 +3043,75 @@ describe("INT-01: Slack app deep webhook flows", () => {
     expect(legacyTerminalOnlyQueries).toBe(1);
     expect(legacyTerminalOnlyUnboundedOutputQueries).toBe(0);
     expect(slackPostMessageCallsJson()).not.toContain("STALE_LEGACY_OUTPUT");
+
+    const legacyCodexText = "Legacy Codex agent message output";
+    let legacyCodexTerminalOutputQueries = 0;
+    let legacyCodexUnboundedAssistantQueries = 0;
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (
+        apl.includes(
+          '| where eventType == "result" or (eventType == "item.completed"',
+        ) &&
+        !apl.includes("| where sequenceNumber <=")
+      ) {
+        legacyCodexTerminalOutputQueries++;
+        return Promise.resolve([
+          {
+            eventType: "result",
+            sequenceNumber: 2,
+            eventData: { result: "" },
+          },
+          {
+            eventType: "item.completed",
+            sequenceNumber: 1,
+            eventData: {
+              item: { type: "agent_message", text: legacyCodexText },
+            },
+          },
+        ]);
+      }
+      if (apl.includes('eventType == "assistant"')) {
+        legacyCodexUnboundedAssistantQueries++;
+        return Promise.resolve([
+          {
+            eventType: "result",
+            sequenceNumber: 0,
+            eventData: { result: "STALE_CODEX_OUTPUT" },
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "handle old runner codex item output",
+      ts: "4050.000195",
+      channel: channelId,
+    });
+    const legacyCodexRunId = await pollSlackRun(runnerGroup);
+    const legacyCodexClaim = await runs.claimRunnerJob(legacyCodexRunId);
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: legacyCodexRunId,
+      sandboxToken: legacyCodexClaim.sandboxToken,
+      cliAgentType: "codex",
+      omitLastEventSequence: true,
+    });
+    await waitForExpectation(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: "4050.000195",
+          text: legacyCodexText,
+        }),
+      );
+    });
+    expect(legacyCodexTerminalOutputQueries).toBe(1);
+    expect(legacyCodexUnboundedAssistantQueries).toBe(0);
+    expect(slackPostMessageCallsJson()).not.toContain("STALE_CODEX_OUTPUT");
 
     context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
       const apl = typeof args[0] === "string" ? args[0] : "";

--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -219,6 +219,7 @@ async function completeSlackTriggeredRun(args: {
   readonly runId: string;
   readonly sandboxToken: string;
   readonly cliAgentType: string;
+  readonly lastEventSequence?: number;
 }): Promise<void> {
   const sandboxHeaders = {
     authorization: `Bearer ${args.sandboxToken}`,
@@ -236,7 +237,13 @@ async function completeSlackTriggeredRun(args: {
     [200],
   );
   await webhooks.requestAgentComplete(
-    { runId: args.runId, exitCode: 0 },
+    {
+      runId: args.runId,
+      exitCode: 0,
+      ...(args.lastEventSequence === undefined
+        ? {}
+        : { lastEventSequence: args.lastEventSequence }),
+    },
     sandboxHeaders,
     [200],
   );
@@ -1230,6 +1237,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       expect.objectContaining({ id: run1Id, triggerSource: "slack" }),
     );
 
+    integrations.mockSlackRunResultOutput("SLACK_SESSION_OUTPUT_1");
     await completeSlackTriggeredRun({
       runId: run1Id,
       sandboxToken: claim1.sandboxToken,
@@ -1273,6 +1281,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       ]),
     );
     expect(claim2.resumeSession?.sessionId).toBe(`bdd-slack-cli-${run1Id}`);
+    integrations.mockSlackRunResultOutput("SLACK_SESSION_OUTPUT_2");
     await completeSlackTriggeredRun({
       runId: run2Id,
       sandboxToken: claim2.sandboxToken,
@@ -1309,6 +1318,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const run3Id = await pollSlackRun(runnerGroup);
     const claim3 = await runs.claimRunnerJob(run3Id);
     expect(claim3.resumeSession).toBeNull();
+    integrations.mockSlackRunResultOutput("SLACK_SWITCH_OUTPUT");
     await completeSlackTriggeredRun({
       runId: run3Id,
       sandboxToken: claim3.sandboxToken,
@@ -1346,6 +1356,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       OPENAI_API_KEY: expect.stringMatching(/.+/),
       OPENAI_MODEL: "gpt-5.5",
     });
+    integrations.mockSlackRunResultOutput("SLACK_GPT_OUTPUT");
     await completeSlackTriggeredRun({
       runId: run4Id,
       sandboxToken: claim4.sandboxToken,
@@ -1370,6 +1381,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const claim5 = await runs.claimRunnerJob(run5Id);
     expect(claim5.cliAgentType).toBe("claude-code");
     expect(claim5.resumeSession).toBeNull();
+    integrations.mockSlackRunResultOutput("SLACK_BACK_TO_CLAUDE_OUTPUT");
     await completeSlackTriggeredRun({
       runId: run5Id,
       sandboxToken: claim5.sandboxToken,
@@ -1410,6 +1422,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const claim1 = await runs.claimRunnerJob(run1Id);
     expect(claim1.cliAgentType).toBe("claude-code");
     expect(claim1.resumeSession).toBeNull();
+    integrations.mockSlackRunResultOutput("SLACK_MINIMAX_OUTPUT");
     await completeSlackTriggeredRun({
       runId: run1Id,
       sandboxToken: claim1.sandboxToken,
@@ -2503,6 +2516,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const run3Id = await pollSlackRun(runnerGroup);
     const claim3 = await runs.claimRunnerJob(run3Id);
     context.mocks.slack.chat.postMessage.mockClear();
+    integrations.mockSlackRunResultOutput("SLACK_SECOND_OPINION_OUTPUT");
     await completeSlackTriggeredRun({
       runId: run3Id,
       sandboxToken: claim3.sandboxToken,
@@ -2601,6 +2615,112 @@ describe("INT-01: Slack app deep webhook flows", () => {
     });
     const run6 = await runs.readRun(actor, run6Id);
     expect(run6.status).toBe("completed");
+  }, 90_000);
+
+  it("waits for Slack completed output before posting success text", async () => {
+    const actor = bdd.user();
+    runs.acceptStorageDownloads();
+    runs.acceptTelemetryIngest();
+    integrations.configureSlackAppMocks();
+    integrations.acceptSlackSessionHistoryDownloads();
+    const runnerGroup = runs.configureRunnerGroup();
+    await runs.grantProEntitlement(actor);
+    await integrations.configureSlackRunModelPolicies(actor);
+    await bdd.readOnboardingStatus(actor);
+    const slackUser = uniqueSlackUserId();
+    const { teamId } = await integrations.installSlackWorkspace(actor, {
+      installerSlackUserId: slackUser,
+    });
+    context.mocks.signalTimers.delay.mockResolvedValue(undefined);
+
+    const delayedText = "First paragraph\n\nSecond paragraph";
+    let visibilityQueryCount = 0;
+    let outputQueryCount = 0;
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (apl.includes("| project sequenceNumber")) {
+        visibilityQueryCount++;
+        if (visibilityQueryCount === 1) {
+          return Promise.reject(new Error("watermark not indexed yet"));
+        }
+        return Promise.resolve([{ sequenceNumber: 0 }]);
+      }
+      if (apl.includes('eventType == "assistant"')) {
+        outputQueryCount++;
+        return Promise.resolve(
+          outputQueryCount === 1
+            ? []
+            : [
+                {
+                  eventType: "result",
+                  sequenceNumber: 0,
+                  eventData: { result: delayedText },
+                },
+              ],
+        );
+      }
+      return Promise.resolve([]);
+    });
+
+    const channelId = "C_BDD_ORG_OUTPUT_WAIT";
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "wait for the final answer",
+      ts: "4050.000100",
+      channel: channelId,
+    });
+    const delayedRunId = await pollSlackRun(runnerGroup);
+    const delayedClaim = await runs.claimRunnerJob(delayedRunId);
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: delayedRunId,
+      sandboxToken: delayedClaim.sandboxToken,
+      cliAgentType: "claude-code",
+      lastEventSequence: 0,
+    });
+
+    await waitForExpectation(() => {
+      expect(context.mocks.slack.chat.postMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          thread_ts: "4050.000100",
+          text: delayedText,
+        }),
+      );
+    });
+    expect(outputQueryCount).toBe(2);
+
+    context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+      const apl = typeof args[0] === "string" ? args[0] : "";
+      if (apl.includes("| project sequenceNumber")) {
+        return Promise.reject(new Error("watermark unavailable"));
+      }
+      return Promise.resolve([]);
+    });
+
+    await integrations.postSlackEvent(teamId, {
+      type: "app_mention",
+      user: slackUser,
+      text: "do not post a fallback before output is visible",
+      ts: "4050.000200",
+      channel: channelId,
+    });
+    const unresolvedRunId = await pollSlackRun(runnerGroup);
+    const unresolvedClaim = await runs.claimRunnerJob(unresolvedRunId);
+    context.mocks.slack.chat.postMessage.mockClear();
+    await completeSlackTriggeredRun({
+      runId: unresolvedRunId,
+      sandboxToken: unresolvedClaim.sandboxToken,
+      cliAgentType: "claude-code",
+      lastEventSequence: 0,
+    });
+    await flushWaitUntilForTest();
+
+    expect(context.mocks.slack.chat.postMessage).not.toHaveBeenCalled();
+    expect(slackPostMessageCallsJson()).not.toContain(
+      "Task completed successfully.",
+    );
   }, 90_000);
 
   it("keeps Slack org callbacks visible when model routes unpin and installs vanish", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-teams.test.ts
@@ -276,6 +276,7 @@ async function completeSandboxRun(args: {
   readonly sandboxToken: string;
   readonly exitCode: number;
   readonly error?: string;
+  readonly lastEventSequence?: number;
 }): Promise<string | undefined> {
   const sandboxHeaders = { authorization: `Bearer ${args.sandboxToken}` };
   if (args.exitCode === 0) {
@@ -310,7 +311,13 @@ async function completeSandboxRun(args: {
       [200],
     );
     await webhooksApi.requestAgentComplete(
-      { runId: args.runId, exitCode: args.exitCode },
+      {
+        runId: args.runId,
+        exitCode: args.exitCode,
+        ...(args.lastEventSequence === undefined
+          ? {}
+          : { lastEventSequence: args.lastEventSequence }),
+      },
       sandboxHeaders,
       [200],
     );
@@ -329,6 +336,16 @@ async function completeSandboxRun(args: {
   );
   await flushWaitUntilForTest();
   return undefined;
+}
+
+function mockVisibleEmptyRunOutput(): void {
+  context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+    const apl = typeof args[0] === "string" ? args[0] : "";
+    if (apl.includes("| project sequenceNumber")) {
+      return Promise.resolve([{ sequenceNumber: 0 }]);
+    }
+    return Promise.resolve([]);
+  });
 }
 
 async function claimFollowUpInThread(args: {
@@ -375,10 +392,12 @@ describe("Teams org internal callbacks", () => {
       runId,
     });
 
+    mockVisibleEmptyRunOutput();
     const cliAgentSessionId = await completeSandboxRun({
       runId,
       sandboxToken: claim.sandboxToken,
       exitCode: 0,
+      lastEventSequence: 0,
     });
 
     expect(teamsApi.tokenRequests).toHaveLength(1);
@@ -499,10 +518,12 @@ describe("Teams org internal callbacks", () => {
       runId,
     });
 
+    mockVisibleEmptyRunOutput();
     await completeSandboxRun({
       runId,
       sandboxToken: claim.sandboxToken,
       exitCode: 0,
+      lastEventSequence: 0,
     });
 
     expect(teamsApi.tokenRequests).toHaveLength(1);

--- a/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/internal-callbacks-telegram.test.ts
@@ -458,12 +458,19 @@ async function dispatchTelegramCallback(body: {
 }
 
 function completedOutput(text = "**Done** with `code`"): void {
-  context.mocks.axiom.query.mockResolvedValueOnce([
-    {
-      eventType: "result",
-      eventData: { result: text },
-    },
-  ]);
+  context.mocks.axiom.query.mockImplementation((...args: unknown[]) => {
+    const apl = typeof args[0] === "string" ? args[0] : "";
+    if (apl.includes("| project sequenceNumber")) {
+      return Promise.resolve([{ sequenceNumber: 0 }]);
+    }
+    return Promise.resolve([
+      {
+        eventType: "result",
+        sequenceNumber: 0,
+        eventData: { result: text },
+      },
+    ]);
+  });
 }
 
 async function enableAuditLink(fixture: TelegramFixture): Promise<void> {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts
@@ -461,7 +461,6 @@ describe("POST /api/zero/integrations/telegram/message", () => {
 
   it("returns 502 when Telegram returns a non-JSON 5xx", async () => {
     const fixture = await seedSendableContext({});
-    trackFixture(fixture);
 
     server.use(
       http.post(

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-telegram-message.test.ts
@@ -458,4 +458,41 @@ describe("POST /api/zero/integrations/telegram/message", () => {
     expect(response.body.error.code).toBe("TELEGRAM_ERROR");
     expect(response.body.error.message).toContain("Service Unavailable");
   });
+
+  it("returns 502 when Telegram returns a non-JSON 5xx", async () => {
+    const fixture = await seedSendableContext({});
+    trackFixture(fixture);
+
+    server.use(
+      http.post(
+        "https://api.telegram.org/bottest-bot-token/sendMessage",
+        () => {
+          return HttpResponse.text("Bad Gateway", { status: 502 });
+        },
+      ),
+    );
+
+    const client = setupApp({ context })(integrationsTelegramMessageContract);
+    const response = await accept(
+      client.sendMessage({
+        body: {
+          botId: fixture.telegramBotId,
+          chatId: "-1001234567890",
+          text: "hello",
+        },
+        headers: {
+          authorization: `Bearer ${zeroToken({
+            userId: fixture.userId,
+            orgId: fixture.orgId,
+            runId: fixture.runId,
+          })}`,
+        },
+      }),
+      [502],
+    );
+    expect(response.body.error).toStrictEqual({
+      code: "TELEGRAM_ERROR",
+      message: "Telegram API error: HTTP 502",
+    });
+  });
 });

--- a/turbo/apps/api/src/signals/routes/webhooks-agent-complete.ts
+++ b/turbo/apps/api/src/signals/routes/webhooks-agent-complete.ts
@@ -38,9 +38,14 @@ const completeAgentRunRoute$ = command(
     signal.throwIfAborted();
 
     if (result.sideEffects) {
+      const backgroundSignal = new AbortController().signal;
       waitUntil(
         tapError(
-          set(dispatchCompleteSideEffects$, result.sideEffects, signal),
+          set(
+            dispatchCompleteSideEffects$,
+            result.sideEffects,
+            backgroundSignal,
+          ),
           (error) => {
             L.error("dispatchCompleteSideEffects failed", {
               runId: result.sideEffects?.runId,

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -471,44 +471,54 @@ async function dispatchInternalCallbackWithoutCcstate(
       return await handleAgentPhoneInternalCallbackWithoutCcstate(
         input.db,
         callbackEnvelope(input),
+        input.signal,
       );
     }
     case "chat": {
       return await handleChatInternalCallbackWithoutCcstate(
         input.db,
         callbackEnvelope(input),
+        input.signal,
       );
     }
     case "github:issues": {
       return await handleGithubIssuesInternalCallbackWithoutCcstate(
         input.db,
         callbackEnvelope(input),
+        input.signal,
       );
     }
     case "slack:org": {
       return await handleSlackOrgInternalCallbackWithoutCcstate(
         input.db,
         callbackEnvelope(input),
+        input.signal,
       );
     }
     case "teams:org": {
       return await handleTeamsOrgInternalCallbackWithoutCcstate(
         input.db,
         callbackEnvelope(input),
+        input.signal,
       );
     }
     case "telegram": {
       return await handleTelegramInternalCallbackWithoutCcstate(
         input.db,
         callbackEnvelope(input),
+        input.signal,
       );
     }
     case "workflow-trigger:cron":
     case "workflow-trigger:loop": {
-      return await handleWorkflowTriggerInternalCallback(input.db, {
-        kind,
-        callback: callbackEnvelope(input),
-      });
+      return await handleWorkflowTriggerInternalCallback(
+        input.db,
+        {
+          kind,
+          callback: callbackEnvelope(input),
+        },
+        input.signal,
+      );
     }
   }
 }

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -9,7 +9,11 @@ import { computeHmacSignature } from "../../lib/event-consumer/hmac";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import { now, nowDate } from "../external/time";
-import { createAbortSignalWithTimeout, settle } from "../utils";
+import {
+  createAbortSignalWithTimeout,
+  discardResponseBody,
+  settle,
+} from "../utils";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { handleAgentInternalCallback$ } from "./internal-agent-run-callback.service";
@@ -531,6 +535,7 @@ async function dispatchHttpCallback(
     await markCallbackFailed(db, callback.id, errorMessage);
     return { callbackId: callback.id, success: false, error: errorMessage };
   }
+  const callbackUrl = callback.url;
   const secret = await decryptPersistentSecretValue(
     callback.encryptedSecret,
     input.featureSwitchContext,
@@ -565,12 +570,16 @@ async function dispatchHttpCallback(
     description: "agent run callback dispatch timeout",
   });
   const responseResult = await settle(
-    fetch(resolveCallbackUrl(callback.url), {
-      method: "POST",
-      headers,
-      body,
-      signal: abort.signal,
-    }).finally(abort.cleanup),
+    (async () => {
+      const response = await fetch(resolveCallbackUrl(callbackUrl), {
+        method: "POST",
+        headers,
+        body,
+        signal: abort.signal,
+      });
+      await discardResponseBody(response);
+      return response;
+    })().finally(abort.cleanup),
   );
 
   if (!responseResult.ok) {

--- a/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callback.service.ts
@@ -9,7 +9,7 @@ import { computeHmacSignature } from "../../lib/event-consumer/hmac";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import { now, nowDate } from "../external/time";
-import { settle } from "../utils";
+import { createAbortSignalWithTimeout, settle } from "../utils";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { handleAgentInternalCallback$ } from "./internal-agent-run-callback.service";
@@ -50,6 +50,7 @@ import {
 import { continueGoalIfIdle$ } from "./zero-goal-continuation.service";
 
 const L = logger("AgentRunCallback");
+const CALLBACK_HTTP_TIMEOUT_MS = 15_000;
 
 interface CallbackRecord {
   readonly id: string;
@@ -83,6 +84,7 @@ interface DispatchSingleCallbackInput {
   readonly result?: Record<string, unknown>;
   readonly error?: string;
   readonly featureSwitchContext: FeatureSwitchContext;
+  readonly signal?: AbortSignal;
 }
 
 interface DispatchInternalRunCallbackInput {
@@ -364,6 +366,7 @@ export const dispatchRunCallbacks$ = command(
             result,
             error,
             featureSwitchContext,
+            signal,
           });
       signal.throwIfAborted();
       results.push(dispatchResult);
@@ -555,12 +558,19 @@ async function dispatchHttpCallback(
     headers["x-vercel-protection-bypass"] = bypass;
   }
 
+  const abort = createAbortSignalWithTimeout({
+    signal: input.signal,
+    timeoutMs: CALLBACK_HTTP_TIMEOUT_MS,
+    timeoutMessage: `Callback dispatch timed out after ${CALLBACK_HTTP_TIMEOUT_MS}ms`,
+    description: "agent run callback dispatch timeout",
+  });
   const responseResult = await settle(
     fetch(resolveCallbackUrl(callback.url), {
       method: "POST",
       headers,
       body,
-    }),
+      signal: abort.signal,
+    }).finally(abort.cleanup),
   );
 
   if (!responseResult.ok) {

--- a/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
@@ -8,7 +8,7 @@ import { computeHmacSignature } from "../../lib/event-consumer/hmac";
 import { env } from "../../lib/env";
 import { now } from "../../lib/time";
 import { db$ } from "../external/db";
-import { createAbortSignalWithTimeout } from "../utils";
+import { createAbortSignalWithTimeout, discardResponseBody } from "../utils";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { handleAgentPhoneInternalCallback$ } from "./internal-agentphone-run-callback.service";
@@ -119,6 +119,7 @@ export const dispatchProgressCallbacks$ = command(
         if (!callback.url) {
           return;
         }
+        const callbackUrl = callback.url;
         const body = JSON.stringify({
           callbackId: callback.id,
           runId,
@@ -141,16 +142,19 @@ export const dispatchProgressCallbacks$ = command(
           timeoutMessage: `Callback dispatch timed out after ${CALLBACK_HTTP_TIMEOUT_MS}ms`,
           description: "agent run progress callback dispatch timeout",
         });
-        return fetch(resolveCallbackUrl(callback.url), {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-VM0-Signature": signature,
-            "X-VM0-Timestamp": timestamp.toString(),
-          },
-          body,
-          signal: abort.signal,
-        }).finally(abort.cleanup);
+        return (async () => {
+          const response = await fetch(resolveCallbackUrl(callbackUrl), {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-VM0-Signature": signature,
+              "X-VM0-Timestamp": timestamp.toString(),
+            },
+            body,
+            signal: abort.signal,
+          });
+          await discardResponseBody(response);
+        })().finally(abort.cleanup);
       }),
     );
   },

--- a/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-callbacks.service.ts
@@ -8,12 +8,15 @@ import { computeHmacSignature } from "../../lib/event-consumer/hmac";
 import { env } from "../../lib/env";
 import { now } from "../../lib/time";
 import { db$ } from "../external/db";
+import { createAbortSignalWithTimeout } from "../utils";
 import { decryptPersistentSecretValue } from "./crypto.utils";
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { handleAgentPhoneInternalCallback$ } from "./internal-agentphone-run-callback.service";
 import { internalRunCallbackKindForRecord } from "./internal-run-callback";
 import { handleSlackOrgInternalCallback$ } from "./internal-slack-org-run-callback.service";
 import { handleTelegramInternalCallback$ } from "./internal-telegram-run-callback.service";
+
+const CALLBACK_HTTP_TIMEOUT_MS = 15_000;
 
 function resolveCallbackUrl(url: string): string {
   return env("ENV") === "development" && url.startsWith("https://tunnel-")
@@ -132,6 +135,12 @@ export const dispatchProgressCallbacks$ = command(
           timestamp,
         );
 
+        const abort = createAbortSignalWithTimeout({
+          signal,
+          timeoutMs: CALLBACK_HTTP_TIMEOUT_MS,
+          timeoutMessage: `Callback dispatch timed out after ${CALLBACK_HTTP_TIMEOUT_MS}ms`,
+          description: "agent run progress callback dispatch timeout",
+        });
         return fetch(resolveCallbackUrl(callback.url), {
           method: "POST",
           headers: {
@@ -140,8 +149,8 @@ export const dispatchProgressCallbacks$ = command(
             "X-VM0-Timestamp": timestamp.toString(),
           },
           body,
-          signal,
-        });
+          signal: abort.signal,
+        }).finally(abort.cleanup);
       }),
     );
   },

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -11,6 +11,7 @@ import { settle } from "../utils";
 
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS = 2;
+const COMPLETED_CHAT_OUTPUT_MISSING_WATERMARK_RETRY_ATTEMPTS = 4;
 const COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS = 500;
 const LATEST_OUTPUT_EVENT_LIMIT = 200;
 
@@ -404,7 +405,11 @@ export async function resolveCompletedChatOutputWithRetry(args: {
   readonly maxAttempts?: number;
   readonly retryDelayMs?: number;
 }): Promise<CompletedChatOutputResolution> {
-  const maxAttempts = args.maxAttempts ?? COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS;
+  const maxAttempts =
+    args.maxAttempts ??
+    (args.lastEventSequence === null
+      ? COMPLETED_CHAT_OUTPUT_MISSING_WATERMARK_RETRY_ATTEMPTS
+      : COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS);
   const retryDelayMs =
     args.retryDelayMs ?? COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS;
   let lastResult: CompletedChatOutputResolution = {

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -418,11 +418,10 @@ export async function resolveCompletedChatOutputWithRetry(args: {
   readonly maxAttempts?: number;
   readonly retryDelayMs?: number;
 }): Promise<CompletedChatOutputResolution> {
-  const maxAttempts =
-    args.maxAttempts ??
-    (args.lastEventSequence === null
-      ? COMPLETED_CHAT_OUTPUT_MISSING_WATERMARK_RETRY_ATTEMPTS
-      : COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS);
+  const maxMissingWatermarkAttempts =
+    args.maxAttempts ?? COMPLETED_CHAT_OUTPUT_MISSING_WATERMARK_RETRY_ATTEMPTS;
+  const maxWatermarkedAttempts =
+    args.maxAttempts ?? COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS;
   const retryDelayMs =
     args.retryDelayMs ?? COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS;
   let lastEventSequence = args.lastEventSequence;
@@ -430,11 +429,19 @@ export async function resolveCompletedChatOutputWithRetry(args: {
     kind: "not_visible_yet",
     reason: "axiom_no_output",
   };
+  let missingWatermarkAttempts = 0;
+  let watermarkedAttempts = 0;
 
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+  for (;;) {
     if (lastEventSequence === null) {
       lastEventSequence = await loadRunLastEventSequence(args.db, args.runId);
       args.signal.throwIfAborted();
+    }
+    const hasWatermark = lastEventSequence !== null;
+    if (hasWatermark) {
+      watermarkedAttempts++;
+    } else {
+      missingWatermarkAttempts++;
     }
 
     lastResult = await resolveCompletedChatOutput({
@@ -446,7 +453,21 @@ export async function resolveCompletedChatOutputWithRetry(args: {
     if (lastResult.kind !== "not_visible_yet") {
       return lastResult;
     }
-    if (attempt + 1 >= maxAttempts) {
+    if (!hasWatermark) {
+      lastEventSequence = await loadRunLastEventSequence(args.db, args.runId);
+      args.signal.throwIfAborted();
+      if (lastEventSequence !== null) {
+        continue;
+      }
+    }
+
+    const attempts = hasWatermark
+      ? watermarkedAttempts
+      : missingWatermarkAttempts;
+    const maxAttempts = hasWatermark
+      ? maxWatermarkedAttempts
+      : maxMissingWatermarkAttempts;
+    if (attempts >= maxAttempts) {
       break;
     }
 

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -284,16 +284,16 @@ ${sequenceCap}
   return { text: null, watermarkVisible };
 }
 
-async function queryLatestTerminalResult(args: {
+async function queryLatestLegacyTerminalOutput(args: {
   readonly runId: string;
   readonly signal: AbortSignal;
 }): Promise<string | null> {
   const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
   const apl = `['${dataset}']
 | where runId == "${escapeAplString(args.runId)}"
-| where eventType == "result"
+| where eventType == "result" or (eventType == "item.completed" and ['eventData.item.type'] == "agent_message")
 | order by sequenceNumber desc
-| limit 1`;
+| limit ${LATEST_OUTPUT_EVENT_LIMIT}`;
 
   const events = await queryAxiomDirect<AxiomChatOutputEvent>(
     apl,
@@ -307,9 +307,13 @@ async function queryLatestTerminalResult(args: {
     if (typeof sequenceNumber !== "number") {
       continue;
     }
-    const fallback = extractResultFallback(sequenceNumber, event);
-    if (fallback !== null) {
-      return fallback.content;
+    const assistantContent = extractAssistantContent(event);
+    if (assistantContent !== null) {
+      return assistantContent;
+    }
+    const resultFallback = extractResultFallback(sequenceNumber, event);
+    if (resultFallback !== null) {
+      return resultFallback.content;
     }
   }
 
@@ -447,7 +451,7 @@ async function resolveCompletedChatOutputOnce(args: {
 
   if (args.lastEventSequence === null) {
     if (args.allowUnwatermarkedTerminalResult) {
-      const terminalResult = await queryLatestTerminalResult({
+      const terminalResult = await queryLatestLegacyTerminalOutput({
         runId: args.runId,
         signal: args.signal,
       });

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -1,0 +1,386 @@
+import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
+import { chatMessages } from "@vm0/db/schema/chat-message";
+import { and, desc, eq, isNotNull, lte, sql } from "drizzle-orm";
+import { delay } from "signal-timers";
+
+import { waitForRunEventWatermarkVisibility } from "../../lib/agent-event-visibility";
+import { escapeAplString } from "../../lib/axiom-apl";
+import { getDatasetName, queryAxiomDirect } from "../external/axiom";
+import type { Db } from "../external/db";
+import { settle } from "../utils";
+
+const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
+const COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS = 2;
+const COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS = 500;
+
+const COMPLETED_CHAT_OUTPUT_UNAVAILABLE_ERROR =
+  "Completed run output was not visible before delivery timeout";
+
+interface ContentBlock {
+  readonly type?: string;
+  readonly text?: string;
+}
+
+interface CodexItem {
+  readonly type?: string;
+  readonly text?: string;
+}
+
+interface AxiomChatOutputEvent {
+  readonly eventType?: string;
+  readonly sequenceNumber?: number;
+  readonly eventData?: {
+    readonly message?: { readonly content?: readonly ContentBlock[] };
+    readonly item?: CodexItem;
+    readonly result?: string;
+    readonly sequenceNumber?: number;
+  };
+}
+
+export interface AssistantEventItem {
+  readonly sequenceNumber: number;
+  readonly content: string;
+}
+
+export interface ResultEventItem {
+  readonly sequenceNumber: number;
+  readonly content: string;
+}
+
+export type DbCompletedChatOutputState =
+  | {
+      readonly kind: "complete";
+      readonly latestAssistantContent: string | null;
+      readonly hasResultFallbackCandidate: boolean;
+    }
+  | { readonly kind: "incomplete" };
+
+type CompletedChatOutputResolution =
+  | { readonly kind: "ready"; readonly text: string }
+  | { readonly kind: "empty_after_complete_visibility" }
+  | {
+      readonly kind: "not_visible_yet";
+      readonly reason:
+        | "missing_last_event_sequence"
+        | "db_incomplete"
+        | "axiom_no_output";
+    }
+  | { readonly kind: "query_failed"; readonly error: unknown };
+
+function extractAnthropicContent(
+  blocks: readonly ContentBlock[],
+): string | null {
+  const parts = blocks.flatMap((block) => {
+    return block.type === "text" &&
+      typeof block.text === "string" &&
+      block.text.trim().length > 0
+      ? [block.text]
+      : [];
+  });
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.length === 1 ? parts[0]! : parts.join("\n\n");
+}
+
+function extractCodexAgentMessageContent(item: CodexItem): string | null {
+  if (
+    item.type !== "agent_message" ||
+    typeof item.text !== "string" ||
+    item.text.trim().length === 0
+  ) {
+    return null;
+  }
+  return item.text;
+}
+
+function extractAssistantContent(event: AxiomChatOutputEvent): string | null {
+  const content =
+    event.eventType === "assistant" ? event.eventData?.message?.content : null;
+  if (content) {
+    return extractAnthropicContent(content);
+  }
+  const item =
+    event.eventType === "item.completed" ? event.eventData?.item : null;
+  if (item) {
+    return extractCodexAgentMessageContent(item);
+  }
+  return null;
+}
+
+function extractResultFallback(
+  sequenceNumber: number,
+  event: AxiomChatOutputEvent,
+): ResultEventItem | null {
+  if (event.eventType !== "result") {
+    return null;
+  }
+
+  const result = event.eventData?.result;
+  if (typeof result !== "string") {
+    return null;
+  }
+  if (!result.trim()) {
+    return null;
+  }
+  return { sequenceNumber, content: result };
+}
+
+export async function queryChatOutputEvents(args: {
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly assistantItems: readonly AssistantEventItem[];
+  readonly resultFallback: ResultEventItem | null;
+  readonly watermarkVisible: boolean;
+}> {
+  const visibility = await waitForRunEventWatermarkVisibility(
+    args.runId,
+    args.lastEventSequence,
+  );
+  args.signal.throwIfAborted();
+  const watermarkVisible =
+    visibility.kind === "checked" ? visibility.visible : false;
+
+  const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
+  const sequenceCap =
+    args.lastEventSequence === null
+      ? ""
+      : `\n| where sequenceNumber <= ${args.lastEventSequence}`;
+  const apl = `['${dataset}']
+| where runId == "${escapeAplString(args.runId)}"
+| where eventType == "assistant" or eventType == "result" or eventType == "item.completed"
+${sequenceCap}
+| order by sequenceNumber asc
+| limit 200`;
+
+  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
+    noCache: true,
+  });
+  args.signal.throwIfAborted();
+
+  const assistantItems: AssistantEventItem[] = [];
+  let resultFallback: ResultEventItem | null = null;
+  for (const event of events) {
+    const sequenceNumber =
+      event.sequenceNumber ?? event.eventData?.sequenceNumber;
+    if (typeof sequenceNumber !== "number") {
+      continue;
+    }
+    if (
+      args.lastEventSequence !== null &&
+      sequenceNumber > args.lastEventSequence
+    ) {
+      continue;
+    }
+
+    const assistant = extractAssistantContent(event);
+    if (assistant !== null) {
+      assistantItems.push({ sequenceNumber, content: assistant });
+      continue;
+    }
+
+    const fallback = extractResultFallback(sequenceNumber, event);
+    if (fallback !== null) {
+      resultFallback = fallback;
+    }
+  }
+
+  return { assistantItems, resultFallback, watermarkVisible };
+}
+
+export async function latestEventBackedAssistantMessage(
+  db: Db,
+  runId: string,
+  options: { readonly maxSequenceNumber?: number } = {},
+): Promise<{ readonly content: string } | null> {
+  const [message] = await db
+    .select({ content: chatMessages.content })
+    .from(chatMessages)
+    .where(
+      and(
+        eq(chatMessages.runId, runId),
+        eq(chatMessages.role, "assistant"),
+        isNotNull(chatMessages.sequenceNumber),
+        isNotNull(chatMessages.content),
+        sql<boolean>`NOT (${chatMessages.content} ~ '^[[:space:]]*$')`,
+        ...(options.maxSequenceNumber === undefined
+          ? []
+          : [lte(chatMessages.sequenceNumber, options.maxSequenceNumber)]),
+      ),
+    )
+    .orderBy(desc(chatMessages.sequenceNumber))
+    .limit(1);
+
+  if (!message || message.content === null) {
+    return null;
+  }
+  return { content: message.content };
+}
+
+export async function loadDbCompletedChatOutputState(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+}): Promise<DbCompletedChatOutputState> {
+  if (args.lastEventSequence === null) {
+    return { kind: "incomplete" };
+  }
+
+  const [state] = await args.db
+    .select({
+      processedThroughSequence:
+        chatOutputMaterializations.processedThroughSequence,
+      latestResultSequence: chatOutputMaterializations.latestResultSequence,
+    })
+    .from(chatOutputMaterializations)
+    .where(eq(chatOutputMaterializations.runId, args.runId))
+    .limit(1);
+
+  if (!state || state.processedThroughSequence < args.lastEventSequence) {
+    return { kind: "incomplete" };
+  }
+
+  const latestAssistant = await latestEventBackedAssistantMessage(
+    args.db,
+    args.runId,
+    { maxSequenceNumber: args.lastEventSequence },
+  );
+  return {
+    kind: "complete",
+    latestAssistantContent: latestAssistant?.content ?? null,
+    hasResultFallbackCandidate:
+      state.latestResultSequence !== null &&
+      state.latestResultSequence <= args.lastEventSequence,
+  };
+}
+
+function latestAssistantText(
+  assistantItems: readonly AssistantEventItem[],
+): string | null {
+  return assistantItems.length > 0
+    ? assistantItems[assistantItems.length - 1]!.content
+    : null;
+}
+
+async function resolveCompletedChatOutputOnce(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+}): Promise<CompletedChatOutputResolution> {
+  const dbOutputState = await loadDbCompletedChatOutputState({
+    db: args.db,
+    runId: args.runId,
+    lastEventSequence: args.lastEventSequence,
+  });
+  args.signal.throwIfAborted();
+
+  if (
+    dbOutputState.kind === "complete" &&
+    dbOutputState.latestAssistantContent !== null
+  ) {
+    return { kind: "ready", text: dbOutputState.latestAssistantContent };
+  }
+
+  if (
+    dbOutputState.kind === "complete" &&
+    !dbOutputState.hasResultFallbackCandidate
+  ) {
+    return { kind: "empty_after_complete_visibility" };
+  }
+
+  const axiomOutput = await queryChatOutputEvents({
+    runId: args.runId,
+    lastEventSequence: args.lastEventSequence,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  const assistantText = latestAssistantText(axiomOutput.assistantItems);
+  if (assistantText !== null) {
+    return { kind: "ready", text: assistantText };
+  }
+  if (axiomOutput.resultFallback !== null) {
+    return { kind: "ready", text: axiomOutput.resultFallback.content };
+  }
+  if (dbOutputState.kind === "complete") {
+    return dbOutputState.hasResultFallbackCandidate
+      ? { kind: "not_visible_yet", reason: "axiom_no_output" }
+      : { kind: "empty_after_complete_visibility" };
+  }
+  if (args.lastEventSequence !== null && axiomOutput.watermarkVisible) {
+    return { kind: "empty_after_complete_visibility" };
+  }
+  return {
+    kind: "not_visible_yet",
+    reason:
+      args.lastEventSequence === null
+        ? "missing_last_event_sequence"
+        : "db_incomplete",
+  };
+}
+
+async function resolveCompletedChatOutput(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+}): Promise<CompletedChatOutputResolution> {
+  const result = await settle(
+    resolveCompletedChatOutputOnce(args),
+    args.signal,
+  );
+  if (result.ok) {
+    return result.value;
+  }
+  return { kind: "query_failed", error: result.error };
+}
+
+export async function resolveCompletedChatOutputWithRetry(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+  readonly maxAttempts?: number;
+  readonly retryDelayMs?: number;
+}): Promise<CompletedChatOutputResolution> {
+  const maxAttempts = args.maxAttempts ?? COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS;
+  const retryDelayMs =
+    args.retryDelayMs ?? COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS;
+  let lastResult: CompletedChatOutputResolution = {
+    kind: "not_visible_yet",
+    reason: "axiom_no_output",
+  };
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    lastResult = await resolveCompletedChatOutput(args);
+    if (lastResult.kind !== "not_visible_yet") {
+      return lastResult;
+    }
+    if (attempt + 1 >= maxAttempts) {
+      break;
+    }
+
+    args.signal.throwIfAborted();
+    await delay(retryDelayMs, { signal: args.signal });
+    args.signal.throwIfAborted();
+  }
+
+  return lastResult;
+}
+
+export function completedChatOutputFailureMessage(
+  result: Extract<
+    CompletedChatOutputResolution,
+    { readonly kind: "not_visible_yet" } | { readonly kind: "query_failed" }
+  >,
+): string {
+  if (result.kind === "query_failed") {
+    const detail =
+      result.error instanceof Error ? `: ${result.error.message}` : "";
+    return `${COMPLETED_CHAT_OUTPUT_UNAVAILABLE_ERROR}: query_failed${detail}`;
+  }
+  return `${COMPLETED_CHAT_OUTPUT_UNAVAILABLE_ERROR}: ${result.reason}`;
+}

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -1,5 +1,6 @@
 import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
 import { chatMessages } from "@vm0/db/schema/chat-message";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { and, desc, eq, isNotNull, lte, sql } from "drizzle-orm";
 import { delay } from "signal-timers";
 
@@ -327,6 +328,18 @@ export async function loadDbCompletedChatOutputState(args: {
   };
 }
 
+async function loadRunLastEventSequence(
+  db: Db,
+  runId: string,
+): Promise<number | null> {
+  const [run] = await db
+    .select({ lastEventSequence: agentRuns.lastEventSequence })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  return run?.lastEventSequence ?? null;
+}
+
 async function resolveCompletedChatOutputOnce(args: {
   readonly db: Db;
   readonly runId: string;
@@ -412,13 +425,24 @@ export async function resolveCompletedChatOutputWithRetry(args: {
       : COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS);
   const retryDelayMs =
     args.retryDelayMs ?? COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS;
+  let lastEventSequence = args.lastEventSequence;
   let lastResult: CompletedChatOutputResolution = {
     kind: "not_visible_yet",
     reason: "axiom_no_output",
   };
 
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    lastResult = await resolveCompletedChatOutput(args);
+    if (lastEventSequence === null) {
+      lastEventSequence = await loadRunLastEventSequence(args.db, args.runId);
+      args.signal.throwIfAborted();
+    }
+
+    lastResult = await resolveCompletedChatOutput({
+      db: args.db,
+      runId: args.runId,
+      lastEventSequence,
+      signal: args.signal,
+    });
     if (lastResult.kind !== "not_visible_yet") {
       return lastResult;
     }

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -375,6 +375,7 @@ async function resolveCompletedChatOutputOnce(args: {
   readonly db: Db;
   readonly runId: string;
   readonly lastEventSequence: number | null;
+  readonly allowUnwatermarkedTerminalResult: boolean;
   readonly signal: AbortSignal;
 }): Promise<CompletedChatOutputResolution> {
   const dbOutputState = await loadDbCompletedChatOutputState({
@@ -399,12 +400,14 @@ async function resolveCompletedChatOutputOnce(args: {
   }
 
   if (args.lastEventSequence === null) {
-    const terminalResult = await queryLatestTerminalResult({
-      runId: args.runId,
-      signal: args.signal,
-    });
-    if (terminalResult !== null) {
-      return { kind: "ready", text: terminalResult };
+    if (args.allowUnwatermarkedTerminalResult) {
+      const terminalResult = await queryLatestTerminalResult({
+        runId: args.runId,
+        signal: args.signal,
+      });
+      if (terminalResult !== null) {
+        return { kind: "ready", text: terminalResult };
+      }
     }
     return {
       kind: "not_visible_yet",
@@ -443,6 +446,7 @@ async function resolveCompletedChatOutput(args: {
   readonly db: Db;
   readonly runId: string;
   readonly lastEventSequence: number | null;
+  readonly allowUnwatermarkedTerminalResult: boolean;
   readonly signal: AbortSignal;
 }): Promise<CompletedChatOutputResolution> {
   const result = await settle(
@@ -493,6 +497,9 @@ export async function resolveCompletedChatOutputWithRetry(args: {
       db: args.db,
       runId: args.runId,
       lastEventSequence,
+      allowUnwatermarkedTerminalResult:
+        !hasWatermark &&
+        missingWatermarkAttempts >= maxMissingWatermarkAttempts,
       signal: args.signal,
     });
     if (lastResult.kind !== "not_visible_yet") {

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -12,6 +12,7 @@ import { settle } from "../utils";
 const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS = 2;
 const COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS = 500;
+const LATEST_OUTPUT_EVENT_LIMIT = 200;
 
 const COMPLETED_CHAT_OUTPUT_UNAVAILABLE_ERROR =
   "Completed run output was not visible before delivery timeout";
@@ -66,6 +67,8 @@ type CompletedChatOutputResolution =
         | "axiom_no_output";
     }
   | { readonly kind: "query_failed"; readonly error: unknown };
+
+type ChatOutputVisibility = { readonly watermarkVisible: boolean };
 
 function extractAnthropicContent(
   blocks: readonly ContentBlock[],
@@ -126,15 +129,11 @@ function extractResultFallback(
   return { sequenceNumber, content: result };
 }
 
-export async function queryChatOutputEvents(args: {
+async function waitForChatOutputVisibility(args: {
   readonly runId: string;
   readonly lastEventSequence: number | null;
   readonly signal: AbortSignal;
-}): Promise<{
-  readonly assistantItems: readonly AssistantEventItem[];
-  readonly resultFallback: ResultEventItem | null;
-  readonly watermarkVisible: boolean;
-}> {
+}): Promise<ChatOutputVisibility> {
   args.signal.throwIfAborted();
   const visibility = await waitForRunEventWatermarkVisibility(
     args.runId,
@@ -148,7 +147,19 @@ export async function queryChatOutputEvents(args: {
   args.signal.throwIfAborted();
   const watermarkVisible =
     visibility.kind === "checked" ? visibility.visible : false;
+  return { watermarkVisible };
+}
 
+export async function queryChatOutputEvents(args: {
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly assistantItems: readonly AssistantEventItem[];
+  readonly resultFallback: ResultEventItem | null;
+  readonly watermarkVisible: boolean;
+}> {
+  const { watermarkVisible } = await waitForChatOutputVisibility(args);
   const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
   const sequenceCap =
     args.lastEventSequence === null
@@ -194,6 +205,59 @@ ${sequenceCap}
   }
 
   return { assistantItems, resultFallback, watermarkVisible };
+}
+
+async function queryLatestChatOutput(args: {
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly text: string | null;
+  readonly watermarkVisible: boolean;
+}> {
+  const { watermarkVisible } = await waitForChatOutputVisibility(args);
+  const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
+  const sequenceCap =
+    args.lastEventSequence === null
+      ? ""
+      : `\n| where sequenceNumber <= ${args.lastEventSequence}`;
+  const apl = `['${dataset}']
+| where runId == "${escapeAplString(args.runId)}"
+| where eventType == "assistant" or eventType == "result" or (eventType == "item.completed" and ['eventData.item.type'] == "agent_message")
+${sequenceCap}
+| order by sequenceNumber desc
+| limit ${LATEST_OUTPUT_EVENT_LIMIT}`;
+
+  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
+    noCache: true,
+  });
+  args.signal.throwIfAborted();
+
+  for (const event of events) {
+    const sequenceNumber =
+      event.sequenceNumber ?? event.eventData?.sequenceNumber;
+    if (typeof sequenceNumber !== "number") {
+      continue;
+    }
+    if (
+      args.lastEventSequence !== null &&
+      sequenceNumber > args.lastEventSequence
+    ) {
+      continue;
+    }
+
+    const assistant = extractAssistantContent(event);
+    if (assistant !== null) {
+      return { text: assistant, watermarkVisible };
+    }
+
+    const fallback = extractResultFallback(sequenceNumber, event);
+    if (fallback !== null) {
+      return { text: fallback.content, watermarkVisible };
+    }
+  }
+
+  return { text: null, watermarkVisible };
 }
 
 export async function latestEventBackedAssistantMessage(
@@ -262,14 +326,6 @@ export async function loadDbCompletedChatOutputState(args: {
   };
 }
 
-function latestAssistantText(
-  assistantItems: readonly AssistantEventItem[],
-): string | null {
-  return assistantItems.length > 0
-    ? assistantItems[assistantItems.length - 1]!.content
-    : null;
-}
-
 async function resolveCompletedChatOutputOnce(args: {
   readonly db: Db;
   readonly runId: string;
@@ -297,19 +353,15 @@ async function resolveCompletedChatOutputOnce(args: {
     return { kind: "empty_after_complete_visibility" };
   }
 
-  const axiomOutput = await queryChatOutputEvents({
+  const axiomOutput = await queryLatestChatOutput({
     runId: args.runId,
     lastEventSequence: args.lastEventSequence,
     signal: args.signal,
   });
   args.signal.throwIfAborted();
 
-  const assistantText = latestAssistantText(axiomOutput.assistantItems);
-  if (assistantText !== null) {
-    return { kind: "ready", text: assistantText };
-  }
-  if (axiomOutput.resultFallback !== null) {
-    return { kind: "ready", text: axiomOutput.resultFallback.content };
+  if (axiomOutput.text !== null) {
+    return { kind: "ready", text: axiomOutput.text };
   }
   if (dbOutputState.kind === "complete") {
     return dbOutputState.hasResultFallbackCandidate

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -262,6 +262,37 @@ ${sequenceCap}
   return { text: null, watermarkVisible };
 }
 
+async function queryLatestTerminalResult(args: {
+  readonly runId: string;
+  readonly signal: AbortSignal;
+}): Promise<string | null> {
+  const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
+  const apl = `['${dataset}']
+| where runId == "${escapeAplString(args.runId)}"
+| where eventType == "result"
+| order by sequenceNumber desc
+| limit 1`;
+
+  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
+    noCache: true,
+  });
+  args.signal.throwIfAborted();
+
+  for (const event of events) {
+    const sequenceNumber =
+      event.sequenceNumber ?? event.eventData?.sequenceNumber;
+    if (typeof sequenceNumber !== "number") {
+      continue;
+    }
+    const fallback = extractResultFallback(sequenceNumber, event);
+    if (fallback !== null) {
+      return fallback.content;
+    }
+  }
+
+  return null;
+}
+
 export async function latestEventBackedAssistantMessage(
   db: Db,
   runId: string,
@@ -368,6 +399,13 @@ async function resolveCompletedChatOutputOnce(args: {
   }
 
   if (args.lastEventSequence === null) {
+    const terminalResult = await queryLatestTerminalResult({
+      runId: args.runId,
+      signal: args.signal,
+    });
+    if (terminalResult !== null) {
+      return { kind: "ready", text: terminalResult };
+    }
     return {
       kind: "not_visible_yet",
       reason: "missing_last_event_sequence",

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -371,6 +371,26 @@ async function loadRunLastEventSequence(
   return run?.lastEventSequence ?? null;
 }
 
+async function hasNewerLastEventSequence(args: {
+  readonly db: Db;
+  readonly runId: string;
+  readonly lastEventSequence: number | null;
+  readonly signal: AbortSignal;
+}): Promise<boolean> {
+  if (args.lastEventSequence === null) {
+    return false;
+  }
+  const persistedLastEventSequence = await loadRunLastEventSequence(
+    args.db,
+    args.runId,
+  );
+  args.signal.throwIfAborted();
+  return (
+    persistedLastEventSequence !== null &&
+    persistedLastEventSequence > args.lastEventSequence
+  );
+}
+
 async function resolveCompletedChatOutputOnce(args: {
   readonly db: Db;
   readonly runId: string;
@@ -396,6 +416,9 @@ async function resolveCompletedChatOutputOnce(args: {
     dbOutputState.kind === "complete" &&
     !dbOutputState.hasResultFallbackCandidate
   ) {
+    if (await hasNewerLastEventSequence(args)) {
+      return { kind: "not_visible_yet", reason: "axiom_no_output" };
+    }
     return { kind: "empty_after_complete_visibility" };
   }
 
@@ -426,11 +449,20 @@ async function resolveCompletedChatOutputOnce(args: {
     return { kind: "ready", text: axiomOutput.text };
   }
   if (dbOutputState.kind === "complete") {
+    if (
+      !dbOutputState.hasResultFallbackCandidate &&
+      (await hasNewerLastEventSequence(args))
+    ) {
+      return { kind: "not_visible_yet", reason: "axiom_no_output" };
+    }
     return dbOutputState.hasResultFallbackCandidate
       ? { kind: "not_visible_yet", reason: "axiom_no_output" }
       : { kind: "empty_after_complete_visibility" };
   }
   if (args.lastEventSequence !== null && axiomOutput.watermarkVisible) {
+    if (await hasNewerLastEventSequence(args)) {
+      return { kind: "not_visible_yet", reason: "axiom_no_output" };
+    }
     return { kind: "empty_after_complete_visibility" };
   }
   return {
@@ -482,10 +514,22 @@ export async function resolveCompletedChatOutputWithRetry(args: {
   let watermarkedAttempts = 0;
 
   for (;;) {
-    if (lastEventSequence === null) {
-      lastEventSequence = await loadRunLastEventSequence(args.db, args.runId);
-      args.signal.throwIfAborted();
+    const persistedLastEventSequence = await loadRunLastEventSequence(
+      args.db,
+      args.runId,
+    );
+    args.signal.throwIfAborted();
+    if (
+      persistedLastEventSequence !== null &&
+      (lastEventSequence === null ||
+        persistedLastEventSequence > lastEventSequence)
+    ) {
+      if (lastEventSequence !== null) {
+        watermarkedAttempts = 0;
+      }
+      lastEventSequence = persistedLastEventSequence;
     }
+
     const hasWatermark = lastEventSequence !== null;
     if (hasWatermark) {
       watermarkedAttempts++;
@@ -505,12 +549,22 @@ export async function resolveCompletedChatOutputWithRetry(args: {
     if (lastResult.kind !== "not_visible_yet") {
       return lastResult;
     }
-    if (!hasWatermark) {
-      lastEventSequence = await loadRunLastEventSequence(args.db, args.runId);
-      args.signal.throwIfAborted();
+
+    const refreshedLastEventSequence = await loadRunLastEventSequence(
+      args.db,
+      args.runId,
+    );
+    args.signal.throwIfAborted();
+    if (
+      refreshedLastEventSequence !== null &&
+      (lastEventSequence === null ||
+        refreshedLastEventSequence > lastEventSequence)
+    ) {
       if (lastEventSequence !== null) {
-        continue;
+        watermarkedAttempts = 0;
       }
+      lastEventSequence = refreshedLastEventSequence;
+      continue;
     }
 
     const attempts = hasWatermark

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -367,6 +367,13 @@ async function resolveCompletedChatOutputOnce(args: {
     return { kind: "empty_after_complete_visibility" };
   }
 
+  if (args.lastEventSequence === null) {
+    return {
+      kind: "not_visible_yet",
+      reason: "missing_last_event_sequence",
+    };
+  }
+
   const axiomOutput = await queryLatestChatOutput({
     runId: args.runId,
     lastEventSequence: args.lastEventSequence,

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -135,9 +135,15 @@ export async function queryChatOutputEvents(args: {
   readonly resultFallback: ResultEventItem | null;
   readonly watermarkVisible: boolean;
 }> {
+  args.signal.throwIfAborted();
   const visibility = await waitForRunEventWatermarkVisibility(
     args.runId,
     args.lastEventSequence,
+    {
+      sleep: (ms) => {
+        return delay(ms, { signal: args.signal });
+      },
+    },
   );
   args.signal.throwIfAborted();
   const watermarkVisible =

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -546,7 +546,10 @@ export async function resolveCompletedChatOutputWithRetry(args: {
         missingWatermarkAttempts >= maxMissingWatermarkAttempts,
       signal: args.signal,
     });
-    if (lastResult.kind !== "not_visible_yet") {
+    if (
+      lastResult.kind !== "not_visible_yet" &&
+      lastResult.kind !== "query_failed"
+    ) {
       return lastResult;
     }
 

--- a/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
+++ b/turbo/apps/api/src/signals/services/completed-chat-output.service.ts
@@ -6,7 +6,11 @@ import { delay } from "signal-timers";
 
 import { waitForRunEventWatermarkVisibility } from "../../lib/agent-event-visibility";
 import { escapeAplString } from "../../lib/axiom-apl";
-import { getDatasetName, queryAxiomDirect } from "../external/axiom";
+import {
+  getDatasetName,
+  queryAxiomDirect,
+  type QueryAxiomOptions,
+} from "../external/axiom";
 import type { Db } from "../external/db";
 import { settle } from "../utils";
 
@@ -14,6 +18,7 @@ const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const COMPLETED_CHAT_OUTPUT_RETRY_ATTEMPTS = 2;
 const COMPLETED_CHAT_OUTPUT_MISSING_WATERMARK_RETRY_ATTEMPTS = 4;
 const COMPLETED_CHAT_OUTPUT_RETRY_DELAY_MS = 500;
+const COMPLETED_CHAT_OUTPUT_AXIOM_QUERY_TIMEOUT_MS = 5000;
 const LATEST_OUTPUT_EVENT_LIMIT = 200;
 
 const COMPLETED_CHAT_OUTPUT_UNAVAILABLE_ERROR =
@@ -131,6 +136,14 @@ function extractResultFallback(
   return { sequenceNumber, content: result };
 }
 
+function freshAxiomOptions(signal: AbortSignal): QueryAxiomOptions {
+  return {
+    noCache: true,
+    signal,
+    timeoutMs: COMPLETED_CHAT_OUTPUT_AXIOM_QUERY_TIMEOUT_MS,
+  };
+}
+
 async function waitForChatOutputVisibility(args: {
   readonly runId: string;
   readonly lastEventSequence: number | null;
@@ -143,6 +156,13 @@ async function waitForChatOutputVisibility(args: {
     {
       sleep: (ms) => {
         return delay(ms, { signal: args.signal });
+      },
+      queryAxiomFn: (apl, options) => {
+        return queryAxiomDirect(apl, {
+          ...options,
+          signal: args.signal,
+          timeoutMs: COMPLETED_CHAT_OUTPUT_AXIOM_QUERY_TIMEOUT_MS,
+        });
       },
     },
   );
@@ -174,9 +194,10 @@ ${sequenceCap}
 | order by sequenceNumber asc
 | limit 200`;
 
-  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
-    noCache: true,
-  });
+  const events = await queryAxiomDirect<AxiomChatOutputEvent>(
+    apl,
+    freshAxiomOptions(args.signal),
+  );
   args.signal.throwIfAborted();
 
   const assistantItems: AssistantEventItem[] = [];
@@ -230,9 +251,10 @@ ${sequenceCap}
 | order by sequenceNumber desc
 | limit ${LATEST_OUTPUT_EVENT_LIMIT}`;
 
-  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
-    noCache: true,
-  });
+  const events = await queryAxiomDirect<AxiomChatOutputEvent>(
+    apl,
+    freshAxiomOptions(args.signal),
+  );
   args.signal.throwIfAborted();
 
   for (const event of events) {
@@ -273,9 +295,10 @@ async function queryLatestTerminalResult(args: {
 | order by sequenceNumber desc
 | limit 1`;
 
-  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
-    noCache: true,
-  });
+  const events = await queryAxiomDirect<AxiomChatOutputEvent>(
+    apl,
+    freshAxiomOptions(args.signal),
+  );
   args.signal.throwIfAborted();
 
   for (const event of events) {

--- a/turbo/apps/api/src/signals/services/internal-agentphone-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-agentphone-run-callback.service.ts
@@ -18,7 +18,6 @@ import {
   userFeatureSwitchOverrides,
 } from "./feature-switches.service";
 import type { InternalRunCallbackEnvelope } from "./internal-run-callback";
-import { getRunOutputText } from "./run-output.service";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
 import {
   formatAgentPhoneAuditLink,
@@ -32,6 +31,10 @@ import {
   type AgentPhoneChannel,
 } from "./agentphone-shared.service";
 import { settle } from "../utils";
+import {
+  completedChatOutputFailureMessage,
+  resolveCompletedChatOutputWithRetry,
+} from "./completed-chat-output.service";
 
 const log = logger("api:callback:agentphone");
 
@@ -75,6 +78,9 @@ type GetFeatureOverrides = (
   orgId: string,
   userId: string,
 ) => Promise<Record<string, boolean>>;
+type CompletionTextResult =
+  | { readonly kind: "ready"; readonly text: string }
+  | { readonly kind: "failed"; readonly error: string };
 
 type AgentPhoneCallbackCompletionResponse =
   | { readonly status: 200; readonly body: { readonly success: true } }
@@ -172,29 +178,49 @@ async function loadRunContext(args: {
 }
 
 async function resolveCompletionText(args: {
+  readonly db: Db;
   readonly runId: string;
   readonly status: "completed" | "failed";
   readonly error: string | undefined;
   readonly run: RunContext | undefined;
   readonly formatRunError: FormatRunError;
   readonly signal: AbortSignal;
-}): Promise<string> {
+}): Promise<CompletionTextResult> {
   if (args.status === "failed") {
-    return await args.formatRunError({
-      runId: args.runId,
-      chatThreadId: args.run?.chatThreadId,
-      errorMessage:
-        args.error ?? "The agent encountered an error during execution.",
-    });
+    return {
+      kind: "ready",
+      text: await args.formatRunError({
+        runId: args.runId,
+        chatThreadId: args.run?.chatThreadId,
+        errorMessage:
+          args.error ?? "The agent encountered an error during execution.",
+      }),
+    };
   }
 
-  const output = await getRunOutputText(args.runId, {
-    waitForOutput: false,
-    knownLastEventSequence: args.run?.lastEventSequence,
+  const output = await resolveCompletedChatOutputWithRetry({
+    db: args.db,
+    runId: args.runId,
+    lastEventSequence: args.run?.lastEventSequence ?? null,
     signal: args.signal,
   });
   args.signal.throwIfAborted();
-  return output ?? "Task completed successfully.";
+
+  switch (output.kind) {
+    case "ready": {
+      return { kind: "ready", text: output.text };
+    }
+    case "empty_after_complete_visibility": {
+      return { kind: "ready", text: "Task completed successfully." };
+    }
+    case "not_visible_yet":
+    case "query_failed": {
+      return {
+        kind: "failed",
+        error: completedChatOutputFailureMessage(output),
+      };
+    }
+  }
 }
 
 function buildAgentPhoneCompletionText(args: {
@@ -380,6 +406,7 @@ async function handleCompletion(args: {
   }
 
   const mainText = await resolveCompletionText({
+    db: args.db,
     runId: args.runId,
     status: args.status,
     error: args.error,
@@ -387,6 +414,9 @@ async function handleCompletion(args: {
     formatRunError: args.formatRunError,
     signal: args.signal,
   });
+  if (mainText.kind === "failed") {
+    return { status: 502, body: { error: mainText.error } };
+  }
   const logsUrl = run
     ? await resolveAgentPhoneAuditLogsUrl({
         orgId: run.orgId,
@@ -406,7 +436,7 @@ async function handleCompletion(args: {
   args.signal.throwIfAborted();
 
   const body = buildAgentPhoneCompletionText({
-    mainText,
+    mainText: mainText.text,
     logsUrl,
     footerText,
   });

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -4,7 +4,6 @@ import { command } from "ccstate";
 import { formatRunErrorForExternalSurface } from "@vm0/api-contracts/contracts/errors";
 import type { ModelProviderCredentialScope } from "@vm0/api-contracts/contracts/model-providers";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { chatOutputMaterializations } from "@vm0/db/schema/chat-output-materialization";
 import {
   chatMessages,
   type ChatMessageGenerationTemplate,
@@ -14,25 +13,12 @@ import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  inArray,
-  isNotNull,
-  lte,
-  ne,
-  sql,
-} from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
 import { z } from "zod";
 
-import { waitForRunEventWatermarkVisible } from "../../lib/agent-event-visibility";
-import { escapeAplString } from "../../lib/axiom-apl";
 import { logger } from "../../lib/log";
 import { now, nowDate } from "../../lib/time";
 import { waitUntil } from "../context/wait-until";
-import { getDatasetName, queryAxiomDirect } from "../external/axiom";
 import { writeDb$, type Db } from "../external/db";
 import {
   publishChatThreadFollowupsFinished,
@@ -78,9 +64,16 @@ import { createZeroRun$ } from "./zero-runs-create.service";
 import { loadActiveGoalForThread } from "./zero-goal.service";
 import { onRejection, settle, tapError, throwIfAbort } from "../utils";
 import { resolveThreadGenerationTemplatePrompt } from "../routes/thread-generation-template";
+import {
+  latestEventBackedAssistantMessage,
+  loadDbCompletedChatOutputState,
+  queryChatOutputEvents,
+  type AssistantEventItem,
+  type DbCompletedChatOutputState,
+  type ResultEventItem,
+} from "./completed-chat-output.service";
 
 const log = logger("callback:chat");
-const AGENT_RUN_EVENTS_DATASET = "agent-run-events";
 const PG_FOREIGN_KEY_VIOLATION = "23503";
 const RECENT_CHAT_RUN_LIMIT = 10;
 const PRIOR_MESSAGE_CHAR_CAP = 4000;
@@ -243,32 +236,6 @@ const chatCallbackPayloadSchema = z
 
 type ChatCallbackPayload = z.infer<typeof chatCallbackPayloadSchema>;
 
-interface ContentBlock {
-  readonly type?: string;
-  readonly text?: string;
-}
-
-interface CodexItem {
-  readonly type?: string;
-  readonly text?: string;
-}
-
-interface AxiomChatOutputEvent {
-  readonly eventType?: string;
-  readonly sequenceNumber?: number;
-  readonly eventData?: {
-    readonly message?: { readonly content?: readonly ContentBlock[] };
-    readonly item?: CodexItem;
-    readonly result?: string;
-    readonly sequenceNumber?: number;
-  };
-}
-
-interface AssistantEventItem {
-  readonly sequenceNumber: number;
-  readonly content: string;
-}
-
 function terminalCallbackErrorMessage(
   callbackError: string | null | undefined,
   runError: string | null | undefined,
@@ -281,19 +248,6 @@ function terminalCallbackErrorMessage(
   }
   return "Run failed";
 }
-
-interface ResultEventItem {
-  readonly sequenceNumber: number;
-  readonly content: string;
-}
-
-type DbCompletedChatOutputState =
-  | {
-      readonly kind: "complete";
-      readonly latestAssistantContent: string | null;
-      readonly hasResultFallbackCandidate: boolean;
-    }
-  | { readonly kind: "incomplete" };
 
 interface CompletedChatOutputLoad {
   readonly assistantItems: readonly AssistantEventItem[];
@@ -511,189 +465,6 @@ function buildQueuedCreateZeroRunArgs(
         ? { modelProvider: input.queuedMessage.modelProviderType }
         : {}),
     },
-  };
-}
-
-function extractAnthropicContent(
-  blocks: readonly ContentBlock[],
-): string | null {
-  const parts = blocks.flatMap((block) => {
-    return block.type === "text" &&
-      typeof block.text === "string" &&
-      block.text.trim().length > 0
-      ? [block.text]
-      : [];
-  });
-  if (parts.length === 0) {
-    return null;
-  }
-  return parts.length === 1 ? parts[0]! : parts.join("\n\n");
-}
-
-function extractCodexAgentMessageContent(item: CodexItem): string | null {
-  if (
-    item.type !== "agent_message" ||
-    typeof item.text !== "string" ||
-    item.text.trim().length === 0
-  ) {
-    return null;
-  }
-  return item.text;
-}
-
-function extractAssistantContent(event: AxiomChatOutputEvent): string | null {
-  const content =
-    event.eventType === "assistant" ? event.eventData?.message?.content : null;
-  if (content) {
-    return extractAnthropicContent(content);
-  }
-  const item =
-    event.eventType === "item.completed" ? event.eventData?.item : null;
-  if (item) {
-    return extractCodexAgentMessageContent(item);
-  }
-  return null;
-}
-
-function extractResultFallback(
-  sequenceNumber: number,
-  event: AxiomChatOutputEvent,
-): ResultEventItem | null {
-  if (event.eventType !== "result") {
-    return null;
-  }
-
-  const result = event.eventData?.result;
-  if (typeof result !== "string") {
-    return null;
-  }
-  if (!result.trim()) {
-    return null;
-  }
-  return { sequenceNumber, content: result };
-}
-
-async function queryChatOutputEvents(args: {
-  readonly runId: string;
-  readonly lastEventSequence: number | null;
-  readonly signal: AbortSignal;
-}): Promise<{
-  readonly assistantItems: readonly AssistantEventItem[];
-  readonly resultFallback: ResultEventItem | null;
-}> {
-  await waitForRunEventWatermarkVisible(args.runId, args.lastEventSequence);
-  args.signal.throwIfAborted();
-
-  const dataset = getDatasetName(AGENT_RUN_EVENTS_DATASET);
-  const sequenceCap =
-    args.lastEventSequence === null
-      ? ""
-      : `\n| where sequenceNumber <= ${args.lastEventSequence}`;
-  const apl = `['${dataset}']
-| where runId == "${escapeAplString(args.runId)}"
-| where eventType == "assistant" or eventType == "result" or eventType == "item.completed"
-${sequenceCap}
-| order by sequenceNumber asc
-| limit 200`;
-
-  const events = await queryAxiomDirect<AxiomChatOutputEvent>(apl, {
-    noCache: true,
-  });
-  args.signal.throwIfAborted();
-
-  const assistantItems: AssistantEventItem[] = [];
-  let resultFallback: ResultEventItem | null = null;
-  for (const event of events) {
-    const sequenceNumber =
-      event.sequenceNumber ?? event.eventData?.sequenceNumber;
-    if (typeof sequenceNumber !== "number") {
-      continue;
-    }
-    if (
-      args.lastEventSequence !== null &&
-      sequenceNumber > args.lastEventSequence
-    ) {
-      continue;
-    }
-
-    const assistant = extractAssistantContent(event);
-    if (assistant !== null) {
-      assistantItems.push({ sequenceNumber, content: assistant });
-      continue;
-    }
-
-    const fallback = extractResultFallback(sequenceNumber, event);
-    if (fallback !== null) {
-      resultFallback = fallback;
-    }
-  }
-
-  return { assistantItems, resultFallback };
-}
-
-async function latestEventBackedAssistantMessage(
-  db: Db,
-  runId: string,
-  options: { readonly maxSequenceNumber?: number } = {},
-): Promise<{ readonly content: string } | null> {
-  const [message] = await db
-    .select({ content: chatMessages.content })
-    .from(chatMessages)
-    .where(
-      and(
-        eq(chatMessages.runId, runId),
-        eq(chatMessages.role, "assistant"),
-        isNotNull(chatMessages.sequenceNumber),
-        isNotNull(chatMessages.content),
-        sql<boolean>`NOT (${chatMessages.content} ~ '^[[:space:]]*$')`,
-        ...(options.maxSequenceNumber === undefined
-          ? []
-          : [lte(chatMessages.sequenceNumber, options.maxSequenceNumber)]),
-      ),
-    )
-    .orderBy(desc(chatMessages.sequenceNumber))
-    .limit(1);
-
-  if (!message || message.content === null) {
-    return null;
-  }
-  return { content: message.content };
-}
-
-async function loadDbCompletedChatOutputState(args: {
-  readonly db: Db;
-  readonly runId: string;
-  readonly lastEventSequence: number | null;
-}): Promise<DbCompletedChatOutputState> {
-  if (args.lastEventSequence === null) {
-    return { kind: "incomplete" };
-  }
-
-  const [state] = await args.db
-    .select({
-      processedThroughSequence:
-        chatOutputMaterializations.processedThroughSequence,
-      latestResultSequence: chatOutputMaterializations.latestResultSequence,
-    })
-    .from(chatOutputMaterializations)
-    .where(eq(chatOutputMaterializations.runId, args.runId))
-    .limit(1);
-
-  if (!state || state.processedThroughSequence < args.lastEventSequence) {
-    return { kind: "incomplete" };
-  }
-
-  const latestAssistant = await latestEventBackedAssistantMessage(
-    args.db,
-    args.runId,
-    { maxSequenceNumber: args.lastEventSequence },
-  );
-  return {
-    kind: "complete",
-    latestAssistantContent: latestAssistant?.content ?? null,
-    hasResultFallbackCandidate:
-      state.latestResultSequence !== null &&
-      state.latestResultSequence <= args.lastEventSequence,
   };
 }
 

--- a/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-chat-run-callback.service.ts
@@ -710,6 +710,7 @@ async function generateRecommendedFollowupsForCompletedRun(args: {
   const suggestions = await generateChatThreadRecommendedFollowupsFromContext({
     messages: args.followupContext,
     threadId: args.threadId,
+    signal: args.signal,
   });
   args.signal.throwIfAborted();
   return suggestions.length > 0 ? suggestions : undefined;
@@ -916,7 +917,12 @@ async function runCompletedChatCallbackSideEffects(args: {
     let summary: string | null = null;
     if (args.lastResultText) {
       const generated = await settle(
-        generateChatNotificationSummary(args.run.prompt, args.lastResultText),
+        generateChatNotificationSummary(
+          args.run.prompt,
+          args.lastResultText,
+          args.signal,
+        ),
+        args.signal,
       );
       if (generated.ok) {
         summary = generated.value;

--- a/turbo/apps/api/src/signals/services/internal-slack-org-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-slack-org-run-callback.service.ts
@@ -35,7 +35,6 @@ import {
   loadUserFeatureSwitchContext,
   userFeatureSwitchOverrides,
 } from "./feature-switches.service";
-import { getRunOutputText } from "./run-output.service";
 import { saveRunSummary, saveRunSummary$ } from "./run-summary.service";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
 import type { InternalRunCallbackEnvelope } from "./internal-run-callback";
@@ -45,6 +44,10 @@ import {
   slackOrgCallbackPayloadSchema,
   type SlackOrgCallbackPayload,
 } from "./slack-org-callback-payload";
+import {
+  completedChatOutputFailureMessage,
+  resolveCompletedChatOutputWithRetry,
+} from "./completed-chat-output.service";
 
 const L = logger("InternalCallbacksSlackOrg");
 const ORG_SENTINEL_USER_ID = "__org__";
@@ -63,6 +66,23 @@ interface RunContext {
 interface SlackInstallation {
   readonly encryptedBotToken: string;
 }
+
+type GetFeatureOverrides = (
+  orgId: string,
+  userId: string,
+) => Promise<Record<string, boolean>>;
+
+type FormatRunError = (params: {
+  readonly runId: string;
+  readonly chatThreadId: string | null | undefined;
+  readonly errorMessage: string;
+}) => Promise<string>;
+
+type SaveRunSummary = (
+  runId: string,
+  prompt: string,
+  resultText: string,
+) => Promise<void>;
 
 type SlackOrgCallbackResult =
   | { readonly status: 200; readonly body: { readonly success: true } }
@@ -387,6 +407,14 @@ function buildResponseText(args: {
   return args.output ?? "Task completed successfully.";
 }
 
+type CompletedOutputResult =
+  | {
+      readonly kind: "ready";
+      readonly responseText: string;
+      readonly summaryText: string;
+    }
+  | { readonly kind: "failed"; readonly error: string };
+
 function refreshThreadStatus(args: {
   readonly token: string;
   readonly channelId: string;
@@ -406,23 +434,60 @@ function refreshThreadStatus(args: {
   );
 }
 
-async function resolveCompletionText(args: {
+async function resolveCompletedOutput(args: {
+  readonly db: Db;
   readonly runId: string;
-  readonly status: TerminalStatus;
   readonly run: RunContext | undefined;
   readonly signal: AbortSignal;
-}): Promise<string | undefined> {
-  if (args.status === "failed") {
-    return undefined;
-  }
-
-  const output = await getRunOutputText(args.runId, {
-    waitForOutput: false,
-    knownLastEventSequence: args.run?.lastEventSequence,
+}): Promise<CompletedOutputResult> {
+  const output = await resolveCompletedChatOutputWithRetry({
+    db: args.db,
+    runId: args.runId,
+    lastEventSequence: args.run?.lastEventSequence ?? null,
     signal: args.signal,
   });
   args.signal.throwIfAborted();
-  return output;
+
+  switch (output.kind) {
+    case "ready": {
+      return {
+        kind: "ready",
+        responseText: output.text,
+        summaryText: output.text,
+      };
+    }
+    case "empty_after_complete_visibility": {
+      return {
+        kind: "ready",
+        responseText: "Task completed successfully.",
+        summaryText: "",
+      };
+    }
+    case "not_visible_yet":
+    case "query_failed": {
+      return {
+        kind: "failed",
+        error: completedChatOutputFailureMessage(output),
+      };
+    }
+  }
+}
+
+async function resolveFailedRunResponseText(args: {
+  readonly status: TerminalStatus;
+  readonly runId: string;
+  readonly run: RunContext | undefined;
+  readonly error: string | undefined;
+  readonly formatRunError: FormatRunError;
+}): Promise<string | undefined> {
+  if (args.status !== "failed") {
+    return undefined;
+  }
+  return await args.formatRunError({
+    runId: args.runId,
+    chatThreadId: args.run?.chatThreadId,
+    errorMessage: args.error ?? "Agent execution failed.",
+  });
 }
 
 async function handleProgress(args: {
@@ -476,20 +541,9 @@ async function handleCompletion(args: {
   readonly status: TerminalStatus;
   readonly error: string | undefined;
   readonly payload: SlackOrgCallbackPayload;
-  readonly getFeatureOverrides: (
-    orgId: string,
-    userId: string,
-  ) => Promise<Record<string, boolean>>;
-  readonly formatRunError: (params: {
-    readonly runId: string;
-    readonly chatThreadId: string | null | undefined;
-    readonly errorMessage: string;
-  }) => Promise<string>;
-  readonly saveRunSummary: (
-    runId: string,
-    prompt: string,
-    resultText: string,
-  ) => Promise<void>;
+  readonly getFeatureOverrides: GetFeatureOverrides;
+  readonly formatRunError: FormatRunError;
+  readonly saveRunSummary: SaveRunSummary;
   readonly signal: AbortSignal;
 }): Promise<SlackOrgCallbackResult> {
   const installation = await loadInstallation({
@@ -520,12 +574,18 @@ async function handleCompletion(args: {
     installation.encryptedBotToken,
     featureSwitchContext,
   );
-  const output = await resolveCompletionText({
-    runId: args.runId,
-    status: args.status,
-    run,
-    signal: args.signal,
-  });
+  const completedOutput =
+    args.status === "completed"
+      ? await resolveCompletedOutput({
+          db: args.db,
+          runId: args.runId,
+          run,
+          signal: args.signal,
+        })
+      : undefined;
+  if (completedOutput?.kind === "failed") {
+    return errorResponse(502, completedOutput.error);
+  }
   const logsUrl = await resolveAuditLogsUrl({
     runId: args.runId,
     run,
@@ -551,20 +611,19 @@ async function handleCompletion(args: {
     : undefined;
   args.signal.throwIfAborted();
 
-  const errorText =
-    args.status === "failed"
-      ? await args.formatRunError({
-          runId: args.runId,
-          chatThreadId: run?.chatThreadId,
-          errorMessage: args.error ?? "Agent execution failed.",
-        })
-      : undefined;
+  const errorText = await resolveFailedRunResponseText({
+    status: args.status,
+    runId: args.runId,
+    run,
+    error: args.error,
+    formatRunError: args.formatRunError,
+  });
   args.signal.throwIfAborted();
 
   const responseText = buildResponseText({
     status: args.status,
     errorText,
-    output,
+    output: completedOutput?.responseText,
   });
   const client = createSlackClient(botToken);
   const postResult = await postMessage(
@@ -582,7 +641,11 @@ async function handleCompletion(args: {
   }
 
   if (run?.prompt) {
-    await args.saveRunSummary(args.runId, run.prompt, output ?? "");
+    await args.saveRunSummary(
+      args.runId,
+      run.prompt,
+      completedOutput?.summaryText ?? "",
+    );
     args.signal.throwIfAborted();
   }
 
@@ -602,20 +665,9 @@ async function handleCompletion(args: {
 interface HandleSlackOrgInternalCallbackInput {
   readonly db: Db;
   readonly callback: InternalRunCallbackEnvelope;
-  readonly getFeatureOverrides: (
-    orgId: string,
-    userId: string,
-  ) => Promise<Record<string, boolean>>;
-  readonly formatRunError: (params: {
-    readonly runId: string;
-    readonly chatThreadId: string | null | undefined;
-    readonly errorMessage: string;
-  }) => Promise<string>;
-  readonly saveRunSummary: (
-    runId: string,
-    prompt: string,
-    resultText: string,
-  ) => Promise<void>;
+  readonly getFeatureOverrides: GetFeatureOverrides;
+  readonly formatRunError: FormatRunError;
+  readonly saveRunSummary: SaveRunSummary;
   readonly signal?: AbortSignal;
 }
 

--- a/turbo/apps/api/src/signals/services/internal-slack-org-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-slack-org-run-callback.service.ts
@@ -584,6 +584,15 @@ async function handleCompletion(args: {
         })
       : undefined;
   if (completedOutput?.kind === "failed") {
+    refreshThreadStatus({
+      token: botToken,
+      channelId: args.payload.channelId,
+      threadTs: args.payload.threadTs,
+      status: "",
+      runId: args.runId,
+      failureMessage:
+        "Failed to clear thread status after output lookup failed",
+    });
     return errorResponse(502, completedOutput.error);
   }
   const logsUrl = await resolveAuditLogsUrl({

--- a/turbo/apps/api/src/signals/services/internal-teams-org-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-teams-org-run-callback.service.ts
@@ -35,11 +35,14 @@ import type {
   InternalRunCallbackEnvelope,
 } from "./internal-run-callback";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
-import { getRunOutputText } from "./run-output.service";
 import {
   teamsOrgCallbackPayloadSchema,
   type TeamsOrgCallbackPayload,
 } from "./teams-org-callback-payload";
+import {
+  completedChatOutputFailureMessage,
+  resolveCompletedChatOutputWithRetry,
+} from "./completed-chat-output.service";
 
 const L = logger("InternalCallbacksTeamsOrg");
 const ORG_SENTINEL_USER_ID = "__org__";
@@ -301,23 +304,39 @@ function buildTeamsResponseText(args: {
     .join("\n\n");
 }
 
-async function resolveCompletionText(args: {
+type CompletedTextResult =
+  | { readonly kind: "ready"; readonly text: string }
+  | { readonly kind: "failed"; readonly error: string };
+
+async function resolveCompletedText(args: {
+  readonly db: Db;
   readonly runId: string;
-  readonly status: TerminalStatus;
   readonly run: RunContext | undefined;
   readonly signal: AbortSignal;
-}): Promise<string | undefined> {
-  if (args.status === "failed") {
-    return undefined;
-  }
-
-  const output = await getRunOutputText(args.runId, {
-    waitForOutput: false,
-    knownLastEventSequence: args.run?.lastEventSequence,
+}): Promise<CompletedTextResult> {
+  const output = await resolveCompletedChatOutputWithRetry({
+    db: args.db,
+    runId: args.runId,
+    lastEventSequence: args.run?.lastEventSequence ?? null,
     signal: args.signal,
   });
   args.signal.throwIfAborted();
-  return output;
+
+  switch (output.kind) {
+    case "ready": {
+      return { kind: "ready", text: output.text };
+    }
+    case "empty_after_complete_visibility": {
+      return { kind: "ready", text: "Task completed successfully." };
+    }
+    case "not_visible_yet":
+    case "query_failed": {
+      return {
+        kind: "failed",
+        error: completedChatOutputFailureMessage(output),
+      };
+    }
+  }
 }
 
 function teamsApiCallbackError(
@@ -491,12 +510,18 @@ async function handleCompletion(args: {
     return errorResponse(400, "Microsoft Teams serviceUrl is missing");
   }
 
-  const output = await resolveCompletionText({
-    runId: args.runId,
-    status: args.status,
-    run,
-    signal: args.signal,
-  });
+  const completedText =
+    args.status === "completed"
+      ? await resolveCompletedText({
+          db: args.db,
+          runId: args.runId,
+          run,
+          signal: args.signal,
+        })
+      : undefined;
+  if (completedText?.kind === "failed") {
+    return errorResponse(502, completedText.error);
+  }
   const logsUrl = await resolveAuditLogsUrl({
     runId: args.runId,
     run,
@@ -527,7 +552,7 @@ async function handleCompletion(args: {
     mainText:
       args.status === "failed"
         ? (errorText ?? "Agent execution failed.")
-        : (output ?? "Task completed successfully."),
+        : (completedText?.text ?? "Task completed successfully."),
     logsUrl,
     footerText,
   });

--- a/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
@@ -30,7 +30,6 @@ import {
   userFeatureSwitchOverrides,
 } from "./feature-switches.service";
 import type { InternalRunCallbackEnvelope } from "./internal-run-callback";
-import { getRunOutputText } from "./run-output.service";
 import { formatRunErrorForRunOwner$ } from "./run-error-format.service";
 import {
   saveTelegramThreadSession,
@@ -38,6 +37,10 @@ import {
 } from "./zero-telegram-callback-persistence.service";
 import { resolveTelegramAgentReplyFooterText } from "./zero-telegram-footer.service";
 import { settle } from "../utils";
+import {
+  completedChatOutputFailureMessage,
+  resolveCompletedChatOutputWithRetry,
+} from "./completed-chat-output.service";
 
 const L = logger("InternalCallbacksTelegram");
 const TELEGRAM_COMPLETION_CHUNK_THROTTLE_MS = 1100;
@@ -348,23 +351,39 @@ async function loadRunContext(args: {
   return run;
 }
 
-async function resolveCompletionText(args: {
+type CompletedTextResult =
+  | { readonly kind: "ready"; readonly text: string }
+  | { readonly kind: "failed"; readonly error: string };
+
+async function resolveCompletedText(args: {
+  readonly db: Db;
   readonly runId: string;
-  readonly status: "completed" | "failed";
   readonly run: RunContext | undefined;
   readonly signal: AbortSignal;
-}): Promise<string | undefined> {
-  if (args.status === "failed") {
-    return undefined;
-  }
-
-  const output = await getRunOutputText(args.runId, {
-    waitForOutput: false,
-    knownLastEventSequence: args.run?.lastEventSequence,
+}): Promise<CompletedTextResult> {
+  const output = await resolveCompletedChatOutputWithRetry({
+    db: args.db,
+    runId: args.runId,
+    lastEventSequence: args.run?.lastEventSequence ?? null,
     signal: args.signal,
   });
   args.signal.throwIfAborted();
-  return output;
+
+  switch (output.kind) {
+    case "ready": {
+      return { kind: "ready", text: output.text };
+    }
+    case "empty_after_complete_visibility": {
+      return { kind: "ready", text: "Task completed successfully." };
+    }
+    case "not_visible_yet":
+    case "query_failed": {
+      return {
+        kind: "failed",
+        error: completedChatOutputFailureMessage(output),
+      };
+    }
+  }
 }
 
 async function resolveCompletionDecorations(args: {
@@ -553,12 +572,18 @@ async function handleCompletion(args: {
     });
   }
 
-  const output = await resolveCompletionText({
-    runId: args.runId,
-    status: args.status,
-    run,
-    signal: args.signal,
-  });
+  const completedText =
+    args.status === "completed"
+      ? await resolveCompletedText({
+          db: args.db,
+          runId: args.runId,
+          run,
+          signal: args.signal,
+        })
+      : undefined;
+  if (completedText?.kind === "failed") {
+    return errorResponse(502, completedText.error);
+  }
   const { logsUrl, footerText } = await resolveCompletionDecorations({
     db: args.db,
     runId: args.runId,
@@ -580,7 +605,7 @@ async function handleCompletion(args: {
   args.signal.throwIfAborted();
   const { htmlOutput, responseText } = buildCompletionOutput({
     status: args.status,
-    output,
+    output: completedText?.text,
     errorDetail,
     logsUrl,
     footerText,

--- a/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
+++ b/turbo/apps/api/src/signals/services/internal-telegram-run-callback.service.ts
@@ -126,6 +126,7 @@ async function sendMessageWithTelegramRateLimitRetry(args: {
   for (let attempt = 0; ; attempt++) {
     const result = await sendMessage(args.botToken, args.chatId, args.text, {
       replyToMessageId: args.replyToMessageId,
+      signal: args.signal,
     });
     args.signal.throwIfAborted();
 
@@ -269,13 +270,20 @@ async function deleteThinkingMessageIfPresent(args: {
   readonly botToken: string;
   readonly chatId: string;
   readonly thinkingMessageId: string | null | undefined;
+  readonly signal: AbortSignal;
 }): Promise<void> {
   if (!args.thinkingMessageId) {
     return;
   }
 
   const result = await settle(
-    deleteMessage(args.botToken, args.chatId, Number(args.thinkingMessageId)),
+    deleteMessage(
+      args.botToken,
+      args.chatId,
+      Number(args.thinkingMessageId),
+      args.signal,
+    ),
+    args.signal,
   );
   if (!result.ok) {
     L.debug("Failed to delete legacy thinking placeholder", {
@@ -551,10 +559,11 @@ async function handleCompletion(args: {
     botToken: args.botToken,
     chatId,
     thinkingMessageId,
+    signal: args.signal,
   });
   args.signal.throwIfAborted();
 
-  await sendChatAction(args.botToken, chatId, "typing");
+  await sendChatAction(args.botToken, chatId, "typing", args.signal);
   args.signal.throwIfAborted();
 
   const run = await loadRunContext({
@@ -683,7 +692,8 @@ async function handleTelegramInternalCallback(
 
   if (callback.status === "progress") {
     const typing = await settle(
-      sendChatAction(botToken, payload.chatId, "typing"),
+      sendChatAction(botToken, payload.chatId, "typing", signal),
+      signal,
     );
     signal.throwIfAborted();
     if (!typing.ok) {

--- a/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-title.service.ts
@@ -10,7 +10,7 @@ import { optionalEnv } from "../../lib/env";
 import { logger } from "../../lib/log";
 import { publishThreadListChanged } from "../external/realtime";
 import type { Db } from "../external/db";
-import { safeJsonParse, settle } from "../utils";
+import { createAbortSignalWithTimeout, safeJsonParse, settle } from "../utils";
 import { visibleChatMessageCondition } from "./zero-chat-message-shared.service";
 import {
   RECOMMENDED_FOLLOWUP_LIMIT,
@@ -22,6 +22,7 @@ const log = logger("api:zero:chat-title");
 const OPENROUTER_CHAT_COMPLETIONS_URL =
   "https://openrouter.ai/api/v1/chat/completions";
 const FAST_CHAT_MODEL = "google/gemini-3.1-flash-lite-preview";
+const TEXT_GENERATION_TIMEOUT_MS = 15_000;
 const TITLE_CONTEXT_CHAR_CAP = 150;
 const TITLE_PRIOR_MESSAGE_CAP = 10;
 const FOLLOWUP_CONTEXT_CHAR_CAP = 700;
@@ -99,6 +100,7 @@ async function generateText(
   maxTokens = 30,
   options?: {
     readonly stripMarkdown?: boolean;
+    readonly signal?: AbortSignal;
   },
 ): Promise<string | null> {
   const apiKey = optionalEnv("OPENROUTER_API_KEY");
@@ -106,37 +108,47 @@ async function generateText(
     return null;
   }
 
-  const response = await fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      model: FAST_CHAT_MODEL,
-      messages,
-      max_tokens: maxTokens,
-      temperature: 0.3,
-    }),
+  const abort = createAbortSignalWithTimeout({
+    signal: options?.signal,
+    timeoutMs: TEXT_GENERATION_TIMEOUT_MS,
+    timeoutMessage: `OpenRouter text generation timed out after ${TEXT_GENERATION_TIMEOUT_MS}ms`,
+    description: "openrouter text generation timeout",
   });
+  return await (async () => {
+    const response = await fetch(OPENROUTER_CHAT_COMPLETIONS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: FAST_CHAT_MODEL,
+        messages,
+        max_tokens: maxTokens,
+        temperature: 0.3,
+      }),
+      signal: abort.signal,
+    });
 
-  if (!response.ok) {
-    const settled = await settle(response.text());
-    const text = settled.ok ? settled.value : "unknown error";
-    throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
-  }
+    if (!response.ok) {
+      const settled = await settle(response.text(), abort.signal);
+      const text = settled.ok ? settled.value : "unknown error";
+      throw new Error(`OpenRouter request failed: ${response.status} ${text}`);
+    }
 
-  const data = (await response.json()) as OpenRouterResponse;
-  const rawContent = data.choices[0]?.message.content;
-  if (rawContent === undefined) {
-    throw new Error("OpenRouter returned empty content");
-  }
-  const content = rawContent.trim();
-  if (!content) {
-    throw new Error("OpenRouter returned empty content");
-  }
+    const data = (await response.json()) as OpenRouterResponse;
+    abort.signal.throwIfAborted();
+    const rawContent = data.choices[0]?.message.content;
+    if (rawContent === undefined) {
+      throw new Error("OpenRouter returned empty content");
+    }
+    const content = rawContent.trim();
+    if (!content) {
+      throw new Error("OpenRouter returned empty content");
+    }
 
-  return options?.stripMarkdown === false ? content : stripMarkdown(content);
+    return options?.stripMarkdown === false ? content : stripMarkdown(content);
+  })().finally(abort.cleanup);
 }
 
 function generateChatTitle(input: ChatTitleInput): Promise<string | null> {
@@ -363,6 +375,7 @@ export async function generateAndPersistChatThreadTitleFromCallback(args: {
 export function generateChatNotificationSummary(
   prompt: string,
   resultText: string,
+  signal?: AbortSignal,
 ): Promise<string | null> {
   return generateText(
     [
@@ -377,6 +390,7 @@ export function generateChatNotificationSummary(
       },
     ],
     35,
+    { signal },
   );
 }
 
@@ -429,6 +443,7 @@ async function getLatestFollowupContextMessages(
 
 async function generateRecommendedFollowups(
   messages: readonly ChatCompletionContextMessage[],
+  signal?: AbortSignal,
 ): Promise<ChatMessageRecommendedFollowups> {
   const last = messages[messages.length - 1];
   if (last?.role !== "assistant" || last.content.trim().length === 0) {
@@ -461,7 +476,7 @@ async function generateRecommendedFollowups(
       },
     ],
     260,
-    { stripMarkdown: false },
+    { signal, stripMarkdown: false },
   );
 
   return text === null ? [] : parseRecommendedFollowups(text);
@@ -477,8 +492,12 @@ export async function loadChatThreadRecommendedFollowupContext(args: {
 export async function generateChatThreadRecommendedFollowupsFromContext(args: {
   readonly messages: readonly ChatCompletionContextMessage[];
   readonly threadId?: string;
+  readonly signal?: AbortSignal;
 }): Promise<ChatMessageRecommendedFollowups> {
-  const result = await settle(generateRecommendedFollowups(args.messages));
+  const result = await settle(
+    generateRecommendedFollowups(args.messages, args.signal),
+    args.signal,
+  );
   if (!result.ok) {
     log.warn("Recommended follow-up generation failed", {
       ...(args.threadId ? { threadId: args.threadId } : {}),

--- a/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
@@ -8,6 +8,7 @@ import type { Db } from "../external/db";
 import { settle } from "../utils";
 
 const log = logger("api:push");
+const PUSH_NOTIFICATION_TIMEOUT_MS = 10_000;
 
 interface PushNotification {
   readonly title: string;
@@ -54,6 +55,7 @@ export async function sendUserPushNotifications(args: {
             },
           },
           payload,
+          { timeout: PUSH_NOTIFICATION_TIMEOUT_MS },
         ),
       );
       if (result.ok) {

--- a/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
@@ -43,43 +43,41 @@ export async function sendUserPushNotifications(args: {
   }
 
   const payload = JSON.stringify(args.notification);
-  await Promise.all(
-    subscriptions.map(async (subscription) => {
-      const result = await settle(
-        webpush.sendNotification(
-          {
-            endpoint: subscription.endpoint,
-            keys: {
-              p256dh: subscription.p256dh,
-              auth: subscription.auth,
-            },
-          },
-          payload,
-          { timeout: PUSH_NOTIFICATION_TIMEOUT_MS },
-        ),
-      );
-      if (result.ok) {
-        return;
-      }
-
-      const statusCode =
-        result.error instanceof WebPushError
-          ? result.error.statusCode
-          : undefined;
-      if (statusCode === 410 || statusCode === 404) {
-        await args.db
-          .delete(pushSubscriptions)
-          .where(eq(pushSubscriptions.id, subscription.id));
-        log.debug("Removed stale push subscription", {
+  for (const subscription of subscriptions) {
+    const result = await settle(
+      webpush.sendNotification(
+        {
           endpoint: subscription.endpoint,
-        });
-        return;
-      }
+          keys: {
+            p256dh: subscription.p256dh,
+            auth: subscription.auth,
+          },
+        },
+        payload,
+        { timeout: PUSH_NOTIFICATION_TIMEOUT_MS },
+      ),
+    );
+    if (result.ok) {
+      continue;
+    }
 
-      log.warn("Failed to send push notification", {
+    const statusCode =
+      result.error instanceof WebPushError
+        ? result.error.statusCode
+        : undefined;
+    if (statusCode === 410 || statusCode === 404) {
+      await args.db
+        .delete(pushSubscriptions)
+        .where(eq(pushSubscriptions.id, subscription.id));
+      log.debug("Removed stale push subscription", {
         endpoint: subscription.endpoint,
-        error: result.error,
       });
-    }),
-  );
+      continue;
+    }
+
+    log.warn("Failed to send push notification", {
+      endpoint: subscription.endpoint,
+      error: result.error,
+    });
+  }
 }

--- a/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-push-notifications.service.ts
@@ -9,11 +9,75 @@ import { settle } from "../utils";
 
 const log = logger("api:push");
 const PUSH_NOTIFICATION_TIMEOUT_MS = 10_000;
+const PUSH_NOTIFICATION_CONCURRENCY = 5;
 
 interface PushNotification {
   readonly title: string;
   readonly body: string;
   readonly url: string;
+}
+
+async function forEachWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  const workerCount = Math.min(Math.max(1, limit), items.length);
+  let nextIndex = 0;
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      for (;;) {
+        const index = nextIndex;
+        nextIndex += 1;
+        const item = items[index];
+        if (item === undefined) {
+          return;
+        }
+        await fn(item);
+      }
+    }),
+  );
+}
+
+async function sendPushToSubscription(args: {
+  readonly db: Db;
+  readonly subscription: typeof pushSubscriptions.$inferSelect;
+  readonly payload: string;
+}): Promise<void> {
+  const result = await settle(
+    webpush.sendNotification(
+      {
+        endpoint: args.subscription.endpoint,
+        keys: {
+          p256dh: args.subscription.p256dh,
+          auth: args.subscription.auth,
+        },
+      },
+      args.payload,
+      { timeout: PUSH_NOTIFICATION_TIMEOUT_MS },
+    ),
+  );
+  if (result.ok) {
+    return;
+  }
+
+  const statusCode =
+    result.error instanceof WebPushError ? result.error.statusCode : undefined;
+  if (statusCode === 410 || statusCode === 404) {
+    await args.db
+      .delete(pushSubscriptions)
+      .where(eq(pushSubscriptions.id, args.subscription.id));
+    log.debug("Removed stale push subscription", {
+      endpoint: args.subscription.endpoint,
+    });
+    return;
+  }
+
+  log.warn("Failed to send push notification", {
+    endpoint: args.subscription.endpoint,
+    error: result.error,
+  });
 }
 
 /**
@@ -43,41 +107,15 @@ export async function sendUserPushNotifications(args: {
   }
 
   const payload = JSON.stringify(args.notification);
-  for (const subscription of subscriptions) {
-    const result = await settle(
-      webpush.sendNotification(
-        {
-          endpoint: subscription.endpoint,
-          keys: {
-            p256dh: subscription.p256dh,
-            auth: subscription.auth,
-          },
-        },
+  await forEachWithConcurrency(
+    subscriptions,
+    PUSH_NOTIFICATION_CONCURRENCY,
+    async (subscription) => {
+      await sendPushToSubscription({
+        db: args.db,
+        subscription,
         payload,
-        { timeout: PUSH_NOTIFICATION_TIMEOUT_MS },
-      ),
-    );
-    if (result.ok) {
-      continue;
-    }
-
-    const statusCode =
-      result.error instanceof WebPushError
-        ? result.error.statusCode
-        : undefined;
-    if (statusCode === 410 || statusCode === 404) {
-      await args.db
-        .delete(pushSubscriptions)
-        .where(eq(pushSubscriptions.id, subscription.id));
-      log.debug("Removed stale push subscription", {
-        endpoint: subscription.endpoint,
       });
-      continue;
-    }
-
-    log.warn("Failed to send push notification", {
-      endpoint: subscription.endpoint,
-      error: result.error,
-    });
-  }
+    },
+  );
 }

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -1,3 +1,5 @@
+import { setTimeout as nativeDelay } from "node:timers/promises";
+
 import { env } from "../lib/env";
 import { logger } from "../lib/log";
 import { singleton } from "../lib/singleton";
@@ -248,12 +250,17 @@ export function detach(
   }
 }
 
-export function createAbortSignalWithTimeout(args: {
+interface AbortSignalWithTimeoutArgs {
   readonly signal?: AbortSignal;
   readonly timeoutMs: number;
   readonly timeoutMessage: string;
   readonly description: string;
-}): {
+}
+
+function createAbortSignalWithTimer(
+  args: AbortSignalWithTimeoutArgs,
+  scheduleTimeout: (signal: AbortSignal) => Promise<void>,
+): {
   readonly signal: AbortSignal;
   readonly cleanup: () => void;
 } {
@@ -261,7 +268,7 @@ export function createAbortSignalWithTimeout(args: {
   const timeoutController = new AbortController();
   detach(
     (async () => {
-      await delay(args.timeoutMs, { signal: timeoutController.signal });
+      await scheduleTimeout(timeoutController.signal);
       controller.abort(new Error(args.timeoutMessage));
     })(),
     Mechanism.BestEffortCleanup,
@@ -287,6 +294,28 @@ export function createAbortSignalWithTimeout(args: {
       callerSignal?.removeEventListener("abort", abortFromCaller);
     },
   };
+}
+
+export function createAbortSignalWithTimeout(
+  args: AbortSignalWithTimeoutArgs,
+): {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+} {
+  return createAbortSignalWithTimer(args, async (signal) => {
+    await delay(args.timeoutMs, { signal });
+  });
+}
+
+export function createNativeAbortSignalWithTimeout(
+  args: AbortSignalWithTimeoutArgs,
+): {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+} {
+  return createAbortSignalWithTimer(args, async (signal) => {
+    await nativeDelay(args.timeoutMs, undefined, { ref: false, signal });
+  });
 }
 
 export function createDeferredPromise<T>(signal: AbortSignal): {

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -1,6 +1,7 @@
 import { env } from "../lib/env";
 import { logger } from "../lib/log";
 import { singleton } from "../lib/singleton";
+import { delay } from "signal-timers";
 
 export enum Mechanism {
   WaitUntil = "wait_until",
@@ -238,6 +239,47 @@ export function detach(
       tracker().descriptions.set(promise, description);
     }
   }
+}
+
+export function createAbortSignalWithTimeout(args: {
+  readonly signal?: AbortSignal;
+  readonly timeoutMs: number;
+  readonly timeoutMessage: string;
+  readonly description: string;
+}): {
+  readonly signal: AbortSignal;
+  readonly cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timeoutController = new AbortController();
+  detach(
+    (async () => {
+      await delay(args.timeoutMs, { signal: timeoutController.signal });
+      controller.abort(new Error(args.timeoutMessage));
+    })(),
+    Mechanism.BestEffortCleanup,
+    args.description,
+  );
+
+  const callerSignal = args.signal;
+  const abortFromCaller = (): void => {
+    controller.abort(callerSignal?.reason);
+  };
+  if (callerSignal) {
+    if (callerSignal.aborted) {
+      abortFromCaller();
+    } else {
+      callerSignal.addEventListener("abort", abortFromCaller, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      timeoutController.abort();
+      callerSignal?.removeEventListener("abort", abortFromCaller);
+    },
+  };
 }
 
 export function createDeferredPromise<T>(signal: AbortSignal): {

--- a/turbo/apps/api/src/signals/utils.ts
+++ b/turbo/apps/api/src/signals/utils.ts
@@ -213,6 +213,13 @@ export async function settle<T>(
   }
 }
 
+export async function discardResponseBody(response: Response): Promise<void> {
+  if (!response.body) {
+    return;
+  }
+  await settle(response.body.cancel());
+}
+
 export function detach(
   promise: Promise<unknown>,
   mechanism: Mechanism,

--- a/turbo/apps/platform/src/lib/preview-bypass-cookie.ts
+++ b/turbo/apps/platform/src/lib/preview-bypass-cookie.ts
@@ -1,9 +1,9 @@
-export const VERCEL_PROTECTION_BYPASS_NAME = "x-vercel-protection-bypass";
+const VERCEL_PROTECTION_BYPASS_NAME = "x-vercel-protection-bypass";
 
 const PREVIEW_BYPASS_COOKIE_MAX_AGE_SECONDS = 60 * 60;
 const PREVIEW_COOKIE_ROOT_DOMAIN = "vm6.ai";
 
-export interface PreviewBypassCookieLocation {
+interface PreviewBypassCookieLocation {
   readonly hostname: string;
   readonly protocol: string;
   readonly search: string;


### PR DESCRIPTION
## Summary

- Add a shared completed chat output resolver that reads DB materialized output first and falls back to watermark-gated Axiom output events.
- Route Slack, Teams, Telegram, and AgentPhone completion callbacks through the resolver so transient output invisibility fails the callback instead of posting a misleading fallback or footer-only response.
- Keep confirmed-empty completions explicit and add route-level regression coverage for delayed Slack output visibility and non-Slack completion paths.

Closes #20643

## Verification

- `pnpm -F api exec vitest run src/signals/routes/__tests__/internal-callbacks-teams.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/internal-callbacks-telegram.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/agentphone.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t "waits for Slack completed output|delivers Slack org callbacks"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t "runs Slack mentions|starts a new Slack session"`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm knip --cache`
- pre-commit `turbo run check-types --concurrency=1`
