### PR TITLE
fix: refine custom plan cancellation copy

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -169,7 +169,7 @@ function maybeShowPendingRestoreToast(status: BillingStatusResponse): void {
   const tier = apiTierToBillingTier(status.tier);
   const restored =
     status.hasSubscription &&
-    (tier === "pro" || tier === "team") &&
+    (tier === "pro" || tier === "team" || tier === "custom") &&
     !status.cancelAtPeriodEnd &&
     status.scheduledChange === null;
   if (!restored) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -327,6 +327,38 @@ describe("organization billing settings", () => {
     }
   });
 
+  it("shows only the end date for a cancelled custom plan", async () => {
+    context.mocks.data.org({
+      id: "org_1",
+      slug: "custom-cancel-org",
+      name: "Custom Cancel Org",
+      role: "admin",
+    });
+    context.mocks.api(zeroBillingStatusContract.get, ({ respond }) => {
+      return respond(200, {
+        ...activeCustomBillingStatus(),
+        cancelAtPeriodEnd: true,
+        scheduledChange: {
+          type: "cancel",
+          targetTier: "pro-suspend",
+          effectiveDate: "2026-08-09T00:00:00Z",
+        },
+      });
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Custom plan")).toBeInTheDocument();
+      expect(
+        screen.getByText("Your custom plan will end on Aug 9, 2026."),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Custom plan has been cancelled/u),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("shows team concurrency add-on and starts checkout for more slots", async () => {
     let requestedQuantity: number | null = null;
     let canceledSubscriptionId: string | null = null;

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -160,7 +160,7 @@ function tierRank(t: BillingTier): number {
 }
 
 function isPaidTier(tier: BillingTier): boolean {
-  return tier === "pro" || tier === "team";
+  return tier === "pro" || tier === "team" || tier === "custom";
 }
 
 function isCustomTier(tier: BillingTier): boolean {
@@ -949,6 +949,16 @@ function billingPeriodLabel(args: {
   return `Renews ${date}`;
 }
 
+function cancellationNoticeText(tier: BillingTier, changeDate: string): string {
+  const formattedDate = formatBillingDate(changeDate);
+  if (tier === "custom") {
+    return `Your custom plan will end on ${formattedDate}.`;
+  }
+  return `Your ${formatTierLabel(
+    tier,
+  )} plan has been cancelled and will end on ${formattedDate}.`;
+}
+
 const CONCURRENCY_SLOT_MONTHLY_PRICE_USD = 10;
 
 function slotCountLabel(count: number): string {
@@ -1403,8 +1413,7 @@ export function OrgBillingTab() {
                   <div className="h-0 zero-border-t mx-5" />
                   <div className="px-5 py-3">
                     <p className="text-[13px] text-amber-600 dark:text-amber-400">
-                      Your {formatTierLabel(currentTier)} plan has been
-                      cancelled and will end on {formatBillingDate(changeDate)}.
+                      {cancellationNoticeText(currentTier, changeDate)}
                     </p>
                   </div>
                 </>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1331,6 +1331,7 @@ export function OrgBillingTab() {
     currentTier,
   );
   const showConcurrency = shouldShowConcurrencyBilling(currentTier);
+  const canManageBilling = isPaid && status?.hasSubscription === true;
   const openBillingPortal = () => {
     return detach(portal(pageSignal), Reason.DomCallback);
   };
@@ -1430,7 +1431,7 @@ export function OrgBillingTab() {
                   </div>
                 </>
               )}
-              {isPaid && (
+              {canManageBilling && (
                 <>
                   <div className="h-0 zero-border-t mx-5" />
                   <div className="flex items-center justify-between gap-4 px-5 py-4">


### PR DESCRIPTION
## Summary
- show only the end date for cancelled custom plans
- keep custom workspaces out of Pro/Team checkout actions
- add coverage for cancelled custom plan copy

## Testing
- git diff --check origin/main...HEAD
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/org-billing-tab.test.tsx (blocked: local Vite import resolution cannot find unicode-emoji-json/data-by-group.json before tests run)
- pnpm -F @vm0/app check-types (blocked: existing connectors generated metadata type errors in packages/connectors/src/firewall-metadata/index.ts)
