### PR TITLE
fix: improve template picker previews

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -594,13 +594,7 @@ async function openTemplatePicker(
   await waitFor(() => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
-
-  await fill(screen.getByLabelText("Search templates"), "no matching deck");
-  await waitFor(() => {
-    expect(screen.getByText("No matches")).toBeInTheDocument();
-  });
-
-  await fill(screen.getByLabelText("Search templates"), template.title);
+  expect(screen.queryByLabelText("Search connectors")).toBeNull();
   await waitFor(() => {
     expect(screen.getByText(template.title)).toBeInTheDocument();
   });
@@ -2598,7 +2592,6 @@ describe("chat composer templates", () => {
           return screen.getByLabelText("Template");
         }),
       );
-      await fill(screen.getByLabelText("Search templates"), template.title);
       expect(
         screen.queryByLabelText(`View template ${template.title}`),
       ).not.toBeInTheDocument();
@@ -2653,10 +2646,6 @@ describe("chat composer templates", () => {
         createObjectUrlCountBeforeLeave,
       );
 
-      await fill(
-        screen.getByLabelText("Search templates"),
-        prismTemplate.title,
-      );
       const currentPrismPreviewFrame = () => {
         return screen.getByTestId(`${prismTemplate.title} card HTML preview`);
       };
@@ -2773,7 +2762,6 @@ describe("chat composer templates", () => {
         return screen.getByLabelText("Template");
       }),
     );
-    await fill(screen.getByLabelText("Search templates"), template.title);
     const preview = screen.getByLabelText(
       `Preview ${template.title} at current slide`,
     ).parentElement;
@@ -2865,7 +2853,6 @@ describe("chat composer templates", () => {
         return screen.getByLabelText("Template");
       }),
     );
-    await fill(screen.getByLabelText("Search templates"), template.title);
     expect(
       screen.queryByLabelText(`Change theme for ${template.title}`),
     ).not.toBeInTheDocument();
@@ -2970,7 +2957,6 @@ describe("chat composer templates", () => {
         return screen.getByLabelText("Template");
       }),
     );
-    await fill(screen.getByLabelText("Search templates"), template.title);
     expect(
       screen.queryByLabelText(`Change theme for ${template.title}`),
     ).not.toBeInTheDocument();
@@ -3059,7 +3045,6 @@ describe("chat composer templates", () => {
         return screen.getByLabelText("Template");
       }),
     );
-    await fill(screen.getByLabelText("Search templates"), template.title);
 
     const preview = screen.getByLabelText(
       `Preview ${template.title} at current slide`,
@@ -3224,7 +3209,6 @@ describe("chat composer templates", () => {
           return screen.getByLabelText("Template");
         }),
       );
-      await fill(screen.getByLabelText("Search templates"), template.title);
       click(
         screen.getByLabelText(`Preview ${template.title} at current slide`),
       );
@@ -3342,7 +3326,6 @@ describe("chat composer templates", () => {
         return screen.getByLabelText("Template");
       }),
     );
-    await fill(screen.getByLabelText("Search templates"), template.title);
     click(screen.getByLabelText(`Preview ${template.title} at current slide`));
 
     const templateDialog = screen.getByRole("dialog");
@@ -3607,12 +3590,7 @@ describe("chat composer templates", () => {
       expect(screen.getByAltText(heroAlt)).toHaveAttribute("src", heroSrc(0));
     });
 
-    await fill(screen.getByLabelText("Search templates"), "no matching style");
-    await waitFor(() => {
-      expect(screen.getByText("No matches")).toBeInTheDocument();
-    });
-
-    await fill(screen.getByLabelText("Search templates"), "ink");
+    expect(screen.queryByLabelText("Search connectors")).toBeNull();
     click(
       screen.getByLabelText(`Select template ${illustrationTemplate.title}`),
     );
@@ -4164,12 +4142,7 @@ describe("chat composer templates", () => {
       ).toBeInTheDocument();
     });
 
