### PR TITLE
build(platform): disable identifier mangling in the platform production bundle

### DIFF
--- a/turbo/apps/platform/vite.config.ts
+++ b/turbo/apps/platform/vite.config.ts
@@ -176,6 +176,13 @@ export default defineConfig({
       output: {
         // Stable generated firewall chunk URLs must also keep stable import contracts.
         minifyInternalExports: false,
+        // Open-source project: compress and strip whitespace, but keep
+        // original identifiers readable (no name mangling).
+        minify: {
+          compress: true,
+          mangle: false,
+          codegen: true,
+        },
         chunkFileNames(chunkInfo) {
           return (
             stableGeneratedFirewallChunkFileName(chunkInfo.name) ??


### PR DESCRIPTION
## Summary

The platform production build (Vite 8 / rolldown, default `oxc` minifier) mangles all identifiers, producing an obfuscated bundle. Since vm0 is an open-source project, there is no reason to ship obfuscated code. This PR overrides `rolldownOptions.output.minify` to keep `compress` and whitespace-removing `codegen` enabled while setting `mangle: false`, so the deployed bundle keeps original variable/function names and stays readable and debuggable directly in the browser.

## User-visible impact

- Deployed platform JS is no longer name-mangled; stack traces and DevTools debugging are readable even without source maps.
- No behavior change; only output format.

## Trade-off

Main chunk size grows from 5,964 kB (gzip 1,700 kB) to 8,357 kB (gzip 1,986 kB), roughly +17% gzipped, since identifiers are no longer shortened.

## Implementation notes

- Vite 8 spreads user `rolldownOptions.output` after its computed defaults, so the explicit `minify` object cleanly overrides the default `minify: true` (verified against vite 8.0.16 sources).
- The existing `minifyInternalExports: false` stable firewall chunk contract is untouched.

## Verification

- `pnpm -F @vm0/platform build` succeeds; inspected `dist/assets/main-*.js` and confirmed original identifiers (e.g. `__vitePreload`, function/parameter names) are preserved while whitespace removal and compression still apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)