### PR TITLE
docs(nbd-cow): clarify device lock contract

### DIFF
--- a/crates/nbd-cow/src/bin/bench/devices/nbd.rs
+++ b/crates/nbd-cow/src/bin/bench/devices/nbd.rs
@@ -2,7 +2,7 @@
 ///
 /// The sysfs `pid` field is the connecting thread TID, not necessarily the
 /// process PID. In multi-runner hosts, only disconnect after acquiring the
-/// host-global NBD claim so an active cooperating runner cannot be interrupted.
+/// cooperative NBD claim so an active cooperating runner cannot be interrupted.
 pub(crate) fn cleanup_stale_nbd_devices() {
     let max = nbd_cow::netlink::nbds_max();
     for i in 0..max {

--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -95,8 +95,9 @@ impl pool::DevicePoolHandle {
     /// device.
     ///
     /// On success, the returned [`PooledNbdCowDevice`] owns a pool lease for a
-    /// host-global `/dev/nbdN` device. Callers must finish the lifecycle with an
-    /// explicit finalizer such as [`PooledNbdCowDevice::destroy_with_retries`],
+    /// `/dev/nbdN` device claimed through the cooperative pool. Callers must
+    /// finish the lifecycle with an explicit finalizer such as
+    /// [`PooledNbdCowDevice::destroy_with_retries`],
     /// [`PooledNbdCowDevice::destroy_keep_cow_with_retries`], or
     /// [`PooledNbdCowDevice::abandon`].
     ///

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -5,11 +5,12 @@
 //! process exits.
 //!
 //! Claims are represented by per-index lock files named
-//! `vm0-nbd-{index}.lock`. The default directory is [`default_lock_dir`],
+//! `vm0-nbd-{index}.lock`. When this API creates a missing lock file, it uses
+//! private file permissions. The default directory is [`default_lock_dir`],
 //! currently `/var/lock`; callers using [`try_acquire_device_claim_in`] may
 //! provide another operator-approved lock-file directory. The directory must
-//! already exist, but this API does not require the directory itself to be
-//! owned by the current effective uid or private to the process.
+//! already exist, but this API does not require the directory itself to be owned
+//! by the current effective uid or private to the process.
 //!
 //! The security-sensitive object is the final per-index lock file. Existing
 //! lock files must be regular files openable for read and write by the current
@@ -85,7 +86,8 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 /// Try to acquire a host-global claim in a custom lock directory.
 ///
 /// `lock_dir` must already exist. The per-index lock path is
-/// `lock_dir/vm0-nbd-{index}.lock`.
+/// `lock_dir/vm0-nbd-{index}.lock`. Missing per-index lock files are created
+/// with private permissions and then validated before locking.
 ///
 /// Existing final lock files must be regular files openable for read and write
 /// by the current process, must be owned by the current effective uid, must not

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -14,8 +14,9 @@
 //! The security-sensitive object is the final per-index lock file. Existing
 //! lock files must be regular files openable for read and write by the current
 //! process, must be owned by the current effective uid, must not have multiple
-//! hard links, and must not be group/other-writable. Unsafe or invalid final
-//! lock paths are reported as I/O errors instead of ordinary lock contention.
+//! hard links, and must not have group/other-writable mode bits. Unsafe or
+//! invalid final lock-file paths are reported as I/O errors instead of ordinary
+//! lock contention.
 
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -88,10 +89,11 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 ///
 /// Existing final lock files must be regular files openable for read and write
 /// by the current process, must be owned by the current effective uid, must not
-/// have multiple hard links, and must not be group/other-writable. Unsafe final
-/// lock paths, including symlinks and non-regular files, are reported as
-/// [`std::io::Error`]. Existing lock files with otherwise acceptable legacy
-/// permissions may be tightened to `0600`.
+/// have multiple hard links, and must not have group/other-writable mode bits.
+/// Unsafe final lock-file paths, including a symlink at the per-index lock path
+/// and non-regular files, are reported as [`std::io::Error`]. Existing lock
+/// files with otherwise acceptable legacy permissions may be tightened to
+/// `0600`.
 ///
 /// Returns `Ok(Some(_))` when the caller owns the claim until the returned
 /// [`NbdDeviceClaim`] is dropped. Returns `Ok(None)` only when another process

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -1,8 +1,8 @@
 //! Host-global NBD device index locks.
 //!
 //! These locks coordinate `/dev/nbdN` ownership across runner processes on the
-//! same host. The kernel releases `flock` locks automatically when the owning
-//! process exits.
+//! same host. Dropping the returned claim closes the lock file descriptor and
+//! releases the corresponding kernel `flock`.
 //!
 //! Claims are represented by per-index lock files named
 //! `vm0-nbd-{index}.lock`. When this API creates a missing lock file, it uses

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -1,8 +1,9 @@
 //! Host-global NBD device index locks.
 //!
-//! These locks coordinate `/dev/nbdN` ownership across runner processes on the
-//! same host. Dropping the returned claim closes the lock file descriptor and
-//! releases the corresponding kernel `flock`.
+//! These locks coordinate `/dev/nbdN` ownership across runner processes that
+//! resolve their lock files through the same host-visible lock directory.
+//! Dropping the returned claim closes the lock file descriptor and releases the
+//! corresponding kernel `flock`.
 //!
 //! Claims are represented by per-index lock files named
 //! `vm0-nbd-{index}.lock`. When this API creates a missing lock file, it uses
@@ -11,8 +12,8 @@
 //! provide another operator-approved lock-file directory. The directory must
 //! already exist, but this API does not require the directory itself to be owned
 //! by the current effective uid or private to the process.
-//! Cooperating processes must use the same lock directory for their claims to
-//! coordinate with each other.
+//! Cooperating processes must use the same resolved lock directory for their
+//! claims to coordinate with each other.
 //!
 //! The security-sensitive object is the final per-index lock file. Existing
 //! lock files must be regular files openable for read and write by the current
@@ -101,7 +102,7 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 /// Processes using different lock directories do not coordinate with each
 /// other. Relative lock directories are resolved by each caller's current
 /// working directory, so cooperating processes should use paths that resolve to
-/// the same directory.
+/// the same directory inode.
 ///
 /// Existing final lock files must be regular files openable for read and write
 /// by the current process, must be owned by the current effective uid, must not

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -24,6 +24,10 @@
 //! The per-index lock file path must remain stable while claims may be held:
 //! kernel `flock` locks the opened inode, so deleting or replacing the path can
 //! create a separate lock domain for later callers.
+//!
+//! A claim only represents cooperative ownership of the lock file. It does not
+//! validate that `/dev/nbdN` exists or is currently free; callers that need a
+//! usable device must check device state while holding the claim.
 
 use std::fs::{File, OpenOptions};
 use std::io;

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -76,7 +76,7 @@ fn device_lock_path_in(index: u32, lock_dir: &Path) -> PathBuf {
 /// `Ok(Some(_))` when the caller owns the claim until the returned
 /// [`NbdDeviceClaim`] is dropped.
 ///
-/// Returns `Ok(None)` only when another process holds the flock on the current
+/// Returns `Ok(None)` only when the flock is already held on the current
 /// per-index lock inode. Unsafe or invalid lock-file state is reported as an
 /// [`std::io::Error`] rather than as `Ok(None)`.
 pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>> {
@@ -98,9 +98,9 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 /// `0600`.
 ///
 /// Returns `Ok(Some(_))` when the caller owns the claim until the returned
-/// [`NbdDeviceClaim`] is dropped. Returns `Ok(None)` only when another process
-/// holds the flock on the current per-index lock inode; unsafe lock-file state
-/// and repeated path replacement during acquisition are reported as I/O errors.
+/// [`NbdDeviceClaim`] is dropped. Returns `Ok(None)` only when the flock is
+/// already held on the current per-index lock inode; unsafe lock-file state and
+/// repeated path replacement during acquisition are reported as I/O errors.
 pub fn try_acquire_device_claim_in(
     index: u32,
     lock_dir: &Path,

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -1,4 +1,4 @@
-//! Host-global NBD device index locks.
+//! Cooperative NBD device index locks.
 //!
 //! These locks coordinate `/dev/nbdN` ownership across runner processes that
 //! resolve their lock files through the same host-visible lock directory.
@@ -44,7 +44,7 @@ const MAX_STALE_INODE_RETRIES: usize = 16;
 const PRIVATE_FILE_MODE: u32 = 0o600;
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 
-/// Owned host-global claim for one NBD device index.
+/// Owned cooperative claim for one NBD device index.
 ///
 /// Dropping this value releases the corresponding per-index `flock`.
 #[derive(Debug)]
@@ -81,7 +81,7 @@ fn device_lock_path_in(index: u32, lock_dir: &Path) -> PathBuf {
     lock_dir.join(format!("{LOCK_FILE_PREFIX}-{index}.lock"))
 }
 
-/// Try to acquire a host-global claim for an NBD device index.
+/// Try to acquire a cooperative claim for an NBD device index.
 ///
 /// This uses [`default_lock_dir`] for the lock file directory. Returns
 /// `Ok(Some(_))` when the caller owns the claim until the returned
@@ -94,7 +94,7 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
     try_acquire_device_claim_in(index, &default_lock_dir())
 }
 
-/// Try to acquire a host-global claim in a custom lock directory.
+/// Try to acquire a cooperative claim in a custom lock directory.
 ///
 /// `lock_dir` must already exist. The per-index lock path is
 /// `lock_dir/vm0-nbd-{index}.lock`. Missing per-index lock files are created

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -12,10 +12,10 @@
 //! owned by the current effective uid or private to the process.
 //!
 //! The security-sensitive object is the final per-index lock file. Existing
-//! lock files must be regular files owned by the current effective uid, must
-//! not have multiple hard links, and must not be group/other-writable. Unsafe
-//! or invalid final lock paths are reported as I/O errors instead of ordinary
-//! lock contention.
+//! lock files must be regular files openable for read and write by the current
+//! process, must be owned by the current effective uid, must not have multiple
+//! hard links, and must not be group/other-writable. Unsafe or invalid final
+//! lock paths are reported as I/O errors instead of ordinary lock contention.
 
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -86,11 +86,12 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 /// `lock_dir` must already exist. The per-index lock path is
 /// `lock_dir/vm0-nbd-{index}.lock`.
 ///
-/// Existing final lock files must be regular files owned by the current
-/// effective uid, must not have multiple hard links, and must not be
-/// group/other-writable. Unsafe final lock paths, including symlinks and
-/// non-regular files, are reported as [`std::io::Error`]. Existing lock files
-/// with otherwise acceptable legacy permissions may be tightened to `0600`.
+/// Existing final lock files must be regular files openable for read and write
+/// by the current process, must be owned by the current effective uid, must not
+/// have multiple hard links, and must not be group/other-writable. Unsafe final
+/// lock paths, including symlinks and non-regular files, are reported as
+/// [`std::io::Error`]. Existing lock files with otherwise acceptable legacy
+/// permissions may be tightened to `0600`.
 ///
 /// Returns `Ok(Some(_))` when the caller owns the claim until the returned
 /// [`NbdDeviceClaim`] is dropped. Returns `Ok(None)` only when another process

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -11,6 +11,8 @@
 //! provide another operator-approved lock-file directory. The directory must
 //! already exist, but this API does not require the directory itself to be owned
 //! by the current effective uid or private to the process.
+//! Cooperating processes must use the same lock directory for their claims to
+//! coordinate with each other.
 //!
 //! The security-sensitive object is the final per-index lock file. Existing
 //! lock files must be regular files openable for read and write by the current
@@ -88,6 +90,8 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 /// `lock_dir` must already exist. The per-index lock path is
 /// `lock_dir/vm0-nbd-{index}.lock`. Missing per-index lock files are created
 /// with private permissions and then validated before locking.
+/// Processes using different lock directories do not coordinate with each
+/// other.
 ///
 /// Existing final lock files must be regular files openable for read and write
 /// by the current process, must be owned by the current effective uid, must not

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -20,6 +20,10 @@
 //! hard links, and must not have group/other-writable mode bits. Unsafe or
 //! invalid final lock-file paths are reported as I/O errors instead of ordinary
 //! lock contention.
+//!
+//! The per-index lock file path must remain stable while claims may be held:
+//! kernel `flock` locks the opened inode, so deleting or replacing the path can
+//! create a separate lock domain for later callers.
 
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -91,7 +95,9 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 /// `lock_dir/vm0-nbd-{index}.lock`. Missing per-index lock files are created
 /// with private permissions and then validated before locking.
 /// Processes using different lock directories do not coordinate with each
-/// other.
+/// other. Relative lock directories are resolved by each caller's current
+/// working directory, so cooperating processes should use paths that resolve to
+/// the same directory.
 ///
 /// Existing final lock files must be regular files openable for read and write
 /// by the current process, must be owned by the current effective uid, must not

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -7,7 +7,7 @@
 //!
 //! Claims are represented by per-index lock files named
 //! `vm0-nbd-{index}.lock`. When this API creates a missing lock file, it uses
-//! private file permissions. The default directory is [`default_lock_dir`],
+//! private mode bits. The default directory is [`default_lock_dir`],
 //! currently `/var/lock`; callers using [`try_acquire_device_claim_in`] may
 //! provide another operator-approved lock-file directory. The directory must
 //! already exist, but this API does not require the directory itself to be owned
@@ -98,7 +98,7 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 ///
 /// `lock_dir` must already exist. The per-index lock path is
 /// `lock_dir/vm0-nbd-{index}.lock`. Missing per-index lock files are created
-/// with private permissions and then validated before locking.
+/// with private mode bits and then validated before locking.
 /// Processes using different lock directories do not coordinate with each
 /// other. Relative lock directories are resolved by each caller's current
 /// working directory, so cooperating processes should use paths that resolve to
@@ -109,8 +109,7 @@ pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>
 /// have multiple hard links, and must not have group/other-writable mode bits.
 /// Unsafe final lock-file paths, including a symlink at the per-index lock path
 /// and non-regular files, are reported as [`std::io::Error`]. Existing lock
-/// files with otherwise acceptable legacy permissions may be tightened to
-/// `0600`.
+/// files with otherwise acceptable legacy mode bits may be tightened to `0600`.
 ///
 /// Returns `Ok(Some(_))` when the caller owns the claim until the returned
 /// [`NbdDeviceClaim`] is dropped. Returns `Ok(None)` only when the flock is

--- a/crates/nbd-cow/src/device_lock.rs
+++ b/crates/nbd-cow/src/device_lock.rs
@@ -3,6 +3,19 @@
 //! These locks coordinate `/dev/nbdN` ownership across runner processes on the
 //! same host. The kernel releases `flock` locks automatically when the owning
 //! process exits.
+//!
+//! Claims are represented by per-index lock files named
+//! `vm0-nbd-{index}.lock`. The default directory is [`default_lock_dir`],
+//! currently `/var/lock`; callers using [`try_acquire_device_claim_in`] may
+//! provide another operator-approved lock-file directory. The directory must
+//! already exist, but this API does not require the directory itself to be
+//! owned by the current effective uid or private to the process.
+//!
+//! The security-sensitive object is the final per-index lock file. Existing
+//! lock files must be regular files owned by the current effective uid, must
+//! not have multiple hard links, and must not be group/other-writable. Unsafe
+//! or invalid final lock paths are reported as I/O errors instead of ordinary
+//! lock contention.
 
 use std::fs::{File, OpenOptions};
 use std::io;
@@ -57,12 +70,32 @@ fn device_lock_path_in(index: u32, lock_dir: &Path) -> PathBuf {
 
 /// Try to acquire a host-global claim for an NBD device index.
 ///
-/// Returns `Ok(None)` when another process holds the per-index lock.
+/// This uses [`default_lock_dir`] for the lock file directory. Returns
+/// `Ok(Some(_))` when the caller owns the claim until the returned
+/// [`NbdDeviceClaim`] is dropped.
+///
+/// Returns `Ok(None)` only when another process holds the flock on the current
+/// per-index lock inode. Unsafe or invalid lock-file state is reported as an
+/// [`std::io::Error`] rather than as `Ok(None)`.
 pub fn try_acquire_device_claim(index: u32) -> io::Result<Option<NbdDeviceClaim>> {
     try_acquire_device_claim_in(index, &default_lock_dir())
 }
 
 /// Try to acquire a host-global claim in a custom lock directory.
+///
+/// `lock_dir` must already exist. The per-index lock path is
+/// `lock_dir/vm0-nbd-{index}.lock`.
+///
+/// Existing final lock files must be regular files owned by the current
+/// effective uid, must not have multiple hard links, and must not be
+/// group/other-writable. Unsafe final lock paths, including symlinks and
+/// non-regular files, are reported as [`std::io::Error`]. Existing lock files
+/// with otherwise acceptable legacy permissions may be tightened to `0600`.
+///
+/// Returns `Ok(Some(_))` when the caller owns the claim until the returned
+/// [`NbdDeviceClaim`] is dropped. Returns `Ok(None)` only when another process
+/// holds the flock on the current per-index lock inode; unsafe lock-file state
+/// and repeated path replacement during acquisition are reported as I/O errors.
 pub fn try_acquire_device_claim_in(
     index: u32,
     lock_dir: &Path,

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -1,7 +1,7 @@
-//! Device pool for host-global NBD device claims.
+//! Device pool for cooperatively claimed NBD devices.
 //!
 //! Allocation is demand-only: each acquire scans for a free `/dev/nbdN`,
-//! acquires the per-index host `flock`, and re-checks sysfs before returning a
+//! acquires the per-index lock-file `flock`, and re-checks sysfs before returning a
 //! lease. Released devices keep their lock through a short cooldown period so
 //! kernel teardown cannot race a different runner process.
 

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -3,7 +3,8 @@
 //! Allocation is demand-only: each acquire scans for a free `/dev/nbdN`,
 //! acquires the per-index lock-file `flock`, and re-checks sysfs before returning a
 //! lease. Released devices keep their lock through a short cooldown period so
-//! kernel teardown cannot race a different runner process.
+//! kernel teardown cannot race another cooperating runner using the same lock
+//! directory.
 
 mod actor;
 mod lease;

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -16,8 +16,9 @@ use super::state::{DevicePool, DevicePoolConfig};
 /// the pool state machine and serializes transitions for `/dev/nbdN` claims,
 /// pending scans, cooldown slots, and checked-out [`DeviceLease`] returns.
 ///
-/// The handle coordinates this process-local pool state, while cross-process
-/// safety still comes from shared per-index lock files and sysfs checks.
+/// The handle coordinates this process-local pool state, while cooperative
+/// cross-process safety still comes from shared per-index lock files and sysfs
+/// checks.
 /// Dropping a handle is not normal device cleanup. Checked-out leases also carry
 /// return senders, so dropping every handle only stops the actor after
 /// outstanding leases release those senders. Successful pooled devices must

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -10,18 +10,18 @@ use super::lease::DeviceLease;
 use super::state::DevicePoolSnapshot;
 use super::state::{DevicePool, DevicePoolConfig};
 
-/// Cloneable handle to the host-global NBD device pool.
+/// Cloneable handle to the cooperative NBD device pool.
 ///
 /// All clones share one background actor and command channel. That actor owns
 /// the pool state machine and serializes transitions for `/dev/nbdN` claims,
 /// pending scans, cooldown slots, and checked-out [`DeviceLease`] returns.
 ///
-/// The handle coordinates this process-local pool state, while host-global
-/// safety still comes from per-index lock files and sysfs checks. Dropping a
-/// handle is not normal device cleanup. Checked-out leases also carry return
-/// senders, so dropping every handle only stops the actor after outstanding
-/// leases release those senders. Successful pooled devices must finish through
-/// an explicit [`crate::PooledNbdCowDevice`] finalizer such as
+/// The handle coordinates this process-local pool state, while cross-process
+/// safety still comes from shared per-index lock files and sysfs checks.
+/// Dropping a handle is not normal device cleanup. Checked-out leases also carry
+/// return senders, so dropping every handle only stops the actor after
+/// outstanding leases release those senders. Successful pooled devices must
+/// finish through an explicit [`crate::PooledNbdCowDevice`] finalizer such as
 /// [`crate::PooledNbdCowDevice::destroy_with_retries`],
 /// [`crate::PooledNbdCowDevice::destroy_keep_cow_with_retries`], or
 /// [`crate::PooledNbdCowDevice::abandon`].

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -429,7 +429,7 @@ impl DevicePool {
 
     /// Collect all indices currently tracked by the pool (cooldown + in-flight)
     /// to exclude from demand scans. Concurrent scans are still safe because the
-    /// shared per-index lock serializes claims across tasks and processes.
+    /// shared per-index lock serializes cooperating tasks and processes.
     pub(super) fn tracked_indices(&self) -> HashSet<u32> {
         self.cooldown
             .iter()

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -429,7 +429,7 @@ impl DevicePool {
 
     /// Collect all indices currently tracked by the pool (cooldown + in-flight)
     /// to exclude from demand scans. Concurrent scans are still safe because the
-    /// host-global per-index lock serializes claims across tasks and processes.
+    /// shared per-index lock serializes claims across tasks and processes.
     pub(super) fn tracked_indices(&self) -> HashSet<u32> {
         self.cooldown
             .iter()


### PR DESCRIPTION
## Summary

- document the public NBD device lock file contract at the module level
- clarify default vs custom lock directory expectations without requiring `/var/lock` to be private
- document `Ok(None)` as flock contention only and unsafe lock-file state as I/O errors

Closes #20775

## Testing

- `cargo fmt --manifest-path crates/Cargo.toml --all`
- `cargo test --manifest-path crates/Cargo.toml -p nbd-cow device_lock`
- `cargo doc --manifest-path crates/Cargo.toml -p nbd-cow --no-deps`
- pre-commit hook: `cargo-fmt`, `cargo-doc`, `cargo-clippy`
