### PR TITLE
refactor: expose auth cache test hooks

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -5,6 +5,7 @@ import math
 import time
 from dataclasses import dataclass, field
 
+from aws_sigv4 import AwsSigV4Credentials
 from firewall_auth_client import (
     FirewallAuthPayload,
     FirewallAuthRequest,
@@ -39,6 +40,21 @@ class _FirewallAuthState:
 
     cache: _FirewallHeaderCacheEntry | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    force_refresh_pending: bool = False
+    last_force_refresh_monotonic_at: float | None = None
+
+
+@dataclass(frozen=True)
+class FirewallAuthStateSnapshotForTests:
+    """Copied auth cache state exposed to tests without leaking private storage."""
+
+    has_cached_headers: bool
+    headers: dict[str, str] = field(default_factory=dict)
+    resolved_secrets: list[str] = field(default_factory=list)
+    base: str | None = None
+    query: dict[str, str] | None = None
+    aws_sigv4: AwsSigV4Credentials | None = None
+    expires_at: object = None
     force_refresh_pending: bool = False
     last_force_refresh_monotonic_at: float | None = None
 
@@ -113,6 +129,87 @@ def evict_stale_cache_keys(active_run_ids: set[str]) -> None:
 def evict_all_cache_keys() -> None:
     """Remove all auth cache entries when active registry ownership is unknown."""
     _auth_state.clear()
+
+
+def reset_cache_for_tests() -> None:
+    """Reset auth cache module state between tests."""
+    _auth_state.clear()
+
+
+def seed_cached_headers_for_tests(
+    cache_key: FirewallAuthCacheKey,
+    *,
+    headers: dict[str, str],
+    expires_at: object = None,
+    resolved_secrets: list[str] | None = None,
+    base: str | None = None,
+    query: dict[str, str] | None = None,
+    aws_sigv4: AwsSigV4Credentials | None = None,
+) -> None:
+    """Seed cached firewall auth payload for focused cache lifecycle tests."""
+    state = _get_auth_state(cache_key)
+    state.cache = _FirewallHeaderCacheEntry(
+        payload=FirewallAuthPayload(
+            headers=dict(headers),
+            resolved_secrets=list(resolved_secrets or []),
+            base=base,
+            query=dict(query) if query is not None else None,
+            aws_sigv4=aws_sigv4,
+        ),
+        expires_at=expires_at,
+    )
+
+
+def set_force_refresh_state_for_tests(
+    cache_key: FirewallAuthCacheKey,
+    *,
+    pending: bool,
+    last_monotonic_at: float | None,
+) -> None:
+    """Seed force-refresh lifecycle state for focused cache lifecycle tests."""
+    state = _get_auth_state(cache_key)
+    state.force_refresh_pending = pending
+    state.last_force_refresh_monotonic_at = last_monotonic_at
+
+
+def auth_state_snapshot_for_tests(
+    cache_key: FirewallAuthCacheKey,
+) -> FirewallAuthStateSnapshotForTests | None:
+    """Return a copied snapshot of one auth cache state for tests."""
+    state = _auth_state.get(cache_key)
+    if state is None:
+        return None
+
+    cache = state.cache
+    if cache is None:
+        return FirewallAuthStateSnapshotForTests(
+            has_cached_headers=False,
+            force_refresh_pending=state.force_refresh_pending,
+            last_force_refresh_monotonic_at=state.last_force_refresh_monotonic_at,
+        )
+
+    payload = cache.payload
+    return FirewallAuthStateSnapshotForTests(
+        has_cached_headers=True,
+        headers=dict(payload.headers),
+        resolved_secrets=list(payload.resolved_secrets),
+        base=payload.base,
+        query=dict(payload.query) if payload.query is not None else None,
+        aws_sigv4=payload.aws_sigv4,
+        expires_at=cache.expires_at,
+        force_refresh_pending=state.force_refresh_pending,
+        last_force_refresh_monotonic_at=state.last_force_refresh_monotonic_at,
+    )
+
+
+def auth_state_is_empty_for_tests() -> bool:
+    """Return whether tests have left the auth cache without any state."""
+    return not _auth_state
+
+
+def force_refresh_cooldown_secs_for_tests() -> float:
+    """Return the force-refresh cooldown used by auth cache tests."""
+    return _FORCE_REFRESH_COOLDOWN_SECS
 
 
 def _has_valid_expiry(value: object, now: float | None = None) -> bool:

--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -207,11 +207,6 @@ def auth_state_is_empty_for_tests() -> bool:
     return not _auth_state
 
 
-def force_refresh_cooldown_secs_for_tests() -> float:
-    """Return the force-refresh cooldown used by auth cache tests."""
-    return _FORCE_REFRESH_COOLDOWN_SECS
-
-
 def _has_valid_expiry(value: object, now: float | None = None) -> bool:
     if isinstance(value, bool) or not isinstance(value, int | float):
         return False

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -2,11 +2,10 @@
 
 import firewall_auth_cache as auth_cache
 from aws_sigv4 import AwsSigV4Credentials
-from firewall_auth_client import FirewallAuthPayload
 
 
 def clear_auth_state() -> None:
-    auth_cache._auth_state.clear()
+    auth_cache.reset_cache_for_tests()
 
 
 def auth_cache_key(
@@ -23,7 +22,11 @@ def auth_cache_key(
 
 
 def has_auth_state(cache_key: auth_cache.FirewallAuthCacheKey) -> bool:
-    return cache_key in auth_cache._auth_state
+    return auth_cache.auth_state_snapshot_for_tests(cache_key) is not None
+
+
+def auth_state_is_empty() -> bool:
+    return auth_cache.auth_state_is_empty_for_tests()
 
 
 def set_cached_headers(
@@ -36,53 +39,72 @@ def set_cached_headers(
     query: dict | None = None,
     aws_sigv4: AwsSigV4Credentials | None = None,
 ) -> None:
-    auth_cache._get_auth_state(cache_key).cache = auth_cache._FirewallHeaderCacheEntry(
-        payload=FirewallAuthPayload(
-            headers=headers,
-            resolved_secrets=resolved_secrets or [],
-            base=base,
-            query=query,
-            aws_sigv4=aws_sigv4,
-        ),
+    auth_cache.seed_cached_headers_for_tests(
+        cache_key,
+        headers=headers,
         expires_at=expires_at,
+        resolved_secrets=resolved_secrets,
+        base=base,
+        query=query,
+        aws_sigv4=aws_sigv4,
     )
+
+
+def auth_state_snapshot(
+    cache_key: auth_cache.FirewallAuthCacheKey,
+) -> auth_cache.FirewallAuthStateSnapshotForTests | None:
+    return auth_cache.auth_state_snapshot_for_tests(cache_key)
 
 
 def cached_headers(
     cache_key: auth_cache.FirewallAuthCacheKey,
-) -> auth_cache._FirewallHeaderCacheEntry | None:
-    state = auth_cache._auth_state.get(cache_key)
-    return state.cache if state else None
+) -> auth_cache.FirewallAuthStateSnapshotForTests | None:
+    snapshot = auth_state_snapshot(cache_key)
+    if snapshot is None or not snapshot.has_cached_headers:
+        return None
+    return snapshot
 
 
 def require_cached_headers(
     cache_key: auth_cache.FirewallAuthCacheKey,
-) -> auth_cache._FirewallHeaderCacheEntry:
-    entry = cached_headers(cache_key)
-    assert entry is not None
-    return entry
+) -> auth_cache.FirewallAuthStateSnapshotForTests:
+    snapshot = cached_headers(cache_key)
+    assert snapshot is not None
+    return snapshot
 
 
 def mark_force_refresh(cache_key: auth_cache.FirewallAuthCacheKey) -> None:
-    auth_cache._get_auth_state(cache_key).force_refresh_pending = True
+    snapshot = auth_state_snapshot(cache_key)
+    auth_cache.set_force_refresh_state_for_tests(
+        cache_key,
+        pending=True,
+        last_monotonic_at=(
+            snapshot.last_force_refresh_monotonic_at if snapshot is not None else None
+        ),
+    )
 
 
 def force_refresh_pending(cache_key: auth_cache.FirewallAuthCacheKey) -> bool:
-    state = auth_cache._auth_state.get(cache_key)
-    return bool(state and state.force_refresh_pending)
+    snapshot = auth_state_snapshot(cache_key)
+    return bool(snapshot and snapshot.force_refresh_pending)
 
 
 def set_last_force_refresh_monotonic_at(
     cache_key: auth_cache.FirewallAuthCacheKey, timestamp: float
 ) -> None:
-    auth_cache._get_auth_state(cache_key).last_force_refresh_monotonic_at = timestamp
+    snapshot = auth_state_snapshot(cache_key)
+    auth_cache.set_force_refresh_state_for_tests(
+        cache_key,
+        pending=bool(snapshot and snapshot.force_refresh_pending),
+        last_monotonic_at=timestamp,
+    )
 
 
 def last_force_refresh_monotonic_at(
     cache_key: auth_cache.FirewallAuthCacheKey,
 ) -> float | None:
-    state = auth_cache._auth_state.get(cache_key)
-    return state.last_force_refresh_monotonic_at if state else None
+    snapshot = auth_state_snapshot(cache_key)
+    return snapshot.last_force_refresh_monotonic_at if snapshot else None
 
 
 def require_last_force_refresh_monotonic_at(

--- a/crates/runner/mitm-addon/tests/auth_state_helpers.py
+++ b/crates/runner/mitm-addon/tests/auth_state_helpers.py
@@ -32,11 +32,11 @@ def auth_state_is_empty() -> bool:
 def set_cached_headers(
     cache_key: auth_cache.FirewallAuthCacheKey,
     *,
-    headers: dict,
+    headers: dict[str, str],
     expires_at: object = None,
-    resolved_secrets: list | None = None,
+    resolved_secrets: list[str] | None = None,
     base: str | None = None,
-    query: dict | None = None,
+    query: dict[str, str] | None = None,
     aws_sigv4: AwsSigV4Credentials | None = None,
 ) -> None:
     auth_cache.seed_cached_headers_for_tests(

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -147,6 +147,38 @@ class TestFirewallHeaderCache:
         assert require_cached_headers(explicit_key).headers == {"Authorization": "Bearer explicit"}
         assert require_cached_headers(default_key).headers == {"Authorization": "Bearer default"}
 
+    def test_cached_header_snapshot_is_detached_from_internal_state(self):
+        """Seeded inputs and returned snapshots cannot mutate live cache state."""
+        cache_key = auth_cache_key()
+        headers = {"Authorization": "Bearer original"}
+        resolved_secrets = ["TOKEN"]
+        query = {"api_key": "original-key"}
+        set_cached_headers(
+            cache_key,
+            headers=headers,
+            resolved_secrets=resolved_secrets,
+            query=query,
+        )
+
+        headers["Authorization"] = "Bearer changed"
+        resolved_secrets.append("OTHER")
+        query["api_key"] = "changed-key"
+
+        snapshot = require_cached_headers(cache_key)
+        assert snapshot.headers == {"Authorization": "Bearer original"}
+        assert snapshot.resolved_secrets == ["TOKEN"]
+        assert snapshot.query == {"api_key": "original-key"}
+
+        snapshot.headers["Authorization"] = "Bearer mutated"
+        snapshot.resolved_secrets.append("MUTATED")
+        assert snapshot.query is not None
+        snapshot.query["api_key"] = "mutated-key"
+
+        fresh_snapshot = require_cached_headers(cache_key)
+        assert fresh_snapshot.headers == {"Authorization": "Bearer original"}
+        assert fresh_snapshot.resolved_secrets == ["TOKEN"]
+        assert fresh_snapshot.query == {"api_key": "original-key"}
+
     async def test_fetch_failure_does_not_cache(self, mitm_ctx):
         """Failed fetch should not populate cache; next caller retries independently."""
         cache_key = auth_cache_key()

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -81,9 +81,7 @@ class TestFirewallHeaderCache:
         cache_hit_flags = [result["cache_hit"] for result in results]
         assert sum(flag is False for flag in cache_hit_flags) == 1
         assert sum(flag is True for flag in cache_hit_flags) == 2
-        assert require_cached_headers(cache_key).payload.headers == {
-            "Authorization": "Bearer token"
-        }
+        assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer token"}
 
     async def test_different_keys_fetch_independently(self, mitm_ctx):
         """Different auth cache keys should fetch independently."""
@@ -113,7 +111,7 @@ class TestFirewallHeaderCache:
         assert first["cache_hit"] is False
         assert second["cache_hit"] is False
         cached_tokens = {
-            require_cached_headers(cache_key).payload.headers["Authorization"]
+            require_cached_headers(cache_key).headers["Authorization"]
             for cache_key in (first_key, second_key)
         }
         assert cached_tokens == {"Bearer token-1", "Bearer token-2"}
@@ -146,12 +144,8 @@ class TestFirewallHeaderCache:
         assert endpoint.request_count == 2
         assert explicit["headers"] == {"Authorization": "Bearer explicit"}
         assert default["headers"] == {"Authorization": "Bearer default"}
-        assert require_cached_headers(explicit_key).payload.headers == {
-            "Authorization": "Bearer explicit"
-        }
-        assert require_cached_headers(default_key).payload.headers == {
-            "Authorization": "Bearer default"
-        }
+        assert require_cached_headers(explicit_key).headers == {"Authorization": "Bearer explicit"}
+        assert require_cached_headers(default_key).headers == {"Authorization": "Bearer default"}
 
     async def test_fetch_failure_does_not_cache(self, mitm_ctx):
         """Failed fetch should not populate cache; next caller retries independently."""
@@ -176,9 +170,7 @@ class TestFirewallHeaderCache:
             assert retry["headers"] == {"Authorization": "Bearer retry"}
             assert retry["cache_hit"] is False
             assert endpoint.request_count == 2
-            assert require_cached_headers(cache_key).payload.headers == {
-                "Authorization": "Bearer retry"
-            }
+            assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer retry"}
 
             cached = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
             assert cached["headers"] == {"Authorization": "Bearer retry"}

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -236,7 +236,7 @@ class TestGetFirewallHeaders:
         assert mock_fetch.call_args.kwargs == {"force_refresh": False}
 
         assert cached_headers(cache_key)
-        assert require_cached_headers(cache_key).payload.headers == mock_headers
+        assert require_cached_headers(cache_key).headers == mock_headers
 
     async def test_cache_hit_returns_cached(self, headers):
         cache_key = auth_cache_key(api_id="https://api.github.com")
@@ -290,7 +290,7 @@ class TestGetFirewallHeaders:
         # fetch_firewall_headers wraps urllib; pins the TTL-expiry→re-fetch contract (#9991).
         mock_fetch.assert_called_once()
         # Verify cache was updated with new entry
-        assert require_cached_headers(cache_key).payload.headers == fresh_headers
+        assert require_cached_headers(cache_key).headers == fresh_headers
 
     async def test_cache_with_null_expires_at_never_evicts(self, headers):
         """Cached entry with expiresAt=None (non-expiring) should never be evicted by TTL."""
@@ -472,7 +472,7 @@ class TestGetFirewallHeaders:
         assert second["query"] == cached_query
         assert second["cache_hit"] is True
         mock_fetch.assert_called_once()
-        assert require_cached_headers(cache_key).payload.query == cached_query
+        assert require_cached_headers(cache_key).query == cached_query
 
     async def test_base_and_query_are_cached_together(self):
         """auth.base and auth.query survive the same cache entry."""
@@ -499,8 +499,8 @@ class TestGetFirewallHeaders:
         assert second["cache_hit"] is True
         mock_fetch.assert_called_once()
         cached = require_cached_headers(cache_key)
-        assert cached.payload.base == cached_base
-        assert cached.payload.query == cached_query
+        assert cached.base == cached_base
+        assert cached.query == cached_query
 
     async def test_cache_hit_omits_base_when_absent(self, headers):
         """Cached entry without 'base' does not include it in result."""
@@ -655,7 +655,7 @@ class TestGetFirewallHeaders:
         assert forced_result["cache_hit"] is False
         assert not force_refresh_pending(cache_key)
         assert require_last_force_refresh_monotonic_at(cache_key) >= before_forced
-        assert require_cached_headers(cache_key).payload.headers == forced_headers
+        assert require_cached_headers(cache_key).headers == forced_headers
 
     async def test_waiting_request_force_refreshes_after_in_flight_marker(self, headers):
         """A same-key waiter must not reuse headers from the stale-prone leader fetch."""
@@ -702,9 +702,7 @@ class TestGetFirewallHeaders:
         assert force_refresh_values == [False, True]
         assert leader_result["headers"] == {"Authorization": "Bearer maybe-stale"}
         assert waiter_result["headers"] == {"Authorization": "Bearer refreshed"}
-        assert require_cached_headers(cache_key).payload.headers == {
-            "Authorization": "Bearer refreshed"
-        }
+        assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer refreshed"}
         assert not force_refresh_pending(cache_key)
 
     async def test_force_refresh_absent_passes_false(self, headers):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -1678,12 +1678,9 @@ class TestResponseHandler:
         cache_key = auth_cache_key(run_id="run-conn-re", api_id="run-conn-re:0")
         flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY] = cache_key
         # Simulate: last forced refresh happened well before the cooldown window
-        set_last_force_refresh_monotonic_at(
-            cache_key,
-            time.monotonic() - auth_cache.force_refresh_cooldown_secs_for_tests() - 1,
-        )
+        set_last_force_refresh_monotonic_at(cache_key, 0.0)
 
-        with mitm_ctx():
+        with patch.object(auth_cache.time, "monotonic", return_value=10_000.0), mitm_ctx():
             mitm_addon.response(flow)
 
         # Cooldown elapsed → marker re-added

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -17,6 +17,7 @@ import request_streaming
 from body_limits import STREAM_BUFFER_LIMIT
 from tests.auth_state_helpers import (
     auth_cache_key,
+    auth_state_is_empty,
     cached_headers,
     force_refresh_pending,
     has_auth_state,
@@ -1679,7 +1680,7 @@ class TestResponseHandler:
         # Simulate: last forced refresh happened well before the cooldown window
         set_last_force_refresh_monotonic_at(
             cache_key,
-            time.monotonic() - auth_cache._FORCE_REFRESH_COOLDOWN_SECS - 1,
+            time.monotonic() - auth_cache.force_refresh_cooldown_secs_for_tests() - 1,
         )
 
         with mitm_ctx():
@@ -1729,12 +1730,12 @@ class TestResponseHandler:
         flow.metadata[metadata_keys.ORIGINAL_URL] = "https://api.github.com/repos"
         flow.response = tutils.tresp(status_code=401, headers=http.Headers())
 
-        assert auth_cache._auth_state == {}
+        assert auth_state_is_empty()
 
         with mitm_ctx():
             mitm_addon.response(flow)
 
-        assert auth_cache._auth_state == {}
+        assert auth_state_is_empty()
 
     def test_error_status_logs_warning(self, tmp_path, real_flow, headers):
         """Response with status >= 400 writes to per-job proxy log."""


### PR DESCRIPTION
## Summary

- Add owner-module `*_for_tests` hooks and a copied auth cache state snapshot in `firewall_auth_cache.py`.
- Convert `tests/auth_state_helpers.py` into a thin wrapper around those hooks instead of touching private cache storage.
- Update auth-cache-related tests to assert snapshot fields and remove direct `_auth_state` / cooldown constant access.

Closes #20647

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff check src/firewall_auth_cache.py tests/auth_state_helpers.py tests/test_auth_cache.py tests/test_firewall_auth.py tests/test_response_handler.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m basedpyright src/firewall_auth_cache.py tests/auth_state_helpers.py tests/test_auth_cache.py tests/test_firewall_auth.py tests/test_response_handler.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_auth_cache.py tests/test_firewall_auth.py tests/test_response_handler.py tests/test_registry_auth_cache_eviction.py tests/test_request_handler_passthrough.py tests/test_firewall_aws_sigv4_auth.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/`
