### PR TITLE
feat: add dot matrix and frosted scatter website templates

### DIFF
--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -138,8 +138,12 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
     "78988a658604a25feb259d54e4543bfe6d57f85efe7ad67737e02c794d25e491",
   "template:coastal-hotel":
     "3907cdbed6078702a058ed9c66c1cdeb76f83f1062efcf3b046cce0bd5c8ed06",
+  "template:dot-matrix":
+    "293a2bc33150ca1f39132a8235c5cf355944e8d3e213b5f7703237314a2ac449",
   "template:frame-stack":
     "efbf1788c8b084aa12b7cd48f7a3bf5fc9964d1e6115edbd9124f8cacfbfb3ca",
+  "template:frosted-scatter":
+    "f23092f727e7a8a20d586e80a6f6cc0ff27d51f2fee3356a7d8ab97c3539c3b9",
   "template:gallery-wall":
     "9e81cd8b35f9f6374440cd3a4a8fc214db4a137962797df69bde46248c4e75f3",
   "template:glass-bloom":

--- a/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
+++ b/turbo/apps/cli/src/commands/zero/generate/__tests__/website.test.ts
@@ -110,24 +110,24 @@ describe("zero generate website command", () => {
       "cli",
       "website",
       "--prompt",
-      "High contrast launch page",
+      "Kinetic onchain brand studio",
       "--template",
-      "black-slabs",
+      "dot-matrix",
       "--site-slug",
-      "black-slabs-demo",
+      "dot-matrix-demo",
     ]);
 
     const stdout = mockConsoleLog.mock.calls.flat().join("\n");
     expect(stdout).toContain(
-      "Selected template: template:black-slabs (Black Slabs)",
+      "Selected template: template:dot-matrix (Dot Matrix)",
     );
     expect(stdout).toContain(
-      "Selected template package: zero resource pull template:black-slabs --dir ./generated/resources",
+      "Selected template package: zero resource pull template:dot-matrix --dir ./generated/resources",
     );
