### PR TITLE
test: centralize connected upstream proof setup

### DIFF
--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -17,18 +17,12 @@ from tests.request_handler_helpers import (
     _write_github_firewall_registry,
     _write_registry,
 )
+from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
 )
-
-
-def _mark_upstream_tls_verified(flow, *, sni: str) -> None:
-    flow.server_conn.sni = sni
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
 
 
 def _write_test_oauth_registry(tmp_path):
@@ -658,7 +652,10 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_when_upstrea
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.peername = ("140.82.112.5", 443)
-    _mark_upstream_tls_verified(flow, sni="attacker.example.com")
+    flow.server_conn.sni = "attacker.example.com"
+    flow.server_conn.timestamp_tls_setup = 1.0
+    flow.server_conn.certificate_list = (object(),)
+    flow.server_conn.error = None
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -692,7 +689,9 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_when_upstrea
     )
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.peername = ("140.82.112.5", 443)
-    _mark_upstream_tls_verified(flow, sni="api.github.com")
+    flow.server_conn.sni = "api.github.com"
+    flow.server_conn.timestamp_tls_setup = 1.0
+    flow.server_conn.certificate_list = (object(),)
     flow.server_conn.error = "certificate verify failed"
 
     with (
@@ -766,10 +765,12 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_after_retarg
         path="/repos",
         request_headers=headers(("Host", "api.github.com")),
     )
