### PR TITLE
fix: always allow cmd+enter on touch devices

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
@@ -76,7 +76,7 @@ describe("zero send key", () => {
     expect(textarea.textContent ?? "").toContain("Composing text");
   });
 
-  it("avoids accidental sends on touch devices", async () => {
+  it("keeps plain Enter as a newline but sends with modified Enter on touch devices", async () => {
     const user = userEvent.setup({ delay: null });
     context.mocks.browser.matchMedia((query) => {
       return query === "(pointer: coarse)";
@@ -84,10 +84,33 @@ describe("zero send key", () => {
     const touchTextarea = await openComposer("enter");
     await fill(touchTextarea, "Touch device draft");
     await user.keyboard("{Enter}");
-    await user.keyboard("{Control>}{Enter}{/Control}");
 
     expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
     expect(touchTextarea.textContent ?? "").toContain("Touch device draft");
+
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Touch device draft")).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+  });
+
+  it("avoids accidental modified sends during IME composition on touch devices", async () => {
+    context.mocks.browser.matchMedia((query) => {
+      return query === "(pointer: coarse)";
+    });
+    const textarea = await openComposer("enter");
+
+    await fill(textarea, "Composing on touch device");
+    fireEvent.keyDown(textarea, {
+      key: "Enter",
+      ctrlKey: true,
+      keyCode: 229,
+    });
+
+    expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+    expect(textarea.textContent ?? "").toContain("Composing on touch device");
   });
 
   it("sends with Enter on touch devices with a fine pointer", async () => {
@@ -102,6 +125,22 @@ describe("zero send key", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Send from Magic Keyboard")).toBeInTheDocument();
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+  });
+
+  it("always sends with modified Enter on touch devices with a fine pointer", async () => {
+    const user = userEvent.setup({ delay: null });
+    context.mocks.browser.matchMedia((query) => {
+      return query === "(pointer: coarse)" || query === "(any-pointer: fine)";
+    });
+    const keyboardTextarea = await openComposer("enter");
+
+    await fill(keyboardTextarea, "Send with modified Enter");
+    await user.keyboard("{Control>}{Enter}{/Control}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Send with modified Enter")).toBeInTheDocument();
       expect(screen.getByLabelText("Stop")).toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -7494,18 +7494,20 @@ export function ZeroChatComposer({
     sendModeLoadable.state === "hasData" ? sendModeLoadable.data : "enter";
 
   const handleKeyDown = (e: KeyboardEventLike) => {
+    const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
     const isTouchOnlyDevice =
-      window.matchMedia("(pointer: coarse)").matches &&
-      !window.matchMedia("(any-pointer: fine)").matches;
-    if (isTouchOnlyDevice) {
-      return;
-    }
+      isTouchDevice && !window.matchMedia("(any-pointer: fine)").matches;
     const send = () => {
       handleSend();
     };
+    if (isTouchOnlyDevice) {
+      processShortcut({ "mod+enter": send }, e);
+      return;
+    }
     processShortcut(
       {
         ...(sendMode === "enter" ? { enter: send } : { "mod+enter": send }),
+        ...(isTouchDevice && sendMode === "enter" ? { "mod+enter": send } : {}),
         escape: () => {
           (e.target as HTMLElement).blur();
         },


### PR DESCRIPTION
## Summary

- keep plain Enter as a newline on touch-only devices to preserve the mobile accidental-send safeguard
- always allow Cmd/Ctrl+Enter to send on coarse-pointer devices, including devices that also report a fine pointer and users configured for Enter-to-send
- route the fallback through the shared shortcut processor so IME composition events remain protected

## Verification

- `pnpm --filter @vm0/app exec vitest run src/views/zero-page/__tests__/zero-send-key.test.tsx` (8 tests passed)
- `pnpm --filter @vm0/app check-types`
- Prettier and Knip pre-commit checks passed; the complete repository pipeline is delegated to CI
