### PR TITLE
fix(guest-agent): reduce gpt-5.6 sol reasoning effort to xhigh

### DIFF
--- a/crates/guest-agent/src/cli/command.rs
+++ b/crates/guest-agent/src/cli/command.rs
@@ -183,7 +183,7 @@ fn push_codex_fast_mode_configs(args: &mut Vec<String>) {
 pub(super) fn default_codex_reasoning_effort_for_model(model: &str) -> Option<&'static str> {
     let bare = model.strip_prefix("openai/").unwrap_or(model);
     match bare {
-        "gpt-5.6-sol" => Some("ultra"),
+        "gpt-5.6-sol" => Some("xhigh"),
         "gpt-5.5" => Some("xhigh"),
         _ => None,
     }
@@ -665,12 +665,12 @@ mod tests {
     }
 
     #[test]
-    fn build_codex_args_gpt_5_6_sol_defaults_reasoning_effort_ultra() {
+    fn build_codex_args_gpt_5_6_sol_defaults_reasoning_effort_xhigh() {
         for model in ["gpt-5.6-sol", "openai/gpt-5.6-sol"] {
             let args = build_codex_args_for_test(model, "", "p");
             assert!(codex_args_have_config(
                 &args,
-                "model_reasoning_effort=ultra"
+                "model_reasoning_effort=xhigh"
             ));
         }
     }


### PR DESCRIPTION
## Summary

- change GPT-5.6 Sol's default Codex reasoning effort from `ultra` to `xhigh`
- keep GPT-5.6 Terra, GPT-5.6 Luna, and GPT-5.5 defaults unchanged
- update the focused argument-building test for both canonical and `openai/`-prefixed model names

## User impact

GPT-5.6 Sol runs use the less expensive and faster `xhigh` reasoning default while retaining a high reasoning level.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p guest-agent build_codex_args_gpt_5_6_sol_defaults_reasoning_effort_xhigh` (1 passed)
