### PR TITLE
fix: surface codex account model support errors in chat

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -129,6 +129,19 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(modelCapacity)).toBe(false);
   });
 
+  it("shows Codex ChatGPT account model support errors verbatim", () => {
+    const unsupportedModel =
+      '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.6-sol\' model is not supported when using Codex with a ChatGPT account."}}';
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: unsupportedModel,
+      }),
+    ).toBe(unsupportedModel);
+    expect(isActionableRunError(unsupportedModel)).toBe(true);
+    expect(isGenericRunErrorForDisplay(unsupportedModel)).toBe(false);
+  });
+
   it("shows Claude Code subscription reconnect guidance for upstream 401s", () => {
     expect(
       formatRunErrorForExternalSurface({

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -181,6 +181,7 @@ export const ACTIONABLE_RUN_ERROR_SNIPPETS = [
   "Invalid signature in thinking block",
   "Run cancelled",
   "Selected model is at capacity. Please try a different model.",
+  "model is not supported when using Codex with a ChatGPT account",
   // Upstream model usage/quota limits are shown verbatim (the CLI already
   // emits clean, user-friendly copy with reset time and upgrade links).
   // Codex: "You've hit your usage limit …"


### PR DESCRIPTION
## Summary
- allowlist Codex provider errors that report a selected model is unsupported for ChatGPT account authentication
- preserve those model errors in Web chat and integrations instead of replacing them with the generic Oops copy
- add regression coverage using the exact raw error envelope from the reported run

## Verification
- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/errors.test.ts` (31 tests)

Related to #17827