### PR TITLE
fix: align typescript tests across local and ci

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -739,9 +739,9 @@ jobs:
       - name: Test Other Packages
         working-directory: turbo
         run: pnpm vitest run --project=@vm0/core --project=@vm0/ui --project=@vm0/firewalls-generator --project=@vm0/api-contracts --project=@vm0/db --coverage.enabled --coverage.reporter=json
-      - name: Test Connectors Firewall Contracts
+      - name: Test Connectors
         working-directory: turbo
-        run: pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-semantics-contract.test.ts src/__tests__/firewall-base-url-validation-contract.test.ts --reporter=default
+        run: pnpm -F @vm0/connectors exec vitest run --reporter=default
       - name: Upload coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ For detailed patterns and examples, use `/testing`.
 - **Lint:** `cd turbo && pnpm turbo run lint` - Check for code style and quality issues
 - **Type Check:** `cd turbo && pnpm check-types` - Verify TypeScript type safety
 - **Format:** `cd turbo && pnpm format` - Auto-format code according to project standards
-- **Test:** `cd turbo && pnpm vitest` - Run all tests to ensure functionality
+- **Test:** `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` - Run all tests without overloading local workers
 - **Knip:** `cd turbo && pnpm knip` - Find and fix unused dependencies, exports, and files
 
 ### Before Committing:
