### PR TITLE
feat: generic mcp plugin manager for desktop computer use

### DIFF
--- a/turbo/apps/desktop/src/computer-use-electron.ts
+++ b/turbo/apps/desktop/src/computer-use-electron.ts
@@ -33,6 +33,12 @@ interface ComputerUseNativeApi {
   readonly removeFilesystemPluginAllowedDirectory: (
     directory: string,
   ) => DesktopComputerUseState;
+  readonly importMcpPluginServers: (json: string) => DesktopComputerUseState;
+  readonly setMcpPluginServerEnabled: (
+    server: string,
+    enabled: boolean,
+  ) => DesktopComputerUseState;
+  readonly removeMcpPluginServer: (server: string) => DesktopComputerUseState;
 }
 
 function isComputerUseStartOptions(
@@ -143,6 +149,39 @@ export function installComputerUseIpc(
         throw new Error("Filesystem plugin enabled state must be a boolean");
       }
       return api.setFilesystemPluginEnabled(enabled);
+    },
+  );
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.importMcpPluginServers,
+    (event, json: unknown) => {
+      assertComputerUsePage(event);
+      if (typeof json !== "string" || !json.trim()) {
+        throw new Error("MCP server configuration must be a JSON string");
+      }
+      return api.importMcpPluginServers(json);
+    },
+  );
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.setMcpPluginServerEnabled,
+    (event, server: unknown, enabled: unknown) => {
+      assertComputerUsePage(event);
+      if (typeof server !== "string" || !server.trim()) {
+        throw new Error("MCP server name must be a string");
+      }
+      if (typeof enabled !== "boolean") {
+        throw new Error("MCP server enabled state must be a boolean");
+      }
+      return api.setMcpPluginServerEnabled(server, enabled);
+    },
+  );
+  ipcMain.handle(
+    COMPUTER_USE_CHANNELS.removeMcpPluginServer,
+    (event, server: unknown) => {
+      assertComputerUsePage(event);
+      if (typeof server !== "string" || !server.trim()) {
+        throw new Error("MCP server name must be a string");
+      }
+      return api.removeMcpPluginServer(server);
     },
   );
   ipcMain.handle(

--- a/turbo/apps/desktop/src/computer-use-ipc-channels.ts
+++ b/turbo/apps/desktop/src/computer-use-ipc-channels.ts
@@ -12,6 +12,9 @@ export const COMPUTER_USE_CHANNELS = {
     "computer-use:add-filesystem-plugin-allowed-directory",
   removeFilesystemPluginAllowedDirectory:
     "computer-use:remove-filesystem-plugin-allowed-directory",
+  importMcpPluginServers: "computer-use:import-mcp-plugin-servers",
+  setMcpPluginServerEnabled: "computer-use:set-mcp-plugin-server-enabled",
+  removeMcpPluginServer: "computer-use:remove-mcp-plugin-server",
   openAccessibilitySettings: "computer-use:open-accessibility-settings",
   openScreenRecordingSettings: "computer-use:open-screen-recording-settings",
   openAutomationSettings: "computer-use:open-automation-settings",

--- a/turbo/apps/desktop/src/computer-use-types.ts
+++ b/turbo/apps/desktop/src/computer-use-types.ts
@@ -116,7 +116,7 @@ export interface DesktopKeepAwakeState {
   readonly active: boolean;
 }
 
-export type DesktopComputerUseFilesystemPluginStatus =
+export type DesktopComputerUsePluginStatus =
   | "disabled"
   | "starting"
   | "running"
@@ -127,14 +127,29 @@ export interface DesktopComputerUseFilesystemPluginState {
   readonly featureEnabled: boolean;
   readonly enabled: boolean;
   readonly allowedDirectories: readonly string[];
-  readonly status: DesktopComputerUseFilesystemPluginStatus;
+  readonly status: DesktopComputerUsePluginStatus;
   readonly lastError: string | null;
   readonly version: string;
   readonly capabilities: readonly string[];
 }
 
+export interface DesktopComputerUseMcpServerState {
+  readonly name: string;
+  readonly transport: "stdio" | "http";
+  readonly enabled: boolean;
+  readonly status: DesktopComputerUsePluginStatus;
+  readonly lastError: string | null;
+  readonly tools: readonly string[];
+}
+
+export interface DesktopComputerUseMcpPluginState {
+  readonly featureEnabled: boolean;
+  readonly servers: readonly DesktopComputerUseMcpServerState[];
+}
+
 export interface DesktopComputerUsePluginsState {
   readonly filesystem: DesktopComputerUseFilesystemPluginState;
+  readonly mcp: DesktopComputerUseMcpPluginState;
 }
 
 export interface DesktopComputerUseState {

--- a/turbo/apps/desktop/src/desktop-bridge.ts
+++ b/turbo/apps/desktop/src/desktop-bridge.ts
@@ -64,6 +64,16 @@ export interface DesktopComputerUseApi {
   readonly removeFilesystemPluginAllowedDirectory: (
     directory: string,
   ) => Promise<DesktopComputerUseState>;
+  readonly importMcpPluginServers: (
+    json: string,
+  ) => Promise<DesktopComputerUseState>;
+  readonly setMcpPluginServerEnabled: (
+    server: string,
+    enabled: boolean,
+  ) => Promise<DesktopComputerUseState>;
+  readonly removeMcpPluginServer: (
+    server: string,
+  ) => Promise<DesktopComputerUseState>;
   readonly openAccessibilitySettings: () => Promise<void>;
   readonly openScreenRecordingSettings: () => Promise<void>;
   readonly openAutomationSettings: () => Promise<void>;

--- a/turbo/apps/desktop/src/desktop-filesystem-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-filesystem-plugin.ts
@@ -11,8 +11,6 @@ import {
   COMPUTER_USE_FILESYSTEM_MCP_VERSION,
   COMPUTER_USE_FILESYSTEM_PLUGIN,
   COMPUTER_USE_PLUGIN_CALL_KIND,
-  COMPUTER_USE_PLUGIN_RESULT_BLOB_MAX_BYTES,
-  COMPUTER_USE_PLUGIN_RESULT_INLINE_TEXT_MAX_BYTES,
   computerUseFilesystemToolNames,
   computerUsePluginCallRequiredCapabilities,
   isComputerUsePluginCallPayload,
@@ -28,6 +26,11 @@ import type {
 import type { DesktopComputerUseFilesystemPluginState } from "./computer-use-types";
 import { PluginRestartPolicy } from "./desktop-plugin-restart-policy";
 import {
+  commandFailure,
+  normalizePluginToolResult,
+  pluginErrorMessage,
+} from "./desktop-plugin-tool-result";
+import {
   readDesktopPreferenceRecord,
   writeDesktopPreferenceRecord,
 } from "./desktop-preferences";
@@ -35,8 +38,6 @@ import {
 const nodeRequire = createRequire(__filename);
 const PREFERENCES_KEY = "computerUsePlugins";
 const FILESYSTEM_KEY = "filesystem";
-const TEXT_MIME_TYPE = "text/plain; charset=utf-8";
-const DEFAULT_FILENAME = "filesystem-result.txt";
 
 interface FilesystemPluginPreferences {
   readonly enabled: boolean;
@@ -130,173 +131,7 @@ function filesystemServerEntry(): string {
   );
 }
 
-function commandFailure(
-  code: ComputerUseCommandFailure["error"]["code"],
-  message: string,
-): ComputerUseCommandExecutionResult {
-  return { status: "failed", error: { code, message } };
-}
-
-function bufferByteLength(value: string): number {
-  return Buffer.byteLength(value, "utf8");
-}
-
-function resultTooLarge(sizeBytes: number): ComputerUseCommandExecutionResult {
-  return commandFailure(
-    "result_too_large",
-    `Filesystem plugin result is ${sizeBytes} bytes and exceeds the ${COMPUTER_USE_PLUGIN_RESULT_BLOB_MAX_BYTES} byte limit.`,
-  );
-}
-
-function filenameForTool(tool: ComputerUseFilesystemTool): string {
-  return `${tool}.txt`;
-}
-
-function pluginContentResult(args: {
-  readonly tool: ComputerUseFilesystemTool;
-  readonly text?: string;
-  readonly dataBase64?: string;
-  readonly mimeType: string;
-  readonly fileName: string;
-  readonly sizeBytes: number;
-}): ComputerUseCommandExecutionResult {
-  if (args.sizeBytes > COMPUTER_USE_PLUGIN_RESULT_BLOB_MAX_BYTES) {
-    return resultTooLarge(args.sizeBytes);
-  }
-  return {
-    status: "succeeded",
-    result: {
-      plugin: COMPUTER_USE_FILESYSTEM_PLUGIN,
-      tool: args.tool,
-      sizeBytes: args.sizeBytes,
-      offloaded: true,
-      ...(args.text ? { summary: `Saved ${args.sizeBytes} bytes` } : {}),
-      pluginContent: {
-        dataBase64:
-          args.dataBase64 ??
-          Buffer.from(args.text ?? "", "utf8").toString("base64"),
-        mimeType: args.mimeType,
-        fileName: args.fileName,
-      },
-    },
-  };
-}
-
-function textResult(
-  tool: ComputerUseFilesystemTool,
-  text: string,
-): ComputerUseCommandExecutionResult {
-  const sizeBytes = bufferByteLength(text);
-  if (sizeBytes <= COMPUTER_USE_PLUGIN_RESULT_INLINE_TEXT_MAX_BYTES) {
-    return {
-      status: "succeeded",
-      result: {
-        plugin: COMPUTER_USE_FILESYSTEM_PLUGIN,
-        tool,
-        content: text,
-        sizeBytes,
-        truncated: false,
-      },
-    };
-  }
-  return pluginContentResult({
-    tool,
-    text,
-    mimeType: TEXT_MIME_TYPE,
-    fileName: filenameForTool(tool),
-    sizeBytes,
-  });
-}
-
-function jsonResult(
-  tool: ComputerUseFilesystemTool,
-  value: unknown,
-): ComputerUseCommandExecutionResult {
-  return textResult(tool, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function normalizeToolResult(
-  tool: ComputerUseFilesystemTool,
-  result: CallToolResult,
-): ComputerUseCommandExecutionResult {
-  if (result.isError) {
-    const message = result.content
-      .map((entry) => {
-        return entry.type === "text" ? entry.text : "";
-      })
-      .filter(Boolean)
-      .join("\n")
-      .trim();
-    return commandFailure(
-      message.toLowerCase().includes("allowed directory") ||
-        message.toLowerCase().includes("access denied")
-        ? "path_denied"
-        : "mcp_error",
-      message || "Filesystem plugin tool failed",
-    );
-  }
-
-  const textEntries = result.content.filter((entry) => {
-    return entry.type === "text";
-  });
-  if (textEntries.length === result.content.length) {
-    return textResult(
-      tool,
-      textEntries
-        .map((entry) => {
-          return entry.text;
-        })
-        .join("\n"),
-    );
-  }
-
-  const firstBinary = result.content.find((entry) => {
-    return entry.type === "image" || entry.type === "audio";
-  });
-  if (firstBinary?.type === "image" || firstBinary?.type === "audio") {
-    const sizeBytes = Buffer.from(firstBinary.data, "base64").length;
-    return pluginContentResult({
-      tool,
-      dataBase64: firstBinary.data,
-      mimeType: firstBinary.mimeType,
-      fileName: DEFAULT_FILENAME,
-      sizeBytes,
-    });
-  }
-
-  const firstResource = result.content.find((entry) => {
-    return entry.type === "resource";
-  });
-  if (firstResource?.type === "resource") {
-    const resource = firstResource.resource;
-    const fileName = path.basename(resource.uri) || DEFAULT_FILENAME;
-    if ("text" in resource) {
-      return pluginContentResult({
-        tool,
-        text: resource.text,
-        mimeType: resource.mimeType ?? TEXT_MIME_TYPE,
-        fileName,
-        sizeBytes: bufferByteLength(resource.text),
-      });
-    }
-    const sizeBytes = Buffer.from(resource.blob, "base64").length;
-    return pluginContentResult({
-      tool,
-      dataBase64: resource.blob,
-      mimeType: resource.mimeType ?? "application/octet-stream",
-      fileName,
-      sizeBytes,
-    });
-  }
-
-  return jsonResult(tool, result.content);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function errorCodeForException(
+function filesystemFailureCode(
   message: string,
 ): ComputerUseCommandFailure["error"]["code"] {
   const normalized = message.toLowerCase();
@@ -495,7 +330,7 @@ export class DesktopFilesystemPluginManager {
         command.payload.arguments,
       );
     } catch (error) {
-      return commandFailure("invalid_arguments", errorMessage(error));
+      return commandFailure("invalid_arguments", pluginErrorMessage(error));
     }
 
     try {
@@ -509,13 +344,17 @@ export class DesktopFilesystemPluginManager {
           "Filesystem plugin returned an unsupported tool result.",
         );
       }
-      return normalizeToolResult(
-        command.payload.tool,
+      return normalizePluginToolResult(
+        {
+          plugin: COMPUTER_USE_FILESYSTEM_PLUGIN,
+          tool: command.payload.tool,
+          mapErrorCode: filesystemFailureCode,
+        },
         result as CallToolResult,
       );
     } catch (error) {
-      const message = errorMessage(error);
-      return commandFailure(errorCodeForException(message), message);
+      const message = pluginErrorMessage(error);
+      return commandFailure(filesystemFailureCode(message), message);
     }
   }
 
@@ -653,11 +492,11 @@ export class DesktopFilesystemPluginManager {
         }
       }
       if (this.shouldRun()) {
-        this.scheduleRestartOrFail(errorMessage(error));
+        this.scheduleRestartOrFail(pluginErrorMessage(error));
         return;
       }
       this.status = "error";
-      this.lastError = errorMessage(error);
+      this.lastError = pluginErrorMessage(error);
       this.onChange();
     }
   }

--- a/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
+++ b/turbo/apps/desktop/src/desktop-ipc-boundary.test.ts
@@ -115,6 +115,18 @@ describe("Desktop IPC boundary", () => {
         channel: COMPUTER_USE_CHANNELS.removeFilesystemPluginAllowedDirectory,
         args: ["/tmp"],
       },
+      {
+        channel: COMPUTER_USE_CHANNELS.importMcpPluginServers,
+        args: ['{"mcpServers":{}}'],
+      },
+      {
+        channel: COMPUTER_USE_CHANNELS.setMcpPluginServerEnabled,
+        args: ["notes", true],
+      },
+      {
+        channel: COMPUTER_USE_CHANNELS.removeMcpPluginServer,
+        args: ["notes"],
+      },
       { channel: COMPUTER_USE_CHANNELS.openAccessibilitySettings, args: [] },
       { channel: COMPUTER_USE_CHANNELS.openScreenRecordingSettings, args: [] },
       { channel: COMPUTER_USE_CHANNELS.openAutomationSettings, args: [] },
@@ -137,6 +149,9 @@ describe("Desktop IPC boundary", () => {
     expect(api.setFilesystemPluginEnabled).not.toHaveBeenCalled();
     expect(api.addFilesystemPluginAllowedDirectory).not.toHaveBeenCalled();
     expect(api.removeFilesystemPluginAllowedDirectory).not.toHaveBeenCalled();
+    expect(api.importMcpPluginServers).not.toHaveBeenCalled();
+    expect(api.setMcpPluginServerEnabled).not.toHaveBeenCalled();
+    expect(api.removeMcpPluginServer).not.toHaveBeenCalled();
     expect(electronMock.shell.openExternal).not.toHaveBeenCalled();
   });
 
@@ -349,6 +364,15 @@ function createComputerUseApi(): {
   readonly removeFilesystemPluginAllowedDirectory: ReturnType<
     typeof vi.fn<(directory: string) => DesktopComputerUseState>
   >;
+  readonly importMcpPluginServers: ReturnType<
+    typeof vi.fn<(json: string) => DesktopComputerUseState>
+  >;
+  readonly setMcpPluginServerEnabled: ReturnType<
+    typeof vi.fn<(server: string, enabled: boolean) => DesktopComputerUseState>
+  >;
+  readonly removeMcpPluginServer: ReturnType<
+    typeof vi.fn<(server: string) => DesktopComputerUseState>
+  >;
 } {
   const state = createComputerUseState();
   return {
@@ -363,6 +387,9 @@ function createComputerUseApi(): {
     setFilesystemPluginEnabled: vi.fn(() => state),
     addFilesystemPluginAllowedDirectory: vi.fn(async () => state),
     removeFilesystemPluginAllowedDirectory: vi.fn(() => state),
+    importMcpPluginServers: vi.fn(() => state),
+    setMcpPluginServerEnabled: vi.fn(() => state),
+    removeMcpPluginServer: vi.fn(() => state),
   };
 }
 

--- a/turbo/apps/desktop/src/desktop-mcp-plugin.test.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ComputerUseCommand } from "./computer-use-accessibility";
+import {
+  DesktopMcpPluginManager,
+  parseMcpServersJson,
+} from "./desktop-mcp-plugin";
+
+const nodeRequire = createRequire(__filename);
+
+function filesystemServerEntry(): string {
+  return nodeRequire.resolve(
+    "@modelcontextprotocol/server-filesystem/dist/index.js",
+  );
+}
+
+function pluginCommand(payload: Record<string, unknown>): ComputerUseCommand {
+  return {
+    id: "cmd-1",
+    kind: "plugin.call",
+    payload,
+  };
+}
+
+async function waitForServerStatus(
+  manager: DesktopMcpPluginManager,
+  name: string,
+  status: string,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  for (;;) {
+    const server = manager
+      .getState()
+      .servers.find((entry) => entry.name === name);
+    if (server?.status === status) {
+      return;
+    }
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(
+        `Timed out waiting for MCP server ${name} to become ${status} (currently ${server?.status ?? "missing"}: ${server?.lastError ?? "no error"})`,
+      );
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+  }
+}
+
+describe("parseMcpServersJson", () => {
+  it("parses the community mcpServers format", () => {
+    const servers = parseMcpServersJson(
+      JSON.stringify({
+        mcpServers: {
+          notes: { command: "npx", args: ["-y", "apple-notes-mcp"] },
+          figma: { url: "http://127.0.0.1:3845/mcp" },
+        },
+      }),
+    );
+    expect(servers).toStrictEqual({
+      notes: { command: "npx", args: ["-y", "apple-notes-mcp"], env: {} },
+      figma: { url: "http://127.0.0.1:3845/mcp" },
+    });
+  });
+
+  it("parses a bare name-to-config map", () => {
+    const servers = parseMcpServersJson(
+      JSON.stringify({ notes: { command: "npx" } }),
+    );
+    expect(Object.keys(servers)).toStrictEqual(["notes"]);
+  });
+
+  it("rejects invalid JSON", () => {
+    expect(() => parseMcpServersJson("{nope")).toThrow(/not valid JSON/);
+  });
+
+  it("rejects invalid server names", () => {
+    expect(() =>
+      parseMcpServersJson(
+        JSON.stringify({ mcpServers: { "Bad Name!": { command: "npx" } } }),
+      ),
+    ).toThrow(/names must match/);
+  });
+
+  it("rejects servers without a command or url", () => {
+    expect(() =>
+      parseMcpServersJson(JSON.stringify({ mcpServers: { notes: {} } })),
+    ).toThrow(/must declare either/);
+  });
+
+  it("rejects empty configurations", () => {
+    expect(() => parseMcpServersJson("{}")).toThrow(/contains no servers/);
+  });
+});
+
+describe("DesktopMcpPluginManager", () => {
+  const managers: DesktopMcpPluginManager[] = [];
+
+  function createManager(preferencesPath: string): DesktopMcpPluginManager {
+    const manager = new DesktopMcpPluginManager({
+      preferencesPath,
+      onChange: () => {},
+    });
+    managers.push(manager);
+    return manager;
+  }
+
+  afterEach(() => {
+    for (const manager of managers.splice(0)) {
+      manager.stop();
+    }
+  });
+
+  it("runs a stdio MCP server end to end", async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), "mcp-plugin-"));
+    writeFileSync(path.join(workspace, "hello.txt"), "hello from mcp\n");
+    const preferencesPath = path.join(workspace, "preferences.json");
+
+    const manager = createManager(preferencesPath);
+    manager.load();
+    manager.importServersJson(
+      JSON.stringify({
+        mcpServers: {
+          files: {
+            command: process.execPath,
+            args: [filesystemServerEntry(), workspace],
+          },
+        },
+      }),
+    );
+    manager.setFeatureEnabled(true);
+    manager.setHostRuntimeOnline(true);
+
+    expect(manager.getState().servers).toStrictEqual([
+      {
+        name: "files",
+        transport: "stdio",
+        enabled: false,
+        status: "disabled",
+        lastError: null,
+        tools: [],
+      },
+    ]);
+    expect(
+      await manager.execute(
+        pluginCommand({
+          plugin: "mcp",
+          server: "files",
+          tool: "read_text_file",
+          arguments: {},
+        }),
+      ),
+    ).toMatchObject({
+      status: "failed",
+      error: { code: "plugin_disabled" },
+    });
+
+    manager.setServerEnabled("files", true);
+    await waitForServerStatus(manager, "files", "running");
+    expect(manager.getCapabilities()).toStrictEqual(["plugin.mcp.files"]);
+
+    const listResult = await manager.execute(
+      pluginCommand({
+        plugin: "mcp",
+        server: "files",
+        tool: "tools/list",
+        arguments: {},
+      }),
+    );
+    expect(listResult.status).toBe("succeeded");
+    if (listResult.status !== "succeeded") {
+      throw new Error("unreachable");
+    }
+    const listed: unknown = JSON.parse(String(listResult.result.content));
+    expect(JSON.stringify(listed)).toContain("read_text_file");
+
+    const readResult = await manager.execute(
+      pluginCommand({
+        plugin: "mcp",
+        server: "files",
+        tool: "read_text_file",
+        arguments: { path: path.join(workspace, "hello.txt") },
+      }),
+    );
+    expect(readResult).toMatchObject({
+      status: "succeeded",
+      result: {
+        plugin: "mcp",
+        server: "files",
+        tool: "read_text_file",
+      },
+    });
+    if (readResult.status !== "succeeded") {
+      throw new Error("unreachable");
+    }
+    expect(String(readResult.result.content)).toContain("hello from mcp");
+
+    expect(
+      await manager.execute(
+        pluginCommand({
+          plugin: "mcp",
+          server: "files",
+          tool: "no_such_tool",
+          arguments: {},
+        }),
+      ),
+    ).toMatchObject({
+      status: "failed",
+      error: { code: "unknown_tool" },
+    });
+
+    expect(
+      await manager.execute(
+        pluginCommand({
+          plugin: "mcp",
+          server: "missing",
+          tool: "read_text_file",
+          arguments: {},
+        }),
+      ),
+    ).toMatchObject({
+      status: "failed",
+      error: { code: "plugin_unavailable" },
+    });
+
+    // Config persists across manager instances and keeps the enabled flag.
+    const reloaded = createManager(preferencesPath);
+    reloaded.load();
+    expect(reloaded.getState().servers).toMatchObject([
+      { name: "files", enabled: true, transport: "stdio" },
+    ]);
+  }, 30_000);
+
+  it("rejects calls while the plugin feature switch is off", async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), "mcp-plugin-"));
+    const manager = createManager(path.join(workspace, "preferences.json"));
+    manager.load();
+    manager.importServersJson(
+      JSON.stringify({ mcpServers: { notes: { command: "npx" } } }),
+    );
+    expect(
+      await manager.execute(
+        pluginCommand({
+          plugin: "mcp",
+          server: "notes",
+          tool: "anything",
+          arguments: {},
+        }),
+      ),
+    ).toMatchObject({
+      status: "failed",
+      error: { code: "feature_disabled" },
+    });
+  });
+});