-    flow.server_conn.address = ("api.github.com", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.peername = ("140.82.112.5", 443)
-    _mark_upstream_tls_verified(flow, sni="api.github.com")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=("api.github.com", 443),
+        peername=("140.82.112.5", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -811,11 +812,13 @@ async def test_matching_sni_and_host_allows_connected_firewall_auth_with_verifie
         path="/repos",
         request_headers=headers(("Host", "api.github.com")),
     )
-    flow.server_conn.address = ("api.github.com", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.peername = None
-    flow.client_conn.sockname = ("140.82.112.5", 443)
-    _mark_upstream_tls_verified(flow, sni="api.github.com")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=("api.github.com", 443),
+        peername=None,
+        client_sockname=("140.82.112.5", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -898,11 +901,13 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_loopbac
         path="/repos",
         request_headers=headers(("Host", "api.github.com")),
     )
-    flow.server_conn.address = ("api.github.com", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.peername = None
-    flow.client_conn.sockname = ("127.0.0.1", 443)
-    _mark_upstream_tls_verified(flow, sni="api.github.com")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=("api.github.com", 443),
+        peername=None,
+        client_sockname=("127.0.0.1", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -1133,9 +1138,12 @@ async def test_matching_sni_and_host_allows_authenticated_connected_vm0_api_edge
             ("Host", "api.vm0.ai"),
         ),
     )
-    flow.server_conn.peername = ("203.0.113.10", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    _mark_upstream_tls_verified(flow, sni="api.vm0.ai")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.vm0.ai",
+        server_address=("203.0.113.10", 443),
+        peername=("203.0.113.10", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(registry_file), api_url="https://api.vm0.ai"),
@@ -1170,9 +1178,12 @@ async def test_matching_sni_and_host_allows_test_connector_on_authenticated_api_
             ("x-vm0-test-endpoint-bypass", "preview-secret"),
         ),
     )
-    flow.server_conn.peername = ("203.0.113.10", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    _mark_upstream_tls_verified(flow, sni="api.vm0.ai")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.vm0.ai",
+        server_address=("203.0.113.10", 443),
+        peername=("203.0.113.10", 443),
+    )
     monkeypatch.setenv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret")
 
     with (
@@ -1459,8 +1470,12 @@ async def test_matching_sni_and_host_blocks_test_connector_api_edge_without_bypa
             ("x-vm0-test-endpoint-bypass", "wrong-secret"),
         ),
     )
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    _mark_upstream_tls_verified(flow, sni="api.vm0.ai")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.vm0.ai",
+        server_address=("203.0.113.10", 443),
+        peername=None,
+    )
     monkeypatch.setenv("VERCEL_AUTOMATION_BYPASS_SECRET", "preview-secret")
 
     with (

--- a/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_public_destination.py
@@ -3,7 +3,6 @@
 import json
 
 import pytest
-from mitmproxy import connection
 from mitmproxy.flow import Error
 
 import auth_base_forwarder
@@ -13,6 +12,7 @@ import request_classification
 import upstream_destination_binding
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import _single_firewall_vm, _write_registry
+from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
 
 def _write_public_destination_firewall_registry(
@@ -467,13 +467,12 @@ async def test_public_destination_allows_connected_prebound_public_original_dest
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("93.184.216.35", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("93.184.216.35", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -500,13 +499,12 @@ async def test_public_destination_blocks_connected_private_transparent_host_desp
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="10.0.0.1")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("93.184.216.35", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("93.184.216.35", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -535,13 +533,12 @@ async def test_public_destination_blocks_connected_public_original_port_mismatch
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("93.184.216.35", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("93.184.216.35", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -570,14 +567,13 @@ async def test_public_destination_allows_connected_public_transparent_sockname_w
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = None
-    flow.client_conn.sockname = ("93.184.216.34", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=None,
+        client_sockname=("93.184.216.34", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -596,14 +592,13 @@ async def test_public_destination_blocks_connected_private_transparent_sockname_
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = None
-    flow.client_conn.sockname = ("10.0.0.1", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=None,
+        client_sockname=("10.0.0.1", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -624,14 +619,13 @@ async def test_public_destination_blocks_private_peer_before_public_transparent_
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("10.0.0.1", 443)
-    flow.client_conn.sockname = ("93.184.216.34", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("10.0.0.1", 443),
+        client_sockname=("93.184.216.34", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -652,13 +646,12 @@ async def test_public_destination_blocks_private_transparent_host_despite_public
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="10.0.0.1")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("93.184.216.35", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("93.184.216.35", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -679,13 +672,12 @@ async def test_public_destination_blocks_private_server_address_despite_public_p
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("10.0.0.1", 443)
-    flow.server_conn.peername = ("93.184.216.35", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("10.0.0.1", 443),
+        peername=("93.184.216.35", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -727,14 +719,13 @@ async def test_public_destination_blocks_loopback_peer_before_public_transparent
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("127.0.0.1", 443)
-    flow.client_conn.sockname = ("93.184.216.34", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("127.0.0.1", 443),
+        client_sockname=("93.184.216.34", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -755,14 +746,13 @@ async def test_public_destination_blocks_transparent_sockname_port_mismatch(
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = None
-    flow.client_conn.sockname = ("93.184.216.34", 8443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=None,
+        client_sockname=("93.184.216.34", 8443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -783,14 +773,13 @@ async def test_public_destination_blocks_peer_port_mismatch_before_transparent_s
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("93.184.216.35", 8443)
-    flow.client_conn.sockname = ("93.184.216.34", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("93.184.216.35", 8443),
+        client_sockname=("93.184.216.34", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -811,13 +800,12 @@ async def test_public_destination_blocks_connected_private_peer_despite_public_o
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("10.0.0.1", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("10.0.0.1", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -846,13 +834,12 @@ async def test_public_destination_blocks_private_original_despite_connected_publ
 ):
     reg_path = _write_public_destination_firewall_registry(tmp_path)
     flow = _public_destination_flow(real_flow, headers, destination_host="service.example.com")
-    flow.server_conn.address = ("service.example.com", 443)
-    flow.server_conn.peername = ("93.184.216.35", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.server_conn.sni = "service.example.com"
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
+    mark_connected_tls_upstream(
+        flow,
+        sni="service.example.com",
+        server_address=("service.example.com", 443),
+        peername=("93.184.216.35", 443),
+    )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
         client=flow.client_conn,
@@ -927,12 +914,12 @@ async def test_public_destination_revalidates_connected_peer_after_requestheader
         assert "Authorization" not in flow.request.headers
         assert flow.server_conn.address == ("service.example.com", 443)
 
-        flow.server_conn.peername = ("10.0.0.1", 443)
-        flow.server_conn.state = connection.ConnectionState.OPEN
-        flow.server_conn.sni = "service.example.com"
-        flow.server_conn.timestamp_tls_setup = 1.0
-        flow.server_conn.certificate_list = (object(),)
-        flow.server_conn.error = None
+        mark_connected_tls_upstream(
+            flow,
+            sni="service.example.com",
+            server_address=("service.example.com", 443),
+            peername=("10.0.0.1", 443),
+        )
 
         await mitm_addon.request(flow)
 
@@ -968,12 +955,12 @@ async def test_public_destination_requestheaders_defers_unresolved_hostname_unti
         assert flow.error is None
         assert flow.server_conn.address == ("service.example.com", 443)
 
-        flow.server_conn.peername = ("93.184.216.35", 443)
-        flow.server_conn.state = connection.ConnectionState.OPEN
-        flow.server_conn.sni = "service.example.com"
-        flow.server_conn.timestamp_tls_setup = 1.0
-        flow.server_conn.certificate_list = (object(),)
-        flow.server_conn.error = None
+        mark_connected_tls_upstream(
+            flow,
+            sni="service.example.com",
+            server_address=("service.example.com", 443),
+            peername=("93.184.216.35", 443),
+        )
 
         await mitm_addon.request(flow)
 
@@ -1006,12 +993,12 @@ async def test_public_destination_requestheaders_deferred_hostname_still_blocks_
         assert flow.response is None
         assert flow.error is None
 
-        flow.server_conn.peername = ("10.0.0.1", 443)
-        flow.server_conn.state = connection.ConnectionState.OPEN
-        flow.server_conn.sni = "service.example.com"
-        flow.server_conn.timestamp_tls_setup = 1.0
-        flow.server_conn.certificate_list = (object(),)
-        flow.server_conn.error = None
+        mark_connected_tls_upstream(
+            flow,
+            sni="service.example.com",
+            server_address=("service.example.com", 443),
+            peername=("10.0.0.1", 443),
+        )
 
         await mitm_addon.request(flow)
 
@@ -1066,12 +1053,12 @@ async def test_public_destination_revalidates_cached_auth_base_classification(
             mitm_addon.STREAM_BUFFER_LIMIT + 1,
         )
 
-        flow.server_conn.peername = ("10.0.0.1", 443)
-        flow.server_conn.state = connection.ConnectionState.OPEN
-        flow.server_conn.sni = "service.example.com"
-        flow.server_conn.timestamp_tls_setup = 1.0
-        flow.server_conn.certificate_list = (object(),)
-        flow.server_conn.error = None
+        mark_connected_tls_upstream(
+            flow,
+            sni="service.example.com",
+            server_address=("service.example.com", 443),
+            peername=("10.0.0.1", 443),
+        )
 
         await mitm_addon.request(flow)
 
@@ -1106,12 +1093,12 @@ async def test_public_destination_revalidates_cached_auth_base_hostname_classifi
             mitm_addon.STREAM_BUFFER_LIMIT + 1,
         )
 
-        flow.server_conn.peername = ("10.0.0.1", 443)
-        flow.server_conn.state = connection.ConnectionState.OPEN
-        flow.server_conn.sni = "service.example.com"
-        flow.server_conn.timestamp_tls_setup = 1.0
-        flow.server_conn.certificate_list = (object(),)
-        flow.server_conn.error = None
+        mark_connected_tls_upstream(
+            flow,
+            sni="service.example.com",
+            server_address=("service.example.com", 443),
+            peername=("10.0.0.1", 443),
+        )
 
         await mitm_addon.request(flow)
 

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -23,18 +23,12 @@ from tests.request_handler_helpers import (
     _write_registry,
 )
 from tests.requestheaders_helpers import await_requestheaders_result
+from tests.upstream_connection_helpers import mark_connected_tls_upstream
 
 _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
 )
-
-
-def _mark_upstream_tls_verified(flow, *, sni: str) -> None:
-    flow.server_conn.sni = sni
-    flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
-    flow.server_conn.error = None
 
 
 def _request_stream(flow):
@@ -173,9 +167,12 @@ async def test_capture_enabled_api_allow_uses_authenticated_connected_edge_upstr
             ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
         ),
     )
-    flow.server_conn.peername = ("203.0.113.10", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    _mark_upstream_tls_verified(flow, sni="api.vm0.ai")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.vm0.ai",
+        server_address=("203.0.113.10", 443),
+        peername=("203.0.113.10", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -216,11 +213,13 @@ async def test_capture_enabled_api_allow_uses_connected_upstream_address_when_tl
             ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
         ),
     )
-    flow.server_conn.address = ("api.vm0.ai", 443)
-    flow.server_conn.peername = None
-    flow.client_conn.sockname = ("198.18.20.34", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    _mark_upstream_tls_verified(flow, sni="api.vm0.ai")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.vm0.ai",
+        server_address=("api.vm0.ai", 443),
+        peername=None,
+        client_sockname=("198.18.20.34", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -263,10 +262,13 @@ async def test_capture_enabled_api_allow_uses_prior_client_binding_when_server_c
             ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
         ),
     )
-    flow.server_conn.peername = None
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    flow.client_conn.sockname = ("198.18.20.34", 443)
-    _mark_upstream_tls_verified(flow, sni="api.vm0.ai")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.vm0.ai",
+        server_address=("127.0.0.1", 443),
+        peername=None,
+        client_sockname=("198.18.20.34", 443),
+    )
 
     server_connect_server = connection.Server(address=("198.18.20.34", 443))
     upstream_destination_binding.record_server_binding(
@@ -1129,9 +1131,12 @@ async def test_firewall_allow_header_auth_uses_connected_upstream_when_tls_verif
             ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
         ),
     )
-    flow.server_conn.peername = ("172.66.0.243", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    _mark_upstream_tls_verified(flow, sni="api.github.com")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=("172.66.0.243", 443),
+        peername=("172.66.0.243", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
@@ -1451,9 +1456,12 @@ async def test_firewall_allow_small_bounded_body_uses_connected_upstream_when_tl
         path="/repos/octocat/hello",
         request_headers=headers(("Host", "api.github.com"), ("Content-Length", "4")),
     )
-    flow.server_conn.peername = ("172.66.0.243", 443)
-    flow.server_conn.state = connection.ConnectionState.OPEN
-    _mark_upstream_tls_verified(flow, sni="api.github.com")
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=("172.66.0.243", 443),
+        peername=("172.66.0.243", 443),
+    )
 
     with (
         mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),

--- a/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
+++ b/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
@@ -1,0 +1,23 @@
+"""Shared helpers for connected upstream mitmproxy test state."""
+
+from mitmproxy import connection, http
+
+
+def mark_connected_tls_upstream(
+    flow: http.HTTPFlow,
+    *,
+    sni: str,
+    server_address: tuple[str, int],
+    peername: tuple[str, int] | None,
+    client_sockname: tuple[str, int] | None = None,
+) -> None:
+    """Mark a real flow as connected to an upstream with verified TLS evidence."""
+    flow.server_conn.address = server_address
+    flow.server_conn.peername = peername
+    if client_sockname is not None:
+        flow.client_conn.sockname = client_sockname
+    flow.server_conn.state = connection.ConnectionState.OPEN
+    flow.server_conn.sni = sni
+    flow.server_conn.timestamp_tls_setup = 1.0
+    flow.server_conn.certificate_list = (object(),)
+    flow.server_conn.error = None

--- a/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
+++ b/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
@@ -14,8 +14,7 @@ def mark_connected_tls_upstream(
     """Mark a real flow as connected to an upstream with verified TLS evidence."""
     flow.server_conn.address = server_address
     flow.server_conn.peername = peername
-    if client_sockname is not None:
-        flow.client_conn.sockname = client_sockname
+    flow.client_conn.sockname = client_sockname
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.sni = sni
     flow.server_conn.timestamp_tls_setup = 1.0

--- a/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
+++ b/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
@@ -1,6 +1,11 @@
 """Shared helpers for connected upstream mitmproxy test state."""
 
-from mitmproxy import connection, http
+from typing import cast
+
+from mitmproxy import certs, connection, http
+
+_NO_CONNECTED_CLIENT_SOCKNAME = ("", 0)
+_TLS_CERTIFICATE_PROOF = cast(certs.Cert, object())
 
 
 def mark_connected_tls_upstream(
@@ -14,9 +19,11 @@ def mark_connected_tls_upstream(
     """Mark a real flow as connected to an upstream with verified TLS evidence."""
     flow.server_conn.address = server_address
     flow.server_conn.peername = peername
-    flow.client_conn.sockname = client_sockname
+    flow.client_conn.sockname = (
+        client_sockname if client_sockname is not None else _NO_CONNECTED_CLIENT_SOCKNAME
+    )
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.server_conn.sni = sni
     flow.server_conn.timestamp_tls_setup = 1.0
-    flow.server_conn.certificate_list = (object(),)
+    flow.server_conn.certificate_list = (_TLS_CERTIFICATE_PROOF,)
     flow.server_conn.error = None

--- a/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
+++ b/crates/runner/mitm-addon/tests/upstream_connection_helpers.py
@@ -4,7 +4,9 @@ from typing import cast
 
 from mitmproxy import certs, connection, http
 
+# Keep the shape mitmproxy types expect without adding an authoritative endpoint.
 _NO_CONNECTED_CLIENT_SOCKNAME = ("", 0)
+# Admission only checks that mitmproxy recorded at least one upstream certificate.
 _TLS_CERTIFICATE_PROOF = cast(certs.Cert, object())
 
 


### PR DESCRIPTION
## Summary

- Add a shared `mark_connected_tls_upstream` helper for mitm-addon tests that need verified connected upstream proof state.
- Migrate public-destination, authority-validation, and requestheaders positive TLS-proof setup to the helper.
- Keep upstream destination binding setup and negative TLS-proof scenarios explicit in each test.

Closes #20752

## Tests

- `python3 -m compileall tests/upstream_connection_helpers.py`
- `.venv/bin/python -m compileall tests/upstream_connection_helpers.py`
- `.venv/bin/ruff check tests/upstream_connection_helpers.py tests/test_request_handler_public_destination.py tests/test_request_handler_authority_validation.py tests/test_request_headers_handler.py`
- `.venv/bin/pytest tests/test_request_handler_public_destination.py tests/test_request_handler_authority_validation.py tests/test_request_headers_handler.py`