### PR TITLE
refactor: remove bundled builtin firewall fallback

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -44,7 +44,7 @@ class BuiltinFirewallCatalogSnapshot:
     dependency_file_key: CatalogFileKey | None
     catalog: BuiltinFirewallCatalog | None
     cache_path: str | None = None
-    fallback_reason: str | None = None
+    unavailable_reason: str | None = None
 
 
 @dataclass
@@ -101,7 +101,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
         return BuiltinFirewallCatalogSnapshot(
             None,
             None,
-            fallback_reason="cache_path_missing",
+            unavailable_reason="cache_path_missing",
         )
 
     path = Path(cache_path)
@@ -116,7 +116,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
             None,
             None,
             cache_path=path_key,
-            fallback_reason=_open_error_fallback_reason(exc),
+            unavailable_reason=_open_error_unavailable_reason(exc),
         )
 
     try:
@@ -128,7 +128,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
                 key,
                 None,
                 cache_path=path_key,
-                fallback_reason=state.failed_reason or "cache_invalid",
+                unavailable_reason=state.failed_reason or "cache_invalid",
             )
         try:
             catalog = _read_catalog(fd, path, st.st_size, key)
@@ -142,7 +142,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
                 key,
                 None,
                 cache_path=path_key,
-                fallback_reason=state.failed_reason,
+                unavailable_reason=state.failed_reason,
             )
     finally:
         os.close(fd)
@@ -154,7 +154,7 @@ def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnaps
     return BuiltinFirewallCatalogSnapshot(key, catalog, cache_path=path_key)
 
 
-def _open_error_fallback_reason(exc: OSError) -> str:
+def _open_error_unavailable_reason(exc: OSError) -> str:
     if isinstance(exc, _CatalogCacheOpenError):
         return exc.reason
     if isinstance(exc, FileNotFoundError):

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -68,6 +68,11 @@ _cache_state = _CatalogCacheState()
 
 def reset_cache_for_tests() -> None:
     """Reset builtin firewall catalog cache state between tests."""
+    clear_cache()
+
+
+def clear_cache() -> None:
+    """Drop the in-process builtin firewall catalog cache."""
     _cache_state.reset()
 
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -392,7 +392,8 @@ def _mark_unavailable(
 ) -> RegistryUnavailable:
     if state.unavailable is None and state.snapshot.loaded_key is not None:
         evict_all_cache_keys()
-        state.builtin_firewall_core_cache.clear()
+    state.snapshot = _empty_snapshot()
+    state.builtin_firewall_core_cache.clear()
     state.unavailable = RegistryUnavailable(reason, message)
     return state.unavailable
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -392,6 +392,7 @@ def _mark_unavailable(
 ) -> RegistryUnavailable:
     if state.unavailable is None and state.snapshot.loaded_key is not None:
         evict_all_cache_keys()
+        state.builtin_firewall_core_cache.clear()
     state.unavailable = RegistryUnavailable(reason, message)
     return state.unavailable
 

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -393,6 +393,7 @@ def _mark_unavailable(
         evict_all_cache_keys()
     state.snapshot = _empty_snapshot()
     state.builtin_firewall_core_cache.clear()
+    registry_firewalls.clear_catalog_cache()
     state.unavailable = RegistryUnavailable(reason, message)
     return state.unavailable
 
@@ -486,6 +487,8 @@ def load_registry_state(registry_path: str) -> RegistryState:
         if uses_builtin_catalog_dependency
         else _NO_BUILTIN_FIREWALL_CATALOG_DEPENDENCY
     )
+    if not uses_builtin_catalog_dependency:
+        registry_firewalls.clear_catalog_cache()
     loaded_key = (
         path_key,
         st.st_dev,

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -81,9 +81,8 @@ class _RegistryCacheState:
     # compiled matcher sidecars are published together.
     snapshot: _RegistrySnapshot = field(default_factory=_empty_snapshot)
     unavailable: RegistryUnavailable | None = None
-    # Known-bad decoded registry input. Unlike the snapshot loaded key, this
-    # means the current snapshot belongs to an older file state and this key
-    # should short-circuit until the file changes again.
+    # Known-bad decoded registry input. This key should short-circuit until the
+    # file changes again, while enforcement continues to see RegistryUnavailable.
     failed_key: _RegistryCacheKey | None = None
     # Open/stat failures do not provide a key, so use a one-shot guard. Read
     # errors have a key but are retried on every call; track their last warning

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -446,6 +446,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
             state.unavailable = None
             state.stat_error_logged = False
             state.read_error_key = None
+            registry_firewalls.clear_catalog_cache()
             return state.snapshot
         if key == state.failed_key:
             return state.unavailable or _mark_unavailable(

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -58,7 +58,12 @@ class _ResolvedBuiltinFirewallEntry:
 
 def reset_cache_for_tests() -> None:
     """Reset builtin firewall resolver cache state between tests."""
-    builtin_firewall_cache.reset_cache_for_tests()
+    clear_catalog_cache()
+
+
+def clear_catalog_cache() -> None:
+    """Drop the cached builtin firewall catalog snapshot."""
+    builtin_firewall_cache.clear_cache()
 
 
 def catalog_file_key(

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -1,18 +1,14 @@
 """Registry VM firewall entry resolution."""
 
 import copy
-from contextlib import suppress
 from dataclasses import dataclass
-
-from mitmproxy import ctx
 
 import builtin_base_url
 import builtin_firewall_cache
 import builtin_host_policy
-from generated.builtin_firewalls import BUILTIN_FIREWALLS
 
 BuiltinFirewallCatalogFileKey = builtin_firewall_cache.CatalogFileKey
-BuiltinFirewallCatalogIdentity = builtin_firewall_cache.CatalogIdentity | tuple[str, str, str]
+BuiltinFirewallCatalogIdentity = builtin_firewall_cache.CatalogIdentity
 BuiltinFirewallCatalogSnapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot
 BuiltinFirewallCoreCacheKey = tuple[
     str,
@@ -60,22 +56,9 @@ class _ResolvedBuiltinFirewallEntry:
     cache_key: BuiltinFirewallCoreCacheKey
 
 
-_bundled_fallback_warnings: set[
-    tuple[
-        str,
-        str,
-        str | None,
-        BuiltinFirewallCatalogFileKey | None,
-        str | None,
-        str | None,
-    ]
-] = set()
-
-
 def reset_cache_for_tests() -> None:
     """Reset builtin firewall resolver cache state between tests."""
     builtin_firewall_cache.reset_cache_for_tests()
-    _bundled_fallback_warnings.clear()
 
 
 def catalog_file_key(
@@ -124,67 +107,26 @@ def _resolution_error(error: Exception) -> FirewallEntryResolutionError:
 def _catalog_source_for_name(
     raw_name: str,
     catalog_snapshot: BuiltinFirewallCatalogSnapshot,
-) -> tuple[dict | None, BuiltinFirewallCatalogIdentity]:
+) -> tuple[dict, BuiltinFirewallCatalogIdentity]:
     cached_catalog = catalog_snapshot.catalog
-    if cached_catalog is not None:
-        catalog_firewall = cached_catalog.firewalls.get(raw_name)
-        if catalog_firewall is not None:
-            return catalog_firewall, cached_catalog.identity
-        fallback_reason = "cache_missing_firewall"
-    else:
-        fallback_reason = catalog_snapshot.fallback_reason or "cache_unavailable"
-
-    catalog_firewall = BUILTIN_FIREWALLS.get(raw_name)
-    if catalog_firewall is not None:
-        _warn_bundled_fallback(
-            raw_name=raw_name,
-            reason=fallback_reason,
-            catalog_snapshot=catalog_snapshot,
+    if cached_catalog is None:
+        reason = catalog_snapshot.unavailable_reason or "cache_unavailable"
+        if catalog_snapshot.cache_path is None:
+            raise FirewallEntryResolutionError(
+                f'builtin firewall "{raw_name}" catalog cache unavailable: {reason}'
+            )
+        raise FirewallEntryResolutionError(
+            f'builtin firewall "{raw_name}" catalog cache unavailable: '
+            f"{reason} ({catalog_snapshot.cache_path})"
         )
-    return catalog_firewall, ("bundled", raw_name, str(id(catalog_firewall)))
-
-
-def _warn_bundled_fallback(
-    *,
-    raw_name: str,
-    reason: str,
-    catalog_snapshot: BuiltinFirewallCatalogSnapshot,
-) -> None:
-    cached_catalog = catalog_snapshot.catalog
-    catalog_digest = None
-    catalog_version = None
-    if cached_catalog is not None:
+    catalog_firewall = cached_catalog.firewalls.get(raw_name)
+    if catalog_firewall is None:
         _, catalog_digest, catalog_version, _ = cached_catalog.identity
-    warning_file_key = None if cached_catalog is not None else catalog_snapshot.dependency_file_key
-
-    warning_key = (
-        raw_name,
-        reason,
-        catalog_snapshot.cache_path,
-        warning_file_key,
-        catalog_digest,
-        catalog_version,
-    )
-    if warning_key in _bundled_fallback_warnings:
-        return
-    _bundled_fallback_warnings.add(warning_key)
-
-    fields = [
-        "Using bundled builtin firewall fallback",
-        f"reason={reason}",
-        f"firewall_name={raw_name}",
-    ]
-    if catalog_snapshot.cache_path is not None:
-        fields.append(f"cache_path={catalog_snapshot.cache_path}")
-    if catalog_digest is not None:
-        fields.append(f"catalog_digest={catalog_digest}")
-    if catalog_version is not None:
-        fields.append(f"catalog_version={catalog_version}")
-    if warning_file_key is not None:
-        fields.append(f"cache_file_key={warning_file_key!r}")
-
-    with suppress(Exception):
-        ctx.log.warn(" ".join(fields))
+        raise FirewallEntryResolutionError(
+            f'builtin firewall "{raw_name}" missing from catalog cache '
+            f"(catalog_digest={catalog_digest}, catalog_version={catalog_version})"
+        )
+    return catalog_firewall, cached_catalog.identity
 
 
 def _resolve_builtin_firewall_entry(
@@ -197,8 +139,6 @@ def _resolve_builtin_firewall_entry(
         raise FirewallEntryResolutionError("builtin firewall entry name must be a non-empty string")
 
     catalog_firewall, catalog_identity = _catalog_source_for_name(raw_name, catalog_snapshot)
-    if catalog_firewall is None:
-        raise FirewallEntryResolutionError(f'unknown builtin firewall "{raw_name}"')
 
     firewall, raw_apis = _copy_builtin_firewall_shell(
         firewall_name=raw_name,

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -3,14 +3,32 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import builtin_host_policy
 import registry
-import registry_firewalls
-from tests.registry_helpers import write_builtin_firewall_registry
+from tests.registry_helpers import (
+    write_builtin_firewall_registry as _write_builtin_firewall_registry,
+)
+
+_TEST_BUILTIN_FIREWALLS: dict[str, dict] = {}
+
+
+class _RegistryOptions:
+    def __init__(self) -> None:
+        self.vm0_builtin_firewall_catalog_cache_path = ""
+
+
+@pytest.fixture(autouse=True)
+def _registry_ctx(monkeypatch):
+    options = _RegistryOptions()
+    monkeypatch.setattr(registry.ctx, "options", options, raising=False)
+    monkeypatch.setattr(registry.ctx, "log", MagicMock(), raising=False)
+    _TEST_BUILTIN_FIREWALLS.clear()
 
 
 def install_test_builtin_firewall(
-    monkeypatch,
+    _monkeypatch=None,
     *,
     name: str,
     base: str,
@@ -19,43 +37,89 @@ def install_test_builtin_firewall(
     api = {
         "base": base,
         "auth": {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
-        "permissions": [],
+        "permissions": [{"name": "read", "rules": ["GET /items"]}],
     }
     if host_policy is not None:
         api["hostPolicy"] = host_policy
-    monkeypatch.setattr(
-        registry_firewalls,
-        "BUILTIN_FIREWALLS",
-        {
-            name: {
-                "name": name,
-                "apis": [api],
-            }
-        },
+    _TEST_BUILTIN_FIREWALLS[name] = {"name": name, "apis": [api]}
+
+
+def _cache_path_for_registry(path):
+    return path.with_name(f"{path.stem}-builtin-firewall-catalog-cache.json")
+
+
+def _write_catalog_cache(path, firewalls: dict[str, dict]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "catalogDigest": (
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                "catalogVersion": "catalog-test",
+                "updatedAt": "2026-07-07T00:00:00.000Z",
+                "firewalls": firewalls,
+            },
+            sort_keys=True,
+        )
     )
+
+
+def _builtin_firewall(name: str) -> dict:
+    base_by_name = {
+        "jira": "https://${{ vars.JIRA_DOMAIN }}",
+        "n8n": "${{ vars.N8N_BASE_URL }}/api/v1",
+        "shopify": "https://${{ vars.SHOPIFY_SHOP }}.myshopify.com/admin/api/2025-01",
+        "snowflake": "https://${{ vars.SNOWFLAKE_ACCOUNT }}.snowflakecomputing.com/api",
+        "strapi": "${{ vars.STRAPI_BASE_URL }}",
+        "zendesk": "https://${{ vars.ZENDESK_SUBDOMAIN }}.zendesk.com",
+    }
+    host_policy_by_name = {
+        "jira": {"kind": "providerOwned", "suffixes": ["atlassian.net"]},
+        "n8n": {"kind": "publicDestination"},
+        "shopify": {"kind": "providerOwned", "suffixes": ["myshopify.com"]},
+        "snowflake": {"kind": "providerOwned", "suffixes": ["snowflakecomputing.com"]},
+        "strapi": {"kind": "publicDestination"},
+    }
+    api = {
+        "base": base_by_name[name],
+        "auth": {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}},
+        "permissions": [{"name": "read", "rules": ["GET /items"]}],
+    }
+    host_policy = host_policy_by_name.get(name)
+    if host_policy is not None:
+        api["hostPolicy"] = host_policy
+    return {"name": name, "apis": [api]}
+
+
+def write_builtin_firewall_registry(
+    path,
+    *,
+    run_id: str,
+    name: str,
+    base_url_vars: dict[str, str],
+    cache_firewall: dict | None = None,
+) -> None:
+    _write_builtin_firewall_registry(
+        path,
+        run_id=run_id,
+        name=name,
+        base_url_vars=base_url_vars,
+    )
+    firewall = cache_firewall or _TEST_BUILTIN_FIREWALLS.get(name) or _builtin_firewall(name)
+    cache_path = _cache_path_for_registry(path)
+    _write_catalog_cache(cache_path, {firewall["name"]: firewall})
+    registry.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
 
 
 class TestRegistryBuiltinBaseUrlVars:
     def test_builtin_firewall_entry_resolves_dynamic_base_url_vars(self, tmp_path):
         path = tmp_path / "registry.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "vms": {
-                        "10.200.0.1": {
-                            "runId": "run-zendesk",
-                            "firewalls": [
-                                {
-                                    "kind": "builtin",
-                                    "name": "zendesk",
-                                    "baseUrlVars": {"ZENDESK_SUBDOMAIN": "acme"},
-                                }
-                            ],
-                        }
-                    },
-                    "updatedAt": 0,
-                }
-            )
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-zendesk",
+            name="zendesk",
+            base_url_vars={"ZENDESK_SUBDOMAIN": "acme"},
         )
 
         context = registry.get_vm_context("10.200.0.1", str(path))
@@ -216,7 +280,7 @@ class TestRegistryBuiltinBaseUrlVars:
         assert not isinstance(state, registry.RegistryUnavailable)
         invalid_vm = state.invalid_vms["10.200.0.1"]
         assert invalid_vm.reason == "invalid_firewalls"
-        assert "resolved base URL is invalid" in invalid_vm.message
+        assert "catalog cache unavailable: cache_invalid" in invalid_vm.message
 
     def test_builtin_provider_owned_accepts_percent_encoded_idna_host(self, tmp_path, monkeypatch):
         install_test_builtin_firewall(
@@ -265,7 +329,7 @@ class TestRegistryBuiltinBaseUrlVars:
         assert not isinstance(state, registry.RegistryUnavailable)
         invalid_vm = state.invalid_vms["10.200.0.1"]
         assert invalid_vm.reason == "invalid_firewalls"
-        assert "resolved base URL is invalid" in invalid_vm.message
+        assert "catalog cache unavailable: cache_invalid" in invalid_vm.message
 
     def test_builtin_public_destination_rejects_empty_port_authority(self, tmp_path, monkeypatch):
         install_test_builtin_firewall(
@@ -290,7 +354,7 @@ class TestRegistryBuiltinBaseUrlVars:
         assert not isinstance(state, registry.RegistryUnavailable)
         invalid_vm = state.invalid_vms["10.200.0.1"]
         assert invalid_vm.reason == "invalid_firewalls"
-        assert "resolved base URL is invalid" in invalid_vm.message
+        assert "catalog cache unavailable: cache_invalid" in invalid_vm.message
 
     def test_builtin_public_destination_rejects_wildcard_hosts(self, tmp_path):
         for index, value in enumerate(("https://*.example.com", "https://%2a.example.com")):
@@ -406,7 +470,7 @@ class TestRegistryBuiltinBaseUrlVars:
                 "hostPolicy has unsupported keys: extra",
             ),
         ]
-        for index, (host_policy, message) in enumerate(cases):
+        for index, (host_policy, _message) in enumerate(cases):
             name = f"provider-owned-invalid-{index}"
             install_test_builtin_firewall(
                 monkeypatch,
@@ -430,7 +494,7 @@ class TestRegistryBuiltinBaseUrlVars:
             assert not isinstance(state, registry.RegistryUnavailable)
             invalid_vm = state.invalid_vms["10.200.0.1"]
             assert invalid_vm.reason == "invalid_firewalls"
-            assert message in invalid_vm.message
+            assert "catalog cache unavailable: cache_invalid" in invalid_vm.message
 
     def test_builtin_provider_owned_whole_authority_rejects_non_default_port(
         self, tmp_path, monkeypatch
@@ -1047,26 +1111,11 @@ class TestRegistryBuiltinBaseUrlVars:
 
     def test_credentialed_builtin_firewall_entry_rejects_http_dynamic_base(self, tmp_path):
         path = tmp_path / "registry.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "vms": {
-                        "10.200.0.1": {
-                            "runId": "run-strapi",
-                            "firewalls": [
-                                {
-                                    "kind": "builtin",
-                                    "name": "strapi",
-                                    "baseUrlVars": {
-                                        "STRAPI_BASE_URL": "http://strapi.example.test"
-                                    },
-                                }
-                            ],
-                        }
-                    },
-                    "updatedAt": 0,
-                }
-            )
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-strapi",
+            name="strapi",
+            base_url_vars={"STRAPI_BASE_URL": "http://strapi.example.test"},
         )
 
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
@@ -1081,26 +1130,11 @@ class TestRegistryBuiltinBaseUrlVars:
 
     def test_credentialed_builtin_firewall_entry_accepts_https_dynamic_base(self, tmp_path):
         path = tmp_path / "registry.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "vms": {
-                        "10.200.0.1": {
-                            "runId": "run-strapi",
-                            "firewalls": [
-                                {
-                                    "kind": "builtin",
-                                    "name": "strapi",
-                                    "baseUrlVars": {
-                                        "STRAPI_BASE_URL": "https://strapi.example.test"
-                                    },
-                                }
-                            ],
-                        }
-                    },
-                    "updatedAt": 0,
-                }
-            )
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-strapi",
+            name="strapi",
+            base_url_vars={"STRAPI_BASE_URL": "https://strapi.example.test"},
         )
 
         context = registry.get_vm_context("10.200.0.1", str(path))
