### PR TITLE
fix: unblock devcontainer setup

### DIFF
--- a/.devcontainer/link-agent-skills.sh
+++ b/.devcontainer/link-agent-skills.sh
@@ -22,7 +22,7 @@ elif [ -e "$AGENT_SKILLS_LINK" ]; then
     exit 0
   fi
 
-  if find "$AGENT_SKILLS_LINK" -mindepth 1 -maxdepth 1 ! -type l | grep -q .; then
+  if find "$AGENT_SKILLS_LINK" -mindepth 1 -maxdepth 1 ! -type l -print -quit | grep -q .; then
     echo "Skipping .agents/skills link because it contains non-symlink entries"
     exit 0
   fi

--- a/.devcontainer/link-agent-skills.sh
+++ b/.devcontainer/link-agent-skills.sh
@@ -18,13 +18,13 @@ if [ -L "$AGENT_SKILLS_LINK" ]; then
   ln -sfn "$LINK_TARGET" "$AGENT_SKILLS_LINK"
 elif [ -e "$AGENT_SKILLS_LINK" ]; then
   if [ ! -d "$AGENT_SKILLS_LINK" ]; then
-    echo "Refusing to replace non-directory: $AGENT_SKILLS_LINK" >&2
-    exit 1
+    echo "Skipping .agents/skills link because a non-directory entry already exists"
+    exit 0
   fi
 
   if find "$AGENT_SKILLS_LINK" -mindepth 1 -maxdepth 1 ! -type l | grep -q .; then
-    echo "Refusing to replace .agents/skills because it contains non-symlink entries" >&2
-    exit 1
+    echo "Skipping .agents/skills link because it contains non-symlink entries"
+    exit 0
   fi
 
   find "$AGENT_SKILLS_LINK" -mindepth 1 -maxdepth 1 -type l -exec rm {} +

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -46,7 +46,7 @@ fi
 
 sudo chown -R postgres:postgres /var/lib/postgresql 2>/dev/null || true
 sudo service postgresql start 2>/dev/null || true
-if sudo -u postgres psql -d postgres -Atqc "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" | grep -qx 1; then
+if sudo -u postgres psql -h /var/run/postgresql -d postgres -Atqc "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" | grep -qx 1; then
   echo "✓ pgvector extension available to PostgreSQL"
 else
   echo "ERROR: pgvector extension is not available to PostgreSQL after installing $PGVECTOR_PACKAGE" >&2

--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+  echo "ERROR: $1" >&2
+  exit 1
+}
+
+copy_script() {
+  local workspace="$1"
+  local script="$2"
+
+  mkdir -p "$workspace/.devcontainer"
+  cp "$REPO_ROOT/.devcontainer/$script" "$workspace/.devcontainer/$script"
+}
+
+test_skill_link_file_conflict() {
+  local workspace="$TEST_ROOT/link-file-conflict"
+  local output
+
+  copy_script "$workspace" "link-agent-skills.sh"
+  mkdir -p "$workspace/.claude/skills" "$workspace/.agents"
+  printf 'keep me\n' > "$workspace/.agents/skills"
+
+  output="$(HOME="$workspace/home" bash "$workspace/.devcontainer/link-agent-skills.sh")"
+
+  grep -Fq "Skipping .agents/skills link because a non-directory entry already exists" <<< "$output" \
+    || fail "non-directory conflict did not report that linking was skipped"
+  grep -Fxq "keep me" "$workspace/.agents/skills" \
+    || fail "non-directory conflict was modified"
+}
+
+test_skill_link_directory_conflict() {
+  local workspace="$TEST_ROOT/link-directory-conflict"
+  local skills_dir="$workspace/.agents/skills"
+  local output
+
+  copy_script "$workspace" "link-agent-skills.sh"
+  mkdir -p "$workspace/.claude/skills" "$skills_dir"
+  mkdir "$skills_dir"/entry-{00001..10000}
+
+  output="$(HOME="$workspace/home" bash "$workspace/.devcontainer/link-agent-skills.sh")"
+
+  grep -Fq "Skipping .agents/skills link because it contains non-symlink entries" <<< "$output" \
+    || fail "directory conflict did not report that linking was skipped"
+  test -d "$skills_dir/entry-10000" \
+    || fail "directory conflict was modified"
+}
+
+test_pgvector_probe_uses_unix_socket() {
+  local workspace="$TEST_ROOT/pgvector-probe"
+  local fake_bin="$workspace/fake-bin"
+  local sudo_log="$workspace/sudo.log"
+
+  copy_script "$workspace" "setup.sh"
+  mkdir -p "$fake_bin" "$workspace/home" "$workspace/turbo"
+
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    "printf 'install ok installed\\n'" \
+    > "$fake_bin/dpkg-query"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s\\n" "$*" >> "$SUDO_CALLS_LOG"' \
+    'if [[ "$*" == "-u postgres psql "* ]]; then' \
+    "  printf '1\\n'" \
+    'fi' \
+    > "$fake_bin/sudo"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'exit 0' \
+    > "$fake_bin/lefthook"
+  chmod +x "$fake_bin/dpkg-query" "$fake_bin/sudo" "$fake_bin/lefthook"
+
+  HOME="$workspace/home" \
+    PATH="$fake_bin:$PATH" \
+    SUDO_CALLS_LOG="$sudo_log" \
+    bash "$workspace/.devcontainer/setup.sh" > /dev/null
+
+  grep -Fq -- "-u postgres psql -h /var/run/postgresql -d postgres -Atqc" "$sudo_log" \
+    || fail "pgvector availability probe did not use the local Unix socket"
+}
+
+test_skill_link_file_conflict
+test_skill_link_directory_conflict
+test_pgvector_probe_uses_unix_socket
+
+echo "Devcontainer integration tests passed"

