### PR TITLE
fix: restore inter-word spacing in user chat message bubbles

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -738,13 +738,6 @@ body {
   margin-bottom: 8px;
 }
 
-.zero-chat-bubble-user .wmde-markdown {
-  /* Pull the ASCII space after a leading emoji closer so the emoji doesn't
-     read as detached from the rest of the user-typed text. word-spacing only
-     affects space-separated runs; CJK characters are unaffected. */
-  word-spacing: -0.15em;
-}
-
 .wmde-markdown h1,
 .wmde-markdown h2,
 .wmde-markdown h3,


### PR DESCRIPTION
## Problem
In the chat UI, a user's own message bubble rendered English text with inter-word spaces collapsed — "for the live demo, I'm thinking of walking..." appeared visually as "forthelivedemo,I'mthinkingofwalking...". Reported by Scarlett with a screenshot.

## Root cause
`turbo/apps/platform/src/views/css/index.css` carried a single rule scoped to user bubbles:

```css
.zero-chat-bubble-user .wmde-markdown {
  word-spacing: -0.15em;
}
```

Its intent (per the comment) was only to pull the ASCII space after a *leading emoji* closer. But CSS `word-spacing` can't target a single space — it applies to **every** space-separated run in the element. At the bubble's 15px font size, -0.15em shaved ~2.25px off every space, so normal English prose read as cramped/joined. Assistant bubbles never had this rule, which is why the bug only showed on the user's own messages. CJK text was unaffected (no ASCII spaces).

## Fix
Remove the rule so ASCII spaces render at their natural width. This is the only `word-spacing`/`letter-spacing` declaration in the platform app, so nothing else depends on it. The minor emoji-adjacent-space cosmetic it targeted is not worth degrading all English text; there is no CSS-only way to scope it to a leading emoji.

## Verification
Pure CSS one-line deletion; relying on the PR pipeline for checks. Confirmed no other spacing rules remain in `turbo/apps/platform/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)