### PR TITLE
fix: show billing recovery for post-dispatch credit failures

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2001,11 +2001,17 @@ describe("CHAT-02: failed chat callbacks", () => {
       "INSUFFICIENT_CREDITS: Insufficient credits. Please add credits to continue.",
     );
 
-    const page = await waitForThreadMessages(actor, run.threadId, (messages) => {
-      return lifecycleMarkers(messages, run.runId, "failed").some((message) => {
-        return message.error === "insufficient_credits";
-      });
-    });
+    const page = await waitForThreadMessages(
+      actor,
+      run.threadId,
+      (messages) => {
+        return lifecycleMarkers(messages, run.runId, "failed").some(
+          (message) => {
+            return message.error === "insufficient_credits";
+          },
+        );
+      },
+    );
     const marker = lifecycleMarkers(page.messages, run.runId, "failed")[0];
     expect(marker?.error).toBe("insufficient_credits");
     expect(marker?.content).toBe("insufficient_credits");

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -1986,6 +1986,31 @@ describe("CHAT-02: failed chat callbacks", () => {
     });
   }, 90_000);
 
+  it("stores insufficient credits failures as the billing recovery marker", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "post-dispatch billing failure",
+    });
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+
+    await failChatRun(
+      run.runId,
+      sandboxHeaders,
+      "INSUFFICIENT_CREDITS: Insufficient credits. Please add credits to continue.",
+    );
+
+    const page = await waitForThreadMessages(actor, run.threadId, (messages) => {
+      return lifecycleMarkers(messages, run.runId, "failed").some((message) => {
+        return message.error === "insufficient_credits";
+      });
+    });
+    const marker = lifecycleMarkers(page.messages, run.runId, "failed")[0];
+    expect(marker?.error).toBe("insufficient_credits");
+    expect(marker?.content).toBe("insufficient_credits");
+  }, 90_000);
+
   it("shows Claude Code credential recovery guidance for upstream auth 401s", async () => {
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const upstreamAuthError =

--- a/turbo/apps/api/src/signals/services/run-error-format.service.ts
+++ b/turbo/apps/api/src/signals/services/run-error-format.service.ts
@@ -22,6 +22,7 @@ import { getMemberRoleAndUpdateCache$ } from "./auth.service";
 
 const REPORT_ERROR_STREAK_THRESHOLD = 2;
 const CHAT_RUN_REPORTABLE_ERROR_MESSAGE = "An unexpected error occurred.";
+const INSUFFICIENT_CREDITS_MARKER = "insufficient_credits";
 const PRO_REQUIRED_MARKER = "pro_required";
 
 interface RunErrorProviderContext {
@@ -72,6 +73,14 @@ function buildClaudeCodeCredentialRecoveryUrl(params: {
 
 function isProRequiredRunError(message: string): boolean {
   return message.toLowerCase().includes(PRO_REQUIRED_MARKER);
+}
+
+function isInsufficientCreditsRunError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("insufficient_credits") ||
+    normalized.includes("insufficient credits")
+  );
 }
 
 function formatLatestSessionProviderType(
@@ -167,6 +176,9 @@ function formatRunErrorLikeWebMessage(
     const errorMessage = params.errorMessage.trim() || "Run failed";
     if (isProRequiredRunError(errorMessage)) {
       return PRO_REQUIRED_MARKER;
+    }
+    if (isInsufficientCreditsRunError(errorMessage)) {
+      return INSUFFICIENT_CREDITS_MARKER;
     }
 
     const providerContext =


### PR DESCRIPTION
## Summary
- Normalize post-dispatch run errors containing `INSUFFICIENT_CREDITS`, `insufficient_credits`, or `Insufficient credits` into the `insufficient_credits` chat error marker.
- Add chat callback coverage so failed runs store the billing recovery marker and the web chat renders the upgrade/top-up card path.

## Verification
- `git diff --check`
- Attempted `pnpm --dir turbo --filter api test -- src/signals/routes/__tests__/chat-callbacks.bdd.test.ts`, but this checkout has no `node_modules` and `vitest` is not installed locally; relying on PR CI for the targeted test run.