### PR TITLE
feat: resolve login shell path for desktop stdio mcp servers

### DIFF
--- a/turbo/apps/desktop/src/desktop-mcp-plugin.test.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -99,10 +105,14 @@ describe("parseMcpServersJson", () => {
 describe("DesktopMcpPluginManager", () => {
   const managers: DesktopMcpPluginManager[] = [];
 
-  function createManager(preferencesPath: string): DesktopMcpPluginManager {
+  function createManager(
+    preferencesPath: string,
+    resolveShellPath?: () => Promise<string | null>,
+  ): DesktopMcpPluginManager {
     const manager = new DesktopMcpPluginManager({
       preferencesPath,
       onChange: () => {},
+      resolveShellPath: resolveShellPath ?? (async () => null),
     });
     managers.push(manager);
     return manager;
@@ -234,6 +244,72 @@ describe("DesktopMcpPluginManager", () => {
     expect(reloaded.getState().servers).toMatchObject([
       { name: "files", enabled: true, transport: "stdio" },
     ]);
+  }, 30_000);
+
+  it("resolves bare stdio commands through the login shell PATH", async () => {
+    const workspace = realpathSync(
+      mkdtempSync(path.join(tmpdir(), "mcp-plugin-")),
+    );
+    const binDir = path.join(workspace, "bin");
+    mkdirSync(binDir);
+    const preferencesPath = path.join(workspace, "preferences.json");
+    writeFileSync(path.join(workspace, "hello.txt"), "hello from path\n");
+    // A bare command that only resolves through the injected shell PATH; it
+    // execs the filesystem MCP server via the node binary running this test.
+    const nodeDir = path.dirname(process.execPath);
+    const script = `#!/bin/sh\nexec node "${filesystemServerEntry()}" "${workspace}"\n`;
+    const scriptPath = path.join(binDir, "fake-mcp");
+    writeFileSync(scriptPath, script, { mode: 0o755 });
+    chmodSync(scriptPath, 0o755);
+
+    const manager = createManager(preferencesPath, async () => {
+      return `${binDir}:${nodeDir}`;
+    });
+    manager.load();
+    manager.importServersJson(
+      JSON.stringify({ mcpServers: { pathy: { command: "fake-mcp" } } }),
+    );
+    manager.setFeatureEnabled(true);
+    manager.setHostRuntimeOnline(true);
+    manager.setServerEnabled("pathy", true);
+
+    await waitForServerStatus(manager, "pathy", "running");
+    expect(manager.getCapabilities()).toStrictEqual(["plugin.mcp.pathy"]);
+  }, 30_000);
+
+  it("lets a configured env.PATH override the resolved shell PATH", async () => {
+    const workspace = realpathSync(
+      mkdtempSync(path.join(tmpdir(), "mcp-plugin-")),
+    );
+    const preferencesPath = path.join(workspace, "preferences.json");
+
+    // Shell PATH would resolve the command, but the explicit env.PATH wins
+    // and points nowhere, so the spawn fails with an ENOENT hint.
+    const manager = createManager(preferencesPath, async () => {
+      return path.dirname(process.execPath);
+    });
+    manager.load();
+    manager.importServersJson(
+      JSON.stringify({
+        mcpServers: {
+          pinned: {
+            command: "node",
+            args: ["-e", "process.exit(0)"],
+            env: { PATH: "/nonexistent-bin" },
+          },
+        },
+      }),
+    );
+    manager.setFeatureEnabled(true);
+    manager.setHostRuntimeOnline(true);
+    manager.setServerEnabled("pinned", true);
+
+    await waitForServerStatus(manager, "pinned", "restarting");
+    const server = manager
+      .getState()
+      .servers.find((entry) => entry.name === "pinned");
+    expect(server?.lastError).toContain("ENOENT");
+    expect(server?.lastError).toContain("PATH");
   }, 30_000);
 
   it("rejects calls while the plugin feature switch is off", async () => {

--- a/turbo/apps/desktop/src/desktop-mcp-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.ts
@@ -24,6 +24,7 @@ import type {
   DesktopComputerUsePluginStatus,
 } from "./computer-use-types";
 import { PluginRestartPolicy } from "./desktop-plugin-restart-policy";
+import { resolveLoginShellPath } from "./desktop-shell-env";
 import {
   commandFailure,
   normalizePluginToolResult,
@@ -80,6 +81,16 @@ interface McpServerSlot {
 interface DesktopMcpPluginManagerOptions {
   readonly preferencesPath: string;
   readonly onChange: () => void;
+  readonly resolveShellPath?: () => Promise<string | null>;
+}
+
+const ENOENT_PATH_HINT =
+  'Command not found on PATH. Set "env": {"PATH": "..."} in the server config or use an absolute command path.';
+
+function withEnoentHint(message: string): string {
+  return message.includes("ENOENT")
+    ? `${message} — ${ENOENT_PATH_HINT}`
+    : message;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -219,10 +230,20 @@ export class DesktopMcpPluginManager {
   private featureEnabled = false;
   private hostRuntimeOnline = false;
   private readonly slots = new Map<string, McpServerSlot>();
+  private readonly resolveShellPath: () => Promise<string | null>;
+  private shellPathPromise: Promise<string | null> | null = null;
 
   constructor(options: DesktopMcpPluginManagerOptions) {
     this.preferencesPath = options.preferencesPath;
     this.onChange = options.onChange;
+    this.resolveShellPath = options.resolveShellPath ?? resolveLoginShellPath;
+  }
+
+  private loginShellPath(): Promise<string | null> {
+    this.shellPathPromise ??= this.resolveShellPath().catch(() => {
+      return null;
+    });
+    return this.shellPathPromise;
   }
 
   load(): void {
@@ -537,14 +558,19 @@ export class DesktopMcpPluginManager {
     await slot.startPromise;
   }
 
-  private createTransport(config: McpServerConfig): Transport {
+  private async createTransport(config: McpServerConfig): Promise<Transport> {
     if (isMcpHttpServerConfig(config)) {
       return new StreamableHTTPClientTransport(new URL(config.url));
     }
+    const shellPath = await this.loginShellPath();
     return new StdioClientTransport({
       command: config.command,
       args: [...config.args],
-      env: { ...getDefaultEnvironment(), ...config.env },
+      env: {
+        ...getDefaultEnvironment(),
+        ...(shellPath ? { PATH: shellPath } : {}),
+        ...config.env,
+      },
       stderr: "pipe",
     });
   }
@@ -562,7 +588,7 @@ export class DesktopMcpPluginManager {
         this.onChange();
         return;
       }
-      transport = this.createTransport(config);
+      transport = await this.createTransport(config);
       transport.onerror = (error) => {
         slot.lastError = error.message;
         this.onChange();
@@ -610,11 +636,15 @@ export class DesktopMcpPluginManager {
         }
       }
       if (this.serverShouldRun(this.preferences.servers[name])) {
-        this.scheduleRestartOrFail(name, slot, pluginErrorMessage(error));
+        this.scheduleRestartOrFail(
+          name,
+          slot,
+          withEnoentHint(pluginErrorMessage(error)),
+        );
         return;
       }
       slot.status = "error";
-      slot.lastError = pluginErrorMessage(error);
+      slot.lastError = withEnoentHint(pluginErrorMessage(error));
       this.onChange();
     }
   }

--- a/turbo/apps/desktop/src/desktop-shell-env.test.ts
+++ b/turbo/apps/desktop/src/desktop-shell-env.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveLoginShellPath } from "./desktop-shell-env";
+
+describe("resolveLoginShellPath", () => {
+  it("resolves PATH from a real login shell", async () => {
+    const path = await resolveLoginShellPath({ shell: "/bin/bash" });
+    expect(path).toBeTruthy();
+    expect(path).toContain("/");
+  }, 15_000);
+
+  it("returns null when the shell does not exist", async () => {
+    const path = await resolveLoginShellPath({
+      shell: "/nonexistent/shell-binary",
+    });
+    expect(path).toBeNull();
+  });
+
+  it("returns null on timeout", async () => {
+    // /bin/sleep ignores the -i -l -c arguments and simply never produces
+    // the marked JSON payload, so the timeout path settles the promise.
+    const path = await resolveLoginShellPath({
+      shell: "/bin/sleep",
+      timeoutMs: 500,
+    });
+    expect(path).toBeNull();
+  });
+});

--- a/turbo/apps/desktop/src/desktop-shell-env.ts
+++ b/turbo/apps/desktop/src/desktop-shell-env.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+const RESOLVE_TIMEOUT_MS = 10_000;
+
+interface ResolveLoginShellPathOptions {
+  readonly shell?: string;
+  readonly timeoutMs?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Resolves the user's login shell PATH. GUI apps on macOS/Linux inherit the
+ * launchd/session environment whose PATH misses Homebrew and version-manager
+ * directories, so commands like `npx` fail with ENOENT when spawned directly.
+ *
+ * Follows VS Code's shell environment resolution: run the login shell
+ * interactively and have it execute this Electron binary as node to print
+ * `process.env` as JSON between random marks, which keeps shell rc output
+ * from corrupting the result. Returns null on Windows, timeout, or any
+ * spawn/parse failure so callers can fall back to the current environment.
+ */
+export function resolveLoginShellPath(
+  options: ResolveLoginShellPathOptions = {},
+): Promise<string | null> {
+  if (process.platform === "win32") {
+    return Promise.resolve(null);
+  }
+  const shell =
+    options.shell ??
+    process.env.SHELL ??
+    (process.platform === "darwin" ? "/bin/zsh" : "/bin/bash");
+  const timeoutMs = options.timeoutMs ?? RESOLVE_TIMEOUT_MS;
+  const mark = randomBytes(6).toString("hex");
+  const command = `'${process.execPath}' -p '"${mark}" + JSON.stringify(process.env) + "${mark}"'`;
+
+  return new Promise((resolve) => {
+    const child = spawn(shell, ["-i", "-l", "-c", command], {
+      detached: true,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+    });
+
+    let settled = false;
+    const settle = (value: string | null) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      }
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      settle(null);
+    }, timeoutMs);
+
+    const buffers: Buffer[] = [];
+    child.stdout.on("data", (buffer: Buffer) => {
+      buffers.push(buffer);
+    });
+    child.on("error", () => {
+      settle(null);
+    });
+    child.on("close", (code) => {
+      if (code !== 0) {
+        return settle(null);
+      }
+      const raw = Buffer.concat(buffers).toString("utf8");
+      const match = new RegExp(`${mark}({.*})${mark}`).exec(raw);
+      const json = match?.[1];
+      if (!json) {
+        return settle(null);
+      }
+      try {
+        const env: unknown = JSON.parse(json);
+        const path =
+          isRecord(env) && typeof env.PATH === "string" ? env.PATH.trim() : "";
+        settle(path ? path : null);
+      } catch {
+        settle(null);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Closes #20799. Part of #20694 (custom desktop MCP plugin framework; epic #20687).

## Problem

Stdio MCP servers configured with the community-standard `"command": "npx"` fail with `spawn npx ENOENT` on macOS (reproduced on a real machine with `mcp-apple-notes`). GUI apps launched from Finder/Dock inherit launchd's minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`); Homebrew and nvm paths only exist in the user's login shell. An absolute command path alone does not fix it because `npx` is a `#!/usr/bin/env node` script whose shebang (and child tool scripts) resolve `node` via `PATH` — the verified manual workaround is a per-server `"env": {"PATH": ...}`.

## What changes

Adopts VS Code's shell environment resolution (`shellEnv.ts`), narrowed to **PATH only** per the design discussion:

- **`desktop-shell-env.ts`** — `resolveLoginShellPath()`: macOS/Linux only; spawns `$SHELL -i -l -c "'<process.execPath>' -p '\"<mark>\" + JSON.stringify(process.env) + \"<mark>\"'"` with `ELECTRON_RUN_AS_NODE=1` (the same Electron-as-node technique the filesystem plugin already uses); extracts JSON between random marks so shell rc output cannot corrupt the result; 10s timeout; returns `null` on any failure.
- **`DesktopMcpPluginManager`** — resolves lazily on the first stdio server start and caches for the manager's lifetime (HTTP-only users never pay the cost); merges as `{ ...getDefaultEnvironment(), ...(shellPath ? { PATH: shellPath } : {}), ...config.env }`, so a user-configured `env.PATH` stays highest priority and existing manual workarounds keep working. The resolver is injectable (`resolveShellPath` option) following the manager's existing DI style.
- **PATH only, not the whole shell env** — the MCP SDK's `getDefaultEnvironment()` is a deliberate sudo-style allowlist (`HOME, LOGNAME, PATH, SHELL, TERM, USER`); merging the full shell env would silently expose every shell-exported secret (cloud keys, tokens, `NODE_OPTIONS`) to every MCP server. Servers needing more use the explicit, auditable `config.env` channel.
- **Readable degradation** — resolution failure falls back to current behavior; ENOENT start failures now append a hint to `lastError`: set `env.PATH` or use an absolute command path.

Filesystem plugin is untouched (it spawns the bundled server via the Electron binary and has no PATH dependence).

## Tests

- `desktop-shell-env.test.ts`: resolves PATH from a **real login shell** (`/bin/bash` on CI), returns null for a nonexistent shell, and settles null on timeout.
- `desktop-mcp-plugin.test.ts` additions: a bare command resolvable **only** through the injected shell PATH starts and reaches `running` (real stdio MCP server behind a wrapper script), and an explicit `env.PATH` overrides the resolved shell PATH with the ENOENT hint surfaced in `lastError`. Existing suite keeps an always-null resolver so prior tests are byte-identical in behavior.
- Local: desktop tsc, oxlint, knip, prettier clean; targeted suites 13/13 green.

## Verification

Static checks and targeted vitest suites run locally as above; full pipeline via PR CI per repo practice. macOS acceptance (real `npx` config without `env.PATH`) tracked on #20799.
