### PR TITLE
fix: allow limited-free billable firewall auth

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -8,6 +8,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 
 import { mockOptionalEnv } from "../../../lib/env";
 import { now } from "../../../lib/time";
+import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
 import {
@@ -275,6 +276,67 @@ describe("FW-2: template resolution without connector refresh", () => {
 });
 
 describe("FW-3: billable firewall lease", () => {
+  it("leases billable auth for limited-free-1 workspaces with spendable credits", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    if (!actor.orgId) {
+      throw new Error("Expected firewall actor to have an org");
+    }
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "limited-free-1",
+      credits: 20_000,
+    });
+
+    const before = Math.floor(now() / 1000);
+    const leased = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({ API_KEY: "paid" }),
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("API_KEY")}`,
+        },
+        firewallBillable: true,
+      },
+      [200],
+    );
+    if (leased.status !== 200) {
+      throw new Error("Expected limited-free-1 billable auth to succeed");
+    }
+    expect(leased.body.expiresAt).not.toBeNull();
+    expect(leased.body.expiresAt ?? 0).toBeGreaterThanOrEqual(before + 25);
+    expect(leased.body.expiresAt ?? 0).toBeLessThanOrEqual(before + 35);
+  });
+
+  it("denies billable auth for pro-suspend workspaces even with credits", async () => {
+    const fw = createFirewallApi(context);
+    const { actor, headers } = await firewallRun();
+    if (!actor.orgId) {
+      throw new Error("Expected firewall actor to have an org");
+    }
+    await seedOrgMetadata({
+      orgId: actor.orgId,
+      tier: "pro-suspend",
+      credits: 20_000,
+    });
+
+    const denied = await fw.requestFirewallAuth(
+      headers,
+      {
+        encryptedSecrets: fw.encryptedSecretsBody({ API_KEY: "paid" }),
+        authHeaders: {
+          Authorization: `Bearer ${secretTemplate("API_KEY")}`,
+        },
+        firewallBillable: true,
+      },
+      [402],
+    );
+    if (denied.status !== 402) {
+      throw new Error("Expected pro-suspend billable auth to be denied");
+    }
+    expect(denied.body.error.code).toBe("INSUFFICIENT_CREDITS");
+  });
+
   it("bounds billable auth expiry by the credit authorization lease", async () => {
     const fw = createFirewallApi(context);
     const { headers } = await firewallRun();

--- a/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts
@@ -441,7 +441,7 @@ describe("FW-3: billable firewall lease", () => {
     );
   });
 
-  it("denies billable firewall auth after the subscription is deleted", async () => {
+  it("continues billable firewall auth after subscription deletion when credits remain", async () => {
     const bdd = createBddApi(context);
     const runsApi = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -487,11 +487,26 @@ describe("FW-3: billable firewall lease", () => {
       [200],
     );
 
-    const denied = await fw.requestFirewallAuth(headers, body, [402]);
-    if (denied.status !== 402) {
-      throw new Error("Expected the suspended billable auth to be denied");
+    const downgraded = await runsApi.readBillingStatus(actor);
+    expect(downgraded.tier).toBe("limited-free-1");
+    expect(downgraded.subscriptionStatus).toBe("canceled");
+
+    const postDeletionBefore = Math.floor(now() / 1000);
+    const postDeletionLease = await fw.requestFirewallAuth(
+      headers,
+      body,
+      [200],
+    );
+    if (postDeletionLease.status !== 200) {
+      throw new Error("Expected the limited-free-1 billable auth to lease");
     }
-    expect(denied.body.error.code).toBe("INSUFFICIENT_CREDITS");
+    expect(postDeletionLease.body.expiresAt).not.toBeNull();
+    expect(postDeletionLease.body.expiresAt ?? 0).toBeGreaterThanOrEqual(
+      postDeletionBefore + 25,
+    );
+    expect(postDeletionLease.body.expiresAt ?? 0).toBeLessThanOrEqual(
+      postDeletionBefore + 35,
+    );
 
     await runsApi.requestCancelRun(actor, run.runId, [200]);
   });

--- a/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts
@@ -294,10 +294,7 @@ async function resolveBillableFirewallCacheExpiry(params: {
   if (!availability) {
     return insufficientCredits();
   }
-  if (
-    availability.tier === "pro-suspend" ||
-    availability.tier === "limited-free-1"
-  ) {
+  if (availability.tier === "pro-suspend") {
     return insufficientCredits();
   }
   const allowance =


### PR DESCRIPTION
## Summary
- Remove the blanket `limited-free-1` rejection from billable firewall auth.
- Keep `pro-suspend` rejected before credit or allowance lease calculation.
- Add firewall auth route coverage for `limited-free-1` with spendable credits and `pro-suspend` with credits.

## Verification
- `pnpm exec prettier --write apps/api/src/signals/services/agent-webhook-firewall-auth.service.ts apps/api/src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts`
- `git diff --check`
- `pnpm -F api exec oxlint src/signals/services/agent-webhook-firewall-auth.service.ts src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/webhooks-agent-firewall-auth.bdd.test.ts` did not complete locally: test Postgres was unavailable (`ECONNREFUSED`) and Docker is not installed in this runtime.
- `pnpm -F api check-types` did not complete locally: Node hit the heap limit on this 4GB/no-swap runtime.