### PR TITLE
fix: preserve composer focus when feedback toolbar closes

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -14,6 +14,7 @@ import {
   setFeedbackSelectionToolbarRef$,
 } from "../zero-page/chat-feedback.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
+import { createDeferredPromise } from "../utils.ts";
 import { testContext } from "./test-helpers.ts";
 
 // Render a minimal assistant bubble inside a thread container, matching the DOM
@@ -60,10 +61,12 @@ function dispatchPointerEvent(
   element.dispatchEvent(event);
 }
 
-function waitForDeferredSelectionCapture(): Promise<void> {
-  return new Promise((resolve) => {
-    window.setTimeout(resolve, 0);
-  });
+function waitForDeferredSelectionCapture(signal: AbortSignal): Promise<void> {
+  const deferred = createDeferredPromise<void>(signal);
+  window.setTimeout(() => {
+    deferred.resolve();
+  }, 0);
+  return deferred.promise;
 }
 
 describe("inline feedback thread scoping", () => {
@@ -303,7 +306,7 @@ describe("inline feedback thread scoping", () => {
       listenersScope,
     );
     const composer = document.createElement("div");
-    composer.setAttribute("data-chat-composer", "true");
+    composer.dataset.chatComposer = "true";
     const editor = document.createElement("div");
     editor.setAttribute("contenteditable", "true");
     composer.appendChild(editor);
@@ -317,7 +320,7 @@ describe("inline feedback thread scoping", () => {
     // until the click completes. The composer interaction should still win.
     selectContents(bubble);
     editor.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
-    await waitForDeferredSelectionCapture();
+    await waitForDeferredSelectionCapture(ctx.signal);
 
     expect(ctx.store.get(feedbackSelectionValue$)).toBeNull();
     cleanup?.();

--- a/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/chat-feedback.test.ts
@@ -10,6 +10,7 @@ import {
   feedbackItemsValue$,
   feedbackSelectionValue$,
   feedbackThreadIdValue$,
+  setFeedbackSelectionListenersRef$,
   setFeedbackSelectionToolbarRef$,
 } from "../zero-page/chat-feedback.ts";
 import { ensureDraft$ } from "../chat-page/create-chat-thread.ts";
@@ -44,6 +45,25 @@ function dispatchShortcut(key: string): KeyboardEvent {
   });
   document.dispatchEvent(event);
   return event;
+}
+
+function dispatchPointerEvent(
+  element: HTMLElement,
+  type: "pointerdown" | "pointerup" | "pointercancel",
+  pointerType = "mouse",
+): void {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, "pointerType", {
+    configurable: true,
+    value: pointerType,
+  });
+  element.dispatchEvent(event);
+}
+
+function waitForDeferredSelectionCapture(): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, 0);
+  });
 }
 
 describe("inline feedback thread scoping", () => {
@@ -269,6 +289,39 @@ describe("inline feedback thread scoping", () => {
     expect(event.defaultPrevented).toBeFalsy();
     expect(ctx.store.get(feedbackItemsValue$)).toHaveLength(0);
     cleanup?.();
+  });
+
+  it("does not restore the toolbar from stale selection after composer interaction starts", async () => {
+    const bubble = mountThreadBubble("thread-a", "Reply from thread A");
+    selectContents(bubble);
+    ctx.store.set(captureFeedbackSelection$);
+    expect(ctx.store.get(feedbackSelectionValue$)).not.toBeNull();
+
+    const listenersScope = document.createElement("span");
+    const cleanup = ctx.store.set(
+      setFeedbackSelectionListenersRef$,
+      listenersScope,
+    );
+    const composer = document.createElement("div");
+    composer.setAttribute("data-chat-composer", "true");
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    composer.appendChild(editor);
+    document.body.appendChild(composer);
+
+    dispatchPointerEvent(editor, "pointerdown");
+    expect(ctx.store.get(feedbackSelectionValue$)).toBeNull();
+    expect(window.getSelection()?.toString()).toBe("Reply from thread A");
+
+    // Some browser event orders can leave the old assistant selection readable
+    // until the click completes. The composer interaction should still win.
+    selectContents(bubble);
+    editor.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    await waitForDeferredSelectionCapture();
+
+    expect(ctx.store.get(feedbackSelectionValue$)).toBeNull();
+    cleanup?.();
+    composer.remove();
   });
 });
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -422,6 +422,13 @@ function shouldDismissSelectionForInteractionTarget(
   );
 }
 
