### PR TITLE
fix: improve image edit entry and sizing

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-image-edit.ts
@@ -158,8 +158,6 @@ type UploadEditableImageCanvasImageArgs = {
   canvasSrc: string;
 };
 
-type ImportEditableImageCanvasImageUrlArgs = UploadEditableImageCanvasImageArgs;
-
 export const openArtifactImageEdit$ = command(
   ({ get, set }, value: OpenArtifactImageEditArgs) => {
     const args =
@@ -347,33 +345,6 @@ async function uploadImageFile({
   signal.throwIfAborted();
 
   return completed.body.url;
-}
-
-async function importImageUrl({
-  createClient,
-  signal,
-  url,
-}: {
-  createClient: ZeroClientFactory;
-  signal: AbortSignal;
-  url: string;
-}) {
-  const client = createClient(zeroUploadsContract);
-  const imported = await accept(
-    client.importImage({
-      body: { url },
-      fetchOptions: { signal },
-    }),
-    [200, 404],
-    { toast: false },
-  );
-  signal.throwIfAborted();
-
-  if (imported.status === 404) {
-    return url;
-  }
-
-  return imported.body.url;
 }
 
 function clampCropCoordinate(value: number, max: number): number {
@@ -833,45 +804,6 @@ export const uploadEditableImageCanvasImage$ = command(
     await withCleanup(
       tapError(run(), () => {
         toast.error("Couldn't upload image, try again");
-      }),
-      () => {
-        set(internalImageEditUploading$, false);
-      },
-    );
-  },
-);
-
-export const importEditableImageCanvasImageUrl$ = command(
-  async (
-    { get, set },
-    args: ImportEditableImageCanvasImageUrlArgs,
-    url: string,
-    parentSignal: AbortSignal,
-  ) => {
-    if (get(internalImageEditUploading$)) {
-      return;
-    }
-
-    const signal = parentSignal;
-    set(internalImageEditUploading$, true);
-
-    const run = async () => {
-      const importedUrl = await importImageUrl({
-        createClient: get(zeroClient$),
-        signal,
-        url,
-      });
-      set(insertEditableImageCanvasItem$, {
-        canvasSrc: args.canvasSrc,
-        key: args.canvasKey,
-        src: importedUrl,
-      });
-      toast.success("Image added");
-    };
-
-    await withCleanup(
-      tapError(run(), () => {
-        toast.error("Couldn't add image link, try again");
       }),
       () => {
         set(internalImageEditUploading$, false);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
@@ -11,7 +11,6 @@ import {
 import { zeroImageIoGenerateContract } from "@vm0/api-contracts/contracts/zero-image-io-generate";
 import { zeroImageIoInterpretMarksContract } from "@vm0/api-contracts/contracts/zero-image-io-interpret-marks";
 import { zeroBuiltInGenerationContract } from "@vm0/api-contracts/contracts/zero-built-in-generation";
-import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
 import { ILLUSTRATION_TEMPLATE_ITEMS } from "@vm0/core";
 
 import { detachedSetupPage, fill } from "../../../__tests__/page-helper.ts";
@@ -27,9 +26,6 @@ const SOURCE_IMAGE_URL =
   "https://cdn.vm7.io/artifacts/test/image-edit/source.png";
 const EDITED_IMAGE_URL =
   "https://cdn.vm7.io/artifacts/test/image-edit/edited.png";
-const LINK_IMAGE_URL = "https://cdn.vm7.io/artifacts/test/image-edit/link.png";
-const IMPORTED_LINK_IMAGE_URL =
-  "https://cdn.vm7.io/artifacts/test/image-edit/imported-link.png";
 const UPLOADED_IMAGE_URL =
   "https://cdn.vm7.io/artifacts/test/image-edit/uploaded.png";
 const SECOND_UPLOADED_IMAGE_URL =
@@ -159,18 +155,6 @@ function mockImageEditGeneration(
       createdAt: "2026-03-10T00:00:00Z",
       startedAt: "2026-03-10T00:00:01Z",
       completedAt: "2026-03-10T00:00:02Z",
-    });
-  });
-}
-
-function mockImageLinkImport(importedUrl = IMPORTED_LINK_IMAGE_URL): void {
-  context.mocks.api(zeroUploadsContract.importImage, ({ respond }) => {
-    return respond(200, {
-      id: "imported-image-edit-link",
-      filename: "imported-link.png",
-      contentType: "image/png",
-      size: 128,
-      url: importedUrl,
     });
   });
 }
@@ -365,6 +349,26 @@ function mockInterpretMarks(
       });
     },
   );
+}
+
+function mockElementClientSize(
+  element: HTMLElement,
+  size: { readonly height: number; readonly width: number },
+): void {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: size.height },
+    clientWidth: { configurable: true, value: size.width },
+  });
+}
+
+function mockImageNaturalSize(
+  image: HTMLImageElement,
+  size: { readonly height: number; readonly width: number },
+): void {
+  Object.defineProperties(image, {
+    naturalHeight: { configurable: true, value: size.height },
+    naturalWidth: { configurable: true, value: size.width },
+  });
 }
 
 async function openImageEditMode(
@@ -597,7 +601,7 @@ describe("image editing", () => {
     expect(
       screen.getByTestId("artifact-sidebar-image-zoom-controls"),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("image-edit-upload-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("image-edit-upload-local")).toBeInTheDocument();
     expect(screen.getByTestId("image-edit-select-region")).toHaveAttribute(
       "aria-label",
       "Cancel area selection",
@@ -631,7 +635,7 @@ describe("image editing", () => {
     });
     expect(screen.getByTestId("image-edit-toolbar")).toBeInTheDocument();
     expect(screen.queryByTestId("image-edit-region-remove")).toBeNull();
-    expect(screen.getByTestId("image-edit-upload-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("image-edit-upload-local")).toBeInTheDocument();
     expect(screen.queryByTestId("image-edit-region-send")).toBeNull();
 
     const commentInput = screen.getByTestId("image-edit-region-comment-input");
@@ -1107,7 +1111,15 @@ describe("image editing", () => {
   it("shows image edit progress in a toast instead of toolbar spinners", async () => {
     const user = userEvent.setup({ delay: null });
     const prompts: string[] = [];
-    mockImageLinkImport();
+    mockSequentialUploads([
+      {
+        id: "upload-image-edit-progress",
+        filename: "progress.png",
+        contentType: "image/png",
+        size: 128,
+        url: UPLOADED_IMAGE_URL,
+      },
+    ]);
     mockPendingImageEditGeneration((body) => {
       prompts.push(body.prompt ?? "");
     });
@@ -1116,16 +1128,14 @@ describe("image editing", () => {
     });
 
     await openImageEditMode(user);
-    await user.click(screen.getByTestId("image-edit-upload-menu"));
-    await user.type(
-      screen.getByTestId("image-edit-upload-link-input"),
-      LINK_IMAGE_URL,
+    await user.upload(
+      screen.getByTestId("image-edit-upload-input"),
+      new File(["progress"], "progress.png", { type: "image/png" }),
     );
-    await user.click(screen.getByTestId("image-edit-upload-link-add"));
     await waitFor(() => {
       expect(
         screen.getByTestId("artifact-sidebar-body-image-copy"),
-      ).toHaveAttribute("src", IMPORTED_LINK_IMAGE_URL);
+      ).toHaveAttribute("src", UPLOADED_IMAGE_URL);
     });
 
     await user.click(screen.getByTestId("artifact-sidebar-body-image"));
@@ -1165,10 +1175,18 @@ describe("image editing", () => {
     ).toBeNull();
   });
 
-  it("edits linked images through the imported artifact URL", async () => {
+  it("edits uploaded images through the uploaded artifact URL", async () => {
     const user = userEvent.setup({ delay: null });
     let sourceImageUrls: readonly string[] = [];
-    mockImageLinkImport();
+    mockSequentialUploads([
+      {
+        id: "upload-image-edit-source",
+        filename: "source-copy.png",
+        contentType: "image/png",
+        size: 128,
+        url: UPLOADED_IMAGE_URL,
+      },
+    ]);
     mockImageEditGeneration((body) => {
       sourceImageUrls = body.sourceImageUrls ?? [];
     });
@@ -1177,17 +1195,15 @@ describe("image editing", () => {
     });
 
     await openImageEditMode(user);
-    await user.click(screen.getByTestId("image-edit-upload-menu"));
-    await user.type(
-      screen.getByTestId("image-edit-upload-link-input"),
-      LINK_IMAGE_URL,
+    await user.upload(
+      screen.getByTestId("image-edit-upload-input"),
+      new File(["source-copy"], "source-copy.png", { type: "image/png" }),
     );
-    await user.click(screen.getByTestId("image-edit-upload-link-add"));
 
     await waitFor(() => {
       expect(
         screen.getByTestId("artifact-sidebar-body-image-copy"),
-      ).toHaveAttribute("src", IMPORTED_LINK_IMAGE_URL);
+      ).toHaveAttribute("src", UPLOADED_IMAGE_URL);
     });
 
     await user.click(screen.getByTestId("artifact-sidebar-body-image-copy"));
@@ -1197,27 +1213,29 @@ describe("image editing", () => {
     await user.click(screen.getByTestId("image-edit-remove-background"));
 
     await waitFor(() => {
-      expect(sourceImageUrls).toStrictEqual([IMPORTED_LINK_IMAGE_URL]);
+      expect(sourceImageUrls).toStrictEqual([UPLOADED_IMAGE_URL]);
     });
   });
 
-  it("only shows the link add action when a URL is entered", async () => {
+  it("shows only the local image upload control in image edit mode", async () => {
     const user = userEvent.setup({ delay: null });
     setupChatThread({
       featureSwitches: { [FeatureSwitchKey.ImageEditing]: true },
     });
 
     await openImageEditMode(user);
-    await user.click(screen.getByTestId("image-edit-upload-menu"));
 
-    expect(screen.getByTestId("image-edit-upload-link-add")).not.toBeVisible();
-
-    const linkInput = screen.getByTestId("image-edit-upload-link-input");
-    await user.type(linkInput, LINK_IMAGE_URL);
-    expect(screen.getByTestId("image-edit-upload-link-add")).toBeVisible();
-
-    await fill(linkInput, " ");
-    expect(screen.getByTestId("image-edit-upload-link-add")).not.toBeVisible();
+    expect(screen.getByTestId("image-edit-upload-local")).toHaveAttribute(
+      "aria-label",
+      "Upload from computer",
+    );
+    expect(screen.getByTestId("image-edit-upload-input")).toHaveAttribute(
+      "multiple",
+    );
+    expect(screen.queryByTestId("image-edit-upload-menu")).toBeNull();
+    expect(screen.queryByTestId("image-edit-upload-popover")).toBeNull();
+    expect(screen.queryByTestId("image-edit-upload-link-input")).toBeNull();
+    expect(screen.queryByTestId("image-edit-upload-link-add")).toBeNull();
   });
 
   it("exposes share targets and delete from the image edit toolbar", async () => {
@@ -1246,9 +1264,8 @@ describe("image editing", () => {
     expect(screen.queryByTestId("artifact-sidebar-body-image")).toBeNull();
   });
 
-  it("adds linked and multiple uploaded local images to the edit canvas", async () => {
+  it("adds multiple uploaded local images to the edit canvas", async () => {
     const user = userEvent.setup({ delay: null });
-    mockImageLinkImport();
     mockSequentialUploads([
       {
         id: "upload-image-edit-local",
@@ -1270,19 +1287,6 @@ describe("image editing", () => {
     });
 
     await openImageEditMode(user);
-    await user.click(screen.getByTestId("image-edit-upload-menu"));
-    await user.type(
-      screen.getByTestId("image-edit-upload-link-input"),
-      LINK_IMAGE_URL,
-    );
-    await user.click(screen.getByTestId("image-edit-upload-link-add"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("artifact-sidebar-body-image-copy"),
-      ).toHaveAttribute("src", IMPORTED_LINK_IMAGE_URL);
-    });
-
     expect(screen.getByTestId("image-edit-upload-input")).toHaveAttribute(
       "multiple",
     );
@@ -1297,7 +1301,6 @@ describe("image editing", () => {
         .map((image) => {
           return image.getAttribute("src");
         });
-      expect(copyImageUrls).toContain(IMPORTED_LINK_IMAGE_URL);
       expect(copyImageUrls).toContain(UPLOADED_IMAGE_URL);
       expect(copyImageUrls).toContain(SECOND_UPLOADED_IMAGE_URL);
     });
@@ -1333,6 +1336,61 @@ describe("image editing", () => {
     ).toBe("40px");
   });
 
+  it("opens image edit from the split-view artifact header", async () => {
+    const user = userEvent.setup({ delay: null });
+    setupChatThread({
+      featureSwitches: { [FeatureSwitchKey.ImageEditing]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveAttribute(
+        "alt",
+        "source.png",
+      );
+    });
+
+    await user.click(screen.getByTestId("artifact-sidebar-edit-image"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("artifact-sidebar-image-edit-canvas"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Share artifact")).toBeNull();
+    expect(screen.queryByLabelText("Download artifact")).toBeNull();
+  });
+
+  it("fits the initial edit image to the visible canvas area", async () => {
+    const user = userEvent.setup({ delay: null });
+    setupChatThread({
+      featureSwitches: { [FeatureSwitchKey.ImageEditing]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("artifact-sidebar-body-image")).toHaveAttribute(
+        "alt",
+        "source.png",
+      );
+    });
+
+    await user.click(screen.getByTestId("artifact-sidebar-edit-image"));
+    const canvas = await screen.findByTestId(
+      "artifact-sidebar-image-edit-canvas",
+    );
+    mockElementClientSize(canvas, { height: 300, width: 400 });
+
+    const image = screen.getByTestId("artifact-sidebar-body-image");
+    if (!(image instanceof HTMLImageElement)) {
+      throw new Error("Expected the edit canvas image to be an image element");
+    }
+    mockImageNaturalSize(image, { height: 900, width: 1200 });
+    fireEvent.load(image);
+
+    await waitFor(() => {
+      expect(image).toHaveStyle({ height: "252px", width: "336px" });
+    });
+  });
+
   it("hides the edit action when the feature switch is off", async () => {
     const user = userEvent.setup({ delay: null });
     setupChatThread({});
@@ -1343,6 +1401,7 @@ describe("image editing", () => {
         "source.png",
       );
     });
+    expect(screen.queryByTestId("artifact-sidebar-edit-image")).toBeNull();
 
     await user.click(screen.getByLabelText("Preview source.png"));
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -13,19 +13,18 @@ import {
   IconDots,
   IconEye,
   IconExternalLink,
+  IconFolderPlus,
   IconLoader2,
-  IconLink,
   IconMessageCircle,
   IconPalette,
-  IconPaperclip,
   IconPencil,
   IconPointer2,
-  IconPlus,
   IconSend2,
   IconShare,
   IconSparkles,
   IconTrash,
   IconUpload,
+  IconWand,
   IconZoomReset,
   IconX,
 } from "@tabler/icons-react";
@@ -97,8 +96,8 @@ import { lightboxDialogVisible$ } from "../../signals/zero-page/zero-attachment-
 import {
   artifactImageEditMode$,
   closeArtifactImageEdit$,
-  importEditableImageCanvasImageUrl$,
   imageEditUploading$,
+  openArtifactImageEdit$,
   type ImageEditRegionComment,
   type ImageEditRegion,
   runImageEdit$,
@@ -586,6 +585,7 @@ function ArtifactSidebarContent({
   const closeImageEditMode = useSet(closeArtifactImageEdit$);
   const markHtmlDomEditPending = useSet(markHtmlDomEditPending$);
   const openHtmlCommentMode = useSet(openArtifactHtmlEditMode$);
+  const openImageEditMode = useSet(openArtifactImageEdit$);
   const publishHtmlDomEditPreviewDraft = useSet(
     publishHtmlDomEditPreviewDraft$,
   );
@@ -631,6 +631,19 @@ function ArtifactSidebarContent({
   const imageEditEnabled = Boolean(features?.[FeatureSwitchKey.ImageEditing]);
   const imageEditActive =
     display.kind === "image" && requestedImageEditMode && imageEditEnabled;
+  const editImage =
+    display.kind === "image" && imageEditEnabled && !imageEditActive
+      ? () => {
+          resetZoomableImageCanvasZoom(
+            zoomableArtifactImageKey(
+              "artifact-sidebar",
+              display.url,
+              fullscreen ? "fullscreen" : "sidebar",
+            ),
+          );
+          openImageEditMode({ fullscreen, url: display.url });
+        }
+      : undefined;
 
   const htmlEditState = createHtmlEditState({
     applyPreview: applyHtmlDomEditPreview,
@@ -665,6 +678,7 @@ function ArtifactSidebarContent({
       imageEditActive={imageEditActive}
       imageNavigation={imageNavigation}
       onBack={onBack}
+      onEditImage={editImage}
       openHtmlCommentMode={openHtmlCommentMode}
       openPresentationEditor={openPresentationEditor}
       pageSignal={pageSignal}
@@ -690,6 +704,7 @@ function ArtifactSidebarResolvedContent({
   imageEditActive,
   imageNavigation,
   onBack,
+  onEditImage,
   openHtmlCommentMode,
   openPresentationEditor,
   pageSignal,
@@ -711,6 +726,7 @@ function ArtifactSidebarResolvedContent({
   readonly imageEditActive: boolean;
   readonly imageNavigation?: ArtifactImageNavigationActions;
   readonly onBack?: () => void;
+  readonly onEditImage?: () => void;
   readonly openHtmlCommentMode: () => void;
   readonly openPresentationEditor: (url: string) => void;
   readonly pageSignal: AbortSignal;
@@ -763,6 +779,7 @@ function ArtifactSidebarResolvedContent({
         fullscreen={fullscreen}
         htmlState={htmlHeaderState}
         imageEditActive={imageEditActive}
+        onEditImage={onEditImage}
         onEditPresentation={editPresentation}
         onEditHtml={editHtml}
         onExitHtmlEdit={exitHtmlEdit}
@@ -1159,6 +1176,7 @@ function ArtifactSidebarHeader({
   imageEditActive,
   onBack,
   onEditHtml,
+  onEditImage,
   onEditPresentation,
   onExitHtmlEdit,
   onExitImageEdit,
@@ -1176,6 +1194,7 @@ function ArtifactSidebarHeader({
   imageEditActive: boolean;
   onBack?: () => void;
   onEditHtml?: () => void;
+  onEditImage?: () => void;
   onEditPresentation?: () => void;
   onExitHtmlEdit?: () => void;
   onExitImageEdit?: () => void;
@@ -1217,6 +1236,7 @@ function ArtifactSidebarHeader({
         kind={kind}
         onClose={onClose}
         onEditHtml={onEditHtml}
+        onEditImage={onEditImage}
         onEditPresentation={onEditPresentation}
         onExitHtmlEdit={onExitHtmlEdit}
         onExitImageEdit={onExitImageEdit}
@@ -1238,6 +1258,7 @@ function ArtifactSidebarActions({
   kind,
   onClose,
   onEditHtml,
+  onEditImage,
   onEditPresentation,
   onExitHtmlEdit,
   onExitImageEdit,
@@ -1254,6 +1275,7 @@ function ArtifactSidebarActions({
   kind?: ArtifactKindForBody;
   onClose: () => void;
   onEditHtml?: () => void;
+  onEditImage?: () => void;
   onEditPresentation?: () => void;
   onExitHtmlEdit?: () => void;
   onExitImageEdit?: () => void;
@@ -1263,8 +1285,6 @@ function ArtifactSidebarActions({
   url?: string;
 }) {
   const features = useLastResolved(featureSwitch$);
-  const showPresentationEdit =
-    artifactKind === "presentation-html" && onEditPresentation !== undefined;
   const showHtmlControls =
     kind === "html" &&
     artifactKind === "hosted-site" &&
@@ -1280,26 +1300,15 @@ function ArtifactSidebarActions({
       {url && (
         <>
           {!hideArtifactActions && (
-            <>
-              {kind === "html" && <ArtifactOpenExternalAction url={url} />}
-              <ArtifactShareButton ariaLabel="Share artifact" url={url} />
-              <ArtifactDownloadMenu
-                ariaLabel="Download artifact"
-                artifactKind={artifactKind}
-                filename={title}
-                syncTarget={syncTarget}
-                url={url}
-              />
-              <ArtifactActionSeparator />
-              {showPresentationEdit && (
-                <>
-                  <ArtifactEditPresentationAction
-                    onClick={onEditPresentation}
-                  />
-                  <ArtifactActionSeparator />
-                </>
-              )}
-            </>
+            <ArtifactSidebarPreviewActions
+              artifactKind={artifactKind}
+              kind={kind}
+              onEditImage={onEditImage}
+              onEditPresentation={onEditPresentation}
+              syncTarget={syncTarget}
+              title={title}
+              url={url}
+            />
           )}
           {showHtmlControls && (
             <>
@@ -1327,6 +1336,55 @@ function ArtifactSidebarActions({
   );
 }
 
+function ArtifactSidebarPreviewActions({
+  artifactKind,
+  kind,
+  onEditImage,
+  onEditPresentation,
+  syncTarget,
+  title,
+  url,
+}: {
+  artifactKind?: ChatThreadArtifactFile["artifactKind"];
+  kind?: ArtifactKindForBody;
+  onEditImage?: () => void;
+  onEditPresentation?: () => void;
+  syncTarget?: ArtifactDownloadSyncTarget;
+  title: string;
+  url: string;
+}) {
+  const showPresentationEdit =
+    artifactKind === "presentation-html" && onEditPresentation !== undefined;
+  const showImageEdit = kind === "image" && onEditImage !== undefined;
+
+  return (
+    <>
+      {kind === "html" && <ArtifactOpenExternalAction url={url} />}
+      <ArtifactShareButton ariaLabel="Share artifact" url={url} />
+      <ArtifactDownloadMenu
+        ariaLabel="Download artifact"
+        artifactKind={artifactKind}
+        filename={title}
+        syncTarget={syncTarget}
+        url={url}
+      />
+      <ArtifactActionSeparator />
+      {showPresentationEdit && (
+        <>
+          <ArtifactEditPresentationAction onClick={onEditPresentation} />
+          <ArtifactActionSeparator />
+        </>
+      )}
+      {showImageEdit && (
+        <>
+          <ArtifactEditImageAction onClick={onEditImage} />
+          <ArtifactActionSeparator />
+        </>
+      )}
+    </>
+  );
+}
+
 function ArtifactEditPresentationAction({ onClick }: { onClick: () => void }) {
   return (
     <ArtifactActionTooltip label="Edit presentation">
@@ -1337,6 +1395,22 @@ function ArtifactEditPresentationAction({ onClick }: { onClick: () => void }) {
         className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
       >
         <IconPencil size={16} stroke={1.5} />
+      </button>
+    </ArtifactActionTooltip>
+  );
+}
+
+function ArtifactEditImageAction({ onClick }: { onClick: () => void }) {
+  return (
+    <ArtifactActionTooltip label="Edit image">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label="Edit image"
+        data-testid="artifact-sidebar-edit-image"
+        className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+      >
+        <IconWand size={16} stroke={1.5} />
       </button>
     </ArtifactActionTooltip>
   );
@@ -2631,26 +2705,32 @@ function ArtifactImageEditUploadFileControl({
 
   return (
     <>
-      <label
+      <button
+        type="button"
         className={cn(
-          "flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors",
+          "absolute left-4 top-4 z-10 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-background/95 text-muted-foreground shadow-sm backdrop-blur-sm transition-colors",
           disabled
             ? "cursor-not-allowed opacity-45"
             : "cursor-pointer hover:bg-muted hover:text-foreground",
         )}
-        htmlFor="image-edit-upload-input-control"
+        disabled={disabled}
         data-testid="image-edit-upload-local"
         aria-label="Upload from computer"
         title="Upload from computer"
+        onClick={(event) => {
+          const input = event.currentTarget.nextElementSibling;
+          if (input instanceof HTMLInputElement) {
+            input.click();
+          }
+        }}
       >
         {uploading ? (
           <IconLoader2 size={16} className="animate-spin" />
         ) : (
-          <IconPaperclip size={16} stroke={1.6} />
+          <IconFolderPlus size={17} stroke={1.8} />
         )}
-      </label>
+      </button>
       <input
-        id="image-edit-upload-input-control"
         type="file"
         accept={IMAGE_EDIT_UPLOAD_ACCEPT}
         multiple
@@ -2663,155 +2743,19 @@ function ArtifactImageEditUploadFileControl({
   );
 }
 
-function ArtifactImageEditUploadLinkForm({
-  disabled,
-  onSelectLink,
-}: {
-  disabled: boolean;
-  onSelectLink: (url: string) => void;
-}) {
-  const setSubmitVisible = (form: HTMLFormElement | null, visible: boolean) => {
-    const submit = form?.querySelector<HTMLButtonElement>(
-      '[data-testid="image-edit-upload-link-add"]',
-    );
-    if (submit) {
-      submit.hidden = !visible;
-    }
-  };
-  const handleLinkSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const form = event.currentTarget;
-    const data = new FormData(form);
-    const value = String(data.get("imageUrl") ?? "").trim();
-    if (!value) {
-      return;
-    }
-    if (!URL.canParse(value)) {
-      toast.error("Enter a valid image link");
-      return;
-    }
-    onSelectLink(new URL(value).toString());
-    form.reset();
-    setSubmitVisible(form, false);
-  };
-  const handleLinkInput = (event: FormEvent<HTMLInputElement>) => {
-    setSubmitVisible(
-      event.currentTarget.form,
-      event.currentTarget.value.trim().length > 0,
-    );
-  };
-
-  return (
-    <form
-      className="flex h-8 min-w-0 flex-1 items-center gap-1 border-l border-border/70 pl-2"
-      onSubmit={handleLinkSubmit}
-    >
-      <IconLink
-        size={15}
-        stroke={1.7}
-        className="shrink-0 text-muted-foreground"
-      />
-      <input
-        className="h-full min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-45"
-        name="imageUrl"
-        placeholder="Paste link"
-        type="url"
-        disabled={disabled}
-        data-testid="image-edit-upload-link-input"
-        onInput={handleLinkInput}
-      />
-      <Button
-        type="submit"
-        size="icon"
-        variant="ghost"
-        className="h-7 w-7 rounded-md p-0 text-muted-foreground hover:text-foreground"
-        disabled={disabled}
-        hidden
-        data-testid="image-edit-upload-link-add"
-        aria-label="Add image link"
-        title="Add image link"
-      >
-        <IconPlus size={16} stroke={1.8} />
-      </Button>
-    </form>
-  );
-}
-
-function ArtifactImageEditUploadMenu({
-  disabled,
-  onSelectFiles,
-  onSelectLink,
-  uploading,
-}: {
-  disabled: boolean;
-  onSelectFiles: (files: readonly File[]) => void;
-  onSelectLink: (url: string) => void;
-  uploading: boolean;
-}) {
-  return (
-    <Popover modal={false}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-12 w-12 rounded-none border-0 bg-transparent p-0 text-muted-foreground shadow-none hover:bg-muted hover:text-foreground disabled:text-muted-foreground/45"
-          disabled={disabled}
-          data-testid="image-edit-upload-menu"
-          aria-label="Upload image"
-          title="Upload image"
-        >
-          {uploading ? (
-            <IconLoader2 size={16} className="animate-spin" />
-          ) : (
-            <IconUpload size={16} stroke={1.8} />
-          )}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        side="top"
-        align="center"
-        sideOffset={8}
-        className="z-[10000] w-56 p-1 shadow-lg"
-        data-testid="image-edit-upload-popover"
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-        }}
-      >
-        <div className="flex items-center gap-1">
-          <ArtifactImageEditUploadFileControl
-            disabled={disabled}
-            onSelectFiles={onSelectFiles}
-            uploading={uploading}
-          />
-          <ArtifactImageEditUploadLinkForm
-            disabled={disabled}
-            onSelectLink={onSelectLink}
-          />
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-function ArtifactImageEditBottomControls({
+function ArtifactImageEditTopLeftControls({
   imageUploading,
   onUploadFiles,
-  onUploadLink,
 }: {
   imageUploading: boolean;
   onUploadFiles: (files: readonly File[]) => void;
-  onUploadLink: (src: string) => void;
 }) {
   return (
-    <div className="absolute bottom-4 left-1/2 z-10 flex w-max -translate-x-1/2 flex-row flex-nowrap items-center justify-center overflow-hidden rounded-full border border-border/70 bg-background/95 shadow-xl backdrop-blur">
-      <ArtifactImageEditUploadMenu
-        disabled={imageUploading}
-        onSelectFiles={onUploadFiles}
-        onSelectLink={onUploadLink}
-        uploading={imageUploading}
-      />
-    </div>
+    <ArtifactImageEditUploadFileControl
+      disabled={imageUploading}
+      onSelectFiles={onUploadFiles}
+      uploading={imageUploading}
+    />
   );
 }
 
@@ -2819,20 +2763,17 @@ function ArtifactImageEditCanvasChrome({
   controls,
   imageUploading,
   onUploadFiles,
-  onUploadLink,
 }: {
   controls: ZoomableImageControls;
   imageUploading: boolean;
   onUploadFiles: (files: readonly File[]) => void;
-  onUploadLink: (src: string) => void;
 }) {
   return (
     <>
       <ArtifactImageZoomControls controls={controls} />
-      <ArtifactImageEditBottomControls
+      <ArtifactImageEditTopLeftControls
         imageUploading={imageUploading}
         onUploadFiles={onUploadFiles}
-        onUploadLink={onUploadLink}
       />
     </>
   );
@@ -2943,7 +2884,6 @@ function useArtifactImageEditActions({
   const clearCanvasRegionSelection = useSet(
     clearEditableImageCanvasRegionSelection$,
   );
-  const importCanvasImageUrl = useSet(importEditableImageCanvasImageUrl$);
   const removeCanvasRegionComment = useSet(
     removeEditableImageCanvasRegionComment$,
   );
@@ -2999,13 +2939,6 @@ function useArtifactImageEditActions({
       "uploadEditableImageCanvasImage",
     );
   };
-  const onUploadLink = (src: string) => {
-    detach(
-      importCanvasImageUrl({ canvasKey, canvasSrc }, src, pageSignal),
-      Reason.DomCallback,
-      "importEditableImageCanvasImageUrl",
-    );
-  };
   const onRegionSelectionToggle = () => {
     if (regionSelectionActive) {
       clearCanvasRegionSelection(canvasKey);
@@ -3050,7 +2983,6 @@ function useArtifactImageEditActions({
     onRegionSelectionToggle,
     onSubmitRegionComments,
     onUploadFiles,
-    onUploadLink,
   };
 }
 
@@ -3151,7 +3083,6 @@ function ArtifactImageEditBody({
                   controls={controls}
                   imageUploading={imageUploading}
                   onUploadFiles={actions.onUploadFiles}
-                  onUploadLink={actions.onUploadLink}
                 />
               );
             }}

--- a/turbo/apps/platform/src/views/zero-page/zero-editable-image-canvas.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-editable-image-canvas.tsx
@@ -46,6 +46,7 @@ import type { ZoomableImageControls } from "./zero-zoomable-image-canvas.tsx";
 
 const IMAGE_ZOOM_STEP = 0.15;
 const MAX_INITIAL_IMAGE_EDGE = 900;
+const IMAGE_VIEWER_PADDING = 24;
 const SELECTED_IMAGE_OUTLINE_WIDTH = 4;
 const SELECTED_IMAGE_HALO_WIDTH = 3;
 const TOOLBAR_OFFSET = 12;
@@ -243,10 +244,26 @@ function nextImageSize(image: HTMLImageElement) {
     return null;
   }
 
-  const scale = Math.min(
-    1,
-    MAX_INITIAL_IMAGE_EDGE / Math.max(naturalWidth, naturalHeight),
+  const root = image.closest<HTMLElement>(
+    "[data-editable-image-canvas-root='true']",
   );
+  const availableWidth =
+    root && root.clientWidth > IMAGE_VIEWER_PADDING * 2
+      ? root.clientWidth - IMAGE_VIEWER_PADDING * 2
+      : 0;
+  const availableHeight =
+    root && root.clientHeight > IMAGE_VIEWER_PADDING * 2
+      ? root.clientHeight - IMAGE_VIEWER_PADDING * 2
+      : 0;
+  const widthScale = availableWidth > 0 ? availableWidth / naturalWidth : 1;
+  const heightScale = availableHeight > 0 ? availableHeight / naturalHeight : 1;
+  const fallbackScale =
+    MAX_INITIAL_IMAGE_EDGE / Math.max(naturalWidth, naturalHeight);
+  const scale =
+    availableWidth > 0 || availableHeight > 0
+      ? Math.min(1, widthScale, heightScale)
+      : Math.min(1, fallbackScale);
+
   return {
     displayHeight: Math.round(naturalHeight * scale),
     displayWidth: Math.round(naturalWidth * scale),


### PR DESCRIPTION
## Summary

- Move image edit upload to a top-left folder-plus local upload action and remove URL-based image import from edit mode.
- Add an image edit action to the split-view artifact header.
- Fit the initial edit canvas image to the visible canvas area so entering edit mode matches normal image viewing and avoids enlargement jumps.

## Test plan

- PASS `pnpm format`
- PASS `pnpm turbo run lint`
- PASS `pnpm check-types`
- PASS `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-image-edit.test.tsx`
- PASS `pnpm knip`
- BLOCKED `pnpm vitest`: local environment is missing an exported `DATABASE_URL`/running PostgreSQL; `scripts/prepare.sh` also failed when pnpm attempted a module purge in a non-TTY shell. The affected image edit test file passes independently.