### PR TITLE
chore: bump codex cli to 0.144.0 in sandbox rootfs template

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -112,7 +112,7 @@ CACHE_TMP_TAR=""
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
 CLAUDE_CODE_VERSION="2.1.205"
-CODEX_CLI_VERSION="0.143.0"
+CODEX_CLI_VERSION="0.144.0"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"
 AGENT_BROWSER_VERSION="0.31.1"


### PR DESCRIPTION
## Summary
- Updated Codex CLI (`@openai/codex`) from `0.143.0` to `0.144.0` in `crates/runner/scripts/build-template.sh`, so new sandbox rootfs templates ship the latest Codex release.
- The version bump changes the script hash, which invalidates the template cache and triggers a rootfs rebuild with the new binary.

## Verification
- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- Version source: `npm view @openai/codex version` → `0.144.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)