@@ -1112,18 +1146,11 @@ class TestRegistryBuiltinBaseUrlVars:
 
     def test_builtin_firewall_entry_missing_dynamic_var_rejects_vm(self, tmp_path):
         path = tmp_path / "registry.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "vms": {
-                        "10.200.0.1": {
-                            "runId": "run-zendesk",
-                            "firewalls": [{"kind": "builtin", "name": "zendesk"}],
-                        }
-                    },
-                    "updatedAt": 0,
-                }
-            )
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-zendesk",
+            name="zendesk",
+            base_url_vars={},
         )
 
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
@@ -1151,6 +1178,9 @@ class TestRegistryBuiltinBaseUrlVars:
                 }
             )
         )
+        cache_path = _cache_path_for_registry(path)
+        _write_catalog_cache(cache_path, {"zendesk": _builtin_firewall("zendesk")})
+        registry.ctx.options.vm0_builtin_firewall_catalog_cache_path = str(cache_path)
 
         with patch.object(registry.ctx, "log", MagicMock(), create=True):
             context = registry.get_vm_context("10.200.0.1", str(path))
@@ -1163,18 +1193,12 @@ class TestRegistryBuiltinBaseUrlVars:
 
     def test_unknown_builtin_firewall_entry_rejects_vm(self, tmp_path):
         path = tmp_path / "registry.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "vms": {
