### PR TITLE
test(runner): restore url query redaction coverage

### DIFF
--- a/crates/runner/src/helper_exec.rs
+++ b/crates/runner/src/helper_exec.rs
@@ -262,6 +262,36 @@ mod tests {
     }
 
     #[test]
+    fn command_output_redaction_preserves_whitespace_between_urls() {
+        let excerpt = format_command_output_excerpt(
+            "stderr",
+            b"first=https://a.example/archive.tar.gz?token=secret\n\tsecond=http://b.example/logs?key=hidden third=https://c.example/blob?sig=private plain=http://d.example/no-query",
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            excerpt,
+            "stderr (captured): first=https://a.example/archive.tar.gz?<redacted>\n\tsecond=http://b.example/logs?<redacted> third=https://c.example/blob?<redacted> plain=http://d.example/no-query"
+        );
+    }
+
+    #[test]
+    fn command_output_redaction_handles_case_insensitive_url_schemes() {
+        let excerpt = format_command_output_excerpt(
+            "stderr",
+            b"first=HtTp://a.example/logs?token=secret second=hTtPs://b.example/archive?sig=hidden",
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            excerpt,
+            "stderr (captured): first=HtTp://a.example/logs?<redacted> second=hTtPs://b.example/archive?<redacted>"
+        );
+    }
+
+    #[test]
     fn termination_label_is_stable_for_logs() {
         assert_eq!(
             helper_exec_termination_label(&exec_result(ExecTermination::Exited { exit_code: 0 })),


### PR DESCRIPTION
## Summary

- restore direct regression coverage for whitespace-preserving query redaction across multiple HTTP(S) URLs
- cover ASCII-case-insensitive variants of both HTTP and HTTPS schemes
- keep the current conservative runtime redaction behavior unchanged

## Scope

This PR changes tests only. It does not add punctuation heuristics, URL parsing, broader secret masking, dependencies, API contracts, migrations, or documentation behavior.

## Validation

- `cargo test --manifest-path crates/Cargo.toml -p runner helper_exec::tests` (9 passed)
- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,261 passed)
- `pnpm knip`

Closes #20959
Related to #20910
