### PR TITLE
fix: show notion icon in workflow automations

### DIFF
--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -21,10 +21,14 @@ import type {
 import {
   IconAlertTriangle,
   IconBrandGithub,
+  IconBrandNotion,
   IconCalendarTime,
   IconChevronDown,
   IconClock,
   IconCopy,
+  IconDatabasePlus,
+  IconFilePencil,
+  IconFilePlus,
   IconFileText,
   IconHistory,
   IconInfoCircle,
@@ -2447,19 +2451,19 @@ function buildNotionTriggerOptions(
       kind: "notion-child-page",
       title: "New Notion child page",
       description: "Run when a direct child page is created.",
-      icon: IconFileText,
+      icon: IconFilePlus,
     },
     {
       kind: "notion-database-item",
       title: "New Notion database item",
       description: "Run when a page is added to a Notion database.",
-      icon: IconFileText,
+      icon: IconDatabasePlus,
     },
     {
       kind: "notion-page-content-updated",
       title: "Notion page content updated",
       description: "Run when a page or database item content changes.",
-      icon: IconFileText,
+      icon: IconFilePencil,
     },
   ];
 }
@@ -2582,7 +2586,7 @@ function buildTriggerCreateCategories({
     {
       key: "notion",
       label: "Notion",
-      icon: IconFileText,
+      icon: IconBrandNotion,
       options: notionOptions,
     },
     {
@@ -3105,7 +3109,7 @@ function CreateNotionDatabaseItemTriggerDialog({
               {creating ? (
                 <IconLoader2 size={14} className="animate-spin" />
               ) : (
-                <IconFileText size={14} stroke={1.5} />
+                <IconBrandNotion size={14} stroke={1.5} />
               )}
               Add Notion automation
             </Button>
@@ -3272,7 +3276,7 @@ function CreateNotionPageContentUpdatedTriggerDialog({
               {creating ? (
                 <IconLoader2 size={14} className="animate-spin" />
               ) : (
-                <IconFileText size={14} stroke={1.5} />
+                <IconBrandNotion size={14} stroke={1.5} />
               )}
               Add Notion automation
             </Button>
@@ -3363,7 +3367,7 @@ function CreateNotionChildPageTriggerDialog({
               {creating ? (
                 <IconLoader2 size={14} className="animate-spin" />
               ) : (
-                <IconFileText size={14} stroke={1.5} />
+                <IconBrandNotion size={14} stroke={1.5} />
               )}
               Add Notion automation
             </Button>

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -14,7 +14,9 @@ import {
   IconBrandGithub,
   IconCalendarTime,
   IconClock,
-  IconFileText,
+  IconDatabasePlus,
+  IconFilePencil,
+  IconFilePlus,
   IconLink,
   IconMail,
   IconMessageCircle,
@@ -322,12 +324,14 @@ export function TriggerListIcon({
     if (trigger.eventType === "google-meet-transcript-generated") {
       return IconVideo;
     }
-    if (
-      trigger.eventType === "notion-child-page-created" ||
-      trigger.eventType === "notion-database-item-created" ||
-      trigger.eventType === "notion-page-content-updated"
-    ) {
-      return IconFileText;
+    if (trigger.eventType === "notion-child-page-created") {
+      return IconFilePlus;
+    }
+    if (trigger.eventType === "notion-database-item-created") {
+      return IconDatabasePlus;
+    }
+    if (trigger.eventType === "notion-page-content-updated") {
+      return IconFilePencil;
     }
     if (trigger.eventType === "gmail-label-applied") {
       return IconTag;


### PR DESCRIPTION
## Summary
- Uses Tabler's outline-style Notion brand icon in the workflow automation picker category rail.
- Uses action-specific outline icons for Notion trigger cards and created automation list entries, so child page, database item, and content update triggers are visually distinct.
- Keeps GitHub-style brand treatment where the card itself represents the connector, while Notion card icons represent the selected trigger action.

## Verification
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app lint`
- `git diff --check`
