### PR TITLE
fix(cli): refresh registry resource release marker

### DIFF
--- a/turbo/apps/cli/src/lib/api/domains/registry-resources.ts
+++ b/turbo/apps/cli/src/lib/api/domains/registry-resources.ts
@@ -3,6 +3,7 @@ import { registryResourceDownloadContract } from "@vm0/api-contracts/contracts/r
 
 import { getClientConfig, handleError } from "../core/client-factory";
 
+// Keep registry resource downloads in the CLI release lifecycle.
 export async function getRegistryResourceDownload(query: {
   id: string;
 }): Promise<{


### PR DESCRIPTION
## Summary
- add a comment-only CLI release marker near registry resource downloads
- intentionally trigger a CLI patch release so the refreshed website template registry publishes to npm

## Verification
- not run locally (comment-only release marker; relying on PR pipeline)