### PR TITLE
feat(api): keyset-paginate the artifacts list endpoint

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -258,4 +258,38 @@ describe("GET /api/zero/artifacts", () => {
       ]),
     );
   }, 120_000);
+
+  it("walks the full set via keyset pagination with a small page size", async () => {
+    const owner = await artifactActor("Artifacts API paging agent");
+
+    const created: string[] = [];
+    for (const label of ["one", "two", "three"]) {
+      const artifact = await createHostedArtifact({
+        actor: owner.actor,
+        agentId: owner.agentId,
+        runnerGroup: owner.runnerGroup,
+        site: `page-${label}-${randomUUID().slice(0, 8)}`,
+      });
+      created.push(artifact.fileId);
+    }
+
+    const collected: string[] = [];
+    let cursor: string | undefined;
+    let pages = 0;
+    do {
+      const page = await chat.listArtifacts(owner.actor, { limit: 1, cursor });
+      expect(page.artifacts.length).toBeLessThanOrEqual(1);
+      for (const artifact of page.artifacts) {
+        collected.push(artifact.fileId);
+      }
+      cursor = page.nextCursor ?? undefined;
+      pages += 1;
+      expect(pages).toBeLessThanOrEqual(10);
+    } while (cursor);
+
+    // Every artifact surfaced exactly once across pages — no cursor-drift dups,
+    // no skips — proving keyset walks the deduped winner set correctly.
+    expect(collected).toHaveLength(created.length);
+    expect(new Set(collected)).toStrictEqual(new Set(created));
+  }, 120_000);
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -1041,10 +1041,14 @@ export function createChatFilesBddApi(context: TestContext) {
       );
     },
 
