### PR TITLE
fix: align tabler icons dependency version

### DIFF
--- a/turbo/apps/desktop/package.json
+++ b/turbo/apps/desktop/package.json
@@ -27,7 +27,7 @@
     "@modelcontextprotocol/server-filesystem": "2026.1.14",
     "@sentry/electron": "^7.13.0",
     "@sentry/react": "^10.50.0",
-    "@tabler/icons-react": "^3.36.1",
+    "@tabler/icons-react": "3.44.0",
     "@vm0/api-contracts": "workspace:*",
     "ccstate": "^5.3.0",
     "ccstate-react": "^5.3.0",

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -17,7 +17,7 @@
     "@clerk/clerk-react": "^5.61.8",
     "@sentry/react": "^10.38.0",
     "@sentry/vite-plugin": "^4.9.0",
-    "@tabler/icons-react": "^3.36.1",
+    "@tabler/icons-react": "3.44.0",
     "@tiptap/core": "3.21.0",
     "@tiptap/markdown": "3.23.1",
     "@tiptap/pm": "3.21.0",

--- a/turbo/packages/ui/package.json
+++ b/turbo/packages/ui/package.json
@@ -46,7 +46,7 @@
     "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/react-switch": "^1.3.3",
     "@radix-ui/react-tooltip": "^1.2.12",
-    "@tabler/icons-react": "^3.31.0",
+    "@tabler/icons-react": "3.44.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -406,8 +406,8 @@ importers:
         specifier: ^10.50.0
         version: 10.50.0(react@19.2.6)
       '@tabler/icons-react':
-        specifier: ^3.36.1
-        version: 3.41.0(react@19.2.6)
+        specifier: 3.44.0
+        version: 3.44.0(react@19.2.6)
       '@vm0/api-contracts':
         specifier: workspace:*
         version: link:../../packages/api-contracts
@@ -521,7 +521,7 @@ importers:
         specifier: ^4.9.0
         version: 4.9.1(encoding@0.1.13)
       '@tabler/icons-react':
-        specifier: ^3.36.1
+        specifier: 3.44.0
         version: 3.44.0(react@19.2.6)
       '@tiptap/core':
         specifier: 3.21.0
@@ -1000,8 +1000,8 @@ importers:
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tabler/icons-react':
-        specifier: ^3.31.0
-        version: 3.41.0(react@19.2.6)
+        specifier: 3.44.0
+        version: 3.44.0(react@19.2.6)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4066,18 +4066,10 @@ packages:
       zod:
         optional: true
 
-  '@tabler/icons-react@3.41.0':
-    resolution: {integrity: sha512-8XKc3wZKf1icxqwIPSOO61M+dtf8yJPwAE/rtFAVzc5Ros+OjCqowfcoI5IpKK09RSo8s0hHrWvydGgnXqYILg==}
-    peerDependencies:
-      react: '>= 16'
-
   '@tabler/icons-react@3.44.0':
     resolution: {integrity: sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==}
     peerDependencies:
       react: '>= 16'
-
-  '@tabler/icons@3.41.0':
-    resolution: {integrity: sha512-arlig0nkaC9UGqTZuT1MMZepX29t3Ysx5HSy2UvmR+CZrhlNxZrCM6Z4qYBoaIO+2ICZykttjBCSpf+p/t0H3w==}
 
   '@tabler/icons@3.44.0':
     resolution: {integrity: sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==}
@@ -12954,17 +12946,10 @@ snapshots:
       typescript: 6.0.3
       zod: 4.3.6
 
-  '@tabler/icons-react@3.41.0(react@19.2.6)':
-    dependencies:
-      '@tabler/icons': 3.41.0
-      react: 19.2.6
-
   '@tabler/icons-react@3.44.0(react@19.2.6)':
     dependencies:
       '@tabler/icons': 3.44.0
       react: 19.2.6
-
-  '@tabler/icons@3.41.0': {}
 
   '@tabler/icons@3.44.0': {}
 


### PR DESCRIPTION
## Summary

- pin `@tabler/icons-react` to `3.44.0` in platform, desktop, and UI
- remove the duplicate `3.41.0` lockfile resolution so Vite cannot prebundle a version missing `IconPointer2`
- keep all consumers on the same icon package version

## Testing

- `pnpm format`
- `pnpm lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm -F @vm0/app exec vitest --maxWorkers=1` (99 files, 962 tests)
- `pnpm knip`
- `pnpm install --frozen-lockfile`
- `pnpm why -r @tabler/icons-react` (one version: 3.44.0)
- verified the Vite prebundle resolves 3.44.0 and exports `IconPointer2`

## Baseline test failures

The full `pnpm test` run still reports two unrelated failures: the Xero firewall permission expectation omits an existing `description`, and the API usage aggregation expectation differs on `creditsCharged`. Both failures reproduce unchanged after stashing every file in this PR and running against the exact `origin/main` tree.