### PR TITLE
fix(cli): pin npm publisher for cli releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1774,8 +1774,8 @@ jobs:
       - name: Install dependencies
         run: cd turbo && pnpm install --frozen-lockfile
 
-      - name: Use latest npm for OIDC support
-        run: npm install -g npm@latest
+      - name: Use stable npm for OIDC support
+        run: npm install -g npm@11.18.0
 
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build

--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@vm0/cli",
   "version": "9.232.2",
   "private": true,
-  "description": "CLI application",
+  "description": "Zero command-line interface",
   "repository": {
     "type": "git",
     "url": "https://github.com/vm0-ai/vm0",


### PR DESCRIPTION
## Summary
- pin the release workflow npm publisher to npm 11.18.0 instead of npm@latest
- update CLI package metadata so release-please produces a new CLI patch release

## Context
The `cli-v9.232.2` GitHub release was created, but the npm publish job failed because npm@12 on the GitHub runner threw `Cannot find module 'sigstore'` during `npm publish`. npm latest on the registry is still `@vm0/cli@9.230.5`, so runners cannot pull the new website template resources.

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('turbo/apps/cli/package.json','utf8'))"`
- `git diff --check`

No full vitest/dev server run; this is a release workflow + package metadata change.