### PR TITLE
perf: stabilize chat thread event state

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-context-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-context-signals.ts
@@ -26,7 +26,6 @@ export const zeroActivityContext$ = computed(async (get) => {
   const result = await accept(
     client.getContext({ params: { id: runId } }),
     [200, 404],
-    { toast: false },
   );
   if (result.status === 404) {
     return {

--- a/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
@@ -4,7 +4,6 @@ import { ZeroActivityDetailPage } from "../../views/zero-page/zero-activity-deta
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { setupActivityLogLoop$ } from "./activity-signals.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
@@ -18,10 +17,7 @@ export const setupActivityDetailPage$ = command(
       return;
     }
 
-    await Promise.all([
-      set(setupActivityLogLoop$, signal),
-      set(reloadChatThreads$),
-    ]);
+    await set(setupActivityLogLoop$, signal);
     signal.throwIfAborted();
   },
 );

--- a/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
@@ -4,7 +4,6 @@ import { ZeroActivityPage } from "../../views/zero-page/zero-activity-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { initZeroActivity$, refreshZeroActivity$ } from "./activity-signals.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
@@ -20,7 +19,5 @@ export const setupActivityPage$ = command(
     if (await set(onboardGuard$, signal)) {
       return;
     }
-
-    set(reloadChatThreads$);
   },
 );

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -9,10 +9,7 @@ import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 import { pathParams$ } from "./route.ts";
 import { activeRoute$ } from "./active-route.ts";
-import {
-  reloadChatThreadsCounter$,
-  reloadChatUnreadStateCounter$,
-} from "./chat-thread-list-reload.ts";
+import { reloadChatUnreadStateCounter$ } from "./chat-thread-list-reload.ts";
 import { chatThreadOnlyUnread$ } from "./chat-page/chat-thread-only-unread.ts";
 import {
   eventDrivenActiveRunChatThreadIds$,
@@ -20,8 +17,6 @@ import {
   eventDrivenChatThreads$,
 } from "./chat-page/chat-thread-event-sourcing.ts";
 import type { EventDrivenChatThread } from "./chat-page/chat-thread-event-replay.ts";
-
-export { reloadChatThreads$ } from "./chat-thread-list-reload.ts";
 
 const internalChatAgentId$ = state<string | null>(null);
 
@@ -138,17 +133,15 @@ const eventDrivenFilteredChatThreads$ = computed(
 const eventDrivenVisibleChatThreads$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
     const threads = await get(eventDrivenFilteredChatThreads$);
-    const activeRunThreadIds = get(eventDrivenActiveRunChatThreadIds$);
 
     return threads.map((thread) => {
-      return eventDrivenThreadToListItem(thread, activeRunThreadIds);
+      return eventDrivenThreadToListItem(thread);
     });
   },
 );
 
 export const chatThreads$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
-    get(reloadChatThreadsCounter$);
     return await get(eventDrivenVisibleChatThreads$);
   },
 );
