### PR TITLE
perf(runner): reduce direct candidate claim delay

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -72,6 +72,12 @@ pub(super) struct HeldSessionStateSnapshot {
 struct HeldSessionStateSnapshotInner {
     workspace_cache_states: Vec<HeldSessionState>,
     workspace_cache_loaded: bool,
+    workspace_cache_revision: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct WorkspaceCacheSnapshotRefresh {
+    revision: u64,
 }
 
 impl HeldSessionStateSnapshot {
@@ -83,11 +89,26 @@ impl HeldSessionStateSnapshot {
         self.lock_inner().workspace_cache_loaded
     }
 
-    pub(super) fn update_workspace_cache_states(&self, states: Vec<HeldSessionState>) {
+    pub(super) fn begin_workspace_cache_refresh(&self) -> WorkspaceCacheSnapshotRefresh {
+        WorkspaceCacheSnapshotRefresh {
+            revision: self.lock_inner().workspace_cache_revision,
+        }
+    }
+
+    pub(super) fn finish_workspace_cache_refresh(
+        &self,
+        refresh: WorkspaceCacheSnapshotRefresh,
+        states: Vec<HeldSessionState>,
+    ) {
         let mut inner = self.lock_inner();
-        inner.workspace_cache_states = states;
+        inner.workspace_cache_states = if inner.workspace_cache_revision == refresh.revision {
+            states
+        } else {
+            merge_workspace_cache_snapshot_states(inner.workspace_cache_states.clone(), states)
+        };
         cap_workspace_cache_snapshot_states(&mut inner.workspace_cache_states);
         inner.workspace_cache_loaded = true;
+        inner.workspace_cache_revision = inner.workspace_cache_revision.wrapping_add(1);
     }
 
     pub(super) fn upsert_workspace_cache_state(&self, state: HeldSessionState) {
@@ -103,6 +124,7 @@ impl HeldSessionStateSnapshot {
             None => inner.workspace_cache_states.push(state),
         }
         cap_workspace_cache_snapshot_states(&mut inner.workspace_cache_states);
+        inner.workspace_cache_revision = inner.workspace_cache_revision.wrapping_add(1);
     }
 
     pub(super) fn might_contain_workspace_cache_session(&self, session_id: &str) -> bool {
@@ -178,8 +200,9 @@ pub(super) async fn refresh_workspace_cache_held_session_snapshot(
     snapshot: &HeldSessionStateSnapshot,
     workspace_cache: Option<&SessionWorkspaceCache>,
 ) -> Vec<HeldSessionState> {
+    let refresh = snapshot.begin_workspace_cache_refresh();
     let states = workspace_cache_held_session_states(workspace_cache).await;
-    snapshot.update_workspace_cache_states(states.clone());
+    snapshot.finish_workspace_cache_refresh(refresh, states.clone());
     states
 }
 
@@ -238,6 +261,22 @@ fn merge_held_session_states(
     states.truncate(MAX_HELD_SESSION_STATES);
     states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
     states
+}
+
+fn merge_workspace_cache_snapshot_states(
+    existing_states: Vec<HeldSessionState>,
+    refreshed_states: Vec<HeldSessionState>,
+) -> Vec<HeldSessionState> {
+    let mut by_session = std::collections::BTreeMap::<String, HeldSessionState>::new();
+    for state in refreshed_states.into_iter().chain(existing_states) {
+        match by_session.get(&state.session_id) {
+            Some(existing) if existing.last_completed_at >= state.last_completed_at => {}
+            _ => {
+                by_session.insert(state.session_id.clone(), state);
+            }
+        }
+    }
+    by_session.into_values().collect()
 }
 
 fn cap_workspace_cache_snapshot_states(states: &mut Vec<HeldSessionState>) {
@@ -359,6 +398,11 @@ mod tests {
         )
         .with_mock_sandbox_name("test")
         .build()
+    }
+
+    fn refresh_snapshot(snapshot: &HeldSessionStateSnapshot, states: Vec<HeldSessionState>) {
+        let refresh = snapshot.begin_workspace_cache_refresh();
+        snapshot.finish_workspace_cache_refresh(refresh, states);
     }
 
     async fn seed_workspace_cache_state(
@@ -657,20 +701,23 @@ mod tests {
     #[tokio::test]
     async fn held_session_snapshot_merges_cached_states_and_filters_active_sessions() {
         let snapshot = HeldSessionStateSnapshot::new();
-        snapshot.update_workspace_cache_states(vec![
-            HeldSessionState {
-                session_id: "sess-cache".into(),
-                last_completed_at: "2026-06-01T00:00:02.000Z".into(),
-            },
-            HeldSessionState {
-                session_id: "sess-claimed".into(),
-                last_completed_at: "2026-06-01T00:00:03.000Z".into(),
-            },
-            HeldSessionState {
-                session_id: "sess-active".into(),
-                last_completed_at: "2026-06-01T00:00:04.000Z".into(),
-            },
-        ]);
+        refresh_snapshot(
+            &snapshot,
+            vec![
+                HeldSessionState {
+                    session_id: "sess-cache".into(),
+                    last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+                },
+                HeldSessionState {
+                    session_id: "sess-claimed".into(),
+                    last_completed_at: "2026-06-01T00:00:03.000Z".into(),
+                },
+                HeldSessionState {
+                    session_id: "sess-active".into(),
+                    last_completed_at: "2026-06-01T00:00:04.000Z".into(),
+                },
+            ],
+        );
         let active_cli_agent_sessions =
             super::super::active_sessions::new_active_cli_agent_sessions();
         super::super::active_sessions::insert_active_cli_agent_session(
@@ -722,7 +769,7 @@ mod tests {
             "unloaded snapshot should trigger one refresh for cache-enabled runners"
         );
 
-        snapshot.update_workspace_cache_states(Vec::new());
+        refresh_snapshot(&snapshot, Vec::new());
         assert!(
             snapshot.workspace_cache_loaded(),
             "refresh should mark workspace-cache state loaded even when empty"
@@ -732,10 +779,13 @@ mod tests {
             "loaded empty snapshot should not keep triggering cache refreshes"
         );
 
-        snapshot.update_workspace_cache_states(vec![HeldSessionState {
-            session_id: "sess-cache".into(),
-            last_completed_at: "2026-06-01T00:00:02.000Z".into(),
-        }]);
+        refresh_snapshot(
+            &snapshot,
+            vec![HeldSessionState {
+                session_id: "sess-cache".into(),
+                last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+            }],
+        );
         assert!(
             snapshot.might_contain_workspace_cache_session("sess-cache"),
             "loaded matching snapshot should trigger refresh when that session is claimed"
@@ -768,6 +818,37 @@ mod tests {
                 .any(|state| state.session_id == format!("sess-{MAX_HELD_SESSION_STATES:04}")),
             "newest upserted workspace-cache state should be retained at the cap"
         );
+    }
+
+    #[test]
+    fn held_session_snapshot_refresh_preserves_concurrent_upsert() {
+        let snapshot = HeldSessionStateSnapshot::new();
+        let original = HeldSessionState {
+            session_id: "sess-original".into(),
+            last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+        };
+        let promoted = HeldSessionState {
+            session_id: "sess-promoted".into(),
+            last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+        };
+        refresh_snapshot(&snapshot, vec![original.clone()]);
+
+        let refresh = snapshot.begin_workspace_cache_refresh();
+        snapshot.upsert_workspace_cache_state(promoted.clone());
+        snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
+
+        let active_cli_agent_sessions =
+            super::super::active_sessions::new_active_cli_agent_sessions();
+        let states =
+            snapshot.current_held_session_states(Vec::new(), &active_cli_agent_sessions, None);
+        assert_eq!(states, vec![original.clone(), promoted]);
+
+        let refresh = snapshot.begin_workspace_cache_refresh();
+        snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
+
+        let states =
+            snapshot.current_held_session_states(Vec::new(), &active_cli_agent_sessions, None);
+        assert_eq!(states, vec![original]);
     }
 
     fn timestamp_for_index(index: usize) -> String {

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -79,10 +79,30 @@ impl HeldSessionStateSnapshot {
         Self::default()
     }
 
+    pub(super) fn workspace_cache_loaded(&self) -> bool {
+        self.lock_inner().workspace_cache_loaded
+    }
+
     pub(super) fn update_workspace_cache_states(&self, states: Vec<HeldSessionState>) {
         let mut inner = self.lock_inner();
         inner.workspace_cache_states = states;
+        cap_workspace_cache_snapshot_states(&mut inner.workspace_cache_states);
         inner.workspace_cache_loaded = true;
+    }
+
+    pub(super) fn upsert_workspace_cache_state(&self, state: HeldSessionState) {
+        let mut inner = self.lock_inner();
+        inner.workspace_cache_loaded = true;
+        match inner
+            .workspace_cache_states
+            .iter_mut()
+            .find(|existing| existing.session_id == state.session_id)
+        {
+            Some(existing) if existing.last_completed_at >= state.last_completed_at => {}
+            Some(existing) => *existing = state,
+            None => inner.workspace_cache_states.push(state),
+        }
+        cap_workspace_cache_snapshot_states(&mut inner.workspace_cache_states);
     }
 
     pub(super) fn might_contain_workspace_cache_session(&self, session_id: &str) -> bool {
@@ -130,10 +150,11 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
         mode,
     );
     drop(pool);
-    let workspace_cache_states =
-        workspace_cache_held_session_states(hb.workspace_cache.as_ref()).await;
-    hb.held_session_snapshot
-        .update_workspace_cache_states(workspace_cache_states.clone());
+    let workspace_cache_states = refresh_workspace_cache_held_session_snapshot(
+        &hb.held_session_snapshot,
+        hb.workspace_cache.as_ref(),
+    )
+    .await;
     state.held_session_states = merge_current_held_session_states(
         state.held_session_states,
         workspace_cache_states,
@@ -151,6 +172,15 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
         "heartbeat held session states"
     );
     hb.provider.heartbeat(&state).await;
+}
+
+pub(super) async fn refresh_workspace_cache_held_session_snapshot(
+    snapshot: &HeldSessionStateSnapshot,
+    workspace_cache: Option<&SessionWorkspaceCache>,
+) -> Vec<HeldSessionState> {
+    let states = workspace_cache_held_session_states(workspace_cache).await;
+    snapshot.update_workspace_cache_states(states.clone());
+    states
 }
 
 async fn workspace_cache_held_session_states(
@@ -208,6 +238,19 @@ fn merge_held_session_states(
     states.truncate(MAX_HELD_SESSION_STATES);
     states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
     states
+}
+
+fn cap_workspace_cache_snapshot_states(states: &mut Vec<HeldSessionState>) {
+    if states.len() <= MAX_HELD_SESSION_STATES {
+        return;
+    }
+    states.sort_unstable_by(|a, b| {
+        b.last_completed_at
+            .cmp(&a.last_completed_at)
+            .then_with(|| a.session_id.cmp(&b.session_id))
+    });
+    states.truncate(MAX_HELD_SESSION_STATES);
+    states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
 }
 
 fn admittable_profiles_for_heartbeat(
@@ -671,11 +714,19 @@ mod tests {
         let snapshot = HeldSessionStateSnapshot::new();
 
         assert!(
+            !snapshot.workspace_cache_loaded(),
+            "new snapshot should start with unknown workspace-cache state"
+        );
+        assert!(
             snapshot.might_contain_workspace_cache_session("sess-cache"),
             "unloaded snapshot should trigger one refresh for cache-enabled runners"
         );
 
         snapshot.update_workspace_cache_states(Vec::new());
+        assert!(
+            snapshot.workspace_cache_loaded(),
+            "refresh should mark workspace-cache state loaded even when empty"
+        );
         assert!(
             !snapshot.might_contain_workspace_cache_session("sess-cache"),
             "loaded empty snapshot should not keep triggering cache refreshes"
@@ -689,6 +740,38 @@ mod tests {
             snapshot.might_contain_workspace_cache_session("sess-cache"),
             "loaded matching snapshot should trigger refresh when that session is claimed"
         );
+    }
+
+    #[test]
+    fn held_session_snapshot_upsert_caps_workspace_cache_states() {
+        let snapshot = HeldSessionStateSnapshot::new();
+        for index in 0..=MAX_HELD_SESSION_STATES {
+            snapshot.upsert_workspace_cache_state(HeldSessionState {
+                session_id: format!("sess-{index:04}"),
+                last_completed_at: timestamp_for_index(index),
+            });
+        }
+
+        let active_cli_agent_sessions =
+            super::super::active_sessions::new_active_cli_agent_sessions();
+        let states =
+            snapshot.current_held_session_states(Vec::new(), &active_cli_agent_sessions, None);
+
+        assert_eq!(states.len(), MAX_HELD_SESSION_STATES);
+        assert!(
+            !states.iter().any(|state| state.session_id == "sess-0000"),
+            "oldest upserted workspace-cache state should be dropped at the cap"
+        );
+        assert!(
+            states
+                .iter()
+                .any(|state| state.session_id == format!("sess-{MAX_HELD_SESSION_STATES:04}")),
+            "newest upserted workspace-cache state should be retained at the cap"
+        );
+    }
+
+    fn timestamp_for_index(index: usize) -> String {
+        format!("2026-06-01T00:{:02}:{:02}.000Z", index / 60, index % 60)
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -99,7 +99,7 @@ impl HeldSessionStateSnapshot {
         &self,
         refresh: WorkspaceCacheSnapshotRefresh,
         states: Vec<HeldSessionState>,
-    ) {
+    ) -> Vec<HeldSessionState> {
         let mut inner = self.lock_inner();
         inner.workspace_cache_states = if inner.workspace_cache_revision == refresh.revision {
             states
@@ -109,6 +109,7 @@ impl HeldSessionStateSnapshot {
         cap_workspace_cache_snapshot_states(&mut inner.workspace_cache_states);
         inner.workspace_cache_loaded = true;
         inner.workspace_cache_revision = inner.workspace_cache_revision.wrapping_add(1);
+        inner.workspace_cache_states.clone()
     }
 
     pub(super) fn upsert_workspace_cache_state(&self, state: HeldSessionState) {
@@ -202,8 +203,7 @@ pub(super) async fn refresh_workspace_cache_held_session_snapshot(
 ) -> Vec<HeldSessionState> {
     let refresh = snapshot.begin_workspace_cache_refresh();
     let states = workspace_cache_held_session_states(workspace_cache).await;
-    snapshot.finish_workspace_cache_refresh(refresh, states.clone());
-    states
+    snapshot.finish_workspace_cache_refresh(refresh, states)
 }
 
 async fn workspace_cache_held_session_states(
@@ -835,7 +835,8 @@ mod tests {
 
         let refresh = snapshot.begin_workspace_cache_refresh();
         snapshot.upsert_workspace_cache_state(promoted.clone());
-        snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
+        let refreshed = snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
+        assert_eq!(refreshed, vec![original.clone(), promoted.clone()]);
 
         let active_cli_agent_sessions =
             super::super::active_sessions::new_active_cli_agent_sessions();

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -457,12 +457,6 @@ async fn current_local_held_session_states(
         let pool = ctx.idle_pool.lock().await;
         pool.held_session_states()
     };
-    if let Some(workspace_cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
-        let cache_states = workspace_cache.held_session_states().await;
-        ctx.spawn_ctx
-            .held_session_snapshot
-            .update_workspace_cache_states(cache_states);
-    }
     ctx.spawn_ctx
         .held_session_snapshot
         .current_held_session_states(idle_states, &ctx.spawn_ctx.active_cli_agent_sessions, None)
@@ -824,6 +818,7 @@ mod tests {
                 idle_pool: Arc::clone(&idle_pool),
                 status,
                 park_notify: Arc::new(tokio::sync::Notify::new()),
+                held_session_snapshot: super::super::heartbeat::HeldSessionStateSnapshot::new(),
                 parking_gate,
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
                 exit_code: 0,

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -245,6 +245,7 @@ struct FinalizationPhase {
     idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
     park_notify: Arc<tokio::sync::Notify>,
+    held_session_snapshot: HeldSessionStateSnapshot,
     parking_gate: ParkingGate,
     network_log_drain: NetworkLogDrainCoordinator,
     cancel: RunCancellationHandle,
@@ -277,6 +278,7 @@ impl FinalizationPhase {
             idle_pool,
             status,
             park_notify,
+            held_session_snapshot,
             parking_gate,
             network_log_drain,
             cancel,
@@ -336,6 +338,7 @@ impl FinalizationPhase {
                 idle_pool,
                 status,
                 park_notify,
+                held_session_snapshot,
                 parking_gate,
                 network_log_drain,
                 exit_code,
@@ -525,6 +528,7 @@ pub(super) fn spawn_job(
     let status = Arc::clone(&ctx.status);
     let idle_pool = Arc::clone(&ctx.idle_pool);
     let park_notify = Arc::clone(&ctx.park_notify);
+    let held_session_snapshot = ctx.held_session_snapshot.clone();
     let usage_flush_tx = ctx.usage_flush_tx.clone();
     let parking_gate = ctx.parking_gate.clone();
     let cleanup_state = RunCleanupState::new();
@@ -598,6 +602,7 @@ pub(super) fn spawn_job(
         idle_pool: Arc::clone(&idle_pool),
         status: Arc::clone(&status),
         park_notify: Arc::clone(&park_notify),
+        held_session_snapshot,
         parking_gate,
         network_log_drain: exec_config.network_log_drain.clone(),
         cancel: job_cancel.clone(),
@@ -1198,6 +1203,7 @@ mod tests {
                 idle_pool: Arc::clone(&self.idle_pool),
                 status: Arc::clone(&self.status),
                 park_notify: Arc::clone(&self.park_notify),
+                held_session_snapshot: HeldSessionStateSnapshot::new(),
                 parking_gate: self.parking_gate.clone(),
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
                 cancel: RunCancellationHandle::new(),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -86,7 +86,7 @@ use active_sessions::new_active_cli_agent_sessions;
 use factory_lifecycle::{shutdown_factories, start_factories};
 use heartbeat::{
     HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeldSessionStateSnapshot,
-    collect_heartbeat_state, send_heartbeat,
+    collect_heartbeat_state, refresh_workspace_cache_held_session_snapshot, send_heartbeat,
 };
 use identity::load_or_generate_runner_id;
 use idle_lifecycle::{
@@ -1289,6 +1289,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         active_cli_agent_sessions: &active_cli_agent_sessions,
         held_session_snapshot: held_session_snapshot.clone(),
     });
+    refresh_workspace_cache_held_session_snapshot(
+        &held_session_snapshot,
+        exec_config.workspace_cache.as_ref(),
+    )
+    .await;
+    debug_assert!(held_session_snapshot.workspace_cache_loaded());
 
     // Pin the discover future so it survives cancellation by other select!
     // branches (heartbeat, idle cleanup, etc.). Without pinning, heartbeat
@@ -1418,7 +1424,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let Some(candidate) = discovered else { break };
                 // Future completed — create a new one for the next discovery.
                 discover_fut = Box::pin(provider_state.provider.discover());
-                let needs_session_affinity_refresh = handle_discovered_job(
+                let mut needs_session_affinity_refresh = handle_discovered_job(
                     DiscoveredJob { candidate },
                     DiscoveredJobContext {
                         profiles: &runner.profiles,
@@ -1433,16 +1439,6 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         jobs: &mut jobs,
                     },
                 ).await;
-                let live_mode = *mode_rx.borrow();
-                if needs_session_affinity_refresh
-                    && matches!(live_mode, RunnerMode::Running | RunnerMode::Draining)
-                {
-                    info!(
-                        source = "post_discovery",
-                        "session affinity state triggered immediate heartbeat"
-                    );
-                    send_heartbeat(&hb_ctx, live_mode).await;
-                }
                 let mut drained_ready_candidates = 0;
                 while drained_ready_candidates < READY_DIRECT_CANDIDATE_DRAIN_LIMIT {
                     let live_mode = *mode_rx.borrow();
@@ -1459,7 +1455,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                         break;
                     };
                     drained_ready_candidates += 1;
-                    let needs_session_affinity_refresh = handle_discovered_job(
+                    let candidate_needs_session_affinity_refresh = handle_discovered_job(
                         DiscoveredJob { candidate },
                         DiscoveredJobContext {
                             profiles: &runner.profiles,
@@ -1474,16 +1470,18 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             jobs: &mut jobs,
                         },
                     ).await;
-                    let live_mode = *mode_rx.borrow();
-                    if needs_session_affinity_refresh
-                        && matches!(live_mode, RunnerMode::Running | RunnerMode::Draining)
-                    {
-                        info!(
-                            source = "ready_direct_candidate_drain",
-                            "session affinity state triggered immediate heartbeat"
-                        );
-                        send_heartbeat(&hb_ctx, live_mode).await;
-                    }
+                    needs_session_affinity_refresh |= candidate_needs_session_affinity_refresh;
+                }
+                let live_mode = *mode_rx.borrow();
+                if needs_session_affinity_refresh
+                    && matches!(live_mode, RunnerMode::Running | RunnerMode::Draining)
+                {
+                    info!(
+                        source = "direct_candidate_batch",
+                        drained_ready_candidates,
+                        "session affinity state triggered immediate heartbeat"
+                    );
+                    send_heartbeat(&hb_ctx, live_mode).await;
                 }
             }
             // Mode changes (signals)

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -169,6 +169,9 @@ pub(super) async fn finalize_sandbox_for_completion(
             storage_fingerprints: storage_fingerprints.clone(),
         })
     });
+    let workspace_promotion_session_id = workspace_promotion
+        .as_ref()
+        .map(|promotion| promotion.cli_agent_session_id().to_owned());
 
     let mut session_affinity_changed = false;
     let budget = if let Some(cli_agent_session_id) = parkable_cli_agent_session_id {
@@ -421,9 +424,11 @@ pub(super) async fn finalize_sandbox_for_completion(
         }
     } else {
         // No parkable session — stop + destroy.
+        let workspace_cache_snapshot_session_id =
+            resolved_cli_agent_session_id.or(workspace_promotion_session_id.as_deref());
         let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
             &held_session_snapshot,
-            resolved_cli_agent_session_id,
+            workspace_cache_snapshot_session_id,
             &completed_at,
             promote_workspace_image_from_active_sandbox(
                 sandbox.as_ref(),
@@ -1265,6 +1270,7 @@ mod tests {
         context.exit_code = 1;
         context.workspace_image = Some(workspace_image);
         context.workspace_image_size_bytes = b"image".len() as u64;
+        let held_session_snapshot = context.held_session_snapshot.clone();
 
         let _completion_ready = finalize_sandbox_for_completion(
             Some(Box::new(MockSandbox::new("lease-session-promotion"))),
@@ -1285,6 +1291,11 @@ mod tests {
         let cache_states = cache.held_session_states().await;
         assert_eq!(cache_states.len(), 1);
         assert_eq!(cache_states[0].session_id, session_id);
+        let active_sessions = super::super::active_sessions::new_active_cli_agent_sessions();
+        let snapshot_states =
+            held_session_snapshot.current_held_session_states(Vec::new(), &active_sessions, None);
+        assert_eq!(snapshot_states.len(), 1);
+        assert_eq!(snapshot_states[0].session_id, session_id);
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -12,6 +12,7 @@ use futures_util::FutureExt;
 use sandbox::{Sandbox, SandboxFactory, SandboxId};
 use tracing::{info, warn};
 
+use super::heartbeat::HeldSessionStateSnapshot;
 use super::idle_lifecycle::{
     SharedIdlePool, destroy_idle_jobs_and_wait, destroy_idle_payload_and_wait,
 };
@@ -35,6 +36,7 @@ use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
+use crate::types::HeldSessionState;
 use crate::workspace_image_cache::{
     WorkspaceCacheTerminalStatus, WorkspaceImageLease, WorkspaceImagePromotionRequest,
 };
@@ -55,6 +57,21 @@ fn mark_session_affinity_refresh(
     }
 }
 
+fn mark_workspace_cache_snapshot_promoted(
+    snapshot: &HeldSessionStateSnapshot,
+    session_id: Option<&str>,
+    completed_at: &str,
+    promoted: bool,
+) -> bool {
+    if promoted && let Some(session_id) = session_id {
+        snapshot.upsert_workspace_cache_state(HeldSessionState {
+            session_id: session_id.to_owned(),
+            last_completed_at: completed_at.to_owned(),
+        });
+    }
+    promoted
+}
+
 pub(super) struct FinalizeContext {
     pub(super) run_id: RunId,
     pub(super) sandbox_id: SandboxId,
@@ -72,6 +89,7 @@ pub(super) struct FinalizeContext {
     pub(super) idle_pool: SharedIdlePool,
     pub(super) status: Arc<StatusTracker>,
     pub(super) park_notify: Arc<tokio::sync::Notify>,
+    pub(super) held_session_snapshot: HeldSessionStateSnapshot,
     pub(super) parking_gate: ParkingGate,
     pub(super) network_log_drain: NetworkLogDrainCoordinator,
     pub(super) exit_code: i32,
@@ -110,6 +128,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         idle_pool,
         status,
         park_notify,
+        held_session_snapshot,
         parking_gate,
         network_log_drain,
         exit_code,
@@ -186,12 +205,17 @@ pub(super) async fn finalize_sandbox_for_completion(
                     error = %failure.error,
                     "sandbox park failed, destroying instead of parking"
                 );
-                let workspace_cache_promoted = promote_workspace_image_from_active_sandbox(
-                    sandbox.as_ref(),
-                    workspace_promotion,
-                    "park_failed",
-                )
-                .await;
+                let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+                    &held_session_snapshot,
+                    Some(&cli_agent_session_id),
+                    &completed_at,
+                    promote_workspace_image_from_active_sandbox(
+                        sandbox.as_ref(),
+                        workspace_promotion,
+                        "park_failed",
+                    )
+                    .await,
+                );
                 let destroy_outcome = stop_and_destroy_sandbox(
                     sandbox,
                     &**failure_factory,
@@ -233,7 +257,12 @@ pub(super) async fn finalize_sandbox_for_completion(
                 destroy_bookkeeping,
             )
             .await;
-            session_affinity_changed |= destroy_result.workspace_cache_promoted;
+            session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
+                &held_session_snapshot,
+                Some(&cli_agent_session_id),
+                &completed_at,
+                destroy_result.workspace_cache_promoted,
+            );
             destroy_result.budget
         } else {
             close_network_log_session(run_id, network_log_session.take(), &network_log_drain).await;
@@ -263,9 +292,15 @@ pub(super) async fn finalize_sandbox_for_completion(
                             destroy_bookkeeping,
                         )
                         .await;
+                        let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+                            &held_session_snapshot,
+                            Some(&cli_agent_session_id),
+                            &completed_at,
+                            destroy_result.workspace_cache_promoted,
+                        );
                         return mark_session_affinity_refresh(
                             CompletionReady::new(completion_payload, destroy_result.budget),
-                            destroy_result.workspace_cache_promoted,
+                            workspace_cache_promoted,
                         );
                     }
                     drop(transfer_guard);
@@ -287,9 +322,15 @@ pub(super) async fn finalize_sandbox_for_completion(
                         destroy_bookkeeping,
                     )
                     .await;
+                    let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+                        &held_session_snapshot,
+                        Some(&cli_agent_session_id),
+                        &completed_at,
+                        destroy_result.workspace_cache_promoted,
+                    );
                     return mark_session_affinity_refresh(
                         CompletionReady::new(completion_payload, destroy_result.budget),
-                        destroy_result.workspace_cache_promoted,
+                        workspace_cache_promoted,
                     );
                 }
                 let candidate = candidate.with_last_completed_at(completed_at.clone());
@@ -367,7 +408,12 @@ pub(super) async fn finalize_sandbox_for_completion(
                             destroy_bookkeeping,
                         )
                         .await;
-                        session_affinity_changed |= destroy_result.workspace_cache_promoted;
+                        session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
+                            &held_session_snapshot,
+                            Some(&cli_agent_session_id),
+                            &completed_at,
+                            destroy_result.workspace_cache_promoted,
+                        );
                         destroy_result.budget
                     }
                 };
@@ -375,17 +421,22 @@ pub(super) async fn finalize_sandbox_for_completion(
         }
     } else {
         // No parkable session — stop + destroy.
-        let workspace_cache_promoted = promote_workspace_image_from_active_sandbox(
-            sandbox.as_ref(),
-            workspace_promotion,
-            active_cleanup_reason(
-                exit_code,
-                cancelled,
-                parking_gate.is_open(),
-                resolved_cli_agent_session_id,
-            ),
-        )
-        .await;
+        let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
+            &held_session_snapshot,
+            resolved_cli_agent_session_id,
+            &completed_at,
+            promote_workspace_image_from_active_sandbox(
+                sandbox.as_ref(),
+                workspace_promotion,
+                active_cleanup_reason(
+                    exit_code,
+                    cancelled,
+                    parking_gate.is_open(),
+                    resolved_cli_agent_session_id,
+                ),
+            )
+            .await,
+        );
         session_affinity_changed |= workspace_cache_promoted;
         let destroy_outcome = stop_and_destroy_sandbox(
             sandbox,
@@ -674,6 +725,7 @@ mod tests {
                 idle_pool: Arc::clone(&self.idle_pool),
                 status: Arc::clone(&self.status),
                 park_notify: Arc::new(tokio::sync::Notify::new()),
+                held_session_snapshot: HeldSessionStateSnapshot::new(),
                 parking_gate: self.parking_gate.clone(),
                 network_log_drain: NetworkLogDrainCoordinator::noop(),
                 exit_code: 0,

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -1,10 +1,15 @@
 use super::super::super::*;
 use super::super::support::{
     assert_run_exits_within, context_with_session, minimal_context, mock_run_config,
-    mock_run_config_with_overrides, push_job, seed_idle_pool, shutdown, test_profiles,
-    wait_budget_count, wait_cancel_token, wait_cancel_token_removed, wait_discover_entered,
+    mock_run_config_with_overrides, push_job, seed_idle_pool, seed_idle_pool_with_overrides,
+    seed_workspace_cache_state, shutdown, test_profiles, wait_budget_count, wait_cancel_token,
+    wait_cancel_token_removed, wait_discover_entered,
 };
+use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
+
+use crate::paths::RunnerPaths;
+use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
 
@@ -451,6 +456,181 @@ async fn affinity_protected_candidate_with_local_session_claims() {
         env.handle.deferred_poll_delays().is_empty(),
         "runner holding the protected session should not defer the claim"
     );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn affinity_protected_candidate_with_workspace_cache_session_claims_from_startup_snapshot() {
+    let session_id = "sess-cache-local";
+    let image_size_bytes = 1024 * 1024;
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
+    let (mut config, env) = mock_run_config(profiles, 8, 32768, 4);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = SessionWorkspaceCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    seed_workspace_cache_state(
+        &workspace_cache,
+        &runner_paths,
+        session_id,
+        "vm0/default",
+        image_size_bytes,
+    )
+    .await;
+    let cache_key = crate::paths::scoped_session_workspace_cache_key(
+        &config.runner.group,
+        "vm0/default",
+        session_id,
+        CANONICAL_WORKING_DIR,
+        image_size_bytes,
+    );
+    let cache_entry_dir = config
+        .paths
+        .home
+        .workspace_image_cache_dir()
+        .join(cache_key);
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    tokio::fs::remove_dir_all(&cache_entry_dir).await.unwrap();
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    env.handle
+        .discover_tx
+        .send(affinity_protected_candidate(run_id, session_id))
+        .unwrap();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        completion.is_some(),
+        "runner should claim from the startup workspace-cache snapshot even if a later scan would miss"
+    );
+
+    let claim_candidates = env.handle.claim_candidates();
+    let claimed_candidate = claim_candidates
+        .iter()
+        .find(|candidate| candidate.run_id() == run_id)
+        .expect("claim should record the protected candidate");
+    assert_eq!(
+        claimed_candidate.pre_local_admission_outcome(),
+        Some(crate::provider::PreLocalAdmissionOutcome::LocalHolder)
+    );
+    assert!(
+        env.handle.deferred_poll_delays().is_empty(),
+        "snapshot-backed local holders should not defer before claim"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn ready_direct_drain_batches_session_affinity_heartbeat() {
+    let wait_gate = sandbox_mock::MockLifecycleGate::new();
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.set_wait_process_lifecycle_gate(wait_gate.clone());
+    let (config, env) =
+        mock_run_config_with_overrides(test_profiles(), 12, 49152, 6, Arc::clone(&overrides));
+    let budget = Arc::clone(&config.capacity.budget);
+    let trigger_session = "sess-batch-trigger";
+    let ready_session_1 = "sess-batch-ready-1";
+    let ready_session_2 = "sess-batch-ready-2";
+    for session_id in [trigger_session, ready_session_1, ready_session_2] {
+        seed_idle_pool_with_overrides(
+            &env.idle_pool,
+            &budget,
+            &overrides,
+            session_id,
+            "vm0/default",
+            2,
+            4096,
+        )
+        .await;
+    }
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+    let heartbeat_count = env.handle.heartbeat_count();
+
+    let trigger_run_id = RunId::new_v4();
+    let ready_run_id_1 = RunId::new_v4();
+    let ready_run_id_2 = RunId::new_v4();
+    env.provider.set_claim_result(
+        trigger_run_id,
+        Some(context_with_session(trigger_run_id, trigger_session)),
+    );
+    env.provider.set_claim_result(
+        ready_run_id_1,
+        Some(context_with_session(ready_run_id_1, ready_session_1)),
+    );
+    env.provider.set_claim_result(
+        ready_run_id_2,
+        Some(context_with_session(ready_run_id_2, ready_session_2)),
+    );
+    env.handle
+        .push_ready_candidate(crate::provider::JobCandidate::new(
+            ready_run_id_1,
+            "vm0/default".into(),
+        ));
+    env.handle
+        .push_ready_candidate(crate::provider::JobCandidate::new(
+            ready_run_id_2,
+            "vm0/default".into(),
+        ));
+
+    push_job(
+        &env,
+        trigger_run_id,
+        "vm0/default",
+        Some(context_with_session(trigger_run_id, trigger_session)),
+    );
+
+    wait_gate
+        .wait_entered(3, Duration::from_secs(5))
+        .await
+        .expect("all reused jobs should block in wait_process");
+    assert!(
+        env.handle
+            .wait_heartbeat_past(heartbeat_count, Duration::from_secs(5))
+            .await,
+        "reusing direct-candidate sessions should trigger a prompt heartbeat"
+    );
+    assert_eq!(
+        env.handle.heartbeat_count(),
+        heartbeat_count + 1,
+        "direct-candidate drain should batch session-affinity refresh into one heartbeat"
+    );
+
+    let claimed_run_ids: std::collections::HashSet<RunId> = env
+        .handle
+        .claim_candidates()
+        .into_iter()
+        .map(|candidate| candidate.run_id())
+        .collect();
+    assert_eq!(
+        claimed_run_ids,
+        std::collections::HashSet::from([trigger_run_id, ready_run_id_1, ready_run_id_2])
+    );
+
+    wait_gate.release_many(3);
+    for run_id in [trigger_run_id, ready_run_id_1, ready_run_id_2] {
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(completion.is_some(), "run {run_id} should complete");
+    }
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -159,6 +159,49 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
     sandbox_id
 }
 
+pub(in super::super) async fn seed_workspace_cache_state(
+    cache: &SessionWorkspaceCache,
+    paths: &RunnerPaths,
+    session_id: &str,
+    profile_name: &str,
+    image_size_bytes: u64,
+) {
+    let run_id = RunId::new_v4();
+    let sandbox_id = SandboxId::new_v4();
+    let lease = cache
+        .prepare(WorkspaceImagePrepareRequest {
+            identity: WorkspaceImageLeaseIdentity {
+                run_id,
+                sandbox_id,
+                profile_name,
+                cli_agent_session_id: Some(session_id),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes,
+            },
+            workspace_drive_required: true,
+        })
+        .await;
+    let active_image = paths.active_workspace_image(&sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    let file = tokio::fs::File::create(&active_image).await.unwrap();
+    file.set_len(image_size_bytes).await.unwrap();
+    drop(file);
+    assert!(
+        lease
+            .promote(
+                run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                TEST_SESSION_LAST_COMPLETED_AT.into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap()
+    );
+}
+
 pub(in super::super) async fn seed_idle_pool_expired(
     pool: &SharedIdlePool,
     budget: &Arc<ResourceBudget>,

--- a/crates/runner/src/cmd/start/tests/support/mod.rs
+++ b/crates/runner/src/cmd/start/tests/support/mod.rs
@@ -11,7 +11,7 @@ pub(super) use self::env::{
 pub(super) use self::idle_pool::{
     TestParkedIdleCandidateSpec, WorkspacePromotionSeedSpec, seed_idle_pool,
     seed_idle_pool_expired, seed_idle_pool_with_overrides, seed_idle_pool_with_timing,
-    seed_idle_pool_with_workspace_promotion,
+    seed_idle_pool_with_workspace_promotion, seed_workspace_cache_state,
 };
 pub(super) use self::jobs::{
     TEST_SESSION_LAST_COMPLETED_AT, context_with_session, minimal_context, push_job, shutdown,


### PR DESCRIPTION
## Summary
- load workspace-cache held-session state into the runner snapshot before discovery starts
- remove workspace-cache filesystem scans from protected admission hot path
- batch direct-candidate session-affinity heartbeats and refresh snapshot on workspace-cache promotion

## Tests
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::heartbeat
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::main_loop::admission
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start::tests::idle_reuse
- cargo test --manifest-path crates/Cargo.toml -p runner cmd::start
- cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings

Closes #20817