### PR TITLE
chore: update vm0-dev image to 20260710

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260622",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260710",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary

- update the devcontainer vm0-dev image pin from 20260622 to 20260710
- use the published multi-architecture image that includes PostgreSQL 17 and pgvector

## Test plan

- `jq empty .devcontainer/devcontainer.json`
- `git diff --check`
- verified `ghcr.io/vm0-ai/vm0-dev:20260710` provides amd64 and arm64 images
- verified the image contains `postgresql-17-pgvector` and `vector.so`
- full repository checks not run (per request)