### PR TITLE
refactor: tighten slack user info resolver coverage

### DIFF
--- a/turbo/apps/api/src/signals/external/slack-message-client.ts
+++ b/turbo/apps/api/src/signals/external/slack-message-client.ts
@@ -6,7 +6,7 @@ import {
 } from "@slack/web-api";
 
 import { optionalEnv } from "../../lib/env";
-import { onRejection, settle } from "../utils";
+import { settle } from "../utils";
 
 type OpenDmResult =
   | { readonly kind: "ok"; readonly channelId: string }
@@ -256,19 +256,15 @@ export function createSlackUserInfoResolver(
   let inFlightHitCount = 0;
 
   const startLookup = (userId: string): Promise<SlackUserInfo | undefined> => {
-    const promise = onRejection(
-      (async () => {
-        const info = await fetchSlackUserInfo(client, userId);
-        if (info) {
-          cache.set(userId, info);
-        }
-        inFlight.delete(userId);
-        return info;
-      })(),
-      () => {
-        inFlight.delete(userId);
-      },
-    );
+    const promise = (async () => {
+      const info = await fetchSlackUserInfo(client, userId);
+      if (info) {
+        cache.set(userId, info);
+      }
+      return info;
+    })().finally(() => {
+      inFlight.delete(userId);
+    });
     inFlight.set(userId, promise);
     return promise;
   };

--- a/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
@@ -10,7 +10,7 @@ import type {
   TestSlackStatePostResponse,
   TestSlackStateResponse,
 } from "@vm0/api-contracts/contracts/test-slack-state";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { setupAppWithRoutes } from "../../../__tests__/test-app";
@@ -20,6 +20,7 @@ import { verifyZeroToken } from "../../auth/tokens";
 import { runnersRoutes } from "../runners";
 import { testSlackDispatchProbeRoutes } from "../test-slack-dispatch-probe";
 import { testSlackStateRoutes } from "../test-slack-state";
+import { createDeferredPromise, settle } from "../../utils";
 import type { ApiTestUser } from "./helpers/api-bdd";
 import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
@@ -40,6 +41,58 @@ interface SlackProbeFixture {
   readonly slackUserId: string;
   readonly defaultAgentId: string | null;
   readonly connectionId: string | null;
+}
+
+interface SlackUserInfoMockResponse {
+  readonly ok: true;
+  readonly user: {
+    readonly profile: {
+      readonly display_name: string;
+      readonly email: string;
+    };
+    readonly tz: string;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sandboxOperationEventsForRun(
+  runId: string,
+): readonly Record<string, unknown>[] {
+  return context.mocks.axiom.sdkIngest.mock.calls.flatMap((call) => {
+    const dataset = call[0];
+    const events = call[1];
+    if (dataset !== "vm0-sandbox-op-log-dev" || !Array.isArray(events)) {
+      return [];
+    }
+    return events.filter((event): event is Record<string, unknown> => {
+      return isRecord(event) && event.run_id === runId;
+    });
+  });
+}
+
+function slackUserInfoCallCount(userId: string): number {
+  return context.mocks.slack.users.info.mock.calls.filter((call) => {
+    const request = call[0];
+    return isRecord(request) && request.user === userId;
+  }).length;
+}
+
+function slackUserInfoResponse(
+  displayName = "Slack User",
+): SlackUserInfoMockResponse {
+  return {
+    ok: true,
+    user: {
+      profile: {
+        display_name: displayName,
+        email: "slack@example.com",
+      },
+      tz: "UTC",
+    },
+  };
 }
 
 function configureSlackProbeTest(): void {
@@ -69,16 +122,7 @@ function configureSlackProbeTest(): void {
     ok: true,
     messages: [],
   });
-  context.mocks.slack.users.info.mockResolvedValue({
-    ok: true,
-    user: {
-      profile: {
-        display_name: "Slack User",
-        email: "slack@example.com",
-      },
-      tz: "UTC",
-    },
-  });
+  context.mocks.slack.users.info.mockResolvedValue(slackUserInfoResponse());
 }
 
 function requestApp(path: string, init?: RequestInit): Promise<Response> {
@@ -448,6 +492,159 @@ describe("POST /api/test/slack-dispatch-probe", () => {
     expect(state.recent_runs).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: claim.runId, triggerSource: "slack" }),
+      ]),
+    );
+  });
+
+  it("coalesces overlapping Slack user info lookups during run creation", async () => {
+    const fixture = await track(
+      seedSlackProbeFixture({ withConnection: true, withDefaultAgent: true }),
+    );
+    const prompt = "slack user info coalescing";
+    const contextMentionedUserId = "U_CONTEXT_MENTIONED";
+    const historyResponse = createDeferredPromise<{
+      readonly ok: true;
+      readonly messages: readonly Record<string, unknown>[];
+    }>(context.signal);
+    const currentUserInfoResponse =
+      createDeferredPromise<SlackUserInfoMockResponse>(context.signal);
+    const releasePendingMocks = (): void => {
+      if (!historyResponse.settled()) {
+        historyResponse.resolve({ ok: true, messages: [] });
+      }
+      if (!currentUserInfoResponse.settled()) {
+        currentUserInfoResponse.resolve(slackUserInfoResponse());
+      }
+    };
+    context.mocks.slack.conversations.history.mockReturnValue(
+      historyResponse.promise,
+    );
+    context.mocks.slack.users.info.mockImplementation(
+      async (request: unknown) => {
+        const requestedUserId =
+          isRecord(request) && typeof request.user === "string"
+            ? request.user
+            : "";
+        if (requestedUserId === fixture.slackUserId) {
+          return await currentUserInfoResponse.promise;
+        }
+        return slackUserInfoResponse(`Slack User ${requestedUserId}`);
+      },
+    );
+
+    const responsePromise = (async () => {
+      const response = await postProbe({
+        team_id: fixture.slackWorkspaceId,
+        channel_id: "C-test",
+        user_id: fixture.slackUserId,
+        message_text: prompt,
+        message_ts: "1710000000.000000",
+        channel_type: "channel",
+      });
+      expect(response.status).toBe(200);
+      await expect(
+        readJson<TestSlackDispatchProbeResponse>(response),
+      ).resolves.toStrictEqual({ ok: true });
+    })();
+    onTestFinished(async () => {
+      releasePendingMocks();
+      await settle(responsePromise);
+    });
+
+    await expect
+      .poll(() => {
+        return slackUserInfoCallCount(fixture.slackUserId);
+      })
+      .toBe(1);
+    await expect
+      .poll(() => {
+        return context.mocks.slack.conversations.history.mock.calls.length;
+      })
+      .toBe(1);
+    historyResponse.resolve({
+      ok: true,
+      messages: [
+        {
+          user: fixture.slackUserId,
+          text: `previous context from the same Slack user and <@${contextMentionedUserId}>`,
+          ts: "1709999999.000000",
+        },
+      ],
+    });
+    await expect
+      .poll(() => {
+        return slackUserInfoCallCount(contextMentionedUserId);
+      })
+      .toBe(1);
+    expect(slackUserInfoCallCount(fixture.slackUserId)).toBe(1);
+
+    currentUserInfoResponse.resolve(slackUserInfoResponse());
+    await responsePromise;
+
+    expect(slackUserInfoCallCount(fixture.slackUserId)).toBe(1);
+    const state = await readSlackState(fixture);
+    const run = state.recent_runs.find((candidate) => {
+      return candidate.promptPreview === prompt;
+    });
+    if (!run) {
+      throw new Error("Expected Slack dispatch probe to create a run");
+    }
+    const timingEvents = sandboxOperationEventsForRun(run.id);
+    expect(timingEvents).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          op_type:
+            "api_dispatch_pre_create_zero_slack_build_run_params_user_info_resolver",
+          slack_user_info_resolver_requested_count_bucket: "2_4",
+          slack_user_info_resolver_cache_hit_count_bucket: "0",
+          slack_user_info_resolver_miss_count_bucket: "2_4",
+          slack_user_info_resolver_in_flight_hit_count_bucket: "1",
+        }),
+      ]),
+    );
+    expect(JSON.stringify(timingEvents)).not.toContain(contextMentionedUserId);
+  });
+
+  it("keeps creating Slack runs when Slack user info lookup rejects", async () => {
+    const fixture = await track(
+      seedSlackProbeFixture({ withConnection: true, withDefaultAgent: true }),
+    );
+    const prompt = "slack user info failure should not fail run creation";
+    context.mocks.slack.conversations.history.mockResolvedValue({
+      ok: true,
+      messages: [
+        {
+          user: fixture.slackUserId,
+          text: "context from the same Slack user",
+          ts: "1709999999.000000",
+        },
+      ],
+    });
+    context.mocks.slack.users.info.mockRejectedValue(
+      new Error("Slack users.info failed"),
+    );
+
+    const response = await postProbe({
+      team_id: fixture.slackWorkspaceId,
+      channel_id: "C-test",
+      user_id: fixture.slackUserId,
+      message_text: prompt,
+      message_ts: "1710000000.000000",
+      channel_type: "channel",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(
+      readJson<TestSlackDispatchProbeResponse>(response),
+    ).resolves.toStrictEqual({ ok: true });
+    expect(slackUserInfoCallCount(fixture.slackUserId)).toBeGreaterThan(0);
+    const state = await readSlackState(fixture);
+    expect(state.recent_runs).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          triggerSource: "slack",
+          promptPreview: prompt,
+        }),
       ]),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/test-telegram-state.test.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 
 import { http, HttpResponse } from "msw";
