### PR TITLE
refactor(guest-agent): clarify runtime bootstrap contract

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -1,4 +1,4 @@
-//! Guest-agent startup configuration parsed from environment snapshots.
+//! Guest-agent startup configuration parsed from captured environment values.
 //!
 //! `GuestConfigRaw::from_process_env` is the only process-env capture boundary
 //! in this module. After startup, callers should pass an owned [`GuestConfig`]
@@ -255,7 +255,17 @@ impl GuestConfig {
         Self::from_raw(raw)
     }
 
-    /// Build an owned config from explicit startup values.
+    /// Build an owned config from explicit captured startup values.
+    ///
+    /// This validates and destructively loads the required run-payload file and
+    /// the optional user-env file against the captured runtime directory. Each
+    /// private file is removed after it is read, before parsing and validation
+    /// finish.
+    ///
+    /// # Errors
+    ///
+    /// A referenced private file may already have been removed when this returns
+    /// an error from parsing, validation, or later config materialization.
     pub fn from_raw(raw: GuestConfigRaw) -> Result<Self, String> {
         let payload = load_run_payload_from_raw(&raw)?;
         let user_env = load_user_env_from_raw(&raw)?;

--- a/crates/guest-agent/src/lib.rs
+++ b/crates/guest-agent/src/lib.rs
@@ -3,7 +3,7 @@
 //! The production runtime model is explicit:
 //! - [`run_context::GuestRuntime::from_process_env`] is the startup boundary
 //!   that captures runner-provided process state.
-//! - [`env::GuestConfigRaw`] is the raw environment snapshot.
+//! - [`env::GuestConfigRaw`] owns captured raw startup values.
 //! - [`env::GuestConfig`] owns immutable run-scoped configuration.
 //! - [`paths::GuestPaths`] owns immutable run-scoped filesystem paths.
 //!

--- a/crates/guest-agent/src/run_context.rs
+++ b/crates/guest-agent/src/run_context.rs
@@ -1,31 +1,8 @@
-//! Explicit immutable guest-agent run context.
+//! Explicit immutable guest-agent runtime state.
 
 use crate::env::{GuestConfig, GuestConfigRaw};
 use crate::http::HttpClient;
 use crate::paths::GuestPaths;
-
-/// Immutable config and derived paths for one guest-agent run.
-#[derive(Clone)]
-pub struct GuestContext {
-    pub config: GuestConfig,
-    pub paths: GuestPaths,
-}
-
-impl GuestContext {
-    /// Build a run context from explicit config and paths.
-    pub fn new(config: GuestConfig, paths: GuestPaths) -> Self {
-        Self { config, paths }
-    }
-
-    /// Build a run context from the current process environment.
-    pub fn from_process_env() -> Result<Self, String> {
-        let raw = GuestConfigRaw::from_process_env();
-        raw.require_run_payload_file()?;
-        let paths = paths_from_raw(&raw)?;
-        let config = GuestConfig::from_raw(raw)?;
-        Ok(Self::new(config, paths))
-    }
-}
 
 /// Production runtime services for one guest-agent run.
 #[derive(Clone)]
@@ -36,7 +13,22 @@ pub struct GuestRuntime {
 }
 
 impl GuestRuntime {
-    /// Build the production runtime from one raw process environment snapshot.
+    /// Build the ordinary production runtime from captured process startup state.
+    ///
+    /// Call this exactly once, after the runner or test has finished configuring
+    /// the process environment. The method captures owned configuration inputs,
+    /// derives immutable run paths from those captured values, installs those
+    /// paths as the process-wide guest-common system-log and sandbox-ops sinks,
+    /// and builds the run-scoped HTTP client.
+    ///
+    /// After successful bootstrap, pass this runtime or its owned fields through
+    /// callers instead of rereading run-scoped process globals.
+    ///
+    /// # Errors
+    ///
+    /// Ordinary startup treats any error as terminal. Bootstrap can perform
+    /// process-wide setup and consume runner-owned inputs before returning, so
+    /// callers must not retry it in the same process.
     pub fn from_process_env() -> Result<Self, String> {
         let raw = GuestConfigRaw::from_process_env();
         raw.require_run_payload_file()?;

--- a/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
+++ b/crates/guest-agent/tests/guest_runtime_missing_api_url.rs
@@ -1,47 +1,66 @@
-//! Production runtime bootstrap should fail fast when API auth is incomplete.
-//!
-//! This test lives in its own binary to isolate process env captured by
-//! `GuestRuntime::from_process_env`.
+//! Production startup should persist post-path bootstrap failures to the run log.
 
 mod common;
 
+use std::process::Command;
+
 #[test]
-fn runtime_bootstrap_requires_api_url_when_api_token_is_set() {
+fn runtime_bootstrap_logs_missing_api_url_to_system_log() {
     let tmp = tempfile::tempdir().unwrap();
     let runtime_dir = tmp.path().join("runtime");
+    let run_payload_file = common::write_run_payload_file_for_test(
+        &runtime_dir,
+        &guest_contracts::env::RunPayload {
+            prompt: "missing api url prompt".to_string(),
+            ..guest_contracts::env::RunPayload::default()
+        },
+    )
+    .unwrap();
 
-    unsafe {
-        common::clear_guest_agent_bootstrap_env_for_test();
-        std::env::set_var(
+    let output = Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+        .env_clear()
+        .env(
             guest_contracts::env::RUN_ID_ENV,
             "guest-runtime-missing-api-url",
-        );
-        std::env::set_var("HOME", tmp.path().join("home"));
-        std::env::set_var(
+        )
+        .env("HOME", tmp.path().join("home"))
+        .env(
             guest_contracts::runtime_paths::GUEST_RUNTIME_DIR_ENV,
             &runtime_dir,
-        );
-        common::set_run_payload_file_env_for_test(
-            &runtime_dir,
-            &guest_contracts::env::RunPayload {
-                prompt: "missing api url prompt".to_string(),
-                ..guest_contracts::env::RunPayload::default()
-            },
         )
+        .env(guest_contracts::env::RUN_PAYLOAD_FILE_ENV, run_payload_file)
+        .env(guest_contracts::env::API_TOKEN_ENV, "test-token")
+        .env(guest_contracts::env::API_URL_ENV, "")
+        .output()
         .unwrap();
-        std::env::set_var(guest_contracts::env::API_TOKEN_ENV, "test-token");
-        std::env::set_var(guest_contracts::env::API_URL_ENV, "");
-        std::env::remove_var(guest_contracts::env::USER_ENV_FILE_ENV);
-    }
 
-    let error = match guest_agent::run_context::GuestRuntime::from_process_env() {
-        Ok(_) => panic!("missing API URL should fail fast"),
-        Err(error) => error,
-    };
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "missing API URL should fail startup; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
+    let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
-        error.contains(guest_contracts::env::API_URL_ENV),
-        "error should identify {}, got: {error}",
+        stderr.contains("Fatal:"),
+        "stderr should be fatal: {stderr}"
+    );
+    assert!(
+        stderr.contains(guest_contracts::env::API_URL_ENV),
+        "stderr should identify {}, got: {stderr}",
+        guest_contracts::env::API_URL_ENV
+    );
+
+    let system_log_path = guest_contracts::runtime_paths::system_log_file(&runtime_dir);
+    let system_log = std::fs::read_to_string(system_log_path).unwrap();
+    assert!(
+        system_log.contains("Fatal:"),
+        "system log should contain the fatal bootstrap diagnostic: {system_log}"
+    );
+    assert!(
+        system_log.contains(guest_contracts::env::API_URL_ENV),
+        "system log should identify {}, got: {system_log}",
         guest_contracts::env::API_URL_ENV
     );
 }


### PR DESCRIPTION
## Summary

- document the terminal, single-run guest runtime bootstrap contract and destructive private-file loading
- cover post-path bootstrap failure logging through the real `guest-agent` binary
- remove the unused `GuestContext` type while retaining active lower-level process-environment constructors

Closes #20828

## Tests

- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_runtime_missing_api_url`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_runtime_process_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test guest_config_process_env`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --test runtime_api_surface`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent --all-targets`
- `cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features`