@@ -164,7 +157,7 @@ export const currentChatThreadListIds$ = computed(
 
 function eventDrivenThreadToListItem(
   thread: EventDrivenChatThread,
-  activeRunThreadIds: ReadonlySet<string>,
+  running = false,
 ): ChatThreadListItem {
   return {
     id: thread.id,
@@ -175,7 +168,7 @@ function eventDrivenThreadToListItem(
     },
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,
-    running: activeRunThreadIds.has(thread.id),
+    running,
     pinnedAt: thread.pinnedAt,
     renamedAt: thread.renamedAt,
   };
@@ -183,9 +176,12 @@ function eventDrivenThreadToListItem(
 
 export const allChatThreadListItems$ = computed(
   async (get): Promise<ChatThreadListItem[]> => {
-    const activeRunThreadIds = get(eventDrivenActiveRunChatThreadIds$);
+    const activeRunThreadIds = await get(eventDrivenActiveRunChatThreadIds$);
     return (await get(eventDrivenChatThreads$)).map((thread) => {
-      return eventDrivenThreadToListItem(thread, activeRunThreadIds);
+      return eventDrivenThreadToListItem(
+        thread,
+        activeRunThreadIds.has(thread.id),
+      );
     });
   },
 );

--- a/turbo/apps/platform/src/signals/agents-page/agents-page-setup.ts
+++ b/turbo/apps/platform/src/signals/agents-page/agents-page-setup.ts
@@ -4,7 +4,6 @@ import { AgentsPage } from "../../views/agents-page/agents-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
 export const setupAgentsPage$ = command(
@@ -16,7 +15,5 @@ export const setupAgentsPage$ = command(
     if (await set(onboardGuard$, signal)) {
       return;
     }
-
-    set(reloadChatThreads$);
   },
 );

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -15,7 +15,7 @@ import {
 } from "./artifact-search.ts";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { clerk$ } from "../auth.ts";
+import { authenticatedIdentity$ } from "../auth.ts";
 import { openChatIdb } from "../external/chat-idb-store.ts";
 import { createArtifactItemCacheStores } from "../external/idb-artifact-item-store.ts";
 import { detachedNavigateTo$ } from "../route.ts";
@@ -136,12 +136,7 @@ export const reloadArtifacts$ = command(({ set }) => {
 export const remoteArtifacts$ = computed(
   async (get): Promise<ArtifactsPageData> => {
     get(internalArtifactsReload$);
-    const clerk = await get(clerk$);
-    const userId = clerk.user?.id;
-    const orgId = clerk.organization?.id;
-    if (!userId || !orgId) {
-      return { artifacts: [] };
-    }
+    const { userId, orgId } = await get(authenticatedIdentity$);
     const client = get(zeroClient$)(artifactsContract);
     const artifacts: ArtifactItem[] = [];
     let cursor: string | undefined;
@@ -149,7 +144,6 @@ export const remoteArtifacts$ = computed(
       const result = await accept(
         client.list({ query: { limit: ARTIFACTS_PAGE_SIZE, cursor } }),
         [200],
-        { toast: false },
       );
       artifacts.push(
         ...result.body.artifacts.map((item) => {
@@ -172,12 +166,7 @@ export const remoteArtifacts$ = computed(
 // (reads degrade to an empty list), so it is always a safe fallback.
 export const cachedArtifacts$ = computed(
   async (get): Promise<ArtifactsPageData> => {
-    const clerk = await get(clerk$);
-    const userId = clerk.user?.id;
-    const orgId = clerk.organization?.id;
-    if (!userId || !orgId) {
-      return { artifacts: [] };
-    }
+    const { userId, orgId } = await get(authenticatedIdentity$);
     const artifacts = await artifactItemCacheStores(
       userId,
       orgId,
@@ -275,15 +264,11 @@ export const toggleArtifactFavorite$ = command(
     });
     signal.throwIfAborted();
 
-    const clerk = await get(clerk$);
+    const { userId, orgId } = await get(authenticatedIdentity$);
     signal.throwIfAborted();
-    const userId = clerk.user?.id;
-    const orgId = clerk.organization?.id;
-    if (userId && orgId) {
-      await artifactItemCacheStores(userId, orgId).writeStore.upsertItems([
-        { ...item, isFavorited: nextIsFavorited },
-      ]);
-    }
+    await artifactItemCacheStores(userId, orgId).writeStore.upsertItems([
+      { ...item, isFavorited: nextIsFavorited },
+    ]);
     signal.throwIfAborted();
     set(reloadArtifacts$);
   },

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -426,6 +426,25 @@ export const user$ = computed(async (get) => {
   return clerk.user ?? undefined;
 });
 
+/**
+ * Stable cache ownership for authenticated pages.
+ *
+ * Route setup guarantees both values before page data is loaded. Keeping this
+ * invariant here prevents cache-backed data sources from independently
+ * treating a missing Clerk value as an empty cache or a remote-only mode.
+ */
+export const authenticatedIdentity$ = computed(async (get) => {
+  const clerk = await get(clerk$);
+  if (!clerk.user || !clerk.organization) {
+    throw new Error("Authenticated user and organization are required");
+  }
+  return {
+    userId: clerk.user.id,
+    orgId: clerk.organization.id,
+    email: clerk.user.primaryEmailAddress?.emailAddress,
+  };
+});
+
 export const currentUserInfo$ = computed(async (get) => {
   get(clerkVersion$);
   const clerk = await get(clerk$);

--- a/turbo/apps/platform/src/signals/authenticated-daemons.ts
+++ b/turbo/apps/platform/src/signals/authenticated-daemons.ts
@@ -1,0 +1,32 @@
+import { command } from "ccstate";
+import { clerk$ } from "./auth.ts";
+import {
+  subscribeChatThreadReadCursorUpdated$,
+  subscribeThreadListChanged$,
+} from "./chat-thread-list-reload.ts";
+import { subscribeBackgroundChatThreadFollowupsFinished$ } from "./chat-page/background-chat-thread-cache.ts";
+import { subscribeEventDrivenChatThreads$ } from "./chat-page/chat-thread-event-sourcing.ts";
+import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
+import { setupRealtime$ } from "./realtime.ts";
+import { setupBillingRealtime$ } from "./zero-page/billing.ts";
+
+/** Start user-scoped background services after Clerk has resolved. */
+export const setupAuthenticatedDaemons$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
+    if (!clerk.user || !clerk.organization) {
+      return;
+    }
+
+    await Promise.all([
+      set(setupRealtime$, signal),
+      set(subscribeThreadListChanged$, signal),
+      set(subscribeChatThreadReadCursorUpdated$, signal),
+      set(subscribeBackgroundChatThreadFollowupsFinished$, signal),
+      set(subscribeEventDrivenChatThreads$, signal),
+      set(setupBillingRealtime$, signal),
+      set(reloadFeatureSwitch$, signal),
+    ]);
+  },
+);

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -61,12 +61,10 @@ import { initSlackOrg$ as handleSlackRedirect$ } from "./zero-page/zero-slack.ts
 import { setupSkeletonPage$, setupErrorPage$ } from "./skeleton-page-setup.ts";
 import { hideAppSkeleton$, startSkeletonCycling$ } from "./app-skeleton.ts";
 import { setupRedeemCampaignPage$ } from "./redeem-campaign/redeem-campaign-page-setup.ts";
-import { setupRealtime$ } from "./realtime.ts";
 import { updatePage$ } from "./react-router.ts";
 import { NotFoundPage } from "../views/not-found-page.tsx";
 
 import { setupGlobalKeyboardShortcuts$ } from "./zero-page/zero-nav.ts";
-import { reloadFeatureSwitch$ } from "./external/feature-switch.ts";
 import { reloadBillingStatus$ } from "./zero-page/billing.ts";
 import { checkUnifiedSettingsParam$ } from "./zero-page/settings/settings-dialog.ts";
 
@@ -441,7 +439,6 @@ export const bootstrap$ = command(
     await Promise.all([
       set(setupRoutes$, signal),
       set(startSkeletonCycling$, signal),
-      set(setupRealtime$, signal),
       set(setupGlobalMethod$, signal),
       set(registerServiceWorker$, signal),
       set(setupNotificationListener$, signal),
@@ -449,7 +446,6 @@ export const bootstrap$ = command(
       set(setupGlobalKeyboardShortcuts$, signal),
       set(setupClerk$, signal),
       set(watchOrgSwitch$, signal),
-      set(reloadFeatureSwitch$, signal),
     ]);
 
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-thread-event-sourcing-local-first.test.ts
@@ -14,7 +14,6 @@ import { testContext } from "../../__tests__/test-helpers.ts";
 import {
   chatThreads$,
   currentChatThreadListIds$,
-  reloadChatThreads$,
   setChatAgentId$,
 } from "../../agent-chat.ts";
 import { renameDialogInput$ } from "../../zero-page/zero-sidebar-state.ts";
@@ -23,7 +22,9 @@ import { setChatThreadOnlyUnread$ } from "../chat-thread-only-unread.ts";
 import { openRenameChatThreadDialogFromThreadMeta$ } from "../chat-thread-rename.ts";
 import {
   eventDrivenChatThread,
+  optimisticChatThreadCreateUnsettled,
   registerOptimisticChatThreadEvent$,
+  syncEventDrivenChatThreads$,
   threadMeta,
   touchOptimisticChatThreadSort$,
 } from "../chat-thread-event-sourcing.ts";
@@ -38,9 +39,6 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
 
   const readSnapshot = vi.fn(() => {
     return Promise.resolve(snapshot);
-  });
-  const readLatestEventId = vi.fn(() => {
-    return Promise.resolve(snapshot?.latestEventId ?? null);
   });
   const readEvents = vi.fn(() => {
     return Promise.resolve(events);
@@ -70,7 +68,6 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
 
   return {
     readSnapshot,
-    readLatestEventId,
     readEvents,
     replaceFromSnapshot,
     upsertEvents,
@@ -88,7 +85,6 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
       snapshot = null;
       events = [];
       readSnapshot.mockClear();
-      readLatestEventId.mockClear();
       readEvents.mockClear();
       replaceFromSnapshot.mockClear();
       upsertEvents.mockClear();
@@ -102,7 +98,6 @@ vi.mock("../../external/idb-chat-thread-event-store.ts", () => {
       return {
         readStore: {
           readSnapshot: idbThreadEventStoreMock.readSnapshot,
-          readLatestEventId: idbThreadEventStoreMock.readLatestEventId,
           readEvents: idbThreadEventStoreMock.readEvents,
         },
         writeStore: {
@@ -250,6 +245,85 @@ describe("chat thread event sourcing local-first list", () => {
     expect(eventsRequests).toBe(1);
     expect(teamRequests).toBe(0);
     expectCallback(unblockEventsRequest)();
+  });
+
+  it("keeps event-sourced thread state stable when incremental sync is empty", async () => {
+    context.store.set(setChatAgentId$, AGENT_ID);
+
+    idbThreadEventStoreMock.setData({
+      snapshot: {
+        latestEventId: EVENT_ID,
+        chatThreads: [
+          {
+            id: THREAD_ID,
+            agentId: AGENT_ID,
+            title: "Cached thread",
+            sortAt: "2026-07-03T02:00:00.000Z",
+            createdAt: "2026-07-03T01:00:00.000Z",
+            updatedAt: "2026-07-03T02:00:00.000Z",
+            pinnedAt: null,
+            renamedAt: null,
+            selectedModel: null,
+          },
+        ],
+      },
+      events: [],
+    });
+
+    const renamedEvent = {
+      id: OPTIMISTIC_EVENT_ID,
+      kind: "renamed",
+      chatThreadId: THREAD_ID,
+      agentId: AGENT_ID,
+      title: "Synced thread",
+      selectedModel: null,
+      createdAt: "2026-07-03T03:00:00.000Z",
+    } satisfies ChatThreadEvent;
+    let eventsRequests = 0;
+    context.mocks.api(chatThreadsContract.events, ({ respond }) => {
+      eventsRequests += 1;
+      if (eventsRequests === 1) {
+        return respond(200, { events: [renamedEvent], hasMore: false });
+      }
+      return respond(200, { events: [], hasMore: false });
+    });
+
+    await setupPage({
+      context,
+      path: "/error",
+      withoutRender: true,
+      user: { id: "user_1", fullName: "Test User" },
+      session: { token: "token" },
+      org: {
+        activeOrg: { id: "org_1", name: "Test Org" },
+        memberships: [{ id: "org_1" }],
+      },
+    });
+    await vi.waitFor(async () => {
+      expect((await context.store.get(chatThreads$))[0]?.title).toBe(
+        "Synced thread",
+      );
+    });
+
+    const before = await context.store.get(chatThreads$);
+    const snapshotReads =
+      idbThreadEventStoreMock.readSnapshot.mock.calls.length;
+    const eventReads = idbThreadEventStoreMock.readEvents.mock.calls.length;
+    idbThreadEventStoreMock.replaceFromSnapshot.mockClear();
+    idbThreadEventStoreMock.upsertEvents.mockClear();
+
+    await context.store.set(syncEventDrivenChatThreads$, context.signal);
+
+    const after = await context.store.get(chatThreads$);
+    expect(after).toBe(before);
+    expect(idbThreadEventStoreMock.readSnapshot).toHaveBeenCalledTimes(
+      snapshotReads,
+    );
+    expect(idbThreadEventStoreMock.readEvents).toHaveBeenCalledTimes(
+      eventReads,
+    );
+    expect(idbThreadEventStoreMock.replaceFromSnapshot).not.toHaveBeenCalled();
+    expect(idbThreadEventStoreMock.upsertEvents).not.toHaveBeenCalled();
   });
 
   it("filters event-sourced visible threads through unread thread ids", async () => {
@@ -653,19 +727,11 @@ describe("chat thread event sourcing local-first list", () => {
     await expect(
       context.store.get(sidebarChatThreadIds$),
     ).resolves.toStrictEqual([OPTIMISTIC_THREAD_ID]);
-
-    idbThreadEventStoreMock.setData({
-      snapshot: {
-        latestEventId: EVENT_ID,
-        chatThreads: [],
-      },
-      events: [],
-    });
-    context.store.set(reloadChatThreads$);
-
-    await expect(
-      context.store.get(sidebarChatThreadIds$),
-    ).resolves.toStrictEqual([]);
+    expect(
+      context.store.get(
+        optimisticChatThreadCreateUnsettled(OPTIMISTIC_THREAD_ID),
+      ),
+    ).toBeFalsy();
   });
 
   it("prefills rename dialog title from provided event-driven thread metadata", async () => {

--- a/turbo/apps/platform/src/signals/chat-page/artifact-google-slides-upload.ts
+++ b/turbo/apps/platform/src/signals/chat-page/artifact-google-slides-upload.ts
@@ -67,7 +67,6 @@ export const uploadPresentationToGoogleSlides$ = command(
         fetchOptions: { signal },
       }),
       [200, 400],
-      { toast: false },
     );
     signal.throwIfAborted();
     if (stagedResult.status === 200) {

--- a/turbo/apps/platform/src/signals/chat-page/chat-goal.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-goal.ts
@@ -23,7 +23,6 @@ export const activeGoalDialogGoal$ = computed(
     const response = await accept(
       client.getForChatThread({ params: { threadId } }),
       [200],
-      { toast: false },
     );
     return response.body;
   },

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -3,11 +3,7 @@ import { onRef } from "../utils.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { navigateToChat$ } from "../zero-page/zero-nav.ts";
-import {
-  currentChatThreadId$,
-  chatThreads$,
-  reloadChatThreads$,
-} from "../agent-chat.ts";
+import { currentChatThreadId$, chatThreads$ } from "../agent-chat.ts";
 import {
   chatThreadByIdContract,
   type ChatThreadEvent,
@@ -23,7 +19,7 @@ import type { BodyRenderBlock } from "./parse-body-blocks.ts";
 import { nowDate } from "../../lib/time.ts";
 import { registerOptimisticChatThreadEvent$ } from "./chat-thread-event-sourcing.ts";
 
-export { chatThreads$, reloadChatThreads$ } from "../agent-chat.ts";
+export { chatThreads$ } from "../agent-chat.ts";
 
 export {
   zeroChatAttachments$,
@@ -109,8 +105,6 @@ export const deleteChatThread$ = command(
         set(navigateToChat$, nextThread.id);
       }
     }
-
-    set(reloadChatThreads$);
   },
 );
 
@@ -147,7 +141,6 @@ export const pinChatThread$ = command(
       [204],
     );
     signal.throwIfAborted();
-    set(reloadChatThreads$);
   },
 );
 
@@ -180,7 +173,6 @@ export const unpinChatThread$ = command(
       [204],
     );
     signal.throwIfAborted();
-    set(reloadChatThreads$);
   },
 );
 
@@ -231,7 +223,6 @@ export const renameChatThread$ = command(
       [204],
     );
     signal.throwIfAborted();
-    set(reloadChatThreads$);
   },
 );
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -249,7 +249,7 @@ const hydrateChatThreadEventState$ = command(
       snapshot: state.snapshot?.chatThreads ?? [],
       events: state.events,
     });
-    await set(syncCurrentChatThreadDocumentTitle$);
+    await set(syncCurrentChatThreadDocumentTitle$, signal);
     return { state, store: storeContext.stores };
   },
 );
@@ -282,7 +282,7 @@ export const syncEventDrivenChatThreads$ = command(
       snapshot: update.state.snapshot?.chatThreads ?? [],
       events: update.state.events,
     });
-    await set(syncCurrentChatThreadDocumentTitle$);
+    await set(syncCurrentChatThreadDocumentTitle$, signal);
   },
 );
 
@@ -383,19 +383,22 @@ export function threadMeta(threadId: string) {
 }
 
 /** Synchronize the active primary chat tab title after committed thread data changes. */
-const syncCurrentChatThreadDocumentTitle$ = command(async ({ get, set }) => {
-  if (get(activeRoute$) !== "chat") {
-    return;
-  }
-  const threadId = get(pathParams$)?.threadId;
-  if (typeof threadId !== "string") {
-    return;
-  }
-  const meta = await get(threadMeta(threadId));
-  if (meta) {
-    set(updateDocumentTitle$, meta.title ?? "New chat");
-  }
-});
+const syncCurrentChatThreadDocumentTitle$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (get(activeRoute$) !== "chat") {
+      return;
+    }
+    const threadId = get(pathParams$)?.threadId;
+    if (typeof threadId !== "string") {
+      return;
+    }
+    const meta = await get(threadMeta(threadId));
+    signal.throwIfAborted();
+    if (meta) {
+      set(updateDocumentTitle$, meta.title ?? "New chat");
+    }
+  },
+);
 
 export const registerOptimisticChatThreadEvent$ = command(
   ({ set }, event: ChatThreadEvent) => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -10,12 +10,15 @@ import type {
   InitClientReturn,
 } from "@vm0/api-contracts/contracts/trpc-contract";
 import { accept } from "../../lib/accept.ts";
+import { activeRoute$ } from "../active-route.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { authenticatedIdentity$ } from "../auth.ts";
+import { updateDocumentTitle$ } from "../document-title.ts";
 import { createIdbChatThreadEventStores } from "../external/idb-chat-thread-event-store.ts";
 import { logger } from "../log.ts";
 import { reloadChatActiveRunIdsCounter$ } from "../chat-thread-list-reload.ts";
 import { setAblyLoop$ } from "../realtime.ts";
+import { pathParams$ } from "../route.ts";
 import { replayChatThreadEvents } from "./chat-thread-event-replay.ts";
 
 const L = logger("ChatThreadEventSourcing");
@@ -246,6 +249,7 @@ const hydrateChatThreadEventState$ = command(
       snapshot: state.snapshot?.chatThreads ?? [],
       events: state.events,
     });
+    await set(syncCurrentChatThreadDocumentTitle$);
     return { state, store: storeContext.stores };
   },
 );
@@ -278,6 +282,7 @@ export const syncEventDrivenChatThreads$ = command(
       snapshot: update.state.snapshot?.chatThreads ?? [],
       events: update.state.events,
     });
+    await set(syncCurrentChatThreadDocumentTitle$);
   },
 );
 
@@ -376,6 +381,21 @@ export function threadMeta(threadId: string) {
     return (await get(chatThreadMetaMap$)).get(threadId) ?? null;
   });
 }
+
+/** Synchronize the active primary chat tab title after committed thread data changes. */
+const syncCurrentChatThreadDocumentTitle$ = command(async ({ get, set }) => {
+  if (get(activeRoute$) !== "chat") {
+    return;
+  }
+  const threadId = get(pathParams$)?.threadId;
+  if (typeof threadId !== "string") {
+    return;
+  }
+  const meta = await get(threadMeta(threadId));
+  if (meta) {
+    set(updateDocumentTitle$, meta.title ?? "New chat");
+  }
+});
 
 export const registerOptimisticChatThreadEvent$ = command(
   ({ set }, event: ChatThreadEvent) => {

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-event-sourcing.ts
@@ -11,12 +11,11 @@ import type {
 } from "@vm0/api-contracts/contracts/trpc-contract";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { clerk$ } from "../auth.ts";
+import { authenticatedIdentity$ } from "../auth.ts";
 import { createIdbChatThreadEventStores } from "../external/idb-chat-thread-event-store.ts";
 import { logger } from "../log.ts";
-import { reloadChatThreadsCounter$ } from "../chat-thread-list-reload.ts";
+import { reloadChatActiveRunIdsCounter$ } from "../chat-thread-list-reload.ts";
 import { setAblyLoop$ } from "../realtime.ts";
-import { settle, withCleanup } from "../utils.ts";
 import { replayChatThreadEvents } from "./chat-thread-event-replay.ts";
 
 const L = logger("ChatThreadEventSourcing");
@@ -34,6 +33,23 @@ interface ChatThreadSnapshotData {
   readonly latestEventId: string | null;
 }
 
+interface ChatThreadEventState {
+  readonly ownerKey: string;
+  readonly snapshot: ChatThreadSnapshotData | null;
+  readonly events: readonly ChatThreadEvent[];
+}
+
+interface ChatThreadEventStores {
+  readonly ownerKey: string;
+  readonly stores: Stores;
+}
+
+interface ChatThreadEventUpdate {
+  readonly state: ChatThreadEventState;
+  readonly replacementSnapshot: ChatThreadSnapshotData | null;
+  readonly newEvents: readonly ChatThreadEvent[];
+}
+
 export interface ThreadMeta {
   readonly id: string;
   readonly agentId: string;
@@ -43,10 +59,7 @@ export interface ThreadMeta {
 }
 
 const optimisticChatThreadEventsState$ = state<readonly ChatThreadEvent[]>([]);
-const chatThreadEventSyncVersionState$ = state(0);
-const chatThreadEventSyncInFlightState$ = state(false);
-const activeRunChatThreadIdsState$ = state<ReadonlySet<string>>(new Set());
-const activeRunChatThreadIdsRefreshInFlightState$ = state(false);
+const chatThreadEventState$ = state<ChatThreadEventState | null>(null);
 
 const optimisticChatThreadCreateIds$ = computed((get): ReadonlySet<string> => {
   return new Set(
@@ -73,68 +86,75 @@ function filterUnsettledOptimisticChatThreadEvents(
   });
 }
 
-async function readChatThreadEventData(
+async function readChatThreadEventState(
+  ownerKey: string,
   store: Stores,
-  fallbackSnapshot: ChatThreadSnapshotData | null = null,
-): Promise<ChatThreadEventData> {
+  signal?: AbortSignal,
+): Promise<ChatThreadEventState> {
   const [snapshot, events] = await Promise.all([
-    store.readStore.readSnapshot(),
-    store.readStore.readEvents(),
+    store.readStore.readSnapshot(signal),
+    store.readStore.readEvents(signal),
   ]);
   return {
-    snapshot: (snapshot ?? fallbackSnapshot)?.chatThreads ?? [],
+    ownerKey,
+    snapshot,
     events,
   };
 }
 
-export const eventDrivenActiveRunChatThreadIds$ = computed((get) => {
-  return get(activeRunChatThreadIdsState$);
+export const eventDrivenActiveRunChatThreadIds$ = computed(
+  async (get): Promise<ReadonlySet<string>> => {
+    get(reloadChatActiveRunIdsCounter$);
+    const client = get(zeroClient$)(chatThreadsContract);
+    const result = await accept(client.activeIds(), [200]);
+    return new Set(result.body.threadIds);
+  },
+);
+
+const chatThreadEventStores$ = computed(
+  async (get): Promise<ChatThreadEventStores> => {
+    const { userId, orgId } = await get(authenticatedIdentity$);
+    return {
+      ownerKey: `${userId}:${orgId}`,
+      stores: createIdbChatThreadEventStores(userId, orgId),
+    };
+  },
+);
+
+const lastEventId$ = computed((get): string | null => {
+  const state = get(chatThreadEventState$);
+  return state?.events.at(-1)?.id ?? state?.snapshot?.latestEventId ?? null;
 });
 
-const chatThreadEventStores$ = computed(async (get): Promise<Stores | null> => {
-  const clerk = await get(clerk$);
-  const userId = clerk.user?.id;
-  const orgId = clerk.organization?.id;
-  if (!userId || !orgId) {
-    return null;
-  }
-
-  return createIdbChatThreadEventStores(userId, orgId);
-});
-
-async function replaceFromRemoteSnapshot(
-  store: Stores["writeStore"],
+async function fetchRemoteSnapshot(
   client: ChatThreadsClient,
   signal?: AbortSignal,
 ): Promise<ChatThreadSnapshotData> {
   const result = await accept(
     client.snapshot({ fetchOptions: { signal } }),
     [200],
-    { toast: false },
   );
   signal?.throwIfAborted();
-  await store.replaceFromSnapshot(result.body, signal);
   return result.body;
 }
 
-async function syncChatThreadEvents(
-  store: Stores,
+async function fetchChatThreadEventUpdate(
+  currentState: ChatThreadEventState,
+  initialCursor: string | null,
   client: ChatThreadsClient,
   signal?: AbortSignal,
-): Promise<ChatThreadSnapshotData | null> {
-  const existingSnapshot = await store.readStore.readSnapshot(signal);
-  let activeSnapshot = existingSnapshot;
-  let cursor =
-    (await store.readStore.readLatestEventId(signal)) ??
-    activeSnapshot?.latestEventId ??
-    null;
-  if (!activeSnapshot || cursor === null) {
-    activeSnapshot = await replaceFromRemoteSnapshot(
-      store.writeStore,
-      client,
-      signal,
-    );
-    cursor = activeSnapshot.latestEventId;
+): Promise<ChatThreadEventUpdate | null> {
+  let snapshot = currentState.snapshot;
+  let events = currentState.events;
+  let cursor = initialCursor;
+  let snapshotReplaced = false;
+  let newEvents: readonly ChatThreadEvent[] = [];
+
+  if (!snapshot || cursor === null) {
+    snapshot = await fetchRemoteSnapshot(client, signal);
+    events = [];
+    cursor = snapshot.latestEventId;
+    snapshotReplaced = true;
   }
 
   for (let page = 0; page < 20; page++) {
@@ -144,142 +164,133 @@ async function syncChatThreadEvents(
         fetchOptions: { signal },
       }),
       [200, 410],
-      { toast: false },
     );
     signal?.throwIfAborted();
 
     if (result.status === 410) {
       L.debug("events cursor expired, reloading snapshot");
-      activeSnapshot = await replaceFromRemoteSnapshot(
-        store.writeStore,
-        client,
-        signal,
-      );
-      cursor = activeSnapshot.latestEventId;
+      snapshot = await fetchRemoteSnapshot(client, signal);
+      events = [];
+      newEvents = [];
+      cursor = snapshot.latestEventId;
+      snapshotReplaced = true;
       continue;
     }
 
     if (result.body.events.length > 0) {
-      await store.writeStore.upsertEvents(result.body.events, signal);
+      events = [...events, ...result.body.events];
+      newEvents = [...newEvents, ...result.body.events];
       cursor = result.body.events[result.body.events.length - 1]!.id;
     }
 
     if (!result.body.hasMore || result.body.events.length === 0) {
-      return activeSnapshot;
+      if (!snapshotReplaced && newEvents.length === 0) {
+        return null;
+      }
+      return {
+        state: {
+          ownerKey: currentState.ownerKey,
+          snapshot,
+          events,
+        },
+        replacementSnapshot: snapshotReplaced ? snapshot : null,
+        newEvents,
+      };
     }
   }
-  return activeSnapshot;
+  if (!snapshotReplaced && newEvents.length === 0) {
+    return null;
+  }
+  return {
+    state: {
+      ownerKey: currentState.ownerKey,
+      snapshot,
+      events,
+    },
+    replacementSnapshot: snapshotReplaced ? snapshot : null,
+    newEvents,
+  };
 }
 
 const chatThreadEventData$ = computed(
   async (get): Promise<ChatThreadEventData> => {
-    get(reloadChatThreadsCounter$);
-    get(chatThreadEventSyncVersionState$);
-    const store = await get(chatThreadEventStores$);
-    if (!store) {
+    const storeContext = await get(chatThreadEventStores$);
+    const state = get(chatThreadEventState$);
+    if (state?.ownerKey !== storeContext.ownerKey) {
       return { snapshot: [], events: [] };
     }
+    return {
+      snapshot: state.snapshot?.chatThreads ?? [],
+      events: state.events,
+    };
+  },
+);
 
-    const cachedSnapshot = await store.readStore.readSnapshot();
-    let syncedSnapshot: ChatThreadSnapshotData | null = null;
-    if (!cachedSnapshot || cachedSnapshot.latestEventId === null) {
-      const client = get(zeroClient$)(chatThreadsContract);
-      syncedSnapshot = await syncChatThreadEvents(store, client);
+const hydrateChatThreadEventState$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const storeContext = await get(chatThreadEventStores$);
+    signal.throwIfAborted();
+    const currentState = get(chatThreadEventState$);
+    if (currentState?.ownerKey === storeContext.ownerKey) {
+      return { state: currentState, store: storeContext.stores };
     }
 
-    return await readChatThreadEventData(store, syncedSnapshot);
+    const state = await readChatThreadEventState(
+      storeContext.ownerKey,
+      storeContext.stores,
+      signal,
+    );
+    signal.throwIfAborted();
+    set(chatThreadEventState$, state);
+    set(reconcileOptimisticChatThreadEvents$, {
+      snapshot: state.snapshot?.chatThreads ?? [],
+      events: state.events,
+    });
+    return { state, store: storeContext.stores };
   },
 );
 
 export const syncEventDrivenChatThreads$ = command(
   async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const store = await get(chatThreadEventStores$);
+    const hydrated = await set(hydrateChatThreadEventState$, signal);
     signal.throwIfAborted();
-    if (!store || get(chatThreadEventSyncInFlightState$)) {
-      return;
-    }
-
-    set(chatThreadEventSyncInFlightState$, true);
-    await withCleanup(
-      (async () => {
-        const client = get(zeroClient$)(chatThreadsContract);
-        const synced = await settle(
-          syncChatThreadEvents(store, client, signal),
-          signal,
-        );
-        if (!synced.ok) {
-          L.debug("event sync failed", { error: synced.error });
-          return;
-        }
-        signal.throwIfAborted();
-        const data = await readChatThreadEventData(store, synced.value);
-        signal.throwIfAborted();
-        set(reconcileOptimisticChatThreadEvents$, data);
-        set(chatThreadEventSyncVersionState$, (version) => {
-          return version + 1;
-        });
-      })(),
-      () => {
-        set(chatThreadEventSyncInFlightState$, false);
-      },
+    const client = get(zeroClient$)(chatThreadsContract);
+    const update = await fetchChatThreadEventUpdate(
+      hydrated.state,
+      get(lastEventId$),
+      client,
+      signal,
     );
-  },
-);
-
-const refreshEventDrivenActiveRunChatThreadIds$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    if (get(activeRunChatThreadIdsRefreshInFlightState$)) {
-      return;
-    }
-
-    const clerk = await get(clerk$);
     signal.throwIfAborted();
-    if (!clerk.user || !clerk.organization) {
-      set(activeRunChatThreadIdsState$, new Set());
+    if (!update) {
       return;
     }
 
-    set(activeRunChatThreadIdsRefreshInFlightState$, true);
-    await withCleanup(
-      (async () => {
-        const client = get(zeroClient$)(chatThreadsContract);
-        const result = await accept(
-          client.activeIds({ fetchOptions: { signal } }),
-          [200],
-          {
-            toast: false,
-          },
-        );
-        signal.throwIfAborted();
-        set(activeRunChatThreadIdsState$, new Set(result.body.threadIds));
-      })(),
-      () => {
-        set(activeRunChatThreadIdsRefreshInFlightState$, false);
-      },
-    );
+    if (update.replacementSnapshot) {
+      await hydrated.store.writeStore.replaceFromSnapshot(
+        update.replacementSnapshot,
+        signal,
+      );
+    }
+    await hydrated.store.writeStore.upsertEvents(update.newEvents, signal);
+    set(chatThreadEventState$, update.state);
+    set(reconcileOptimisticChatThreadEvents$, {
+      snapshot: update.state.snapshot?.chatThreads ?? [],
+      events: update.state.events,
+    });
   },
 );
 
 export const subscribeEventDrivenChatThreads$ = command(
-  async ({ get, set }, signal: AbortSignal): Promise<void> => {
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
-    if (!clerk.user || !clerk.organization) {
-      set(activeRunChatThreadIdsState$, new Set());
-      return;
-    }
-
+  async ({ set }, signal: AbortSignal): Promise<void> => {
     const syncOnThreadListChanged$ = command(
       async ({ set }, signal: AbortSignal): Promise<boolean> => {
         await set(syncEventDrivenChatThreads$, signal);
-        await set(refreshEventDrivenActiveRunChatThreadIds$, signal);
         return false;
       },
     );
 
     await set(syncEventDrivenChatThreads$, signal);
-    signal.throwIfAborted();
-    await set(refreshEventDrivenActiveRunChatThreadIds$, signal);
     signal.throwIfAborted();
     await set(
       setAblyLoop$,

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -40,7 +40,7 @@ import {
   reconcileOptimisticChatMessages$,
   type OptimisticChatMessageEntry,
 } from "./optimistic-chat-messages.ts";
-import { reloadChatThreads$, type ChatThread } from "../agent-chat.ts";
+import type { ChatThread } from "../agent-chat.ts";
 import {
   chatMessagesContract,
   chatThreadArtifactsContract,
@@ -546,7 +546,6 @@ function createModelSelection(
       );
       signal.throwIfAborted();
       set(dataSource.reloadThread$);
-      set(reloadChatThreads$);
     },
   );
 
@@ -627,7 +626,6 @@ function createComputerUseHostSelection(
         dirty: false,
       });
       set(dataSource.reloadThread$);
-      set(reloadChatThreads$);
     },
   );
 
@@ -2708,7 +2706,6 @@ function createSendMessage(deps: SendMessageDeps) {
         signal.throwIfAborted();
         set(scrollToBottom$);
       }
-      set(reloadChatThreads$);
     },
   );
 }
@@ -2848,7 +2845,6 @@ function createQueueMessage(deps: QueueMessageDeps) {
       ]);
       signal.throwIfAborted();
 
-      set(reloadChatThreads$);
       L.debug("queueMessage$ done", { threadId });
     },
   );
@@ -3047,7 +3043,6 @@ function createCancelRunWithQueuedRecall({
       }),
     ]);
     signal.throwIfAborted();
-    set(reloadChatThreads$);
   });
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
+++ b/turbo/apps/platform/src/signals/chat-page/idb-cached-chat-thread-data-source.ts
@@ -5,7 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/chat-threads";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { clerk$ } from "../auth.ts";
+import { authenticatedIdentity$ } from "../auth.ts";
 import {
   chatIdbReadOr,
   chatIdbWriteBestEffort,
@@ -79,7 +79,6 @@ const warmListMessagesAfter$ = command(
         fetchOptions: { signal },
       }),
       [200, 404],
