### PR TITLE
fix(runner): bill openai cache write tokens

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/__init__.py
@@ -122,8 +122,15 @@ def buffer_source_usage_events(
     run_id: str,
     events: Iterable[UsageEvent],
     proxy_log_path: str,
+    *,
+    atomic_source_key: str | None = None,
 ) -> int:
-    """Buffer source events without replacing their idempotency keys."""
+    """Buffer source events without replacing their idempotency keys.
+
+    When ``atomic_source_key`` is provided, the batch is admitted only when the
+    group key and every member event key are new to the bounded source-key set.
+    The internal group key is not included in the webhook payload.
+    """
     return _usage_event_buffer.buffer_usage_events(
         url,
         sandbox_token,
@@ -131,6 +138,7 @@ def buffer_source_usage_events(
         events,
         proxy_log_path,
         preserve_source_idempotency=True,
+        atomic_source_key=atomic_source_key,
     )
 
 
@@ -140,8 +148,10 @@ def buffer_source_model_usage_observations(
     run_id: str,
     events: Iterable[UsageEvent],
     proxy_log_path: str,
+    *,
+    atomic_source_key: str | None = None,
 ) -> int:
-    """Buffer model usage observations without replacing their source keys."""
+    """Buffer source observations, optionally admitting the batch atomically."""
     return _usage_event_buffer.buffer_usage_events(
         url,
         sandbox_token,
@@ -152,6 +162,7 @@ def buffer_source_model_usage_observations(
         include_kind=False,
         log_type="model_usage_observation",
         preserve_source_idempotency=True,
+        atomic_source_key=atomic_source_key,
     )
 
 

--- a/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/orchestrator.py
@@ -116,6 +116,7 @@ class UsageEventBuffer:
         include_kind: bool = True,
         log_type: str = "usage_event",
         preserve_source_idempotency: bool = False,
+        atomic_source_key: str | None = None,
     ) -> int:
         """Add source usage events and flush if the buffer exceeds a bound."""
         flush_now = False
@@ -131,6 +132,7 @@ class UsageEventBuffer:
                 include_kind=include_kind,
                 log_type=log_type,
                 preserve_source_idempotency=preserve_source_idempotency,
+                atomic_source_key=atomic_source_key,
             )
             if accepted_count == 0:
                 return 0

--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -48,8 +48,8 @@ class _UsageBufferState:
         self._flush_sequence = 0
         self._buckets: dict[_DestinationKey, dict[_AggregateKey, _AggregateBucket]] = {}
         self._source_events: dict[_DestinationKey, list[_BufferedSourceEvent]] = {}
-        # Keep source keys across flushes so aggregate idempotency does not
-        # turn response/error duplicates into distinct server-side rows.
+        # Keep source and atomic admission keys across flushes so lifecycle
+        # duplicates do not become distinct server-side rows.
         self._seen_source_keys: OrderedDict[str, None] = OrderedDict()
         self._source_event_count = 0
         self._active_enqueue_count = 0
@@ -77,7 +77,15 @@ class _UsageBufferState:
         include_kind: bool,
         log_type: str,
         preserve_source_idempotency: bool,
+        atomic_source_key: str | None,
     ) -> int:
