### PR TITLE
fix: skip template-interpolation references in zero host asset scan

### DIFF
--- a/turbo/apps/cli/src/lib/host/__tests__/static-site.test.ts
+++ b/turbo/apps/cli/src/lib/host/__tests__/static-site.test.ts
@@ -66,6 +66,26 @@ describe("scanStaticSite", () => {
     );
   });
 
+  it("skips references containing template interpolation", async () => {
+    const root = await tempRoot();
+    await writeFile(
+      join(root, "index.html"),
+      [
+        '<img src="${s.url}">',
+        '<source src="/media/{{item.file}}">',
+        '<link rel="stylesheet" href="<%= assetPath %>">',
+      ].join("\n"),
+    );
+
+    const result = await scanStaticSite(root);
+
+    expect(
+      result.files.map((file) => {
+        return file.path;
+      }),
+    ).toEqual(["/index.html"]);
+  });
+
   it("adds a default robots.txt when requested and missing", async () => {
     const root = await tempRoot();
     await writeFile(join(root, "index.html"), "<main>Hosted site</main>");

--- a/turbo/apps/cli/src/lib/host/static-site.ts
+++ b/turbo/apps/cli/src/lib/host/static-site.ts
@@ -94,6 +94,13 @@ function isExternalReference(value: string): boolean {
   return /^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/iu.test(value);
 }
 
+// References containing template interpolation are resolved at runtime, not on
+// disk. Covers JS template literals (`${...}`), mustache/Vue/Angular/Handlebars
+// (`{{...}}`), and EJS/ERB (`<%...%>`). These cannot be validated statically.
+function isDynamicReference(value: string): boolean {
+  return /\$\{|\{\{|<%/u.test(value);
+}
+
 function stripQueryAndHash(value: string): string {
   const hashIndex = value.indexOf("#");
   const withoutHash = hashIndex >= 0 ? value.slice(0, hashIndex) : value;
@@ -103,7 +110,7 @@ function stripQueryAndHash(value: string): string {
 
 function normalizeReference(fromPath: string, raw: string): string | null {
   const trimmed = raw.trim();
-  if (!trimmed || isExternalReference(trimmed)) {
+  if (!trimmed || isExternalReference(trimmed) || isDynamicReference(trimmed)) {
     return null;
   }
   const stripped = stripQueryAndHash(trimmed);


### PR DESCRIPTION
## Problem

`zero host` runs a pre-publish static-site scan (`assertReferencesExist` in `turbo/apps/cli/src/lib/host/static-site.ts`) that requires every HTML/CSS asset reference to resolve to a file on disk. Templated attribute values that contain interpolation placeholders — e.g. `<img src="${s.url}">` — were captured verbatim by the reference collector and treated as ordinary relative paths:

- `${s.url}` has no scheme / `//` / `#`, so `isExternalReference` returned false
- it passed `isSafeSitePath`, so `normalizeReference` returned `/${s.url}`
- `extname("${s.url}")` is non-empty, so `shouldRequireHtmlReference` marked it **required**
- `byPath` has no such file → the scan throws `Missing asset referenced by ...` and **hard-fails the publish**

Because the failure was in the scanner rather than the content, authors had been working around it by rewriting product code to avoid template literals — distorting source to satisfy a tooling false-positive.

## Fix

Add `isDynamicReference` and short-circuit such references alongside external ones in `normalizeReference`. Interpolation placeholders are resolved at runtime, not on disk, so they cannot be validated statically and should be skipped rather than hard-failed. Covers the common template syntaxes:

- JS template literals — `${...}`
- mustache / Vue / Angular / Handlebars — `{{...}}`
- EJS / ERB — `<%...%>`

## User-visible impact

`zero host` no longer blocks publishing a bundle whose HTML/CSS contains templated asset references. Genuinely missing static assets are still caught, so the guard against broken links is preserved.

## Verification

- Added a regression test in `static-site.test.ts` covering `${...}`, `{{...}}`, and `<%...%>` in HTML attributes; the scan now skips them instead of throwing.
- `pnpm -F @vm0/cli exec vitest run src/lib/host/__tests__/static-site.test.ts` → **5/5 pass**
- ESLint clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)