### PR TITLE
feat: use image previews for website template picker

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -4148,7 +4148,11 @@ describe("chat composer templates", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByTitle(`${websiteTemplate.title} website template preview`),
-      ).toHaveAttribute("src", websiteTemplate.previewUrl);
+      ).toHaveAttribute("src", websiteTemplate.previewImageUrl);
+      expect(
+        screen.getByTitle(`${websiteTemplate.title} website template preview`)
+          .tagName,
+      ).toBe("IMG");
       expect(screen.queryByText(websiteTemplate.description)).toBeNull();
       expect(screen.queryByText(websiteTemplate.resourceId)).toBeNull();
       expect(screen.queryByText("Saas Landing")).not.toBeInTheDocument();
@@ -4189,7 +4193,11 @@ describe("chat composer templates", () => {
       expect(tabByText("Website")).toHaveAttribute("aria-selected", "true");
       expect(
         screen.getByTitle(`${websiteTemplate.title} website template preview`),
-      ).toHaveAttribute("src", websiteTemplate.previewUrl);
+      ).toHaveAttribute("src", websiteTemplate.previewImageUrl);
+      expect(
+        screen.getByTitle(`${websiteTemplate.title} website template preview`)
+          .tagName,
+      ).toBe("IMG");
     });
 
     click(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1412,12 +1412,14 @@ function WebsiteTemplateCard({
       )}
     >
       <div className="relative aspect-[16/9] shrink-0 overflow-hidden bg-muted">
-        <iframe
+        <img
+          alt={`${item.title} website template preview`}
           title={`${item.title} website template preview`}
-          src={item.previewUrl}
-          sandbox="allow-same-origin"
-          tabIndex={-1}
-          className="pointer-events-none h-full w-full border-0 bg-background"
+          src={item.previewImageUrl}
+          loading="lazy"
+          decoding="async"
+          draggable={false}
+          className="pointer-events-none h-full w-full bg-background object-cover"
         />
       </div>
       <div className="flex flex-1 flex-wrap items-center gap-2 px-3.5 py-3">

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -59,20 +59,28 @@ describe("website template items", () => {
       templateId: "template:black-slabs",
       resourceId: "template:black-slabs",
       previewKind: "iframe",
+      previewImageUrl:
+        "https://static.vm0.io/vm0/artifact-templates/website/website-studio-v2-20260708-5f944f83/black-slabs-preview-480x270.webp",
       sourcePath: "black-slabs",
       target: "website",
     });
   });
 
-  it("uses a static-hosted iframe preview asset", () => {
+  it("uses static-hosted preview assets", () => {
     for (const item of WEBSITE_TEMPLATE_ITEMS) {
       expect(item.previewKind).toBe("iframe");
       expect(item.previewUrl).toMatch(
         /^https:\/\/static\.vm0\.io\/vm0\/artifact-templates\/website\/.+\.html$/u,
       );
+      expect(item.previewImageUrl).toMatch(
+        /^https:\/\/static\.vm0\.io\/vm0\/artifact-templates\/website\/.+-preview-480x270\.webp$/u,
+      );
       expect(item.previewUrl).not.toContain("drive.google.com");
       expect(item.previewUrl).not.toContain("docs.google.com");
       expect(item.previewUrl).not.toContain("raw.githubusercontent.com");
+      expect(item.previewImageUrl).not.toContain("drive.google.com");
+      expect(item.previewImageUrl).not.toContain("docs.google.com");
+      expect(item.previewImageUrl).not.toContain("raw.githubusercontent.com");
     }
   });
 

--- a/turbo/packages/core/src/website-template-items.ts
+++ b/turbo/packages/core/src/website-template-items.ts
@@ -7,6 +7,7 @@ export interface WebsiteTemplateItem {
   readonly resourceId: `template:${string}`;
   readonly previewKind: "iframe";
   readonly previewUrl: string;
+  readonly previewImageUrl: string;
   readonly sourcePath: string;
   readonly target: "website";
 }
@@ -28,6 +29,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:black-slabs",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/black-slabs-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/black-slabs-preview-480x270.webp`,
     sourcePath: "black-slabs",
     target: "website",
   },
@@ -41,6 +43,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:blueprint-grid",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/blueprint-grid-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/blueprint-grid-preview-480x270.webp`,
     sourcePath: "blueprint-grid",
     target: "website",
   },
@@ -54,6 +57,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:coastal-hotel",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/coastal-hotel-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/coastal-hotel-preview-480x270.webp`,
     sourcePath: "coastal-hotel",
     target: "website",
   },
@@ -67,6 +71,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:frame-stack",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/frame-stack-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/frame-stack-preview-480x270.webp`,
     sourcePath: "frame-stack",
     target: "website",
   },
@@ -80,6 +85,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:gallery-wall",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/gallery-wall-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/gallery-wall-preview-480x270.webp`,
     sourcePath: "gallery-wall",
     target: "website",
   },
@@ -93,6 +99,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:glass-bloom",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/glass-bloom-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/glass-bloom-preview-480x270.webp`,
     sourcePath: "glass-bloom",
     target: "website",
   },
@@ -106,6 +113,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:serif-stack",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/serif-stack-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/serif-stack-preview-480x270.webp`,
     sourcePath: "serif-stack",
     target: "website",
   },
@@ -119,6 +127,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:sticker-pop",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/sticker-pop-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/sticker-pop-preview-480x270.webp`,
     sourcePath: "sticker-pop",
     target: "website",
   },
@@ -132,6 +141,7 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     resourceId: "template:warm-cards",
     previewKind: "iframe",
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/warm-cards-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/warm-cards-preview-480x270.webp`,
     sourcePath: "warm-cards",
     target: "website",
   },


### PR DESCRIPTION
## Summary
- add `previewImageUrl` to the built-in website template catalog for the 9 R2-backed website templates
- switch the website template picker cards from iframe previews to lightweight 480x270 WebP images
- keep the full website preview dialog backed by the existing static HTML iframe URLs

## Static assets
- added and merged the 9 preview images in `vm0-ai/static-files#30`
- image URLs live under `static.vm0.io/vm0/artifact-templates/website/website-studio-v2-20260708-5f944f83/`
- verified all 9 image URLs return `200 image/webp`

## Verification
- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm check-types`
- `pnpm exec vitest run packages/core/src/__tests__/website-template-items.spec.ts`
- `pnpm exec vitest run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`

Notes:
- The first `pnpm check-types` run failed because local ignored firewall metadata generated files were stale after pulling latest `main`; regenerating them fixed that local-only state and no generated files are included in this PR.
- A later `pnpm check-types` run hit API package Node heap OOM at the default heap limit; rerunning with `NODE_OPTIONS=--max-old-space-size=8192` passed.