### PR TITLE
feat: mcp plugin command routing and zero computer-use plugin mcp cli

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/computer-use.bdd.test.ts
@@ -992,6 +992,69 @@ describe("FILE-03 desktop computer-use runtime", () => {
     });
   });
 
+  it("routes mcp plugin commands by server capability and passes arguments through", async () => {
+    const actor = bdd.user();
+    await enableComputerUseDesktopPlugins(actor);
+
+    const invalidName = await api.requestCreateComputerUsePluginCommand(
+      actor,
+      {
+        plugin: "mcp",
+        server: "Bad Name!",
+        tool: "create_note",
+        arguments: {},
+      },
+      [400],
+    );
+    expectApiError(invalidName.body);
+
+    const notesHost = await api.startComputerUseHost(actor, {
+      supportedCapabilities: ["plugin.call", "plugin.mcp.notes"],
+    });
+
+    const unsupported = await api.requestCreateComputerUsePluginCommand(
+      actor,
+      {
+        plugin: "mcp",
+        server: "figma",
+        tool: "get_selection",
+        arguments: {},
+      },
+      [409],
+    );
+    expectApiError(unsupported.body);
+    expect(unsupported.body.error.message).toBe(
+      "No online computer-use host supports this plugin tool",
+    );
+
+    const created = await api.createComputerUsePluginCommand(actor, {
+      plugin: "mcp",
+      server: "notes",
+      tool: "create_note",
+      arguments: { title: "hello", nested: { tags: ["a", "b"] } },
+    });
+
+    const claimed = await api.claimNextComputerUseCommand(notesHost.hostToken, [
+      "plugin.call",
+      "plugin.mcp.notes",
+    ]);
+    expect(claimed.status).toBe("command");
+    if (claimed.status !== "command") {
+      throw new Error("Expected notes host to claim the mcp plugin command");
+    }
+    expect(claimed.command).toMatchObject({
+      id: created.commandId,
+      hostId: notesHost.hostId,
+      kind: "plugin.call",
+      payload: {
+        plugin: "mcp",
+        server: "notes",
+        tool: "create_note",
+        arguments: { title: "hello", nested: { tags: ["a", "b"] } },
+      },
+    });
+  });
+
   it("offloads filesystem plugin content and records metadata-only audit", async () => {
     const fake = api.installComputerUseS3Fake();
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-computer-use.ts
@@ -23,7 +23,7 @@ import {
   type ComputerUseReadCommandKind,
   type ComputerUseWriteCommandKind,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
-import type { ComputerUsePluginCallBody } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
+import type { ComputerUseAnyPluginCallBody } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
 
 import { now } from "../../../../lib/time";
 import {
@@ -72,12 +72,12 @@ interface ComputerUseWriteCommandBody {
   readonly clickCount?: number;
 }
 
-type ComputerUsePluginCommandBody = Omit<
-  ComputerUsePluginCallBody,
-  "timeoutMs"
-> & {
-  readonly timeoutMs?: number;
-};
+type OptionalTimeout<Body> = Body extends unknown
+  ? Omit<Body, "timeoutMs"> & { readonly timeoutMs?: number }
+  : never;
+
+type ComputerUsePluginCommandBody =
+  OptionalTimeout<ComputerUseAnyPluginCallBody>;
 
 type ComputerUseCompleteBody =
   | {

--- a/turbo/apps/api/src/signals/routes/zero-computer-use.ts
+++ b/turbo/apps/api/src/signals/routes/zero-computer-use.ts
@@ -8,7 +8,10 @@ import {
   zeroComputerUsePluginCommandContract,
   zeroComputerUseWriteCommandContract,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
-import { COMPUTER_USE_PLUGIN_CALL_KIND } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
+import {
+  COMPUTER_USE_MCP_PLUGIN,
+  COMPUTER_USE_PLUGIN_CALL_KIND,
+} from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/core/feature-switch-key";
 
@@ -345,11 +348,19 @@ const pluginCommandCreateInner$ = command(
         orgId: auth.orgId,
         userId: auth.userId,
         kind: COMPUTER_USE_PLUGIN_CALL_KIND,
-        payload: {
-          plugin: bodyResult.data.plugin,
-          tool: bodyResult.data.tool,
-          arguments: bodyResult.data.arguments,
-        },
+        payload:
+          bodyResult.data.plugin === COMPUTER_USE_MCP_PLUGIN
+            ? {
+                plugin: bodyResult.data.plugin,
+                server: bodyResult.data.server,
+                tool: bodyResult.data.tool,
+                arguments: bodyResult.data.arguments,
+              }
+            : {
+                plugin: bodyResult.data.plugin,
+                tool: bodyResult.data.tool,
+                arguments: bodyResult.data.arguments,
+              },
         timeoutMs: bodyResult.data.timeoutMs,
         ...(auth.tokenType === "zero"
           ? { runId: auth.runId, targetHostId }

--- a/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-computer-use.service.ts
@@ -35,7 +35,9 @@ import {
   COMPUTER_USE_PLUGIN_RESULT_BLOB_MAX_BYTES,
   COMPUTER_USE_PLUGIN_RESULT_INLINE_TEXT_MAX_BYTES,
   computerUseFilesystemToolIsDestructive,
+  computerUseMcpPluginCallRequiredCapabilities,
   computerUsePluginCallRequiredCapabilities,
+  isComputerUseMcpPluginCallPayload,
   isComputerUsePluginCallPayload,
 } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
 import {
@@ -116,6 +118,7 @@ interface ComputerUseCommandPayload {
   readonly key?: string;
   readonly action?: string;
   readonly plugin?: string;
+  readonly server?: string;
   readonly tool?: string;
   readonly arguments?: Record<string, unknown>;
 }
@@ -317,6 +320,11 @@ function commandRequiredCapabilities(params: {
   readonly payload: Record<string, unknown>;
 }): readonly string[] {
   if (params.kind === COMPUTER_USE_PLUGIN_CALL_KIND) {
+    if (isComputerUseMcpPluginCallPayload(params.payload)) {
+      return computerUseMcpPluginCallRequiredCapabilities(
+        params.payload.server,
+      );
+    }
     if (!isComputerUsePluginCallPayload(params.payload)) {
       return [COMPUTER_USE_PLUGIN_CALL_KIND];
     }
@@ -396,6 +404,9 @@ function commandPayload(
   }
   if (params.plugin) {
     payload.plugin = params.plugin.trim();
+  }
+  if (params.server) {
+    payload.server = params.server.trim();
   }
   if (params.tool) {
     payload.tool = params.tool.trim();

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -670,6 +670,173 @@ describe("computer-use command visibility", () => {
     expect(output).toContain('"summary": "Typed text"');
   });
 
+  it("should call an mcp plugin tool with json arguments", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    let createBody: unknown;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/zero/computer-use/plugin-commands",
+        async ({ request }) => {
+          createBody = await request.json();
+          return HttpResponse.json({ commandId: "cmd_mcp", status: "queued" });
+        },
+      ),
+      http.get(
+        "http://localhost:3000/api/zero/computer-use/commands/cmd_mcp",
+        () => {
+          return HttpResponse.json({
+            id: "cmd_mcp",
+            kind: "plugin.call",
+            status: "succeeded",
+            hostId: "host_1",
+            hostName: "Desktop",
+            payload: { plugin: "mcp", server: "notes", tool: "create_note" },
+            result: {
+              plugin: "mcp",
+              server: "notes",
+              tool: "create_note",
+              content: "Created note hello",
+              sizeBytes: 18,
+              truncated: false,
+            },
+            timeoutMs: 10_000,
+            createdAt: "2026-05-21T10:00:00.000Z",
+            claimedAt: "2026-05-21T10:00:01.000Z",
+            completedAt: "2026-05-21T10:00:02.000Z",
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "plugin",
+      "mcp",
+      "call",
+      "notes",
+      "create_note",
+      "--args",
+      '{"title":"hello"}',
+      "--timeout",
+      "10",
+    ]);
+
+    expect(createBody).toMatchObject({
+      plugin: "mcp",
+      server: "notes",
+      tool: "create_note",
+      arguments: { title: "hello" },
+      timeoutMs: 10_000,
+    });
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Created note hello");
+  });
+
+  it("should list a server's mcp tools via the reserved tools/list call", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    let createBody: unknown;
+    server.use(
+      http.post(
+        "http://localhost:3000/api/zero/computer-use/plugin-commands",
+        async ({ request }) => {
+          createBody = await request.json();
+          return HttpResponse.json({ commandId: "cmd_list", status: "queued" });
+        },
+      ),
+      http.get(
+        "http://localhost:3000/api/zero/computer-use/commands/cmd_list",
+        () => {
+          return HttpResponse.json({
+            id: "cmd_list",
+            kind: "plugin.call",
+            status: "succeeded",
+            hostId: "host_1",
+            hostName: "Desktop",
+            payload: { plugin: "mcp", server: "notes", tool: "tools/list" },
+            result: {
+              plugin: "mcp",
+              server: "notes",
+              tool: "tools/list",
+              content: '{"server":"notes","tools":[{"name":"create_note"}]}',
+              sizeBytes: 51,
+              truncated: false,
+            },
+            timeoutMs: 10_000,
+            createdAt: "2026-05-21T10:00:00.000Z",
+            claimedAt: "2026-05-21T10:00:01.000Z",
+            completedAt: "2026-05-21T10:00:02.000Z",
+          });
+        },
+      ),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "plugin",
+      "mcp",
+      "list",
+      "notes",
+      "--timeout",
+      "10",
+    ]);
+
+    expect(createBody).toMatchObject({
+      plugin: "mcp",
+      server: "notes",
+      tool: "tools/list",
+      arguments: {},
+    });
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("create_note");
+  });
+
+  it("should list mcp servers reported by linked hosts", async () => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    server.use(
+      http.get("http://localhost:3000/api/zero/computer-use/hosts", () => {
+        return HttpResponse.json({
+          hosts: [
+            {
+              id: "host_1",
+              displayName: "Lancy's Mac",
+              appVersion: "1.0.0",
+              osVersion: "macOS 15",
+              supportedCapabilities: [
+                "plugin.call",
+                "plugin.mcp.notes",
+                "plugin.mcp.figma",
+                "plugin.filesystem",
+              ],
+              permissions: { accessibility: true, screenRecording: true },
+              status: "online",
+              lastSeenAt: "2026-05-21T10:00:00.000Z",
+              createdAt: "2026-05-21T10:00:00.000Z",
+            },
+          ],
+        });
+      }),
+    );
+
+    await zeroComputerUseCommand.parseAsync([
+      "node",
+      "cli",
+      "plugin",
+      "mcp",
+      "list",
+    ]);
+
+    const output = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(output).toContain("Lancy's Mac (online): notes, figma");
+  });
+
   it("should download pointer-backed screenshots through the API proxy", async () => {
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Command } from "commander";
 import type {
@@ -7,12 +8,16 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-computer-use";
 import {
   COMPUTER_USE_FILESYSTEM_PLUGIN,
+  COMPUTER_USE_MCP_LIST_TOOLS,
+  COMPUTER_USE_MCP_PLUGIN,
+  type ComputerUseMcpPluginCallBody,
   type ComputerUseFilesystemTool,
   type ComputerUsePluginCallBody,
 } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
 import {
   ApiRequestError,
   createComputerUsePluginCommand,
+  listComputerUseHosts,
   createComputerUseReadCommand,
   createComputerUseWriteCommand,
   fetchComputerUsePluginContent,
@@ -1168,11 +1173,142 @@ const filesystemPluginCommand = new Command()
   .addCommand(filesystemSearchFilesCommand)
   .addCommand(filesystemGetFileInfoCommand);
 
+const MCP_SERVER_CAPABILITY_PREFIX = `plugin.${COMPUTER_USE_MCP_PLUGIN}.`;
+
+interface ComputerUseMcpCallOptions extends ComputerUseCommandOptions {
+  readonly args?: string;
+  readonly argsFile?: string;
+}
+
+function parseMcpToolArguments(
+  options: ComputerUseMcpCallOptions,
+): Record<string, unknown> {
+  if (options.args && options.argsFile) {
+    throw new Error("Pass either --args or --args-file, not both");
+  }
+  if (options.argsFile) {
+    return parseArgumentsJson(readFileSync(options.argsFile, "utf8"));
+  }
+  return parseArgumentsJson(options.args);
+}
+
+async function runMcpPluginCommand(
+  server: string,
+  tool: string,
+  options: ComputerUseCommandOptions,
+  args: Record<string, unknown>,
+): Promise<void> {
+  const timeoutSeconds = parseTimeoutSeconds(options.timeout);
+  const body: ComputerUseMcpPluginCallBody = {
+    plugin: COMPUTER_USE_MCP_PLUGIN,
+    server,
+    tool,
+    arguments: args,
+    timeoutMs: timeoutSeconds * 1000,
+  };
+  try {
+    const created = await createComputerUsePluginCommand(body);
+    await waitForCommand(
+      created.commandId,
+      timeoutSeconds,
+      pluginCommandOutputText,
+    );
+  } catch (error) {
+    throwComputerUseAuthorizationGuidanceError(error);
+  }
+}
+
+async function printMcpServers(): Promise<void> {
+  const hosts = await listComputerUseHosts().catch((error: unknown) => {
+    throwComputerUseAuthorizationGuidanceError(error);
+  });
+  const lines: string[] = [];
+  for (const host of hosts) {
+    const servers = host.supportedCapabilities
+      .filter((capability) => {
+        return capability.startsWith(MCP_SERVER_CAPABILITY_PREFIX);
+      })
+      .map((capability) => {
+        return capability.slice(MCP_SERVER_CAPABILITY_PREFIX.length);
+      });
+    if (servers.length === 0) {
+      continue;
+    }
+    lines.push(`${host.displayName} (${host.status}): ${servers.join(", ")}`);
+  }
+  if (lines.length === 0) {
+    console.log(
+      "No MCP servers are running on any linked host. Configure and enable them in the Zero Desktop app's Developer Tools section.",
+    );
+    return;
+  }
+  console.log(lines.join("\n"));
+}
+
+const mcpListCommand = new Command()
+  .name("list")
+  .description(
+    "List MCP servers on linked hosts, or a server's tools and schemas",
+  )
+  .argument("[server]", "MCP server name; omit to list available servers")
+  .action(
+    withErrorHandler(
+      async (
+        server: string | undefined,
+        _options: Record<string, never>,
+        command: Command,
+      ) => {
+        if (!server) {
+          await printMcpServers();
+          return;
+        }
+        await runMcpPluginCommand(
+          server,
+          COMPUTER_USE_MCP_LIST_TOOLS,
+          command.optsWithGlobals<ComputerUseCommandOptions>(),
+          {},
+        );
+      },
+    ),
+  );
+
+const mcpCallCommand = new Command()
+  .name("call")
+  .description("Call a tool on a configured MCP server")
+  .argument("<server>", "MCP server name (see: plugin mcp list)")
+  .argument("<tool>", "Tool name (see: plugin mcp list <server>)")
+  .option("--args <json>", "Tool arguments as a JSON object")
+  .option("--args-file <path>", "Read tool arguments JSON from a file")
+  .action(
+    withErrorHandler(
+      async (
+        server: string,
+        tool: string,
+        options: ComputerUseMcpCallOptions,
+        command: Command,
+      ) => {
+        await runMcpPluginCommand(
+          server,
+          tool,
+          command.optsWithGlobals<ComputerUseCommandOptions>(),
+          parseMcpToolArguments(options),
+        );
+      },
+    ),
+  );
+
+const mcpPluginCommand = new Command()
+  .name("mcp")
+  .description("Use custom MCP servers configured in the Zero Desktop app")
+  .addCommand(mcpListCommand)
+  .addCommand(mcpCallCommand);
+
 const pluginCommand = addTargetOptions(
   new Command()
     .name("plugin")
     .description("Use Desktop Computer Use plugins")
-    .addCommand(filesystemPluginCommand),
+    .addCommand(filesystemPluginCommand)
+    .addCommand(mcpPluginCommand),
 );
 
 export const zeroComputerUseCommand = new Command()

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -3,13 +3,15 @@ import type {
   ComputerUseAuthorizationRequestCreateResponse,
   ComputerUseCommandCreateResponse,
   ComputerUseCommandResponse,
+  ComputerUseHost,
   ComputerUseReadCommandKind,
   ComputerUseWriteCommandKind,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
-import type { ComputerUsePluginCallBody } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
+import type { ComputerUseAnyPluginCallBody } from "@vm0/api-contracts/contracts/zero-computer-use-plugins";
 import {
   zeroComputerUseAuthorizationRequestsContract,
   zeroComputerUseCommandContract,
+  zeroComputerUseHostsContract,
   zeroComputerUsePluginCommandContract,
   zeroComputerUseWriteCommandContract,
 } from "@vm0/api-contracts/contracts/zero-computer-use";
@@ -144,7 +146,7 @@ export async function createComputerUseWriteCommand(
 }
 
 export async function createComputerUsePluginCommand(
-  params: ComputerUsePluginCallBody,
+  params: ComputerUseAnyPluginCallBody,
 ): Promise<ComputerUseCommandCreateResponse> {
   const config = await getComputerUseClientConfig();
   const client = initClient(zeroComputerUsePluginCommandContract, config);
@@ -155,6 +157,20 @@ export async function createComputerUsePluginCommand(
   }
 
   handleError(result, "Failed to create computer-use plugin command");
+}
+
+export async function listComputerUseHosts(): Promise<
+  readonly ComputerUseHost[]
+> {
+  const config = await getComputerUseClientConfig();
+  const client = initClient(zeroComputerUseHostsContract, config);
+  const result = await client.list({});
+
+  if (result.status === 200) {
+    return result.body.hosts;
+  }
+
+  handleError(result, "Failed to list computer-use hosts");
 }
 
 export async function getComputerUseCommand(

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -231,6 +231,7 @@ export {
 export {
   createComputerUseAuthorizationRequest,
   createComputerUsePluginCommand,
+  listComputerUseHosts,
   createComputerUseReadCommand,
   createComputerUseWriteCommand,
   fetchComputerUsePluginContent,

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use-plugins.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use-plugins.ts
@@ -288,6 +288,41 @@ export function computerUseMcpServerCapability(server: string): string {
   return `plugin.${COMPUTER_USE_MCP_PLUGIN}.${server}`;
 }
 
+export const computerUseMcpPluginCallBodySchema = z.object({
+  plugin: z.literal(COMPUTER_USE_MCP_PLUGIN),
+  server: z
+    .string()
+    .regex(
+      COMPUTER_USE_MCP_SERVER_NAME_PATTERN,
+      "MCP server names must match [a-z0-9_-]{1,64}",
+    ),
+  tool: z.string().trim().min(1).max(256),
+  arguments: z.record(z.string(), z.unknown()).default({}),
+  timeoutMs: z.number().int().min(1_000).max(120_000).default(60_000),
+});
+
+export type ComputerUseMcpPluginCallBody = z.infer<
+  typeof computerUseMcpPluginCallBodySchema
+>;
+
+export const computerUseAnyPluginCallBodySchema = z.union([
+  computerUsePluginCallBodySchema,
+  computerUseMcpPluginCallBodySchema,
+]);
+
+export type ComputerUseAnyPluginCallBody = z.infer<
+  typeof computerUseAnyPluginCallBodySchema
+>;
+
+export function computerUseMcpPluginCallRequiredCapabilities(
+  server: string,
+): readonly string[] {
+  return [
+    COMPUTER_USE_PLUGIN_CALL_KIND,
+    computerUseMcpServerCapability(server),
+  ];
+}
+
 export interface ComputerUseMcpPluginCallPayload {
   readonly plugin: typeof COMPUTER_USE_MCP_PLUGIN;
   readonly server: string;

--- a/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-computer-use.ts
@@ -3,7 +3,7 @@ import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
 import {
   COMPUTER_USE_PLUGIN_CALL_KIND,
-  computerUsePluginCallBodySchema,
+  computerUseAnyPluginCallBodySchema,
 } from "./zero-computer-use-plugins";
 
 const c = initContract();
@@ -748,7 +748,7 @@ export const zeroComputerUsePluginCommandContract = c.router({
     method: "POST",
     path: "/api/zero/computer-use/plugin-commands",
     headers: authHeadersSchema,
-    body: computerUsePluginCallBodySchema,
+    body: computerUseAnyPluginCallBodySchema,
     responses: {
       200: computerUseCommandCreateResponseSchema,
       400: apiErrorSchema,


### PR DESCRIPTION
Implements steps 3–4 of #20694 (custom desktop MCP plugin framework; epic #20687). Completes the end-to-end path on top of the desktop-side manager shipped in #20740: agents can now discover and call user-configured desktop MCP servers from the sandbox.

## What changes

### Contracts (`@vm0/api-contracts`)
- New `computerUseMcpPluginCallBodySchema`: `{ plugin: "mcp", server, tool, arguments, timeoutMs }` with the `[a-z0-9_-]{1,64}` server-name constraint. Per decision Q1a on #20694, arguments pass through verbatim — no per-tool zod validation (the MCP server validates against its own inputSchema).
- The plugin-commands endpoint body becomes `computerUseAnyPluginCallBodySchema = z.union([filesystem, mcp])`, so existing filesystem requests are unchanged.
- `computerUseMcpPluginCallRequiredCapabilities(server)` → `["plugin.call", "plugin.mcp.<server>"]` (server-level routing only, per Q7).

### API (`apps/api`)
- `POST /api/zero/computer-use/plugin-commands` accepts the mcp payload and preserves `server` through payload normalization (`commandPayload` previously stripped unknown keys).
- Host routing: mcp commands route only to online hosts reporting `plugin.mcp.<server>`; unsupported servers fail with the existing `409 No online computer-use host supports this plugin tool`. Agent authorization stays the shared `computer-use:write` capability — no route changes needed there.

### CLI (`@vm0/cli`)
```bash
zero computer-use plugin mcp list                # servers reported by linked hosts (from plugin.mcp.* capabilities)
zero computer-use plugin mcp list <server>      # live tools + inputSchemas via the reserved tools/list call
zero computer-use plugin mcp call <server> <tool> --args '{...}' [--args-file <path>] [--timeout <seconds>]
```
- Results reuse the existing plugin output path (inline text or S3-offloaded file download).
- `--args`/`--args-file` are mutually exclusive; `--args-file` avoids shell-escaping for large payloads (Q6).
- New `listComputerUseHosts()` CLI API function backing server discovery.
- Note: the `plugin` parent command's `--timeout` option shadows leaf-level options in commander (parent parses it first), so the mcp subcommands read the merged `optsWithGlobals()` instead of declaring their own duplicate flag.

### Compatibility
Older desktop hosts never report `plugin.mcp.*` capabilities, so mcp commands against them fail with the standard 409 rather than being queued to a host that cannot execute them. Filesystem plugin behavior is untouched (union keeps the original schema first; existing bdd tests unmodified and passing).

## Tests
- `computer-use.bdd.test.ts`: new integration test covering server-name validation (400), capability-based routing (409 for an unconfigured server, claim by the matching host only), and verbatim arguments passthrough including nested objects.
- `computer-use.test.ts` (CLI, MSW): `mcp call` posts the exact mcp body and prints the tool result; `mcp list <server>` issues the reserved `tools/list` call; `mcp list` renders servers derived from host capabilities.
- Local: full `computer-use.bdd.test.ts` suite (15/15) against a real PostgreSQL, CLI computer-use suite (19/19), tsc for api/cli/api-contracts, oxlint, knip, prettier all green.

## Verification
Targeted integration suites and static checks run locally as above; full pipeline via PR CI per repo practice.
