### PR TITLE
fix: persist vercel preview bypass for app api calls

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1230,7 +1230,7 @@ jobs:
           if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
             encoded_bypass="$(node -e 'process.stdout.write(encodeURIComponent(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || ""))')"
             echo "::add-mask::$encoded_bypass"
-            FORWARD_URL="${FORWARD_URL}?vm0_preview_bypass=${encoded_bypass}"
+            FORWARD_URL="${FORWARD_URL}?x-vercel-protection-bypass=${encoded_bypass}"
           fi
           EXTRA_VARS="$(jq -nc \
             --arg ansible_user "$METAL_USER" \
@@ -1352,7 +1352,7 @@ jobs:
           if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
             encoded_bypass="$(node -e 'process.stdout.write(encodeURIComponent(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || ""))')"
             echo "::add-mask::$encoded_bypass"
-            forward_url="${forward_url}?vm0_preview_bypass=${encoded_bypass}"
+            forward_url="${forward_url}?x-vercel-protection-bypass=${encoded_bypass}"
           fi
           stripe listen \
             --api-key "$STRIPE_SECRET_KEY" \

--- a/e2e/scripts/generate-test-token.sh
+++ b/e2e/scripts/generate-test-token.sh
@@ -41,11 +41,11 @@ BYPASS_QUERY=""
 if [[ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]]; then
   CURL_HEADERS+=(-H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET")
   # The API preview probe may run after Vercel consumes the automation header.
-  CURL_HEADERS+=(-H "Cookie: vm0_preview_bypass=$VERCEL_AUTOMATION_BYPASS_SECRET")
+  CURL_HEADERS+=(-H "Cookie: x-vercel-protection-bypass=$VERCEL_AUTOMATION_BYPASS_SECRET")
   ENCODED_BYPASS=$(node -e 'process.stdout.write(encodeURIComponent(process.argv[1]))' "$VERCEL_AUTOMATION_BYPASS_SECRET")
   BYPASS_FINGERPRINT=$(node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHash("sha256").update(process.argv[1]).digest("hex").slice(0, 12))' "$VERCEL_AUTOMATION_BYPASS_SECRET")
   echo "Bypass fingerprint: ${BYPASS_FINGERPRINT}" >&2
-  BYPASS_QUERY="&vm0_preview_bypass=${ENCODED_BYPASS}"
+  BYPASS_QUERY="&x-vercel-protection-bypass=${ENCODED_BYPASS}"
 fi
 
 # Check if error is retryable (deployment propagation / cold start)

--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -588,26 +588,41 @@ describe("createApp", () => {
       expect(response.status).toBe(200);
     });
 
-    it("allows preview requests with a matching bypass cookie value", async () => {
+    it("allows preview requests with a matching Vercel bypass cookie", async () => {
       mockEnv("ENV", "preview");
       mockEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
       const app = createApp({ signal: context.signal });
 
       const response = await app.request("/health", {
         method: "GET",
-        headers: { cookie: "unrelated=1; bypass=preview-secret" },
+        headers: {
+          cookie: "unrelated=1; x-vercel-protection-bypass=preview-secret",
+        },
       });
 
       expect(response.status).toBe(200);
     });
 
-    it("allows preview requests with a matching diagnostic bypass query", async () => {
+    it("rejects preview requests with the bypass secret in an unrelated cookie", async () => {
+      mockEnv("ENV", "preview");
+      mockEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
+      const app = createApp({ signal: context.signal });
+
+      const response = await app.request("/health", {
+        method: "GET",
+        headers: { cookie: "unrelated=preview-secret" },
+      });
+
+      expect(response.status).toBe(403);
+    });
+
+    it("allows preview requests with the matching Vercel bypass query", async () => {
       mockEnv("ENV", "preview");
       mockEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
       const app = createApp({ signal: context.signal });
 
       const response = await app.request(
-        "/health?vm0_preview_bypass=preview-secret",
+        "/health?x-vercel-protection-bypass=preview-secret",
         { method: "GET" },
       );
 

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -37,7 +37,7 @@ const L = logger("App");
 
 const WEB_AUTH_PATHS = ["/sign-in", "/sign-up"] as const;
 const VERCEL_PROTECTION_BYPASS_HEADER = "x-vercel-protection-bypass";
-const VM0_PREVIEW_BYPASS_QUERY_PARAM = "vm0_preview_bypass";
+const VERCEL_PROTECTION_BYPASS_COOKIE = VERCEL_PROTECTION_BYPASS_HEADER;
 const PREVIEW_AUTOMATION_BYPASS_ERROR = "Preview automation bypass required";
 const BYPASS_FINGERPRINT_LENGTH = 12;
 const UNHANDLED_REQUEST_ERROR_TYPE = "unhandled_request_error" as const;
@@ -304,20 +304,40 @@ function unquoteCookieValue(value: string): string {
     : value;
 }
 
-function cookieHeaderContainsBypassSecret(
+function safeDecodeURIComponent(value: string): string {
+  const result = safeSync(() => {
+    return decodeURIComponent(value);
+  });
+  return "ok" in result ? result.ok : value;
+}
+
+function cookieHeaderValue(
+  cookieHeader: string | undefined,
+  name: string,
+): string | undefined {
+  for (const cookie of cookieHeader?.split(";") ?? []) {
+    const separatorIndex = cookie.indexOf("=");
+    if (separatorIndex === -1) {
+      continue;
+    }
+    const key = cookie.slice(0, separatorIndex).trim();
+    if (key !== name) {
+      continue;
+    }
+    return unquoteCookieValue(cookie.slice(separatorIndex + 1).trim());
+  }
+  return undefined;
+}
+
+function cookieHeaderHasBypassSecret(
   cookieHeader: string | undefined,
   secret: string,
 ): boolean {
-  return (
-    cookieHeader?.split(";").some((cookie) => {
-      const separatorIndex = cookie.indexOf("=");
-      if (separatorIndex === -1) {
-        return false;
-      }
-      const rawValue = cookie.slice(separatorIndex + 1).trim();
-      return unquoteCookieValue(rawValue) === secret;
-    }) ?? false
+  const value = cookieHeaderValue(
+    cookieHeader,
+    VERCEL_PROTECTION_BYPASS_COOKIE,
   );
+  return value === secret || safeDecodeURIComponent(value ?? "") === secret;
 }
 
 function requestHasPreviewAutomationBypass(
@@ -328,16 +348,10 @@ function requestHasPreviewAutomationBypass(
     return true;
   }
   const url = safeUrlParse(context.req.url);
-  if (
-    url?.searchParams.get(VM0_PREVIEW_BYPASS_QUERY_PARAM) === secret ||
-    url?.searchParams.get(VERCEL_PROTECTION_BYPASS_HEADER) === secret
-  ) {
+  if (url?.searchParams.get(VERCEL_PROTECTION_BYPASS_HEADER) === secret) {
     return true;
   }
-  return cookieHeaderContainsBypassSecret(
-    requestHeader(context, "cookie"),
-    secret,
-  );
+  return cookieHeaderHasBypassSecret(requestHeader(context, "cookie"), secret);
 }
 
 function isCorsPreflightRequest(context: Context): boolean {
@@ -366,10 +380,13 @@ function previewAutomationBypassDebug(context: Context, secret: string) {
       requestHeader(context, VERCEL_PROTECTION_BYPASS_HEADER),
     ),
     query: bypassFingerprint(
-      url?.searchParams.get(VM0_PREVIEW_BYPASS_QUERY_PARAM) ?? undefined,
-    ),
-    vercelQuery: bypassFingerprint(
       url?.searchParams.get(VERCEL_PROTECTION_BYPASS_HEADER) ?? undefined,
+    ),
+    cookie: bypassFingerprint(
+      cookieHeaderValue(
+        requestHeader(context, "cookie"),
+        VERCEL_PROTECTION_BYPASS_COOKIE,
+      ),
     ),
     cookieHeaderPresent: Boolean(requestHeader(context, "cookie")),
   };

--- a/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/force-upgrade.test.ts
@@ -38,7 +38,7 @@ describe("force upgrade", () => {
       "https://api.example.test/api/client/compatibility?version=0.540.0",
       {
         cache: "no-store",
-        credentials: "omit",
+        credentials: "include",
         method: "GET",
       },
     );

--- a/turbo/apps/platform/src/lib/__tests__/preview-bypass-cookie.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/preview-bypass-cookie.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildPreviewBypassCookie,
+  writePreviewBypassCookie,
+} from "../preview-bypass-cookie.ts";
+
+describe("preview bypass cookie", () => {
+  it("builds a vm6.ai scoped Vercel bypass cookie from the standard query", () => {
+    expect(
+      buildPreviewBypassCookie({
+        hostname: "pr-123-app.vm6.ai",
+        protocol: "https:",
+        search: "?x-vercel-protection-bypass=preview-secret",
+      }),
+    ).toBe(
+      "x-vercel-protection-bypass=preview-secret; Path=/; Max-Age=3600; SameSite=Lax; Domain=.vm6.ai; Secure",
+    );
+  });
+
+  it("does not read legacy vm0 preview bypass query params", () => {
+    expect(
+      buildPreviewBypassCookie({
+        hostname: "pr-123-app.vm6.ai",
+        protocol: "https:",
+        search: "?vm0_preview_bypass=preview-secret",
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to a host-only cookie outside vm6.ai", () => {
+    expect(
+      buildPreviewBypassCookie({
+        hostname: "localhost",
+        protocol: "http:",
+        search: "?x-vercel-protection-bypass=preview-secret",
+      }),
+    ).toBe(
+      "x-vercel-protection-bypass=preview-secret; Path=/; Max-Age=3600; SameSite=Lax",
+    );
+  });
+
+  it("writes the cookie when the bypass query is present", () => {
+    const setCookie = vi.fn();
+
+    expect(
+      writePreviewBypassCookie(
+        {
+          hostname: "staging-app.vm6.ai",
+          protocol: "https:",
+          search: "?x-vercel-protection-bypass=preview%20secret",
+        },
+        setCookie,
+      ),
+    ).toBeTruthy();
+    expect(setCookie).toHaveBeenCalledWith(
+      "x-vercel-protection-bypass=preview%20secret; Path=/; Max-Age=3600; SameSite=Lax; Domain=.vm6.ai; Secure",
+    );
+  });
+});

--- a/turbo/apps/platform/src/lib/force-upgrade.ts
+++ b/turbo/apps/platform/src/lib/force-upgrade.ts
@@ -62,7 +62,7 @@ export async function shouldForceUpgrade(
 
   const response = await fetcher(buildForceUpgradeUrl(version, apiBase), {
     cache: "no-store",
-    credentials: "omit",
+    credentials: "include",
     method: "GET",
   });
 

--- a/turbo/apps/platform/src/lib/preview-bypass-cookie-bootstrap.ts
+++ b/turbo/apps/platform/src/lib/preview-bypass-cookie-bootstrap.ts
@@ -1,0 +1,3 @@
+import { capturePreviewBypassCookieFromLocation } from "./preview-bypass-cookie.ts";
+
+capturePreviewBypassCookieFromLocation();

--- a/turbo/apps/platform/src/lib/preview-bypass-cookie.ts
+++ b/turbo/apps/platform/src/lib/preview-bypass-cookie.ts
@@ -1,0 +1,66 @@
+export const VERCEL_PROTECTION_BYPASS_NAME = "x-vercel-protection-bypass";
+
+const PREVIEW_BYPASS_COOKIE_MAX_AGE_SECONDS = 60 * 60;
+const PREVIEW_COOKIE_ROOT_DOMAIN = "vm6.ai";
+
+export interface PreviewBypassCookieLocation {
+  readonly hostname: string;
+  readonly protocol: string;
+  readonly search: string;
+}
+
+function previewCookieDomain(hostname: string): string | undefined {
+  const normalized = hostname.toLowerCase();
+  return normalized === PREVIEW_COOKIE_ROOT_DOMAIN ||
+    normalized.endsWith(`.${PREVIEW_COOKIE_ROOT_DOMAIN}`)
+    ? `.${PREVIEW_COOKIE_ROOT_DOMAIN}`
+    : undefined;
+}
+
+export function buildPreviewBypassCookie(
+  location: PreviewBypassCookieLocation,
+): string | null {
+  const bypass = new URLSearchParams(location.search).get(
+    VERCEL_PROTECTION_BYPASS_NAME,
+  );
+  if (!bypass) {
+    return null;
+  }
+
+  const segments = [
+    `${VERCEL_PROTECTION_BYPASS_NAME}=${encodeURIComponent(bypass)}`,
+    "Path=/",
+    `Max-Age=${PREVIEW_BYPASS_COOKIE_MAX_AGE_SECONDS}`,
+    "SameSite=Lax",
+  ];
+  const domain = previewCookieDomain(location.hostname);
+  if (domain) {
+    segments.push(`Domain=${domain}`);
+  }
+  if (location.protocol === "https:") {
+    segments.push("Secure");
+  }
+  return segments.join("; ");
+}
+
+export function writePreviewBypassCookie(
+  location: PreviewBypassCookieLocation,
+  setCookie: (cookie: string) => void,
+): boolean {
+  const cookie = buildPreviewBypassCookie(location);
+  if (!cookie) {
+    return false;
+  }
+  setCookie(cookie);
+  return true;
+}
+
+export function capturePreviewBypassCookieFromLocation(): void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+  writePreviewBypassCookie(window.location, (cookie) => {
+    // oxlint-disable-next-line unicorn/no-document-cookie -- must synchronously set the shared preview cookie before the first API request.
+    document.cookie = cookie;
+  });
+}

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -1,3 +1,4 @@
+import "./lib/preview-bypass-cookie-bootstrap.ts";
 import { initSentry, Sentry } from "./lib/sentry.ts";
 import { initPostHog } from "./lib/posthog.ts";
 import { setupVisualViewportKeyboardState } from "./lib/visual-viewport-keyboard.ts";

--- a/turbo/apps/platform/src/signals/api-client-base.ts
+++ b/turbo/apps/platform/src/signals/api-client-base.ts
@@ -48,7 +48,12 @@ export function createAuthedContractClient<T extends AppRouter>(
           headers.set("Authorization", `Bearer ${token}`);
         }
         addClientHeaders(headers);
-        return trpcRestFetchApi({ ...args, headers, path });
+        return trpcRestFetchApi({
+          ...args,
+          fetchOptions: { ...args.fetchOptions, credentials: "include" },
+          headers,
+          path,
+        });
       };
 
       let response = await requestWithToken(initialToken);


### PR DESCRIPTION
## Summary
- Capture the standard `x-vercel-protection-bypass` query in the platform bootstrap and persist it as a shared `.vm6.ai` cookie before the app issues API requests.
- Tighten the API preview bypass cookie check to the exact `x-vercel-protection-bypass` cookie name while keeping the standard header/query paths.
- Update preview/E2E helpers away from `vm0_preview_bypass` and ensure app API clients include credentials for cross-origin cookie delivery.

## Verification
- `pnpm -F @vm0/app exec vitest run src/lib/__tests__/preview-bypass-cookie.test.ts src/lib/__tests__/force-upgrade.test.ts`
- `pnpm -F api exec vitest run src/__tests__/app-factory.test.ts`
- `pnpm -F @vm0/app check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F @vm0/app lint`
- `pnpm -F api lint`
- `git diff --check`