### PR TITLE
test(mitm-addon): align usage executor boundaries

### DIFF
--- a/crates/runner/mitm-addon/tests/test_error_handler.py
+++ b/crates/runner/mitm-addon/tests/test_error_handler.py
@@ -594,7 +594,7 @@ class TestErrorHandler:
         assert "#frag" not in entry["message"]
 
     def test_full_path_error_to_webhook(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, usage_webhook_api
     ):
         """Integration: error() -> _maybe_report -> _enqueue -> _retry -> webhook.
 
@@ -619,7 +619,6 @@ class TestErrorHandler:
         with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 2
         requests_by_path = {request.path: request for request in webhook.requests}

--- a/crates/runner/mitm-addon/tests/test_model_provider_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_usage.py
@@ -18,9 +18,11 @@ from tests.jsonl_log_helpers import (
 class TestReportModelProviderUsage:
     """Tests for report_model_provider_usage helper."""
 
-    def test_reports_usage_for_model_provider(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    @pytest.fixture(autouse=True)
+    def _sync_executor(self, sync_usage_executor):
+        """Run delivery inline for reporting behavior tests."""
+
+    def test_reports_usage_for_model_provider(self, real_flow, usage_webhook_api):
         """Model-provider usage reaches the webhook boundary with correct payload."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -40,7 +42,6 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage(flow, "run-abc-123")
             assert webhook.request_count == 0
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 1
         assert webhook.requests[0].path == "/api/webhooks/agent/usage-event"
@@ -80,9 +81,7 @@ class TestReportModelProviderUsage:
         for event in body["events"]:
             uuid.UUID(event["idempotencyKey"])
 
