### PR TITLE
feat: auto-restart desktop computer use plugin mcp server process with bounded backoff

### DIFF
--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -120,6 +120,7 @@ export type DesktopComputerUseFilesystemPluginStatus =
   | "disabled"
   | "starting"
   | "running"
+  | "restarting"
   | "error";
 
 export interface DesktopComputerUseFilesystemPluginState {

--- a/turbo/apps/desktop/src/desktop-filesystem-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-filesystem-plugin.ts
@@ -26,6 +26,7 @@ import type {
   ComputerUseCommandFailure,
 } from "./computer-use-accessibility";
 import type { DesktopComputerUseFilesystemPluginState } from "./computer-use-types";
+import { PluginRestartPolicy } from "./desktop-plugin-restart-policy";
 import {
   readDesktopPreferenceRecord,
   writeDesktopPreferenceRecord,
@@ -321,6 +322,8 @@ export class DesktopFilesystemPluginManager {
   private hostRuntimeOnline = false;
   private runtime: FilesystemPluginRuntime | null = null;
   private startPromise: Promise<void> | null = null;
+  private readonly restartPolicy = new PluginRestartPolicy();
+  private restartTimer: NodeJS.Timeout | null = null;
   private status: DesktopComputerUseFilesystemPluginState["status"] =
     "disabled";
   private lastError: string | null = null;
@@ -466,10 +469,10 @@ export class DesktopFilesystemPluginManager {
         "Filesystem plugin has no allowed directories.",
       );
     }
-    if (this.status === "starting") {
+    if (this.status === "starting" || this.status === "restarting") {
       return commandFailure(
         "plugin_restarting",
-        "Filesystem plugin is starting.",
+        `Filesystem plugin is ${this.status}.`,
       );
     }
     if (this.status !== "running" || !this.runtime) {
@@ -517,6 +520,8 @@ export class DesktopFilesystemPluginManager {
   }
 
   stop(): void {
+    this.cancelScheduledRestart();
+    this.restartPolicy.reset();
     void this.stopRuntime();
   }
 
@@ -530,11 +535,40 @@ export class DesktopFilesystemPluginManager {
   }
 
   private reconcile(): void {
+    this.cancelScheduledRestart();
+    this.restartPolicy.reset();
     if (!this.shouldRun()) {
       void this.stopRuntime();
       return;
     }
     void this.restartRuntime();
+  }
+
+  private cancelScheduledRestart(): void {
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+  }
+
+  private scheduleRestartOrFail(message: string): void {
+    if (this.restartTimer) {
+      return;
+    }
+    const delayMs = this.restartPolicy.nextDelayMs();
+    if (delayMs === null) {
+      this.status = "error";
+      this.lastError = message;
+      this.onChange();
+      return;
+    }
+    this.status = "restarting";
+    this.lastError = message;
+    this.onChange();
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      void this.restartRuntime();
+    }, delayMs);
   }
 
   private save(): void {
@@ -556,8 +590,9 @@ export class DesktopFilesystemPluginManager {
   }
 
   private async startRuntime(): Promise<void> {
+    let transport: StdioClientTransport | null = null;
     try {
-      const transport = new StdioClientTransport({
+      transport = new StdioClientTransport({
         command: process.execPath,
         args: [filesystemServerEntry(), ...this.preferences.allowedDirectories],
         env: {
@@ -574,12 +609,11 @@ export class DesktopFilesystemPluginManager {
       transport.onclose = () => {
         this.runtime = null;
         if (this.shouldRun()) {
-          this.status = "error";
-          this.lastError = "Filesystem plugin process exited.";
-        } else {
-          this.status = "disabled";
-          this.lastError = null;
+          this.scheduleRestartOrFail("Filesystem plugin process exited.");
+          return;
         }
+        this.status = "disabled";
+        this.lastError = null;
         this.onChange();
       };
       const client = new Client(
@@ -605,9 +639,23 @@ export class DesktopFilesystemPluginManager {
       this.runtime = { client, transport, tools };
       this.status = "running";
       this.lastError = null;
+      this.restartPolicy.notifyStarted();
       this.onChange();
     } catch (error) {
       this.runtime = null;
+      if (transport) {
+        transport.onclose = undefined;
+        transport.onerror = undefined;
+        try {
+          await transport.close();
+        } catch (closeError) {
+          console.warn("Unable to close filesystem plugin process", closeError);
+        }
+      }
+      if (this.shouldRun()) {
+        this.scheduleRestartOrFail(errorMessage(error));
+        return;
+      }
       this.status = "error";
       this.lastError = errorMessage(error);
       this.onChange();

--- a/turbo/apps/desktop/src/desktop-plugin-restart-policy.test.ts
+++ b/turbo/apps/desktop/src/desktop-plugin-restart-policy.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { PluginRestartPolicy } from "./desktop-plugin-restart-policy";
+
+function createPolicy(options: { readonly stableUptimeMs?: number } = {}) {
+  let nowMs = 0;
+  const policy = new PluginRestartPolicy({
+    delaysMs: [1_000, 5_000, 30_000],
+    stableUptimeMs: options.stableUptimeMs ?? 60_000,
+    now: () => nowMs,
+  });
+  return {
+    policy,
+    advance: (ms: number) => {
+      nowMs += ms;
+    },
+  };
+}
+
+describe("PluginRestartPolicy", () => {
+  it("returns backoff delays in order and null once the budget is exhausted", () => {
+    const { policy } = createPolicy();
+    expect(policy.nextDelayMs()).toBe(1_000);
+    expect(policy.nextDelayMs()).toBe(5_000);
+    expect(policy.nextDelayMs()).toBe(30_000);
+    expect(policy.nextDelayMs()).toBeNull();
+    expect(policy.nextDelayMs()).toBeNull();
+  });
+
+  it("keeps consuming the budget when the process never starts", () => {
+    const { policy, advance } = createPolicy();
+    expect(policy.nextDelayMs()).toBe(1_000);
+    advance(120_000);
+    expect(policy.nextDelayMs()).toBe(5_000);
+    expect(policy.nextDelayMs()).toBe(30_000);
+    expect(policy.nextDelayMs()).toBeNull();
+  });
+
+  it("does not reset the budget after a short-lived start", () => {
+    const { policy, advance } = createPolicy();
+    expect(policy.nextDelayMs()).toBe(1_000);
+    policy.notifyStarted();
+    advance(10_000);
+    expect(policy.nextDelayMs()).toBe(5_000);
+    expect(policy.nextDelayMs()).toBe(30_000);
+    expect(policy.nextDelayMs()).toBeNull();
+  });
+
+  it("resets the budget after a stable uptime window", () => {
+    const { policy, advance } = createPolicy();
+    expect(policy.nextDelayMs()).toBe(1_000);
+    expect(policy.nextDelayMs()).toBe(5_000);
+    policy.notifyStarted();
+    advance(60_000);
+    expect(policy.nextDelayMs()).toBe(1_000);
+    expect(policy.nextDelayMs()).toBe(5_000);
+    expect(policy.nextDelayMs()).toBe(30_000);
+    expect(policy.nextDelayMs()).toBeNull();
+  });
+
+  it("resets the budget explicitly", () => {
+    const { policy } = createPolicy();
+    expect(policy.nextDelayMs()).toBe(1_000);
+    expect(policy.nextDelayMs()).toBe(5_000);
+    policy.reset();
+    expect(policy.nextDelayMs()).toBe(1_000);
+  });
+
+  it("uses each stable uptime only once", () => {
+    const { policy, advance } = createPolicy();
+    expect(policy.nextDelayMs()).toBe(1_000);
+    policy.notifyStarted();
+    advance(60_000);
+    expect(policy.nextDelayMs()).toBe(1_000);
+    expect(policy.nextDelayMs()).toBe(5_000);
+    expect(policy.nextDelayMs()).toBe(30_000);
+    expect(policy.nextDelayMs()).toBeNull();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-plugin-restart-policy.ts
+++ b/turbo/apps/desktop/src/desktop-plugin-restart-policy.ts
@@ -1,0 +1,54 @@
+const DEFAULT_RESTART_DELAYS_MS = [1_000, 5_000, 30_000] as const;
+const DEFAULT_STABLE_UPTIME_MS = 60_000;
+
+interface PluginRestartPolicyOptions {
+  readonly delaysMs?: readonly number[];
+  readonly stableUptimeMs?: number;
+  readonly now?: () => number;
+}
+
+/**
+ * Bounded exponential-backoff restart policy for desktop plugin MCP server
+ * processes. Shared by plugin managers so every plugin runtime recovers from
+ * crashes the same way: retry with increasing delays, give up after the
+ * budget is exhausted, and forget past failures once a process has stayed up
+ * for a stable window.
+ */
+export class PluginRestartPolicy {
+  private readonly delaysMs: readonly number[];
+  private readonly stableUptimeMs: number;
+  private readonly now: () => number;
+  private attempts = 0;
+  private startedAtMs: number | null = null;
+
+  constructor(options: PluginRestartPolicyOptions = {}) {
+    this.delaysMs = options.delaysMs ?? DEFAULT_RESTART_DELAYS_MS;
+    this.stableUptimeMs = options.stableUptimeMs ?? DEFAULT_STABLE_UPTIME_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  notifyStarted(): void {
+    this.startedAtMs = this.now();
+  }
+
+  nextDelayMs(): number | null {
+    if (
+      this.startedAtMs !== null &&
+      this.now() - this.startedAtMs >= this.stableUptimeMs
+    ) {
+      this.attempts = 0;
+    }
+    this.startedAtMs = null;
+    const delayMs = this.delaysMs[this.attempts];
+    if (delayMs === undefined) {
+      return null;
+    }
+    this.attempts += 1;
+    return delayMs;
+  }
+
+  reset(): void {
+    this.attempts = 0;
+    this.startedAtMs = null;
+  }
+}

--- a/turbo/apps/desktop/src/renderer/hero/index.tsx
+++ b/turbo/apps/desktop/src/renderer/hero/index.tsx
@@ -43,6 +43,7 @@ const FILESYSTEM_PLUGIN_STATUS_LABELS = {
   disabled: "Disabled",
   starting: "Starting",
   running: "Ready",
+  restarting: "Restarting",
   error: "Error",
 } as const satisfies Record<FilesystemPluginState["status"], string>;
 


### PR DESCRIPTION
Closes #20702. Part of #20694 / epic #20687.

## What changes

The desktop Computer Use filesystem plugin previously treated any MCP server process exit as terminal: `transport.onclose` set `status = "error"` and the user had to notice the broken plugin in the desktop UI and manually re-enable it. This PR makes the plugin runtime recover from crashes automatically, with a bounded budget so misconfigured servers cannot cause a restart storm.

- **Bounded auto-restart with exponential backoff**: on unexpected process exit (or a failed start attempt) while the plugin should be running, the manager retries after 1s → 5s → 30s (max 3 attempts). After the budget is exhausted it falls back to the previous behavior: `error` + `lastError`, manual re-enable required.
- **Stable-uptime reset**: once the server has stayed up for 60s, the retry budget resets, so a long-running server that crashes occasionally keeps recovering indefinitely, while a crash-on-start config error still terminates after 3 attempts.
- **New `restarting` status** in `DesktopComputerUseFilesystemPluginStatus`, surfaced in the desktop UI status label ("Restarting") and in CLI-facing command failures (`plugin_restarting` with a "restarting" message instead of "unavailable").
- **No restart on intentional stop**: disabling the plugin, feature switch off, config changes, and app quit cancel any scheduled restart and reset the budget (config changes are treated as new intent).
- **Startup-failure cleanup**: a failed start now detaches transport handlers and closes the transport before retrying, so repeated start attempts cannot leak child processes (previously a post-spawn failure such as a missing required tool leaked the process).

## Reusability for the generic MCP plugin manager (#20694)

The backoff/budget/stable-uptime decision logic lives in a new standalone `PluginRestartPolicy` class (`desktop-plugin-restart-policy.ts`) with injectable delays and clock. The upcoming generalized MCP plugin manager reuses this class directly; only the ~20 lines of timer wiring stay in the manager.

## Tests

- `desktop-plugin-restart-policy.test.ts` covers: backoff sequence and budget exhaustion, no reset on short-lived starts, reset after stable uptime (used once per stable run), explicit reset, and never-started crash loops.
- The `satisfies Record<status, string>` on the UI label map type-enforces the new `restarting` label.
- Manager wiring (timer scheduling, intentional-stop cancellation) verified by review; external-kill recovery is covered by the policy tests plus the acceptance checklist on #20702 for manual desktop verification.

## Verification

Formatted with the lockfile-pinned prettier. Full vitest/CI left to the PR pipeline per repo practice.
