### PR TITLE
refactor: remove dead fallbacks in memory document adapters and ingestion

### DIFF
--- a/turbo/apps/api/src/signals/services/gmail-memory-document-adapter.service.ts
+++ b/turbo/apps/api/src/signals/services/gmail-memory-document-adapter.service.ts
@@ -14,7 +14,10 @@ interface GmailMemoryDocumentInput {
   readonly reason: string;
 }
 
-function gmailDocumentContent(input: GmailMemoryDocumentInput): string {
+function gmailDocumentContent(
+  input: GmailMemoryDocumentInput,
+  bodyText: string,
+): string {
   return [
     input.subject ? `# ${input.subject}` : "# Gmail message",
     "",
@@ -23,7 +26,7 @@ function gmailDocumentContent(input: GmailMemoryDocumentInput): string {
     input.cc.length > 0 ? `Cc: ${input.cc.join(", ")}` : null,
     `Direction: ${input.direction}`,
     "",
-    input.bodyText ?? "",
+    bodyText,
   ]
     .filter((line): line is string => {
       return line !== null;
@@ -34,7 +37,8 @@ function gmailDocumentContent(input: GmailMemoryDocumentInput): string {
 export function gmailMemoryDocumentAdapter(
   input: GmailMemoryDocumentInput,
 ): ReturnType<MemoryConnectorDocumentAdapter<GmailMemoryDocumentInput>> {
-  if (!input.bodyText?.trim()) {
+  const bodyText = input.bodyText;
+  if (!bodyText?.trim()) {
     return null;
   }
   const conversationId = input.threadId ?? input.messageId;
@@ -43,7 +47,7 @@ export function gmailMemoryDocumentAdapter(
     sourceType: "gmail_message",
     externalId: input.messageId,
     title: input.subject,
-    content: gmailDocumentContent(input),
+    content: gmailDocumentContent(input, bodyText),
     occurredAt: input.occurredAt,
     contextSpace: {
       type: "user",

--- a/turbo/apps/api/src/signals/services/slack-memory-document-adapter.service.ts
+++ b/turbo/apps/api/src/signals/services/slack-memory-document-adapter.service.ts
@@ -33,8 +33,11 @@ function slackConversationTitle(channelType: SlackMemoryChannelType): string {
   }
 }
 
-function slackDocumentContent(input: SlackMemoryDocumentInput): string {
-  const files = (input.files ?? []).flatMap((file) => {
+function slackDocumentContent(
+  input: SlackMemoryDocumentInput,
+  files: readonly SlackFile[],
+): string {
+  const fileLines = files.flatMap((file) => {
     return file.name ? [`File: ${file.name}`] : [];
   });
   return [
@@ -44,7 +47,7 @@ function slackDocumentContent(input: SlackMemoryDocumentInput): string {
     `Message timestamp: ${input.messageTs}`,
     "",
     input.messageText,
-    ...files,
+    ...fileLines,
   ].join("\n");
 }
 
@@ -56,7 +59,8 @@ function slackMessageDate(messageTs: string): Date | null {
 export function slackMemoryDocumentAdapter(
   input: SlackMemoryDocumentInput,
 ): ReturnType<MemoryConnectorDocumentAdapter<SlackMemoryDocumentInput>> {
-  if (!input.messageText.trim() && (input.files ?? []).length === 0) {
+  const files = input.files ?? [];
+  if (!input.messageText.trim() && files.length === 0) {
     return null;
   }
   const conversationTs = input.threadTs ?? input.messageTs;
@@ -68,7 +72,7 @@ export function slackMemoryDocumentAdapter(
     sourceType: "slack_message",
     externalId,
     title: slackConversationTitle(input.channelType),
-    content: slackDocumentContent(input),
+    content: slackDocumentContent(input, files),
     occurredAt: slackMessageDate(input.messageTs),
     contextSpace: {
       type: "project",

--- a/turbo/apps/api/src/signals/services/zero-memory-document-ingestion.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-document-ingestion.service.ts
@@ -181,6 +181,15 @@ function buildDocumentChunks(content: string): readonly DocumentChunkInput[] {
   });
 }
 
+// Citation and document metadata share one external URL. The citation URL is
+// authoritative; the metadata URL only fills in when the adapter did not set a
+// citation URL.
+function documentExternalUrl(
+  args: MemoryDocumentIngestionInput,
+): string | null {
+  return args.citation?.url ?? args.metadata?.externalUrl ?? null;
+}
+
 function buildCitation(
   args: MemoryDocumentIngestionInput & {
     readonly title: string | null;
@@ -192,7 +201,7 @@ function buildCitation(
     sourceId: args.sourceId ?? "",
     externalId: args.externalId,
     title: args.title,
-    url: args.citation?.url ?? args.metadata?.externalUrl ?? null,
+    url: documentExternalUrl(args),
     locator: args.citation?.locator ?? null,
     occurredAt: args.occurredAt?.toISOString() ?? null,
   };
@@ -215,7 +224,7 @@ function prepareMemoryDocument(
       ...args.metadata,
       provider: args.provider,
       sourceType: args.sourceType,
-      externalUrl: args.metadata?.externalUrl ?? args.citation?.url ?? null,
+      externalUrl: documentExternalUrl(args),
     },
   };
 }


### PR DESCRIPTION
## Summary

- Gmail memory document adapter: the entry guard already rejects messages without body text, but `gmailDocumentContent` still rendered the body through `input.bodyText ?? ""`. Pass the narrowed non-null body text into the content builder so the dead fallback is gone and the type states the invariant.
- Slack memory document adapter: `input.files ?? []` was normalized independently in the guard and in the content builder. Normalize once at the adapter entry and pass the resolved list down.
- Memory document ingestion: the external URL was resolved twice with mirrored precedence — `citation?.url ?? metadata?.externalUrl` for the chunk citation and `metadata?.externalUrl ?? citation?.url` for the document metadata. All current callers (GitHub, Notion, Gmail, Slack) pass identical values whenever both sides are set, so the contradictory precedence never took effect. Resolve the URL once in `documentExternalUrl` with a single documented precedence (citation URL wins) and use it for both fields.

## Behavior impact

None intended. All three changes are behavior-preserving for every current caller; they remove unreachable fallbacks and make the remaining precedence explicit at one point.

## Not changed (noted for a follow-up)

- `buildCitation` still stores `sourceId: args.sourceId ?? ""` because `MemoryDocumentChunkCitation.sourceId` is a required string. Making it nullable is a JSONB/response contract change that ripples into api-contracts and UI, so it is out of scope for this cleanup pass.

## Verification

- `pnpm format`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `pnpm exec vitest run --project=api apps/api/src/signals/routes/__tests__/zero-memory-recall.test.ts` — 13 passed (local pgvector Postgres)
- `pnpm exec vitest run --project=api apps/api/src/signals/routes/__tests__/zero-relationships.test.ts` — 14 passed (covers Gmail/Slack document ingestion through the changed adapters)
