### PR TITLE
fix: inject browser rendering token into production api

### DIFF
--- a/.github/actions/web-api-env/action.yml
+++ b/.github/actions/web-api-env/action.yml
@@ -193,6 +193,9 @@ runs:
         if [[ "$INPUT_APP" == "api" ]]; then
           add_env VM0_WEB_URL "$web_url"
           add_env ENV "$deploy_env"
+          if [[ "$INPUT_ENVIRONMENT" == "production" ]]; then
+            add_secret CLOUDFLARE_BROWSER_RENDERING_API_TOKEN CLOUDFLARE_BROWSER_RENDERING_API_TOKEN
+          fi
           if [[ "$INPUT_ENVIRONMENT" == "preview" && -n "$INPUT_JOB_REF" ]]; then
             add_env VM0_PREVIEW_JOB_REF "$INPUT_JOB_REF"
           fi

--- a/.github/scripts/tests/web-api-env-action-test.sh
+++ b/.github/scripts/tests/web-api-env-action-test.sh
@@ -133,7 +133,7 @@ run_action() {
     INPUT_API_URL="https://pr-123-api.vm0.test" \
     INPUT_API_BACKEND_URL="https://pr-123-api-backend.vm0.test" \
     REPO_VARS_JSON='{"GH_OAUTH_CLIENT_ID":"github-gh-client-id","SLACK_OAUTH_CLIENT_ID":"github-slack-client-id","VM0_API_URL":"https://api.github.test","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-var","FINICITY_PARTNER_ID":"github-finicity-partner-id","POSTHOG_KEY":"github-posthog-key","POSTHOG_HOST":"https://posthog.github.test","ATOM_URL":"https://atom.github.test","STRIPE_OAUTH_CLIENT_ID":"ca_test_connect_client","MICROSOFT_TEAMS_BOT_APP_ID":"github-teams-bot-app-id","MICROSOFT_TEAMS_APP_TENANT_ID":"github-teams-app-tenant-id","ZERO_PRICE_PRO":"price_test_pro","ZERO_PRICE_TEAM":"price_test_team","ATOM_GRANT_PRICE":"price_test_atom_grant","ZERO_PRICE_CUSTOM_CREDITS":"price_test_custom_credits","ZERO_PRICE_CONCURRENCY":"price_test_concurrency","GMAIL_PUBSUB_TOPIC_NAME":"projects/github/topics/gmail","GMAIL_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/gmail","GMAIL_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"gmail-push@github.test","GOOGLE_WORKSPACE_EVENTS_PUBSUB_TOPIC_NAME":"projects/github/topics/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_AUDIENCE":"https://api.github.test/api/webhooks/google-workspace-events","GOOGLE_WORKSPACE_EVENTS_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL":"workspace-events-push@github.test"}' \
-    REPO_SECRETS_JSON='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret"}' \
+    REPO_SECRETS_JSON='{"GH_OAUTH_CLIENT_SECRET":"github-gh-client-secret","SLACK_OAUTH_CLIENT_SECRET":"github-slack-client-secret","GOOGLE_ADS_DEVELOPER_TOKEN":"github-google-ads-secret","STEAM_WEB_API_KEY":"github-steam-web-api-key","FINICITY_APP_KEY":"github-finicity-app-key","FINICITY_APP_SECRET":"github-finicity-app-secret","UNSPLASH_ACCESS_KEY":"github-unsplash-access-key","VM0_MACHINE_SECRET_KEY":"github-atom-machine-secret","MICROSOFT_TEAMS_BOT_APP_PASSWORD":"github-teams-bot-app-password","VERCEL_AUTOMATION_BYPASS_SECRET":"github-vercel-bypass-secret","CLOUDFLARE_BROWSER_RENDERING_API_TOKEN":"github-cloudflare-browser-rendering-token"}' \
     DOPPLER_SECRETS_JSON="$doppler_secrets_json" \
     bash "$action_script"
 }
@@ -188,6 +188,7 @@ assert_env_absent_value "$success_env_file" "github-gh-client-secret"
 assert_env_absent_value "$success_env_file" "github-slack-client-id"
 assert_env_absent_value "$success_env_file" "github-slack-client-secret"
 assert_env_absent_value "$success_env_file" "github-posthog-key"
+assert_env_absent_value "$success_env_file" "github-cloudflare-browser-rendering-token"
 
 production_web_dir="$(mktemp -d)"
 TEMP_DIRS+=("$production_web_dir")
@@ -199,6 +200,7 @@ assert_env_value "$production_web_env_file" POSTHOG_HOST "https://posthog.github
 assert_env_value "$production_web_env_file" GIT_COMMIT_SHA "$EXPECTED_BUILD_COMMIT_SHA"
 assert_env_absent_value "$production_web_env_file" "ATOM_URL="
 assert_env_absent_value "$production_web_env_file" "VM0_MACHINE_SECRET_KEY="
+assert_env_absent_value "$production_web_env_file" "github-cloudflare-browser-rendering-token"
 
 production_api_dir="$(mktemp -d)"
 TEMP_DIRS+=("$production_api_dir")
@@ -212,6 +214,7 @@ assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_ID "github-t
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_BOT_APP_PASSWORD "github-teams-bot-app-password"
 assert_env_value "$production_api_env_file" MICROSOFT_TEAMS_APP_TENANT_ID "github-teams-app-tenant-id"
 assert_env_value "$production_api_env_file" ONBOARDING_URL "https://www.vm0.ai"
+assert_env_value "$production_api_env_file" CLOUDFLARE_BROWSER_RENDERING_API_TOKEN "github-cloudflare-browser-rendering-token"
 
 missing_dir="$(mktemp -d)"
 TEMP_DIRS+=("$missing_dir")


### PR DESCRIPTION
## Summary

- inject the production `CLOUDFLARE_BROWSER_RENDERING_API_TOKEN` environment secret into the API deployment so HTML artifact previews can call Cloudflare Browser Rendering
- keep the token out of preview API and web deployment environment files
- cover production API injection and preview/web isolation in the environment action regression test

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=3072 pnpm check-types`
- `bash .github/scripts/tests/web-api-env-action-test.sh`
