### PR TITLE
perf: reduce goal continuation memory search cost

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -19,7 +19,10 @@ import { testContext } from "../../../__tests__/test-context";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
-import { seedSemanticRecallMemory } from "../../../test-fixtures/relationship-memory";
+import {
+  seedLexicalRelationshipMemory,
+  seedSemanticRecallMemory,
+} from "../../../test-fixtures/relationship-memory";
 import { createDeferredPromise } from "../../utils";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
@@ -1232,6 +1235,78 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     );
     expect(goalContext.body.appendSystemPrompt ?? "").toContain(
       "The user prefers JPM IJTXX Treasury allocation.",
+    );
+
+    await api.requestCancelRun(actor, goalContinuation.runId, [200]);
+    await waitForRunStatus(actor, goalContinuation.runId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
+  it("does not broad-load runtime memory when a goal memory query compacts to empty", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for goal continuation");
+    }
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", undefined);
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: actor.orgRole },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+    const broadMemoryText = "The user wants broad memory to stay out.";
+    await seedLexicalRelationshipMemory({
+      fixture: { orgId: actor.orgId, userId: actor.userId },
+      displayName: "Broad Memory",
+      kind: "preference",
+      text: broadMemoryText,
+    });
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before markdown-only goal continuation",
+    });
+    const goalObjective = "---";
+    const goalBrief = goalObjective;
+    await createGoalForRun(actor, first.runId, goalObjective);
+
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before markdown-only goal continuation"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return isGoalContinuationUserMessage(message, goalBrief);
+        });
+      },
+    );
+    const goalContinuation = userMessages(messages.messages).find((message) => {
+      return isGoalContinuationUserMessage(message, goalBrief);
+    });
+    expect(goalContinuation?.goalSnapshot).toStrictEqual({
+      objectiveBrief: goalBrief,
+    });
+    if (!goalContinuation?.runId) {
+      throw new Error("Expected markdown-only goal continuation run id");
+    }
+    const goalContext = await waitForRunContext(actor, goalContinuation.runId);
+    expect(goalContext.body.prompt).toContain("# Active thread goal");
+    expect(goalContext.body.prompt).toContain(goalObjective);
+    expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
+      broadMemoryText,
     );
 
     await api.requestCancelRun(actor, goalContinuation.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1242,7 +1242,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await flushWaitUntilForTest();
   }, 90_000);
 
