### PR TITLE
fix(api): reduce firewall metadata type-check memory

### DIFF
--- a/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-metadata.test.ts
@@ -71,23 +71,11 @@ const KNOWN_MISSING_PERMISSION_DESCRIPTION_GAPS: Partial<
     missingNamesSha256:
       "29130e444cd58beaaa654c0207dbec064be945113ca97cf2d391f3614cb37cc1",
   },
-  sentry: {
-    issue: 19612,
-    missingCount: 22,
-    missingNamesSha256:
-      "ddae869f18724903f394137a9a30186c0199c174c7a569bcb6f40349c0eaf904",
-  },
   vercel: {
     issue: 19613,
     missingCount: 68,
     missingNamesSha256:
       "8ccddb8850744d7bdc07fc73a57b0cd5831cdc6a482c724a920abadd3317782e",
-  },
-  xero: {
-    issue: 19614,
-    missingCount: 35,
-    missingNamesSha256:
-      "0234b2bf557b118688656df62d5018f872195b32d3d8d04ff191cf8f0b9efca0",
   },
 };
 let runtimeEntriesPromise: Promise<
@@ -266,7 +254,9 @@ function exportFromSpecifiers(source: string): string[] {
 
 function dynamicImportSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
-  for (const match of source.matchAll(/import\(\s*["']([^"']+)["']\s*\)/g)) {
+  for (const match of source.matchAll(
+    /import\(\s*["']([^"']+)["'](?:\s+as\s+string)?\s*\)/g,
+  )) {
     specifiers.push(match[1]!);
   }
   return specifiers;

--- a/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-runtime-loader.test.ts
@@ -27,6 +27,9 @@ function parseSource(source: string): ts.SourceFile {
 }
 
 function stringLiteralText(node: ts.Node | undefined): string | null {
+  if (node !== undefined && ts.isAsExpression(node)) {
+    return stringLiteralText(node.expression);
+  }
   if (
     node === undefined ||
     (!ts.isStringLiteral(node) && !ts.isNoSubstitutionTemplateLiteral(node))

--- a/turbo/packages/connectors/src/firewall-metadata/index.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/index.ts
@@ -1,5 +1,8 @@
 import { loadGeneratedFirewallPermissionMetadata } from "./permission-detail-loader.generated";
-import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./permission-summaries.generated";
+import {
+  FIREWALL_PERMISSION_METADATA_SUMMARIES,
+  type FirewallPermissionMetadataConnectorType,
+} from "./permission-summaries.generated";
 import type {
   FirewallPermissionDetailMetadata,
   FirewallPermissionSummaryMetadata,
@@ -37,7 +40,7 @@ export type {
 } from "./types";
 
 export type FirewallMetadataConnectorType =
-  keyof typeof FIREWALL_PERMISSION_METADATA_SUMMARIES;
+  FirewallPermissionMetadataConnectorType;
 
 export function isFirewallMetadataConnectorType(
   type: string,

--- a/turbo/packages/connectors/src/firewall-metadata/routing.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/routing.ts
@@ -1,4 +1,8 @@
-import { FIREWALL_ROUTING_METADATA_INDEX } from "./routing-index.generated";
+import {
+  FIREWALL_ROUTING_METADATA_CONNECTOR_TYPES,
+  FIREWALL_ROUTING_METADATA_INDEX,
+  type FirewallRoutingMetadataConnectorType,
+} from "./routing-index.generated";
 import { loadGeneratedFirewallRoutingMetadata } from "./routing-loader.generated";
 import type {
   FirewallRoutingIndexMetadata,
@@ -14,12 +18,8 @@ export type {
   FirewallRoutingRouteMetadata,
 } from "./types";
 
-export type FirewallRoutingMetadataConnectorType =
-  keyof typeof FIREWALL_ROUTING_METADATA_INDEX;
-
-export const FIREWALL_ROUTING_METADATA_CONNECTOR_TYPES = Object.keys(
-  FIREWALL_ROUTING_METADATA_INDEX,
-) as FirewallRoutingMetadataConnectorType[];
+export { FIREWALL_ROUTING_METADATA_CONNECTOR_TYPES };
+export type { FirewallRoutingMetadataConnectorType };
 
 export function isFirewallRoutingMetadataConnectorType(
   type: string,

--- a/turbo/packages/connectors/src/firewall-metadata/server.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/server.ts
@@ -4,12 +4,18 @@ import {
   type FirewallPolicyValue,
 } from "../firewall-types";
 import { loadGeneratedFirewallPermissionMetadata } from "./permission-detail-loader.generated";
-import { FIREWALL_PERMISSION_METADATA_SUMMARIES } from "./permission-summaries.generated";
+import {
+  FIREWALL_PERMISSION_METADATA_SUMMARIES,
+  type FirewallPermissionMetadataConnectorType,
+} from "./permission-summaries.generated";
 import {
   createFirewallMetadataPolicyResolver,
   type FirewallMetadataPolicyResolver,
 } from "./policy-resolver";
-import { FIREWALL_SERVER_EXECUTION_METADATA } from "./server-execution.generated";
+import {
+  FIREWALL_SERVER_EXECUTION_METADATA,
+  type FirewallServerExecutionMetadataConnectorType,
+} from "./server-execution.generated";
 import { BUILTIN_FIREWALL_FIXED_HOST_OWNERS } from "./server.generated";
 import type {
   FirewallExecutionMetadata,
@@ -21,9 +27,9 @@ import type {
 export type { FirewallExecutionMetadata } from "./types";
 
 export type FirewallServerMetadataConnectorType =
-  keyof typeof FIREWALL_PERMISSION_METADATA_SUMMARIES;
+  FirewallPermissionMetadataConnectorType;
 export type FirewallExecutionMetadataConnectorType =
-  keyof typeof FIREWALL_SERVER_EXECUTION_METADATA;
+  FirewallServerExecutionMetadataConnectorType;
 
 export interface BuiltinConnectorHostOwner {
   readonly type: FirewallServerMetadataConnectorType;

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -90,7 +90,9 @@ function staticValueModuleSpecifiers(source: string): string[] {
 
 function dynamicImportSpecifiers(source: string): string[] {
   const specifiers: string[] = [];
-  for (const match of source.matchAll(/import\(\s*["']([^"']+)["']\s*\)/g)) {
+  for (const match of source.matchAll(
+    /import\(\s*["']([^"']+)["'](?:\s+as\s+string)?\s*\)/g,
+  )) {
     specifiers.push(match[1]!);
   }
   return specifiers;
@@ -142,8 +144,11 @@ function routingMetadataFromSource(source: ConnectorFirewallSource): unknown {
 }
 
 function sourceHasObjectKey(source: string, key: string): boolean {
+  const quotedKey = JSON.stringify(key);
+  const escapedQuotedKey = quotedKey.replaceAll('"', '\\"');
   return (
-    source.includes(`${JSON.stringify(key)}:`) ||
+    source.includes(`${quotedKey}:`) ||
+    source.includes(`${escapedQuotedKey}:`) ||
     new RegExp(`^\\s*${key}:`, "m").test(source)
   );
 }
@@ -625,13 +630,13 @@ describe("firewall metadata generator", () => {
     );
 
     expect(staticValueModuleSpecifiers(source)).toStrictEqual([]);
-    expect(source).toContain('"api.github.com": "github"');
-    expect(source).toContain('"{network}.g.alchemy.com": "alchemy"');
-    expect(source).toContain('"slack.com": "slack"');
+    expect(source).toContain('\\"api.github.com\\": \\"github\\"');
+    expect(source).toContain('\\"{network}.g.alchemy.com\\": \\"alchemy\\"');
+    expect(source).toContain('\\"slack.com\\": \\"slack\\"');
     expect(source).not.toContain("${{");
-    expect(source).not.toContain('"permissions"');
-    expect(source).not.toContain('"description"');
-    expect(source).not.toContain('"rules"');
+    expect(sourceHasObjectKey(source, "permissions")).toBe(false);
+    expect(sourceHasObjectKey(source, "description")).toBe(false);
+    expect(sourceHasObjectKey(source, "rules")).toBe(false);
   });
 
   it("keeps generated server execution metadata eager and server-shaped", () => {
@@ -646,13 +651,13 @@ describe("firewall metadata generator", () => {
     expect(staticValueModuleSpecifiers(source)).toStrictEqual([]);
     expect(dynamicImportSpecifiers(source)).toStrictEqual([]);
     expect(source).toContain("FIREWALL_SERVER_EXECUTION_METADATA");
-    expect(source).toContain('"baseUrlVarNames"');
-    expect(source).toContain('"baseUrlTemplates"');
-    expect(source).toContain('"secretPlaceholderNames"');
-    expect(source).toContain('"placeholderValues"');
-    expect(source).not.toContain('"permissions":');
-    expect(source).not.toContain('"description"');
-    expect(source).not.toContain('"rules"');
+    expect(sourceHasObjectKey(source, "baseUrlVarNames")).toBe(true);
+    expect(sourceHasObjectKey(source, "baseUrlTemplates")).toBe(true);
+    expect(sourceHasObjectKey(source, "secretPlaceholderNames")).toBe(true);
+    expect(sourceHasObjectKey(source, "placeholderValues")).toBe(true);
+    expect(sourceHasObjectKey(source, "permissions")).toBe(false);
+    expect(sourceHasObjectKey(source, "description")).toBe(false);
+    expect(sourceHasObjectKey(source, "rules")).toBe(false);
   });
 
   it("keeps the generated metadata loader literal and nullable", () => {
@@ -767,12 +772,16 @@ describe("firewall metadata generator", () => {
     expect(staticValueModuleSpecifiers(slackDetailSource)).toStrictEqual([]);
     expect(dynamicImportSpecifiers(slackDetailSource)).toStrictEqual([]);
     expect(slackDetailSource).toContain("firewallRoutingMetadata");
-    expect(sourceHasObjectKey(slackDetailSource, "base")).toBe(true);
-    expect(sourceHasObjectKey(slackDetailSource, "routes")).toBe(true);
-    expect(sourceHasObjectKey(slackDetailSource, "permissionName")).toBe(true);
-    expect(sourceHasObjectKey(slackDetailSource, "rule")).toBe(true);
-    expect(sourceHasObjectKey(slackDetailSource, "permissions")).toBe(false);
-    expect(sourceHasObjectKey(slackDetailSource, "rules")).toBe(false);
+    expect(slackDetailSource).toContain("JSON.parse");
+    expect(slackDetailSource).toContain(
+      "firewallRoutingMetadataValue as FirewallRoutingMetadata",
+    );
+    expect(slackDetailSource).toContain('\\"base\\"');
+    expect(slackDetailSource).toContain('\\"routes\\"');
+    expect(slackDetailSource).toContain('\\"permissionName\\"');
+    expect(slackDetailSource).toContain('\\"rule\\"');
+    expect(slackDetailSource).not.toContain('\\"permissions\\"');
+    expect(slackDetailSource).not.toContain('\\"rules\\"');
     assertRoutingMetadataSourceExcludesAuthData(
       slackDetailSource,
       "routing-details/slack.generated.ts",
@@ -797,9 +806,10 @@ describe("firewall metadata generator", () => {
           "utf-8",
         );
         expect(detailSource, filename).toContain(
-          `export const firewallRoutingMetadata = ${stableJson(
-            routingMetadataFromSource(source),
-          )} as const satisfies FirewallRoutingMetadata;`,
+          `const firewallRoutingMetadataJson = ${JSON.stringify(stableJson(routingMetadataFromSource(source)))};`,
+        );
+        expect(detailSource, filename).toContain(
+          "export const firewallRoutingMetadata = firewallRoutingMetadataValue as FirewallRoutingMetadata;",
         );
         assertRoutingMetadataSourceExcludesAuthData(detailSource, filename);
       }
@@ -848,8 +858,10 @@ describe("firewall metadata generator", () => {
         ),
         "utf-8",
       );
-      expect(googleDriveRuntimeSource).toMatch(/"?name"?:\s*"google-drive"/);
-      expect(googleDriveRuntimeSource).not.toContain('"description"');
+      expect(googleDriveRuntimeSource).toContain(
+        '\\"name\\": \\"google-drive\\"',
+      );
+      expect(googleDriveRuntimeSource).not.toContain('\\"description\\"');
       expect(googleDriveRuntimeSource).not.toContain("placeholders");
       expect(googleDriveRuntimeSource).not.toContain("defaultPolicies");
     },

--- a/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
+++ b/turbo/packages/firewalls-generator/src/lazy-loader-renderer.ts
@@ -15,8 +15,10 @@ function compareEntryKeys(a: LazyLoaderEntry, b: LazyLoaderEntry): number {
 }
 
 function renderLazyLoaderEntry(entry: LazyLoaderEntry): string {
+  // Preserve a literal import in emitted JavaScript for bundlers while avoiding
+  // TypeScript resolving every generated detail module during type-checking.
   return `  [${JSON.stringify(entry.key)}]: async () => {
-    return (await import(${JSON.stringify(entry.moduleSpecifier)}))[${JSON.stringify(entry.exportName)}];
+    return (await import(${JSON.stringify(entry.moduleSpecifier)} as string))[${JSON.stringify(entry.exportName)}];
   },`;
 }
 

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -658,55 +658,103 @@ function buildRoutingIndexMetadata(
 function renderDetailFile(metadata: FirewallPermissionDetailMetadata): string {
   return `${generatedHeader()}import type { FirewallPermissionDetailMetadata } from "../types";
 
-export const firewallPermissionMetadata = ${stableJson(metadata)} as const satisfies FirewallPermissionDetailMetadata;
+const firewallPermissionMetadataJson = ${JSON.stringify(stableJson(metadata))};
+const firewallPermissionMetadataValue: unknown = JSON.parse(firewallPermissionMetadataJson);
+
+export const firewallPermissionMetadata = firewallPermissionMetadataValue as FirewallPermissionDetailMetadata;
 `;
 }
 
 function renderRoutingDetailFile(metadata: FirewallRoutingMetadata): string {
   return `${generatedHeader()}import type { FirewallRoutingMetadata } from "../types";
 
-export const firewallRoutingMetadata = ${stableJson(metadata)} as const satisfies FirewallRoutingMetadata;
+const firewallRoutingMetadataJson = ${JSON.stringify(stableJson(metadata))};
+const firewallRoutingMetadataValue: unknown = JSON.parse(firewallRoutingMetadataJson);
+
+export const firewallRoutingMetadata = firewallRoutingMetadataValue as FirewallRoutingMetadata;
 `;
 }
 
 function renderRunnerRuntimeDetailFile(firewall: Firewall): string {
   return `${generatedHeader()}import type { Firewall } from "../../firewall-types";
 
-export const runnerRuntimeFirewall = ${stableJson(firewall)} as const satisfies Firewall;
+const runnerRuntimeFirewallJson = ${JSON.stringify(stableJson(firewall))};
+const runnerRuntimeFirewallValue: unknown = JSON.parse(runnerRuntimeFirewallJson);
+
+export const runnerRuntimeFirewall = runnerRuntimeFirewallValue as Firewall;
 `;
 }
 
 function renderRoutingIndexFile(
   metadata: Record<string, FirewallRoutingIndexMetadata>,
 ): string {
+  const connectorTypes = Object.keys(metadata);
   return `${generatedHeader()}import type { FirewallRoutingIndexMetadata } from "./types";
 
-export const FIREWALL_ROUTING_METADATA_INDEX = ${stableJson(metadata)} as const satisfies Readonly<Record<string, FirewallRoutingIndexMetadata>>;
+export const FIREWALL_ROUTING_METADATA_CONNECTOR_TYPES = Object.freeze(${stableJson(connectorTypes)} as const);
+export type FirewallRoutingMetadataConnectorType =
+  (typeof FIREWALL_ROUTING_METADATA_CONNECTOR_TYPES)[number];
+
+const firewallRoutingMetadataIndexJson = ${JSON.stringify(stableJson(metadata))};
+const firewallRoutingMetadataIndexValue: unknown = JSON.parse(firewallRoutingMetadataIndexJson);
+
+export const FIREWALL_ROUTING_METADATA_INDEX =
+  firewallRoutingMetadataIndexValue as Readonly<
+    Record<FirewallRoutingMetadataConnectorType, FirewallRoutingIndexMetadata>
+  >;
 `;
 }
 
 function renderSummaryFile(
   summaries: Record<string, FirewallPermissionSummaryMetadata>,
 ): string {
+  const connectorTypes = Object.keys(summaries);
   return `${generatedHeader()}import type { FirewallPermissionSummaryMetadata } from "./types";
 
-export const FIREWALL_PERMISSION_METADATA_SUMMARIES = ${stableJson(summaries)} as const satisfies Readonly<Record<string, FirewallPermissionSummaryMetadata>>;
+export const FIREWALL_PERMISSION_METADATA_CONNECTOR_TYPES = Object.freeze(${stableJson(connectorTypes)} as const);
+export type FirewallPermissionMetadataConnectorType =
+  (typeof FIREWALL_PERMISSION_METADATA_CONNECTOR_TYPES)[number];
+
+const firewallPermissionMetadataSummariesJson = ${JSON.stringify(stableJson(summaries))};
+const firewallPermissionMetadataSummariesValue: unknown = JSON.parse(firewallPermissionMetadataSummariesJson);
+
+export const FIREWALL_PERMISSION_METADATA_SUMMARIES =
+  firewallPermissionMetadataSummariesValue as Readonly<
+    Record<FirewallPermissionMetadataConnectorType, FirewallPermissionSummaryMetadata>
+  >;
 `;
 }
 
 function renderServerExecutionFile(
   metadata: Record<string, FirewallExecutionMetadata>,
 ): string {
+  const connectorTypes = Object.keys(metadata);
   return `${generatedHeader()}import type { FirewallExecutionMetadata } from "./types";
 
-export const FIREWALL_SERVER_EXECUTION_METADATA = ${stableJson(metadata)} as const satisfies Readonly<Record<string, FirewallExecutionMetadata>>;
+export const FIREWALL_SERVER_EXECUTION_METADATA_CONNECTOR_TYPES = Object.freeze(${stableJson(connectorTypes)} as const);
+export type FirewallServerExecutionMetadataConnectorType =
+  (typeof FIREWALL_SERVER_EXECUTION_METADATA_CONNECTOR_TYPES)[number];
+
+const firewallServerExecutionMetadataJson = ${JSON.stringify(stableJson(metadata))};
+const firewallServerExecutionMetadataValue: unknown = JSON.parse(firewallServerExecutionMetadataJson);
+
+export const FIREWALL_SERVER_EXECUTION_METADATA =
+  firewallServerExecutionMetadataValue as Readonly<
+    Record<FirewallServerExecutionMetadataConnectorType, FirewallExecutionMetadata>
+  >;
 `;
 }
 
 function renderServerFile(fixedHostOwners: Record<string, string>): string {
-  return `${generatedHeader()}import type { FirewallPermissionSummaryMetadata } from "./types";
+  return `${generatedHeader()}import type { FirewallPermissionMetadataConnectorType } from "./permission-summaries.generated";
 
-export const BUILTIN_FIREWALL_FIXED_HOST_OWNERS = ${stableJson(fixedHostOwners)} as const satisfies Readonly<Record<string, FirewallPermissionSummaryMetadata["type"]>>;
+const builtinFirewallFixedHostOwnersJson = ${JSON.stringify(stableJson(fixedHostOwners))};
+const builtinFirewallFixedHostOwnersValue: unknown = JSON.parse(builtinFirewallFixedHostOwnersJson);
+
+export const BUILTIN_FIREWALL_FIXED_HOST_OWNERS =
+  builtinFirewallFixedHostOwnersValue as Readonly<
+    Record<string, FirewallPermissionMetadataConnectorType>
+  >;
 `;
 }
 


### PR DESCRIPTION
## Summary

- Stop downstream TypeScript programs from resolving every generated firewall detail module by emitting lazy imports as `import("..." as string)`. TypeScript no longer follows those targets, while emitted JavaScript still contains literal dynamic imports for bundlers.
- Generate firewall metadata detail/index/server/runtime payloads as typed `JSON.parse` values instead of giant `as const satisfies ...` literals, avoiding deep literal inference over generated data.
- Preserve connector-name unions through generated connector type tuples, and update metadata source-shape tests for the JSON-backed output.

## Impact

Before this change, `api` type-check pulled 548 generated firewall detail modules into its TypeScript program. After this change, it pulls 0 permission/routing/runner-runtime detail modules while keeping the public metadata facades typed.

Measured locally:

- Before: 6464 `api` TS program files, 559 firewall metadata files, 548 generated detail files, 3,307,388K memory with 4GB heap.
- After: 5916 `api` TS program files, 11 firewall metadata facade/index files, 0 generated detail files, 2,963,417K memory with 4GB heap.

The local default 2GB heap still OOMs because the API type graph remains around 2.96GB; this PR removes the duplicated generated firewall metadata cost rather than solving the whole API type-check size.

## Verification

- `pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/metadata.test.ts`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-metadata.test.ts src/__tests__/firewall-routing-metadata.test.ts src/__tests__/firewall-runtime-loader.test.ts`
- `pnpm -F @vm0/firewalls-generator check-types`
- `pnpm -F @vm0/connectors check-types`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm -F api exec tsc --noEmit --listFilesOnly`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api exec tsc --noEmit --extendedDiagnostics`