+        if atomic_source_key is not None:
+            events = tuple(events)
+            if atomic_source_key in self._seen_source_keys or any(
+                event["idempotencyKey"] in self._seen_source_keys for event in events
+            ):
+                return 0
+
         buckets: dict[_AggregateKey, _AggregateBucket] | None = None
         source_events: list[_BufferedSourceEvent] | None = None
         destination = _DestinationKey(
@@ -112,6 +120,10 @@ class _UsageBufferState:
                 bucket.source_event_count += 1
             self._source_event_count += 1
             accepted_count += 1
+        # Keep the admission key newer than its member keys so its bounded LRU
+        # lifetime covers the entire group.
+        if atomic_source_key is not None and accepted_count > 0:
+            self._seen_source_keys[atomic_source_key] = None
         self._evict_source_keys()
         return accepted_count
 

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -29,6 +29,7 @@ from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT
 from .json_probe import probe_top_level_string_field
 from .json_selective import JsonSelectiveExtractor, ScalarField
 from .model_tokens import (
+    MODEL_USAGE_CATEGORY_CACHE_CREATION,
     MODEL_USAGE_CATEGORY_CACHE_READ,
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
@@ -76,6 +77,7 @@ _OPENAI_RESPONSES_USAGE_CATEGORIES = (
     MODEL_USAGE_CATEGORY_INPUT,
     MODEL_USAGE_CATEGORY_OUTPUT,
     MODEL_USAGE_CATEGORY_CACHE_READ,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION,
 )
 
 _RESPONSES_RESPONSE_SCALAR_FIELDS = {
@@ -84,6 +86,7 @@ _RESPONSES_RESPONSE_SCALAR_FIELDS = {
     ("usage", "input_tokens"): ScalarField("int", max_bytes=64),
     ("usage", "output_tokens"): ScalarField("int", max_bytes=64),
     ("usage", "input_tokens_details", "cached_tokens"): ScalarField("int", max_bytes=64),
+    ("usage", "input_tokens_details", "cache_write_tokens"): ScalarField("int", max_bytes=64),
 }
 
 _RESPONSES_SSE_RESPONSE_SCALAR_FIELDS = {
@@ -172,21 +175,29 @@ def _has_usage_quantity(values: dict) -> bool:
     return False
 
 
-def _split_input_tokens(
+def _partition_input_tokens(
     input_tokens: object,
     cached_tokens: object,
-) -> tuple[int | None, int | None]:
-    # OpenAI's ``input_tokens`` includes cached tokens. The usage_event ledger
-    # prices uncached input and cached input as separate platform categories,
-    # so split the upstream total before reporting.
+    cache_write_tokens: object,
+) -> tuple[int | None, int | None, int | None]:
+    # OpenAI reports cache reads and writes as details of ``input_tokens``. The
+    # usage-event ledger prices all three categories independently, so partition
+    # the upstream total before reporting to avoid charging any token twice.
     if not _is_usage_quantity(input_tokens):
-        return None, None
+        return None, None, None
 
+    remaining_input_tokens = input_tokens
+    cached_input_tokens = None
     if _is_usage_quantity(cached_tokens):
-        cached_input_tokens = min(cached_tokens, input_tokens)
-        return max(input_tokens - cached_input_tokens, 0), cached_input_tokens
+        cached_input_tokens = min(cached_tokens, remaining_input_tokens)
+        remaining_input_tokens -= cached_input_tokens
 
-    return input_tokens, None
+    cache_creation_tokens = None
+    if _is_usage_quantity(cache_write_tokens):
+        cache_creation_tokens = min(cache_write_tokens, remaining_input_tokens)
+        remaining_input_tokens -= cache_creation_tokens
+
+    return remaining_input_tokens, cached_input_tokens, cache_creation_tokens
 
 
 def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] = ()) -> None:
@@ -198,9 +209,10 @@ def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] =
     if isinstance(message_id, str) and message_id:
         target["message_id"] = message_id
 
-    uncached_input_tokens, cached_tokens = _split_input_tokens(
+    uncached_input_tokens, cached_tokens, cache_creation_tokens = _partition_input_tokens(
         values.get((*prefix, "usage", "input_tokens")),
         values.get((*prefix, "usage", "input_tokens_details", "cached_tokens")),
+        values.get((*prefix, "usage", "input_tokens_details", "cache_write_tokens")),
     )
     _store_quantity(
         target,
@@ -217,6 +229,11 @@ def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] =
         target,
         MODEL_USAGE_CATEGORY_CACHE_READ,
         cached_tokens,
+    )
+    _store_quantity(
+        target,
+        MODEL_USAGE_CATEGORY_CACHE_CREATION,
+        cache_creation_tokens,
     )
 
 
@@ -531,7 +548,8 @@ def extract_openai_responses_usage_from_json(
     parsing fails, the decoded body is empty, or no platform usage categories
     can be extracted. Otherwise returns a dict keyed by platform model usage
     categories such as ``MODEL_USAGE_CATEGORY_INPUT``,
-    ``MODEL_USAGE_CATEGORY_OUTPUT``, and ``MODEL_USAGE_CATEGORY_CACHE_READ``.
+    ``MODEL_USAGE_CATEGORY_OUTPUT``, ``MODEL_USAGE_CATEGORY_CACHE_READ``, and
+    ``MODEL_USAGE_CATEGORY_CACHE_CREATION``.
     """
 
     if headers:
@@ -556,9 +574,10 @@ def extract_openai_responses_usage_with_error_from_json(
     platform usage categories can be extracted from valid JSON. Otherwise
     returns a dict keyed by platform model usage categories such as
     ``MODEL_USAGE_CATEGORY_INPUT``, ``MODEL_USAGE_CATEGORY_OUTPUT``, and
-    ``MODEL_USAGE_CATEGORY_CACHE_READ``. OpenAI ``input_tokens`` include cached
-    tokens, so this extractor splits them into uncached input and cache-read
-    categories before reporting.
+    ``MODEL_USAGE_CATEGORY_CACHE_READ`` and ``MODEL_USAGE_CATEGORY_CACHE_CREATION``.
+    OpenAI ``input_tokens`` include cache reads and writes, so this extractor
+    partitions them into ordinary input, cache-read, and cache-creation categories
+    before reporting.
     """
 
     if headers:

--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -200,6 +200,64 @@ def _partition_input_tokens(
     return remaining_input_tokens, cached_input_tokens, cache_creation_tokens
 
 
+def _normalized_input_snapshot(values: dict) -> tuple[int, int | None, int | None] | None:
+    ordinary_input_tokens = values.get(MODEL_USAGE_CATEGORY_INPUT)
+    if not _is_usage_quantity(ordinary_input_tokens):
+        return None
+
+    cached_tokens = values.get(MODEL_USAGE_CATEGORY_CACHE_READ)
+    if not _is_usage_quantity(cached_tokens):
+        cached_tokens = None
+
+    cache_write_tokens = values.get(MODEL_USAGE_CATEGORY_CACHE_CREATION)
+    if not _is_usage_quantity(cache_write_tokens):
+        cache_write_tokens = None
+
+    input_tokens = ordinary_input_tokens
+    if cached_tokens is not None:
+        input_tokens += cached_tokens
+    if cache_write_tokens is not None:
+        input_tokens += cache_write_tokens
+    return input_tokens, cached_tokens, cache_write_tokens
+
+
+def _merge_input_partition(target: dict, source: dict) -> None:
+    source_snapshot = _normalized_input_snapshot(source)
+    if source_snapshot is None:
+        return
+
+    merged_raw: dict = {}
+    for snapshot in (_normalized_input_snapshot(target), source_snapshot):
+        if snapshot is None:
+            continue
+        input_tokens, cached_tokens, cache_write_tokens = snapshot
+        _store_quantity(merged_raw, MODEL_USAGE_CATEGORY_INPUT, input_tokens)
+        _store_quantity(merged_raw, MODEL_USAGE_CATEGORY_CACHE_READ, cached_tokens)
+        _store_quantity(
+            merged_raw,
+            MODEL_USAGE_CATEGORY_CACHE_CREATION,
+            cache_write_tokens,
+        )
+
+    ordinary_input_tokens, cached_tokens, cache_write_tokens = _partition_input_tokens(
+        merged_raw.get(MODEL_USAGE_CATEGORY_INPUT),
+        merged_raw.get(MODEL_USAGE_CATEGORY_CACHE_READ),
+        merged_raw.get(MODEL_USAGE_CATEGORY_CACHE_CREATION),
+    )
+    if ordinary_input_tokens is None:
+        return
+
+    target[MODEL_USAGE_CATEGORY_INPUT] = ordinary_input_tokens
+    for category, value in (
+        (MODEL_USAGE_CATEGORY_CACHE_READ, cached_tokens),
+        (MODEL_USAGE_CATEGORY_CACHE_CREATION, cache_write_tokens),
+    ):
+        if value is None:
+            target.pop(category, None)
+        else:
+            target[category] = value
+
+
 def _store_response_values(values: dict, target: dict, prefix: tuple[str, ...] = ()) -> None:
     model = values.get((*prefix, "model"))
     if isinstance(model, str) and model:
@@ -242,10 +300,11 @@ def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
 
     ``response_streaming.py`` uses this for terminal SSE events and
     single-frame WebSocket event JSON, where multiple events may describe the
-    same upstream response. Usage quantities use positive-wins semantics:
-    positive source values replace the accumulator value, while zero values are
-    only stored for categories the accumulator has not seen yet. This preserves
-    real token counts when a later empty event reports zeros.
+    same upstream response. Output usage uses positive-wins semantics directly.
+    Input usage is first reconstructed into total input, cache reads, and cache
+    writes; those raw components use positive-wins semantics before being
+    repartitioned atomically. This preserves the input partition when a later
+    event reports a zero or omits one cache detail.
 
     Metadata follows usage ownership. When the accumulator already has positive
     usage and the source has no positive usage quantity, source metadata is
@@ -256,8 +315,12 @@ def merge_openai_responses_usage_result(target: dict, source: dict) -> None:
 
     target_has_positive_quantity = _has_positive_usage_quantity(target)
     source_has_positive_quantity = _has_positive_usage_quantity(source)
-    for category in _OPENAI_RESPONSES_USAGE_CATEGORIES:
-        _store_quantity(target, category, source.get(category))
+    _merge_input_partition(target, source)
+    _store_quantity(
+        target,
+        MODEL_USAGE_CATEGORY_OUTPUT,
+        source.get(MODEL_USAGE_CATEGORY_OUTPUT),
+    )
 
     if target_has_positive_quantity and not source_has_positive_quantity:
         return

--- a/crates/runner/mitm-addon/src/usage/providers/model_provider.py
+++ b/crates/runner/mitm-addon/src/usage/providers/model_provider.py
@@ -36,11 +36,23 @@ from ..idempotency import (
     USAGE_OBSERVATION_NAMESPACE_MODEL,
     derive_usage_idempotency_key,
 )
-from ..model_tokens import MODEL_USAGE_CATEGORIES
+from ..model_tokens import (
+    MODEL_USAGE_CATEGORIES,
+    MODEL_USAGE_CATEGORY_CACHE_CREATION,
+    MODEL_USAGE_CATEGORY_CACHE_READ,
+    MODEL_USAGE_CATEGORY_INPUT,
+)
 from ..reporting_context import UsageReportingContext, usage_reporting_context
 from ..underbilling import log_usage_underbilling
 
 MODEL_USAGE_KIND = "model"
+_MODEL_INPUT_PARTITION_CATEGORIES = frozenset(
+    (
+        MODEL_USAGE_CATEGORY_INPUT,
+        MODEL_USAGE_CATEGORY_CACHE_READ,
+        MODEL_USAGE_CATEGORY_CACHE_CREATION,
+    )
+)
 
 
 def is_model_provider_usage_observable(flow: http.HTTPFlow) -> bool:
@@ -135,10 +147,14 @@ def report_model_provider_usage_source(
 
     Unlike flow-terminal reporting, this preserves the source idempotency keys
     in the webhook payload so the platform can dedupe one response source even
-    when a later lifecycle hook sees the same source again. Callers can drop the
-    source from flow metadata after this returns: observable flows carry the
-    canonical ``MODEL_USAGE_PROVIDER``, so zero-usage source model hints do not
-    need to be retained for later same-response-id frames.
+    when a later lifecycle hook sees the same source again. Input, cache-read,
+    and cache-creation events use one bounded atomic admission key so later
+    frames cannot add a second input partition for the same response id. Output
+    remains independently admissible for compatible transports that report it
+    in a later frame. Callers can drop the source from flow metadata after this
+    returns: observable flows carry the canonical ``MODEL_USAGE_PROVIDER``, so
+    zero-usage source model hints do not need to be retained for later
+    same-response-id frames.
     """
     usage_events: list[UsageEvent] = []
     observation_events: list[UsageEvent] = []
@@ -176,9 +192,19 @@ def report_model_provider_usage_source(
         return
 
     if usage_events:
-        _buffer_source_model_provider_usage_events(context, run_id, usage_events)
+        _buffer_source_model_provider_usage_events(
+            context,
+            run_id,
+            source_id,
+            usage_events,
+        )
     if observation_events:
-        _buffer_source_model_provider_usage_observations(context, run_id, observation_events)
+        _buffer_source_model_provider_usage_observations(
+            context,
+            run_id,
+            source_id,
+            observation_events,
+        )
 
 
 def _buffer_model_provider_usage_events(
@@ -223,28 +249,86 @@ def _buffer_model_provider_usage_observations(
 def _buffer_source_model_provider_usage_events(
     context: UsageReportingContext,
     run_id: str,
+    source_id: str,
     events: list[UsageEvent],
 ) -> None:
-    buffer_source_usage_events(
-        context.usage_event_url(),
-        context.sandbox_token,
-        run_id,
-        events,
-        context.proxy_log_path,
-    )
+    input_partition_events, independent_events = _split_model_input_partition_events(events)
+    if input_partition_events:
+        buffer_source_usage_events(
+            context.usage_event_url(),
+            context.sandbox_token,
+            run_id,
+            input_partition_events,
+            context.proxy_log_path,
+            atomic_source_key=_model_input_partition_source_key(
+                USAGE_EVENT_NAMESPACE_MODEL,
+                run_id,
+                source_id,
+            ),
+        )
+    if independent_events:
+        buffer_source_usage_events(
+            context.usage_event_url(),
+            context.sandbox_token,
+            run_id,
+            independent_events,
+            context.proxy_log_path,
+        )
 
 
 def _buffer_source_model_provider_usage_observations(
     context: UsageReportingContext,
     run_id: str,
+    source_id: str,
     events: list[UsageEvent],
 ) -> None:
-    buffer_source_model_usage_observations(
-        context.model_usage_observation_url(),
-        context.sandbox_token,
-        run_id,
-        events,
-        context.proxy_log_path,
+    input_partition_events, independent_events = _split_model_input_partition_events(events)
+    if input_partition_events:
+        buffer_source_model_usage_observations(
+            context.model_usage_observation_url(),
+            context.sandbox_token,
+            run_id,
+            input_partition_events,
+            context.proxy_log_path,
+            atomic_source_key=_model_input_partition_source_key(
+                USAGE_OBSERVATION_NAMESPACE_MODEL,
+                run_id,
+                source_id,
+            ),
+        )
+    if independent_events:
+        buffer_source_model_usage_observations(
+            context.model_usage_observation_url(),
+            context.sandbox_token,
+            run_id,
+            independent_events,
+            context.proxy_log_path,
+        )
+
+
+def _split_model_input_partition_events(
+    events: list[UsageEvent],
+) -> tuple[list[UsageEvent], list[UsageEvent]]:
+    input_partition_events: list[UsageEvent] = []
+    independent_events: list[UsageEvent] = []
+    for event in events:
+        target = (
+            input_partition_events
+            if event["category"] in _MODEL_INPUT_PARTITION_CATEGORIES
+            else independent_events
+        )
+        target.append(event)
+    return input_partition_events, independent_events
+
+
+def _model_input_partition_source_key(
+    namespace: uuid.UUID,
+    run_id: str,
+    source_id: str,
+) -> str:
+    return derive_usage_idempotency_key(
+        namespace,
+        (run_id, source_id, "model_input_partition", "atomic_source"),
     )
 
 

--- a/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
+++ b/crates/runner/mitm-addon/tests/model_provider_response_helpers.py
@@ -240,6 +240,7 @@ def standard_success_payload(
     input_tokens: int | None = None,
     output_tokens: int | None = None,
     cached_tokens: int | None = None,
+    cache_write_tokens: int | None = None,
 ) -> bytes:
     resolved_input_tokens = provider_case.input_tokens if input_tokens is None else input_tokens
     resolved_output_tokens = provider_case.output_tokens if output_tokens is None else output_tokens
@@ -248,10 +249,14 @@ def standard_success_payload(
         "input_tokens": resolved_input_tokens,
         "output_tokens": resolved_output_tokens,
     }
-    if provider_case.uses_openai_responses and resolved_cached_tokens is not None:
-        usage_payload["input_tokens_details"] = {
-            "cached_tokens": resolved_cached_tokens,
-        }
+    if provider_case.uses_openai_responses:
+        input_tokens_details: dict[str, int] = {}
+        if resolved_cached_tokens is not None:
+            input_tokens_details["cached_tokens"] = resolved_cached_tokens
+        if cache_write_tokens is not None:
+            input_tokens_details["cache_write_tokens"] = cache_write_tokens
+        if input_tokens_details:
+            usage_payload["input_tokens_details"] = input_tokens_details
     payload: dict[str, object] = {
         "id": provider_case.message_id,
         "model": provider_case.model,
@@ -268,6 +273,7 @@ def expected_model_usage(
     input_tokens: int | None = None,
     output_tokens: int | None = None,
     cached_tokens: int | None = None,
+    cache_write_tokens: int | None = None,
 ) -> dict[str, object]:
     resolved_input_tokens = provider_case.input_tokens if input_tokens is None else input_tokens
     resolved_output_tokens = provider_case.output_tokens if output_tokens is None else output_tokens
@@ -278,17 +284,31 @@ def expected_model_usage(
         "tokens.input": resolved_input_tokens,
         "tokens.output": resolved_output_tokens,
     }
-    if provider_case.uses_openai_responses and resolved_cached_tokens is not None:
-        assert resolved_cached_tokens <= resolved_input_tokens
-        expected["tokens.input"] = resolved_input_tokens - resolved_cached_tokens
-        expected["tokens.cache_read"] = resolved_cached_tokens
+    if provider_case.uses_openai_responses:
+        remaining_input_tokens = resolved_input_tokens
+        if resolved_cached_tokens is not None:
+            assert resolved_cached_tokens <= remaining_input_tokens
+            remaining_input_tokens -= resolved_cached_tokens
+            expected["tokens.cache_read"] = resolved_cached_tokens
+        if cache_write_tokens is not None:
+            assert cache_write_tokens <= remaining_input_tokens
+            remaining_input_tokens -= cache_write_tokens
+            expected["tokens.cache_creation"] = cache_write_tokens
+        expected["tokens.input"] = remaining_input_tokens
     return expected
 
 
-def expected_event_quantities(provider_case: ModelProviderJsonCase) -> dict[str, int]:
+def expected_event_quantities(
+    provider_case: ModelProviderJsonCase,
+    *,
+    cache_write_tokens: int | None = None,
+) -> dict[str, int]:
     return {
         category: quantity
-        for category, quantity in expected_model_usage(provider_case).items()
+        for category, quantity in expected_model_usage(
+            provider_case,
+            cache_write_tokens=cache_write_tokens,
+        ).items()
         if category.startswith("tokens.")
         and isinstance(quantity, int)
         and not isinstance(quantity, bool)

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_fallback.py
@@ -68,8 +68,12 @@ class TestModelProviderJsonFallback:
     def test_openai_non_streaming_json_fallback(self, tmp_path, real_flow):
         """Legacy JSON fallback should use OpenAI Responses mapping."""
         provider_case = OPENAI_RESPONSES_CASE
+        cache_write_tokens = 15
         flow = model_provider_flow(real_flow, tmp_path, provider_case)
-        body = standard_success_payload(provider_case)
+        body = standard_success_payload(
+            provider_case,
+            cache_write_tokens=cache_write_tokens,
+        )
         set_response_stream_buffer(flow, body)
         flow.response = tutils.tresp(
             status_code=200,
@@ -81,15 +85,23 @@ class TestModelProviderJsonFallback:
         webhook = run_response(flow, self._usage_webhook_api)
 
         extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
-        expected = expected_model_usage(provider_case)
+        expected = expected_model_usage(
+            provider_case,
+            cache_write_tokens=cache_write_tokens,
+        )
         assert extracted["message_id"] == expected["message_id"]
         assert extracted["model"] == expected["model"]
         assert extracted["tokens.input"] == expected["tokens.input"]
         assert extracted["tokens.output"] == expected["tokens.output"]
         assert extracted["tokens.cache_read"] == expected["tokens.cache_read"]
+        assert extracted["tokens.cache_creation"] == expected["tokens.cache_creation"]
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
-        assert by_category == expected_event_quantities(provider_case)
+        assert len(events) == len(by_category)
+        assert by_category == expected_event_quantities(
+            provider_case,
+            cache_write_tokens=cache_write_tokens,
+        )
 
     def test_anthropic_json_fallback_parse_error_logs_proxy_warning(self, tmp_path, real_flow):
         """Legacy JSON fallback parse failures should be observable."""

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -120,7 +120,11 @@ class TestModelProviderJsonStreaming:
             provider_case,
             proxy_log_path=tmp_path / "proxy.jsonl",
         )
-        payload = standard_success_payload(provider_case)
+        cache_write_tokens = 15 if provider_case.uses_openai_responses else None
+        payload = standard_success_payload(
+            provider_case,
+            cache_write_tokens=cache_write_tokens,
+        )
         compressed = gzip.compress(payload)
         flow.response = tutils.tresp(
             status_code=200,
@@ -135,16 +139,24 @@ class TestModelProviderJsonStreaming:
         webhook = run_response(flow, self._usage_webhook_api)
 
         extracted = flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE]
-        expected_usage = expected_model_usage(provider_case)
+        expected_usage = expected_model_usage(
+            provider_case,
+            cache_write_tokens=cache_write_tokens,
+        )
         assert extracted["message_id"] == expected_usage["message_id"]
         assert extracted["model"] == expected_usage["model"]
         assert extracted["tokens.input"] == expected_usage["tokens.input"]
         assert extracted["tokens.output"] == expected_usage["tokens.output"]
         if provider_case.uses_openai_responses:
             assert extracted["tokens.cache_read"] == expected_usage["tokens.cache_read"]
+            assert extracted["tokens.cache_creation"] == expected_usage["tokens.cache_creation"]
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
-        assert by_category == expected_event_quantities(provider_case)
+        assert len(events) == len(by_category)
+        assert by_category == expected_event_quantities(
+            provider_case,
+            cache_write_tokens=cache_write_tokens,
+        )
 
     def test_full_pipeline_small_zstd_model_json_uses_bounded_fallback(
         self,

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -1,6 +1,7 @@
 """Tests for model-provider SSE usage reporting paths."""
 
 import gzip
+import json
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -416,3 +417,81 @@ class TestModelProviderSseUsage:
         for key in idempotency_by_category.values():
             uuid.UUID(key)
         assert {event["provider"] for event in events} == {"gpt-5.5"}
+
+    @pytest.mark.parametrize(
+        "later_cache_write_tokens",
+        [0, None],
+        ids=["zero", "omitted"],
+    )
+    def test_full_pipeline_model_sse_raw_snapshots_preserve_input_partition(
+        self,
+        tmp_path,
+        real_flow,
+        later_cache_write_tokens,
+    ):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+        later_input_details = {"cached_tokens": 20}
+        if later_cache_write_tokens is not None:
+            later_input_details["cache_write_tokens"] = later_cache_write_tokens
+        first_snapshot = {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_sse_partition",
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 0,
+                    "input_tokens_details": {
+                        "cached_tokens": 20,
+                        "cache_write_tokens": 30,
+                    },
+                },
+            },
+        }
+        later_snapshot = {
+            "type": "response.done",
+            "response": {
+                "id": "resp_sse_partition",
+                "model": "gpt-5.5",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 40,
+                    "input_tokens_details": later_input_details,
+                },
+            },
+        }
+        response_stream(flow)(
+            b"event: response.completed\n"
+            + b"data: "
+            + json.dumps(first_snapshot).encode()
+            + b"\n\n"
+            + b"event: response.done\n"
+            + b"data: "
+            + json.dumps(later_snapshot).encode()
+            + b"\n\n"
+        )
+
+        webhook = self._run_response(flow)
+
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert len(events) == len(by_category) == 4
+        assert by_category == {
+            "tokens.input": 50,
+            "tokens.output": 40,
+            "tokens.cache_read": 20,
+            "tokens.cache_creation": 30,
+        }
+        assert (
+            by_category["tokens.input"]
+            + by_category["tokens.cache_read"]
+            + by_category["tokens.cache_creation"]
+            == 100
+        )
+        observation_events = webhook.model_usage_observation_events()
+        observations_by_category = {
+            event["category"]: event["quantity"] for event in observation_events
+        }
+        assert len(observation_events) == len(observations_by_category) == 4
+        assert observations_by_category == by_category

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -109,17 +109,20 @@ class TestModelProviderSseUsage:
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
             b'"usage":{"input_tokens":50,"output_tokens":20,'
-            b'"input_tokens_details":{"cached_tokens":10}}}}'
+            b'"input_tokens_details":{"cached_tokens":10,'
+            b'"cache_write_tokens":15}}}}'
         )
 
         webhook = self._run_response(flow)
 
         events = webhook.usage_events()
         by_category = {event["category"]: event["quantity"] for event in events}
+        assert len(events) == len(by_category)
         assert by_category == {
-            "tokens.input": 40,
+            "tokens.input": 25,
             "tokens.output": 20,
             "tokens.cache_read": 10,
+            "tokens.cache_creation": 15,
         }
 
     def test_full_pipeline_model_sse_reports_response_incomplete_usage(self, tmp_path, real_flow):

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -417,6 +417,66 @@ class TestModelProviderWebSocketUsage:
             "tokens.output": 12,
         }
 
+    def test_model_websocket_late_same_id_snapshot_does_not_mix_input_partition(
+        self, tmp_path, real_flow
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_partition",
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 0,
+                            "input_tokens_details": {"cached_tokens": 20},
+                        },
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "id": "resp_ws_partition",
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 40,
+                            "input_tokens_details": {
+                                "cached_tokens": 20,
+                                "cache_write_tokens": 30,
+                            },
+                        },
+                    },
+                }
+            ).encode(),
+        )
+
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert len(events) == len(by_category) == 3
+        assert len({event["idempotencyKey"] for event in events}) == 3
+        assert by_category == {
+            "tokens.input": 80,
+            "tokens.output": 40,
+            "tokens.cache_read": 20,
+        }
+        observation_events = webhook.model_usage_observation_events()
+        observations_by_category = {
+            event["category"]: event["quantity"] for event in observation_events
+        }
+        assert len(observation_events) == len(observations_by_category) == 3
+        assert len({event["idempotencyKey"] for event in observation_events}) == 3
+        assert observations_by_category == by_category
+        assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
+        assert _model_websocket_usage_sources(flow) == {}
+
     def test_model_websocket_zero_frame_model_is_used_by_later_positive_frame(
         self, tmp_path, real_flow
     ):
@@ -728,6 +788,79 @@ class TestModelProviderWebSocketUsage:
             "tokens.input": 17,
             "tokens.output": 5,
         }
+
+    @pytest.mark.parametrize(
+        "later_cache_write_tokens",
+        [0, None],
+        ids=["zero", "omitted"],
+    )
+    def test_model_websocket_missing_id_raw_snapshots_preserve_input_partition(
+        self,
+        tmp_path,
+        real_flow,
+        later_cache_write_tokens,
+    ):
+        flow = _openai_model_websocket_flow(tmp_path, real_flow)
+        mitm_addon.responseheaders(flow)
+        later_input_details = {"cached_tokens": 20}
+        if later_cache_write_tokens is not None:
+            later_input_details["cache_write_tokens"] = later_cache_write_tokens
+
+        webhook = self._run_websocket_messages_and_end(
+            flow,
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 0,
+                            "input_tokens_details": {
+                                "cached_tokens": 20,
+                                "cache_write_tokens": 30,
+                            },
+                        },
+                    },
+                }
+            ).encode(),
+            json.dumps(
+                {
+                    "type": "response.done",
+                    "response": {
+                        "model": "gpt-5.5",
+                        "usage": {
+                            "input_tokens": 100,
+                            "output_tokens": 40,
+                            "input_tokens_details": later_input_details,
+                        },
+                    },
+                }
+            ).encode(),
+        )
+
+        events = webhook.usage_events()
+        by_category = {event["category"]: event["quantity"] for event in events}
+        assert len(events) == len(by_category) == 4
+        assert by_category == {
+            "tokens.input": 50,
+            "tokens.output": 40,
+            "tokens.cache_read": 20,
+            "tokens.cache_creation": 30,
+        }
+        assert (
+            by_category["tokens.input"]
+            + by_category["tokens.cache_read"]
+            + by_category["tokens.cache_creation"]
+            == 100
+        )
+        observation_events = webhook.model_usage_observation_events()
+        observations_by_category = {
+            event["category"]: event["quantity"] for event in observation_events
+        }
+        assert len(observation_events) == len(observations_by_category) == 4
+        assert observations_by_category == by_category
+        assert _model_websocket_usage_sources(flow) == {}
 
     async def test_model_websocket_response_keeps_usage_flow_tracked_until_end(
         self,

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -193,7 +193,10 @@ class TestModelProviderWebSocketUsage:
                         "usage": {
                             "input_tokens": 50,
                             "output_tokens": 20,
-                            "input_tokens_details": {"cached_tokens": 10},
+                            "input_tokens_details": {
+                                "cached_tokens": 10,
+                                "cache_write_tokens": 15,
+                            },
                         },
                     },
                 }
@@ -204,12 +207,14 @@ class TestModelProviderWebSocketUsage:
 
         events = webhook.usage_events()
         by_category = _sum_quantities_by_category(events)
+        assert len(events) == len(by_category)
         assert flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] == {}
         assert _model_websocket_usage_sources(flow) == {}
         assert by_category == {
-            "tokens.input": 40,
+            "tokens.input": 25,
             "tokens.output": 20,
             "tokens.cache_read": 10,
+            "tokens.cache_creation": 15,
         }
 
     def test_model_websocket_missing_context_releases_positive_source(

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -563,6 +563,7 @@ def test_merge_cache_creation_positive_usage_owns_metadata():
         {
             "message_id": "resp_2",
             "model": "gpt-5.6-sol",
+            "tokens.input": 0,
             "tokens.cache_creation": 7,
         },
     )
@@ -570,6 +571,7 @@ def test_merge_cache_creation_positive_usage_owns_metadata():
     assert target == {
         "message_id": "resp_2",
         "model": "gpt-5.6-sol",
+        "tokens.input": 0,
         "tokens.output": 10,
         "tokens.cache_creation": 7,
     }

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -15,11 +15,14 @@ def test_extracts_usage_from_wrapped_response_completed_event():
             "type": "response.completed",
             "response": {
                 "id": "resp_1",
-                "model": "gpt-5.5",
+                "model": "gpt-5.6-sol",
                 "usage": {
                     "input_tokens": 100,
                     "output_tokens": 40,
-                    "input_tokens_details": {"cached_tokens": 25},
+                    "input_tokens_details": {
+                        "cached_tokens": 25,
+                        "cache_write_tokens": 30,
+                    },
                 },
             },
         }
@@ -27,10 +30,11 @@ def test_extracts_usage_from_wrapped_response_completed_event():
 
     assert extract_openai_responses_usage_from_event_json(body) == {
         "message_id": "resp_1",
-        "model": "gpt-5.5",
-        "tokens.input": 75,
+        "model": "gpt-5.6-sol",
+        "tokens.input": 45,
         "tokens.output": 40,
         "tokens.cache_read": 25,
+        "tokens.cache_creation": 30,
     }
 
 
@@ -136,7 +140,10 @@ def test_extracts_zero_usage_quantities():
                 "usage": {
                     "input_tokens": 0,
                     "output_tokens": 0,
-                    "input_tokens_details": {"cached_tokens": 0},
+                    "input_tokens_details": {
+                        "cached_tokens": 0,
+                        "cache_write_tokens": 0,
+                    },
                 },
             },
         }
@@ -148,6 +155,7 @@ def test_extracts_zero_usage_quantities():
         "tokens.input": 0,
         "tokens.output": 0,
         "tokens.cache_read": 0,
+        "tokens.cache_creation": 0,
     }
 
 
@@ -415,6 +423,7 @@ def test_merge_preserves_positive_quantities_when_source_has_zero():
         "model": "gpt-5.5",
         "tokens.input": 75,
         "tokens.output": 40,
+        "tokens.cache_creation": 30,
     }
 
     merge_openai_responses_usage_result(
@@ -425,6 +434,7 @@ def test_merge_preserves_positive_quantities_when_source_has_zero():
             "tokens.input": 0,
             "tokens.output": 0,
             "tokens.cache_read": 0,
+            "tokens.cache_creation": 0,
         },
     )
 
@@ -434,6 +444,7 @@ def test_merge_preserves_positive_quantities_when_source_has_zero():
         "tokens.input": 75,
         "tokens.output": 40,
         "tokens.cache_read": 0,
+        "tokens.cache_creation": 30,
     }
 
 
@@ -444,6 +455,7 @@ def test_merge_zero_only_source_does_not_relabel_existing_positive_usage():
         "tokens.input": 75,
         "tokens.output": 40,
         "tokens.cache_read": 25,
+        "tokens.cache_creation": 30,
     }
 
     merge_openai_responses_usage_result(
@@ -454,6 +466,7 @@ def test_merge_zero_only_source_does_not_relabel_existing_positive_usage():
             "tokens.input": 0,
             "tokens.output": 0,
             "tokens.cache_read": 0,
+            "tokens.cache_creation": 0,
         },
     )
 
@@ -463,6 +476,7 @@ def test_merge_zero_only_source_does_not_relabel_existing_positive_usage():
         "tokens.input": 75,
         "tokens.output": 40,
         "tokens.cache_read": 25,
+        "tokens.cache_creation": 30,
     }
 
 
@@ -475,6 +489,7 @@ def test_merge_stores_zero_quantities_when_target_is_missing_category():
             "tokens.input": 0,
             "tokens.output": 0,
             "tokens.cache_read": 0,
+            "tokens.cache_creation": 0,
         },
     )
 
@@ -482,6 +497,7 @@ def test_merge_stores_zero_quantities_when_target_is_missing_category():
         "tokens.input": 0,
         "tokens.output": 0,
         "tokens.cache_read": 0,
+        "tokens.cache_creation": 0,
     }
 
 
@@ -514,6 +530,7 @@ def test_merge_allows_positive_corrections_to_lower_quantities():
         "tokens.input": 20,
         "tokens.output": 12,
         "tokens.cache_read": 8,
+        "tokens.cache_creation": 6,
     }
 
     merge_openai_responses_usage_result(
@@ -522,6 +539,7 @@ def test_merge_allows_positive_corrections_to_lower_quantities():
             "tokens.input": 10,
             "tokens.output": 7,
             "tokens.cache_read": 3,
+            "tokens.cache_creation": 2,
         },
     )
 
@@ -529,6 +547,31 @@ def test_merge_allows_positive_corrections_to_lower_quantities():
         "tokens.input": 10,
         "tokens.output": 7,
         "tokens.cache_read": 3,
+        "tokens.cache_creation": 2,
+    }
+
+
+def test_merge_cache_creation_positive_usage_owns_metadata():
+    target = {
+        "message_id": "resp_1",
+        "model": "gpt-5.5",
+        "tokens.output": 10,
+    }
+
+    merge_openai_responses_usage_result(
+        target,
+        {
+            "message_id": "resp_2",
+            "model": "gpt-5.6-sol",
+            "tokens.cache_creation": 7,
+        },
+    )
+
+    assert target == {
+        "message_id": "resp_2",
+        "model": "gpt-5.6-sol",
+        "tokens.output": 10,
+        "tokens.cache_creation": 7,
     }
 
 
@@ -539,7 +582,6 @@ def test_merge_ignores_unknown_keys():
         target,
         {
             "tokens.input": 1,
-            "tokens.cache_creation": 99,
             "unknown": "value",
         },
     )

--- a/crates/runner/mitm-addon/tests/test_openai_responses_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_json.py
@@ -3,6 +3,8 @@
 import gzip
 import json
 
+import pytest
+
 from usage import (
     extract_openai_responses_usage_from_json,
     extract_openai_responses_usage_with_error_from_json,
@@ -12,15 +14,18 @@ from usage import (
 class TestExtractOpenAIResponsesUsageFromJson:
     """Tests for OpenAI Responses API usage extraction."""
 
-    def test_extracts_model_tokens_and_cached_input(self):
+    def test_extracts_model_tokens_and_cache_details(self):
         body = json.dumps(
             {
                 "id": "resp_123",
-                "model": "gpt-5.5",
+                "model": "gpt-5.6-sol",
                 "usage": {
                     "input_tokens": 100,
                     "output_tokens": 40,
-                    "input_tokens_details": {"cached_tokens": 25},
+                    "input_tokens_details": {
+                        "cached_tokens": 25,
+                        "cache_write_tokens": 30,
+                    },
                     "output_tokens_details": {"reasoning_tokens": 10},
                 },
             }
@@ -29,10 +34,11 @@ class TestExtractOpenAIResponsesUsageFromJson:
         assert result is not None
         assert result == {
             "message_id": "resp_123",
-            "model": "gpt-5.5",
-            "tokens.input": 75,
+            "model": "gpt-5.6-sol",
+            "tokens.input": 45,
             "tokens.output": 40,
             "tokens.cache_read": 25,
+            "tokens.cache_creation": 30,
         }
         assert "reasoning_tokens" not in result
 
@@ -54,7 +60,10 @@ class TestExtractOpenAIResponsesUsageFromJson:
                 "usage": {
                     "input_tokens": -1,
                     "output_tokens": True,
-                    "input_tokens_details": {"cached_tokens": "25"},
+                    "input_tokens_details": {
+                        "cached_tokens": "25",
+                        "cache_write_tokens": 3,
+                    },
                 },
             }
         ).encode()
@@ -72,6 +81,54 @@ class TestExtractOpenAIResponsesUsageFromJson:
             "tokens.input": 10,
         }
         assert "tokens.cache_read" not in result
+
+    def test_cache_write_without_cache_read_is_reportable(self):
+        body = (
+            b'{"id":"resp_cache_write","model":"gpt-5.6-sol",'
+            b'"usage":{"input_tokens":10,'
+            b'"input_tokens_details":{"cache_write_tokens":10}}}'
+        )
+        result = extract_openai_responses_usage_from_json(body, None)
+        assert result == {
+            "message_id": "resp_cache_write",
+            "model": "gpt-5.6-sol",
+            "tokens.input": 0,
+            "tokens.cache_creation": 10,
+        }
+
+    @pytest.mark.parametrize("cache_write_tokens", [-1, True, "25", 1.5])
+    def test_invalid_cache_write_does_not_suppress_valid_input(self, cache_write_tokens: object):
+        body = json.dumps(
+            {
+                "model": "gpt-5.6-sol",
+                "usage": {
+                    "input_tokens": 10,
+                    "input_tokens_details": {
+                        "cached_tokens": 2,
+                        "cache_write_tokens": cache_write_tokens,
+                    },
+                },
+            }
+        ).encode()
+        result = extract_openai_responses_usage_from_json(body, None)
+        assert result == {
+            "model": "gpt-5.6-sol",
+            "tokens.input": 8,
+            "tokens.cache_read": 2,
+        }
+
+    def test_cache_write_tokens_are_clamped_to_input_remaining_after_cache_read(self):
+        body = (
+            b'{"model":"gpt-5.6-sol","usage":{"input_tokens":10,'
+            b'"input_tokens_details":{"cached_tokens":8,"cache_write_tokens":5}}}'
+        )
+        result = extract_openai_responses_usage_from_json(body, None)
+        assert result == {
+            "model": "gpt-5.6-sol",
+            "tokens.input": 0,
+            "tokens.cache_read": 8,
+            "tokens.cache_creation": 2,
+        }
 
     def test_gzip_compressed(self, headers):
         original = (

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -16,16 +16,18 @@ class TestOpenAIResponsesSseUsageExtractor:
         parse(
             b"event: response.completed\n"
             b'data: {"type":"response.completed","response":{"id":"resp_1",'
-            b'"model":"gpt-5.5","usage":{"input_tokens":100,'
-            b'"output_tokens":40,"input_tokens_details":{"cached_tokens":25},'
+            b'"model":"gpt-5.6-sol","usage":{"input_tokens":100,'
+            b'"output_tokens":40,"input_tokens_details":{"cached_tokens":25,'
+            b'"cache_write_tokens":30},'
             b'"output_tokens_details":{"reasoning_tokens":10}}}}\n\n'
         )
         assert usage == {
             "message_id": "resp_1",
-            "model": "gpt-5.5",
-            "tokens.input": 75,
+            "model": "gpt-5.6-sol",
+            "tokens.input": 45,
             "tokens.output": 40,
             "tokens.cache_read": 25,
+            "tokens.cache_creation": 30,
         }
         assert "reasoning_tokens" not in usage
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -112,6 +112,132 @@ def test_source_preserving_usage_buffer_keeps_source_idempotency_keys(tmp_path):
     }
 
 
+def test_source_preserving_atomic_group_rejects_repeated_group_key(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+
+    assert (
+        usage.buffer_source_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [],
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 0
+    )
+    assert (
+        usage.buffer_source_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                event(source_key="source-input", quantity=10),
+                event(
+                    source_key="source-cache-read",
+                    category="tokens.cache_read",
+                    quantity=4,
+                ),
+            ],
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 2
+    )
+    assert (
+        usage.buffer_source_usage_events(
+            "https://api.test/api/webhooks/agent/usage-event",
+            "token-a",
+            "run-1",
+            [
+                event(
+                    source_key="source-cache-creation",
+                    category="tokens.cache_creation",
+                    quantity=3,
+                )
+            ],
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 0
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload == {
+        "runId": "run-1",
+        "events": [
+            {
+                "idempotencyKey": "source-input",
+                "kind": "model",
+                "provider": "claude-sonnet-4-6",
+                "category": "tokens.input",
+                "quantity": 10,
+            },
+            {
+                "idempotencyKey": "source-cache-read",
+                "kind": "model",
+                "provider": "claude-sonnet-4-6",
+                "category": "tokens.cache_read",
+                "quantity": 4,
+            },
+        ],
+    }
+
+
+def test_source_preserving_atomic_group_rejects_when_member_key_was_seen(tmp_path):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+    url = "https://api.test/api/webhooks/agent/usage-event"
+
+    assert (
+        usage.buffer_source_usage_events(
+            url,
+            "token-a",
+            "run-1",
+            [event(source_key="source-input", quantity=10)],
+            proxy_log_path,
+        )
+        == 1
+    )
+    assert (
+        usage.buffer_source_usage_events(
+            url,
+            "token-a",
+            "run-1",
+            [
+                event(source_key="source-input", quantity=20),
+                event(
+                    source_key="source-cache-read",
+                    category="tokens.cache_read",
+                    quantity=8,
+                ),
+            ],
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 0
+    )
+
+    assert usage.flush_usage_events(trigger="test") == 1
+    enqueue.assert_called_once()
+    assert enqueue.last_call.payload == {
+        "runId": "run-1",
+        "events": [
+            {
+                "idempotencyKey": "source-input",
+                "kind": "model",
+                "provider": "claude-sonnet-4-6",
+                "category": "tokens.input",
+                "quantity": 10,
+            }
+        ],
+    }
+
+
 def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):
     enqueue = RecordingEnqueue()
     usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)


### PR DESCRIPTION
## Summary

- parse `usage.input_tokens_details.cache_write_tokens` from OpenAI Responses payloads
- partition total input across ordinary input, cache reads, and cache creation to avoid duplicate billing
- merge repeated terminal input snapshots atomically so zero or omitted cache-write details cannot inflate the partition
- admit response-ID WebSocket input partitions as one bounded idempotency group while still accepting late output
- preserve compatibility when cache-write usage is absent or invalid without changing the webhook or API contract

## Testing

- `pytest tests/ -q` (3,750 passed)
- focused OpenAI Responses and model-provider usage tests (95 passed)
- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`

Local `pnpm vitest` completed 7,192 tests (7,179 passed, 1 skipped, 12 failed outside this Python-only diff). The four platform files that timed out under full-suite load passed when rerun scoped (106 tests); UTC-scoped reruns cleared the artifact-pagination and allowance-window failures. Two deterministic stale expectations remain unchanged from `origin/main`: the Xero permission description and usage-member credit total. No unrelated files are included here.

Closes #20868
