### PR TITLE
feat: add workflow queue inspection and control api with per-thread realtime signal

### DIFF
--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -165,6 +165,27 @@ export async function publishChatThreadAutomationsChangedSafely(
   );
 }
 
+/**
+ * Notify a chat thread's UI that its workflow queue changed (event enqueued,
+ * drained, skipped, cleared, paused, or resumed). Best-effort like the
+ * automations signal: a failed publish must not fail the mutation. The client
+ * re-fetches the authoritative queue state on any delivery.
+ */
+export async function publishChatThreadWorkflowQueueChangedSafely(
+  userId: string,
+  threadId: string,
+): Promise<void> {
+  await tapError(
+    publishUserSignal([userId], `chatThreadWorkflowQueueChanged:${threadId}`),
+    (error) => {
+      L.warn("Failed to publish chat thread workflow queue changed signal", {
+        threadId,
+        error,
+      });
+    },
+  );
+}
+
 export async function publishBuiltInGenerationChanged(
   userId: string,
   generationId: string,

--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -141,6 +141,7 @@ import { zeroMeModelProvidersUpsertRoutes } from "./routes/zero-me-model-provide
 import { zeroSecretsRoutes } from "./routes/zero-secrets";
 import { zeroWorkflowsRoutes } from "./routes/zero-workflows";
 import { zeroWorkflowTriggersRoutes } from "./routes/zero-workflow-triggers";
+import { zeroWorkflowQueueRoutes } from "./routes/zero-workflow-queue";
 import { integrationsGithubRoutes } from "./routes/integrations-github";
 import { zeroIntegrationsAgentPhoneRoutes } from "./routes/zero-integrations-agentphone";
 import { zeroIntegrationsPhoneDownloadFileRoutes } from "./routes/zero-integrations-phone-download-file";
@@ -341,6 +342,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroSecretsRoutes,
   ...zeroWorkflowsRoutes,
   ...zeroWorkflowTriggersRoutes,
+  ...zeroWorkflowQueueRoutes,
   ...integrationsGithubRoutes,
   ...zeroSlackBrowserConnectRoutes,
   ...zeroSlackConnectRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-queue-api.test.ts
@@ -1,0 +1,333 @@
+import { createHash } from "node:crypto";
+
+import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
+import { zeroWorkflowTriggersContract } from "@vm0/api-contracts/contracts/zero-workflows";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
+import { computeHmacSignature } from "../../../lib/event-consumer/hmac";
+import { mockOptionalEnv } from "../../../lib/env";
+import { now } from "../../../lib/time";
+import { flushWaitUntilForTest } from "../../context/wait-until";
+import type { ApiTestUser } from "./helpers/api-bdd";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
+import { createWebhookCallbackApi } from "./helpers/api-bdd-webhooks";
+import { createWorkflowsBddApi } from "./helpers/api-bdd-workflows";
+import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
+import { createZeroRouteMocks } from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+const wf = createWorkflowsBddApi(context);
+const runsApi = createRunsAutomationsApi(context);
+const webhooksApi = createWebhookCallbackApi(context);
+
+const WORKFLOW_NAME = "workflow-queue-api-workflow";
+
+function authHeaders() {
+  return { authorization: "Bearer clerk-session" };
+}
+
+function triggersClient() {
+  return setupApp({ context })(zeroWorkflowTriggersContract);
+}
+
+function queueClient() {
+  return setupApp({ context })(zeroWorkflowQueueContract);
+}
+
+interface Scenario {
+  readonly actor: ApiTestUser;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly agentId: string;
+  readonly workflowId: string;
+  readonly runnerGroup: string;
+}
+
+async function setup(
+  options: { readonly workflowQueue?: boolean } = {},
+): Promise<Scenario> {
+  const runnerGroup = runsApi.configureRunnerGroup();
+  mockOptionalEnv("RUNNER_DEFAULT_GROUP", "vm0/test");
+  const { actor } = await wf.setupWorkflowOrg();
+  if (!actor.orgId) {
+    throw new Error("Expected an org-scoped workflow actor");
+  }
+  const agent = await wf.createAgent(actor, {
+    displayName: "Workflow Queue API Agent",
+  });
+  const workflowId = await wf.createWorkflow(actor, {
+    agentId: agent.agentId,
+    name: WORKFLOW_NAME,
+  });
+  const fixture = { orgId: actor.orgId, userId: actor.userId };
+  await updateFeatureSwitchesForUser(context, fixture, {
+    [FeatureSwitchKey.WorkflowWebhookTriggers]: true,
+    ...(options.workflowQueue === false
+      ? {}
+      : { [FeatureSwitchKey.WorkflowQueue]: true }),
+  });
+  mocks.clerk.session(actor.userId, actor.orgId);
+  context.mocks.s3.send.mockResolvedValue({});
+  return {
+    actor,
+    orgId: actor.orgId,
+    userId: actor.userId,
+    agentId: agent.agentId,
+    workflowId,
+    runnerGroup,
+  };
+}
+
+interface WebhookTrigger {
+  readonly triggerId: string;
+  readonly threadId: string;
+  readonly token: string;
+  readonly secret: string;
+}
+
+async function createWebhookTrigger(
+  scenario: Scenario,
+): Promise<WebhookTrigger> {
+  const created = await accept(
+    triggersClient().create({
+      headers: authHeaders(),
+      params: { workflowId: scenario.workflowId },
+      body: { kind: "event", eventType: "webhook-received" },
+    }),
+    [201],
+  );
+  if (
+    created.body.kind !== "event" ||
+    created.body.eventType !== "webhook-received" ||
+    !created.body.webhookUrl ||
+    !created.body.webhookSecret ||
+    !created.body.chatThreadId
+  ) {
+    throw new Error("Expected a thread-bound webhook trigger with a secret");
+  }
+  const token = new URL(created.body.webhookUrl).pathname.split("/").at(-1);
+  if (!token) {
+    throw new Error("Expected webhook URL token");
+  }
+  return {
+    triggerId: created.body.id,
+    threadId: created.body.chatThreadId,
+    token,
+    secret: created.body.webhookSecret,
+  };
+}
+
+async function postWorkflowWebhook(
+  trigger: WebhookTrigger,
+  payload: string,
+): Promise<string | null> {
+  const rawBody = JSON.stringify({ event: payload });
+  const timestamp = Math.floor(now() / 1000);
+  const response = await createApp({ signal: context.signal }).request(
+    `/api/webhooks/workflow-triggers/${trigger.token}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-VM0-Timestamp": String(timestamp),
+        "X-VM0-Signature": computeHmacSignature(
+          rawBody,
+          trigger.secret,
+          timestamp,
+        ),
+      },
+      body: rawBody,
+    },
+  );
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { readonly runId?: string };
+  return body.runId ?? null;
+}
+
+/** Run ids of trigger-fired `/workflow-name` user messages, oldest first. */
+async function workflowRunIds(threadId: string): Promise<readonly string[]> {
+  const messages = await wf.readThreadMessages(threadId);
+  return messages.flatMap((message) => {
+    if (
+      message.role !== "user" ||
+      message.content !== `/${WORKFLOW_NAME}` ||
+      !message.runId
+    ) {
+      return [];
+    }
+    return [message.runId];
+  });
+}
+
+async function completeRunThroughSandbox(
+  scenario: Scenario,
+  runId: string,
+): Promise<void> {
+  await runsApi.heartbeatRunner(scenario.runnerGroup);
+  const claim = await runsApi.claimRunnerJob(runId);
+  const sandboxHeaders = { authorization: `Bearer ${claim.sandboxToken}` };
+  await webhooksApi.requestAgentCheckpoint(
+    {
+      runId,
+      cliAgentType: "claude-code",
+      cliAgentSessionId: `workflow-queue-api-cli-${runId}`,
+      cliAgentSessionHistoryHash: createHash("sha256")
+        .update(`workflow queue api history ${runId}`)
+        .digest("hex"),
+    },
+    sandboxHeaders,
+    [200],
+  );
+  await webhooksApi.requestAgentComplete(
+    { runId, exitCode: 0 },
+    sandboxHeaders,
+    [200],
+  );
+  await flushWaitUntilForTest();
+}
+
+/** Occupy the workflow with one run and leave `pendingCount` queued events. */
+async function busyQueueFixture(pendingCount: number): Promise<{
+  readonly scenario: Scenario;
+  readonly trigger: WebhookTrigger;
+  readonly runningRunId: string;
+}> {
+  const scenario = await setup();
+  const trigger = await createWebhookTrigger(scenario);
+  const runningRunId = await postWorkflowWebhook(trigger, "busy");
+  if (!runningRunId) {
+    throw new Error("Expected the first webhook event to create a run");
+  }
+  for (let index = 0; index < pendingCount; index++) {
+    const queued = await postWorkflowWebhook(trigger, `pending-${index}`);
+    expect(queued).toBeNull();
+  }
+  return { scenario, trigger, runningRunId };
+}
+
+describe("workflow queue API", () => {
+  it("returns the running run, FIFO pending events, and pause state", async () => {
+    const { trigger, runningRunId } = await busyQueueFixture(2);
+
+    const queue = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: trigger.threadId },
+      }),
+      [200],
+    );
+    expect(queue.body.running?.runId).toBe(runningRunId);
+    expect(queue.body.pending).toHaveLength(2);
+    expect(
+      queue.body.pending.map((event) => {
+        return event.triggerId;
+      }),
+    ).toStrictEqual([trigger.triggerId, trigger.triggerId]);
+    expect(Date.parse(queue.body.pending[0]!.createdAt)).toBeLessThanOrEqual(
+      Date.parse(queue.body.pending[1]!.createdAt),
+    );
+    expect(queue.body.pausedAt).toBeNull();
+    expect(queue.body.pauseReason).toBeNull();
+  });
+
+  it("rejects queue reads when the feature switch is off", async () => {
+    const scenario = await setup({ workflowQueue: false });
+    const trigger = await createWebhookTrigger(scenario);
+
+    await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: trigger.threadId },
+      }),
+      [403],
+    );
+  });
+
+  it("skips a single pending event", async () => {
+    const { scenario, trigger, runningRunId } = await busyQueueFixture(2);
+
+    const before = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: trigger.threadId },
+      }),
+      [200],
+    );
+    const skipped = await accept(
+      queueClient().skipEvent({
+        headers: authHeaders(),
+        params: { id: before.body.pending[0]!.id },
+      }),
+      [200],
+    );
+    expect(skipped.body.pending).toHaveLength(1);
+
+    // Only the remaining event drains after the running run completes.
+    await completeRunThroughSandbox(scenario, runningRunId);
+    const runIds = await workflowRunIds(trigger.threadId);
+    expect(runIds).toHaveLength(2);
+    await completeRunThroughSandbox(scenario, runIds[1]!);
+    await expect(workflowRunIds(trigger.threadId)).resolves.toHaveLength(2);
+  });
+
+  it("clears all pending events", async () => {
+    const { scenario, trigger, runningRunId } = await busyQueueFixture(2);
+
+    const cleared = await accept(
+      queueClient().clear({
+        headers: authHeaders(),
+        params: { threadId: trigger.threadId },
+      }),
+      [200],
+    );
+    expect(cleared.body.pending).toHaveLength(0);
+
+    await completeRunThroughSandbox(scenario, runningRunId);
+    await expect(workflowRunIds(trigger.threadId)).resolves.toHaveLength(1);
+  });
+
+  it("pause freezes consumption while intake continues; resume drains", async () => {
+    const { scenario, trigger, runningRunId } = await busyQueueFixture(1);
+
+    const paused = await accept(
+      queueClient().pause({
+        headers: authHeaders(),
+        params: { threadId: trigger.threadId },
+      }),
+      [200],
+    );
+    expect(paused.body.pausedAt).not.toBeNull();
+
+    // Intake continues while paused.
+    await expect(
+      postWorkflowWebhook(trigger, "while-paused"),
+    ).resolves.toBeNull();
+
+    // Terminal run does not drain a paused queue.
+    await completeRunThroughSandbox(scenario, runningRunId);
+    const stillPaused = await accept(
+      queueClient().get({
+        headers: authHeaders(),
+        params: { threadId: trigger.threadId },
+      }),
+      [200],
+    );
+    expect(stillPaused.body.running).toBeNull();
+    expect(stillPaused.body.pending).toHaveLength(2);
+
+    // Resume drains the head event immediately.
+    const resumed = await accept(
+      queueClient().resume({
+        headers: authHeaders(),
+        params: { threadId: trigger.threadId },
+      }),
+      [200],
+    );
+    expect(resumed.body.pausedAt).toBeNull();
+    expect(resumed.body.running).not.toBeNull();
+    expect(resumed.body.pending).toHaveLength(1);
+  });
+});

--- a/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflow-queue.ts
@@ -1,0 +1,264 @@
+import { command, computed, type Computed } from "ccstate";
+import { zeroWorkflowQueueContract } from "@vm0/api-contracts/contracts/zero-workflow-queue";
+import { FeatureSwitchKey } from "@vm0/core";
+import { isFeatureEnabled } from "@vm0/core/feature-switch";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { pathParamsOf } from "../context/request";
+import { db$, writeDb$, type ReadonlyDb } from "../external/db";
+import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtime";
+import { notFound } from "../../lib/error";
+import { nowDate } from "../external/time";
+import { userFeatureSwitchOverrides } from "../services/feature-switches.service";
+import {
+  clearWorkflowQueueEvents,
+  deleteWorkflowQueueEventById,
+  listPendingWorkflowQueueEvents,
+  loadRunningWorkflowThreadRun,
+  loadWorkflowQueueThread,
+  setWorkflowQueuePause,
+  type WorkflowQueueThreadRow,
+} from "../services/zero-workflow-queue.service";
+import { drainWorkflowQueueForThread$ } from "../services/zero-workflow-queue-drain.service";
+import type { RouteEntry } from "../route-entry";
+
+const workflowReadAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:read",
+} as const;
+
+const workflowWriteAuth = {
+  requireOrganization: true,
+  missingOrganizationStatus: 401,
+  requiredCapability: "agent:write",
+} as const;
+
+const featureDisabled = Object.freeze({
+  status: 403 as const,
+  body: {
+    error: {
+      message: "The workflow queue feature is not available",
+      code: "FORBIDDEN",
+    },
+  },
+});
+
+interface AuthIdentity {
+  readonly orgId: string;
+  readonly userId: string;
+}
+
+type ComputedGetter = <T>(computedValue: Computed<T>) => T;
+
+async function workflowQueueDisabled(
+  get: ComputedGetter,
+  auth: AuthIdentity,
+): Promise<boolean> {
+  const overrides = await get(
+    userFeatureSwitchOverrides(auth.orgId, auth.userId),
+  );
+  return !isFeatureEnabled(FeatureSwitchKey.WorkflowQueue, {
+    userId: auth.userId,
+    orgId: auth.orgId,
+    overrides,
+  });
+}
+
+async function workflowQueueResponse(
+  db: ReadonlyDb,
+  thread: WorkflowQueueThreadRow,
+  threadId: string,
+) {
+  const [running, pending] = await Promise.all([
+    loadRunningWorkflowThreadRun(db, threadId),
+    listPendingWorkflowQueueEvents(db, thread),
+  ]);
+  return {
+    status: 200 as const,
+    body: {
+      running: running
+        ? {
+            runId: running.runId,
+            status: running.status,
+            triggerBrief: running.triggerBrief,
+            createdAt: running.createdAt.toISOString(),
+          }
+        : null,
+      pending: pending.map((event) => {
+        return {
+          id: event.id,
+          triggerId: event.triggerId,
+          triggerSource: event.triggerSource,
+          triggerBrief: event.triggerBrief,
+          createdAt: event.createdAt.toISOString(),
+        };
+      }),
+      pausedAt: thread.queuePausedAt?.toISOString() ?? null,
+      pauseReason: thread.pauseReason,
+    },
+  };
+}
+
+const getQueueInner$ = computed(async (get) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroWorkflowQueueContract.get));
+  if (await workflowQueueDisabled(get, auth)) {
+    return featureDisabled;
+  }
+  const db = get(db$);
+  const thread = await loadWorkflowQueueThread(db, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    threadId: params.threadId,
+  });
+  if (!thread) {
+    return notFound(`No workflow queue for thread: ${params.threadId}`);
+  }
+  return await workflowQueueResponse(db, thread, params.threadId);
+});
+
+const skipEventInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroWorkflowQueueContract.skipEvent));
+  if (await workflowQueueDisabled(get, auth)) {
+    return featureDisabled;
+  }
+  const db = set(writeDb$);
+  const deleted = await deleteWorkflowQueueEventById(db, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    eventId: params.id,
+  });
+  signal.throwIfAborted();
+  if (!deleted) {
+    return notFound(`No workflow queue event: ${params.id}`);
+  }
+  const thread = await loadWorkflowQueueThread(db, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    threadId: deleted.chatThreadId,
+  });
+  signal.throwIfAborted();
+  if (!thread) {
+    return notFound(`No workflow queue for thread: ${deleted.chatThreadId}`);
+  }
+  await publishChatThreadWorkflowQueueChangedSafely(
+    auth.userId,
+    deleted.chatThreadId,
+  );
+  signal.throwIfAborted();
+  return await workflowQueueResponse(db, thread, deleted.chatThreadId);
+});
+
+const clearQueueInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const params = get(pathParamsOf(zeroWorkflowQueueContract.clear));
+  if (await workflowQueueDisabled(get, auth)) {
+    return featureDisabled;
+  }
+  const db = set(writeDb$);
+  const thread = await loadWorkflowQueueThread(db, {
+    orgId: auth.orgId,
+    userId: auth.userId,
+    threadId: params.threadId,
+  });
+  signal.throwIfAborted();
+  if (!thread) {
+    return notFound(`No workflow queue for thread: ${params.threadId}`);
+  }
+  await clearWorkflowQueueEvents(db, thread);
+  signal.throwIfAborted();
+  await publishChatThreadWorkflowQueueChangedSafely(
+    auth.userId,
+    params.threadId,
+  );
+  signal.throwIfAborted();
+  return await workflowQueueResponse(db, thread, params.threadId);
+});
+
+const setPauseInner = (paused: boolean) => {
+  return command(async ({ get, set }, signal: AbortSignal) => {
+    const auth = get(organizationAuthContext$);
+    const params = get(
+      pathParamsOf(
+        paused
+          ? zeroWorkflowQueueContract.pause
+          : zeroWorkflowQueueContract.resume,
+      ),
+    );
+    if (await workflowQueueDisabled(get, auth)) {
+      return featureDisabled;
+    }
+    const db = set(writeDb$);
+    const thread = await loadWorkflowQueueThread(db, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      threadId: params.threadId,
+    });
+    signal.throwIfAborted();
+    if (!thread) {
+      return notFound(`No workflow queue for thread: ${params.threadId}`);
+    }
+    const currentTime = nowDate();
+    await setWorkflowQueuePause(
+      db,
+      thread,
+      paused ? { pausedAt: currentTime, pauseReason: null } : null,
+      currentTime,
+    );
+    signal.throwIfAborted();
+    if (!paused) {
+      // Resuming re-drains immediately instead of waiting for the next
+      // terminal run or the safety-net cron.
+      await set(
+        drainWorkflowQueueForThread$,
+        { chatThreadId: params.threadId },
+        signal,
+      );
+      signal.throwIfAborted();
+    }
+    await publishChatThreadWorkflowQueueChangedSafely(
+      auth.userId,
+      params.threadId,
+    );
+    signal.throwIfAborted();
+    const updated = await loadWorkflowQueueThread(db, {
+      orgId: auth.orgId,
+      userId: auth.userId,
+      threadId: params.threadId,
+    });
+    signal.throwIfAborted();
+    if (!updated) {
+      return notFound(`No workflow queue for thread: ${params.threadId}`);
+    }
+    return await workflowQueueResponse(db, updated, params.threadId);
+  });
+};
+
+const pauseQueueInner$ = setPauseInner(true);
+const resumeQueueInner$ = setPauseInner(false);
+
+export const zeroWorkflowQueueRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroWorkflowQueueContract.get,
+    handler: authRoute(workflowReadAuth, getQueueInner$),
+  },
+  {
+    route: zeroWorkflowQueueContract.skipEvent,
+    handler: authRoute(workflowWriteAuth, skipEventInner$),
+  },
+  {
+    route: zeroWorkflowQueueContract.clear,
+    handler: authRoute(workflowWriteAuth, clearQueueInner$),
+  },
+  {
+    route: zeroWorkflowQueueContract.pause,
+    handler: authRoute(workflowWriteAuth, pauseQueueInner$),
+  },
+  {
+    route: zeroWorkflowQueueContract.resume,
+    handler: authRoute(workflowWriteAuth, resumeQueueInner$),
+  },
+];

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue-drain.service.ts
@@ -8,6 +8,7 @@ import { command } from "ccstate";
 import { and, eq } from "drizzle-orm";
 
 import { logger } from "../../lib/log";
+import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtime";
 import { writeDb$, type Db } from "../external/db";
 import { now, nowDate } from "../external/time";
 import { dispatchFailedRunCallbacks } from "./agent-run-callback.service";
@@ -66,7 +67,7 @@ async function loadDequeueTarget(
  * fire are consumed and skipped; a run-creation failure restores the event to
  * the queue head and pauses the queue so the backlog is preserved.
  */
-const drainWorkflowQueueForThread$ = command(
+export const drainWorkflowQueueForThread$ = command(
   async (
     { set },
     args: { readonly chatThreadId: string },
@@ -88,6 +89,11 @@ const drainWorkflowQueueForThread$ = command(
           eventId: event.id,
           triggerId: event.triggerId,
         });
+        await publishChatThreadWorkflowQueueChangedSafely(
+          event.userId,
+          event.chatThreadId,
+        );
+        signal.throwIfAborted();
         continue;
       }
 
@@ -131,6 +137,11 @@ const drainWorkflowQueueForThread$ = command(
       signal.throwIfAborted();
 
       if (result.kind === "ok" || result.kind === "enqueued") {
+        await publishChatThreadWorkflowQueueChangedSafely(
+          event.userId,
+          event.chatThreadId,
+        );
+        signal.throwIfAborted();
         return;
       }
       if (result.kind === "conflict") {
@@ -153,6 +164,11 @@ const drainWorkflowQueueForThread$ = command(
         chatThreadId: event.chatThreadId,
         code: result.response.body.error.code,
       });
+      await publishChatThreadWorkflowQueueChangedSafely(
+        event.userId,
+        event.chatThreadId,
+      );
+      signal.throwIfAborted();
       return;
     }
   },

--- a/turbo/apps/api/src/signals/services/zero-workflow-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-queue.service.ts
@@ -11,7 +11,7 @@ import { zeroWorkflowQueueEvents } from "@vm0/db/schema/zero-workflow-queue";
 import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 
-import type { Db } from "../external/db";
+import type { Db, ReadonlyDb } from "../external/db";
 import {
   decryptPersistentSecretsMap,
   encryptPersistentSecretsMap,
@@ -361,4 +361,190 @@ export async function pendingWorkflowQueueThreadIds(
   return rows.map((row) => {
     return row.chatThreadId;
   });
+}
+
+export interface WorkflowQueueThreadRow {
+  readonly orgId: string;
+  readonly userId: string;
+  readonly workflowId: string;
+  readonly queuePausedAt: Date | null;
+  readonly pauseReason: string | null;
+}
+
+/**
+ * Resolve the caller-owned workflow-queue key for a chat thread. Null when
+ * the thread has no workflow queue or belongs to another org/user.
+ */
+export async function loadWorkflowQueueThread(
+  db: ReadonlyDb,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly threadId: string;
+  },
+): Promise<WorkflowQueueThreadRow | null> {
+  const [row] = await db
+    .select({
+      orgId: workflowUserTriggerThreads.orgId,
+      userId: workflowUserTriggerThreads.userId,
+      workflowId: workflowUserTriggerThreads.workflowId,
+      queuePausedAt: workflowUserTriggerThreads.queuePausedAt,
+      pauseReason: workflowUserTriggerThreads.pauseReason,
+    })
+    .from(workflowUserTriggerThreads)
+    .where(
+      and(
+        eq(workflowUserTriggerThreads.chatThreadId, args.threadId),
+        eq(workflowUserTriggerThreads.orgId, args.orgId),
+        eq(workflowUserTriggerThreads.userId, args.userId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+interface WorkflowQueueRunningRun {
+  readonly runId: string;
+  readonly status: string;
+  readonly triggerBrief: string | null;
+  readonly createdAt: Date;
+}
+
+interface PendingWorkflowQueueEvent {
+  readonly id: string;
+  readonly triggerId: string;
+  readonly triggerSource: string;
+  readonly triggerBrief: string | null;
+  readonly createdAt: Date;
+}
+
+export async function loadRunningWorkflowThreadRun(
+  db: ReadonlyDb,
+  threadId: string,
+): Promise<WorkflowQueueRunningRun | null> {
+  const [run] = await db
+    .select({
+      runId: zeroRuns.id,
+      status: agentRuns.status,
+      triggerBrief: zeroRuns.triggerBrief,
+      createdAt: agentRuns.createdAt,
+    })
+    .from(zeroRuns)
+    .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
+    .where(
+      and(
+        eq(zeroRuns.chatThreadId, threadId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+      ),
+    )
+    .orderBy(asc(agentRuns.createdAt))
+    .limit(1);
+  return run ?? null;
+}
+
+export async function listPendingWorkflowQueueEvents(
+  db: ReadonlyDb,
+  key: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+  },
+): Promise<readonly PendingWorkflowQueueEvent[]> {
+  return await db
+    .select({
+      id: zeroWorkflowQueueEvents.id,
+      triggerId: zeroWorkflowQueueEvents.triggerId,
+      triggerSource: zeroWorkflowQueueEvents.triggerSource,
+      triggerBrief: zeroWorkflowQueueEvents.triggerBrief,
+      createdAt: zeroWorkflowQueueEvents.createdAt,
+    })
+    .from(zeroWorkflowQueueEvents)
+    .where(
+      and(
+        eq(zeroWorkflowQueueEvents.orgId, key.orgId),
+        eq(zeroWorkflowQueueEvents.userId, key.userId),
+        eq(zeroWorkflowQueueEvents.workflowId, key.workflowId),
+      ),
+    )
+    .orderBy(
+      asc(zeroWorkflowQueueEvents.createdAt),
+      asc(zeroWorkflowQueueEvents.id),
+    );
+}
+
+/**
+ * Delete one pending event owned by the caller. Returns its chat thread id
+ * for the realtime signal, or null when no such event exists.
+ */
+export async function deleteWorkflowQueueEventById(
+  db: Db,
+  args: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly eventId: string;
+  },
+): Promise<{ readonly chatThreadId: string } | null> {
+  const [deleted] = await db
+    .delete(zeroWorkflowQueueEvents)
+    .where(
+      and(
+        eq(zeroWorkflowQueueEvents.id, args.eventId),
+        eq(zeroWorkflowQueueEvents.orgId, args.orgId),
+        eq(zeroWorkflowQueueEvents.userId, args.userId),
+      ),
+    )
+    .returning({ chatThreadId: zeroWorkflowQueueEvents.chatThreadId });
+  return deleted ?? null;
+}
+
+export async function clearWorkflowQueueEvents(
+  db: Db,
+  key: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+  },
+): Promise<void> {
+  await db
+    .delete(zeroWorkflowQueueEvents)
+    .where(
+      and(
+        eq(zeroWorkflowQueueEvents.orgId, key.orgId),
+        eq(zeroWorkflowQueueEvents.userId, key.userId),
+        eq(zeroWorkflowQueueEvents.workflowId, key.workflowId),
+      ),
+    );
+}
+
+/**
+ * Manual pause/resume. Pause freezes consumption while intake continues;
+ * resume clears both the pause timestamp and any stored reason.
+ */
+export async function setWorkflowQueuePause(
+  db: Db,
+  key: {
+    readonly orgId: string;
+    readonly userId: string;
+    readonly workflowId: string;
+  },
+  pause: {
+    readonly pausedAt: Date;
+    readonly pauseReason: string | null;
+  } | null,
+  updatedAt: Date,
+): Promise<void> {
+  await db
+    .update(workflowUserTriggerThreads)
+    .set({
+      queuePausedAt: pause?.pausedAt ?? null,
+      pauseReason: pause?.pauseReason ?? null,
+      updatedAt,
+    })
+    .where(
+      and(
+        eq(workflowUserTriggerThreads.orgId, key.orgId),
+        eq(workflowUserTriggerThreads.userId, key.userId),
+        eq(workflowUserTriggerThreads.workflowId, key.workflowId),
+      ),
+    );
 }

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
@@ -8,6 +8,7 @@ import { command, type Computed } from "ccstate";
 import { eq } from "drizzle-orm";
 
 import { writeDb$, type Db } from "../external/db";
+import { publishChatThreadWorkflowQueueChangedSafely } from "../external/realtime";
 import { now, nowDate } from "../external/time";
 import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
@@ -419,7 +420,15 @@ async function enqueueWorkflowTriggerEventIfBusy(input: {
     },
   });
   signal.throwIfAborted();
-  return admission === "enqueued";
+  if (admission === "enqueued") {
+    await publishChatThreadWorkflowQueueChangedSafely(
+      trigger.ownerUserId,
+      chatThreadId,
+    );
+    signal.throwIfAborted();
+    return true;
+  }
+  return false;
 }
 
 async function recordWorkflowTriggerRunStart(input: {

--- a/turbo/packages/api-contracts/src/contracts/zero-workflow-queue.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflow-queue.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const threadIdParams = z.object({ threadId: z.string().min(1) });
+const eventIdParams = z.object({ id: z.string().uuid() });
+
+export const workflowQueueEventSchema = z.object({
+  id: z.string(),
+  triggerId: z.string(),
+  triggerSource: z.string(),
+  triggerBrief: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type WorkflowQueueEvent = z.infer<typeof workflowQueueEventSchema>;
+
+export const workflowQueueRunningRunSchema = z.object({
+  runId: z.string(),
+  status: z.string(),
+  triggerBrief: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+/**
+ * Snapshot of a chat thread's workflow queue: the in-flight trigger run (if
+ * any), the pending events in FIFO order, and the pause state. Mutations
+ * return the same shape so the client can render without a follow-up fetch.
+ */
+export const workflowQueueResponseSchema = z.object({
+  running: workflowQueueRunningRunSchema.nullable(),
+  pending: z.array(workflowQueueEventSchema),
+  pausedAt: z.string().nullable(),
+  pauseReason: z.string().nullable(),
+});
+export type WorkflowQueueResponse = z.infer<typeof workflowQueueResponseSchema>;
+
+export const zeroWorkflowQueueContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/chat-threads/:threadId/workflow-queue",
+    headers: authHeadersSchema,
+    pathParams: threadIdParams,
+    responses: {
+      200: workflowQueueResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Read the chat thread's workflow queue state",
+  },
+  skipEvent: {
+    method: "DELETE",
+    path: "/api/zero/workflow-queue/events/:id",
+    headers: authHeadersSchema,
+    pathParams: eventIdParams,
+    body: c.noBody(),
+    responses: {
+      200: workflowQueueResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Remove one pending event from its workflow queue",
+  },
+  clear: {
+    method: "DELETE",
+    path: "/api/zero/chat-threads/:threadId/workflow-queue",
+    headers: authHeadersSchema,
+    pathParams: threadIdParams,
+    body: c.noBody(),
+    responses: {
+      200: workflowQueueResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Remove all pending events from the thread's workflow queue",
+  },
+  pause: {
+    method: "POST",
+    path: "/api/zero/chat-threads/:threadId/workflow-queue/pause",
+    headers: authHeadersSchema,
+    pathParams: threadIdParams,
+    body: c.noBody(),
+    responses: {
+      200: workflowQueueResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Pause the thread's workflow queue (events keep enqueueing)",
+  },
+  resume: {
+    method: "POST",
+    path: "/api/zero/chat-threads/:threadId/workflow-queue/resume",
+    headers: authHeadersSchema,
+    pathParams: threadIdParams,
+    body: c.noBody(),
+    responses: {
+      200: workflowQueueResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Resume the thread's workflow queue and drain it",
+  },
+});


### PR DESCRIPTION
Closes #20876. Part 2 of 3 for #20824 (per-workflow event queue). Builds on the queue core merged in #20882.

## What changes for users

Still nothing by default — every endpoint is gated by `FeatureSwitchKey.WorkflowQueue` (403 when off). With the switch on, the chat-thread workflow queue becomes inspectable and controllable:

- `GET /api/zero/chat-threads/:threadId/workflow-queue` — the in-flight trigger run (runId/status/brief), pending events in FIFO order (id, triggerId, triggerSource, triggerBrief, createdAt), and pause state (`pausedAt`/`pauseReason`).
- `DELETE /api/zero/workflow-queue/events/:id` — skip a single pending event.
- `DELETE /api/zero/chat-threads/:threadId/workflow-queue` — clear the backlog.
- `POST .../workflow-queue/pause` — freeze consumption; events keep enqueueing (per the #20824 design, pause governs dequeue only).
- `POST .../workflow-queue/resume` — clear the pause (including auto-pause reasons from failed dequeues) and re-drain immediately.

Mutations return the updated queue snapshot so the client renders without a follow-up fetch.

## Implementation

- New contract `zeroWorkflowQueueContract` (`packages/api-contracts/src/contracts/zero-workflow-queue.ts`), routes in `apps/api/src/signals/routes/zero-workflow-queue.ts` registered per the existing `RouteEntry` convention with `agent:read`/`agent:write` capability auth. Queue access resolves through `workflow_user_trigger_threads` filtered by the caller's org+user, so only the trigger owner sees or mutates their queue.
- Query/mutation helpers added to `zero-workflow-queue.service.ts` (running-run lookup, FIFO pending list, delete-by-id with ownership, clear, pause/resume). Read paths typed against `ReadonlyDb`.
- Realtime: new `publishChatThreadWorkflowQueueChangedSafely` (user channel, best-effort, mirroring `chatThreadAutomationsChanged`) published from the PR① enqueue path, all drain outcomes (drained, dropped-stale, failure-pause), and every mutation route — the PR③ header UI subscribes to this topic.
- `drainWorkflowQueueForThread$` exported so resume can drain inline instead of waiting for the next terminal run or the safety-net cron.

## Verification

- New integration suite `zero-workflow-queue-api.test.ts` (5 tests, passing locally against a real Postgres): queue snapshot shape and FIFO order; 403 when the switch is off; skip-one leaves the rest to drain; clear empties the backlog; pause freezes consumption across a terminal run while intake continues, and resume drains immediately.
- Regression: PR① `zero-workflow-queue.test.ts` (4 tests) and `webhooks-workflow-triggers.test.ts` pass locally with the new publish hooks in place.
- `tsc --noEmit` (api + api-contracts), eslint/oxlint, knip clean.

## Out of scope

UI (badge, queue section, auto-expand) — #20877 / PR ③.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
