### PR TITLE
fix(api): prevent chat loading failures for webhook workflows

### DIFF
--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -695,6 +695,15 @@ export const chatThreadWorkflowNotionPageContentUpdatedTriggerSchema =
     scheduleSummary: z.null(),
   });
 
+export const chatThreadWorkflowWebhookReceivedTriggerSchema =
+  chatThreadWorkflowTriggerBaseSchema.extend({
+    kind: z.literal("event"),
+    eventType: z.literal("webhook-received"),
+    eventConfig: webhookReceivedEventConfigSchema,
+    schedule: z.null(),
+    scheduleSummary: z.null(),
+  });
+
 export const chatThreadWorkflowTriggerSchema = z.union([
   chatThreadWorkflowScheduleTriggerSchema,
   chatThreadWorkflowGmailNewMessageTriggerSchema,
@@ -707,6 +716,7 @@ export const chatThreadWorkflowTriggerSchema = z.union([
   chatThreadWorkflowNotionChildPageCreatedTriggerSchema,
   chatThreadWorkflowNotionDatabaseItemCreatedTriggerSchema,
   chatThreadWorkflowNotionPageContentUpdatedTriggerSchema,
+  chatThreadWorkflowWebhookReceivedTriggerSchema,
 ]);
 export type ChatThreadWorkflowTrigger = z.infer<
   typeof chatThreadWorkflowTriggerSchema


### PR DESCRIPTION
## Summary
- include `webhook-received` in the chat-thread workflow-trigger response contract
- allow chat threads backed by webhook workflows to load instead of returning HTTP 500 during API response validation

## Verification
- `npx -y prettier@3.8.1 --check packages/api-contracts/src/contracts/zero-workflows.ts`
- package lint and type checks were not run locally because dependencies are not installed in this checkout; CI will run the repository checks.