@@ -193,6 +193,11 @@ For detailed patterns and examples, use `/testing`.
    pnpm -F @vm0/app exec vitest
    ```
    Replace `@vm0/app` with the workspace name relevant to your changes (e.g. `@vm0/cli`, `@vm0/api`).
+3. **Limit full-suite worker concurrency** - When an all-workspace run is necessary, cap file workers to avoid resource-contention timeouts:
+   ```
+   pnpm vitest run --maxWorkers=4 --silent=passed-only
+   ```
+   Do not increase test timeouts to compensate for excessive local concurrency.
 
 ### CRITICAL: Never run checks in background
 **All pre-commit checks (lint, format, typecheck, test, knip) MUST run in the foreground.** Never use `run_in_background` for these commands. The results must be available immediately so the commit can proceed — background execution defeats this purpose.

--- a/turbo/apps/api/src/lib/time.ts
+++ b/turbo/apps/api/src/lib/time.ts
@@ -16,6 +16,12 @@ export function nowDate(): Date {
   return new Date(now());
 }
 
+export function timestampWithoutTimeZone(value: Date): string {
+  // Raw SQL Date params compare as timestamptz; project timestamp columns store
+  // UTC wall-clock values without timezone metadata.
+  return value.toISOString().replace("T", " ").replace("Z", "");
+}
+
 export function mockNow(value: Date | number): void {
   setMockedNow(value instanceof Date ? value.getTime() : value);
 }

--- a/turbo/apps/api/src/signals/external/time.ts
+++ b/turbo/apps/api/src/signals/external/time.ts
@@ -1,1 +1,1 @@
-export { now, nowDate } from "../../lib/time";
+export { now, nowDate, timestampWithoutTimeZone } from "../../lib/time";

--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { cronArtifactPreviewContract } from "@vm0/api-contracts/contracts/cron";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
@@ -79,10 +79,16 @@ function mockCloudflareScreenshot(): ScreenshotRequest[] {
   return requests;
 }
 
-function mockCloudflareVideoFrame(status = 200): MediaFrameRequest[] {
+function mockCloudflareVideoFrame(
+  userId: string,
+  status = 200,
+): MediaFrameRequest[] {
   const requests: MediaFrameRequest[] = [];
   server.use(
     http.get(CLOUDFLARE_MEDIA_FRAME_URL, ({ request }) => {
+      if (!request.url.includes(`/artifacts/${userId}/`)) {
+        return new HttpResponse("foreign test artifact", { status: 415 });
+      }
       requests.push({ url: request.url });
       if (status !== 200) {
         return new HttpResponse("unsupported video", { status });
@@ -456,7 +462,7 @@ describe("GET /api/cron/artifact-preview", () => {
     }
     mockEnv("CRON_SECRET", CRON_SECRET);
     mockEnv("CLOUDFLARE_BROWSER_RENDERING_API_TOKEN", undefined);
-    const frameRequests = mockCloudflareVideoFrame();
+    const frameRequests = mockCloudflareVideoFrame(owner.actor.userId);
 
     const videoArtifact = await createRunUploadedFile({
       owner,
@@ -536,7 +542,7 @@ describe("GET /api/cron/artifact-preview", () => {
       );
     }
     mockEnv("CRON_SECRET", CRON_SECRET);
-    const frameRequests = mockCloudflareVideoFrame();
+    const frameRequests = mockCloudflareVideoFrame(owner.actor.userId);
 
     const videoArtifact = await createRunUploadedFile({
       owner,
@@ -587,7 +593,7 @@ describe("GET /api/cron/artifact-preview", () => {
       );
     }
     mockEnv("CRON_SECRET", CRON_SECRET);
-    const frameRequests = mockCloudflareVideoFrame(415);
+    const frameRequests = mockCloudflareVideoFrame(owner.actor.userId, 415);
 
     const videoArtifact = await createRunUploadedFile({
       owner,
@@ -609,6 +615,15 @@ describe("GET /api/cron/artifact-preview", () => {
         [FeatureSwitchKey.ArtifactVideoPreview]: true,
       },
     );
+    onTestFinished(async () => {
+      await updateFeatureSwitchesForUser(
+        context,
+        featureSwitchActor(owner.actor),
+        {
+          [FeatureSwitchKey.ArtifactVideoPreview]: false,
+        },
+      );
+    });
 
     const generated = await accept(
       cronClient().generate({ headers: cronHeaders() }),

--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -21,7 +21,7 @@ import {
   type ModelProviderType,
 } from "@vm0/api-contracts/contracts/model-providers";
 import { zeroModelProvidersMainContract } from "@vm0/api-contracts/contracts/zero-model-providers";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { z } from "zod";
 
 import { createApp } from "../../../app-factory";
@@ -47,6 +47,7 @@ import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import { overwriteModelProviderSecretForTests } from "./helpers/zero-model-provider-state";
 import {
   deleteBddVm0ApiKeys,
+  hasVm0ApiKeyLabel,
   replaceBddVm0ApiKeys,
 } from "../../../test-fixtures/chat-messages";
 
@@ -1944,6 +1945,14 @@ describe("CHAT-02: model-first provider policies", () => {
     const keySuffix = randomUUID();
     const fakeKey = `vm0-key-bdd-fake-${keySuffix}`;
     const devSeedKey = `vm0-key-bdd-dev-seed-${keySuffix}`;
+    let runId: string | null = null;
+
+    onTestFinished(async () => {
+      await Promise.all([
+        deleteBddVm0ApiKeys({ vendor: "zai", model: "glm-5.2" }),
+        ...(runId ? [api.requestCancelRun(actor, runId, [200])] : []),
+      ]);
+    });
 
     await replaceBddVm0ApiKeys({
       vendor: "zai",
@@ -1975,6 +1984,7 @@ describe("CHAT-02: model-first provider policies", () => {
       prompt: "run with the selected vm0 provider",
       model: "glm-5.2",
     });
+    runId = run.runId;
 
     const { claim, sandboxHeaders } = await claimChatRun(
       runnerGroup,
@@ -2005,13 +2015,18 @@ describe("CHAT-02: model-first provider policies", () => {
     if (resolved.status !== 200) {
       throw new Error("Expected vm0 firewall auth to resolve");
     }
-    expect(resolved.body.headers.Authorization).toBe(`Bearer ${devSeedKey}`);
-
-    await api.requestCancelRun(actor, run.runId, [200]);
-    await deleteBddVm0ApiKeys({
-      vendor: "zai",
-      model: "glm-5.2",
-    });
+    const authorization = resolved.body.headers.Authorization;
+    if (!authorization?.startsWith("Bearer ")) {
+      throw new Error("Expected vm0 firewall auth to return a bearer token");
+    }
+    await expect(
+      hasVm0ApiKeyLabel({
+        vendor: "zai",
+        model: "glm-5.2",
+        apiKey: authorization.slice("Bearer ".length),
+        label: "dev-seed",
+      }),
+    ).resolves.toBeTruthy();
   }, 90_000);
   it("rejects legacy blank OpenRouter provider secrets during firewall auth", async () => {
     const fw = createFirewallApi(context);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -31,7 +31,11 @@ import {
   seedLexicalRelationshipMemory,
   seedMemoryDocumentChunk,
 } from "../../../test-fixtures/relationship-memory";
-import { seedOrgMetadata } from "../../../test-fixtures/system-config-seeds";
+import {
+  deleteUsagePricingRows,
+  seedOrgMetadata,
+  seedUsagePricingRows,
+} from "../../../test-fixtures/system-config-seeds";
 import {
   createBddApi,
   expectApiError,
@@ -7368,6 +7372,24 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
     expect(beforeUsage.body.period).not.toBeNull();
     expect(beforeUsage.body.members).toStrictEqual([]);
 
+    const imageProvider = `bdd-member-usage-${randomUUID()}`;
+    onTestFinished(async () => {
+      await deleteUsagePricingRows({
+        kind: "image",
+        provider: imageProvider,
+        categories: ["output_image.low.standard"],
+      });
+    });
+    await seedUsagePricingRows([
+      {
+        kind: "image",
+        provider: imageProvider,
+        category: "output_image.low.standard",
+        unitPrice: 7,
+        unitSize: 1,
+      },
+    ]);
+
     const member = bdd.user({ orgId: actor.orgId });
     const memberAgent = await bdd.createAgent(member, {
       displayName: "BDD member usage agent",
@@ -7396,7 +7418,7 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
           {
             idempotencyKey: randomUUID(),
             kind: "image",
-            provider: "gpt-image-2",
+            provider: imageProvider,
             category: "output_image.low.standard",
             quantity: 1,
           },
@@ -7412,7 +7434,7 @@ describe("BILL-02: usage reads for an entitled organization with runs", () => {
           {
             idempotencyKey: randomUUID(),
             kind: "image",
-            provider: "gpt-image-2",
+            provider: imageProvider,
             category: "output_image.low.standard",
             quantity: 2,
           },

--- a/turbo/apps/api/src/signals/routes/__tests__/system-storage-presigned-url-cache.suite.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/system-storage-presigned-url-cache.suite.ts
@@ -11,14 +11,14 @@ import {
   SYSTEM_ORG_ID,
   VOLUME_ORG_USER_ID,
 } from "@vm0/core/storage-names";
-import { SEED_SKILLS } from "@vm0/core/zero-seed-skills";
+import { GOAL_SKILL_NAME } from "@vm0/core/zero-seed-skills";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { createAppWithRoutes } from "../../../app-factory-core";
 import { setupAppWithRoutes } from "../../../__tests__/test-app";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
-import { nowDate } from "../../../lib/time";
+import { mockNow, nowDate } from "../../../lib/time";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { testSystemStoragePresignedUrlCacheStateRoutes } from "../test-system-storage-presigned-url-cache-state";
@@ -27,6 +27,7 @@ import { cronRefreshStoragePresignedUrlsRoutes } from "../cron-refresh-storage-p
 const context = testContext();
 const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storages";
+const ISOLATED_CACHE_CRON_NOW = Date.parse("2000-01-01T00:00:00.000Z");
 
 interface CacheRow {
   readonly cache_key: string;
@@ -267,12 +268,11 @@ function mockUniquePresignedUrls(): void {
   );
 }
 
-function firstSeedSkillStorage() {
-  const skillName = SEED_SKILLS[0];
-  if (!skillName) {
-    throw new Error("Expected at least one seed skill");
-  }
-  const skillRef = resolveSkillRef(skillName);
+function isolatedSystemSkillStorage() {
+  // Goal is mounted on every Zero run but is not rewritten by the
+  // cron-sync-skills test fixture, so its system storage head is stable while
+  // this suite exercises the cache.
+  const skillRef = resolveSkillRef(GOAL_SKILL_NAME);
   const fullPath = skillRef.replace("https://github.com/", "");
   const storageName = getSkillStorageName(fullPath);
   const versionId = randomUUID()
@@ -281,7 +281,7 @@ function firstSeedSkillStorage() {
     .slice(0, 64);
   const s3Prefix = `${SYSTEM_ORG_ID}/volume/${storageName}`;
   const s3Key = `${s3Prefix}/${versionId}`;
-  return { skillName, storageName, versionId, s3Prefix, s3Key };
+  return { storageName, versionId, s3Prefix, s3Key };
 }
 
 function cronClient() {
@@ -306,7 +306,7 @@ describe("system storage presigned URL cache", () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     mockUniquePresignedUrls();
-    const skill = firstSeedSkillStorage();
+    const skill = isolatedSystemSkillStorage();
     await withCacheCleanup(
       {
         objectKeyPrefix: skill.s3Prefix,
@@ -341,9 +341,8 @@ describe("system storage presigned URL cache", () => {
                 return storage.vasStorageName === skill.storageName;
               },
             );
-            expect(firstSkillEntry?.archiveUrl).toContain(skill.versionId);
 
-            // The dev-seeded skill storage is shared platform state, so
+            // The system skill storage is shared platform state, so
             // concurrently running files' claims may hold cache rows under
             // the same prefix — assert this claim's row exists rather than
             // an exact global row count.
@@ -352,7 +351,11 @@ describe("system storage presigned URL cache", () => {
             );
             expect(
               rowsAfterFirst.some((row) => {
-                return row.presigned_url === firstSkillEntry?.archiveUrl;
+                return (
+                  row.presigned_url === firstSkillEntry?.archiveUrl &&
+                  row.storage_version_id === skill.versionId &&
+                  row.object_key.includes(skill.versionId)
+                );
               }),
             ).toBeTruthy();
 
@@ -381,6 +384,7 @@ describe("system storage presigned URL cache", () => {
   });
 
   it("refreshes only a bounded due cache batch from cron", async () => {
+    mockNow(ISOLATED_CACHE_CRON_NOW);
     const prefix = `${SYSTEM_ORG_ID}/volume/cache-cron-${randomUUID()}`;
     await withCacheCleanup(
       {
@@ -443,6 +447,7 @@ describe("system storage presigned URL cache", () => {
   });
 
   it("skips inactive due cache rows in cron", async () => {
+    mockNow(ISOLATED_CACHE_CRON_NOW);
     const prefix = `${SYSTEM_ORG_ID}/volume/cache-inactive-${randomUUID()}`;
     await withCacheCleanup(
       {
@@ -514,6 +519,7 @@ describe("system storage presigned URL cache", () => {
   });
 
   it("prunes inactive expired cache rows from cron", async () => {
+    mockNow(ISOLATED_CACHE_CRON_NOW);
     const prefix = `${SYSTEM_ORG_ID}/volume/cache-prune-${randomUUID()}`;
     await withCacheCleanup(
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
@@ -536,27 +536,28 @@ describe("workflow skill storage presigned URL cache", () => {
         },
       });
 
-      // A second tick refreshes the two active rows left by the bounded first
-      // batch. The inactive fresh row is never touched.
-      await expect
-        .poll(async () => {
-          await accept(cronClient().refresh({ headers: cronHeaders() }), [200]);
-          const rows = await readCacheRowsByObjectKeyPrefix(prefix);
-          return {
-            total: rows.length,
-            refreshed: rows.filter((row) => {
-              return row.presigned_url.includes("?sig=");
-            }).length,
-            inactiveFreshUrl: rows.find((row) => {
-              return row.storage_version_id === inactiveFreshVersionId;
-            })?.presigned_url,
-          };
-        })
-        .toStrictEqual({
-          total: 6,
-          refreshed: 5,
-          inactiveFreshUrl: "https://r2.example.com/inactive-fresh-old",
-        });
+      const secondTick = await accept(
+        cronClient().refresh({ headers: cronHeaders() }),
+        [200],
+      );
+      expect(secondTick.body.workflowSkill).toStrictEqual({
+        due: 2,
+        refreshed: 2,
+        pruned: 0,
+      });
+
+      const rows = await readCacheRowsByObjectKeyPrefix(prefix);
+      expect(rows).toHaveLength(6);
+      expect(
+        rows.filter((row) => {
+          return row.presigned_url.includes("?sig=");
+        }),
+      ).toHaveLength(5);
+      expect(
+        rows.find((row) => {
+          return row.storage_version_id === inactiveFreshVersionId;
+        })?.presigned_url,
+      ).toBe("https://r2.example.com/inactive-fresh-old");
     });
   });
 });

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
@@ -12,7 +12,7 @@ import { createAppWithRoutes } from "../../../app-factory-core";
 import { setupAppWithRoutes } from "../../../__tests__/test-app";
 import { accept, testContext } from "../../../__tests__/test-context";
 import { mockEnv } from "../../../lib/env";
-import { nowDate } from "../../../lib/time";
+import { mockNow, nowDate } from "../../../lib/time";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
@@ -23,6 +23,7 @@ const context = testContext();
 const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storages";
 const WORKFLOW_CACHE_TTL_SECONDS = 2 * 60 * 60;
+const ISOLATED_CACHE_CRON_NOW = Date.parse("2000-01-02T00:00:00.000Z");
 
 interface CacheRow {
   readonly cache_key: string;
@@ -464,26 +465,9 @@ describe("workflow skill storage presigned URL cache", () => {
   });
 
   it("refreshes bounded active cache rows and prunes inactive expired rows from cron", async () => {
+    mockNow(ISOLATED_CACHE_CRON_NOW);
     const prefix = `org_${randomUUID()}/volume/workflow-cache-cron-${randomUUID()}`;
     await withCacheCleanup(prefix, async () => {
-      // The refresh cron sweeps the shared cache table with a bounded
-      // per-tick budget, oldest refresh_after first. Rows left behind by
-      // other tests and earlier runs mature into "due" over time and would
-      // starve this fixture's rows out of every tick, so first tick the cron
-      // until the global backlog is drained.
-      for (let tick = 0; tick < 120; tick += 1) {
-        const drainTick = await accept(
-          cronClient().refresh({ headers: cronHeaders() }),
-          [200],
-        );
-        if (
-          drainTick.body.workflowSkill.due === 0 &&
-          drainTick.body.workflowSkill.pruned === 0
-        ) {
-          break;
-        }
-      }
-
       const now = nowDate();
       const expiresAt = new Date(now.getTime() + 60 * 60 * 1000);
       const expiredAt = new Date(now.getTime() - 60 * 60 * 1000);
@@ -538,16 +522,22 @@ describe("workflow skill storage presigned URL cache", () => {
         cronClient().refresh({ headers: cronHeaders() }),
         [200],
       );
-      expect(firstTick.body.success).toBeTruthy();
-      // The per-tick refresh budget is bounded no matter how many rows are
-      // due — the counter is global, so this holds even when concurrently
-      // running files contribute due rows of their own.
-      expect(firstTick.body.workflowSkill.refreshed).toBeLessThanOrEqual(3);
+      expect(firstTick.body).toStrictEqual({
+        success: true,
+        system: expect.objectContaining({
+          due: expect.any(Number),
+          refreshed: expect.any(Number),
+          pruned: expect.any(Number),
+        }),
+        workflowSkill: {
+          due: 3,
+          refreshed: 3,
+          pruned: 2,
+        },
+      });
 
-      // Each tick's budget is shared with other files' due rows, so this
-      // fixture's rows converge over repeated ticks exactly as production
-      // does: active due rows get refreshed, inactive expired rows get
-      // pruned, and the inactive fresh row is never touched.
+      // A second tick refreshes the two active rows left by the bounded first
+      // batch. The inactive fresh row is never touched.
       await expect
         .poll(async () => {
           await accept(cronClient().refresh({ headers: cronHeaders() }), [200]);

--- a/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
+++ b/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
@@ -6,7 +6,7 @@ import { and, asc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 
 import type { Db } from "../external/db";
 import { generatePresignedGetUrl } from "../external/s3";
-import { nowDate } from "../external/time";
+import { nowDate, timestampWithoutTimeZone } from "../external/time";
 
 type ComputedGetter = <T>(computedValue: Computed<T>) => T;
 type StoragePresignedUrlCacheScope =
@@ -183,11 +183,6 @@ function activeCutoff(issuedAt: Date): Date {
     issuedAt.getTime() -
       SYSTEM_STORAGE_PRESIGNED_URL_ACTIVE_WINDOW_SECONDS * 1000,
   );
-}
-
-function timestampWithoutTimeZone(value: Date): string {
-  // Raw SQL Date params compare as timestamptz; these columns store UTC timestamp.
-  return value.toISOString().replace("T", " ").replace("Z", "");
 }
 
 function storagePresignedUrlCacheScope(

--- a/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
+++ b/turbo/apps/api/src/signals/services/webhooks-stripe.service.ts
@@ -13,7 +13,7 @@ import { and, eq, gt, isNull, lte, sql } from "drizzle-orm";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
-import { now, nowDate } from "../../lib/time";
+import { now, nowDate, timestampWithoutTimeZone } from "../../lib/time";
 import { clerk$ } from "../external/clerk";
 import { writeDb$, type Db } from "../external/db";
 import { getStripeClient } from "../external/stripe-client";
@@ -3102,7 +3102,7 @@ async function expireActiveUsageAllowanceWindows(
       return db
         .update(orgUsageAllowanceWindows)
         .set({
-          expiresAt: sql<Date>`GREATEST(${args.at}, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
+          expiresAt: sql<Date>`GREATEST(${timestampWithoutTimeZone(args.at)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
           updatedAt: args.updatedAt,
         })
         .where(

--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -140,6 +140,7 @@ type ArtifactListSqlRow = Record<string, unknown> & {
   readonly preview_image_url: string | null;
   readonly metadata: unknown;
   readonly created_at: Date | string;
+  readonly cursor_created_at: string;
   readonly thread_id: string;
   readonly thread_title: string | null;
   readonly agent_id: string;
@@ -1125,7 +1126,7 @@ export const zeroArtifacts$ = command(
     // DESC. Pushing it into scoped_artifacts (pre-dedup) would let an older row
     // of an already-emitted url slip past the cursor and re-surface as a dup.
     const keysetClause = cursor
-      ? sql`WHERE (created_at, row_id) < (${cursor.createdAt}::timestamptz, ${cursor.rowId}::uuid)`
+      ? sql`WHERE (deduped_artifacts.created_at, deduped_artifacts.row_id) < (${cursor.createdAt}::timestamptz AT TIME ZONE 'UTC', ${cursor.rowId}::uuid)`
       : sql``;
     const conditions = generatedArtifactVisibilityConditions(args);
 
@@ -1176,6 +1177,10 @@ export const zeroArtifacts$ = command(
       )
       SELECT
         deduped_artifacts.*,
+        to_char(
+          deduped_artifacts.created_at,
+          'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+        ) AS cursor_created_at,
         (${userArtifactFavorites.artifactUrl} IS NOT NULL) AS is_favorited
       FROM deduped_artifacts
       LEFT JOIN ${userArtifactFavorites}
@@ -1195,7 +1200,7 @@ export const zeroArtifacts$ = command(
     const nextCursor =
       hasMore && lastRow
         ? encodeArtifactCursor({
-            createdAt: artifactRowCreatedAt(lastRow).toISOString(),
+            createdAt: lastRow.cursor_created_at,
             rowId: lastRow.row_id,
           })
         : null;

--- a/turbo/apps/api/src/test-fixtures/chat-messages.ts
+++ b/turbo/apps/api/src/test-fixtures/chat-messages.ts
@@ -80,3 +80,29 @@ export async function deleteBddVm0ApiKeys(args: {
     .delete(vm0ApiKeys)
     .where(bddVm0ApiKeyFilter(args.vendor, args.model));
 }
+
+/**
+ * Checks the operator-managed label for a key returned through a public test
+ * entry point. The key pool has no product read surface, and local dev seeds
+ * may contain additional valid keys for the same vendor and model.
+ */
+export async function hasVm0ApiKeyLabel(args: {
+  readonly vendor: string;
+  readonly model: string;
+  readonly apiKey: string;
+  readonly label: string;
+}): Promise<boolean> {
+  const rows = await db()
+    .select({ id: vm0ApiKeys.id })
+    .from(vm0ApiKeys)
+    .where(
+      and(
+        eq(vm0ApiKeys.vendor, args.vendor),
+        eq(vm0ApiKeys.model, args.model),
+        eq(vm0ApiKeys.apiKey, args.apiKey),
+        eq(vm0ApiKeys.label, args.label),
+      ),
+    )
+    .limit(1);
+  return rows.length === 1;
+}

--- a/turbo/apps/api/src/test-fixtures/usage-allowance.ts
+++ b/turbo/apps/api/src/test-fixtures/usage-allowance.ts
@@ -18,6 +18,7 @@ import {
 import { createStore } from "ccstate";
 import { and, eq, gt, lte, sql } from "drizzle-orm";
 
+import { timestampWithoutTimeZone } from "../lib/time";
 import { writeDb$ } from "../signals/external/db";
 
 interface UsageAllowanceEntitlementFixtureState {
@@ -131,7 +132,7 @@ export async function cancelUsageAllowanceEntitlementFixture(values: {
   await db
     .update(orgUsageAllowanceWindows)
     .set({
-      expiresAt: sql<Date>`GREATEST(${values.canceledAt}, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
+      expiresAt: sql<Date>`GREATEST(${timestampWithoutTimeZone(values.canceledAt)}::timestamp, ${orgUsageAllowanceWindows.startsAt} + INTERVAL '1 millisecond')`,
       updatedAt: values.canceledAt,
     })
     .where(

--- a/turbo/apps/api/vitest.config.ts
+++ b/turbo/apps/api/vitest.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    env: {
+      TZ: "UTC",
+    },
     setupFiles: ["./src/__tests__/env-stub.ts", "./src/__tests__/setup.ts"],
     exclude: ["node_modules/**", "dist/**", "**/__benches__/**"],
     benchmark: {

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
@@ -572,11 +572,10 @@ describe("known endpoint-scoped firewall bases", () => {
 
     expect(bases).toContain("https://api.xero.com/Connections");
     expect(bases).not.toContain("https://api.xero.com");
-    expect(connectionsApi?.permissions).toEqual([
-      {
-        name: "connections",
-        rules: ["GET /", "DELETE /{id}"],
-      },
-    ]);
+    expect(connectionsApi?.permissions).toHaveLength(1);
+    expect(connectionsApi?.permissions?.[0]).toMatchObject({
+      name: "connections",
+      rules: ["GET /", "DELETE /{id}"],
+    });
   });
 });

