### PR TITLE
fix(api): refresh api release marker comment

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker to exercise the full release pipeline)
+// (no-op API release marker refreshed 2026-07-10 to trigger a release)
 
 const app = (() => {
   const instanceAbortController = new AbortController();


### PR DESCRIPTION
Intentionally comment-only change under `turbo/apps/api` to trigger a release-please API release. No runtime behavior change.

Refreshes the existing no-op release marker comment in `turbo/apps/api/src/index.ts` so release-please cuts a new `api` patch release and runs the production release pipeline.