### PR TITLE
feat: run gpt-5.6 sol with ultra reasoning by default

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -179,12 +179,11 @@ fn push_codex_fast_mode_configs(args: &mut Vec<String>) {
     args.push(r#"service_tier="fast""#.to_string());
 }
 
-/// Per-model default for the codex `model_reasoning_effort` config. GPT-5.5
-/// invests heavily in reasoning depth, so default it to `xhigh` rather than
-/// the codex CLI's stock `medium`.
+/// Per-model overrides for the codex `model_reasoning_effort` config.
 pub(super) fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'static str> {
     let bare = model.strip_prefix("openai/").unwrap_or(model);
     match bare {
+        "gpt-5.6-sol" => Some("ultra"),
         "gpt-5.5" => Some("xhigh"),
         _ => None,
     }
@@ -666,8 +665,26 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_args_non_gpt_5_5_omits_reasoning_effort() {
-        for model in ["gpt-5.4", "gpt-5.4-mini", "openai/gpt-5.4", ""] {
+    fn build_codex_args_gpt_5_6_sol_defaults_reasoning_effort_ultra() {
+        for model in ["gpt-5.6-sol", "openai/gpt-5.6-sol"] {
+            let args = build_codex_args_for_test(model, "", "p");
+            assert!(codex_args_have_config(
+                &args,
+                "model_reasoning_effort=ultra"
+            ));
+        }
+    }
+
+    #[test]
+    fn build_codex_args_models_without_overrides_omit_reasoning_effort() {
+        for model in [
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "openai/gpt-5.4",
+            "",
+        ] {
             let args = build_codex_args_for_test(model, "", "p");
             assert!(
                 !args


### PR DESCRIPTION
## Summary

GPT-5.6 Sol runs now explicitly request `ultra` reasoning in both Codex CLI and app-server execution paths. GPT-5.6 Terra and Luna remain unchanged and continue using their Codex model defaults.

## Implementation

- Add a per-model reasoning override mapping `gpt-5.6-sol` to `ultra`.
- Preserve the existing GPT-5.5 `xhigh` override.
- Cover bare and `openai/`-prefixed Sol model IDs.
- Assert that Terra and Luna do not receive a reasoning override.

## Verification

- `cargo fmt --check`
- `cargo test -p guest-agent build_codex_args_ --lib` (22 passed)