### PR TITLE
fix(sandbox-fc): replace bespoke firecracker http codec

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -2798,6 +2798,7 @@ dependencies = [
  "libc",
  "nbd-cow",
  "nix",
+ "reqwest",
  "sandbox",
  "serde",
  "serde_json",

--- a/crates/sandbox-fc/Cargo.toml
+++ b/crates/sandbox-fc/Cargo.toml
@@ -11,6 +11,7 @@ guest-contracts.workspace = true
 nbd-cow.workspace = true
 libc.workspace = true
 nix = { workspace = true, features = ["user", "inotify", "fs", "signal"] }
+reqwest.workspace = true
 sandbox.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/crates/sandbox-fc/src/api/client.rs
+++ b/crates/sandbox-fc/src/api/client.rs
@@ -14,7 +14,7 @@ use super::http;
 pub enum ApiError {
     /// Failed to connect to the Unix domain socket.
     #[error("connect: {0}")]
-    Connect(std::io::Error),
+    Connect(#[source] std::io::Error),
     /// Firecracker returned a non-2xx HTTP response.
     #[error("HTTP {status}: {body}")]
     Http { status: u16, body: String },

--- a/crates/sandbox-fc/src/api/client.rs
+++ b/crates/sandbox-fc/src/api/client.rs
@@ -1,9 +1,10 @@
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::config::RateLimiterConfig;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
+use reqwest::Method;
 use tokio::io::unix::AsyncFd;
 
 use super::http;
@@ -17,6 +18,9 @@ pub enum ApiError {
     /// Firecracker returned a non-2xx HTTP response.
     #[error("HTTP {status}: {body}")]
     Http { status: u16, body: String },
+    /// HTTP client construction, protocol, or response-body failure.
+    #[error("HTTP transport: {0}")]
+    Transport(#[source] reqwest::Error),
     /// Other failure (I/O during request, timeout, setup).
     #[error("{0}")]
     Other(String),
@@ -27,7 +31,7 @@ impl ApiError {
     pub(super) fn is_retryable(&self) -> bool {
         match self {
             Self::Connect(e) => e.kind() == std::io::ErrorKind::ConnectionRefused,
-            Self::Http { .. } | Self::Other(_) => true,
+            Self::Http { .. } | Self::Transport(_) | Self::Other(_) => true,
         }
     }
 }
@@ -79,14 +83,18 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// (up to 4 GiB for browser profile) can exceed the default 30s timeout.
 const SNAPSHOT_CREATE_TIMEOUT: Duration = Duration::from_secs(120);
 
-/// Minimal HTTP-over-Unix-socket client for the Firecracker API.
-pub struct ApiClient<'a> {
-    socket_path: &'a Path,
+/// HTTP-over-Unix-socket client for the Firecracker API.
+pub struct ApiClient {
+    socket_path: PathBuf,
+    http: reqwest::Client,
 }
 
-impl<'a> ApiClient<'a> {
-    pub fn new(socket_path: &'a Path) -> Self {
-        Self { socket_path }
+impl ApiClient {
+    pub fn new(socket_path: &Path) -> Result<Self, ApiError> {
+        Ok(Self {
+            socket_path: socket_path.to_owned(),
+            http: http::build_client(socket_path)?,
+        })
     }
 
     /// Wait for the Firecracker API socket to accept connections.
@@ -96,11 +104,11 @@ impl<'a> ApiClient<'a> {
         let deadline = tokio::time::Instant::now() + timeout;
 
         // Phase 1: wait for socket file via inotify.
-        if !tokio::fs::try_exists(self.socket_path)
+        if !tokio::fs::try_exists(&self.socket_path)
             .await
             .unwrap_or(false)
         {
-            tokio::time::timeout_at(deadline, wait_for_socket_file(self.socket_path))
+            tokio::time::timeout_at(deadline, wait_for_socket_file(&self.socket_path))
                 .await
                 .map_err(|_| {
                     ApiError::Other(format!(
@@ -115,13 +123,20 @@ impl<'a> ApiClient<'a> {
         loop {
             match tokio::time::timeout_at(
                 deadline,
-                http::send_request(self.socket_path, "GET", "/", None),
+                http::send_request(
+                    &self.http,
+                    Method::GET,
+                    "/",
+                    None,
+                    http::ResponseMode::StatusOnly,
+                ),
             )
             .await
             {
                 Ok(Ok(_)) => return Ok(()),
                 Ok(Err(e)) if e.is_retryable() => {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    let retry_at = tokio::time::Instant::now() + Duration::from_millis(10);
+                    tokio::time::sleep_until(retry_at.min(deadline)).await;
                 }
                 Ok(Err(e)) => return Err(e),
                 Err(_) => {
@@ -141,7 +156,7 @@ impl<'a> ApiClient<'a> {
         resume_vm: bool,
     ) -> Result<(), ApiError> {
         self.send_json(
-            "PUT",
+            Method::PUT,
             "/snapshot/load",
             &serde_json::json!({
                 "snapshot_path": snapshot_path,
@@ -160,28 +175,26 @@ impl<'a> ApiClient<'a> {
     ///
     /// The VM must be paused before creating a snapshot.
     pub async fn pause(&self) -> Result<(), ApiError> {
-        self.send(
-            "PATCH",
+        self.send_json(
+            Method::PATCH,
             "/vm",
-            Some(br#"{"state":"Paused"}"#),
+            &serde_json::json!({ "state": "Paused" }),
             REQUEST_TIMEOUT,
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     /// Resume a paused VM via PATCH /vm.
     ///
     /// Must be called before any guest interaction after a [`Self::pause`].
     pub async fn resume(&self) -> Result<(), ApiError> {
-        self.send(
-            "PATCH",
+        self.send_json(
+            Method::PATCH,
             "/vm",
-            Some(br#"{"state":"Resumed"}"#),
+            &serde_json::json!({ "state": "Resumed" }),
             REQUEST_TIMEOUT,
         )
-        .await?;
-        Ok(())
+        .await
     }
 
     /// Create a snapshot via PUT /snapshot/create.
@@ -195,7 +208,7 @@ impl<'a> ApiClient<'a> {
         mem_path: &str,
     ) -> Result<(), ApiError> {
         self.send_json(
-            "PUT",
+            Method::PUT,
             "/snapshot/create",
             &serde_json::json!({
                 "snapshot_type": "Full",
@@ -214,7 +227,7 @@ impl<'a> ApiClient<'a> {
         mem_size_mib: u32,
     ) -> Result<(), ApiError> {
         self.send_json(
-            "PUT",
+            Method::PUT,
             "/machine-config",
             &serde_json::json!({
                 "vcpu_count": vcpu_count,
@@ -232,7 +245,7 @@ impl<'a> ApiClient<'a> {
         boot_args: &str,
     ) -> Result<(), ApiError> {
         self.send_json(
-            "PUT",
+            Method::PUT,
             "/boot-source",
             &serde_json::json!({
                 "kernel_image_path": kernel_image_path,
@@ -270,7 +283,7 @@ impl<'a> ApiClient<'a> {
             );
         }
         self.send_json(
-            "PUT",
+            Method::PUT,
             &path,
             &serde_json::Value::Object(body),
             REQUEST_TIMEOUT,
@@ -286,7 +299,7 @@ impl<'a> ApiClient<'a> {
     ) -> Result<(), ApiError> {
         let path = format!("/drives/{drive_id}");
         self.send_json(
-            "PATCH",
+            Method::PATCH,
             &path,
             &serde_json::json!({
                 "drive_id": drive_id,
@@ -330,7 +343,7 @@ impl<'a> ApiClient<'a> {
             );
         }
         self.send_json(
-            "PUT",
+            Method::PUT,
             &path,
             &serde_json::Value::Object(body),
             REQUEST_TIMEOUT,
@@ -347,7 +360,7 @@ impl<'a> ApiClient<'a> {
     ) -> Result<(), ApiError> {
         let path = format!("/network-interfaces/{iface_id}");
         self.send_json(
-            "PATCH",
+            Method::PATCH,
             &path,
             &serde_json::json!({
                 "iface_id": iface_id,
@@ -362,7 +375,7 @@ impl<'a> ApiClient<'a> {
     /// Configure the vsock device via PUT /vsock.
     pub async fn configure_vsock(&self, guest_cid: u32, uds_path: &str) -> Result<(), ApiError> {
         self.send_json(
-            "PUT",
+            Method::PUT,
             "/vsock",
             &serde_json::json!({
                 "guest_cid": guest_cid,
@@ -379,7 +392,7 @@ impl<'a> ApiClient<'a> {
     /// while the VM is running to dynamically inflate or deflate the balloon.
     pub async fn patch_balloon(&self, amount_mib: u32) -> Result<(), ApiError> {
         self.send_json(
-            "PATCH",
+            Method::PATCH,
             "/balloon",
             &serde_json::json!({ "amount_mib": amount_mib }),
             REQUEST_TIMEOUT,
@@ -393,9 +406,9 @@ impl<'a> ApiClient<'a> {
     /// [`Self::configure_balloon`]. Returns an error if statistics were not enabled.
     pub async fn get_balloon_statistics(&self) -> Result<BalloonStatistics, ApiError> {
         let body = self
-            .send("GET", "/balloon/statistics", None, REQUEST_TIMEOUT)
+            .send_body(Method::GET, "/balloon/statistics", REQUEST_TIMEOUT)
             .await?;
-        serde_json::from_str(&body)
+        serde_json::from_slice(&body)
             .map_err(|e| ApiError::Other(format!("parse balloon statistics: {e}")))
     }
 
@@ -411,7 +424,7 @@ impl<'a> ApiClient<'a> {
         stats_polling_interval_s: u32,
     ) -> Result<(), ApiError> {
         self.send_json(
-            "PUT",
+            Method::PUT,
             "/balloon",
             &serde_json::json!({
                 "amount_mib": amount_mib,
@@ -425,45 +438,59 @@ impl<'a> ApiClient<'a> {
 
     /// Start the VM instance via PUT /actions.
     pub async fn start_instance(&self) -> Result<(), ApiError> {
-        self.send(
-            "PUT",
+        self.send_json(
+            Method::PUT,
             "/actions",
-            Some(br#"{"action_type":"InstanceStart"}"#),
+            &serde_json::json!({ "action_type": "InstanceStart" }),
             REQUEST_TIMEOUT,
         )
-        .await?;
+        .await
+    }
+
+    async fn send_status(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&serde_json::Value>,
+        timeout: Duration,
+    ) -> Result<(), ApiError> {
+        tokio::time::timeout(
+            timeout,
+            http::send_request(
+                &self.http,
+                method,
+                path,
+                body,
+                http::ResponseMode::StatusOnly,
+            ),
+        )
+        .await
+        .map_err(|_| ApiError::Other(format!("request timed out after {timeout:?}")))??;
         Ok(())
     }
 
-    /// Send a request with a timeout and return the response body.
-    async fn send(
+    async fn send_body(
         &self,
-        method: &str,
+        method: Method,
         path: &str,
-        body: Option<&[u8]>,
         timeout: Duration,
-    ) -> Result<String, ApiError> {
+    ) -> Result<Vec<u8>, ApiError> {
         tokio::time::timeout(
             timeout,
-            http::send_request(self.socket_path, method, path, body),
+            http::send_request(&self.http, method, path, None, http::ResponseMode::Collect),
         )
         .await
         .map_err(|_| ApiError::Other(format!("request timed out after {timeout:?}")))?
     }
 
-    /// Serialize a JSON value and send it with the given method and timeout.
     async fn send_json(
         &self,
-        method: &str,
+        method: Method,
         path: &str,
         value: &serde_json::Value,
         timeout: Duration,
     ) -> Result<(), ApiError> {
-        let body =
-            serde_json::to_string(value).map_err(|e| ApiError::Other(format!("json: {e}")))?;
-        self.send(method, path, Some(body.as_bytes()), timeout)
-            .await?;
-        Ok(())
+        self.send_status(method, path, Some(value), timeout).await
     }
 }
 

--- a/crates/sandbox-fc/src/api/client.rs
+++ b/crates/sandbox-fc/src/api/client.rs
@@ -99,7 +99,7 @@ impl ApiClient {
 
     /// Wait for the Firecracker API socket to accept connections.
     ///
-    /// Uses inotify to wait for the socket file, then polls GET / until 200.
+    /// Uses inotify to wait for the socket file, then polls GET / until it succeeds.
     pub async fn wait_for_ready(&self, timeout: Duration) -> Result<(), ApiError> {
         let deadline = tokio::time::Instant::now() + timeout;
 

--- a/crates/sandbox-fc/src/api/client.rs
+++ b/crates/sandbox-fc/src/api/client.rs
@@ -21,7 +21,7 @@ pub enum ApiError {
     /// HTTP client construction, protocol, or response-body failure.
     #[error("HTTP transport: {0}")]
     Transport(#[source] reqwest::Error),
-    /// Other failure (I/O during request, timeout, setup).
+    /// Other failure (readiness setup, timeout, serialization, parsing, or size limits).
     #[error("{0}")]
     Other(String),
 }

--- a/crates/sandbox-fc/src/api/http.rs
+++ b/crates/sandbox-fc/src/api/http.rs
@@ -1,130 +1,125 @@
+use std::error::Error as _;
+use std::io;
 use std::path::Path;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
+use reqwest::header::{ACCEPT, HeaderValue};
+use reqwest::{Method, Response};
 
 use super::client::ApiError;
 
-/// Send a raw HTTP/1.1 request over a Unix domain socket.
-///
-/// Returns the response body on 2xx success, or an `ApiError` containing the
-/// status code and Firecracker `fault_message` on failure.
+const API_ORIGIN: &str = "http://localhost";
+const MAX_COLLECTED_BODY_BYTES: usize = 64 * 1024;
+const BODY_LIMIT_DIAGNOSTIC: &str = "response body exceeds 64 KiB limit";
+
+pub(super) enum ResponseMode {
+    StatusOnly,
+    Collect,
+}
+
+enum BodyCollectionError {
+    TooLarge,
+    Transport(reqwest::Error),
+}
+
+pub(super) fn build_client(socket_path: &Path) -> Result<reqwest::Client, ApiError> {
+    reqwest::Client::builder()
+        .unix_socket(socket_path)
+        .http1_only()
+        .redirect(reqwest::redirect::Policy::none())
+        .retry(reqwest::retry::never())
+        .no_proxy()
+        .pool_max_idle_per_host(0)
+        .build()
+        .map_err(map_transport_error)
+}
+
 pub(super) async fn send_request(
-    socket_path: &Path,
-    method: &str,
+    client: &reqwest::Client,
+    method: Method,
     path: &str,
-    body: Option<&[u8]>,
-) -> Result<String, ApiError> {
-    let mut stream = UnixStream::connect(socket_path)
-        .await
-        .map_err(ApiError::Connect)?;
+    body: Option<&serde_json::Value>,
+    response_mode: ResponseMode,
+) -> Result<Vec<u8>, ApiError> {
+    let mut request = client
+        .request(method, format!("{API_ORIGIN}{path}"))
+        .header(ACCEPT, HeaderValue::from_static("application/json"));
+    if let Some(body) = body {
+        request = request.json(body);
+    }
 
-    let header = if let Some(b) = body {
-        format!(
-            "{method} {path} HTTP/1.1\r\n\
-             Host: localhost\r\n\
-             Accept: application/json\r\n\
-             Content-Type: application/json\r\n\
-             Content-Length: {}\r\n\
-             \r\n",
-            b.len(),
-        )
-    } else {
-        format!(
-            "{method} {path} HTTP/1.1\r\n\
-             Host: localhost\r\n\
-             Accept: application/json\r\n\
-             \r\n"
-        )
+    let response = request.send().await.map_err(map_transport_error)?;
+    let status = response.status();
+
+    if status.is_success() {
+        return match response_mode {
+            ResponseMode::StatusOnly => Ok(Vec::new()),
+            ResponseMode::Collect => collect_body(response).await.map_err(|error| match error {
+                BodyCollectionError::TooLarge => ApiError::Other(BODY_LIMIT_DIAGNOSTIC.into()),
+                BodyCollectionError::Transport(error) => map_transport_error(error),
+            }),
+        };
+    }
+
+    let status = status.as_u16();
+    let body = match collect_body(response).await {
+        Ok(body) => fault_message_or_body(&body),
+        Err(BodyCollectionError::TooLarge) => BODY_LIMIT_DIAGNOSTIC.into(),
+        Err(BodyCollectionError::Transport(error)) => return Err(map_transport_error(error)),
     };
+    Err(ApiError::Http { status, body })
+}
 
-    stream
-        .write_all(header.as_bytes())
-        .await
-        .map_err(|e| ApiError::Other(format!("write header: {e}")))?;
-
-    if let Some(b) = body {
-        stream
-            .write_all(b)
-            .await
-            .map_err(|e| ApiError::Other(format!("write body: {e}")))?;
-    }
-
-    // Read response into a buffer. Firecracker uses keep-alive so we
-    // cannot rely on connection close; instead we read until we find the
-    // header/body boundary (\r\n\r\n), parse Content-Length, then read
-    // exactly that many remaining body bytes.
-    let mut reader = tokio::io::BufReader::new(stream);
-    let mut buf = Vec::with_capacity(4096);
-
-    // Phase 1: read until we have the full header block.
-    loop {
-        let n = reader
-            .read_buf(&mut buf)
-            .await
-            .map_err(|e| ApiError::Other(format!("read response: {e}")))?;
-        if n == 0 || buf.windows(4).any(|w| w == b"\r\n\r\n") {
-            break;
+async fn collect_body(mut response: Response) -> Result<Vec<u8>, BodyCollectionError> {
+    let capacity = match response.content_length() {
+        Some(length) if length > MAX_COLLECTED_BODY_BYTES as u64 => {
+            return Err(BodyCollectionError::TooLarge);
         }
-    }
-
-    let response = String::from_utf8_lossy(&buf);
-
-    // Find where headers end.
-    let header_end = response.find("\r\n\r\n").unwrap_or(response.len());
-
-    // Parse status code from "HTTP/1.1 204 No Content\r\n..."
-    let status = response
-        .get(9..12)
-        .and_then(|s| s.parse::<u16>().ok())
-        .unwrap_or(0);
-
-    // Parse Content-Length from headers.
-    let content_length = response
-        .get(..header_end)
-        .unwrap_or_default()
-        .lines()
-        .find_map(|line| {
-            let (key, value) = line.split_once(':')?;
-            if key.trim().eq_ignore_ascii_case("content-length") {
-                value.trim().parse::<usize>().ok()
-            } else {
-                None
-            }
-        })
-        .unwrap_or(0);
-
-    // Body bytes already read (past the \r\n\r\n separator).
-    let body_start = header_end + 4;
-    let already_read = buf.len().saturating_sub(body_start);
-    let body_str = if content_length > 0 {
-        if already_read < content_length {
-            // Need to read remaining body bytes from the stream.
-            let remaining = content_length - already_read;
-            let mut tail = vec![0u8; remaining];
-            reader
-                .read_exact(&mut tail)
-                .await
-                .map_err(|e| ApiError::Other(format!("read body: {e}")))?;
-            buf.extend_from_slice(&tail);
-        }
-        let end = body_start + content_length;
-        String::from_utf8_lossy(buf.get(body_start..end).unwrap_or_default()).to_string()
-    } else {
-        String::new()
+        Some(length) => usize::try_from(length).map_err(|_| BodyCollectionError::TooLarge)?,
+        None => 0,
     };
+    let mut body = Vec::with_capacity(capacity);
 
-    if (200..300).contains(&status) {
-        Ok(body_str)
-    } else {
-        // Try to extract fault_message from Firecracker error JSON.
-        let message = serde_json::from_str::<serde_json::Value>(&body_str)
-            .ok()
-            .and_then(|v| v.get("fault_message")?.as_str().map(String::from))
-            .unwrap_or(body_str);
-        Err(ApiError::Http {
-            status,
-            body: message,
-        })
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(BodyCollectionError::Transport)?
+    {
+        let length = body
+            .len()
+            .checked_add(chunk.len())
+            .ok_or(BodyCollectionError::TooLarge)?;
+        if length > MAX_COLLECTED_BODY_BYTES {
+            return Err(BodyCollectionError::TooLarge);
+        }
+        body.extend_from_slice(&chunk);
     }
+
+    Ok(body)
+}
+
+fn fault_message_or_body(body: &[u8]) -> String {
+    serde_json::from_slice::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| value.get("fault_message")?.as_str().map(String::from))
+        .unwrap_or_else(|| String::from_utf8_lossy(body).into_owned())
+}
+
+fn map_transport_error(error: reqwest::Error) -> ApiError {
+    if !error.is_connect() {
+        return ApiError::Transport(error);
+    }
+
+    let kind = io_error_kind(&error).unwrap_or(io::ErrorKind::Other);
+    ApiError::Connect(io::Error::new(kind, error))
+}
+
+fn io_error_kind(error: &reqwest::Error) -> Option<io::ErrorKind> {
+    let mut source = error.source();
+    while let Some(error) = source {
+        if let Some(error) = error.downcast_ref::<io::Error>() {
+            return Some(error.kind());
+        }
+        source = error.source();
+    }
+    None
 }

--- a/crates/sandbox-fc/src/api/tests.rs
+++ b/crates/sandbox-fc/src/api/tests.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::oneshot;
 
@@ -29,6 +29,19 @@ fn test_rate_limiter(size: u64) -> RateLimiterConfig {
         }),
         ops: None,
     }
+}
+
+fn bind_raw_api() -> (tempfile::TempDir, PathBuf, UnixListener) {
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("fc.sock");
+    let listener = UnixListener::bind(&sock_path).unwrap();
+    (dir, sock_path, listener)
+}
+
+async fn accept_mock_request(listener: &UnixListener) -> (UnixStream, MockRequest) {
+    let (mut stream, _) = listener.accept().await.unwrap();
+    let request = read_mock_request(&mut stream).await.unwrap();
+    (stream, request)
 }
 
 async fn run_with_split_response<T, Fut>(
@@ -116,7 +129,7 @@ async fn mock_firecracker_api_drains_captured_requests_without_waiting() {
     assert!(api.drain_requests().is_empty());
 
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     client.patch_balloon(123).await.unwrap();
     client.patch_balloon(456).await.unwrap();
 
@@ -176,7 +189,7 @@ fn api_error_is_retryable_other() {
 async fn wait_for_ready_succeeds_on_200() {
     let mut api = MockFirecrackerApi::repeating(MockResponse::ok());
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.wait_for_ready(Duration::from_secs(2)).await;
     assert!(result.is_ok());
 
@@ -188,7 +201,7 @@ async fn wait_for_ready_succeeds_on_200() {
 async fn wait_for_ready_times_out_on_missing_socket() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("missing.sock");
-    let client = ApiClient::new(&path);
+    let client = ApiClient::new(&path).unwrap();
     let result = client.wait_for_ready(Duration::ZERO).await;
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -199,7 +212,7 @@ async fn wait_for_ready_times_out_on_missing_socket() {
 async fn load_snapshot_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client
         .load_snapshot("/snap/state", "/snap/memory", true)
         .await;
@@ -218,7 +231,7 @@ async fn load_snapshot_succeeds_on_204() {
 async fn load_snapshot_can_leave_vm_paused() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client
         .load_snapshot("/snap/state", "/snap/memory", false)
         .await;
@@ -235,7 +248,7 @@ async fn wait_for_ready_detects_deferred_socket() {
     let (mut api, bind_socket) = MockFirecrackerApi::deferred_repeating(MockResponse::ok());
     let sock_path = api.socket_path().to_path_buf();
     let waiter = tokio::spawn(async move {
-        let client = ApiClient::new(&sock_path);
+        let client = ApiClient::new(&sock_path).unwrap();
         client.wait_for_ready(Duration::from_secs(2)).await
     });
 
@@ -256,7 +269,7 @@ async fn wait_for_ready_retries_until_success() {
         MockResponse::ok(),
     ]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.wait_for_ready(Duration::from_secs(2)).await;
     assert!(result.is_ok());
 
@@ -271,7 +284,7 @@ async fn load_snapshot_error_falls_back_to_raw_body() {
     let mut api =
         MockFirecrackerApi::with_responses([MockResponse::internal_error_raw("plain text error")]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client
         .load_snapshot("/snap/state", "/snap/memory", true)
         .await;
@@ -291,7 +304,7 @@ async fn load_snapshot_returns_error_on_non_204() {
     let mut api =
         MockFirecrackerApi::with_responses([MockResponse::bad_request_fault(fault_message)]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client
         .load_snapshot("/snap/state", "/snap/memory", true)
         .await;
@@ -310,7 +323,7 @@ async fn load_snapshot_returns_error_on_non_204() {
 async fn pause_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.pause().await;
     assert!(result.is_ok());
 
@@ -324,7 +337,7 @@ async fn pause_succeeds_on_204() {
 async fn resume_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.resume().await;
     assert!(result.is_ok());
 
@@ -338,7 +351,7 @@ async fn resume_succeeds_on_204() {
 async fn create_snapshot_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.create_snapshot("/snap/state", "/snap/memory").await;
     assert!(result.is_ok());
 
@@ -355,7 +368,7 @@ async fn pause_returns_error_on_failure() {
     let mut api =
         MockFirecrackerApi::with_responses([MockResponse::bad_request_fault("cannot pause")]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let ApiError::Http { status, body } = client.pause().await.unwrap_err() else {
         panic!("expected Http error");
     };
@@ -370,7 +383,7 @@ async fn pause_returns_error_on_failure() {
 async fn configure_machine_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.configure_machine(2, 256).await;
     assert!(result.is_ok());
 
@@ -385,7 +398,7 @@ async fn configure_machine_succeeds_on_204() {
 async fn configure_boot_source_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client
         .configure_boot_source("/path/to/kernel", "console=ttyS0")
         .await;
@@ -402,7 +415,7 @@ async fn configure_boot_source_succeeds_on_204() {
 async fn configure_drive_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client
         .configure_drive("rootfs", "/path/to/rootfs", true, true, None)
         .await;
@@ -422,7 +435,7 @@ async fn configure_drive_succeeds_on_204() {
 async fn configure_drive_with_rate_limiter_serializes_limiter() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let limiter = RateLimiterConfig {
         bandwidth: Some(crate::config::TokenBucketConfig {
             size: 1024,
@@ -454,7 +467,7 @@ async fn configure_drive_with_rate_limiter_serializes_limiter() {
 async fn patch_drive_rate_limiter_serializes_partial_drive() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let limiter = test_rate_limiter(2048);
 
     let result = client.patch_drive_rate_limiter("rootfs", &limiter).await;
@@ -471,7 +484,7 @@ async fn patch_drive_rate_limiter_serializes_partial_drive() {
 async fn configure_network_interface_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client
         .configure_network_interface("eth0", "02:00:00:00:00:01", "vm0-tap", None, None)
         .await;
@@ -491,7 +504,7 @@ async fn configure_network_interface_succeeds_on_204() {
 async fn configure_network_interface_with_rate_limiters_serializes_limiters() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let rx = test_rate_limiter(4096);
     let tx = test_rate_limiter(8192);
     let result = client
@@ -513,7 +526,7 @@ async fn configure_network_interface_with_rate_limiters_serializes_limiters() {
 async fn patch_network_rate_limiters_serializes_partial_network_interface() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let rx = test_rate_limiter(4096);
     let tx = test_rate_limiter(8192);
 
@@ -532,7 +545,7 @@ async fn patch_network_rate_limiters_serializes_partial_network_interface() {
 async fn configure_vsock_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.configure_vsock(3, "/tmp/vsock.sock").await;
     assert!(result.is_ok());
 
@@ -547,7 +560,7 @@ async fn configure_vsock_succeeds_on_204() {
 async fn start_instance_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.start_instance().await;
     assert!(result.is_ok());
 
@@ -561,7 +574,7 @@ async fn start_instance_succeeds_on_204() {
 async fn patch_balloon_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.patch_balloon(512).await;
     assert!(result.is_ok());
 
@@ -576,7 +589,7 @@ async fn get_balloon_statistics_parses_response() {
     let body = r#"{"target_mib":512,"actual_mib":256,"target_pages":131072,"actual_pages":65536,"free_memory":1073741824,"available_memory":1610612736,"total_memory":2147483648}"#;
     let mut api = MockFirecrackerApi::with_responses([MockResponse::ok_body(body)]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let stats = client.get_balloon_statistics().await.unwrap();
     assert_eq!(stats.target_mib, 512);
     assert_eq!(stats.actual_mib, 256);
@@ -598,7 +611,7 @@ async fn get_balloon_statistics_reads_split_response_body() {
     let body = r#"{"target_mib":768,"actual_mib":384,"target_pages":196608,"actual_pages":98304}"#;
     let (result, request) =
         run_with_split_response(MockResponse::ok_body(body), |sock_path| async move {
-            let client = ApiClient::new(&sock_path);
+            let client = ApiClient::new(&sock_path).unwrap();
             client.get_balloon_statistics().await
         })
         .await;
@@ -618,7 +631,7 @@ async fn load_snapshot_error_reads_split_response_body() {
     let (result, request) = run_with_split_response(
         MockResponse::bad_request_fault(fault_message),
         |sock_path| async move {
-            let client = ApiClient::new(&sock_path);
+            let client = ApiClient::new(&sock_path).unwrap();
             client
                 .load_snapshot("/snap/state", "/snap/memory", true)
                 .await
@@ -639,7 +652,7 @@ async fn get_balloon_statistics_handles_minimal_response() {
     let body = r#"{"target_mib":0,"actual_mib":0,"target_pages":0,"actual_pages":0}"#;
     let mut api = MockFirecrackerApi::with_responses([MockResponse::ok_body(body)]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let stats = client.get_balloon_statistics().await.unwrap();
     assert_eq!(stats.target_mib, 0);
     assert_eq!(stats.actual_mib, 0);
@@ -654,7 +667,7 @@ async fn get_balloon_statistics_handles_minimal_response() {
 async fn get_balloon_statistics_returns_error_on_malformed_response() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::ok_body("{not json")]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let ApiError::Other(message) = client.get_balloon_statistics().await.unwrap_err() else {
         panic!("expected parse error");
     };
@@ -671,7 +684,7 @@ async fn get_balloon_statistics_returns_error_on_malformed_response() {
 async fn configure_balloon_succeeds_on_204() {
     let mut api = MockFirecrackerApi::with_responses([MockResponse::no_content()]);
     let sock_path = api.socket_path().to_path_buf();
-    let client = ApiClient::new(&sock_path);
+    let client = ApiClient::new(&sock_path).unwrap();
     let result = client.configure_balloon(0, true, 0).await;
     assert!(result.is_ok());
 
@@ -681,6 +694,306 @@ async fn configure_balloon_succeeds_on_204() {
     assert_eq!(body["amount_mib"], 0);
     assert_eq!(body["deflate_on_oom"], true);
     assert_eq!(body["stats_polling_interval_s"], 0);
+}
+
+#[tokio::test]
+async fn oversized_unterminated_response_head_is_rejected_while_held_open() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, request) = accept_mock_request(&listener).await;
+        let mut head = b"HTTP/1.1 204 No Content\r\nX-Oversized: ".to_vec();
+        head.resize(640 * 1024, b'a');
+        let _ = stream.write_all(&head).await;
+        let _ = release_rx.await;
+        request
+    });
+
+    let client = ApiClient::new(&sock_path).unwrap();
+    let result = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, client.pause())
+        .await
+        .expect("client did not reject oversized response head");
+    assert!(result.is_err());
+
+    release_tx.send(()).unwrap();
+    let request = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, server)
+        .await
+        .expect("oversized-head server did not stop")
+        .unwrap();
+    assert_request(&request, "PATCH", "/vm");
+}
+
+#[tokio::test]
+async fn balloon_response_rejects_declared_body_over_limit_before_reading_it() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, request) = accept_mock_request(&listener).await;
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 65537\r\n\r\n")
+            .await
+            .unwrap();
+        let _ = release_rx.await;
+        request
+    });
+
+    let client = ApiClient::new(&sock_path).unwrap();
+    let result = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, client.get_balloon_statistics())
+        .await
+        .expect("client waited for an oversized declared body");
+    let ApiError::Other(message) = result.unwrap_err() else {
+        panic!("expected body-limit error");
+    };
+    assert!(message.contains("64 KiB limit"), "got: {message}");
+
+    release_tx.send(()).unwrap();
+    let request = server.await.unwrap();
+    assert_request(&request, "GET", "/balloon/statistics");
+}
+
+#[tokio::test]
+async fn balloon_response_rejects_chunked_body_over_limit() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, request) = accept_mock_request(&listener).await;
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+            .await
+            .unwrap();
+        let first = vec![b'a'; 32 * 1024];
+        let second = vec![b'b'; 32 * 1024 + 1];
+        stream
+            .write_all(format!("{:X}\r\n", first.len()).as_bytes())
+            .await
+            .unwrap();
+        stream.write_all(&first).await.unwrap();
+        stream.write_all(b"\r\n").await.unwrap();
+        stream
+            .write_all(format!("{:X}\r\n", second.len()).as_bytes())
+            .await
+            .unwrap();
+        let _ = stream.write_all(&second).await;
+        let _ = stream.write_all(b"\r\n").await;
+        let _ = release_rx.await;
+        request
+    });
+
+    let client = ApiClient::new(&sock_path).unwrap();
+    let result = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, client.get_balloon_statistics())
+        .await
+        .expect("client waited after chunked body exceeded the limit");
+    let ApiError::Other(message) = result.unwrap_err() else {
+        panic!("expected body-limit error");
+    };
+    assert!(message.contains("64 KiB limit"), "got: {message}");
+
+    release_tx.send(()).unwrap();
+    let request = server.await.unwrap();
+    assert_request(&request, "GET", "/balloon/statistics");
+}
+
+#[tokio::test]
+async fn oversized_error_body_preserves_status_and_uses_bounded_diagnostic() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, request) = accept_mock_request(&listener).await;
+        stream
+            .write_all(b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 65537\r\n\r\n")
+            .await
+            .unwrap();
+        let _ = release_rx.await;
+        request
+    });
+
+    let client = ApiClient::new(&sock_path).unwrap();
+    let result = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, client.pause())
+        .await
+        .expect("client waited for an oversized error body");
+    let ApiError::Http { status, body } = result.unwrap_err() else {
+        panic!("expected HTTP error");
+    };
+    assert_eq!(status, 503);
+    assert_eq!(body, "response body exceeds 64 KiB limit");
+
+    release_tx.send(()).unwrap();
+    let request = server.await.unwrap();
+    assert_request(&request, "PATCH", "/vm");
+}
+
+#[tokio::test]
+async fn status_only_success_drops_large_body_and_closes_connection() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let server = tokio::spawn(async move {
+        let (mut stream, request) = accept_mock_request(&listener).await;
+        stream
+            .write_all(b"HTTP/1.1 201 Created\r\nContent-Length: 65537\r\n\r\n")
+            .await
+            .unwrap();
+        let mut byte = [0];
+        let read = stream.read(&mut byte).await.unwrap();
+        (request, read)
+    });
+
+    let client = ApiClient::new(&sock_path).unwrap();
+    tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, client.pause())
+        .await
+        .expect("status-only request waited for the response body")
+        .unwrap();
+
+    let (request, read) = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, server)
+        .await
+        .expect("server did not observe the status-only connection closing")
+        .unwrap();
+    assert_eq!(read, 0);
+    assert_request(&request, "PATCH", "/vm");
+}
+
+#[tokio::test]
+async fn redirect_is_returned_without_following_location() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let (done_tx, done_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, first_request) = accept_mock_request(&listener).await;
+        stream
+            .write_all(
+                b"HTTP/1.1 302 Found\r\nLocation: http://localhost/redirected\r\nContent-Length: 0\r\n\r\n",
+            )
+            .await
+            .unwrap();
+
+        let mut requests = vec![first_request];
+        tokio::select! {
+            accepted = listener.accept() => {
+                let (mut stream, _) = accepted.unwrap();
+                requests.push(read_mock_request(&mut stream).await.unwrap());
+                stream.write_all(b"HTTP/1.1 204 No Content\r\n\r\n").await.unwrap();
+            }
+            result = done_rx => {
+                result.unwrap();
+            }
+        }
+        requests
+    });
+
+    let client = ApiClient::new(&sock_path).unwrap();
+    let result = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, client.pause())
+        .await
+        .expect("redirect request did not finish");
+    let _ = done_tx.send(());
+
+    let ApiError::Http { status, .. } = result.unwrap_err() else {
+        panic!("expected redirect HTTP error");
+    };
+    assert_eq!(status, 302);
+    let requests = server.await.unwrap();
+    assert_eq!(requests.len(), 1, "redirect created an extra request");
+    assert_request(&requests[0], "PATCH", "/vm");
+}
+
+#[tokio::test]
+async fn sequential_calls_use_separate_connections() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let server = async move {
+        let (mut first_stream, first_request) = accept_mock_request(&listener).await;
+        first_stream
+            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+
+        let (mut second_stream, second_request) = accept_mock_request(&listener).await;
+        second_stream
+            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+        drop(first_stream);
+        (first_request, second_request)
+    };
+    let client = ApiClient::new(&sock_path).unwrap();
+    let calls = async {
+        client.pause().await?;
+        client.resume().await
+    };
+
+    let (result, (first_request, second_request)) =
+        tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, async {
+            tokio::join!(calls, server)
+        })
+        .await
+        .expect("second request reused the first Unix connection");
+    result.unwrap();
+    assert_request(&first_request, "PATCH", "/vm");
+    assert_request(&second_request, "PATCH", "/vm");
+}
+
+#[tokio::test]
+async fn wait_for_ready_deadline_covers_unfinished_error_body() {
+    let (_dir, sock_path, listener) = bind_raw_api();
+    let (release_tx, release_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (mut stream, request) = accept_mock_request(&listener).await;
+        stream
+            .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 1\r\n\r\n")
+            .await
+            .unwrap();
+        let _ = release_rx.await;
+        request
+    });
+
+    let client = ApiClient::new(&sock_path).unwrap();
+    let result = tokio::time::timeout(
+        MOCK_REQUEST_READ_TIMEOUT,
+        client.wait_for_ready(Duration::from_millis(100)),
+    )
+    .await
+    .expect("readiness ignored its deadline");
+    let ApiError::Other(message) = result.unwrap_err() else {
+        panic!("expected readiness timeout");
+    };
+    assert!(message.contains("timed out"), "got: {message}");
+
+    release_tx.send(()).unwrap();
+    let request = server.await.unwrap();
+    assert_request(&request, "GET", "/");
+}
+
+#[tokio::test]
+async fn wait_for_ready_retries_connection_refused_until_socket_is_rebound() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("fc.sock");
+    let stale_listener = UnixListener::bind(&sock_path).unwrap();
+    drop(stale_listener);
+
+    let waiter_path = sock_path.clone();
+    let waiter = tokio::spawn(async move {
+        let client = ApiClient::new(&waiter_path).unwrap();
+        client.wait_for_ready(Duration::from_secs(2)).await
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !waiter.is_finished(),
+        "ConnectionRefused should remain retryable"
+    );
+
+    std::fs::remove_file(&sock_path).unwrap();
+    let listener = UnixListener::bind(&sock_path).unwrap();
+    let server = async move {
+        let (mut stream, request) = accept_mock_request(&listener).await;
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .unwrap();
+        request
+    };
+
+    let (result, request) = tokio::time::timeout(MOCK_REQUEST_READ_TIMEOUT, async {
+        tokio::join!(waiter, server)
+    })
+    .await
+    .expect("readiness did not recover after the socket was rebound");
+    result.unwrap().unwrap();
+    assert_request(&request, "GET", "/");
 }
 
 #[tokio::test]
@@ -699,17 +1012,15 @@ async fn wait_for_ready_fails_fast_on_permission_denied() {
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(&sock_path, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-    let client = ApiClient::new(&sock_path);
-    let start = std::time::Instant::now();
-    let result = client.wait_for_ready(Duration::from_secs(5)).await;
-    let elapsed = start.elapsed();
+    let client = ApiClient::new(&sock_path).unwrap();
+    let result = tokio::time::timeout(
+        MOCK_REQUEST_READ_TIMEOUT,
+        client.wait_for_ready(Duration::from_secs(30)),
+    )
+    .await
+    .expect("PermissionDenied should fail before the readiness deadline");
 
-    // Should fail immediately, not spin for 5 seconds.
     assert!(result.is_err(), "expected error");
-    assert!(
-        elapsed < Duration::from_secs(1),
-        "should fail fast, took {elapsed:?}"
-    );
     let ApiError::Connect(ref io_err) = result.unwrap_err() else {
         panic!("expected Connect error");
     };

--- a/crates/sandbox-fc/src/api/tests.rs
+++ b/crates/sandbox-fc/src/api/tests.rs
@@ -158,6 +158,24 @@ fn api_error_is_not_retryable_permission_denied() {
     assert!(!err.is_retryable());
 }
 
+#[tokio::test]
+async fn connect_error_preserves_io_kind_and_transport_source() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir.path().join("missing.sock");
+    let client = ApiClient::new(&socket_path).unwrap();
+
+    let error = client.pause().await.unwrap_err();
+    let source = std::error::Error::source(&error).expect("missing I/O error source");
+    let io_error = source
+        .downcast_ref::<std::io::Error>()
+        .expect("connect source is not an I/O error");
+    assert_eq!(io_error.kind(), std::io::ErrorKind::NotFound);
+    assert!(
+        std::error::Error::source(io_error).is_some(),
+        "missing Reqwest transport source"
+    );
+}
+
 #[test]
 fn api_error_is_retryable_http_server_error() {
     let err = ApiError::Http {

--- a/crates/sandbox-fc/src/balloon.rs
+++ b/crates/sandbox-fc/src/balloon.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::time::Duration;
 
 use tokio::sync::watch;
@@ -43,9 +42,9 @@ pub(crate) struct ControllerHandle {
 }
 
 impl ControllerHandle {
-    fn spawn(api_sock: PathBuf, memory_mb: u32, state_rx: watch::Receiver<SandboxState>) -> Self {
+    fn spawn(client: ApiClient, memory_mb: u32, state_rx: watch::Receiver<SandboxState>) -> Self {
         Self {
-            task: Some(tokio::spawn(run_loop(api_sock, memory_mb, state_rx))),
+            task: Some(tokio::spawn(run_loop(client, memory_mb, state_rx))),
         }
     }
 
@@ -94,15 +93,14 @@ impl Drop for ControllerHandle {
 
 /// Spawn the balloon controller loop.
 pub(crate) fn spawn(
-    api_sock: PathBuf,
+    client: ApiClient,
     memory_mb: u32,
     state_rx: watch::Receiver<SandboxState>,
 ) -> ControllerHandle {
-    ControllerHandle::spawn(api_sock, memory_mb, state_rx)
+    ControllerHandle::spawn(client, memory_mb, state_rx)
 }
 
-async fn run_loop(api_sock: PathBuf, memory_mb: u32, mut state_rx: watch::Receiver<SandboxState>) {
-    let client = ApiClient::new(&api_sock);
+async fn run_loop(client: ApiClient, memory_mb: u32, mut state_rx: watch::Receiver<SandboxState>) {
     let max_inflate = memory_mb.saturating_sub(MIN_GUEST_MIB);
     if max_inflate == 0 {
         info!(
@@ -162,7 +160,7 @@ async fn wait_for_crash_or_stop(state_rx: &mut watch::Receiver<SandboxState>) {
 /// - Inflate when `free_memory > TARGET_FREE + INFLATE_HYSTERESIS`
 /// - Deflate when `available_memory < TARGET_FREE - DEFLATE_HYSTERESIS`
 /// - No action in between to prevent oscillation
-async fn tick(client: &ApiClient<'_>, max_inflate: u32, tick_count: u64) {
+async fn tick(client: &ApiClient, max_inflate: u32, tick_count: u64) {
     let stats = match client.get_balloon_statistics().await {
         Ok(s) => s,
         Err(e) => {
@@ -247,6 +245,8 @@ fn parse_meminfo(content: &str) -> Option<(u64, u64)> {
 mod tests {
     use super::*;
 
+    use std::path::PathBuf;
+
     use crate::api::test_support::{MockFirecrackerApi, MockRequest, MockResponse};
 
     const LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(1);
@@ -311,7 +311,7 @@ mod tests {
             MockResponse::no_content(),
         ]);
         let sock_path = api.socket_path().to_path_buf();
-        let client = ApiClient::new(&sock_path);
+        let client = ApiClient::new(&sock_path).unwrap();
         tick(&client, max_inflate, tick_count).await;
 
         let requests = api.drain_requests();
@@ -418,15 +418,17 @@ mod tests {
             let (_dir, sock_path) = missing_api_sock_path();
             let (_state_tx, state_rx) = watch::channel(SandboxState::Running);
             let context = format!("small-memory balloon controller ({memory_mb} MiB)");
+            let client = ApiClient::new(&sock_path).unwrap();
 
-            await_controller_exit(spawn(sock_path, memory_mb, state_rx), &context).await;
+            await_controller_exit(spawn(client, memory_mb, state_rx), &context).await;
         }
     }
 
     async fn assert_spawn_exits_on_state(state: SandboxState) {
         let (_dir, sock_path) = missing_api_sock_path();
         let (state_tx, state_rx) = watch::channel(SandboxState::Running);
-        let handle = spawn(sock_path, MIN_GUEST_MIB + 1, state_rx);
+        let client = ApiClient::new(&sock_path).unwrap();
+        let handle = spawn(client, MIN_GUEST_MIB + 1, state_rx);
 
         state_tx.send(state).unwrap();
         let context = format!("balloon controller after {state:?}");
@@ -580,7 +582,7 @@ mod tests {
             MockResponse::no_content(),
         ]);
         let sock_path = api.socket_path().to_path_buf();
-        let client = ApiClient::new(&sock_path);
+        let client = ApiClient::new(&sock_path).unwrap();
         // Should not panic — just logs warning and returns.
         tick(&client, 1536, 0).await;
 

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -862,7 +862,10 @@ impl FirecrackerSandbox {
     }
 
     /// Start using a fresh boot with `--config-file --api-sock`.
-    async fn start_fresh(&mut self, runtime_cancel: CancellationToken) -> sandbox::Result<()> {
+    async fn start_fresh(
+        &mut self,
+        runtime_cancel: CancellationToken,
+    ) -> sandbox::Result<ApiClient> {
         let config = self.build_config()?;
         let config_json =
             serde_json::to_string_pretty(&config).map_err(|e| SandboxError::Start {
@@ -908,7 +911,9 @@ impl FirecrackerSandbox {
         ));
 
         // Wait for API socket readiness so the balloon controller can connect.
-        let client = ApiClient::new(&api_sock);
+        let client = ApiClient::new(&api_sock).map_err(|e| SandboxError::Start {
+            message: format!("create API client: {e}"),
+        })?;
         tokio::select! {
             result = client.wait_for_ready(API_READY_TIMEOUT) => {
                 result.map_err(|e| {
@@ -934,14 +939,14 @@ impl FirecrackerSandbox {
         }
 
         info!(id = %self.id, "firecracker started (fresh boot)");
-        Ok(())
+        Ok(client)
     }
 
     /// Start from a snapshot using `--api-sock` and bind mounts.
     async fn start_from_snapshot(
         &mut self,
         runtime_cancel: CancellationToken,
-    ) -> sandbox::Result<()> {
+    ) -> sandbox::Result<ApiClient> {
         let snapshot =
             self.factory_config
                 .snapshot
@@ -1039,7 +1044,9 @@ impl FirecrackerSandbox {
 
         // Wait for Firecracker API to be ready, but bail early if the
         // process crashes before the socket appears.
-        let client = ApiClient::new(&api_sock);
+        let client = ApiClient::new(&api_sock).map_err(|e| SandboxError::Start {
+            message: format!("create API client: {e}"),
+        })?;
         tokio::select! {
             result = client.wait_for_ready(API_READY_TIMEOUT) => {
                 result.map_err(|e| {
@@ -1076,7 +1083,7 @@ impl FirecrackerSandbox {
         .await?;
 
         info!(id = %self.id, "snapshot loaded and resumed");
-        Ok(())
+        Ok(client)
     }
 }
 
@@ -1492,11 +1499,14 @@ impl Sandbox for FirecrackerSandbox {
             self.start_fresh(runtime_cancel.clone()).await
         };
 
-        if let Err(e) = start_result {
-            abort_and_join(vsock_task).await;
-            self.runtime.kill_process().await;
-            return Err(e);
-        }
+        let client = match start_result {
+            Ok(client) => client,
+            Err(e) => {
+                abort_and_join(vsock_task).await;
+                self.runtime.kill_process().await;
+                return Err(e);
+            }
+        };
 
         // Wait for guest to connect via vsock.
         let vsock_guest = tokio::select! {
@@ -1573,7 +1583,7 @@ impl Sandbox for FirecrackerSandbox {
 
         // Spawn balloon controller to reclaim unused guest memory.
         self.runtime.set_balloon(balloon::spawn(
-            self.sock_paths.api_sock().to_owned(),
+            client,
             self.config.resources.memory_mb,
             self.state_tx.subscribe(),
         ));
@@ -2784,7 +2794,7 @@ fn log_balloon_settle_timeout(
 /// [`BALLOON_SETTLE_TIMEOUT`] (partial inflation is better than none).
 /// Errors from stats fetching are non-fatal — we log and
 /// proceed to pause.
-async fn wait_for_balloon(client: &ApiClient<'_>, target_mib: u32, log_id: &str) {
+async fn wait_for_balloon(client: &ApiClient, target_mib: u32, log_id: &str) {
     let deadline = tokio::time::Instant::now() + BALLOON_SETTLE_TIMEOUT;
     let tolerance_mib = balloon_settle_tolerance_mib(target_mib);
     let mut summary = BalloonSettleSummary::new(target_mib);
@@ -2934,7 +2944,10 @@ async fn park_inner(
     }
 
     let target = memory_mb.saturating_sub(balloon::MIN_GUEST_MIB);
-    let client = ApiClient::new(api_sock);
+    let client = ApiClient::new(api_sock).map_err(|e| SandboxError::IdleTransition {
+        transition: SandboxIdleTransition::Park,
+        message: format!("create API client: {e}"),
+    })?;
 
     if target > 0 {
         // Stop the reactive controller so we're the sole writer to /balloon.
@@ -3020,7 +3033,10 @@ async fn unpark_inner(
     // already running. Within unpark_inner this only happens if a prior
     // partial unpark (resume OK, deflate failed) already resumed the VM.
     // Treat as success to preserve the trait's retry contract.
-    let client = ApiClient::new(api_sock);
+    let client = ApiClient::new(api_sock).map_err(|e| SandboxError::IdleTransition {
+        transition: SandboxIdleTransition::Unpark,
+        message: format!("create API client: {e}"),
+    })?;
     match client.resume().await {
         Ok(()) => {}
         Err(ApiError::Http { status: 400, .. }) => {
@@ -3066,7 +3082,7 @@ async fn unpark_inner(
                 message: format!("balloon deflate: {e}"),
             })?;
 
-        *balloon_controller = Some(balloon::spawn(api_sock.to_path_buf(), memory_mb, state_rx));
+        *balloon_controller = Some(balloon::spawn(client, memory_mb, state_rx));
     }
 
     *is_parked = false;

--- a/crates/sandbox-fc/src/sandbox/snapshot_restore.rs
+++ b/crates/sandbox-fc/src/sandbox/snapshot_restore.rs
@@ -16,7 +16,7 @@ pub(super) const SNAPSHOT_RESTORE_INNER_CMD: &str = r#"umount -- "$4" 2>/dev/nul
 pub(super) const UNSHARE_MOUNT_ARGS: &[&str] = &["--mount", "--propagation", "private"];
 
 pub(super) async fn load_snapshot_and_apply_rate_limits(
-    client: &ApiClient<'_>,
+    client: &ApiClient,
     snapshot_path: &str,
     memory_path: &str,
     rate_limits: Option<&FirecrackerDeviceRateLimits>,

--- a/crates/sandbox-fc/src/sandbox/tests.rs
+++ b/crates/sandbox-fc/src/sandbox/tests.rs
@@ -3548,7 +3548,7 @@ fn balloon_statistics(target_mib: u32, actual_mib: u32) -> BalloonStatistics {
     }
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
     let target_mib = 4096 - balloon::MIN_GUEST_MIB;
     let (sock, _reqs, _dir) = spawn_mock_fc_api_with_stats(
@@ -3559,7 +3559,7 @@ async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
         ))]),
     )
     .await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
 
     let (_, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "near-target")).await;
@@ -3585,7 +3585,7 @@ async fn wait_for_balloon_near_target_logs_summary_without_timeout() {
     assert_event_field(event, "actual_delta_mib", "Some(0)");
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let (sock, _reqs, _dir) = spawn_mock_fc_api_with_stats(
@@ -3595,7 +3595,7 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
         ))]),
     )
     .await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
 
     let (_, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "stalled")).await;
@@ -3617,7 +3617,7 @@ async fn wait_for_balloon_timeout_logs_actual_stalled_reason() {
     assert_event_field(event, "reason", "actual_stalled");
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let stats = MockBalloonStats::new(target_mib, 1250).with_memory(mib(64), mib(128), mib(2048));
@@ -3626,7 +3626,7 @@ async fn wait_for_balloon_accepts_pressure_limited_partial_reclaim() {
         std::collections::VecDeque::from([MockBalloonStatsReply::Ok(stats)]),
     )
     .await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
 
     let (_, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "pressure-limited")).await;
@@ -3711,7 +3711,7 @@ fn pressure_limited_reclaim_ignores_free_memory_when_available_memory_is_missing
     );
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let (sock, _reqs, _dir) = spawn_mock_fc_api_with_stats(
@@ -3721,7 +3721,7 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
         ))]),
     )
     .await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
 
     let (_, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "stale-target")).await;
@@ -3736,7 +3736,7 @@ async fn wait_for_balloon_timeout_logs_target_not_observed_reason() {
     assert_event_field(event, "reason", "target_not_observed");
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let (sock, _reqs, _dir) = spawn_mock_fc_api_with_stats(
@@ -3747,7 +3747,7 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
         )]),
     )
     .await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
 
     let (_, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "slow-stats")).await;
@@ -3763,7 +3763,7 @@ async fn wait_for_balloon_stats_poll_is_bounded_by_settle_timeout() {
     assert_event_field(event, "deficit_mib", "None");
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let stats = MockBalloonStats::new(target_mib, 900).with_memory(mib(32), mib(0), mib(2048));
@@ -3772,7 +3772,7 @@ async fn wait_for_balloon_timeout_logs_severe_deficit_and_memory_stats() {
         std::collections::VecDeque::from([MockBalloonStatsReply::Ok(stats)]),
     )
     .await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
 
     let (_, events) =
         capture_async_log_events(wait_for_balloon(&client, target_mib, "severe")).await;
@@ -3830,7 +3830,7 @@ async fn park_pauses_when_balloon_stats_are_unavailable() {
 async fn snapshot_restore_with_limiters_loads_paused_patches_then_resumes() {
     let (sock, reqs, _dir) =
         spawn_mock_fc_api(std::collections::VecDeque::from(vec![204, 204, 204]), None).await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
     let rate_limits = test_rate_limits();
 
     load_snapshot_and_apply_rate_limits(&client, "/snap/state", "/snap/memory", Some(&rate_limits))
@@ -3880,7 +3880,7 @@ async fn snapshot_restore_with_limiters_loads_paused_patches_then_resumes() {
 #[tokio::test]
 async fn snapshot_restore_without_limiters_loads_and_resumes_without_patching() {
     let (sock, reqs, _dir) = spawn_mock_fc_api(std::collections::VecDeque::new(), None).await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
 
     load_snapshot_and_apply_rate_limits(&client, "/snap/state", "/snap/memory", None)
         .await
@@ -3897,7 +3897,7 @@ async fn snapshot_restore_without_limiters_loads_and_resumes_without_patching() 
 async fn snapshot_restore_limiter_patch_failure_does_not_resume() {
     let (sock, reqs, _dir) =
         spawn_mock_fc_api(std::collections::VecDeque::from(vec![500]), None).await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
     let rate_limits = test_rate_limits();
 
     let err = load_snapshot_and_apply_rate_limits(
@@ -3925,7 +3925,7 @@ async fn snapshot_restore_limiter_patch_failure_does_not_resume() {
 async fn snapshot_restore_workspace_limiter_patch_failure_does_not_resume() {
     let (sock, reqs, _dir) =
         spawn_mock_fc_api(std::collections::VecDeque::from(vec![204, 500]), None).await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
     let rate_limits = test_rate_limits();
 
     let err = load_snapshot_and_apply_rate_limits(
@@ -3960,7 +3960,7 @@ async fn snapshot_restore_workspace_limiter_patch_failure_does_not_resume() {
 async fn snapshot_restore_network_limiter_patch_failure_does_not_resume() {
     let (sock, reqs, _dir) =
         spawn_mock_fc_api(std::collections::VecDeque::from(vec![204, 204, 500]), None).await;
-    let client = ApiClient::new(&sock);
+    let client = ApiClient::new(&sock).unwrap();
     let rate_limits = test_rate_limits();
 
     let err = load_snapshot_and_apply_rate_limits(
@@ -4589,11 +4589,11 @@ async fn unpark_retry_after_partial_failure_resumes_idempotently() {
     }
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn park_waits_for_balloon_before_pause() {
-    // Mock returns actual_mib = 0 initially, then 1536 after we advance
-    // time past the first poll interval. Using `start_paused = true` for
-    // deterministic timing — no wall-clock dependencies.
+    // Mock returns actual_mib = 0 initially, then 1536 before the next
+    // poll interval. This uses the real clock because
+    // the API boundary uses a real Unix socket.
     let balloon_actual = Arc::new(AtomicU32::new(0));
     let (sock, reqs, _dir) = spawn_mock_fc_api(
         std::collections::VecDeque::new(),
@@ -4601,11 +4601,10 @@ async fn park_waits_for_balloon_before_pause() {
     )
     .await;
 
-    // After the first poll sees actual=0 and sleeps 500ms, the auto-advance
-    // fires. Set actual to target so the second poll succeeds.
+    // Set actual to target before the second 500ms poll.
     let actual_clone = Arc::clone(&balloon_actual);
     tokio::spawn(async move {
-        // Wait for one poll cycle (the 500ms sleep auto-advances).
+        // Let the first stats request complete before changing the value.
         tokio::time::sleep(Duration::from_millis(250)).await;
         actual_clone.store(1536, Ordering::Relaxed);
     });
@@ -4638,7 +4637,7 @@ async fn park_waits_for_balloon_before_pause() {
     assert!(ps[1].body.contains("Paused"));
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn park_pauses_when_balloon_is_within_settle_tolerance() {
     // Production samples have shown 4 GiB VMs often settling with a
     // low-hundreds MiB residual while the guest reports little available
@@ -4676,7 +4675,7 @@ async fn park_pauses_when_balloon_is_within_settle_tolerance() {
     assert!(ps[1].body.contains("Paused"));
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn park_pauses_when_balloon_deficit_equals_settle_tolerance() {
     let target_mib = 4096 - balloon::MIN_GUEST_MIB;
     let balloon_actual = Arc::new(AtomicU32::new(
@@ -4719,7 +4718,7 @@ async fn park_pauses_when_balloon_deficit_equals_settle_tolerance() {
     assert!(ps[1].body.contains("Paused"));
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn park_pauses_when_balloon_reclaim_is_pressure_limited() {
     let target_mib = 2048 - balloon::MIN_GUEST_MIB;
     let stats = MockBalloonStats::new(target_mib, 1250).with_memory(mib(64), mib(128), mib(2048));
@@ -4768,12 +4767,10 @@ async fn park_pauses_when_balloon_reclaim_is_pressure_limited() {
     assert!(ps[1].body.contains("Paused"));
 }
 
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn park_pauses_after_balloon_settle_timeout() {
     // Balloon never reaches target — wait_for_balloon must time out
-    // and proceed to pause anyway. With `start_paused = true`, tokio
-    // auto-advances simulated time when all tasks await timers, so
-    // the timeout completes instantly in wall-clock time.
+    // and proceed to pause anyway.
     let balloon_actual = Arc::new(AtomicU32::new(0)); // stuck at 0
     let (sock, reqs, _dir) = spawn_mock_fc_api(
         std::collections::VecDeque::new(),

--- a/crates/sandbox-fc/src/snapshot/runtime.rs
+++ b/crates/sandbox-fc/src/snapshot/runtime.rs
@@ -287,7 +287,7 @@ async fn run_with_firecracker(
 ) -> Result<SnapshotConfig, SnapshotError> {
     // 5. Wait for API socket ready.
     let api_sock = sock_paths.api_sock();
-    let client = ApiClient::new(&api_sock);
+    let client = ApiClient::new(&api_sock)?;
     client.wait_for_ready(API_READY_TIMEOUT).await?;
     set_private_runtime_socket_mode(&api_sock)?;
 
@@ -430,7 +430,7 @@ fn prewarm_failure_detail(stderr: &str, diagnostic: &str) -> String {
 }
 
 async fn configure_snapshot_vm(
-    client: &ApiClient<'_>,
+    client: &ApiClient,
     config: &SnapshotCreateConfig,
     paths: &SandboxPaths,
     sock_paths: &SockPaths,
@@ -637,7 +637,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let paths = SandboxPaths::new(dir.path().join("work"));
         let sock_paths = SockPaths::new(dir.path().join("sock"));
-        let client = ApiClient::new(api.socket_path());
+        let client = ApiClient::new(api.socket_path()).unwrap();
         let config = snapshot_create_config(dir.path().join("snapshot-output"));
         let inv = InvariantConfig::new();
 


### PR DESCRIPTION
## Summary

- replace the bespoke Firecracker HTTP/1.1 request and response codec with a deliberately configured Reqwest client over the Firecracker Unix socket
- collect only balloon statistics and non-2xx diagnostics, with a fixed 64 KiB checked limit, while successful status-only operations drop response bodies
- preserve any-2xx behavior, fault-message extraction, operation deadlines, and readiness connect-error classification through an owned, fallible `ApiClient`
- pass initialized clients through startup and balloon lifecycle boundaries and add real-UDS regression coverage for head/body bounds, redirects, connection reuse, deadlines, and retry behavior

## Scope

- no Firecracker boot, snapshot, vsock, or device-configuration ordering changes
- no connection pooling, transport retries, redirects, proxies, or response-size configuration
- no runner/guest protocol, persisted-state, database, or product API changes

## Validation

Passed:

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p sandbox-fc --all-targets --all-features`
- `cd crates && cargo test -p sandbox-fc`
- `cd crates && cargo check -p runner`
- `cd crates && cargo clippy --all-targets --all-features`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo test --all-targets --all-features`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm knip`
- `git diff --check`

Local full-suite note:

- `cd turbo && pnpm vitest` was run after `scripts/prepare.sh`; 7,236 tests passed, 8 tests outside this Rust-only diff failed, and 1 was skipped. The migration-related API failure and representative platform timeout both passed when rerun in isolation; one existing usage-allowance assertion remains independently reproducible with no `turbo/` changes in this branch.

Closes #20908

