### PR TITLE
chore: remove runtime pgvector installation

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -31,25 +31,15 @@ else
   echo "✓ Turbo workspace not found, skipping cache cleanup"
 fi
 
-# Setup PostgreSQL (handled by postgresql feature). Migrations create the
-# `vector` extension, so the local server must have the pgvector package.
-POSTGRES_VERSION=17
-PGVECTOR_PACKAGE="postgresql-${POSTGRES_VERSION}-pgvector"
-echo "🐘 Ensuring PostgreSQL pgvector extension package is installed..."
-if dpkg-query -W -f='${Status}' "$PGVECTOR_PACKAGE" 2>/dev/null | grep -q "install ok installed"; then
-  echo "✓ $PGVECTOR_PACKAGE already installed"
-else
-  sudo apt-get update -qq
-  sudo apt-get install -y -qq "$PGVECTOR_PACKAGE"
-  echo "✓ Installed $PGVECTOR_PACKAGE"
-fi
-
+# PostgreSQL is initialized by the postgresql feature, while pgvector is
+# provided by the vm0-dev image.
+echo "🐘 Checking PostgreSQL pgvector extension..."
 sudo chown -R postgres:postgres /var/lib/postgresql 2>/dev/null || true
 sudo service postgresql start 2>/dev/null || true
 if sudo -u postgres psql -h /var/run/postgresql -d postgres -Atqc "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" | grep -qx 1; then
   echo "✓ pgvector extension available to PostgreSQL"
 else
-  echo "ERROR: pgvector extension is not available to PostgreSQL after installing $PGVECTOR_PACKAGE" >&2
+  echo "ERROR: pgvector extension is not available to PostgreSQL" >&2
   exit 1
 fi
 

--- a/.devcontainer/test.sh
+++ b/.devcontainer/test.sh
@@ -62,10 +62,6 @@ test_pgvector_probe_uses_unix_socket() {
 
   printf '%s\n' \
     '#!/usr/bin/env bash' \
-    "printf 'install ok installed\\n'" \
-    > "$fake_bin/dpkg-query"
-  printf '%s\n' \
-    '#!/usr/bin/env bash' \
     'printf "%s\\n" "$*" >> "$SUDO_CALLS_LOG"' \
     'if [[ "$*" == "-u postgres psql "* ]]; then' \
     "  printf '1\\n'" \
@@ -75,7 +71,7 @@ test_pgvector_probe_uses_unix_socket() {
     '#!/usr/bin/env bash' \
     'exit 0' \
     > "$fake_bin/lefthook"
-  chmod +x "$fake_bin/dpkg-query" "$fake_bin/sudo" "$fake_bin/lefthook"
+  chmod +x "$fake_bin/sudo" "$fake_bin/lefthook"
 
   HOME="$workspace/home" \
     PATH="$fake_bin:$PATH" \


### PR DESCRIPTION
## Summary

- remove the runtime apt installation of `postgresql-17-pgvector` from devcontainer setup
- rely on the package baked into the pinned `vm0-dev:20260710` image
- retain PostgreSQL initialization, startup, and the Unix-socket pgvector availability check
- remove the obsolete fake `dpkg-query` test fixture

## Test plan

- `docker run --rm --entrypoint bash -v /Users/yuma/workspaces/vm0:/workspace -w /workspace ghcr.io/vm0-ai/vm0-dev:20260710 .devcontainer/test.sh`
- `git diff --check`
- full repository checks not run