-                        "10.200.0.1": {
-                            "runId": "run-missing",
-                            "firewalls": [{"kind": "builtin", "name": "missing-firewall"}],
-                        }
-                    },
-                    "updatedAt": 0,
-                }
-            )
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-missing",
+            name="missing-firewall",
+            base_url_vars={},
+            cache_firewall=_builtin_firewall("zendesk"),
         )
 
         with patch.object(registry.ctx, "log", MagicMock(), create=True):

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -28,7 +28,6 @@ def _registry_ctx(monkeypatch):
 
 
 def install_test_builtin_firewall(
-    _monkeypatch=None,
     *,
     name: str,
     base: str,
@@ -255,11 +254,8 @@ class TestRegistryBuiltinBaseUrlVars:
             assert compiled_firewalls is not None
             assert vm_info["firewalls"][0]["apis"][0]["base"] == f"https://{host}"
 
-    def test_builtin_provider_owned_rejects_unsafe_idna_compatibility_host(
-        self, tmp_path, monkeypatch
-    ):
+    def test_builtin_provider_owned_rejects_unsafe_idna_compatibility_host(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="unsafe-provider-host",
             base="https://fa\u212a.example.com",
             host_policy={"kind": "providerOwned", "suffixes": ["example.com"]},
@@ -282,9 +278,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert "catalog cache unavailable: cache_invalid" in invalid_vm.message
 
-    def test_builtin_provider_owned_accepts_percent_encoded_idna_host(self, tmp_path, monkeypatch):
+    def test_builtin_provider_owned_accepts_percent_encoded_idna_host(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="encoded-provider-host",
             base="https://${{ vars.API_HOST }}",
             host_policy={"kind": "providerOwned", "suffixes": ["example.com"]},
@@ -304,11 +299,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == ("https://b%C3%BCcher.example.com")
 
-    def test_builtin_public_destination_rejects_unsafe_idna_compatibility_host(
-        self, tmp_path, monkeypatch
-    ):
+    def test_builtin_public_destination_rejects_unsafe_idna_compatibility_host(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="unsafe-public-host",
             base="https://fa\u212a.example.com",
             host_policy={"kind": "publicDestination"},
@@ -331,9 +323,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert "catalog cache unavailable: cache_invalid" in invalid_vm.message
 
-    def test_builtin_public_destination_rejects_empty_port_authority(self, tmp_path, monkeypatch):
+    def test_builtin_public_destination_rejects_empty_port_authority(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="empty-port-public-host",
             base="https://example.com:",
             host_policy={"kind": "publicDestination"},
@@ -423,7 +414,7 @@ class TestRegistryBuiltinBaseUrlVars:
             assert invalid_vm.reason == "invalid_firewalls"
             assert "host policy does not allow resolved host" in invalid_vm.message
 
-    def test_builtin_rejects_invalid_host_policies(self, tmp_path, monkeypatch):
+    def test_builtin_rejects_invalid_host_policies(self, tmp_path):
         cases = [
             (
                 {"kind": "providerOwned", "exactHosts": [".api.example.com"]},
@@ -473,7 +464,6 @@ class TestRegistryBuiltinBaseUrlVars:
         for index, (host_policy, _message) in enumerate(cases):
             name = f"provider-owned-invalid-{index}"
             install_test_builtin_firewall(
-                monkeypatch,
                 name=name,
                 base="https://${{ vars.API_HOST }}",
                 host_policy=host_policy,
@@ -496,11 +486,8 @@ class TestRegistryBuiltinBaseUrlVars:
             assert invalid_vm.reason == "invalid_firewalls"
             assert "catalog cache unavailable: cache_invalid" in invalid_vm.message
 
-    def test_builtin_provider_owned_whole_authority_rejects_non_default_port(
-        self, tmp_path, monkeypatch
-    ):
+    def test_builtin_provider_owned_whole_authority_rejects_non_default_port(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="provider-owned-port",
             base="https://${{ vars.API_HOST }}:444/v1",
             host_policy={"kind": "providerOwned", "suffixes": ["example.com"]},
@@ -823,9 +810,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "N8N_BASE_URL"' in invalid_vm.message
 
-    def test_builtin_path_segment_var_accepts_fixed_suffix(self, tmp_path, monkeypatch):
+    def test_builtin_path_segment_var_accepts_fixed_suffix(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="tenant-path",
             base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
         )
@@ -846,9 +832,8 @@ class TestRegistryBuiltinBaseUrlVars:
             "https://api.example.test/accounts/acme:prod/v1"
         )
 
-    def test_builtin_path_segment_var_rejects_path_injection(self, tmp_path, monkeypatch):
+    def test_builtin_path_segment_var_rejects_path_injection(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="tenant-path",
             base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
         )
@@ -870,9 +855,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "TENANT"' in invalid_vm.message
 
-    def test_builtin_path_segment_var_rejects_encoded_path_separator(self, tmp_path, monkeypatch):
+    def test_builtin_path_segment_var_rejects_encoded_path_separator(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="tenant-path",
             base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
         )
@@ -894,9 +878,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "TENANT"' in invalid_vm.message
 
-    def test_builtin_path_segment_var_rejects_dot_segment(self, tmp_path, monkeypatch):
+    def test_builtin_path_segment_var_rejects_dot_segment(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="tenant-path",
             base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
         )
@@ -918,11 +901,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "TENANT"' in invalid_vm.message
 
-    def test_builtin_path_segment_var_rejects_path_parameter_dot_segment(
-        self, tmp_path, monkeypatch
-    ):
+    def test_builtin_path_segment_var_rejects_path_parameter_dot_segment(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="tenant-path",
             base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
         )
@@ -944,11 +924,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "TENANT"' in invalid_vm.message
 
-    def test_builtin_path_segment_var_rejects_nested_encoded_dot_segment(
-        self, tmp_path, monkeypatch
-    ):
+    def test_builtin_path_segment_var_rejects_nested_encoded_dot_segment(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="tenant-path",
             base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
         )
@@ -970,11 +947,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "TENANT"' in invalid_vm.message
 
-    def test_builtin_path_segment_var_rejects_compatibility_dot_segment(
-        self, tmp_path, monkeypatch
-    ):
+    def test_builtin_path_segment_var_rejects_compatibility_dot_segment(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="tenant-path",
             base="https://api.example.test/accounts/${{ vars.TENANT }}/v1",
         )
@@ -996,9 +970,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'base URL variable "TENANT"' in invalid_vm.message
 
-    def test_builtin_path_var_allows_dot_outside_dot_segment(self, tmp_path, monkeypatch):
+    def test_builtin_path_var_allows_dot_outside_dot_segment(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="path-fragment",
             base="https://api.example.test/v${{ vars.VERSION }}",
         )
@@ -1017,9 +990,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == ("https://api.example.test/v%2e1")
 
-    def test_builtin_path_vars_reject_combined_dot_segment(self, tmp_path, monkeypatch):
+    def test_builtin_path_vars_reject_combined_dot_segment(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="multi-path-segment",
             base="https://api.example.test/accounts/${{ vars.A }}${{ vars.B }}/v1",
         )
@@ -1041,9 +1013,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert "resolved base URL has unsafe path segments" in invalid_vm.message
 
-    def test_builtin_path_vars_accept_combined_safe_segment(self, tmp_path, monkeypatch):
+    def test_builtin_path_vars_accept_combined_safe_segment(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="multi-path-segment",
             base="https://api.example.test/accounts/${{ vars.A }}${{ vars.B }}/v1",
         )
@@ -1064,9 +1035,8 @@ class TestRegistryBuiltinBaseUrlVars:
             "https://api.example.test/accounts/v1/v1"
         )
 
-    def test_builtin_port_var_accepts_numeric_port(self, tmp_path, monkeypatch):
+    def test_builtin_port_var_accepts_numeric_port(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="port-api",
             base="https://api.example.test:${{ vars.API_PORT }}/v1",
         )
@@ -1085,9 +1055,8 @@ class TestRegistryBuiltinBaseUrlVars:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == ("https://api.example.test:8443/v1")
 
-    def test_builtin_port_var_rejects_non_numeric_port(self, tmp_path, monkeypatch):
+    def test_builtin_port_var_rejects_non_numeric_port(self, tmp_path):
         install_test_builtin_firewall(
-            monkeypatch,
             name="port-api",
             base="https://api.example.test:${{ vars.API_PORT }}/v1",
         )

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -1124,6 +1124,7 @@ class TestRegistryBuiltinCache:
             context = registry.get_vm_context("10.200.0.1", str(path))
             assert context is not None
             assert len(registry._registry_state.builtin_firewall_core_cache) == 1
+            assert builtin_firewall_cache._cache_state.catalog is not None
 
             path.write_text("{ broken")
             unavailable = registry.load_registry_state(str(path))
@@ -1131,6 +1132,36 @@ class TestRegistryBuiltinCache:
         assert isinstance(unavailable, registry.RegistryUnavailable)
         assert unavailable.reason == "parse_failed"
         assert registry._registry_state.builtin_firewall_core_cache == {}
+        assert builtin_firewall_cache._cache_state.catalog is None
+
+    def test_builtin_catalog_cache_is_cleared_when_registry_drops_builtin_entries(
+        self, tmp_path, mitm_ctx
+    ):
+        path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"cache-a": _cache_firewall("cache-a", "https://api-a.example.com")},
+        )
+        write_multi_vm_registry(path, {"10.200.0.1": builtin_vm("run-cache-a", "cache-a")})
+        os.utime(path, ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000))
+
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            assert context is not None
+            assert builtin_firewall_cache._cache_state.catalog is not None
+
+            write_multi_vm_registry(path, {"10.200.0.1": inline_vm("run-inline")})
+            os.utime(path, ns=(1_700_000_000_000_000_001, 1_700_000_000_000_000_001))
+            inline_context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert inline_context is not None
+        assert builtin_firewall_cache._cache_state.catalog is None
 
     def test_inline_firewalls_do_not_share_compiled_core(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -1163,6 +1163,34 @@ class TestRegistryBuiltinCache:
         assert inline_context is not None
         assert builtin_firewall_cache._cache_state.catalog is None
 
+    def test_no_builtin_registry_fast_path_clears_catalog_cache(self, tmp_path, mitm_ctx):
+        path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"cache-a": _cache_firewall("cache-a", "https://api-a.example.com")},
+        )
+        write_multi_vm_registry(path, {"10.200.0.1": inline_vm("run-inline")})
+
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            first_context = registry.get_vm_context("10.200.0.1", str(path))
+            assert first_context is not None
+            assert builtin_firewall_cache._cache_state.catalog is None
+
+            snapshot = registry_firewalls.load_catalog_snapshot(str(cache_path))
+            assert snapshot.catalog is not None
+            assert builtin_firewall_cache._cache_state.catalog is not None
+
+            second_context = registry.get_vm_context("10.200.0.1", str(path))
+
+        assert second_context is not None
+        assert builtin_firewall_cache._cache_state.catalog is None
+
     def test_inline_firewalls_do_not_share_compiled_core(self, tmp_path):
         path = tmp_path / "registry.json"
         write_multi_vm_registry(

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -43,6 +43,32 @@ def _cache_firewall(name: str, base: str, *, rules: list[str] | None = None) -> 
     }
 
 
+def _github_cache_firewall() -> dict:
+    return {
+        "name": "github",
+        "apis": [
+            {
+                "base": "https://api.github.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "read", "rules": ["GET /repos/{owner}/{repo}"]}],
+            }
+        ],
+    }
+
+
+def _zendesk_cache_firewall() -> dict:
+    return {
+        "name": "zendesk",
+        "apis": [
+            {
+                "base": "https://${{ vars.ZENDESK_SUBDOMAIN }}.zendesk.com",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "read", "rules": ["GET /api/v2/tickets"]}],
+            }
+        ],
+    }
+
+
 def _write_catalog_cache(
     path,
     *,
@@ -64,6 +90,26 @@ def _write_catalog_cache(
     )
 
 
+def _write_registry_with_cache(
+    tmp_path,
+    vms: dict,
+    firewalls: dict[str, dict],
+    *,
+    digest: str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    version: str = "catalog-a",
+):
+    registry_path = tmp_path / "registry.json"
+    cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+    write_multi_vm_registry(registry_path, vms)
+    _write_catalog_cache(
+        cache_path,
+        digest=digest,
+        version=version,
+        firewalls=firewalls,
+    )
+    return registry_path, cache_path
+
+
 def _catalog_snapshot(
     *,
     digest_char: str,
@@ -81,32 +127,37 @@ def _catalog_snapshot(
     )
 
 
-def _assert_cache_firewall_falls_back_to_bundled(
+def _assert_invalid_builtin_vm(
+    *,
+    registry_path,
+    cache_path,
+    mitm_ctx,
+    expected_message: str,
+) -> None:
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_catalog_cache_path=str(cache_path),
+    ):
+        context = registry.get_vm_context("10.200.0.1", str(registry_path))
+        state = registry.load_registry_state(str(registry_path))
+
+    assert context is None
+    assert not isinstance(state, registry.RegistryUnavailable)
+    invalid_vm = state.invalid_vms["10.200.0.1"]
+    assert invalid_vm.reason == "invalid_firewalls"
+    assert expected_message in invalid_vm.message
+
+
+def _assert_cache_firewall_is_invalid(
     tmp_path,
-    monkeypatch,
     mitm_ctx,
     firewall: dict,
     *,
+    expected_message: str = "catalog cache unavailable: cache_invalid",
     cache_mode: int | None = None,
 ) -> None:
     registry_path = tmp_path / "registry.json"
     cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-    monkeypatch.setattr(
-        registry_firewalls,
-        "BUILTIN_FIREWALLS",
-        {
-            "fallback": {
-                "name": "fallback",
-                "apis": [
-                    {
-                        "base": "https://bundled.example.com",
-                        "auth": {"headers": {}},
-                        "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                    }
-                ],
-            }
-        },
-    )
     _write_catalog_cache(
         cache_path,
         digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -120,19 +171,18 @@ def _assert_cache_firewall_falls_back_to_bundled(
         {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
     )
 
-    with mitm_ctx(
-        registry_path=str(registry_path),
-        builtin_firewall_catalog_cache_path=str(cache_path),
-    ):
-        context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-    assert context is not None
-    vm_info, compiled_firewalls, _ = context
-    assert compiled_firewalls is not None
-    assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
+    _assert_invalid_builtin_vm(
+        registry_path=registry_path,
+        cache_path=cache_path,
+        mitm_ctx=mitm_ctx,
+        expected_message=expected_message,
+    )
 
 
 class TestRegistryBuiltinCache:
+    def test_registry_firewalls_does_not_expose_runtime_bundled_catalog(self):
+        assert not hasattr(registry_firewalls, "BUILTIN_FIREWALLS")
+
     def test_resolved_firewall_entries_enforces_cache_key_alignment(self):
         inline_firewall = {"name": "inline", "apis": []}
 
@@ -147,23 +197,18 @@ class TestRegistryBuiltinCache:
         with pytest.raises(ValueError, match="align with resolved firewalls"):
             registry_firewalls.ResolvedFirewallEntries([inline_firewall], ())
 
-    def test_builtin_firewall_entry_resolves_from_catalog(self, tmp_path):
-        path = tmp_path / "registry.json"
-        path.write_text(
-            json.dumps(
-                {
-                    "vms": {
-                        "10.200.0.1": {
-                            "runId": "run-github",
-                            "firewalls": [{"kind": "builtin", "name": "github"}],
-                        }
-                    },
-                    "updatedAt": 0,
-                }
-            )
+    def test_builtin_firewall_entry_resolves_from_catalog_cache(self, tmp_path, mitm_ctx):
+        registry_path, cache_path = _write_registry_with_cache(
+            tmp_path,
+            {"10.200.0.1": builtin_vm("run-github", "github")},
+            {"github": _github_cache_firewall()},
         )
 
-        context = registry.get_vm_context("10.200.0.1", str(path))
+        with mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            context = registry.get_vm_context("10.200.0.1", str(registry_path))
 
         assert context is not None
         vm_info, compiled_firewalls, _ = context
@@ -253,22 +298,6 @@ class TestRegistryBuiltinCache:
                 )
             },
         )
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "racy-cache": {
-                    "name": "racy-cache",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         original_catalog_file_key = registry_firewalls.catalog_file_key
         calls = 0
 
@@ -294,36 +323,22 @@ class TestRegistryBuiltinCache:
             cache_path.unlink()
 
             context = registry.get_vm_context("10.200.0.1", str(registry_path))
+            state = registry.load_registry_state(str(registry_path))
 
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert state.invalid_vms["10.200.0.1"].reason == "invalid_firewalls"
+        assert (
+            "catalog cache unavailable: cache_file_missing"
+            in state.invalid_vms["10.200.0.1"].message
+        )
 
-    def test_builtin_registry_reload_when_catalog_cache_appears(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_builtin_registry_reload_when_catalog_cache_appears(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
         write_multi_vm_registry(
             registry_path,
             {"10.200.0.1": builtin_vm("run-late-cache", "late-cache")},
-        )
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "late-cache": {
-                    "name": "late-cache",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
         )
 
         with mitm_ctx(
@@ -344,22 +359,15 @@ class TestRegistryBuiltinCache:
             )
             second_context = registry.get_vm_context("10.200.0.1", str(registry_path))
 
-        assert first_context is not None
+        assert first_context is None
         assert second_context is not None
-        first_vm_info, first_compiled, _ = first_context
         second_vm_info, second_compiled, _ = second_context
-        assert first_compiled is not None
         assert second_compiled is not None
-        assert first_vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
         assert second_vm_info["firewalls"][0]["apis"][0]["base"] == "https://cache.example.com"
-        assert _first_firewall_core(first_compiled) is not _first_firewall_core(second_compiled)
 
-    def test_unknown_builtin_registry_reload_when_catalog_cache_appears(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_unknown_builtin_registry_reload_when_catalog_cache_appears(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(registry_firewalls, "BUILTIN_FIREWALLS", {})
         write_multi_vm_registry(
             registry_path,
             {"10.200.0.1": builtin_vm("run-cache-only", "cache-only")},
@@ -392,68 +400,26 @@ class TestRegistryBuiltinCache:
         assert second_compiled is not None
         assert second_vm_info["firewalls"][0]["apis"][0]["base"] == "https://cache.example.com"
 
-    def test_missing_runner_catalog_cache_logs_bundled_fallback_once(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_missing_runner_catalog_cache_fails_closed(self, tmp_path):
         cache_path = tmp_path / "missing-builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         snapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
             dependency_file_key=None,
             catalog=None,
             cache_path=str(cache_path),
-            fallback_reason="cache_file_missing",
+            unavailable_reason="cache_file_missing",
         )
 
-        with mitm_ctx() as log:
-            for _ in range(2):
-                resolved = registry_firewalls.resolve_firewall_entries(
-                    builtin_vm("run-fallback", "fallback"),
-                    builtin_firewall_catalog_snapshot=snapshot,
-                )
-                assert resolved.firewalls is not None
-                assert resolved.firewalls[0]["apis"][0]["base"] == "https://bundled.example.com"
+        with pytest.raises(
+            registry_firewalls.FirewallEntryResolutionError,
+            match='builtin firewall "fallback" catalog cache unavailable: '
+            f"cache_file_missing \\({cache_path}\\)",
+        ):
+            registry_firewalls.resolve_firewall_entries(
+                builtin_vm("run-fallback", "fallback"),
+                builtin_firewall_catalog_snapshot=snapshot,
+            )
 
-        log.warn.assert_called_once()
-        warning = log.warn.call_args.args[0]
-        assert "Using bundled builtin firewall fallback" in warning
-        assert "reason=cache_file_missing" in warning
-        assert "firewall_name=fallback" in warning
-        assert f"cache_path={cache_path}" in warning
-
-    def test_runner_catalog_cache_missing_firewall_logs_bundled_fallback(
-        self, monkeypatch, mitm_ctx
-    ):
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
+    def test_runner_catalog_cache_missing_firewall_fails_closed(self):
         snapshot = _catalog_snapshot(
             digest_char="a",
             version="catalog-a",
@@ -468,27 +434,18 @@ class TestRegistryBuiltinCache:
             dependency_file_key=("catalog-cache/catalog-a.json", 1, 2, 3, 4),
             catalog=snapshot.catalog,
         )
+        expected_digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-        with mitm_ctx() as log:
-            for current_snapshot in (snapshot, rewritten_snapshot):
-                resolved = registry_firewalls.resolve_firewall_entries(
+        for current_snapshot in (snapshot, rewritten_snapshot):
+            with pytest.raises(
+                registry_firewalls.FirewallEntryResolutionError,
+                match='builtin firewall "fallback" missing from catalog cache '
+                rf"\(catalog_digest={expected_digest}, catalog_version=catalog-a\)",
+            ):
+                registry_firewalls.resolve_firewall_entries(
                     builtin_vm("run-fallback", "fallback"),
                     builtin_firewall_catalog_snapshot=current_snapshot,
                 )
-                assert resolved.firewalls is not None
-                assert resolved.firewalls[0]["apis"][0]["base"] == "https://bundled.example.com"
-
-        log.warn.assert_called_once()
-        warning = log.warn.call_args.args[0]
-        assert "Using bundled builtin firewall fallback" in warning
-        assert "reason=cache_missing_firewall" in warning
-        assert "firewall_name=fallback" in warning
-        assert (
-            "catalog_digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            in warning
-        )
-        assert "catalog_version=catalog-a" in warning
-        assert "cache_file_key=" not in warning
 
     def test_registry_reload_pins_one_catalog_snapshot_for_builtin_entries(
         self, tmp_path, monkeypatch, mitm_ctx
@@ -507,7 +464,6 @@ class TestRegistryBuiltinCache:
                 }
             },
         )
-        monkeypatch.setattr(registry_firewalls, "BUILTIN_FIREWALLS", {})
         snapshots = [
             _catalog_snapshot(
                 digest_char="a",
@@ -595,65 +551,25 @@ class TestRegistryBuiltinCache:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.example.com"
 
-    def test_malformed_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_malformed_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
         cache_path.write_text('{"schemaVersion":1}')
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         write_multi_vm_registry(
             registry_path,
             {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
         )
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+        _assert_invalid_builtin_vm(
+            registry_path=registry_path,
+            cache_path=cache_path,
+            mitm_ctx=mitm_ctx,
+            expected_message="catalog cache unavailable: cache_invalid",
+        )
 
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_empty_api_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_empty_api_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         _write_catalog_cache(
             cache_path,
             digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -665,289 +581,64 @@ class TestRegistryBuiltinCache:
             {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
         )
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_malformed_static_base_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
-        registry_path = tmp_path / "registry.json"
-        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
+        _assert_invalid_builtin_vm(
+            registry_path=registry_path,
+            cache_path=cache_path,
+            mitm_ctx=mitm_ctx,
+            expected_message="catalog cache unavailable: cache_invalid",
         )
+
+    def test_malformed_static_base_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["base"] = "not-a-url"
-        _write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": firewall},
-        )
-        write_multi_vm_registry(
-            registry_path,
-            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_malformed_parameterized_base_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
+    def test_malformed_parameterized_base_runner_catalog_cache_fails_closed(
+        self, tmp_path, mitm_ctx
     ):
-        registry_path = tmp_path / "registry.json"
-        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["base"] = "https://api.{tenant+}.example.com"
-        _write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": firewall},
-        )
-        write_multi_vm_registry(
-            registry_path,
-            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_malformed_template_base_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
-        registry_path = tmp_path / "registry.json"
-        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
+    def test_malformed_template_base_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["base"] = "https://${{ secrets.TENANT }}.example.com"
-        _write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": firewall},
-        )
-        write_multi_vm_registry(
-            registry_path,
-            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_malformed_template_parameter_base_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
+    def test_malformed_template_parameter_base_runner_catalog_cache_fails_closed(
+        self, tmp_path, mitm_ctx
     ):
-        registry_path = tmp_path / "registry.json"
-        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["base"] = "https://${{ vars.TENANT }}.{tenant+}.example.com"
-        _write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": firewall},
-        )
-        write_multi_vm_registry(
-            registry_path,
-            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_non_ascii_template_variable_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
+    def test_non_ascii_template_variable_runner_catalog_cache_fails_closed(
+        self, tmp_path, mitm_ctx
     ):
-        registry_path = tmp_path / "registry.json"
-        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["base"] = "https://${{ vars.\u00e9 }}.example.com"
-        _write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": firewall},
-        )
-        write_multi_vm_registry(
-            registry_path,
-            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_malformed_auth_base_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_malformed_auth_base_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["auth"] = {"base": "http://auth.example.com"}
 
-        _assert_cache_firewall_falls_back_to_bundled(
-            tmp_path,
-            monkeypatch,
-            mitm_ctx,
-            firewall,
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-    def test_world_writable_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_world_writable_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
 
-        _assert_cache_firewall_falls_back_to_bundled(
+        _assert_cache_firewall_is_invalid(
             tmp_path,
-            monkeypatch,
             mitm_ctx,
             firewall,
+            expected_message="catalog cache unavailable: cache_untrusted",
             cache_mode=0o666,
         )
 
-    def test_world_writable_runner_catalog_cache_logs_untrusted_fallback(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_world_writable_runner_catalog_cache_reports_untrusted(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
         _write_catalog_cache(
             cache_path,
             digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -960,141 +651,39 @@ class TestRegistryBuiltinCache:
             {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
         )
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ) as log:
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+        _assert_invalid_builtin_vm(
+            registry_path=registry_path,
+            cache_path=cache_path,
+            mitm_ctx=mitm_ctx,
+            expected_message="catalog cache unavailable: cache_untrusted",
+        )
 
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-        log.warn.assert_called_once()
-        warning = log.warn.call_args.args[0]
-        assert "Using bundled builtin firewall fallback" in warning
-        assert "reason=cache_untrusted" in warning
-        assert "firewall_name=fallback" in warning
-        assert f"cache_path={cache_path}" in warning
-
-    def test_malformed_aws_sigv4_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_malformed_aws_sigv4_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         del firewall["apis"][0]["auth"]["awsSigv4"]["secretAccessKey"]
 
-        _assert_cache_firewall_falls_back_to_bundled(
-            tmp_path,
-            monkeypatch,
-            mitm_ctx,
-            firewall,
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-    def test_malformed_host_policy_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
+    def test_malformed_host_policy_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["hostPolicy"] = {
             "kind": "providerOwned",
             "exactHosts": ["127.0.0.1"],
         }
 
-        _assert_cache_firewall_falls_back_to_bundled(
-            tmp_path,
-            monkeypatch,
-            mitm_ctx,
-            firewall,
-        )
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-    def test_malformed_permission_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
-        registry_path = tmp_path / "registry.json"
-        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
+    def test_malformed_permission_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["permissions"][0]["rules"] = []
-        _write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": firewall},
-        )
-        write_multi_vm_registry(
-            registry_path,
-            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
-        )
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
-
-    def test_malformed_rule_runner_catalog_cache_falls_back_to_bundled(
-        self, tmp_path, monkeypatch, mitm_ctx
-    ):
-        registry_path = tmp_path / "registry.json"
-        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
-                "fallback": {
-                    "name": "fallback",
-                    "apis": [
-                        {
-                            "base": "https://bundled.example.com",
-                            "auth": {"headers": {}},
-                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
-                        }
-                    ],
-                }
-            },
-        )
+    def test_malformed_rule_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         firewall = _cache_firewall("fallback", "https://cache.example.com")
         firewall["apis"][0]["permissions"][0]["rules"] = ["GET /items/{path+}/tail"]
-        _write_catalog_cache(
-            cache_path,
-            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            version="catalog-a",
-            firewalls={"fallback": firewall},
-        )
-        write_multi_vm_registry(
-            registry_path,
-            {"10.200.0.1": builtin_vm("run-fallback", "fallback")},
-        )
 
-        with mitm_ctx(
-            registry_path=str(registry_path),
-            builtin_firewall_catalog_cache_path=str(cache_path),
-        ):
-            context = registry.get_vm_context("10.200.0.1", str(registry_path))
-
-        assert context is not None
-        vm_info, compiled_firewalls, _ = context
-        assert compiled_firewalls is not None
-        assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://bundled.example.com"
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
     def test_runner_catalog_cache_change_invalidates_registry_snapshot(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
@@ -1214,18 +803,24 @@ class TestRegistryBuiltinCache:
         assert isinstance(second_result, matching.FirewallBlock)
         assert second_result.reason == "unknown_endpoint"
 
-    def test_repeated_builtin_firewall_refs_share_core_but_keep_vm_api_ids(self, tmp_path):
-        path = tmp_path / "registry.json"
-        write_multi_vm_registry(
-            path,
+    def test_repeated_builtin_firewall_refs_share_core_but_keep_vm_api_ids(
+        self, tmp_path, mitm_ctx
+    ):
+        path, cache_path = _write_registry_with_cache(
+            tmp_path,
             {
                 "10.200.0.1": builtin_vm("run-github-a", "github"),
                 "10.200.0.2": builtin_vm("run-github-b", "github"),
             },
+            {"github": _github_cache_firewall()},
         )
 
-        first_context = registry.get_vm_context("10.200.0.1", str(path))
-        second_context = registry.get_vm_context("10.200.0.2", str(path))
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            first_context = registry.get_vm_context("10.200.0.1", str(path))
+            second_context = registry.get_vm_context("10.200.0.2", str(path))
 
         assert first_context is not None
         assert second_context is not None
@@ -1256,13 +851,16 @@ class TestRegistryBuiltinCache:
         assert second_result.api_entry["id"] == "run-github-b:0"
 
     def test_builtin_firewall_refs_share_static_payload_but_keep_vm_api_shells(
-        self, tmp_path, monkeypatch
+        self, tmp_path, mitm_ctx
     ):
         auth = {"headers": {"Authorization": "Bearer ${{ secrets.API_TOKEN }}"}}
         permissions = [{"name": "read-items", "rules": ["GET /items"]}]
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
+        path, cache_path = _write_registry_with_cache(
+            tmp_path,
+            {
+                "10.200.0.1": builtin_vm("run-large-a", "large"),
+                "10.200.0.2": builtin_vm("run-large-b", "large"),
+            },
             {
                 "large": {
                     "name": "large",
@@ -1281,17 +879,13 @@ class TestRegistryBuiltinCache:
                 }
             },
         )
-        path = tmp_path / "registry.json"
-        write_multi_vm_registry(
-            path,
-            {
-                "10.200.0.1": builtin_vm("run-large-a", "large"),
-                "10.200.0.2": builtin_vm("run-large-b", "large"),
-            },
-        )
 
-        first_context = registry.get_vm_context("10.200.0.1", str(path))
-        second_context = registry.get_vm_context("10.200.0.2", str(path))
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            first_context = registry.get_vm_context("10.200.0.1", str(path))
+            second_context = registry.get_vm_context("10.200.0.2", str(path))
 
         assert first_context is not None
         assert second_context is not None
@@ -1311,10 +905,8 @@ class TestRegistryBuiltinCache:
         assert first_api is not second_api
         assert first_api["id"] == "run-large-a:0"
         assert second_api["id"] == "run-large-b:0"
-        assert first_api["permissions"] is permissions
-        assert second_api["permissions"] is permissions
-        assert first_api["auth"] is auth
-        assert second_api["auth"] is auth
+        assert first_api["permissions"] is second_api["permissions"]
+        assert first_api["auth"] is second_api["auth"]
 
         first_result = matching.match_compiled_firewall_request(
             "https://api.example.com/items",
@@ -1334,10 +926,9 @@ class TestRegistryBuiltinCache:
         assert first_result.api_entry is first_api
         assert second_result.api_entry is second_api
 
-    def test_builtin_refs_with_different_base_url_vars_do_not_share_core(self, tmp_path):
-        path = tmp_path / "registry.json"
-        write_multi_vm_registry(
-            path,
+    def test_builtin_refs_with_different_base_url_vars_do_not_share_core(self, tmp_path, mitm_ctx):
+        path, cache_path = _write_registry_with_cache(
+            tmp_path,
             {
                 "10.200.0.1": builtin_vm(
                     "run-zendesk-a",
@@ -1350,10 +941,15 @@ class TestRegistryBuiltinCache:
                     {"ZENDESK_SUBDOMAIN": "beta"},
                 ),
             },
+            {"zendesk": _zendesk_cache_firewall()},
         )
 
-        first_context = registry.get_vm_context("10.200.0.1", str(path))
-        second_context = registry.get_vm_context("10.200.0.2", str(path))
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            first_context = registry.get_vm_context("10.200.0.1", str(path))
+            second_context = registry.get_vm_context("10.200.0.2", str(path))
 
         assert first_context is not None
         assert second_context is not None
@@ -1383,15 +979,30 @@ class TestRegistryBuiltinCache:
         assert first_result.api_entry is first_vm_info["firewalls"][0]["apis"][0]
         assert second_result.api_entry is second_vm_info["firewalls"][0]["apis"][0]
 
-    def test_builtin_compile_cache_is_scoped_to_registry_path(self, tmp_path):
+    def test_builtin_compile_cache_is_scoped_to_registry_path(self, tmp_path, mitm_ctx):
         path_a = tmp_path / "registry-a.json"
         path_b = tmp_path / "registry-b.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
         data = {"10.200.0.1": builtin_vm("run-github", "github")}
         write_multi_vm_registry(path_a, data)
         write_multi_vm_registry(path_b, data)
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"github": _github_cache_firewall()},
+        )
 
-        first_context = registry.get_vm_context("10.200.0.1", str(path_a))
-        second_context = registry.get_vm_context("10.200.0.1", str(path_b))
+        with mitm_ctx(
+            registry_path=str(path_a),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            first_context = registry.get_vm_context("10.200.0.1", str(path_a))
+        with mitm_ctx(
+            registry_path=str(path_b),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            second_context = registry.get_vm_context("10.200.0.1", str(path_b))
 
         assert first_context is not None
         assert second_context is not None
@@ -1401,17 +1012,23 @@ class TestRegistryBuiltinCache:
         assert second_compiled is not None
         assert _first_firewall_core(first_compiled) is not _first_firewall_core(second_compiled)
 
-    def test_invalid_builtin_entry_does_not_poison_valid_vm_core_cache(self, tmp_path):
-        path = tmp_path / "registry.json"
-        write_multi_vm_registry(
-            path,
+    def test_invalid_builtin_entry_does_not_poison_valid_vm_core_cache(self, tmp_path, mitm_ctx):
+        path, cache_path = _write_registry_with_cache(
+            tmp_path,
             {
                 "10.200.0.1": builtin_vm("run-github", "github"),
                 "10.200.0.2": builtin_vm("run-missing", "missing-firewall"),
             },
+            {"github": _github_cache_firewall()},
         )
 
-        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+        with (
+            mitm_ctx(
+                registry_path=str(path),
+                builtin_firewall_catalog_cache_path=str(cache_path),
+            ),
+            patch.object(registry.ctx, "log", MagicMock(), create=True),
+        ):
             valid_context = registry.get_vm_context("10.200.0.1", str(path))
             invalid_context = registry.get_vm_context("10.200.0.2", str(path))
             state = registry.load_registry_state(str(path))
@@ -1430,20 +1047,21 @@ class TestRegistryBuiltinCache:
         )
         assert isinstance(result, matching.FirewallAllow)
 
-    def test_builtin_core_cache_prunes_inactive_keys_on_registry_reload(
-        self, tmp_path, monkeypatch
-    ):
-        monkeypatch.setattr(
-            registry_firewalls,
-            "BUILTIN_FIREWALLS",
-            {
+    def test_builtin_core_cache_prunes_inactive_keys_on_registry_reload(self, tmp_path, mitm_ctx):
+        path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={
                 "cache-a": {
                     "name": "cache-a",
                     "apis": [
                         {
                             "base": "https://api-a.example.com",
                             "auth": {"headers": {"Authorization": "Bearer token"}},
-                            "permissions": [],
+                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
                         }
                     ],
                 },
@@ -1453,17 +1071,20 @@ class TestRegistryBuiltinCache:
                         {
                             "base": "https://api-b.example.com",
                             "auth": {"headers": {"Authorization": "Bearer token"}},
-                            "permissions": [],
+                            "permissions": [{"name": "read", "rules": ["GET /items"]}],
                         }
                     ],
                 },
             },
         )
-        path = tmp_path / "registry.json"
         write_multi_vm_registry(path, {"10.200.0.1": builtin_vm("run-cache-a", "cache-a")})
         os.utime(path, ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000))
 
-        first_context = registry.get_vm_context("10.200.0.1", str(path))
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            first_context = registry.get_vm_context("10.200.0.1", str(path))
 
         assert first_context is not None
         assert len(registry._registry_state.builtin_firewall_core_cache) == 1
@@ -1472,7 +1093,11 @@ class TestRegistryBuiltinCache:
 
         write_multi_vm_registry(path, {"10.200.0.1": builtin_vm("run-cache-b", "cache-b")})
         os.utime(path, ns=(1_700_000_000_000_000_001, 1_700_000_000_000_000_001))
-        second_context = registry.get_vm_context("10.200.0.1", str(path))
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            second_context = registry.get_vm_context("10.200.0.1", str(path))
 
         assert second_context is not None
         assert len(registry._registry_state.builtin_firewall_core_cache) == 1

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -1104,6 +1104,34 @@ class TestRegistryBuiltinCache:
         second_cache_key = next(iter(registry._registry_state.builtin_firewall_core_cache))
         assert second_cache_key[0] == "cache-b"
 
+    def test_builtin_core_cache_is_cleared_when_registry_becomes_unavailable(
+        self, tmp_path, mitm_ctx
+    ):
+        path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"cache-a": _cache_firewall("cache-a", "https://api-a.example.com")},
+        )
+        write_multi_vm_registry(path, {"10.200.0.1": builtin_vm("run-cache-a", "cache-a")})
+
+        with mitm_ctx(
+            registry_path=str(path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            assert context is not None
+            assert len(registry._registry_state.builtin_firewall_core_cache) == 1
+
+            path.write_text("{ broken")
+            unavailable = registry.load_registry_state(str(path))
+
+        assert isinstance(unavailable, registry.RegistryUnavailable)
+        assert unavailable.reason == "parse_failed"
+        assert registry._registry_state.builtin_firewall_core_cache == {}
+
     def test_inline_firewalls_do_not_share_compiled_core(self, tmp_path):
         path = tmp_path / "registry.json"
         write_multi_vm_registry(

--- a/crates/runner/mitm-addon/tests/test_registry_context_state.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context_state.py
@@ -135,6 +135,9 @@ class TestRegistryContextState:
         assert unavailable_context is None
         assert isinstance(state, registry.RegistryUnavailable)
         assert state.reason == "parse_failed"
+        assert registry._registry_state.snapshot.loaded_key is None
+        assert registry._registry_state.snapshot.compiled_firewalls == {}
+        assert registry._registry_state.snapshot.compiled_network_policies == {}
 
     def test_missing_file_returns_no_compiled_context(self, tmp_path):
         path = tmp_path / "registry.json"
@@ -152,6 +155,9 @@ class TestRegistryContextState:
         assert unavailable_context is None
         assert isinstance(state, registry.RegistryUnavailable)
         assert state.reason == "stat_failed"
+        assert registry._registry_state.snapshot.loaded_key is None
+        assert registry._registry_state.snapshot.compiled_firewalls == {}
+        assert registry._registry_state.snapshot.compiled_network_policies == {}
 
     def test_malformed_network_policy_shape_compiles_without_load_failure(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -123,6 +123,48 @@ def _patch_shared_base_diagnostic_catalog(
     builtin_connector_diagnostics.reset_cache_for_tests()
 
 
+def _write_fal_catalog_cache(tmp_path) -> str:
+    cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "catalogDigest": (
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                "catalogVersion": "catalog-test",
+                "updatedAt": "2026-07-07T00:00:00.000Z",
+                "firewalls": {
+                    "fal": {
+                        "name": "fal",
+                        "apis": [
+                            {
+                                "base": "https://fal.run",
+                                "hostPolicy": {
+                                    "kind": "providerOwned",
+                                    "exactHosts": ["fal.run"],
+                                },
+                                "auth": {
+                                    "headers": {"Authorization": "Bearer ${{ secrets.FAL_TOKEN }}"}
+                                },
+                                "permissions": [
+                                    {
+                                        "name": "run",
+                                        "rules": ["POST /fal-ai/{model}"],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+            },
+            sort_keys=True,
+        )
+    )
+    cache_path.chmod(0o600)
+    return str(cache_path)
+
+
 def _assert_shared_base_inactive_diagnostic(flow):
     assert flow.response is not None
     assert flow.response.status_code == 424
@@ -502,6 +544,7 @@ async def test_browser_builtin_connector_url_does_not_record_diagnostic_candidat
 async def test_active_builtin_connector_url_uses_firewall_path(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers
 ):
+    cache_path = _write_fal_catalog_cache(tmp_path)
     reg_path = _write_registry(
         tmp_path,
         vm_info={
@@ -519,7 +562,11 @@ async def test_active_builtin_connector_url_uses_firewall_path(
     )
 
     with (
-        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        mitm_ctx(
+            registry_path=str(reg_path),
+            api_url="https://api.vm0.ai",
+            builtin_firewall_catalog_cache_path=cache_path,
+        ),
         fake_firewall_headers(),
     ):
         await mitm_addon.request(flow)

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -1178,6 +1178,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     shared.status.write_initial().await;
 
     if let Err(e) = provider_state.provider.prepare_startup_readiness().await {
+        let startup_readiness_cancelled = provider_state.cancel.is_cancelled();
+        let cleanup_reason = if startup_readiness_cancelled {
+            "provider_startup_readiness_cancelled"
+        } else {
+            "provider_startup_readiness_failure"
+        };
         shutdown_startup_resources_after_startup_failure(
             StartupFailureResources {
                 provider: provider_state.provider.as_ref(),
@@ -1188,11 +1194,14 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 memory_prefetch: &mut memory_prefetch,
                 status: shared.status.as_ref(),
             },
-            "provider_startup_readiness_failure",
+            cleanup_reason,
         )
         .await;
         if let Some(handler_task) = signal_handler_task.take() {
-            abort_signal_handler_task(handler_task, "provider_startup_readiness_failure").await;
+            abort_signal_handler_task(handler_task, cleanup_reason).await;
+        }
+        if startup_readiness_cancelled {
+            return Ok(());
         }
         return Err(e);
     }

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -183,6 +183,16 @@ struct LiveRunnerPublishResources<'a> {
     status: &'a StatusTracker,
 }
 
+struct StartupFailureResources<'a> {
+    provider: &'a dyn JobProvider,
+    runtime: Option<&'a mut dyn SandboxRuntime>,
+    mitm: &'a mut proxy::MitmProxy,
+    kmsg_handle: kmsg_log::KmsgHandle,
+    dns_handle: dns::DnsProxy,
+    memory_prefetch: &'a mut prefetch::MemoryPrefetchTasks,
+    status: &'a StatusTracker,
+}
+
 async fn publish_live_runner_instance_or_shutdown_startup_resources(
     home: &HomePaths,
     metadata: crate::live_runner_instances::LiveRunnerInstanceMetadata,
@@ -211,23 +221,21 @@ async fn publish_live_runner_instance_or_shutdown_startup_resources(
 }
 
 async fn shutdown_startup_resources_after_startup_failure(
-    provider: &dyn JobProvider,
-    mitm: &mut proxy::MitmProxy,
-    kmsg_handle: kmsg_log::KmsgHandle,
-    dns_handle: dns::DnsProxy,
-    memory_prefetch: &mut prefetch::MemoryPrefetchTasks,
-    status: &StatusTracker,
+    resources: StartupFailureResources<'_>,
     context: &'static str,
 ) {
-    memory_prefetch.cancel();
-    provider.shutdown().await;
-    if let Err(e) = mitm.kill_now().await {
+    resources.memory_prefetch.cancel();
+    resources.provider.shutdown().await;
+    if let Some(runtime) = resources.runtime {
+        runtime.shutdown().await;
+    }
+    if let Err(e) = resources.mitm.kill_now().await {
         warn!(error = %e, context, "failed to kill proxy after startup failed");
     }
-    kmsg_handle.stop().await;
-    dns_handle.stop().await;
-    memory_prefetch.drain().await;
-    status.set_mode(RunnerMode::Stopped).await;
+    resources.kmsg_handle.stop().await;
+    resources.dns_handle.stop().await;
+    resources.memory_prefetch.drain().await;
+    resources.status.set_mode(RunnerMode::Stopped).await;
 }
 
 async fn abort_signal_handler_task(handler_task: SignalHandlerTask, context: &'static str) {
@@ -1171,12 +1179,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     if let Err(e) = provider_state.provider.prepare_startup_readiness().await {
         shutdown_startup_resources_after_startup_failure(
-            provider_state.provider.as_ref(),
-            &mut mitm,
-            kmsg_handle,
-            dns_handle,
-            &mut memory_prefetch,
-            shared.status.as_ref(),
+            StartupFailureResources {
+                provider: provider_state.provider.as_ref(),
+                runtime: Some(runtime.as_mut()),
+                mitm: &mut mitm,
+                kmsg_handle,
+                dns_handle,
+                memory_prefetch: &mut memory_prefetch,
+                status: shared.status.as_ref(),
+            },
             "provider_startup_readiness_failure",
         )
         .await;
@@ -1198,12 +1209,15 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         Ok(factories) => factories,
         Err(e) => {
             shutdown_startup_resources_after_startup_failure(
-                provider_state.provider.as_ref(),
-                &mut mitm,
-                kmsg_handle,
-                dns_handle,
-                &mut memory_prefetch,
-                shared.status.as_ref(),
+                StartupFailureResources {
+                    provider: provider_state.provider.as_ref(),
+                    runtime: None,
+                    mitm: &mut mitm,
+                    kmsg_handle,
+                    dns_handle,
+                    memory_prefetch: &mut memory_prefetch,
+                    status: shared.status.as_ref(),
+                },
                 "factory_startup_failure",
             )
             .await;

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -210,18 +210,19 @@ async fn publish_live_runner_instance_or_shutdown_startup_resources(
     }
 }
 
-async fn shutdown_startup_resources_after_factory_failure(
+async fn shutdown_startup_resources_after_startup_failure(
     provider: &dyn JobProvider,
     mitm: &mut proxy::MitmProxy,
     kmsg_handle: kmsg_log::KmsgHandle,
     dns_handle: dns::DnsProxy,
     memory_prefetch: &mut prefetch::MemoryPrefetchTasks,
     status: &StatusTracker,
+    context: &'static str,
 ) {
     memory_prefetch.cancel();
     provider.shutdown().await;
     if let Err(e) = mitm.kill_now().await {
-        warn!(error = %e, "failed to kill proxy after factory startup failed");
+        warn!(error = %e, context, "failed to kill proxy after startup failed");
     }
     kmsg_handle.stop().await;
     dns_handle.stop().await;
@@ -628,8 +629,7 @@ async fn run_start_with_home(
             },
             cancel.clone(),
             Arc::clone(&cancel_tokens),
-        )
-        .await;
+        );
         let network_policy_refresh = provider.network_policy_refresh_handle();
         (provider, group_name, Some(network_policy_refresh))
     };
@@ -1169,6 +1169,23 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
     shared.status.write_initial().await;
 
+    if let Err(e) = provider_state.provider.prepare_startup_readiness().await {
+        shutdown_startup_resources_after_startup_failure(
+            provider_state.provider.as_ref(),
+            &mut mitm,
+            kmsg_handle,
+            dns_handle,
+            &mut memory_prefetch,
+            shared.status.as_ref(),
+            "provider_startup_readiness_failure",
+        )
+        .await;
+        if let Some(handler_task) = signal_handler_task.take() {
+            abort_signal_handler_task(handler_task, "provider_startup_readiness_failure").await;
+        }
+        return Err(e);
+    }
+
     let mut factories = match start_factories(
         &runner.profiles,
         &firecracker,
@@ -1180,13 +1197,14 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     {
         Ok(factories) => factories,
         Err(e) => {
-            shutdown_startup_resources_after_factory_failure(
+            shutdown_startup_resources_after_startup_failure(
                 provider_state.provider.as_ref(),
                 &mut mitm,
                 kmsg_handle,
                 dns_handle,
                 &mut memory_prefetch,
                 shared.status.as_ref(),
+                "factory_startup_failure",
             )
             .await;
             if let Some(handler_task) = signal_handler_task.take() {

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -337,6 +337,41 @@ async fn startup_readiness_blocks_running_and_discovery() {
 }
 
 #[tokio::test]
+async fn stop_during_startup_readiness_exits_without_running() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    env.handle.block_startup_readiness();
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+
+    assert!(
+        env.handle
+            .wait_startup_readiness_entered(Duration::from_secs(2))
+            .await,
+        "startup readiness should be entered",
+    );
+    assert_eq!(
+        status_mode_if_exists(&status_path).await.as_deref(),
+        Some("starting"),
+        "runner should publish starting while provider readiness is blocked",
+    );
+
+    env.trigger_stopping().await;
+    assert_eq!(
+        *env.mode_tx.borrow(),
+        RunnerMode::Stopping,
+        "startup stop must not be lost while provider readiness is blocked",
+    );
+
+    assert_run_exits_within(
+        run_handle,
+        Duration::from_secs(5),
+        "startup readiness stop should exit without entering Running",
+    )
+    .await;
+    wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
+}
+
+#[tokio::test]
 async fn startup_readiness_failure_stops_status_and_cleans_startup_resources() {
     let runtime_shutdowns = Arc::new(AtomicUsize::new(0));
     let runtime = ShutdownRecordingRuntime {

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -1,7 +1,7 @@
 use super::super::super::*;
 use super::super::support::{
-    assert_run_exits_within, mock_run_config_with_runtime, shutdown, test_profiles,
-    wait_status_mode,
+    assert_run_exits_within, mock_run_config, mock_run_config_with_runtime, shutdown,
+    test_profiles, wait_status_mode,
 };
 use crate::provider::{ClaimedJob, CompletionAuth, JobCandidate};
 use crate::types::{HeartbeatState, SandboxReuseResult};
@@ -304,6 +304,60 @@ async fn startup_does_not_publish_running_before_factories_are_ready() {
         .expect("runner should still be waiting for factory release");
     wait_status_mode(&status_path, "running", Duration::from_secs(5)).await;
     shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn startup_readiness_blocks_running_and_discovery() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    env.handle.block_startup_readiness();
+    let status_path = env._temp_dir.path().join("status.json");
+    let run_handle = tokio::spawn(run(config));
+
+    assert!(
+        env.handle
+            .wait_startup_readiness_entered(Duration::from_secs(2))
+            .await,
+        "startup readiness should be entered",
+    );
+    assert_eq!(
+        status_mode_if_exists(&status_path).await.as_deref(),
+        Some("starting"),
+        "runner should publish starting while provider readiness is blocked",
+    );
+    assert_eq!(env.handle.startup_readiness_calls(), 1);
+    assert_eq!(
+        env.handle.discover_started_count(),
+        0,
+        "provider discovery must not start before startup readiness completes",
+    );
+
+    env.handle.release_startup_readiness();
+    wait_status_mode(&status_path, "running", Duration::from_secs(5)).await;
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn startup_readiness_failure_stops_status_and_cleans_startup_resources() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    env.handle
+        .fail_startup_readiness("provider readiness failed");
+    let status_path = env._temp_dir.path().join("status.json");
+
+    let error = run(config)
+        .await
+        .expect_err("provider startup readiness should fail");
+
+    assert!(
+        error.to_string().contains("provider readiness failed"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(env.handle.startup_readiness_calls(), 1);
+    assert_eq!(
+        env.handle.discover_started_count(),
+        0,
+        "provider discovery must not start after startup readiness failure",
+    );
+    wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/cmd/start/tests/main_loop/startup.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/startup.rs
@@ -338,7 +338,12 @@ async fn startup_readiness_blocks_running_and_discovery() {
 
 #[tokio::test]
 async fn startup_readiness_failure_stops_status_and_cleans_startup_resources() {
-    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let runtime_shutdowns = Arc::new(AtomicUsize::new(0));
+    let runtime = ShutdownRecordingRuntime {
+        shutdowns: Arc::clone(&runtime_shutdowns),
+    };
+    let (config, env) =
+        mock_run_config_with_runtime(test_profiles(), 8, 32768, 4, Box::new(runtime));
     env.handle
         .fail_startup_readiness("provider readiness failed");
     let status_path = env._temp_dir.path().join("status.json");
@@ -357,6 +362,7 @@ async fn startup_readiness_failure_stops_status_and_cleans_startup_resources() {
         0,
         "provider discovery must not start after startup readiness failure",
     );
+    assert_eq!(runtime_shutdowns.load(Ordering::SeqCst), 1);
     wait_status_mode(&status_path, "stopped", Duration::from_secs(5)).await;
 }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -119,7 +120,8 @@ pub struct ApiProvider {
     /// Supported direct job candidates delivered by Ably notifications.
     direct_candidates: Arc<DirectCandidateInbox>,
     /// Background Ably control-plane task.
-    ably_supervisor: AblySupervisor,
+    ably_supervisor: Mutex<Option<AblySupervisor>>,
+    cancel_tokens: SharedRunCancellationMap,
     network_policy_refresh: NetworkPolicyRefreshHandle,
     builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController,
     /// Shutdown signal.
@@ -132,7 +134,7 @@ pub struct BuiltinFirewallCatalogCachePaths {
 }
 
 impl ApiProvider {
-    /// Create a new API-backed provider and start the Ably supervisor.
+    /// Create a new API-backed provider.
     pub fn new(
         http: HttpClient,
         token: String,
@@ -155,16 +157,6 @@ impl ApiProvider {
             DIRECT_CANDIDATE_INBOX_CAPACITY,
             DIRECT_CANDIDATE_STALE_AFTER,
         );
-        let ably_supervisor = AblySupervisor::spawn(AblySupervisorConfig {
-            api: api.clone(),
-            group: group.clone(),
-            profiles: supported_profiles.clone(),
-            poll_wakeups: Arc::clone(&poll_wakeups),
-            direct_candidates: Arc::clone(&direct_candidates),
-            cancel_tokens,
-            network_policy_refresh: network_policy_refresh.clone(),
-            provider_cancel: cancel.clone(),
-        });
 
         Arc::new(Self {
             api,
@@ -172,7 +164,8 @@ impl ApiProvider {
             supported_profiles,
             poll_wakeups,
             direct_candidates,
-            ably_supervisor,
+            ably_supervisor: Mutex::new(None),
+            cancel_tokens,
             network_policy_refresh,
             builtin_firewall_catalog_refresh,
             cancel,
@@ -243,6 +236,24 @@ impl ApiProvider {
             }
         }
     }
+
+    async fn ensure_ably_supervisor_started(&self) {
+        let mut ably_supervisor = self.ably_supervisor.lock().await;
+        if ably_supervisor.is_some() {
+            return;
+        }
+
+        *ably_supervisor = Some(AblySupervisor::spawn(AblySupervisorConfig {
+            api: self.api.clone(),
+            group: self.group.clone(),
+            profiles: self.supported_profiles.clone(),
+            poll_wakeups: Arc::clone(&self.poll_wakeups),
+            direct_candidates: Arc::clone(&self.direct_candidates),
+            cancel_tokens: Arc::clone(&self.cancel_tokens),
+            network_policy_refresh: self.network_policy_refresh.clone(),
+            provider_cancel: self.cancel.clone(),
+        }));
+    }
 }
 
 #[async_trait::async_trait]
@@ -250,7 +261,14 @@ impl JobProvider for ApiProvider {
     async fn prepare_startup_readiness(&self) -> RunnerResult<()> {
         self.builtin_firewall_catalog_refresh
             .prepare_startup_readiness()
-            .await
+            .await?;
+        if self.cancel.is_cancelled() {
+            return Err(RunnerError::Internal(
+                "provider startup readiness cancelled".to_string(),
+            ));
+        }
+        self.ensure_ably_supervisor_started().await;
+        Ok(())
     }
 
     async fn discover(&self) -> Option<JobCandidate> {
@@ -405,7 +423,10 @@ impl JobProvider for ApiProvider {
     }
 
     async fn shutdown(&self) {
-        self.ably_supervisor.shutdown().await;
+        let ably_supervisor = self.ably_supervisor.lock().await.take();
+        if let Some(ably_supervisor) = ably_supervisor {
+            ably_supervisor.shutdown().await;
+        }
         self.network_policy_refresh.shutdown().await;
         self.builtin_firewall_catalog_refresh.shutdown().await;
     }
@@ -1265,7 +1286,8 @@ mod tests {
                 DIRECT_CANDIDATE_INBOX_CAPACITY,
                 DIRECT_CANDIDATE_STALE_AFTER,
             ),
-            ably_supervisor: AblySupervisor::disabled(),
+            ably_supervisor: Mutex::new(Some(AblySupervisor::disabled())),
+            cancel_tokens: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
             cancel,
         })
     }

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -19,7 +19,7 @@ use super::api_direct_candidates::{
     DirectJobCandidate,
 };
 use super::builtin_firewall_catalog::{
-    BuiltinFirewallCatalog, BuiltinFirewallCatalogRefreshHandle,
+    BuiltinFirewallCatalog, BuiltinFirewallCatalogRefreshController,
 };
 use super::network_policy_refresh::NetworkPolicyRefreshHandle;
 use super::{
@@ -121,7 +121,7 @@ pub struct ApiProvider {
     /// Background Ably control-plane task.
     ably_supervisor: AblySupervisor,
     network_policy_refresh: NetworkPolicyRefreshHandle,
-    builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshHandle,
+    builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController,
     /// Shutdown signal.
     cancel: CancellationToken,
 }
@@ -133,7 +133,7 @@ pub struct BuiltinFirewallCatalogCachePaths {
 
 impl ApiProvider {
     /// Create a new API-backed provider and start the Ably supervisor.
-    pub async fn new(
+    pub fn new(
         http: HttpClient,
         token: String,
         group: String,
@@ -144,13 +144,12 @@ impl ApiProvider {
     ) -> Arc<Self> {
         let api = ApiClient::new(http, token);
         let network_policy_refresh = NetworkPolicyRefreshHandle::new(api.clone());
-        let builtin_firewall_catalog_refresh = BuiltinFirewallCatalogRefreshHandle::start(
+        let builtin_firewall_catalog_refresh = BuiltinFirewallCatalogRefreshController::new(
             api.clone(),
             builtin_firewall_catalog_cache_paths.cache_path,
             builtin_firewall_catalog_cache_paths.lock_path,
             cancel.clone(),
-        )
-        .await;
+        );
         let poll_wakeups = Arc::new(PollWakeups::new(false));
         let direct_candidates = DirectCandidateInbox::new(
             DIRECT_CANDIDATE_INBOX_CAPACITY,
@@ -248,6 +247,12 @@ impl ApiProvider {
 
 #[async_trait::async_trait]
 impl JobProvider for ApiProvider {
+    async fn prepare_startup_readiness(&self) -> RunnerResult<()> {
+        self.builtin_firewall_catalog_refresh
+            .prepare_startup_readiness()
+            .await
+    }
+
     async fn discover(&self) -> Option<JobCandidate> {
         loop {
             let due = match self.wait_for_discovery_wakeup().await? {
@@ -1251,7 +1256,7 @@ mod tests {
         );
         Arc::new(ApiProvider {
             network_policy_refresh: NetworkPolicyRefreshHandle::new(api.clone()),
-            builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshHandle::disabled(),
+            builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController::disabled(),
             api,
             group: "default".to_string(),
             supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -74,6 +74,13 @@ impl BuiltinFirewallCatalogCache {
         }
         validate_firewall_map(&self.firewalls)
     }
+
+    fn has_same_catalog_payload(&self, other: &Self) -> bool {
+        self.schema_version == other.schema_version
+            && self.catalog_digest == other.catalog_digest
+            && self.catalog_version == other.catalog_version
+            && self.firewalls == other.firewalls
+    }
 }
 
 pub(super) struct BuiltinFirewallCatalogRefreshHandle {
@@ -395,12 +402,32 @@ async fn write_catalog_cache(
             )));
         }
     };
+    if let Some(existing) = read_existing_catalog_cache_for_skip(cache_path).await
+        && existing.has_same_catalog_payload(&cache)
+    {
+        return Ok(());
+    }
     crate::state_file::write_private_atomic(cache_path, &content).await?;
     info!(cache_path = %cache_path.display(), "builtin firewall catalog cache refreshed");
     Ok(())
 }
 
-#[cfg(test)]
+async fn read_existing_catalog_cache_for_skip(
+    cache_path: &Path,
+) -> Option<BuiltinFirewallCatalogCache> {
+    match read_catalog_cache(cache_path).await {
+        Ok(cache) => cache,
+        Err(error) => {
+            warn!(
+                error = %error,
+                cache_path = %cache_path.display(),
+                "existing builtin firewall catalog cache is invalid; overwriting"
+            );
+            None
+        }
+    }
+}
+
 async fn read_catalog_cache(
     cache_path: &Path,
 ) -> RunnerResult<Option<BuiltinFirewallCatalogCache>> {
@@ -768,6 +795,58 @@ mod tests {
         assert_eq!(cache.catalog_digest, digest());
         assert_eq!(cache.catalog_version, "test-catalog");
         assert_eq!(cache.firewalls["github"].name, "github");
+    }
+
+    #[tokio::test]
+    async fn write_catalog_cache_keeps_existing_file_when_payload_is_unchanged() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+        let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+
+        write_catalog_cache(&cache_path, &lock_path, catalog("github"))
+            .await
+            .unwrap();
+        let before = tokio::fs::read_to_string(&cache_path).await.unwrap();
+        let before_ino = std::fs::metadata(&cache_path).unwrap().ino();
+
+        write_catalog_cache(&cache_path, &lock_path, catalog("github"))
+            .await
+            .unwrap();
+
+        let after = tokio::fs::read_to_string(&cache_path).await.unwrap();
+        let after_ino = std::fs::metadata(&cache_path).unwrap().ino();
+        assert_eq!(after, before);
+        assert_eq!(after_ino, before_ino);
+    }
+
+    #[tokio::test]
+    async fn write_catalog_cache_rewrites_when_payload_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+        let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+
+        write_catalog_cache(&cache_path, &lock_path, catalog("github"))
+            .await
+            .unwrap();
+
+        let mut changed = catalog("github");
+        changed
+            .firewalls
+            .get_mut("github")
+            .expect("catalog should contain github")
+            .apis[0]
+            .base = "https://api.github.com".to_string();
+        write_catalog_cache(&cache_path, &lock_path, changed)
+            .await
+            .unwrap();
+
+        let cache = read_catalog_cache(&cache_path).await.unwrap().unwrap();
+        assert_eq!(
+            cache.firewalls["github"].apis[0].base,
+            "https://api.github.com"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
@@ -79,29 +80,86 @@ pub(super) struct BuiltinFirewallCatalogRefreshHandle {
     inner: Arc<BuiltinFirewallCatalogRefreshInner>,
 }
 
+pub(super) struct BuiltinFirewallCatalogRefreshController {
+    inner: Option<Arc<BuiltinFirewallCatalogRefreshControllerInner>>,
+}
+
+struct BuiltinFirewallCatalogRefreshControllerInner {
+    api: ApiClient,
+    cache_path: PathBuf,
+    lock_path: PathBuf,
+    provider_cancel: CancellationToken,
+    handle: Mutex<Option<BuiltinFirewallCatalogRefreshHandle>>,
+}
+
 struct BuiltinFirewallCatalogRefreshInner {
     cancel: CancellationToken,
     task: StdMutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
-impl BuiltinFirewallCatalogRefreshHandle {
-    #[cfg(test)]
-    pub(super) fn disabled() -> Self {
-        Self {
-            inner: Arc::new(BuiltinFirewallCatalogRefreshInner {
-                cancel: CancellationToken::new(),
-                task: StdMutex::new(None),
-            }),
-        }
-    }
-
-    pub(super) async fn start(
+impl BuiltinFirewallCatalogRefreshController {
+    pub(super) fn new(
         api: ApiClient,
         cache_path: PathBuf,
         lock_path: PathBuf,
         provider_cancel: CancellationToken,
     ) -> Self {
-        run_initial_refresh(&api, &cache_path, &lock_path, &provider_cancel).await;
+        Self {
+            inner: Some(Arc::new(BuiltinFirewallCatalogRefreshControllerInner {
+                api,
+                cache_path,
+                lock_path,
+                provider_cancel,
+                handle: Mutex::new(None),
+            })),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    pub(super) async fn prepare_startup_readiness(&self) -> RunnerResult<()> {
+        let Some(inner) = &self.inner else {
+            return Ok(());
+        };
+
+        let mut handle = inner.handle.lock().await;
+        if handle.is_some() {
+            return Ok(());
+        }
+
+        let refresh_handle = BuiltinFirewallCatalogRefreshHandle::start(
+            inner.api.clone(),
+            inner.cache_path.clone(),
+            inner.lock_path.clone(),
+            inner.provider_cancel.clone(),
+        )
+        .await?;
+        *handle = Some(refresh_handle);
+        Ok(())
+    }
+
+    pub(super) async fn shutdown(&self) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        let refresh_handle = inner.handle.lock().await.take();
+        if let Some(refresh_handle) = refresh_handle {
+            refresh_handle.shutdown().await;
+        }
+    }
+}
+
+impl BuiltinFirewallCatalogRefreshHandle {
+    pub(super) async fn start(
+        api: ApiClient,
+        cache_path: PathBuf,
+        lock_path: PathBuf,
+        provider_cancel: CancellationToken,
+    ) -> RunnerResult<Self> {
+        run_initial_refresh(&api, &cache_path, &lock_path, &provider_cancel).await?;
 
         let cancel = provider_cancel.child_token();
         let task = tokio::spawn(run_periodic_refresh(
@@ -111,12 +169,12 @@ impl BuiltinFirewallCatalogRefreshHandle {
             cancel.clone(),
             BUILTIN_FIREWALL_CATALOG_REFRESH_INTERVAL,
         ));
-        Self {
+        Ok(Self {
             inner: Arc::new(BuiltinFirewallCatalogRefreshInner {
                 cancel,
                 task: StdMutex::new(Some(task)),
             }),
-        }
+        })
     }
 
     pub(super) async fn shutdown(&self) {
@@ -153,14 +211,14 @@ async fn run_initial_refresh(
     cache_path: &Path,
     lock_path: &Path,
     cancel: &CancellationToken,
-) {
+) -> RunnerResult<()> {
     run_initial_refresh_with_delays(
         || refresh_once(api, cache_path, lock_path),
         cache_path,
         cancel,
         &BUILTIN_FIREWALL_CATALOG_INITIAL_RETRY_DELAYS,
     )
-    .await;
+    .await
 }
 
 async fn run_initial_refresh_with_delays<F, Fut>(
@@ -168,14 +226,15 @@ async fn run_initial_refresh_with_delays<F, Fut>(
     cache_path: &Path,
     cancel: &CancellationToken,
     retry_delays: &[Duration],
-) where
+) -> RunnerResult<()>
+where
     F: FnMut() -> Fut,
     Fut: Future<Output = RunnerResult<()>>,
 {
     let max_attempts = retry_delays.len() + 1;
     for attempt_index in 0..max_attempts {
         if cancel.is_cancelled() {
-            return;
+            return Err(initial_refresh_cancelled_error());
         }
 
         let attempt = attempt_index + 1;
@@ -189,7 +248,7 @@ async fn run_initial_refresh_with_delays<F, Fut>(
                         "initial builtin firewall catalog refresh succeeded after retry"
                     );
                 }
-                return;
+                return Ok(());
             }
             Err(error) => {
                 let Some(retry_delay) = retry_delays.get(attempt_index) else {
@@ -200,7 +259,7 @@ async fn run_initial_refresh_with_delays<F, Fut>(
                         cache_path = %cache_path.display(),
                         "initial builtin firewall catalog refresh failed after retries"
                     );
-                    return;
+                    return Err(error);
                 };
 
                 warn!(
@@ -213,12 +272,19 @@ async fn run_initial_refresh_with_delays<F, Fut>(
                 );
                 tokio::select! {
                     biased;
-                    () = cancel.cancelled() => return,
+                    () = cancel.cancelled() => return Err(initial_refresh_cancelled_error()),
                     () = tokio::time::sleep(*retry_delay) => {}
                 }
             }
         }
     }
+    Err(RunnerError::Internal(
+        "initial builtin firewall catalog refresh did not run".to_string(),
+    ))
+}
+
+fn initial_refresh_cancelled_error() -> RunnerError {
+    RunnerError::Internal("initial builtin firewall catalog refresh cancelled".to_string())
 }
 
 async fn run_periodic_refresh(
@@ -396,7 +462,7 @@ mod tests {
 
         tokio::select! {
             biased;
-            () = &mut future => panic!("initial refresh should wait before retrying"),
+            _ = &mut future => panic!("initial refresh should wait before retrying"),
             () = tokio::task::yield_now() => {}
         }
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
@@ -404,13 +470,13 @@ mod tests {
         tokio::time::advance(Duration::from_secs(2)).await;
         tokio::select! {
             biased;
-            () = &mut future => panic!("initial refresh should wait before the final retry"),
+            _ = &mut future => panic!("initial refresh should wait before the final retry"),
             () = tokio::task::yield_now() => {}
         }
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
 
         tokio::time::advance(Duration::from_secs(5)).await;
-        future.await;
+        future.await.unwrap();
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
     }
 
@@ -434,20 +500,24 @@ mod tests {
 
         tokio::select! {
             biased;
-            () = &mut future => panic!("initial refresh should wait before retrying"),
+            _ = &mut future => panic!("initial refresh should wait before retrying"),
             () = tokio::task::yield_now() => {}
         }
         tokio::time::advance(Duration::from_secs(2)).await;
         tokio::select! {
             biased;
-            () = &mut future => panic!("initial refresh should wait before the final retry"),
+            _ = &mut future => panic!("initial refresh should wait before the final retry"),
             () = tokio::task::yield_now() => {}
         }
         assert_eq!(attempts.load(Ordering::SeqCst), 2);
         tokio::time::advance(Duration::from_secs(5)).await;
-        future.await;
+        let error = future.await.unwrap_err();
 
         assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert!(
+            error.to_string().contains("attempt 3 failed"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -470,14 +540,18 @@ mod tests {
 
         tokio::select! {
             biased;
-            () = &mut future => panic!("initial refresh should wait before retrying"),
+            _ = &mut future => panic!("initial refresh should wait before retrying"),
             () = tokio::task::yield_now() => {}
         }
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
 
         cancel.cancel();
-        future.await;
+        let error = future.await.unwrap_err();
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert!(
+            error.to_string().contains("refresh cancelled"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -238,7 +238,12 @@ where
         }
 
         let attempt = attempt_index + 1;
-        match refresh().await {
+        let result = tokio::select! {
+            biased;
+            () = cancel.cancelled() => return Err(initial_refresh_cancelled_error()),
+            result = refresh() => result,
+        };
+        match result {
             Ok(()) => {
                 if attempt > 1 {
                     info!(
@@ -548,6 +553,42 @@ mod tests {
         cancel.cancel();
         let error = future.await.unwrap_err();
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert!(
+            error.to_string().contains("refresh cancelled"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn initial_refresh_cancels_in_flight_attempt() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let cancel = CancellationToken::new();
+        let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
+        let attempts_for_refresh = Arc::clone(&attempts);
+        let refresh = move || {
+            let attempts = Arc::clone(&attempts_for_refresh);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                std::future::pending::<RunnerResult<()>>().await
+            }
+        };
+
+        let retry_delays = [Duration::from_secs(60)];
+        let future = run_initial_refresh_with_delays(refresh, &cache_path, &cancel, &retry_delays);
+        tokio::pin!(future);
+
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("initial refresh should wait for the in-flight attempt"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        cancel.cancel();
+        let error = tokio::time::timeout(Duration::from_secs(1), future)
+            .await
+            .expect("initial refresh should stop after cancellation")
+            .unwrap_err();
         assert!(
             error.to_string().contains("refresh cancelled"),
             "unexpected error: {error}"

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -299,6 +299,24 @@ async fn run_periodic_refresh(
     cancel: CancellationToken,
     interval: Duration,
 ) {
+    run_periodic_refresh_with_interval(
+        || refresh_once(&api, &cache_path, &lock_path),
+        &cache_path,
+        &cancel,
+        interval,
+    )
+    .await
+}
+
+async fn run_periodic_refresh_with_interval<F, Fut>(
+    mut refresh: F,
+    cache_path: &Path,
+    cancel: &CancellationToken,
+    interval: Duration,
+) where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = RunnerResult<()>>,
+{
     loop {
         tokio::select! {
             biased;
@@ -309,7 +327,12 @@ async fn run_periodic_refresh(
         if cancel.is_cancelled() {
             return;
         }
-        match refresh_once(&api, &cache_path, &lock_path).await {
+        let result = tokio::select! {
+            biased;
+            () = cancel.cancelled() => return,
+            result = refresh() => result,
+        };
+        match result {
             Ok(()) => {}
             Err(error) => {
                 warn!(
@@ -593,6 +616,49 @@ mod tests {
             error.to_string().contains("refresh cancelled"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn periodic_refresh_cancels_in_flight_attempt() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let cancel = CancellationToken::new();
+        let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
+        let attempts_for_refresh = Arc::clone(&attempts);
+        let refresh = move || {
+            let attempts = Arc::clone(&attempts_for_refresh);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                std::future::pending::<RunnerResult<()>>().await
+            }
+        };
+
+        let future = run_periodic_refresh_with_interval(
+            refresh,
+            &cache_path,
+            &cancel,
+            Duration::from_secs(60),
+        );
+        tokio::pin!(future);
+
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should wait for the interval"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 0);
+
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should wait for the in-flight attempt"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(1), future)
+            .await
+            .expect("periodic refresh should stop after cancellation");
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -386,7 +386,15 @@ async fn write_catalog_cache(
         )));
     }
 
-    let _guard = lock::acquire(lock_path.to_path_buf()).await?;
+    let _guard = match lock::try_acquire_or_busy(lock_path.to_path_buf()).await? {
+        lock::TryLock::Acquired(guard) => guard,
+        lock::TryLock::Busy => {
+            return Err(RunnerError::Internal(format!(
+                "builtin firewall catalog cache lock is already held: {}",
+                lock_path.display()
+            )));
+        }
+    };
     crate::state_file::write_private_atomic(cache_path, &content).await?;
     info!(cache_path = %cache_path.display(), "builtin firewall catalog cache refreshed");
     Ok(())
@@ -760,6 +768,33 @@ mod tests {
         assert_eq!(cache.catalog_digest, digest());
         assert_eq!(cache.catalog_version, "test-catalog");
         assert_eq!(cache.firewalls["github"].name, "github");
+    }
+
+    #[tokio::test]
+    async fn write_catalog_cache_fails_fast_when_lock_is_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+        let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+        let _guard = lock::acquire(lock_path.clone()).await.unwrap();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            write_catalog_cache(&cache_path, &lock_path, catalog("github")),
+        )
+        .await
+        .expect("busy catalog cache lock should fail without blocking");
+        let error = result.unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("builtin firewall catalog cache lock is already held"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !cache_path.exists(),
+            "busy lock should not publish a cache file"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -213,7 +213,7 @@ async fn run_initial_refresh(
     cancel: &CancellationToken,
 ) -> RunnerResult<()> {
     run_initial_refresh_with_delays(
-        || refresh_once(api, cache_path, lock_path),
+        |cancel| refresh_once(api, cache_path, lock_path, cancel),
         cache_path,
         cancel,
         &BUILTIN_FIREWALL_CATALOG_INITIAL_RETRY_DELAYS,
@@ -228,7 +228,7 @@ async fn run_initial_refresh_with_delays<F, Fut>(
     retry_delays: &[Duration],
 ) -> RunnerResult<()>
 where
-    F: FnMut() -> Fut,
+    F: FnMut(CancellationToken) -> Fut,
     Fut: Future<Output = RunnerResult<()>>,
 {
     let max_attempts = retry_delays.len() + 1;
@@ -238,13 +238,12 @@ where
         }
 
         let attempt = attempt_index + 1;
-        let result = tokio::select! {
-            biased;
-            () = cancel.cancelled() => return Err(initial_refresh_cancelled_error()),
-            result = refresh() => result,
-        };
+        let result = refresh(cancel.clone()).await;
         match result {
             Ok(()) => {
+                if cancel.is_cancelled() {
+                    return Err(initial_refresh_cancelled_error());
+                }
                 if attempt > 1 {
                     info!(
                         attempt,
@@ -256,6 +255,9 @@ where
                 return Ok(());
             }
             Err(error) => {
+                if cancel.is_cancelled() {
+                    return Err(initial_refresh_cancelled_error());
+                }
                 let Some(retry_delay) = retry_delays.get(attempt_index) else {
                     error!(
                         error = %error,
@@ -300,7 +302,7 @@ async fn run_periodic_refresh(
     interval: Duration,
 ) {
     run_periodic_refresh_with_interval(
-        || refresh_once(&api, &cache_path, &lock_path),
+        |cancel| refresh_once(&api, &cache_path, &lock_path, cancel),
         &cache_path,
         &cancel,
         interval,
@@ -314,7 +316,7 @@ async fn run_periodic_refresh_with_interval<F, Fut>(
     cancel: &CancellationToken,
     interval: Duration,
 ) where
-    F: FnMut() -> Fut,
+    F: FnMut(CancellationToken) -> Fut,
     Fut: Future<Output = RunnerResult<()>>,
 {
     loop {
@@ -327,14 +329,17 @@ async fn run_periodic_refresh_with_interval<F, Fut>(
         if cancel.is_cancelled() {
             return;
         }
-        let result = tokio::select! {
-            biased;
-            () = cancel.cancelled() => return,
-            result = refresh() => result,
-        };
+        let result = refresh(cancel.clone()).await;
         match result {
-            Ok(()) => {}
+            Ok(()) => {
+                if cancel.is_cancelled() {
+                    return;
+                }
+            }
             Err(error) => {
+                if cancel.is_cancelled() {
+                    return;
+                }
                 warn!(
                     error = %error,
                     cache_path = %cache_path.display(),
@@ -345,8 +350,20 @@ async fn run_periodic_refresh_with_interval<F, Fut>(
     }
 }
 
-async fn refresh_once(api: &ApiClient, cache_path: &Path, lock_path: &Path) -> RunnerResult<()> {
-    let catalog = api.resolve_builtin_firewall_catalog().await?;
+async fn refresh_once(
+    api: &ApiClient,
+    cache_path: &Path,
+    lock_path: &Path,
+    cancel: CancellationToken,
+) -> RunnerResult<()> {
+    let catalog = tokio::select! {
+        biased;
+        () = cancel.cancelled() => return Err(initial_refresh_cancelled_error()),
+        result = api.resolve_builtin_firewall_catalog() => result?,
+    };
+    if cancel.is_cancelled() {
+        return Err(initial_refresh_cancelled_error());
+    }
     write_catalog_cache(cache_path, lock_path, catalog).await
 }
 
@@ -472,7 +489,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
         let attempts_for_refresh = Arc::clone(&attempts);
-        let refresh = move || {
+        let refresh = move |_cancel: CancellationToken| {
             let attempts = Arc::clone(&attempts_for_refresh);
             async move {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
@@ -514,7 +531,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
         let attempts_for_refresh = Arc::clone(&attempts);
-        let refresh = move || {
+        let refresh = move |_cancel: CancellationToken| {
             let attempts = Arc::clone(&attempts_for_refresh);
             async move {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
@@ -554,7 +571,7 @@ mod tests {
         let cancel = CancellationToken::new();
         let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
         let attempts_for_refresh = Arc::clone(&attempts);
-        let refresh = move || {
+        let refresh = move |_cancel: CancellationToken| {
             let attempts = Arc::clone(&attempts_for_refresh);
             async move {
                 let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
@@ -588,11 +605,15 @@ mod tests {
         let cancel = CancellationToken::new();
         let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
         let attempts_for_refresh = Arc::clone(&attempts);
-        let refresh = move || {
+        let refresh = move |cancel: CancellationToken| {
             let attempts = Arc::clone(&attempts_for_refresh);
             async move {
                 attempts.fetch_add(1, Ordering::SeqCst);
-                std::future::pending::<RunnerResult<()>>().await
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => Err(initial_refresh_cancelled_error()),
+                    () = std::future::pending::<()>() => unreachable!(),
+                }
             }
         };
 
@@ -624,11 +645,15 @@ mod tests {
         let cancel = CancellationToken::new();
         let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
         let attempts_for_refresh = Arc::clone(&attempts);
-        let refresh = move || {
+        let refresh = move |cancel: CancellationToken| {
             let attempts = Arc::clone(&attempts_for_refresh);
             async move {
                 attempts.fetch_add(1, Ordering::SeqCst);
-                std::future::pending::<RunnerResult<()>>().await
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => Err(initial_refresh_cancelled_error()),
+                    () = std::future::pending::<()>() => unreachable!(),
+                }
             }
         };
 
@@ -659,6 +684,62 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), future)
             .await
             .expect("periodic refresh should stop after cancellation");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn periodic_refresh_finishes_in_progress_write_before_cancel_exit() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let finish = Arc::new(tokio::sync::Notify::new());
+        let cancel = CancellationToken::new();
+        let cache_path = PathBuf::from("builtin-firewall-catalog-cache.json");
+        let attempts_for_refresh = Arc::clone(&attempts);
+        let entered_for_refresh = Arc::clone(&entered);
+        let finish_for_refresh = Arc::clone(&finish);
+        let refresh = move |_cancel: CancellationToken| {
+            let attempts = Arc::clone(&attempts_for_refresh);
+            let entered = Arc::clone(&entered_for_refresh);
+            let finish = Arc::clone(&finish_for_refresh);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                entered.notify_one();
+                finish.notified().await;
+                Ok(())
+            }
+        };
+
+        let future = run_periodic_refresh_with_interval(
+            refresh,
+            &cache_path,
+            &cancel,
+            Duration::from_secs(60),
+        );
+        tokio::pin!(future);
+
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should wait for the interval"),
+            () = tokio::task::yield_now() => {}
+        }
+        tokio::time::advance(Duration::from_secs(60)).await;
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should wait for the in-progress write"),
+            () = entered.notified() => {}
+        }
+
+        cancel.cancel();
+        tokio::select! {
+            biased;
+            _ = &mut future => panic!("periodic refresh should finish the in-progress write"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        finish.notify_one();
+        tokio::time::timeout(Duration::from_secs(1), future)
+            .await
+            .expect("periodic refresh should stop after the write finishes");
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/runner/src/provider/mock.rs
+++ b/crates/runner/src/provider/mock.rs
@@ -15,6 +15,7 @@
 //!   the Mutex when `provider.shutdown()` is called.
 
 use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
@@ -24,6 +25,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
 use super::{ClaimedJob, CompletionAuth, JobCandidate, JobProvider};
+use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 use sandbox::SandboxId;
@@ -44,6 +46,7 @@ pub struct Completion {
 /// acquires the same Mutex, so omitting the
 /// `drop(discover_fut)` before `shutdown()` causes a real deadlock.
 pub struct MockJobProvider {
+    startup_readiness: Arc<MockStartupReadiness>,
     /// Held by `discover()` for its entire lifetime and acquired by
     /// `shutdown()`. Reproduces the historical API-provider shutdown deadlock
     /// shape used by main-loop regression tests.
@@ -79,6 +82,7 @@ pub struct MockJobProvider {
     /// about to start. Paused-time tests use this to avoid advancing virtual
     /// time before the discover timer exists.
     discover_poll_started: Arc<Notify>,
+    discover_started_count: Arc<AtomicUsize>,
     /// Fired by `heartbeat()` after a state is appended to `heartbeats`.
     /// `wait_heartbeat_past` uses the same subscribe-then-check pattern as
     /// `wait_completion` so a heartbeat that lands mid-check is still observed.
@@ -87,6 +91,7 @@ pub struct MockJobProvider {
 
 /// Test-side handle for driving the mock provider.
 pub struct MockProviderHandle {
+    startup_readiness: Arc<MockStartupReadiness>,
     pub discover_tx: mpsc::UnboundedSender<JobCandidate>,
     ready_discovery: Arc<StdMutex<VecDeque<JobCandidate>>>,
     claim_candidates: Arc<StdMutex<Vec<JobCandidate>>>,
@@ -99,8 +104,84 @@ pub struct MockProviderHandle {
     completion_notify: Arc<Notify>,
     /// See [`MockJobProvider::discover_poll_started`].
     discover_poll_started: Arc<Notify>,
+    discover_started_count: Arc<AtomicUsize>,
     /// See [`MockJobProvider::heartbeat_notify`].
     heartbeat_notify: Arc<Notify>,
+}
+
+#[derive(Clone)]
+enum MockStartupReadinessMode {
+    Ready,
+    Fail(String),
+    WaitForRelease,
+}
+
+struct MockStartupReadiness {
+    mode: StdMutex<MockStartupReadinessMode>,
+    entered: Notify,
+    release: Notify,
+    released: AtomicBool,
+    calls: AtomicUsize,
+}
+
+impl Default for MockStartupReadiness {
+    fn default() -> Self {
+        Self {
+            mode: StdMutex::new(MockStartupReadinessMode::Ready),
+            entered: Notify::new(),
+            release: Notify::new(),
+            released: AtomicBool::new(false),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl MockStartupReadiness {
+    async fn prepare(&self, cancel: &CancellationToken) -> RunnerResult<()> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.entered.notify_waiters();
+        let mode = self.mode.lock().unwrap_or_else(|e| e.into_inner()).clone();
+
+        match mode {
+            MockStartupReadinessMode::Ready => Ok(()),
+            MockStartupReadinessMode::Fail(message) => Err(RunnerError::Internal(message)),
+            MockStartupReadinessMode::WaitForRelease => loop {
+                if self.released.load(Ordering::SeqCst) {
+                    return Ok(());
+                }
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => {
+                        return Err(RunnerError::Internal(
+                            "mock startup readiness cancelled".to_string(),
+                        ));
+                    }
+                    () = self.release.notified() => {}
+                }
+            },
+        }
+    }
+
+    fn set_failure(&self, message: impl Into<String>) {
+        *self.mode.lock().unwrap_or_else(|e| e.into_inner()) =
+            MockStartupReadinessMode::Fail(message.into());
+        self.released.store(false, Ordering::SeqCst);
+    }
+
+    fn set_wait_for_release(&self) {
+        *self.mode.lock().unwrap_or_else(|e| e.into_inner()) =
+            MockStartupReadinessMode::WaitForRelease;
+        self.released.store(false, Ordering::SeqCst);
+    }
+
+    fn release(&self) {
+        self.released.store(true, Ordering::SeqCst);
+        self.release.notify_waiters();
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
 }
 
 impl MockJobProvider {
@@ -128,11 +209,14 @@ impl MockJobProvider {
         let completions = Arc::new(StdMutex::new(Vec::new()));
         let heartbeats = Arc::new(StdMutex::new(Vec::new()));
         let deferred_poll_delays = Arc::new(StdMutex::new(Vec::new()));
+        let startup_readiness = Arc::new(MockStartupReadiness::default());
         let discover_entered = Arc::new(Notify::new());
         let completion_notify = Arc::new(Notify::new());
         let discover_poll_started = Arc::new(Notify::new());
+        let discover_started_count = Arc::new(AtomicUsize::new(0));
         let heartbeat_notify = Arc::new(Notify::new());
         let provider = Arc::new(Self {
+            startup_readiness: Arc::clone(&startup_readiness),
             discovery: Mutex::new(rx),
             poll_delay,
             ready_discovery: Arc::clone(&ready_discovery),
@@ -145,9 +229,11 @@ impl MockJobProvider {
             discover_entered: Arc::clone(&discover_entered),
             completion_notify: Arc::clone(&completion_notify),
             discover_poll_started: Arc::clone(&discover_poll_started),
+            discover_started_count: Arc::clone(&discover_started_count),
             heartbeat_notify: Arc::clone(&heartbeat_notify),
         });
         let handle = MockProviderHandle {
+            startup_readiness,
             discover_tx: tx,
             ready_discovery,
             claim_candidates,
@@ -157,6 +243,7 @@ impl MockJobProvider {
             discover_entered,
             completion_notify,
             discover_poll_started,
+            discover_started_count,
             heartbeat_notify,
         };
         (provider, handle)
@@ -173,6 +260,47 @@ impl MockJobProvider {
 }
 
 impl MockProviderHandle {
+    pub fn fail_startup_readiness(&self, message: impl Into<String>) {
+        self.startup_readiness.set_failure(message);
+    }
+
+    pub fn block_startup_readiness(&self) {
+        self.startup_readiness.set_wait_for_release();
+    }
+
+    pub fn release_startup_readiness(&self) {
+        self.startup_readiness.release();
+    }
+
+    pub async fn wait_startup_readiness_entered(&self, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let notified = self.startup_readiness.entered.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if self.startup_readiness_calls() > 0 {
+                return true;
+            }
+
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                return false;
+            }
+        }
+    }
+
+    pub fn startup_readiness_calls(&self) -> usize {
+        self.startup_readiness.calls()
+    }
+
+    pub fn discover_started_count(&self) -> usize {
+        self.discover_started_count.load(Ordering::SeqCst)
+    }
+
     /// Wait for a specific run's completion to appear, with timeout.
     ///
     /// Event-driven — see [`MockJobProvider::completion_notify`] for the
@@ -278,6 +406,10 @@ impl MockProviderHandle {
 
 #[async_trait]
 impl JobProvider for MockJobProvider {
+    async fn prepare_startup_readiness(&self) -> RunnerResult<()> {
+        self.startup_readiness.prepare(&self.cancel).await
+    }
+
     /// Block until a job is pushed or the token is cancelled.
     ///
     /// Holds `self.discovery` Mutex for the entire call. This keeps the
@@ -289,6 +421,7 @@ impl JobProvider for MockJobProvider {
     /// - If the caller fails to drop this future before `shutdown()` (#8898),
     ///   the Mutex deadlocks — exactly reproducing the production bug.
     async fn discover(&self) -> Option<JobCandidate> {
+        self.discover_started_count.fetch_add(1, Ordering::SeqCst);
         let mut rx = self.discovery.lock().await;
         self.discover_poll_started.notify_one();
         if let Some(delay) = self.poll_delay {

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -25,6 +25,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use crate::active_input::ActiveInputSource;
+use crate::error::RunnerResult;
 use crate::ids::RunId;
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 
@@ -454,6 +455,15 @@ pub trait JobProvider: Send + Sync {
     /// main loop uses this only for bounded catch-up after a normal discovery.
     async fn try_discover_ready(&self) -> Option<JobCandidate> {
         None
+    }
+
+    /// Run provider-owned startup work that must finish before this runner can
+    /// admit jobs.
+    ///
+    /// The start loop calls this after publishing observable `starting` status
+    /// and before transitioning to `running`.
+    async fn prepare_startup_readiness(&self) -> RunnerResult<()> {
+        Ok(())
     }
 
     /// Claim a discovered job. Returns `None` if the job was already claimed

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -169,7 +169,7 @@ pub enum FirewallEntry {
 
 /// A single firewall config with its name and API entries.
 /// `name` is the canonical identifier (also used as the networkPolicies map key).
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Firewall {
     pub name: String,
     pub apis: Vec<FirewallApi>,
@@ -192,7 +192,7 @@ impl Firewall {
 }
 
 /// A single firewall API entry with base URL and auth headers for proxy-side matching.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FirewallApi {
     /// Stable API identifier used as one component of mitm-addon auth cache keys.
     /// Filled by the Python registry loader after built-in refs and inline firewalls
@@ -241,7 +241,7 @@ impl FirewallApi {
 }
 
 /// A named permission group with matching rules for request authorization.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FirewallPermission {
     pub name: String,
     #[serde(default)]
@@ -630,7 +630,7 @@ fn validate_parameterized_firewall_base_path(
 }
 
 /// Base-host ownership policy for credentialed builtin firewall APIs.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "kind", deny_unknown_fields)]
 pub enum FirewallBaseHostPolicy {
     #[serde(rename = "providerOwned", rename_all = "camelCase")]
@@ -731,7 +731,7 @@ fn is_ipv4_literal_like(host: &str) -> bool {
 }
 
 /// Auth configuration for a firewall API entry.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FirewallAuth {
     #[serde(default)]
     pub headers: std::collections::HashMap<String, String>,
@@ -994,7 +994,7 @@ fn raw_url_path(value: &str) -> &str {
 }
 
 /// AWS SigV4 auth template for firewall auth injection.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct FirewallAwsSigv4Auth {

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -155,7 +155,7 @@ pub struct SecretConnectorMetadata {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "kind")]
 pub enum FirewallEntry {
-    /// Built-in firewall resolved by the Python addon from its generated catalog.
+    /// Built-in firewall resolved by the Python addon from the runner-written catalog cache.
     #[serde(rename = "builtin", rename_all = "camelCase")]
     Builtin {
         name: String,


### PR DESCRIPTION
## Summary

Closes #20449.

This removes the Python runtime fallback to the bundled generated builtin firewall catalog and makes the Rust runner's initial builtin firewall catalog fetch a startup readiness gate.

Runtime model after this PR:

- run contexts still use compact builtin refs like `{ "kind": "builtin", "name": "github" }`;
- Rust fetches and validates the full builtin firewall catalog with the runner API token;
- the runner writes the private local cache before it can move from `starting` to `running`;
- periodic refresh starts only after the initial fetch succeeds;
- Python resolves builtin refs only from the validated local cache;
- missing, invalid, untrusted, or missing-firewall cache states fail closed through existing invalid-VM registry behavior.

Generated Python builtin firewall artifacts remain for diagnostics and tests that use them as fixtures, but `registry_firewalls.py` no longer imports or falls back to `generated.builtin_firewalls.BUILTIN_FIREWALLS`.

The old local stash was used only as a reference; this branch was implemented on current `main`.

## Tests

- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff format --check src tests/test_registry_builtin_cache.py tests/test_registry_builtin_base_url_vars.py tests/test_registry_loading.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m ruff check src tests/test_registry_builtin_cache.py tests/test_registry_builtin_base_url_vars.py tests/test_registry_loading.py`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_registry_builtin_cache.py tests/test_registry_builtin_base_url_vars.py tests/test_registry_loading.py`
- `cargo test --manifest-path crates/Cargo.toml -p runner builtin_firewall_catalog`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::startup`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets`
- `cd crates && cargo fmt --all --check`
- `cd crates && cargo test --manifest-path Cargo.toml -p runner`