+function clearWindowTimer(timerId: number | null): null {
+  if (timerId !== null) {
+    window.clearTimeout(timerId);
+  }
+  return null;
+}
+
 export const setFeedbackSelectionToolbarRef$ = onRef(
   command(({ set }, el: HTMLElement, signal: AbortSignal) => {
     const toolbarSignal = set(resetFeedbackSelectionToolbarSignal$, signal);
@@ -470,9 +477,7 @@ export const setFeedbackSelectionListenersRef$ = onRef(
     };
     const captureDeferred = (dismissWhenEmpty: boolean) => {
       pendingDismissWhenEmpty ||= dismissWhenEmpty;
-      if (captureTimerId !== null) {
-        window.clearTimeout(captureTimerId);
-      }
+      captureTimerId = clearWindowTimer(captureTimerId);
       captureTimerId = window.setTimeout(() => {
         const shouldDismissWhenEmpty = pendingDismissWhenEmpty;
         captureTimerId = null;
@@ -485,9 +490,9 @@ export const setFeedbackSelectionListenersRef$ = onRef(
       }, 0);
     };
     const clearSuppressedSelectionCaptureSoon = () => {
-      if (suppressSelectionClearTimerId !== null) {
-        window.clearTimeout(suppressSelectionClearTimerId);
-      }
+      suppressSelectionClearTimerId = clearWindowTimer(
+        suppressSelectionClearTimerId,
+      );
       suppressSelectionClearTimerId = window.setTimeout(() => {
         suppressSelectionCapture = false;
         suppressSelectionClearTimerId = null;
@@ -528,11 +533,9 @@ export const setFeedbackSelectionListenersRef$ = onRef(
       },
       { signal },
     );
-    doc.addEventListener(
-      "pointercancel",
-      clearSuppressedSelectionCaptureSoon,
-      { signal },
-    );
+    doc.addEventListener("pointercancel", clearSuppressedSelectionCaptureSoon, {
+      signal,
+    });
     doc.addEventListener(
       "mousedown",
       () => {
@@ -585,14 +588,10 @@ export const setFeedbackSelectionListenersRef$ = onRef(
     signal.addEventListener(
       "abort",
       () => {
-        if (captureTimerId !== null) {
-          window.clearTimeout(captureTimerId);
-          captureTimerId = null;
-        }
-        if (suppressSelectionClearTimerId !== null) {
-          window.clearTimeout(suppressSelectionClearTimerId);
-          suppressSelectionClearTimerId = null;
-        }
+        captureTimerId = clearWindowTimer(captureTimerId);
+        suppressSelectionClearTimerId = clearWindowTimer(
+          suppressSelectionClearTimerId,
+        );
       },
       { once: true },
     );

--- a/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-feedback.ts
@@ -13,6 +13,7 @@ const ASSISTANT_GROUP_SELECTOR = '[data-role="assistant"]';
 // Each chat thread renders inside a container tagged with its thread id. We
 // read it off the selection so a feedback draft stays bound to its own thread.
 const THREAD_CONTAINER_SELECTOR = "[data-chat-thread-container-id]";
+const CHAT_COMPOSER_SELECTOR = "[data-chat-composer]";
 
 export interface FeedbackSelectionRect {
   readonly top: number;
@@ -247,10 +248,17 @@ function formatFeedbackPrompt(items: readonly FeedbackItem[]): string {
   return `${intro}\n\n${blocks.join("\n\n---\n\n")}`;
 }
 
-export const closeFeedbackSelectionToolbar$ = command(({ set }) => {
+const hideFeedbackSelectionToolbar$ = command(({ set }) => {
   set(resetFeedbackSelectionToolbarSignal$);
-  window.getSelection()?.removeAllRanges();
   set(feedbackSelection$, null);
+});
+
+export const closeFeedbackSelectionToolbar$ = command(({ get, set }) => {
+  if (get(feedbackSelection$) === null) {
+    return;
+  }
+  set(hideFeedbackSelectionToolbar$);
+  window.getSelection()?.removeAllRanges();
 });
 
 // Watch the document selection and drive the floating toolbar. The toolbar
@@ -403,6 +411,17 @@ function shouldIgnoreTextShortcut(event: KeyboardEvent): boolean {
   return isEditableTarget(event.target);
 }
 
+function shouldDismissSelectionForInteractionTarget(
+  target: EventTarget | null,
+): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  return (
+    isEditableTarget(target) || target.closest(CHAT_COMPOSER_SELECTOR) !== null
+  );
+}
+
 export const setFeedbackSelectionToolbarRef$ = onRef(
   command(({ set }, el: HTMLElement, signal: AbortSignal) => {
     const toolbarSignal = set(resetFeedbackSelectionToolbarSignal$, signal);
@@ -436,11 +455,13 @@ export const setFeedbackSelectionToolbarRef$ = onRef(
 );
 
 export const setFeedbackSelectionListenersRef$ = onRef(
-  command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+  command(({ get, set }, el: HTMLElement, signal: AbortSignal) => {
     const doc = el.ownerDocument;
     let captureTimerId: number | null = null;
     let pendingDismissWhenEmpty = false;
     let mouseIsDown = false;
+    let suppressSelectionCapture = false;
+    let suppressSelectionClearTimerId: number | null = null;
     const capture = () => {
       set(captureFeedbackSelection$);
     };
@@ -463,7 +484,55 @@ export const setFeedbackSelectionListenersRef$ = onRef(
         captureIfPresent();
       }, 0);
     };
+    const clearSuppressedSelectionCaptureSoon = () => {
+      if (suppressSelectionClearTimerId !== null) {
+        window.clearTimeout(suppressSelectionClearTimerId);
+      }
+      suppressSelectionClearTimerId = window.setTimeout(() => {
+        suppressSelectionCapture = false;
+        suppressSelectionClearTimerId = null;
+      }, 0);
+    };
+    const dismissSelectionForComposerInteraction = (
+      target: EventTarget | null,
+    ) => {
+      if (
+        get(feedbackSelection$) === null ||
+        !shouldDismissSelectionForInteractionTarget(target)
+      ) {
+        return;
+      }
+      suppressSelectionCapture = true;
+      // Do not clear the native selection here: the composer may already own
+      // the caret by the time the popover finishes closing.
+      set(hideFeedbackSelectionToolbar$);
+    };
 
+    // Starting an interaction in the composer should hand focus back to the
+    // composer, not let a stale assistant selection reopen the toolbar.
+    doc.addEventListener(
+      "pointerdown",
+      (event) => {
+        dismissSelectionForComposerInteraction(event.target);
+      },
+      { capture: true, signal },
+    );
+    doc.addEventListener(
+      "pointerup",
+      (event) => {
+        // Mouse interactions finish through the mouseup path below; touch/pen
+        // may not, so clear their suppression after the pointer sequence.
+        if ((event as PointerEvent).pointerType !== "mouse") {
+          clearSuppressedSelectionCaptureSoon();
+        }
+      },
+      { signal },
+    );
+    doc.addEventListener(
+      "pointercancel",
+      clearSuppressedSelectionCaptureSoon,
+      { signal },
+    );
     doc.addEventListener(
       "mousedown",
       () => {
@@ -475,6 +544,10 @@ export const setFeedbackSelectionListenersRef$ = onRef(
       "mouseup",
       () => {
         mouseIsDown = false;
+        if (suppressSelectionCapture) {
+          suppressSelectionCapture = false;
+          return;
+        }
         captureDeferred(true);
       },
       { signal },
@@ -490,7 +563,7 @@ export const setFeedbackSelectionListenersRef$ = onRef(
     doc.addEventListener(
       "selectionchange",
       () => {
-        if (mouseIsDown) {
+        if (mouseIsDown || suppressSelectionCapture) {
           return;
         }
         captureDeferred(false);
@@ -515,6 +588,10 @@ export const setFeedbackSelectionListenersRef$ = onRef(
         if (captureTimerId !== null) {
           window.clearTimeout(captureTimerId);
           captureTimerId = null;
+        }
+        if (suppressSelectionClearTimerId !== null) {
+          window.clearTimeout(suppressSelectionClearTimerId);
+          suppressSelectionClearTimerId = null;
         }
       },
       { once: true },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-inline-feedback.test.tsx
@@ -123,6 +123,18 @@ function buttonByText(text: string): HTMLElement {
   return button;
 }
 
+async function findComposerEditor(): Promise<HTMLElement> {
+  return await waitFor(() => {
+    const editor = document.querySelector(
+      '.zero-composer [contenteditable="true"]',
+    );
+    if (!(editor instanceof HTMLElement)) {
+      throw new Error("Composer editor not found");
+    }
+    return editor;
+  });
+}
+
 function dispatchDocumentShortcut(key: string): KeyboardEvent {
   const event = new KeyboardEvent("keydown", {
     bubbles: true,
@@ -260,6 +272,55 @@ describe("chat inline feedback", () => {
     await waitFor(() => {
       expect(screen.getByText("Provide feedback")).toBeInTheDocument();
     });
+  });
+
+  it("keeps composer focus after the inline feedback toolbar closes", async () => {
+    const user = userEvent.setup({ delay: null });
+    const assistantReply = "The composer should keep focus after feedback.";
+
+    mockChatLifecycle(context, {
+      threadId: FEEDBACK_THREAD_ID,
+      threadTitle: "Feedback review",
+      chatMessages: [
+        {
+          id: "msg-feedback-composer-focus-user",
+          role: "user",
+          content: "Review this launch summary",
+          runId: "run-feedback-composer-focus",
+          createdAt: "2026-06-09T10:00:00Z",
+        },
+        {
+          id: "msg-feedback-composer-focus-assistant",
+          role: "assistant",
+          content: assistantReply,
+          runId: "run-feedback-composer-focus",
+          createdAt: "2026-06-09T10:01:00Z",
+        },
+      ],
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/chats/${FEEDBACK_THREAD_ID}`,
+    });
+
+    const assistantReplyElement = await screen.findByText(assistantReply);
+    selectTextForInlineFeedback(assistantReplyElement);
+
+    await waitFor(() => {
+      expect(screen.getByText("Provide feedback")).toBeInTheDocument();
+    });
+
+    const composerEditor = await findComposerEditor();
+    await user.click(composerEditor);
+    expect(composerEditor).toHaveFocus();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Provide feedback")).not.toBeInTheDocument();
+    });
+    await waitForDeferredSelectionCapture();
+
+    expect(composerEditor).toHaveFocus();
   });
 
   it("focuses the inline feedback composer when started from the keyboard shortcut", async () => {


### PR DESCRIPTION
## Summary
- Fix the inline feedback toolbar dismissal path so clicking back into the chat composer does not lose composer focus when the toolbar closes.
- Handle composer/editor interactions in the feedback selection listener with pointer events, covering mouse, touch, and pen without forcing focus or opening the mobile keyboard.
- Split toolbar hiding from native selection clearing so the composer interaction path does not call `removeAllRanges()` after the editor may already own the caret.

## Verification
- `pnpm --dir turbo -F @vm0/app exec vitest run src/signals/__tests__/chat-feedback.test.ts --reporter=verbose`
- `pnpm --dir turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-inline-feedback.test.tsx --reporter=verbose`
- `pnpm --dir turbo -F @vm0/app exec tsc -p tsconfig.tests.json --noEmit --pretty false`
- `git diff --check`
