### PR TITLE
refactor: remove chat thread emoji rollout switch

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-keyboard.ts
@@ -1,6 +1,5 @@
 import { command } from "ccstate";
 import { isEditableTarget, matchShortcut } from "@vm0/ui";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   currentLeftThread$,
   currentRightThread$,
@@ -19,7 +18,6 @@ import { CHAT_THREAD_EMOJI_OPTIONS } from "./chat-thread-title.ts";
 import type { ScrollStepDirection } from "../auto-scroll.ts";
 import { onRef } from "../utils.ts";
 import { openChatThreadEmojiMenu$ } from "../zero-page/zero-sidebar-state.ts";
-import { featureSwitch$ } from "../external/feature-switch.ts";
 import {
   currentChatThreadId$,
   currentChatThreadListIds$,
@@ -226,16 +224,13 @@ function setupChatPageGlobalShortcutListener({
 
 const setFocusedThreadEmoji$ = command(
   async (
-    { get, set },
+    { set },
     args: {
       thread: ChatThreadSignals;
       emoji: string;
     },
     signal: AbortSignal,
   ) => {
-    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
-      return;
-    }
     await set(
       setChatThreadEmojiFromThreadMeta$,
       {
@@ -248,14 +243,7 @@ const setFocusedThreadEmoji$ = command(
 );
 
 const clearFocusedThreadEmoji$ = command(
-  async (
-    { get, set },
-    args: { thread: ChatThreadSignals },
-    signal: AbortSignal,
-  ) => {
-    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
-      return;
-    }
+  async ({ set }, args: { thread: ChatThreadSignals }, signal: AbortSignal) => {
     await set(
       clearChatThreadEmojiFromThreadMeta$,
       {
@@ -341,9 +329,6 @@ const openFocusedThreadEmojiMenu$ = command(
     args: { thread: ChatThreadSignals },
     signal: AbortSignal,
   ) => {
-    if (!(get(featureSwitch$)[FeatureSwitchKey.ChatThreadEmoji] ?? false)) {
-      return;
-    }
     const threadMeta = await get(args.thread.threadMeta$);
     signal.throwIfAborted();
     set(openChatThreadEmojiMenu$, {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3353,7 +3353,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -3520,36 +3519,6 @@ describe("chat lifecycle", () => {
     });
   });
 
-  it("hides the chat emoji shortcut when the feature switch is off", async () => {
-    mockResizeObserver();
-    mockKeyboardNavigationThreads();
-
-    detachedSetupPage({
-      context,
-      path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: false },
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Current thread launch note"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getAllByText("Current keyboard thread").length,
-      ).toBeGreaterThan(0);
-    });
-
-    expect(screen.queryByLabelText("Change icon")).not.toBeInTheDocument();
-
-    const threadRegion = screen.getByLabelText("Chat thread");
-    threadRegion.focus();
-    fireEvent.keyDown(threadRegion, { key: "F2", shiftKey: true });
-
-    await waitFor(() => {
-      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-    });
-  });
-
   it("opens the current chat rename dialog with F2", async () => {
     mockResizeObserver();
     mockKeyboardNavigationThreads();
@@ -3557,7 +3526,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -3841,7 +3809,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -3883,7 +3850,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -3925,7 +3891,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708?sidebar=b0000000-0000-4000-a000-000000000709",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -3970,7 +3935,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -4013,7 +3977,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -4053,7 +4016,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -4080,7 +4042,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -4142,7 +4103,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -4186,7 +4146,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {
@@ -4223,7 +4182,6 @@ describe("chat lifecycle", () => {
     detachedSetupPage({
       context,
       path: "/chats/b0000000-0000-4000-a000-000000000708",
-      featureSwitches: { [FeatureSwitchKey.ChatThreadEmoji]: true },
     });
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/chat-shortcut-help-dialog.tsx
@@ -1,7 +1,5 @@
-import { useGet, useLastResolved, useSet } from "ccstate-react";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { useGet, useSet } from "ccstate-react";
 import { activeRoute$ } from "../../signals/active-route.ts";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import type { RouteKey } from "../../signals/route-paths.ts";
 import {
   chatShortcutHelpOpen$,
@@ -79,28 +77,9 @@ const SIDEBAR_SHORTCUT_SECTIONS = [
   },
 ] as const;
 
-function isChatThreadEmojiShortcutKey(key: string): boolean {
-  return key === "shift+f2" || key === "ctrl+shift+1" || key === "ctrl+shift+0";
-}
-
-function shortcutSectionsForRoute(
-  route: RouteKey | null,
-  chatThreadEmojiEnabled: boolean,
-) {
+function shortcutSectionsForRoute(route: RouteKey | null) {
   if (route === "chat") {
-    return chatThreadEmojiEnabled
-      ? CHAT_THREAD_SHORTCUT_SECTIONS
-      : CHAT_THREAD_SHORTCUT_SECTIONS.map((section) => {
-          if (section.title !== "Global") {
-            return section;
-          }
-          return {
-            ...section,
-            shortcuts: section.shortcuts.filter((shortcut) => {
-              return !isChatThreadEmojiShortcutKey(shortcut.key);
-            }),
-          };
-        });
+    return CHAT_THREAD_SHORTCUT_SECTIONS;
   }
   if (route === "agentChat" || route === "home") {
     return AGENT_CHAT_SHORTCUT_SECTIONS;
@@ -112,13 +91,7 @@ export function ChatShortcutHelpDialog() {
   const shortcutHelpOpen = useGet(chatShortcutHelpOpen$);
   const setShortcutHelpOpen = useSet(setChatShortcutHelpOpen$);
   const activeRoute = useGet(activeRoute$);
-  const features = useLastResolved(featureSwitch$);
-  const chatThreadEmojiEnabled =
-    features?.[FeatureSwitchKey.ChatThreadEmoji] ?? false;
-  const shortcutSections = shortcutSectionsForRoute(
-    activeRoute,
-    chatThreadEmojiEnabled,
-  );
+  const shortcutSections = shortcutSectionsForRoute(activeRoute);
 
   return (
     <ShortcutHelpDialog

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -106,9 +106,7 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
 import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { emptyArtifactImg, emptyChatImg } from "./platform-assets.ts";
-import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import type { FirewallPolicyValue } from "@vm0/connectors/firewall-types";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -431,14 +429,10 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const threadMetaLoadable = useLastLoadable(thread.threadMeta$);
   const threadTitleEmoji = useLastResolved(thread.threadTitleEmoji$);
   const threadTitleText = useLastResolved(thread.threadTitleText$) ?? "";
-  const features = useLastResolved(featureSwitch$);
-  const chatThreadEmojiEnabled =
-    features?.[FeatureSwitchKey.ChatThreadEmoji] ?? false;
   const threadTitle =
     threadMetaLoadable.state === "hasData"
       ? (threadMetaLoadable.data?.title?.trim() ?? "")
       : "";
-  const displayTitle = chatThreadEmojiEnabled ? threadTitleText : threadTitle;
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
@@ -447,16 +441,14 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
           <Skeleton className="h-5 w-48 rounded" />
         ) : (
           <>
-            {chatThreadEmojiEnabled && (
-              <ChatThreadEmojiMenuButton
-                threadId={thread.threadId}
-                title={threadTitle}
-                emoji={threadTitleEmoji}
-              />
-            )}
-            {displayTitle && (
+            <ChatThreadEmojiMenuButton
+              threadId={thread.threadId}
+              title={threadTitle}
+              emoji={threadTitleEmoji}
+            />
+            {threadTitleText && (
               <span className="min-w-0 truncate text-sm font-medium text-foreground">
-                {displayTitle}
+                {threadTitleText}
               </span>
             )}
           </>

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -49,7 +49,6 @@ export enum FeatureSwitchKey {
   ComposerUploadPopover = "composerUploadPopover",
 
   ZapierConnector = "zapierConnector",
-  ChatThreadEmoji = "chatThreadEmoji",
   MemoryViewer = "memoryViewer",
   RelationshipMemory = "relationshipMemory",
   RelationshipMemoryRuntimeInjection = "relationshipMemoryRuntimeInjection",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -131,7 +131,6 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
       false,
     );
-    expect(staffOrgStates[FeatureSwitchKey.ChatThreadEmoji]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.RelationshipMemory]).toBe(true);
     expect(
       staffOrgStates[FeatureSwitchKey.RelationshipMemoryRuntimeInjection],
@@ -161,7 +160,6 @@ describe("getAllFeatureStates", () => {
     expect(otherOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
       false,
     );
-    expect(otherOrgStates[FeatureSwitchKey.ChatThreadEmoji]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.RelationshipMemory]).toBe(false);
     expect(
       otherOrgStates[FeatureSwitchKey.RelationshipMemoryRuntimeInjection],
@@ -187,13 +185,6 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.AhrefsConnector]).toBe(true);
     // Non-overridden disabled feature stays false
     expect(states[FeatureSwitchKey.DropboxConnector]).toBe(false);
-  });
-
-  it("should enable chat thread emoji globally", () => {
-    const states = getAllFeatureStates({
-      orgId: "org_nonexistent",
-    });
-    expect(states[FeatureSwitchKey.ChatThreadEmoji]).toBe(true);
   });
 
   it("should apply overrides to disable enabled features", () => {

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -285,12 +285,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Enable the Zapier connector. When disabled, Zapier is hidden from the connectors list and cannot be connected.",
     enabled: false,
   },
-  [FeatureSwitchKey.ChatThreadEmoji]: {
-    maintainer: "ethan@vm0.ai",
-    description:
-      "Show the chat thread emoji icon in chat headers and enable the Shift+F2 emoji picker shortcut.",
-    enabled: true,
-  },
   [FeatureSwitchKey.MemoryViewer]: {
     maintainer: "lancy@vm0.ai",
     description:


### PR DESCRIPTION
## Summary
- Remove the retired `ChatThreadEmoji` feature switch key and registry entry now that the chat thread emoji feature is fully rolled out.
- Make the chat header emoji control, shortcut help entries, and emoji keyboard handlers run unconditionally.
- Delete switch-off coverage and remove obsolete test feature-switch overrides from emoji lifecycle tests.

## Verification
- `pnpm -F @vm0/core test src/__tests__/feature-switch.test.ts`
- `pnpm -F @vm0/core check-types`
- `pnpm -F @vm0/connectors check-types`
- `pnpm -F @vm0/core lint`
- `pnpm -F @vm0/connectors lint`
- `pnpm -F @vm0/app exec tsc -p tsconfig.production.json --noEmit --pretty false`
- `pnpm -F @vm0/app exec tsc -p tsconfig.tests.json --noEmit --pretty false`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app test src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "emoji|icon|keyboard shortcuts|rename dialog"`
- `pnpm -F @vm0/app test src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "sends a recommended follow-up from the latest assistant reply|opens run logs from assistant message actions|emoji|icon|keyboard shortcuts|rename dialog"`