### PR TITLE
fix: constrain and dismiss the mobile slash workflow menu

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-composer.ts
@@ -54,6 +54,16 @@ export const setSlashWorkflowCaretIndex$ = command(
   },
 );
 
+const internalSlashWorkflowEditorFocused$ = state(false);
+export const slashWorkflowEditorFocused$ = computed((get) => {
+  return get(internalSlashWorkflowEditorFocused$);
+});
+export const setSlashWorkflowEditorFocused$ = command(
+  ({ set }, focused: boolean) => {
+    set(internalSlashWorkflowEditorFocused$, focused);
+  },
+);
+
 const internalSelectedSlashWorkflowIndex$ = state(0);
 export const selectedSlashWorkflowIndex$ = computed((get) => {
   return get(internalSelectedSlashWorkflowIndex$);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -891,6 +891,10 @@ describe("chat composer models", () => {
     const slashWorkflowMenu = screen.getByTestId("slash-workflow-menu");
     expect(slashWorkflowMenu).toBeInTheDocument();
     expect(slashWorkflowMenu).toHaveClass(
+      "max-h-[min(16rem,var(--radix-popover-content-available-height))]",
+      "md:max-h-[min(20rem,var(--radix-popover-content-available-height))]",
+    );
+    expect(slashWorkflowMenu).not.toHaveClass(
       "h-[min(16rem,var(--radix-popover-content-available-height))]",
       "md:h-[min(20rem,var(--radix-popover-content-available-height))]",
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -890,6 +890,11 @@ describe("chat composer models", () => {
     // cross-browser placement), so it lives outside the composer element.
     const slashWorkflowMenu = screen.getByTestId("slash-workflow-menu");
     expect(slashWorkflowMenu).toBeInTheDocument();
+    expect(slashWorkflowMenu).toHaveClass(
+      "h-[min(16rem,var(--radix-popover-content-available-height))]",
+      "md:h-[min(20rem,var(--radix-popover-content-available-height))]",
+    );
+    expect(slashWorkflowMenu).not.toHaveClass("max-h-80");
 
     await user.keyboard("sales");
 
@@ -911,6 +916,81 @@ describe("chat composer models", () => {
         return element.tagName.toLowerCase() === "span";
       });
     expect(highlightedWorkflow).toHaveClass("text-primary");
+  });
+
+  it("closes the slash workflow menu when focus leaves the composer input", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
+      return respond(200, [
+        workflowSummary({
+          name: "sales-research",
+          displayName: "Sales Research",
+          description: "Find account context before outreach",
+          agentId: AGENT_ID,
+        }),
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("/");
+    await expect(
+      screen.findByTestId("slash-workflow-menu"),
+    ).resolves.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Template"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("slash-workflow-menu"),
+      ).not.toBeInTheDocument();
+    });
+    expect(editor).not.toHaveFocus();
+  });
+
+  it("closes the slash workflow menu with Escape after a non-empty query", async () => {
+    const user = userEvent.setup({ delay: null });
+    mockOrgModelRoutes("kimi-k2.7-code");
+    mockAgent();
+    context.mocks.api(zeroWorkflowsCollectionContract.list, ({ respond }) => {
+      return respond(200, [
+        workflowSummary({
+          name: "sales-research",
+          displayName: "Sales Research",
+          description: "Find account context before outreach",
+          agentId: AGENT_ID,
+        }),
+      ]);
+    });
+
+    detachedSetupPage({
+      context,
+      path: `/agents/${AGENT_ID}/chat`,
+    });
+
+    const editor = await findComposerEditor();
+    await user.click(editor);
+    await user.keyboard("/sales");
+    await expect(
+      screen.findByTestId("slash-workflow-menu"),
+    ).resolves.toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("slash-workflow-menu"),
+      ).not.toBeInTheDocument();
+    });
+    expect(editor).toHaveTextContent("/sales");
+    expect(editor).toHaveFocus();
   });
 
   it("does not suggest workflows that are not attached to the current agent", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -891,12 +891,12 @@ describe("chat composer models", () => {
     const slashWorkflowMenu = screen.getByTestId("slash-workflow-menu");
     expect(slashWorkflowMenu).toBeInTheDocument();
     expect(slashWorkflowMenu).toHaveClass(
-      "max-h-[min(16rem,var(--radix-popover-content-available-height))]",
-      "md:max-h-[min(20rem,var(--radix-popover-content-available-height))]",
-    );
-    expect(slashWorkflowMenu).not.toHaveClass(
       "h-[min(16rem,var(--radix-popover-content-available-height))]",
       "md:h-[min(20rem,var(--radix-popover-content-available-height))]",
+    );
+    expect(slashWorkflowMenu).not.toHaveClass(
+      "max-h-[min(16rem,var(--radix-popover-content-available-height))]",
+      "md:max-h-[min(20rem,var(--radix-popover-content-available-height))]",
     );
     expect(slashWorkflowMenu).not.toHaveClass("max-h-80");
 

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -25,6 +25,10 @@ export function findActiveSlashWorkflowRange(
   value: string,
   caretIndex: number,
 ): SlashWorkflowRange | null {
+  if (caretIndex < 0 || caretIndex > value.length) {
+    return null;
+  }
+
   const beforeCaret = value.slice(0, caretIndex);
   const match = /(?:^|\s)\/([a-z0-9-]*)$/i.exec(beforeCaret);
   if (!match) {
@@ -129,7 +133,7 @@ export function SlashWorkflowMenu({
       onOpenAutoFocus={(event) => {
         event.preventDefault();
       }}
-      className="flex max-h-80 w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0"
+      className="flex h-[min(16rem,var(--radix-popover-content-available-height))] w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:h-[min(20rem,var(--radix-popover-content-available-height))]"
       data-testid="slash-workflow-menu"
     >
       <div className="px-2.5 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -133,7 +133,7 @@ export function SlashWorkflowMenu({
       onOpenAutoFocus={(event) => {
         event.preventDefault();
       }}
-      className="flex h-[min(16rem,var(--radix-popover-content-available-height))] w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:h-[min(20rem,var(--radix-popover-content-available-height))]"
+      className="flex max-h-[min(16rem,var(--radix-popover-content-available-height))] w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:max-h-[min(20rem,var(--radix-popover-content-available-height))]"
       data-testid="slash-workflow-menu"
     >
       <div className="px-2.5 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -133,7 +133,7 @@ export function SlashWorkflowMenu({
       onOpenAutoFocus={(event) => {
         event.preventDefault();
       }}
-      className="flex max-h-[min(16rem,var(--radix-popover-content-available-height))] w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:max-h-[min(20rem,var(--radix-popover-content-available-height))]"
+      className="flex h-[min(16rem,var(--radix-popover-content-available-height))] w-[260px] max-w-[calc(100vw-1.5rem)] flex-col overflow-hidden p-0 md:h-[min(20rem,var(--radix-popover-content-available-height))]"
       data-testid="slash-workflow-menu"
     >
       <div className="px-2.5 pt-2 pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-workflow-composer.tsx
@@ -20,6 +20,8 @@ import { composerWorkflows$ } from "../../signals/workflows-page/workflows-signa
 import {
   slashWorkflowCaretIndex$,
   setSlashWorkflowCaretIndex$,
+  slashWorkflowEditorFocused$,
+  setSlashWorkflowEditorFocused$,
   selectedSlashWorkflowIndex$,
   setSelectedSlashWorkflowIndex$,
 } from "../../signals/zero-page/zero-chat-composer.ts";
@@ -372,6 +374,15 @@ function SlashCaretAnchor({
   return virtualRef ? <PopoverAnchor virtualRef={virtualRef} /> : null;
 }
 
+function handleSlashPopoverOpenChange(
+  open: boolean,
+  setCaretIndex: (index: number) => void,
+): void {
+  if (!open) {
+    setCaretIndex(-1);
+  }
+}
+
 interface SlashMenuKeyContext {
   readonly suggestions: readonly ComposerSlashWorkflow[];
   readonly selectedIndex: number;
@@ -430,6 +441,7 @@ interface EditorOptionsParams {
   readonly setInputRef: ((el: HTMLElement | null) => void) | undefined;
   readonly setSelectedWorkflowIndex: (index: number) => void;
   readonly setCaretIndex: (index: number) => void;
+  readonly setEditorFocused: (focused: boolean) => void;
   readonly onEditorKeyDown: (event: KeyboardEvent) => boolean;
 }
 
@@ -473,11 +485,19 @@ function buildEditorOptions(
     onSelectionUpdate: ({ editor }) => {
       params.setCaretIndex(caretStringIndex(editor));
     },
+    onFocus: ({ editor }) => {
+      params.setEditorFocused(true);
+      params.setCaretIndex(caretStringIndex(editor));
+    },
+    onBlur: () => {
+      params.setEditorFocused(false);
+    },
     onCreate: ({ editor }) => {
       params.setInputRef?.(editor.view.dom);
     },
     onDestroy: () => {
       params.setInputRef?.(null);
+      params.setEditorFocused(false);
     },
   };
 }
@@ -519,6 +539,12 @@ interface TiptapWorkflowComposerProps {
   readonly singleLineOnMobile: boolean;
 }
 
+function workflowComposerPlaceholder(sending: boolean | undefined): string {
+  return sending
+    ? "Type your next message…"
+    : "Ask me to automate workflows, manage tasks...";
+}
+
 export function TiptapWorkflowComposer({
   input,
   onInputChange,
@@ -532,6 +558,8 @@ export function TiptapWorkflowComposer({
 }: TiptapWorkflowComposerProps) {
   const caretIndex = useGet(slashWorkflowCaretIndex$);
   const setCaretIndex = useSet(setSlashWorkflowCaretIndex$);
+  const editorFocused = useGet(slashWorkflowEditorFocused$);
+  const setEditorFocused = useSet(setSlashWorkflowEditorFocused$);
   const selectedWorkflowIndex = useGet(selectedSlashWorkflowIndex$);
   const setSelectedWorkflowIndex = useSet(setSelectedSlashWorkflowIndex$);
   const currentAgentId = useLastResolved(currentChatAgentRecordId$);
@@ -555,10 +583,8 @@ export function TiptapWorkflowComposer({
       })
     : [];
   const isLoadingOrgWorkflows = composerWorkflowsLoadable.state === "loading";
-  const showSlashWorkflowMenu = slashRange !== null;
-  const placeholder = sending
-    ? "Type your next message…"
-    : "Ask me to automate workflows, manage tasks...";
+  const showSlashWorkflowMenu = slashRange !== null && editorFocused;
+  const placeholder = workflowComposerPlaceholder(sending);
 
   const editor = useEditor(
     buildEditorOptions({
@@ -571,9 +597,8 @@ export function TiptapWorkflowComposer({
       setInputRef,
       setSelectedWorkflowIndex,
       setCaretIndex,
-      onEditorKeyDown: (event) => {
-        return handleEditorKeyDown(event);
-      },
+      setEditorFocused,
+      onEditorKeyDown: handleEditorKeyDown,
     }),
   );
 
@@ -626,11 +651,14 @@ export function TiptapWorkflowComposer({
   }
 
   return (
-    // Radix Popover (Floating UI) positions the menu cross-browser; the anchor is
-    // a zero-size element pinned to the slash the user typed (viewport coords from
-    // ProseMirror), so the menu opens at the `/` rather than a fixed corner. `open`
-    // is fully controlled by composer state, so Escape/typing close it.
-    <Popover open={showSlashWorkflowMenu}>
+    // The controlled Radix Popover follows a virtual anchor at the typed slash.
+    // Composer focus, Escape, and typing determine its visibility.
+    <Popover
+      open={showSlashWorkflowMenu}
+      onOpenChange={(open) => {
+        handleSlashPopoverOpenChange(open, setCaretIndex);
+      }}
+    >
       <SlashCaretAnchor editor={editor} slashRange={slashRange} />
       <div
         className={`relative ${singleLineOnMobile ? "min-h-[44px] md:min-h-[96px]" : "min-h-[96px]"}`}


### PR DESCRIPTION
## Summary

- keep the Slash workflow menu at a consistent 256px mobile height and 320px desktop height while capping it to Radix's available viewport space, so long lists stay reachable and the menu can flip above or below the typed Slash
- track TipTap focus so the menu closes whenever focus leaves the composer input and restores the real caret position when the editor is focused again
- honor controlled Popover close requests and reject invalid caret indexes so Escape also closes non-empty Slash queries
- cover responsive sizing, toolbar focus transfer, and non-empty Escape dismissal with composer integration tests

## Verification

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx` — 60 passed
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx -t 'suggests current agent workflows|closes the slash workflow menu'` — 3 passed
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `git diff --check`

Browser verification was not run because the fresh workspace does not have `apps/platform/.env.local` or an authenticated local Agent Chat session.