-  it("does not broad-load runtime memory when a goal memory query compacts to empty", async () => {
+  it("does not broad-load runtime memory when a goal has no searchable text", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
     if (!actor.orgId) {
@@ -1258,7 +1258,8 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
         [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
       },
     );
-    const broadMemoryText = "The user wants broad memory to stay out.";
+    const broadMemoryText =
+      "The user keeps unrelated placeholder plans named Untitled goal.";
     await seedLexicalRelationshipMemory({
       fixture: { orgId: actor.orgId, userId: actor.userId },
       displayName: "Broad Memory",
@@ -1269,14 +1270,14 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
 
     const first = await startChatRun(actor, {
       agentId,
-      prompt: "finish before markdown-only goal continuation",
+      prompt: "finish before empty-text goal continuation",
     });
-    const goalObjective = "---";
-    const goalBrief = goalObjective;
+    const goalObjective = "   ";
+    const goalBrief = "Untitled goal";
     await createGoalForRun(actor, first.runId, goalObjective);
 
     chatCallbacks.mockChatOutputEvents([
-      assistantEvent(0, "completed before markdown-only goal continuation"),
+      assistantEvent(0, "completed before empty-text goal continuation"),
     ]);
 
     const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
@@ -1300,12 +1301,12 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       objectiveBrief: goalBrief,
     });
     if (!goalContinuation?.runId) {
-      throw new Error("Expected markdown-only goal continuation run id");
+      throw new Error("Expected empty-text goal continuation run id");
     }
     const goalRunId = goalContinuation.runId;
     const goalContext = await waitForRunContext(actor, goalRunId);
     expect(goalContext.body.prompt).toContain("# Active thread goal");
-    expect(goalContext.body.prompt).toContain(goalObjective);
+    expect(goalContext.body.prompt).toContain(goalBrief);
     expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
       broadMemoryText,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1249,7 +1249,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       throw new Error("Expected an org-scoped actor for goal continuation");
     }
     mockOptionalEnv("OPENROUTER_API_KEY", undefined);
-    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", undefined);
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
     await updateFeatureSwitchesForUser(
       context,
       { userId: actor.userId, orgId: actor.orgId, orgRole: actor.orgRole },
@@ -1302,15 +1302,43 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     if (!goalContinuation?.runId) {
       throw new Error("Expected markdown-only goal continuation run id");
     }
-    const goalContext = await waitForRunContext(actor, goalContinuation.runId);
+    const goalRunId = goalContinuation.runId;
+    const goalContext = await waitForRunContext(actor, goalRunId);
     expect(goalContext.body.prompt).toContain("# Active thread goal");
     expect(goalContext.body.prompt).toContain(goalObjective);
     expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
       broadMemoryText,
     );
+    await expect
+      .poll(() => {
+        return sandboxOperationEventsForRun(goalRunId).map((event) => {
+          return event.op_type;
+        });
+      })
+      .toContain(
+        "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+      );
+    const timingEvents = sandboxOperationEventsForRun(goalRunId);
+    expect(timingEvents).toContainEqual(
+      expect.objectContaining({
+        op_type:
+          "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+        memory_runtime_search_query_length_bucket: "0",
+      }),
+    );
+    expect(
+      timingEvents.filter((event) => {
+        return (
+          typeof event.op_type === "string" &&
+          event.op_type.startsWith(
+            "api_dispatch_pre_create_zero_memory_profile_",
+          )
+        );
+      }),
+    ).toHaveLength(0);
 
-    await api.requestCancelRun(actor, goalContinuation.runId, [200]);
-    await waitForRunStatus(actor, goalContinuation.runId, "cancelled");
+    await api.requestCancelRun(actor, goalRunId, [200]);
+    await waitForRunStatus(actor, goalRunId, "cancelled");
     await flushWaitUntilForTest();
   }, 90_000);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1184,10 +1184,10 @@ describe("CHAT-02: completed chat callback", () => {
     const goalBrief = "Keep making autonomous progress";
     const goalObjective = `${goalBrief}
 
-Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and account ACME-42 before marking done.`;
+Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-42](https://acme.example.com/treasury) before marking done.`;
     await seedSemanticRecallMemory(
       { orgId: actor.orgId, userId: actor.userId },
-      "Keep making autonomous progress Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and account ACME-42 before marking done.",
+      "Keep making autonomous progress Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and ACME-42 https://acme.example.com/treasury before marking done.",
     );
     await createGoalForRun(actor, first.runId, goalObjective);
 

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -8,6 +8,7 @@ import type {
   GenerationTemplateRequest,
   PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import { PRESENTATION_TEMPLATE_PICKER_ITEMS } from "@vm0/core";
 import { describe, expect, it, onTestFinished } from "vitest";
@@ -18,6 +19,7 @@ import { testContext } from "../../../__tests__/test-context";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import { flushWaitUntilForTest } from "../../context/wait-until";
 import { now } from "../../external/time";
+import { seedSemanticRecallMemory } from "../../../test-fixtures/relationship-memory";
 import { createDeferredPromise } from "../../utils";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { mockClerkMembership } from "./helpers/api-bdd-clerk";
@@ -1160,7 +1162,19 @@ describe("CHAT-02: completed chat callback", () => {
   it("continues an active goal with the full objective in the run prompt and the brief in the user message snapshot", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for goal continuation");
+    }
     mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: actor.orgRole },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
     chatCallbacks.failIfChatCallbackRouteIsFetched();
 
     const first = await startChatRun(actor, {
@@ -1170,10 +1184,11 @@ describe("CHAT-02: completed chat callback", () => {
     const goalBrief = "Keep making autonomous progress";
     const goalObjective = `${goalBrief}
 
-Detailed goal procedure:
-- Inspect the current external state before deciding completion.
-- Persist progress outside the sandbox.
-- Complete the goal only after auditing every requirement.`;
+Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and account ACME-42 before marking done.`;
+    await seedSemanticRecallMemory(
+      { orgId: actor.orgId, userId: actor.userId },
+      "Keep making autonomous progress Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and account ACME-42 before marking done.",
+    );
     await createGoalForRun(actor, first.runId, goalObjective);
 
     chatCallbacks.mockChatOutputEvents([
@@ -1211,6 +1226,12 @@ Detailed goal procedure:
     expect(goalContext.body.prompt).toContain(goalObjective);
     expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
       "# Active thread goal",
+    );
+    expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
+      "# How to operate",
+    );
+    expect(goalContext.body.appendSystemPrompt ?? "").toContain(
+      "The user prefers JPM IJTXX Treasury allocation.",
     );
 
     await api.requestCancelRun(actor, goalContinuation.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1376,7 +1376,7 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
       agentId,
       prompt: "finish before default-placeholder goal continuation",
     });
-    const goalObjective = "Untitled goal";
+    const goalObjective = "untitled goal.";
     await createGoalForRun(actor, first.runId, goalObjective);
 
     chatCallbacks.mockChatOutputEvents([

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1245,6 +1245,82 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await flushWaitUntilForTest();
   }, 90_000);
 
+  it("truncates goal runtime memory queries without splitting Unicode codepoints", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for goal continuation");
+    }
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: actor.orgRole },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before unicode goal continuation",
+    });
+    const goalBrief = "Preserve Unicode query boundaries";
+    const rareLetterPrefix = "\u{10400}".repeat(1100);
+    const goalObjective = `${goalBrief}
+
+${rareLetterPrefix}
+
+Continue after the long Unicode prefix.`;
+    const expectedMemoryQuery = [
+      ...`${goalBrief} ${rareLetterPrefix} Continue after the long Unicode prefix.`,
+    ]
+      .slice(0, 1024)
+      .join("")
+      .trimEnd();
+    await seedSemanticRecallMemory(
+      { orgId: actor.orgId, userId: actor.userId },
+      expectedMemoryQuery,
+    );
+    await createGoalForRun(actor, first.runId, goalObjective);
+
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before unicode goal continuation"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return isGoalContinuationUserMessage(message, goalBrief);
+        });
+      },
+    );
+    const goalContinuation = userMessages(messages.messages).find((message) => {
+      return isGoalContinuationUserMessage(message, goalBrief);
+    });
+    if (!goalContinuation?.runId) {
+      throw new Error("Expected unicode goal continuation run id");
+    }
+    const goalContext = await waitForRunContext(actor, goalContinuation.runId);
+    expect(goalContext.body.prompt).toContain(goalObjective);
+    expect(goalContext.body.appendSystemPrompt ?? "").toContain(
+      "The user prefers JPM IJTXX Treasury allocation.",
+    );
+
+    await api.requestCancelRun(actor, goalContinuation.runId, [200]);
+    await waitForRunStatus(actor, goalContinuation.runId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
   it("does not broad-load runtime memory when a goal has no searchable text", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1343,6 +1343,92 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     await flushWaitUntilForTest();
   }, 90_000);
 
+  it("does not search runtime memory for punctuation-only goal continuations", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for goal continuation");
+    }
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: actor.orgRole },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before punctuation-only goal continuation",
+    });
+    const goalObjective = "!!!";
+    await createGoalForRun(actor, first.runId, goalObjective);
+
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(0, "completed before punctuation-only goal continuation"),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return isGoalContinuationUserMessage(message, goalObjective);
+        });
+      },
+    );
+    const goalContinuation = userMessages(messages.messages).find((message) => {
+      return isGoalContinuationUserMessage(message, goalObjective);
+    });
+    if (!goalContinuation?.runId) {
+      throw new Error("Expected punctuation-only goal continuation run id");
+    }
+    const goalRunId = goalContinuation.runId;
+    const goalContext = await waitForRunContext(actor, goalRunId);
+    expect(goalContext.body.prompt).toContain("# Active thread goal");
+    expect(goalContext.body.prompt).toContain(goalObjective);
+    await expect
+      .poll(() => {
+        return sandboxOperationEventsForRun(goalRunId).map((event) => {
+          return event.op_type;
+        });
+      })
+      .toContain(
+        "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+      );
+    const timingEvents = sandboxOperationEventsForRun(goalRunId);
+    expect(timingEvents).toContainEqual(
+      expect.objectContaining({
+        op_type:
+          "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+        memory_runtime_search_query_length_bucket: "0",
+      }),
+    );
+    expect(
+      timingEvents.filter((event) => {
+        return (
+          typeof event.op_type === "string" &&
+          event.op_type.startsWith(
+            "api_dispatch_pre_create_zero_memory_profile_",
+          )
+        );
+      }),
+    ).toHaveLength(0);
+
+    await api.requestCancelRun(actor, goalRunId, [200]);
+    await waitForRunStatus(actor, goalRunId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
   it("auto-sends a queued user message before continuing an active goal", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
     await enableGoalWorkflows(actor);

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1185,7 +1185,10 @@ describe("CHAT-02: completed chat callback", () => {
       prompt: "finish before goal continuation",
     });
     const goalBrief = "Keep making autonomous progress";
+    const noisySeparator = "!".repeat(1100);
     const goalObjective = `${goalBrief}
+
+${noisySeparator}
 
 Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-42](https://acme.example.com/treasury) before marking done.`;
     await seedSemanticRecallMemory(
@@ -1307,6 +1310,106 @@ Continue the JPM IJTXX Treasury allocation follow-up for issue #20818 and [ACME-
     const goalContext = await waitForRunContext(actor, goalRunId);
     expect(goalContext.body.prompt).toContain("# Active thread goal");
     expect(goalContext.body.prompt).toContain(goalBrief);
+    expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
+      broadMemoryText,
+    );
+    await expect
+      .poll(() => {
+        return sandboxOperationEventsForRun(goalRunId).map((event) => {
+          return event.op_type;
+        });
+      })
+      .toContain(
+        "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+      );
+    const timingEvents = sandboxOperationEventsForRun(goalRunId);
+    expect(timingEvents).toContainEqual(
+      expect.objectContaining({
+        op_type:
+          "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+        memory_runtime_search_query_length_bucket: "0",
+      }),
+    );
+    expect(
+      timingEvents.filter((event) => {
+        return (
+          typeof event.op_type === "string" &&
+          event.op_type.startsWith(
+            "api_dispatch_pre_create_zero_memory_profile_",
+          )
+        );
+      }),
+    ).toHaveLength(0);
+
+    await api.requestCancelRun(actor, goalRunId, [200]);
+    await waitForRunStatus(actor, goalRunId, "cancelled");
+    await flushWaitUntilForTest();
+  }, 90_000);
+
+  it("does not broad-load runtime memory when a goal only has the default placeholder text", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    await enableGoalWorkflows(actor);
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for goal continuation");
+    }
+    mockOptionalEnv("OPENROUTER_API_KEY", undefined);
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: actor.orgRole },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+    const broadMemoryText =
+      "The user keeps unrelated placeholder plans named Untitled goal.";
+    await seedLexicalRelationshipMemory({
+      fixture: { orgId: actor.orgId, userId: actor.userId },
+      displayName: "Broad Placeholder Memory",
+      kind: "preference",
+      text: broadMemoryText,
+    });
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+
+    const first = await startChatRun(actor, {
+      agentId,
+      prompt: "finish before default-placeholder goal continuation",
+    });
+    const goalObjective = "Untitled goal";
+    await createGoalForRun(actor, first.runId, goalObjective);
+
+    chatCallbacks.mockChatOutputEvents([
+      assistantEvent(
+        0,
+        "completed before default-placeholder goal continuation",
+      ),
+    ]);
+
+    const sandboxHeaders = await claimChatRun(runnerGroup, first.runId);
+    await completeChatRunOk(first.runId, sandboxHeaders, {
+      lastEventSequence: 0,
+    });
+
+    const messages = await waitForThreadMessages(
+      actor,
+      first.threadId,
+      (items) => {
+        return userMessages(items).some((message) => {
+          return isGoalContinuationUserMessage(message, goalObjective);
+        });
+      },
+    );
+    const goalContinuation = userMessages(messages.messages).find((message) => {
+      return isGoalContinuationUserMessage(message, goalObjective);
+    });
+    if (!goalContinuation?.runId) {
+      throw new Error("Expected default-placeholder goal continuation run id");
+    }
+    const goalRunId = goalContinuation.runId;
+    const goalContext = await waitForRunContext(actor, goalRunId);
+    expect(goalContext.body.prompt).toContain("# Active thread goal");
+    expect(goalContext.body.prompt).toContain(goalObjective);
     expect(goalContext.body.appendSystemPrompt ?? "").not.toContain(
       broadMemoryText,
     );

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1260,6 +1260,48 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
+  it("reports empty runtime memory search queries after trimming run prompts", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Memory runtime empty query test requires an org");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt: "   ",
+      modelProvider: "anthropic-api-key",
+    });
+
+    const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        memory_runtime_injection_enabled: "true",
+        memory_runtime_prompt_length_bucket: "1_256",
+        memory_runtime_search_query_length_bucket: "0",
+      }),
+    );
+    expectNoApiDispatchActions(
+      timingEvents,
+      API_DISPATCH_ZERO_MEMORY_PROFILE_ACTION_TYPES,
+    );
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
   it("emits disabled memory runtime attribution without profile spans", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -230,6 +230,7 @@ const API_DISPATCH_ZERO_MEMORY_PROFILE_ACTION_TYPES = [
 ] as const;
 const ZERO_MEMORY_TIMING_BUCKET_DIMENSION_KEYS = [
   "memory_runtime_prompt_length_bucket",
+  "memory_runtime_search_query_length_bucket",
   "memory_profile_static_result_count_bucket",
   "memory_profile_dynamic_result_count_bucket",
   "memory_profile_search_result_count_bucket",
@@ -1132,8 +1133,20 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect.objectContaining({
         memory_runtime_injection_enabled: "true",
         memory_runtime_prompt_length_bucket: "1_256",
+        memory_runtime_search_query_length_bucket: "1_256",
         zero_run_origin: "zero_run",
         trigger_source: "web",
+      }),
+    );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        memory_profile_lexical_candidate_count_bucket: "1",
+        memory_profile_lexical_query_eligible: "true",
       }),
     );
     expect(
@@ -1165,6 +1178,83 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       seeded.entityId,
       seeded.memoryId,
       seededMemoryText,
+    ]);
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
+  it("skips runtime memory lexical search for long noisy zero run prompts", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Memory runtime long prompt test requires an org");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+    const prompt = [
+      "# Current context",
+      "You are autonomously continuing a persistent goal on this web chat thread.",
+      "Everything you output is shown to the user in this thread.",
+      "# Active thread goal",
+      "Investigate the long runtime memory query shape for issue #20818 and keep working until the API path is fast.",
+      "# How to operate",
+      "Make concrete progress, persist progress externally, and continue without asking the user to wait.",
+    ].join("\n");
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt,
+      modelProvider: "anthropic-api-key",
+    });
+
+    const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        memory_runtime_injection_enabled: "true",
+        memory_runtime_prompt_length_bucket: "257_1024",
+        memory_runtime_search_query_length_bucket: "257_1024",
+      }),
+    );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        memory_profile_lexical_candidate_count_bucket: "0",
+        memory_profile_lexical_query_eligible: "false",
+      }),
+    );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_pre_create_zero_memory_profile_search_semantic_embedding",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        memory_profile_semantic_embedding_result: "empty",
+      }),
+    );
+    expectNoApiDispatchActions(timingEvents, [
+      "api_dispatch_pre_create_zero_memory_profile_search_semantic_query",
+    ]);
+    expectApiDispatchTimingEventsNotToLeak(timingEvents, [
+      prompt,
+      agentId,
+      actor.userId,
+      actor.orgId,
     ]);
 
     await api.requestCancelRun(actor, created.runId, [200]);
