### PR TITLE
fix: open chat rename from header title double-click

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -3568,6 +3568,26 @@ describe("chat lifecycle", () => {
     );
   });
 
+  it("opens the current chat rename dialog by double-clicking the header title", async () => {
+    mockResizeObserver();
+    mockKeyboardNavigationThreads();
+
+    detachedSetupPage({
+      context,
+      path: "/chats/b0000000-0000-4000-a000-000000000708",
+    });
+
+    const headerTitle = await screen.findByTestId("chat-thread-header-title");
+    expect(headerTitle).toHaveTextContent("Current keyboard thread");
+
+    fireEvent.doubleClick(headerTitle);
+
+    const dialog = await screen.findByRole("dialog", { name: "Rename chat" });
+    expect(within(dialog).getByPlaceholderText("Chat title")).toHaveValue(
+      "Current keyboard thread",
+    );
+  });
+
   it("keeps F2 rename available after renaming the current chat", async () => {
     const user = userEvent.setup({ delay: null });
     mockResizeObserver();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -263,6 +263,7 @@ import {
   setChatThreadEmojiQuery$,
   type ChatThreadEmojiItem,
 } from "../../signals/chat-page/chat-thread-emoji.ts";
+import { openRenameChatThreadDialogForThreadId$ } from "../../signals/chat-page/chat-thread-rename.ts";
 import type { ChatThread } from "../../signals/agent-chat.ts";
 import { ATTACH_ONLY_PLACEHOLDER } from "../../signals/chat-page/resolve-draft-attachments.ts";
 import {
@@ -429,10 +430,22 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const threadMetaLoadable = useLastLoadable(thread.threadMeta$);
   const threadTitleEmoji = useLastResolved(thread.threadTitleEmoji$);
   const threadTitleText = useLastResolved(thread.threadTitleText$) ?? "";
+  const openRenameChatThreadDialog = useSet(
+    openRenameChatThreadDialogForThreadId$,
+  );
+  const pageSignal = useGet(pageSignal$);
   const threadTitle =
     threadMetaLoadable.state === "hasData"
       ? (threadMetaLoadable.data?.title?.trim() ?? "")
       : "";
+
+  function openRenameDialog(event: ReactMouseEvent<HTMLSpanElement>) {
+    event.preventDefault();
+    detach(
+      openRenameChatThreadDialog(thread.threadId, pageSignal),
+      Reason.DomCallback,
+    );
+  }
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
@@ -447,7 +460,11 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
               emoji={threadTitleEmoji}
             />
             {threadTitleText && (
-              <span className="min-w-0 truncate text-sm font-medium text-foreground">
+              <span
+                className="min-w-0 truncate text-sm font-medium text-foreground"
+                data-testid="chat-thread-header-title"
+                onDoubleClick={openRenameDialog}
+              >
                 {threadTitleText}
               </span>
             )}


### PR DESCRIPTION
## Summary
- Let the desktop chat header title open the existing Rename chat dialog on double-click.
- Reuse the same thread-id based rename dialog command used by the sidebar thread list.
- Add a page-level regression test for double-clicking the header title.

## Verification
- pnpm exec prettier --write apps/platform/src/views/zero-page/zero-chat-thread-page.tsx apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "opens the current chat rename dialog by double-clicking the header title"
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app lint