### PR TITLE
refactor: reduce fallback slop in zero run settings

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
@@ -28,7 +28,10 @@ async function resolveAgentLabel(
     .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
     .where(eq(agentRuns.id, runId))
     .limit(1);
-  return row?.displayName ?? row?.name ?? undefined;
+  if (!row) {
+    return undefined;
+  }
+  return row.displayName === null ? row.name : row.displayName;
 }
 
 async function resolveSelectedModel(
@@ -40,7 +43,10 @@ async function resolveSelectedModel(
     .from(zeroRuns)
     .where(eq(zeroRuns.id, runId))
     .limit(1);
-  return row?.selectedModel ?? undefined;
+  if (!row || row.selectedModel === null) {
+    return undefined;
+  }
+  return row.selectedModel;
 }
 
 async function resolveUserMention(

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -105,6 +105,10 @@ interface UserInfo {
   readonly agentphoneHandle?: string;
 }
 
+function optionalAgentSetting(value: string | null): string | undefined {
+  return value === null ? undefined : value;
+}
+
 interface ZeroRunPromptContext {
   readonly userInfo: UserInfo;
   readonly relationshipMemoryEnabled: boolean;
@@ -848,6 +852,8 @@ async function buildZeroCreateAgentRunArgs(args: {
   readonly timing: ApiDispatchTimingCollector;
 }): Promise<CreateAgentRunArgs> {
   const command = args.command;
+  const agentModelProviderId = optionalAgentSetting(args.agent.modelProviderId);
+  const agentSelectedModel = optionalAgentSetting(args.agent.selectedModel);
   const memoryRuntimeAppendSystemPrompt =
     await loadMemoryRuntimeAppendSystemPrompt(args.db, {
       enabled: args.relationshipMemoryRuntimeInjectionEnabled,
@@ -870,12 +876,10 @@ async function buildZeroCreateAgentRunArgs(args: {
       appendSystemPrompt: command.appendSystemPrompt,
     }),
     apiStartTime: command.apiStartTime,
-    modelProviderId:
-      command.modelProviderId ?? args.agent.modelProviderId ?? undefined,
+    modelProviderId: command.modelProviderId ?? agentModelProviderId,
     modelProviderCredentialScope: command.modelProviderCredentialScope,
     modelProviderType: command.body.modelProvider,
-    selectedModelOverride:
-      command.selectedModelOverride ?? args.agent.selectedModel ?? undefined,
+    selectedModelOverride: command.selectedModelOverride ?? agentSelectedModel,
     chatThreadId: command.chatThreadId,
     extraEnvironment: buildZeroRunExtraEnvironment({
       agentId: args.agent.id,
@@ -949,8 +953,8 @@ async function buildZeroIntegrationCreateAgentRunArgs(args: {
       appendSystemPrompt: command.appendSystemPrompt,
     }),
     apiStartTime: command.apiStartTime,
-    modelProviderId: args.agent.modelProviderId ?? undefined,
-    selectedModelOverride: args.agent.selectedModel ?? undefined,
+    modelProviderId: optionalAgentSetting(args.agent.modelProviderId),
+    selectedModelOverride: optionalAgentSetting(args.agent.selectedModel),
     extraEnvironment: { ZERO_AGENT_ID: args.agent.id },
     callbacks: command.callbacks,
     includeZeroTokenSecret: true,


### PR DESCRIPTION
## Summary

Daily AI-slop fallback cleanup focused on nullable database boundaries in zero run settings. This keeps existing command-over-agent precedence and makes null-to-undefined normalization explicit where downstream `CreateAgentRunArgs` and Slack message footer resolvers expect optional strings.

## Scan

- Scan timestamp: 2026-07-08T20:01:54.675Z
- Base commit: 18a10c5009cda73be721d281d33bc93c99e8d5ea
- Files scanned: 4052

Total matches by category:
- nullish: 5589
- nullish-chain: 126
- field-fallback-chain: 102
- optional-prop: 5832
- zod-optional: 2174
- zod-loose-optional: 3
- loose-record: 1272
- loose-index-signature: 5
- as-any: 0
- as-unknown-as: 30
- empty-fallback: 650
- string-fallback: 707
- null-undefined-fallback: 1524
- empty-catch: 3
- promise-catch-swallow: 14
- rust-unwrap-or: 602
- rust-ok-discard: 144

## Budget

- actionable_total: 223 high-confidence production-actionable scanner records
- initial edit_budget: 12 scanner records
- adjusted edit_budget: 6 scanner records after reading surrounding code and excluding sampled external adapters, presentation fallbacks, generic type bridges, and compatibility fallbacks
- candidates changed: 6 scanner records across 3 semantic cleanups

## Files Changed

- `turbo/apps/api/src/signals/services/zero-runs-create.service.ts`: normalizes nullable agent `modelProviderId` and `selectedModel` values through an explicit helper before passing optional run settings. This is safe because `zeroAgents` stores these fields as nullable database columns while `CreateAgentRunArgs` accepts omitted optional strings; command-level overrides still take precedence.
- `turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts`: replaces fallback chains in internal agent/run row resolvers with explicit missing-row and null checks. This preserves existing outputs, including non-null `zeroAgents.name` fallback and `undefined` for missing selected model.

## Verification

- `node /home/user/.codex/skills/ai-slop-fallback-cleanup/scan-ai-slop-fallbacks.mjs /home/user/workspace/vm0 --out /tmp/ai-slop-fallback-scan-after.json` confirmed no remaining high-confidence actionable records in touched files; total high-confidence production-actionable records dropped from 223 to 217.
- `git diff --check`
- `pnpm -F api check-types` could not run in this fresh clone because `node_modules` is absent and `tsc` is unavailable; the PR pipeline will run dependency-backed checks.

This workflow intentionally leaves the remaining candidates for later daily runs.