### PR TITLE
feat: remember codex fast mode locally

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -2,6 +2,7 @@ import { command, computed } from "ccstate";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import {
   chatMessagesContract,
+  chatThreadModelSelectionContract,
   chatThreadsContract,
   type AttachFile,
   type ChatThreadEvent,
@@ -34,10 +35,14 @@ import {
   appendOptimisticChatMessage$,
   type OptimisticChatMessageEntry,
 } from "./optimistic-chat-messages.ts";
-import { resolveModelFirstUserDefaultSelection } from "../zero-page/model-default-selection.ts";
+import {
+  applyCodexFastModeDefault,
+  resolveModelFirstUserDefaultSelection,
+} from "../zero-page/model-default-selection.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
+import { codexFastModeLocalDefault$ } from "../zero-page/codex-fast-local-default.ts";
 import { generationTemplateForFeatureSwitches } from "./generation-template-feature-switch.ts";
 import { logger } from "../log.ts";
 import {
@@ -152,14 +157,21 @@ function resolveNewThreadModelSelection(
   args: {
     readonly policies: OrgModelPoliciesResponse | null | undefined;
     readonly userPreference: UserModelPreferenceResponse | null | undefined;
+    readonly codexFastModeDefault: boolean;
+    readonly codexFastModeEnabled: boolean;
   },
 ): ModelProviderSelection | null {
   if (modelSelection) {
     return modelSelection;
   }
-  return resolveModelFirstUserDefaultSelection({
-    userPreference: args.userPreference,
+  return applyCodexFastModeDefault({
+    selection: resolveModelFirstUserDefaultSelection({
+      userPreference: args.userPreference,
+      policies: args.policies,
+    }),
     policies: args.policies,
+    codexFastModeEnabled: args.codexFastModeEnabled,
+    codexFastModeDefault: args.codexFastModeDefault,
   });
 }
 
@@ -296,6 +308,26 @@ async function createChatThread(args: {
     }),
     [201],
   );
+  args.signal.throwIfAborted();
+  if (args.modelSelection.codexServiceTier === "fast") {
+    const modelSelectionClient = args.createClient(
+      chatThreadModelSelectionContract,
+    );
+    await accept(
+      modelSelectionClient.update({
+        params: { id: args.clientThreadId },
+        body: {
+          modelSelection: modelSelectionRequestFromSelection(
+            args.modelSelection,
+          ),
+          codexServiceTier: "fast",
+          eventId: crypto.randomUUID(),
+        },
+        fetchOptions: { signal: args.signal },
+      }),
+      [204],
+    );
+  }
 }
 
 const startNewChatThreadCreate$ = command(
@@ -313,9 +345,15 @@ const startNewChatThreadCreate$ = command(
     signal.throwIfAborted();
     const userPreference = await get(userModelPreference$);
     signal.throwIfAborted();
+    const codexFastModeDefault = await get(codexFastModeLocalDefault$);
+    signal.throwIfAborted();
+    const featureSwitches = get(featureSwitch$);
     const modelSelection = resolveNewThreadModelSelection(null, {
       policies,
       userPreference,
+      codexFastModeDefault,
+      codexFastModeEnabled:
+        featureSwitches[FeatureSwitchKey.CodexFastMode] ?? false,
     });
     if (!modelSelection) {
       throw new Error("A model selection is required");
@@ -393,11 +431,17 @@ const sendNewThreadMessage$ = command(
     signal.throwIfAborted();
     const userPreference = await get(userModelPreference$);
     signal.throwIfAborted();
+    const codexFastModeDefault = await get(codexFastModeLocalDefault$);
+    signal.throwIfAborted();
+    const featureSwitches = get(featureSwitch$);
     const resolvedModelSelection = resolveNewThreadModelSelection(
       modelSelection,
       {
         policies,
         userPreference,
+        codexFastModeDefault,
+        codexFastModeEnabled:
+          featureSwitches[FeatureSwitchKey.CodexFastMode] ?? false,
       },
     );
     if (!resolvedModelSelection) {

--- a/turbo/apps/platform/src/signals/zero-page/codex-fast-local-default.ts
+++ b/turbo/apps/platform/src/signals/zero-page/codex-fast-local-default.ts
@@ -1,0 +1,72 @@
+import { command, computed } from "ccstate";
+import { currentOrgInfo$, currentUserInfo$ } from "../auth.ts";
+import { localStorageSignals } from "../external/local-storage.ts";
+import { jsonParseOr } from "../utils.ts";
+
+export const CODEX_FAST_MODE_LOCAL_DEFAULT_STORAGE_KEY =
+  "codexFastModeDefaultByUserOrg";
+
+const { get$: rawDefaultByScope$, set$: setRawDefaultByScope$ } =
+  localStorageSignals(CODEX_FAST_MODE_LOCAL_DEFAULT_STORAGE_KEY);
+
+type CodexFastModeDefaultByScope = Record<string, boolean>;
+
+function parseDefaultByScope(raw: string | null): CodexFastModeDefaultByScope {
+  if (!raw) {
+    return {};
+  }
+  const parsed = jsonParseOr<unknown>(raw, {});
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {};
+  }
+  const result: CodexFastModeDefaultByScope = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === "boolean") {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function storageScope(params: {
+  readonly userId: string | undefined;
+  readonly orgId: string | null | undefined;
+}): string | null {
+  if (!params.userId || !params.orgId) {
+    return null;
+  }
+  return `${params.userId}:${params.orgId}`;
+}
+
+export const codexFastModeLocalDefault$ = computed(
+  async (get): Promise<boolean> => {
+    const [user, org] = await Promise.all([
+      get(currentUserInfo$),
+      get(currentOrgInfo$),
+    ]);
+    const scope = storageScope({ userId: user?.id, orgId: org?.id });
+    if (!scope) {
+      return false;
+    }
+    return parseDefaultByScope(get(rawDefaultByScope$))[scope] ?? false;
+  },
+);
+
+export const setCodexFastModeLocalDefault$ = command(
+  async ({ get, set }, enabled: boolean, signal: AbortSignal) => {
+    const [user, org] = await Promise.all([
+      get(currentUserInfo$),
+      get(currentOrgInfo$),
+    ]);
+    signal.throwIfAborted();
+    const scope = storageScope({ userId: user?.id, orgId: org?.id });
+    if (!scope) {
+      return;
+    }
+    const next = {
+      ...parseDefaultByScope(get(rawDefaultByScope$)),
+      [scope]: enabled,
+    };
+    set(setRawDefaultByScope$, JSON.stringify(next));
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/model-default-selection.ts
+++ b/turbo/apps/platform/src/signals/zero-page/model-default-selection.ts
@@ -31,6 +31,47 @@ function resolveModelFirstWorkspaceDefaultSelection(
   );
 }
 
+export function isCodexFastModeAvailableForSelection(params: {
+  readonly policies: OrgModelPoliciesResponse | null | undefined;
+  readonly selectedModel: string | null | undefined;
+  readonly codexFastModeEnabled: boolean;
+}): boolean {
+  if (
+    !params.codexFastModeEnabled ||
+    !params.selectedModel ||
+    params.selectedModel !== "gpt-5.5"
+  ) {
+    return false;
+  }
+  const policy = params.policies?.policies.find((candidate) => {
+    return candidate.model === params.selectedModel;
+  });
+  return (
+    policy?.routeStatus === "valid" &&
+    policy.defaultProviderType === "codex-oauth-token"
+  );
+}
+
+export function applyCodexFastModeDefault(params: {
+  readonly selection: ModelProviderSelection | null;
+  readonly policies: OrgModelPoliciesResponse | null | undefined;
+  readonly codexFastModeEnabled: boolean;
+  readonly codexFastModeDefault: boolean;
+}): ModelProviderSelection | null {
+  if (
+    !params.codexFastModeDefault ||
+    !params.selection ||
+    !isCodexFastModeAvailableForSelection({
+      policies: params.policies,
+      selectedModel: params.selection.selectedModel,
+      codexFastModeEnabled: params.codexFastModeEnabled,
+    })
+  ) {
+    return params.selection;
+  }
+  return { ...params.selection, codexServiceTier: "fast" };
+}
+
 export function resolveModelFirstUserDefaultSelection(params: {
   userPreference: UserModelDefaultSource | null | undefined;
   policies: OrgModelPoliciesResponse | null | undefined;

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -5,8 +5,13 @@ import { featureSwitch$ } from "../external/feature-switch.ts";
 import { connectorCatalogStatusByRef$ } from "../external/connectors.ts";
 import { orgModelPolicies$ } from "../external/org-model-policies.ts";
 import { userModelPreference$ } from "../external/user-model-preference.ts";
-import { resolveModelFirstUserDefaultSelection } from "./model-default-selection.ts";
+import {
+  applyCodexFastModeDefault,
+  resolveModelFirstUserDefaultSelection,
+} from "./model-default-selection.ts";
 import type { ModelProviderSelection } from "../../views/zero-page/components/model-provider-picker.tsx";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { codexFastModeLocalDefault$ } from "./codex-fast-local-default.ts";
 
 // ---------------------------------------------------------------------------
 // Landing page local UI state for ZeroChatPage
@@ -64,9 +69,17 @@ export const chatPageModelSelection$ = computed(
     }
     const policies = await get(orgModelPolicies$);
     const userPreference = await get(userModelPreference$);
-    return resolveModelFirstUserDefaultSelection({
-      userPreference,
+    const codexFastModeDefault = await get(codexFastModeLocalDefault$);
+    const featureSwitches = get(featureSwitch$);
+    return applyCodexFastModeDefault({
+      selection: resolveModelFirstUserDefaultSelection({
+        userPreference,
+        policies,
+      }),
       policies,
+      codexFastModeEnabled:
+        featureSwitches[FeatureSwitchKey.CodexFastMode] ?? false,
+      codexFastModeDefault,
     });
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -50,6 +50,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { reloadUserModelPreference$ } from "../../../signals/external/user-model-preference.ts";
+import { localStorageSignals } from "../../../signals/external/local-storage.ts";
+import { CODEX_FAST_MODE_LOCAL_DEFAULT_STORAGE_KEY } from "../../../signals/zero-page/codex-fast-local-default.ts";
+import { resetChatPageModelSelection$ } from "../../../signals/zero-page/zero-chat-page.ts";
 import { templateCardThemeIdBySlug$ } from "../../../signals/zero-page/zero-chat-composer.ts";
 import {
   click,
@@ -70,6 +73,10 @@ const THREAD_ID = "b1000000-0000-4000-a000-000000000101";
 const ANTHROPIC_PROVIDER_ID = "00000000-0000-4000-a000-000000000001";
 const MOONSHOT_PROVIDER_ID = "00000000-0000-4000-a000-000000000002";
 const ZAI_PROVIDER_ID = "00000000-0000-4000-a000-000000000003";
+const {
+  set$: setCodexFastModeDefaultStorageForTest$,
+  clear$: clearCodexFastModeDefaultStorageForTest$,
+} = localStorageSignals(CODEX_FAST_MODE_LOCAL_DEFAULT_STORAGE_KEY);
 
 function applyUserConnectorUpdate(
   current: readonly string[],
@@ -1182,6 +1189,171 @@ describe("chat composer models", () => {
         codexServiceTier: "fast",
       });
     });
+  });
+
+  it("remembers Codex fast mode for new chats in the current browser account", async () => {
+    const user = userEvent.setup({ delay: null });
+    const codexProvider = buildProvider({
+      id: "00000000-0000-4000-a000-000000000923",
+      type: "codex-oauth-token",
+      framework: "codex",
+      secretName: null,
+      authMethod: "auth_json",
+      secretNames: ["CODEX_AUTH_JSON"],
+    });
+    let sentBody:
+      | {
+          modelSelection?: {
+            modelProviderId: string;
+            selectedModel: string;
+          } | null;
+          runOptions?: { codexServiceTier?: "fast" };
+        }
+      | undefined;
+    let updatedModelSelection:
+      | {
+          modelSelection?: {
+            modelProviderId: string;
+            selectedModel: string;
+          } | null;
+          codexServiceTier?: "fast" | null;
+        }
+      | undefined;
+
+    context.mocks.data.orgModelPolicies([
+      buildModelPolicy({
+        id: "00000000-0000-4000-a000-000000000924",
+        model: "gpt-5.5",
+        modelLabel: "GPT 5.5",
+        isDefault: true,
+        defaultProviderType: "codex-oauth-token",
+        credentialScope: "member",
+      }),
+    ]);
+    context.mocks.data.personalModelProviders([codexProvider]);
+    mockAgent();
+    mockChatLifecycle(context, {
+      onModelSelectionUpdate: (body) => {
+        updatedModelSelection = body;
+      },
+      onRunCreate: (body) => {
+        sentBody = body;
+      },
+    });
+
+    detachedSetupPage({
+      context,
+      featureSwitches: { [FeatureSwitchKey.CodexFastMode]: true },
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    click(await findComposerModel("GPT 5.5"));
+    const runSpeed = await screen.findByRole("group", { name: "Run speed" });
+    click(buttonContainingText("Fast", runSpeed));
+    await waitFor(() => {
+      expect(buttonContainingText("Fast", runSpeed)).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+    act(() => {
+      context.store.set(resetChatPageModelSelection$);
+    });
+
+    await expectComposerModel("GPT 5.5");
+
+    await sendMessageInUI(
+      user,
+      screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      "Remember fast mode",
+    );
+
+    await waitFor(() => {
+      expect(updatedModelSelection?.modelSelection).toStrictEqual({
+        modelProviderId: "00000000-0000-4000-8000-000000000000",
+        selectedModel: "gpt-5.5",
+      });
+      expect(updatedModelSelection?.codexServiceTier).toBe("fast");
+      expect(sentBody?.runOptions).toStrictEqual({
+        codexServiceTier: "fast",
+      });
+    });
+  });
+
+  it("does not apply a remembered Codex fast mode default when the switch is off", async () => {
+    const user = userEvent.setup({ delay: null });
+    const codexProvider = buildProvider({
+      id: "00000000-0000-4000-a000-000000000925",
+      type: "codex-oauth-token",
+      framework: "codex",
+      secretName: null,
+      authMethod: "auth_json",
+      secretNames: ["CODEX_AUTH_JSON"],
+    });
+    let sentBody:
+      | {
+          runOptions?: { codexServiceTier?: "fast" };
+        }
+      | undefined;
+    act(() => {
+      context.store.set(
+        setCodexFastModeDefaultStorageForTest$,
+        JSON.stringify({ "test-user-123:org_default": true }),
+      );
+    });
+
+    try {
+      context.mocks.data.orgModelPolicies([
+        buildModelPolicy({
+          id: "00000000-0000-4000-a000-000000000926",
+          model: "gpt-5.5",
+          modelLabel: "GPT 5.5",
+          isDefault: true,
+          defaultProviderType: "codex-oauth-token",
+          credentialScope: "member",
+        }),
+      ]);
+      context.mocks.data.personalModelProviders([codexProvider]);
+      mockAgent();
+      mockChatLifecycle(context, {
+        onRunCreate: (body) => {
+          sentBody = body;
+        },
+      });
+
+      detachedSetupPage({
+        context,
+        featureSwitches: { [FeatureSwitchKey.CodexFastMode]: false },
+        path: `/agents/${AGENT_ID}/chat`,
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("combobox", { name: /^GPT 5\.5$/ }),
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole("group", { name: "Run speed" }),
+        ).not.toBeInTheDocument();
+      });
+
+      await sendMessageInUI(
+        user,
+        screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+        "Use standard mode",
+      );
+
+      await waitFor(() => {
+        expect(sentBody?.runOptions).toBeUndefined();
+      });
+    } finally {
+      act(() => {
+        context.store.set(clearCodexFastModeDefaultStorageForTest$);
+      });
+    }
   });
 
   it("keeps Codex fast mode when continuing a hydrated thread", async () => {

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -91,6 +91,9 @@ import {
 } from "../../signals/view-component-state.ts";
 import { personalModelProvider$ } from "../../signals/zero-page/model-first-personal-oauth.ts";
 import { updateUserModelPreference$ } from "../../signals/external/user-model-preference.ts";
+import { orgModelPolicies$ } from "../../signals/external/org-model-policies.ts";
+import { setCodexFastModeLocalDefault$ } from "../../signals/zero-page/codex-fast-local-default.ts";
+import { isCodexFastModeAvailableForSelection } from "../../signals/zero-page/model-default-selection.ts";
 import {
   resolveChatComposerSubmitBlocker,
   usePersonalOauthConfigurationAction,
@@ -462,7 +465,12 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
       : null;
   const setModelSelection = useSet(setChatPageModelSelection$);
   const updateUserModelPreference = useSet(updateUserModelPreference$);
+  const setCodexFastModeLocalDefault = useSet(setCodexFastModeLocalDefault$);
   const personalModelProvider = useLastResolved(personalModelProvider$);
+  const policiesLoadable = useLoadable(orgModelPolicies$);
+  const policies =
+    policiesLoadable.state === "hasData" ? policiesLoadable.data : undefined;
+  const featureSwitches = useGet(featureSwitch$);
   const openPersonalOauthConfiguration = usePersonalOauthConfigurationAction();
 
   const handleModelSelectionChange = (
@@ -473,6 +481,22 @@ function useAgentChatComposerModel(pageSignal: AbortSignal) {
     if (isSupportedRunModel(selectedModel)) {
       detach(
         updateUserModelPreference({ selectedModel }, pageSignal),
+        Reason.DomCallback,
+      );
+    }
+    if (
+      isCodexFastModeAvailableForSelection({
+        policies,
+        selectedModel,
+        codexFastModeEnabled:
+          featureSwitches[FeatureSwitchKey.CodexFastMode] ?? false,
+      })
+    ) {
+      detach(
+        setCodexFastModeLocalDefault(
+          selection?.codexServiceTier === "fast",
+          pageSignal,
+        ),
         Reason.DomCallback,
       );
     }


### PR DESCRIPTION
## Summary
- remember the last Codex Fast toggle in browser local storage scoped by user and org
- apply the stored Fast default only when GPT 5.5 is available through the Codex OAuth route and the CodexFastMode switch is enabled
- use the existing thread model-selection update route to persist Fast on newly created empty threads without adding a backend preference field or migration

## Verification
- pnpm --filter @vm0/app run lint
- pnpm --filter @vm0/app exec tsc -p tsconfig.json --noEmit
- pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx