### PR TITLE
fix: enable codex subscriptions for gpt 5.6 models

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -661,7 +661,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
     },
   );
 
-  it("rejects unsupported GPT 5.6 Codex OAuth member routes", async () => {
+  it("allows GPT 5.6 Codex OAuth member routes", async () => {
     const fixture = await seedFixture();
     useSession(fixture);
     const client = apiClient();
@@ -686,13 +686,15 @@ describe("GET/PUT /api/zero/model-policies", () => {
       body: { policies: updates },
     });
 
-    expect(response.status).toBe(400);
-    expect(response.body).toStrictEqual({
-      error: {
-        message:
-          'Model "gpt-5.6-sol" is not supported by provider "codex-oauth-token"',
-        code: "BAD_REQUEST",
-      },
+    expect(response.status).toBe(200);
+    const sol = response.body.policies.find((policy) => {
+      return policy.model === "gpt-5.6-sol";
+    });
+    expect(sol).toMatchObject({
+      defaultProviderType: "codex-oauth-token",
+      credentialScope: "member",
+      modelProviderId: null,
+      routeStatus: "missing_provider",
     });
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -681,12 +681,14 @@ describe("GET/PUT /api/zero/model-policies", () => {
       };
     });
 
-    const response = await client.update({
-      headers: authHeaders(),
-      body: { policies: updates },
-    });
+    const response = await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { policies: updates },
+      }),
+      [200],
+    );
 
-    expect(response.status).toBe(200);
     const sol = response.body.policies.find((policy) => {
       return policy.model === "gpt-5.6-sol";
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -696,7 +696,7 @@ describe("GET/PUT /api/zero/model-policies", () => {
       defaultProviderType: "codex-oauth-token",
       credentialScope: "member",
       modelProviderId: null,
-      routeStatus: "missing_provider",
+      routeStatus: "valid",
     });
   });
 

--- a/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/model-providers.test.ts
@@ -265,14 +265,17 @@ describe("model-first canonical catalog", () => {
     expect(getProvidersForModel("gpt-5.6-sol")).toEqual([
       "vm0",
       "openai-api-key",
+      "codex-oauth-token",
     ]);
     expect(getProvidersForModel("gpt-5.6-terra")).toEqual([
       "vm0",
       "openai-api-key",
+      "codex-oauth-token",
     ]);
     expect(getProvidersForModel("gpt-5.6-luna")).toEqual([
       "vm0",
       "openai-api-key",
+      "codex-oauth-token",
     ]);
     expect(getProvidersForModel("openai/gpt-5.6-sol")).toEqual([]);
     expect(getProvidersForModel("deepseek/deepseek-v4-pro")).toContain(
@@ -328,7 +331,7 @@ describe("model-first canonical catalog", () => {
       true,
     );
     expect(isModelSupportedByProvider("gpt-5.6-sol", "codex-oauth-token")).toBe(
-      false,
+      true,
     );
     expect(isModelSupportedByProvider("gpt-5.6-sol", "openrouter-codex")).toBe(
       false,
@@ -1150,11 +1153,13 @@ describe("codex-oauth-token codex provider", () => {
 
   it("offers gpt-5.x models with gpt-5.5 default", () => {
     expect(getModels("codex-oauth-token")).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
       "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
     ]);
-    expect(getModels("codex-oauth-token")).not.toContain("gpt-5.6-sol");
     expect(getDefaultModel("codex-oauth-token")).toBe("gpt-5.5");
   });
 

--- a/turbo/packages/api-contracts/src/contracts/model-providers.ts
+++ b/turbo/packages/api-contracts/src/contracts/model-providers.ts
@@ -876,7 +876,14 @@ export const MODEL_PROVIDER_TYPES = {
       CHATGPT_ACCOUNT_ID: "$secrets.CHATGPT_ACCOUNT_ID",
       OPENAI_MODEL: "$model",
     } satisfies ModelProviderEnvBindings,
-    models: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini"] as string[],
+    models: [
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+    ] as string[],
     defaultModel: "gpt-5.5",
   },
   "azure-foundry": {
@@ -1032,9 +1039,9 @@ const MODEL_FIRST_PROVIDER_COMPATIBILITY = {
     "openrouter-api-key",
     "vercel-ai-gateway",
   ],
-  "gpt-5.6-sol": ["vm0", "openai-api-key"],
-  "gpt-5.6-terra": ["vm0", "openai-api-key"],
-  "gpt-5.6-luna": ["vm0", "openai-api-key"],
+  "gpt-5.6-sol": ["vm0", "openai-api-key", "codex-oauth-token"],
+  "gpt-5.6-terra": ["vm0", "openai-api-key", "codex-oauth-token"],
+  "gpt-5.6-luna": ["vm0", "openai-api-key", "codex-oauth-token"],
   "gpt-5.5": [
     "vm0",
     "openai-api-key",


### PR DESCRIPTION
## Summary
- allow GPT 5.6 Sol, Terra, and Luna to use member-scoped ChatGPT (Codex) subscription credentials
- expose all three GPT 5.6 models in the `codex-oauth-token` model catalog while keeping GPT 5.5 as the provider default
- keep OpenRouter Codex and Vercel AI Gateway Codex routes unsupported for GPT 5.6

## User impact
Users with a connected ChatGPT/Codex subscription can select it as the provider route for GPT 5.6 Sol, Terra, or Luna, matching the existing GPT 5.5 subscription behavior.

## Verification
- `pnpm -F @vm0/api-contracts test -- src/contracts/__tests__/model-providers.test.ts` (394 passed)
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm exec prettier --check packages/api-contracts/src/contracts/model-providers.ts packages/api-contracts/src/contracts/__tests__/model-providers.test.ts apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts`
- API route test requires the local PostgreSQL test service; without it, database-backed cases fail with `ECONNREFUSED`