--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - 'docker/toolchain/**'
+      - '.devcontainer/link-agent-skills.sh'
+      - '.devcontainer/setup.sh'
+      - '.devcontainer/test.sh'
       - '.github/workflows/docker-toolchain.yml'
 
 concurrency:
@@ -14,6 +17,15 @@ permissions:
   contents: read
 
 jobs:
+  devcontainer-scripts:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Test devcontainer scripts
+        run: bash .devcontainer/test.sh
+
   toolchain:
     # Skip for release-please PRs (only version bumps and changelogs)
     if: "!startsWith(github.head_ref || '', 'release-please--branches--')"

--- a/.github/workflows/docker-toolchain.yml
+++ b/.github/workflows/docker-toolchain.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Test devcontainer scripts
         run: bash .devcontainer/test.sh

--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -285,5 +285,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tmux \
     && rm -rf /var/lib/apt/lists/*
 
+# Install PostgreSQL and pgvector for local development.
+ARG POSTGRES_VERSION=17
+RUN install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsS \
+        -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+        https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    && . /etc/os-release \
+    && printf '%s\n' \
+        'Types: deb' \
+        'URIs: https://apt.postgresql.org/pub/repos/apt' \
+        "Suites: ${VERSION_CODENAME}-pgdg" \
+        "Architectures: $(dpkg --print-architecture)" \
+        'Components: main' \
+        'Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc' \
+        > /etc/apt/sources.list.d/pgdg.sources \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        "postgresql-${POSTGRES_VERSION}-pgvector" \
+    && test -f "/usr/lib/postgresql/${POSTGRES_VERSION}/lib/vector.so" \
+    && rm -rf /var/lib/apt/lists/*
+
 # Default command
 CMD ["/usr/bin/zsh"]


### PR DESCRIPTION
## Summary

- force the pgvector availability check to use the local PostgreSQL Unix socket
- preserve existing .agents/skills entries and skip linking when they conflict
- allow the remaining post-start setup to continue after a skill-link conflict
- bake the PostgreSQL 17 pgvector package into the vm0-dev development image
- add integration coverage for devcontainer setup and skill-link conflict handling
- run the devcontainer script checks when their sources change

## Test plan

- `git diff --check`
- `bash -n .devcontainer/link-agent-skills.sh .devcontainer/setup.sh .devcontainer/test.sh`
- `docker build --target development -t vm0-dev:pgvector docker/toolchain` (stopped after PGDG package download stalled; all preceding image layers completed)
- full repository checks not run (per request)