### PR TITLE
fix(api): prevent workflow schedule run now message 500s

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -1957,7 +1957,7 @@ describe("zero workflow triggers", () => {
     );
   });
 
-  it("runs a trigger immediately in its bound chat thread", async () => {
+  it("runs a one-time trigger immediately in its bound chat thread", async () => {
     mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
     const { workflowId } = await setupFixture();
     const created = await accept(
@@ -1966,9 +1966,9 @@ describe("zero workflow triggers", () => {
         params: { workflowId },
         body: {
           schedule: {
-            type: "cron",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
+            type: "once",
+            atTime: futureIso(86_400_000),
+            timezone: "Asia/Shanghai",
           },
         },
       }),
@@ -2039,5 +2039,8 @@ describe("zero workflow triggers", () => {
     });
     expect(workflowMessage).toBeDefined();
     expect(workflowMessage?.runId).toBe(run.body.runId);
+    expect(workflowMessage?.workflowSnapshot?.triggerBrief).toMatch(
+      /^Once at \d{1,2}:\d{2} [AP]M, [A-Z][a-z]{2} \d{1,2}, \d{4} \(Asia\/Shanghai\)$/u,
+    );
   });
 });

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -40,6 +40,7 @@ import { threadGoals } from "@vm0/db/schema/thread-goal";
 import { runUploadedFiles } from "@vm0/db/schema/run-uploaded-file";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
+import { zeroWorkflowTriggers } from "@vm0/db/schema/zero-workflow";
 import {
   and,
   asc,
@@ -347,7 +348,7 @@ const messageColumns = {
       ON "zero_workflow_triggers"."id" = "zero_runs"."workflow_trigger_id"
     WHERE "zero_runs"."id" = "chat_messages"."run_id"
     LIMIT 1
-  )`,
+  )`.mapWith(zeroWorkflowTriggers.atTime),
   workflowTriggerTimezone: sql<string | null>`(
     SELECT "zero_workflow_triggers"."timezone"
     FROM "zero_runs"

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-brief.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-brief.service.ts
@@ -40,6 +40,15 @@ function formatClockTime(hour: number, minute: number): string {
   return `${h12}:${pad2(minute)} ${ampm}`;
 }
 
+type WorkflowTriggerDateTimeInput = Date | string | number;
+
+function normalizeWorkflowTriggerDateTime(
+  value: WorkflowTriggerDateTimeInput,
+): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
 function formatWorkflowTriggerDateTime(date: Date, timezone: string): string {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
@@ -293,11 +302,11 @@ function formatCronRule(args: {
 }
 
 export function buildWorkflowScheduleTriggerBrief(args: {
-  readonly createdAt: Date;
+  readonly createdAt: WorkflowTriggerDateTimeInput;
   readonly scheduleType: string | null;
   readonly cronExpression: string | null;
   readonly intervalSeconds: number | null;
-  readonly atTime: Date | null;
+  readonly atTime: WorkflowTriggerDateTimeInput | null;
   readonly triggerTimezone: string | null;
   readonly userTimezone: string | null;
 }): string | null {
@@ -309,7 +318,11 @@ export function buildWorkflowScheduleTriggerBrief(args: {
     args.triggerTimezone !== null && isValidTimeZone(args.triggerTimezone)
       ? args.triggerTimezone
       : timezone;
-  const triggeredAt = formatWorkflowTriggerDateTime(args.createdAt, timezone);
+  const createdAt = normalizeWorkflowTriggerDateTime(args.createdAt);
+  if (createdAt === null) {
+    return null;
+  }
+  const triggeredAt = formatWorkflowTriggerDateTime(createdAt, timezone);
   if (args.scheduleType === "cron") {
     const cronExpression = args.cronExpression?.trim();
     if (!cronExpression) {
@@ -321,7 +334,7 @@ export function buildWorkflowScheduleTriggerBrief(args: {
         cronExpression,
         triggerTimezone,
         displayTimezone: timezone,
-        referenceDate: args.createdAt,
+        referenceDate: createdAt,
       })}`,
     ].join("\n");
   }