-    def test_falls_back_to_response_model_then_unknown(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_falls_back_to_response_model_then_unknown(self, real_flow, usage_webhook_api):
         """Provider falls back only when selected vm0 model metadata is absent."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -96,7 +95,6 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[0].json_body()
         assert body["events"][0]["provider"] == "unknown"
@@ -113,14 +111,11 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[-1].json_body()
         assert body["events"][0]["provider"] == "claude-sonnet-4-6"
 
-    def test_skips_when_no_positive_token_quantities(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_skips_when_no_positive_token_quantities(self, real_flow, usage_webhook_api):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
@@ -136,13 +131,10 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
 
-    def test_skips_when_firewall_not_billable(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_skips_when_firewall_not_billable(self, real_flow, usage_webhook_api):
         """Should NOT report usage when firewall_billable is False.
 
         Simulates a user supplying their own Anthropic key — the web layer
@@ -158,13 +150,10 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
 
-    def test_reports_non_billable_observable_model_provider(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_reports_non_billable_observable_model_provider(self, real_flow, usage_webhook_api):
         """BYOK model providers report observations without billing events."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -180,7 +169,6 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage_observation(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 1
         assert webhook.requests[0].path == "/api/webhooks/agent/model-usage-observation"
@@ -195,7 +183,7 @@ class TestReportModelProviderUsage:
         assert body["events"][0]["quantity"] == 100
 
     def test_billable_model_provider_reports_billing_and_observation(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0"
@@ -211,7 +199,6 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.report_model_provider_usage_observation(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
@@ -230,7 +217,7 @@ class TestReportModelProviderUsage:
         )
 
     def test_billable_model_provider_without_model_usage_provider_skips_observation(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:vm0"
@@ -245,7 +232,6 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             observed = usage.report_model_provider_usage_observation(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert observed is False
         assert webhook.request_count == 0
@@ -275,7 +261,7 @@ class TestReportModelProviderUsage:
         )
         assert entry["type"] == "model_usage_observation"
 
-    def test_skips_non_model_provider(self, real_flow, fresh_usage_executor, usage_webhook_api):
+    def test_skips_non_model_provider(self, real_flow, usage_webhook_api):
         """Should NOT reach the webhook boundary for non-model-provider requests."""
         flow = real_flow(with_response=False, host="api.github.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "github"
@@ -284,14 +270,11 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
 
     @pytest.mark.parametrize("firewall_name", [None, 42])
-    def test_skips_malformed_firewall_name(
-        self, real_flow, fresh_usage_executor, usage_webhook_api, firewall_name
-    ):
+    def test_skips_malformed_firewall_name(self, real_flow, usage_webhook_api, firewall_name):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
@@ -301,14 +284,11 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             accepted = usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert accepted is False
         assert webhook.request_count == 0
 
-    def test_skips_when_no_model_provider_usage(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_skips_when_no_model_provider_usage(self, real_flow, usage_webhook_api):
         """Should NOT reach the webhook boundary when model_provider_usage is absent."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -318,11 +298,10 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
 
-    def test_skips_when_no_run_id(self, real_flow, fresh_usage_executor, usage_webhook_api):
+    def test_skips_when_no_run_id(self, real_flow, usage_webhook_api):
         """Should NOT reach the webhook boundary when run_id is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -331,7 +310,6 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
 
@@ -361,9 +339,7 @@ class TestReportModelProviderUsage:
         assert entry["missing_sandbox_token"] is True
         assert entry["missing_api_url"] is False
 
-    def test_logs_underbilling_when_missing_api_url(
-        self, tmp_path, real_flow, fresh_usage_executor, mitm_ctx
-    ):
+    def test_logs_underbilling_when_missing_api_url(self, tmp_path, real_flow, mitm_ctx):
         """Should emit an alertable underbilling signal when api_url is empty."""
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -376,7 +352,6 @@ class TestReportModelProviderUsage:
         with mitm_ctx(api_url=""):
             usage.report_model_provider_usage(flow, "run-abc-123")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert jsonl_exists_after_flush(proxy_log)
         [entry] = read_jsonl_entries_after_flush(proxy_log)
@@ -391,9 +366,7 @@ class TestReportModelProviderUsage:
         assert entry["missing_sandbox_token"] is False
         assert entry["missing_api_url"] is True
 
-    def test_source_dedupe_uses_flow_id_when_message_id_missing(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_source_dedupe_uses_flow_id_when_message_id_missing(self, real_flow, usage_webhook_api):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-uuid-xyz-123"
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -408,14 +381,11 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage(flow, "run-fallback")
             usage.report_model_provider_usage(flow, "run-fallback")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10
 
-    def test_source_dedupe_uses_flow_id_when_message_id_present(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
-    ):
+    def test_source_dedupe_uses_flow_id_when_message_id_present(self, real_flow, usage_webhook_api):
         flow = real_flow(with_response=False, host="api.anthropic.com")
         flow.id = "flow-uuid-xyz-123"
         flow.metadata[metadata_keys.FIREWALL_NAME] = "model-provider:anthropic-api-key"
@@ -431,13 +401,12 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage(flow, "run-fallback")
             usage.report_model_provider_usage(flow, "run-fallback")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 10
 
     def test_source_dedupe_aggregates_model_provider_usage_sources(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.id = "flow-uuid-xyz-123"
@@ -464,7 +433,6 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage_observation(flow, "run-websocket")
             usage.report_model_provider_usage_observation(flow, "run-websocket")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         requests_by_path = {request.path: request for request in webhook.requests}
         assert set(requests_by_path) == {
@@ -500,7 +468,7 @@ class TestReportModelProviderUsage:
         uuid.UUID(observation_body["events"][0]["idempotencyKey"])
 
     def test_source_dedupe_separates_billing_sources_by_response_model_without_context_model(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.id = "flow-uuid-xyz-123"
@@ -523,7 +491,6 @@ class TestReportModelProviderUsage:
         with usage_webhook_api() as webhook:
             usage.report_model_provider_usage(flow, "run-websocket")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 1
         assert webhook.requests[0].path == "/api/webhooks/agent/usage-event"
@@ -537,7 +504,7 @@ class TestReportModelProviderUsage:
         }
 
     def test_source_dedupe_skips_malformed_model_provider_usage_sources(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         flow = real_flow(with_response=False, host="api.openai.com")
         flow.id = "flow-uuid-xyz-123"
@@ -554,14 +521,13 @@ class TestReportModelProviderUsage:
             accepted = usage.report_model_provider_usage(flow, "run-websocket")
             observed = usage.report_model_provider_usage_observation(flow, "run-websocket")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert accepted is False
         assert observed is False
         assert webhook.request_count == 0
 
     def test_source_dedupe_separates_flows_when_message_id_missing(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         first = real_flow(with_response=False, host="api.anthropic.com")
         first.id = "flow-first"
@@ -580,13 +546,12 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage(first, "run-fallback")
             usage.report_model_provider_usage(second, "run-fallback")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 20
 
     def test_source_dedupe_separates_flows_when_message_id_matches(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         first = real_flow(with_response=False, host="api.anthropic.com")
         first.id = "flow-first"
@@ -606,13 +571,12 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage(first, "run-preserved")
             usage.report_model_provider_usage(second, "run-preserved")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 20
 
     def test_observation_source_dedupe_separates_flows_when_message_id_matches(
-        self, real_flow, fresh_usage_executor, usage_webhook_api
+        self, real_flow, usage_webhook_api
     ):
         first = real_flow(with_response=False, host="api.anthropic.com")
         first.id = "flow-first"
@@ -633,7 +597,6 @@ class TestReportModelProviderUsage:
             usage.report_model_provider_usage_observation(first, "run-preserved")
             usage.report_model_provider_usage_observation(second, "run-preserved")
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         body = webhook.requests[0].json_body()
         assert body["events"][0]["quantity"] == 20

--- a/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
+++ b/crates/runner/mitm-addon/tests/test_usage_reporting_idempotency.py
@@ -4,6 +4,7 @@ import time
 import uuid
 from pathlib import Path
 
+import pytest
 from mitmproxy.flow import Error
 from mitmproxy.test import tutils
 
@@ -22,8 +23,12 @@ from tests.stream_buffer_helpers import set_response_stream_buffer
 class TestUsageReportingIdempotency:
     """Tests for duplicate-reporting guards and stable usage sources."""
 
+    @pytest.fixture(autouse=True)
+    def _sync_executor(self, sync_usage_executor):
+        """Run delivery inline for idempotency behavior tests."""
+
     def test_response_then_error_does_not_enqueue_model_usage_twice(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, usage_webhook_api
     ):
         """If mitmproxy fires both hooks for one flow, model usage reports once."""
         flow = make_model_provider_flow(
@@ -52,7 +57,6 @@ class TestUsageReportingIdempotency:
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         events = webhook.usage_events()
         assert [event["category"] for event in events] == ["tokens.output"]
@@ -65,7 +69,7 @@ class TestUsageReportingIdempotency:
             )
 
     def test_empty_model_usage_does_not_block_later_error_usage(
-        self, tmp_path, real_flow, mitm_ctx, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, usage_webhook_api
     ):
         """A no-event response pass must not mark the flow reported."""
         flow = make_model_provider_flow(
@@ -90,13 +94,12 @@ class TestUsageReportingIdempotency:
             flow.error = Error("connection reset after response")
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         events = webhook.usage_events()
         assert [event["category"] for event in events] == ["tokens.output"]
 
     def test_reports_usage_without_provider_message_id(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
         """Missing message_id in model_provider_usage still reports usage.
 
@@ -128,7 +131,6 @@ class TestUsageReportingIdempotency:
         with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 2
         requests_by_path = {request.path: request for request in webhook.requests}
@@ -151,7 +153,7 @@ class TestUsageReportingIdempotency:
         assert observation_key != billing_key
 
     def test_reports_usage_with_provider_message_id(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
         """Provider message_id metadata must not block ordinary usage reporting."""
         log_path = str(tmp_path / "network.jsonl")
@@ -178,7 +180,6 @@ class TestUsageReportingIdempotency:
         with usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 2
         requests_by_path = {request.path: request for request in webhook.requests}

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -29,13 +29,12 @@ from tests.webhook_test_helpers import (
 )
 
 
-def _flush_model_usage(flow, *, run_id: str = "run-1") -> None:
+def _report_and_flush_model_usage(flow, *, run_id: str = "run-1") -> None:
     usage.report_model_provider_usage(flow, run_id)
     usage.flush_usage_events(trigger="test")
-    usage.webhook.usage_executor.shutdown(wait=True)
 
 
-def test_does_not_follow_redirects(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_does_not_follow_redirects(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
 
     with usage_webhook_api() as webhook:
@@ -43,7 +42,7 @@ def test_does_not_follow_redirects(tmp_path, real_flow, fresh_usage_executor, us
             302,
             headers=(("Location", webhook.url("/redirected")),),
         )
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert [request.path for request in webhook.requests] == ["/api/webhooks/agent/usage-event"]
     log_entries = read_jsonl_entries_after_flush(
@@ -85,7 +84,7 @@ def test_rejects_invalid_url_before_open(tmp_path, sync_usage_executor):
     )
 
 
-def test_closes_http_error_response(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_closes_http_error_response(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
 
     with (
@@ -95,13 +94,13 @@ def test_closes_http_error_response(tmp_path, real_flow, fresh_usage_executor, u
     ):
         webhook.queue_response(500)
         webhook.queue_response(500)
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert webhook.request_count == 2
     assert close_mock.call_count == 2
 
 
-def test_succeeds_on_first_attempt(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_succeeds_on_first_attempt(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
     flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {
         "model": "claude-sonnet-4-6",
@@ -109,7 +108,7 @@ def test_succeeds_on_first_attempt(tmp_path, real_flow, fresh_usage_executor, us
     }
 
     with usage_webhook_api() as webhook:
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert webhook.request_count == 1
     request = webhook.requests[0]
@@ -153,19 +152,19 @@ def test_succeeds_on_first_attempt(tmp_path, real_flow, fresh_usage_executor, us
         )
 
 
-def test_adds_vercel_bypass_header(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_adds_vercel_bypass_header(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
 
     with (
         patch.object(platform_api, "VERCEL_BYPASS", "bypass-secret"),
         usage_webhook_api() as webhook,
     ):
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert webhook.requests[0].header("x-vercel-protection-bypass") == "bypass-secret"
 
 
-def test_retries_on_failure(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_retries_on_failure(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
 
     with (
@@ -174,13 +173,13 @@ def test_retries_on_failure(tmp_path, real_flow, fresh_usage_executor, usage_web
     ):
         webhook.queue_response(500)
         webhook.queue_response(204)
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert webhook.request_count == 2
     mock_sleep.assert_called_once_with(0.5)
 
 
-def test_gives_up_after_retry_budget(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_gives_up_after_retry_budget(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
     proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
@@ -190,7 +189,7 @@ def test_gives_up_after_retry_budget(tmp_path, real_flow, fresh_usage_executor, 
     ):
         webhook.queue_response(500)
         webhook.queue_response(500)
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert webhook.request_count == 2
     assert jsonl_exists_after_flush(proxy_log)
@@ -289,7 +288,7 @@ def test_retry_success_logs_body_free_payload_summary_with_colliding_fields(
         )
 
 
-def test_http_429_is_retryable(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_http_429_is_retryable(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
     proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
@@ -299,7 +298,7 @@ def test_http_429_is_retryable(tmp_path, real_flow, fresh_usage_executor, usage_
     ):
         webhook.queue_response(429)
         webhook.queue_response(429)
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert webhook.request_count == 2
     mock_sleep.assert_called_once_with(0.5)
@@ -385,13 +384,13 @@ def test_retry_failure_sanitizes_sensitive_webhook_url_in_message_and_error(
         assert_sensitive_webhook_url_parts_absent(entry)
 
 
-def test_http_400_is_permanent(tmp_path, real_flow, fresh_usage_executor, usage_webhook_api):
+def test_http_400_is_permanent(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
     proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
 
     with usage_webhook_api() as webhook:
         webhook.queue_response(400)
-        _flush_model_usage(flow)
+        _report_and_flush_model_usage(flow)
 
     assert webhook.request_count == 1
     entries = [entry for entry in read_jsonl_entries_after_flush(proxy_log) if "attempt" in entry]

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -126,7 +126,7 @@ class TestXConnectorResponsePipeline:
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate", "br", "zstd"])
     def test_full_response_pipeline_truncated_compressed_x_json_does_not_bill(
-        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor, encoding_case
+        self, tmp_path, real_flow, mitm_ctx, encoding_case
     ):
         flow = make_x_pipeline_flow(
             real_flow,
@@ -227,9 +227,7 @@ class TestXConnectorResponsePipeline:
         assert events[0]["category"] == "posts.read"
         assert events[0]["quantity"] == 3
 
-    def test_full_streaming_pipeline_filtered_stream(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
-    ):
+    def test_full_streaming_pipeline_filtered_stream(self, tmp_path, real_flow, mitm_ctx, headers):
         """End-to-end: responseheaders registers parser, chunks accumulate, response() logs."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
 
@@ -254,7 +252,6 @@ class TestXConnectorResponsePipeline:
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Verify billing payloads
         payloads = webhook.usage_events()
@@ -265,7 +262,7 @@ class TestXConnectorResponsePipeline:
         assert by_cat["user.read"] == 3
 
     def test_full_streaming_pipeline_counts_final_line_without_newline(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers
     ):
         """End-to-end: response() finalizes a complete NDJSON row without trailing newline."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
@@ -278,7 +275,6 @@ class TestXConnectorResponsePipeline:
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
@@ -286,7 +282,7 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
 
     def test_full_pipeline_compressed_stream_error_does_not_bill_unverified_rows(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
         assert flow.response is not None
@@ -305,7 +301,6 @@ class TestXConnectorResponsePipeline:
         with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count == 0
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
@@ -318,7 +313,7 @@ class TestXConnectorResponsePipeline:
         assert lost_visibility_entries[0]["parse_error"] == "incomplete compressed body"
 
     def test_full_streaming_pipeline_ignores_malformed_include_values(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers
     ):
         """Malformed include values are ignored while valid siblings still bill."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
@@ -343,7 +338,6 @@ class TestXConnectorResponsePipeline:
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
@@ -357,7 +351,7 @@ class TestXConnectorResponsePipeline:
         ],
     )
     def test_full_streaming_pipeline_continues_after_json_parser_failure(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, failed_line
+        self, tmp_path, real_flow, mitm_ctx, headers, failed_line
     ):
         """A hostile NDJSON row must not stop later valid rows from billing."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
@@ -376,14 +370,13 @@ class TestXConnectorResponsePipeline:
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
         assert by_cat == {"posts.read": 1, "user.read": 1}
 
     def test_full_streaming_pipeline_bounds_unknown_include_categories(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor
+        self, tmp_path, real_flow, mitm_ctx, headers
     ):
         """Long-lived streams fold unknown include overflow into one fallback-priced bucket."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
@@ -406,7 +399,6 @@ class TestXConnectorResponsePipeline:
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}
@@ -419,9 +411,7 @@ class TestXConnectorResponsePipeline:
         assert len(by_cat) == 67
         assert all(len(category) <= 100 for category in by_cat)
 
-    def test_response_logs_incremental_x_json_parse_error(
-        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
-    ):
+    def test_response_logs_incremental_x_json_parse_error(self, tmp_path, real_flow, mitm_ctx):
         """Full response hook should audit parse errors from the incremental X JSON parser."""
         flow = make_x_pipeline_flow(
             real_flow,
@@ -454,7 +444,7 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
 
     def test_response_logs_x_json_parse_error_after_forensic_buffer_truncates(
-        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
+        self, tmp_path, real_flow, mitm_ctx
     ):
         """The X JSON parser should stay authoritative after the forensic buffer fills."""
         flow = make_x_pipeline_flow(
@@ -487,7 +477,7 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
 
     def test_response_uses_request_hints_for_incremental_x_json_parse_error(
-        self, tmp_path, real_flow, mitm_ctx, sync_usage_executor
+        self, tmp_path, real_flow, mitm_ctx
     ):
         """Incremental X JSON parser failures should still bill from URL hints."""
         flow = make_x_pipeline_flow(
@@ -520,8 +510,12 @@ class TestXConnectorResponsePipeline:
 class TestXConnectorErrorPipeline:
     """Tests for X connector usage through responseheaders -> error."""
 
+    @pytest.fixture(autouse=True)
+    def _sync_executor(self, sync_usage_executor):
+        """Run delivery inline for error-pipeline behavior tests."""
+
     def test_error_logs_connector_usage_for_x_stream(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
         """Mid-flight stream crash: partial counts still reported (issue #9534)."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
@@ -537,7 +531,6 @@ class TestXConnectorErrorPipeline:
         with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         assert webhook.request_count > 0
         payloads = webhook.usage_events()
@@ -546,7 +539,7 @@ class TestXConnectorErrorPipeline:
         assert by_cat["user.read"] == 5
 
     def test_full_pipeline_stream_error_midflight(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
         """End-to-end: responseheaders -> partial chunks -> error() logs observed counts.
 
@@ -572,7 +565,6 @@ class TestXConnectorErrorPipeline:
         with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         # 4. Billing must reflect the 2 complete tweets (partial 3rd is dropped)
         payloads = webhook.usage_events()
@@ -581,7 +573,7 @@ class TestXConnectorErrorPipeline:
         assert by_cat["user.read"] == 1
 
     def test_full_pipeline_stream_error_counts_complete_final_line_without_newline(
-        self, tmp_path, real_flow, mitm_ctx, headers, fresh_usage_executor, usage_webhook_api
+        self, tmp_path, real_flow, mitm_ctx, headers, usage_webhook_api
     ):
         """Connection error finalizes a complete NDJSON row without trailing newline."""
         flow = make_x_stream_pipeline_flow(real_flow, tmp_path)
@@ -595,7 +587,6 @@ class TestXConnectorErrorPipeline:
         with usage_webhook_api() as webhook:
             mitm_addon.error(flow)
             usage.flush_usage_events(trigger="test")
-            usage.webhook.usage_executor.shutdown(wait=True)
 
         payloads = webhook.usage_events()
         by_cat = {payload["category"]: payload["quantity"] for payload in payloads}


### PR DESCRIPTION
## Summary

- run ordinary usage delivery behavior tests through the existing synchronous executor fixture
- remove shutdown-as-wait coupling, including the provider test that changed execution modes between delivery cycles
- preserve the explicit real-background success path, post-shutdown fallback coverage, and dedicated lifecycle/concurrency suites

## Scope

- test-only changes in five mitm-addon test files
- no production executor, webhook, buffer, protocol, API, or deployment behavior changes
- no new executor implementation or completion barrier

## Validation

- `python3 -m ruff format tests/test_webhook_http_delivery.py tests/test_model_provider_usage.py tests/test_x_connector_pipeline.py tests/test_usage_reporting_idempotency.py tests/test_error_handler.py`
- `python3 -m ruff check tests/test_webhook_http_delivery.py tests/test_model_provider_usage.py tests/test_x_connector_pipeline.py tests/test_usage_reporting_idempotency.py tests/test_error_handler.py`
- `python3 -m basedpyright -p .`
- `python3 -m pytest tests/test_webhook_http_delivery.py tests/test_webhook_delivery_admission.py`
- `python3 -m pytest tests/test_model_provider_usage.py tests/test_usage_reporting_idempotency.py`
- `python3 -m pytest tests/test_x_connector_pipeline.py tests/test_error_handler.py`
- `python3 -m pytest tests/test_fresh_usage_executor.py tests/test_sync_usage_executor.py tests/test_usage_buffer_flush_failures.py tests/test_done_hook.py`
- `python3 -m pytest tests/test_runner_usage_flush_signal.py tests/test_usage_buffer_timer_shutdown.py`
- `python3 -m pytest tests/` (3,758 passed)
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,261 passed; existing startup benchmark skipped)
- `pnpm knip`

Closes #20921
