### PR TITLE
fix(desktop): improve mcp servers configuration panel

### DIFF
--- a/turbo/apps/desktop/src/renderer/hero/index.tsx
+++ b/turbo/apps/desktop/src/renderer/hero/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   IconAlertCircle,
   IconBuilding,
+  IconCode,
   IconDots,
   IconFolderPlus,
   IconLogout,
@@ -52,6 +53,18 @@ const FILESYSTEM_PLUGIN_STATUS_LABELS = {
 } as const satisfies Record<FilesystemPluginState["status"], string>;
 
 const MCP_SERVER_STATUS_LABELS = FILESYSTEM_PLUGIN_STATUS_LABELS;
+
+const MCP_SERVERS_SAMPLE_CONFIG = `{
+  "mcpServers": {
+    "apple-notes": {
+      "command": "npx",
+      "args": ["-y", "mcp-apple-notes"]
+    },
+    "figma": {
+      "url": "http://127.0.0.1:3845/mcp"
+    }
+  }
+}`;
 
 const ARRIVAL_ANIMATION_MS = 1_100;
 
@@ -447,28 +460,35 @@ function McpPluginsPanel({
         ) : (
           plugin.servers.map((server) => {
             return (
-              <div key={server.name}>
-                <CheckboxRow
-                  title={server.name}
-                  subtitle={`${server.transport === "http" ? "Streamable HTTP" : "stdio"}${
-                    server.status === "running"
-                      ? ` · ${server.tools.length} tools`
-                      : ""
-                  }`}
-                  meta={MCP_SERVER_STATUS_LABELS[server.status]}
-                  checked={server.enabled}
-                  disabled={busy}
-                  onChange={(enabled) => {
-                    void setServerEnabled({ server: server.name, enabled });
-                  }}
-                />
-                {server.lastError && (
-                  <div className="inline-alert inline-alert-error">
-                    <IconAlertCircle size={16} />
-                    <span>{server.lastError}</span>
-                  </div>
-                )}
-                <div className="panel-actions">
+              <div className="mcp-server-entry" key={server.name}>
+                <div className="mcp-server-row">
+                  <label className="mcp-server-toggle">
+                    <input
+                      type="checkbox"
+                      checked={server.enabled}
+                      disabled={busy}
+                      onChange={(event) => {
+                        void setServerEnabled({
+                          server: server.name,
+                          enabled: event.currentTarget.checked,
+                        });
+                      }}
+                    />
+                    <span className="checkbox-row-copy">
+                      <span className="row-title">{server.name}</span>
+                      <span className="row-meta">
+                        {server.transport === "http"
+                          ? "Streamable HTTP"
+                          : "stdio"}
+                        {server.status === "running"
+                          ? ` · ${server.tools.length} tools`
+                          : ""}
+                      </span>
+                    </span>
+                    <span className="checkbox-row-meta">
+                      {MCP_SERVER_STATUS_LABELS[server.status]}
+                    </span>
+                  </label>
                   <button
                     type="button"
                     className="icon-only-button"
@@ -482,6 +502,12 @@ function McpPluginsPanel({
                     <IconTrash size={15} />
                   </button>
                 </div>
+                {server.lastError && (
+                  <div className="inline-alert inline-alert-error">
+                    <IconAlertCircle size={16} />
+                    <span>{server.lastError}</span>
+                  </div>
+                )}
               </div>
             );
           })
@@ -489,9 +515,9 @@ function McpPluginsPanel({
       </div>
       <textarea
         className="mcp-config-input"
-        placeholder='Paste an "mcpServers" JSON config to add servers'
+        placeholder={MCP_SERVERS_SAMPLE_CONFIG}
         value={configJson}
-        rows={5}
+        rows={8}
         spellCheck={false}
         disabled={busy}
         onChange={(event) => {
@@ -505,6 +531,16 @@ function McpPluginsPanel({
         </div>
       )}
       <div className="panel-actions">
+        <IconButton
+          icon={<IconCode size={15} />}
+          onClick={() => {
+            setImportError(null);
+            setConfigJson(MCP_SERVERS_SAMPLE_CONFIG);
+          }}
+          disabled={busy}
+        >
+          Use sample
+        </IconButton>
         <IconButton
           icon={<IconPlug size={15} />}
           onClick={() => {

--- a/turbo/apps/desktop/src/renderer/styles.css
+++ b/turbo/apps/desktop/src/renderer/styles.css
@@ -684,6 +684,45 @@ button {
   overflow-wrap: anywhere;
 }
 
+.mcp-server-entry {
+  display: grid;
+  gap: 8px;
+}
+
+.mcp-server-row {
+  min-height: 58px;
+  border: 1px solid rgba(30, 38, 52, 0.08);
+  border-radius: 7px;
+  padding: 6px 6px 6px 10px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  background: rgba(249, 250, 251, 0.76);
+}
+
+.mcp-server-toggle {
+  min-width: 0;
+  min-height: 44px;
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.mcp-server-toggle input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: var(--brand);
+}
+
+.mcp-server-toggle:has(input:disabled) {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
 .mcp-config-input {
   width: 100%;
   border: 1px solid rgba(30, 38, 52, 0.08);
@@ -697,6 +736,11 @@ button {
   font-size: 12px;
   line-height: 1.35;
   resize: vertical;
+}
+
+.mcp-config-input::placeholder {
+  color: #667085;
+  opacity: 0.78;
 }
 
 .raw-log-details summary {
@@ -1566,6 +1610,18 @@ button {
   }
 
   .checkbox-row-meta {
+    grid-column: 2;
+  }
+
+  .mcp-server-row {
+    align-items: start;
+  }
+
+  .mcp-server-toggle {
+    grid-template-columns: 20px minmax(0, 1fr);
+  }
+
+  .mcp-server-toggle .checkbox-row-meta {
     grid-column: 2;
   }
 


### PR DESCRIPTION
## Summary
- Add an inline sample `mcpServers` JSON configuration for the Desktop MCP servers textarea, with apple-notes stdio and Figma Streamable HTTP examples.
- Add a `Use sample` action that fills the textarea and clears stale import errors.
- Rework MCP server rows so the enable toggle, status, and remove button sit in one row, keeping errors below the server row and preserving responsive behavior.

## Verification
- `npx prettier@3.6.2 --check turbo/apps/desktop/src/renderer/hero/index.tsx turbo/apps/desktop/src/renderer/styles.css`
- `git diff --check origin/main...HEAD`
- Not run: `pnpm -C turbo -F @vm0/desktop check-types` because this fresh checkout has no `node_modules`, so `tsc` is unavailable before type-checking starts.
