### PR TITLE
fix(runner): add template rebuild marker comment to force image rebuild

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -5,6 +5,8 @@
 # part of the template build-input hash, so any change here automatically
 # invalidates the shared template cache.
 #
+# Rebuild marker: 2026-07-10 — comment-only change to force a template rebuild.
+#
 # Uses debootstrap + chroot instead of Docker to avoid the Docker daemon
 # dependency and eliminate multiple I/O round-trips (tar export, tar extract,
 # cp to ext4 mount). mkfs.ext4 -d populates the ext4 image directly from


### PR DESCRIPTION
Comment-only change in `crates/runner/scripts/build-template.sh` to trigger a runner template image rebuild and release. No runtime behavior change.

The script's content is hashed as part of the template build-input hash, so this change invalidates the shared template cache and forces a rootfs rebuild. The `fix(runner)` commit type also triggers a release-please version bump for the `runner-rs` component, so merging the subsequent release PR will build and promote a fresh production runner image.

## Verification
- `bash -n crates/runner/scripts/build-template.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)