### PR TITLE
fix: refresh frosted scatter archive

### DIFF
--- a/turbo/apps/api/src/signals/routes/registry-resources-download.ts
+++ b/turbo/apps/api/src/signals/routes/registry-resources-download.ts
@@ -143,7 +143,7 @@ const PRIVATE_REGISTRY_RESOURCE_ARCHIVE_VERSION_IDS = {
   "template:frame-stack":
     "efbf1788c8b084aa12b7cd48f7a3bf5fc9964d1e6115edbd9124f8cacfbfb3ca",
   "template:frosted-scatter":
-    "f23092f727e7a8a20d586e80a6f6cc0ff27d51f2fee3356a7d8ab97c3539c3b9",
+    "c4507fd54d252dc905df36d99f23ab65a4d41185b78e62515ff3eb3d87a381a4",
   "template:gallery-wall":
     "9e81cd8b35f9f6374440cd3a4a8fc214db4a137962797df69bde46248c4e75f3",
   "template:glass-bloom":

--- a/turbo/packages/core/src/__tests__/website-template-items.spec.ts
+++ b/turbo/packages/core/src/__tests__/website-template-items.spec.ts
@@ -36,7 +36,7 @@ const EXPECTED_WEBSITE_TEMPLATE_SHA256: Record<string, string> = {
   "frame-stack":
     "4587e93da51652c0c16c2d0706e8437001305214e4e6b8b1c18a6538b3daa127",
   "frosted-scatter":
-    "7ad1c3b16b7beeb82e1a2f39a1fe7fff168592fb06e7b5fedf3c2450e1412f43",
+    "00e343ace0673ece5903a2b6abbad6bb960c17796e0cfa5cce0bcab7e6bcdd7b",
   "gallery-wall":
     "c90332053b24572feadecb3994925ed317957e1cb17b0080cfebc6f4d9e93bd1",
   "glass-bloom":

--- a/turbo/packages/core/src/resource-registry.ts
+++ b/turbo/packages/core/src/resource-registry.ts
@@ -3648,7 +3648,7 @@ const WEBSITE_TEMPLATE_ARCHIVE_SHA256: Record<string, string> = {
   "frame-stack":
     "4587e93da51652c0c16c2d0706e8437001305214e4e6b8b1c18a6538b3daa127",
   "frosted-scatter":
-    "7ad1c3b16b7beeb82e1a2f39a1fe7fff168592fb06e7b5fedf3c2450e1412f43",
+    "00e343ace0673ece5903a2b6abbad6bb960c17796e0cfa5cce0bcab7e6bcdd7b",
   "gallery-wall":
     "c90332053b24572feadecb3994925ed317957e1cb17b0080cfebc6f4d9e93bd1",
   "glass-bloom":


### PR DESCRIPTION
## Summary
- Upload the refreshed `frosted-scatter.tar.gz` Drive package contents to R2 as `registry-resource@template:frosted-scatter`
- Update the API private registry resource version id to the new storage version
- Update the built-in website template archive SHA used by the registry and tests

## R2 upload
- Storage: `registry-resource@template:frosted-scatter`
- Version: `c4507fd54d252dc905df36d99f23ab65a4d41185b78e62515ff3eb3d87a381a4`
- Archive SHA256: `00e343ace0673ece5903a2b6abbad6bb960c17796e0cfa5cce0bcab7e6bcdd7b`
- Files: 19

## Verification
- Downloaded the committed R2 archive back from the storage download endpoint and verified its SHA256 matches `00e343ace0673ece5903a2b6abbad6bb960c17796e0cfa5cce0bcab7e6bcdd7b`
- `pnpm --filter @vm0/core test -- src/__tests__/website-template-items.spec.ts`
- `pnpm exec vitest run src/commands/zero/resource/__tests__/index.test.ts src/commands/zero/generate/__tests__/website.test.ts` from `turbo/apps/cli`
- `pnpm exec vitest run src/signals/routes/__tests__/registry-resources-download.test.ts` from `turbo/apps/api`

Note: broad package test invocations were stopped because the local environment lacks the test database and exposed unrelated auth/DB failures; the exact target tests above passed.