### PR TITLE
perf: eliminate redundant runner claim secret materialization

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
@@ -113,3 +113,15 @@ export async function readAutomationsFakeKmsDecryptCallCount(
   const response = await postAction(context, { action: "read-fake-kms-state" });
   return response.decrypt_call_count ?? 0;
 }
+
+export async function mutateRunnerJobSecretValueEnvironmentKeys(
+  context: TestContext,
+  runId: string,
+  mode: "remove" | "invalid",
+): Promise<void> {
+  await postAction(context, {
+    action: "mutate-runner-job-secret-value-environment-keys",
+    run_id: runId,
+    mode,
+  });
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -57,6 +57,7 @@ import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import {
   deleteVm0ManagedDefaultModelKey,
   enableAutomationsFakeKms,
+  mutateRunnerJobSecretValueEnvironmentKeys,
   readAutomationComposeHeadVersion,
   readAutomationsFakeKmsDecryptCallCount,
   resetAutomationsFakeKms,
@@ -98,10 +99,12 @@ const CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES = [
   "claim_route_request_prepare",
   "claim_route_lookup_authorization",
   "claim_route_context_parse",
-  "claim_route_feature_switch_context",
-  "claim_route_secret_materialization",
   "claim_route_response_assembly",
   "claim_route_transition_running",
+] as const;
+const CLAIM_ROUTE_PREPARED_PATH_OMITTED_ACTION_TYPES = [
+  "claim_route_feature_switch_context",
+  "claim_route_secret_materialization",
 ] as const;
 const CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES = [
   "claim_route_transition_lock_run",
@@ -389,6 +392,8 @@ const FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS = [
   "environment",
   "execution_context",
   "stored_context",
+  "secret_value_environment_keys",
+  "secretValueEnvironmentKeys",
   "sandbox_token",
   "sandboxToken",
   "presigned_url",
@@ -2832,6 +2837,10 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
   it("queues runs over the concurrency limit and promotes them after cancellation", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
+    await enableAutomationsFakeKms(context);
+    onTestFinished(async () => {
+      await resetAutomationsFakeKms(context);
+    });
 
     const first = await api.createRun(actor, {
       agentId,
@@ -2864,9 +2873,20 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(promoted.status).toBe("pending");
     const drained = await waitForRunQueueLength(api, actor, 0);
     expect(drained.body.queue).toHaveLength(0);
+    const decryptCountBeforeClaim =
+      await readAutomationsFakeKmsDecryptCallCount(context);
     await api.heartbeatRunner(runnerGroup);
     const thirdClaim = await api.claimRunnerJob(third.runId);
     expect(thirdClaim.prompt).toBe("queued run three");
+    const zeroToken = thirdClaim.environment?.ZERO_TOKEN;
+    if (!zeroToken) {
+      throw new Error("Expected the promoted claim to expose the zero token");
+    }
+    expect(thirdClaim.secretValues).toContain(zeroToken);
+    expect(thirdClaim).not.toHaveProperty("secretValueEnvironmentKeys");
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      decryptCountBeforeClaim,
+    );
 
     await api.requestCancelRun(actor, second.runId, [200]);
     await api.requestCancelRun(actor, third.runId, [200]);
@@ -4999,20 +5019,18 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("resolves compose secret references into direct run environments", async () => {
+  it("restores prepared masking values from direct run environments", async () => {
     const bdd = createBddApi(context);
     const api = createRunsAutomationsApi(context);
-    const authOrg = createAuthOrgAgentsBddApi(context);
     const actor = bdd.user();
     bdd.acceptAgentStorageWrites();
     api.acceptStorageDownloads();
     api.acceptTelemetryIngest();
     api.configureRunnerGroup();
     await api.grantProEntitlement(actor);
-
-    await authOrg.setSecret(actor, {
-      name: "SHARED_TOKEN",
-      value: "user-shared-secret",
+    await enableAutomationsFakeKms(context);
+    onTestFinished(async () => {
+      await resetAutomationsFakeKms(context);
     });
     const composeName = `bdd-secret-refs-${randomUUID().slice(0, 8)}`;
     const compose = await api.createCompose(actor, {
@@ -5022,7 +5040,8 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
           framework: "claude-code",
           environment: {
             ANTHROPIC_API_KEY: "bdd-inline-key",
-            EXTERNAL_TOKEN: `\${{ secrets.SHARED_TOKEN }}`,
+            FIRST_TOKEN: `\${{ secrets.FIRST_TOKEN }}`,
+            SECOND_TOKEN: `\${{ secrets.SECOND_TOKEN }}`,
           },
         },
       },
@@ -5030,17 +5049,114 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
 
     const run = await api.createDirectRun(actor, {
       agentComposeId: compose.composeId,
-      prompt: "resolve referenced secrets",
+      prompt: "restore prepared masking values",
+      secrets: {
+        FIRST_TOKEN: "first-secret-value",
+        SECOND_TOKEN: "second-secret-value",
+        REPEATED_TOKEN: "first-secret-value",
+        UNUSED_TOKEN: "unused-secret-value",
+      },
     });
+    const decryptCountBeforeClaim =
+      await readAutomationsFakeKmsDecryptCallCount(context);
     const claim = await api.claimRunnerJob(run.runId);
-    expect(claim.environment?.EXTERNAL_TOKEN).toBe("user-shared-secret");
-    expect(claim.secretValues).toContain("user-shared-secret");
+    expect(claim.environment?.FIRST_TOKEN).toBe("first-secret-value");
+    expect(claim.environment?.SECOND_TOKEN).toBe("second-secret-value");
+    expect(claim.secretValues).toStrictEqual([
+      "first-secret-value",
+      "second-secret-value",
+      "first-secret-value",
+    ]);
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      decryptCountBeforeClaim,
+    );
+    expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
+    const claimActionTypes = new Set(
+      claimRouteTimingEventsForRun(run.runId).map((event) => {
+        return event.op_type;
+      }),
+    );
+    for (const actionType of CLAIM_ROUTE_PREPARED_PATH_OMITTED_ACTION_TYPES) {
+      expect(claimActionTypes).not.toContain(actionType);
+    }
     expect(claim.firewalls ?? []).toStrictEqual([]);
     expect(claim.networkPolicies ?? {}).toStrictEqual({});
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+  });
+
+  it("falls back completely for legacy and invalid masking metadata", async () => {
+    const bdd = createBddApi(context);
+    const api = createRunsAutomationsApi(context);
+    const actor = bdd.user();
+    bdd.acceptAgentStorageWrites();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    api.configureRunnerGroup();
+    await api.grantProEntitlement(actor);
+
+    await enableAutomationsFakeKms(context);
+    onTestFinished(async () => {
+      await resetAutomationsFakeKms(context);
+    });
+    const composeName = `bdd-secret-fallback-${randomUUID().slice(0, 8)}`;
+    const compose = await api.createCompose(actor, {
+      version: "1",
+      agents: {
+        [composeName]: {
+          framework: "claude-code",
+          environment: {
+            ANTHROPIC_API_KEY: "bdd-inline-key",
+            FIRST_TOKEN: `\${{ secrets.FIRST_TOKEN }}`,
+            SECOND_TOKEN: `\${{ secrets.SECOND_TOKEN }}`,
+          },
+        },
+      },
+    });
+
+    for (const mode of ["remove", "invalid"] as const) {
+      const run = await api.createDirectRun(actor, {
+        agentComposeId: compose.composeId,
+        prompt: `materialize ${mode} masking metadata`,
+        secrets: {
+          FIRST_TOKEN: "first-fallback-secret",
+          SECOND_TOKEN: "second-fallback-secret",
+        },
+      });
+      await mutateRunnerJobSecretValueEnvironmentKeys(context, run.runId, mode);
+      const decryptCountBeforeClaim =
+        await readAutomationsFakeKmsDecryptCallCount(context);
+
+      const claim = await api.claimRunnerJob(run.runId);
+
+      expect(claim.secretValues).toStrictEqual([
+        "first-fallback-secret",
+        "second-fallback-secret",
+      ]);
+      await expect(
+        readAutomationsFakeKmsDecryptCallCount(context),
+      ).resolves.toBe(decryptCountBeforeClaim + 1);
+      expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
+      const materializationEvent = singleSandboxOperationEvent(
+        claimRouteTimingEventsForRun(run.runId),
+        "claim_route_secret_materialization",
+      );
+      expect(materializationEvent).toStrictEqual(
+        expect.objectContaining({
+          fallback_reason: mode === "remove" ? "missing_field" : "invalid_keys",
+          span_kind: "top_level",
+        }),
+      );
+      expect(
+        claimRouteTimingEventsForRun(run.runId).some((event) => {
+          return event.op_type === "claim_route_feature_switch_context";
+        }),
+      ).toBeFalsy();
+
+      await api.requestCancelRun(actor, run.runId, [200]);
+    }
   });
 });
 
@@ -5099,6 +5215,7 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
       `Bearer \${{ secrets.${secretKey} }}`,
     );
     expect(claim.networkPolicies?.[internalName]?.unknownPolicy).toBe("allow");
+    expect(claim.secretValues).not.toContain("custom-secret-value");
 
     const resolved = await fw.requestFirewallAuth(
       { authorization: `Bearer ${claim.sandboxToken}` },
@@ -6395,6 +6512,9 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     for (const actionType of CLAIM_ROUTE_TIMING_ACTION_TYPES) {
       expect(observedClaimRouteActionTypes).toContain(actionType);
     }
+    for (const actionType of CLAIM_ROUTE_PREPARED_PATH_OMITTED_ACTION_TYPES) {
+      expect(observedClaimRouteActionTypes).not.toContain(actionType);
+    }
     for (const actionType of CLAIM_ROUTE_TOP_LEVEL_TIMING_ACTION_TYPES) {
       const events = claimRouteTimingEvents.filter((event) => {
         return event.op_type === actionType;
@@ -6434,6 +6554,7 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
       expect(event.duration_ms).toStrictEqual(expect.any(Number));
       expect(Number(event.duration_ms)).toBeGreaterThanOrEqual(0);
       expect(["top_level", "nested"]).toContain(event.span_kind);
+      expect(event).not.toHaveProperty("fallback_reason");
       for (const forbiddenKey of FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS) {
         expect(event).not.toHaveProperty(forbiddenKey);
       }
@@ -6749,6 +6870,10 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     api.acceptTelemetryIngest();
     api.configureRunnerGroup();
     await api.grantProEntitlement(actor);
+    await enableAutomationsFakeKms(context);
+    onTestFinished(async () => {
+      await resetAutomationsFakeKms(context);
+    });
 
     // A plain compose carries inline environment values but no body, model
     // provider, or connector secrets, so no encrypted secrets map is stored
@@ -6770,13 +6895,34 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     });
     expect(run.status).toBe("pending");
 
+    const decryptCountBeforeNullClaim =
+      await readAutomationsFakeKmsDecryptCallCount(context);
     const claim = await api.claimRunnerJob(run.runId);
     expect(claim.secretValues).toBeNull();
     expect(claim.prompt).toBe("claim without stored secrets");
+    expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      decryptCountBeforeNullClaim,
+    );
 
     await api.requestCancelRun(actor, run.runId, [200]);
     const cancelled = await api.readRun(actor, run.runId);
     expect(cancelled.status).toBe("cancelled");
+
+    const emptyRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "claim without matching environment secrets",
+      secrets: { UNUSED_TOKEN: "unused-secret-value" },
+    });
+    const decryptCountBeforeEmptyClaim =
+      await readAutomationsFakeKmsDecryptCallCount(context);
+    const emptyClaim = await api.claimRunnerJob(emptyRun.runId);
+    expect(emptyClaim.secretValues).toStrictEqual([]);
+    expect(emptyClaim).not.toHaveProperty("secretValueEnvironmentKeys");
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      decryptCountBeforeEmptyClaim,
+    );
+    await api.requestCancelRun(actor, emptyRun.runId, [200]);
 
     // A compose pinned to a non-vm0 runner group fails dispatch at creation.
     const foreignName = `bdd-foreign-${randomUUID().slice(0, 8)}`;

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -21,7 +21,6 @@ import {
   loadRunnerRuntimeFirewalls,
 } from "@vm0/connectors/firewall-metadata/runner-runtime";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
-import type { FeatureSwitchContext } from "@vm0/core/feature-switch";
 import { agentRuns } from "@vm0/db/schema/agent-run";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { blobs } from "@vm0/db/schema/blob";
@@ -58,7 +57,6 @@ import {
   networkPolicyRefreshConnectorRefs,
   resolveActiveNetworkPolicyRefreshes,
 } from "../services/zero-user-permission-grants.service";
-import { loadUserFeatureSwitchContext } from "../services/feature-switches.service";
 import {
   type CompressedSessionHistoryBlobEncoding,
   resumeSessionHistoryBlobKey,
@@ -128,11 +126,11 @@ function isResumeSessionHistoryLoadError(
 }
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
+type SecretValueFallbackReason = "missing_field" | "invalid_keys";
 type ClaimRouteTimingActionType =
   | "claim_route_request_prepare"
   | "claim_route_lookup_authorization"
   | "claim_route_context_parse"
-  | "claim_route_feature_switch_context"
   | "claim_route_secret_materialization"
   | "claim_route_response_assembly"
   | "claim_route_transition_running"
@@ -146,6 +144,7 @@ interface ClaimRouteTimingRecord {
   readonly spanKind: ClaimRouteTimingSpanKind;
   readonly durationMs: number;
   readonly timestamp: string;
+  readonly fallbackReason?: SecretValueFallbackReason;
 }
 
 class ClaimRouteTimingCollector {
@@ -173,6 +172,23 @@ class ClaimRouteTimingCollector {
     const startedAt = now();
     return operation().finally(() => {
       this.recordElapsed(actionType, spanKind, startedAt);
+    });
+  }
+
+  measureSecretMaterialization<T>(
+    fallbackReason: SecretValueFallbackReason,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const startedAt = now();
+    return operation().finally(() => {
+      const finishedAt = now();
+      this.records.push({
+        actionType: "claim_route_secret_materialization",
+        spanKind: "top_level",
+        durationMs: Math.max(0, finishedAt - startedAt),
+        timestamp: new Date(finishedAt).toISOString(),
+        fallbackReason,
+      });
     });
   }
 
@@ -209,6 +225,9 @@ class ClaimRouteTimingCollector {
           dimensions: {
             ...dimensions,
             span_kind: record.spanKind,
+            ...(record.fallbackReason
+              ? { fallback_reason: record.fallbackReason }
+              : {}),
           },
         };
       }),
@@ -912,24 +931,72 @@ async function failPoisonQueuedJob(
   });
 }
 
-async function secretValuesForRunner(
+type PreparedSecretValuesResult =
+  | {
+      readonly status: "resolved";
+      readonly secretValues: string[] | null;
+    }
+  | {
+      readonly status: "fallback";
+      readonly reason: SecretValueFallbackReason;
+    };
+
+function preparedSecretValuesForRunner(
   storedContext: StoredExecutionContext,
-  featureSwitchContext: FeatureSwitchContext,
-): Promise<string[] | null> {
-  const secretsMap = await decryptPersistentSecretsMap(
-    storedContext.encryptedSecrets,
-    featureSwitchContext,
-  );
-  if (!secretsMap) {
-    return null;
+): PreparedSecretValuesResult {
+  const keys = storedContext.secretValueEnvironmentKeys;
+  if (keys === undefined) {
+    return { status: "fallback", reason: "missing_field" };
+  }
+  if (keys === null) {
+    return { status: "resolved", secretValues: null };
   }
 
-  const envValues = storedContext.environment
-    ? new Set(Object.values(storedContext.environment))
-    : new Set<string>();
-  return Object.values(secretsMap).filter((value) => {
-    return envValues.has(value);
-  });
+  const secretValues: string[] = [];
+  for (const key of keys) {
+    if (
+      !storedContext.environment ||
+      !Object.hasOwn(storedContext.environment, key)
+    ) {
+      return { status: "fallback", reason: "invalid_keys" };
+    }
+    const value = storedContext.environment[key];
+    if (typeof value !== "string") {
+      return { status: "fallback", reason: "invalid_keys" };
+    }
+    secretValues.push(value);
+  }
+  return { status: "resolved", secretValues };
+}
+
+async function secretValuesForRunner(
+  storedContext: StoredExecutionContext,
+  timing: ClaimRouteTimingCollector,
+): Promise<string[] | null> {
+  const prepared = preparedSecretValuesForRunner(storedContext);
+  if (prepared.status === "resolved") {
+    return prepared.secretValues;
+  }
+
+  return await timing.measureSecretMaterialization(
+    prepared.reason,
+    async () => {
+      const secretsMap = await decryptPersistentSecretsMap(
+        storedContext.encryptedSecrets,
+        {},
+      );
+      if (!secretsMap) {
+        return null;
+      }
+
+      const envValues = storedContext.environment
+        ? new Set(Object.values(storedContext.environment))
+        : new Set<string>();
+      return Object.values(secretsMap).filter((value) => {
+        return envValues.has(value);
+      });
+    },
+  );
 }
 
 async function agentIdForRun(
@@ -1306,24 +1373,9 @@ async function buildClaimResponseBody(args: {
     objectKey: string,
   ) => Promise<string>;
 }): Promise<ExecutionContext> {
-  const featureSwitchContext = await args.timing.measure(
-    "claim_route_feature_switch_context",
-    "top_level",
-    () => {
-      return loadUserFeatureSwitchContext(
-        args.db,
-        args.run.orgId,
-        args.run.userId,
-      );
-    },
-  );
-  args.signal.throwIfAborted();
-  const secretValues = await args.timing.measure(
-    "claim_route_secret_materialization",
-    "top_level",
-    () => {
-      return secretValuesForRunner(args.storedContext, featureSwitchContext);
-    },
+  const secretValues = await secretValuesForRunner(
+    args.storedContext,
+    args.timing,
   );
   args.signal.throwIfAborted();
   return await args.timing.measure(
@@ -1357,8 +1409,12 @@ async function buildClaimResponseBody(args: {
         storedContext: args.storedContext,
       });
       args.signal.throwIfAborted();
+      const {
+        secretValueEnvironmentKeys: _secretValueEnvironmentKeys,
+        ...runnerStoredContext
+      } = args.storedContext;
       return {
-        ...args.storedContext,
+        ...runnerStoredContext,
         runId: args.run.id,
         prompt: args.run.prompt,
         appendSystemPrompt: args.run.appendSystemPrompt,

--- a/turbo/apps/api/src/signals/routes/test-automations-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-automations-state.ts
@@ -12,8 +12,9 @@ import {
 import { command } from "ccstate";
 import { testAutomationsStateContract } from "@vm0/api-contracts/contracts/test-automations-state";
 import { agentComposes } from "@vm0/db/schema/agent-compose";
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { vm0ApiKeys } from "@vm0/db/schema/vm0-api-key";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 
 import { bodyResultOf } from "../context/request";
@@ -141,6 +142,28 @@ async function deleteVm0ManagedDefaultModelKey(
   signal.throwIfAborted();
 }
 
+async function mutateRunnerJobSecretValueEnvironmentKeys(
+  db: Db,
+  runId: string,
+  mode: "remove" | "invalid",
+  signal: AbortSignal,
+): Promise<void> {
+  const executionContext =
+    mode === "remove"
+      ? sql`${runnerJobQueue.executionContext} - 'secretValueEnvironmentKeys'`
+      : sql`jsonb_set(
+          ${runnerJobQueue.executionContext},
+          '{secretValueEnvironmentKeys}',
+          '["__missing_secret_value_environment_key__"]'::jsonb,
+          true
+        )`;
+  await db
+    .update(runnerJobQueue)
+    .set({ executionContext })
+    .where(eq(runnerJobQueue.runId, runId));
+  signal.throwIfAborted();
+}
+
 const postAutomationsStateAction$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (!isTestEndpointAllowed(get(request$))) {
@@ -225,6 +248,15 @@ const postAutomationsStateAction$ = command(
             decrypt_call_count: fakeKmsDecryptCallCount.get(),
           },
         };
+      }
+      case "mutate-runner-job-secret-value-environment-keys": {
+        await mutateRunnerJobSecretValueEnvironmentKeys(
+          db,
+          body.run_id,
+          body.mode,
+          signal,
+        );
+        return { status: 200 as const, body: { ok: true as const } };
       }
     }
   },

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4782,23 +4782,36 @@ async function buildStoredExecutionContext(args: {
   const secretValues = executionSecrets.secrets
     ? Object.values(executionSecrets.secrets)
     : [];
+  const environment = {
+    ...expandEnvironment({
+      content: args.resolved.content,
+      vars: args.body.vars,
+      secrets: executionSecrets.secrets,
+      additionalEnvironment: args.modelProvider?.environment,
+      environmentSecretPlaceholders: permissions?.environmentSecretPlaceholders,
+      storedConnectorEnvironment: args.connectorContext.storedEnvironment,
+      connectorVars: args.connectorContext.vars,
+    }),
+    ...args.extraEnvironment,
+  };
+  const environmentKeyByValue = new Map<string, string>();
+  for (const [key, value] of Object.entries(environment)) {
+    if (!environmentKeyByValue.has(value)) {
+      environmentKeyByValue.set(value, key);
+    }
+  }
+  const secretValueEnvironmentKeys = executionSecrets.secrets
+    ? Object.values(executionSecrets.secrets).flatMap((value) => {
+        const key = environmentKeyByValue.get(value);
+        return key === undefined ? [] : [key];
+      })
+    : null;
 
   return {
     context: {
       storageManifest: args.storageManifest,
-      environment: {
-        ...expandEnvironment({
-          content: args.resolved.content,
-          vars: args.body.vars,
-          secrets: executionSecrets.secrets,
-          additionalEnvironment: args.modelProvider?.environment,
-          environmentSecretPlaceholders:
-            permissions?.environmentSecretPlaceholders,
-          storedConnectorEnvironment: args.connectorContext.storedEnvironment,
-          connectorVars: args.connectorContext.vars,
-        }),
-        ...args.extraEnvironment,
-      },
+      environment,
+      secretValueEnvironmentKeys,
       vars: args.connectorContext.vars ?? null,
       resumeSession: args.resolved.resumeSession ?? null,
       encryptedSecrets: await encryptPersistentSecretsMap(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -4801,7 +4801,7 @@ async function buildStoredExecutionContext(args: {
     }
   }
   const secretValueEnvironmentKeys = executionSecrets.secrets
-    ? Object.values(executionSecrets.secrets).flatMap((value) => {
+    ? secretValues.flatMap((value) => {
         const key = environmentKeyByValue.get(value);
         return key === undefined ? [] : [key];
       })

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -364,15 +364,6 @@ async function promoteQueuedCandidate(
   });
 }
 
-async function loadQueuedRunnerJobPayload(
-  encryptedParams: string | null,
-  signal: AbortSignal,
-): Promise<QueuedRunnerJobPayload | null> {
-  const payload = await decryptQueuedRunnerJobPayload(encryptedParams);
-  signal.throwIfAborted();
-  return payload;
-}
-
 async function publishRemovedStaleQueueSideEffects(
   orgId: string,
 ): Promise<void> {
@@ -496,8 +487,9 @@ export const drainOrgQueue$ = command(
     for (const row of queueRows) {
       const payload =
         row.runStatus === "queued"
-          ? await loadQueuedRunnerJobPayload(row.encryptedParams, signal)
+          ? await decryptQueuedRunnerJobPayload(row.encryptedParams)
           : null;
+      signal.throwIfAborted();
 
       const result = await promoteQueuedCandidateWithSideEffects(writeDb, {
         orgId: args.orgId,

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -16,7 +16,6 @@ import {
 import { logger } from "../../lib/log";
 import { activePendingRunPredicate } from "./agent-run-activity.service";
 import { decryptQueuedRunnerJobPayload } from "./agent-run-queue-payload.service";
-import { loadUserFeatureSwitchContext } from "./feature-switches.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import {
@@ -366,24 +365,10 @@ async function promoteQueuedCandidate(
 }
 
 async function loadQueuedRunnerJobPayload(
-  db: Db,
-  args: {
-    readonly orgId: string;
-    readonly userId: string;
-    readonly encryptedParams: string | null;
-  },
+  encryptedParams: string | null,
   signal: AbortSignal,
 ): Promise<QueuedRunnerJobPayload | null> {
-  const featureSwitchContext = await loadUserFeatureSwitchContext(
-    db,
-    args.orgId,
-    args.userId,
-  );
-  signal.throwIfAborted();
-  const payload = await decryptQueuedRunnerJobPayload(
-    args.encryptedParams,
-    featureSwitchContext,
-  );
+  const payload = await decryptQueuedRunnerJobPayload(encryptedParams);
   signal.throwIfAborted();
   return payload;
 }
@@ -511,15 +496,7 @@ export const drainOrgQueue$ = command(
     for (const row of queueRows) {
       const payload =
         row.runStatus === "queued"
-          ? await loadQueuedRunnerJobPayload(
-              writeDb,
-              {
-                orgId: args.orgId,
-                userId: row.userId,
-                encryptedParams: row.encryptedParams,
-              },
-              signal,
-            )
+          ? await loadQueuedRunnerJobPayload(row.encryptedParams, signal)
           : null;
 
       const result = await promoteQueuedCandidateWithSideEffects(writeDb, {

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -360,6 +360,11 @@ export const secretConnectorMetadataMapSchema = z.record(
 export const storedExecutionContextSchema = z.object({
   storageManifest: storageManifestSchema.nullable(),
   environment: z.record(z.string(), z.string()).nullable(),
+  // API-only references used to reconstruct runner masking values from the
+  // stored environment. Missing means legacy/stripped data, null means no
+  // persistent secret map, and array order/repetition follows secret-map values.
+  // This field must not be included in the runner-facing ExecutionContext.
+  secretValueEnvironmentKeys: z.array(z.string()).nullable().optional(),
   // Connector-owned runtime vars used by proxy/firewall template resolution.
   // User-provided run vars stay in agent_runs.vars and are merged at claim time.
   vars: z.record(z.string(), z.string()).nullable().optional(),

--- a/turbo/packages/api-contracts/src/contracts/test-automations-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-automations-state.ts
@@ -44,6 +44,11 @@ export const testAutomationsStateActionBodySchema = z.discriminatedUnion(
     z.object({
       action: z.literal("read-fake-kms-state"),
     }),
+    z.object({
+      action: z.literal("mutate-runner-job-secret-value-environment-keys"),
+      run_id: z.uuid(),
+      mode: z.enum(["remove", "invalid"]),
+    }),
   ],
 );
 


### PR DESCRIPTION
## Summary

- prepare API-only `secretValueEnvironmentKeys` references from the final run environment
- reconstruct runner masking values locally for new jobs, while retaining complete KMS fallback for legacy or invalid metadata
- remove crypto-only feature-switch reads from runner claim and delayed queue promotion
- add route integration coverage for ordering, duplicates, null/empty values, fallback telemetry, response omission, and queued promotion

## Compatibility

- no database schema or migration change; the optional field lives in existing temporary persisted JSON
- no runner protocol, Rust, or guest-agent change; the private field is explicitly omitted from claim responses
- old or compatibility-stripped jobs continue through the existing KMS path with bounded `missing_field` telemetry
- `invalid_keys` remains an all-or-nothing safety fallback; #20955 tracks the later evidence-gated retirement of only the legacy missing-field branch

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (94 passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm vitest --maxWorkers=2 --reporter=dot` (7241 passed, 4 unrelated failures; the three stable failures were reproduced unchanged on `origin/main@0a1b776934`, and the fourth passed when rerun in isolation)

Closes #20942
