### PR TITLE
chore(rust): update regex dependencies

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2443,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2455,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
## Summary
- Updated the Rust workspace lockfile with `cargo update --verbose`.
- `regex` was updated from `1.12.4` to `1.13.0`.
- `regex-automata` was updated from `0.4.14` to `0.4.15`.

## Dependencies that could not be updated
- `generic-array` remains at `0.14.7` even though `0.14.9` is available. `cargo update -p generic-array --precise 0.14.9 --verbose` fails because `crypto-common v0.1.7` requires `generic-array = "=0.14.7"` through the transitive chain `digest v0.10.7` -> `crc-fast v1.10.0` -> `aws-smithy-checksums v0.65.0` -> `aws-sdk-s3 v1.138.0` -> `runner`.

## Manual version bumps
- None. The only available direct workspace updates were lockfile-only patch/minor-compatible updates from `cargo update`.

## Test status
- `cargo test --workspace --locked` was attempted, but the sandbox ran out of disk space while compiling (`No space left on device`).
- Per-package validation was then run with `CARGO_BUILD_JOBS=1`, `CARGO_INCREMENTAL=0`, `RUSTFLAGS='-C debuginfo=0'`, `CARGO_PROFILE_DEV_DEBUG=0`, and `CARGO_PROFILE_TEST_DEBUG=0`, cleaning the target directory between packages.
- Passed per-package tests: `ably-subscriber`, `api-contracts`, `guest-common`, `guest-contracts`, `process-control-ipc`, `shell-quote`, `vsock-guest`, `vsock-proto`, `vsock-host`, `tracing-test-support`, `guest-download`, `guest-init`, `guest-mock-claude`, `guest-mock-codex`, `guest-reseed`, `guest-write-file`, `nbd-cow`, `sandbox`, `sandbox-fc`, `sandbox-mock`, and `vsock-test`.
- Not completed due to sandbox disk limits: `guest-agent` failed at final test linking with `No space left on device`; `runner` failed while building `crc-fast` with `No space left on device`. No update-related test assertion or compilation failures were observed before the disk-space failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)