-    await fill(screen.getByLabelText("Search templates"), "no matching style");
-    await waitFor(() => {
-      expect(screen.getByText("No matches")).toBeInTheDocument();
-    });
-
-    await fill(screen.getByLabelText("Search templates"), "luxury");
+    expect(screen.queryByLabelText("Search connectors")).toBeNull();
     click(screen.getByLabelText(`Select video template ${videoStyle.title}`));
 
     await waitFor(() => {
@@ -4229,12 +4202,16 @@ describe("chat composer templates", () => {
       ).toBeInTheDocument();
     });
 
-    await fill(screen.getByLabelText("Search templates"), "no workflow match");
+    expect(screen.getByLabelText("Search connectors")).toHaveAttribute(
+      "placeholder",
+      "Search connector...",
+    );
+    await fill(screen.getByLabelText("Search connectors"), "no workflow match");
     await waitFor(() => {
       expect(screen.getByText("No matches")).toBeInTheDocument();
     });
 
-    await fill(screen.getByLabelText("Search templates"), "auto-inbox");
+    await fill(screen.getByLabelText("Search connectors"), "auto-inbox");
     click(
       screen.getByLabelText(
         `Select workflow template ${workflowTemplate.title}`,
@@ -4255,9 +4232,7 @@ describe("chat composer templates", () => {
     });
 
     const editor = await findComposerEditor();
-    await user.click(editor);
-    await user.keyboard("Create this inbox workflow");
-    await user.keyboard("{Enter}");
+    await sendMessageInUI(user, editor, "Create this inbox workflow");
 
     await waitFor(() => {
       expect(submittedTemplate).toStrictEqual({
@@ -4279,6 +4254,10 @@ describe("chat composer templates", () => {
   it("selects and sends a website template behind the feature switch", async () => {
     const user = userEvent.setup({ delay: null });
     const websiteTemplate = WEBSITE_TEMPLATE_ITEMS[0]!;
+    const websiteTemplatePreviewImageUrl = r2ImageTransformUrl(
+      websiteTemplate.previewImageUrl,
+      { width: 480, height: 270 },
+    );
     let submittedTemplate: GenerationTemplateRequest | undefined;
     mockChatLifecycle(context, {
       threadId: THREAD_ID,
@@ -4311,7 +4290,7 @@ describe("chat composer templates", () => {
       ).toBeInTheDocument();
       expect(
         screen.getByTitle(`${websiteTemplate.title} website template preview`),
-      ).toHaveAttribute("src", websiteTemplate.previewImageUrl);
+      ).toHaveAttribute("src", websiteTemplatePreviewImageUrl);
       expect(
         screen.getByTitle(`${websiteTemplate.title} website template preview`)
           .tagName,
@@ -4320,16 +4299,7 @@ describe("chat composer templates", () => {
       expect(screen.queryByText(websiteTemplate.resourceId)).toBeNull();
       expect(screen.queryByText("Saas Landing")).not.toBeInTheDocument();
     });
-
-    await fill(screen.getByLabelText("Search templates"), "no website match");
-    await waitFor(() => {
-      expect(screen.getByText("No matches")).toBeInTheDocument();
-    });
-
-    await fill(
-      screen.getByLabelText("Search templates"),
-      websiteTemplate.title,
-    );
+    expect(screen.queryByLabelText("Search connectors")).toBeNull();
     click(
       screen.getByLabelText(`Select website template ${websiteTemplate.title}`),
     );
@@ -4356,7 +4326,7 @@ describe("chat composer templates", () => {
       expect(tabByText("Website")).toHaveAttribute("aria-selected", "true");
       expect(
         screen.getByTitle(`${websiteTemplate.title} website template preview`),
-      ).toHaveAttribute("src", websiteTemplate.previewImageUrl);
+      ).toHaveAttribute("src", websiteTemplatePreviewImageUrl);
       expect(
         screen.getByTitle(`${websiteTemplate.title} website template preview`)
           .tagName,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -5018,7 +5018,9 @@ function TemplatePickerDialog({
               <div
                 className={cn(
                   "pb-3 pt-2 sm:w-64",
-                  selectedCategory === "workflow" ? "w-full" : "hidden sm:block",
+                  selectedCategory === "workflow"
+                    ? "w-full"
+                    : "hidden sm:block",
                 )}
               >
                 {selectedCategory === "workflow" ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1010,42 +1010,6 @@ function selectedIllustrationTemplateItem(
   });
 }
 
-function formatPresentationRunbookKind(templateId: string): string {
-  const label = templateId
-    .replace(/^template:/, "")
-    .replace(/^html-ppt-/, "")
-    .replace(/-/g, " ");
-  return label.charAt(0).toUpperCase() + label.slice(1);
-}
-
-function presentationTemplateMatchesSearch(
-  item: PresentationTemplateItem,
-  query: string,
-): boolean {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return true;
-  }
-  const searchable = [
-    item.title,
-    item.templateId,
-    formatPresentationRunbookKind(item.templateId),
-  ].join(" ");
-  return searchable.toLowerCase().includes(normalizedQuery);
-}
-
-function illustrationTemplateMatchesSearch(
-  item: IllustrationTemplateItem,
-  query: string,
-): boolean {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return true;
-  }
-  const searchable = [item.title, item.illustrationStyleId].join(" ");
-  return searchable.toLowerCase().includes(normalizedQuery);
-}
-
 function isSelectedVideoTemplate(
   item: VideoTemplateItem,
   value: GenerationTemplateRequest | undefined,
@@ -1072,24 +1036,6 @@ function selectedVideoTemplateItem(
     return undefined;
   }
   return findVideoTemplateItem(value.selection.stylePresetId);
-}
-
-function videoTemplateMatchesSearch(
-  item: VideoTemplateItem,
-  query: string,
-): boolean {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return true;
-  }
-  const searchable = [
-    item.title,
-    item.id,
-    item.slug,
-    item.description,
-    item.sourcePath,
-  ].join(" ");
-  return searchable.toLowerCase().includes(normalizedQuery);
 }
 
 function isSelectedWorkflowTemplate(
@@ -1164,24 +1110,8 @@ function selectedWebsiteTemplateItem(
   return findWebsiteTemplateItem(value.selection.websiteTemplateId);
 }
 
-function websiteTemplateMatchesSearch(
-  item: WebsiteTemplateItem,
-  query: string,
-): boolean {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) {
-    return true;
-  }
-  const searchable = [
-    item.title,
-    item.id,
-    item.slug,
-    item.description,
-    item.resourceId,
-    item.sourcePath,
-    item.templateId,
-  ].join(" ");
-  return searchable.toLowerCase().includes(normalizedQuery);
+function websiteTemplateCardImageUrl(item: WebsiteTemplateItem): string {
+  return r2ImageTransformUrl(item.previewImageUrl, TEMPLATE_CARD_PREVIEW_SIZE);
 }
 
 function playVideoTemplatePreview(video: HTMLVideoElement | null): void {
@@ -1389,6 +1319,7 @@ function WebsiteTemplateCard({
   onSelect: (item: WebsiteTemplateItem) => void;
   onPreview: (item: WebsiteTemplateItem) => void;
 }) {
+  const previewImageUrl = websiteTemplateCardImageUrl(item);
   const preview = () => {
     onPreview(item);
   };
@@ -1415,9 +1346,10 @@ function WebsiteTemplateCard({
         <img
           alt={`${item.title} website template preview`}
           title={`${item.title} website template preview`}
-          src={item.previewImageUrl}
-          loading="lazy"
+          src={previewImageUrl}
+          loading="eager"
           decoding="async"
+          fetchPriority="high"
           draggable={false}
           className="pointer-events-none h-full w-full bg-background object-cover"
         />
@@ -1853,6 +1785,14 @@ function videoPreviewImageUrlsForItems(
   });
 }
 
+function websitePreviewImageUrlsForItems(
+  items: readonly WebsiteTemplateItem[],
+): string[] {
+  return items.map((item) => {
+    return websiteTemplateCardImageUrl(item);
+  });
+}
+
 function initialTemplatePreviewImageUrlsForCategory({
   category,
   hasPptTab,
@@ -1884,7 +1824,7 @@ function initialTemplatePreviewImageUrlsForCategory({
     return videoPreviewImageUrlsForItems(VIDEO_TEMPLATE_ITEMS);
   }
   if (category === "website" && hasWebsiteTab) {
-    return [];
+    return websitePreviewImageUrlsForItems(WEBSITE_TEMPLATE_ITEMS);
   }
   return [];
 }
@@ -4819,20 +4759,10 @@ function TemplatePickerDialog({
       ? "flex h-[min(90dvh,760px)] max-w-6xl flex-col sm:h-auto"
       : "flex h-[min(82vh,760px)] max-w-4xl flex-col",
   );
-  const filteredPptItems = presentationItems.filter((item) => {
-    return presentationTemplateMatchesSearch(item, search);
-  });
-  const filteredIllustrationItems = ILLUSTRATION_TEMPLATE_ITEMS.filter(
-    (item) => {
-      return illustrationTemplateMatchesSearch(item, search);
-    },
-  );
-  const filteredVideoItems = VIDEO_TEMPLATE_ITEMS.filter((item) => {
-    return videoTemplateMatchesSearch(item, search);
-  });
-  const filteredWebsiteItems = WEBSITE_TEMPLATE_ITEMS.filter((item) => {
-    return websiteTemplateMatchesSearch(item, search);
-  });
+  const filteredPptItems = presentationItems;
+  const filteredIllustrationItems = ILLUSTRATION_TEMPLATE_ITEMS;
+  const filteredVideoItems = VIDEO_TEMPLATE_ITEMS;
+  const filteredWebsiteItems = WEBSITE_TEMPLATE_ITEMS;
   // The persona catalog rolls out behind a feature switch, and a persona pill
   // filters the grid, ideation-gallery style. resolveWorkflowCatalog() keeps
   // that branching out of this component to stay under the complexity budget.
@@ -4856,55 +4786,31 @@ function TemplatePickerDialog({
     hasWorkflowTab,
   });
 
-  const filteredIllustrationItemsForSearch = (value: string) => {
-    return ILLUSTRATION_TEMPLATE_ITEMS.filter((item) => {
-      return illustrationTemplateMatchesSearch(item, value);
-    });
-  };
-
-  const filteredPresentationItemsForSearch = (value: string) => {
-    return presentationItems.filter((item) => {
-      return presentationTemplateMatchesSearch(item, value);
-    });
-  };
-
-  const filteredVideoItemsForSearch = (value: string) => {
-    return VIDEO_TEMPLATE_ITEMS.filter((item) => {
-      return videoTemplateMatchesSearch(item, value);
-    });
-  };
-
-  const previewImageUrlsForCategory = (
-    targetCategory: string,
-    query: string,
-  ) => {
+  const previewImageUrlsForCategory = (targetCategory: string) => {
     if (targetCategory === "slides" && hasPptTab) {
       return presentationPreviewImageUrlsForItems(
-        filteredPresentationItemsForSearch(query),
+        presentationItems,
         cardThemeIdBySlug,
       );
     }
     if (targetCategory === "illustration" && hasIllustrationTab) {
       return illustrationPreviewImageUrlsForItems({
-        items: filteredIllustrationItemsForSearch(query),
+        items: ILLUSTRATION_TEMPLATE_ITEMS,
         variantIndexBySlug: illustrationVariantIndex,
       });
     }
     if (targetCategory === "video" && hasVideoTab) {
-      return videoPreviewImageUrlsForItems(filteredVideoItemsForSearch(query));
+      return videoPreviewImageUrlsForItems(VIDEO_TEMPLATE_ITEMS);
     }
     if (targetCategory === "website" && hasWebsiteTab) {
-      return [];
+      return websitePreviewImageUrlsForItems(WEBSITE_TEMPLATE_ITEMS);
     }
     return [];
   };
 
-  const prewarmTemplatePreviewsForCategory = (
-    targetCategory: string,
-    query = search,
-  ) => {
+  const prewarmTemplatePreviewsForCategory = (targetCategory: string) => {
     prewarmTemplatePreviewImages(
-      previewImageUrlsForCategory(targetCategory, query),
+      previewImageUrlsForCategory(targetCategory),
       templatePreviewPrewarmImageCountForCategory(targetCategory),
     );
   };
@@ -5048,7 +4954,7 @@ function TemplatePickerDialog({
   const handleSearchChange = (value: string) => {
     setSearch(value);
     if (!isPreviewing) {
-      prewarmTemplatePreviewsForCategory(selectedCategory, value);
+      prewarmTemplatePreviewsForCategory(selectedCategory);
     }
   };
 
@@ -5099,7 +5005,7 @@ function TemplatePickerDialog({
             <DialogHeader className="shrink-0 border-b border-border px-5 py-4">
               <DialogTitle>Create with template</DialogTitle>
             </DialogHeader>
-            <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 pt-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex shrink-0 flex-col gap-3 border-b border-border px-5 pt-3 sm:flex-row sm:items-center sm:justify-between">
               <TemplatePickerTabs
                 selectedCategory={selectedCategory}
                 hasPptTab={hasPptTab}
@@ -5109,22 +5015,31 @@ function TemplatePickerDialog({
                 hasWorkflowTab={hasWorkflowTab}
                 onChange={handleCategoryChange}
               />
-              <div className="w-full pb-3 sm:w-64">
-                <div className="relative">
-                  <IconSearch
-                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                    stroke={1.8}
-                  />
-                  <Input
-                    aria-label="Search templates"
-                    className="h-8 pl-9 text-sm"
-                    value={search}
-                    onChange={(event) => {
-                      handleSearchChange(event.target.value);
-                    }}
-                    placeholder="Search templates"
-                  />
-                </div>
+              <div
+                className={cn(
+                  "pb-3 pt-2 sm:w-64",
+                  selectedCategory === "workflow" ? "w-full" : "hidden sm:block",
+                )}
+              >
+                {selectedCategory === "workflow" ? (
+                  <div className="relative">
+                    <IconSearch
+                      className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+                      stroke={1.8}
+                    />
+                    <Input
+                      aria-label="Search connectors"
+                      className="h-8 pl-9 text-sm"
+                      value={search}
+                      onChange={(event) => {
+                        handleSearchChange(event.target.value);
+                      }}
+                      placeholder="Search connector..."
+                    />
+                  </div>
+                ) : (
+                  <div aria-hidden="true" className="h-8" />
+                )}
               </div>
             </div>
             <TemplatePickerCategoryContent


### PR DESCRIPTION
## Summary
- prewarm and eagerly load transformed website template card previews
- show template picker search only on the Workflow tab with connector copy
- update picker tests for the workflow-only search behavior

## Tests
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec oxlint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
- pnpm -F @vm0/app exec eslint src/views/zero-page/zero-chat-composer.tsx src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --max-warnings 0