@@ -1209,6 +1299,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect.objectContaining({
         memory_runtime_injection_enabled: "false",
         memory_runtime_prompt_length_bucket: "1_256",
+        memory_runtime_search_query_length_bucket: "1_256",
       }),
     );
     expectApiDispatchTimingEventsNotToLeak(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -1260,6 +1260,56 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
+  it("keeps short Unicode runtime memory queries eligible for lexical search", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId } = await entitledRunActor();
+    if (!actor.orgId) {
+      throw new Error("Memory runtime Unicode prompt test requires an org");
+    }
+    await updateFeatureSwitchesForUser(
+      context,
+      { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+    const prompt = "\u{10428}".repeat(70);
+
+    const created = await api.createRun(actor, {
+      agentId,
+      prompt,
+      modelProvider: "anthropic-api-key",
+    });
+
+    const timingEvents = apiDispatchTimingEventsForRun(created.runId);
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_pre_create_zero_build_create_run_args_memory_runtime_injection",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        memory_runtime_injection_enabled: "true",
+        memory_runtime_prompt_length_bucket: "1_256",
+        memory_runtime_search_query_length_bucket: "1_256",
+      }),
+    );
+    expect(
+      singleApiDispatchEvent(
+        timingEvents,
+        "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+      ),
+    ).toStrictEqual(
+      expect.objectContaining({
+        memory_profile_lexical_candidate_count_bucket: "0",
+        memory_profile_lexical_query_eligible: "true",
+      }),
+    );
+
+    await api.requestCancelRun(actor, created.runId, [200]);
+  });
+
   it("reports empty runtime memory search queries after trimming run prompts", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -298,7 +298,7 @@ describe("zero goals", () => {
     );
   });
 
