### PR TITLE
chore: preview for UI workflow eval run3

### DIFF
--- a/turbo/apps/api/src/lib/build-info.ts
+++ b/turbo/apps/api/src/lib/build-info.ts
@@ -1,6 +1,6 @@
 import apiPackage from "../../package.json";
 
-// Trigger preview deploy for UI-driven workflow evaluation on 2026-07-08.
+// Trigger preview deploy for UI-driven workflow evaluation run3 on 2026-07-08.
 const GIT_COMMIT_SHA_REGEX = /^[0-9a-f]{40}$/u;
 
 export function normalizeBuildCommitSha(value: unknown): string | null {


### PR DESCRIPTION
## What

Triggers a fresh preview environment for the automated **task-evaluation workflow** (run3), built on top of `main` which now includes the merged `realAgentInPreview` gate (#20723).

This is an evaluation-harness PR: the only change is a one-line no-op comment in `build-info.ts` to force API/App preview builds. No product behavior changes.

## Why

The previous automated batch (`preview-pr-20723-2026-07-08-ui-run2`) ran before the `realAgentInPreview` fix landed, so all 10 runs hit the Bash mock and failed. This run rebuilds a preview on post-fix `main` so the 5-model × 2-task evaluation executes against the real agent runtime.

## Verification

Relies on the PR preview pipeline (deploy-api / deploy-app / stripe-listener) plus the downstream `/_/lab` `realAgentInPreview` smoke.
