### PR TITLE
test: centralize aws sigv4 test fixtures

### DIFF
--- a/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
@@ -1,0 +1,151 @@
+"""Shared AWS SigV4 fixture builders for mitm-addon tests."""
+
+import urllib.parse
+
+from aws_sigv4 import AwsSigV4Credentials
+
+AWS_SIGV4_ALGORITHM = "AWS4-HMAC-SHA256"
+DEFAULT_SIGV4_DATE = "20260101"
+DEFAULT_SIGV4_TIMESTAMP = "20260101T000000Z"
+DEFAULT_AWS_REGION = "us-east-1"
+DEFAULT_AWS_SERVICE = "sts"
+PLACEHOLDER_ACCESS_KEY_ID = "PLACEHOLDER"
+PLACEHOLDER_SIGNATURE = "placeholder"
+REAL_AWS_ACCESS_KEY_ID = "AKIDEXAMPLE"
+REAL_AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+REAL_AWS_SESSION_TOKEN = "real-session-token"
+SIGNER_TEST_SECRET_ACCESS_KEY = "secret"
+STS_HOST = "sts.amazonaws.com"
+STS_FORM_BODY = b"Action=GetCallerIdentity&Version=2011-06-15"
+STS_QUERY = "Action=GetCallerIdentity&Version=2011-06-15"
+
+
+def aws_credential_scope(
+    *,
+    access_key_id: str = PLACEHOLDER_ACCESS_KEY_ID,
+    date: str = DEFAULT_SIGV4_DATE,
+    region: str = DEFAULT_AWS_REGION,
+    service: str = DEFAULT_AWS_SERVICE,
+) -> str:
+    return f"{access_key_id}/{date}/{region}/{service}/aws4_request"
+
+
+def quote_sigv4_value(value: str) -> str:
+    return urllib.parse.quote(value, safe="")
+
+
+def aws_sigv4_authorization(
+    *,
+    access_key_id: str = PLACEHOLDER_ACCESS_KEY_ID,
+    date: str = DEFAULT_SIGV4_DATE,
+    region: str = DEFAULT_AWS_REGION,
+    service: str = DEFAULT_AWS_SERVICE,
+    credential_scope: str | None = None,
+    signed_headers: str = "host;x-amz-date",
+    signature: str = PLACEHOLDER_SIGNATURE,
+    algorithm: str = AWS_SIGV4_ALGORITHM,
+) -> str:
+    scope = credential_scope or aws_credential_scope(
+        access_key_id=access_key_id,
+        date=date,
+        region=region,
+        service=service,
+    )
+    return f"{algorithm} Credential={scope}, SignedHeaders={signed_headers}, Signature={signature}"
+
+
+def aws_sigv4_header_auth_headers(
+    *,
+    host: str = STS_HOST,
+    authorization: str | None = None,
+    content_type: str | None = None,
+    amz_date: str | None = DEFAULT_SIGV4_TIMESTAMP,
+    extra_headers: tuple[tuple[str, str], ...] = (),
+) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = [("Host", host)]
+    if content_type is not None:
+        pairs.append(("Content-Type", content_type))
+    if amz_date is not None:
+        pairs.append(("X-Amz-Date", amz_date))
+    pairs.extend(extra_headers)
+    pairs.append(("Authorization", authorization or aws_sigv4_authorization()))
+    return pairs
+
+
+def aws_sigv4_presigned_query_path(
+    *,
+    credential_scope: str | None = None,
+    access_key_id: str = PLACEHOLDER_ACCESS_KEY_ID,
+    date: str = DEFAULT_SIGV4_DATE,
+    region: str = DEFAULT_AWS_REGION,
+    service: str = DEFAULT_AWS_SERVICE,
+    timestamp: str = DEFAULT_SIGV4_TIMESTAMP,
+    expires: str = "60",
+    signed_headers: str = "host",
+    signature: str | None = PLACEHOLDER_SIGNATURE,
+    leading_query: str = STS_QUERY,
+) -> str:
+    scope = credential_scope or aws_credential_scope(
+        access_key_id=access_key_id,
+        date=date,
+        region=region,
+        service=service,
+    )
+    query = (
+        f"{leading_query}"
+        f"&X-Amz-Algorithm={AWS_SIGV4_ALGORITHM}"
+        f"&X-Amz-Credential={quote_sigv4_value(scope)}"
+        f"&X-Amz-Date={timestamp}"
+        f"&X-Amz-Expires={expires}"
+        f"&X-Amz-SignedHeaders={quote_sigv4_value(signed_headers)}"
+    )
+    if signature is not None:
+        query = f"{query}&X-Amz-Signature={signature}"
+    return f"/?{query}"
+
+
+def aws_sigv4_presigned_url(
+    host: str,
+    *,
+    credential_scope: str | None = None,
+    access_key_id: str = PLACEHOLDER_ACCESS_KEY_ID,
+    date: str = DEFAULT_SIGV4_DATE,
+    region: str = DEFAULT_AWS_REGION,
+    service: str = DEFAULT_AWS_SERVICE,
+    timestamp: str = DEFAULT_SIGV4_TIMESTAMP,
+    expires: str = "60",
+    signed_headers: str = "host",
+    signature: str | None = PLACEHOLDER_SIGNATURE,
+    leading_query: str = STS_QUERY,
+) -> str:
+    path = aws_sigv4_presigned_query_path(
+        credential_scope=credential_scope,
+        access_key_id=access_key_id,
+        date=date,
+        region=region,
+        service=service,
+        timestamp=timestamp,
+        expires=expires,
+        signed_headers=signed_headers,
+        signature=signature,
+        leading_query=leading_query,
+    )
+    return f"https://{host}{path}"
+
+
+def signer_test_credentials(
+    *,
+    access_key_id: str = REAL_AWS_ACCESS_KEY_ID,
+    secret_access_key: str = SIGNER_TEST_SECRET_ACCESS_KEY,
+    session_token: str | None = None,
+) -> AwsSigV4Credentials:
+    return AwsSigV4Credentials(access_key_id, secret_access_key, session_token)
+
+
+def resolved_aws_sigv4_credentials(
+    *,
+    access_key_id: str = REAL_AWS_ACCESS_KEY_ID,
+    secret_access_key: str = REAL_AWS_SECRET_ACCESS_KEY,
+    session_token: str | None = REAL_AWS_SESSION_TOKEN,
+) -> AwsSigV4Credentials:
+    return AwsSigV4Credentials(access_key_id, secret_access_key, session_token)

--- a/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
@@ -104,16 +104,21 @@ def aws_sigv4_presigned_query_path(
         if credential_scope is None
         else credential_scope
     )
