### PR TITLE
feat: migrate member model preferences to workspace default when org removes a model

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-model-policies.test.ts
@@ -9,6 +9,7 @@ import {
   type UpdateOrgModelPolicy,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroModelPoliciesMainContract } from "@vm0/api-contracts/contracts/zero-model-policies";
+import { zeroUserModelPreferenceContract } from "@vm0/api-contracts/contracts/zero-user-model-preference";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
@@ -385,6 +386,101 @@ describe("GET/PUT /api/zero/model-policies", () => {
         return policy.model === removedModel;
       }),
     ).toBeFalsy();
+  });
+
+  it("migrates member preferences from removed models to the workspace default", async () => {
+    const fixture = await seedFixture();
+    useSession(fixture);
+    const client = apiClient();
+    const preferenceClient = setupApp({ context })(
+      zeroUserModelPreferenceContract,
+    );
+    const listResponse = await accept(
+      client.list({ headers: authHeaders() }),
+      [200],
+    );
+    const removedModel = DEFAULT_ORG_MODEL_POLICY_MODELS.find((model) => {
+      return model !== DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
+    });
+    if (!removedModel) {
+      throw new Error("Default policy seed must include a non-default model");
+    }
+    await accept(
+      preferenceClient.update({
+        headers: authHeaders(),
+        body: { selectedModel: removedModel },
+      }),
+      [200],
+    );
+
+    const updates = toUpdate(listResponse.body).filter((policy) => {
+      return policy.model !== removedModel;
+    });
+    await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { policies: updates },
+      }),
+      [200],
+    );
+
+    const preferenceResponse = await accept(
+      preferenceClient.get({ headers: authHeaders() }),
+      [200],
+    );
+    expect(preferenceResponse.body.selectedModel).toBe(
+      DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL,
+    );
+  });
+
+  it("keeps member preferences for models still allowed after an update", async () => {
+    const fixture = await seedFixture();
+    useSession(fixture);
+    const client = apiClient();
+    const preferenceClient = setupApp({ context })(
+      zeroUserModelPreferenceContract,
+    );
+    const listResponse = await accept(
+      client.list({ headers: authHeaders() }),
+      [200],
+    );
+    const keptModel = DEFAULT_ORG_MODEL_POLICY_MODELS.find((model) => {
+      return model !== DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL;
+    });
+    const removedModel = DEFAULT_ORG_MODEL_POLICY_MODELS.find((model) => {
+      return (
+        model !== DEFAULT_ORG_MODEL_POLICY_DEFAULT_MODEL && model !== keptModel
+      );
+    });
+    if (!keptModel || !removedModel) {
+      throw new Error(
+        "Default policy seed must include two non-default models",
+      );
+    }
+    await accept(
+      preferenceClient.update({
+        headers: authHeaders(),
+        body: { selectedModel: keptModel },
+      }),
+      [200],
+    );
+
+    const updates = toUpdate(listResponse.body).filter((policy) => {
+      return policy.model !== removedModel;
+    });
+    await accept(
+      client.update({
+        headers: authHeaders(),
+        body: { policies: updates },
+      }),
+      [200],
+    );
+
+    const preferenceResponse = await accept(
+      preferenceClient.get({ headers: authHeaders() }),
+      [200],
+    );
+    expect(preferenceResponse.body.selectedModel).toBe(keptModel);
   });
 
   it("allows adding a supported model that was not seeded by default", async () => {

--- a/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-model-policy.service.ts
@@ -20,6 +20,7 @@ import {
 } from "@vm0/api-contracts/contracts/model-providers";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { modelProviders } from "@vm0/db/schema/model-provider";
+import { orgMembersMetadata } from "@vm0/db/schema/org-members-metadata";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { orgModelPolicies } from "@vm0/db/schema/org-model-policy";
 
@@ -653,18 +654,39 @@ export const updateOrgModelPolicies$ = command(
           target: [orgModelPolicies.orgId, orgModelPolicies.model],
         });
 
-      await tx.delete(orgModelPolicies).where(
-        and(
-          eq(orgModelPolicies.orgId, params.orgId),
-          inArray(orgModelPolicies.model, [...SUPPORTED_RUN_MODELS]),
-          notInArray(
-            orgModelPolicies.model,
-            validation.data.map((policy) => {
-              return policy.model;
-            }),
+      const removedRows = await tx
+        .delete(orgModelPolicies)
+        .where(
+          and(
+            eq(orgModelPolicies.orgId, params.orgId),
+            inArray(orgModelPolicies.model, [...SUPPORTED_RUN_MODELS]),
+            notInArray(
+              orgModelPolicies.model,
+              validation.data.map((policy) => {
+                return policy.model;
+              }),
+            ),
           ),
-        ),
-      );
+        )
+        .returning({ model: orgModelPolicies.model });
+
+      const removedModels = removedRows.map((row) => {
+        return row.model;
+      });
+      const defaultPolicy = validation.data.find((policy) => {
+        return policy.isDefault;
+      });
+      if (removedModels.length > 0 && defaultPolicy) {
+        await tx
+          .update(orgMembersMetadata)
+          .set({ selectedModel: defaultPolicy.model, updatedAt: now })
+          .where(
+            and(
+              eq(orgMembersMetadata.orgId, params.orgId),
+              inArray(orgMembersMetadata.selectedModel, removedModels),
+            ),
+          );
+      }
 
       await tx
         .update(orgModelPolicies)


### PR DESCRIPTION
## Summary

When an org admin removes a model from the organization's model policies (`PUT /api/zero/model-policies`), members who had that removed model as their personal preference kept a stale `org_members_metadata.selected_model` value pointing at a model the org no longer allows. This surfaced as errors for members/agents still pinned to a deleted model (e.g. after `gpt-5.5` was removed from an org).

This PR migrates those members inside the same policy-update transaction: any member whose `selected_model` is among the models being removed is switched to the update's workspace default model. Members whose preference is still in the allowed list are untouched.

## Implementation

- `updateOrgModelPolicies$` (`zero-model-policy.service.ts`): the delete of removed policy rows now uses `.returning()` to capture which models were actually removed, then updates `org_members_metadata.selected_model` to the new default for members in that org whose preference was removed. Runs inside the existing transaction, so a failed update leaves preferences unchanged.
- Scope note: `zero_agents.selected_model` was intentionally left alone — the API has no write path for that column today, and run-time member preference resolution (`resolveDefaultModelFirstPin`) already falls back to the org default when a preferred model has no policy row. This change makes the stored preference itself consistent, as discussed (batch-migrate members from the removed model to the default).

## Tests

Two new integration tests in `zero-model-policies.test.ts`, exercised through the real routes (policy update + user model preference endpoints):
- removing a model migrates a member's preference to the workspace default
- a preference for a model that remains allowed is not modified

## Verification

Formatted with the lockfile-pinned prettier (3.8.1). Relying on the PR pipeline for lint/type/test per repo practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)