### PR TITLE
feat: add videos filter to artifacts page

### DIFF
--- a/turbo/apps/platform/src/signals/artifacts-page/artifact-category.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifact-category.ts
@@ -2,6 +2,7 @@ import type { ArtifactItem } from "@vm0/api-contracts/contracts/chat-threads";
 
 export type ArtifactCategory =
   | "image"
+  | "video"
   | "website"
   | "presentation"
   | "document"
@@ -18,6 +19,13 @@ function filenameMatches(filename: string, pattern: RegExp): boolean {
 
 function isImageArtifact(item: ArtifactItem): boolean {
   return normalizedContentType(item.contentType).startsWith("image/");
+}
+
+function isVideoArtifact(item: ArtifactItem): boolean {
+  return (
+    normalizedContentType(item.contentType).startsWith("video/") ||
+    filenameMatches(item.filename, /\.(mp4|webm|mov|ogv)$/)
+  );
 }
 
 function isWebsiteArtifact(item: ArtifactItem): boolean {
@@ -85,6 +93,10 @@ export function artifactMatchesCategory(
     return isImageArtifact(item);
   }
 
+  if (category === "video") {
+    return isVideoArtifact(item);
+  }
+
   if (category === "website") {
     return isWebsiteArtifact(item);
   }
@@ -103,6 +115,7 @@ export function artifactMatchesCategory(
 
   return (
     !isImageArtifact(item) &&
+    !isVideoArtifact(item) &&
     !isWebsiteArtifact(item) &&
     !isPresentationArtifact(item) &&
     !isDocumentArtifact(item) &&

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -519,6 +519,22 @@ describe("artifacts page", () => {
             artifactKind: undefined,
           }),
           createArtifact({
+            artifactItemId: "run-video:file-1",
+            runId: "run-video",
+            fileId: "file-video",
+            filename: "launch-video.mp4",
+            contentType: "video/mp4",
+            artifactKind: undefined,
+          }),
+          createArtifact({
+            artifactItemId: "run-archive:file-1",
+            runId: "run-archive",
+            fileId: "file-archive",
+            filename: "launch-assets.zip",
+            contentType: "application/zip",
+            artifactKind: undefined,
+          }),
+          createArtifact({
             artifactItemId: "run-brief:file-1",
             runId: "run-brief",
             fileId: "file-brief",
@@ -535,13 +551,35 @@ describe("artifacts page", () => {
 
     await screen.findByText("launch-plan.html");
     await screen.findByText("launch-image.png");
+    await screen.findByText("launch-video.mp4");
+    await screen.findByText("launch-assets.zip");
     await screen.findByText("research-brief.html");
 
     click(buttonByLabel("Show image artifacts"));
     await waitFor(() => {
       expect(screen.queryByText("launch-plan.html")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-video.mp4")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-assets.zip")).not.toBeInTheDocument();
       expect(screen.queryByText("research-brief.html")).not.toBeInTheDocument();
       expect(screen.getByText("launch-image.png")).toBeInTheDocument();
+    });
+
+    click(buttonByLabel("Show video artifacts"));
+    await waitFor(() => {
+      expect(screen.queryByText("launch-plan.html")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-image.png")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-assets.zip")).not.toBeInTheDocument();
+      expect(screen.queryByText("research-brief.html")).not.toBeInTheDocument();
+      expect(screen.getByText("launch-video.mp4")).toBeInTheDocument();
+    });
+
+    click(buttonByLabel("Show other artifacts"));
+    await waitFor(() => {
+      expect(screen.queryByText("launch-plan.html")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-image.png")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-video.mp4")).not.toBeInTheDocument();
+      expect(screen.queryByText("research-brief.html")).not.toBeInTheDocument();
+      expect(screen.getByText("launch-assets.zip")).toBeInTheDocument();
     });
 
     click(buttonByLabel("Show all artifacts"));
@@ -550,6 +588,8 @@ describe("artifacts page", () => {
       expect(screen.getByText("research-brief.html")).toBeInTheDocument();
       expect(screen.queryByText("launch-plan.html")).not.toBeInTheDocument();
       expect(screen.queryByText("launch-image.png")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-video.mp4")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-assets.zip")).not.toBeInTheDocument();
     });
 
     await fill(screen.getByLabelText("Search artifacts"), "");
@@ -559,6 +599,8 @@ describe("artifacts page", () => {
       expect(screen.getByText("research-brief.html")).toBeInTheDocument();
       expect(screen.queryByText("launch-plan.html")).not.toBeInTheDocument();
       expect(screen.queryByText("launch-image.png")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-video.mp4")).not.toBeInTheDocument();
+      expect(screen.queryByText("launch-assets.zip")).not.toBeInTheDocument();
     });
 
     // All filtering was client-side: the bulk endpoint was hit once.

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -55,6 +55,7 @@ const ARTIFACT_CATEGORY_OPTIONS: readonly {
 }[] = [
   { ariaLabel: "Show all artifacts", label: "All", value: null },
   { ariaLabel: "Show image artifacts", label: "Images", value: "image" },
+  { ariaLabel: "Show video artifacts", label: "Videos", value: "video" },
   { ariaLabel: "Show website artifacts", label: "Websites", value: "website" },
   {
     ariaLabel: "Show presentation artifacts",


### PR DESCRIPTION
## Summary
- Add a Videos category chip to the Artifacts page filters.
- Classify video artifacts from `video/*` content types and common video file extensions so they no longer fall into Other.
- Extend the Artifacts page test to cover the Videos filter and verify Other excludes videos.

## Verification
- `pnpm exec prettier --check apps/platform/src/signals/artifacts-page/artifact-category.ts apps/platform/src/views/artifacts-page/artifacts-page.tsx apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx`
- `pnpm exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx`
- `pnpm exec oxlint src/signals/artifacts-page/artifact-category.ts src/views/artifacts-page/artifacts-page.tsx src/views/artifacts-page/__tests__/artifacts-page.test.tsx`
- `pnpm exec eslint src/signals/artifacts-page/artifact-category.ts src/views/artifacts-page/artifacts-page.tsx src/views/artifacts-page/__tests__/artifacts-page.test.tsx --max-warnings 0`
- `git diff --check`
- `pnpm --filter @vm0/app check-types`

Did not run the full local Vitest suite or start a local dev server, per vm0 PR verification preference.
