### PR TITLE
test(api): drain slack install waituntil before app home check

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
@@ -2063,6 +2063,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
     const { teamId } = await integrations.installSlackWorkspace(actor, {
       installerSlackUserId: slackUserId,
     });
+    await flushWaitUntilForTest();
     integrations.clearSlackCallHistory();
 
     const switchResponse = await integrations.postSlackCommand({
@@ -2133,11 +2134,7 @@ describe("INT-01: Slack app deep webhook flows", () => {
       tab: "home",
       channel: "D_BDD_HIDDEN_HOME",
     });
-    await waitForExpectation(() => {
-      expect(
-        JSON.stringify(context.mocks.slack.views.publish.mock.calls),
-      ).toContain("_No agent configured yet._");
-    });
+    await flushWaitUntilForTest();
     const homeViewJson = JSON.stringify(
       context.mocks.slack.views.publish.mock.calls.at(-1),
     );


### PR DESCRIPTION
## Summary
- Drain Slack install waitUntil work before clearing Slack mock history in the hidden-default App Home test.
- Replace the broad poll over Slack publish mock calls with an explicit waitUntil flush after the app_home_opened event.
- Keeps the test on the API/event boundary while avoiding a late connect-notification App Home publish racing into the final assertion.

## Verification
- pnpm exec prettier --check apps/api/src/signals/routes/__tests__/integrations.bdd.test.ts
- pnpm -F api exec vitest run src/signals/routes/__tests__/integrations.bdd.test.ts -t "hides an inaccessible private org default" *(blocked locally: Postgres unavailable, ECONNREFUSED while creating the test agent)*