### PR TITLE
refactor: require github user id at the memory issues api boundary

### DIFF
--- a/turbo/apps/api/src/signals/services/github-issues-api.service.ts
+++ b/turbo/apps/api/src/signals/services/github-issues-api.service.ts
@@ -21,7 +21,7 @@ export interface GithubIssueComment {
   readonly user: {
     readonly login: string;
     readonly type: string;
-    readonly id?: number;
+    readonly id: number;
   };
   readonly body: string;
   readonly created_at: string;
@@ -35,7 +35,7 @@ export interface GithubIssueDetail {
   readonly created_at?: string;
   readonly updated_at?: string;
   readonly user: {
-    readonly id?: number;
+    readonly id: number;
     readonly login: string;
     readonly type: string;
   };

--- a/turbo/apps/api/src/signals/services/github-memory-backfill.service.ts
+++ b/turbo/apps/api/src/signals/services/github-memory-backfill.service.ts
@@ -754,7 +754,7 @@ function issueLikeForRecorder(issue: GithubIssueDetail) {
     updated_at: issue.updated_at,
     labels: issue.labels ?? [],
     user: {
-      id: issue.user.id ?? 0,
+      id: issue.user.id,
       login: issue.user.login,
       type: issue.user.type,
     },
@@ -767,7 +767,7 @@ function commentLikeForRecorder(comment: GithubIssueComment) {
     body: comment.body,
     created_at: comment.created_at,
     user: {
-      id: comment.user.id ?? 0,
+      id: comment.user.id,
       login: comment.user.login,
       type: comment.user.type,
     },
@@ -799,7 +799,7 @@ async function recordBackfillIssue(args: {
     repository: { full_name: args.repository.fullName },
     installation: { id: Number(args.installation.remoteInstallationId) },
     sender: {
-      id: args.issue.user.id ?? 0,
+      id: args.issue.user.id,
       login: args.issue.user.login,
       type: args.issue.user.type,
     },
@@ -858,7 +858,7 @@ async function recordBackfillComments(args: {
       repository: { full_name: args.repository.fullName },
       installation: { id: Number(args.installation.remoteInstallationId) },
       sender: {
-        id: comment.user.id ?? 0,
+        id: comment.user.id,
         login: comment.user.login,
         type: comment.user.type,
       },


### PR DESCRIPTION
## Summary

The GitHub REST API always returns `user.id` for issue and comment authors, but the local boundary types `GithubIssueDetail` and `GithubIssueComment` (`github-issues-api.service.ts`) declared it optional. Four call sites in the GitHub memory backfill then masked the phantom absence with `?? 0`.

Had that fallback ever fired, the recorder would have stored a fabricated actor identity — `githubActorId: "0"` — on memory sources, and the trusted-contributor check would have silently degraded to login-only matching. Since the API contract guarantees the field, this change makes `id: number` required at the boundary and deletes the four dead fallbacks, so the type states the invariant instead of the fallback hiding it.

## Behavior impact

None. `user.id` is always present in real GitHub responses, so the removed fallbacks were unreachable; every other consumer of these types passes typecheck unchanged.

## Verification

- `pnpm format`
- `pnpm -F api lint`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm -F api check-types`
- `pnpm exec vitest run --project=api apps/api/src/signals/routes/__tests__/zero-relationships.test.ts` — 14 passed against a local pgvector Postgres (covers the GitHub memory ingestion path)