--- a/turbo/apps/desktop/src/desktop-mcp-plugin.test.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -115,7 +115,9 @@ describe("DesktopMcpPluginManager", () => {
   });
 
   it("runs a stdio MCP server end to end", async () => {
-    const workspace = mkdtempSync(path.join(tmpdir(), "mcp-plugin-"));
+    const workspace = realpathSync(
+      mkdtempSync(path.join(tmpdir(), "mcp-plugin-")),
+    );
     writeFileSync(path.join(workspace, "hello.txt"), "hello from mcp\n");
     const preferencesPath = path.join(workspace, "preferences.json");
 

--- a/turbo/apps/desktop/src/desktop-mcp-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.ts
@@ -606,7 +606,7 @@ export class DesktopMcpPluginManager {
         try {
           await transport.close();
         } catch (closeError) {
-          console.warn(`Unable to close MCP server ${name}`, closeError);
+          console.warn("Unable to close MCP server", name, closeError);
         }
       }
       if (this.serverShouldRun(this.preferences.servers[name])) {
@@ -638,12 +638,12 @@ export class DesktopMcpPluginManager {
     try {
       await runtime.client.close();
     } catch (error) {
-      console.warn(`Unable to close MCP client ${name}`, error);
+      console.warn("Unable to close MCP client", name, error);
     }
     try {
       await runtime.transport.close();
     } catch (error) {
-      console.warn(`Unable to close MCP server ${name}`, error);
+      console.warn("Unable to close MCP server", name, error);
     }
   }
 }

--- a/turbo/apps/desktop/src/desktop-mcp-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.ts
@@ -1,0 +1,649 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  StdioClientTransport,
+  getDefaultEnvironment,
+} from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  COMPUTER_USE_MCP_LIST_TOOLS,
+  COMPUTER_USE_MCP_PLUGIN,
+  COMPUTER_USE_MCP_SERVER_NAME_PATTERN,
+  computerUseMcpServerCapability,
+  isComputerUseMcpPluginCallPayload,
+  type ComputerUseMcpPluginCallPayload,
+} from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
+import type {
+  ComputerUseCommand,
+  ComputerUseCommandExecutionResult,
+} from "./computer-use-accessibility";
+import type {
+  DesktopComputerUseMcpPluginState,
+  DesktopComputerUseMcpServerState,
+  DesktopComputerUsePluginStatus,
+} from "./computer-use-types";
+import { PluginRestartPolicy } from "./desktop-plugin-restart-policy";
+import {
+  commandFailure,
+  normalizePluginToolResult,
+  pluginErrorMessage,
+  pluginJsonResult,
+} from "./desktop-plugin-tool-result";
+import {
+  readDesktopPreferenceRecord,
+  writeDesktopPreferenceRecord,
+} from "./desktop-preferences";
+
+const PREFERENCES_KEY = "computerUsePlugins";
+const MCP_KEY = "mcp";
+const MCP_CLIENT_NAME = "zero-desktop-mcp-plugin";
+const MCP_CLIENT_VERSION = "1.0.0";
+
+interface McpStdioServerConfig {
+  readonly enabled: boolean;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+}
+
+interface McpHttpServerConfig {
+  readonly enabled: boolean;
+  readonly url: string;
+}
+
+type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;
+
+type McpServerConfigInput =
+  | Omit<McpStdioServerConfig, "enabled">
+  | Omit<McpHttpServerConfig, "enabled">;
+
+interface McpPluginPreferences {
+  readonly servers: Readonly<Record<string, McpServerConfig>>;
+}
+
+interface McpServerRuntime {
+  readonly client: Client;
+  readonly transport: Transport;
+  readonly tools: readonly string[];
+}
+
+interface McpServerSlot {
+  status: DesktopComputerUsePluginStatus;
+  lastError: string | null;
+  runtime: McpServerRuntime | null;
+  startPromise: Promise<void> | null;
+  restartTimer: NodeJS.Timeout | null;
+  readonly restartPolicy: PluginRestartPolicy;
+}
+
+interface DesktopMcpPluginManagerOptions {
+  readonly preferencesPath: string;
+  readonly onChange: () => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMcpHttpServerConfig(
+  config: McpServerConfig,
+): config is McpHttpServerConfig {
+  return "url" in config;
+}
+
+function normalizeStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const record: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === "string") {
+      record[key] = entry;
+    }
+  }
+  return record;
+}
+
+function normalizeServerConfig(value: unknown): McpServerConfig | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const enabled = value.enabled === true;
+  if (typeof value.url === "string" && value.url.trim()) {
+    return { enabled, url: value.url.trim() };
+  }
+  if (typeof value.command === "string" && value.command.trim()) {
+    const args = Array.isArray(value.args)
+      ? value.args.filter((entry): entry is string => {
+          return typeof entry === "string";
+        })
+      : [];
+    return {
+      enabled,
+      command: value.command.trim(),
+      args,
+      env: normalizeStringRecord(value.env),
+    };
+  }
+  return null;
+}
+
+function readMcpPluginPreferences(
+  preferencesPath: string,
+): McpPluginPreferences {
+  const preferences = readDesktopPreferenceRecord(preferencesPath);
+  const plugins = preferences[PREFERENCES_KEY];
+  const mcp = isRecord(plugins) ? plugins[MCP_KEY] : null;
+  const rawServers = isRecord(mcp) ? mcp.servers : null;
+  if (!isRecord(rawServers)) {
+    return { servers: {} };
+  }
+  const servers: Record<string, McpServerConfig> = {};
+  for (const [name, entry] of Object.entries(rawServers)) {
+    if (!COMPUTER_USE_MCP_SERVER_NAME_PATTERN.test(name)) {
+      continue;
+    }
+    const config = normalizeServerConfig(entry);
+    if (config) {
+      servers[name] = config;
+    }
+  }
+  return { servers };
+}
+
+function writeMcpPluginPreferences(
+  preferencesPath: string,
+  mcp: McpPluginPreferences,
+): void {
+  const preferences = readDesktopPreferenceRecord(preferencesPath);
+  const plugins = isRecord(preferences[PREFERENCES_KEY])
+    ? preferences[PREFERENCES_KEY]
+    : {};
+  writeDesktopPreferenceRecord(preferencesPath, {
+    ...preferences,
+    [PREFERENCES_KEY]: {
+      ...plugins,
+      [MCP_KEY]: { servers: mcp.servers },
+    },
+  });
+}
+
+/**
+ * Parses a user-pasted MCP server configuration document. Accepts the
+ * community `{"mcpServers": {...}}` format (Claude Desktop / Cursor style) or
+ * a bare name-to-config map. Throws with a readable message on invalid input.
+ */
+export function parseMcpServersJson(
+  json: string,
+): Readonly<Record<string, McpServerConfigInput>> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("MCP server configuration is not valid JSON");
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("MCP server configuration must be a JSON object");
+  }
+  const entries = isRecord(parsed.mcpServers) ? parsed.mcpServers : parsed;
+  if (!isRecord(entries) || Object.keys(entries).length === 0) {
+    throw new Error("MCP server configuration contains no servers");
+  }
+  const servers: Record<string, McpServerConfigInput> = {};
+  for (const [name, entry] of Object.entries(entries)) {
+    if (!COMPUTER_USE_MCP_SERVER_NAME_PATTERN.test(name)) {
+      throw new Error(
+        `MCP server name "${name}" is invalid: names must match [a-z0-9_-]{1,64}`,
+      );
+    }
+    const config = normalizeServerConfig(
+      isRecord(entry) ? { ...entry, enabled: false } : entry,
+    );
+    if (!config) {
+      throw new Error(
+        `MCP server "${name}" must declare either "command" (stdio) or "url" (Streamable HTTP)`,
+      );
+    }
+    servers[name] = isMcpHttpServerConfig(config)
+      ? { url: config.url }
+      : { command: config.command, args: config.args, env: config.env };
+  }
+  return servers;
+}
+
+export class DesktopMcpPluginManager {
+  private readonly preferencesPath: string;
+  private readonly onChange: () => void;
+  private preferences: McpPluginPreferences = { servers: {} };
+  private featureEnabled = false;
+  private hostRuntimeOnline = false;
+  private readonly slots = new Map<string, McpServerSlot>();
+
+  constructor(options: DesktopMcpPluginManagerOptions) {
+    this.preferencesPath = options.preferencesPath;
+    this.onChange = options.onChange;
+  }
+
+  load(): void {
+    this.preferences = readMcpPluginPreferences(this.preferencesPath);
+    this.reconcile();
+  }
+
+  getState(): DesktopComputerUseMcpPluginState {
+    const servers: DesktopComputerUseMcpServerState[] = Object.entries(
+      this.preferences.servers,
+    ).map(([name, config]) => {
+      const slot = this.slots.get(name);
+      return {
+        name,
+        transport: isMcpHttpServerConfig(config) ? "http" : "stdio",
+        enabled: config.enabled,
+        status: slot?.status ?? "disabled",
+        lastError: slot?.lastError ?? null,
+        tools: slot?.runtime?.tools ?? [],
+      };
+    });
+    return { featureEnabled: this.featureEnabled, servers };
+  }
+
+  getCapabilities(): readonly string[] {
+    const capabilities: string[] = [];
+    for (const [name, slot] of this.slots) {
+      if (slot.status === "running") {
+        capabilities.push(computerUseMcpServerCapability(name));
+      }
+    }
+    return capabilities;
+  }
+
+  setFeatureEnabled(enabled: boolean): void {
+    if (this.featureEnabled === enabled) {
+      return;
+    }
+    this.featureEnabled = enabled;
+    this.reconcile();
+    this.onChange();
+  }
+
+  setHostRuntimeOnline(online: boolean): void {
+    if (this.hostRuntimeOnline === online) {
+      return;
+    }
+    this.hostRuntimeOnline = online;
+    this.reconcile();
+    this.onChange();
+  }
+
+  importServersJson(json: string): void {
+    const imported = parseMcpServersJson(json);
+    const servers: Record<string, McpServerConfig> = {
+      ...this.preferences.servers,
+    };
+    for (const [name, config] of Object.entries(imported)) {
+      servers[name] = {
+        ...config,
+        enabled: this.preferences.servers[name]?.enabled ?? false,
+      };
+    }
+    this.preferences = { servers };
+    this.save();
+    this.reconcile();
+    this.onChange();
+  }
+
+  setServerEnabled(name: string, enabled: boolean): void {
+    const config = this.preferences.servers[name];
+    if (!config || config.enabled === enabled) {
+      return;
+    }
+    this.preferences = {
+      servers: { ...this.preferences.servers, [name]: { ...config, enabled } },
+    };
+    this.save();
+    this.reconcile();
+    this.onChange();
+  }
+
+  removeServer(name: string): void {
+    if (!this.preferences.servers[name]) {
+      return;
+    }
+    const servers = { ...this.preferences.servers };
+    delete servers[name];
+    this.preferences = { servers };
+    this.save();
+    this.reconcile();
+    this.onChange();
+  }
+
+  async execute(
+    command: ComputerUseCommand,
+  ): Promise<ComputerUseCommandExecutionResult> {
+    if (!isComputerUseMcpPluginCallPayload(command.payload)) {
+      return commandFailure(
+        "invalid_arguments",
+        "MCP plugin command payload is invalid.",
+      );
+    }
+    const payload = command.payload;
+    if (!this.featureEnabled) {
+      return commandFailure(
+        "feature_disabled",
+        "Computer Use Desktop plugins are disabled.",
+      );
+    }
+    const config = this.preferences.servers[payload.server];
+    if (!config) {
+      return commandFailure(
+        "plugin_unavailable",
+        `MCP server is not configured on this host: ${payload.server}`,
+      );
+    }
+    if (!config.enabled) {
+      return commandFailure(
+        "plugin_disabled",
+        `MCP server is disabled: ${payload.server}`,
+      );
+    }
+    const slot = this.slots.get(payload.server);
+    if (slot && (slot.status === "starting" || slot.status === "restarting")) {
+      return commandFailure(
+        "plugin_restarting",
+        `MCP server is ${slot.status}: ${payload.server}`,
+      );
+    }
+    if (!slot || slot.status !== "running" || !slot.runtime) {
+      return commandFailure(
+        "plugin_unavailable",
+        `MCP server is unavailable: ${payload.server}${
+          slot?.lastError ? ` (${slot.lastError})` : ""
+        }`,
+      );
+    }
+    if (payload.tool === COMPUTER_USE_MCP_LIST_TOOLS) {
+      return this.executeListTools(payload, slot.runtime);
+    }
+    return this.executeToolCall(payload, slot.runtime);
+  }
+
+  stop(): void {
+    for (const [name, slot] of this.slots) {
+      this.cancelScheduledRestart(slot);
+      slot.restartPolicy.reset();
+      void this.stopSlotRuntime(name, slot);
+    }
+  }
+
+  private async executeListTools(
+    payload: ComputerUseMcpPluginCallPayload,
+    runtime: McpServerRuntime,
+  ): Promise<ComputerUseCommandExecutionResult> {
+    try {
+      const listed = await runtime.client.listTools();
+      return pluginJsonResult(
+        {
+          plugin: COMPUTER_USE_MCP_PLUGIN,
+          server: payload.server,
+          tool: payload.tool,
+        },
+        {
+          server: payload.server,
+          tools: listed.tools.map((tool) => {
+            return {
+              name: tool.name,
+              description: tool.description ?? "",
+              inputSchema: tool.inputSchema,
+            };
+          }),
+        },
+      );
+    } catch (error) {
+      return commandFailure("mcp_error", pluginErrorMessage(error));
+    }
+  }
+
+  private async executeToolCall(
+    payload: ComputerUseMcpPluginCallPayload,
+    runtime: McpServerRuntime,
+  ): Promise<ComputerUseCommandExecutionResult> {
+    if (!runtime.tools.includes(payload.tool)) {
+      const listed = await runtime.client.listTools().catch(() => null);
+      const live = listed?.tools.some((tool) => {
+        return tool.name === payload.tool;
+      });
+      if (!live) {
+        return commandFailure(
+          "unknown_tool",
+          `MCP server ${payload.server} does not expose tool: ${payload.tool}`,
+        );
+      }
+    }
+    try {
+      const result = await runtime.client.callTool({
+        name: payload.tool,
+        arguments: payload.arguments,
+      });
+      if (!("content" in result) || !Array.isArray(result.content)) {
+        return commandFailure(
+          "mcp_error",
+          `MCP server ${payload.server} returned an unsupported tool result.`,
+        );
+      }
+      return normalizePluginToolResult(
+        {
+          plugin: COMPUTER_USE_MCP_PLUGIN,
+          server: payload.server,
+          tool: payload.tool,
+        },
+        result as CallToolResult,
+      );
+    } catch (error) {
+      return commandFailure("mcp_error", pluginErrorMessage(error));
+    }
+  }
+
+  private serverShouldRun(config: McpServerConfig | undefined): boolean {
+    return Boolean(
+      this.featureEnabled && this.hostRuntimeOnline && config && config.enabled,
+    );
+  }
+
+  private ensureSlot(name: string): McpServerSlot {
+    const existing = this.slots.get(name);
+    if (existing) {
+      return existing;
+    }
+    const slot: McpServerSlot = {
+      status: "disabled",
+      lastError: null,
+      runtime: null,
+      startPromise: null,
+      restartTimer: null,
+      restartPolicy: new PluginRestartPolicy(),
+    };
+    this.slots.set(name, slot);
+    return slot;
+  }
+
+  private reconcile(): void {
+    for (const [name, slot] of this.slots) {
+      this.cancelScheduledRestart(slot);
+      slot.restartPolicy.reset();
+      if (!this.preferences.servers[name]) {
+        void this.stopSlotRuntime(name, slot);
+        this.slots.delete(name);
+      }
+    }
+    for (const [name, config] of Object.entries(this.preferences.servers)) {
+      const slot = this.ensureSlot(name);
+      if (!this.serverShouldRun(config)) {
+        void this.stopSlotRuntime(name, slot);
+        continue;
+      }
+      void this.restartSlotRuntime(name, slot);
+    }
+  }
+
+  private save(): void {
+    writeMcpPluginPreferences(this.preferencesPath, this.preferences);
+  }
+
+  private cancelScheduledRestart(slot: McpServerSlot): void {
+    if (slot.restartTimer) {
+      clearTimeout(slot.restartTimer);
+      slot.restartTimer = null;
+    }
+  }
+
+  private scheduleRestartOrFail(
+    name: string,
+    slot: McpServerSlot,
+    message: string,
+  ): void {
+    if (slot.restartTimer) {
+      return;
+    }
+    const delayMs = slot.restartPolicy.nextDelayMs();
+    if (delayMs === null) {
+      slot.status = "error";
+      slot.lastError = message;
+      this.onChange();
+      return;
+    }
+    slot.status = "restarting";
+    slot.lastError = message;
+    this.onChange();
+    slot.restartTimer = setTimeout(() => {
+      slot.restartTimer = null;
+      void this.restartSlotRuntime(name, slot);
+    }, delayMs);
+  }
+
+  private async restartSlotRuntime(
+    name: string,
+    slot: McpServerSlot,
+  ): Promise<void> {
+    await this.stopSlotRuntime(name, slot);
+    if (slot.startPromise) {
+      return slot.startPromise;
+    }
+    slot.status = "starting";
+    slot.lastError = null;
+    this.onChange();
+    slot.startPromise = this.startSlotRuntime(name, slot).finally(() => {
+      slot.startPromise = null;
+    });
+    await slot.startPromise;
+  }
+
+  private createTransport(config: McpServerConfig): Transport {
+    if (isMcpHttpServerConfig(config)) {
+      return new StreamableHTTPClientTransport(new URL(config.url));
+    }
+    return new StdioClientTransport({
+      command: config.command,
+      args: [...config.args],
+      env: { ...getDefaultEnvironment(), ...config.env },
+      stderr: "pipe",
+    });
+  }
+
+  private async startSlotRuntime(
+    name: string,
+    slot: McpServerSlot,
+  ): Promise<void> {
+    let transport: Transport | null = null;
+    try {
+      const config = this.preferences.servers[name];
+      if (!this.serverShouldRun(config) || !config) {
+        slot.status = "disabled";
+        slot.lastError = null;
+        this.onChange();
+        return;
+      }
+      transport = this.createTransport(config);
+      transport.onerror = (error) => {
+        slot.lastError = error.message;
+        this.onChange();
+      };
+      transport.onclose = () => {
+        slot.runtime = null;
+        if (this.serverShouldRun(this.preferences.servers[name])) {
+          this.scheduleRestartOrFail(
+            name,
+            slot,
+            `MCP server process exited: ${name}`,
+          );
+          return;
+        }
+        slot.status = "disabled";
+        slot.lastError = null;
+        this.onChange();
+      };
+      const client = new Client(
+        { name: MCP_CLIENT_NAME, version: MCP_CLIENT_VERSION },
+        { capabilities: {} },
+      );
+      await client.connect(transport);
+      const listed = await client.listTools();
+      slot.runtime = {
+        client,
+        transport,
+        tools: listed.tools.map((tool) => {
+          return tool.name;
+        }),
+      };
+      slot.status = "running";
+      slot.lastError = null;
+      slot.restartPolicy.notifyStarted();
+      this.onChange();
+    } catch (error) {
+      slot.runtime = null;
+      if (transport) {
+        transport.onclose = undefined;
+        transport.onerror = undefined;
+        try {
+          await transport.close();
+        } catch (closeError) {
+          console.warn(`Unable to close MCP server ${name}`, closeError);
+        }
+      }
+      if (this.serverShouldRun(this.preferences.servers[name])) {
+        this.scheduleRestartOrFail(name, slot, pluginErrorMessage(error));
+        return;
+      }
+      slot.status = "error";
+      slot.lastError = pluginErrorMessage(error);
+      this.onChange();
+    }
+  }
+
+  private async stopSlotRuntime(
+    name: string,
+    slot: McpServerSlot,
+  ): Promise<void> {
+    const runtime = slot.runtime;
+    slot.runtime = null;
+    if (slot.status !== "disabled") {
+      slot.status = "disabled";
+      slot.lastError = null;
+      this.onChange();
+    }
+    if (!runtime) {
+      return;
+    }
+    runtime.transport.onclose = undefined;
+    runtime.transport.onerror = undefined;
+    try {
+      await runtime.client.close();
+    } catch (error) {
+      console.warn(`Unable to close MCP client ${name}`, error);
+    }
+    try {
+      await runtime.transport.close();
+    } catch (error) {
+      console.warn(`Unable to close MCP server ${name}`, error);
+    }
+  }
+}