@@ -334,9 +347,10 @@ export function buildWorkflowScheduleTriggerBrief(args: {
       `Every ${formatWorkflowIntervalSeconds(args.intervalSeconds)}`,
     ].join("\n");
   }
-  const onceAt = formatWorkflowTriggerDateTime(
-    args.atTime ?? args.createdAt,
-    timezone,
-  );
+  const onceDate =
+    args.atTime === null
+      ? createdAt
+      : (normalizeWorkflowTriggerDateTime(args.atTime) ?? createdAt);
+  const onceAt = formatWorkflowTriggerDateTime(onceDate, timezone);
   return `Once at ${onceAt}`;
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -31,6 +31,7 @@ import {
   type ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { parseScheduledAtTime } from "@vm0/core/timezone";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import {
   workflowUserTriggerThreads,
@@ -88,6 +89,7 @@ import {
   ensureWorkflowUserTriggerThread,
   loadWorkflowUserTriggerThreadId,
 } from "./zero-workflow-user-trigger-thread.service";
+import { buildWorkflowScheduleTriggerBrief } from "./zero-workflow-trigger-brief.service";
 
 type TriggerRow = typeof zeroWorkflowTriggers.$inferSelect;
 type WorkflowRow = typeof zeroWorkflows.$inferSelect;
@@ -696,6 +698,23 @@ async function loadTriggerRow(
     )
     .limit(1);
   return row ?? null;
+}
+
+async function loadTriggerOwnerTimezone(
+  db: ReadonlyDb,
+  trigger: TriggerRow,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ timezone: orgMembersMetadata.timezone })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        eq(orgMembersMetadata.orgId, trigger.orgId),
+        eq(orgMembersMetadata.userId, trigger.ownerUserId),
+      ),
+    )
+    .limit(1);
+  return row?.timezone ?? null;
 }
 
 /**
@@ -2073,6 +2092,8 @@ export const runOwnedWorkflowTriggerNow$ = command(
     }
 
     const currentTime = nowDate();
+    const ownerTimezone = await loadTriggerOwnerTimezone(writeDb, trigger);
+    signal.throwIfAborted();
     const chatThreadId = await writeDb.transaction(async (tx) => {
       return await ensureWorkflowUserTriggerThread(tx, {
         orgId: trigger.orgId,
@@ -2096,6 +2117,16 @@ export const runOwnedWorkflowTriggerNow$ = command(
         },
         apiStartTime: currentTime.getTime(),
         triggerSource: manualTriggerSource(trigger),
+        triggerBrief:
+          buildWorkflowScheduleTriggerBrief({
+            createdAt: currentTime,
+            scheduleType: trigger.scheduleType,
+            cronExpression: trigger.cronExpression,
+            intervalSeconds: trigger.intervalSeconds,
+            atTime: trigger.atTime,
+            triggerTimezone: trigger.timezone,
+            userTimezone: ownerTimezone,
+          }) ?? undefined,
         appendSystemPrompt: manualWorkflowTriggerSystemPrompt(
           target.workflowName,
         ),


### PR DESCRIPTION
## Summary
- normalize workflow schedule trigger brief dates so message reads do not throw on raw timestamp/string values
- map the `zero_workflow_triggers.at_time` message subquery through the Drizzle schema mapper
- persist schedule trigger briefs for manual run-now executions and cover one-time run-now message reads

## User impact
Users who create a scheduled workflow automation and click Run now can reopen the bound chat thread without the messages endpoint returning HTTP 500. Manual workflow runs also show the schedule trigger context consistently instead of relying on read-time reconstruction.

## Verification
- `git diff --check`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F api check-types`
- Attempted `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-workflow-triggers.test.ts --testNamePattern "runs a one-time trigger immediately"`; local run was blocked by missing local Postgres (`ECONNREFUSED` during `/api/zero/onboarding/setup`).
