### PR TITLE
fix: install pgvector in devcontainer setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -31,9 +31,27 @@ else
   echo "✓ Turbo workspace not found, skipping cache cleanup"
 fi
 
-# Setup PostgreSQL (handled by postgresql feature)
+# Setup PostgreSQL (handled by postgresql feature). Migrations create the
+# `vector` extension, so the local server must have the pgvector package.
+POSTGRES_VERSION=17
+PGVECTOR_PACKAGE="postgresql-${POSTGRES_VERSION}-pgvector"
+echo "🐘 Ensuring PostgreSQL pgvector extension package is installed..."
+if dpkg-query -W -f='${Status}' "$PGVECTOR_PACKAGE" 2>/dev/null | grep -q "install ok installed"; then
+  echo "✓ $PGVECTOR_PACKAGE already installed"
+else
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq "$PGVECTOR_PACKAGE"
+  echo "✓ Installed $PGVECTOR_PACKAGE"
+fi
+
 sudo chown -R postgres:postgres /var/lib/postgresql 2>/dev/null || true
 sudo service postgresql start 2>/dev/null || true
+if sudo -u postgres psql -d postgres -Atqc "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" | grep -qx 1; then
+  echo "✓ pgvector extension available to PostgreSQL"
+else
+  echo "ERROR: pgvector extension is not available to PostgreSQL after installing $PGVECTOR_PACKAGE" >&2
+  exit 1
+fi
 
 # Generate locale for UTF-8 support
 echo "🌐 Setting up locale..."


### PR DESCRIPTION
## Summary
- Install the PostgreSQL 17 pgvector server extension package during devcontainer setup.
- Keep the existing in-container PostgreSQL feature flow, then verify `vector` is available via `pg_available_extensions` before migrations run.

## User impact
Local devcontainers can run `pnpm -F @vm0/db db:migrate` after migrations that create pgvector-backed tables and HNSW indexes.

## Verification
- `bash -n .devcontainer/setup.sh`
- `git diff --check`

Full test suite not run; this is a devcontainer setup-only change and PR CI should cover repository checks.
