### PR TITLE
fix: reset chat indexeddb cache

### DIFF
--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.test.ts
@@ -154,6 +154,14 @@ function expectArtifactItemsStoreCreated(
   ).toHaveBeenCalledWith(ARTIFACT_ITEMS_RUN_FILE_INDEX, ["runId", "fileId"]);
 }
 
+function expectAllLocalCacheStoresDeleted(
+  deleteObjectStore: ReturnType<typeof fakeDb>["deleteObjectStore"],
+): void {
+  expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_MESSAGES_STORE);
+  expectThreadEventStoresDeleted(deleteObjectStore);
+  expect(deleteObjectStore).toHaveBeenCalledWith(ARTIFACT_ITEMS_STORE);
+}
+
 describe("upgradeChatIdb", () => {
   it("clears legacy chat cache when upgrading from before v4", () => {
     const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
@@ -249,7 +257,7 @@ describe("upgradeChatIdb", () => {
     expectArtifactItemsStoreCreated(createdStores, createObjectStore);
   });
 
-  it("adds artifact items when upgrading from the previous chat schema", () => {
+  it("resets v11 local cache data during the v13 cache reset", () => {
     const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
       CHAT_MESSAGES_STORE,
       CHAT_THREAD_SNAPSHOT_STORE,
@@ -259,13 +267,17 @@ describe("upgradeChatIdb", () => {
 
     upgradeChatIdb(db, 11);
 
-    expect(deleteObjectStore).not.toHaveBeenCalled();
-    expect(createObjectStore).toHaveBeenCalledTimes(1);
+    expect(deleteObjectStore).toHaveBeenCalledTimes(4);
+    expect(deleteObjectStore).toHaveBeenCalledWith(CHAT_MESSAGES_STORE);
+    expectThreadEventStoresDeleted(deleteObjectStore);
+    expect(createObjectStore).toHaveBeenCalledTimes(5);
+    expectChatMessagesStoreCreated(createdStores, createObjectStore);
+    expectThreadEventStoresCreated(createdStores, createObjectStore);
     expectArtifactItemsStoreCreated(createdStores, createObjectStore);
   });
 
-  it("does not recreate artifact items when the store already exists", () => {
-    const { db, createObjectStore, deleteObjectStore } = fakeDb([
+  it("resets v12 local cache data and recreates empty stores", () => {
+    const { db, createdStores, createObjectStore, deleteObjectStore } = fakeDb([
       CHAT_MESSAGES_STORE,
       CHAT_THREAD_SNAPSHOT_STORE,
       CHAT_THREAD_EVENTS_STORE,
@@ -274,6 +286,25 @@ describe("upgradeChatIdb", () => {
     ]);
 
     upgradeChatIdb(db, 12);
+
+    expect(deleteObjectStore).toHaveBeenCalledTimes(5);
+    expectAllLocalCacheStoresDeleted(deleteObjectStore);
+    expect(createObjectStore).toHaveBeenCalledTimes(5);
+    expectChatMessagesStoreCreated(createdStores, createObjectStore);
+    expectThreadEventStoresCreated(createdStores, createObjectStore);
+    expectArtifactItemsStoreCreated(createdStores, createObjectStore);
+  });
+
+  it("does not recreate stores after the cache reset version", () => {
+    const { db, createObjectStore, deleteObjectStore } = fakeDb([
+      CHAT_MESSAGES_STORE,
+      CHAT_THREAD_SNAPSHOT_STORE,
+      CHAT_THREAD_EVENTS_STORE,
+      CHAT_THREAD_EVENT_SYNC_STORE,
+      ARTIFACT_ITEMS_STORE,
+    ]);
+
+    upgradeChatIdb(db, 13);
 
     expect(deleteObjectStore).not.toHaveBeenCalled();
     expect(createObjectStore).not.toHaveBeenCalled();

--- a/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
+++ b/turbo/apps/platform/src/signals/external/chat-idb-schema.ts
@@ -4,7 +4,8 @@ const CHAT_IDB_FULL_CACHE_RESET_VERSION = 4;
 const CHAT_IDB_MESSAGES_ORDER_RESET_VERSION = 6;
 const CHAT_IDB_RUN_FINISH_UNREAD_RESET_VERSION = 10;
 const CHAT_IDB_THREAD_EVENT_CACHE_RESET_VERSION = 11;
-const CHAT_IDB_SCHEMA_VERSION = 12;
+const CHAT_IDB_LOCAL_CACHE_RESET_VERSION = 13;
+const CHAT_IDB_SCHEMA_VERSION = 13;
 const LEGACY_CHAT_THREAD_META_STORE = "chat_thread_agents";
 
 export const CHAT_IDB_VERSION = CHAT_IDB_SCHEMA_VERSION;
@@ -81,8 +82,19 @@ function deleteObjectStoreIfExists(db: IDBPDatabase, storeName: string): void {
   }
 }
 
+function deleteLocalCacheStores(db: IDBPDatabase): void {
+  deleteObjectStoreIfExists(db, CHAT_MESSAGES_STORE);
+  deleteObjectStoreIfExists(db, CHAT_THREAD_SNAPSHOT_STORE);
+  deleteObjectStoreIfExists(db, CHAT_THREAD_EVENTS_STORE);
+  deleteObjectStoreIfExists(db, CHAT_THREAD_EVENT_SYNC_STORE);
+  deleteObjectStoreIfExists(db, ARTIFACT_ITEMS_STORE);
+  deleteObjectStoreIfExists(db, LEGACY_CHAT_THREAD_META_STORE);
+}
+
 export function upgradeChatIdb(db: IDBPDatabase, oldVersion: number): void {
-  if (oldVersion < CHAT_IDB_FULL_CACHE_RESET_VERSION) {
+  if (oldVersion < CHAT_IDB_LOCAL_CACHE_RESET_VERSION) {
+    deleteLocalCacheStores(db);
+  } else if (oldVersion < CHAT_IDB_FULL_CACHE_RESET_VERSION) {
     deleteObjectStoreIfExists(db, CHAT_MESSAGES_STORE);
   } else if (oldVersion < CHAT_IDB_MESSAGES_ORDER_RESET_VERSION) {
     deleteObjectStoreIfExists(db, CHAT_MESSAGES_STORE);


### PR DESCRIPTION
## Summary
- Bumps the chat IndexedDB schema version from 12 to 13 so existing browser caches run an upgrade migration.
- Clears local chat cache stores during the v13 upgrade: chat messages, thread snapshots, thread events, sync cursor, artifact items, and the legacy thread metadata store.
- Recreates the stores empty through the existing schema setup, forcing clients to hydrate fresh thread-list data from the API.

## Verification
- `pnpm exec prettier --check src/signals/external/chat-idb-schema.ts src/signals/external/chat-idb-schema.test.ts`
- `pnpm exec eslint src/signals/external/chat-idb-schema.ts src/signals/external/chat-idb-schema.test.ts --max-warnings 0`
- `pnpm exec vitest run src/signals/external/chat-idb-schema.test.ts --reporter dot`
- `pnpm -F @vm0/app check-types`

Full local vitest suite was not run per vm0 PR guidance; CI will cover it.