-import { onTestFinished } from "vitest";
 import type { TestSlackStateResponse } from "@vm0/api-contracts/contracts/test-slack-state";
 import type {
   TestTelegramStateResponse,
@@ -16,7 +15,6 @@ import { testSlackDispatchProbeRoutes } from "../test-slack-dispatch-probe";
 import { testSlackStateRoutes } from "../test-slack-state";
 import { testTelegramDispatchProbeRoutes } from "../test-telegram-dispatch-probe";
 import { testTelegramStateRoutes } from "../test-telegram-state";
-import { createDeferredPromise, settle } from "../../utils";
 import { createFixtureTracker } from "./helpers/zero-route-test";
 
 const context = testContext();
@@ -38,17 +36,6 @@ interface TelegramFixture {
 interface SlackFixture {
   readonly teamId: string;
   readonly slackUserId: string;
-}
-
-interface SlackUserInfoMockResponse {
-  readonly ok: true;
-  readonly user: {
-    readonly profile: {
-      readonly display_name: string;
-      readonly email: string;
-    };
-    readonly tz: string;
-  };
 }
 
 interface RecentRun {
@@ -122,13 +109,6 @@ function sandboxOperationActionTypes(
   );
 }
 
-function slackUserInfoCallCount(userId: string): number {
-  return context.mocks.slack.users.info.mock.calls.filter((call) => {
-    const request = call[0];
-    return isRecord(request) && request.user === userId;
-  }).length;
-}
-
 function mockClerkTestUser(args: {
   readonly userId: string;
   readonly orgId: string;
@@ -163,21 +143,6 @@ function mockTelegramTyping(): void {
   );
 }
 
-function slackUserInfoResponse(
-  displayName = "Slack User",
-): SlackUserInfoMockResponse {
-  return {
-    ok: true,
-    user: {
-      profile: {
-        display_name: displayName,
-        email: "slack@example.com",
-      },
-      tz: "UTC",
-    },
-  };
-}
-
 function configureSlackDispatchMocks(): void {
   mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
   mockOptionalEnv("VM0_API_URL", "http://localhost:3000");
@@ -204,7 +169,16 @@ function configureSlackDispatchMocks(): void {
     ok: true,
     messages: [],
   });
-  context.mocks.slack.users.info.mockResolvedValue(slackUserInfoResponse());
+  context.mocks.slack.users.info.mockResolvedValue({
+    ok: true,
+    user: {
+      profile: {
+        display_name: "Slack User",
+        email: "slack@example.com",
+      },
+      tz: "UTC",
+    },
+  });
 }
 
 function postTelegramState(body: Record<string, unknown>): Promise<Response> {
@@ -348,10 +322,11 @@ async function dispatchTelegramMessage(args: {
   ).resolves.toStrictEqual({ ok: true });
 }
 
-async function postSlackDispatchProbe(args: {
+async function dispatchSlackMessage(args: {
   readonly fixture: SlackFixture;
   readonly text: string;
 }): Promise<void> {
+  configureSlackDispatchMocks();
   const response = await requestApp(SLACK_DISPATCH_PROBE_ROUTE, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -368,14 +343,6 @@ async function postSlackDispatchProbe(args: {
   await expect(
     readJson<{ readonly ok: true }>(response),
   ).resolves.toStrictEqual({ ok: true });
-}
-
-async function dispatchSlackMessage(args: {
-  readonly fixture: SlackFixture;
-  readonly text: string;
-}): Promise<void> {
-  configureSlackDispatchMocks();
-  await postSlackDispatchProbe(args);
 }
 describe("GET /api/test/telegram-state", () => {
   it("returns 404 when the test endpoint is not allowed", async () => {
@@ -805,143 +772,6 @@ describe("POST /api/test/telegram-state", () => {
     ]) {
       expect(serializedTimingEvents).not.toContain(forbiddenValue);
     }
-  });
-
-  it("coalesces overlapping Slack user info lookups during run creation", async () => {
-    mockEnv("ENV", "development");
-    const userId = uniqueId("user");
-    const orgId = uniqueId("org");
-    const email = `${randomUUID()}@example.test`;
-    const slack = await seedSlackFixture({ userId, orgId, email });
-    const prompt = "slack user info coalescing";
-    const contextMentionedUserId = "U_CONTEXT_MENTIONED";
-    configureSlackDispatchMocks();
-    const historyResponse = createDeferredPromise<{
-      readonly ok: true;
-      readonly messages: readonly Record<string, unknown>[];
-    }>(context.signal);
-    const currentUserInfoResponse =
-      createDeferredPromise<SlackUserInfoMockResponse>(context.signal);
-    const releasePendingMocks = (): void => {
-      if (!historyResponse.settled()) {
-        historyResponse.resolve({ ok: true, messages: [] });
-      }
-      if (!currentUserInfoResponse.settled()) {
-        currentUserInfoResponse.resolve(slackUserInfoResponse());
-      }
-    };
-    context.mocks.slack.conversations.history.mockReturnValue(
-      historyResponse.promise,
-    );
-    context.mocks.slack.users.info.mockImplementation(
-      async (request: unknown) => {
-        const requestedUserId =
-          isRecord(request) && typeof request.user === "string"
-            ? request.user
-            : "";
-        if (requestedUserId === slack.slackUserId) {
-          return await currentUserInfoResponse.promise;
-        }
-        return slackUserInfoResponse(`Slack User ${requestedUserId}`);
-      },
-    );
-
-    const responsePromise = (async () => {
-      await postSlackDispatchProbe({ fixture: slack, text: prompt });
-    })();
-    onTestFinished(async () => {
-      releasePendingMocks();
-      await settle(responsePromise);
-    });
-
-    await expect
-      .poll(() => {
-        return slackUserInfoCallCount(slack.slackUserId);
-      })
-      .toBe(1);
-    await expect
-      .poll(() => {
-        return context.mocks.slack.conversations.history.mock.calls.length;
-      })
-      .toBe(1);
-    historyResponse.resolve({
-      ok: true,
-      messages: [
-        {
-          user: slack.slackUserId,
-          text: `previous context from the same Slack user and <@${contextMentionedUserId}>`,
-          ts: "1709999999.000000",
-        },
-      ],
-    });
-    await expect
-      .poll(() => {
-        return slackUserInfoCallCount(contextMentionedUserId);
-      })
-      .toBe(1);
-    expect(slackUserInfoCallCount(slack.slackUserId)).toBe(1);
-
-    currentUserInfoResponse.resolve(slackUserInfoResponse());
-    await responsePromise;
-
-    expect(slackUserInfoCallCount(slack.slackUserId)).toBe(1);
-    const slackState = await readSlackState(slack.teamId);
-    const run = recentRuns(slackState.recent_runs).find((candidate) => {
-      return candidate.promptPreview === prompt;
-    });
-    if (!run) {
-      throw new Error("Expected Slack dispatch probe to create a run");
-    }
-    const timingEvents = sandboxOperationEventsForRun(run.id);
-    expect(timingEvents).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          op_type:
-            "api_dispatch_pre_create_zero_slack_build_run_params_user_info_resolver",
-          slack_user_info_resolver_requested_count_bucket: "2_4",
-          slack_user_info_resolver_cache_hit_count_bucket: "0",
-          slack_user_info_resolver_miss_count_bucket: "2_4",
-          slack_user_info_resolver_in_flight_hit_count_bucket: "1",
-        }),
-      ]),
-    );
-    expect(JSON.stringify(timingEvents)).not.toContain(contextMentionedUserId);
-  });
-
-  it("keeps creating Slack runs when Slack user info lookup rejects", async () => {
-    mockEnv("ENV", "development");
-    const userId = uniqueId("user");
-    const orgId = uniqueId("org");
-    const email = `${randomUUID()}@example.test`;
-    const slack = await seedSlackFixture({ userId, orgId, email });
-    const prompt = "slack user info failure should not fail run creation";
-    configureSlackDispatchMocks();
-    context.mocks.slack.conversations.history.mockResolvedValue({
-      ok: true,
-      messages: [
-        {
-          user: slack.slackUserId,
-          text: "context from the same Slack user",
-          ts: "1709999999.000000",
-        },
-      ],
-    });
-    context.mocks.slack.users.info.mockRejectedValue(
-      new Error("Slack users.info failed"),
-    );
-
-    await postSlackDispatchProbe({ fixture: slack, text: prompt });
-
-    expect(slackUserInfoCallCount(slack.slackUserId)).toBeGreaterThan(0);
-    const slackState = await readSlackState(slack.teamId);
-    expect(recentRuns(slackState.recent_runs)).toStrictEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          triggerSource: "slack",
-          promptPreview: prompt,
-        }),
-      ]),
-    );
   });
 });
 

--- a/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-slack-webhooks.service.ts
@@ -1903,13 +1903,12 @@ const buildRunAgentParams$ = command(
       fetchConversationContextDimensions:
         conversationContextObserver.dimensions,
     });
-    await measureApiDispatchTiming(
-      args.timing,
+    const userInfoResolverStatsRecordedAt = now();
+    args.timing.recordElapsed(
       "api_dispatch_pre_create_zero_slack_build_run_params_user_info_resolver",
       "nested",
-      () => {
-        return undefined;
-      },
+      userInfoResolverStatsRecordedAt,
+      userInfoResolverStatsRecordedAt,
       slackUserInfoResolverDimensions(userInfoResolver.stats()),
     );
 


### PR DESCRIPTION
## Summary
- simplify Slack user info resolver cleanup with a direct finally handler
- record resolver stats with a direct elapsed timing event instead of an empty measured operation
- move Slack user-info resolver tests into the Slack dispatch probe test suite

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/test-slack-dispatch-probe.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/test-telegram-state.test.ts
- pnpm -F api run lint

Notes: this is follow-up cleanup from review of #20724 after that PR had already been squash-merged.