### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -111,14 +111,14 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.204"
+CLAUDE_CODE_VERSION="2.1.205"
 CODEX_CLI_VERSION="0.143.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"
 AGENT_BROWSER_VERSION="0.31.1"
 PNPM_VERSION="11.10.0"
-CHROMIUM_VERSION="149.0.7827.196-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260626T014759Z"
+CHROMIUM_VERSION="150.0.7871.100-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260709T001500Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks
@@ -372,7 +372,7 @@ install_packages() {
 
   # Chromium from Debian Bookworm security (Ubuntu 24.04 snap stub does not work).
   # Installed separately to avoid cross-distro dependency conflicts.
-  # Pin to 149 until Debian #1141488 is fixed in the Bookworm security package.
+  # Pin to a Debian security snapshot for reproducible Chromium packages.
   sudo chroot "$ROOTFS_DIR" env \
     CHROMIUM_VERSION="$CHROMIUM_VERSION" \
     CHROMIUM_SECURITY_SNAPSHOT_URL="$CHROMIUM_SECURITY_SNAPSHOT_URL" \

--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -118,7 +118,7 @@ XURL_VERSION="1.2.2"
 AGENT_BROWSER_VERSION="0.31.1"
 PNPM_VERSION="11.10.0"
 CHROMIUM_VERSION="150.0.7871.100-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260709T001500Z"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260709T060000Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary
- Updated Claude Code CLI from `2.1.204` to `2.1.205` in `crates/runner/scripts/build-template.sh`.
- Updated Debian Chromium from `149.0.7827.196-1~deb12u1` to `150.0.7871.100-1~deb12u1`.
- Updated the Chromium Debian security snapshot from `20260626T014759Z` to `20260709T001500Z` and refreshed the obsolete bug-specific comment.

## Verification
- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- `shellcheck crates/runner/scripts/build-template.sh` was not run because `shellcheck` is not installed in this environment.

## Notes
- Checked Go, Codex CLI, Google Workspace CLI, xurl, agent-browser, pnpm, Node.js 24 LTS, and PostgreSQL 18; no other stable/LTS updates were found.
- Debian #1141488 is fixed in Chromium `150.0.7871.100-1`, and the selected Bookworm security snapshot contains matching `chromium`, `chromium-common`, and `chromium-sandbox` packages.