--- a/turbo/apps/desktop/src/desktop-plugin-tool-result.ts
+++ b/turbo/apps/desktop/src/desktop-plugin-tool-result.ts
@@ -1,0 +1,195 @@
+import path from "node:path";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  COMPUTER_USE_PLUGIN_RESULT_BLOB_MAX_BYTES,
+  COMPUTER_USE_PLUGIN_RESULT_INLINE_TEXT_MAX_BYTES,
+} from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
+import type {
+  ComputerUseCommandExecutionResult,
+  ComputerUseCommandFailure,
+} from "./computer-use-accessibility";
+
+const TEXT_MIME_TYPE = "text/plain; charset=utf-8";
+const DEFAULT_FILENAME = "plugin-result.txt";
+
+/**
+ * Identifies the plugin call a normalized result belongs to. `server` is set
+ * for MCP plugin calls only; `mapErrorCode` lets a plugin map server error
+ * messages to a more specific failure code than `mcp_error`.
+ */
+interface PluginToolResultContext {
+  readonly plugin: string;
+  readonly tool: string;
+  readonly server?: string;
+  readonly mapErrorCode?: (
+    message: string,
+  ) => ComputerUseCommandFailure["error"]["code"];
+}
+
+export function commandFailure(
+  code: ComputerUseCommandFailure["error"]["code"],
+  message: string,
+): ComputerUseCommandExecutionResult {
+  return { status: "failed", error: { code, message } };
+}
+
+export function pluginErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function bufferByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function resultTooLarge(sizeBytes: number): ComputerUseCommandExecutionResult {
+  return commandFailure(
+    "result_too_large",
+    `Plugin result is ${sizeBytes} bytes and exceeds the ${COMPUTER_USE_PLUGIN_RESULT_BLOB_MAX_BYTES} byte limit.`,
+  );
+}
+
+function resultBase(context: PluginToolResultContext): Record<string, unknown> {
+  return {
+    plugin: context.plugin,
+    ...(context.server ? { server: context.server } : {}),
+    tool: context.tool,
+  };
+}
+
+function filenameForTool(context: PluginToolResultContext): string {
+  const safeTool = context.tool.replace(/[^a-zA-Z0-9_-]/g, "_");
+  return `${safeTool}.txt`;
+}
+
+function pluginContentResult(
+  context: PluginToolResultContext,
+  args: {
+    readonly text?: string;
+    readonly dataBase64?: string;
+    readonly mimeType: string;
+    readonly fileName: string;
+    readonly sizeBytes: number;
+  },
+): ComputerUseCommandExecutionResult {
+  if (args.sizeBytes > COMPUTER_USE_PLUGIN_RESULT_BLOB_MAX_BYTES) {
+    return resultTooLarge(args.sizeBytes);
+  }
+  return {
+    status: "succeeded",
+    result: {
+      ...resultBase(context),
+      sizeBytes: args.sizeBytes,
+      offloaded: true,
+      ...(args.text ? { summary: `Saved ${args.sizeBytes} bytes` } : {}),
+      pluginContent: {
+        dataBase64:
+          args.dataBase64 ??
+          Buffer.from(args.text ?? "", "utf8").toString("base64"),
+        mimeType: args.mimeType,
+        fileName: args.fileName,
+      },
+    },
+  };
+}
+
+function pluginTextResult(
+  context: PluginToolResultContext,
+  text: string,
+): ComputerUseCommandExecutionResult {
+  const sizeBytes = bufferByteLength(text);
+  if (sizeBytes <= COMPUTER_USE_PLUGIN_RESULT_INLINE_TEXT_MAX_BYTES) {
+    return {
+      status: "succeeded",
+      result: {
+        ...resultBase(context),
+        content: text,
+        sizeBytes,
+        truncated: false,
+      },
+    };
+  }
+  return pluginContentResult(context, {
+    text,
+    mimeType: TEXT_MIME_TYPE,
+    fileName: filenameForTool(context),
+    sizeBytes,
+  });
+}
+
+export function pluginJsonResult(
+  context: PluginToolResultContext,
+  value: unknown,
+): ComputerUseCommandExecutionResult {
+  return pluginTextResult(context, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function normalizePluginToolResult(
+  context: PluginToolResultContext,
+  result: CallToolResult,
+): ComputerUseCommandExecutionResult {
+  if (result.isError) {
+    const message = result.content
+      .map((entry) => {
+        return entry.type === "text" ? entry.text : "";
+      })
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    return commandFailure(
+      context.mapErrorCode?.(message) ?? "mcp_error",
+      message || `Plugin tool ${context.tool} failed`,
+    );
+  }
+
+  const textEntries = result.content.filter((entry) => {
+    return entry.type === "text";
+  });
+  if (textEntries.length === result.content.length) {
+    return pluginTextResult(
+      context,
+      textEntries
+        .map((entry) => {
+          return entry.text;
+        })
+        .join("\n"),
+    );
+  }
+
+  const firstBinary = result.content.find((entry) => {
+    return entry.type === "image" || entry.type === "audio";
+  });
+  if (firstBinary?.type === "image" || firstBinary?.type === "audio") {
+    const sizeBytes = Buffer.from(firstBinary.data, "base64").length;
+    return pluginContentResult(context, {
+      dataBase64: firstBinary.data,
+      mimeType: firstBinary.mimeType,
+      fileName: DEFAULT_FILENAME,
+      sizeBytes,
+    });
+  }
+
+  const firstResource = result.content.find((entry) => {
+    return entry.type === "resource";
+  });
+  if (firstResource?.type === "resource") {
+    const resource = firstResource.resource;
+    const fileName = path.basename(resource.uri) || DEFAULT_FILENAME;
+    if ("text" in resource) {
+      return pluginContentResult(context, {
+        text: resource.text,
+        mimeType: resource.mimeType ?? TEXT_MIME_TYPE,
+        fileName,
+        sizeBytes: bufferByteLength(resource.text),
+      });
+    }
+    const sizeBytes = Buffer.from(resource.blob, "base64").length;
+    return pluginContentResult(context, {
+      dataBase64: resource.blob,
+      mimeType: resource.mimeType ?? "application/octet-stream",
+      fileName,
+      sizeBytes,
+    });
+  }
+
+  return pluginJsonResult(context, result.content);
+}

--- a/turbo/apps/desktop/src/main.ts
+++ b/turbo/apps/desktop/src/main.ts
@@ -19,7 +19,10 @@ import {
   SUPPORTED_COMPUTER_USE_CAPABILITIES,
   executeComputerUseCommand,
 } from "./computer-use-accessibility";
-import { COMPUTER_USE_PLUGIN_CALL_KIND } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
+import {
+  COMPUTER_USE_PLUGIN_CALL_KIND,
+  isComputerUseMcpPluginCallPayload,
+} from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
 import {
   MAC_AUTOMATION_SETTINGS_URL,
   createAutomationPermissionDeniedPrompt,
@@ -59,6 +62,7 @@ import { DesktopComputerUseAutoStartSupervisor } from "./desktop-computer-use-au
 import { createDesktopComputerUseSessionFetch } from "./desktop-computer-use-api";
 import { readOrCreateComputerUseInstallationId } from "./desktop-computer-use-installation";
 import { DesktopFilesystemPluginManager } from "./desktop-filesystem-plugin";
+import { DesktopMcpPluginManager } from "./desktop-mcp-plugin";
 import { DesktopKeepAwakeController } from "./desktop-keep-awake";
 import { startDesktopLaunchComputerUse } from "./desktop-launch-computer-use";
 import {
@@ -144,6 +148,7 @@ let computerUseNativeBackendDisposed = false;
 let desktopTray: DesktopTrayController | null = null;
 let keepAwakeController: DesktopKeepAwakeController | null = null;
 let filesystemPluginManager: DesktopFilesystemPluginManager | null = null;
+let mcpPluginManager: DesktopMcpPluginManager | null = null;
 let desktopAutoUpdatesInstalled = false;
 const desktopAuthStartGate = createDesktopAuthStartGate();
 const computerUseSnapshotStore = new ComputerUseSnapshotStore();
@@ -191,6 +196,7 @@ const developerTools = new DeveloperToolsController({
     ),
   setFilesystemPluginFeatureEnabled: (enabled) => {
     filesystemPluginManager?.setFeatureEnabled(enabled);
+    mcpPluginManager?.setFeatureEnabled(enabled);
   },
   onChange: notifyDeveloperToolsChanged,
   logRefreshError: (error) => {
@@ -203,6 +209,7 @@ const computerUseController = new ComputerUseRuntimeController({
   getAuthState: () => getAuthSession().getAuthState(),
   setHostRuntimeOnline: (online) => {
     filesystemPluginManager?.setHostRuntimeOnline(online);
+    mcpPluginManager?.setHostRuntimeOnline(online);
   },
   onChange: notifyComputerUseChanged,
 });
@@ -217,6 +224,9 @@ function refreshDesktopTrayAuth(): void {
 
 function notifyComputerUseChanged(): void {
   filesystemPluginManager?.setHostRuntimeOnline(
+    computerUseController.isRuntimeOnline(),
+  );
+  mcpPluginManager?.setHostRuntimeOnline(
     computerUseController.isRuntimeOnline(),
   );
   notifyDesktopComputerUseChanged();
@@ -399,6 +409,10 @@ function getComputerUseBridgeState(): DesktopComputerUseState {
         version: "",
         capabilities: [],
       },
+      mcp: mcpPluginManager?.getState() ?? {
+        featureEnabled: false,
+        servers: [],
+      },
     },
   };
 }
@@ -435,10 +449,22 @@ function ensureFilesystemPluginManager(): DesktopFilesystemPluginManager {
   return filesystemPluginManager;
 }
 
+function ensureMcpPluginManager(): DesktopMcpPluginManager {
+  if (!mcpPluginManager) {
+    mcpPluginManager = new DesktopMcpPluginManager({
+      preferencesPath: desktopPreferencesPath(),
+      onChange: notifyComputerUseChanged,
+    });
+    mcpPluginManager.load();
+  }
+  return mcpPluginManager;
+}
+
 function supportedComputerUseCapabilities(): readonly string[] {
   return [
     ...SUPPORTED_COMPUTER_USE_CAPABILITIES,
     ...(filesystemPluginManager?.getCapabilities() ?? []),
+    ...(mcpPluginManager?.getCapabilities() ?? []),
   ];
 }
 
@@ -467,6 +493,9 @@ function createComputerUseHostRuntime(): ComputerUseHostRuntime {
     getSupportedCapabilities: supportedComputerUseCapabilities,
     executeCommand: (command, permissions) => {
       if (command.kind === COMPUTER_USE_PLUGIN_CALL_KIND) {
+        if (isComputerUseMcpPluginCallPayload(command.payload)) {
+          return ensureMcpPluginManager().execute(command);
+        }
         return ensureFilesystemPluginManager().execute(command);
       }
       return executeComputerUseCommand(command, permissions, {
@@ -493,6 +522,24 @@ async function stopComputerUseRuntime(): Promise<DesktopComputerUseState> {
 
 function setFilesystemPluginEnabled(enabled: boolean): DesktopComputerUseState {
   ensureFilesystemPluginManager().setEnabled(enabled);
+  return getComputerUseBridgeState();
+}
+
+function importMcpPluginServers(json: string): DesktopComputerUseState {
+  ensureMcpPluginManager().importServersJson(json);
+  return getComputerUseBridgeState();
+}
+
+function setMcpPluginServerEnabled(
+  server: string,
+  enabled: boolean,
+): DesktopComputerUseState {
+  ensureMcpPluginManager().setServerEnabled(server, enabled);
+  return getComputerUseBridgeState();
+}
+
+function removeMcpPluginServer(server: string): DesktopComputerUseState {
+  ensureMcpPluginManager().removeServer(server);
   return getComputerUseBridgeState();
 }
 
@@ -551,6 +598,7 @@ async function probeComputerUseAutomation(
 
 function installComputerUse(): void {
   ensureFilesystemPluginManager();
+  ensureMcpPluginManager();
   installComputerUseIpc(
     {
       getState: getComputerUseBridgeState,
@@ -564,6 +612,9 @@ function installComputerUse(): void {
       setFilesystemPluginEnabled,
       addFilesystemPluginAllowedDirectory,
       removeFilesystemPluginAllowedDirectory,
+      importMcpPluginServers,
+      setMcpPluginServerEnabled,
+      removeMcpPluginServer,
     },
     { rendererUrl: localRendererUrl },
   );

--- a/turbo/apps/desktop/src/preload.test.ts
+++ b/turbo/apps/desktop/src/preload.test.ts
@@ -126,6 +126,9 @@ describe("Desktop preload bridge", () => {
     await computerUse.setFilesystemPluginEnabled(true);
     await computerUse.addFilesystemPluginAllowedDirectory();
     await computerUse.removeFilesystemPluginAllowedDirectory("/tmp/project");
+    await computerUse.importMcpPluginServers('{"mcpServers":{}}');
+    await computerUse.setMcpPluginServerEnabled("notes", true);
+    await computerUse.removeMcpPluginServer("notes");
     await computerUse.openAccessibilitySettings();
     await computerUse.openScreenRecordingSettings();
     await computerUse.openAutomationSettings();
@@ -145,6 +148,9 @@ describe("Desktop preload bridge", () => {
         COMPUTER_USE_CHANNELS.removeFilesystemPluginAllowedDirectory,
         "/tmp/project",
       ],
+      [COMPUTER_USE_CHANNELS.importMcpPluginServers, '{"mcpServers":{}}'],
+      [COMPUTER_USE_CHANNELS.setMcpPluginServerEnabled, "notes", true],
+      [COMPUTER_USE_CHANNELS.removeMcpPluginServer, "notes"],
       [COMPUTER_USE_CHANNELS.openAccessibilitySettings],
       [COMPUTER_USE_CHANNELS.openScreenRecordingSettings],
       [COMPUTER_USE_CHANNELS.openAutomationSettings],

--- a/turbo/apps/desktop/src/preload.ts
+++ b/turbo/apps/desktop/src/preload.ts
@@ -92,6 +92,28 @@ const desktopComputerUseApi: DesktopComputerUseApi = {
       directory,
     );
   },
+  importMcpPluginServers(json: string): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(
+      COMPUTER_USE_CHANNELS.importMcpPluginServers,
+      json,
+    );
+  },
+  setMcpPluginServerEnabled(
+    server: string,
+    enabled: boolean,
+  ): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(
+      COMPUTER_USE_CHANNELS.setMcpPluginServerEnabled,
+      server,
+      enabled,
+    );
+  },
+  removeMcpPluginServer(server: string): Promise<DesktopComputerUseState> {
+    return ipcRenderer.invoke(
+      COMPUTER_USE_CHANNELS.removeMcpPluginServer,
+      server,
+    );
+  },
   openAccessibilitySettings(): Promise<void> {
     return ipcRenderer.invoke(COMPUTER_USE_CHANNELS.openAccessibilitySettings);
   },

--- a/turbo/apps/desktop/src/renderer/App.test.tsx
+++ b/turbo/apps/desktop/src/renderer/App.test.tsx
@@ -61,6 +61,10 @@ function createComputerUsePluginsState(): DesktopComputerUsePluginsState {
       version: "2026.1.14",
       capabilities: [],
     },
+    mcp: {
+      featureEnabled: true,
+      servers: [],
+    },
   };
 }
 
@@ -237,6 +241,21 @@ function createComputerUseBridge(initialState: DesktopComputerUseState): {
     setFilesystemPluginEnabled,
     addFilesystemPluginAllowedDirectory,
     removeFilesystemPluginAllowedDirectory,
+    importMcpPluginServers: vi.fn<
+      DesktopComputerUseApi["importMcpPluginServers"]
+    >(async () => {
+      return currentState;
+    }),
+    setMcpPluginServerEnabled: vi.fn<
+      DesktopComputerUseApi["setMcpPluginServerEnabled"]
+    >(async () => {
+      return currentState;
+    }),
+    removeMcpPluginServer: vi.fn<
+      DesktopComputerUseApi["removeMcpPluginServer"]
+    >(async () => {
+      return currentState;
+    }),
     openAccessibilitySettings: vi.fn<
       DesktopComputerUseApi["openAccessibilitySettings"]
     >(async () => {}),

--- a/turbo/apps/desktop/src/renderer/computer-use-state.ts
+++ b/turbo/apps/desktop/src/renderer/computer-use-state.ts
@@ -172,6 +172,30 @@ export const addFilesystemPluginAllowedDirectory$ = command(async ({ set }) => {
   set(reloadComputerUse$);
 });
 
+export const importMcpPluginServers$ = command(
+  async ({ set }, json: string) => {
+    await desktopComputerUseApi().importMcpPluginServers(json);
+    set(reloadComputerUse$);
+  },
+);
+
+export const setMcpPluginServerEnabled$ = command(
+  async (
+    { set },
+    { server, enabled }: { readonly server: string; readonly enabled: boolean },
+  ) => {
+    await desktopComputerUseApi().setMcpPluginServerEnabled(server, enabled);
+    set(reloadComputerUse$);
+  },
+);
+
+export const removeMcpPluginServer$ = command(
+  async ({ set }, server: string) => {
+    await desktopComputerUseApi().removeMcpPluginServer(server);
+    set(reloadComputerUse$);
+  },
+);
+
 export const removeFilesystemPluginAllowedDirectory$ = command(
   async ({ set }, directory: string) => {
     await desktopComputerUseApi().removeFilesystemPluginAllowedDirectory(

--- a/turbo/apps/desktop/src/renderer/hero/index.tsx
+++ b/turbo/apps/desktop/src/renderer/hero/index.tsx
@@ -7,6 +7,7 @@ import {
   IconLogout,
   IconPlayerPlay,
   IconPlayerStop,
+  IconPlug,
   IconTrash,
 } from "@tabler/icons-react";
 import { useLoadableSet } from "ccstate-react/experimental";
@@ -17,9 +18,12 @@ import {
 } from "../../computer-use-types";
 import {
   addFilesystemPluginAllowedDirectory$,
+  importMcpPluginServers$,
   openDesktopOrgSelection$,
   removeFilesystemPluginAllowedDirectory$,
+  removeMcpPluginServer$,
   setFilesystemPluginEnabled$,
+  setMcpPluginServerEnabled$,
   signOutDesktop$,
   startComputerUse$,
   stopComputerUse$,
@@ -46,6 +50,8 @@ const FILESYSTEM_PLUGIN_STATUS_LABELS = {
   restarting: "Restarting",
   error: "Error",
 } as const satisfies Record<FilesystemPluginState["status"], string>;
+
+const MCP_SERVER_STATUS_LABELS = FILESYSTEM_PLUGIN_STATUS_LABELS;
 
 const ARRIVAL_ANIMATION_MS = 1_100;
 
@@ -398,6 +404,121 @@ function FilesystemPluginPanel({
   );
 }
 
+function McpPluginsPanel({
+  state,
+}: {
+  readonly state: DesktopComputerUseState;
+}) {
+  const plugin = state.plugins?.mcp;
+  const [configJson, setConfigJson] = useState("");
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importLoadable, importServers] = useLoadableSet(
+    importMcpPluginServers$,
+  );
+  const [setEnabledLoadable, setServerEnabled] = useLoadableSet(
+    setMcpPluginServerEnabled$,
+  );
+  const [removeLoadable, removeServer] = useLoadableSet(removeMcpPluginServer$);
+
+  if (!plugin?.featureEnabled) {
+    return null;
+  }
+
+  const busy =
+    importLoadable.state === "loading" ||
+    setEnabledLoadable.state === "loading" ||
+    removeLoadable.state === "loading";
+
+  const submitImport = async () => {
+    setImportError(null);
+    try {
+      await importServers(configJson);
+      setConfigJson("");
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  return (
+    <Panel title="MCP servers" icon={<IconPlug size={18} />}>
+      <div className="filesystem-directory-list">
+        {plugin.servers.length === 0 ? (
+          <div className="compact-empty">No MCP servers configured.</div>
+        ) : (
+          plugin.servers.map((server) => {
+            return (
+              <div key={server.name}>
+                <CheckboxRow
+                  title={server.name}
+                  subtitle={`${server.transport === "http" ? "Streamable HTTP" : "stdio"}${
+                    server.status === "running"
+                      ? ` · ${server.tools.length} tools`
+                      : ""
+                  }`}
+                  meta={MCP_SERVER_STATUS_LABELS[server.status]}
+                  checked={server.enabled}
+                  disabled={busy}
+                  onChange={(enabled) => {
+                    void setServerEnabled({ server: server.name, enabled });
+                  }}
+                />
+                {server.lastError && (
+                  <div className="inline-alert inline-alert-error">
+                    <IconAlertCircle size={16} />
+                    <span>{server.lastError}</span>
+                  </div>
+                )}
+                <div className="panel-actions">
+                  <button
+                    type="button"
+                    className="icon-only-button"
+                    aria-label={`Remove ${server.name}`}
+                    title="Remove server"
+                    disabled={busy}
+                    onClick={() => {
+                      void removeServer(server.name);
+                    }}
+                  >
+                    <IconTrash size={15} />
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+      <textarea
+        className="mcp-config-input"
+        placeholder='Paste an "mcpServers" JSON config to add servers'
+        value={configJson}
+        rows={5}
+        spellCheck={false}
+        disabled={busy}
+        onChange={(event) => {
+          setConfigJson(event.target.value);
+        }}
+      />
+      {importError && (
+        <div className="inline-alert inline-alert-error">
+          <IconAlertCircle size={16} />
+          <span>{importError}</span>
+        </div>
+      )}
+      <div className="panel-actions">
+        <IconButton
+          icon={<IconPlug size={15} />}
+          onClick={() => {
+            void submitImport();
+          }}
+          disabled={busy || !configJson.trim()}
+        >
+          Import servers
+        </IconButton>
+      </div>
+    </Panel>
+  );
+}
+
 export function ReadyExperience({
   authState,
   developerToolsEnabled,
@@ -437,6 +558,7 @@ export function ReadyExperience({
       {developerToolsEnabled && (
         <>
           <FilesystemPluginPanel state={state} />
+          <McpPluginsPanel state={state} />
           <RuntimePanel state={state} />
           <CommandLogPanel state={state} />
         </>

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -684,6 +684,21 @@ button {
   overflow-wrap: anywhere;
 }
 
+.mcp-config-input {
+  width: 100%;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 7px;
+  padding: 8px 10px;
+  background: #f8fafc;
+  color: #202631;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 12px;
+  line-height: 1.35;
+  resize: vertical;
+}
+
 .raw-log-details summary {
   color: #3d4a5c;
   font-size: 12px;

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use-plugins.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use-plugins.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 export const COMPUTER_USE_PLUGIN_CALL_KIND = "plugin.call" as const;
 export const COMPUTER_USE_FILESYSTEM_PLUGIN = "filesystem" as const;
+export const COMPUTER_USE_MCP_PLUGIN = "mcp" as const;
+export const COMPUTER_USE_MCP_LIST_TOOLS = "tools/list" as const;
 export const COMPUTER_USE_FILESYSTEM_MCP_PACKAGE =
   "@modelcontextprotocol/server-filesystem" as const;
 export const COMPUTER_USE_FILESYSTEM_MCP_VERSION = "2026.1.14" as const;
@@ -274,6 +276,43 @@ export function isComputerUsePluginCallPayload(
     payload.plugin === COMPUTER_USE_FILESYSTEM_PLUGIN &&
     typeof payload.tool === "string" &&
     isComputerUseFilesystemTool(payload.tool) &&
+    typeof payload.arguments === "object" &&
+    payload.arguments !== null &&
+    !Array.isArray(payload.arguments)
+  );
+}
+
+export const COMPUTER_USE_MCP_SERVER_NAME_PATTERN = /^[a-z0-9_-]{1,64}$/;
+
+export function computerUseMcpServerCapability(server: string): string {
+  return `plugin.${COMPUTER_USE_MCP_PLUGIN}.${server}`;
+}
+
+export interface ComputerUseMcpPluginCallPayload {
+  readonly plugin: typeof COMPUTER_USE_MCP_PLUGIN;
+  readonly server: string;
+  readonly tool: string;
+  readonly arguments: Record<string, unknown>;
+}
+
+export function isComputerUseMcpPluginCallPayload(
+  value: unknown,
+): value is ComputerUseMcpPluginCallPayload {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const payload = value as {
+    readonly plugin?: unknown;
+    readonly server?: unknown;
+    readonly tool?: unknown;
+    readonly arguments?: unknown;
+  };
+  return (
+    payload.plugin === COMPUTER_USE_MCP_PLUGIN &&
+    typeof payload.server === "string" &&
+    COMPUTER_USE_MCP_SERVER_NAME_PATTERN.test(payload.server) &&
+    typeof payload.tool === "string" &&
+    payload.tool.length > 0 &&
     typeof payload.arguments === "object" &&
     payload.arguments !== null &&
     !Array.isArray(payload.arguments)


### PR DESCRIPTION
Implements step 2 of #20694 (custom desktop MCP plugin framework; epic #20687). Builds on the restart lifecycle shipped in #20710.

## What changes

Generalizes the Computer Use desktop plugin system from the single hard-coded filesystem plugin into a **generic MCP plugin relay**: users paste a standard `mcpServers` JSON config into the desktop app's Developer Tools section, and the desktop app acts as a thin MCP client/forwarding wrapper for those servers. Per the design decisions recorded on #20694: arguments pass through verbatim (servers validate against their own inputSchema), enabling a server means trusting it, config lives only in local desktop preferences, and both `stdio` and Streamable HTTP transports are supported (SSE is not).

### Contracts (`@vm0/api-contracts`)
- New `mcp` plugin payload: `{ plugin: "mcp", server, tool, arguments }` with `isComputerUseMcpPluginCallPayload` guard; reserved tool name `tools/list` for live tool discovery
- Server names constrained to `[a-z0-9_-]{1,64}`; host-routing capability `plugin.mcp.<server>` (server-level only — tool lists are dynamic, per Q7 on #20694)

### Desktop
- **`DesktopMcpPluginManager`** (`desktop-mcp-plugin.ts`): per-server lifecycle (enabled ⇒ resident) reusing `PluginRestartPolicy` from #20710 for bounded crash recovery per server; stdio servers spawn as child processes, HTTP servers just connect (no process management); `tools/list` fetches the live tool list on every call; unknown tools re-check live before failing with `unknown_tool`
- **`parseMcpServersJson`**: accepts the community `{"mcpServers": {...}}` format (Claude Desktop / Cursor style) or a bare name→config map; readable errors for invalid JSON, bad names, and entries missing both `command` and `url`; imported servers start disabled and keep the enabled flag on re-import
- **Shared result normalization** (`desktop-plugin-tool-result.ts`): extracted from the filesystem plugin (inline text vs S3-offload thresholds, image/audio/resource handling) and reused by both managers; filesystem keeps its `path_denied` error mapping via an injectable mapper
- **Wiring**: plugin command dispatch by payload shape; `plugin.mcp.<server>` capabilities reported alongside filesystem capabilities; gated by the existing `computerUseDesktopPlugins` feature switch (Q8 — no new switch)
- **Developer Tools UI**: new "MCP servers" panel (renders only when developer tools are enabled, same gating as the filesystem panel) — paste-JSON import with inline validation errors, per-server enable/disable with status (`Disabled/Starting/Ready/Restarting/Error`), transport + tool count, last error, and remove

### Not in this PR (next PR, step 3–4 of #20694)
API route acceptance of `mcp` plugin commands and the `zero computer-use plugin mcp list|call` CLI. Until then the manager is reachable through the desktop command execution path but no cloud entry point emits mcp payloads.

## Tests

- `desktop-mcp-plugin.test.ts`: **real stdio integration** — spawns the actual `@modelcontextprotocol/server-filesystem` package as a generic MCP server, drives the manager end to end (import → enable → running → capabilities → `tools/list` → real `read_text_file` call → unknown tool → unconfigured server → config persistence across manager instances), plus `parseMcpServersJson` validation cases and feature-switch gating; no mocks
- Extended `preload.test.ts` / `desktop-ipc-boundary.test.ts` for the three new IPC channels (routing + untrusted-frame rejection); `App.test.tsx` fixtures updated
- Full desktop suite: 34 files / 300 tests passing locally; `tsc --noEmit`, oxlint, knip, prettier all clean

## Verification

Type-check, lint, knip, format, and the desktop vitest suite run locally (green). Full pipeline via PR CI per repo practice.