-    async listArtifacts(actor: ApiTestUser): Promise<ArtifactsListResponse> {
+    async listArtifacts(
+      actor: ApiTestUser,
+      query: { readonly limit?: number; readonly cursor?: string } = {},
+    ): Promise<ArtifactsListResponse> {
       const response = await accept(
         artifactsClient().list({
           headers: authenticate(context, actor),
+          query,
         }),
         [200],
       );

--- a/turbo/apps/api/src/signals/routes/zero-artifacts.ts
+++ b/turbo/apps/api/src/signals/routes/zero-artifacts.ts
@@ -3,18 +3,22 @@ import { artifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
+import { queryOf } from "../context/request";
 import { zeroArtifacts$ } from "../services/zero-chat-thread.service";
 import type { RouteEntry } from "../route-entry";
 
 const listArtifactsInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
+    const query = get(queryOf(artifactsContract.list));
 
     const result = await set(
       zeroArtifacts$,
       {
         userId: auth.userId,
         orgId: auth.orgId,
+        limit: query.limit,
+        cursor: query.cursor,
       },
       signal,
     );
@@ -25,6 +29,7 @@ const listArtifactsInner$ = command(
       body: {
         artifacts: result.artifacts,
         truncated: result.truncated,
+        nextCursor: result.nextCursor,
       },
     };
   },

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -986,16 +986,39 @@ function toArtifactItem(row: ArtifactListSqlRow): ArtifactItem {
   };
 }
 
-const ARTIFACTS_BULK_LIMIT = 10_000;
+// Default page size when a caller passes no `limit`. Kept at the historical
+// bulk cap so un-paginated callers (older frontend bundles) see the exact same
+// first page as before.
+const ARTIFACTS_DEFAULT_LIMIT = 10_000;
+const ARTIFACTS_MAX_LIMIT = 10_000;
+
+const artifactCursorSchema = z.object({
+  createdAt: z.string(),
+  rowId: z.string(),
+});
+type ArtifactCursor = z.infer<typeof artifactCursorSchema>;
+
+function encodeArtifactCursor(cursor: ArtifactCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeArtifactCursor(raw: string): ArtifactCursor {
+  return artifactCursorSchema.parse(
+    JSON.parse(Buffer.from(raw, "base64url").toString("utf8")),
+  );
+}
 
 interface ZeroArtifactsArgs {
   readonly userId: string;
   readonly orgId: string;
+  readonly limit?: number;
+  readonly cursor?: string;
 }
 
 interface ZeroArtifactsResult {
   readonly artifacts: readonly ArtifactItem[];
   readonly truncated: boolean;
+  readonly nextCursor: string | null;
 }
 
 export const zeroArtifacts$ = command(
@@ -1005,6 +1028,18 @@ export const zeroArtifacts$ = command(
     signal: AbortSignal,
   ): Promise<ZeroArtifactsResult> => {
     const db = set(writeDb$);
+    const limit = Math.min(
+      args.limit ?? ARTIFACTS_DEFAULT_LIMIT,
+      ARTIFACTS_MAX_LIMIT,
+    );
+    const cursor = args.cursor ? decodeArtifactCursor(args.cursor) : null;
+    // Keyset must be applied AFTER the DISTINCT ON (url) dedup (on the deduped
+    // representatives), matching the final ORDER BY created_at DESC, row_id
+    // DESC. Pushing it into scoped_artifacts (pre-dedup) would let an older row
+    // of an already-emitted url slip past the cursor and re-surface as a dup.
+    const keysetClause = cursor
+      ? sql`WHERE (created_at, row_id) < (${cursor.createdAt}::timestamptz, ${cursor.rowId}::uuid)`
+      : sql``;
     const conditions: SQL[] = [
       sql`${agentRuns.orgId} = ${args.orgId}`,
       sql`${chatThreads.userId} = ${args.userId}`,
@@ -1069,19 +1104,28 @@ export const zeroArtifacts$ = command(
       )
       SELECT *
       FROM deduped_artifacts
+      ${keysetClause}
       ORDER BY created_at DESC, row_id DESC
-      LIMIT ${ARTIFACTS_BULK_LIMIT + 1}
+      LIMIT ${limit + 1}
     `);
     signal.throwIfAborted();
 
-    const truncated = rows.rows.length > ARTIFACTS_BULK_LIMIT;
-    const pageRows = truncated
-      ? rows.rows.slice(0, ARTIFACTS_BULK_LIMIT)
-      : rows.rows;
+    // Over-fetch one row to detect whether a further page exists.
+    const hasMore = rows.rows.length > limit;
+    const pageRows = hasMore ? rows.rows.slice(0, limit) : rows.rows;
+    const lastRow = pageRows.at(-1);
+    const nextCursor =
+      hasMore && lastRow
+        ? encodeArtifactCursor({
+            createdAt: artifactRowCreatedAt(lastRow).toISOString(),
+            rowId: lastRow.row_id,
+          })
+        : null;
 
     return {
       artifacts: pageRows.map(toArtifactItem),
-      truncated,
+      truncated: hasMore,
+      nextCursor,
     };
   },
 );

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -204,7 +204,7 @@ export const apiAgentsHandlers = [
 
   // GET /api/zero/artifacts
   mockApi(artifactsContract.list, ({ respond }) => {
-    return respond(200, { artifacts: [], truncated: false });
+    return respond(200, { artifacts: [], truncated: false, nextCursor: null });
   }),
 
   // GET /api/zero/chat-threads/:id (thread detail)

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -363,7 +363,11 @@ function createArtifact(overrides: Partial<ArtifactItem> = {}): ArtifactItem {
 
 function mockArtifacts(artifacts: readonly ArtifactItem[]): void {
   context.mocks.api(artifactsContract.list, ({ respond }) => {
-    return respond(200, { artifacts: [...artifacts], truncated: false });
+    return respond(200, {
+      artifacts: [...artifacts],
+      truncated: false,
+      nextCursor: null,
+    });
   });
 }
 
@@ -452,7 +456,11 @@ describe("artifacts page", () => {
     let requested = false;
     context.mocks.api(artifactsContract.list, ({ respond }) => {
       requested = true;
-      return respond(200, { artifacts: [], truncated: false });
+      return respond(200, {
+        artifacts: [],
+        truncated: false,
+        nextCursor: null,
+      });
     });
 
     setupArtifactsPage({ scope, enabled: false });
@@ -544,6 +552,7 @@ describe("artifacts page", () => {
           }),
         ],
         truncated: false,
+        nextCursor: null,
       });
     });
 
@@ -735,6 +744,7 @@ describe("artifacts page", () => {
           }),
         ],
         truncated: true,
+        nextCursor: "next-page-token",
       });
     });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -86,9 +86,19 @@ describe("chat thread generation template contract", () => {
 });
 
 describe("artifacts contract", () => {
-  it("exposes an org-level bulk generated artifacts route", () => {
+  it("exposes an org-level generated artifacts route", () => {
     expect(artifactsContract.list.method).toBe("GET");
     expect(artifactsContract.list.path).toBe("/api/zero/artifacts");
+  });
+
+  it("accepts keyset pagination query params", () => {
+    const parsed = artifactsContract.list.query.safeParse({
+      limit: "50",
+      cursor: "opaque-token",
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.limit).toBe(50);
   });
 
   it("accepts a minimal generated artifact item", () => {
@@ -147,12 +157,22 @@ describe("artifacts contract", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("accepts a bulk list response", () => {
+  it("accepts a keyset-paginated list response", () => {
+    const parsed = artifactsListResponseSchema.safeParse({
+      artifacts: [],
+      truncated: false,
+      nextCursor: null,
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it("requires nextCursor on the list response", () => {
     const parsed = artifactsListResponseSchema.safeParse({
       artifacts: [],
       truncated: false,
     });
 
-    expect(parsed.success).toBe(true);
+    expect(parsed.success).toBe(false);
   });
 });

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -71,9 +71,28 @@ const artifactItemSchema = z.object({
   googleDriveSync: chatThreadArtifactGoogleDriveSyncSchema.optional(),
 });
 
+/**
+ * Keyset pagination for the artifacts list. Both fields are optional so
+ * un-paginated callers (older frontend bundles) still get a valid first page.
+ * `cursor` is an opaque token returned as `nextCursor` from a previous page.
+ */
+const artifactsListQuerySchema = z.object({
+  limit: z.coerce.number().int().positive().max(10_000).optional(),
+  cursor: z.string().optional(),
+});
+
 const artifactsListResponseSchema = z.object({
   artifacts: z.array(artifactItemSchema),
+  /**
+   * True when more artifacts exist beyond this page. Retained for backward
+   * compatibility with older frontend bundles that read it; new clients follow
+   * `nextCursor` instead.
+   */
   truncated: z.boolean(),
+  /**
+   * Opaque cursor for the next page, or null when this is the last page.
+   */
+  nextCursor: z.string().nullable(),
 });
 
 const htmlArtifactEditSnapshotQuerySchema = z.object({
@@ -1131,13 +1150,14 @@ export const artifactsContract = c.router({
     method: "GET",
     path: "/api/zero/artifacts",
     headers: authHeadersSchema,
+    query: artifactsListQuerySchema,
     responses: {
       200: artifactsListResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
     },
     summary:
-      "List all generated artifacts for the caller's current organization (bulk, capped)",
+      "List generated artifacts for the caller's current organization (keyset-paginated)",
   },
 });
 


### PR DESCRIPTION
## What

First step toward removing the **10k artifacts fetch ceiling** (`GET /api/zero/artifacts` currently returns one bulk response capped at 10,000 rows, silently dropping older artifacts). This PR adds **backward-compatible keyset pagination** to the endpoint.

- **Contract** (`chat-threads.ts`): optional `limit` / `cursor` query params; response adds `nextCursor: string | null`. `truncated` is **retained** — the UI still shows a "showing the newest 10,000" banner from it, and older frontend bundles read it.
- **Service** (`zeroArtifacts$`): keyset on `(created_at, row_id)` applied **after** the `DISTINCT ON (url)` dedup CTE. Applying it before dedup would let an older row of an already-emitted url slip past the cursor and re-surface as a duplicate on a later page. Default limit stays at the historical cap so un-paginated callers get the exact same first page.
- **Route** (`zero-artifacts.ts`): reads the query, threads `limit`/`cursor`, returns `nextCursor`.

## Compatibility

Fully backward compatible (deploy backend before frontend):

- No `limit`/`cursor` → identical first page to today; `truncated` unchanged.
- Old frontend bundles ignore the extra `nextCursor` (zod strips unknown keys) and still read `truncated`.

## Tests

- New api bdd test walks the full set with `limit=1`, asserting every artifact appears **exactly once** across pages — no cursor-drift duplicates, no skips.
- Contract test covers the new query schema and requires `nextCursor` on the response.
- MSW mock, frontend page-test mocks, and the `listArtifacts` bdd helper updated to the paginated shape.

## Follow-ups (not in this PR)

- **PR2 (frontend)**: delta-sync + background backfill via an IndexedDB sync watermark, re-key the artifact cache to `url` (matching the server's dedup identity), in-memory url-dedup on merge, and windowed rendering.
- **PR3**: drop the now-unused `truncated` once no old frontend references remain.

## Verification note

Type-checked clean for every changed file (`@vm0/api-contracts` fully green; the residual `tsc` errors in `api`/`@vm0/app` are a pre-existing environment gap in this checkout — stale firewall-metadata codegen + missing `cmdk` — not from this change). Vitest/lint could not run locally because this checkout's `node_modules` is built for the Linux container (esbuild `linux-arm64`) while the shell is on the macOS host; **CI runs the full suite**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
