### PR TITLE
feat(runner): add service unit-state command

### DIFF
--- a/crates/runner/src/cmd/service/mod.rs
+++ b/crates/runner/src/cmd/service/mod.rs
@@ -15,6 +15,7 @@ mod diagnostic;
 mod drain_override;
 mod gate;
 mod signal;
+mod state;
 mod stop;
 mod systemctl;
 mod target;
@@ -59,6 +60,8 @@ enum ServiceCommand {
     Resume(ServiceResumeArgs),
     /// Wait until a runner service is active and job-admitting
     WaitRunning(ServiceWaitRunningArgs),
+    /// Show machine-readable systemd unit state for runner services
+    UnitState(state::UnitStateArgs),
     /// Show service status (all runner services if --name is omitted)
     Status(ServiceStatusArgs),
     /// Show service logs
@@ -149,6 +152,7 @@ pub async fn run_service(args: ServiceArgs) -> RunnerResult<()> {
         ServiceCommand::Drain(a) => drain(a).await,
         ServiceCommand::Resume(a) => resume(a).await,
         ServiceCommand::WaitRunning(a) => wait_running(a).await,
+        ServiceCommand::UnitState(a) => state::run(a).await,
         ServiceCommand::Status(a) => status(a).await,
         ServiceCommand::Logs(a) => logs(a).await,
     }

--- a/crates/runner/src/cmd/service/state.rs
+++ b/crates/runner/src/cmd/service/state.rs
@@ -29,9 +29,14 @@ struct UnitStateEntry {
 }
 
 pub(super) async fn run(args: UnitStateArgs) -> RunnerResult<()> {
-    let mut services = Vec::with_capacity(args.names.len());
-    for name in args.names {
-        let unit = RunnerServiceUnit::from_suffix(&name)?;
+    let units = args
+        .names
+        .iter()
+        .map(|name| RunnerServiceUnit::from_suffix(name))
+        .collect::<RunnerResult<Vec<_>>>()?;
+
+    let mut services = Vec::with_capacity(units.len());
+    for unit in units {
         let state = read_service_unit_state(&unit).await?;
         services.push(unit_state_entry(unit, state));
     }

--- a/crates/runner/src/cmd/service/state.rs
+++ b/crates/runner/src/cmd/service/state.rs
@@ -1,0 +1,133 @@
+use clap::Args;
+use serde::Serialize;
+
+use crate::error::{RunnerError, RunnerResult};
+
+use super::systemctl::{ServiceUnitState, read_service_unit_state};
+use super::target::RunnerServiceUnit;
+
+#[derive(Args)]
+pub(super) struct UnitStateArgs {
+    /// Service name suffix (repeat to query multiple runner services)
+    #[arg(long = "name", value_name = "SUFFIX", required = true)]
+    names: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UnitStateOutput {
+    services: Vec<UnitStateEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UnitStateEntry {
+    name: String,
+    unit: String,
+    #[serde(flatten)]
+    state: ServiceUnitState,
+}
+
+pub(super) async fn run(args: UnitStateArgs) -> RunnerResult<()> {
+    let mut services = Vec::with_capacity(args.names.len());
+    for name in args.names {
+        let unit = RunnerServiceUnit::from_suffix(&name)?;
+        let state = read_service_unit_state(&unit).await?;
+        services.push(unit_state_entry(unit, state));
+    }
+
+    let output = UnitStateOutput { services };
+    let json = serde_json::to_string(&output)
+        .map_err(|e| RunnerError::Internal(format!("serialize unit state json: {e}")))?;
+    println!("{json}");
+    Ok(())
+}
+
+fn unit_state_entry(unit: RunnerServiceUnit, state: ServiceUnitState) -> UnitStateEntry {
+    UnitStateEntry {
+        name: unit.suffix().to_string(),
+        unit: unit.service_name().to_string(),
+        state,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::cmd::service::systemctl::NormalizedUnitState;
+
+    fn service_unit(suffix: &str) -> RunnerServiceUnit {
+        RunnerServiceUnit::from_suffix(suffix).unwrap()
+    }
+
+    #[test]
+    fn unit_state_output_uses_stable_wrapper_shape() {
+        let state = ServiceUnitState::for_test(
+            "loaded",
+            "deactivating",
+            "stop-sigterm",
+            "success",
+            NormalizedUnitState::ActiveLike,
+        );
+        let output = UnitStateOutput {
+            services: vec![unit_state_entry(service_unit("v1.2.3"), state)],
+        };
+
+        let value = serde_json::to_value(output).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "services": [
+                    {
+                        "name": "v1.2.3",
+                        "unit": "vm0-runner-v1.2.3.service",
+                        "loadState": "loaded",
+                        "activeState": "deactivating",
+                        "subState": "stop-sigterm",
+                        "result": "success",
+                        "normalizedState": "active-like",
+                        "activeLike": true
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn unit_state_output_keeps_multiple_services_in_order() {
+        let output = UnitStateOutput {
+            services: vec![
+                unit_state_entry(
+                    service_unit("v1.2.3"),
+                    ServiceUnitState::for_test(
+                        "loaded",
+                        "active",
+                        "running",
+                        "success",
+                        NormalizedUnitState::ActiveLike,
+                    ),
+                ),
+                unit_state_entry(
+                    service_unit("v1.2.2"),
+                    ServiceUnitState::for_test(
+                        "not-found",
+                        "inactive",
+                        "dead",
+                        "success",
+                        NormalizedUnitState::NotFound,
+                    ),
+                ),
+            ],
+        };
+
+        let value = serde_json::to_value(output).unwrap();
+
+        assert_eq!(value["services"][0]["name"], "v1.2.3");
+        assert_eq!(value["services"][1]["name"], "v1.2.2");
+        assert_eq!(value["services"][0]["activeLike"], true);
+        assert_eq!(value["services"][1]["activeLike"], false);
+    }
+}

--- a/crates/runner/src/cmd/service/state.rs
+++ b/crates/runner/src/cmd/service/state.rs
@@ -61,7 +61,6 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::cmd::service::systemctl::NormalizedUnitState;
 
     fn service_unit(suffix: &str) -> RunnerServiceUnit {
         RunnerServiceUnit::from_suffix(suffix).unwrap()
@@ -69,13 +68,7 @@ mod tests {
 
     #[test]
     fn unit_state_output_uses_stable_wrapper_shape() {
-        let state = ServiceUnitState::for_test(
-            "loaded",
-            "deactivating",
-            "stop-sigterm",
-            "success",
-            NormalizedUnitState::ActiveLike,
-        );
+        let state = ServiceUnitState::for_test("loaded", "deactivating", "stop-sigterm", "success");
         let output = UnitStateOutput {
             services: vec![unit_state_entry(service_unit("v1.2.3"), state)],
         };
@@ -107,23 +100,11 @@ mod tests {
             services: vec![
                 unit_state_entry(
                     service_unit("v1.2.3"),
-                    ServiceUnitState::for_test(
-                        "loaded",
-                        "active",
-                        "running",
-                        "success",
-                        NormalizedUnitState::ActiveLike,
-                    ),
+                    ServiceUnitState::for_test("loaded", "active", "running", "success"),
                 ),
                 unit_state_entry(
                     service_unit("v1.2.2"),
-                    ServiceUnitState::for_test(
-                        "not-found",
-                        "inactive",
-                        "dead",
-                        "success",
-                        NormalizedUnitState::NotFound,
-                    ),
+                    ServiceUnitState::for_test("not-found", "inactive", "dead", "success"),
                 ),
             ],
         };

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -270,7 +270,7 @@ impl CleanupUnitActiveState {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub(super) enum NormalizedUnitState {
+enum NormalizedUnitState {
     ActiveLike,
     Inactive,
     Failed,

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -3,7 +3,8 @@ use std::process::{ExitStatus, Output, Stdio};
 use std::time::Duration;
 
 use crate::error::{RunnerError, RunnerResult};
-use serde::Serialize;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use tokio::io::AsyncReadExt;
 use tokio::task::JoinHandle;
 
@@ -283,15 +284,13 @@ impl NormalizedUnitState {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct ServiceUnitState {
     load_state: String,
     active_state: String,
     sub_state: String,
     result: String,
     normalized_state: NormalizedUnitState,
-    active_like: bool,
 }
 
 impl ServiceUnitState {
@@ -301,16 +300,20 @@ impl ServiceUnitState {
         active_state: &str,
         sub_state: &str,
         result: &str,
-        normalized_state: NormalizedUnitState,
     ) -> Self {
+        let normalized_state =
+            normalize_unit_state("vm0-runner-test.service", load_state, active_state).unwrap();
         Self {
             load_state: load_state.to_string(),
             active_state: active_state.to_string(),
             sub_state: sub_state.to_string(),
             result: result.to_string(),
             normalized_state,
-            active_like: normalized_state.is_active_like(),
         }
+    }
+
+    fn active_like(&self) -> bool {
+        self.normalized_state.is_active_like()
     }
 
     #[cfg(test)]
@@ -320,7 +323,23 @@ impl ServiceUnitState {
 
     #[cfg(test)]
     fn is_active_like(&self) -> bool {
-        self.active_like
+        self.active_like()
+    }
+}
+
+impl Serialize for ServiceUnitState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("ServiceUnitState", 6)?;
+        state.serialize_field("loadState", &self.load_state)?;
+        state.serialize_field("activeState", &self.active_state)?;
+        state.serialize_field("subState", &self.sub_state)?;
+        state.serialize_field("result", &self.result)?;
+        state.serialize_field("normalizedState", &self.normalized_state)?;
+        state.serialize_field("activeLike", &self.active_like())?;
+        state.end()
     }
 }
 
@@ -604,7 +623,6 @@ fn service_unit_state_from_systemctl_show(
         sub_state: sub_state.to_string(),
         result: result.to_string(),
         normalized_state,
-        active_like: normalized_state.is_active_like(),
     })
 }
 

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -277,6 +277,12 @@ pub(super) enum NormalizedUnitState {
     NotFound,
 }
 
+impl NormalizedUnitState {
+    fn is_active_like(self) -> bool {
+        self == Self::ActiveLike
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct ServiceUnitState {
@@ -303,7 +309,7 @@ impl ServiceUnitState {
             sub_state: sub_state.to_string(),
             result: result.to_string(),
             normalized_state,
-            active_like: normalized_state == NormalizedUnitState::ActiveLike,
+            active_like: normalized_state.is_active_like(),
         }
     }
 
@@ -521,7 +527,7 @@ fn systemctl_property<'a>(
 
 fn classify_unit_active(svc: &str, load_state: &str, active_state: &str) -> RunnerResult<bool> {
     let normalized_state = normalize_unit_state(svc, load_state, active_state)?;
-    Ok(normalized_state == NormalizedUnitState::ActiveLike && active_state != "deactivating")
+    Ok(normalized_state.is_active_like() && active_state != "deactivating")
 }
 
 fn normalize_unit_state(
@@ -569,8 +575,7 @@ fn cleanup_unit_active_state_from_systemctl_show(
 ) -> RunnerResult<CleanupUnitActiveState> {
     let load_state = required_systemctl_property(svc, values, "LoadState")?;
     let active_state = required_systemctl_property(svc, values, "ActiveState")?;
-    let active_like =
-        normalize_unit_state(svc, load_state, active_state)? == NormalizedUnitState::ActiveLike;
+    let active_like = normalize_unit_state(svc, load_state, active_state)?.is_active_like();
     let missing_unit = load_state == "not-found" && !active_like;
     ensure_systemctl_show_status(svc, properties, status, stderr, missing_unit)?;
     Ok(CleanupUnitActiveState {
@@ -599,7 +604,7 @@ fn service_unit_state_from_systemctl_show(
         sub_state: sub_state.to_string(),
         result: result.to_string(),
         normalized_state,
-        active_like: normalized_state == NormalizedUnitState::ActiveLike,
+        active_like: normalized_state.is_active_like(),
     })
 }
 

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -3,6 +3,7 @@ use std::process::{ExitStatus, Output, Stdio};
 use std::time::Duration;
 
 use crate::error::{RunnerError, RunnerResult};
+use serde::Serialize;
 use tokio::io::AsyncReadExt;
 use tokio::task::JoinHandle;
 
@@ -265,6 +266,76 @@ impl CleanupUnitActiveState {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) enum NormalizedUnitState {
+    ActiveLike,
+    Inactive,
+    Failed,
+    Maintenance,
+    NotFound,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ServiceUnitState {
+    load_state: String,
+    active_state: String,
+    sub_state: String,
+    result: String,
+    normalized_state: NormalizedUnitState,
+    active_like: bool,
+}
+
+impl ServiceUnitState {
+    #[cfg(test)]
+    pub(super) fn for_test(
+        load_state: &str,
+        active_state: &str,
+        sub_state: &str,
+        result: &str,
+        normalized_state: NormalizedUnitState,
+    ) -> Self {
+        Self {
+            load_state: load_state.to_string(),
+            active_state: active_state.to_string(),
+            sub_state: sub_state.to_string(),
+            result: result.to_string(),
+            normalized_state,
+            active_like: normalized_state == NormalizedUnitState::ActiveLike,
+        }
+    }
+
+    #[cfg(test)]
+    fn active_state(&self) -> &str {
+        &self.active_state
+    }
+
+    #[cfg(test)]
+    fn is_active_like(&self) -> bool {
+        self.active_like
+    }
+}
+
+/// Read the systemd unit state for machine-readable service reporting.
+pub(super) async fn read_service_unit_state(
+    unit: &RunnerServiceUnit,
+) -> RunnerResult<ServiceUnitState> {
+    let svc = unit.service_name();
+    let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+    let output = run_systemctl_show(svc, &properties).await?;
+    service_unit_state_from_output(svc, &properties, &output)
+}
+
+fn service_unit_state_from_output(
+    svc: &str,
+    properties: &[&str],
+    output: &Output,
+) -> RunnerResult<ServiceUnitState> {
+    let values = parse_systemctl_show_output(svc, properties, output)?;
+    service_unit_state_from_systemctl_show(svc, properties, &output.status, &values, &output.stderr)
+}
+
 /// Read the systemd ActiveState using cleanup semantics.
 ///
 /// Normal health checks intentionally treat `deactivating` as inactive because
@@ -433,10 +504,55 @@ fn required_systemctl_property<'a>(
     Ok(value)
 }
 
+fn systemctl_property<'a>(
+    svc: &str,
+    values: &'a BTreeMap<String, String>,
+    property: &str,
+) -> RunnerResult<&'a str> {
+    let value = values.get(property).ok_or_else(|| {
+        RunnerError::Internal(format!(
+            "missing systemctl show property for {svc}: {property}"
+        ))
+    })?;
+    Ok(value.trim())
+}
+
 fn classify_unit_active(svc: &str, load_state: &str, active_state: &str) -> RunnerResult<bool> {
     match active_state {
         "active" | "activating" | "reloading" | "refreshing" => Ok(true),
         "inactive" | "failed" | "deactivating" | "maintenance" => Ok(false),
+        _ => Err(RunnerError::Internal(format!(
+            "unknown ActiveState for {svc}: {active_state} (LoadState={load_state})"
+        ))),
+    }
+}
+
+fn normalize_unit_state(
+    svc: &str,
+    load_state: &str,
+    active_state: &str,
+) -> RunnerResult<NormalizedUnitState> {
+    if load_state == "not-found" {
+        return match active_state {
+            "inactive" | "failed" | "maintenance" => Ok(NormalizedUnitState::NotFound),
+            "active" | "activating" | "reloading" | "refreshing" | "deactivating" => {
+                Err(RunnerError::Internal(format!(
+                    "not-found unit {svc} reported active-like ActiveState={active_state}"
+                )))
+            }
+            _ => Err(RunnerError::Internal(format!(
+                "unknown ActiveState for {svc}: {active_state} (LoadState={load_state})"
+            ))),
+        };
+    }
+
+    match active_state {
+        "active" | "activating" | "reloading" | "refreshing" | "deactivating" => {
+            Ok(NormalizedUnitState::ActiveLike)
+        }
+        "inactive" => Ok(NormalizedUnitState::Inactive),
+        "failed" => Ok(NormalizedUnitState::Failed),
+        "maintenance" => Ok(NormalizedUnitState::Maintenance),
         _ => Err(RunnerError::Internal(format!(
             "unknown ActiveState for {svc}: {active_state} (LoadState={load_state})"
         ))),
@@ -487,6 +603,36 @@ fn cleanup_unit_active_state_from_systemctl_show(
     Ok(CleanupUnitActiveState {
         active_state: active_state.to_string(),
         active_like,
+    })
+}
+
+fn service_unit_state_from_systemctl_show(
+    svc: &str,
+    properties: &[&str],
+    status: &ExitStatus,
+    values: &BTreeMap<String, String>,
+    stderr: &[u8],
+) -> RunnerResult<ServiceUnitState> {
+    let load_state = required_systemctl_property(svc, values, "LoadState")?;
+    let active_state = required_systemctl_property(svc, values, "ActiveState")?;
+    let sub_state = systemctl_property(svc, values, "SubState")?;
+    let result = systemctl_property(svc, values, "Result")?;
+    let normalized_state = normalize_unit_state(svc, load_state, active_state)?;
+    ensure_systemctl_show_status(
+        svc,
+        properties,
+        status,
+        stderr,
+        normalized_state == NormalizedUnitState::NotFound,
+    )?;
+
+    Ok(ServiceUnitState {
+        load_state: load_state.to_string(),
+        active_state: active_state.to_string(),
+        sub_state: sub_state.to_string(),
+        result: result.to_string(),
+        normalized_state,
+        active_like: normalized_state == NormalizedUnitState::ActiveLike,
     })
 }
 
@@ -901,6 +1047,156 @@ mod tests {
 
         assert_eq!(state.active_state(), "inactive");
         assert!(!state.is_active_like());
+    }
+
+    #[test]
+    fn service_unit_state_keeps_deactivating_active_like_for_reporting() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=loaded\nActiveState=deactivating\nSubState=stop-sigterm\nResult=success\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0);
+        let state = service_unit_state_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"",
+        )
+        .unwrap();
+
+        assert_eq!(state.active_state(), "deactivating");
+        assert!(state.is_active_like());
+        assert_eq!(state.normalized_state, NormalizedUnitState::ActiveLike);
+    }
+
+    #[test]
+    fn service_unit_state_preserves_empty_optional_fields() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=loaded\nActiveState=inactive\nSubState=\nResult=\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0);
+        let state = service_unit_state_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"",
+        )
+        .unwrap();
+
+        assert_eq!(state.sub_state, "");
+        assert_eq!(state.result, "");
+        assert!(!state.is_active_like());
+        assert_eq!(state.normalized_state, NormalizedUnitState::Inactive);
+    }
+
+    #[test]
+    fn service_unit_state_allows_not_found_on_failed_status() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=not-found\nActiveState=inactive\nSubState=dead\nResult=success\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+        let state = service_unit_state_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"Unit not found\n",
+        )
+        .unwrap();
+
+        assert_eq!(state.normalized_state, NormalizedUnitState::NotFound);
+        assert!(!state.is_active_like());
+    }
+
+    #[test]
+    fn service_unit_state_rejects_not_found_active_like_state() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=not-found\nActiveState=deactivating\nSubState=stop-sigterm\nResult=success\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+        let err = service_unit_state_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"Unit not found\n",
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("not-found unit"));
+    }
+
+    #[test]
+    fn service_unit_state_rejects_unknown_active_state() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=loaded\nActiveState=half-active\nSubState=unknown\nResult=success\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0);
+        let err = service_unit_state_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"",
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown ActiveState"));
+    }
+
+    #[test]
+    fn service_unit_state_rejects_not_found_unknown_active_state() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let values = parse_systemctl_show_properties(
+            "vm0-runner-test.service",
+            &properties,
+            b"LoadState=not-found\nActiveState=half-active\nSubState=unknown\nResult=success\n",
+        )
+        .unwrap();
+        let status = ExitStatus::from_raw(0x100);
+        let err = service_unit_state_from_systemctl_show(
+            "vm0-runner-test.service",
+            &properties,
+            &status,
+            &values,
+            b"Unit not found\n",
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown ActiveState"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -11,6 +11,7 @@ use super::diagnostic::status_field_preview;
 use super::target::RunnerServiceUnit;
 
 const BOUNDED_COMMAND_KILL_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
+const SERVICE_UNIT_STATE_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub(super) fn journalctl_logs_status(svc: &str, status: ExitStatus) -> RunnerResult<()> {
     if status.success() {
@@ -323,7 +324,8 @@ pub(super) async fn read_service_unit_state(
 ) -> RunnerResult<ServiceUnitState> {
     let svc = unit.service_name();
     let properties = ["LoadState", "ActiveState", "SubState", "Result"];
-    let output = run_systemctl_show(svc, &properties).await?;
+    let output =
+        run_systemctl_show_bounded(svc, &properties, SERVICE_UNIT_STATE_QUERY_TIMEOUT).await?;
     service_unit_state_from_output(svc, &properties, &output)
 }
 

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -532,23 +532,12 @@ fn normalize_unit_state(
     load_state: &str,
     active_state: &str,
 ) -> RunnerResult<NormalizedUnitState> {
-    if load_state == "not-found" {
-        return match active_state {
-            "inactive" | "failed" | "maintenance" => Ok(NormalizedUnitState::NotFound),
-            "active" | "activating" | "reloading" | "refreshing" | "deactivating" => {
-                Err(RunnerError::Internal(format!(
-                    "not-found unit {svc} reported active-like ActiveState={active_state}"
-                )))
-            }
-            _ => Err(RunnerError::Internal(format!(
-                "unknown ActiveState for {svc}: {active_state} (LoadState={load_state})"
-            ))),
-        };
-    }
-
     match active_state {
         "active" | "activating" | "reloading" | "refreshing" | "deactivating" => {
             Ok(NormalizedUnitState::ActiveLike)
+        }
+        "inactive" | "failed" | "maintenance" if load_state == "not-found" => {
+            Ok(NormalizedUnitState::NotFound)
         }
         "inactive" => Ok(NormalizedUnitState::Inactive),
         "failed" => Ok(NormalizedUnitState::Failed),
@@ -618,13 +607,7 @@ fn service_unit_state_from_systemctl_show(
     let sub_state = systemctl_property(svc, values, "SubState")?;
     let result = systemctl_property(svc, values, "Result")?;
     let normalized_state = normalize_unit_state(svc, load_state, active_state)?;
-    ensure_systemctl_show_status(
-        svc,
-        properties,
-        status,
-        stderr,
-        normalized_state == NormalizedUnitState::NotFound,
-    )?;
+    ensure_systemctl_show_status(svc, properties, status, stderr, load_state == "not-found")?;
 
     Ok(ServiceUnitState {
         load_state: load_state.to_string(),
@@ -1237,7 +1220,7 @@ mod tests {
     }
 
     #[test]
-    fn service_unit_state_rejects_not_found_active_like_state() {
+    fn service_unit_state_reports_not_found_active_like_state() {
         use std::os::unix::process::ExitStatusExt;
 
         let properties = ["LoadState", "ActiveState", "SubState", "Result"];
@@ -1248,16 +1231,18 @@ mod tests {
         )
         .unwrap();
         let status = ExitStatus::from_raw(0x100);
-        let err = service_unit_state_from_systemctl_show(
+        let state = service_unit_state_from_systemctl_show(
             "vm0-runner-test.service",
             &properties,
             &status,
             &values,
             b"Unit not found\n",
         )
-        .unwrap_err();
+        .unwrap();
 
-        assert!(err.to_string().contains("not-found unit"));
+        assert_eq!(state.load_state, "not-found");
+        assert_eq!(state.normalized_state, NormalizedUnitState::ActiveLike);
+        assert!(state.is_active_like());
     }
 
     #[test]

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -520,13 +520,8 @@ fn systemctl_property<'a>(
 }
 
 fn classify_unit_active(svc: &str, load_state: &str, active_state: &str) -> RunnerResult<bool> {
-    match active_state {
-        "active" | "activating" | "reloading" | "refreshing" => Ok(true),
-        "inactive" | "failed" | "deactivating" | "maintenance" => Ok(false),
-        _ => Err(RunnerError::Internal(format!(
-            "unknown ActiveState for {svc}: {active_state} (LoadState={load_state})"
-        ))),
-    }
+    let normalized_state = normalize_unit_state(svc, load_state, active_state)?;
+    Ok(normalized_state == NormalizedUnitState::ActiveLike && active_state != "deactivating")
 }
 
 fn normalize_unit_state(

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -534,11 +534,10 @@ fn normalize_unit_state(
     load_state: &str,
     active_state: &str,
 ) -> RunnerResult<NormalizedUnitState> {
-    if classify_unit_lifecycle_active_like(svc, load_state, active_state)? {
-        return Ok(NormalizedUnitState::ActiveLike);
-    }
-
     match active_state {
+        "active" | "activating" | "reloading" | "refreshing" | "deactivating" => {
+            Ok(NormalizedUnitState::ActiveLike)
+        }
         "inactive" | "failed" | "maintenance" if load_state == "not-found" => {
             Ok(NormalizedUnitState::NotFound)
         }
@@ -547,20 +546,6 @@ fn normalize_unit_state(
         "maintenance" => Ok(NormalizedUnitState::Maintenance),
         _ => Err(RunnerError::Internal(format!(
             "unknown ActiveState for {svc}: {active_state} (LoadState={load_state})"
-        ))),
-    }
-}
-
-fn classify_unit_lifecycle_active_like(
-    svc: &str,
-    load_state: &str,
-    active_state: &str,
-) -> RunnerResult<bool> {
-    match active_state {
-        "active" | "activating" | "reloading" | "refreshing" | "deactivating" => Ok(true),
-        "inactive" | "failed" | "maintenance" => Ok(false),
-        _ => Err(RunnerError::Internal(format!(
-            "unknown ActiveState for active-like classification of {svc}: {active_state} (LoadState={load_state})"
         ))),
     }
 }
@@ -589,7 +574,8 @@ fn cleanup_unit_active_state_from_systemctl_show(
 ) -> RunnerResult<CleanupUnitActiveState> {
     let load_state = required_systemctl_property(svc, values, "LoadState")?;
     let active_state = required_systemctl_property(svc, values, "ActiveState")?;
-    let active_like = classify_unit_lifecycle_active_like(svc, load_state, active_state)?;
+    let active_like =
+        normalize_unit_state(svc, load_state, active_state)? == NormalizedUnitState::ActiveLike;
     let missing_unit = load_state == "not-found" && !active_like;
     ensure_systemctl_show_status(svc, properties, status, stderr, missing_unit)?;
     Ok(CleanupUnitActiveState {
@@ -975,7 +961,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_unit_lifecycle_active_like_keeps_deactivating_active_like() {
+    fn normalize_unit_state_keeps_lifecycle_active_like_states() {
         for active_state in [
             "active",
             "activating",
@@ -983,29 +969,25 @@ mod tests {
             "refreshing",
             "deactivating",
         ] {
-            assert!(
-                classify_unit_lifecycle_active_like(
-                    "vm0-runner-test.service",
-                    "loaded",
-                    active_state,
-                )
-                .unwrap(),
-                "{active_state} should be lifecycle active-like"
+            assert_eq!(
+                normalize_unit_state("vm0-runner-test.service", "loaded", active_state).unwrap(),
+                NormalizedUnitState::ActiveLike,
+                "{active_state} should normalize to active-like"
             );
         }
     }
 
     #[test]
-    fn classify_unit_lifecycle_active_like_accepts_inactive_states() {
-        for active_state in ["inactive", "failed", "maintenance"] {
-            assert!(
-                !classify_unit_lifecycle_active_like(
-                    "vm0-runner-test.service",
-                    "loaded",
-                    active_state,
-                )
-                .unwrap(),
-                "{active_state} should be lifecycle inactive-like"
+    fn normalize_unit_state_preserves_loaded_inactive_states() {
+        for (active_state, normalized_state) in [
+            ("inactive", NormalizedUnitState::Inactive),
+            ("failed", NormalizedUnitState::Failed),
+            ("maintenance", NormalizedUnitState::Maintenance),
+        ] {
+            assert_eq!(
+                normalize_unit_state("vm0-runner-test.service", "loaded", active_state).unwrap(),
+                normalized_state,
+                "{active_state} should preserve its loaded normalized state"
             );
         }
     }

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -534,10 +534,11 @@ fn normalize_unit_state(
     load_state: &str,
     active_state: &str,
 ) -> RunnerResult<NormalizedUnitState> {
+    if classify_unit_lifecycle_active_like(svc, load_state, active_state)? {
+        return Ok(NormalizedUnitState::ActiveLike);
+    }
+
     match active_state {
-        "active" | "activating" | "reloading" | "refreshing" | "deactivating" => {
-            Ok(NormalizedUnitState::ActiveLike)
-        }
         "inactive" | "failed" | "maintenance" if load_state == "not-found" => {
             Ok(NormalizedUnitState::NotFound)
         }
@@ -550,7 +551,7 @@ fn normalize_unit_state(
     }
 }
 
-fn classify_cleanup_unit_active_like(
+fn classify_unit_lifecycle_active_like(
     svc: &str,
     load_state: &str,
     active_state: &str,
@@ -559,7 +560,7 @@ fn classify_cleanup_unit_active_like(
         "active" | "activating" | "reloading" | "refreshing" | "deactivating" => Ok(true),
         "inactive" | "failed" | "maintenance" => Ok(false),
         _ => Err(RunnerError::Internal(format!(
-            "unknown ActiveState for cleanup of {svc}: {active_state} (LoadState={load_state})"
+            "unknown ActiveState for active-like classification of {svc}: {active_state} (LoadState={load_state})"
         ))),
     }
 }
@@ -588,7 +589,7 @@ fn cleanup_unit_active_state_from_systemctl_show(
 ) -> RunnerResult<CleanupUnitActiveState> {
     let load_state = required_systemctl_property(svc, values, "LoadState")?;
     let active_state = required_systemctl_property(svc, values, "ActiveState")?;
-    let active_like = classify_cleanup_unit_active_like(svc, load_state, active_state)?;
+    let active_like = classify_unit_lifecycle_active_like(svc, load_state, active_state)?;
     let missing_unit = load_state == "not-found" && !active_like;
     ensure_systemctl_show_status(svc, properties, status, stderr, missing_unit)?;
     Ok(CleanupUnitActiveState {
@@ -974,7 +975,7 @@ mod tests {
     }
 
     #[test]
-    fn classify_cleanup_unit_active_like_keeps_deactivating_active_like() {
+    fn classify_unit_lifecycle_active_like_keeps_deactivating_active_like() {
         for active_state in [
             "active",
             "activating",
@@ -983,28 +984,28 @@ mod tests {
             "deactivating",
         ] {
             assert!(
-                classify_cleanup_unit_active_like(
+                classify_unit_lifecycle_active_like(
                     "vm0-runner-test.service",
                     "loaded",
                     active_state,
                 )
                 .unwrap(),
-                "{active_state} should be active-like during cleanup"
+                "{active_state} should be lifecycle active-like"
             );
         }
     }
 
     #[test]
-    fn classify_cleanup_unit_active_like_accepts_inactive_states() {
+    fn classify_unit_lifecycle_active_like_accepts_inactive_states() {
         for active_state in ["inactive", "failed", "maintenance"] {
             assert!(
-                !classify_cleanup_unit_active_like(
+                !classify_unit_lifecycle_active_like(
                     "vm0-runner-test.service",
                     "loaded",
                     active_state,
                 )
                 .unwrap(),
-                "{active_state} should be inactive-like during cleanup"
+                "{active_state} should be lifecycle inactive-like"
             );
         }
     }

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -1204,6 +1204,39 @@ mod tests {
     }
 
     #[test]
+    fn service_unit_state_accepts_not_found_inactive_like_states() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let status = ExitStatus::from_raw(0x100);
+        for active_state in ["inactive", "failed", "maintenance"] {
+            let stdout = format!(
+                "LoadState=not-found\nActiveState={active_state}\nSubState=dead\nResult=success\n"
+            );
+            let values = parse_systemctl_show_properties(
+                "vm0-runner-test.service",
+                &properties,
+                stdout.as_bytes(),
+            )
+            .unwrap();
+            let state = service_unit_state_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"Unit not found\n",
+            )
+            .unwrap();
+
+            assert_eq!(state.normalized_state, NormalizedUnitState::NotFound);
+            assert!(
+                !state.is_active_like(),
+                "{active_state} should not be active-like"
+            );
+        }
+    }
+
+    #[test]
     fn service_unit_state_rejects_not_found_active_like_state() {
         use std::os::unix::process::ExitStatusExt;
 

--- a/crates/runner/src/cmd/service/systemctl.rs
+++ b/crates/runner/src/cmd/service/systemctl.rs
@@ -1076,6 +1076,82 @@ mod tests {
     }
 
     #[test]
+    fn service_unit_state_accepts_all_active_like_states_for_reporting() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let status = ExitStatus::from_raw(0);
+        for active_state in [
+            "active",
+            "activating",
+            "reloading",
+            "refreshing",
+            "deactivating",
+        ] {
+            let stdout = format!(
+                "LoadState=loaded\nActiveState={active_state}\nSubState=running\nResult=success\n"
+            );
+            let values = parse_systemctl_show_properties(
+                "vm0-runner-test.service",
+                &properties,
+                stdout.as_bytes(),
+            )
+            .unwrap();
+            let state = service_unit_state_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"",
+            )
+            .unwrap();
+
+            assert_eq!(state.normalized_state, NormalizedUnitState::ActiveLike);
+            assert!(
+                state.is_active_like(),
+                "{active_state} should be active-like"
+            );
+        }
+    }
+
+    #[test]
+    fn service_unit_state_accepts_inactive_like_states_for_reporting() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let properties = ["LoadState", "ActiveState", "SubState", "Result"];
+        let status = ExitStatus::from_raw(0);
+        for (active_state, normalized_state) in [
+            ("inactive", NormalizedUnitState::Inactive),
+            ("failed", NormalizedUnitState::Failed),
+            ("maintenance", NormalizedUnitState::Maintenance),
+        ] {
+            let stdout = format!(
+                "LoadState=loaded\nActiveState={active_state}\nSubState=dead\nResult=success\n"
+            );
+            let values = parse_systemctl_show_properties(
+                "vm0-runner-test.service",
+                &properties,
+                stdout.as_bytes(),
+            )
+            .unwrap();
+            let state = service_unit_state_from_systemctl_show(
+                "vm0-runner-test.service",
+                &properties,
+                &status,
+                &values,
+                b"",
+            )
+            .unwrap();
+
+            assert_eq!(state.normalized_state, normalized_state);
+            assert!(
+                !state.is_active_like(),
+                "{active_state} should not be active-like"
+            );
+        }
+    }
+
+    #[test]
     fn service_unit_state_preserves_empty_optional_fields() {
         use std::os::unix::process::ExitStatusExt;
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -358,6 +358,27 @@ mod tests {
     }
 
     #[test]
+    fn service_unit_state_command_is_registered() {
+        assert!(
+            Cli::try_parse_from([
+                "runner",
+                "service",
+                "unit-state",
+                "--name",
+                "v1.2.3",
+                "--name",
+                "v1.2.2",
+            ])
+            .is_ok(),
+            "service unit-state should accept one or more --name values"
+        );
+        assert!(
+            Cli::try_parse_from(["runner", "service", "unit-state"]).is_err(),
+            "service unit-state should require at least one --name"
+        );
+    }
+
+    #[test]
     fn old_gc_workspace_image_cache_command_is_removed() {
         assert!(
             Cli::try_parse_from(["runner", "gc-workspace-image-cache", "--dry-run"]).is_err(),


### PR DESCRIPTION
## Summary
- add `runner service unit-state` with stable JSON output for one or more runner service suffixes
- expose raw systemd fields plus runner-owned normalized state and `activeLike` for cleanup/liveness consumers
- keep existing `runner service status`, `wait-running`, and `is_unit_active` readiness semantics unchanged

The force-stop cleanup portion discussed in the issue is already covered on `main` by #20769, so this PR completes the remaining machine-readable unit-state layer.

Fixes #20744

## Tests
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::service`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `git diff --check`