### PR TITLE
fix: preserve sidebar virtual list position on touch focus

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -1087,6 +1087,70 @@ describe("zero sidebar", () => {
     });
   });
 
+  it("does not scroll the current chat into view from pointer focus after virtual scrolling", async () => {
+    prepareDefaultAgent();
+    const overflowThreads = Array.from({ length: 23 }, (_, index) => {
+      return createThread(
+        `b2100000-0000-4000-a000-${String(index).padStart(12, "0")}`,
+        `Touchable overflow ${index + 1}`,
+      );
+    });
+    mockSidebarThreadStory(
+      [
+        createThread(EXISTING_THREAD_ID, "Release plan"),
+        createThread(AUTOMATION_THREAD_ID, "Scheduled launch"),
+      ],
+      [
+        ...overflowThreads,
+        createThread(ARCHIVED_THREAD_ID, "Archived context"),
+      ],
+    );
+
+    setupSidebarPage({
+      context,
+      path: `/chats/${EXISTING_THREAD_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("sidebar-chat-threads-virtual-list"),
+      ).toBeInTheDocument();
+    });
+
+    const scrollArea = screen.getByTestId("sidebar-scroll-area");
+    let scrollTop = 780;
+    Object.defineProperty(scrollArea, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scrollArea, "scrollHeight", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(scrollArea, "scrollTop", {
+      configurable: true,
+      get: () => {
+        return scrollTop;
+      },
+      set: (value) => {
+        scrollTop = value;
+      },
+    });
+    fireEvent.scroll(scrollArea);
+
+    await waitFor(() => {
+      expect(
+        within(sidebar()).getByText("Archived context"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.pointerDown(scrollArea, { pointerType: "touch" });
+    fireEvent.focus(scrollArea);
+
+    expect(scrollTop).toBe(780);
+    expect(within(sidebar()).getByText("Archived context")).toBeInTheDocument();
+  });
+
   it("keeps the chat thread focus ring inside the virtual row", async () => {
     prepareDefaultAgent();
     mockSidebarThreadStory([

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -973,6 +973,27 @@ function ChatThreadsSkeleton() {
   );
 }
 
+function markPointerFocus(viewport: HTMLElement) {
+  const token = Math.random().toString(36);
+  viewport.dataset.sidebarPointerFocusToken = token;
+  viewport.ownerDocument.defaultView?.setTimeout(() => {
+    if (viewport.dataset.sidebarPointerFocusToken !== token) {
+      return;
+    }
+
+    delete viewport.dataset.sidebarPointerFocusToken;
+  }, 350);
+}
+
+function consumePointerFocus(viewport: HTMLElement) {
+  if (!viewport.dataset.sidebarPointerFocusToken) {
+    return false;
+  }
+
+  delete viewport.dataset.sidebarPointerFocusToken;
+  return true;
+}
+
 function ChatThreadsContent() {
   // useLastLoadable keeps the previous resolved list rendered while
   // sidebarChatThreads$ recomputes on a pane/thread switch; useLoadable would
@@ -1058,8 +1079,14 @@ function ChatThreadsContent() {
       aria-label="Chat threads"
       data-testid="sidebar-scroll-area"
       tabIndex={currentMainThreadId ? 0 : undefined}
+      onPointerDownCapture={(event) => {
+        markPointerFocus(event.currentTarget);
+      }}
       onFocus={(event) => {
         if (event.target !== event.currentTarget) {
+          return;
+        }
+        if (consumePointerFocus(event.currentTarget)) {
           return;
         }
         focusCurrentMainThreadLink(event.currentTarget);

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-scroll.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-scroll.tsx
@@ -1,6 +1,7 @@
 import type {
   CSSProperties,
   FocusEventHandler,
+  PointerEventHandler,
   ReactNode,
   UIEvent,
 } from "react";
@@ -20,6 +21,7 @@ export function OverlayScrollArea({
   className,
   children,
   onFocus,
+  onPointerDownCapture,
   onScroll,
   style,
   "data-testid": dataTestId,
@@ -29,6 +31,7 @@ export function OverlayScrollArea({
   className?: string;
   children: ReactNode;
   onFocus?: FocusEventHandler<HTMLDivElement>;
+  onPointerDownCapture?: PointerEventHandler<HTMLDivElement>;
   onScroll?: (e: UIEvent<HTMLDivElement>) => void;
   style?: CSSProperties;
   "data-testid"?: string;
@@ -78,6 +81,7 @@ export function OverlayScrollArea({
         className="h-full overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={style}
         onFocus={onFocus}
+        onPointerDownCapture={onPointerDownCapture}
         onScroll={handleScroll}
         tabIndex={tabIndex}
         aria-label={ariaLabel}


### PR DESCRIPTION
## Summary
- prevent pointer/touch focus on the sidebar chat scroll area from running the keyboard-only current-chat auto-scroll
- keep keyboard focus behavior intact by only skipping the auto-scroll when focus follows a pointer down
- add a regression test for the deep virtual-scroll case where the current chat has been virtualized out

## Verification
- pnpm exec prettier --check apps/platform/src/views/zero-page/sidebar-threads.tsx apps/platform/src/views/zero-page/zero-sidebar-scroll.tsx apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-sidebar.test.tsx
- git diff --check