### PR TITLE
chore: trigger API preview for bypass smoke test

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker to exercise the full release pipeline)
+// (no-op API preview marker to exercise the Vercel bypass path)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
## Summary
- update the API Vercel entry comment as a no-op change
- trigger a fresh preview deployment for Vercel bypass-header verification

## Verification
- Not run locally; comment-only API change intended to exercise preview deployment.