--- a/turbo/vitest.config.ts
+++ b/turbo/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   test: {
     globals: true,
     passWithNoTests: true,
+    env: {
+      TZ: "UTC",
+    },
 
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- run the complete connectors test suite in CI instead of two selected contract files
- standardize Vitest on UTC and make timestamp-without-time-zone SQL and artifact cursors explicit and deployment-compatible
- isolate database-backed tests from persistent development seeds and cross-file state without changing their behavioral purpose
- keep pricing assertions independent of operator-managed prices and clean up test-owned state
- document a validated four-worker limit for local all-workspace Vitest runs and make cache cron batching deterministic

## Scope

- does not set `TZ` in the GitHub Actions workflow
- does not configure Vitest worker counts or increase test timeouts
- does not use production or operator-managed pricing as a test expectation

## Validation

- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (all non-API projects passed before the interactive run was interrupted)
- `pnpm vitest run --project=api --maxWorkers=4 --silent=passed-only` (154 files, 2,036 tests)
- `pnpm -F @vm0/connectors exec vitest run --reporter=default --silent=passed-only` (58 files, 1,160 tests)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts src/signals/routes/__tests__/storage-presigned-url-cache.test.ts --maxWorkers=4 --silent=passed-only` (2 files, 100 tests after rebasing)
- focused artifact pagination, chat message, and usage allowance API integration tests
- `pnpm -F api lint`
- `pnpm -F api check-types`

## CI

All required Turbo, security, CodeQL, unit/integration, deploy, and CLI E2E checks pass after rebasing onto `main`.
