### PR TITLE
refactor: enforce fresh auth.base requests without catalog header policy

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -21,6 +21,7 @@ from auth_base_forwarder import (
     MAX_AUTH_BASE_REQUEST_BODY_BYTES,
     AuthBaseForwardingSaturatedError,
     ForwardedRequestTooLargeError,
+    InvalidAuthBaseRequestHeadersError,
     InvalidResolvedAuthHeaderError,
     forward_request,
     forwarded_auth_base_client_header_pairs,
@@ -256,14 +257,6 @@ def _merge_auth_headers(
     ] + auth_pairs
 
 
-def _auth_config_header_names(allow: matching.FirewallAllow) -> frozenset[str]:
-    auth_config = allow.api_entry.get("auth", {})
-    auth_headers = auth_config.get("headers") if isinstance(auth_config, dict) else None
-    if not isinstance(auth_headers, dict):
-        return frozenset()
-    return frozenset(name.lower() for name in auth_headers if isinstance(name, str))
-
-
 def _record_firewall_auth_success_metadata(flow: http.HTTPFlow, token_meta: dict) -> None:
     flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
     flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] = token_meta.get("resolved_secrets", [])
@@ -365,23 +358,6 @@ def _sign_flow_request_with_aws_sigv4(
     flow.request.url = signed_url
     flow.request.headers = http.Headers(
         [(name.encode(), value.encode()) for name, value in signed_headers]
-    )
-
-
-def _sign_forwarded_request_with_aws_sigv4(
-    *,
-    method: str,
-    url: str,
-    headers: list[tuple[str, str]],
-    body: bytes | None,
-    credentials: AwsSigV4Credentials,
-) -> tuple[str, list[tuple[str, str]]]:
-    return sign_request(
-        method=method,
-        url=url,
-        headers=headers,
-        body=body,
-        credentials=credentials,
     )
 
 
@@ -761,9 +737,9 @@ async def _apply_url_rewrite(
     *,
     allow: matching.FirewallAllow,
     resolved_base: str,
+    client_representation_headers: list[tuple[str, str]],
     headers: dict[str, str],
     resolved_query: dict | None,
-    aws_sigv4: AwsSigV4Credentials | None,
     firewall_base: str,
     proxy_log_path: str,
 ) -> FirewallAuthHandlingResult:
@@ -783,36 +759,10 @@ async def _apply_url_rewrite(
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    # Filter untrusted client headers before adding trusted auth headers, so
-    # placeholder-scoped credentials cannot cross the auth.base rewrite.
-    # Repeated request headers are preserved; resolved auth headers
-    # intentionally replace any client-supplied value with the same name.
-    client_headers = forwarded_auth_base_client_header_pairs(
-        flow.request.headers,
-        preserve_aws_sigv4_authorization=aws_sigv4 is not None,
-        extra_excluded_names=_auth_config_header_names(allow),
-    )
-    req_headers = _merge_auth_headers(client_headers, headers)
+    # These client pairs were selected before auth resolution. Trusted resolved
+    # auth is applied only after that fresh-request boundary is established.
+    req_headers = _merge_auth_headers(client_representation_headers, headers)
     req_body = flow.request.raw_content if flow.request.raw_content is not None else None
-    if aws_sigv4 is not None:
-        try:
-            new_url, req_headers = _sign_forwarded_request_with_aws_sigv4(
-                method=flow.request.method,
-                url=new_url,
-                headers=req_headers,
-                body=req_body,
-                credentials=aws_sigv4,
-            )
-        except AwsSigV4SigningError as e:
-            _set_matched_firewall_failure_response(
-                flow,
-                status=502,
-                action="ALLOW",
-                error_code="aws_sigv4_auth_failed",
-                message=str(e),
-                permission=allow.name,
-            )
-            return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
     try:
         admission = take_forward_request_admission_from_flow(flow)
@@ -864,28 +814,38 @@ async def _apply_url_rewrite(
 async def _apply_resolved_firewall_auth(
     flow: http.HTTPFlow,
     *,
-    allow: matching.FirewallAllow,
+    context: _FirewallAuthContext,
     token_meta: dict,
-    firewall_base: str,
-    proxy_log_path: str,
+    auth_base_client_headers: list[tuple[str, str]] | None,
 ) -> FirewallAuthHandlingResult:
     """Apply resolved firewall auth and return request ownership outcome."""
     headers = token_meta["headers"]
     resolved_query = token_meta.get("query")
-    resolved_base = token_meta.get("base")
-    aws_sigv4 = token_meta.get("aws_sigv4")
 
     try:
-        if resolved_base:
+        if context.auth_request.auth_base is not None:
+            resolved_base = token_meta.get("base")
+            if not isinstance(resolved_base, str) or not resolved_base:
+                return _set_firewall_auth_resolution_failure(
+                    flow,
+                    context,
+                    ValueError("resolved auth base is missing"),
+                )
+            if auth_base_client_headers is None:
+                return _set_firewall_auth_resolution_failure(
+                    flow,
+                    context,
+                    ValueError("auth.base client request headers are unavailable"),
+                )
             return await _apply_url_rewrite(
                 flow,
-                allow=allow,
+                allow=context.allow,
                 resolved_base=resolved_base,
+                client_representation_headers=auth_base_client_headers,
                 headers=headers,
                 resolved_query=resolved_query,
-                aws_sigv4=aws_sigv4,
-                firewall_base=firewall_base,
-                proxy_log_path=proxy_log_path,
+                firewall_base=context.firewall_base,
+                proxy_log_path=context.proxy_log_path,
             )
 
         release_forward_request_admission_from_flow(flow)
@@ -897,14 +857,21 @@ async def _apply_resolved_firewall_auth(
     except InvalidResolvedAuthHeaderError as e:
         _set_invalid_resolved_auth_header_response(
             flow,
-            allow=allow,
-            proxy_log_path=proxy_log_path,
-            firewall_base=firewall_base,
+            allow=context.allow,
+            proxy_log_path=context.proxy_log_path,
+            firewall_base=context.firewall_base,
             error=e,
         )
         return FirewallAuthHandlingResult.LOCAL_RESPONSE
 
-    if aws_sigv4 is not None:
+    if context.auth_request.auth_aws_sigv4 is not None:
+        aws_sigv4 = token_meta.get("aws_sigv4")
+        if not isinstance(aws_sigv4, AwsSigV4Credentials):
+            return _set_firewall_auth_resolution_failure(
+                flow,
+                context,
+                ValueError("resolved AWS SigV4 credentials are missing"),
+            )
         try:
             _sign_flow_request_with_aws_sigv4(flow, aws_sigv4)
         except AwsSigV4SigningError as e:
@@ -914,7 +881,7 @@ async def _apply_resolved_firewall_auth(
                 action="ALLOW",
                 error_code="aws_sigv4_auth_failed",
                 message=str(e),
-                permission=allow.name,
+                permission=context.allow.name,
             )
             return FirewallAuthHandlingResult.LOCAL_RESPONSE
     return FirewallAuthHandlingResult.CONTINUE_UPSTREAM
@@ -960,6 +927,34 @@ async def handle_firewall_request(
         if preflight_result is not None:
             return _finish_firewall_auth_result(flow, preflight_result)
 
+        auth_base_client_headers: list[tuple[str, str]] | None = None
+        if context.auth_request.auth_base is not None:
+            try:
+                auth_base_client_headers = forwarded_auth_base_client_header_pairs(
+                    flow.request.headers
+                )
+            except InvalidAuthBaseRequestHeadersError as exc:
+                log_proxy_entry(
+                    context.proxy_log_path,
+                    "warn",
+                    "Invalid auth.base request headers",
+                    type="firewall",
+                    firewall_base=context.firewall_base,
+                    error_type=type(exc).__name__,
+                )
+                _set_matched_firewall_failure_response(
+                    flow,
+                    status=400,
+                    action="ALLOW",
+                    error_code="invalid_auth_base_request_headers",
+                    message=str(exc),
+                    permission=context.allow.name,
+                )
+                return _finish_firewall_auth_result(
+                    flow,
+                    FirewallAuthHandlingResult.LOCAL_RESPONSE,
+                )
+
         if _firewall_auth_context_needs_resolution(context):
             try:
                 token_meta = await get_firewall_headers(
@@ -976,10 +971,9 @@ async def handle_firewall_request(
 
         auth_result = await _apply_resolved_firewall_auth(
             flow,
-            allow=context.allow,
+            context=context,
             token_meta=token_meta,
-            firewall_base=context.firewall_base,
-            proxy_log_path=context.proxy_log_path,
+            auth_base_client_headers=auth_base_client_headers,
         )
         if auth_result is FirewallAuthHandlingResult.LOCAL_RESPONSE:
             return _finish_firewall_auth_result(flow, auth_result)

--- a/crates/runner/mitm-addon/src/auth_base_forwarder.py
+++ b/crates/runner/mitm-addon/src/auth_base_forwarder.py
@@ -17,7 +17,6 @@ import threading
 import urllib.parse
 from concurrent.futures import Future, InvalidStateError
 from contextlib import suppress
-from functools import cache
 from typing import NamedTuple, Protocol
 
 from mitmproxy import http
@@ -31,7 +30,6 @@ from authority_utils import (
     percent_decode_host,
     raw_authority_host,
 )
-from generated.builtin_firewalls import BUILTIN_FIREWALLS
 from host_normalization import normalize_idna_hostname
 from http_header_syntax import has_forbidden_header_value_control, is_http_header_name
 
@@ -47,60 +45,6 @@ HOP_BY_HOP: frozenset[str] = frozenset(
         "trailer",
         "upgrade",
     )
-)
-_RESOLVED_AUTH_HEADER_EXCLUDED: frozenset[str] = HOP_BY_HOP | frozenset(
-    ("host", "content-length", "transfer-encoding")
-)
-_CLIENT_CREDENTIAL_HEADER_NAMES: frozenset[str] = frozenset(
-    (
-        "access-token",
-        "api-key",
-        "api_access_token",
-        "api_key",
-        "apikey",
-        "app_id",
-        "app_key",
-        "authorization",
-        "chatgpt-account-id",
-        "cookie",
-        "developer-token",
-        "mailsac-key",
-        "private-token",
-        "project-access-token",
-        "x-access-token",
-        "x-amz-security-token",
-        "x-api-key",
-        "x-api-secret",
-        "x-api-token",
-        "x-apikey",
-        "x-auth-token",
-        "x-bb-api-key",
-        "x-browser-use-api-key",
-        "x-cg-demo-api-key",
-        "x-cg-pro-api-key",
-        "x-faire-access-token",
-        "x-figma-token",
-        "x-goog-api-key",
-        "x-hume-api-key",
-        "x-key",
-        "x-luma-api-key",
-        "x-manus-api-key",
-        "x-modal-token-id",
-        "x-modal-token-secret",
-        "x-moss-project-id",
-        "x-n8n-api-key",
-        "x-rapidapi-key",
-        "x-secret-api-key",
-        "x-server-id",
-        "x-shopify-access-token",
-        "x-subscription-token",
-        "x-user-id",
-        "xi-api-key",
-    )
-)
-_AWS_SIGV4_AUTHORIZATION_PREFIXES: tuple[str, ...] = (
-    "AWS4-HMAC-SHA256 ",
-    "AWS4-ECDSA-P256-SHA256 ",
 )
 DEFAULT_HTTPS_PORT = 443
 MAX_AUTH_BASE_REQUEST_BODY_BYTES = 32 * 1024 * 1024
@@ -130,18 +74,6 @@ _forward_request_active_closeables: set["_Closeable"] = set()
 _forward_request_active_closeables_lock = threading.Lock()
 _https_context: ssl.SSLContext | None = None
 _https_context_lock = threading.Lock()
-
-
-@cache
-def _templated_builtin_auth_header_names() -> frozenset[str]:
-    names: set[str] = set()
-    for firewall in BUILTIN_FIREWALLS.values():
-        for api in firewall.get("apis", []):
-            auth_headers = api.get("auth", {}).get("headers", {})
-            for name, value in auth_headers.items():
-                if isinstance(name, str) and isinstance(value, str) and "${{" in value:
-                    names.add(name.lower())
-    return frozenset(names)
 
 
 class _Closeable(Protocol):
@@ -277,6 +209,10 @@ class UnsafeAuthBaseDestinationError(Exception):
 
 class InvalidResolvedAuthHeaderError(Exception):
     """Raised when resolved auth data contains an invalid HTTP header."""
+
+
+class InvalidAuthBaseRequestHeadersError(Exception):
+    """Raised when client representation headers cannot be forwarded safely."""
 
 
 class AuthBaseForwardingAdmission:
@@ -469,40 +405,21 @@ def forwarded_request_header_pairs(headers) -> list[tuple[str, str]]:
     )
 
 
-def _is_aws_sigv4_authorization(value: str) -> bool:
-    return value.startswith(_AWS_SIGV4_AUTHORIZATION_PREFIXES)
-
-
 def forwarded_auth_base_client_header_pairs(
     headers,
-    *,
-    preserve_aws_sigv4_authorization: bool = False,
-    extra_excluded_names: frozenset[str] = frozenset(),
 ) -> list[tuple[str, str]]:
-    """Return client headers allowed to cross an auth.base rewrite.
+    """Select representation metadata allowed to cross an auth.base rewrite."""
+    raw_pairs = header_pairs(headers)
+    content_type_count = sum(1 for name, _value in raw_pairs if name.lower() == "content-type")
+    if content_type_count > 1:
+        raise InvalidAuthBaseRequestHeadersError(
+            "auth.base requests must contain at most one Content-Type header"
+        )
 
-    This applies forwarded request filtering, then strips client
-    credential-like headers named by ``_CLIENT_CREDENTIAL_HEADER_NAMES`` so
-    placeholder-scoped credentials do not cross the rewrite. Within that
-    stripped set, the only exception is ``Authorization`` when
-    ``preserve_aws_sigv4_authorization`` is enabled and the value is a
-    supported AWS SigV4 authorization value.
-    """
-    pairs = forwarded_request_header_pairs(headers)
-    excluded_names = (
-        _CLIENT_CREDENTIAL_HEADER_NAMES
-        | _templated_builtin_auth_header_names()
-        | extra_excluded_names
-    )
     return [
         (name, value)
-        for name, value in pairs
-        if name.lower() not in excluded_names
-        or (
-            preserve_aws_sigv4_authorization
-            and name.lower() == "authorization"
-            and _is_aws_sigv4_authorization(value)
-        )
+        for name, value in forwarded_request_header_pairs(raw_pairs)
+        if name.lower() in {"content-type", "content-encoding"}
     ]
 
 
@@ -523,17 +440,18 @@ def resolved_auth_header_pairs(headers) -> list[tuple[str, str]]:
     """Validate and filter resolved auth headers before outbound injection.
 
     Each resolved header name and value is validated before any pair is
-    returned; invalid pairs raise ``InvalidResolvedAuthHeaderError``. Headers
-    excluded by ``_RESOLVED_AUTH_HEADER_EXCLUDED`` are then dropped. This
-    helper does not merge with or replace client headers; callers that combine
-    resolved and client headers own that policy.
+    returned; invalid pairs raise ``InvalidResolvedAuthHeaderError``. Transport,
+    authority, and framing headers are then dropped. This helper does not merge
+    with or replace client headers; callers that combine resolved and client
+    headers own that policy.
     """
     pairs = header_pairs(headers)
     for name, value in pairs:
         _validate_resolved_auth_header_pair(name, value)
-    return [
-        (name, value) for name, value in pairs if name.lower() not in _RESOLVED_AUTH_HEADER_EXCLUDED
-    ]
+    return _filter_header_pairs(
+        pairs,
+        extra_excluded={"host", "content-length", "transfer-encoding"},
+    )
 
 
 def trusted_request_header_pairs(headers) -> list[tuple[str, str]]:

--- a/crates/runner/mitm-addon/src/aws_sigv4.py
+++ b/crates/runner/mitm-addon/src/aws_sigv4.py
@@ -7,9 +7,8 @@ placeholder SigV4 metadata in either the ``Authorization`` header or presigned
 ``X-Amz-*`` query parameters.
 
 Unsupported, ambiguous, or malformed requests fail closed by raising
-``AwsSigV4SigningError``. The same contract is used by normal firewall auth
-injection in ``auth._sign_flow_request_with_aws_sigv4`` and by ``auth.base``
-forwarding in ``auth._sign_forwarded_request_with_aws_sigv4``.
+``AwsSigV4SigningError``. The contract is used by normal firewall auth
+injection in ``auth._sign_flow_request_with_aws_sigv4``.
 """
 
 from __future__ import annotations

--- a/crates/runner/mitm-addon/src/firewall_auth_client.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_client.py
@@ -228,7 +228,10 @@ def _parse_optional_aws_sigv4_credentials(
     )
 
 
-def _parse_firewall_auth_success(decoded: object) -> FirewallAuthSuccess:
+def _parse_firewall_auth_success(
+    decoded: object,
+    request: FirewallAuthRequest,
+) -> FirewallAuthSuccess:
     if not isinstance(decoded, dict):
         raise _malformed_firewall_auth_success("response must be an object")
 
@@ -236,16 +239,36 @@ def _parse_firewall_auth_success(decoded: object) -> FirewallAuthSuccess:
     if "headers" not in decoded_map:
         raise _malformed_firewall_auth_success("headers is required")
 
-    base = decoded_map.get("base")
-    if base is not None and not isinstance(base, str):
-        raise _malformed_firewall_auth_success("base must be a string")
-
     headers = _parse_string_map(decoded_map["headers"], "headers")
     resolved_secrets = _parse_optional_string_list(decoded_map, "resolvedSecrets")
     refreshed_connectors = _parse_optional_string_list(decoded_map, "refreshedConnectors")
     refreshed_secrets = _parse_optional_string_list(decoded_map, "refreshedSecrets")
+    base = _parse_optional_string(decoded_map, "base")
     query = _parse_optional_string_map(decoded_map, "query")
     aws_sigv4 = _parse_optional_aws_sigv4_credentials(decoded_map)
+
+    if set(headers) != set(request.auth_headers):
+        raise _malformed_firewall_auth_success(
+            "headers must match the configured auth header names"
+        )
+    if set(query or {}) != set(request.auth_query or {}):
+        raise _malformed_firewall_auth_success("query must match the configured auth query names")
+    if (base is not None) != (request.auth_base is not None):
+        raise _malformed_firewall_auth_success("base presence must match the configured auth base")
+    if (aws_sigv4 is not None) != (request.auth_aws_sigv4 is not None):
+        raise _malformed_firewall_auth_success(
+            "awsSigv4 presence must match the configured auth mode"
+        )
+    request_session_token_present = (
+        request.auth_aws_sigv4 is not None
+        and request.auth_aws_sigv4.get("sessionToken") is not None
+    )
+    response_session_token_present = aws_sigv4 is not None and aws_sigv4.session_token is not None
+    if response_session_token_present != request_session_token_present:
+        raise _malformed_firewall_auth_success(
+            "awsSigv4.sessionToken presence must match the configured auth mode"
+        )
+
     payload = FirewallAuthPayload(
         headers=headers,
         resolved_secrets=resolved_secrets,
@@ -279,7 +302,7 @@ def _fetch_firewall_headers_sync(
         # nosemgrep: dynamic-urllib-use-detected
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
             decoded: object = json.loads(_read_firewall_auth_response_body(resp))
-            return _parse_firewall_auth_success(decoded)
+            return _parse_firewall_auth_success(decoded, request)
     except urllib.error.HTTPError as e:
         # HTTPError wraps an open socket; `with e` closes on every exit
         # path to avoid FD exhaustion under sustained cache-miss load (#10475).

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -368,6 +368,8 @@ def _auth_config_is_valid(api_entry: dict) -> bool:
             return False
         if raw_auth.get("query"):
             return False
+        if "base" in raw_auth:
+            return False
     if "base" in raw_auth and not isinstance(raw_auth["base"], str):
         return False
     return "base" not in raw_auth or _static_auth_base_is_valid(raw_auth["base"])

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -53,10 +53,11 @@ class TestFirewallHeaderCache:
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
             started = [asyncio.Event() for _ in range(3)]
             cache_key = auth_cache_key()
+            auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
 
             async def fetch_headers(started_event: asyncio.Event) -> dict:
                 started_event.set()
-                return await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+                return await auth_cache.get_firewall_headers(cache_key, auth_request)
 
             tasks = [asyncio.create_task(fetch_headers(started_event)) for started_event in started]
             try:
@@ -102,9 +103,10 @@ class TestFirewallHeaderCache:
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
             first_key = auth_cache_key(api_id="api-1")
             second_key = auth_cache_key(api_id="api-2")
+            auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
             first, second = await asyncio.gather(
-                auth_cache.get_firewall_headers(first_key, _firewall_auth_request()),
-                auth_cache.get_firewall_headers(second_key, _firewall_auth_request()),
+                auth_cache.get_firewall_headers(first_key, auth_request),
+                auth_cache.get_firewall_headers(second_key, auth_request),
             )
 
         assert endpoint.request_count == 2
@@ -138,8 +140,9 @@ class TestFirewallHeaderCache:
         default_key = auth_cache_key(auth_identity="default-permission")
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
-            explicit = await auth_cache.get_firewall_headers(explicit_key, _firewall_auth_request())
-            default = await auth_cache.get_firewall_headers(default_key, _firewall_auth_request())
+            auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
+            explicit = await auth_cache.get_firewall_headers(explicit_key, auth_request)
+            default = await auth_cache.get_firewall_headers(default_key, auth_request)
 
         assert endpoint.request_count == 2
         assert explicit["headers"] == {"Authorization": "Bearer explicit"}
@@ -190,21 +193,22 @@ class TestFirewallHeaderCache:
                 "expiresAt": time.time() + 3600,
             }
         )
+        auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
 
         with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
             with pytest.raises(urllib.error.HTTPError):
-                await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+                await auth_cache.get_firewall_headers(cache_key, auth_request)
 
             assert endpoint.request_count == 1
             assert cached_headers(cache_key) is None
 
-            retry = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            retry = await auth_cache.get_firewall_headers(cache_key, auth_request)
             assert retry["headers"] == {"Authorization": "Bearer retry"}
             assert retry["cache_hit"] is False
             assert endpoint.request_count == 2
             assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer retry"}
 
-            cached = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            cached = await auth_cache.get_firewall_headers(cache_key, auth_request)
             assert cached["headers"] == {"Authorization": "Bearer retry"}
             assert cached["cache_hit"] is True
             assert endpoint.request_count == 2

--- a/crates/runner/mitm-addon/tests/test_auth_query_injection.py
+++ b/crates/runner/mitm-addon/tests/test_auth_query_injection.py
@@ -189,7 +189,7 @@ class TestAuthQueryInjection:
         assert "authorization" not in forwarded_header_names
         assert "cookie" not in forwarded_header_names
         assert "x-api-key" not in forwarded_header_names
-        assert ("X-Keep", "client") in req_headers
+        assert "x-keep" not in forwarded_header_names
         assert "api_key" not in flow.request.query
         assert flow.request.query["client"] == "visible"
         assert flow.request.headers["Authorization"] == "Bearer agent"

--- a/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_auth.py
+++ b/crates/runner/mitm-addon/tests/test_compiled_firewall_malformed_auth.py
@@ -45,6 +45,7 @@ def _github_policies(*, unknown_policy="allow"):
         {"headers": {123: "Bearer token"}},
         {"base": None},
         {"base": 123},
+        {"base": ""},
         {"base": "ftp://example.com/hook"},
         {"base": "http://example.com/hook"},
         {"base": "http://${{ vars.WEBHOOK_HOST }}/hook"},
@@ -79,6 +80,18 @@ def _github_policies(*, unknown_policy="allow"):
         {"query": "api_key"},
         {"query": {"api_key": 123}},
         {"query": {123: "token"}},
+        {
+            "headers": {"Authorization": "token"},
+            "awsSigv4": {"accessKeyId": "key", "secretAccessKey": "secret"},
+        },
+        {
+            "query": {"api_key": "token"},
+            "awsSigv4": {"accessKeyId": "key", "secretAccessKey": "secret"},
+        },
+        {
+            "base": "https://hooks.example.com/secret",
+            "awsSigv4": {"accessKeyId": "key", "secretAccessKey": "secret"},
+        },
     ],
 )
 def test_malformed_auth_config_fails_closed_after_base_match(auth_config):
@@ -118,6 +131,51 @@ def test_malformed_auth_config_fails_closed_after_base_match(auth_config):
     ],
 )
 def test_valid_auth_base_config_can_match(auth_config):
+    result = match_compiled_firewalls(
+        REPO_URL,
+        _github_firewalls_with_auth(auth_config),
+        _github_policies(unknown_policy="deny"),
+    )
+
+    assert isinstance(result, matching.FirewallAllow)
+    assert result.permission == "repo-read"
+
+
+@pytest.mark.parametrize(
+    "auth_config",
+    [
+        {"headers": {"Authorization": "token"}},
+        {"query": {"api_key": "token"}},
+        {
+            "headers": {"Authorization": "token"},
+            "query": {"api_key": "token"},
+        },
+        {
+            "base": "https://hooks.example.com/secret",
+            "headers": {"Authorization": "token"},
+        },
+        {
+            "base": "https://hooks.example.com/secret",
+            "query": {"api_key": "token"},
+        },
+        {
+            "base": "https://hooks.example.com/secret",
+            "headers": {"Authorization": "token"},
+            "query": {"api_key": "token"},
+        },
+        {
+            "base": "https://hooks.example.com/secret",
+            "headers": {},
+            "query": {},
+        },
+        {
+            "headers": {},
+            "query": {},
+            "awsSigv4": {"accessKeyId": "key", "secretAccessKey": "secret"},
+        },
+    ],
+)
+def test_valid_auth_strategy_config_can_match(auth_config):
     result = match_compiled_firewalls(
         REPO_URL,
         _github_firewalls_with_auth(auth_config),

--- a/crates/runner/mitm-addon/tests/test_firewall_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_auth.py
@@ -453,7 +453,10 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            result = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            result = await auth_cache.get_firewall_headers(
+                cache_key,
+                _firewall_auth_request(auth_base="${{ secrets.WEBHOOK_URL }}"),
+            )
 
         assert result["base"] == "https://discord.com/api/webhooks/123/abc"
         assert result["cache_hit"] is True
@@ -470,10 +473,16 @@ class TestGetFirewallHeaders:
                 query=cached_query,
             )
         )
+        request = _firewall_auth_request(
+            auth_query={
+                "api_key": "${{ secrets.QUERY_KEY }}",
+                "empty_auth": "${{ vars.EMPTY }}",
+            }
+        )
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            first = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
-            second = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            first = await auth_cache.get_firewall_headers(cache_key, request)
+            second = await auth_cache.get_firewall_headers(cache_key, request)
 
         assert first["query"] == cached_query
         assert first["cache_hit"] is False
@@ -494,10 +503,17 @@ class TestGetFirewallHeaders:
                 query=cached_query,
             )
         )
+        request = _firewall_auth_request(
+            auth_base="${{ secrets.WEBHOOK_URL }}",
+            auth_query={
+                "api_key": "${{ secrets.QUERY_KEY }}",
+                "empty_auth": "${{ vars.EMPTY }}",
+            },
+        )
 
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            first = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
-            second = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            first = await auth_cache.get_firewall_headers(cache_key, request)
+            second = await auth_cache.get_firewall_headers(cache_key, request)
 
         assert first["base"] == cached_base
         assert first["query"] == cached_query
@@ -522,7 +538,12 @@ class TestGetFirewallHeaders:
 
         mock_fetch = AsyncMock()
         with patch.object(auth_cache, "fetch_firewall_headers", mock_fetch):
-            result = await auth_cache.get_firewall_headers(cache_key, _firewall_auth_request())
+            result = await auth_cache.get_firewall_headers(
+                cache_key,
+                _firewall_auth_request(
+                    auth_headers={"Authorization": "Bearer ${{ secrets.TOKEN }}"}
+                ),
+            )
 
         assert "base" not in result
         assert result["cache_hit"] is True
@@ -942,7 +963,27 @@ class TestHandleFirewallRequest:
             path="/repos?existing=1",
         )
         api_entry = _api_entry(
-            auth_config={"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+            auth_config={
+                "headers": dict.fromkeys(
+                    (
+                        "Connection",
+                        "Host",
+                        "Content-Length",
+                        "Transfer-Encoding",
+                        "Keep-Alive",
+                        "Proxy-Authenticate",
+                        "Proxy-Authorization",
+                        "Proxy-Connection",
+                        "TE",
+                        "Trailer",
+                        "Upgrade",
+                        "Authorization",
+                        "X-Injected",
+                    ),
+                    "${{ secrets.VALUE }}",
+                ),
+                "query": {"api_key": "${{ secrets.API_KEY }}"},
+            },
         )
         vm_info = _vm_info(tmp_path)
         allow = _allow(api_entry)
@@ -984,8 +1025,8 @@ class TestHandleFirewallRequest:
         assert "te" not in header_names
         assert "trailer" not in header_names
         assert "upgrade" not in header_names
-        assert flow.request.headers["Authorization"] == "Bearer real-token"
-        assert flow.request.headers["X-Injected"] == "trusted"
+        assert "authorization" not in header_names
+        assert "x-injected" not in header_names
         assert flow.request.query["existing"] == "1"
         assert flow.request.query["api_key"] == "secret"
 
@@ -1236,6 +1277,45 @@ class TestHandleFirewallRequest:
         assert body["base"] == "https://api.github.com"
         assert "connectors" not in body
         mock_resp.__exit__.assert_called_once()
+
+    async def test_strategy_inconsistent_success_returns_502_without_auth_mutation(
+        self,
+        real_flow,
+        mitm_ctx,
+        tmp_path,
+    ):
+        flow = _firewall_flow(real_flow, path="/repos?existing=1")
+        api_entry = _api_entry(
+            auth_config={
+                "headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"},
+                "base": "${{ secrets.WEBHOOK_URL }}",
+                "query": {"api_key": "${{ secrets.GITHUB_TOKEN }}"},
+            },
+        )
+        vm_info = _vm_info(tmp_path)
+        allow = _allow(api_entry)
+        mock_resp = _json_response(
+            {
+                "headers": {"Authorization": "Bearer resolved"},
+                "query": {"api_key": "resolved-key"},
+            }
+        )
+
+        with (
+            patch("firewall_auth_client.urllib.request.urlopen", return_value=mock_resp),
+            mitm_ctx(),
+        ):
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
+
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert json.loads(flow.response.content)["error"] == "auth_failed"
+        assert "Authorization" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert flow.request.query["existing"] == "1"
+        assert cached_headers(flow.metadata[metadata_keys.FIREWALL_AUTH_CACHE_KEY]) is None
+        assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
 
     async def test_oversized_success_response_returns_502_without_auth_mutation(
         self,
@@ -1763,11 +1843,6 @@ class TestFetchFirewallHeaders:
                 },
                 "base": "https://example.com/webhook/secret",
                 "query": {"api_key": "resolved-key"},
-                "awsSigv4": {
-                    "accessKeyId": "access-key-id",
-                    "secretAccessKey": "secret-access-key",
-                    "sessionToken": "session-token",
-                },
                 "expiresAt": expires_at,
                 "resolvedSecrets": ["API_TOKEN"],
                 "refreshedConnectors": ["notion"],
@@ -1781,7 +1856,16 @@ class TestFetchFirewallHeaders:
             mitm_ctx(api_url=endpoint.api_url),
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
-            result = await auth_client.fetch_firewall_headers(_firewall_auth_request())
+            result = await auth_client.fetch_firewall_headers(
+                _firewall_auth_request(
+                    auth_headers={
+                        "Authorization": "Bearer ${{ secrets.TOKEN }}",
+                        "X-Custom": "${{ secrets.CUSTOM }}",
+                    },
+                    auth_base="${{ secrets.WEBHOOK_URL }}",
+                    auth_query={"api_key": "${{ secrets.API_KEY }}"},
+                )
+            )
 
         assert result.payload.headers == {
             "Authorization": "Bearer tok",
@@ -1789,20 +1873,179 @@ class TestFetchFirewallHeaders:
         }
         assert result.payload.base == "https://example.com/webhook/secret"
         assert result.payload.query == {"api_key": "resolved-key"}
-        assert result.payload.aws_sigv4 == AwsSigV4Credentials(
-            "access-key-id",
-            "secret-access-key",
-            "session-token",
-        )
+        assert result.payload.aws_sigv4 is None
         assert result.expires_at == expires_at
         assert result.payload.resolved_secrets == ["API_TOKEN"]
         assert result.refreshed_connectors == ["notion"]
         assert result.refreshed_secrets == ["NOTION_TOKEN"]
         assert not hasattr(result, "futureField")
 
+    async def test_sigv4_success_response_shape_is_mapped(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            {
+                "headers": {},
+                "awsSigv4": {
+                    "accessKeyId": "access-key-id",
+                    "secretAccessKey": "secret-access-key",
+                    "sessionToken": "session-token",
+                },
+            }
+        )
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+        ):
+            result = await auth_client.fetch_firewall_headers(
+                _firewall_auth_request(
+                    auth_aws_sigv4={
+                        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                        "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                    }
+                )
+            )
+
+        assert result.payload.aws_sigv4 == AwsSigV4Credentials(
+            "access-key-id",
+            "secret-access-key",
+            "session-token",
+        )
+
+    @pytest.mark.parametrize(
+        ("auth_request", "response"),
+        [
+            (
+                _firewall_auth_request(auth_base="${{ secrets.WEBHOOK_URL }}"),
+                {"headers": {}},
+            ),
+            (
+                _firewall_auth_request(),
+                {"headers": {}, "base": "https://hooks.example.com/secret"},
+            ),
+            (
+                _firewall_auth_request(auth_base="${{ secrets.WEBHOOK_URL }}"),
+                {"headers": {}, "base": ""},
+            ),
+            (
+                _firewall_auth_request(
+                    auth_aws_sigv4={
+                        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                    }
+                ),
+                {"headers": {}},
+            ),
+            (
+                _firewall_auth_request(),
+                {
+                    "headers": {},
+                    "awsSigv4": {
+                        "accessKeyId": "access-key-id",
+                        "secretAccessKey": "secret-access-key",
+                    },
+                },
+            ),
+            (
+                _firewall_auth_request(
+                    auth_aws_sigv4={
+                        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                    }
+                ),
+                {
+                    "headers": {},
+                    "awsSigv4": {
+                        "accessKeyId": "access-key-id",
+                        "secretAccessKey": "secret-access-key",
+                        "sessionToken": "session-token",
+                    },
+                },
+            ),
+            (
+                _firewall_auth_request(
+                    auth_aws_sigv4={
+                        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                        "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                    }
+                ),
+                {
+                    "headers": {},
+                    "awsSigv4": {
+                        "accessKeyId": "access-key-id",
+                        "secretAccessKey": "secret-access-key",
+                    },
+                },
+            ),
+            (
+                _firewall_auth_request(auth_headers={"Authorization": "template"}),
+                {"headers": {"X-Unexpected": "value"}},
+            ),
+            (
+                _firewall_auth_request(auth_query={"api_key": "template"}),
+                {"headers": {}, "query": {"unexpected": "value"}},
+            ),
+        ],
+        ids=[
+            "missing-base",
+            "unexpected-base",
+            "empty-base",
+            "missing-sigv4",
+            "unexpected-sigv4",
+            "unexpected-session-token",
+            "missing-session-token",
+            "header-name-mismatch",
+            "query-name-mismatch",
+        ],
+    )
+    async def test_rejects_response_inconsistent_with_request(
+        self,
+        mitm_ctx,
+        auth_request: auth_client.FirewallAuthRequest,
+        response: dict[str, object],
+    ):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(response)
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+            pytest.raises(ValueError, match=_MALFORMED_SUCCESS_PREFIX),
+        ):
+            await auth_client.fetch_firewall_headers(auth_request)
+
+    async def test_inconsistent_response_is_not_cached(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response({"headers": {}})
+        cache_key = auth_cache_key()
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+            pytest.raises(ValueError, match=_MALFORMED_SUCCESS_PREFIX),
+        ):
+            await auth_cache.get_firewall_headers(
+                cache_key,
+                _firewall_auth_request(auth_base="${{ secrets.WEBHOOK_URL }}"),
+            )
+
+        assert cached_headers(cache_key) is None
+
     async def test_sends_optional_request_body_fields(self, mitm_ctx):
         endpoint = FakeAuthEndpoint()
-        endpoint.queue_json_response({"headers": {}, "expiresAt": time.time() + 30})
+        endpoint.queue_json_response(
+            {
+                "headers": {},
+                "base": "https://hooks.example.com/secret",
+                "query": {"api_key": "resolved-key"},
+                "expiresAt": time.time() + 30,
+            }
+        )
 
         with (
             endpoint.run(),
@@ -1816,11 +2059,6 @@ class TestFetchFirewallHeaders:
                     vars_map={"TEAM": "vm0"},
                     auth_base="${{ secrets.WEBHOOK_URL }}",
                     auth_query={"api_key": "${{ secrets.API_KEY }}"},
-                    auth_aws_sigv4={
-                        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-                        "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                    },
                     firewall_billable=True,
                 ),
                 force_refresh=True,
@@ -1834,17 +2072,51 @@ class TestFetchFirewallHeaders:
         assert body["vars"] == {"TEAM": "vm0"}
         assert body["authBase"] == "${{ secrets.WEBHOOK_URL }}"
         assert body["authQuery"] == {"api_key": "${{ secrets.API_KEY }}"}
-        assert body["authAwsSigv4"] == {
-            "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-            "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-        }
+        assert "authAwsSigv4" not in body
         assert body["firewallBillable"] is True
         assert body["forceRefresh"] is True
         assert "firewallName" not in body
         assert "modelUsageProvider" not in body
 
-    async def test_omits_falsey_optional_request_body_fields(self, mitm_ctx):
+    async def test_sends_sigv4_request_body(self, mitm_ctx):
+        endpoint = FakeAuthEndpoint()
+        endpoint.queue_json_response(
+            {
+                "headers": {},
+                "awsSigv4": {
+                    "accessKeyId": "access-key-id",
+                    "secretAccessKey": "secret-access-key",
+                    "sessionToken": "session-token",
+                },
+            }
+        )
+
+        with (
+            endpoint.run(),
+            mitm_ctx(api_url=endpoint.api_url),
+            patch.object(platform_api, "VERCEL_BYPASS", ""),
+        ):
+            await auth_client.fetch_firewall_headers(
+                _firewall_auth_request(
+                    auth_aws_sigv4={
+                        "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                        "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                        "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+                    }
+                ),
+            )
+
+        assert endpoint.requests[0].json_body() == {
+            "encryptedSecrets": "iv:tag:data",
+            "authHeaders": {},
+            "authAwsSigv4": {
+                "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
+            },
+        }
+
+    async def test_omits_empty_optional_request_body_fields(self, mitm_ctx):
         endpoint = FakeAuthEndpoint()
         endpoint.queue_json_response({"headers": {}})
 
@@ -1855,9 +2127,7 @@ class TestFetchFirewallHeaders:
         ):
             await auth_client.fetch_firewall_headers(
                 _firewall_auth_request(
-                    auth_base="",
                     auth_query={},
-                    auth_aws_sigv4={},
                     secret_connector_map={},
                     secret_connector_metadata_map={},
                     vars_map={},
@@ -2175,7 +2445,11 @@ class TestFetchFirewallHeaders:
             patch.object(platform_api, "VERCEL_BYPASS", ""),
         ):
             result = await auth_client.fetch_firewall_headers(
-                _firewall_auth_request(encrypted_secrets="enc", sandbox_auth="sandbox-tok")
+                _firewall_auth_request(
+                    encrypted_secrets="enc",
+                    auth_headers={"Auth": "${{ secrets.TOKEN }}"},
+                    sandbox_auth="sandbox-tok",
+                )
             )
 
         assert result.payload.headers == {"Auth": "tok"}
@@ -2194,6 +2468,7 @@ class TestFirewallAuthSuccessParser:
             pytest.param({"headers": []}, id="headers-array"),
             pytest.param({"headers": {"Authorization": 123}}, id="header-value-number"),
             pytest.param({"headers": {}, "base": []}, id="base-array"),
+            pytest.param({"headers": {}, "base": ""}, id="base-empty"),
             pytest.param({"headers": {}, "query": []}, id="query-array"),
             pytest.param({"headers": {}, "query": {"api_key": 123}}, id="query-value-number"),
             pytest.param({"headers": {}, "resolvedSecrets": "TOKEN"}, id="resolved-secrets-string"),
@@ -2209,7 +2484,7 @@ class TestFirewallAuthSuccessParser:
     )
     def test_malformed_success_response_shape_raises_value_error(self, body: object):
         with pytest.raises(ValueError, match=_MALFORMED_SUCCESS_PREFIX):
-            auth_client._parse_firewall_auth_success(body)
+            auth_client._parse_firewall_auth_success(body, _firewall_auth_request())
 
 
 class TestFirewallAuthResponseBodyReader:

--- a/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_aws_sigv4_auth.py
@@ -492,7 +492,6 @@ async def test_header_sigv4_with_invalid_resolved_access_key_fails_closed(
         mitm_ctx,
         auth_response=aws_auth_response(
             access_key_id="AKID/EXAMPLE",
-            include_session_token=False,
         ),
     )
 

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_forwarding.py
@@ -5,32 +5,14 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
 import auth
 import auth_base_forwarder as forwarder
 import flow_metadata_keys as metadata_keys
-from generated.builtin_firewalls import BUILTIN_FIREWALLS
 from tests.auth_base_forwarder_helpers import fake_forwarder_upstream
-from tests.aws_sigv4_helpers import (
-    DEFAULT_SIGV4_TIMESTAMP,
-    RESOLVED_AWS_SESSION_TOKEN,
-    STS_FORM_BODY,
-    aws_sigv4_authorization,
-    aws_sigv4_presigned_query_path,
-    resolved_aws_sigv4_credentials,
-)
 from tests.firewall_rewrite_helpers import make_forwarding_rewrite_inputs
 from tests.jsonl_log_helpers import read_jsonl_text_after_flush
-
-
-def _templated_builtin_auth_header_names() -> list[str]:
-    names: set[str] = set()
-    for firewall in BUILTIN_FIREWALLS.values():
-        for api in firewall.get("apis", []):
-            auth_headers = api.get("auth", {}).get("headers", {})
-            for name, value in auth_headers.items():
-                if isinstance(name, str) and isinstance(value, str) and "${{" in value:
-                    names.add(name)
-    return sorted(names, key=str.lower)
 
 
 def _request_line_parts(upstream) -> tuple[str, str, str]:
@@ -61,8 +43,13 @@ class TestAuthBaseUrlRewriteForwarding:
                 ("X-Repeat", "one"),
                 ("X-Repeat", "two"),
                 ("X-Keep", "client"),
+                ("cOnTeNt-TyPe", "application/json; charset=utf-8"),
             ),
             auth_overrides={
+                "headers": {
+                    "Authorization": "Bearer ${{ secrets.TOKEN }}",
+                    "X-Custom": "${{ secrets.CUSTOM }}",
+                },
                 "query": {"api_key": "${{ secrets.API_KEY }}"},
             },
             token_overrides={
@@ -116,10 +103,14 @@ class TestAuthBaseUrlRewriteForwarding:
         assert upstream.socket.request_header_values("Host") == ["real.example.com"]
         assert upstream.socket.request_header_values("Authorization") == ["Bearer real-token"]
         assert upstream.socket.request_header_values("X-Custom") == ["injected-value"]
-        assert upstream.socket.request_header_values("X-Repeat") == ["one", "two"]
-        assert upstream.socket.request_header_values("X-Keep") == ["client"]
+        assert upstream.socket.request_header_values("X-Repeat") == []
+        assert upstream.socket.request_header_values("X-Keep") == []
         assert upstream.socket.request_header_values("Cookie") == []
         assert upstream.socket.request_header_values("X-Api-Key") == []
+        assert upstream.socket.request_header_values("Content-Type") == [
+            "application/json; charset=utf-8"
+        ]
+        assert "cOnTeNt-TyPe: application/json; charset=utf-8" in upstream.socket.request_lines()
         assert upstream.socket.request_header_values("Content-Length") == [str(len(request_body))]
         assert upstream.socket.request_text().endswith("\r\n\r\n" + request_body.decode("ascii"))
 
@@ -165,6 +156,13 @@ class TestAuthBaseUrlRewriteForwarding:
                 ("Authorization", "Bearer agent"),
                 ("X-Api-Key", "agent-api-key"),
             ),
+            auth_overrides={
+                "headers": {
+                    "Authorization": "Bearer ${{ secrets.TOKEN }}",
+                    "X-Api-Key": "${{ secrets.API_KEY }}",
+                    "X-Custom": "${{ secrets.CUSTOM }}",
+                }
+            },
         )
         token_meta["headers"] = {
             "Authorization": "Bearer real-token",
@@ -185,15 +183,18 @@ class TestAuthBaseUrlRewriteForwarding:
         assert flow.request.headers["X-Api-Key"] == "agent-api-key"
         assert "X-Custom" not in flow.request.headers
 
-    async def test_url_rewrite_strips_client_credentials_without_resolved_headers(
+    async def test_url_rewrite_drops_non_representation_client_headers(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
-        """auth.base forwarding must not leak placeholder-scoped credentials."""
+        """auth.base forwarding does not inherit arbitrary client headers."""
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
             request_headers=headers(
                 ("Host", "firewall-placeholder.vm3.ai"),
+                ("Connection", "Content-Type, Content-Encoding"),
+                ("Content-Type", "application/json"),
+                ("Content-Encoding", "gzip"),
                 ("Authorization", "Bearer agent"),
                 ("authorization", "Bearer lower-agent"),
                 ("AUTHORIZATION", "Bearer upper-agent"),
@@ -201,6 +202,14 @@ class TestAuthBaseUrlRewriteForwarding:
                 ("X-Api-Key", "agent-api-key"),
                 ("X-Auth-Token", "agent-auth-token"),
                 ("Private-Token", "agent-private-token"),
+                ("Accept", "application/json"),
+                ("User-Agent", "agent-client"),
+                ("Reap-Version", "2025-02-14"),
+                ("X-Api-Version", "2025-11-01"),
+                (
+                    "X-Snowflake-Authorization-Token-Type",
+                    "PROGRAMMATIC_ACCESS_TOKEN",
+                ),
                 ("X-Repeat", "one"),
                 ("X-Repeat", "two"),
                 ("X-Keep", "client"),
@@ -214,123 +223,58 @@ class TestAuthBaseUrlRewriteForwarding:
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
 
+        assert upstream.socket.request_header_values("Connection") == []
         assert upstream.socket.request_header_values("Authorization") == []
         assert upstream.socket.request_header_values("Cookie") == []
         assert upstream.socket.request_header_values("X-Api-Key") == []
         assert upstream.socket.request_header_values("X-Auth-Token") == []
         assert upstream.socket.request_header_values("Private-Token") == []
-        assert upstream.socket.request_header_values("X-Repeat") == ["one", "two"]
-        assert upstream.socket.request_header_values("X-Keep") == ["client"]
+        assert upstream.socket.request_header_values("Accept") == []
+        assert upstream.socket.request_header_values("User-Agent") == []
+        assert upstream.socket.request_header_values("Reap-Version") == []
+        assert upstream.socket.request_header_values("X-Api-Version") == []
+        assert upstream.socket.request_header_values("X-Snowflake-Authorization-Token-Type") == []
+        assert upstream.socket.request_header_values("X-Repeat") == []
+        assert upstream.socket.request_header_values("X-Keep") == []
+        assert upstream.socket.request_header_values("Content-Type") == []
+        assert upstream.socket.request_header_values("Content-Encoding") == []
         request_headers = list(flow.request.headers.items(multi=True))
         assert ("Authorization", "Bearer agent") in request_headers
         assert ("authorization", "Bearer lower-agent") in request_headers
         assert ("AUTHORIZATION", "Bearer upper-agent") in request_headers
         assert flow.request.headers["Cookie"] == "session=agent"
 
-    async def test_url_rewrite_strips_templated_builtin_auth_headers_without_resolved_headers(
+    async def test_url_rewrite_preserves_coded_body_metadata_and_auth_override(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
-        """Client-provided templated builtin auth headers must not cross auth.base rewrites."""
-        auth_header_names = _templated_builtin_auth_header_names()
-        assert auth_header_names
+        """Representation metadata stays ordered and trusted auth can override it."""
+        request_body = b"\x1f\x8b\x08\x00coded-body"
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
+            method="POST",
+            request_body=request_body,
             request_headers=headers(
                 ("Host", "firewall-placeholder.vm3.ai"),
-                *[(name, f"client-{index}") for index, name in enumerate(auth_header_names)],
-                ("X-Keep", "client"),
-            ),
-        )
-        token_meta["headers"] = {}
-        with (
-            fake_forwarder_upstream() as upstream,
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
-
-        for name in auth_header_names:
-            assert upstream.socket.request_header_values(name) == []
-        assert upstream.socket.request_header_values("X-Keep") == ["client"]
-
-    async def test_url_rewrite_strips_current_auth_headers_without_resolved_headers(
-        self, headers, real_flow, mitm_ctx, tmp_path
-    ):
-        """Client-provided current auth headers must not cross auth.base rewrites."""
-        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
-            real_flow,
-            tmp_path,
-            request_headers=headers(
-                ("Host", "firewall-placeholder.vm3.ai"),
-                ("X-Tenant", "client-tenant"),
-                ("X-Keep", "client"),
-            ),
-            auth_overrides={
-                "headers": {
-                    "X-Tenant": "${{ vars.TENANT }}",
-                },
-            },
-        )
-        token_meta["headers"] = {}
-        with (
-            fake_forwarder_upstream() as upstream,
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
-
-        assert upstream.socket.request_header_values("X-Tenant") == []
-        assert upstream.socket.request_header_values("X-Keep") == ["client"]
-
-    async def test_url_rewrite_preserves_client_static_metadata_headers(
-        self, headers, real_flow, mitm_ctx, tmp_path
-    ):
-        """Client-provided non-secret metadata headers should still reach auth.base targets."""
-        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
-            real_flow,
-            tmp_path,
-            request_headers=headers(
-                ("Host", "firewall-placeholder.vm3.ai"),
-                ("Reap-Version", "2025-02-14"),
-                ("X-Api-Version", "2025-11-01"),
-                ("X-Snowflake-Authorization-Token-Type", "PROGRAMMATIC_ACCESS_TOKEN"),
-            ),
-        )
-        token_meta["headers"] = {}
-        with (
-            fake_forwarder_upstream() as upstream,
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
-            mitm_ctx(),
-        ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
-
-        assert upstream.socket.request_header_values("Reap-Version") == ["2025-02-14"]
-        assert upstream.socket.request_header_values("X-Api-Version") == ["2025-11-01"]
-        assert upstream.socket.request_header_values("X-Snowflake-Authorization-Token-Type") == [
-            "PROGRAMMATIC_ACCESS_TOKEN"
-        ]
-
-    async def test_url_rewrite_preserves_duplicate_headers_and_auth_override(
-        self, headers, real_flow, mitm_ctx, tmp_path
-    ):
-        """auth.base forwarding keeps repeated headers unless auth overrides that name."""
-        flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
-            real_flow,
-            tmp_path,
-            request_headers=headers(
-                ("Host", "firewall-placeholder.vm3.ai"),
-                ("Connection", "Authorization, X-Remove"),
+                ("Connection", "X-Remove"),
                 ("X-Remove", "drop"),
                 ("X-Repeat", "one"),
                 ("X-Repeat", "two"),
-                ("Authorization", "Bearer agent"),
-                ("authorization", "Bearer lower-agent"),
-                ("AUTHORIZATION", "Bearer upper-agent"),
-                ("Authorization", "Bearer stale"),
+                ("Content-Encoding", "gzip"),
+                ("content-encoding", "br"),
+                ("Content-Type", "application/client"),
             ),
+            auth_overrides={
+                "headers": {
+                    "content-type": "${{ vars.CONTENT_TYPE }}",
+                    "Authorization": "Bearer ${{ secrets.TOKEN }}",
+                }
+            },
         )
-        token_meta["headers"] = {"Authorization": "Bearer real"}
+        token_meta["headers"] = {
+            "content-type": "application/provider",
+            "Authorization": "Bearer real",
+        }
         with (
             fake_forwarder_upstream() as upstream,
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -340,13 +284,20 @@ class TestAuthBaseUrlRewriteForwarding:
 
         assert upstream.socket.request_header_values("Connection") == []
         assert upstream.socket.request_header_values("X-Remove") == []
-        assert upstream.socket.request_header_values("X-Repeat") == ["one", "two"]
+        assert upstream.socket.request_header_values("X-Repeat") == []
+        assert upstream.socket.request_header_values("Content-Encoding") == ["gzip", "br"]
+        assert upstream.socket.request_header_values("Content-Type") == ["application/provider"]
         assert upstream.socket.request_header_values("Authorization") == ["Bearer real"]
+        request_lines = upstream.socket.request_lines()
+        assert request_lines.index("Content-Encoding: gzip") < request_lines.index(
+            "content-encoding: br"
+        )
+        assert bytes(upstream.socket.sent).endswith(b"\r\n\r\n" + request_body)
 
     async def test_url_rewrite_filters_client_and_injected_unsafe_headers(
         self, headers, real_flow, mitm_ctx, tmp_path
     ):
-        """Unsafe client and injected headers are stripped without suppressing auth."""
+        """Client and resolved transport-owned headers are stripped."""
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
@@ -365,6 +316,26 @@ class TestAuthBaseUrlRewriteForwarding:
                 ("Authorization", "Bearer agent"),
                 ("X-Keep", "client"),
             ),
+            auth_overrides={
+                "headers": dict.fromkeys(
+                    (
+                        "Connection",
+                        "Keep-Alive",
+                        "Host",
+                        "Content-Length",
+                        "Transfer-Encoding",
+                        "Proxy-Authenticate",
+                        "Proxy-Authorization",
+                        "Proxy-Connection",
+                        "TE",
+                        "Trailer",
+                        "Upgrade",
+                        "Authorization",
+                        "X-Injected",
+                    ),
+                    "${{ secrets.VALUE }}",
+                )
+            },
         )
         token_meta["headers"] = {
             "Connection": "Authorization, X-Injected",
@@ -399,9 +370,9 @@ class TestAuthBaseUrlRewriteForwarding:
         assert upstream.socket.request_header_values("Trailer") == []
         assert upstream.socket.request_header_values("Transfer-Encoding") == []
         assert upstream.socket.request_header_values("Upgrade") == []
-        assert upstream.socket.request_header_values("Authorization") == ["Bearer real"]
-        assert upstream.socket.request_header_values("X-Injected") == ["trusted"]
-        assert upstream.socket.request_header_values("X-Keep") == ["client"]
+        assert upstream.socket.request_header_values("Authorization") == []
+        assert upstream.socket.request_header_values("X-Injected") == []
+        assert upstream.socket.request_header_values("X-Keep") == []
 
     async def test_forward_request_rejects_malformed_injected_header(
         self, real_flow, mitm_ctx, tmp_path
@@ -411,6 +382,12 @@ class TestAuthBaseUrlRewriteForwarding:
             real_flow,
             tmp_path,
             resolved_base="https://discord.com/api/webhooks/123/abc",
+            auth_overrides={
+                "headers": {
+                    "Authorization": "Bearer ${{ secrets.TOKEN }}",
+                    "X-Test": "${{ secrets.TEST }}",
+                }
+            },
         )
         token_meta["headers"] = {
             "Authorization": "Bearer real-token",
@@ -433,43 +410,39 @@ class TestAuthBaseUrlRewriteForwarding:
         body = json.loads(flow.response.content)
         assert body["error"] == "invalid_resolved_auth_header"
 
-    async def test_url_rewrite_signs_rewritten_aws_sigv4_request(
+    @pytest.mark.parametrize(
+        ("content_type", "request_body"),
+        [
+            ("application/json; charset=utf-8", b'{"message":"hello"}'),
+            ("application/x-www-form-urlencoded", b"message=hello+world"),
+            (
+                "multipart/form-data; boundary=vm0-boundary",
+                b"--vm0-boundary\r\nContent-Disposition: form-data; name=message\r\n\r\nhello\r\n"
+                b"--vm0-boundary--\r\n",
+            ),
+        ],
+        ids=["json", "form", "multipart"],
+    )
+    async def test_url_rewrite_preserves_one_exact_content_type(
         self,
         headers,
         real_flow,
         mitm_ctx,
         tmp_path,
+        content_type: str,
+        request_body: bytes,
     ):
-        """auth.base forwarding signs the rewritten upstream URL, not the placeholder."""
-        placeholder_authorization = aws_sigv4_authorization(
-            signed_headers="content-type;host;x-amz-date"
-        )
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
-            resolved_base="https://STS.AMAZONAWS.COM:443/",
             method="POST",
-            request_body=STS_FORM_BODY,
+            request_body=request_body,
             request_headers=headers(
-                ("Host", "firewall-placeholder.vm3.ai"),
-                ("Content-Type", "application/x-www-form-urlencoded"),
-                ("X-Amz-Date", DEFAULT_SIGV4_TIMESTAMP),
-                ("Authorization", placeholder_authorization),
-                ("Cookie", "session=agent"),
-                ("X-Api-Key", "agent-api-key"),
-                ("X-Amz-Security-Token", "placeholder-session-token"),
+                ("cOnTeNt-TyPe", content_type),
+                ("X-Drop", "client-metadata"),
             ),
-            auth_overrides={
-                "awsSigv4": {
-                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-                    "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                },
-            },
-            token_overrides={
-                "aws_sigv4": resolved_aws_sigv4_credentials(),
-            },
         )
+
         with (
             fake_forwarder_upstream() as upstream,
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
@@ -477,77 +450,49 @@ class TestAuthBaseUrlRewriteForwarding:
         ):
             await auth.handle_firewall_request(flow, allow, vm_info)
 
-        method, request_target, _version = _request_line_parts(upstream)
-        assert method == "POST"
-        assert request_target == "/"
-        authorization = upstream.socket.request_header_values("Authorization")[0]
-        assert upstream.getaddrinfo_calls == [("sts.amazonaws.com", 443)]
-        assert upstream.socket.request_header_values("Host") == ["sts.amazonaws.com"]
-        assert "Credential=AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request" in authorization
-        assert (
-            "Signature=1735aaa47d56839a3157c545e28e02eb8fa1526da431e9fc980b7414df9c4f53"
-            in authorization
-        )
-        assert upstream.socket.request_header_values("X-Amz-Security-Token") == [
-            RESOLVED_AWS_SESSION_TOKEN
-        ]
-        assert upstream.socket.request_header_values("Cookie") == []
-        assert upstream.socket.request_header_values("X-Api-Key") == []
-        assert upstream.socket.request_header_values("Content-Length") == ["43"]
-        assert upstream.socket.request_text().endswith(
-            "\r\n\r\nAction=GetCallerIdentity&Version=2011-06-15"
-        )
-        assert flow.request.headers["Authorization"] == placeholder_authorization
+        assert f"cOnTeNt-TyPe: {content_type}" in upstream.socket.request_lines()
+        assert upstream.socket.request_header_values("X-Drop") == []
+        assert bytes(upstream.socket.sent).endswith(b"\r\n\r\n" + request_body)
 
-    async def test_url_rewrite_strips_unrelated_authorization_for_aws_query_sigv4(
+    async def test_duplicate_content_type_returns_400_before_auth_or_forwarding(
         self,
         headers,
         real_flow,
         mitm_ctx,
         tmp_path,
     ):
-        """auth.base query SigV4 ignores unrelated client Authorization headers."""
         flow, allow, vm_info, token_meta = make_forwarding_rewrite_inputs(
             real_flow,
             tmp_path,
-            path=aws_sigv4_presigned_query_path(),
-            resolved_base="https://STS.AMAZONAWS.COM:443/",
-            method="GET",
+            method="POST",
+            request_body=b"body",
             request_headers=headers(
-                ("Host", "firewall-placeholder.vm3.ai"),
-                ("Authorization", "Bearer agent"),
-                ("Cookie", "session=agent"),
-                ("X-Amz-Security-Token", "placeholder-session-token"),
+                ("Content-Type", "application/json"),
+                ("content-type", "text/plain"),
             ),
-            auth_overrides={
-                "awsSigv4": {
-                    "accessKeyId": "${{ secrets.AWS_ACCESS_KEY_ID }}",
-                    "secretAccessKey": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-                    "sessionToken": "${{ secrets.AWS_SESSION_TOKEN }}",
-                },
-            },
-            token_overrides={
-                "aws_sigv4": resolved_aws_sigv4_credentials(),
-            },
         )
+        get_headers = AsyncMock(return_value=token_meta)
+        mock_forward = AsyncMock()
+
         with (
-            fake_forwarder_upstream() as upstream,
-            patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
+            patch.object(auth, "get_firewall_headers", get_headers),
+            patch.object(auth, "forward_request", mock_forward),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
 
-        method, request_target, _version = _request_line_parts(upstream)
-        query = dict(parse_qs(urlparse(request_target).query))
-        assert method == "GET"
-        assert upstream.getaddrinfo_calls == [("sts.amazonaws.com", 443)]
-        assert upstream.socket.request_header_values("Host") == ["sts.amazonaws.com"]
-        assert query["X-Amz-Credential"] == ["AKIDEXAMPLE/20260101/us-east-1/sts/aws4_request"]
-        assert query["X-Amz-Security-Token"] == [RESOLVED_AWS_SESSION_TOKEN]
-        assert query["X-Amz-Signature"] != ["placeholder"]
-        assert upstream.socket.request_header_values("Authorization") == []
-        assert upstream.socket.request_header_values("Cookie") == []
-        assert upstream.socket.request_header_values("X-Amz-Security-Token") == []
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        get_headers.assert_not_called()
+        mock_forward.assert_not_called()
+        assert flow.response is not None
+        assert flow.response.status_code == 400
+        assert json.loads(flow.response.content) == {
+            "error": "invalid_auth_base_request_headers",
+            "message": "auth.base requests must contain at most one Content-Type header",
+            "permission": allow.name,
+            "base": allow.api_entry["base"],
+        }
+        assert flow.metadata[metadata_keys.FIREWALL_ERROR] == ("invalid_auth_base_request_headers")
 
     async def test_url_rewrite_sends_raw_body_for_any_method(self, real_flow, mitm_ctx, tmp_path):
         """auth.base forwarding does not drop bodies for non-POST methods."""
@@ -645,6 +590,7 @@ class TestAuthBaseUrlRewriteForwarding:
             tmp_path,
             method="POST",
             request_body=request_body,
+            auth_overrides={"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
             token_overrides={
                 "base": "https://real.example.com/webhook/super-secret-token",
                 "headers": {"Authorization": "Bearer real-token"},
@@ -705,6 +651,7 @@ class TestAuthBaseUrlRewriteForwarding:
             method="POST",
             request_body=b"1234",
             resolved_base="https://real.example.com/webhook/super-secret-token",
+            auth_overrides={"headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"}},
             token_overrides={"headers": {"Authorization": "Bearer real-token"}},
         )
         mock_forward = AsyncMock(side_effect=forwarder.ForwardedRequestTooLargeError())
@@ -786,6 +733,13 @@ class TestAuthBaseUrlRewriteForwarding:
                 ("Host", "firewall-placeholder.vm3.ai"),
                 ("Authorization", "Bearer agent"),
             ),
+            auth_overrides={
+                "headers": {
+                    "Authorization": "Bearer ${{ secrets.TOKEN }}",
+                    "X-Custom": "${{ secrets.CUSTOM }}",
+                },
+                "query": {"api_key": "${{ secrets.API_KEY }}"},
+            },
             token_overrides={
                 "headers": {
                     "Authorization": "Bearer real-token",

--- a/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
+++ b/crates/runner/mitm-addon/tests/test_firewall_rewrite_safety.py
@@ -347,8 +347,7 @@ class TestAuthBaseUrlRewriteSafety:
             assert "super-secret-token" not in json.dumps(log_call.args)
             assert "super-secret-token" not in json.dumps(log_call.kwargs)
 
-    async def test_no_rewrite_when_resolved_base_empty_string(self, real_flow, mitm_ctx, tmp_path):
-        """Empty string base from server uses standard auth injection."""
+    async def test_empty_resolved_base_fails_closed(self, real_flow, mitm_ctx, tmp_path):
         flow, allow, vm_info, token_meta = make_safety_rewrite_inputs(
             real_flow,
             tmp_path,
@@ -368,12 +367,16 @@ class TestAuthBaseUrlRewriteSafety:
             patch.object(auth, "get_firewall_headers", AsyncMock(return_value=token_meta)),
             mitm_ctx(),
         ):
-            await auth.handle_firewall_request(flow, allow, vm_info)
+            result = await auth.handle_firewall_request(flow, allow, vm_info)
         updated_url = urlparse(flow.request.url)
         assert updated_url.scheme == original_url.scheme
         assert updated_url.netloc == original_url.netloc
         assert updated_url.path == original_url.path
         assert metadata_keys.AUTH_URL_REWRITE not in flow.metadata
-        assert flow.request.headers["Authorization"] == "Bearer real-token"
-        assert flow.request.query["api_key"] == "resolved-key"
-        assert flow.metadata[metadata_keys.AUTH_RESOLVED_SECRETS] == ["TOKEN", "API_KEY"]
+        assert result is auth.FirewallAuthHandlingResult.LOCAL_RESPONSE
+        assert flow.response is not None
+        assert flow.response.status_code == 502
+        assert json.loads(flow.response.content)["error"] == "auth_failed"
+        assert "Authorization" not in flow.request.headers
+        assert "api_key" not in flow.request.query
+        assert metadata_keys.AUTH_RESOLVED_SECRETS not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_auth_base_body.py
@@ -578,7 +578,13 @@ async def test_auth_base_requestheaders_admission_released_on_auth_failure(
 async def test_auth_base_requestheaders_admission_released_when_resolved_base_missing(
     tmp_path, real_flow, mitm_ctx, headers
 ):
-    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    reg_path = _write_auth_base_firewall_registry(
+        tmp_path,
+        auth_config={
+            "headers": {"Authorization": "Bearer ${{ secrets.TOKEN }}"},
+            "base": "${{ secrets.WEBHOOK_URL }}",
+        },
+    )
     declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
     flow = real_flow(
         with_response=False,
@@ -611,8 +617,53 @@ async def test_auth_base_requestheaders_admission_released_when_resolved_base_mi
         )
         await mitm_addon.request(flow)
 
-    assert flow.response is None
-    assert flow.request.headers["Authorization"] == "Bearer resolved"
+    assert flow.response is not None
+    assert flow.response.status_code == 502
+    assert json.loads(flow.response.content)["error"] == "auth_failed"
+    assert "Authorization" not in flow.request.headers
+    assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
+    assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
+
+
+async def test_auth_base_duplicate_content_type_releases_requestheaders_admission(
+    tmp_path, real_flow, mitm_ctx, headers
+):
+    reg_path = _write_auth_base_firewall_registry(tmp_path)
+    declared_size = mitm_addon.STREAM_BUFFER_LIMIT + 1
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="placeholder.example.com",
+        method="POST",
+        path="/",
+        request_headers=headers(
+            ("Host", "placeholder.example.com"),
+            ("Content-Length", str(declared_size)),
+            ("Content-Type", "application/json"),
+            ("content-type", "text/plain"),
+        ),
+        request_body=b"ok",
+    )
+    get_headers = AsyncMock()
+    mock_forward = AsyncMock()
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        patch.object(auth, "get_firewall_headers", get_headers),
+        patch.object(auth, "forward_request", mock_forward),
+    ):
+        mitm_addon.requestheaders(flow)
+        assert auth_base_forwarder.forward_request_admission_state_for_tests() == (
+            1,
+            declared_size,
+        )
+        await mitm_addon.request(flow)
+
+    get_headers.assert_not_called()
+    mock_forward.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 400
+    assert json.loads(flow.response.content)["error"] == ("invalid_auth_base_request_headers")
     assert metadata_keys.AUTH_BASE_FORWARD_ADMISSION not in flow.metadata
     assert auth_base_forwarder.forward_request_admission_state_for_tests() == (0, 0)
 

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -518,6 +518,129 @@ mod tests {
         }
     }
 
+    fn catalog_with_auth(auth: serde_json::Value) -> BuiltinFirewallCatalog {
+        let mut catalog = catalog("auth-strategy");
+        catalog.firewalls.get_mut("auth-strategy").unwrap().apis[0].auth =
+            serde_json::from_value(auth).unwrap();
+        catalog
+    }
+
+    #[test]
+    fn validates_auth_strategy_combinations_at_catalog_boundary() {
+        let aws_sigv4 = serde_json::json!({
+            "accessKeyId": "access-key",
+            "secretAccessKey": "secret-key"
+        });
+        let valid = [
+            (
+                "direct headers",
+                serde_json::json!({"headers": {"Authorization": "token"}}),
+            ),
+            (
+                "direct query",
+                serde_json::json!({"query": {"api_key": "token"}}),
+            ),
+            (
+                "direct headers and query",
+                serde_json::json!({
+                    "headers": {"Authorization": "token"},
+                    "query": {"api_key": "token"}
+                }),
+            ),
+            (
+                "base only",
+                serde_json::json!({"base": "https://hooks.example.com/secret"}),
+            ),
+            (
+                "base and headers",
+                serde_json::json!({
+                    "base": "https://hooks.example.com/secret",
+                    "headers": {"Authorization": "token"}
+                }),
+            ),
+            (
+                "base and query",
+                serde_json::json!({
+                    "base": "https://hooks.example.com/secret",
+                    "query": {"api_key": "token"}
+                }),
+            ),
+            (
+                "base, headers, and query",
+                serde_json::json!({
+                    "base": "https://hooks.example.com/secret",
+                    "headers": {"Authorization": "token"},
+                    "query": {"api_key": "token"}
+                }),
+            ),
+            (
+                "base with empty maps",
+                serde_json::json!({
+                    "base": "https://hooks.example.com/secret",
+                    "headers": {},
+                    "query": {}
+                }),
+            ),
+            ("SigV4", serde_json::json!({"awsSigv4": aws_sigv4.clone()})),
+            (
+                "SigV4 with empty maps",
+                serde_json::json!({
+                    "headers": {},
+                    "query": {},
+                    "awsSigv4": aws_sigv4.clone()
+                }),
+            ),
+        ];
+
+        for (name, auth) in valid {
+            catalog_with_auth(auth)
+                .validate_for_api_response()
+                .unwrap_or_else(|error| panic!("{name} should be valid: {error}"));
+        }
+
+        let invalid = [
+            (
+                "empty base",
+                serde_json::json!({"base": ""}),
+                "auth.base must be non-empty",
+            ),
+            (
+                "SigV4 and headers",
+                serde_json::json!({
+                    "headers": {"Authorization": "token"},
+                    "awsSigv4": aws_sigv4.clone()
+                }),
+                "auth.headers cannot be combined",
+            ),
+            (
+                "SigV4 and query",
+                serde_json::json!({
+                    "query": {"api_key": "token"},
+                    "awsSigv4": aws_sigv4.clone()
+                }),
+                "auth.query cannot be combined",
+            ),
+            (
+                "SigV4 and base",
+                serde_json::json!({
+                    "base": "https://hooks.example.com/secret",
+                    "awsSigv4": aws_sigv4
+                }),
+                "auth.base cannot be combined",
+            ),
+        ];
+
+        for (name, auth, expected) in invalid {
+            let error = catalog_with_auth(auth)
+                .validate_for_api_response()
+                .unwrap_err();
+            assert!(
+                error.contains(expected),
+                "{name}: unexpected error: {error}"
+            );
+        }
+    }
+
     #[tokio::test(start_paused = true)]
     async fn initial_refresh_retries_after_failure() {
         let attempts = Arc::new(AtomicUsize::new(0));

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -732,7 +732,7 @@ pub struct FirewallAuth {
     #[serde(default)]
     pub headers: std::collections::HashMap<String, String>,
     /// Optional base URL template for URL rewriting (e.g. webhook-url connectors).
-    /// When set, the proxy rewrites the request URL instead of injecting headers.
+    /// When set, the proxy rewrites the request URL before applying resolved auth.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base: Option<String>,
     /// Optional query parameters with secret/var templates for query-param auth.
@@ -753,6 +753,9 @@ impl FirewallAuth {
             return Ok(());
         };
         aws_sigv4.validate_for_cache()?;
+        if self.base.is_some() {
+            return Err("auth.base cannot be combined with auth.awsSigv4".to_string());
+        }
         if !self.headers.is_empty() {
             return Err("auth.headers cannot be combined with auth.awsSigv4".to_string());
         }

--- a/turbo/packages/connectors/src/__tests__/firewall-auth-strategy.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-auth-strategy.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { findMatchingPermissions } from "../firewall-rule-matcher";
+import { firewallConfigSchema, type FirewallConfig } from "../firewall-types";
+
+type FirewallAuthConfig = FirewallConfig["apis"][number]["auth"];
+
+const AWS_SIGV4 = {
+  accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",
+  secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+} as const;
+
+function configWithAuth(auth: FirewallAuthConfig): FirewallConfig {
+  return {
+    name: "auth-strategy",
+    apis: [
+      {
+        base: "https://api.example.com",
+        auth,
+        permissions: [{ name: "use", rules: ["GET /"] }],
+      },
+    ],
+  };
+}
+
+const VALID_AUTH_CASES: ReadonlyArray<{
+  readonly name: string;
+  readonly auth: FirewallAuthConfig;
+}> = [
+  { name: "direct headers", auth: { headers: { Authorization: "token" } } },
+  { name: "direct query", auth: { query: { api_key: "token" } } },
+  {
+    name: "direct headers and query",
+    auth: { headers: { Authorization: "token" }, query: { api_key: "token" } },
+  },
+  { name: "base only", auth: { base: "https://hooks.example.com/secret" } },
+  {
+    name: "base and headers",
+    auth: {
+      base: "https://hooks.example.com/secret",
+      headers: { Authorization: "token" },
+    },
+  },
+  {
+    name: "base and query",
+    auth: {
+      base: "https://hooks.example.com/secret",
+      query: { api_key: "token" },
+    },
+  },
+  {
+    name: "base, headers, and query",
+    auth: {
+      base: "https://hooks.example.com/secret",
+      headers: { Authorization: "token" },
+      query: { api_key: "token" },
+    },
+  },
+  {
+    name: "base with empty maps",
+    auth: { base: "https://hooks.example.com/secret", headers: {}, query: {} },
+  },
+  { name: "SigV4", auth: { awsSigv4: AWS_SIGV4 } },
+  {
+    name: "SigV4 with empty maps",
+    auth: { headers: {}, query: {}, awsSigv4: AWS_SIGV4 },
+  },
+];
+
+const INVALID_AUTH_CASES: ReadonlyArray<{
+  readonly name: string;
+  readonly auth: FirewallAuthConfig;
+}> = [
+  { name: "empty base", auth: { base: "" } },
+  {
+    name: "SigV4 and headers",
+    auth: { headers: { Authorization: "token" }, awsSigv4: AWS_SIGV4 },
+  },
+  {
+    name: "SigV4 and query",
+    auth: { query: { api_key: "token" }, awsSigv4: AWS_SIGV4 },
+  },
+  {
+    name: "SigV4 and base",
+    auth: { base: "https://hooks.example.com/secret", awsSigv4: AWS_SIGV4 },
+  },
+];
+
+describe("firewall auth strategy validation", () => {
+  for (const { name, auth } of VALID_AUTH_CASES) {
+    it(`accepts ${name} at schema and executable matcher boundaries`, () => {
+      const config = configWithAuth(auth);
+
+      expect(firewallConfigSchema.safeParse(config).success).toBe(true);
+      expect(findMatchingPermissions("GET", "/", config)).toEqual(["use"]);
+    });
+  }
+
+  for (const { name, auth } of INVALID_AUTH_CASES) {
+    it(`rejects ${name} at schema and executable matcher boundaries`, () => {
+      const config = configWithAuth(auth);
+
+      expect(firewallConfigSchema.safeParse(config).success).toBe(false);
+      expect(findMatchingPermissions("GET", "/", config)).toEqual([]);
+    });
+  }
+});

--- a/turbo/packages/connectors/src/firewall-rule-matcher.ts
+++ b/turbo/packages/connectors/src/firewall-rule-matcher.ts
@@ -442,6 +442,7 @@ function isValidAuthConfig(auth: unknown, serviceName: string): boolean {
   if (auth.base !== undefined) {
     if (typeof auth.base !== "string") return false;
     validateAuthBaseUrl(auth.base, serviceName);
+    if (auth.awsSigv4 !== undefined) return false;
   }
   return true;
 }

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -34,7 +34,7 @@ export const firewallAwsSigv4AuthSchema = z
 const firewallAuthSchema = z
   .object({
     headers: z.record(z.string(), z.string()).optional(),
-    base: z.string().optional(),
+    base: z.string().min(1).optional(),
     query: z.record(z.string(), z.string()).optional(),
     awsSigv4: firewallAwsSigv4AuthSchema.optional(),
   })
@@ -54,6 +54,13 @@ const firewallAuthSchema = z
         code: "custom",
         path: ["query"],
         message: "auth.query cannot be combined with auth.awsSigv4",
+      });
+    }
+    if (auth.base !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["base"],
+        message: "auth.base cannot be combined with auth.awsSigv4",
       });
     }
   });

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -365,6 +365,52 @@ describe("firewall metadata generator", () => {
   );
 
   it(
+    "rejects auth.base with SigV4 at the generated source boundary",
+    async () => {
+      await loadGeneratedConnectorFirewallSource("github", {
+        connectorsDir: CONNECTORS_DIR,
+      });
+      const previousSource = getGeneratedFirewallOutput("github");
+      if (previousSource === null) {
+        throw new Error("missing generated github firewall source");
+      }
+
+      writeOutput(
+        "github",
+        [
+          "export const githubFirewall = {",
+          '  name: "github",',
+          "  apis: [",
+          "    {",
+          '      base: "https://api.github.com",',
+          "      auth: {",
+          '        base: "https://hooks.example.com/secret",',
+          "        awsSigv4: {",
+          '          accessKeyId: "${{ secrets.AWS_ACCESS_KEY_ID }}",',
+          '          secretAccessKey: "${{ secrets.AWS_SECRET_ACCESS_KEY }}",',
+          "        },",
+          "      },",
+          "      permissions: [],",
+          "    },",
+          "  ],",
+          "};",
+        ].join("\n"),
+      );
+
+      try {
+        await expect(
+          loadGeneratedConnectorFirewallSource("github", {
+            connectorsDir: CONNECTORS_DIR,
+          }),
+        ).rejects.toThrow("auth.base cannot be combined with auth.awsSigv4");
+      } finally {
+        writeOutput("github", previousSource);
+      }
+    },
+    FULL_FIREWALL_SOURCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "requires host policy for credentialed whole-host dynamic bases",
     async () => {
       await loadGeneratedConnectorFirewallSource("github", {


### PR DESCRIPTION
## Summary

- enforce the same `auth.base`/headers/query/SigV4 strategy matrix at the TypeScript, Rust, and Python executable boundaries
- validate firewall-auth success payloads against the originating request before cache admission, then dispatch request mutation from validated configuration
- build `auth.base` forwards from fresh client representation metadata (`Content-Type` and ordered `Content-Encoding`) plus trusted resolved auth, and remove catalog-derived header policy and rewrite-specific SigV4 handling

## Scope

- keeps `auth.base` composable with resolved headers and query parameters
- changes no wire shape, cache schema, database/R2 state, feature flag, or telemetry
- leaves connector diagnostics and generated-package removal to the successor issues

## Validation

Passed:

```text
pnpm exec vitest run packages/connectors/src/__tests__/firewall-auth-strategy.test.ts packages/connectors/src/__tests__/firewall-rule-matcher.test.ts packages/firewalls-generator/src/__tests__/metadata.test.ts
pnpm -F @vm0/connectors check-types
pnpm -F @vm0/connectors lint
pnpm -F @vm0/firewalls-generator check-types
pnpm -F @vm0/firewalls-generator generate
git diff --exit-code -- crates/runner/mitm-addon/src/generated
cargo test -p runner
cargo fmt --all -- --check
cargo clippy -p runner --all-targets --all-features
.venv/bin/python -m pytest tests/ -q
.venv/bin/ruff check .
.venv/bin/ruff format --check .
.venv/bin/python -m basedpyright -p .
pnpm turbo run lint
pnpm check-types
pnpm format
pnpm knip
```

Post-rebase focused validation passed with TypeScript 220/220, Python 413/413, and runner Rust 2594 passed with 5 ignored. The earlier complete Python run passed 3784/3784.

After rebasing onto `1613d7fe2c`, a complete unsharded `pnpm vitest` run completed 7277 tests: 7274 passed, 1 skipped, and 2 unrelated API timing tests failed under full-suite load (`chat-callbacks.bdd.test.ts` title persistence and `zero-workflow-queue-api.test.ts` queue drain timing). Both files passed immediately together in a focused rerun, 26/26. The former Xero snapshot, artifact pagination, and cancelled usage allowance failures were fixed on main by #20963 and no longer reproduce.

Closes #20891