-  it("normalizes legacy goal marker JSON with invalid objective briefs", async () => {
+  it("normalizes invalid legacy goal marker JSON", async () => {
     const fixture = await seedGoalApiFixture();
     const chat = createChatFilesBddApi(context);
     await createGoal(fixture, "ship goals");
@@ -315,6 +315,21 @@ describe("zero goals", () => {
         AND goal_event IS NOT NULL
     `);
     expect(updated.rowCount).toBe(1);
+    const inserted = await db().execute(sql`
+      INSERT INTO chat_messages (
+        chat_thread_id,
+        role,
+        goal_event,
+        goal_snapshot
+      )
+      VALUES (
+        ${fixture.threadId},
+        'assistant',
+        '{"type":"state","status":"unknown","objectiveBrief":"bad"}'::jsonb,
+        '{"objectiveBrief":{"bad":true}}'::jsonb
+      )
+    `);
+    expect(inserted.rowCount).toBe(1);
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const messages = await chat.listThreadMessages(
@@ -327,17 +342,24 @@ describe("zero goals", () => {
       fixture.threadId,
     );
 
-    expect(messages.messages).toContainEqual(
-      expect.objectContaining({
-        role: "assistant",
-        goalEvent: {
-          type: "state",
-          status: "active",
-          objectiveBrief: "Untitled goal",
-        },
-        goalSnapshot: { objectiveBrief: "Untitled goal" },
+    const legacyMessages = messages.messages.filter((message) => {
+      return message.goalSnapshot?.objectiveBrief === "Untitled goal";
+    });
+    expect(legacyMessages).toHaveLength(2);
+    expect(
+      legacyMessages.some((message) => {
+        return (
+          message.goalEvent?.type === "state" &&
+          message.goalEvent.status === "active" &&
+          message.goalEvent.objectiveBrief === "Untitled goal"
+        );
       }),
-    );
+    ).toBeTruthy();
+    expect(
+      legacyMessages.some((message) => {
+        return message.goalEvent === undefined;
+      }),
+    ).toBeTruthy();
   });
 
   it("clears the current goal and writes a cleared marker", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -1,7 +1,9 @@
 import type { ZeroCapability } from "@vm0/api-contracts/contracts/composes";
 import { chatThreadsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
+import { sql } from "drizzle-orm";
 
+import { db } from "../../../lib/db";
 import { mockOptionalEnv } from "../../../lib/env";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -292,6 +294,45 @@ describe("zero goals", () => {
           status: "active",
           objectiveBrief: "---",
         },
+      }),
+    );
+  });
+
+  it("normalizes legacy goal marker JSON without objective briefs", async () => {
+    const fixture = await seedGoalApiFixture();
+    const chat = createChatFilesBddApi(context);
+    await createGoal(fixture, "ship goals");
+
+    const updated = await db().execute(sql`
+      UPDATE chat_messages
+      SET
+        goal_event = '{"type":"state","status":"active"}'::jsonb,
+        goal_snapshot = '{}'::jsonb
+      WHERE chat_thread_id = ${fixture.threadId}
+        AND goal_event IS NOT NULL
+    `);
+    expect(updated.rowCount).toBe(1);
+
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const messages = await chat.listThreadMessages(
+      {
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "org:member",
+        email: "goal-user@example.com",
+      },
+      fixture.threadId,
+    );
+
+    expect(messages.messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        goalEvent: {
+          type: "state",
+          status: "active",
+          objectiveBrief: "Untitled goal",
+        },
+        goalSnapshot: { objectiveBrief: "Untitled goal" },
       }),
     );
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -298,16 +298,19 @@ describe("zero goals", () => {
     );
   });
 
-  it("normalizes legacy goal marker JSON without objective briefs", async () => {
+  it("normalizes legacy goal marker JSON with invalid objective briefs", async () => {
     const fixture = await seedGoalApiFixture();
     const chat = createChatFilesBddApi(context);
     await createGoal(fixture, "ship goals");
 
+    // This bad persisted shape cannot be produced through the public API, but
+    // older or manually repaired jsonb rows can still be read by the messages
+    // endpoint.
     const updated = await db().execute(sql`
       UPDATE chat_messages
       SET
-        goal_event = '{"type":"state","status":"active"}'::jsonb,
-        goal_snapshot = '{}'::jsonb
+        goal_event = '{"type":"state","status":"active","objectiveBrief":123}'::jsonb,
+        goal_snapshot = '{"objectiveBrief":{"bad":true}}'::jsonb
       WHERE chat_thread_id = ${fixture.threadId}
         AND goal_event IS NOT NULL
     `);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -305,6 +305,19 @@ describe("zero goals", () => {
     );
   });
 
+  it("keeps Unicode objective briefs at the codepoint limit untruncated", async () => {
+    const fixture = await seedGoalApiFixture();
+    const rareLetter = "\u{10400}";
+    const objective = rareLetter.repeat(140);
+    const created = await createGoal(fixture, objective);
+
+    expect(created.body).toStrictEqual({
+      objective,
+      objectiveBrief: objective,
+      status: "active",
+    });
+  });
+
   it("keeps markdown-only goal objective briefs non-empty", async () => {
     const fixture = await seedGoalApiFixture();
     const chat = createChatFilesBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -264,6 +264,38 @@ describe("zero goals", () => {
     });
   });
 
+  it("keeps markdown-only goal objective briefs non-empty", async () => {
+    const fixture = await seedGoalApiFixture();
+    const chat = createChatFilesBddApi(context);
+    const created = await createGoal(fixture, "---");
+
+    expect(created.body).toStrictEqual({
+      objective: "---",
+      objectiveBrief: "---",
+      status: "active",
+    });
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const messages = await chat.listThreadMessages(
+      {
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "org:member",
+        email: "goal-user@example.com",
+      },
+      fixture.threadId,
+    );
+    expect(messages.messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        goalEvent: {
+          type: "state",
+          status: "active",
+          objectiveBrief: "---",
+        },
+      }),
+    );
+  });
+
   it("clears the current goal and writes a cleared marker", async () => {
     const fixture = await seedGoalApiFixture();
     await createGoal(fixture, "ship thread goals");

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -266,6 +266,45 @@ describe("zero goals", () => {
     });
   });
 
+  it("truncates long Unicode objective briefs without splitting codepoints", async () => {
+    const fixture = await seedGoalApiFixture();
+    const chat = createChatFilesBddApi(context);
+    const rareLetter = "\u{10400}";
+    const objective = rareLetter.repeat(200);
+    const expectedBrief = `${rareLetter.repeat(137)}...`;
+    const created = await createGoal(fixture, objective);
+
+    expect(created.body).toStrictEqual({
+      objective,
+      objectiveBrief: expectedBrief,
+      status: "active",
+    });
+    for (const char of created.body.objectiveBrief) {
+      expect(char === rareLetter || char === ".").toBeTruthy();
+    }
+
+    mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
+    const messages = await chat.listThreadMessages(
+      {
+        userId: fixture.userId,
+        orgId: fixture.orgId,
+        orgRole: "org:member",
+        email: "goal-user@example.com",
+      },
+      fixture.threadId,
+    );
+    expect(messages.messages).toContainEqual(
+      expect.objectContaining({
+        role: "assistant",
+        goalEvent: {
+          type: "state",
+          status: "active",
+          objectiveBrief: expectedBrief,
+        },
+      }),
+    );
+  });
+
   it("keeps markdown-only goal objective briefs non-empty", async () => {
     const fixture = await seedGoalApiFixture();
     const chat = createChatFilesBddApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-goals.test.ts
@@ -330,6 +330,21 @@ describe("zero goals", () => {
       )
     `);
     expect(inserted.rowCount).toBe(1);
+    const insertedMissingSnapshotBrief = await db().execute(sql`
+      INSERT INTO chat_messages (
+        chat_thread_id,
+        role,
+        content,
+        goal_snapshot
+      )
+      VALUES (
+        ${fixture.threadId},
+        'user',
+        'legacy snapshot without objective brief',
+        '{"bad":true}'::jsonb
+      )
+    `);
+    expect(insertedMissingSnapshotBrief.rowCount).toBe(1);
 
     mocks.clerk.session(fixture.userId, fixture.orgId, "org:member");
     const messages = await chat.listThreadMessages(
@@ -360,6 +375,15 @@ describe("zero goals", () => {
         return message.goalEvent === undefined;
       }),
     ).toBeTruthy();
+    const missingSnapshotBriefMessage = messages.messages.find((message) => {
+      return message.content === "legacy snapshot without objective brief";
+    });
+    expect(missingSnapshotBriefMessage).toStrictEqual(
+      expect.objectContaining({
+        role: "user",
+      }),
+    );
+    expect(missingSnapshotBriefMessage?.goalSnapshot).toBeUndefined();
   });
 
   it("clears the current goal and writes a cleared marker", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-recall.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-recall.test.ts
@@ -477,10 +477,15 @@ describe("GET /api/zero/memory/recall", () => {
       appendSystemPrompt: "",
       profile: { static: [], dynamic: [] },
       queryMemories: [],
+      documentEvidence: [],
       stats: {
         injectedCount: 0,
         omittedCount: 0,
         characterCount: 0,
+        tokenCount: 0,
+        profileTokenCount: 0,
+        memoryTokenCount: 0,
+        documentTokenCount: 0,
       },
     });
   });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-recall.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-recall.test.ts
@@ -456,6 +456,35 @@ describe("GET /api/zero/memory/recall", () => {
     expect(response.body.stats.documentTokenCount).toBeGreaterThan(0);
   });
 
+  it("does not inject memory for whitespace-only runtime prompts", async () => {
+    const fixture = await seedRelationshipFixture({
+      relationshipMemoryEnabled: true,
+      runtimeInjectionEnabled: true,
+    });
+    await seedSemanticRecallMemory(fixture, "cash management sweep fund");
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+
+    const response = await accept(
+      memoryClient().injectionPreview({
+        headers: authHeaders(),
+        body: { prompt: "   " },
+      }),
+      [200],
+    );
+
+    expect(response.body).toStrictEqual({
+      prompt: "",
+      appendSystemPrompt: "",
+      profile: { static: [], dynamic: [] },
+      queryMemories: [],
+      stats: {
+        injectedCount: 0,
+        omittedCount: 0,
+        characterCount: 0,
+      },
+    });
+  });
+
   it("rejects injection preview when runtime injection is disabled", async () => {
     await seedRelationshipFixture({
       relationshipMemoryEnabled: true,

--- a/turbo/apps/api/src/signals/services/zero-chat-automation-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-automation-message.service.ts
@@ -18,6 +18,7 @@ import {
 } from "../external/realtime";
 import { nowDate } from "../external/time";
 import { appendQueuedRunAssistantMarker } from "./zero-chat-queue-marker.service";
+import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 import {
   MODEL_FIRST_SELECTION_PROVIDER_ID,
   type ModelFirstPin,
@@ -158,6 +159,13 @@ export async function postAutomationUserMessage(params: {
   readonly runGroupId?: string;
   readonly goalSnapshot?: ChatMessageGoalSnapshot;
 }): Promise<void> {
+  const goalSnapshot = params.goalSnapshot
+    ? {
+        objectiveBrief: nonEmptyGoalObjectiveBrief(
+          params.goalSnapshot.objectiveBrief,
+        ),
+      }
+    : undefined;
   await params.db.transaction(async (tx) => {
     const [inserted] = await tx
       .insert(chatMessages)
@@ -167,7 +175,7 @@ export async function postAutomationUserMessage(params: {
         content: params.prompt,
         runId: params.runId,
         runGroupId: params.runGroupId,
-        goalSnapshot: params.goalSnapshot,
+        goalSnapshot,
       })
       .returning({ createdAt: chatMessages.createdAt });
     if (params.appendQueueMarker) {

--- a/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-goal-marker.service.ts
@@ -5,6 +5,7 @@ import {
 import { sql } from "drizzle-orm";
 
 import type { Db } from "../external/db";
+import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 
 /**
  * Goal state is published into the chat thread as assistant control messages so
@@ -31,7 +32,11 @@ export async function appendGoalEventMarker(
 }
 
 export function activeGoalEvent(objectiveBrief: string): ChatMessageGoalEvent {
-  return { type: "state", status: "active", objectiveBrief };
+  return {
+    type: "state",
+    status: "active",
+    objectiveBrief: nonEmptyGoalObjectiveBrief(objectiveBrief),
+  };
 }
 
 export function hiddenGoalStateEvent(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -71,6 +71,7 @@ import {
 import { normalizeRecommendedFollowups } from "./zero-chat-recommended-followups.service";
 import { appendChatThreadEvent } from "./zero-chat-thread-event.service";
 import { excludeGoalMarkerCondition } from "./zero-chat-goal-marker.service";
+import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 import { cancelRun$, type CancelRunResult } from "./zero-run-cancel.service";
 import { buildWorkflowScheduleTriggerBrief } from "./zero-workflow-trigger-brief.service";
 
@@ -574,6 +575,33 @@ function workflowSnapshotFromRow(
   };
 }
 
+function goalEventFromRow(
+  event: ChatMessageGoalEvent | null,
+): ChatMessageGoalEvent | undefined {
+  if (!event) {
+    return undefined;
+  }
+  if (event.type === "state" && event.status === "active") {
+    return {
+      ...event,
+      objectiveBrief: nonEmptyGoalObjectiveBrief(event.objectiveBrief),
+    };
+  }
+  return event;
+}
+
+function goalSnapshotFromRow(
+  snapshot: ChatMessageGoalSnapshot | null,
+): ChatMessageGoalSnapshot | undefined {
+  if (!snapshot) {
+    return undefined;
+  }
+  return {
+    ...snapshot,
+    objectiveBrief: nonEmptyGoalObjectiveBrief(snapshot.objectiveBrief),
+  };
+}
+
 function toPagedMessage(
   userId: string,
   row: ChatMessageRow,
@@ -593,8 +621,8 @@ function toPagedMessage(
       isGoalRun: row.isGoalRun || undefined,
       usage: normalizeUsagePayload(row.usagePayload),
       runEventId: row.runEventId ?? undefined,
-      goalEvent: row.goalEvent ?? undefined,
-      goalSnapshot: row.goalSnapshot ?? undefined,
+      goalEvent: goalEventFromRow(row.goalEvent),
+      goalSnapshot: goalSnapshotFromRow(row.goalSnapshot),
       revokesMessageId: row.revokesMessageId ?? undefined,
       interruptsRunId: row.interruptsRunId ?? undefined,
       error: row.error ?? undefined,

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -575,30 +575,49 @@ function workflowSnapshotFromRow(
   };
 }
 
-function goalEventFromRow(
-  event: ChatMessageGoalEvent | null,
-): ChatMessageGoalEvent | undefined {
-  if (!event) {
+function recordFromJson(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function goalEventFromRow(event: unknown): ChatMessageGoalEvent | undefined {
+  const record = recordFromJson(event);
+  if (!record) {
     return undefined;
   }
-  if (event.type === "state" && event.status === "active") {
+  if (record.type === "cleared") {
+    return { type: "cleared" };
+  }
+  if (record.type !== "state") {
+    return undefined;
+  }
+  if (record.status === "active") {
     return {
-      ...event,
-      objectiveBrief: nonEmptyGoalObjectiveBrief(event.objectiveBrief),
+      type: "state",
+      status: "active",
+      objectiveBrief: nonEmptyGoalObjectiveBrief(record.objectiveBrief),
     };
   }
-  return event;
+  if (
+    record.status === "paused" ||
+    record.status === "blocked" ||
+    record.status === "complete"
+  ) {
+    return { type: "state", status: record.status };
+  }
+  return undefined;
 }
 
 function goalSnapshotFromRow(
-  snapshot: ChatMessageGoalSnapshot | null,
+  snapshot: unknown,
 ): ChatMessageGoalSnapshot | undefined {
-  if (!snapshot) {
+  const record = recordFromJson(snapshot);
+  if (!record) {
     return undefined;
   }
   return {
-    ...snapshot,
-    objectiveBrief: nonEmptyGoalObjectiveBrief(snapshot.objectiveBrief),
+    objectiveBrief: nonEmptyGoalObjectiveBrief(record.objectiveBrief),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -71,7 +71,7 @@ import {
 import { normalizeRecommendedFollowups } from "./zero-chat-recommended-followups.service";
 import { appendChatThreadEvent } from "./zero-chat-thread-event.service";
 import { excludeGoalMarkerCondition } from "./zero-chat-goal-marker.service";
-import { nonEmptyGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
+import { goalObjectiveBriefFromJson } from "./zero-goal-objective-brief-normalization.service";
 import { cancelRun$, type CancelRunResult } from "./zero-run-cancel.service";
 import { buildWorkflowScheduleTriggerBrief } from "./zero-workflow-trigger-brief.service";
 
@@ -596,7 +596,7 @@ function goalEventFromRow(event: unknown): ChatMessageGoalEvent | undefined {
     return {
       type: "state",
       status: "active",
-      objectiveBrief: nonEmptyGoalObjectiveBrief(record.objectiveBrief),
+      objectiveBrief: goalObjectiveBriefFromJson(record.objectiveBrief),
     };
   }
   if (
@@ -617,7 +617,7 @@ function goalSnapshotFromRow(
     return undefined;
   }
   return {
-    objectiveBrief: nonEmptyGoalObjectiveBrief(record.objectiveBrief),
+    objectiveBrief: goalObjectiveBriefFromJson(record.objectiveBrief),
   };
 }
 

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -613,7 +613,7 @@ function goalSnapshotFromRow(
   snapshot: unknown,
 ): ChatMessageGoalSnapshot | undefined {
   const record = recordFromJson(snapshot);
-  if (!record) {
+  if (!record || !("objectiveBrief" in record)) {
     return undefined;
   }
   return {

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -124,7 +124,7 @@ function stripGoalMemoryQueryMarkdown(text: string): string {
     .replace(/^#{1,6}\s+/gm, "")
     .replace(/^[-*_]{3,}\s*$/gm, "")
     .replace(/`([^`]+)`/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 $2")
     .replace(/^["'](.+)["']$/, "$1")
     .trim();
 }

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -80,6 +80,9 @@ type ModelContext =
       readonly failure: Exclude<RunGoalResult, { kind: "ok" }>;
     };
 
+const GOAL_MEMORY_OBJECTIVE_EXCERPT_MAX_CHARS = 1024;
+const GOAL_MEMORY_RETRIEVAL_QUERY_MAX_CHARS = 1400;
+
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
 }
@@ -113,6 +116,52 @@ function failureMessage(error: RunGoalResult): string {
     return `${error.response.status} ${error.response.body.error.code}: ${error.response.body.error.message}`;
   }
   return `Unexpected successful run result: ${error.runId}`;
+}
+
+function stripGoalMemoryQueryMarkdown(text: string): string {
+  return text
+    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^["'](.+)["']$/, "$1")
+    .trim();
+}
+
+function compactGoalMemoryQueryText(text: string): string {
+  return stripGoalMemoryQueryMarkdown(text).replace(/\s+/g, " ").trim();
+}
+
+function capGoalMemoryQueryText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return text.slice(0, maxChars).trimEnd();
+}
+
+function buildGoalMemoryRetrievalQuery(goal: {
+  readonly objective: string;
+  readonly objectiveBrief: string;
+}): string {
+  const objectiveBrief = compactGoalMemoryQueryText(goal.objectiveBrief);
+  const objectiveExcerpt = capGoalMemoryQueryText(
+    compactGoalMemoryQueryText(goal.objective),
+    GOAL_MEMORY_OBJECTIVE_EXCERPT_MAX_CHARS,
+  );
+  const parts =
+    objectiveBrief === objectiveExcerpt ||
+    objectiveExcerpt.startsWith(`${objectiveBrief} `)
+      ? [objectiveExcerpt]
+      : [objectiveBrief, objectiveExcerpt];
+  return capGoalMemoryQueryText(
+    parts
+      .filter((part) => {
+        return part.length > 0;
+      })
+      .join(" "),
+    GOAL_MEMORY_RETRIEVAL_QUERY_MAX_CHARS,
+  );
 }
 
 function buildGoalContinuationPrompt(goal: {
@@ -298,6 +347,7 @@ const runGoalNow$ = command(
     const { modelPin, effectiveModelProvider } = modelContext;
 
     const prompt = buildGoalContinuationPrompt(goal);
+    const memoryRuntimeRetrievalQuery = buildGoalMemoryRetrievalQuery(goal);
     const result = await set(
       createZeroRun$,
       {
@@ -317,6 +367,7 @@ const runGoalNow$ = command(
         },
         apiStartTime: now(),
         triggerSource: "workflow-event",
+        memoryRuntimeRetrievalQuery,
         chatThreadId: goal.threadId,
         modelProviderId: modelPin.modelProviderId ?? undefined,
         modelProviderCredentialScope:

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -151,7 +151,16 @@ function capGoalMemoryQueryText(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }
-  return text.slice(0, maxChars).trimEnd();
+  let endIndex = 0;
+  let charCount = 0;
+  for (const char of text) {
+    if (charCount === maxChars) {
+      return text.slice(0, endIndex).trimEnd();
+    }
+    endIndex += char.length;
+    charCount += 1;
+  }
+  return text;
 }
 
 function hasGoalMemorySearchTerm(text: string): boolean {

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -20,7 +20,10 @@ import {
   loadActiveGoalForThread,
   type GoalBootstrap,
 } from "./zero-goal.service";
-import { normalizeGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
+import {
+  DEFAULT_GOAL_OBJECTIVE_BRIEF,
+  normalizeGoalObjectiveBrief,
+} from "./zero-goal-objective-brief-normalization.service";
 import {
   resolveModelFirstProviderAdmission,
   type ModelFirstPin,
@@ -150,6 +153,12 @@ function buildGoalMemoryRetrievalQuery(goal: {
     compactGoalMemoryQueryText(goal.objective),
     GOAL_MEMORY_OBJECTIVE_EXCERPT_MAX_CHARS,
   );
+  if (
+    objectiveExcerpt.length === 0 &&
+    objectiveBrief === DEFAULT_GOAL_OBJECTIVE_BRIEF
+  ) {
+    return "";
+  }
   const parts =
     objectiveBrief === objectiveExcerpt ||
     objectiveExcerpt.startsWith(`${objectiveBrief} `)

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -20,6 +20,7 @@ import {
   loadActiveGoalForThread,
   type GoalBootstrap,
 } from "./zero-goal.service";
+import { normalizeGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 import {
   resolveModelFirstProviderAdmission,
   type ModelFirstPin,
@@ -346,8 +347,16 @@ const runGoalNow$ = command(
     }
     const { modelPin, effectiveModelProvider } = modelContext;
 
-    const prompt = buildGoalContinuationPrompt(goal);
-    const memoryRuntimeRetrievalQuery = buildGoalMemoryRetrievalQuery(goal);
+    const normalizedGoal = {
+      ...goal,
+      objectiveBrief: normalizeGoalObjectiveBrief({
+        objective: goal.objective,
+        objectiveBrief: goal.objectiveBrief,
+      }),
+    };
+    const prompt = buildGoalContinuationPrompt(normalizedGoal);
+    const memoryRuntimeRetrievalQuery =
+      buildGoalMemoryRetrievalQuery(normalizedGoal);
     const result = await set(
       createZeroRun$,
       {
@@ -396,7 +405,7 @@ const runGoalNow$ = command(
       prompt,
       appendQueueMarker: result.body.status === "queued",
       runGroupId: goal.goalId,
-      goalSnapshot: { objectiveBrief: goal.objectiveBrief },
+      goalSnapshot: { objectiveBrief: normalizedGoal.objectiveBrief },
     });
     signal.throwIfAborted();
 

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -86,6 +86,7 @@ type ModelContext =
 
 const GOAL_MEMORY_OBJECTIVE_EXCERPT_MAX_CHARS = 1024;
 const GOAL_MEMORY_RETRIEVAL_QUERY_MAX_CHARS = 1400;
+const GOAL_MEMORY_NO_SEARCH_SEPARATOR_MIN_CHARS = 32;
 
 function generateCallbackSecret(): string {
   return randomBytes(32).toString("hex");
@@ -134,7 +135,16 @@ function stripGoalMemoryQueryMarkdown(text: string): string {
 }
 
 function compactGoalMemoryQueryText(text: string): string {
-  return stripGoalMemoryQueryMarkdown(text).replace(/\s+/g, " ").trim();
+  return stripGoalMemoryQueryMarkdown(text)
+    .replace(
+      new RegExp(
+        `[^\\p{L}\\p{N}]{${GOAL_MEMORY_NO_SEARCH_SEPARATOR_MIN_CHARS},}`,
+        "gu",
+      ),
+      " ",
+    )
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function capGoalMemoryQueryText(text: string, maxChars: number): string {
@@ -157,15 +167,19 @@ function buildGoalMemoryRetrievalQuery(goal: {
     compactGoalMemoryQueryText(goal.objective),
     GOAL_MEMORY_OBJECTIVE_EXCERPT_MAX_CHARS,
   );
+  const isDefaultObjectiveBrief =
+    objectiveBrief === DEFAULT_GOAL_OBJECTIVE_BRIEF;
   if (
-    objectiveExcerpt.length === 0 &&
-    objectiveBrief === DEFAULT_GOAL_OBJECTIVE_BRIEF
+    isDefaultObjectiveBrief &&
+    (objectiveExcerpt.length === 0 ||
+      objectiveExcerpt === DEFAULT_GOAL_OBJECTIVE_BRIEF)
   ) {
     return "";
   }
-  const parts =
-    objectiveBrief === objectiveExcerpt ||
-    objectiveExcerpt.startsWith(`${objectiveBrief} `)
+  const parts = isDefaultObjectiveBrief
+    ? [objectiveExcerpt]
+    : objectiveBrief === objectiveExcerpt ||
+        objectiveExcerpt.startsWith(`${objectiveBrief} `)
       ? [objectiveExcerpt]
       : [objectiveBrief, objectiveExcerpt];
   const query = capGoalMemoryQueryText(

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -158,6 +158,21 @@ function hasGoalMemorySearchTerm(text: string): boolean {
   return /[\p{L}\p{N}]/u.test(text);
 }
 
+function goalMemoryPlaceholderKey(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isDefaultGoalMemoryPlaceholder(text: string): boolean {
+  return (
+    goalMemoryPlaceholderKey(text) ===
+    goalMemoryPlaceholderKey(DEFAULT_GOAL_OBJECTIVE_BRIEF)
+  );
+}
+
 function buildGoalMemoryRetrievalQuery(goal: {
   readonly objective: string;
   readonly objectiveBrief: string;
@@ -168,11 +183,11 @@ function buildGoalMemoryRetrievalQuery(goal: {
     GOAL_MEMORY_OBJECTIVE_EXCERPT_MAX_CHARS,
   );
   const isDefaultObjectiveBrief =
-    objectiveBrief === DEFAULT_GOAL_OBJECTIVE_BRIEF;
+    isDefaultGoalMemoryPlaceholder(objectiveBrief);
   if (
     isDefaultObjectiveBrief &&
     (objectiveExcerpt.length === 0 ||
-      objectiveExcerpt === DEFAULT_GOAL_OBJECTIVE_BRIEF)
+      isDefaultGoalMemoryPlaceholder(objectiveExcerpt))
   ) {
     return "";
   }

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -144,6 +144,10 @@ function capGoalMemoryQueryText(text: string, maxChars: number): string {
   return text.slice(0, maxChars).trimEnd();
 }
 
+function hasGoalMemorySearchTerm(text: string): boolean {
+  return /[\p{L}\p{N}]/u.test(text);
+}
+
 function buildGoalMemoryRetrievalQuery(goal: {
   readonly objective: string;
   readonly objectiveBrief: string;
@@ -164,7 +168,7 @@ function buildGoalMemoryRetrievalQuery(goal: {
     objectiveExcerpt.startsWith(`${objectiveBrief} `)
       ? [objectiveExcerpt]
       : [objectiveBrief, objectiveExcerpt];
-  return capGoalMemoryQueryText(
+  const query = capGoalMemoryQueryText(
     parts
       .filter((part) => {
         return part.length > 0;
@@ -172,6 +176,7 @@ function buildGoalMemoryRetrievalQuery(goal: {
       .join(" "),
     GOAL_MEMORY_RETRIEVAL_QUERY_MAX_CHARS,
   );
+  return hasGoalMemorySearchTerm(query) ? query : "";
 }
 
 function buildGoalContinuationPrompt(goal: {

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
@@ -1,5 +1,5 @@
 const OBJECTIVE_BRIEF_MAX_CHARS = 140;
-const DEFAULT_OBJECTIVE_BRIEF = "Untitled goal";
+export const DEFAULT_GOAL_OBJECTIVE_BRIEF = "Untitled goal";
 
 function stripMarkdown(text: string): string {
   return text
@@ -45,7 +45,7 @@ export function fallbackGoalObjectiveBrief(objective: string): string {
     firstNonEmptyLine ??
     (compactObjective.length > 0 ? compactObjective : undefined) ??
     rawFirstNonEmptyLine ??
-    DEFAULT_OBJECTIVE_BRIEF;
+    DEFAULT_GOAL_OBJECTIVE_BRIEF;
   return capGoalObjectiveBriefText(fallback);
 }
 
@@ -55,7 +55,7 @@ export function nonEmptyGoalObjectiveBrief(
   const trimmed = objectiveBrief?.trim() ?? "";
   return trimmed.length > 0
     ? capGoalObjectiveBriefText(trimmed)
-    : DEFAULT_OBJECTIVE_BRIEF;
+    : DEFAULT_GOAL_OBJECTIVE_BRIEF;
 }
 
 export function goalObjectiveBriefFromJson(value: unknown): string {

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
@@ -17,17 +17,16 @@ export function compactGoalObjectiveBriefText(text: string): string {
 }
 
 export function capGoalObjectiveBriefText(text: string): string {
-  if (text.length <= OBJECTIVE_BRIEF_MAX_CHARS) {
-    return text;
-  }
   const maxTextChars = OBJECTIVE_BRIEF_MAX_CHARS - 3;
   let endIndex = 0;
   let charCount = 0;
   for (const char of text) {
-    if (charCount === maxTextChars) {
+    if (charCount === OBJECTIVE_BRIEF_MAX_CHARS) {
       return `${text.slice(0, endIndex).trimEnd()}...`;
     }
-    endIndex += char.length;
+    if (charCount < maxTextChars) {
+      endIndex += char.length;
+    }
     charCount += 1;
   }
   return text;

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
@@ -49,12 +49,17 @@ export function fallbackGoalObjectiveBrief(objective: string): string {
   return capGoalObjectiveBriefText(fallback);
 }
 
-export function nonEmptyGoalObjectiveBrief(objectiveBrief: unknown): string {
-  const trimmed =
-    typeof objectiveBrief === "string" ? objectiveBrief.trim() : "";
+export function nonEmptyGoalObjectiveBrief(
+  objectiveBrief: string | null | undefined,
+): string {
+  const trimmed = objectiveBrief?.trim() ?? "";
   return trimmed.length > 0
     ? capGoalObjectiveBriefText(trimmed)
     : DEFAULT_OBJECTIVE_BRIEF;
+}
+
+export function goalObjectiveBriefFromJson(value: unknown): string {
+  return nonEmptyGoalObjectiveBrief(typeof value === "string" ? value : null);
 }
 
 export function normalizeGoalObjectiveBrief(args: {

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
@@ -1,0 +1,67 @@
+const OBJECTIVE_BRIEF_MAX_CHARS = 140;
+const DEFAULT_OBJECTIVE_BRIEF = "Untitled goal";
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/^["'](.+)["']$/, "$1")
+    .trim();
+}
+
+export function compactGoalObjectiveBriefText(text: string): string {
+  return stripMarkdown(text).replace(/\s+/g, " ").trim();
+}
+
+export function capGoalObjectiveBriefText(text: string): string {
+  if (text.length <= OBJECTIVE_BRIEF_MAX_CHARS) {
+    return text;
+  }
+  return `${text.slice(0, OBJECTIVE_BRIEF_MAX_CHARS - 3).trimEnd()}...`;
+}
+
+export function fallbackGoalObjectiveBrief(objective: string): string {
+  const firstNonEmptyLine = objective
+    .split(/\r?\n/)
+    .map((line) => {
+      return compactGoalObjectiveBriefText(line);
+    })
+    .find((line) => {
+      return line.length > 0;
+    });
+  const rawFirstNonEmptyLine = objective
+    .split(/\r?\n/)
+    .map((line) => {
+      return line.trim();
+    })
+    .find((line) => {
+      return line.length > 0;
+    });
+  const compactObjective = compactGoalObjectiveBriefText(objective);
+  const fallback =
+    firstNonEmptyLine ??
+    (compactObjective.length > 0 ? compactObjective : undefined) ??
+    rawFirstNonEmptyLine ??
+    DEFAULT_OBJECTIVE_BRIEF;
+  return capGoalObjectiveBriefText(fallback);
+}
+
+export function nonEmptyGoalObjectiveBrief(objectiveBrief: string): string {
+  const trimmed = objectiveBrief.trim();
+  return trimmed.length > 0
+    ? capGoalObjectiveBriefText(trimmed)
+    : DEFAULT_OBJECTIVE_BRIEF;
+}
+
+export function normalizeGoalObjectiveBrief(args: {
+  readonly objective: string;
+  readonly objectiveBrief: string;
+}): string {
+  const trimmed = args.objectiveBrief.trim();
+  return trimmed.length > 0
+    ? capGoalObjectiveBriefText(trimmed)
+    : fallbackGoalObjectiveBrief(args.objective);
+}

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
@@ -49,10 +49,9 @@ export function fallbackGoalObjectiveBrief(objective: string): string {
   return capGoalObjectiveBriefText(fallback);
 }
 
-export function nonEmptyGoalObjectiveBrief(
-  objectiveBrief: string | null | undefined,
-): string {
-  const trimmed = objectiveBrief?.trim() ?? "";
+export function nonEmptyGoalObjectiveBrief(objectiveBrief: unknown): string {
+  const trimmed =
+    typeof objectiveBrief === "string" ? objectiveBrief.trim() : "";
   return trimmed.length > 0
     ? capGoalObjectiveBriefText(trimmed)
     : DEFAULT_OBJECTIVE_BRIEF;

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
@@ -49,8 +49,10 @@ export function fallbackGoalObjectiveBrief(objective: string): string {
   return capGoalObjectiveBriefText(fallback);
 }
 
-export function nonEmptyGoalObjectiveBrief(objectiveBrief: string): string {
-  const trimmed = objectiveBrief.trim();
+export function nonEmptyGoalObjectiveBrief(
+  objectiveBrief: string | null | undefined,
+): string {
+  const trimmed = objectiveBrief?.trim() ?? "";
   return trimmed.length > 0
     ? capGoalObjectiveBriefText(trimmed)
     : DEFAULT_OBJECTIVE_BRIEF;

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief-normalization.service.ts
@@ -20,7 +20,17 @@ export function capGoalObjectiveBriefText(text: string): string {
   if (text.length <= OBJECTIVE_BRIEF_MAX_CHARS) {
     return text;
   }
-  return `${text.slice(0, OBJECTIVE_BRIEF_MAX_CHARS - 3).trimEnd()}...`;
+  const maxTextChars = OBJECTIVE_BRIEF_MAX_CHARS - 3;
+  let endIndex = 0;
+  let charCount = 0;
+  for (const char of text) {
+    if (charCount === maxTextChars) {
+      return `${text.slice(0, endIndex).trimEnd()}...`;
+    }
+    endIndex += char.length;
+    charCount += 1;
+  }
+  return text;
 }
 
 export function fallbackGoalObjectiveBrief(objective: string): string {

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief.service.ts
@@ -1,64 +1,19 @@
 import { logger } from "../../lib/log";
 import { generateText } from "../external/openrouter";
 import { settle } from "../utils";
+import {
+  capGoalObjectiveBriefText,
+  compactGoalObjectiveBriefText,
+  fallbackGoalObjectiveBrief,
+} from "./zero-goal-objective-brief-normalization.service";
 
 const log = logger("api:zero-goal-objective-brief");
 const OBJECTIVE_BRIEF_MODEL = "google/gemini-3.1-flash-lite-preview";
 const OBJECTIVE_CONTEXT_CHAR_CAP = 4000;
-const OBJECTIVE_BRIEF_MAX_CHARS = 140;
-
-function stripMarkdown(text: string): string {
-  return text
-    .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
-    .replace(/^#{1,6}\s+/gm, "")
-    .replace(/^[-*_]{3,}\s*$/gm, "")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/^["'](.+)["']$/, "$1")
-    .trim();
-}
-
-function compactText(text: string): string {
-  return stripMarkdown(text).replace(/\s+/g, " ").trim();
-}
-
-function capText(text: string): string {
-  if (text.length <= OBJECTIVE_BRIEF_MAX_CHARS) {
-    return text;
-  }
-  return `${text.slice(0, OBJECTIVE_BRIEF_MAX_CHARS - 3).trimEnd()}...`;
-}
-
-function fallbackObjectiveBrief(objective: string): string {
-  const firstNonEmptyLine = objective
-    .split(/\r?\n/)
-    .map((line) => {
-      return compactText(line);
-    })
-    .find((line) => {
-      return line.length > 0;
-    });
-  const rawFirstNonEmptyLine = objective
-    .split(/\r?\n/)
-    .map((line) => {
-      return line.trim();
-    })
-    .find((line) => {
-      return line.length > 0;
-    });
-  const compactObjective = compactText(objective);
-  const fallback =
-    firstNonEmptyLine ??
-    (compactObjective.length > 0 ? compactObjective : undefined) ??
-    rawFirstNonEmptyLine ??
-    "Untitled goal";
-  return capText(fallback);
-}
-
 export async function generateGoalObjectiveBrief(
   objective: string,
 ): Promise<string> {
-  const fallback = fallbackObjectiveBrief(objective);
+  const fallback = fallbackGoalObjectiveBrief(objective);
   const generated = await settle(
     generateText(
       OBJECTIVE_BRIEF_MODEL,
@@ -90,6 +45,8 @@ export async function generateGoalObjectiveBrief(
     return fallback;
   }
 
-  const brief = capText(compactText(generated.value));
+  const brief = capGoalObjectiveBriefText(
+    compactGoalObjectiveBriefText(generated.value),
+  );
   return brief.length > 0 ? brief : fallback;
 }

--- a/turbo/apps/api/src/signals/services/zero-goal-objective-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-objective-brief.service.ts
@@ -38,7 +38,21 @@ function fallbackObjectiveBrief(objective: string): string {
     .find((line) => {
       return line.length > 0;
     });
-  return capText(firstNonEmptyLine ?? compactText(objective));
+  const rawFirstNonEmptyLine = objective
+    .split(/\r?\n/)
+    .map((line) => {
+      return line.trim();
+    })
+    .find((line) => {
+      return line.length > 0;
+    });
+  const compactObjective = compactText(objective);
+  const fallback =
+    firstNonEmptyLine ??
+    (compactObjective.length > 0 ? compactObjective : undefined) ??
+    rawFirstNonEmptyLine ??
+    "Untitled goal";
+  return capText(fallback);
 }
 
 export async function generateGoalObjectiveBrief(

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -19,6 +19,7 @@ import {
   clearedGoalEvent,
   hiddenGoalStateEvent,
 } from "./zero-chat-goal-marker.service";
+import { normalizeGoalObjectiveBrief } from "./zero-goal-objective-brief-normalization.service";
 import { generateGoalObjectiveBrief } from "./zero-goal-objective-brief.service";
 import { appendChatThreadEvent } from "./zero-chat-thread-event.service";
 import {
@@ -84,7 +85,10 @@ function hasUserControlCapability(auth: GoalAuth): boolean {
 function goalResponse(row: GoalRow): ZeroGoalResponse {
   return {
     objective: row.objective,
-    objectiveBrief: row.objectiveBrief,
+    objectiveBrief: normalizeGoalObjectiveBrief({
+      objective: row.objective,
+      objectiveBrief: row.objectiveBrief,
+    }),
     status: row.status as ZeroGoalStatus,
   };
 }
@@ -610,7 +614,12 @@ export async function resumeCurrentGoal(
     });
     await appendGoalEventMarker(tx, {
       chatThreadId: goal.threadId,
-      event: activeGoalEvent(current.objectiveBrief),
+      event: activeGoalEvent(
+        normalizeGoalObjectiveBrief({
+          objective: current.objective,
+          objectiveBrief: current.objectiveBrief,
+        }),
+      ),
     });
     return row;
   });

--- a/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
@@ -207,6 +207,24 @@ export async function buildZeroMemoryRuntimeInjection(
   const prompt = params.prompt.trim();
   const trimmedRetrievalQuery = params.retrievalQuery?.trim();
   const retrievalQuery = trimmedRetrievalQuery || prompt;
+  if (retrievalQuery.length === 0) {
+    return {
+      prompt,
+      appendSystemPrompt: "",
+      profile: { static: [], dynamic: [] },
+      queryMemories: [],
+      documentEvidence: [],
+      stats: {
+        injectedCount: 0,
+        omittedCount: 0,
+        characterCount: 0,
+        tokenCount: 0,
+        profileTokenCount: 0,
+        memoryTokenCount: 0,
+        documentTokenCount: 0,
+      },
+    };
+  }
   const [profile, search] = await Promise.all([
     getZeroMemoryProfile(db, {
       orgId: params.orgId,

--- a/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
@@ -205,8 +205,8 @@ export async function buildZeroMemoryRuntimeInjection(
   params: ZeroMemoryInjectionParams,
 ): Promise<MemoryInjectionPreviewResponse> {
   const prompt = params.prompt.trim();
-  const retrievalQuery =
-    params.retrievalQuery === undefined ? prompt : params.retrievalQuery.trim();
+  const trimmedRetrievalQuery = params.retrievalQuery?.trim();
+  const retrievalQuery = trimmedRetrievalQuery || prompt;
   const [profile, search] = await Promise.all([
     getZeroMemoryProfile(db, {
       orgId: params.orgId,

--- a/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
@@ -205,8 +205,8 @@ export async function buildZeroMemoryRuntimeInjection(
   params: ZeroMemoryInjectionParams,
 ): Promise<MemoryInjectionPreviewResponse> {
   const prompt = params.prompt.trim();
-  const trimmedRetrievalQuery = params.retrievalQuery?.trim();
-  const retrievalQuery = trimmedRetrievalQuery || prompt;
+  const retrievalQuery =
+    params.retrievalQuery === undefined ? prompt : params.retrievalQuery.trim();
   if (retrievalQuery.length === 0) {
     return {
       prompt,

--- a/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
@@ -54,6 +54,15 @@ type DocumentEvidence = Extract<
   { readonly kind: "document_chunk" }
 >;
 
+export function zeroMemoryRuntimeRetrievalQuery(args: {
+  readonly prompt: string;
+  readonly retrievalQuery?: string;
+}): string {
+  return args.retrievalQuery === undefined
+    ? args.prompt.trim()
+    : args.retrievalQuery.trim();
+}
+
 function kindLabel(kind: MemoryKind): string {
   switch (kind) {
     case "preference": {
@@ -205,8 +214,7 @@ export async function buildZeroMemoryRuntimeInjection(
   params: ZeroMemoryInjectionParams,
 ): Promise<MemoryInjectionPreviewResponse> {
   const prompt = params.prompt.trim();
-  const retrievalQuery =
-    params.retrievalQuery === undefined ? prompt : params.retrievalQuery.trim();
+  const retrievalQuery = zeroMemoryRuntimeRetrievalQuery(params);
   if (retrievalQuery.length === 0) {
     return {
       prompt,

--- a/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-injection.service.ts
@@ -21,6 +21,7 @@ interface MemoryScope {
 
 interface ZeroMemoryInjectionParams extends MemoryScope {
   readonly prompt: string;
+  readonly retrievalQuery?: string;
   readonly timing?: ZeroMemoryTimingObserver;
 }
 
@@ -204,11 +205,13 @@ export async function buildZeroMemoryRuntimeInjection(
   params: ZeroMemoryInjectionParams,
 ): Promise<MemoryInjectionPreviewResponse> {
   const prompt = params.prompt.trim();
+  const retrievalQuery =
+    params.retrievalQuery === undefined ? prompt : params.retrievalQuery.trim();
   const [profile, search] = await Promise.all([
     getZeroMemoryProfile(db, {
       orgId: params.orgId,
       userId: params.userId,
-      query: prompt,
+      query: retrievalQuery,
       staticKinds: STATIC_PROFILE_KINDS,
       dynamicKinds: DYNAMIC_PROFILE_KINDS,
       searchKinds: QUERY_MEMORY_KINDS,
@@ -221,7 +224,7 @@ export async function buildZeroMemoryRuntimeInjection(
     searchZeroMemory(db, {
       orgId: params.orgId,
       userId: params.userId,
-      q: prompt,
+      q: retrievalQuery,
       mode: "documents",
       limit: DEFAULT_QUERY_LIMIT,
     }),

--- a/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
@@ -34,6 +34,8 @@ import {
 
 const log = logger("zero-memory-profile");
 const SEMANTIC_SCORE_THRESHOLD = 0.24;
+const LEXICAL_QUERY_MAX_CHARACTERS = 128;
+const LEXICAL_QUERY_MAX_TOKENS = 8;
 
 interface MemoryScope {
   readonly orgId: string;
@@ -241,6 +243,20 @@ function tokenMatchScore(values: readonly (string | null)[], query: string) {
     return haystack.includes(token);
   }).length;
   return matched / tokens.length;
+}
+
+function isLexicalQueryEligible(normalizedQuery: string): boolean {
+  if (!normalizedQuery) {
+    return false;
+  }
+  if (normalizedQuery.length > LEXICAL_QUERY_MAX_CHARACTERS) {
+    return false;
+  }
+  if (/\r|\n/.test(normalizedQuery)) {
+    return false;
+  }
+  const tokens = tokenize(normalizedQuery);
+  return tokens.length > 0 && tokens.length <= LEXICAL_QUERY_MAX_TOKENS;
 }
 
 function lexicalScore(row: LexicalCandidateRow, normalizedQuery: string) {
@@ -1035,15 +1051,22 @@ async function loadSearchResults(
   }
 
   const candidates = new Map<string, CandidateScore>();
+  const lexicalQueryEligible = isLexicalQueryEligible(normalizedQuery);
   const lexicalCandidates = await measureMemoryList(
     args.timing,
     "profile_search_lexical",
     "memory_profile_lexical_candidate_count_bucket",
     async () => {
+      if (!lexicalQueryEligible) {
+        return [];
+      }
       return await loadLexicalCandidates(db, {
         ...args,
         normalizedQuery,
       });
+    },
+    {
+      memory_profile_lexical_query_eligible: String(lexicalQueryEligible),
     },
   );
   for (const candidate of lexicalCandidates) {

--- a/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
@@ -245,11 +245,22 @@ function tokenMatchScore(values: readonly (string | null)[], query: string) {
   return matched / tokens.length;
 }
 
+function hasMoreThanCharacters(value: string, maxCharacters: number): boolean {
+  let characterCount = 0;
+  for (const _character of value) {
+    characterCount += 1;
+    if (characterCount > maxCharacters) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isLexicalQueryEligible(normalizedQuery: string): boolean {
   if (!normalizedQuery) {
     return false;
   }
-  if (normalizedQuery.length > LEXICAL_QUERY_MAX_CHARACTERS) {
+  if (hasMoreThanCharacters(normalizedQuery, LEXICAL_QUERY_MAX_CHARACTERS)) {
     return false;
   }
   if (/\r|\n/.test(normalizedQuery)) {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -158,6 +158,7 @@ interface CreateZeroRunCommandArgs {
   readonly apiStartTime: number;
   readonly triggerSource?: TriggerSource;
   readonly appendSystemPrompt?: string;
+  readonly memoryRuntimeRetrievalQuery?: string;
   readonly userInfoExtras?: Pick<
     UserInfo,
     | "slackDisplayName"
@@ -687,9 +688,11 @@ async function loadMemoryRuntimeAppendSystemPrompt(
     readonly orgId: string;
     readonly userId: string;
     readonly prompt: string;
+    readonly retrievalQuery?: string;
     readonly timing?: ZeroMemoryTimingObserver;
   },
 ): Promise<string | undefined> {
+  const searchQuery = args.retrievalQuery ?? args.prompt;
   return await measureZeroMemoryTiming(
     args.timing,
     "runtime_injection",
@@ -701,6 +704,9 @@ async function loadMemoryRuntimeAppendSystemPrompt(
         orgId: args.orgId,
         userId: args.userId,
         prompt: args.prompt,
+        ...(args.retrievalQuery !== undefined
+          ? { retrievalQuery: args.retrievalQuery }
+          : {}),
         timing: args.timing,
       });
       return result.appendSystemPrompt || undefined;
@@ -710,6 +716,8 @@ async function loadMemoryRuntimeAppendSystemPrompt(
       memory_runtime_prompt_length_bucket: zeroMemoryPromptLengthBucket(
         args.prompt,
       ),
+      memory_runtime_search_query_length_bucket:
+        zeroMemoryPromptLengthBucket(searchQuery),
     },
   );
 }
@@ -919,6 +927,9 @@ async function buildZeroCreateAgentRunArgs(args: {
       orgId: command.auth.orgId,
       userId: command.auth.userId,
       prompt: command.body.prompt,
+      ...(command.memoryRuntimeRetrievalQuery !== undefined
+        ? { retrievalQuery: command.memoryRuntimeRetrievalQuery }
+        : {}),
       timing: memoryTiming,
     });
   return {

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -42,7 +42,10 @@ import { loadActiveUserPermissionGrants } from "./zero-user-permission-grants.se
 import { loadWorkflowsForRun } from "./zero-workflow-data.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import { loadUserFeatureSwitchContext } from "./feature-switches.service";
-import { buildZeroMemoryRuntimeInjection } from "./zero-memory-injection.service";
+import {
+  buildZeroMemoryRuntimeInjection,
+  zeroMemoryRuntimeRetrievalQuery,
+} from "./zero-memory-injection.service";
 import {
   measureZeroMemoryTiming,
   type ZeroMemoryTimingObserver,
@@ -692,10 +695,7 @@ async function loadMemoryRuntimeAppendSystemPrompt(
     readonly timing?: ZeroMemoryTimingObserver;
   },
 ): Promise<string | undefined> {
-  const searchQuery =
-    args.retrievalQuery === undefined
-      ? args.prompt.trim()
-      : args.retrievalQuery.trim();
+  const searchQuery = zeroMemoryRuntimeRetrievalQuery(args);
   return await measureZeroMemoryTiming(
     args.timing,
     "runtime_injection",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -692,8 +692,10 @@ async function loadMemoryRuntimeAppendSystemPrompt(
     readonly timing?: ZeroMemoryTimingObserver;
   },
 ): Promise<string | undefined> {
-  const trimmedRetrievalQuery = args.retrievalQuery?.trim();
-  const searchQuery = trimmedRetrievalQuery || args.prompt;
+  const searchQuery =
+    args.retrievalQuery === undefined
+      ? args.prompt
+      : args.retrievalQuery.trim();
   return await measureZeroMemoryTiming(
     args.timing,
     "runtime_injection",

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -694,7 +694,7 @@ async function loadMemoryRuntimeAppendSystemPrompt(
 ): Promise<string | undefined> {
   const searchQuery =
     args.retrievalQuery === undefined
-      ? args.prompt
+      ? args.prompt.trim()
       : args.retrievalQuery.trim();
   return await measureZeroMemoryTiming(
     args.timing,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -692,7 +692,8 @@ async function loadMemoryRuntimeAppendSystemPrompt(
     readonly timing?: ZeroMemoryTimingObserver;
   },
 ): Promise<string | undefined> {
-  const searchQuery = args.retrievalQuery ?? args.prompt;
+  const trimmedRetrievalQuery = args.retrievalQuery?.trim();
+  const searchQuery = trimmedRetrievalQuery || args.prompt;
   return await measureZeroMemoryTiming(
     args.timing,
     "runtime_injection",


### PR DESCRIPTION
## Summary

- split goal-continuation runtime memory retrieval from the generated run prompt
- build a bounded goal memory query from `objectiveBrief` plus a compact objective excerpt
- skip the current multi-table lexical `ILIKE` search for long, multiline, or high-token query shapes while preserving short lexical recall
- add low-cardinality timing dimensions for runtime search-query length and lexical eligibility

Fixes #20818

## Tests

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --testNamePattern "continues an active goal"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --testNamePattern "memory runtime"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --testNamePattern "skips runtime memory lexical"`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --testNamePattern "goal"`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --testNamePattern "(memory runtime|runtime memory)"`

Note: local DB migration initially failed because the container PostgreSQL 17 installation did not have `pgvector`; I installed `postgresql-17-pgvector`, then `db:migrate` passed.
