### PR TITLE
fix: align google slides upload with drive connection

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -167,7 +167,7 @@ async function authorizeGoogleDriveForAgent(params: {
 
 export const waitForGoogleDriveAuthorization$ = command(
   async (
-    { get, set },
+    { set },
     params: { readonly agentId: string },
     signal: AbortSignal,
   ): Promise<void> => {

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-drive-sync.ts
@@ -165,14 +165,14 @@ async function authorizeGoogleDriveForAgent(params: {
   params.signal.throwIfAborted();
 }
 
-export const waitForGoogleDriveAndSyncArtifacts$ = command(
+export const waitForGoogleDriveAuthorization$ = command(
   async (
-    { set },
-    params: ArtifactGoogleDriveSyncFilesParams & { readonly agentId: string },
+    { get, set },
+    params: { readonly agentId: string },
     signal: AbortSignal,
-  ) => {
-    const syncWhenConnected$ = command(
-      async ({ get, set }, sig: AbortSignal) => {
+  ): Promise<void> => {
+    const authorizeWhenConnected$ = command(
+      async ({ get, set }, sig: AbortSignal): Promise<boolean> => {
         set(reloadConnectors$);
         const { connectors } = await get(connectors$);
         sig.throwIfAborted();
@@ -186,11 +186,10 @@ export const waitForGoogleDriveAndSyncArtifacts$ = command(
           return false;
         }
 
-        const createClient = get(zeroClient$);
         await withCleanup(
           authorizeGoogleDriveForAgent({
             agentId: params.agentId,
-            createClient,
+            createClient: get(zeroClient$),
             signal: sig,
           }),
           () => {
@@ -198,25 +197,39 @@ export const waitForGoogleDriveAndSyncArtifacts$ = command(
           },
         );
         sig.throwIfAborted();
-
-        await syncArtifactFilesToGoogleDrive({
-          createClient,
-          threadId: params.threadId,
-          files: params.files,
-          signal: sig,
-        });
         return true;
       },
     );
 
-    if (await set(syncWhenConnected$, signal)) {
+    if (await set(authorizeWhenConnected$, signal)) {
       return;
     }
     signal.throwIfAborted();
     await set(
       setAblyLoop$,
-      { topic: "connector:changed", loopCommand$: syncWhenConnected$ },
+      { topic: "connector:changed", loopCommand$: authorizeWhenConnected$ },
       signal,
     );
+  },
+);
+
+export const waitForGoogleDriveAndSyncArtifacts$ = command(
+  async (
+    { get, set },
+    params: ArtifactGoogleDriveSyncFilesParams & { readonly agentId: string },
+    signal: AbortSignal,
+  ) => {
+    await set(
+      waitForGoogleDriveAuthorization$,
+      { agentId: params.agentId },
+      signal,
+    );
+    signal.throwIfAborted();
+    await syncArtifactFilesToGoogleDrive({
+      createClient: get(zeroClient$),
+      threadId: params.threadId,
+      files: params.files,
+      signal,
+    });
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -2145,6 +2145,93 @@ describe("zero artifact sidebar", () => {
     });
   });
 
+  it("uploads a presentation to Google Slides after authorizing Google Drive for the agent", async () => {
+    const presentationUrl = "https://deck.sites.vm7.io/quarterly-roadmap.html";
+    const artifactFiles = [
+      artifactFile(presentationUrl, {
+        id: "artifact-quarterly-roadmap",
+        filename: "quarterly-roadmap.html",
+        contentType: "text/html",
+        artifactKind: "presentation-html",
+        googleDriveSync: { status: "disconnected" },
+        size: 1024,
+      }),
+    ];
+    context.mocks.data.connectors([googleDriveConnector()]);
+    context.mocks.http.get(presentationUrl, () => {
+      return new Response(presentationHtml(), {
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+    context.mocks.http.get("*/__vm0-dev-artifact-fetch", () => {
+      return new Response(presentationHtml(), {
+        headers: { "Content-Type": "text/html" },
+      });
+    });
+    let agentAuthorized = false;
+    let slidesUploaded = false;
+    context.mocks.api(
+      zeroUserConnectorsContract.update,
+      ({ body, params, respond }) => {
+        expect(params.id).toBe(AGENT_ID);
+        expect(body).toStrictEqual({
+          enabledTypes: ["google-drive"],
+          operation: "add",
+        });
+        agentAuthorized = true;
+        return respond(200, { enabledTypes: ["google-drive"] });
+      },
+    );
+    context.mocks.http.post(
+      "*/api/zero/chat-threads/:threadId/artifacts/google-slides",
+      async ({ request }) => {
+        expect(agentAuthorized).toBeTruthy();
+        const file = (await request.formData()).get("file");
+        expect(file).toBeInstanceOf(File);
+        slidesUploaded = true;
+        return HttpResponse.json({
+          id: "slides-file-quarterly-roadmap",
+          name: "quarterly-roadmap",
+          webViewLink: null,
+        });
+      },
+    );
+    setupChatThread({
+      artifactFiles,
+      content: `[Quarterly roadmap](${presentationUrl})`,
+      featureSwitches: {
+        [FeatureSwitchKey.PresentationGoogleSlidesUpload]: true,
+      },
+      path: `${THREAD_PATH}?artifact=${encodeURIComponent(presentationUrl)}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Download artifact"));
+    await waitFor(() => {
+      expect(menuItemByText("Connect Google Drive")).toBeEnabled();
+    });
+    click(menuItemByText("Connect Google Drive"));
+
+    await waitFor(() => {
+      expect(agentAuthorized).toBeTruthy();
+    });
+    const exportFrame = await waitFor(() => {
+      const frame = document.querySelector(
+        'iframe[title="Presentation PPTX export"]',
+      );
+      expect(frame).toBeInstanceOf(HTMLIFrameElement);
+      return frame as HTMLIFrameElement;
+    });
+    completePresentationPptxExport(exportFrame, await presentationPptxBlob());
+
+    await waitFor(() => {
+      expect(slidesUploaded).toBeTruthy();
+    });
+  });
+
   it("preserves deck-level slide backgrounds for editable PPTX export", async () => {
     const presentationUrl = "https://deck.sites.vm7.io/dog-world.html";
     const downloads = captureDownloads(context.signal);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -2116,6 +2116,35 @@ describe("zero artifact sidebar", () => {
     }
   });
 
+  it("requires Google Drive connection before uploading a presentation to Google Slides", async () => {
+    const presentationUrl = "https://deck.sites.vm7.io/quarterly-roadmap.html";
+    setupPresentationArtifactThread(presentationUrl, presentationHtml(), {
+      featureSwitches: {
+        [FeatureSwitchKey.PresentationGoogleSlidesUpload]: true,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar")).toBeInTheDocument();
+      expect(screen.getByLabelText("Download artifact")).toBeInTheDocument();
+    });
+
+    click(screen.getByLabelText("Download artifact"));
+    await waitFor(() => {
+      const connectActions = queryAllByRoleFast("menuitem").filter(
+        (element) => {
+          return element.textContent?.trim() === "Connect Google Drive";
+        },
+      );
+      expect(connectActions).toHaveLength(2);
+      expect(
+        queryAllByRoleFast("menuitem").find((element) => {
+          return element.textContent?.trim() === "Upload to Google Slides";
+        }),
+      ).toBeUndefined();
+    });
+  });
+
   it("preserves deck-level slide backgrounds for editable PPTX export", async () => {
     const presentationUrl = "https://deck.sites.vm7.io/dog-world.html";
     const downloads = captureDownloads(context.signal);

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -690,10 +690,6 @@ export function ArtifactDownloadMenu({
   const open = openKey === menuKey;
   const downloadPending = pendingKey === menuKey;
   const showPresentationPptxDownload = artifactKind === "presentation-html";
-  const showGoogleSlidesUpload = shouldShowGoogleSlidesUpload(
-    artifactKind,
-    features,
-  );
   const downloadFilename = artifactDownloadFilename(
     artifactKind,
     filename,
@@ -784,7 +780,7 @@ export function ArtifactDownloadMenu({
             Download (.pptx)
           </ArtifactDownloadMenuItem>
         )}
-        {showGoogleSlidesUpload && syncTarget && (
+        {shouldShowGoogleSlidesUpload(artifactKind, features) && syncTarget && (
           <GoogleSlidesMenuItem
             closeMenu={closeMenu}
             filename={downloadFilename}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -629,6 +629,19 @@ function ArtifactDownloadTrigger({
   );
 }
 
+function setArtifactDownloadMenuOpen(params: {
+  readonly closeMenu: () => void;
+  readonly nextOpen: boolean;
+  readonly openMenu: (key: string) => void;
+  readonly menuKey: string;
+}): void {
+  if (params.nextOpen) {
+    params.openMenu(params.menuKey);
+    return;
+  }
+  params.closeMenu();
+}
+
 export function ArtifactDownloadMenu({
   align = "end",
   ariaLabel = "Download options",
@@ -676,11 +689,12 @@ export function ArtifactDownloadMenu({
       modal={false}
       open={open}
       onOpenChange={(nextOpen) => {
-        if (nextOpen) {
-          openMenu(menuKey);
-          return;
-        }
-        closeMenu();
+        setArtifactDownloadMenuOpen({
+          closeMenu,
+          menuKey,
+          nextOpen,
+          openMenu,
+        });
       }}
     >
       <ArtifactActionTooltip label={ariaLabel}>

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -23,7 +23,7 @@ import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { zeroConnectorOauthStartContract } from "@vm0/api-contracts/contracts/zero-connectors";
 import type { ChatThreadArtifactFile } from "@vm0/api-contracts/contracts/chat-threads";
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
-import { accept } from "../../lib/accept.ts";
+import { accept, ApiError } from "../../lib/accept.ts";
 import {
   OAUTH_WEB_API_BASE,
   zeroClient$,
@@ -42,9 +42,8 @@ import {
   startArtifactDownload$,
 } from "../../signals/zero-page/zero-artifact-actions.ts";
 import {
-  type ArtifactGoogleDriveSyncFile,
   syncArtifactFileToGoogleDrive,
-  waitForGoogleDriveAndSyncArtifacts$,
+  waitForGoogleDriveAuthorization$,
 } from "../../signals/chat-page/artifact-google-drive-sync.ts";
 import { uploadPresentationToGoogleSlides$ } from "../../signals/chat-page/artifact-google-slides-upload.ts";
 import {
@@ -98,14 +97,12 @@ function artifactDownloadFilename(
     : filename;
 }
 
-type WaitForGoogleDriveAndSyncArtifactsFn = (
-  params: {
-    readonly agentId: string;
-    readonly threadId: string;
-    readonly files: readonly ArtifactGoogleDriveSyncFile[];
-  },
+type WaitForGoogleDriveAuthorizationFn = (
+  params: { readonly agentId: string },
   signal: AbortSignal,
 ) => Promise<unknown>;
+
+type GoogleDriveReadyRun = () => Promise<void>;
 
 export type ArtifactDownloadSyncTarget = {
   readonly agentId: string | null | undefined;
@@ -134,14 +131,38 @@ function isPlainPrimaryLinkClick(
   );
 }
 
-function startGoogleDriveConnectAndSync(params: {
+function runWhenGoogleDriveReady(params: {
+  agentId: string | null | undefined;
+  pageSignal: AbortSignal;
+  run: GoogleDriveReadyRun;
+  waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
+  description: string;
+}): void {
+  if (!params.agentId) {
+    toast.error("Agent is still loading");
+    return;
+  }
+  const agentId = params.agentId;
+  detach(
+    (async () => {
+      await params.waitForGoogleDriveAuthorization(
+        { agentId },
+        params.pageSignal,
+      );
+      await params.run();
+    })(),
+    Reason.DomCallback,
+    params.description,
+  );
+}
+
+function startGoogleDriveConnectAndRun(params: {
   agentId: string | null | undefined;
   createClient: ZeroClientFactory;
-  file: ArtifactGoogleDriveSyncFile;
   pageSignal: AbortSignal;
-  threadId: string;
-  waitForGoogleDriveAndSyncArtifacts: WaitForGoogleDriveAndSyncArtifactsFn;
-  onSyncComplete: () => void;
+  run: GoogleDriveReadyRun;
+  waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
+  description: string;
 }): void {
   if (!params.agentId) {
     toast.error("Agent is still loading");
@@ -156,7 +177,6 @@ function startGoogleDriveConnectAndSync(params: {
     toast.error("Failed to open Google Drive connection page");
     return;
   }
-  const agentId = params.agentId;
   detach(
     (async () => {
       const client = params.createClient(zeroConnectorOauthStartContract, {
@@ -176,67 +196,23 @@ function startGoogleDriveConnectAndSync(params: {
     Reason.DomCallback,
     "artifact google drive oauth start",
   );
-  detach(
-    (async () => {
-      await params.waitForGoogleDriveAndSyncArtifacts(
-        {
-          agentId,
-          threadId: params.threadId,
-          files: [params.file],
-        },
-        params.pageSignal,
-      );
-      params.onSyncComplete();
-    })(),
-    Reason.DomCallback,
-    "artifact google drive connect sync",
-  );
+  runWhenGoogleDriveReady({
+    agentId: params.agentId,
+    pageSignal: params.pageSignal,
+    run: params.run,
+    waitForGoogleDriveAuthorization: params.waitForGoogleDriveAuthorization,
+    description: params.description,
+  });
 }
 
-function syncArtifactToGoogleDriveAndRefresh(params: {
-  sync: Promise<boolean>;
-  onSyncSuccess: () => void;
-}): void {
-  detach(
-    (async () => {
-      const success = await params.sync;
-      if (success) {
-        params.onSyncSuccess();
-      }
-    })(),
-    Reason.DomCallback,
-    "artifact google drive sync",
-  );
-}
-
-function authorizeGoogleDriveAndSyncArtifacts(params: {
+function authorizeGoogleDriveAndRun(params: {
   agentId: string | null | undefined;
-  file: ArtifactGoogleDriveSyncFile;
   pageSignal: AbortSignal;
-  threadId: string;
-  waitForGoogleDriveAndSyncArtifacts: WaitForGoogleDriveAndSyncArtifactsFn;
-  onSyncComplete: () => void;
+  run: GoogleDriveReadyRun;
+  waitForGoogleDriveAuthorization: WaitForGoogleDriveAuthorizationFn;
+  description: string;
 }): void {
-  if (!params.agentId) {
-    toast.error("Agent is still loading");
-    return;
-  }
-  const agentId = params.agentId;
-  detach(
-    (async () => {
-      await params.waitForGoogleDriveAndSyncArtifacts(
-        {
-          agentId,
-          threadId: params.threadId,
-          files: [params.file],
-        },
-        params.pageSignal,
-      );
-      params.onSyncComplete();
-    })(),
-    Reason.DomCallback,
-    "artifact google drive authorize sync",
-  );
+  runWhenGoogleDriveReady(params);
 }
 
 async function downloadPresentationPptx(params: {
@@ -260,38 +236,37 @@ type UploadPresentationSlidesFn = (
   signal: AbortSignal,
 ) => Promise<{ readonly webViewLink: string | null }>;
 
-function uploadPresentationToGoogleSlides(params: {
+async function uploadPresentationToGoogleSlides(params: {
   filename: string;
   pageSignal: AbortSignal;
   threadId: string;
   upload: UploadPresentationSlidesFn;
   url: string;
-}): void {
+}): Promise<void> {
   const toastId = toast.loading("Uploading to Google Slides...");
-  detach(
-    tapError(
-      (async () => {
-        const built = await buildPresentationHtmlPptxBlobFromUrl({
-          filename: params.filename,
-          signal: params.pageSignal,
-          url: params.url,
-        });
-        await params.upload(
-          {
-            threadId: params.threadId,
-            filename: built.filename,
-            blob: built.blob,
-          },
-          params.pageSignal,
-        );
-        toast.success("Uploaded to Google Slides", { id: toastId });
-      })(),
-      () => {
-        toast.dismiss(toastId);
-      },
-    ),
-    Reason.DomCallback,
-    "presentation google slides upload",
+  await tapError(
+    (async () => {
+      const built = await buildPresentationHtmlPptxBlobFromUrl({
+        filename: params.filename,
+        signal: params.pageSignal,
+        url: params.url,
+      });
+      await params.upload(
+        {
+          threadId: params.threadId,
+          filename: built.filename,
+          blob: built.blob,
+        },
+        params.pageSignal,
+      );
+      toast.success("Uploaded to Google Slides", { id: toastId });
+    })(),
+    (error) => {
+      toast.dismiss(toastId);
+      if (!(error instanceof ApiError)) {
+        toast.error("Failed to upload to Google Slides");
+      }
+    },
   );
 }
 
@@ -390,13 +365,9 @@ function ArtifactDownloadMenuItem({
   );
 }
 
-function GoogleDriveMenuItem({
-  closeMenu,
-  syncTarget,
-}: {
-  closeMenu: () => void;
-  syncTarget?: ArtifactDownloadSyncTarget;
-}) {
+function useGoogleDriveAvailability(
+  syncTarget: ArtifactDownloadSyncTarget | undefined,
+) {
   const connectorListLoadable = useLoadable(connectors$);
   const lastConnectorList = useLastResolved(connectors$);
   const connectorList =
@@ -405,7 +376,6 @@ function GoogleDriveMenuItem({
       : connectorListLoadable.state === "loading"
         ? lastConnectorList
         : undefined;
-  const connectorListLoaded = connectorList !== undefined;
   const googleDriveConnected =
     connectorList?.connectors.some((connector) => {
       return (
@@ -413,12 +383,27 @@ function GoogleDriveMenuItem({
         connector.connectionStatus === "connected"
       );
     }) ?? false;
-  const googleDriveReady =
-    googleDriveConnected && syncTarget?.disconnected !== true;
+
+  return {
+    connectorListLoaded: connectorList !== undefined,
+    googleDriveConnected,
+    googleDriveReady: googleDriveConnected && syncTarget?.disconnected !== true,
+  };
+}
+
+function GoogleDriveMenuItem({
+  closeMenu,
+  syncTarget,
+}: {
+  closeMenu: () => void;
+  syncTarget?: ArtifactDownloadSyncTarget;
+}) {
+  const { connectorListLoaded, googleDriveConnected, googleDriveReady } =
+    useGoogleDriveAvailability(syncTarget);
   const createClient = useGet(zeroClient$);
   const pageSignal = useGet(pageSignal$);
-  const waitForGoogleDriveAndSyncArtifacts = useSet(
-    waitForGoogleDriveAndSyncArtifacts$,
+  const waitForGoogleDriveAuthorization = useSet(
+    waitForGoogleDriveAuthorization$,
   );
 
   if (!syncTarget) {
@@ -455,44 +440,40 @@ function GoogleDriveMenuItem({
 
   const syncOrConnect = () => {
     closeMenu();
-    const file = {
-      runId: syncTarget.runId,
-      fileId: syncTarget.fileId,
-      filename: syncTarget.filename,
+    const run = async () => {
+      const success = await syncArtifactFileToGoogleDrive({
+        createClient,
+        threadId: syncTarget.threadId,
+        runId: syncTarget.runId,
+        fileId: syncTarget.fileId,
+        filename: syncTarget.filename,
+        signal: pageSignal,
+      });
+      if (success) {
+        syncTarget.onSyncSuccess();
+      }
     };
     if (googleDriveReady) {
-      syncArtifactToGoogleDriveAndRefresh({
-        sync: syncArtifactFileToGoogleDrive({
-          createClient,
-          threadId: syncTarget.threadId,
-          runId: syncTarget.runId,
-          fileId: syncTarget.fileId,
-          filename: syncTarget.filename,
-          signal: pageSignal,
-        }),
-        onSyncSuccess: syncTarget.onSyncSuccess,
-      });
+      detach(run(), Reason.DomCallback, "artifact google drive sync");
       return;
     }
     if (googleDriveConnected) {
-      authorizeGoogleDriveAndSyncArtifacts({
+      authorizeGoogleDriveAndRun({
         agentId: syncTarget.agentId,
-        file,
         pageSignal,
-        threadId: syncTarget.threadId,
-        waitForGoogleDriveAndSyncArtifacts,
-        onSyncComplete: syncTarget.onSyncSuccess,
+        run,
+        waitForGoogleDriveAuthorization,
+        description: "artifact google drive authorize sync",
       });
       return;
     }
-    startGoogleDriveConnectAndSync({
+    startGoogleDriveConnectAndRun({
       agentId: syncTarget.agentId,
       createClient,
-      file,
       pageSignal,
-      threadId: syncTarget.threadId,
-      waitForGoogleDriveAndSyncArtifacts,
-      onSyncComplete: syncTarget.onSyncSuccess,
+      run,
+      waitForGoogleDriveAuthorization,
+      description: "artifact google drive connect sync",
     });
   };
 
@@ -525,31 +506,76 @@ function GoogleDriveMenuItem({
 function GoogleSlidesMenuItem({
   closeMenu,
   filename,
+  syncTarget,
   threadId,
   url,
 }: {
   closeMenu: () => void;
   filename: string;
+  syncTarget: ArtifactDownloadSyncTarget;
   threadId: string;
   url: string;
 }) {
+  const { connectorListLoaded, googleDriveConnected, googleDriveReady } =
+    useGoogleDriveAvailability(syncTarget);
+  const createClient = useGet(zeroClient$);
   const pageSignal = useGet(pageSignal$);
   const upload = useSet(uploadPresentationToGoogleSlides$);
+  const waitForGoogleDriveAuthorization = useSet(
+    waitForGoogleDriveAuthorization$,
+  );
+  const run = () => {
+    return uploadPresentationToGoogleSlides({
+      filename,
+      pageSignal,
+      threadId,
+      upload,
+      url,
+    });
+  };
+
+  if (!connectorListLoaded) {
+    return (
+      <ArtifactDownloadMenuItem disabled>
+        <IconPresentation size={14} stroke={1.5} />
+        Connect Google Drive
+      </ArtifactDownloadMenuItem>
+    );
+  }
+
+  const connectOrUpload = () => {
+    closeMenu();
+    if (googleDriveReady) {
+      detach(run(), Reason.DomCallback, "presentation google slides upload");
+      return;
+    }
+    if (googleDriveConnected) {
+      authorizeGoogleDriveAndRun({
+        agentId: syncTarget.agentId,
+        pageSignal,
+        run,
+        waitForGoogleDriveAuthorization,
+        description: "presentation google slides authorize upload",
+      });
+      return;
+    }
+    startGoogleDriveConnectAndRun({
+      agentId: syncTarget.agentId,
+      createClient,
+      pageSignal,
+      run,
+      waitForGoogleDriveAuthorization,
+      description: "presentation google slides connect upload",
+    });
+  };
+
+  const label = googleDriveReady
+    ? "Upload to Google Slides"
+    : "Connect Google Drive";
   return (
-    <ArtifactDownloadMenuItem
-      onClick={() => {
-        closeMenu();
-        uploadPresentationToGoogleSlides({
-          filename,
-          pageSignal,
-          threadId,
-          upload,
-          url,
-        });
-      }}
-    >
+    <ArtifactDownloadMenuItem onClick={connectOrUpload}>
       <IconPresentation size={14} stroke={1.5} />
-      Upload to Google Slides
+      {label}
     </ArtifactDownloadMenuItem>
   );
 }
@@ -723,6 +749,7 @@ export function ArtifactDownloadMenu({
           <GoogleSlidesMenuItem
             closeMenu={closeMenu}
             filename={downloadFilename}
+            syncTarget={syncTarget}
             threadId={syncTarget.threadId}
             url={url}
           />

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -642,6 +642,22 @@ function setArtifactDownloadMenuOpen(params: {
   params.closeMenu();
 }
 
+function startArtifactDownloadWithCleanup(params: {
+  readonly closeMenu: () => void;
+  readonly description: string;
+  readonly download: Promise<void>;
+  readonly finish: () => void;
+  readonly start: () => void;
+}): void {
+  params.closeMenu();
+  params.start();
+  detach(
+    withCleanup(params.download, params.finish),
+    Reason.DomCallback,
+    params.description,
+  );
+}
+
 export function ArtifactDownloadMenu({
   align = "end",
   ariaLabel = "Download options",
@@ -672,17 +688,6 @@ export function ArtifactDownloadMenu({
     filename,
     url,
   );
-  const startDownload = (download: Promise<void>, description: string) => {
-    closeMenu();
-    startArtifactDownload(menuKey);
-    detach(
-      withCleanup(download, () => {
-        finishArtifactDownload(menuKey);
-      }),
-      Reason.DomCallback,
-      description,
-    );
-  };
   return (
     <Popover
       modal={false}
@@ -732,10 +737,17 @@ export function ArtifactDownloadMenu({
       >
         <ArtifactDownloadMenuItem
           onClick={() => {
-            startDownload(
-              downloadAttachmentUrl(url, pageSignal, downloadFilename),
-              "artifact download",
-            );
+            startArtifactDownloadWithCleanup({
+              closeMenu,
+              description: "artifact download",
+              download: downloadAttachmentUrl(
+                url,
+                pageSignal,
+                downloadFilename,
+              ),
+              finish: () => finishArtifactDownload(menuKey),
+              start: () => startArtifactDownload(menuKey),
+            });
           }}
         >
           <IconDownload size={14} stroke={1.5} />
@@ -744,14 +756,17 @@ export function ArtifactDownloadMenu({
         {showPresentationPptxDownload && (
           <ArtifactDownloadMenuItem
             onClick={() => {
-              startDownload(
-                downloadPresentationPptx({
+              startArtifactDownloadWithCleanup({
+                closeMenu,
+                description: "presentation html pptx download",
+                download: downloadPresentationPptx({
                   filename: downloadFilename,
                   signal: pageSignal,
                   url,
                 }),
-                "presentation html pptx download",
-              );
+                finish: () => finishArtifactDownload(menuKey),
+                start: () => startArtifactDownload(menuKey),
+              });
             }}
           >
             <IconDownload size={14} stroke={1.5} />

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -670,7 +670,6 @@ export function ArtifactDownloadMenu({
       description,
     );
   };
-
   return (
     <Popover
       modal={false}

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -658,6 +658,16 @@ function startArtifactDownloadWithCleanup(params: {
   );
 }
 
+function shouldShowGoogleSlidesUpload(
+  artifactKind: ChatThreadArtifactFile["artifactKind"] | undefined,
+  features: Record<string, boolean | undefined>,
+): boolean {
+  return (
+    artifactKind === "presentation-html" &&
+    (features[FeatureSwitchKey.PresentationGoogleSlidesUpload] ?? false)
+  );
+}
+
 export function ArtifactDownloadMenu({
   align = "end",
   ariaLabel = "Download options",
@@ -680,9 +690,10 @@ export function ArtifactDownloadMenu({
   const open = openKey === menuKey;
   const downloadPending = pendingKey === menuKey;
   const showPresentationPptxDownload = artifactKind === "presentation-html";
-  const showGoogleSlidesUpload =
-    showPresentationPptxDownload &&
-    (features[FeatureSwitchKey.PresentationGoogleSlidesUpload] ?? false);
+  const showGoogleSlidesUpload = shouldShowGoogleSlidesUpload(
+    artifactKind,
+    features,
+  );
   const downloadFilename = artifactDownloadFilename(
     artifactKind,
     filename,

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-actions.tsx
@@ -646,13 +646,16 @@ function startArtifactDownloadWithCleanup(params: {
   readonly closeMenu: () => void;
   readonly description: string;
   readonly download: Promise<void>;
-  readonly finish: () => void;
-  readonly start: () => void;
+  readonly finish: (key: string) => void;
+  readonly menuKey: string;
+  readonly start: (key: string) => void;
 }): void {
   params.closeMenu();
-  params.start();
+  params.start(params.menuKey);
   detach(
-    withCleanup(params.download, params.finish),
+    withCleanup(params.download, () => {
+      params.finish(params.menuKey);
+    }),
     Reason.DomCallback,
     params.description,
   );
@@ -689,7 +692,6 @@ export function ArtifactDownloadMenu({
   const features = useGet(featureSwitch$);
   const open = openKey === menuKey;
   const downloadPending = pendingKey === menuKey;
-  const showPresentationPptxDownload = artifactKind === "presentation-html";
   const downloadFilename = artifactDownloadFilename(
     artifactKind,
     filename,
@@ -752,15 +754,16 @@ export function ArtifactDownloadMenu({
                 pageSignal,
                 downloadFilename,
               ),
-              finish: () => finishArtifactDownload(menuKey),
-              start: () => startArtifactDownload(menuKey),
+              finish: finishArtifactDownload,
+              menuKey,
+              start: startArtifactDownload,
             });
           }}
         >
           <IconDownload size={14} stroke={1.5} />
           Download
         </ArtifactDownloadMenuItem>
-        {showPresentationPptxDownload && (
+        {artifactKind === "presentation-html" && (
           <ArtifactDownloadMenuItem
             onClick={() => {
               startArtifactDownloadWithCleanup({
@@ -771,8 +774,9 @@ export function ArtifactDownloadMenu({
                   signal: pageSignal,
                   url,
                 }),
-                finish: () => finishArtifactDownload(menuKey),
-                start: () => startArtifactDownload(menuKey),
+                finish: finishArtifactDownload,
+                menuKey,
+                start: startArtifactDownload,
               });
             }}
           >


### PR DESCRIPTION
## Summary

- Require the same Google Drive connection and agent authorization states before a presentation can upload as Google Slides.
- Continue automatically with the Google Slides upload after connection or authorization completes.
- Show a failure toast when client-side PPTX conversion fails, while retaining API-provided upload errors.
- Cover the disconnected presentation flow in the artifact sidebar test.

## Verification

- `pnpm -F @vm0/app test --run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx`
- `pnpm -F @vm0/app check-types`
- `git diff --check`

## Notes

- The pre-commit hook started repository-wide Knip/type checks; those were stopped because vm0 PR verification relies on the PR pipeline for full checks.