-      { toast: false },
     );
     signal.throwIfAborted();
     if (result.status === 404) {
@@ -186,19 +185,8 @@ function createListMessagesBefore(
       { threadId: tid, beforeId }: ListMessagesBeforeArgs,
       signal: AbortSignal,
     ) => {
-      const clerk = await get(clerk$);
+      const { userId, orgId } = await get(authenticatedIdentity$);
       signal.throwIfAborted();
-      const userId = clerk.user?.id;
-      const orgId = clerk.organization?.id;
-
-      if (!userId || !orgId) {
-        L.debug("listBefore:noAuth", { threadId: tid, beforeId });
-        return set(
-          remote.listMessagesBefore$,
-          { threadId: tid, beforeId },
-          signal,
-        );
-      }
 
       const stores = getStores(userId, orgId);
       const readStore = stores.readStore;
@@ -281,12 +269,9 @@ function createListMessagesAfter(
         signal,
       );
 
-      const clerk = await get(clerk$);
-      signal.throwIfAborted();
-      const userId = clerk.user?.id;
-      const orgId = clerk.organization?.id;
-
-      if (userId && orgId && result.messages.length > 0) {
+      if (result.messages.length > 0) {
+        const { userId, orgId } = await get(authenticatedIdentity$);
+        signal.throwIfAborted();
         const stores = getStores(userId, orgId);
         // Only cache when the anchor (sinceId) still exists locally.
         // If it doesn't, local state has diverged and writing would create
@@ -321,13 +306,6 @@ function createListMessagesAfter(
           sinceId,
           count: result.messages.length,
         });
-      } else {
-        L.debug("listAfter:skipCache", {
-          threadId: tid,
-          sinceId,
-          hasAuth: Boolean(userId && orgId),
-          count: result.messages.length,
-        });
       }
 
       return result;
@@ -352,15 +330,12 @@ function createGetMessage(
       );
       signal.throwIfAborted();
 
-      const clerk = await get(clerk$);
-      signal.throwIfAborted();
-      const userId = clerk.user?.id;
-      const orgId = clerk.organization?.id;
-
-      if (!userId || !orgId || message === null) {
+      if (message === null) {
         return message;
       }
 
+      const { userId, orgId } = await get(authenticatedIdentity$);
+      signal.throwIfAborted();
       const stores = getStores(userId, orgId);
       await chatIdbWriteBestEffort(
         "cachedDataSource:upsertMessage",
@@ -377,16 +352,8 @@ function createGetMessage(
 
 export const warmLatestChatThreadMessages$ = command(
   async ({ get, set }, threadId: string, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
+    const { userId, orgId } = await get(authenticatedIdentity$);
     signal.throwIfAborted();
-    const userId = clerk.user?.id;
-    const orgId = clerk.organization?.id;
-
-    if (!userId || !orgId) {
-      L.debug("warmLatest:noAuth", { threadId });
-      return;
-    }
-
     const stores = createIdbMessageStores(userId, orgId);
     const latest = await chatIdbReadOr(
       "cachedDataSource:warmReadLatest",
@@ -483,15 +450,7 @@ export function createIdbCachedDataSource(
   }
 
   const initialPage$ = computed(async (get): Promise<InitialPage> => {
-    const clerk = await get(clerk$);
-    const userId = clerk.user?.id;
-    const orgId = clerk.organization?.id;
-
-    if (!userId || !orgId) {
-      L.debug("initialPage:noAuth", { threadId });
-      return get(remote.initialPage$);
-    }
-
+    const { userId, orgId } = await get(authenticatedIdentity$);
     const stores = getStores(userId, orgId);
     const readStore = stores.readStore;
     const cached = await chatIdbReadOr(

--- a/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
+++ b/turbo/apps/platform/src/signals/chat-page/optimistic-chat-thread-page.ts
@@ -14,11 +14,7 @@ import type { UserModelPreferenceResponse } from "@vm0/api-contracts/contracts/z
 import { accept } from "../../lib/accept.ts";
 import { nowDate } from "../../lib/time.ts";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
-import {
-  chatThreads$,
-  currentChatThreadId$,
-  reloadChatThreads$,
-} from "../agent-chat.ts";
+import { chatThreads$, currentChatThreadId$ } from "../agent-chat.ts";
 import { detachedNavigateTo$, searchParams$ } from "../route.ts";
 import { loadRightThread$ } from "./chat-thread-panes.ts";
 import {
@@ -171,37 +167,6 @@ function resolveNewThreadModelSelection(
     codexFastModeDefault: args.codexFastModeDefault,
   });
 }
-
-const settleNewThreadSend$ = command(
-  async (
-    { set },
-    args: {
-      readonly clearDraftResult: Promise<void>;
-      readonly createResult: Promise<void>;
-      readonly createClient: ZeroClientFactory;
-      readonly body: ReturnType<typeof newThreadSendBody>;
-    },
-    signal: AbortSignal,
-  ): Promise<SendNewThreadMessageResult> => {
-    await Promise.all([args.clearDraftResult, args.createResult]);
-    signal.throwIfAborted();
-
-    const result = await accept(
-      args.createClient(chatMessagesContract).send({
-        body: args.body,
-        fetchOptions: { signal },
-      }),
-      [201],
-    );
-    signal.throwIfAborted();
-    L.debug("sendNewThreadMessage$ POST chat/messages 201", {
-      threadId: result.body.threadId,
-      runId: result.body.runId,
-    });
-    set(reloadChatThreads$);
-    return { threadId: result.body.threadId, runId: result.body.runId };
-  },
-);
 
 const routeMainChatThread$ = command(({ get, set }, threadId: string) => {
   const next = new URLSearchParams(get(searchParams$));
@@ -493,27 +458,36 @@ const sendNewThreadMessage$ = command(
       L.debug("sendNewThreadMessage$ POST chat-threads 201", { threadId });
       signal.throwIfAborted();
     })();
-    const sendResult = set(
-      settleNewThreadSend$,
-      {
-        clearDraftResult,
-        createResult,
-        createClient,
-        body: newThreadSendBody({
-          agentId,
-          threadId,
-          clientMessageId,
-          prepared,
-          modelSelection: resolvedModelSelection,
-          codexFastModeEnabled: codexFastModeSwitchEnabled(get(featureSwitch$)),
-          realAgentInPreviewEnabled:
-            get(featureSwitch$)[FeatureSwitchKey.RealAgentInPreview] ?? false,
-          generationTemplate,
-          computerUseHostId,
+    const sendBody = newThreadSendBody({
+      agentId,
+      threadId,
+      clientMessageId,
+      prepared,
+      modelSelection: resolvedModelSelection,
+      codexFastModeEnabled: codexFastModeSwitchEnabled(get(featureSwitch$)),
+      realAgentInPreviewEnabled:
+        get(featureSwitch$)[FeatureSwitchKey.RealAgentInPreview] ?? false,
+      generationTemplate,
+      computerUseHostId,
+    });
+    const sendResult = (async (): Promise<SendNewThreadMessageResult> => {
+      await Promise.all([clearDraftResult, createResult]);
+      signal.throwIfAborted();
+
+      const result = await accept(
+        createClient(chatMessagesContract).send({
+          body: sendBody,
+          fetchOptions: { signal },
         }),
-      },
-      signal,
-    );
+        [201],
+      );
+      signal.throwIfAborted();
+      L.debug("sendNewThreadMessage$ POST chat/messages 201", {
+        threadId: result.body.threadId,
+        runId: result.body.runId,
+      });
+      return { threadId: result.body.threadId, runId: result.body.runId };
+    })();
     return { threadId, sendResult };
   },
 );

--- a/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
+++ b/turbo/apps/platform/src/signals/chat-page/sidebar-unread-threads.ts
@@ -93,9 +93,7 @@ export const unreadAgentIds$ = computed(
       return new Set();
     }
     const client = get(zeroClient$)(chatThreadsContract);
-    const result = await accept(client.unreadAgents(), [200], {
-      toast: false,
-    });
+    const result = await accept(client.unreadAgents(), [200]);
     return new Set(result.body.agentIds);
   },
 );
@@ -114,7 +112,7 @@ export const currentAgentUnreadChatThreads$ = computed(
     if (unreadThreadIds.size === 0) {
       return [];
     }
-    const activeRunThreadIds = get(eventDrivenActiveRunChatThreadIds$);
+    const activeRunThreadIds = await get(eventDrivenActiveRunChatThreadIds$);
     return (await get(eventDrivenChatThreads$))
       .filter((thread) => {
         return thread.agentId === agentId && unreadThreadIds.has(thread.id);

--- a/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
+++ b/turbo/apps/platform/src/signals/chat-page/workflow-queue.ts
@@ -13,7 +13,7 @@ import { openHeaderAutomationSidebar$ } from "./header-automation-sidebar.ts";
 const workflowQueueReload$ = state(0);
 
 /** Bump to force the workflow queue panel to refetch. */
-export const reloadWorkflowQueue$ = command(({ get, set }) => {
+const reloadWorkflowQueue$ = command(({ get, set }) => {
   set(workflowQueueReload$, get(workflowQueueReload$) + 1);
 });
 
@@ -115,7 +115,7 @@ const lastPendingCounts$ = state<Readonly<Record<string, number>>>({});
  * auto-expand the Automations panel only when the backlog transitions from
  * empty to non-empty, so it never fights a user who closed the panel.
  */
-export const handleWorkflowQueueChanged$ = command(
+const handleWorkflowQueueChanged$ = command(
   async ({ get, set }, threadId: string, signal: AbortSignal) => {
     set(reloadWorkflowQueue$);
     const queue = await get(workflowQueueForThread(threadId));

--- a/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
+++ b/turbo/apps/platform/src/signals/chat-thread-list-reload.ts
@@ -1,29 +1,15 @@
 import { command, computed, state } from "ccstate";
 import { setAblyLoop$ } from "./realtime.ts";
 
-const internalReloadChatThreads$ = state(0);
 const internalReloadChatUnreadState$ = state(0);
-
-/**
- * Read-only view of the reload counter. Consumers subscribe to this to
- * re-run their computeds whenever the counter bumps.
- */
-export const reloadChatThreadsCounter$ = computed((get) => {
-  return get(internalReloadChatThreads$);
-});
+const internalReloadChatActiveRunIds$ = state(0);
 
 export const reloadChatUnreadStateCounter$ = computed((get) => {
   return get(internalReloadChatUnreadState$);
 });
 
-/**
- * Bump the sidebar thread-list reload counter. Triggers `chatThreads$`
- * to refetch on the next read.
- */
-export const reloadChatThreads$ = command(({ set }) => {
-  set(internalReloadChatThreads$, (n) => {
-    return n + 1;
-  });
+export const reloadChatActiveRunIdsCounter$ = computed((get) => {
+  return get(internalReloadChatActiveRunIds$);
 });
 
 export const reloadChatUnreadState$ = command(({ set }) => {
@@ -32,11 +18,16 @@ export const reloadChatUnreadState$ = command(({ set }) => {
   });
 });
 
+export const reloadChatActiveRunIds$ = command(({ set }) => {
+  set(internalReloadChatActiveRunIds$, (n) => {
+    return n + 1;
+  });
+});
+
 /**
- * Subscribe to the user-level `threadListChanged` topic and trigger a
- * sidebar reload on every signal. Server publishes this on any mutation
- * that alters the thread list shape (create, delete, new message, run
- * create/update, title update). These changes can also affect unread state.
+ * Subscribe to the user-level `threadListChanged` topic and invalidate active
+ * run and unread snapshots. Event-sourced thread data has its own incremental
+ * subscription.
  *
  * Loop command returns false so it keeps listening until the signal aborts.
  * Isolated in its own file to avoid an import cycle when `route.ts` wires
@@ -45,7 +36,7 @@ export const reloadChatUnreadState$ = command(({ set }) => {
 export const subscribeThreadListChanged$ = command(
   async ({ set }, signal: AbortSignal) => {
     const onChanged$ = command(({ set }) => {
-      set(reloadChatThreads$);
+      set(reloadChatActiveRunIds$);
       set(reloadChatUnreadState$);
       return false;
     });

--- a/turbo/apps/platform/src/signals/export-page/export-page-signals.ts
+++ b/turbo/apps/platform/src/signals/export-page/export-page-signals.ts
@@ -24,7 +24,7 @@ export const userExportStatus$ = computed(
   async (get): Promise<UserExportStatusResponse> => {
     get(statusReload$);
     const client = get(zeroClient$)(userExportContract);
-    const result = await accept(client.get(), [200], { toast: false });
+    const result = await accept(client.get(), [200]);
     return result.body;
   },
 );
@@ -61,7 +61,6 @@ export const startUserExport$ = command(
         fetchOptions: { signal },
       }),
       [202, 429],
-      { toast: false },
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -2,7 +2,7 @@ import { command, computed } from "ccstate";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { clerk$ } from "../auth";
+import { authenticatedIdentity$, clerk$ } from "../auth";
 import { accept } from "../../lib/accept.ts";
 import { resolveApiBaseForTarget } from "../api-base.ts";
 import { createAuthedContractClient } from "../api-client-base.ts";
@@ -55,13 +55,8 @@ export const featureSwitch$ = computed((get) => {
 
 export const reloadFeatureSwitch$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
+    const identity = await get(authenticatedIdentity$);
     signal.throwIfAborted();
-
-    const user = clerk.user;
-    if (!user) {
-      return;
-    }
 
     const client = get(apiFeatureSwitchClient$);
     const result = await accept(
@@ -71,9 +66,9 @@ export const reloadFeatureSwitch$ = command(
     signal.throwIfAborted();
 
     const combined = getAllFeatureStates({
-      userId: user.id,
-      email: user.primaryEmailAddress?.emailAddress,
-      orgId: clerk.organization?.id,
+      userId: identity.userId,
+      email: identity.email,
+      orgId: identity.orgId,
     });
     applySwitches(combined, result.body.switches);
 

--- a/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
+++ b/turbo/apps/platform/src/signals/external/idb-chat-thread-event-store.ts
@@ -24,11 +24,6 @@ interface StoredChatThreadSnapshot extends ChatThreadSnapshotRecord {
   readonly id: typeof SINGLETON_ID;
 }
 
-interface StoredChatThreadEventSync {
-  readonly id: typeof SINGLETON_ID;
-  readonly latestEventId: string | null;
-}
-
 type GetDb = ReturnType<typeof createGetDb>;
 
 function createGetDb(userId: string, orgId: string) {
@@ -94,26 +89,6 @@ function createReadStore(getDb: GetDb) {
         signal,
       );
     },
-
-    async readLatestEventId(signal?: AbortSignal) {
-      return await chatIdbReadOr(
-        "threadEvents:readLatestEventId",
-        async () => {
-          const db = await getDb();
-          signal?.throwIfAborted();
-          const raw = (await db
-            .transaction(CHAT_THREAD_EVENT_SYNC_STORE, "readonly")
-            .store.get(SINGLETON_ID)) as
-            | Partial<StoredChatThreadEventSync>
-            | undefined;
-          return typeof raw?.latestEventId === "string"
-            ? raw.latestEventId
-            : null;
-        },
-        null,
-        signal,
-      );
-    },
   };
 }
 
@@ -129,11 +104,7 @@ function createWriteStore(getDb: GetDb) {
           const db = await getDb();
           signal?.throwIfAborted();
           const tx = db.transaction(
-            [
-              CHAT_THREAD_SNAPSHOT_STORE,
-              CHAT_THREAD_EVENTS_STORE,
-              CHAT_THREAD_EVENT_SYNC_STORE,
-            ],
+            [CHAT_THREAD_SNAPSHOT_STORE, CHAT_THREAD_EVENTS_STORE],
             "readwrite",
           );
           await tx.objectStore(CHAT_THREAD_EVENTS_STORE).clear();
@@ -142,10 +113,6 @@ function createWriteStore(getDb: GetDb) {
             chatThreads: [...snapshot.chatThreads],
             latestEventId: snapshot.latestEventId,
           } satisfies StoredChatThreadSnapshot);
-          await tx.objectStore(CHAT_THREAD_EVENT_SYNC_STORE).put({
-            id: SINGLETON_ID,
-            latestEventId: snapshot.latestEventId,
-          } satisfies StoredChatThreadEventSync);
           await tx.done;
         },
         signal,
@@ -164,19 +131,12 @@ function createWriteStore(getDb: GetDb) {
         async () => {
           const db = await getDb();
           signal?.throwIfAborted();
-          const tx = db.transaction(
-            [CHAT_THREAD_EVENTS_STORE, CHAT_THREAD_EVENT_SYNC_STORE],
-            "readwrite",
-          );
-          const eventStore = tx.objectStore(CHAT_THREAD_EVENTS_STORE);
+          const tx = db.transaction(CHAT_THREAD_EVENTS_STORE, "readwrite");
+          const eventStore = tx.store;
           for (const event of events) {
             signal?.throwIfAborted();
             await eventStore.put(event);
           }
-          await tx.objectStore(CHAT_THREAD_EVENT_SYNC_STORE).put({
-            id: SINGLETON_ID,
-            latestEventId: events[events.length - 1]!.id,
-          } satisfies StoredChatThreadEventSync);
           await tx.done;
         },
         signal,

--- a/turbo/apps/platform/src/signals/external/org-members.ts
+++ b/turbo/apps/platform/src/signals/external/org-members.ts
@@ -5,7 +5,6 @@ import type {
   OrgPendingInvitation,
   OrgMembershipRequest,
 } from "@vm0/api-contracts/contracts/org-members";
-import { org$ } from "../org";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept.ts";
 
@@ -15,11 +14,6 @@ const orgMembersVersion$ = state(0);
 
 const orgMembersResponse$ = computed(async (get) => {
   get(orgMembersVersion$);
-  const org = await get(org$);
-  if (!org) {
-    return null;
-  }
-
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgMembersContract);
   const result = await accept(client.members(), [200]);
@@ -28,17 +22,17 @@ const orgMembersResponse$ = computed(async (get) => {
 
 export const orgMembers$ = computed(async (get) => {
   const response = await get(orgMembersResponse$);
-  return response?.members ?? [];
+  return response.members ?? [];
 });
 
 export const orgPendingInvitations$ = computed(async (get) => {
   const response = await get(orgMembersResponse$);
-  return response?.pendingInvitations ?? [];
+  return response.pendingInvitations ?? [];
 });
 
 export const orgMembershipRequests$ = computed(async (get) => {
   const response = await get(orgMembersResponse$);
-  return response?.membershipRequests ?? [];
+  return response.membershipRequests ?? [];
 });
 
 export const refreshOrgMembers$ = command(({ get, set }) => {

--- a/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
+++ b/turbo/apps/platform/src/signals/firewall-permission-metadata.ts
@@ -54,7 +54,6 @@ function createFirewallPermissionMetadataFactory(): (
           params: { connectorRef: key },
         }),
         [200, 404],
-        { toast: false },
       );
       if (result.status === 404) {
         return null;

--- a/turbo/apps/platform/src/signals/lab-page/lab-page-setup.ts
+++ b/turbo/apps/platform/src/signals/lab-page/lab-page-setup.ts
@@ -4,7 +4,6 @@ import { LabPage } from "../../views/lab-page/lab-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
 export const setupLabPage$ = command(async ({ set }, signal: AbortSignal) => {
@@ -15,6 +14,4 @@ export const setupLabPage$ = command(async ({ set }, signal: AbortSignal) => {
   if (await set(onboardGuard$, signal)) {
     return;
   }
-
-  set(reloadChatThreads$);
 });

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
@@ -4,7 +4,6 @@ import { NetworkInsightsPage } from "../../views/network-insights/network-insigh
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../agent-chat.ts";
 import {
   reloadInsights$,
   syncUsageRangeFromInsights$,
@@ -22,7 +21,6 @@ export const setupNetworkInsightsPage$ = command(
       return;
     }
 
-    set(reloadChatThreads$);
     set(reloadInsights$);
   },
 );

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -1,6 +1,5 @@
 import { command, computed, state } from "ccstate";
 import { zeroOrgContract } from "@vm0/api-contracts/contracts/zero-org";
-import { user$ } from "./auth.ts";
 import { zeroClient$ } from "./api-client.ts";
 import { accept } from "../lib/accept.ts";
 
@@ -8,15 +7,10 @@ const reloadOrg$ = state(0);
 
 /**
  * Current user's default org.
- * Returns undefined if user has no org or is not authenticated.
+ * Returns undefined when the API reports that the user has no org.
  */
 export const org$ = computed(async (get) => {
   get(reloadOrg$);
-  const user = await get(user$);
-  if (!user) {
-    return undefined;
-  }
-
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgContract);
   // 404 is a valid response: a newly-signed-up user has no org yet.

--- a/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
+++ b/turbo/apps/platform/src/signals/permission-allow/permission-allow-page-setup.ts
@@ -5,7 +5,6 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { currentAgentId$, rememberLastUsedAgentId$ } from "../agent.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
 export const setupPermissionAllowPage$ = command(
@@ -23,7 +22,5 @@ export const setupPermissionAllowPage$ = command(
     if (await set(onboardGuard$, signal)) {
       return;
     }
-
-    set(reloadChatThreads$);
   },
 );

--- a/turbo/apps/platform/src/signals/preferences-page/preferences-page-setup.ts
+++ b/turbo/apps/platform/src/signals/preferences-page/preferences-page-setup.ts
@@ -4,7 +4,6 @@ import { ZeroPreferencesPage } from "../../views/zero-page/zero-account-page.tsx
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
 export const setupPreferencesPage$ = command(
@@ -16,7 +15,5 @@ export const setupPreferencesPage$ = command(
     if (await set(onboardGuard$, signal)) {
       return;
     }
-
-    set(reloadChatThreads$);
   },
 );

--- a/turbo/apps/platform/src/signals/realtime.ts
+++ b/turbo/apps/platform/src/signals/realtime.ts
@@ -4,7 +4,6 @@ import { Realtime, type RealtimeChannel, type InboundMessage } from "ably";
 import { delay } from "signal-timers";
 import { IN_VITEST } from "../env.ts";
 import { zeroClient$ } from "./api-client.ts";
-import { clerk$ } from "./auth.ts";
 import { createAblyAuthCallback } from "../lib/ably-auth.ts";
 import { createDeferredPromise, setLoop, throwIfAbort } from "./utils.ts";
 import { logger } from "./log.ts";
@@ -369,13 +368,6 @@ const runWithChannelPayload$ = command(
  */
 export const setupRealtime$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
-
-    if (!clerk.user) {
-      return;
-    }
-
     const createClient = get(zeroClient$);
     const client = createClient(platformRealtimeTokenContract);
 

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-page-setup.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-page-setup.ts
@@ -6,7 +6,6 @@ import { hideAppSkeleton$ } from "../app-skeleton.ts";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import { reloadWorkflows$ } from "./workflows-signals.ts";
 
 export const setupWorkflowsPage$ = command(
@@ -19,7 +18,5 @@ export const setupWorkflowsPage$ = command(
     if (await set(onboardGuard$, signal)) {
       return;
     }
-
-    set(reloadChatThreads$);
   },
 );

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -5,7 +5,6 @@ import { ZeroWorksPage } from "../../views/zero-page/zero-works-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { reloadChatThreads$ } from "../chat-page/chat-message.ts";
 import {
   initSlackOrg$,
   watchSlackConnection$,
@@ -55,6 +54,5 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   await Promise.all([
     set(hideAppSkeleton$, signal),
     set(onboardGuard$, signal),
-    set(reloadChatThreads$),
   ]);
 });

--- a/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agent-connector-authorizations.ts
@@ -50,9 +50,7 @@ function createAuthorizationsAtom(
     const request = client.get({ params: { id: agentId } });
     const result =
       options.missing === "null"
-        ? await accept(request, [200, 404], {
-            toast: false,
-          })
+        ? await accept(request, [200, 404])
         : await accept(request, [200]);
     if (result.status === 404) {
       return null;

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -15,7 +15,6 @@ import {
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { zeroClient$ } from "../api-client.ts";
 import { reloadUsageRecords$ } from "./settings/personal-usage-record.ts";
-import { clerk$ } from "../auth.ts";
 import { setAblyLoop$ } from "../realtime.ts";
 import { accept } from "../../lib/accept.ts";
 import {
@@ -285,13 +284,7 @@ const reloadBillingStatusFromRealtime$ = command(({ set }) => {
 });
 
 export const setupBillingRealtime$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
-    if (!clerk.user) {
-      return;
-    }
-
+  async ({ set }, signal: AbortSignal) => {
     await set(
       setAblyLoop$,
       {

--- a/turbo/apps/platform/src/signals/zero-page/github-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/github-connect-signals.ts
@@ -1,7 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { integrationsGithubContract } from "@vm0/api-contracts/contracts/integrations-github";
 import { accept } from "../../lib/accept.ts";
-import { clerk$ } from "../auth.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { searchParams$ } from "../route.ts";
 import { parseGithubConnectParams } from "./github-connect-params.ts";
@@ -20,11 +19,6 @@ export const githubConnectLinkStatus$ = computed(
     get(internalGithubConnectLinkStatusReload$);
     const parsed = parseGithubConnectParams(get(searchParams$));
     if (!parsed.ok) {
-      return null;
-    }
-
-    const clerk = await get(clerk$);
-    if (!clerk.user) {
       return null;
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -129,7 +129,6 @@ function createQueuePosition(runId: string) {
       const result = await accept(
         client.getPosition({ query: { runId } }),
         [200],
-        { toast: false },
       );
       return result.body.position;
     }),

--- a/turbo/apps/platform/src/signals/zero-page/settings/build-info.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/build-info.ts
@@ -13,7 +13,7 @@ export const backendBuildInfo$ = computed(
   async (get): Promise<BackendBuildInfo> => {
     const createClient = get(zeroClient$);
     const client = createClient(buildInfoContract);
-    const result = await accept(client.get(), [200], { toast: false });
+    const result = await accept(client.get(), [200]);
 
     return {
       backendCommitSha: result.body.commitSha,

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -370,7 +370,7 @@ export const saveOrgProfile$ = command(
     const org = await get(org$);
     signal.throwIfAborted();
     if (!org) {
-      return;
+      throw new Error("Organization is required to update its profile");
     }
 
     const hasNameChange = input.name !== (org.name ?? "");

--- a/turbo/apps/platform/src/signals/zero-page/telegram-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/telegram-connect-signals.ts
@@ -5,7 +5,6 @@ import {
 } from "@vm0/api-contracts/contracts/zero-integrations-telegram";
 import { accept } from "../../lib/accept.ts";
 import { capturePlausibleEvent } from "../../lib/plausible.ts";
-import { clerk$ } from "../auth.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { webBaseForNavigation$ } from "../fetch.ts";
 import { searchParams$ } from "../route.ts";
@@ -24,11 +23,6 @@ export const telegramConnectLinkStatus$ = computed(
     get(internalTelegramConnectLinkStatusReload$);
     const parsed = parseTelegramConnectParams(get(searchParams$));
     if (!parsed.ok) {
-      return null;
-    }
-
-    const clerk = await get(clerk$);
-    if (!clerk.user) {
       return null;
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-artifact-sidebar.ts
@@ -564,7 +564,6 @@ export const loadHtmlEditSnapshotRestoreDraft$ = command(
           fetchOptions: { signal: loadSignal },
         }),
         [200],
-        { toast: false },
       ),
       markDetachedErrorHandled,
     );
@@ -663,7 +662,6 @@ export const deleteHtmlEditSnapshotDraft$ = command(
         fetchOptions: { signal },
       }),
       [204],
-      { toast: false },
     );
     signal.throwIfAborted();
 

--- a/turbo/apps/platform/src/views/main.tsx
+++ b/turbo/apps/platform/src/views/main.tsx
@@ -7,14 +7,8 @@ import { AppSkeletonOverlay, Router } from "./router.tsx";
 import { VM0ClerkProvider } from "./clerk/clerk-provider.tsx";
 import { ForceUpgradeDialog } from "./components/force-upgrade-dialog.tsx";
 import { InspectLogFileInput } from "./inspect-log-file-input.tsx";
-import {
-  subscribeChatThreadReadCursorUpdated$,
-  subscribeThreadListChanged$,
-} from "../signals/chat-thread-list-reload.ts";
 import { pollForceUpgradeDialog$ } from "../signals/force-upgrade.ts";
-import { subscribeBackgroundChatThreadFollowupsFinished$ } from "../signals/chat-page/background-chat-thread-cache.ts";
-import { subscribeEventDrivenChatThreads$ } from "../signals/chat-page/chat-thread-event-sourcing.ts";
-import { setupBillingRealtime$ } from "../signals/zero-page/billing.ts";
+import { setupAuthenticatedDaemons$ } from "../signals/authenticated-daemons.ts";
 import { rootSignal$ } from "../signals/root-signal.ts";
 import { detach, Reason } from "../signals/utils.ts";
 import { IN_VITEST } from "../env.ts";
@@ -25,22 +19,12 @@ export const setupRouter = (
   render: (children: React.ReactNode) => void,
 ) => {
   const signal = store.get(rootSignal$);
-  detach(store.set(subscribeThreadListChanged$, signal), Reason.Daemon);
+  detach(store.set(setupAuthenticatedDaemons$, signal), Reason.Daemon);
   detach(
     store.set(pollForceUpgradeDialog$, signal),
     Reason.Daemon,
     "force-upgrade",
   );
-  detach(
-    store.set(subscribeChatThreadReadCursorUpdated$, signal),
-    Reason.Daemon,
-  );
-  detach(
-    store.set(subscribeBackgroundChatThreadFollowupsFinished$, signal),
-    Reason.Daemon,
-  );
-  detach(store.set(subscribeEventDrivenChatThreads$, signal), Reason.Daemon);
-  detach(store.set(setupBillingRealtime$, signal), Reason.Daemon);
   render(
     <StrictMode>
       <StoreProvider value={store}>

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -9,6 +9,7 @@ import {
   chatThreadMessagesContract,
   chatThreadRenameContract,
   chatThreadsContract,
+  type ChatThreadEvent,
   type PagedChatMessage,
 } from "@vm0/api-contracts/contracts/chat-threads";
 import {
@@ -41,6 +42,7 @@ import {
   createMockWorkflowTrigger,
   setMockWorkflowTriggers,
 } from "../../../mocks/handlers/workflow-triggers-store.ts";
+import { triggerAblyEvent } from "../../../mocks/ably.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { eventDrivenChatThread } from "../../../signals/chat-page/chat-thread-event-sourcing.ts";
 import { CHAT_THREAD_VIRTUAL_ROW_HEIGHT } from "../../../signals/zero-page/zero-sidebar-state.ts";
@@ -3656,6 +3658,7 @@ describe("chat lifecycle", () => {
     });
     lifecycle.setThreadList([thread]);
     const renameRequest = vi.fn();
+    let persistedRenameEvent: ChatThreadEvent | null = null;
 
     context.mocks.api(chatThreadByIdContract.get, ({ never }) => {
       return never();
@@ -3679,12 +3682,27 @@ describe("chat lifecycle", () => {
       });
     });
     context.mocks.api(chatThreadsContract.events, ({ respond }) => {
-      return respond(200, { events: [], hasMore: false });
+      return respond(200, {
+        events: persistedRenameEvent ? [persistedRenameEvent] : [],
+        hasMore: false,
+      });
     });
     context.mocks.api(
       chatThreadRenameContract.rename,
       ({ body, params, respond }) => {
         renameRequest(params.id, body.title);
+        if (!body.eventId) {
+          throw new Error("Expected rename event id");
+        }
+        persistedRenameEvent = {
+          id: body.eventId,
+          kind: "renamed",
+          chatThreadId: EVENT_SOURCED_RENAME_THREAD_ID,
+          agentId: AGENT_ID,
+          title: body.title,
+          selectedModel: null,
+          createdAt: "2026-06-01T00:00:01.000Z",
+        };
         return respond(204);
       },
     );
@@ -3697,6 +3715,7 @@ describe("chat lifecycle", () => {
     const threadRegion = await screen.findByLabelText("Chat thread");
     await waitFor(() => {
       expect(within(threadRegion).getByText(originalTitle)).toBeInTheDocument();
+      expect(document.title).toBe(`${originalTitle} | VM0`);
     });
     expect(
       within(threadRegion).queryByText("Thread detail should stay pending"),
@@ -3718,6 +3737,12 @@ describe("chat lifecycle", () => {
         renamedTitle,
       );
       expect(within(threadRegion).getByText(renamedTitle)).toBeInTheDocument();
+    });
+
+    expect(document.title).toBe(`${originalTitle} | VM0`);
+    triggerAblyEvent("threadListChanged");
+    await waitFor(() => {
+      expect(document.title).toBe(`${renamedTitle} | VM0`);
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/workflow-queue-panel.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor } from "@testing-library/react";
-import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import {
   zeroWorkflowQueueContract,
   type WorkflowQueueResponse,
@@ -16,7 +15,6 @@ import {
   createMockWorkflowTrigger,
   setMockWorkflowTriggers,
 } from "../../../mocks/handlers/workflow-triggers-store.ts";
-import { setFeatureSwitch$ } from "../../../signals/external/feature-switch.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
@@ -68,21 +66,9 @@ function buttonByLabel(label: string): HTMLElement {
   return button;
 }
 
-async function enableWorkflowQueueSwitch(): Promise<void> {
-  context.mocks.api(zeroFeatureSwitchesContract.get, ({ respond }) => {
-    return respond(200, {
-      switches: { [FeatureSwitchKey.WorkflowQueue]: true },
-      effectiveSwitches: { [FeatureSwitchKey.WorkflowQueue]: true },
-    });
-  });
-  await context.store.set(
-    setFeatureSwitch$,
-    { [FeatureSwitchKey.WorkflowQueue]: true },
-    context.signal,
-  );
-}
-
-async function openAutomationsPanel(): Promise<void> {
+async function openAutomationsPanel(
+  workflowQueueEnabled = true,
+): Promise<void> {
   mockChatLifecycle(context, {
     threadId: THREAD_ID,
     threadTitle: "Workflow queue thread",
@@ -102,7 +88,13 @@ async function openAutomationsPanel(): Promise<void> {
     }),
   ]);
 
-  detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+  detachedSetupPage({
+    context,
+    path: `/chats/${THREAD_ID}`,
+    featureSwitches: {
+      [FeatureSwitchKey.WorkflowQueue]: workflowQueueEnabled,
+    },
+  });
 
   await waitFor(() => {
     expect(buttonByLabel("Automations")).toBeInTheDocument();
@@ -115,7 +107,6 @@ async function openAutomationsPanel(): Promise<void> {
 
 describe("workflow queue panel", () => {
   it("shows the pending badge, running event, and FIFO pending list", async () => {
-    await enableWorkflowQueueSwitch();
     context.mocks.api(zeroWorkflowQueueContract.get, ({ respond }) => {
       return respond(200, queueResponse());
     });
@@ -135,7 +126,6 @@ describe("workflow queue panel", () => {
   });
 
   it("skips a single pending event", async () => {
-    await enableWorkflowQueueSwitch();
     let skippedEventId: string | null = null;
     let pending = queueResponse().pending;
     context.mocks.api(zeroWorkflowQueueContract.get, ({ respond }) => {
@@ -173,7 +163,6 @@ describe("workflow queue panel", () => {
   });
 
   it("pauses the queue and shows the paused banner", async () => {
-    await enableWorkflowQueueSwitch();
     let paused = false;
     context.mocks.api(zeroWorkflowQueueContract.get, ({ respond }) => {
       return respond(
@@ -208,7 +197,7 @@ describe("workflow queue panel", () => {
       return respond(200, queueResponse());
     });
 
-    await openAutomationsPanel();
+    await openAutomationsPanel(false);
 
     await waitFor(() => {
       expect(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -103,9 +103,6 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
   const readSnapshot = vi.fn(() => {
     return Promise.resolve(snapshot);
   });
-  const readLatestEventId = vi.fn(() => {
-    return Promise.resolve(snapshot?.latestEventId ?? null);
-  });
   const readEvents = vi.fn(() => {
     return Promise.resolve(events);
   });
@@ -134,7 +131,6 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
 
   return {
     readSnapshot,
-    readLatestEventId,
     readEvents,
     replaceFromSnapshot,
     upsertEvents,
@@ -152,7 +148,6 @@ const idbThreadEventStoreMock = vi.hoisted(() => {
       snapshot = null;
       events = [];
       readSnapshot.mockClear();
-      readLatestEventId.mockClear();
       readEvents.mockClear();
       replaceFromSnapshot.mockClear();
       upsertEvents.mockClear();
@@ -183,7 +178,6 @@ vi.mock("../../../signals/external/idb-chat-thread-event-store.ts", () => {
       return {
         readStore: {
           readSnapshot: idbThreadEventStoreMock.readSnapshot,
-          readLatestEventId: idbThreadEventStoreMock.readLatestEventId,
           readEvents: idbThreadEventStoreMock.readEvents,
         },
         writeStore: {


### PR DESCRIPTION
## Summary

- keep chat thread snapshots and events in memory after the initial IndexedDB hydration, and only publish state when incremental sync returns data
- derive active and unread thread state from computed signals without page-level reload counters
- centralize authenticated background startup and remove leaf-level unauthenticated fallbacks
- restore default API error toasts where failures were previously silent, while retaining suppression for explicitly handled UI, protocol, and best-effort flows

## Validation

- `pnpm -F @vm0/app lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types` (pre-commit hook, all workspaces)
- `pnpm knip`
- scoped platform Vitest: 11 files, 70 tests passed
- browser profiling of chat send and thread switching