### PR TITLE
fix: bound zstd usage validation

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -30,6 +30,8 @@ from body_limits import (
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
+# zstd's Python decompression object has no zlib-style max_length argument.
+# Keep validation input chunks small so the discarded decoded output is bounded.
 _ZSTD_VALIDATE_INPUT_CHUNK_SIZE = 32
 INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
@@ -401,6 +403,8 @@ def _decompress_zlib_json_usage_body(
 
 
 def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:
+    # stream_reader can silently accept a valid frame followed by a truncated
+    # frame, so strict JSON usage decoding needs a separate complete-frame pass.
     if max_output <= 0:
         return DECODED_BODY_LIMIT_EXCEEDED if data else None
 

--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -30,6 +30,7 @@ from body_limits import (
 _BROTLI_DECOMPRESS_MIN_INPUT_CHUNK_SIZE = 16
 _BROTLI_DECOMPRESS_MAX_INPUT_CHUNK_SIZE = 1024
 _BROTLI_DECOMPRESS_TARGET_INPUT_CHUNKS = 64
+_ZSTD_VALIDATE_INPUT_CHUNK_SIZE = 32
 INVALID_COMPRESSED_BODY = "invalid compressed body"
 INCOMPLETE_COMPRESSED_BODY = "incomplete compressed body"
 DECODED_BODY_LIMIT_EXCEEDED = "decoded body limit exceeded"
@@ -399,17 +400,38 @@ def _decompress_zlib_json_usage_body(
     return bytes(out), None
 
 
-def _validate_complete_zstd_frames(data: bytes) -> str | None:
+def _validate_complete_zstd_frames(data: bytes, max_output: int) -> str | None:
+    if max_output <= 0:
+        return DECODED_BODY_LIMIT_EXCEEDED if data else None
+
     remaining_data = data
+    decoded_size = 0
     while remaining_data:
         obj = zstandard.ZstdDecompressor().decompressobj()
-        try:
-            obj.decompress(remaining_data)
-        except zstandard.ZstdError:
-            return INVALID_COMPRESSED_BODY
-        if not obj.eof:
+        offset = 0
+        unconsumed_tail = b""
+
+        while offset < len(remaining_data) or unconsumed_tail:
+            if unconsumed_tail:
+                chunk = unconsumed_tail
+                unconsumed_tail = b""
+            else:
+                chunk = remaining_data[offset : offset + _ZSTD_VALIDATE_INPUT_CHUNK_SIZE]
+                offset += len(chunk)
+            try:
+                decoded = obj.decompress(chunk)
+            except zstandard.ZstdError:
+                return INVALID_COMPRESSED_BODY
+
+            decoded_size += len(decoded)
+            if decoded_size > max_output:
+                return DECODED_BODY_LIMIT_EXCEEDED
+            if obj.eof:
+                remaining_data = obj.unused_data + remaining_data[offset:]
+                break
+            unconsumed_tail = obj.unconsumed_tail
+        else:
             return INCOMPLETE_COMPRESSED_BODY
-        remaining_data = obj.unused_data
     return None
 
 
@@ -430,7 +452,7 @@ def _decompress_zstd_json_usage_body(data: bytes, max_output: int) -> tuple[byte
 
     if extra:
         return body, DECODED_BODY_LIMIT_EXCEEDED
-    return body, _validate_complete_zstd_frames(data)
+    return body, _validate_complete_zstd_frames(data, max_output)
 
 
 def _decode_supported_body_with_complete_status(

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -7,7 +7,6 @@ import brotli
 import pytest
 import zstandard
 
-import body_decoding
 from body_decoding import (
     can_stream_decode_usage,
     create_stream_decode_feed,
@@ -571,7 +570,7 @@ class TestDecompressJsonUsageBody:
         body = frame_body * 200
         hdrs = headers(("Content-Encoding", "zstd"))
         validation_input_sizes: list[int] = []
-        real_factory = body_decoding.zstandard.ZstdDecompressor
+        real_factory = zstandard.ZstdDecompressor
 
         class TrackingDecompressionObj:
             def __init__(self, wrapped):

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -7,12 +7,14 @@ import brotli
 import pytest
 import zstandard
 
+import body_decoding
 from body_decoding import (
     can_stream_decode_usage,
     create_stream_decode_feed,
     create_stream_decode_session,
     decode_request_body_for_network_log_capture,
     decompress_body,
+    decompress_json_usage_body,
 )
 from body_limits import DEFAULT_BODY_DECODE_LIMIT, STREAM_DECODE_CHUNK_LIMIT
 from tests.body_decode_helpers import (
@@ -477,3 +479,142 @@ class TestDecodeRequestBodyForNetworkLogCapture:
         )
 
         assert decoded == body[:128]
+
+
+class TestDecompressJsonUsageBody:
+    """Direct tests for strict JSON usage decompression."""
+
+    def test_zstd_valid_single_frame_returns_decoded_body(self, headers):
+        body = b'{"usage":{"input_tokens":1}}'
+        compressed = zstandard.ZstdCompressor().compress(body)
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=1024)
+
+        assert decoded == body
+        assert error is None
+
+    def test_zstd_valid_concatenated_frames_return_decoded_body(self, headers):
+        first = b'{"usage":'
+        second = b'{"input_tokens":1}}'
+        compressed = zstandard.ZstdCompressor().compress(
+            first
+        ) + zstandard.ZstdCompressor().compress(second)
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=1024)
+
+        assert decoded == first + second
+        assert error is None
+
+    def test_zstd_invalid_body_returns_error(self, headers):
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        _decoded, error = decompress_json_usage_body(b"not zstd", hdrs, max_output=1024)
+
+        assert error == "invalid compressed body"
+
+    def test_zstd_truncated_first_frame_returns_error(self, headers):
+        compressed = zstandard.ZstdCompressor().compress(b'{"ok":true}')
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        _decoded, error = decompress_json_usage_body(compressed[:-1], hdrs, max_output=1024)
+
+        assert error == "incomplete compressed body"
+
+    def test_zstd_trailing_garbage_returns_error(self, headers):
+        compressed = zstandard.ZstdCompressor().compress(b'{"ok":true}') + b"garbage"
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        _decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=1024)
+
+        assert error == "invalid compressed body"
+
+    def test_zstd_trailing_truncated_frame_returns_error(self, headers):
+        first = zstandard.ZstdCompressor().compress(b'{"ok":true}')
+        trailing_frame = zstandard.ZstdCompressor().compress(b"{}")
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        _decoded, error = decompress_json_usage_body(
+            first + trailing_frame[:5],
+            hdrs,
+            max_output=1024,
+        )
+
+        assert error == "incomplete compressed body"
+
+    def test_zstd_decoded_limit_exceeded_returns_error(self, headers):
+        body = b"x" * 1024
+        compressed = zstandard.ZstdCompressor().compress(body)
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=128)
+
+        assert decoded == body[:128]
+        assert error == "decoded body limit exceeded"
+
+    def test_zstd_without_content_size_returns_decoded_body(self, headers):
+        body = b'{"usage":{"input_tokens":1}}'
+        compressed = zstandard.ZstdCompressor(write_content_size=False).compress(body)
+        hdrs = headers(("Content-Encoding", "zstd"))
+
+        decoded, error = decompress_json_usage_body(compressed, hdrs, max_output=1024)
+
+        assert decoded == body
+        assert error is None
+
+    def test_zstd_validation_does_not_decompress_full_remaining_input_at_once(
+        self, headers, monkeypatch
+    ):
+        frame_body = b"A" * 1024
+        compressed = b"".join(zstandard.ZstdCompressor().compress(frame_body) for _ in range(200))
+        body = frame_body * 200
+        hdrs = headers(("Content-Encoding", "zstd"))
+        validation_input_sizes: list[int] = []
+        real_factory = body_decoding.zstandard.ZstdDecompressor
+
+        class TrackingDecompressionObj:
+            def __init__(self, wrapped):
+                self._wrapped = wrapped
+
+            def decompress(self, data):
+                validation_input_sizes.append(len(data))
+                return self._wrapped.decompress(data)
+
+            @property
+            def eof(self):
+                return self._wrapped.eof
+
+            @property
+            def unused_data(self):
+                return self._wrapped.unused_data
+
+            @property
+            def unconsumed_tail(self):
+                return self._wrapped.unconsumed_tail
+
+        class TrackingZstdDecompressor:
+            def __init__(self, *args, **kwargs):
+                self._wrapped = real_factory(*args, **kwargs)
+
+            def stream_reader(self, *args, **kwargs):
+                return self._wrapped.stream_reader(*args, **kwargs)
+
+            def decompressobj(self, *args, **kwargs):
+                return TrackingDecompressionObj(self._wrapped.decompressobj(*args, **kwargs))
+
+        monkeypatch.setattr(
+            "body_decoding.zstandard.ZstdDecompressor",
+            TrackingZstdDecompressor,
+        )
+
+        decoded, error = decompress_json_usage_body(
+            compressed,
+            hdrs,
+            max_output=len(body),
+        )
+
+        assert decoded == body
+        assert error is None
+        assert validation_input_sizes
+        assert max(validation_input_sizes) < len(compressed)

--- a/crates/runner/mitm-addon/tests/test_body_decoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_decoding.py
@@ -617,4 +617,4 @@ class TestDecompressJsonUsageBody:
         assert decoded == body
         assert error is None
         assert validation_input_sizes
-        assert max(validation_input_sizes) < len(compressed)
+        assert max(validation_input_sizes) <= 32


### PR DESCRIPTION
## Summary

- bound zstd JSON usage frame validation by draining decoded output in controlled chunks instead of validating with a whole-input decompress call
- keep the existing fast `stream_reader` body production path and preserve fail-closed strict fallback semantics
- add direct strict zstd JSON usage tests for valid, concatenated, invalid, incomplete, trailing-data, limit, and no-content-size cases

Closes #20646

## Tests

- `PATH="/tmp/mitm-addon-venv/bin:$PATH" pytest crates/runner/mitm-addon/tests/test_body_decoding.py`
- `PATH="/tmp/mitm-addon-venv/bin:$PATH" pytest crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py crates/runner/mitm-addon/tests/test_x_connector_pipeline.py`
- `PATH="/tmp/mitm-addon-venv/bin:$PATH" pytest crates/runner/mitm-addon/tests/test_body_decoding.py crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py crates/runner/mitm-addon/tests/test_x_connector_pipeline.py`
- `PATH="/tmp/mitm-addon-venv/bin:$PATH" ruff check crates/runner/mitm-addon/src/body_decoding.py crates/runner/mitm-addon/tests/test_body_decoding.py`
