### PR TITLE
chore: trigger task evaluation preview

### DIFF
--- a/turbo/apps/api/src/lib/build-info.ts
+++ b/turbo/apps/api/src/lib/build-info.ts
@@ -1,5 +1,6 @@
 import apiPackage from "../../package.json";
 
+// Evaluation preview trigger: task workflow run 2026-07-08.
 const GIT_COMMIT_SHA_REGEX = /^[0-9a-f]{40}$/u;
 
 export function normalizeBuildCommitSha(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- Adds a behavior-free API comment to trigger a fresh PR preview environment for the Notion task evaluation workflow.
- The preview will be used to run the currently enabled evaluation tasks: PPT template and illustration template.

## Verification
- Not run; this PR intentionally only changes a comment and relies on the PR pipeline to build preview environments.