### PR TITLE
fix: reject unsafe firewall base paths

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_base_url.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 import matching
 from authority_utils import percent_decode_host
-from path_security import has_unsafe_path
+from path_security import has_unsafe_path, has_unsafe_url_path
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 _BASE_URL_VAR_PATTERN = re.compile(r"\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
@@ -402,11 +402,11 @@ def resolve_base_url_template(
     resolved_parts.append(base[last_index:])
     resolved = "".join(resolved_parts)
     if not matching.firewall_base_config_is_valid(resolved):
+        if has_unsafe_url_path(resolved):
+            raise BuiltinBaseUrlResolutionError(
+                f'builtin firewall "{firewall_name}" resolved base URL has unsafe path segments'
+            )
         raise BuiltinBaseUrlResolutionError(
             f'builtin firewall "{firewall_name}" resolved base URL is invalid'
-        )
-    if has_unsafe_path(urllib.parse.urlsplit(resolved).path):
-        raise BuiltinBaseUrlResolutionError(
-            f'builtin firewall "{firewall_name}" resolved base URL has unsafe path segments'
         )
     return resolved

--- a/crates/runner/mitm-addon/src/builtin_base_url.py
+++ b/crates/runner/mitm-addon/src/builtin_base_url.py
@@ -148,6 +148,13 @@ def _validate_base_url_prefix_variable(
     name: str,
     value: str,
 ) -> None:
+    if has_unsafe_url_path(value):
+        raise _base_url_variable_error(
+            firewall_name=firewall_name,
+            base=base,
+            name=name,
+            detail="must not contain unsafe path segments before a fixed path suffix",
+        )
     if not matching.firewall_base_config_is_valid(value):
         raise _base_url_variable_error(
             firewall_name=firewall_name,
@@ -162,13 +169,6 @@ def _validate_base_url_prefix_variable(
             base=base,
             name=name,
             detail="must not contain query or fragment before a fixed path suffix",
-        )
-    if has_unsafe_path(parts.path):
-        raise _base_url_variable_error(
-            firewall_name=firewall_name,
-            base=base,
-            name=name,
-            detail="must not contain unsafe path segments before a fixed path suffix",
         )
 
 

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -11,6 +11,7 @@ from mitmproxy import ctx
 
 import builtin_host_policy
 import matching
+from path_security import has_unsafe_path, has_unsafe_url_path
 from url_syntax import has_raw_whitespace, has_unsafe_url_codepoint
 
 MAX_BUILTIN_FIREWALL_CATALOG_BYTES = 16 * 1024 * 1024
@@ -320,6 +321,15 @@ def _validate_api_entry(firewall_name: str, api: dict) -> None:
         raise BuiltinFirewallCatalogCacheError(
             f'catalog cache firewall "{firewall_name}" api base has invalid syntax'
         )
+    if template_syntax_target is not None:
+        if template_syntax_target.startswith("template/"):
+            known_path = template_syntax_target.removeprefix("template")
+        else:
+            known_path = ""
+        if has_unsafe_url_path(template_syntax_target) or has_unsafe_path(known_path):
+            raise BuiltinFirewallCatalogCacheError(
+                f'catalog cache firewall "{firewall_name}" api base has unsafe path'
+            )
     if (
         template_syntax_target is not None
         and ("{" in template_syntax_target or "}" in template_syntax_target)

--- a/crates/runner/mitm-addon/src/firewall_matching/base_url.py
+++ b/crates/runner/mitm-addon/src/firewall_matching/base_url.py
@@ -26,6 +26,7 @@ from host_normalization import (
     normalize_idna_hostname,
     translate_idna_dot_separators,
 )
+from path_security import has_unsafe_url_path
 from url_syntax import (
     has_raw_whitespace,
     has_unsafe_runtime_url_syntax,
@@ -394,6 +395,7 @@ def _compile_firewall_config_base(raw_base: str) -> _CompiledFirewallConfigBase 
         or base.parts.host_malformed
         or base.parts.has_userinfo
         or base.parts.port_malformed
+        or has_unsafe_url_path(raw_base)
         or not _compiled_base_params_are_valid(base),
     )
 

--- a/crates/runner/mitm-addon/src/path_security.py
+++ b/crates/runner/mitm-addon/src/path_security.py
@@ -19,6 +19,24 @@ def has_unsafe_path(path: str) -> bool:
     return any(_segment_has_unsafe_path(raw_segment) for raw_segment in path.split("/"))
 
 
+def has_unsafe_url_path(url: str) -> bool:
+    """Return whether a raw absolute URL contains an unsafe path."""
+    scheme_end = url.find("://")
+    if scheme_end == -1:
+        return False
+    after_scheme = url[scheme_end + len("://") :]
+    path_start = after_scheme.find("/")
+    if path_start == -1:
+        return False
+    path_and_after = after_scheme[path_start:]
+    path_end = len(path_and_after)
+    for delimiter in ("?", "#"):
+        delimiter_index = path_and_after.find(delimiter)
+        if delimiter_index != -1:
+            path_end = min(path_end, delimiter_index)
+    return has_unsafe_path(path_and_after[:path_end])
+
+
 def _segment_has_unsafe_path(raw_segment: str) -> bool:
     segment = raw_segment
     for _ in range(_MAX_PERCENT_DECODE_PASSES):

--- a/crates/runner/mitm-addon/src/path_security.py
+++ b/crates/runner/mitm-addon/src/path_security.py
@@ -25,10 +25,14 @@ def has_unsafe_url_path(url: str) -> bool:
     if scheme_end == -1:
         return False
     after_scheme = url[scheme_end + len("://") :]
-    path_start = after_scheme.find("/")
-    if path_start == -1:
+    component_start = len(after_scheme)
+    for delimiter in ("/", "?", "#"):
+        delimiter_index = after_scheme.find(delimiter)
+        if delimiter_index != -1:
+            component_start = min(component_start, delimiter_index)
+    if component_start == len(after_scheme) or after_scheme[component_start] != "/":
         return False
-    path_and_after = after_scheme[path_start:]
+    path_and_after = after_scheme[component_start:]
     path_end = len(path_and_after)
     for delimiter in ("?", "#"):
         delimiter_index = path_and_after.find(delimiter)

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -736,6 +736,32 @@ class TestRegistryBuiltinBaseUrlVars:
         assert invalid_vm.reason == "invalid_firewalls"
         assert 'builtin firewall "strapi" resolved base URL is invalid' in invalid_vm.message
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://strapi.example.test?next=/../",
+            "https://strapi.example.test#next=/../",
+        ],
+    )
+    def test_builtin_base_url_does_not_treat_query_or_fragment_as_path(self, tmp_path, value):
+        path = tmp_path / "registry.json"
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-strapi",
+            name="strapi",
+            base_url_vars={"STRAPI_BASE_URL": value},
+        )
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert 'builtin firewall "strapi" resolved base URL is invalid' in invalid_vm.message
+
     def test_builtin_base_url_prefix_preserves_fixed_path_suffix(self, tmp_path):
         path = tmp_path / "registry.json"
         write_builtin_firewall_registry(
@@ -789,7 +815,10 @@ class TestRegistryBuiltinBaseUrlVars:
         assert not isinstance(state, registry.RegistryUnavailable)
         invalid_vm = state.invalid_vms["10.200.0.1"]
         assert invalid_vm.reason == "invalid_firewalls"
-        assert 'base URL variable "N8N_BASE_URL"' in invalid_vm.message
+        assert (
+            'base URL variable "N8N_BASE_URL" must not contain unsafe path segments '
+            "before a fixed path suffix"
+        ) in invalid_vm.message
 
     def test_builtin_base_url_prefix_rejects_encoded_path_dot_segments(self, tmp_path):
         path = tmp_path / "registry.json"
@@ -808,7 +837,10 @@ class TestRegistryBuiltinBaseUrlVars:
         assert not isinstance(state, registry.RegistryUnavailable)
         invalid_vm = state.invalid_vms["10.200.0.1"]
         assert invalid_vm.reason == "invalid_firewalls"
-        assert 'base URL variable "N8N_BASE_URL"' in invalid_vm.message
+        assert (
+            'base URL variable "N8N_BASE_URL" must not contain unsafe path segments '
+            "before a fixed path suffix"
+        ) in invalid_vm.message
 
     def test_builtin_path_segment_var_accepts_fixed_suffix(self, tmp_path):
         install_test_builtin_firewall(

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -593,6 +593,24 @@ class TestRegistryBuiltinCache:
         firewall["apis"][0]["base"] = "not-a-url"
         _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
 
+    @pytest.mark.parametrize(
+        "base",
+        [
+            "https://api.example.com/a/../admin",
+            "https://api.example.com/%252e%252e/admin",
+            "https://api.example.com/..;version=1/admin",
+            "https://api.example.com/%255cadmin",
+            "https://api.example.com/v1/../{org}",
+            "https://${{ vars.TENANT }}.example.com/v1/../items",
+            "${{ vars.API_BASE_URL }}/v1/%2e%2e/items",
+        ],
+    )
+    def test_unsafe_base_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx, base):
+        firewall = _cache_firewall("fallback", base)
+        firewall["apis"][0].pop("hostPolicy")
+
+        _assert_cache_firewall_is_invalid(tmp_path, mitm_ctx, firewall)
+
     def test_malformed_parameterized_base_runner_catalog_cache_fails_closed(
         self, tmp_path, mitm_ctx
     ):

--- a/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_firewall_dispatch.py
@@ -956,3 +956,55 @@ async def test_firewall_unsafe_path_blocks_before_auth_injection(
     assert proxy_log_entry["type"] == "firewall_block"
     assert proxy_log_entry["name"] == "github"
     assert proxy_log_entry["reason"] == "unsafe_path"
+
+
+async def test_unsafe_firewall_base_still_blocks_before_auth_injection(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    """Unsafe request paths take precedence over malformed base configuration."""
+    unsafe_base = "https://api.github.com/repos/%2e%2e"
+    path = "/repos/%2e%2e/admin"
+    reg_path = _write_registry(
+        tmp_path,
+        vm_info=_single_firewall_vm(
+            tmp_path,
+            api_entry={
+                "base": unsafe_base,
+                "auth": {"headers": {"Authorization": "Bearer ${{ secrets.GITHUB_TOKEN }}"}},
+                "permissions": [
+                    {
+                        "name": "full-access",
+                        "rules": ["ANY /{path+}"],
+                    },
+                ],
+            },
+            network_policy={
+                "allow": ["full-access"],
+                "deny": [],
+                "ask": [],
+                "unknownPolicy": "allow",
+            },
+        ),
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="api.github.com",
+        path=path,
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as mock_headers,
+    ):
+        await mitm_addon.request(flow)
+
+    mock_headers.assert_not_called()
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "DENY"
+    assert flow.metadata[metadata_keys.FIREWALL_BASE] == unsafe_base
+    assert "Authorization" not in flow.request.headers
+    body = json.loads(flow.response.content)
+    assert body["reason"] == "unsafe_path"
+    assert body["base"] == unsafe_base

--- a/crates/runner/src/provider/builtin_firewall_catalog.rs
+++ b/crates/runner/src/provider/builtin_firewall_catalog.rs
@@ -641,6 +641,17 @@ mod tests {
         }
     }
 
+    fn catalog_with_base(base: &str) -> BuiltinFirewallCatalog {
+        let mut value = catalog("github");
+        value
+            .firewalls
+            .get_mut("github")
+            .expect("catalog should contain github")
+            .apis[0]
+            .base = base.to_string();
+        value
+    }
+
     #[tokio::test(start_paused = true)]
     async fn initial_refresh_retries_after_failure() {
         let attempts = Arc::new(AtomicUsize::new(0));
@@ -1045,6 +1056,82 @@ mod tests {
             cache.firewalls["github"].apis[0].base,
             "https://${{ vars.TENANT }}.example.com"
         );
+    }
+
+    #[tokio::test]
+    async fn write_catalog_cache_accepts_safe_base_paths() {
+        for base in [
+            "https://api.example.com/v1/a..b",
+            "https://api.example.com/.well-known",
+            "https://api.example.com/callback;version=1",
+            "https://api.example.com/work%2fflows",
+            "https://api.example.com/v1/{org}",
+            "https://${{ vars.TENANT }}.example.com/v1/items",
+            "${{ vars.API_BASE_URL }}/v1/items",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+            let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+
+            write_catalog_cache(&cache_path, &lock_path, catalog_with_base(base))
+                .await
+                .unwrap();
+
+            let cache = read_catalog_cache(&cache_path).await.unwrap().unwrap();
+            assert_eq!(cache.firewalls["github"].apis[0].base, base);
+        }
+    }
+
+    #[tokio::test]
+    async fn unsafe_base_catalogs_never_publish() {
+        for base in [
+            "https://api.example.com/a/../admin",
+            "https://api.example.com/a/./admin",
+            "https://api.example.com/%2e%2e/admin",
+            "https://api.example.com/%252e%252e/admin",
+            "https://api.example.com/..;version=1/admin",
+            "https://api.example.com/%5cadmin",
+            "https://api.example.com/%zz/admin",
+            "https://api.example.com/%ff/admin",
+            "https://api.example.com/．．/admin",
+            "https://api.example.com/v1/../{org}",
+            "https://${{ vars.TENANT }}.example.com/v1/../items",
+            "${{ vars.API_BASE_URL }}/v1/%2e%2e/items",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let cache_path = dir.path().join("builtin-firewall-catalog-cache.json");
+            let lock_path = dir.path().join("builtin-firewall-catalog-cache.json.lock");
+
+            let initial_error =
+                write_catalog_cache(&cache_path, &lock_path, catalog_with_base(base))
+                    .await
+                    .unwrap_err();
+            assert!(
+                initial_error
+                    .to_string()
+                    .contains("base URL must not contain unsafe path"),
+                "unexpected error for {base:?}: {initial_error}"
+            );
+            assert!(!cache_path.exists(), "unsafe base {base:?} was published");
+
+            write_catalog_cache(&cache_path, &lock_path, catalog("github"))
+                .await
+                .unwrap();
+            let before = tokio::fs::read_to_string(&cache_path).await.unwrap();
+
+            let refresh_error =
+                write_catalog_cache(&cache_path, &lock_path, catalog_with_base(base))
+                    .await
+                    .unwrap_err();
+            assert!(
+                refresh_error
+                    .to_string()
+                    .contains("base URL must not contain unsafe path"),
+                "unexpected error for {base:?}: {refresh_error}"
+            );
+            let after = tokio::fs::read_to_string(&cache_path).await.unwrap();
+            assert_eq!(after, before, "unsafe base {base:?} replaced the cache");
+        }
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -427,6 +427,17 @@ fn validate_firewall_base_for_cache(base: &str) -> Result<(), String> {
     if raw_syntax_target.contains('#') {
         return Err("base URL must not contain fragment".to_string());
     }
+    let raw_path = if template_syntax_target.is_some() && !raw_syntax_target.contains("://") {
+        raw_syntax_target
+            .strip_prefix("template")
+            .filter(|suffix| suffix.starts_with('/'))
+            .unwrap_or("")
+    } else {
+        raw_url_path(raw_syntax_target)
+    };
+    if path_has_unsafe_segments_for_cache(raw_path) {
+        return Err("base URL must not contain unsafe path".to_string());
+    }
     if template_syntax_target.is_some() {
         if (raw_syntax_target.contains('{') || raw_syntax_target.contains('}'))
             && raw_syntax_target.contains("://")

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -993,9 +993,12 @@ fn raw_url_path(value: &str) -> &str {
     let Some(rest) = value.split_once("://").map(|(_, rest)| rest) else {
         return "";
     };
-    let Some(path_start) = rest.find('/') else {
+    let Some(path_start) = rest.find(['/', '?', '#']) else {
         return "";
     };
+    if !rest[path_start..].starts_with('/') {
+        return "";
+    }
     let path_and_after = &rest[path_start..];
     let path_end = path_and_after
         .find(['?', '#'])
@@ -1254,6 +1257,17 @@ impl SandboxReuseResult {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn raw_url_path_does_not_treat_query_or_fragment_content_as_path() {
+        assert_eq!(raw_url_path("https://api.example.com?next=/../"), "");
+        assert_eq!(raw_url_path("https://api.example.com#next=/../"), "");
+    }
+
+    #[test]
+    fn firewall_auth_base_allows_path_syntax_in_query() {
+        validate_auth_base_for_cache("https://api.example.com?next=/../").unwrap();
+    }
 
     #[test]
     fn poll_response_with_job() {

--- a/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
+++ b/turbo/packages/connectors/src/__tests__/firewall-base-url-validation-contract.json
@@ -401,6 +401,96 @@
       "name": "duplicate path parameter name is invalid",
       "base": "https://api.example.com/{org}/{org}",
       "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "dotted path segment name is valid",
+      "base": "https://api.example.com/v1/a..b",
+      "expectedValid": true
+    },
+    {
+      "category": "path-safety",
+      "name": "well-known path segment is valid",
+      "base": "https://api.example.com/.well-known",
+      "expectedValid": true
+    },
+    {
+      "category": "path-safety",
+      "name": "ordinary matrix path segment is valid",
+      "base": "https://api.example.com/callback;version=1",
+      "expectedValid": true
+    },
+    {
+      "category": "path-safety",
+      "name": "encoded slash path data is valid",
+      "base": "https://api.example.com/work%2fflows",
+      "expectedValid": true
+    },
+    {
+      "category": "path-safety",
+      "name": "literal parent path segment is invalid",
+      "base": "https://api.example.com/a/../admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "literal current path segment is invalid",
+      "base": "https://api.example.com/a/./admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "encoded parent path segment is invalid",
+      "base": "https://api.example.com/%2e%2e/admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "repeatedly encoded parent path segment is invalid",
+      "base": "https://api.example.com/%252e%252e/admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "matrix parent path segment is invalid",
+      "base": "https://api.example.com/..;version=1/admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "encoded backslash path is invalid",
+      "base": "https://api.example.com/%5cadmin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "repeatedly encoded backslash path is invalid",
+      "base": "https://api.example.com/%255cadmin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "malformed path percent encoding is invalid",
+      "base": "https://api.example.com/%zz/admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "percent-encoded invalid utf8 path is invalid",
+      "base": "https://api.example.com/%ff/admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "compatibility parent path segment is invalid",
+      "base": "https://api.example.com/\uff0e\uff0e/admin",
+      "expectedValid": false
+    },
+    {
+      "category": "path-safety",
+      "name": "parameterized base with parent path segment is invalid",
+      "base": "https://api.example.com/v1/../{org}",
+      "expectedValid": false
     }
   ]
 }

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -691,13 +691,13 @@ describe("validateBaseUrl", () => {
 
   it("should reject URLs with query string", () => {
     expect(() => {
-      return validateBaseUrl("https://api.example.com?key=val", "fw");
+      return validateBaseUrl("https://api.example.com?next=/../", "fw");
     }).toThrow("must not contain query string");
   });
 
   it("should reject URLs with fragment", () => {
     expect(() => {
-      return validateBaseUrl("https://api.example.com#section", "fw");
+      return validateBaseUrl("https://api.example.com#next=/../", "fw");
     }).toThrow("must not contain fragment");
   });
 

--- a/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-expander.test.ts
@@ -66,6 +66,23 @@ describe("firewall expander helpers", () => {
     expect([...names].sort()).toEqual(["read", "upload"]);
   });
 
+  it("collectAndValidatePermissions rejects unsafe firewall base paths", () => {
+    const config: FirewallConfig = {
+      name: "unsafe-base",
+      apis: [
+        {
+          base: "https://api.example.com/v1/../admin",
+          auth: { headers: {} },
+          permissions: [{ name: "read", rules: ["GET /items"] }],
+        },
+      ],
+    };
+
+    expect(() => {
+      return collectAndValidatePermissions(config);
+    }).toThrow("must not contain unsafe path segments");
+  });
+
   it("collectAndValidatePermissions validates static base URL host policies", () => {
     const config = (
       base: string,
@@ -690,6 +707,33 @@ describe("validateBaseUrl", () => {
         "https://${{ vars.ZENDESK_SUBDOMAIN }}.zendesk.com",
         "zendesk",
       );
+    }).not.toThrow();
+  });
+
+  it("should reject unsafe fixed paths in template base URLs", () => {
+    expect(() => {
+      return validateBaseUrl(
+        "https://${{ vars.API_HOST }}/v1/../admin",
+        "templated",
+      );
+    }).toThrow("must not contain unsafe path segments");
+    expect(() => {
+      return validateBaseUrl(
+        "${{ vars.API_BASE_URL }}/v1/%2e%2e/admin",
+        "templated",
+      );
+    }).toThrow("must not contain unsafe path segments");
+  });
+
+  it("should allow safe fixed paths in unresolved template base URLs", () => {
+    expect(() => {
+      return validateBaseUrl(
+        "https://${{ vars.API_HOST }}/v1/items",
+        "templated",
+      );
+    }).not.toThrow();
+    expect(() => {
+      return validateBaseUrl("${{ vars.API_BASE_URL }}/v1/items", "templated");
     }).not.toThrow();
   });
 

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -1113,6 +1113,15 @@ function validateBaseUrlPrefixVariable({
   readonly name: string;
   readonly value: string;
 }): void {
+  const rawPath = rawPathFromBaseUrl(value);
+  if (hasUnsafeFirewallPath(rawPath)) {
+    throw baseUrlVariableError(
+      base,
+      serviceName,
+      name,
+      "must not contain unsafe path segments before a fixed path suffix",
+    );
+  }
   validateBaseUrl(value, serviceName);
   const url = new URL(value);
   if (url.search || url.hash) {
@@ -1122,17 +1131,6 @@ function validateBaseUrlPrefixVariable({
       name,
       "must not contain query or fragment before a fixed path suffix",
     );
-  }
-  const rawPath = rawPathFromBaseUrl(value);
-  for (const segment of rawPath.split("/")) {
-    if (pathSegmentHasUnsafeSyntax(segment, false)) {
-      throw baseUrlVariableError(
-        base,
-        serviceName,
-        name,
-        "must not contain unsafe path segments before a fixed path suffix",
-      );
-    }
   }
 }
 
@@ -2842,6 +2840,7 @@ export function validateBaseUrl(base: string, serviceName: string): void {
     );
   }
 
+  const hasTemplateVars = hasBaseUrlVars(base);
   const rawSyntaxTarget = baseUrlRawSyntaxTarget(base);
   if (hasRawWhitespace(rawSyntaxTarget)) {
     throw new Error(
@@ -2854,8 +2853,22 @@ export function validateBaseUrl(base: string, serviceName: string): void {
     );
   }
 
+  let knownRawPath = rawPathFromBaseUrl(rawSyntaxTarget);
+  if (
+    knownRawPath === "" &&
+    hasTemplateVars &&
+    rawSyntaxTarget.startsWith(`${AUTH_TEMPLATE_URL_PLACEHOLDER}/`)
+  ) {
+    knownRawPath = rawSyntaxTarget.slice(AUTH_TEMPLATE_URL_PLACEHOLDER.length);
+  }
+  if (hasUnsafeFirewallPath(knownRawPath)) {
+    throw new Error(
+      errMsg(base, serviceName, "must not contain unsafe path segments"),
+    );
+  }
+
   // Template base URLs are validated after variable resolution at compose time.
-  if (hasBaseUrlVars(base)) return;
+  if (hasTemplateVars) return;
 
   validateUrlSchemeDelimiter(base, serviceName, "base URL");
 

--- a/turbo/packages/connectors/src/firewall-types.ts
+++ b/turbo/packages/connectors/src/firewall-types.ts
@@ -1095,8 +1095,8 @@ function rawPathFromBaseUrl(value: string): string {
   const schemeEnd = value.indexOf("://");
   if (schemeEnd === -1) return "";
   const afterScheme = value.slice(schemeEnd + 3);
-  const pathStart = afterScheme.indexOf("/");
-  if (pathStart === -1) return "";
+  const pathStart = afterScheme.search(/[/?#]/);
+  if (pathStart === -1 || afterScheme[pathStart] !== "/") return "";
   const pathAndAfter = afterScheme.slice(pathStart);
   const pathEnd = pathAndAfter.search(/[?#]/);
   return pathEnd === -1 ? pathAndAfter : pathAndAfter.slice(0, pathEnd);


### PR DESCRIPTION
## Summary

- reject builtin firewall base URLs whose raw paths contain unsafe dot segments, encoded backslashes, malformed percent encodings, or invalid UTF-8 before URL normalization can erase the evidence
- enforce the same phase-aware path-safety contract in connector authoring, Rust catalog publication, and the Python runtime/cache boundary
- validate statically known path suffixes in unresolved templates, then validate the complete path after variable resolution
- keep invalid catalog refreshes from replacing the last-good cache and preserve `unsafe_path` blocking before auth injection
- preserve query/fragment and template-variable diagnostics by separating raw path extraction from later URL components

## Compatibility and data

- no database schema or migration changes, and no persisted-data shape changes
- no API, runner protocol, queue payload, or catalog serialization changes
- no URL canonicalization, fallback catalog, or digest changes
- the observable change is value validity and failure timing: an existing custom connector with an unsafe base may fail earlier, although the same request shape is already blocked before auth injection
- the issue audit scanned 281 generated builtin firewalls and found 0 affected API bases; production persisted custom connector values have not been audited

## Validation

- `pnpm format`
- `pnpm turbo run lint` (12/12 tasks)
- `pnpm check-types` (13/13 tasks)
- `pnpm knip`
- full Turbo Vitest suite after rebasing onto current `main` (7,302 passed, 1 skipped)
- full Python mitm addon suite after rebasing (3,809 passed)
- full Rust runner suite after rebasing (2,598 passed, 5 ignored)
- connectors lint and type checks, Ruff, basedpyright, Cargo fmt, and Clippy
- focused regression coverage for TypeScript query/fragment diagnostics, Python template resolution, and Rust raw-path/auth-base behavior

Closes #20909
