### PR TITLE
feat: refresh org credit balance when account menu opens

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-account-menu.test.tsx
@@ -187,18 +187,11 @@ async function openAccountMenu(): Promise<HTMLElement> {
   return screen.findByRole("menu");
 }
 
-function mockAdminAccountSidebar(): void {
-  prepareDefaultAgent();
-  context.mocks.data.org({
-    id: "org_1",
-    slug: "test-org",
-    name: "Test Org",
-    role: "admin",
-  });
+function mockAdminBillingStatus(credits: number): void {
   context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
     return respond(200, {
       tier: "pro",
-      credits: 12_500,
+      credits,
       onboardingPaymentPending: false,
       subscriptionStatus: "active",
       currentPeriodEnd: "2026-04-01T00:00:00Z",
@@ -228,6 +221,17 @@ function mockAdminAccountSidebar(): void {
       concurrencySubscriptions: [],
     });
   });
+}
+
+function mockAdminAccountSidebar(): void {
+  prepareDefaultAgent();
+  context.mocks.data.org({
+    id: "org_1",
+    slug: "test-org",
+    name: "Test Org",
+    role: "admin",
+  });
+  mockAdminBillingStatus(12_500);
 }
 
 describe("zero sidebar account menu", () => {
@@ -275,6 +279,39 @@ describe("zero sidebar account menu", () => {
       expect(screen.getByText("Pro credits")).toBeInTheDocument();
       expect(screen.getByText("Launch bonus")).toBeInTheDocument();
     });
+  });
+
+  it("refreshes the org credit balance when the menu opens", async () => {
+    mockAdminAccountSidebar();
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+      user: {
+        id: "test-user-123",
+        fullName: "Alex Rivera",
+        email: "alex.rivera@example.test",
+      },
+    });
+
+    let menu = await openAccountMenu();
+    await waitFor(() => {
+      expect(within(menu).getByText("12,500 credits")).toBeInTheDocument();
+    });
+
+    // The org spends credits elsewhere; the next menu open must reflect it.
+    mockAdminBillingStatus(500);
+
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+
+    menu = await openAccountMenu();
+    await waitFor(() => {
+      expect(within(menu).getByText("500 credits")).toBeInTheDocument();
+    });
+    expect(within(menu).queryByText("12,500 credits")).not.toBeInTheDocument();
   });
 
   it("hides account menu subscriptions when the feature switch is disabled", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -54,7 +54,10 @@ import {
 } from "../../signals/zero-page/settings/settings-dialog.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
-import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
+import {
+  billingStatusAsync$,
+  reloadBillingStatus$,
+} from "../../signals/zero-page/billing.ts";
 import {
   accountMenuCodexResetDialog$,
   personalActionPromise$,
@@ -602,6 +605,7 @@ export function AccountDropdown({
     consumePendingAccountMenuSettingsSection$,
   );
   const reloadSubscriptions = useSet(reloadAccountMenuSubscriptionUsageRows$);
+  const reloadBilling = useSet(reloadBillingStatus$);
   const resetCodexSubscriptionUsage = useSet(
     resetPersonalCodexSubscriptionUsage$,
   );
@@ -710,10 +714,17 @@ export function AccountDropdown({
   };
 
   const handleMenuOpenChange = (open: boolean) => {
-    if (open) {
-      setPendingSettingsSection(settingsOwnerId, null);
+    if (!open) {
+      return;
     }
-    if (!open || hidePreferences || !subscriptionsEnabled) {
+    setPendingSettingsSection(settingsOwnerId, null);
+    if (hidePreferences) {
+      return;
+    }
+    // Refresh the org credit balance every time the menu opens so the
+    // displayed remaining credit reflects the latest usage.
+    reloadBilling();
+    if (!subscriptionsEnabled) {
       return;
     }
 


### PR DESCRIPTION
## What

The bottom-left account dropdown (`AccountDropdown` in `zero-sidebar-account.tsx`) shows the organization's remaining credit. That value comes from the `billingStatusAsync$` signal, which fetches **once on first access** and is only re-fetched when `reloadBillingStatus$` bumps its reload counter. The account menu's `onOpenChange` handler previously only reloaded the model-provider subscription usage rows — it never reloaded the credit balance. As a result, reopening the menu could still show a stale balance after credit had been consumed elsewhere.

## Change

- Call `reloadBillingStatus$` in `handleMenuOpenChange` whenever the menu **opens** and the credit is actually visible (i.e. `hidePreferences` is false), so every open reflects the latest remaining credit.
- Restructured the handler to early-return on close and reuse the existing gating, keeping the pre-existing subscription-usage reload behavior unchanged.

## User-visible impact

Opening the bottom-left account menu now always reflects the org's current remaining credit, instead of a value cached from the first time the menu was opened.

## Verification

Relying on the PR pipeline (lint / type-check / tests) per team convention. The change is confined to the account dropdown view; `reloadBillingStatus$` is an existing, cheap counter-bump command already used across the codebase.