-    query = (
-        f"{leading_query}"
-        f"&X-Amz-Algorithm={AWS_SIGV4_ALGORITHM}"
-        f"&X-Amz-Credential={quote_sigv4_value(scope)}"
-        f"&X-Amz-Date={timestamp}"
-        f"&X-Amz-Expires={expires}"
-        f"&X-Amz-SignedHeaders={quote_sigv4_value(signed_headers)}"
+    query_parts: list[str] = []
+    if leading_query:
+        query_parts.append(leading_query)
+    query_parts.extend(
+        [
+            f"X-Amz-Algorithm={AWS_SIGV4_ALGORITHM}",
+            f"X-Amz-Credential={quote_sigv4_value(scope)}",
+            f"X-Amz-Date={timestamp}",
+            f"X-Amz-Expires={expires}",
+            f"X-Amz-SignedHeaders={quote_sigv4_value(signed_headers)}",
+        ]
     )
     if signature is not None:
-        query = f"{query}&X-Amz-Signature={signature}"
+        query_parts.append(f"X-Amz-Signature={signature}")
+    query = "&".join(query_parts)
     return f"/?{query}"
 
 

--- a/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
@@ -1,6 +1,7 @@
 """Shared AWS SigV4 fixture builders for mitm-addon tests."""
 
 import urllib.parse
+from collections.abc import Sequence
 
 from aws_sigv4 import AwsSigV4Credentials
 
@@ -64,7 +65,7 @@ def aws_sigv4_header_auth_headers(
     authorization: str | None = None,
     content_type: str | None = None,
     amz_date: str | None = DEFAULT_SIGV4_TIMESTAMP,
-    extra_headers: tuple[tuple[str, str], ...] = (),
+    extra_headers: Sequence[tuple[str, str]] = (),
 ) -> list[tuple[str, str]]:
     pairs: list[tuple[str, str]] = [("Host", host)]
     if content_type is not None:

--- a/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
@@ -12,9 +12,9 @@ DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_AWS_SERVICE = "sts"
 PLACEHOLDER_ACCESS_KEY_ID = "PLACEHOLDER"
 PLACEHOLDER_SIGNATURE = "placeholder"
-REAL_AWS_ACCESS_KEY_ID = "AKIDEXAMPLE"
-REAL_AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
-REAL_AWS_SESSION_TOKEN = "real-session-token"
+RESOLVED_AWS_ACCESS_KEY_ID = "AKIDEXAMPLE"
+RESOLVED_AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+RESOLVED_AWS_SESSION_TOKEN = "resolved-session-token"
 SIGNER_TEST_SECRET_ACCESS_KEY = "secret"
 STS_HOST = "sts.amazonaws.com"
 STS_FORM_BODY = b"Action=GetCallerIdentity&Version=2011-06-15"
@@ -154,7 +154,7 @@ def aws_sigv4_presigned_url(
 
 def signer_test_credentials(
     *,
-    access_key_id: str = REAL_AWS_ACCESS_KEY_ID,
+    access_key_id: str = RESOLVED_AWS_ACCESS_KEY_ID,
     secret_access_key: str = SIGNER_TEST_SECRET_ACCESS_KEY,
     session_token: str | None = None,
 ) -> AwsSigV4Credentials:
@@ -163,8 +163,8 @@ def signer_test_credentials(
 
 def resolved_aws_sigv4_credentials(
     *,
-    access_key_id: str = REAL_AWS_ACCESS_KEY_ID,
-    secret_access_key: str = REAL_AWS_SECRET_ACCESS_KEY,
-    session_token: str | None = REAL_AWS_SESSION_TOKEN,
+    access_key_id: str = RESOLVED_AWS_ACCESS_KEY_ID,
+    secret_access_key: str = RESOLVED_AWS_SECRET_ACCESS_KEY,
+    session_token: str | None = RESOLVED_AWS_SESSION_TOKEN,
 ) -> AwsSigV4Credentials:
     return AwsSigV4Credentials(access_key_id, secret_access_key, session_token)

--- a/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/aws_sigv4_helpers.py
@@ -45,11 +45,15 @@ def aws_sigv4_authorization(
     signature: str = PLACEHOLDER_SIGNATURE,
     algorithm: str = AWS_SIGV4_ALGORITHM,
 ) -> str:
-    scope = credential_scope or aws_credential_scope(
-        access_key_id=access_key_id,
-        date=date,
-        region=region,
-        service=service,
+    scope = (
+        aws_credential_scope(
+            access_key_id=access_key_id,
+            date=date,
+            region=region,
+            service=service,
+        )
+        if credential_scope is None
+        else credential_scope
     )
     return f"{algorithm} Credential={scope}, SignedHeaders={signed_headers}, Signature={signature}"
 
@@ -68,7 +72,12 @@ def aws_sigv4_header_auth_headers(
     if amz_date is not None:
         pairs.append(("X-Amz-Date", amz_date))
     pairs.extend(extra_headers)
-    pairs.append(("Authorization", authorization or aws_sigv4_authorization()))
+    pairs.append(
+        (
+            "Authorization",
+            aws_sigv4_authorization() if authorization is None else authorization,
+        )
+    )
     return pairs
 
 
@@ -85,11 +94,15 @@ def aws_sigv4_presigned_query_path(
     signature: str | None = PLACEHOLDER_SIGNATURE,
     leading_query: str = STS_QUERY,
 ) -> str:
-    scope = credential_scope or aws_credential_scope(
-        access_key_id=access_key_id,
-        date=date,
-        region=region,
-        service=service,
+    scope = (
+        aws_credential_scope(
+            access_key_id=access_key_id,
+            date=date,
+            region=region,
+            service=service,
+        )
+        if credential_scope is None
+        else credential_scope
     )
     query = (
         f"{leading_query}"

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -282,9 +282,11 @@ def cache_aws_sigv4_credentials(
     vm_info: AwsVmInfo | None = None,
     credentials: AwsSigV4Credentials | None = None,
     headers: dict[str, str] | None = None,
+    query: dict[str, str] | None = None,
 ) -> None:
     set_cached_headers(
         aws_auth_cache_key(tmp_path, api_entry=api_entry, vm_info=vm_info),
         headers=dict(headers) if headers is not None else {},
+        query=dict(query) if query is not None else None,
         aws_sigv4=(resolved_aws_sigv4_credentials() if credentials is None else credentials),
     )

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -26,6 +26,7 @@ from tests.aws_sigv4_helpers import (
 from url_utils import get_original_url
 
 DEFAULT_SANDBOX_TOKEN = "sandbox-token"
+FAR_FUTURE_EXPIRES_AT = 9_999_999_999
 
 
 class AwsAuthConfigBase(TypedDict):
@@ -170,7 +171,7 @@ def aws_auth_response(
     response: dict[str, object] = {
         "headers": dict(headers) if headers is not None else {},
         "awsSigv4": aws_sigv4,
-        "expiresAt": 1_800_000_000,
+        "expiresAt": FAR_FUTURE_EXPIRES_AT,
         "resolvedSecrets": resolved_secrets,
         "refreshedConnectors": refreshed_connectors,
         "refreshedSecrets": refreshed_secrets,

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -19,9 +19,9 @@ from tests.auth_state_helpers import auth_cache_key, set_cached_headers
 from tests.aws_sigv4_helpers import (
     DEFAULT_AWS_REGION,
     DEFAULT_SIGV4_TIMESTAMP,
-    REAL_AWS_ACCESS_KEY_ID,
-    REAL_AWS_SECRET_ACCESS_KEY,
-    REAL_AWS_SESSION_TOKEN,
+    RESOLVED_AWS_ACCESS_KEY_ID,
+    RESOLVED_AWS_SECRET_ACCESS_KEY,
+    RESOLVED_AWS_SESSION_TOKEN,
     STS_FORM_BODY,
     STS_HOST,
     aws_sigv4_authorization,
@@ -174,9 +174,9 @@ def aws_vm_info(
 def aws_auth_response(
     *,
     include_session_token: bool = True,
-    access_key_id: str = REAL_AWS_ACCESS_KEY_ID,
-    secret_access_key: str = REAL_AWS_SECRET_ACCESS_KEY,
-    session_token: str = REAL_AWS_SESSION_TOKEN,
+    access_key_id: str = RESOLVED_AWS_ACCESS_KEY_ID,
+    secret_access_key: str = RESOLVED_AWS_SECRET_ACCESS_KEY,
+    session_token: str = RESOLVED_AWS_SESSION_TOKEN,
     headers: Mapping[str, str] | None = None,
     query: Mapping[str, str] | None = None,
 ) -> dict[str, object]:

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -251,19 +251,20 @@ def assert_sigv4_failed_closed(
 def aws_auth_cache_key(
     tmp_path: Path,
     api_entry: AwsApiEntry | None = None,
+    vm_info: AwsVmInfo | None = None,
 ):
     resolved_api_entry = aws_api_entry() if api_entry is None else api_entry
-    vm_info = aws_vm_info(tmp_path)
+    resolved_vm_info = aws_vm_info(tmp_path) if vm_info is None else vm_info
     auth_config = resolved_api_entry["auth"]
     auth_request = auth_client.FirewallAuthRequest(
-        encrypted_secrets=vm_info["encryptedSecrets"],
+        encrypted_secrets=resolved_vm_info["encryptedSecrets"],
         auth_headers=auth_config["headers"],
-        sandbox_token=vm_info["sandboxToken"],
+        sandbox_token=resolved_vm_info["sandboxToken"],
         auth_aws_sigv4=auth_config["awsSigv4"],
-        vars_map=vm_info["vars"],
+        vars_map=resolved_vm_info["vars"],
     )
     return auth_cache_key(
-        run_id=vm_info["runId"],
+        run_id=resolved_vm_info["runId"],
         api_id=resolved_api_entry["base"],
         auth_identity=auth._build_firewall_auth_identity(
             firewall_name="aws",
@@ -277,11 +278,12 @@ def cache_aws_sigv4_credentials(
     tmp_path: Path,
     *,
     api_entry: AwsApiEntry | None = None,
+    vm_info: AwsVmInfo | None = None,
     credentials: AwsSigV4Credentials | None = None,
     headers: dict[str, str] | None = None,
 ) -> None:
     set_cached_headers(
-        aws_auth_cache_key(tmp_path, api_entry),
+        aws_auth_cache_key(tmp_path, api_entry=api_entry, vm_info=vm_info),
         headers=dict(headers) if headers is not None else {},
         aws_sigv4=(resolved_aws_sigv4_credentials() if credentials is None else credentials),
     )

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -69,7 +69,7 @@ def aws_api_entry(
     include_session_token: bool = True,
 ) -> AwsApiEntry:
     auth_config: AwsAuthConfig = {
-        "headers": dict(auth_headers or {}),
+        "headers": dict(auth_headers) if auth_headers is not None else {},
         "awsSigv4": aws_sigv4_auth_config(include_session_token=include_session_token),
     }
     if auth_query is not None:
@@ -93,7 +93,7 @@ def aws_allow(
         dict(aws_api_entry() if api_entry is None else api_entry),
         firewall_name,
         permission,
-        params or {},
+        {} if params is None else params,
         rule,
         rel_path,
     )
@@ -143,7 +143,7 @@ def aws_auth_response(
         refreshed_secrets.append("AWS_SESSION_TOKEN")
 
     response: dict[str, object] = {
-        "headers": dict(headers or {}),
+        "headers": dict(headers) if headers is not None else {},
         "awsSigv4": aws_sigv4,
         "expiresAt": 1_800_000_000,
         "resolvedSecrets": resolved_secrets,
@@ -186,8 +186,11 @@ def make_sts_header_sigv4_flow(
                 host=host,
                 amz_date=amz_date,
                 extra_headers=extra_headers,
-                authorization=authorization
-                or aws_sigv4_authorization(signed_headers=signed_headers),
+                authorization=(
+                    aws_sigv4_authorization(signed_headers=signed_headers)
+                    if authorization is None
+                    else authorization
+                ),
             )
         ),
     )
@@ -212,7 +215,7 @@ async def handle_firewall_request_with_auth_endpoint(
     allow: matching.FirewallAllow | None = None,
     vm_info: AwsVmInfo | None = None,
 ) -> auth.FirewallAuthHandlingResult:
-    resolved_endpoint = endpoint or FakeAuthEndpoint()
+    resolved_endpoint = FakeAuthEndpoint() if endpoint is None else endpoint
     resolved_endpoint.queue_json_response(
         aws_auth_response() if auth_response is None else auth_response
     )
@@ -274,6 +277,6 @@ def cache_aws_sigv4_credentials(
 ) -> None:
     set_cached_headers(
         aws_auth_cache_key(tmp_path, api_entry),
-        headers=dict(headers or {}),
-        aws_sigv4=credentials or resolved_aws_sigv4_credentials(),
+        headers=dict(headers) if headers is not None else {},
+        aws_sigv4=(resolved_aws_sigv4_credentials() if credentials is None else credentials),
     )

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -1,0 +1,279 @@
+"""AWS SigV4 firewall-auth integration helpers for mitm-addon tests."""
+
+from pathlib import Path
+from typing import TypedDict
+
+import auth
+import firewall_auth_client as auth_client
+import flow_metadata_keys as metadata_keys
+import matching
+from aws_sigv4 import AwsSigV4Credentials
+from tests.auth_endpoint_helpers import FakeAuthEndpoint
+from tests.auth_state_helpers import auth_cache_key, set_cached_headers
+from tests.aws_sigv4_helpers import (
+    DEFAULT_AWS_REGION,
+    DEFAULT_SIGV4_TIMESTAMP,
+    REAL_AWS_ACCESS_KEY_ID,
+    REAL_AWS_SECRET_ACCESS_KEY,
+    REAL_AWS_SESSION_TOKEN,
+    STS_FORM_BODY,
+    STS_HOST,
+    aws_sigv4_authorization,
+    aws_sigv4_header_auth_headers,
+    aws_sigv4_presigned_query_path,
+    resolved_aws_sigv4_credentials,
+)
+from url_utils import get_original_url
+
+DEFAULT_SANDBOX_TOKEN = "sandbox-token"
+
+
+class AwsAuthConfigBase(TypedDict):
+    headers: dict[str, str]
+    awsSigv4: dict[str, str]
+
+
+class AwsAuthConfig(AwsAuthConfigBase, total=False):
+    query: dict[str, str]
+
+
+class AwsApiEntry(TypedDict):
+    base: str
+    auth: AwsAuthConfig
+
+
+class AwsVmInfo(TypedDict):
+    runId: str
+    sandboxToken: str
+    encryptedSecrets: str
+    networkLogPath: str
+    billableFirewalls: list[object]
+    vars: dict[str, str]
+
+
+def aws_sigv4_auth_config(*, include_session_token: bool = True) -> dict[str, str]:
+    config = {
+        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+    }
+    if include_session_token:
+        config["sessionToken"] = "${{ secrets.AWS_SESSION_TOKEN }}"
+    return config
+
+
+def aws_api_entry(
+    *,
+    base: str = f"https://{STS_HOST}",
+    auth_headers: dict[str, str] | None = None,
+    auth_query: dict[str, str] | None = None,
+    include_session_token: bool = True,
+) -> AwsApiEntry:
+    auth_config: AwsAuthConfig = {
+        "headers": dict(auth_headers or {}),
+        "awsSigv4": aws_sigv4_auth_config(include_session_token=include_session_token),
+    }
+    if auth_query is not None:
+        auth_config["query"] = dict(auth_query)
+    return {
+        "base": base,
+        "auth": auth_config,
+    }
+
+
+def aws_allow(
+    api_entry: AwsApiEntry | None = None,
+    *,
+    firewall_name: str = "aws",
+    permission: str = "identity",
+    params: dict[str, str] | None = None,
+    rule: str = "POST /",
+    rel_path: str = "/",
+) -> matching.FirewallAllow:
+    return matching.FirewallAllow(
+        dict(aws_api_entry() if api_entry is None else api_entry),
+        firewall_name,
+        permission,
+        params or {},
+        rule,
+        rel_path,
+    )
+
+
+def aws_vm_info(
+    tmp_path: Path,
+    *,
+    run_id: str = "run-1",
+    sandbox_token: str | None = None,
+    encrypted_secrets: str = "iv:tag:data",
+    region: str = DEFAULT_AWS_REGION,
+) -> AwsVmInfo:
+    return {
+        "runId": run_id,
+        "sandboxToken": DEFAULT_SANDBOX_TOKEN if sandbox_token is None else sandbox_token,
+        "encryptedSecrets": encrypted_secrets,
+        "networkLogPath": str(tmp_path / "network.jsonl"),
+        "billableFirewalls": [],
+        "vars": {"AWS_REGION": region},
+    }
+
+
+def aws_auth_response(
+    *,
+    include_session_token: bool = True,
+    access_key_id: str = REAL_AWS_ACCESS_KEY_ID,
+    secret_access_key: str = REAL_AWS_SECRET_ACCESS_KEY,
+    session_token: str = REAL_AWS_SESSION_TOKEN,
+    headers: dict[str, str] | None = None,
+    query: dict[str, str] | None = None,
+) -> dict[str, object]:
+    aws_sigv4 = {
+        "accessKeyId": access_key_id,
+        "secretAccessKey": secret_access_key,
+    }
+    resolved_secrets = [
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+    ]
+    refreshed_connectors: list[str] = []
+    refreshed_secrets: list[str] = []
+    if include_session_token:
+        aws_sigv4["sessionToken"] = session_token
+        resolved_secrets.append("AWS_SESSION_TOKEN")
+        refreshed_connectors.append("aws")
+        refreshed_secrets.append("AWS_SESSION_TOKEN")
+
+    response: dict[str, object] = {
+        "headers": dict(headers or {}),
+        "awsSigv4": aws_sigv4,
+        "expiresAt": 1_800_000_000,
+        "resolvedSecrets": resolved_secrets,
+        "refreshedConnectors": refreshed_connectors,
+        "refreshedSecrets": refreshed_secrets,
+    }
+    if query is not None:
+        response["query"] = dict(query)
+    return response
+
+
+def prepare_firewall_request(flow, *, original_url: str | None = None) -> None:
+    flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
+    flow.metadata[metadata_keys.ORIGINAL_URL] = (
+        get_original_url(flow) if original_url is None else original_url
+    )
+
+
+def make_sts_header_sigv4_flow(
+    real_flow,
+    headers,
+    *,
+    host: str = STS_HOST,
+    path: str = "/",
+    method: str = "POST",
+    request_body: bytes | None = None,
+    authorization: str | None = None,
+    signed_headers: str = "host;x-amz-date",
+    amz_date: str | None = DEFAULT_SIGV4_TIMESTAMP,
+    extra_headers: tuple[tuple[str, str], ...] = (),
+):
+    return real_flow(
+        with_response=False,
+        host=host,
+        path=path,
+        method=method,
+        request_body=STS_FORM_BODY if request_body is None else request_body,
+        request_headers=headers(
+            *aws_sigv4_header_auth_headers(
+                host=host,
+                amz_date=amz_date,
+                extra_headers=extra_headers,
+                authorization=authorization
+                or aws_sigv4_authorization(signed_headers=signed_headers),
+            )
+        ),
+    )
+
+
+def make_sts_query_sigv4_flow(real_flow, *, path: str | None = None):
+    return real_flow(
+        with_response=False,
+        host=STS_HOST,
+        path=aws_sigv4_presigned_query_path() if path is None else path,
+        method="GET",
+    )
+
+
+async def handle_firewall_request_with_auth_endpoint(
+    flow,
+    tmp_path: Path,
+    mitm_ctx,
+    *,
+    endpoint: FakeAuthEndpoint | None = None,
+    auth_response: dict[str, object] | None = None,
+    allow: matching.FirewallAllow | None = None,
+    vm_info: AwsVmInfo | None = None,
+) -> auth.FirewallAuthHandlingResult:
+    resolved_endpoint = endpoint or FakeAuthEndpoint()
+    resolved_endpoint.queue_json_response(
+        aws_auth_response() if auth_response is None else auth_response
+    )
+    prepare_firewall_request(flow)
+
+    with resolved_endpoint.run(), mitm_ctx(api_url=resolved_endpoint.api_url):
+        resolved_vm_info = aws_vm_info(tmp_path) if vm_info is None else vm_info
+        return await auth.handle_firewall_request(
+            flow,
+            aws_allow() if allow is None else allow,
+            dict(resolved_vm_info),
+        )
+
+
+def assert_sigv4_failed_closed(
+    result: auth.FirewallAuthHandlingResult,
+    flow,
+    message_fragment: str,
+) -> None:
+    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    response = flow.response.json()
+    assert response["error"] == "aws_sigv4_auth_failed"
+    assert message_fragment in response["message"]
+
+
+def aws_auth_cache_key(
+    tmp_path: Path,
+    api_entry: AwsApiEntry | None = None,
+):
+    resolved_api_entry = aws_api_entry() if api_entry is None else api_entry
+    vm_info = aws_vm_info(tmp_path)
+    auth_config = resolved_api_entry["auth"]
+    auth_request = auth_client.FirewallAuthRequest(
+        encrypted_secrets=vm_info["encryptedSecrets"],
+        auth_headers=auth_config["headers"],
+        sandbox_token=vm_info["sandboxToken"],
+        auth_aws_sigv4=auth_config["awsSigv4"],
+        vars_map=vm_info["vars"],
+    )
+    return auth_cache_key(
+        run_id=vm_info["runId"],
+        api_id=resolved_api_entry["base"],
+        auth_identity=auth._build_firewall_auth_identity(
+            firewall_name="aws",
+            firewall_base=resolved_api_entry["base"],
+            auth_request=auth_request,
+        ),
+    )
+
+
+def cache_aws_sigv4_credentials(
+    tmp_path: Path,
+    *,
+    api_entry: AwsApiEntry | None = None,
+    credentials: AwsSigV4Credentials | None = None,
+    headers: dict[str, str] | None = None,
+) -> None:
+    set_cached_headers(
+        aws_auth_cache_key(tmp_path, api_entry),
+        headers=dict(headers or {}),
+        aws_sigv4=credentials or resolved_aws_sigv4_credentials(),
+    )

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -1,5 +1,6 @@
 """AWS SigV4 firewall-auth integration helpers for mitm-addon tests."""
 
+import copy
 from pathlib import Path
 from typing import TypedDict
 
@@ -62,28 +63,6 @@ class AwsVmInfo(AwsVmInfoBase, total=False):
     secretConnectorMetadataMap: dict[str, object]
 
 
-def _copy_aws_auth_config(auth_config: AwsAuthConfig) -> AwsAuthConfig:
-    copied_auth_config: AwsAuthConfig = {
-        "headers": dict(auth_config["headers"]),
-        "awsSigv4": dict(auth_config["awsSigv4"]),
-    }
-    if "base" in auth_config:
-        copied_auth_config["base"] = auth_config["base"]
-    if "query" in auth_config:
-        copied_auth_config["query"] = dict(auth_config["query"])
-    return copied_auth_config
-
-
-def _copy_aws_api_entry(api_entry: AwsApiEntry) -> AwsApiEntry:
-    copied_api_entry: AwsApiEntry = {
-        "base": api_entry["base"],
-        "auth": _copy_aws_auth_config(api_entry["auth"]),
-    }
-    if "id" in api_entry:
-        copied_api_entry["id"] = api_entry["id"]
-    return copied_api_entry
-
-
 def aws_sigv4_auth_config(*, include_session_token: bool = True) -> dict[str, str]:
     config = {
         "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
@@ -130,7 +109,7 @@ def aws_allow(
     rel_path: str = "/",
 ) -> matching.FirewallAllow:
     return matching.FirewallAllow(
-        dict(_copy_aws_api_entry(aws_api_entry() if api_entry is None else api_entry)),
+        dict(copy.deepcopy(aws_api_entry() if api_entry is None else api_entry)),
         firewall_name,
         permission,
         {} if params is None else dict(params),

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -45,15 +45,18 @@ class _RealFlowFactory(Protocol):
         request_body: bytes | None = ...,
         request_headers: http.Headers | None = ...,
         with_response: bool = ...,
-    ) -> http.HTTPFlow: ...
+    ) -> http.HTTPFlow:
+        raise NotImplementedError
 
 
 class _HeaderFactory(Protocol):
-    def __call__(self, *pairs: tuple[str, str]) -> http.Headers: ...
+    def __call__(self, *pairs: tuple[str, str]) -> http.Headers:
+        raise NotImplementedError
 
 
 class _MitmContextFactory(Protocol):
-    def __call__(self, *, api_url: str = ...) -> AbstractContextManager[object]: ...
+    def __call__(self, *, api_url: str = ...) -> AbstractContextManager[object]:
+        raise NotImplementedError
 
 
 class AwsAuthConfigBase(TypedDict):

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -54,7 +54,7 @@ class AwsVmInfoBase(TypedDict):
     sandboxToken: str
     encryptedSecrets: str
     networkLogPath: str
-    billableFirewalls: list[object]
+    billableFirewalls: list[str]
     vars: dict[str, str]
 
 
@@ -125,7 +125,7 @@ def aws_vm_info(
     sandbox_token: str | None = None,
     encrypted_secrets: str = "iv:tag:data",
     region: str = DEFAULT_AWS_REGION,
-    billable_firewalls: list[object] | None = None,
+    billable_firewalls: list[str] | None = None,
     secret_connector_map: dict[str, str] | None = None,
     secret_connector_metadata_map: dict[str, object] | None = None,
 ) -> AwsVmInfo:
@@ -140,7 +140,7 @@ def aws_vm_info(
     if secret_connector_map is not None:
         vm_info["secretConnectorMap"] = dict(secret_connector_map)
     if secret_connector_metadata_map is not None:
-        vm_info["secretConnectorMetadataMap"] = dict(secret_connector_metadata_map)
+        vm_info["secretConnectorMetadataMap"] = copy.deepcopy(secret_connector_metadata_map)
     return vm_info
 
 

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -155,8 +155,13 @@ def aws_auth_response(
     return response
 
 
-def prepare_firewall_request(flow, *, original_url: str | None = None) -> None:
-    flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
+def prepare_firewall_request(
+    flow,
+    *,
+    original_url: str | None = None,
+    run_id: str = "run-1",
+) -> None:
+    flow.metadata[metadata_keys.VM_RUN_ID] = run_id
     flow.metadata[metadata_keys.ORIGINAL_URL] = (
         get_original_url(flow) if original_url is None else original_url
     )
@@ -219,10 +224,10 @@ async def handle_firewall_request_with_auth_endpoint(
     resolved_endpoint.queue_json_response(
         aws_auth_response() if auth_response is None else auth_response
     )
-    prepare_firewall_request(flow)
+    resolved_vm_info = aws_vm_info(tmp_path) if vm_info is None else vm_info
+    prepare_firewall_request(flow, run_id=resolved_vm_info["runId"])
 
     with resolved_endpoint.run(), mitm_ctx(api_url=resolved_endpoint.api_url):
-        resolved_vm_info = aws_vm_info(tmp_path) if vm_info is None else vm_info
         return await auth.handle_firewall_request(
             flow,
             aws_allow() if allow is None else allow,

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -232,7 +232,7 @@ def make_sts_header_sigv4_flow(
     authorization: str | None = None,
     signed_headers: str = "host;x-amz-date",
     amz_date: str | None = DEFAULT_SIGV4_TIMESTAMP,
-    extra_headers: tuple[tuple[str, str], ...] = (),
+    extra_headers: Sequence[tuple[str, str]] = (),
 ) -> http.HTTPFlow:
     return real_flow(
         with_response=False,

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -1,6 +1,7 @@
 """AWS SigV4 firewall-auth integration helpers for mitm-addon tests."""
 
 import copy
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TypedDict
 
@@ -100,7 +101,7 @@ def aws_api_entry(
 
 
 def aws_allow(
-    api_entry: AwsApiEntry | None = None,
+    api_entry: Mapping[str, object] | None = None,
     *,
     firewall_name: str = "aws",
     permission: str = "identity",
@@ -108,8 +109,9 @@ def aws_allow(
     rule: str = "POST /",
     rel_path: str = "/",
 ) -> matching.FirewallAllow:
+    resolved_api_entry = aws_api_entry() if api_entry is None else api_entry
     return matching.FirewallAllow(
-        dict(copy.deepcopy(aws_api_entry() if api_entry is None else api_entry)),
+        copy.deepcopy(dict(resolved_api_entry)),
         firewall_name,
         permission,
         {} if params is None else dict(params),

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -260,6 +260,7 @@ def aws_auth_cache_key(
         encrypted_secrets=resolved_vm_info["encryptedSecrets"],
         auth_headers=auth_config["headers"],
         sandbox_token=resolved_vm_info["sandboxToken"],
+        auth_query=auth_config.get("query"),
         auth_aws_sigv4=auth_config["awsSigv4"],
         vars_map=resolved_vm_info["vars"],
     )

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -1,13 +1,15 @@
 """AWS SigV4 firewall-auth integration helpers for mitm-addon tests."""
 
 import copy
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import TypedDict
+from typing import Protocol, TypedDict
 
 from mitmproxy import http
 
 import auth
+import firewall_auth_cache as auth_cache
 import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
 import matching
@@ -31,8 +33,27 @@ from url_utils import get_original_url
 
 DEFAULT_SANDBOX_TOKEN = "sandbox-token"
 FAR_FUTURE_EXPIRES_AT = 9_999_999_999
-_RealFlowFactory = Callable[..., http.HTTPFlow]
-_HeaderFactory = Callable[..., http.Headers]
+
+
+class _RealFlowFactory(Protocol):
+    def __call__(
+        self,
+        *,
+        host: str = ...,
+        path: str = ...,
+        method: str = ...,
+        request_body: bytes | None = ...,
+        request_headers: http.Headers | None = ...,
+        with_response: bool = ...,
+    ) -> http.HTTPFlow: ...
+
+
+class _HeaderFactory(Protocol):
+    def __call__(self, *pairs: tuple[str, str]) -> http.Headers: ...
+
+
+class _MitmContextFactory(Protocol):
+    def __call__(self, *, api_url: str = ...) -> AbstractContextManager[object]: ...
 
 
 class AwsAuthConfigBase(TypedDict):
@@ -189,7 +210,7 @@ def aws_auth_response(
 
 
 def prepare_firewall_request(
-    flow,
+    flow: http.HTTPFlow,
     *,
     original_url: str | None = None,
     run_id: str = "run-1",
@@ -246,9 +267,9 @@ def make_sts_query_sigv4_flow(
 
 
 async def handle_firewall_request_with_auth_endpoint(
-    flow,
+    flow: http.HTTPFlow,
     tmp_path: Path,
-    mitm_ctx,
+    mitm_ctx: _MitmContextFactory,
     *,
     endpoint: FakeAuthEndpoint | None = None,
     auth_response: dict[str, object] | None = None,
@@ -272,7 +293,7 @@ async def handle_firewall_request_with_auth_endpoint(
 
 def assert_sigv4_failed_closed(
     result: auth.FirewallAuthHandlingResult,
-    flow,
+    flow: http.HTTPFlow,
     message_fragment: str,
 ) -> None:
     assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
@@ -287,7 +308,7 @@ def _aws_auth_cache_key(
     tmp_path: Path,
     allow: matching.FirewallAllow | None = None,
     vm_info: AwsVmInfo | None = None,
-):
+) -> auth_cache.FirewallAuthCacheKey:
     resolved_allow = aws_allow() if allow is None else allow
     resolved_api_entry = resolved_allow.api_entry
     resolved_vm_info = aws_vm_info(tmp_path) if vm_info is None else vm_info

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -1,7 +1,7 @@
 """AWS SigV4 firewall-auth integration helpers for mitm-addon tests."""
 
 import copy
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Protocol, TypedDict
@@ -104,8 +104,8 @@ def aws_api_entry(
     api_id: str | None = None,
     base: str = f"https://{STS_HOST}",
     auth_base: str | None = None,
-    auth_headers: dict[str, str] | None = None,
-    auth_query: dict[str, str] | None = None,
+    auth_headers: Mapping[str, str] | None = None,
+    auth_query: Mapping[str, str] | None = None,
     include_session_token: bool = True,
 ) -> AwsApiEntry:
     auth_config: AwsAuthConfig = {
@@ -130,7 +130,7 @@ def aws_allow(
     *,
     firewall_name: str = "aws",
     permission: str = "identity",
-    params: dict[str, str] | None = None,
+    params: Mapping[str, str] | None = None,
     rule: str = "POST /",
     rel_path: str = "/",
 ) -> matching.FirewallAllow:
@@ -152,9 +152,9 @@ def aws_vm_info(
     sandbox_token: str | None = None,
     encrypted_secrets: str = "iv:tag:data",
     region: str = DEFAULT_AWS_REGION,
-    billable_firewalls: list[str] | None = None,
-    secret_connector_map: dict[str, str] | None = None,
-    secret_connector_metadata_map: dict[str, object] | None = None,
+    billable_firewalls: Sequence[str] | None = None,
+    secret_connector_map: Mapping[str, str] | None = None,
+    secret_connector_metadata_map: Mapping[str, object] | None = None,
 ) -> AwsVmInfo:
     vm_info: AwsVmInfo = {
         "runId": run_id,
@@ -167,7 +167,7 @@ def aws_vm_info(
     if secret_connector_map is not None:
         vm_info["secretConnectorMap"] = dict(secret_connector_map)
     if secret_connector_metadata_map is not None:
-        vm_info["secretConnectorMetadataMap"] = copy.deepcopy(secret_connector_metadata_map)
+        vm_info["secretConnectorMetadataMap"] = copy.deepcopy(dict(secret_connector_metadata_map))
     return vm_info
 
 
@@ -177,8 +177,8 @@ def aws_auth_response(
     access_key_id: str = REAL_AWS_ACCESS_KEY_ID,
     secret_access_key: str = REAL_AWS_SECRET_ACCESS_KEY,
     session_token: str = REAL_AWS_SESSION_TOKEN,
-    headers: dict[str, str] | None = None,
-    query: dict[str, str] | None = None,
+    headers: Mapping[str, str] | None = None,
+    query: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     aws_sigv4 = {
         "accessKeyId": access_key_id,
@@ -345,8 +345,8 @@ def cache_aws_sigv4_credentials(
     allow: matching.FirewallAllow | None = None,
     vm_info: AwsVmInfo | None = None,
     credentials: AwsSigV4Credentials | None = None,
-    headers: dict[str, str] | None = None,
-    query: dict[str, str] | None = None,
+    headers: Mapping[str, str] | None = None,
+    query: Mapping[str, str] | None = None,
     expires_at: object = None,
 ) -> None:
     set_cached_headers(

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -111,7 +111,7 @@ def aws_allow(
         dict(aws_api_entry() if api_entry is None else api_entry),
         firewall_name,
         permission,
-        {} if params is None else params,
+        {} if params is None else dict(params),
         rule,
         rel_path,
     )
@@ -133,7 +133,7 @@ def aws_vm_info(
         "sandboxToken": DEFAULT_SANDBOX_TOKEN if sandbox_token is None else sandbox_token,
         "encryptedSecrets": encrypted_secrets,
         "networkLogPath": str(tmp_path / "network.jsonl"),
-        "billableFirewalls": [] if billable_firewalls is None else billable_firewalls,
+        "billableFirewalls": [] if billable_firewalls is None else list(billable_firewalls),
         "vars": {"AWS_REGION": region},
     }
     if secret_connector_map is not None:

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -34,21 +34,31 @@ class AwsAuthConfigBase(TypedDict):
 
 
 class AwsAuthConfig(AwsAuthConfigBase, total=False):
+    base: str
     query: dict[str, str]
 
 
-class AwsApiEntry(TypedDict):
+class AwsApiEntryBase(TypedDict):
     base: str
     auth: AwsAuthConfig
 
 
-class AwsVmInfo(TypedDict):
+class AwsApiEntry(AwsApiEntryBase, total=False):
+    id: str
+
+
+class AwsVmInfoBase(TypedDict):
     runId: str
     sandboxToken: str
     encryptedSecrets: str
     networkLogPath: str
     billableFirewalls: list[object]
     vars: dict[str, str]
+
+
+class AwsVmInfo(AwsVmInfoBase, total=False):
+    secretConnectorMap: dict[str, str]
+    secretConnectorMetadataMap: dict[str, object]
 
 
 def aws_sigv4_auth_config(*, include_session_token: bool = True) -> dict[str, str]:
@@ -63,7 +73,9 @@ def aws_sigv4_auth_config(*, include_session_token: bool = True) -> dict[str, st
 
 def aws_api_entry(
     *,
+    api_id: str | None = None,
     base: str = f"https://{STS_HOST}",
+    auth_base: str | None = None,
     auth_headers: dict[str, str] | None = None,
     auth_query: dict[str, str] | None = None,
     include_session_token: bool = True,
@@ -72,12 +84,17 @@ def aws_api_entry(
         "headers": dict(auth_headers) if auth_headers is not None else {},
         "awsSigv4": aws_sigv4_auth_config(include_session_token=include_session_token),
     }
+    if auth_base is not None:
+        auth_config["base"] = auth_base
     if auth_query is not None:
         auth_config["query"] = dict(auth_query)
-    return {
+    api_entry: AwsApiEntry = {
         "base": base,
         "auth": auth_config,
     }
+    if api_id is not None:
+        api_entry["id"] = api_id
+    return api_entry
 
 
 def aws_allow(
@@ -106,15 +123,23 @@ def aws_vm_info(
     sandbox_token: str | None = None,
     encrypted_secrets: str = "iv:tag:data",
     region: str = DEFAULT_AWS_REGION,
+    billable_firewalls: list[object] | None = None,
+    secret_connector_map: dict[str, str] | None = None,
+    secret_connector_metadata_map: dict[str, object] | None = None,
 ) -> AwsVmInfo:
-    return {
+    vm_info: AwsVmInfo = {
         "runId": run_id,
         "sandboxToken": DEFAULT_SANDBOX_TOKEN if sandbox_token is None else sandbox_token,
         "encryptedSecrets": encrypted_secrets,
         "networkLogPath": str(tmp_path / "network.jsonl"),
-        "billableFirewalls": [],
+        "billableFirewalls": [] if billable_firewalls is None else billable_firewalls,
         "vars": {"AWS_REGION": region},
     }
+    if secret_connector_map is not None:
+        vm_info["secretConnectorMap"] = dict(secret_connector_map)
+    if secret_connector_metadata_map is not None:
+        vm_info["secretConnectorMetadataMap"] = dict(secret_connector_metadata_map)
+    return vm_info
 
 
 def aws_auth_response(
@@ -250,25 +275,33 @@ def assert_sigv4_failed_closed(
 
 def aws_auth_cache_key(
     tmp_path: Path,
-    api_entry: AwsApiEntry | None = None,
+    allow: matching.FirewallAllow | None = None,
     vm_info: AwsVmInfo | None = None,
 ):
-    resolved_api_entry = aws_api_entry() if api_entry is None else api_entry
+    resolved_allow = aws_allow() if allow is None else allow
+    resolved_api_entry = resolved_allow.api_entry
     resolved_vm_info = aws_vm_info(tmp_path) if vm_info is None else vm_info
     auth_config = resolved_api_entry["auth"]
     auth_request = auth_client.FirewallAuthRequest(
         encrypted_secrets=resolved_vm_info["encryptedSecrets"],
         auth_headers=auth_config["headers"],
         sandbox_token=resolved_vm_info["sandboxToken"],
+        auth_base=auth_config.get("base"),
         auth_query=auth_config.get("query"),
         auth_aws_sigv4=auth_config["awsSigv4"],
+        secret_connector_map=resolved_vm_info.get("secretConnectorMap"),
+        secret_connector_metadata_map=resolved_vm_info.get("secretConnectorMetadataMap"),
         vars_map=resolved_vm_info["vars"],
+        firewall_billable=auth.is_billable_firewall(
+            resolved_allow.name,
+            dict(resolved_vm_info),
+        ),
     )
     return auth_cache_key(
         run_id=resolved_vm_info["runId"],
-        api_id=resolved_api_entry["base"],
+        api_id=resolved_api_entry.get("id", resolved_api_entry["base"]),
         auth_identity=auth._build_firewall_auth_identity(
-            firewall_name="aws",
+            firewall_name=resolved_allow.name,
             firewall_base=resolved_api_entry["base"],
             auth_request=auth_request,
         ),
@@ -278,15 +311,17 @@ def aws_auth_cache_key(
 def cache_aws_sigv4_credentials(
     tmp_path: Path,
     *,
-    api_entry: AwsApiEntry | None = None,
+    allow: matching.FirewallAllow | None = None,
     vm_info: AwsVmInfo | None = None,
     credentials: AwsSigV4Credentials | None = None,
     headers: dict[str, str] | None = None,
     query: dict[str, str] | None = None,
+    expires_at: object = None,
 ) -> None:
     set_cached_headers(
-        aws_auth_cache_key(tmp_path, api_entry=api_entry, vm_info=vm_info),
+        aws_auth_cache_key(tmp_path, allow=allow, vm_info=vm_info),
         headers=dict(headers) if headers is not None else {},
+        expires_at=expires_at,
         query=dict(query) if query is not None else None,
         aws_sigv4=(resolved_aws_sigv4_credentials() if credentials is None else credentials),
     )

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -1,9 +1,11 @@
 """AWS SigV4 firewall-auth integration helpers for mitm-addon tests."""
 
 import copy
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TypedDict
+
+from mitmproxy import http
 
 import auth
 import firewall_auth_client as auth_client
@@ -29,6 +31,8 @@ from url_utils import get_original_url
 
 DEFAULT_SANDBOX_TOKEN = "sandbox-token"
 FAR_FUTURE_EXPIRES_AT = 9_999_999_999
+_RealFlowFactory = Callable[..., http.HTTPFlow]
+_HeaderFactory = Callable[..., http.Headers]
 
 
 class AwsAuthConfigBase(TypedDict):
@@ -64,7 +68,7 @@ class AwsVmInfo(AwsVmInfoBase, total=False):
     secretConnectorMetadataMap: dict[str, object]
 
 
-def aws_sigv4_auth_config(*, include_session_token: bool = True) -> dict[str, str]:
+def _aws_sigv4_auth_config(*, include_session_token: bool = True) -> dict[str, str]:
     config = {
         "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
         "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
@@ -85,7 +89,7 @@ def aws_api_entry(
 ) -> AwsApiEntry:
     auth_config: AwsAuthConfig = {
         "headers": dict(auth_headers) if auth_headers is not None else {},
-        "awsSigv4": aws_sigv4_auth_config(include_session_token=include_session_token),
+        "awsSigv4": _aws_sigv4_auth_config(include_session_token=include_session_token),
     }
     if auth_base is not None:
         auth_config["base"] = auth_base
@@ -197,8 +201,8 @@ def prepare_firewall_request(
 
 
 def make_sts_header_sigv4_flow(
-    real_flow,
-    headers,
+    real_flow: _RealFlowFactory,
+    headers: _HeaderFactory,
     *,
     host: str = STS_HOST,
     path: str = "/",
@@ -208,7 +212,7 @@ def make_sts_header_sigv4_flow(
     signed_headers: str = "host;x-amz-date",
     amz_date: str | None = DEFAULT_SIGV4_TIMESTAMP,
     extra_headers: tuple[tuple[str, str], ...] = (),
-):
+) -> http.HTTPFlow:
     return real_flow(
         with_response=False,
         host=host,
@@ -230,7 +234,9 @@ def make_sts_header_sigv4_flow(
     )
 
 
-def make_sts_query_sigv4_flow(real_flow, *, path: str | None = None):
+def make_sts_query_sigv4_flow(
+    real_flow: _RealFlowFactory, *, path: str | None = None
+) -> http.HTTPFlow:
     return real_flow(
         with_response=False,
         host=STS_HOST,
@@ -277,7 +283,7 @@ def assert_sigv4_failed_closed(
     assert message_fragment in response["message"]
 
 
-def aws_auth_cache_key(
+def _aws_auth_cache_key(
     tmp_path: Path,
     allow: matching.FirewallAllow | None = None,
     vm_info: AwsVmInfo | None = None,
@@ -323,7 +329,7 @@ def cache_aws_sigv4_credentials(
     expires_at: object = None,
 ) -> None:
     set_cached_headers(
-        aws_auth_cache_key(tmp_path, allow=allow, vm_info=vm_info),
+        _aws_auth_cache_key(tmp_path, allow=allow, vm_info=vm_info),
         headers=dict(headers) if headers is not None else {},
         expires_at=expires_at,
         query=dict(query) if query is not None else None,

--- a/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
+++ b/crates/runner/mitm-addon/tests/firewall_aws_sigv4_helpers.py
@@ -62,6 +62,28 @@ class AwsVmInfo(AwsVmInfoBase, total=False):
     secretConnectorMetadataMap: dict[str, object]
 
 
+def _copy_aws_auth_config(auth_config: AwsAuthConfig) -> AwsAuthConfig:
+    copied_auth_config: AwsAuthConfig = {
+        "headers": dict(auth_config["headers"]),
+        "awsSigv4": dict(auth_config["awsSigv4"]),
+    }
+    if "base" in auth_config:
+        copied_auth_config["base"] = auth_config["base"]
+    if "query" in auth_config:
+        copied_auth_config["query"] = dict(auth_config["query"])
+    return copied_auth_config
+
+
+def _copy_aws_api_entry(api_entry: AwsApiEntry) -> AwsApiEntry:
+    copied_api_entry: AwsApiEntry = {
+        "base": api_entry["base"],
+        "auth": _copy_aws_auth_config(api_entry["auth"]),
+    }
+    if "id" in api_entry:
+        copied_api_entry["id"] = api_entry["id"]
+    return copied_api_entry
+
+
 def aws_sigv4_auth_config(*, include_session_token: bool = True) -> dict[str, str]:
     config = {
         "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
@@ -108,7 +130,7 @@ def aws_allow(
     rel_path: str = "/",
 ) -> matching.FirewallAllow:
     return matching.FirewallAllow(
-        dict(aws_api_entry() if api_entry is None else api_entry),
+        dict(_copy_aws_api_entry(aws_api_entry() if api_entry is None else api_entry)),
         firewall_name,
         permission,
         {} if params is None else dict(params),

--- a/crates/runner/mitm-addon/tests/test_aws_sigv4.py
+++ b/crates/runner/mitm-addon/tests/test_aws_sigv4.py
@@ -5,25 +5,30 @@ import urllib.parse
 import pytest
 
 from aws_sigv4 import AwsSigV4Credentials, AwsSigV4SigningError, sign_request
+from tests.aws_sigv4_helpers import (
+    DEFAULT_SIGV4_TIMESTAMP,
+    STS_HOST,
+    aws_credential_scope,
+    aws_sigv4_authorization,
+    aws_sigv4_presigned_url,
+    signer_test_credentials,
+)
 
 _INVALID_UNICODE = "\ud800"
 
 
 def _credentials() -> AwsSigV4Credentials:
-    return AwsSigV4Credentials("AKIDEXAMPLE", "secret")
+    return signer_test_credentials()
 
 
 def _header_auth_headers() -> list[tuple[str, str]]:
     return [
         (
             "Authorization",
-            "AWS4-HMAC-SHA256 "
-            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-            "SignedHeaders=host;x-amz-date, "
-            "Signature=placeholder",
+            aws_sigv4_authorization(),
         ),
-        ("X-Amz-Date", "20260101T000000Z"),
-        ("Host", "sts.amazonaws.com"),
+        ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
+        ("Host", STS_HOST),
     ]
 
 
@@ -31,14 +36,11 @@ def _header_auth_headers_with_content_hash(value: str) -> list[tuple[str, str]]:
     return [
         (
             "Authorization",
-            "AWS4-HMAC-SHA256 "
-            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
-            "Signature=placeholder",
+            aws_sigv4_authorization(signed_headers="host;x-amz-content-sha256;x-amz-date"),
         ),
-        ("X-Amz-Date", "20260101T000000Z"),
+        ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
         ("X-Amz-Content-Sha256", value),
-        ("Host", "sts.amazonaws.com"),
+        ("Host", STS_HOST),
     ]
 
 
@@ -46,31 +48,16 @@ def _header_auth_headers_with_signed_test_header(value: str) -> list[tuple[str, 
     return [
         (
             "Authorization",
-            "AWS4-HMAC-SHA256 "
-            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-            "SignedHeaders=host;x-amz-date;x-test, "
-            "Signature=placeholder",
+            aws_sigv4_authorization(signed_headers="host;x-amz-date;x-test"),
         ),
-        ("X-Amz-Date", "20260101T000000Z"),
-        ("Host", "sts.amazonaws.com"),
+        ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
+        ("Host", STS_HOST),
         ("X-Test", value),
     ]
 
 
 def _presigned_url(host: str) -> str:
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
-    return (
-        f"https://{host}/?Action=GetCallerIdentity&Version=2011-06-15"
-        "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-        f"&X-Amz-Credential={placeholder_credential}"
-        "&X-Amz-Date=20260101T000000Z"
-        "&X-Amz-Expires=60"
-        "&X-Amz-SignedHeaders=host"
-        "&X-Amz-Signature=placeholder"
-    )
+    return aws_sigv4_presigned_url(host)
 
 
 def test_header_auth_malformed_url_raises_signing_error() -> None:
@@ -108,10 +95,7 @@ def test_presigned_query_malformed_url_raises_signing_error() -> None:
 
 def test_presigned_query_double_encoded_credential_raises_signing_error() -> None:
     double_encoded_credential = urllib.parse.quote(
-        urllib.parse.quote(
-            "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-            safe="",
-        ),
+        urllib.parse.quote(aws_credential_scope(), safe=""),
         safe="",
     )
     url = (

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -31,6 +31,14 @@ from tests.auth_state_helpers import (
     set_cached_headers,
     set_last_force_refresh_monotonic_at,
 )
+from tests.aws_sigv4_helpers import (
+    DEFAULT_SIGV4_TIMESTAMP,
+    REAL_AWS_SESSION_TOKEN,
+    STS_FORM_BODY,
+    STS_HOST,
+    aws_sigv4_authorization,
+    resolved_aws_sigv4_credentials,
+)
 from tests.firewall_helpers import cancel_pending_task
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 from url_utils import get_original_url
@@ -984,22 +992,19 @@ class TestHandleFirewallRequest:
     async def test_standard_auth_filters_unsafe_headers_before_aws_sigv4_signing(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
-        placeholder_authorization = (
-            "AWS4-HMAC-SHA256 "
-            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-            "SignedHeaders=content-type;host;x-amz-date, "
-            "Signature=placeholder"
+        placeholder_authorization = aws_sigv4_authorization(
+            signed_headers="content-type;host;x-amz-date"
         )
         flow = real_flow(
             with_response=False,
-            host="sts.amazonaws.com",
+            host=STS_HOST,
             path="/",
             method="POST",
-            request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+            request_body=STS_FORM_BODY,
             request_headers=headers(
-                ("Host", "sts.amazonaws.com"),
+                ("Host", STS_HOST),
                 ("Content-Type", "application/x-www-form-urlencoded"),
-                ("X-Amz-Date", "20260101T000000Z"),
+                ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
                 ("Authorization", placeholder_authorization),
             ),
         )
@@ -1024,11 +1029,7 @@ class TestHandleFirewallRequest:
                 "X-Amz-Meta-Test": "trusted-meta",
             },
         )
-        token_meta["aws_sigv4"] = AwsSigV4Credentials(
-            "AKIDEXAMPLE",
-            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-            "real-session-token",
-        )
+        token_meta["aws_sigv4"] = resolved_aws_sigv4_credentials()
 
         with (
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -1037,9 +1038,9 @@ class TestHandleFirewallRequest:
             result = await auth.handle_firewall_request(flow, allow, vm_info)
 
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
-        assert flow.request.headers["host"] == "sts.amazonaws.com"
+        assert flow.request.headers["host"] == STS_HOST
         assert flow.request.headers["x-amz-meta-test"] == "trusted-meta"
-        assert flow.request.headers["x-amz-security-token"] == "real-session-token"
+        assert flow.request.headers["x-amz-security-token"] == REAL_AWS_SESSION_TOKEN
         assert (
             "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"
             in flow.request.headers["authorization"]

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -33,7 +33,7 @@ from tests.auth_state_helpers import (
 )
 from tests.aws_sigv4_helpers import (
     DEFAULT_SIGV4_TIMESTAMP,
-    REAL_AWS_SESSION_TOKEN,
+    RESOLVED_AWS_SESSION_TOKEN,
     STS_FORM_BODY,
     STS_HOST,
     aws_sigv4_authorization,
@@ -1040,7 +1040,7 @@ class TestHandleFirewallRequest:
         assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
         assert flow.request.headers["host"] == STS_HOST
         assert flow.request.headers["x-amz-meta-test"] == "trusted-meta"
-        assert flow.request.headers["x-amz-security-token"] == REAL_AWS_SESSION_TOKEN
+        assert flow.request.headers["x-amz-security-token"] == RESOLVED_AWS_SESSION_TOKEN
         assert (
             "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"
             in flow.request.headers["authorization"]

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -533,6 +533,7 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
         tmp_path,
         api_entry=api_entry,
         credentials=resolved_aws_sigv4_credentials(session_token=None),
+        query={"trace": "resolved-trace"},
     )
 
     with mitm_ctx():
@@ -545,6 +546,7 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
     assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is True
     assert flow.response is None
+    assert flow.request.query["trace"] == "resolved-trace"
     assert flow.request.headers["Authorization"].startswith(
         "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"
     )

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -9,8 +9,8 @@ import flow_metadata_keys as metadata_keys
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.aws_sigv4_helpers import (
     DEFAULT_SIGV4_TIMESTAMP,
-    REAL_AWS_ACCESS_KEY_ID,
-    REAL_AWS_SESSION_TOKEN,
+    RESOLVED_AWS_ACCESS_KEY_ID,
+    RESOLVED_AWS_SESSION_TOKEN,
     STS_FORM_BODY,
     STS_HOST,
     STS_QUERY,
@@ -67,7 +67,7 @@ async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_
     assert authorization.startswith("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/")
     assert "PLACEHOLDER" not in authorization
     assert "Signature=placeholder" not in authorization
-    assert flow.request.headers["x-amz-security-token"] == REAL_AWS_SESSION_TOKEN
+    assert flow.request.headers["x-amz-security-token"] == RESOLVED_AWS_SESSION_TOKEN
     assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == [
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
@@ -341,7 +341,7 @@ async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
     query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(flow.request.url).query))
     assert query["X-Amz-Algorithm"] == "AWS4-HMAC-SHA256"
     assert query["X-Amz-Credential"] == "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"
-    assert query["X-Amz-Security-Token"] == REAL_AWS_SESSION_TOKEN
+    assert query["X-Amz-Security-Token"] == RESOLVED_AWS_SESSION_TOKEN
     assert query["X-Amz-Signature"] != "placeholder"
     assert "PLACEHOLDER" not in flow.request.url
 
@@ -368,7 +368,7 @@ async def test_re_signs_query_sigv4_request_strips_session_token_header(
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
     assert "x-amz-security-token" not in flow.request.headers
     query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(flow.request.url).query))
-    assert query["X-Amz-Security-Token"] == REAL_AWS_SESSION_TOKEN
+    assert query["X-Amz-Security-Token"] == RESOLVED_AWS_SESSION_TOKEN
 
 
 async def test_re_signs_query_sigv4_request_preserves_literal_plus(
@@ -758,7 +758,7 @@ async def test_header_sigv4_with_real_source_access_key_fails_closed(
     flow = make_sts_header_sigv4_flow(
         real_flow,
         headers,
-        authorization=aws_sigv4_authorization(access_key_id=REAL_AWS_ACCESS_KEY_ID),
+        authorization=aws_sigv4_authorization(access_key_id=RESOLVED_AWS_ACCESS_KEY_ID),
     )
 
     result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
@@ -995,7 +995,7 @@ async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, m
 async def test_query_sigv4_with_real_source_access_key_fails_closed(real_flow, tmp_path, mitm_ctx):
     flow = make_sts_query_sigv4_flow(
         real_flow,
-        path=aws_sigv4_presigned_query_path(access_key_id=REAL_AWS_ACCESS_KEY_ID),
+        path=aws_sigv4_presigned_query_path(access_key_id=RESOLVED_AWS_ACCESS_KEY_ID),
     )
 
     result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
@@ -1004,7 +1004,9 @@ async def test_query_sigv4_with_real_source_access_key_fails_closed(real_flow, t
 
 
 async def test_query_sigv4_with_duplicate_credential_fails_closed(real_flow, tmp_path, mitm_ctx):
-    real_credential = quote_sigv4_value(aws_credential_scope(access_key_id=REAL_AWS_ACCESS_KEY_ID))
+    real_credential = quote_sigv4_value(
+        aws_credential_scope(access_key_id=RESOLVED_AWS_ACCESS_KEY_ID)
+    )
     flow = make_sts_query_sigv4_flow(
         real_flow,
         path=(

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -22,6 +22,7 @@ from tests.aws_sigv4_helpers import (
     resolved_aws_sigv4_credentials,
 )
 from tests.firewall_aws_sigv4_helpers import (
+    FAR_FUTURE_EXPIRES_AT,
     assert_sigv4_failed_closed,
     aws_allow,
     aws_api_entry,
@@ -569,7 +570,7 @@ async def test_header_sigv4_seeded_cache_matches_allow_context_identity(
         allow=allow,
         vm_info=vm_info,
         credentials=resolved_aws_sigv4_credentials(session_token=None),
-        expires_at=1_800_000_000,
+        expires_at=FAR_FUTURE_EXPIRES_AT,
     )
 
     with mitm_ctx():

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -270,8 +270,10 @@ async def test_re_signs_header_sigv4_request_keeps_resolved_query_with_trusted_u
     tmp_path,
     mitm_ctx,
 ):
-    auth_response = aws_auth_response(include_session_token=False)
-    auth_response["query"] = {"Trace": "secret-value"}
+    auth_response = aws_auth_response(
+        include_session_token=False,
+        query={"Trace": "secret-value"},
+    )
     api_entry = aws_api_entry(
         base="https://iam.amazonaws.com",
         auth_query={"Trace": "${{ secrets.TRACE }}"},
@@ -482,18 +484,16 @@ async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    response = aws_auth_response()
-    response["awsSigv4"] = {
-        "accessKeyId": "AKID/EXAMPLE",
-        "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-    }
     flow = make_sts_header_sigv4_flow(real_flow, headers)
 
     result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
-        auth_response=response,
+        auth_response=aws_auth_response(
+            access_key_id="AKID/EXAMPLE",
+            include_session_token=False,
+        ),
     )
 
     assert_sigv4_failed_closed(result, flow, "Invalid AWS access key ID")

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -5,176 +5,55 @@ import urllib.parse
 import pytest
 
 import auth
-import firewall_auth_client as auth_client
 import flow_metadata_keys as metadata_keys
-import matching
-from aws_sigv4 import AwsSigV4Credentials
 from tests.auth_endpoint_helpers import FakeAuthEndpoint
-from tests.auth_state_helpers import auth_cache_key, set_cached_headers
-from url_utils import get_original_url
-
-
-def _api_entry() -> dict:
-    return {
-        "base": "https://sts.amazonaws.com",
-        "auth": {
-            "headers": {},
-            "awsSigv4": {
-                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-                "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-            },
-        },
-    }
-
-
-def _allow(api_entry: dict) -> matching.FirewallAllow:
-    return matching.FirewallAllow(
-        api_entry,
-        "aws",
-        "identity",
-        {},
-        "POST /",
-        "/",
-    )
-
-
-def _vm_info(tmp_path, *, encrypted_secrets: str = "iv:tag:data") -> dict:
-    return {
-        "runId": "run-1",
-        "sandboxToken": "sandbox-token",
-        "encryptedSecrets": encrypted_secrets,
-        "networkLogPath": str(tmp_path / "network.jsonl"),
-        "billableFirewalls": [],
-        "vars": {"AWS_REGION": "us-east-1"},
-    }
-
-
-def _auth_response() -> dict[str, object]:
-    return {
-        "headers": {},
-        "awsSigv4": {
-            "accessKeyId": "AKIDEXAMPLE",
-            "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-            "sessionToken": "real-session-token",
-        },
-        "expiresAt": 1_800_000_000,
-        "resolvedSecrets": [
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_SESSION_TOKEN",
-        ],
-        "refreshedConnectors": ["aws"],
-        "refreshedSecrets": ["AWS_SESSION_TOKEN"],
-    }
-
-
-def _auth_response_without_session_token() -> dict[str, object]:
-    return {
-        "headers": {},
-        "awsSigv4": {
-            "accessKeyId": "AKIDEXAMPLE",
-            "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-        },
-        "expiresAt": 1_800_000_000,
-        "resolvedSecrets": [
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-        ],
-        "refreshedConnectors": [],
-        "refreshedSecrets": [],
-    }
-
-
-def _prepare_firewall_request(flow, *, original_url: str | None = None) -> None:
-    flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
-    flow.metadata[metadata_keys.ORIGINAL_URL] = (
-        get_original_url(flow) if original_url is None else original_url
-    )
-
-
-async def _handle_firewall_request_with_auth_endpoint(
-    flow,
-    tmp_path,
-    mitm_ctx,
-    *,
-    endpoint: FakeAuthEndpoint | None = None,
-    auth_response: dict[str, object] | None = None,
-    allow: matching.FirewallAllow | None = None,
-    vm_info: dict | None = None,
-) -> auth.FirewallAuthHandlingResult:
-    resolved_endpoint = endpoint or FakeAuthEndpoint()
-    resolved_endpoint.queue_json_response(
-        _auth_response() if auth_response is None else auth_response
-    )
-    _prepare_firewall_request(flow)
-
-    with resolved_endpoint.run(), mitm_ctx(api_url=resolved_endpoint.api_url):
-        return await auth.handle_firewall_request(
-            flow,
-            _allow(_api_entry()) if allow is None else allow,
-            _vm_info(tmp_path) if vm_info is None else vm_info,
-        )
-
-
-def _assert_sigv4_failed_closed(
-    result: auth.FirewallAuthHandlingResult,
-    flow,
-    message_fragment: str,
-) -> None:
-    assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
-    assert flow.response is not None
-    assert flow.response.status_code == 502
-    response = flow.response.json()
-    assert response["error"] == "aws_sigv4_auth_failed"
-    assert message_fragment in response["message"]
-
-
-def _aws_auth_cache_key(tmp_path, api_entry: dict | None = None):
-    resolved_api_entry = api_entry or _api_entry()
-    vm_info = _vm_info(tmp_path)
-    auth_config = resolved_api_entry["auth"]
-    auth_request = auth_client.FirewallAuthRequest(
-        encrypted_secrets=vm_info["encryptedSecrets"],
-        auth_headers=auth_config["headers"],
-        sandbox_token=vm_info["sandboxToken"],
-        auth_aws_sigv4=auth_config["awsSigv4"],
-        vars_map=vm_info["vars"],
-    )
-    return auth_cache_key(
-        run_id=vm_info["runId"],
-        api_id=resolved_api_entry["base"],
-        auth_identity=auth._build_firewall_auth_identity(
-            firewall_name="aws",
-            firewall_base=resolved_api_entry["base"],
-            auth_request=auth_request,
-        ),
-    )
+from tests.aws_sigv4_helpers import (
+    DEFAULT_SIGV4_TIMESTAMP,
+    REAL_AWS_ACCESS_KEY_ID,
+    REAL_AWS_SESSION_TOKEN,
+    STS_FORM_BODY,
+    STS_HOST,
+    STS_QUERY,
+    aws_credential_scope,
+    aws_sigv4_authorization,
+    aws_sigv4_header_auth_headers,
+    aws_sigv4_presigned_query_path,
+    quote_sigv4_value,
+    resolved_aws_sigv4_credentials,
+)
+from tests.firewall_aws_sigv4_helpers import (
+    assert_sigv4_failed_closed,
+    aws_allow,
+    aws_api_entry,
+    aws_auth_response,
+    aws_vm_info,
+    cache_aws_sigv4_credentials,
+    handle_firewall_request_with_auth_endpoint,
+    make_sts_header_sigv4_flow,
+    make_sts_query_sigv4_flow,
+    prepare_firewall_request,
+)
 
 
 async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_ctx):
     endpoint = FakeAuthEndpoint()
     flow = real_flow(
         with_response=False,
-        host="sts.amazonaws.com",
+        host=STS_HOST,
         path="/",
         method="POST",
-        request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+        request_body=STS_FORM_BODY,
         request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("Content-Type", "application/x-www-form-urlencoded"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=content-type;host;x-amz-date, "
-                "Signature=placeholder",
+            *aws_sigv4_header_auth_headers(
+                content_type="application/x-www-form-urlencoded",
+                authorization=aws_sigv4_authorization(
+                    signed_headers="content-type;host;x-amz-date"
+                ),
             ),
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(
+    result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
@@ -187,7 +66,7 @@ async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_
     assert authorization.startswith("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/")
     assert "PLACEHOLDER" not in authorization
     assert "Signature=placeholder" not in authorization
-    assert flow.request.headers["x-amz-security-token"] == "real-session-token"
+    assert flow.request.headers["x-amz-security-token"] == REAL_AWS_SESSION_TOKEN
     assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == [
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
@@ -195,7 +74,7 @@ async def test_re_signs_header_sigv4_request(real_flow, headers, tmp_path, mitm_
     ]
 
     body = endpoint.requests[0].json_body()
-    assert body["authAwsSigv4"] == _api_entry()["auth"]["awsSigv4"]
+    assert body["authAwsSigv4"] == aws_api_entry()["auth"]["awsSigv4"]
 
 
 async def test_re_signs_header_sigv4_request_to_reference_signature(
@@ -204,17 +83,8 @@ async def test_re_signs_header_sigv4_request_to_reference_signature(
     tmp_path,
     mitm_ctx,
 ):
-    auth_response = _auth_response_without_session_token()
-    api_entry = {
-        "base": "https://iam.amazonaws.com",
-        "auth": {
-            "headers": {},
-            "awsSigv4": {
-                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            },
-        },
-    }
+    auth_response = aws_auth_response(include_session_token=False)
+    api_entry = aws_api_entry(base="https://iam.amazonaws.com", include_session_token=False)
     flow = real_flow(
         with_response=False,
         host="iam.amazonaws.com",
@@ -226,20 +96,21 @@ async def test_re_signs_header_sigv4_request_to_reference_signature(
             ("X-Amz-Date", "20150830T123600Z"),
             (
                 "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
-                "SignedHeaders=content-type;host;x-amz-date, "
-                "Signature=placeholder",
+                aws_sigv4_authorization(
+                    date="20150830",
+                    service="iam",
+                    signed_headers="content-type;host;x-amz-date",
+                ),
             ),
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(
+    result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
         auth_response=auth_response,
-        allow=matching.FirewallAllow(api_entry, "aws", "list-users", {}, "GET /", "/"),
+        allow=aws_allow(api_entry, permission="list-users", rule="GET /", rel_path="/"),
     )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -258,17 +129,8 @@ async def test_re_signs_header_sigv4_request_with_encoded_path(
     tmp_path,
     mitm_ctx,
 ):
-    auth_response = _auth_response_without_session_token()
-    api_entry = {
-        "base": "https://iam.amazonaws.com",
-        "auth": {
-            "headers": {},
-            "awsSigv4": {
-                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            },
-        },
-    }
+    auth_response = aws_auth_response(include_session_token=False)
+    api_entry = aws_api_entry(base="https://iam.amazonaws.com", include_session_token=False)
     flow = real_flow(
         with_response=False,
         host="iam.amazonaws.com",
@@ -279,26 +141,24 @@ async def test_re_signs_header_sigv4_request_with_encoded_path(
             ("X-Amz-Date", "20150830T123600Z"),
             (
                 "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
+                aws_sigv4_authorization(
+                    date="20150830",
+                    service="iam",
+                ),
             ),
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(
+    result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
         auth_response=auth_response,
-        allow=matching.FirewallAllow(
+        allow=aws_allow(
             api_entry,
-            "aws",
-            "encoded-path",
-            {},
-            "GET /{path+}",
-            "/a/../long/path%20name/",
+            permission="encoded-path",
+            rule="GET /{path+}",
+            rel_path="/a/../long/path%20name/",
         ),
     )
 
@@ -318,17 +178,8 @@ async def test_re_signs_header_sigv4_request_with_normalized_host(
     tmp_path,
     mitm_ctx,
 ):
-    auth_response = _auth_response_without_session_token()
-    api_entry = {
-        "base": "https://iam.amazonaws.com",
-        "auth": {
-            "headers": {},
-            "awsSigv4": {
-                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            },
-        },
-    }
+    auth_response = aws_auth_response(include_session_token=False)
+    api_entry = aws_api_entry(base="https://iam.amazonaws.com", include_session_token=False)
     flow = real_flow(
         with_response=False,
         host="IAM.AMAZONAWS.COM",
@@ -339,20 +190,20 @@ async def test_re_signs_header_sigv4_request_with_normalized_host(
             ("X-Amz-Date", "20150830T123600Z"),
             (
                 "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
+                aws_sigv4_authorization(
+                    date="20150830",
+                    service="iam",
+                ),
             ),
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(
+    result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
         auth_response=auth_response,
-        allow=matching.FirewallAllow(api_entry, "aws", "normalized-host", {}, "GET /", "/"),
+        allow=aws_allow(api_entry, permission="normalized-host", rule="GET /", rel_path="/"),
     )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -371,17 +222,8 @@ async def test_re_signs_header_sigv4_request_with_trusted_original_url(
     tmp_path,
     mitm_ctx,
 ):
-    auth_response = _auth_response_without_session_token()
-    api_entry = {
-        "base": "https://iam.amazonaws.com",
-        "auth": {
-            "headers": {},
-            "awsSigv4": {
-                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            },
-        },
-    }
+    auth_response = aws_auth_response(include_session_token=False)
+    api_entry = aws_api_entry(base="https://iam.amazonaws.com", include_session_token=False)
     flow = real_flow(
         with_response=False,
         host="203.0.113.10",
@@ -393,21 +235,21 @@ async def test_re_signs_header_sigv4_request_with_trusted_original_url(
             ("X-Amz-Date", "20150830T123600Z"),
             (
                 "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
+                aws_sigv4_authorization(
+                    date="20150830",
+                    service="iam",
+                ),
             ),
         ),
     )
     flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "iam.amazonaws.com"
 
-    result = await _handle_firewall_request_with_auth_endpoint(
+    result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
         auth_response=auth_response,
-        allow=matching.FirewallAllow(api_entry, "aws", "trusted-url", {}, "GET /", "/"),
+        allow=aws_allow(api_entry, permission="trusted-url", rule="GET /", rel_path="/"),
     )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -427,19 +269,13 @@ async def test_re_signs_header_sigv4_request_keeps_resolved_query_with_trusted_u
     tmp_path,
     mitm_ctx,
 ):
-    auth_response = _auth_response_without_session_token()
+    auth_response = aws_auth_response(include_session_token=False)
     auth_response["query"] = {"Trace": "secret-value"}
-    api_entry = {
-        "base": "https://iam.amazonaws.com",
-        "auth": {
-            "headers": {},
-            "query": {"Trace": "${{ secrets.TRACE }}"},
-            "awsSigv4": {
-                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            },
-        },
-    }
+    api_entry = aws_api_entry(
+        base="https://iam.amazonaws.com",
+        auth_query={"Trace": "${{ secrets.TRACE }}"},
+        include_session_token=False,
+    )
     flow = real_flow(
         with_response=False,
         host="203.0.113.10",
@@ -452,21 +288,22 @@ async def test_re_signs_header_sigv4_request_keeps_resolved_query_with_trusted_u
             ("X-Amz-Date", "20150830T123600Z"),
             (
                 "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20150830/us-east-1/iam/aws4_request, "
-                "SignedHeaders=content-type;host;x-amz-date, "
-                "Signature=placeholder",
+                aws_sigv4_authorization(
+                    date="20150830",
+                    service="iam",
+                    signed_headers="content-type;host;x-amz-date",
+                ),
             ),
         ),
     )
     flow.metadata[metadata_keys.TRUSTED_AUTHORITY_HOST] = "iam.amazonaws.com"
 
-    result = await _handle_firewall_request_with_auth_endpoint(
+    result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
         auth_response=auth_response,
-        allow=matching.FirewallAllow(api_entry, "aws", "trusted-query", {}, "GET /", "/"),
+        allow=aws_allow(api_entry, permission="trusted-query", rule="GET /", rel_path="/"),
     )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -487,33 +324,21 @@ async def test_re_signs_header_sigv4_request_keeps_resolved_query_with_trusted_u
 
 
 async def test_re_signs_query_sigv4_request(real_flow, tmp_path, mitm_ctx):
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
     flow = real_flow(
         with_response=False,
-        host="sts.amazonaws.com",
-        path=(
-            "/?Action=GetCallerIdentity&Version=2011-06-15"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={placeholder_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=60"
-            "&X-Amz-SignedHeaders=host"
-            "&X-Amz-Signature=placeholder"
-        ),
+        host=STS_HOST,
+        path=aws_sigv4_presigned_query_path(),
         method="GET",
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
     assert "authorization" not in flow.request.headers
     query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(flow.request.url).query))
     assert query["X-Amz-Algorithm"] == "AWS4-HMAC-SHA256"
     assert query["X-Amz-Credential"] == "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"
-    assert query["X-Amz-Security-Token"] == "real-session-token"
+    assert query["X-Amz-Security-Token"] == REAL_AWS_SESSION_TOKEN
     assert query["X-Amz-Signature"] != "placeholder"
     assert "PLACEHOLDER" not in flow.request.url
 
@@ -524,22 +349,10 @@ async def test_re_signs_query_sigv4_request_strips_session_token_header(
     tmp_path,
     mitm_ctx,
 ):
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
     flow = real_flow(
         with_response=False,
-        host="sts.amazonaws.com",
-        path=(
-            "/?Action=GetCallerIdentity&Version=2011-06-15"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={placeholder_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=60"
-            "&X-Amz-SignedHeaders=host"
-            "&X-Amz-Signature=placeholder"
-        ),
+        host=STS_HOST,
+        path=aws_sigv4_presigned_query_path(),
         method="GET",
         request_headers=headers(
             ("Host", "sts.amazonaws.com"),
@@ -547,12 +360,12 @@ async def test_re_signs_query_sigv4_request_strips_session_token_header(
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
     assert "x-amz-security-token" not in flow.request.headers
     query = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(flow.request.url).query))
-    assert query["X-Amz-Security-Token"] == "real-session-token"
+    assert query["X-Amz-Security-Token"] == REAL_AWS_SESSION_TOKEN
 
 
 async def test_re_signs_query_sigv4_request_preserves_literal_plus(
@@ -560,26 +373,16 @@ async def test_re_signs_query_sigv4_request_preserves_literal_plus(
     tmp_path,
     mitm_ctx,
 ):
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
     flow = real_flow(
         with_response=False,
-        host="sts.amazonaws.com",
-        path=(
-            "/?Action=GetCallerIdentity&LiteralPlus=a+b&EncodedPlus=c%2Bd"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={placeholder_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=60"
-            "&X-Amz-SignedHeaders=host"
-            "&X-Amz-Signature=placeholder"
+        host=STS_HOST,
+        path=aws_sigv4_presigned_query_path(
+            leading_query=f"{STS_QUERY}&LiteralPlus=a+b&EncodedPlus=c%2Bd"
         ),
         method="GET",
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
     raw_query = urllib.parse.urlsplit(flow.request.url).query
@@ -607,9 +410,9 @@ async def test_sigv4a_request_fails_closed(real_flow, headers, tmp_path, mitm_ct
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "SigV4A is not supported")
+    assert_sigv4_failed_closed(result, flow, "SigV4A is not supported")
 
 
 async def test_hmac_sigv4_wildcard_region_fails_closed(real_flow, headers, tmp_path, mitm_ctx):
@@ -630,9 +433,9 @@ async def test_hmac_sigv4_wildcard_region_fails_closed(real_flow, headers, tmp_p
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Wildcard AWS signing region requires SigV4A")
+    assert_sigv4_failed_closed(result, flow, "Wildcard AWS signing region requires SigV4A")
 
 
 async def test_header_sigv4_with_malformed_scope_fails_closed(
@@ -641,27 +444,17 @@ async def test_header_sigv4_with_malformed_scope_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1%0d%0aX-Bad:x/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        authorization=aws_sigv4_authorization(
+            credential_scope="PLACEHOLDER/20260101/us-east-1%0d%0aX-Bad:x/sts/aws4_request"
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS credential scope")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS credential scope")
 
 
 async def test_header_sigv4_with_control_character_header_fails_closed(
@@ -670,28 +463,16 @@ async def test_header_sigv4_with_control_character_header_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            ("X-Test", "a\n b"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date;x-test, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        signed_headers="host;x-amz-date;x-test",
+        extra_headers=(("X-Test", "a\n b"),),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "AWS request header contains invalid text")
+    assert_sigv4_failed_closed(result, flow, "AWS request header contains invalid text")
 
 
 async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
@@ -700,37 +481,21 @@ async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    response = _auth_response()
+    response = aws_auth_response()
     response["awsSigv4"] = {
         "accessKeyId": "AKID/EXAMPLE",
         "secretAccessKey": "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
     }
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
-    )
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
 
-    result = await _handle_firewall_request_with_auth_endpoint(
+    result = await handle_firewall_request_with_auth_endpoint(
         flow,
         tmp_path,
         mitm_ctx,
         auth_response=response,
     )
 
-    _assert_sigv4_failed_closed(result, flow, "Invalid AWS access key ID")
+    assert_sigv4_failed_closed(result, flow, "Invalid AWS access key ID")
 
 
 async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
@@ -739,34 +504,20 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
+    prepare_firewall_request(flow)
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        credentials=resolved_aws_sigv4_credentials(
+            secret_access_key="",
+            session_token=None,
         ),
-    )
-    _prepare_firewall_request(flow)
-    set_cached_headers(
-        _aws_auth_cache_key(tmp_path),
-        headers={},
-        aws_sigv4=AwsSigV4Credentials("AKIDEXAMPLE", ""),
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
 
-    _assert_sigv4_failed_closed(result, flow, "Invalid AWS secret access key")
+    assert_sigv4_failed_closed(result, flow, "Invalid AWS secret access key")
 
 
 async def test_header_sigv4_without_trusted_original_url_fails_closed(
@@ -775,37 +526,17 @@ async def test_header_sigv4_without_trusted_original_url_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
-    )
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
     flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
-    set_cached_headers(
-        _aws_auth_cache_key(tmp_path),
-        headers={},
-        aws_sigv4=AwsSigV4Credentials(
-            "AKIDEXAMPLE",
-            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-        ),
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        credentials=resolved_aws_sigv4_credentials(session_token=None),
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
 
-    _assert_sigv4_failed_closed(result, flow, "AWS request URL is unavailable")
+    assert_sigv4_failed_closed(result, flow, "AWS request URL is unavailable")
 
 
 @pytest.mark.parametrize(
@@ -822,38 +553,18 @@ async def test_header_sigv4_with_malformed_current_request_target_fails_closed(
     mitm_ctx,
     request_path,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
-    )
-    _prepare_firewall_request(flow)
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
+    prepare_firewall_request(flow)
     flow.request.path = request_path
-    set_cached_headers(
-        _aws_auth_cache_key(tmp_path),
-        headers={},
-        aws_sigv4=AwsSigV4Credentials(
-            "AKIDEXAMPLE",
-            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-        ),
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        credentials=resolved_aws_sigv4_credentials(session_token=None),
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
 
-    _assert_sigv4_failed_closed(result, flow, "AWS request URL is malformed")
+    assert_sigv4_failed_closed(result, flow, "AWS request URL is malformed")
 
 
 async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
@@ -862,38 +573,17 @@ async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
-    )
-    _prepare_firewall_request(flow)
-    set_cached_headers(
-        _aws_auth_cache_key(tmp_path),
-        headers={},
-        aws_sigv4=AwsSigV4Credentials(
-            "AKIDEXAMPLE",
-            "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-            "",
-        ),
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
+    prepare_firewall_request(flow)
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        credentials=resolved_aws_sigv4_credentials(session_token=""),
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, _allow(_api_entry()), _vm_info(tmp_path))
+        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
 
-    _assert_sigv4_failed_closed(result, flow, "Invalid AWS session token")
+    assert_sigv4_failed_closed(result, flow, "Invalid AWS session token")
 
 
 async def test_header_sigv4_with_real_source_access_key_fails_closed(
@@ -902,27 +592,15 @@ async def test_header_sigv4_with_real_source_access_key_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        authorization=aws_sigv4_authorization(access_key_id=REAL_AWS_ACCESS_KEY_ID),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "placeholder access key ID")
+    assert_sigv4_failed_closed(result, flow, "placeholder access key ID")
 
 
 async def test_header_sigv4_with_duplicate_credential_fails_closed(
@@ -931,28 +609,21 @@ async def test_header_sigv4_with_duplicate_credential_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request, "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        authorization=(
+            "AWS4-HMAC-SHA256 "
+            "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request, "
+            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+            "SignedHeaders=host;x-amz-date, "
+            "Signature=placeholder"
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS authorization header")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS authorization header")
 
 
 async def test_header_sigv4_with_duplicate_authorization_headers_fails_closed(
@@ -961,28 +632,23 @@ async def test_header_sigv4_with_duplicate_authorization_headers_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    authorization = (
-        "AWS4-HMAC-SHA256 "
-        "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-        "SignedHeaders=host;x-amz-date, "
-        "Signature=placeholder"
-    )
+    authorization = aws_sigv4_authorization()
     flow = real_flow(
         with_response=False,
         host="sts.amazonaws.com",
         path="/",
         method="POST",
         request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
+            ("Host", STS_HOST),
+            ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
             ("Authorization", authorization),
             ("Authorization", authorization),
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS authorization header")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS authorization header")
 
 
 async def test_header_sigv4_without_signature_fails_closed(
@@ -991,26 +657,19 @@ async def test_header_sigv4_without_signature_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date",
-            ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        authorization=(
+            "AWS4-HMAC-SHA256 "
+            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
+            "SignedHeaders=host;x-amz-date"
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS authorization header")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS authorization header")
 
 
 async def test_header_sigv4_with_duplicate_signed_header_fails_closed(
@@ -1019,27 +678,15 @@ async def test_header_sigv4_with_duplicate_signed_header_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        signed_headers="host;host;x-amz-date",
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
 
 
 async def test_header_sigv4_with_empty_signed_header_segment_fails_closed(
@@ -1048,27 +695,15 @@ async def test_header_sigv4_with_empty_signed_header_segment_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        signed_headers="host;;x-amz-date",
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
 
 
 async def test_header_sigv4_without_amz_date_fails_closed(
@@ -1077,26 +712,16 @@ async def test_header_sigv4_without_amz_date_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        amz_date=None,
+        authorization=aws_sigv4_authorization(signed_headers="host"),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "requires x-amz-date")
+    assert_sigv4_failed_closed(result, flow, "requires x-amz-date")
 
 
 async def test_header_sigv4_with_malformed_amz_date_fails_closed(
@@ -1105,27 +730,15 @@ async def test_header_sigv4_with_malformed_amz_date_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "not-a-date"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        amz_date="not-a-date",
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS signing date")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS signing date")
 
 
 async def test_header_sigv4_with_scope_date_mismatch_fails_closed(
@@ -1134,27 +747,15 @@ async def test_header_sigv4_with_scope_date_mismatch_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260102T000000Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        amz_date="20260102T000000Z",
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(
+    assert_sigv4_failed_closed(
         result,
         flow,
         "AWS signing date does not match credential scope",
@@ -1167,28 +768,15 @@ async def test_header_sigv4_with_duplicate_amz_date_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            ("X-Amz-Date", "20260101T000001Z"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        extra_headers=(("X-Amz-Date", "20260101T000001Z"),),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "requires a single x-amz-date")
+    assert_sigv4_failed_closed(result, flow, "requires a single x-amz-date")
 
 
 async def test_header_sigv4_with_duplicate_content_hash_fails_closed(
@@ -1197,30 +785,19 @@ async def test_header_sigv4_with_duplicate_content_hash_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        signed_headers="host;x-amz-content-sha256;x-amz-date",
+        extra_headers=(
             ("X-Amz-Content-Sha256", "placeholder-hash-1"),
             ("X-Amz-Content-Sha256", "placeholder-hash-2"),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
-                "Signature=placeholder",
-            ),
         ),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "AWS content hash header is ambiguous")
+    assert_sigv4_failed_closed(result, flow, "AWS content hash header is ambiguous")
 
 
 async def test_header_sigv4_with_empty_content_hash_fails_closed(
@@ -1229,108 +806,54 @@ async def test_header_sigv4_with_empty_content_hash_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path="/",
-        method="POST",
-        request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
-        request_headers=headers(
-            ("Host", "sts.amazonaws.com"),
-            ("X-Amz-Date", "20260101T000000Z"),
-            ("X-Amz-Content-Sha256", ""),
-            (
-                "Authorization",
-                "AWS4-HMAC-SHA256 "
-                "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-                "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
-                "Signature=placeholder",
-            ),
-        ),
+    flow = make_sts_header_sigv4_flow(
+        real_flow,
+        headers,
+        signed_headers="host;x-amz-content-sha256;x-amz-date",
+        extra_headers=(("X-Amz-Content-Sha256", ""),),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "AWS content hash header is empty")
+    assert_sigv4_failed_closed(result, flow, "AWS content hash header is empty")
 
 
 async def test_query_sigv4_without_signature_fails_closed(real_flow, tmp_path, mitm_ctx):
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path=(
-            "/?Action=GetCallerIdentity&Version=2011-06-15"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={placeholder_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=60"
-            "&X-Amz-SignedHeaders=host"
-        ),
-        method="GET",
+    flow = make_sts_query_sigv4_flow(
+        real_flow,
+        path=aws_sigv4_presigned_query_path(signature=None),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS presigned query")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS presigned query")
 
 
 async def test_query_sigv4_with_real_source_access_key_fails_closed(real_flow, tmp_path, mitm_ctx):
-    source_credential = urllib.parse.quote(
-        "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path=(
-            "/?Action=GetCallerIdentity&Version=2011-06-15"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={source_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=60"
-            "&X-Amz-SignedHeaders=host"
-            "&X-Amz-Signature=placeholder"
-        ),
-        method="GET",
+    flow = make_sts_query_sigv4_flow(
+        real_flow,
+        path=aws_sigv4_presigned_query_path(access_key_id=REAL_AWS_ACCESS_KEY_ID),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "placeholder access key ID")
+    assert_sigv4_failed_closed(result, flow, "placeholder access key ID")
 
 
 async def test_query_sigv4_with_duplicate_credential_fails_closed(real_flow, tmp_path, mitm_ctx):
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
-    real_credential = urllib.parse.quote(
-        "AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
+    real_credential = quote_sigv4_value(aws_credential_scope(access_key_id=REAL_AWS_ACCESS_KEY_ID))
+    flow = make_sts_query_sigv4_flow(
+        real_flow,
         path=(
-            "/?Action=GetCallerIdentity&Version=2011-06-15"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={placeholder_credential}"
+            f"{aws_sigv4_presigned_query_path(signature=None)}"
             f"&X-Amz-Credential={real_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=60"
-            "&X-Amz-SignedHeaders=host"
             "&X-Amz-Signature=placeholder"
         ),
-        method="GET",
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS presigned query")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS presigned query")
 
 
 async def test_query_sigv4_with_duplicate_signed_header_fails_closed(
@@ -1338,51 +861,22 @@ async def test_query_sigv4_with_duplicate_signed_header_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
-    signed_headers = urllib.parse.quote("host;host", safe="")
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path=(
-            "/?Action=GetCallerIdentity&Version=2011-06-15"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={placeholder_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=60"
-            f"&X-Amz-SignedHeaders={signed_headers}"
-            "&X-Amz-Signature=placeholder"
-        ),
-        method="GET",
+    flow = make_sts_query_sigv4_flow(
+        real_flow,
+        path=aws_sigv4_presigned_query_path(signed_headers="host;host"),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS signed headers")
 
 
 async def test_query_sigv4_with_malformed_expiry_fails_closed(real_flow, tmp_path, mitm_ctx):
-    placeholder_credential = urllib.parse.quote(
-        "PLACEHOLDER/20260101/us-east-1/sts/aws4_request",
-        safe="",
-    )
-    flow = real_flow(
-        with_response=False,
-        host="sts.amazonaws.com",
-        path=(
-            "/?Action=GetCallerIdentity&Version=2011-06-15"
-            "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-            f"&X-Amz-Credential={placeholder_credential}"
-            "&X-Amz-Date=20260101T000000Z"
-            "&X-Amz-Expires=sixty"
-            "&X-Amz-SignedHeaders=host"
-            "&X-Amz-Signature=placeholder"
-        ),
-        method="GET",
+    flow = make_sts_query_sigv4_flow(
+        real_flow,
+        path=aws_sigv4_presigned_query_path(expires="sixty"),
     )
 
-    result = await _handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
+    result = await handle_firewall_request_with_auth_endpoint(flow, tmp_path, mitm_ctx)
 
-    _assert_sigv4_failed_closed(result, flow, "Malformed AWS presigned query expiry")
+    assert_sigv4_failed_closed(result, flow, "Malformed AWS presigned query expiry")

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -527,11 +527,12 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
     mitm_ctx,
 ):
     api_entry = aws_api_entry(auth_query={"trace": "${{ secrets.TRACE_ID }}"})
+    allow = aws_allow(api_entry)
     flow = make_sts_header_sigv4_flow(real_flow, headers)
     prepare_firewall_request(flow)
     cache_aws_sigv4_credentials(
         tmp_path,
-        api_entry=api_entry,
+        allow=allow,
         credentials=resolved_aws_sigv4_credentials(session_token=None),
         query={"trace": "resolved-trace"},
     )
@@ -539,7 +540,7 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
     with mitm_ctx():
         result = await auth.handle_firewall_request(
             flow,
-            aws_allow(api_entry),
+            allow,
             dict(aws_vm_info(tmp_path)),
         )
 
@@ -547,6 +548,38 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
     assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is True
     assert flow.response is None
     assert flow.request.query["trace"] == "resolved-trace"
+    assert flow.request.headers["Authorization"].startswith(
+        "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"
+    )
+
+
+async def test_header_sigv4_seeded_cache_matches_allow_context_identity(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    api_entry = aws_api_entry(api_id="aws-sts-api")
+    allow = aws_allow(api_entry, firewall_name="custom-aws")
+    vm_info = aws_vm_info(tmp_path, billable_firewalls=["custom-aws"])
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
+    prepare_firewall_request(flow, run_id=vm_info["runId"])
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        allow=allow,
+        vm_info=vm_info,
+        credentials=resolved_aws_sigv4_credentials(session_token=None),
+        expires_at=1_800_000_000,
+    )
+
+    with mitm_ctx():
+        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is True
+    assert flow.metadata[metadata_keys.FIREWALL_API_ID] == "aws-sts-api"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is True
+    assert flow.response is None
     assert flow.request.headers["Authorization"].startswith(
         "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"
     )

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -505,10 +505,14 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
+    allow = aws_allow()
+    vm_info = aws_vm_info(tmp_path)
     flow = make_sts_header_sigv4_flow(real_flow, headers)
-    prepare_firewall_request(flow)
+    prepare_firewall_request(flow, run_id=vm_info["runId"])
     cache_aws_sigv4_credentials(
         tmp_path,
+        allow=allow,
+        vm_info=vm_info,
         credentials=resolved_aws_sigv4_credentials(
             secret_access_key="",
             session_token=None,
@@ -516,7 +520,7 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
+        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
 
     assert_sigv4_failed_closed(result, flow, "Invalid AWS secret access key")
 
@@ -529,11 +533,13 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
 ):
     api_entry = aws_api_entry(auth_query={"trace": "${{ secrets.TRACE_ID }}"})
     allow = aws_allow(api_entry)
+    vm_info = aws_vm_info(tmp_path)
     flow = make_sts_header_sigv4_flow(real_flow, headers)
-    prepare_firewall_request(flow)
+    prepare_firewall_request(flow, run_id=vm_info["runId"])
     cache_aws_sigv4_credentials(
         tmp_path,
         allow=allow,
+        vm_info=vm_info,
         credentials=resolved_aws_sigv4_credentials(session_token=None),
         query={"trace": "resolved-trace"},
     )
@@ -542,7 +548,7 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
         result = await auth.handle_firewall_request(
             flow,
             allow,
-            dict(aws_vm_info(tmp_path)),
+            dict(vm_info),
         )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -567,11 +573,13 @@ async def test_header_sigv4_cache_miss_when_auth_query_changes(
             include_session_token=False,
         )
     )
+    vm_info = aws_vm_info(tmp_path)
     endpoint = FakeAuthEndpoint()
     flow = make_sts_header_sigv4_flow(real_flow, headers)
     cache_aws_sigv4_credentials(
         tmp_path,
         allow=cached_allow,
+        vm_info=vm_info,
         credentials=resolved_aws_sigv4_credentials(session_token=None),
         query={"trace": "cached-trace"},
     )
@@ -586,6 +594,7 @@ async def test_header_sigv4_cache_miss_when_auth_query_changes(
             query={"trace": "fresh-trace"},
         ),
         allow=active_allow,
+        vm_info=vm_info,
     )
 
     assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -668,15 +677,19 @@ async def test_header_sigv4_without_trusted_original_url_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
+    allow = aws_allow()
+    vm_info = aws_vm_info(tmp_path)
     flow = make_sts_header_sigv4_flow(real_flow, headers)
-    flow.metadata[metadata_keys.VM_RUN_ID] = "run-1"
+    flow.metadata[metadata_keys.VM_RUN_ID] = vm_info["runId"]
     cache_aws_sigv4_credentials(
         tmp_path,
+        allow=allow,
+        vm_info=vm_info,
         credentials=resolved_aws_sigv4_credentials(session_token=None),
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
+        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
 
     assert_sigv4_failed_closed(result, flow, "AWS request URL is unavailable")
 
@@ -695,16 +708,20 @@ async def test_header_sigv4_with_malformed_current_request_target_fails_closed(
     mitm_ctx,
     request_path,
 ):
+    allow = aws_allow()
+    vm_info = aws_vm_info(tmp_path)
     flow = make_sts_header_sigv4_flow(real_flow, headers)
-    prepare_firewall_request(flow)
+    prepare_firewall_request(flow, run_id=vm_info["runId"])
     flow.request.path = request_path
     cache_aws_sigv4_credentials(
         tmp_path,
+        allow=allow,
+        vm_info=vm_info,
         credentials=resolved_aws_sigv4_credentials(session_token=None),
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
+        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
 
     assert_sigv4_failed_closed(result, flow, "AWS request URL is malformed")
 
@@ -715,15 +732,19 @@ async def test_header_sigv4_with_empty_resolved_session_token_fails_closed(
     tmp_path,
     mitm_ctx,
 ):
+    allow = aws_allow()
+    vm_info = aws_vm_info(tmp_path)
     flow = make_sts_header_sigv4_flow(real_flow, headers)
-    prepare_firewall_request(flow)
+    prepare_firewall_request(flow, run_id=vm_info["runId"])
     cache_aws_sigv4_credentials(
         tmp_path,
+        allow=allow,
+        vm_info=vm_info,
         credentials=resolved_aws_sigv4_credentials(session_token=""),
     )
 
     with mitm_ctx():
-        result = await auth.handle_firewall_request(flow, aws_allow(), dict(aws_vm_info(tmp_path)))
+        result = await auth.handle_firewall_request(flow, allow, dict(vm_info))
 
     assert_sigv4_failed_closed(result, flow, "Invalid AWS session token")
 

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -520,6 +520,36 @@ async def test_header_sigv4_with_empty_resolved_secret_key_fails_closed(
     assert_sigv4_failed_closed(result, flow, "Invalid AWS secret access key")
 
 
+async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    api_entry = aws_api_entry(auth_query={"trace": "${{ secrets.TRACE_ID }}"})
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
+    prepare_firewall_request(flow)
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        api_entry=api_entry,
+        credentials=resolved_aws_sigv4_credentials(session_token=None),
+    )
+
+    with mitm_ctx():
+        result = await auth.handle_firewall_request(
+            flow,
+            aws_allow(api_entry),
+            dict(aws_vm_info(tmp_path)),
+        )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is True
+    assert flow.response is None
+    assert flow.request.headers["Authorization"].startswith(
+        "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"
+    )
+
+
 async def test_header_sigv4_without_trusted_original_url_fails_closed(
     real_flow,
     headers,

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -554,6 +554,46 @@ async def test_header_sigv4_seeded_cache_matches_auth_query_identity(
     )
 
 
+async def test_header_sigv4_cache_miss_when_auth_query_changes(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    cached_allow = aws_allow(aws_api_entry(include_session_token=False))
+    active_allow = aws_allow(
+        aws_api_entry(
+            auth_query={"trace": "${{ secrets.TRACE_ID }}"},
+            include_session_token=False,
+        )
+    )
+    endpoint = FakeAuthEndpoint()
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        allow=cached_allow,
+        credentials=resolved_aws_sigv4_credentials(session_token=None),
+        query={"trace": "cached-trace"},
+    )
+
+    result = await handle_firewall_request_with_auth_endpoint(
+        flow,
+        tmp_path,
+        mitm_ctx,
+        endpoint=endpoint,
+        auth_response=aws_auth_response(
+            include_session_token=False,
+            query={"trace": "fresh-trace"},
+        ),
+        allow=active_allow,
+    )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
+    assert len(endpoint.requests) == 1
+    assert flow.request.query["trace"] == "fresh-trace"
+
+
 async def test_header_sigv4_seeded_cache_matches_allow_context_identity(
     real_flow,
     headers,
@@ -584,6 +624,42 @@ async def test_header_sigv4_seeded_cache_matches_allow_context_identity(
     assert flow.request.headers["Authorization"].startswith(
         "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"
     )
+
+
+async def test_header_sigv4_cache_miss_when_billable_context_changes(
+    real_flow,
+    headers,
+    tmp_path,
+    mitm_ctx,
+):
+    allow = aws_allow(aws_api_entry(api_id="aws-sts-api", include_session_token=False))
+    cached_vm_info = aws_vm_info(tmp_path)
+    active_vm_info = aws_vm_info(tmp_path, billable_firewalls=["aws"])
+    endpoint = FakeAuthEndpoint()
+    flow = make_sts_header_sigv4_flow(real_flow, headers)
+    cache_aws_sigv4_credentials(
+        tmp_path,
+        allow=allow,
+        vm_info=cached_vm_info,
+        credentials=resolved_aws_sigv4_credentials(session_token=None),
+        expires_at=FAR_FUTURE_EXPIRES_AT,
+    )
+
+    result = await handle_firewall_request_with_auth_endpoint(
+        flow,
+        tmp_path,
+        mitm_ctx,
+        endpoint=endpoint,
+        auth_response=aws_auth_response(include_session_token=False),
+        allow=allow,
+        vm_info=active_vm_info,
+    )
+
+    assert result is auth.FirewallAuthHandlingResult.CONTINUE_UPSTREAM
+    assert flow.metadata[metadata_keys.AUTH_CACHE_HIT] is False
+    assert flow.metadata[metadata_keys.FIREWALL_API_ID] == "aws-sts-api"
+    assert flow.metadata[metadata_keys.FIREWALL_BILLABLE] is True
+    assert len(endpoint.requests) == 1
 
 
 async def test_header_sigv4_without_trusted_original_url_fails_closed(

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -8,9 +8,16 @@ from urllib.parse import parse_qs, urlparse
 import auth
 import auth_base_forwarder as forwarder
 import flow_metadata_keys as metadata_keys
-from aws_sigv4 import AwsSigV4Credentials
 from generated.builtin_firewalls import BUILTIN_FIREWALLS
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
+from tests.aws_sigv4_helpers import (
+    DEFAULT_SIGV4_TIMESTAMP,
+    REAL_AWS_SESSION_TOKEN,
+    STS_FORM_BODY,
+    aws_sigv4_authorization,
+    aws_sigv4_presigned_query_path,
+    resolved_aws_sigv4_credentials,
+)
 from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
 
@@ -405,22 +412,19 @@ class TestAuthBaseUrlRewriteForwarding:
         tmp_path,
     ):
         """auth.base forwarding signs the rewritten upstream URL, not the placeholder."""
-        placeholder_authorization = (
-            "AWS4-HMAC-SHA256 "
-            "Credential=PLACEHOLDER/20260101/us-east-1/sts/aws4_request, "
-            "SignedHeaders=content-type;host;x-amz-date, "
-            "Signature=placeholder"
+        placeholder_authorization = aws_sigv4_authorization(
+            signed_headers="content-type;host;x-amz-date"
         )
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
             resolved_base="https://STS.AMAZONAWS.COM:443/",
             method="POST",
-            request_body=b"Action=GetCallerIdentity&Version=2011-06-15",
+            request_body=STS_FORM_BODY,
             request_headers=headers(
                 ("Host", "firewall-placeholder.vm3.ai"),
                 ("Content-Type", "application/x-www-form-urlencoded"),
-                ("X-Amz-Date", "20260101T000000Z"),
+                ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
                 ("Authorization", placeholder_authorization),
                 ("Cookie", "session=agent"),
                 ("X-Api-Key", "agent-api-key"),
@@ -434,11 +438,7 @@ class TestAuthBaseUrlRewriteForwarding:
                 },
             },
             token_overrides={
-                "aws_sigv4": AwsSigV4Credentials(
-                    "AKIDEXAMPLE",
-                    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-                    "real-session-token",
-                ),
+                "aws_sigv4": resolved_aws_sigv4_credentials(),
             },
         )
         with (
@@ -460,7 +460,7 @@ class TestAuthBaseUrlRewriteForwarding:
             in authorization
         )
         assert upstream.socket.request_header_values("X-Amz-Security-Token") == [
-            "real-session-token"
+            REAL_AWS_SESSION_TOKEN
         ]
         assert upstream.socket.request_header_values("Cookie") == []
         assert upstream.socket.request_header_values("X-Api-Key") == []
@@ -478,21 +478,10 @@ class TestAuthBaseUrlRewriteForwarding:
         tmp_path,
     ):
         """auth.base query SigV4 ignores unrelated client Authorization headers."""
-        placeholder_credential = ("PLACEHOLDER/20260101/us-east-1/sts/aws4_request").replace(
-            "/", "%2F"
-        )
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
-            path=(
-                "/?Action=GetCallerIdentity&Version=2011-06-15"
-                "&X-Amz-Algorithm=AWS4-HMAC-SHA256"
-                f"&X-Amz-Credential={placeholder_credential}"
-                "&X-Amz-Date=20260101T000000Z"
-                "&X-Amz-Expires=60"
-                "&X-Amz-SignedHeaders=host"
-                "&X-Amz-Signature=placeholder"
-            ),
+            path=aws_sigv4_presigned_query_path(),
             resolved_base="https://STS.AMAZONAWS.COM:443/",
             method="GET",
             request_headers=headers(
@@ -509,11 +498,7 @@ class TestAuthBaseUrlRewriteForwarding:
                 },
             },
             token_overrides={
-                "aws_sigv4": AwsSigV4Credentials(
-                    "AKIDEXAMPLE",
-                    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-                    "real-session-token",
-                ),
+                "aws_sigv4": resolved_aws_sigv4_credentials(),
             },
         )
         with (
@@ -529,7 +514,7 @@ class TestAuthBaseUrlRewriteForwarding:
         assert upstream.getaddrinfo_calls == [("sts.amazonaws.com", 443)]
         assert upstream.socket.request_header_values("Host") == ["sts.amazonaws.com"]
         assert query["X-Amz-Credential"] == ["AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"]
-        assert query["X-Amz-Security-Token"] == ["real-session-token"]
+        assert query["X-Amz-Security-Token"] == [REAL_AWS_SESSION_TOKEN]
         assert query["X-Amz-Signature"] != ["placeholder"]
         assert upstream.socket.request_header_values("Authorization") == []
         assert upstream.socket.request_header_values("Cookie") == []

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -12,7 +12,7 @@ from generated.builtin_firewalls import BUILTIN_FIREWALLS
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
 from tests.aws_sigv4_helpers import (
     DEFAULT_SIGV4_TIMESTAMP,
-    REAL_AWS_SESSION_TOKEN,
+    RESOLVED_AWS_SESSION_TOKEN,
     STS_FORM_BODY,
     aws_sigv4_authorization,
     aws_sigv4_presigned_query_path,
@@ -456,11 +456,11 @@ class TestAuthBaseUrlRewriteForwarding:
         assert upstream.socket.request_header_values("Host") == ["sts.amazonaws.com"]
         assert "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request" in authorization
         assert (
-            "Signature=d58b7e131d8f54e75a6ee98fd426242a7bab02e04a9e7eaec5dfad94425ab4ae"
+            "Signature=1735aaa47d56839a3157c545e28e02eb8fa1526da431e9fc980b7414df9c4f53"
             in authorization
         )
         assert upstream.socket.request_header_values("X-Amz-Security-Token") == [
-            REAL_AWS_SESSION_TOKEN
+            RESOLVED_AWS_SESSION_TOKEN
         ]
         assert upstream.socket.request_header_values("Cookie") == []
         assert upstream.socket.request_header_values("X-Api-Key") == []
@@ -514,7 +514,7 @@ class TestAuthBaseUrlRewriteForwarding:
         assert upstream.getaddrinfo_calls == [("sts.amazonaws.com", 443)]
         assert upstream.socket.request_header_values("Host") == ["sts.amazonaws.com"]
         assert query["X-Amz-Credential"] == ["AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"]
-        assert query["X-Amz-Security-Token"] == [REAL_AWS_SESSION_TOKEN]
+        assert query["X-Amz-Security-Token"] == [RESOLVED_AWS_SESSION_TOKEN]
         assert query["X-Amz-Signature"] != ["placeholder"]
         assert upstream.socket.request_header_values("Authorization") == []
         assert upstream.socket.request_header_values("Cookie") == []


### PR DESCRIPTION
## Summary

Closes #20785.

This is a test-only refactor for the mitm-addon AWS SigV4 coverage. It adds two focused helper layers:

- `tests/aws_sigv4_helpers.py` for pure SigV4 fixture vocabulary such as credential scopes, placeholder auth headers, presigned query paths, and test credentials.
- `tests/firewall_aws_sigv4_helpers.py` for firewall-auth integration setup while keeping the real `auth.handle_firewall_request(...)` path.

The large firewall AWS SigV4 test file now uses the shared helpers, while expected final signatures and malformed inputs remain visible at the test sites. Neighboring SigV4 tests were updated only for direct fixture reuse. No production code changed.

## Validation

- `pytest --collect-only -q tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py tests/test_firewall_auth.py tests/test_firewall_rewrite_forwarding.py` -> 223 tests collected
- `ruff check tests/aws_sigv4_helpers.py tests/firewall_aws_sigv4_helpers.py tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py tests/test_firewall_auth.py tests/test_firewall_rewrite_forwarding.py`
- `basedpyright tests/aws_sigv4_helpers.py tests/firewall_aws_sigv4_helpers.py tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py tests/test_firewall_auth.py tests/test_firewall_rewrite_forwarding.py`
- `pytest tests/test_firewall_aws_sigv4_auth.py tests/test_aws_sigv4.py tests/test_firewall_auth.py tests/test_firewall_rewrite_forwarding.py` -> 223 passed
