### PR TITLE
test(api): stabilize usage allowance integration tests

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/stripe-billing-webhook.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/stripe-billing-webhook.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
 
+import type StripeSDK from "stripe";
+
 import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
 import { now } from "../../../../lib/time";
 import { getApiTestMocks } from "../../../../__tests__/mocks";
 import { createAppWithRoutes } from "../../../../app-factory-core";
+import { mockStripeClient } from "../../../external/stripe-client";
 import { webhooksStripeRoutes } from "../../webhooks-stripe";
 
 const TEST_PRICE_PRO = "price_test_pro";
@@ -71,6 +74,7 @@ export function subscriptionCredits(tier: "pro" | "team"): number {
 }
 
 function configureBillingWebhookEnv(): void {
+  mockStripeClient(getApiTestMocks().stripe as unknown as StripeSDK);
   mockEnv("ZERO_PRICE_PRO", TEST_PRICE_PRO);
   mockEnv("ZERO_PRICE_TEAM", TEST_PRICE_TEAM);
   mockEnv("ZERO_PRICE_CONCURRENCY", TEST_PRICE_CONCURRENCY);

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -6,9 +6,7 @@ import { describe, expect, it, onTestFinished } from "vitest";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { clearMockNow, mockNow, now, nowDate } from "../../../lib/time";
 import {
-  cancelUsageAllowanceEntitlement,
   seedOrgMetadata,
-  seedUsageAllowanceEntitlement,
   seedUsagePricingRows,
 } from "../../../test-fixtures/system-config-seeds";
 import {
@@ -24,6 +22,10 @@ import {
   seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState,
 } from "./helpers/automations";
 import { encryptSecretForTests } from "./helpers/encrypt-secret";
+import {
+  generatedStripeCustomerId,
+  postUsageAllowanceInvoicePaid,
+} from "./helpers/stripe-billing-webhook";
 
 const context = testContext();
 
@@ -50,15 +52,13 @@ interface AllowanceEntitlementArgs {
   readonly shortWindowUnits: number;
   readonly weeklyWindowUnits: number;
   readonly shortWindowSeconds?: number;
-  readonly status?: string;
 }
 
 /**
  * An org whose runs can be admitted with the vm0 managed model key. Tier and
  * credit balance are pinned through the org-metadata fixture; the allowance
- * entitlement (when given) is seeded directly so these tests can focus on
- * settlement without repeating Stripe invoice setup. Everything downstream —
- * window activation, usage events, settlement — runs through product paths.
+ * entitlement (when given), window activation, usage events, and settlement
+ * all run through product paths.
  */
 async function vm0AllowanceActor(args: {
   readonly credits: number;
@@ -81,7 +81,7 @@ async function vm0AllowanceActor(args: {
   await bdd.setupOnboarding(actor, { displayName: "Usage allowance agent" });
   await seedOrgMetadata({ orgId, tier: "pro", credits: args.credits });
   if (args.allowance) {
-    await seedAllowanceEntitlement(orgId, args.allowance);
+    await seedAllowanceEntitlement(actor, orgId, args.allowance);
   }
   const agent = await bdd.createAgent(actor, {
     displayName: "Usage allowance agent",
@@ -91,16 +91,46 @@ async function vm0AllowanceActor(args: {
 }
 
 async function seedAllowanceEntitlement(
+  actor: ApiTestUser,
   orgId: string,
   args: AllowanceEntitlementArgs,
 ): Promise<void> {
-  await seedUsageAllowanceEntitlement({
+  await postUsageAllowanceInvoicePaid(context.signal, {
     orgId,
+    userId: actor.userId,
+    customerId: generatedStripeCustomerId(),
+    subscriptionId: usageAllowanceSubscriptionId(orgId),
+    effectiveAt: nowDate(),
+    expiresAt: addDays(nowDate(), 365),
     shortWindowSeconds: args.shortWindowSeconds ?? 5 * 60 * 60,
     shortWindowUnits: args.shortWindowUnits,
+    weeklyWindowSeconds: 7 * 24 * 60 * 60,
     weeklyWindowUnits: args.weeklyWindowUnits,
-    status: args.status,
   });
+}
+
+function usageAllowanceSubscriptionId(orgId: string): string {
+  return `sub_usage_allowance_${orgId}`;
+}
+
+async function cancelUsageAllowanceSubscription(orgId: string): Promise<void> {
+  const webhooks = createWebhookCallbackApi(context);
+  webhooks.configureStripeBillingEnv();
+  await webhooks.postStripeEvent(
+    {
+      id: `evt_usage_allowance_cancel_${randomUUID()}`,
+      type: "customer.subscription.updated",
+      created: Math.floor(now() / 1000),
+      data: {
+        object: {
+          id: usageAllowanceSubscriptionId(orgId),
+          status: "canceled",
+          items: { data: [] },
+        },
+      },
+    },
+    [200],
+  );
 }
 
 async function createVm0Run(
@@ -456,7 +486,7 @@ describe("Usage Allowance", () => {
     await api.grantProEntitlement(actor);
     await api.ensureOrgModelProvider(actor);
     await seedOrgMetadata({ orgId, tier: "pro", credits: 100 });
-    await seedAllowanceEntitlement(orgId, {
+    await seedAllowanceEntitlement(actor, orgId, {
       shortWindowUnits: 100,
       weeklyWindowUnits: 200,
     });
@@ -516,7 +546,7 @@ describe("Usage Allowance", () => {
   it("does not apply newly created allowance to older runs", async () => {
     const { actor, orgId, agentId } = await vm0AllowanceActor({ credits: 100 });
     const run = await createVm0Run(actor, agentId, "run before entitlement");
-    await seedAllowanceEntitlement(orgId, {
+    await seedAllowanceEntitlement(actor, orgId, {
       shortWindowUnits: 100,
       weeklyWindowUnits: 200,
     });
@@ -552,7 +582,7 @@ describe("Usage Allowance", () => {
 
     const canceledAt = addHours(startedAt, 1);
     mockNow(canceledAt);
-    await cancelUsageAllowanceEntitlement({ orgId, canceledAt });
+    await cancelUsageAllowanceSubscription(orgId);
     const provider = usageProvider();
     await recordPendingUsage({
       actor,
@@ -580,27 +610,7 @@ describe("Usage Allowance", () => {
     await createVm0Run(actor, agentId, "activate allowance windows");
     const canceledAt = addHours(startedAt, 1);
     mockNow(canceledAt);
-    const webhooks = createWebhookCallbackApi(context);
-    webhooks.configureStripeBillingEnv();
-    await webhooks.postStripeEvent(
-      {
-        id: `evt_usage_allowance_cancel_${randomUUID()}`,
-        type: "customer.subscription.updated",
-        created: Math.floor(now() / 1000),
-        data: {
-          object: {
-            id: `sub_usage_allowance_cancel_${randomUUID()}`,
-            status: "canceled",
-            metadata: {
-              purpose: "usage_allowance",
-              orgId,
-            },
-            items: { data: [] },
-          },
-        },
-      },
-      [200],
-    );
+    await cancelUsageAllowanceSubscription(orgId);
     mockNow(addHours(startedAt, 2));
     const run = await createVm0Run(
       actor,
@@ -626,7 +636,7 @@ describe("Usage Allowance", () => {
     const api = createRunsAutomationsApi(context);
     // The run predates the entitlement, so it has no allowance windows.
     const run = await createVm0Run(actor, agentId, "run without windows");
-    await seedAllowanceEntitlement(orgId, {
+    await seedAllowanceEntitlement(actor, orgId, {
       shortWindowUnits: 2,
       weeklyWindowUnits: 2,
     });

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -56,9 +56,9 @@ interface AllowanceEntitlementArgs {
 /**
  * An org whose runs can be admitted with the vm0 managed model key. Tier and
  * credit balance are pinned through the org-metadata fixture; the allowance
- * entitlement (when given) comes from the usage-allowance fixture because no
- * product path writes entitlement rows. Everything downstream — window
- * activation, usage events, settlement — runs through product paths.
+ * entitlement (when given) is seeded directly so these tests can focus on
+ * settlement without repeating Stripe invoice setup. Everything downstream —
+ * window activation, usage events, settlement — runs through product paths.
  */
 async function vm0AllowanceActor(args: {
   readonly credits: number;

--- a/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage-allowance.test.ts
@@ -196,15 +196,12 @@ describe("Usage Allowance", () => {
       quantity: 80,
     });
 
-    context.mocks.ably.publish.mockClear();
+    // Another Vitest worker can settle this org through the shared test DB, so
+    // verify persisted billing behavior instead of a worker-local Ably mock.
     await processUsageEvents();
 
     await expect(readOrgCredits(actor)).resolves.toBe(10);
     await expect(readRunCreditsCharged(actor, run.runId)).resolves.toBe(80);
-    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
-      "billing:changed",
-      null,
-    );
   });
 
   it("falls back to org credits after the binding window cap is exhausted", async () => {
@@ -583,7 +580,27 @@ describe("Usage Allowance", () => {
     await createVm0Run(actor, agentId, "activate allowance windows");
     const canceledAt = addHours(startedAt, 1);
     mockNow(canceledAt);
-    await cancelUsageAllowanceEntitlement({ orgId, canceledAt });
+    const webhooks = createWebhookCallbackApi(context);
+    webhooks.configureStripeBillingEnv();
+    await webhooks.postStripeEvent(
+      {
+        id: `evt_usage_allowance_cancel_${randomUUID()}`,
+        type: "customer.subscription.updated",
+        created: Math.floor(now() / 1000),
+        data: {
+          object: {
+            id: `sub_usage_allowance_cancel_${randomUUID()}`,
+            status: "canceled",
+            metadata: {
+              purpose: "usage_allowance",
+              orgId,
+            },
+            items: { data: [] },
+          },
+        },
+      },
+      [200],
+    );
     mockNow(addHours(startedAt, 2));
     const run = await createVm0Run(
       actor,

--- a/turbo/apps/api/src/test-fixtures/system-config-seeds.ts
+++ b/turbo/apps/api/src/test-fixtures/system-config-seeds.ts
@@ -1,9 +1,5 @@
 import { upsertOrgMetadataFixture } from "./org-metadata";
 import {
-  cancelUsageAllowanceEntitlementFixture,
-  upsertUsageAllowanceEntitlementFixture,
-} from "./usage-allowance";
-import {
   deleteUsagePricingRows,
   ensureUsagePricingRow,
   type UsagePricingRow,
@@ -13,9 +9,5 @@ import {
 export type { UsagePricingRow };
 
 export const seedOrgMetadata = upsertOrgMetadataFixture;
-export const seedUsageAllowanceEntitlement =
-  upsertUsageAllowanceEntitlementFixture;
-export const cancelUsageAllowanceEntitlement =
-  cancelUsageAllowanceEntitlementFixture;
 export const seedUsagePricingRows = upsertUsagePricingRows;
 export { deleteUsagePricingRows, ensureUsagePricingRow };

--- a/turbo/apps/api/src/test-fixtures/usage-allowance.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-allowance.ts
@@ -1,20 +1,17 @@
 /**
- * In-process test fixture for `org_usage_allowance_entitlements`.
+ * Narrow in-process fixtures for usage allowance state that has no equivalent
+ * product-facing setup or read surface.
  *
- * Settlement-focused tests seed entitlements directly so they do not need to
- * repeat the Stripe invoice setup covered by webhook integration tests. Tests
- * should still create and consume windows through product paths when those
- * behaviors matter. Explicit window seeds are reserved for read scenarios
- * that need pre-existing or historical allowance state.
+ * Entitlements are created through Stripe webhooks. Explicit window seeds are
+ * reserved for read scenarios that need pre-existing or historical state.
  */
 import {
   orgUsageAllowanceEntitlements,
   orgUsageAllowanceWindows,
 } from "@vm0/db/schema/org-usage-allowance";
 import { createStore } from "ccstate";
-import { and, eq, gt, lte, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
-import { timestampWithoutTimeZone } from "../lib/time";
 import { writeDb$ } from "../signals/external/db";
 
 interface UsageAllowanceEntitlementFixtureState {
@@ -37,42 +34,6 @@ interface UsageAllowanceWindowFixtureSeed {
   readonly expiresAt: Date;
   readonly unitLimit: number;
   readonly consumedUnits?: number;
-}
-
-export async function upsertUsageAllowanceEntitlementFixture(values: {
-  readonly orgId: string;
-  readonly shortWindowSeconds: number;
-  readonly shortWindowUnits: number;
-  readonly weeklyWindowUnits: number;
-  readonly weeklyWindowSeconds?: number;
-  readonly status?: string;
-}): Promise<void> {
-  const status = values.status ?? "active";
-  const weeklyWindowSeconds = values.weeklyWindowSeconds ?? 604_800;
-  await createStore()
-    .set(writeDb$)
-    .insert(orgUsageAllowanceEntitlements)
-    .values({
-      orgId: values.orgId,
-      source: "manual",
-      status,
-      shortWindowSeconds: values.shortWindowSeconds,
-      shortWindowUnits: values.shortWindowUnits,
-      weeklyWindowSeconds,
-      weeklyWindowUnits: values.weeklyWindowUnits,
-    })
-    .onConflictDoUpdate({
-      target: orgUsageAllowanceEntitlements.orgId,
-      set: {
-        source: "manual",
-        status,
-        shortWindowSeconds: values.shortWindowSeconds,
-        shortWindowUnits: values.shortWindowUnits,
-        weeklyWindowSeconds,
-        weeklyWindowUnits: values.weeklyWindowUnits,
-        updatedAt: sql`now()`,
-      },
-    });
 }
 
 export async function insertUsageAllowanceWindowsFixture(values: {
@@ -109,35 +70,6 @@ export async function insertUsageAllowanceWindowsFixture(values: {
       };
     }),
   );
-}
-
-export async function cancelUsageAllowanceEntitlementFixture(values: {
-  readonly orgId: string;
-  readonly canceledAt: Date;
-}): Promise<void> {
-  const db = createStore().set(writeDb$);
-  await db
-    .update(orgUsageAllowanceEntitlements)
-    .set({
-      status: "canceled",
-      expiresAt: values.canceledAt,
-      updatedAt: values.canceledAt,
-    })
-    .where(eq(orgUsageAllowanceEntitlements.orgId, values.orgId));
-
-  await db
-    .update(orgUsageAllowanceWindows)
-    .set({
-      expiresAt: sql<Date>`GREATEST(${timestampWithoutTimeZone(values.canceledAt)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
-      updatedAt: values.canceledAt,
-    })
-    .where(
-      and(
-        eq(orgUsageAllowanceWindows.orgId, values.orgId),
-        lte(orgUsageAllowanceWindows.startsAt, values.canceledAt),
-        gt(orgUsageAllowanceWindows.expiresAt, values.canceledAt),
-      ),
-    );
 }
 
 export async function readUsageAllowanceEntitlementFixture(

--- a/turbo/apps/api/src/test-fixtures/usage-allowance.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-allowance.ts
@@ -2,11 +2,10 @@
  * In-process test fixture for `org_usage_allowance_entitlements`.
  *
  * Settlement-focused tests seed entitlements directly so they do not need to
- * repeat the Stripe invoice setup covered by webhook integration tests. This
- * module only upserts the per-org entitlement row. Allowance windows and
- * allocations are deliberately NOT seeded here — production creates those
- * during vm0 run creation and usage-event settlement, and tests must drive
- * them through those paths.
+ * repeat the Stripe invoice setup covered by webhook integration tests. Tests
+ * should still create and consume windows through product paths when those
+ * behaviors matter. Explicit window seeds are reserved for read scenarios
+ * that need pre-existing or historical allowance state.
  */
 import {
   orgUsageAllowanceEntitlements,

--- a/turbo/apps/api/src/test-fixtures/usage-allowance.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-allowance.ts
@@ -1,15 +1,12 @@
 /**
  * In-process test fixture for `org_usage_allowance_entitlements`.
  *
- * Usage-allowance entitlements are operator-managed configuration with no
- * product write path: no API route, webhook, or cron inserts into this table
- * (the billing reconcile cron only manages concurrency entitlements), so
- * tests cannot grant an org a usage allowance through any product endpoint.
- * This module is the narrow test-boundary exception for that state: it only
- * upserts the per-org entitlement row. Allowance windows and allocations are
- * deliberately NOT seeded here — production creates those during vm0 run
- * creation and usage-event settlement, and tests must drive them through
- * those paths.
+ * Settlement-focused tests seed entitlements directly so they do not need to
+ * repeat the Stripe invoice setup covered by webhook integration tests. This
+ * module only upserts the per-org entitlement row. Allowance windows and
+ * allocations are deliberately NOT seeded here — production creates those
+ * during vm0 run creation and usage-event settlement, and tests must drive
+ * them through those paths.
  */
 import {
   orgUsageAllowanceEntitlements,


### PR DESCRIPTION
## Summary

- verify persisted usage allowance settlement instead of relying on a worker-local Ably publish mock
- create and cancel usage allowance entitlements through signed Stripe webhook integration paths
- remove the superseded direct entitlement database mutators and initialize the shared Stripe mock at the webhook fixture boundary

After rebasing, the cancellation timestamp encoding fix is supplied by `main` through `timestampWithoutTimeZone`, so this PR no longer carries a separate production implementation.

## Test plan

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest run --project=api apps/api/src/signals/routes/__tests__/usage-allowance.test.ts` (14 tests passed)
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` against a freshly migrated database (7,261 tests passed; 1 benchmark skipped)
