### PR TITLE
fix: remove centered play icon from video artifact posters

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -727,7 +727,7 @@ describe("artifacts page", () => {
     });
   });
 
-  it("renders video poster images with a play affordance while preserving the video fallback", async () => {
+  it("renders video poster images without a play affordance while preserving the video fallback", async () => {
     setupTeam();
     const scope = testAuthScope("video-preview-image");
     const posterUrl = "https://cdn.vm7.io/artifacts/user/video-row/poster.jpg";
@@ -766,7 +766,7 @@ describe("artifacts page", () => {
     expect(posterImages).toHaveLength(1);
     expect(
       document.querySelector(".tabler-icon-player-play-filled"),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     expect(
       Array.from(document.querySelectorAll("video")).some((video) => {
         return (

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -11,7 +11,6 @@ import {
   IconMessagePlus,
   IconPackage,
   IconPhoto,
-  IconPlayerPlayFilled,
   IconPresentationAnalytics,
   IconSearch,
   IconVideo,
@@ -440,8 +439,7 @@ function ArtifactPreview({ item }: { readonly item: ArtifactItem }) {
   // A pre-rendered static snapshot (page screenshot for HTML/website, poster
   // frame for video) replaces the live iframe/video entirely, so the grid loads
   // a single image. Absent for old / not-yet-rendered / render-failed artifacts,
-  // which fall through to the live preview below. Video posters get a play
-  // affordance so the still reads as a video.
+  // which fall through to the live preview below.
   if (item.previewImageUrl) {
     return (
       <ArtifactPreviewSurface iconKind={iconKind}>
@@ -451,11 +449,6 @@ function ArtifactPreview({ item }: { readonly item: ArtifactItem }) {
           loading="lazy"
           className="h-full w-full object-cover"
         />
-        {previewKind === "video" && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <IconPlayerPlayFilled className="h-10 w-10 text-white/90 drop-shadow-md" />
-          </div>
-        )}
       </ArtifactPreviewSurface>
     );
   }


### PR DESCRIPTION
## Summary

- Remove the centered filled play icon from video poster cards on the Artifacts page
- Keep the video type badge, poster image, and video fallback behavior unchanged
- Update the existing video poster test to prevent the overlay from returning

## Verification

- Prettier check on both changed files
- ESLint on both changed files
- Targeted artifacts page Vitest: 1 passed