-    expect(stdout).toContain('"id": "template:black-slabs"');
+    expect(stdout).toContain('"id": "template:dot-matrix"');
     expect(stdout).toContain('"type": "tar.gz"');
     expect(stdout).toContain(
-      '"sha256": "8f30984e444283bf0322106a1099623346e153bc11d26e3044fbf61ef43514c3"',
+      '"sha256": "f489a51fb99d8fadff8712d0406df06ac1a530116ebe612ab3f8605daa2bcce2"',
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/zero/resource/__tests__/index.test.ts
@@ -23,17 +23,17 @@ describe("zero resource pull registry resolver", () => {
   });
 
   it("resolves a built-in website template package archive", () => {
-    expect(findRegistryResourceForPull("template:black-slabs")).toEqual(
+    expect(findRegistryResourceForPull("template:dot-matrix")).toEqual(
       expect.objectContaining({
-        id: "template:black-slabs",
+        id: "template:dot-matrix",
         kind: "template",
         targets: ["website"],
         source: expect.objectContaining({
-          path: "black-slabs",
+          path: "dot-matrix",
           archive: expect.objectContaining({
             type: "tar.gz",
             sha256:
-              "8f30984e444283bf0322106a1099623346e153bc11d26e3044fbf61ef43514c3",
+              "f489a51fb99d8fadff8712d0406df06ac1a530116ebe612ab3f8605daa2bcce2",
           }),
         }),
       }),
@@ -41,8 +41,8 @@ describe("zero resource pull registry resolver", () => {
   });
 
   it("canonicalizes unprefixed built-in website template ids", () => {
-    expect(findRegistryResourceForPull("black-slabs")?.id).toBe(
-      "template:black-slabs",
+    expect(findRegistryResourceForPull("dot-matrix")?.id).toBe(
+      "template:dot-matrix",
     );
   });
 });

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -14,7 +14,9 @@ const EXPECTED_WEBSITE_TEMPLATE_IDS = [
   "website-template:black-slabs",
   "website-template:blueprint-grid",
   "website-template:coastal-hotel",
+  "website-template:dot-matrix",
   "website-template:frame-stack",
+  "website-template:frosted-scatter",
   "website-template:gallery-wall",
   "website-template:glass-bloom",
   "website-template:serif-stack",
@@ -29,8 +31,12 @@ const EXPECTED_WEBSITE_TEMPLATE_SHA256: Record<string, string> = {
     "97c2edd94467bc414f0d9fc27cafa048cb2a7aaba3df5159df519a2bb2b97a4e",
   "coastal-hotel":
     "9633475124da5728cbf99a7333b494f74842232faaf675bc7878a3ebcdf59bcb",
+  "dot-matrix":
+    "f489a51fb99d8fadff8712d0406df06ac1a530116ebe612ab3f8605daa2bcce2",
   "frame-stack":
     "4587e93da51652c0c16c2d0706e8437001305214e4e6b8b1c18a6538b3daa127",
+  "frosted-scatter":
+    "7ad1c3b16b7beeb82e1a2f39a1fe7fff168592fb06e7b5fedf3c2450e1412f43",
   "gallery-wall":
     "c90332053b24572feadecb3994925ed317957e1cb17b0080cfebc6f4d9e93bd1",
   "glass-bloom":
@@ -73,7 +79,7 @@ describe("website template items", () => {
         /^https:\/\/static\.vm0\.io\/vm0\/artifact-templates\/website\/.+\.html$/u,
       );
       expect(item.previewImageUrl).toMatch(
-        /^https:\/\/static\.vm0\.io\/vm0\/artifact-templates\/website\/.+-preview-480x270\.webp$/u,
+        /^https:\/\/static\.vm0\.io\/vm0\/artifact-templates\/website\/.+-preview-(?:480x270|960x540)\.webp$/u,
       );
       expect(item.previewUrl).not.toContain("drive.google.com");
       expect(item.previewUrl).not.toContain("docs.google.com");

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -3643,8 +3643,12 @@ const WEBSITE_TEMPLATE_ARCHIVE_SHA256: Record<string, string> = {
     "97c2edd94467bc414f0d9fc27cafa048cb2a7aaba3df5159df519a2bb2b97a4e",
   "coastal-hotel":
     "9633475124da5728cbf99a7333b494f74842232faaf675bc7878a3ebcdf59bcb",
+  "dot-matrix":
+    "f489a51fb99d8fadff8712d0406df06ac1a530116ebe612ab3f8605daa2bcce2",
   "frame-stack":
     "4587e93da51652c0c16c2d0706e8437001305214e4e6b8b1c18a6538b3daa127",
+  "frosted-scatter":
+    "7ad1c3b16b7beeb82e1a2f39a1fe7fff168592fb06e7b5fedf3c2450e1412f43",
   "gallery-wall":
     "c90332053b24572feadecb3994925ed317957e1cb17b0080cfebc6f4d9e93bd1",
   "glass-bloom":

--- a/turbo/packages/core/src/website-template-items.ts
+++ b/turbo/packages/core/src/website-template-items.ts
@@ -62,6 +62,20 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     target: "website",
   },
   {
+    id: "website-template:dot-matrix",
+    slug: "dot-matrix",
+    title: "Dot Matrix",
+    description:
+      "Kinetic website template with LED dot-matrix imagery, an oversized organic wordmark, numbered service indexing, and scrolling tag marquees.",
+    templateId: "template:dot-matrix",
+    resourceId: "template:dot-matrix",
+    previewKind: "iframe",
+    previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/dot-matrix-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/dot-matrix-preview-960x540.webp`,
+    sourcePath: "dot-matrix",
+    target: "website",
+  },
+  {
     id: "website-template:frame-stack",
     slug: "frame-stack",
     title: "Frame Stack",
@@ -73,6 +87,20 @@ export const WEBSITE_TEMPLATE_ITEMS: readonly WebsiteTemplateItem[] = [
     previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/frame-stack-example.html`,
     previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/frame-stack-preview-480x270.webp`,
     sourcePath: "frame-stack",
+    target: "website",
+  },
+  {
+    id: "website-template:frosted-scatter",
+    slug: "frosted-scatter",
+    title: "Frosted Scatter",
+    description:
+      "Frosted-glass website template with scattered parallax photography, a flashlight grid cursor, line-by-line copy, and oversized numeric storytelling.",
+    templateId: "template:frosted-scatter",
+    resourceId: "template:frosted-scatter",
+    previewKind: "iframe",
+    previewUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/frosted-scatter-example.html`,
+    previewImageUrl: `${WEBSITE_TEMPLATE_PREVIEW_BASE_URL}/frosted-scatter-preview-960x540.webp`,
+    sourcePath: "frosted-scatter",
     target: "website",
   },
   {


### PR DESCRIPTION
## Summary
- add Dot Matrix and Frosted Scatter to the built-in website template picker and website-targeted generation catalog
- register both private R2 template archives with their uploaded storage version IDs and SHA256 digests
- point picker cards and full previews at the new 960x540 WebP and HTML assets from companion static-files PR vm0-ai/static-files#34
- update core and CLI coverage so the new packages resolve through `zero generate website` and `zero resource pull`

## R2 packages
- `template:dot-matrix`: version `293a2bc33150ca1f39132a8235c5cf355944e8d3e213b5f7703237314a2ac449`, SHA256 `f489a51fb99d8fadff8712d0406df06ac1a530116ebe612ab3f8605daa2bcce2`
- `template:frosted-scatter`: version `f23092f727e7a8a20d586e80a6f6cc0ff27d51f2fee3356a7d8ab97c3539c3b9`, SHA256 `7ad1c3b16b7beeb82e1a2f39a1fe7fff168592fb06e7b5fedf3c2450e1412f43`

Both uploaded archives were downloaded through `/api/storages/download` and matched the Drive source SHA256 exactly.

## Verification
- `git diff --check`
- verified R2 round-trip SHA256 for both archives
- rendered and visually inspected both HTML previews at 960x540
- local vitest/type-check not run; relying on the PR pipeline per repository preference

## Dependency
- merge vm0-ai/static-files#34 before this PR so the referenced static preview URLs are published.