### PR TITLE
feat: delete canvas image with delete or backspace key

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
@@ -1482,4 +1482,45 @@ describe("image editing", () => {
       screen.getByTestId("artifact-sidebar-body-image-copy"),
     ).toHaveAttribute("src", SOURCE_IMAGE_URL);
   });
+
+  it("deletes the selected image with the Delete or Backspace key", async () => {
+    const user = userEvent.setup({ delay: null });
+    setupChatThread({
+      featureSwitches: { [FeatureSwitchKey.ImageEditing]: true },
+    });
+
+    await openSelectedImageEditToolbar(user);
+    const canvas = screen.getByTestId("artifact-sidebar-image-edit-canvas");
+
+    // Duplicate the source, then remove the copy with Backspace.
+    fireEvent.keyDown(canvas, { key: "c", metaKey: true });
+    fireEvent.keyDown(canvas, { key: "v", metaKey: true });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("artifact-sidebar-body-image-copy"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(canvas, { key: "Backspace" });
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("artifact-sidebar-body-image-copy"),
+      ).toBeNull();
+    });
+    expect(
+      screen.getByTestId("artifact-sidebar-body-image"),
+    ).toBeInTheDocument();
+
+    // Select the source itself, then remove it with Delete.
+    await user.click(screen.getByTestId("artifact-sidebar-body-image"));
+    await waitFor(() => {
+      expect(screen.getByTestId("image-edit-toolbar")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(canvas, { key: "Delete" });
+    await waitFor(() => {
+      expect(screen.queryByTestId("artifact-sidebar-body-image")).toBeNull();
+    });
+    expect(screen.queryByTestId("image-edit-toolbar")).toBeNull();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-editable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-editable-image-canvas.tsx
@@ -26,6 +26,7 @@ import {
   createInitialEditableImageCanvasItem,
   DEFAULT_CANVAS_HEIGHT,
   DEFAULT_CANVAS_WIDTH,
+  deleteEditableImageCanvasItem$,
   editableImageCanvasItemsByKey$,
   editableImageCanvasRegionCommentsByKey$,
   editableImageCanvasRegionSelectionActiveByKey$,
@@ -172,6 +173,7 @@ function useEditableImageCanvasState(canvasKey: string, src: string) {
     completeEditableImageCanvasRegionSelection$,
   );
   const copySelection = useSet(copyEditableImageCanvasSelection$);
+  const deleteItem = useSet(deleteEditableImageCanvasItem$);
   const moveItem = useSet(moveEditableImageCanvasItem$);
   const pasteSelection = useSet(pasteEditableImageCanvasSelection$);
   const resizeItem = useSet(resizeEditableImageCanvasItem$);
@@ -187,6 +189,7 @@ function useEditableImageCanvasState(canvasKey: string, src: string) {
     clearRegionSelection,
     completeRegionSelection,
     copySelection,
+    deleteItem,
     displayZoom: zoomByKey[canvasKey] ?? 1,
     items,
     moveItem,
@@ -475,6 +478,56 @@ function startImageItemMoveDrag({
   window.addEventListener("pointermove", handlePointerMove);
   window.addEventListener("pointerup", stopDragging);
   window.addEventListener("pointercancel", stopDragging);
+}
+
+function handleEditableImageCanvasKeyDown({
+  canvasKey,
+  canvasState,
+  event,
+  src,
+}: {
+  canvasKey: string;
+  canvasState: EditableImageCanvasState;
+  event: KeyboardEvent<HTMLDivElement>;
+  src: string;
+}): void {
+  if (isEditableTextTarget(event.target)) {
+    return;
+  }
+
+  if (
+    event.key === "Escape" &&
+    (canvasState.regionSelectionActive || canvasState.selectedRegion !== null)
+  ) {
+    event.preventDefault();
+    canvasState.clearRegionSelection(canvasKey);
+    return;
+  }
+
+  if (
+    (event.key === "Backspace" || event.key === "Delete") &&
+    canvasState.selectedItem !== null
+  ) {
+    event.preventDefault();
+    canvasState.deleteItem({
+      itemId: canvasState.selectedItem.id,
+      key: canvasKey,
+      src,
+    });
+    return;
+  }
+
+  const key = event.key.toLowerCase();
+  const shortcutPressed = event.metaKey || event.ctrlKey;
+  if (shortcutPressed && key === "c" && canvasState.selectedItem !== null) {
+    event.preventDefault();
+    canvasState.copySelection(canvasKey, src);
+    return;
+  }
+  if (shortcutPressed && key === "v") {
+    event.preventDefault();
+    canvasState.pasteSelection(canvasKey, src);
+  }
 }
 
 function CanvasItemView({
@@ -1004,30 +1057,7 @@ export function EditableArtifactImageCanvas({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (isEditableTextTarget(event.target)) {
-      return;
-    }
-
-    if (
-      event.key === "Escape" &&
-      (canvasState.regionSelectionActive || canvasState.selectedRegion !== null)
-    ) {
-      event.preventDefault();
-      canvasState.clearRegionSelection(canvasKey);
-      return;
-    }
-
-    const key = event.key.toLowerCase();
-    const shortcutPressed = event.metaKey || event.ctrlKey;
-    if (shortcutPressed && key === "c" && canvasState.selectedItem !== null) {
-      event.preventDefault();
-      canvasState.copySelection(canvasKey, src);
-      return;
-    }
-    if (shortcutPressed && key === "v") {
-      event.preventDefault();
-      canvasState.pasteSelection(canvasKey, src);
-    }
+    handleEditableImageCanvasKeyDown({ canvasKey, canvasState, event, src });
   };
 
   return (


### PR DESCRIPTION
## What

图片编辑画布支持用 `Delete` / `Backspace` 键删除当前选中的图片。

## Why

之前画布已经支持 `Cmd/Ctrl+C` 复制、`Cmd/Ctrl+V` 粘贴,以及工具栏的删除按钮,但没有键盘删除快捷键。补齐这个常见交互。

## How

- 把已有的 `deleteEditableImageCanvasItem$` command 接到画布的 `handleKeyDown` 里,按下 `Delete` / `Backspace` 且有选中图片时删除该图片 —— 行为与工具栏删除按钮完全一致(会一并清理关联的 region 选区/评论)。
- 文本输入中(`isEditableTextTarget`)不触发,避免干扰评论输入。
- 把 `handleKeyDown` 逻辑抽成模块级 `handleEditableImageCanvasKeyDown`,以满足 `max-lines-per-function` 上限(与其他 handler helper 同一模式)。

## Test

- 新增集成测试:复制出副本后用 `Backspace` 删除,再选中源图用 `Delete` 删除。
- 在 devcontainer 内验证:`zero-image-edit.test.tsx` 18/18 通过,`check-types` / `lint` / `format` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)