### PR TITLE
fix: upload large presentations to google slides

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-threads.bdd.test.ts
@@ -2013,12 +2013,13 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
 
   it("uploads a presentation to Google Slides behind a feature flag", async () => {
     const { actor } = await entitledChatActor("Slides upload agent");
+    const objectStore = chatCallbacks.acceptChatObjectStorage();
     const orgId = actor.orgId;
     if (!orgId) {
       throw new Error("entitled actor is missing an organization");
     }
     const threadId = randomUUID();
-    const pptx = {
+    const legacyPptx = {
       name: "deck.pptx",
       bytes: new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04]),
     };
@@ -2027,7 +2028,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     const gated = await chat.requestUploadThreadArtifactGoogleSlides(
       actor,
       threadId,
-      pptx,
+      legacyPptx,
       [403],
     );
     expectApiError(gated.body);
@@ -2043,7 +2044,7 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
     const noDrive = await chat.requestUploadThreadArtifactGoogleSlides(
       actor,
       threadId,
-      pptx,
+      legacyPptx,
       [400],
     );
     expectApiError(noDrive.body);
@@ -2063,23 +2064,88 @@ describe("CHAT-03 thread artifacts and google drive status", () => {
       state: stateFromAuthorizationUrl(start.authorizationUrl),
     });
 
-    // Drive converts the uploaded PPTX into a native Google Slides deck.
-    const uploadRecorder = mockGoogleDriveSlidesUpload();
-    const uploaded = await chat.requestUploadThreadArtifactGoogleSlides(
-      actor,
-      threadId,
-      pptx,
-      [200],
+    const missingUpload =
+      await chat.requestUploadThreadArtifactGoogleSlidesFromUpload(
+        actor,
+        threadId,
+        randomUUID(),
+        [404],
+      );
+    expectApiError(missingUpload.body);
+    expect(missingUpload.body.error.message).toBe(
+      "Presentation upload not found",
     );
+
+    const oversizedUploadId = randomUUID();
+    objectStore.addObject({
+      bucket: "test-user-artifacts",
+      key: `artifacts/${encodeURIComponent(actor.userId)}/${oversizedUploadId}/too-large.pptx`,
+      size: 100 * 1024 * 1024 + 1,
+    });
+    const oversized =
+      await chat.requestUploadThreadArtifactGoogleSlidesFromUpload(
+        actor,
+        threadId,
+        oversizedUploadId,
+        [400],
+      );
+    expectApiError(oversized.body);
+    expect(oversized.body.error.message).toBe(
+      "Presentation file is too large (max 100 MB)",
+    );
+
+    // A PPTX larger than Vercel's request-body limit is staged in R2, then
+    // Drive converts it into a native Google Slides deck via resumable upload.
+    const stagedPptx = new Uint8Array(5 * 1024 * 1024);
+    stagedPptx.set([0x50, 0x4b, 0x03, 0x04]);
+    const prepared = await chat.prepareUpload(actor, {
+      filename: "large-deck.pptx",
+      contentType:
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      size: stagedPptx.byteLength,
+    });
+    const stagedKey = `artifacts/${encodeURIComponent(actor.userId)}/${prepared.id}/large-deck.pptx`;
+    objectStore.addObject({
+      bucket: "test-user-artifacts",
+      body: stagedPptx,
+      key: stagedKey,
+      size: stagedPptx.byteLength,
+    });
+    const uploadRecorder = mockGoogleDriveSlidesUpload();
+    const uploaded =
+      await chat.requestUploadThreadArtifactGoogleSlidesFromUpload(
+        actor,
+        threadId,
+        prepared.id,
+        [200],
+      );
     expect(uploaded.body).toStrictEqual({
       id: "slides-file-1",
       name: "deck",
       webViewLink: "https://docs.google.com/presentation/d/slides-file-1/edit",
     });
-    expect(uploadRecorder.uploadBodies).toHaveLength(1);
-    expect(uploadRecorder.uploadBodies[0]).toContain(
+    expect(uploadRecorder.metadataBodies[0]).toContain(
       "application/vnd.google-apps.presentation",
     );
+    expect(uploadRecorder.uploadBodies[0]).toHaveLength(stagedPptx.byteLength);
+    expect(uploadRecorder.uploadBodies[0]?.slice(0, 4)).toStrictEqual(
+      stagedPptx.slice(0, 4),
+    );
+    expect(objectStore.deletedKeys).toContain(stagedKey);
+
+    // Old browser bundles can still send the PPTX inline during deployment.
+    const legacyUploaded = await chat.requestUploadThreadArtifactGoogleSlides(
+      actor,
+      threadId,
+      legacyPptx,
+      [200],
+    );
+    expect(legacyUploaded.body).toStrictEqual({
+      id: "slides-file-1",
+      name: "deck",
+      webViewLink: "https://docs.google.com/presentation/d/slides-file-1/edit",
+    });
+    expect(uploadRecorder.uploadBodies[1]).toStrictEqual(legacyPptx.bytes);
   }, 120_000);
 
   it("dedupes artifact urls and filters hosted-site runs", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-callbacks.ts
@@ -32,6 +32,7 @@ type OpenRouterCompletionBody = z.infer<typeof openRouterCompletionBodySchema>;
 
 interface StoredS3Object {
   readonly bucket: string;
+  readonly body?: Uint8Array;
   readonly key: string;
   readonly size: number;
 }
@@ -80,6 +81,56 @@ function commandName(command: unknown): string {
   return typeof command === "object" && command !== null
     ? command.constructor.name
     : "";
+}
+
+function storedS3ObjectResponse(
+  objects: readonly StoredS3Object[],
+  bucket: string,
+  key: string,
+) {
+  const object = objects.find((candidate) => {
+    return candidate.bucket === bucket && candidate.key === key;
+  });
+  const body =
+    object?.body ?? (object ? new Uint8Array(object.size) : undefined);
+  return {
+    ContentLength: object?.size,
+    Body: body
+      ? {
+          async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+            yield body;
+          },
+        }
+      : undefined,
+  };
+}
+
+function deleteStoredS3Objects(
+  objects: StoredS3Object[],
+  deletedKeys: string[],
+  bucket: string,
+  input: Record<string, unknown>,
+): void {
+  const deletion = isRecord(input.Delete) ? input.Delete : {};
+  const deletionObjects = Array.isArray(deletion.Objects)
+    ? deletion.Objects
+    : [];
+  for (const deletionObject of deletionObjects) {
+    if (!isRecord(deletionObject)) {
+      continue;
+    }
+    const deletionKey = deletionObject.Key;
+    if (typeof deletionKey !== "string") {
+      continue;
+    }
+    deletedKeys.push(deletionKey);
+    const index = objects.findIndex((candidate) => {
+      return candidate.bucket === bucket && candidate.key === deletionKey;
+    });
+    if (index !== -1) {
+      objects.splice(index, 1);
+    }
+  }
 }
 
 /**
@@ -239,9 +290,11 @@ export function createChatCallbacksApi(context: TestContext) {
      */
     acceptChatObjectStorage(): {
       addObject(object: StoredS3Object): void;
+      readonly deletedKeys: readonly string[];
       readonly puts: readonly CapturedS3Put[];
     } {
       const objects: StoredS3Object[] = [];
+      const deletedKeys: string[] = [];
       const puts: CapturedS3Put[] = [];
       context.mocks.s3.send.mockImplementation((...args: unknown[]) => {
         const input = commandInput(args[0]);
@@ -260,13 +313,21 @@ export function createChatCallbacksApi(context: TestContext) {
         }
         const bucket = typeof input.Bucket === "string" ? input.Bucket : "";
         const prefix = typeof input.Prefix === "string" ? input.Prefix : "";
-        if (commandName(args[0]) === "PutObjectCommand") {
+        const name = commandName(args[0]);
+        if (name === "PutObjectCommand") {
           puts.push({
             bucket,
             key,
             contentType:
               typeof input.ContentType === "string" ? input.ContentType : null,
           });
+        }
+        if (name === "GetObjectCommand") {
+          return Promise.resolve(storedS3ObjectResponse(objects, bucket, key));
+        }
+        if (name === "DeleteObjectsCommand") {
+          deleteStoredS3Objects(objects, deletedKeys, bucket, input);
+          return Promise.resolve({});
         }
         if (prefix !== "") {
           const contents = objects
@@ -288,6 +349,7 @@ export function createChatCallbacksApi(context: TestContext) {
         addObject(object: StoredS3Object): void {
           objects.push(object);
         },
+        deletedKeys,
         puts,
       };
     },

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -1222,6 +1222,24 @@ export function createChatFilesBddApi(context: TestContext) {
       );
     },
 
+    async requestUploadThreadArtifactGoogleSlidesFromUpload(
+      actor: ApiTestUser | null,
+      threadId: string,
+      uploadId: string,
+      statuses: readonly (200 | 400 | 401 | 403 | 404 | 503)[],
+    ) {
+      const formData = new FormData();
+      formData.append("uploadId", uploadId);
+      return await accept(
+        threadArtifactsClient().uploadGoogleSlides({
+          headers: authenticate(context, actor),
+          params: { threadId },
+          body: formData,
+        }),
+        statuses,
+      );
+    },
+
     async requestSendMessage(
       actor: ApiTestUser | null,
       body: BddSendMessageBody,

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-connectors.ts
@@ -394,22 +394,27 @@ interface GoogleDriveSlidesUploadOptions {
 }
 
 interface GoogleDriveSlidesUploadRecorder {
-  /** Raw multipart bodies of every POST to the Drive resumable/multipart upload. */
-  readonly uploadBodies: string[];
+  /** Metadata bodies used to initiate Drive resumable uploads. */
+  readonly metadataBodies: string[];
+  /** PPTX bodies sent to Drive resumable upload sessions. */
+  readonly uploadBodies: Uint8Array[];
 }
 
 /**
  * Google Drive boundary for the "upload PPTX as native Google Slides" flow:
  * folder lookups always miss (forcing creation), folder creation succeeds, and
- * the multipart upload records its body and answers with the converted Slides
- * file. The recorded body lets tests assert the Google Slides conversion
- * mimeType was requested.
+ * the resumable upload records metadata plus PPTX bytes before answering with
+ * the converted Slides file.
  */
 export function mockGoogleDriveSlidesUpload(
   options: GoogleDriveSlidesUploadOptions = {},
 ): GoogleDriveSlidesUploadRecorder {
-  const recorder: GoogleDriveSlidesUploadRecorder = { uploadBodies: [] };
+  const recorder: GoogleDriveSlidesUploadRecorder = {
+    metadataBodies: [],
+    uploadBodies: [],
+  };
   let folderCounter = 0;
+  const resumableUploadUrl = `${GOOGLE_DRIVE_UPLOAD_URL}?uploadType=resumable&upload_id=slides-upload-1`;
 
   server.use(
     http.get(GOOGLE_DRIVE_FILES_URL, () => {
@@ -424,7 +429,14 @@ export function mockGoogleDriveSlidesUpload(
       });
     }),
     http.post(GOOGLE_DRIVE_UPLOAD_URL, async ({ request }) => {
-      recorder.uploadBodies.push(await request.text());
+      recorder.metadataBodies.push(await request.text());
+      return new HttpResponse(null, {
+        status: 200,
+        headers: { Location: resumableUploadUrl },
+      });
+    }),
+    http.put(GOOGLE_DRIVE_UPLOAD_URL, async ({ request }) => {
+      recorder.uploadBodies.push(new Uint8Array(await request.arrayBuffer()));
       const status = options.uploadStatus ?? 200;
       if (status !== 200) {
         return new HttpResponse(null, { status });

--- a/turbo/apps/api/src/signals/routes/zero-chat-threads-artifacts-sync.ts
+++ b/turbo/apps/api/src/signals/routes/zero-chat-threads-artifacts-sync.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { isFeatureEnabled } from "@vm0/core/feature-switch";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { z } from "zod";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -65,6 +66,38 @@ function googleSlidesUploadDisabled() {
   };
 }
 
+const presentationUploadIdSchema = z.string().uuid();
+
+type GoogleSlidesUploadSource =
+  | { readonly type: "staged"; readonly uploadId: string }
+  | {
+      readonly type: "inline";
+      readonly filename: string;
+      readonly pptx: Buffer;
+    };
+
+async function googleSlidesUploadSource(
+  formData: FormData,
+): Promise<GoogleSlidesUploadSource | ReturnType<typeof badRequestMessage>> {
+  const uploadId = formData.get("uploadId");
+  if (typeof uploadId === "string") {
+    const parsed = presentationUploadIdSchema.safeParse(uploadId);
+    return parsed.success
+      ? { type: "staged", uploadId: parsed.data }
+      : badRequestMessage("Invalid presentation upload ID");
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return badRequestMessage("No presentation file provided");
+  }
+  return {
+    type: "inline",
+    filename: file.name,
+    pptx: Buffer.from(await file.arrayBuffer()),
+  };
+}
+
 const uploadGoogleSlidesInner$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const auth = get(organizationAuthContext$);
@@ -88,13 +121,11 @@ const uploadGoogleSlidesInner$ = command(
     const request = get(request$);
     const formData = await request.raw.formData();
     signal.throwIfAborted();
-
-    const file = formData.get("file");
-    if (!(file instanceof File)) {
-      return badRequestMessage("No presentation file provided");
-    }
-    const pptx = Buffer.from(await file.arrayBuffer());
+    const source = await googleSlidesUploadSource(formData);
     signal.throwIfAborted();
+    if ("status" in source) {
+      return source;
+    }
 
     const result = await set(
       uploadPresentationToGoogleSlides$,
@@ -102,14 +133,16 @@ const uploadGoogleSlidesInner$ = command(
         orgId: auth.orgId,
         userId: auth.userId,
         threadId: params.threadId,
-        filename: file.name,
-        pptx,
+        source,
       },
       signal,
     );
     signal.throwIfAborted();
 
     if (isBadRequestResponse(result)) {
+      return result;
+    }
+    if (isNotFoundResponse(result)) {
       return result;
     }
     return result;

--- a/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
+++ b/turbo/apps/api/src/signals/services/google-drive-artifact-sync.service.ts
@@ -22,12 +22,16 @@ import { env, optionalEnv } from "../../lib/env";
 import { badRequestMessage, notFound } from "../../lib/error";
 import {
   buildArtifactKey,
+  buildArtifactPrefix,
   storageUserIdFromFileUrlSegment,
 } from "../../lib/file-url";
 import { db$, type ReadonlyDb } from "../external/db";
 import {
+  deleteS3Objects,
   downloadHostedSitesS3Buffer,
   downloadS3Buffer,
+  downloadS3BufferWithMaxBytes,
+  listS3Objects,
   s3ObjectExists,
 } from "../external/s3";
 import { createDeferredPromise, safeSync, settle } from "../utils";
@@ -1176,6 +1180,20 @@ export const syncArtifactToGoogleDrive$ = command(
 const GOOGLE_SLIDES_MIME_TYPE = "application/vnd.google-apps.presentation";
 const PPTX_MIME_TYPE =
   "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const MAX_GOOGLE_SLIDES_PPTX_BYTES = 100 * 1024 * 1024;
+
+type PresentationPptxSource =
+  | {
+      readonly type: "inline";
+      readonly filename: string;
+      readonly pptx: Buffer;
+    }
+  | { readonly type: "staged"; readonly uploadId: string };
+
+interface ResolvedPresentationPptx {
+  readonly filename: string;
+  readonly pptx: Buffer;
+}
 
 function slidesTitle(filename: string): string {
   const trimmed = filename.trim();
@@ -1183,55 +1201,121 @@ function slidesTitle(filename: string): string {
   return base.length > 0 ? base : "presentation";
 }
 
+function resolvePresentationPptx(
+  userId: string,
+  source: PresentationPptxSource,
+): Computed<
+  Promise<ResolvedPresentationPptx | BadRequestResponse | NotFoundResponse>
+> {
+  return computed(async (get) => {
+    if (source.type === "inline") {
+      return { filename: source.filename, pptx: source.pptx };
+    }
+
+    const bucket = env("R2_USER_ARTIFACTS_BUCKET_NAME");
+    const objects = await get(
+      listS3Objects(bucket, buildArtifactPrefix(userId, source.uploadId)),
+    );
+    const object = objects[0];
+    if (!object) {
+      return notFound("Presentation upload not found");
+    }
+
+    const filename = object.key.split("/").pop() ?? source.uploadId;
+    if (!filename.toLowerCase().endsWith(".pptx")) {
+      return badRequestMessage("Presentation upload must be a PPTX file");
+    }
+    if (object.size > MAX_GOOGLE_SLIDES_PPTX_BYTES) {
+      return badRequestMessage("Presentation file is too large (max 100 MB)");
+    }
+
+    const pptx = await get(
+      downloadS3BufferWithMaxBytes(
+        bucket,
+        object.key,
+        MAX_GOOGLE_SLIDES_PPTX_BYTES,
+      ),
+    );
+    await get(deleteS3Objects(bucket, [object.key]));
+    return { filename, pptx };
+  });
+}
+
+async function startGoogleSlidesUpload(args: {
+  readonly accessToken: string;
+  readonly parentFolderId: string;
+  readonly filename: string;
+  readonly size: number;
+}): Promise<DriveTokenResult<string>> {
+  const metadata = JSON.stringify({
+    name: slidesTitle(args.filename),
+    mimeType: GOOGLE_SLIDES_MIME_TYPE,
+    parents: [args.parentFolderId],
+  });
+
+  const uploadUrl = new URL(GOOGLE_DRIVE_UPLOAD_URL);
+  uploadUrl.searchParams.set("uploadType", "resumable");
+  uploadUrl.searchParams.set("fields", "id,name,webViewLink");
+
+  const response = await fetch(uploadUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${args.accessToken}`,
+      "Content-Type": "application/json; charset=UTF-8",
+      "X-Upload-Content-Length": String(args.size),
+      "X-Upload-Content-Type": PPTX_MIME_TYPE,
+    },
+    body: metadata,
+  });
+  if (response.status === 401) {
+    return { type: "unauthorized" };
+  }
+  if (!response.ok) {
+    throw badRequestMessage(
+      `Google Slides upload failed with HTTP ${String(response.status)}`,
+    );
+  }
+  const sessionUrl = response.headers.get("location");
+  if (!sessionUrl) {
+    throw badRequestMessage("Google Slides upload session was not created");
+  }
+  return { type: "ok", value: sessionUrl };
+}
+
 /**
- * Upload PPTX bytes and let Drive convert them into a native Google Slides
- * deck by declaring the target `mimeType` on the file metadata. Unlike the
- * raw-artifact sync, no `appProperties` are attached so the Slides file does
- * not appear as a "synced" raw artifact in the Drive status lookup.
+ * Upload PPTX bytes through a Drive resumable session and let Drive convert
+ * them into a native Google Slides deck. Unlike the raw-artifact sync, no
+ * `appProperties` are attached so the Slides file does not appear as a
+ * "synced" raw artifact in the Drive status lookup.
  */
 async function uploadPptxAsGoogleSlides(args: {
   readonly accessToken: string;
   readonly parentFolderId: string;
   readonly filename: string;
   readonly pptx: Buffer;
-}): Promise<Response> {
-  const boundary = `vm0-${randomUUID()}`;
-  const metadata = JSON.stringify({
-    name: slidesTitle(args.filename),
-    mimeType: GOOGLE_SLIDES_MIME_TYPE,
-    parents: [args.parentFolderId],
+}): Promise<DriveTokenResult<Response>> {
+  const session = await startGoogleSlidesUpload({
+    accessToken: args.accessToken,
+    parentFolderId: args.parentFolderId,
+    filename: args.filename,
+    size: args.pptx.length,
   });
-  const body = Buffer.concat([
-    Buffer.from(
-      [
-        `--${boundary}`,
-        "Content-Type: application/json; charset=UTF-8",
-        "",
-        metadata,
-        `--${boundary}`,
-        `Content-Type: ${PPTX_MIME_TYPE}`,
-        "",
-        "",
-      ].join("\r\n"),
-      "utf8",
-    ),
-    args.pptx,
-    Buffer.from(`\r\n--${boundary}--\r\n`, "utf8"),
-  ]);
+  if (session.type === "unauthorized") {
+    return session;
+  }
 
-  const uploadUrl = new URL(GOOGLE_DRIVE_UPLOAD_URL);
-  uploadUrl.searchParams.set("uploadType", "multipart");
-  uploadUrl.searchParams.set("fields", "id,name,webViewLink");
-
-  return await fetch(uploadUrl, {
-    method: "POST",
+  const response = await fetch(session.value, {
+    method: "PUT",
     headers: {
       Authorization: `Bearer ${args.accessToken}`,
-      "Content-Type": `multipart/related; boundary=${boundary}`,
-      "Content-Length": String(body.length),
+      "Content-Type": PPTX_MIME_TYPE,
+      "Content-Length": String(args.pptx.length),
     },
-    body,
+    body: Uint8Array.from(args.pptx),
   });
+  return response.status === 401
+    ? { type: "unauthorized" }
+    : { type: "ok", value: response };
 }
 
 async function uploadSlidesWithToken(args: {
@@ -1247,16 +1331,12 @@ async function uploadSlidesWithToken(args: {
   if (folder.type === "unauthorized") {
     return folder;
   }
-  const response = await uploadPptxAsGoogleSlides({
+  return await uploadPptxAsGoogleSlides({
     accessToken: args.accessToken,
     parentFolderId: folder.value,
     filename: args.filename,
     pptx: args.pptx,
   });
-  if (response.status === 401) {
-    return { type: "unauthorized" };
-  }
-  return { type: "ok", value: response };
 }
 
 /**
@@ -1266,6 +1346,8 @@ async function uploadSlidesWithToken(args: {
  * Error mapping mirrors {@link syncArtifactToGoogleDrive$}:
  *  - 400 "Connect Google Drive before uploading to Google Slides" — connector
  *    absent or `needsReconnect`.
+ *  - 400 for invalid or oversized staged presentation files.
+ *  - 404 "Presentation upload not found" — staged upload absent or cross-user.
  *  - 400 "Google Slides upload failed with HTTP <status>" — upload error after
  *    refresh-token retry exhausted.
  *  - 200 with `{ id, name, webViewLink }`.
@@ -1277,12 +1359,12 @@ export const uploadPresentationToGoogleSlides$ = command(
       readonly orgId: string;
       readonly userId: string;
       readonly threadId: string;
-      readonly filename: string;
-      readonly pptx: Buffer;
+      readonly source: PresentationPptxSource;
     },
     signal: AbortSignal,
   ): Promise<
     | BadRequestResponse
+    | NotFoundResponse
     | { readonly status: 200; readonly body: DriveSyncResult }
   > => {
     const db = get(db$);
@@ -1303,11 +1385,19 @@ export const uploadPresentationToGoogleSlides$ = command(
       );
     }
 
+    const presentation = await get(
+      resolvePresentationPptx(args.userId, args.source),
+    );
+    signal.throwIfAborted();
+    if ("status" in presentation) {
+      return presentation;
+    }
+
     let result = await uploadSlidesWithToken({
       accessToken: tokens.accessToken,
       threadId: args.threadId,
-      filename: args.filename,
-      pptx: args.pptx,
+      filename: presentation.filename,
+      pptx: presentation.pptx,
     });
     signal.throwIfAborted();
 
@@ -1318,8 +1408,8 @@ export const uploadPresentationToGoogleSlides$ = command(
         result = await uploadSlidesWithToken({
           accessToken: refreshed,
           threadId: args.threadId,
-          filename: args.filename,
-          pptx: args.pptx,
+          filename: presentation.filename,
+          pptx: presentation.pptx,
         });
         signal.throwIfAborted();
       }

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-slides-upload.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-slides-upload.ts
@@ -1,6 +1,8 @@
 import { command } from "ccstate";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
-import { accept } from "../../lib/accept.ts";
+import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { accept, ApiError } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 
 const PPTX_MIME_TYPE =
@@ -13,10 +15,11 @@ interface GoogleSlidesUploadResult {
 }
 
 /**
- * Upload a client-generated presentation PPTX blob to the backend, which
- * forwards it to the user's Google Drive as a native Google Slides deck. The
- * blob is generated in the view (browser-only DOM work) and passed in here so
- * this command stays a pure HTTP call.
+ * Upload a client-generated presentation PPTX blob directly to artifact
+ * storage, then ask the backend to forward the staged file to the user's
+ * Google Drive as a native Google Slides deck. The blob is generated in the
+ * view (browser-only DOM work) and passed in here so this command stays a pure
+ * HTTP flow.
  */
 export const uploadPresentationToGoogleSlides$ = command(
   async (
@@ -28,16 +31,69 @@ export const uploadPresentationToGoogleSlides$ = command(
     },
     signal: AbortSignal,
   ): Promise<GoogleSlidesUploadResult> => {
-    const formData = new FormData();
-    formData.append(
+    const createClient = get(zeroClient$);
+    const prepared = await accept(
+      createClient(zeroUploadsContract).prepare({
+        body: {
+          filename: params.filename,
+          contentType: PPTX_MIME_TYPE,
+          size: params.blob.size,
+        },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
+
+    const uploaded = await fetch(prepared.body.uploadUrl, {
+      method: "PUT",
+      body: params.blob,
+      headers: { "content-type": prepared.body.contentType },
+      signal,
+    });
+    signal.throwIfAborted();
+    if (!uploaded.ok) {
+      throw new Error(
+        `artifact storage returned ${String(uploaded.status)} ${uploaded.statusText}`,
+      );
+    }
+
+    const client = createClient(chatThreadArtifactsContract);
+    const stagedFormData = new FormData();
+    stagedFormData.append("uploadId", prepared.body.id);
+    const stagedResult = await accept(
+      client.uploadGoogleSlides({
+        params: { threadId: params.threadId },
+        body: stagedFormData,
+        fetchOptions: { signal },
+      }),
+      [200, 400],
+      { toast: false },
+    );
+    signal.throwIfAborted();
+    if (stagedResult.status === 200) {
+      return stagedResult.body;
+    }
+    if (stagedResult.body.error.message !== "No presentation file provided") {
+      toast.error(stagedResult.body.error.message);
+      throw new ApiError(
+        stagedResult.body.error.message,
+        stagedResult.body.error.code,
+        stagedResult.status,
+      );
+    }
+
+    // Rollout compatibility with API revisions before staged Slides uploads.
+    // Remove after this API revision is the minimum supported backend.
+    const inlineFormData = new FormData();
+    inlineFormData.append(
       "file",
       new File([params.blob], params.filename, { type: PPTX_MIME_TYPE }),
     );
-    const client = get(zeroClient$)(chatThreadArtifactsContract);
     const result = await accept(
       client.uploadGoogleSlides({
         params: { threadId: params.threadId },
-        body: formData,
+        body: inlineFormData,
         fetchOptions: { signal },
       }),
       [200],

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-slides-upload.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-slides-upload.ts
@@ -1,8 +1,7 @@
 import { command } from "ccstate";
 import { chatThreadArtifactsContract } from "@vm0/api-contracts/contracts/chat-threads";
 import { zeroUploadsContract } from "@vm0/api-contracts/contracts/zero-uploads";
-import { toast } from "@vm0/ui/components/ui/sonner";
-import { accept, ApiError } from "../../lib/accept.ts";
+import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
 
 const PPTX_MIME_TYPE =
@@ -75,12 +74,7 @@ export const uploadPresentationToGoogleSlides$ = command(
       return stagedResult.body;
     }
     if (stagedResult.body.error.message !== "No presentation file provided") {
-      toast.error(stagedResult.body.error.message);
-      throw new ApiError(
-        stagedResult.body.error.message,
-        stagedResult.body.error.code,
-        stagedResult.status,
-      );
+      return await accept(Promise.resolve(stagedResult), [200]);
     }
 
     // Rollout compatibility with API revisions before staged Slides uploads.

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -308,6 +308,85 @@ function presentationPptxBlob(): Promise<Blob> {
   return zip.generateAsync({ type: "blob" });
 }
 
+const PRESENTATION_PPTX_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const PRESENTATION_UPLOAD_ID = "123e4567-e89b-42d3-a456-426614174000";
+
+interface PresentationUploadCapture {
+  finalizedUploadId: string | null;
+  legacyUploaded: File | null;
+  prepared: {
+    readonly contentType: string;
+    readonly filename: string;
+    readonly size: number;
+  } | null;
+  uploaded: Blob | null;
+}
+
+function mockPresentationGoogleSlidesUpload(options: {
+  readonly beforeFinalize?: () => void;
+  readonly previousApi?: boolean;
+  readonly response: {
+    readonly id: string;
+    readonly name: string;
+    readonly webViewLink: string | null;
+  };
+}): PresentationUploadCapture {
+  const capture: PresentationUploadCapture = {
+    finalizedUploadId: null,
+    legacyUploaded: null,
+    prepared: null,
+    uploaded: null,
+  };
+  const uploadUrl = `https://mock-upload.example.com/${PRESENTATION_UPLOAD_ID}`;
+
+  context.mocks.http.post("*/api/zero/uploads/prepare", async ({ request }) => {
+    const body = (await request.json()) as {
+      contentType: string;
+      filename: string;
+      size: number;
+    };
+    capture.prepared = body;
+    return HttpResponse.json({
+      ...body,
+      id: PRESENTATION_UPLOAD_ID,
+      uploadUrl,
+      url: `https://cdn.vm7.io/artifacts/test/${PRESENTATION_UPLOAD_ID}/${body.filename}`,
+    });
+  });
+  context.mocks.http.put(uploadUrl, async ({ request }) => {
+    capture.uploaded = await request.blob();
+    return new HttpResponse(null, { status: 200 });
+  });
+  context.mocks.http.post(
+    "*/api/zero/chat-threads/:threadId/artifacts/google-slides",
+    async ({ request }) => {
+      options.beforeFinalize?.();
+      const formData = await request.formData();
+      const uploadId = formData.get("uploadId");
+      if (typeof uploadId === "string") {
+        capture.finalizedUploadId = uploadId;
+      }
+      if (options.previousApi && typeof uploadId === "string") {
+        return HttpResponse.json(
+          {
+            error: {
+              code: "BAD_REQUEST",
+              message: "No presentation file provided",
+            },
+          },
+          { status: 400 },
+        );
+      }
+      const legacyUploaded = formData.get("file");
+      capture.legacyUploaded =
+        legacyUploaded instanceof File ? legacyUploaded : null;
+      return HttpResponse.json(options.response);
+    },
+  );
+  return capture;
+}
+
 function captureDownloads(signal: AbortSignal): string[] {
   const downloads: string[] = [];
   const onClick = (event: MouseEvent) => {
@@ -2045,25 +2124,15 @@ describe("zero artifact sidebar", () => {
       context.mocks.browser.authWindow(),
     );
     const successToast = vi.spyOn(toast, "success");
-    const upload = { file: null as File | null };
     context.mocks.data.connectors([googleDriveConnector()]);
-    context.mocks.http.post(
-      "*/api/zero/chat-threads/:threadId/artifacts/google-slides",
-      async ({ request }) => {
-        const formData = await request.formData();
-        const file = formData.get("file");
-        if (!(file instanceof File)) {
-          throw new Error("Google Slides upload did not include a file");
-        }
-        upload.file = file;
-        return HttpResponse.json({
-          id: "slides-file-quarterly-roadmap",
-          name: "quarterly-roadmap",
-          webViewLink:
-            "https://docs.google.com/presentation/d/slides-file-quarterly-roadmap/edit",
-        });
+    const upload = mockPresentationGoogleSlidesUpload({
+      response: {
+        id: "slides-file-quarterly-roadmap",
+        name: "quarterly-roadmap",
+        webViewLink:
+          "https://docs.google.com/presentation/d/slides-file-quarterly-roadmap/edit",
       },
-    );
+    });
     setupPresentationArtifactThread(presentationUrl, presentationHtml(), {
       featureSwitches: {
         [FeatureSwitchKey.PresentationGoogleSlidesUpload]: true,
@@ -2091,10 +2160,11 @@ describe("zero artifact sidebar", () => {
       });
       expect(openMock.calls).toStrictEqual([]);
 
-      completePresentationPptxExport(exportFrame, await presentationPptxBlob());
+      const pptx = await presentationPptxBlob();
+      completePresentationPptxExport(exportFrame, pptx);
 
       await waitFor(() => {
-        expect(upload.file).not.toBeNull();
+        expect(upload.finalizedUploadId).toBe(PRESENTATION_UPLOAD_ID);
         expect(successToast).toHaveBeenCalledWith("Uploaded to Google Slides", {
           id: expect.anything(),
         });
@@ -2102,14 +2172,13 @@ describe("zero artifact sidebar", () => {
           document.querySelector('iframe[title="Presentation PPTX export"]'),
         ).not.toBeInTheDocument();
       });
-      if (!upload.file) {
-        throw new Error("Google Slides upload did not send a file");
-      }
-      expect(upload.file.name).toBe("quarterly-roadmap.pptx");
-      expect(upload.file.type).toBe(
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-      );
-      expect(upload.file.size).toBeGreaterThan(0);
+      expect(upload.prepared).toStrictEqual({
+        contentType: PRESENTATION_PPTX_MIME_TYPE,
+        filename: "quarterly-roadmap.pptx",
+        size: upload.uploaded?.size,
+      });
+      expect(upload.uploaded?.size).toBeGreaterThanOrEqual(pptx.size);
+      expect(upload.uploaded?.type).toBe(PRESENTATION_PPTX_MIME_TYPE);
       expect(openMock.calls).toStrictEqual([]);
     } finally {
       successToast.mockRestore();
@@ -2169,7 +2238,6 @@ describe("zero artifact sidebar", () => {
       });
     });
     let agentAuthorized = false;
-    let slidesUploaded = false;
     context.mocks.api(
       zeroUserConnectorsContract.update,
       ({ body, params, respond }) => {
@@ -2182,20 +2250,17 @@ describe("zero artifact sidebar", () => {
         return respond(200, { enabledTypes: ["google-drive"] });
       },
     );
-    context.mocks.http.post(
-      "*/api/zero/chat-threads/:threadId/artifacts/google-slides",
-      async ({ request }) => {
+    const upload = mockPresentationGoogleSlidesUpload({
+      beforeFinalize: () => {
         expect(agentAuthorized).toBeTruthy();
-        const file = (await request.formData()).get("file");
-        expect(file).toBeInstanceOf(File);
-        slidesUploaded = true;
-        return HttpResponse.json({
-          id: "slides-file-quarterly-roadmap",
-          name: "quarterly-roadmap",
-          webViewLink: null,
-        });
       },
-    );
+      previousApi: true,
+      response: {
+        id: "slides-file-quarterly-roadmap",
+        name: "quarterly-roadmap",
+        webViewLink: null,
+      },
+    });
     setupChatThread({
       artifactFiles,
       content: `[Quarterly roadmap](${presentationUrl})`,
@@ -2228,8 +2293,11 @@ describe("zero artifact sidebar", () => {
     completePresentationPptxExport(exportFrame, await presentationPptxBlob());
 
     await waitFor(() => {
-      expect(slidesUploaded).toBeTruthy();
+      expect(upload.legacyUploaded).toBeInstanceOf(File);
     });
+    expect(upload.finalizedUploadId).toBe(PRESENTATION_UPLOAD_ID);
+    expect(upload.legacyUploaded?.name).toBe("quarterly-roadmap.pptx");
+    expect(upload.legacyUploaded?.size).toBeGreaterThan(0);
   });
 
   it("preserves deck-level slide backgrounds for editable PPTX export", async () => {


### PR DESCRIPTION
## Summary

- stage browser-generated PPTX files through the existing signed R2 upload flow so presentation bytes no longer pass through the Vercel Function request body
- resolve and validate the user-scoped staged upload in the API, enforce Google Slides' 100 MB conversion limit, remove the temporary object, and convert it with a Google Drive resumable upload
- preserve the previous inline multipart request shape for open browser sessions and add a narrow frontend fallback for rollout windows where new assets briefly reach the previous API

## User impact

Uploading larger presentation artifacts to Google Slides no longer fails with Vercel's `413 Content Too Large` response. Google credentials remain server-side, and the result is still created as a native Google Slides presentation in the thread's Drive artifact folder.

## Verification

- `pnpm -F api lint`
- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS='--max-old-space-size=3072' pnpm -F api check-types`
- `pnpm -F @vm0/app check-types`
- `DATABASE_URL='postgresql://postgres@localhost:5432/vm0_test' pnpm -F api exec vitest run src/signals/routes/__tests__/chat-threads.bdd.test.ts -t 'uploads a presentation to Google Slides behind a feature flag'`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx -t 'Google Slides'`
- `pnpm exec prettier --check` on all changed files

The targeted API coverage includes a 5 MB staged PPTX, missing and oversized uploads, temporary-object cleanup, native Slides metadata, and the previous inline request shape. The platform coverage includes signed R2 upload, staged finalization, Google Drive authorization, and the previous-API rollout fallback.
