### PR TITLE
fix: remove minimax codex legacy base url

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -603,14 +603,14 @@ mod tests {
     #[test]
     fn build_codex_args_with_openai_base_url() {
         let args = build_codex_args_with_base_url_for_test(
-            "MiniMax-M3",
-            "https://api.minimax.io/v1",
+            "legacy-model",
+            "https://api.legacy-provider.test/v1",
             "",
             "p",
         );
         assert!(codex_args_have_config(
             &args,
-            r#"openai_base_url="https://api.minimax.io/v1""#
+            r#"openai_base_url="https://api.legacy-provider.test/v1""#
         ));
     }
 
@@ -635,7 +635,7 @@ mod tests {
         disable_system_log();
         let args = build_codex_args(
             "MiniMax-M3",
-            "https://api.minimax.io/v1",
+            "https://api.should-not-win.test/v1",
             &[r#"model_provider="minimax""#.to_string()],
             false,
             "",

--- a/crates/guest-agent/src/cli/mod.rs
+++ b/crates/guest-agent/src/cli/mod.rs
@@ -368,6 +368,8 @@ impl<'a> CliRuntimeConfig<'a> {
         {
             return Cow::Borrowed(self.user_env);
         }
+        // Structured Codex runtime config is authoritative; do not let stale
+        // provider env leak a conflicting base URL into the child process.
         let mut user_env = self.user_env.clone();
         user_env.remove(OPENAI_BASE_URL_ENV_KEY);
         Cow::Owned(user_env)
@@ -1512,7 +1514,7 @@ mod tests {
     }
 
     #[test]
-    fn structured_codex_runtime_config_omits_legacy_openai_base_url_from_child_env() {
+    fn structured_codex_runtime_config_omits_stale_openai_base_url_from_child_env() {
         let user_env = HashMap::from([
             ("OPENAI_API_KEY".to_string(), "sk-test".to_string()),
             ("OPENAI_MODEL".to_string(), "MiniMax-M3".to_string()),

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -3088,9 +3088,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(claim.cliAgentType).toBe("codex");
     expect(claim.environment).toMatchObject({
       OPENAI_API_KEY: minimaxApiKeyPlaceholder,
-      OPENAI_BASE_URL: "https://api.minimax.io/v1",
       OPENAI_MODEL: "MiniMax-M3",
     });
+    expect(claim.environment).not.toHaveProperty("OPENAI_BASE_URL");
     expect(claim.codexRuntimeConfig).toMatchObject({
       providerId: "minimax",
       name: "MiniMax",
@@ -3160,9 +3160,9 @@ describe("RUN-02: model provider selection and vm0 admission", () => {
     expect(claim.cliAgentType).toBe("codex");
     expect(claim.environment).toMatchObject({
       OPENAI_API_KEY: minimaxApiKeyPlaceholder,
-      OPENAI_BASE_URL: "https://api.minimax.io/v1",
       OPENAI_MODEL: "MiniMax-M3",
     });
+    expect(claim.environment).not.toHaveProperty("OPENAI_BASE_URL");
     expect(claim.codexRuntimeConfig).toMatchObject({
       providerId: "minimax",
       name: "MiniMax",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -741,14 +741,14 @@ describe("minimax-api-key provider", () => {
     expect(getSecretNameForType("minimax-api-key")).toBe("MINIMAX_API_KEY");
   });
 
-  it("maps Codex env bindings with old-runner base URL compatibility", () => {
+  it("maps MiniMax Codex env bindings without provider base URL", () => {
     const envBindings = getModelProviderEnvBindings("minimax-api-key", {
       [FeatureSwitchKey.CodexFrameworkForMinimax]: true,
     });
-    expect(envBindings).toBeDefined();
-    expect(envBindings!["OPENAI_API_KEY"]).toBe("$secret");
-    expect(envBindings!["OPENAI_BASE_URL"]).toBe("https://api.minimax.io/v1");
-    expect(envBindings!["OPENAI_MODEL"]).toBe("$model");
+    expect(envBindings).toStrictEqual({
+      OPENAI_API_KEY: "$secret",
+      OPENAI_MODEL: "$model",
+    });
   });
 
   it("declares MiniMax Codex runtime config when the feature flag is enabled", () => {

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -93,12 +93,6 @@ const MINIMAX_CODEX_BASE_URL = "https://api.minimax.io/v1";
 
 const MINIMAX_CODEX_ENV_BINDINGS = {
   OPENAI_API_KEY: "$secret",
-  // Deployment compatibility: old runners ignore codexRuntimeConfig and still
-  // need the legacy base URL. New guest-agent code ignores OPENAI_BASE_URL
-  // whenever structured Codex runtime config is present. Remove this after the
-  // first runner version with codexRuntimeConfig support is fully deployed and
-  // older runners have drained.
-  OPENAI_BASE_URL: MINIMAX_CODEX_BASE_URL,
   OPENAI_MODEL: "$model",
 } as const satisfies ModelProviderEnvBindings;
 


### PR DESCRIPTION
## Summary

- Remove the MiniMax Codex `OPENAI_BASE_URL` env binding so MiniMax uses `codexRuntimeConfig` as the base URL source.
- Update API contract and run-claim coverage to assert MiniMax Codex environments no longer include the legacy base URL.
- Keep the guest-agent stale `OPENAI_BASE_URL` filter as a structured runtime config precedence guard and rename its test accordingly.
- Use neutral legacy-provider fixtures for generic Codex `openai_base_url` fallback tests so they no longer look like MiniMax compatibility coverage.

Closes #20653

## Verification

- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/model-providers.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "claims MiniMax Codex runs with structured runtime config"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts -t "claims vm0-managed MiniMax Codex runs with structured runtime config"`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent structured_codex_runtime_config_omits_stale_openai_base_url_from_child_env -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent legacy_codex_child_env_keeps_openai_base_url_without_structured_runtime_config -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test codex_app_server_backend -- --nocapture`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent build_codex_args -- --nocapture`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets -- -D warnings`
- `git diff --check`

## Local pre-commit note

- The first local commit was created with `--no-verify` because `pnpm knip --cache` reported unrelated unused platform exports/types in files untouched by this PR. GitHub `lint-knip` passed on the PR.
