### PR TITLE
fix: exempt external webhooks from preview automation bypass guard

### DIFF
--- a/turbo/apps/api/src/__tests__/app-factory.test.ts
+++ b/turbo/apps/api/src/__tests__/app-factory.test.ts
@@ -628,6 +628,30 @@ describe("createApp", () => {
 
       expect(response.status).toBe(200);
     });
+
+    it("exempts external webhook paths from the guard without the bypass secret", async () => {
+      mockEnv("ENV", "preview");
+      mockEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret");
+      const app = createApp({ signal: context.signal });
+
+      // A non-webhook path is still rejected by the guard before route matching.
+      const guarded = await app.request("/api/legacy/fallthrough", {
+        method: "GET",
+      });
+      expect(guarded.status).toBe(403);
+
+      // Stripe (and every other) webhook is exempt, so the request reaches
+      // routing instead of the guard. GET does not match the POST-only handler,
+      // yielding a normal 404 rather than a bypass rejection — proof the
+      // server-to-server webhook would have reached its handler.
+      const webhook = await app.request("/api/webhooks/stripe", {
+        method: "GET",
+      });
+      expect(webhook.status).toBe(404);
+      await expect(webhook.json()).resolves.toStrictEqual({
+        error: "Not found",
+      });
+    });
   });
 
   describe("cors", () => {

--- a/turbo/apps/api/src/app-factory-core.ts
+++ b/turbo/apps/api/src/app-factory-core.ts
@@ -362,6 +362,18 @@ function isCorsPreflightRequest(context: Context): boolean {
   );
 }
 
+// External server-to-server webhook callers cannot present the Vercel bypass
+// secret, so the preview automation guard must let their paths through even on
+// protected preview/staging deployments. This covers every third-party and
+// runner webhook (Stripe/Clerk/GitHub/... and `/api/webhooks/agent/*`). Each of
+// these endpoints authenticates its own requests (webhook signatures, runner
+// auth tokens), so exempting them from the preview guard does not widen access.
+// Browser-driven OAuth callbacks are intentionally excluded: they carry the
+// bypass cookie and stay behind the guard.
+function isPreviewAutomationBypassExemptPath(context: Context): boolean {
+  return context.req.path.startsWith("/api/webhooks/");
+}
+
 function bypassFingerprint(value: string | undefined): string | undefined {
   if (!value) {
     return undefined;
@@ -400,6 +412,7 @@ async function previewAutomationBypassMiddleware(
   if (
     !secret ||
     isCorsPreflightRequest(context) ||
+    isPreviewAutomationBypassExemptPath(context) ||
     requestHasPreviewAutomationBypass(context, secret)
   ) {
     await next();


### PR DESCRIPTION
## Problem

The `previewAutomationBypassMiddleware` added in #20640 is mounted globally (`app.use("*", …)`) and returns **403 `Preview automation bypass required`** for any request to a preview/staging API deployment (`ENV=preview` + `VERCEL_AUTOMATION_BYPASS_SECRET` set) that does not carry the Vercel bypass secret via header, query, or cookie.

External **server-to-server webhooks cannot present that secret**, so they have been 403'd on every preview/staging deploy since the guard shipped:

- `/api/webhooks/stripe`, `/clerk`, `/github`, `/gmail`, `/google-calendar`, `/google-workspace-events`, `/notion`, `/workflow-triggers`, `/built-in-generations/*`
- runner callbacks under `/api/webhooks/agent/*`

### User-visible impact (verified)

This broke the **paid-onboarding** flow on staging. Stripe's Dashboard-configured webhook to `staging-api.vm6.ai/api/webhooks/stripe` was rejected at the guard → `checkout.session.completed` never processed → the org was never upgraded to Pro → the onboarding SPA hung on its loading skeleton (`Almost there...`) and never handed off to the app.

The `cli-e2e-02-playwright` job reflects exactly this: **last green 2026-07-08 10:48 UTC, failing on every run since 11:18 UTC** (13+ consecutive failures), timing out in `waitForPaidOnboardingAppHandoff` after 180s. The non-paid `cli-e2e-02-browser` job stayed green because all its requests come from the Playwright browser, which injects the bypass header.

Probing staging confirmed the root cause is application-level, not Vercel Deployment Protection:

```
POST https://staging-api.vm6.ai/api/webhooks/stripe
-> 403 {"error":"Preview automation bypass required","debug":{"expected":"63caf3369d87","cookieHeaderPresent":false}}
```

## Fix

Exempt the `/api/webhooks/*` prefix from the guard, alongside the existing CORS-preflight exemption. Every webhook endpoint already authenticates its own requests (Stripe/Clerk/svix signatures, runner auth tokens), so skipping the preview guard for these paths does not widen access.

Browser-driven OAuth/connector callbacks are intentionally **left behind the guard** — they are reached via browser redirects that carry the bypass cookie (persisted in #20715), so they do not need an exemption.

## Verification

- Added an integration test in `app-factory.test.ts`: in preview mode without the bypass secret, a non-webhook path still returns `403`, while `GET /api/webhooks/stripe` passes the guard and reaches routing (`404`, since the handler is POST-only) — proving the exemption.
- Relying on the PR pipeline for full lint/type/test per project workflow.