### PR TITLE
refactor(api): require runner redaction metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -5087,7 +5087,7 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
     expect(cancelled.status).toBe("cancelled");
   });
 
-  it("falls back completely for legacy and invalid masking metadata", async () => {
+  it("rejects missing masking metadata but falls back completely for invalid keys", async () => {
     const bdd = createBddApi(context);
     const api = createRunsAutomationsApi(context);
     const actor = bdd.user();
@@ -5116,47 +5116,83 @@ describe("RUN-02: stored connector injection into claimed runs", () => {
       },
     });
 
-    for (const mode of ["remove", "invalid"] as const) {
-      const run = await api.createDirectRun(actor, {
-        agentComposeId: compose.composeId,
-        prompt: `materialize ${mode} masking metadata`,
-        secrets: {
-          FIRST_TOKEN: "first-fallback-secret",
-          SECOND_TOKEN: "second-fallback-secret",
-        },
-      });
-      await mutateRunnerJobSecretValueEnvironmentKeys(context, run.runId, mode);
-      const decryptCountBeforeClaim =
-        await readAutomationsFakeKmsDecryptCallCount(context);
+    const missingRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "reject missing masking metadata",
+      secrets: {
+        FIRST_TOKEN: "first-missing-secret",
+        SECOND_TOKEN: "second-missing-secret",
+      },
+    });
+    await mutateRunnerJobSecretValueEnvironmentKeys(
+      context,
+      missingRun.runId,
+      "remove",
+    );
+    const decryptCountBeforeMissingClaim =
+      await readAutomationsFakeKmsDecryptCallCount(context);
 
-      const claim = await api.claimRunnerJob(run.runId);
+    const missingClaim = await api.requestClaimRunnerJob(
+      true,
+      missingRun.runId,
+      [400],
+    );
+    expectApiError(missingClaim.body);
+    expect(missingClaim.body.error.message).toBe(
+      "Job missing execution context",
+    );
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      decryptCountBeforeMissingClaim,
+    );
+    const failedMissingRun = await api.readRun(actor, missingRun.runId);
+    expect(failedMissingRun.status).toBe("failed");
+    expect(failedMissingRun.error).toBe(
+      "Runner job missing valid execution context",
+    );
 
-      expect(claim.secretValues).toStrictEqual([
-        "first-fallback-secret",
-        "second-fallback-secret",
-      ]);
-      await expect(
-        readAutomationsFakeKmsDecryptCallCount(context),
-      ).resolves.toBe(decryptCountBeforeClaim + 1);
-      expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
-      const materializationEvent = singleSandboxOperationEvent(
-        claimRouteTimingEventsForRun(run.runId),
-        "claim_route_secret_materialization",
-      );
-      expect(materializationEvent).toStrictEqual(
-        expect.objectContaining({
-          fallback_reason: mode === "remove" ? "missing_field" : "invalid_keys",
-          span_kind: "top_level",
-        }),
-      );
-      expect(
-        claimRouteTimingEventsForRun(run.runId).some((event) => {
-          return event.op_type === "claim_route_feature_switch_context";
-        }),
-      ).toBeFalsy();
+    const invalidRun = await api.createDirectRun(actor, {
+      agentComposeId: compose.composeId,
+      prompt: "materialize invalid masking metadata",
+      secrets: {
+        FIRST_TOKEN: "first-fallback-secret",
+        SECOND_TOKEN: "second-fallback-secret",
+      },
+    });
+    await mutateRunnerJobSecretValueEnvironmentKeys(
+      context,
+      invalidRun.runId,
+      "invalid",
+    );
+    const decryptCountBeforeInvalidClaim =
+      await readAutomationsFakeKmsDecryptCallCount(context);
 
-      await api.requestCancelRun(actor, run.runId, [200]);
-    }
+    const claim = await api.claimRunnerJob(invalidRun.runId);
+
+    expect(claim.secretValues).toStrictEqual([
+      "first-fallback-secret",
+      "second-fallback-secret",
+    ]);
+    await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
+      decryptCountBeforeInvalidClaim + 1,
+    );
+    expect(claim).not.toHaveProperty("secretValueEnvironmentKeys");
+    const materializationEvent = singleSandboxOperationEvent(
+      claimRouteTimingEventsForRun(invalidRun.runId),
+      "claim_route_secret_materialization",
+    );
+    expect(materializationEvent).toStrictEqual(
+      expect.objectContaining({
+        fallback_reason: "invalid_keys",
+        span_kind: "top_level",
+      }),
+    );
+    expect(
+      claimRouteTimingEventsForRun(invalidRun.runId).some((event) => {
+        return event.op_type === "claim_route_feature_switch_context";
+      }),
+    ).toBeFalsy();
+
+    await api.requestCancelRun(actor, invalidRun.runId, [200]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -126,7 +126,7 @@ function isResumeSessionHistoryLoadError(
 }
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
-type SecretValueFallbackReason = "missing_field" | "invalid_keys";
+type SecretValueFallbackReason = "invalid_keys";
 type ClaimRouteTimingActionType =
   | "claim_route_request_prepare"
   | "claim_route_lookup_authorization"
@@ -945,9 +945,6 @@ function preparedSecretValuesForRunner(
   storedContext: StoredExecutionContext,
 ): PreparedSecretValuesResult {
   const keys = storedContext.secretValueEnvironmentKeys;
-  if (keys === undefined) {
-    return { status: "fallback", reason: "missing_field" };
-  }
   if (keys === null) {
     return { status: "resolved", secretValues: null };
   }

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -126,7 +126,6 @@ function isResumeSessionHistoryLoadError(
 }
 
 type ClaimRouteTimingSpanKind = "top_level" | "nested";
-type SecretValueFallbackReason = "invalid_keys";
 type ClaimRouteTimingActionType =
   | "claim_route_request_prepare"
   | "claim_route_lookup_authorization"
@@ -144,7 +143,7 @@ interface ClaimRouteTimingRecord {
   readonly spanKind: ClaimRouteTimingSpanKind;
   readonly durationMs: number;
   readonly timestamp: string;
-  readonly fallbackReason?: SecretValueFallbackReason;
+  readonly fallbackReason?: "invalid_keys";
 }
 
 class ClaimRouteTimingCollector {
@@ -175,8 +174,7 @@ class ClaimRouteTimingCollector {
     });
   }
 
-  measureSecretMaterialization<T>(
-    fallbackReason: SecretValueFallbackReason,
+  measureInvalidKeySecretMaterialization<T>(
     operation: () => Promise<T>,
   ): Promise<T> {
     const startedAt = now();
@@ -187,7 +185,7 @@ class ClaimRouteTimingCollector {
         spanKind: "top_level",
         durationMs: Math.max(0, finishedAt - startedAt),
         timestamp: new Date(finishedAt).toISOString(),
-        fallbackReason,
+        fallbackReason: "invalid_keys",
       });
     });
   }
@@ -937,8 +935,7 @@ type PreparedSecretValuesResult =
       readonly secretValues: string[] | null;
     }
   | {
-      readonly status: "fallback";
-      readonly reason: SecretValueFallbackReason;
+      readonly status: "invalid-keys";
     };
 
 function preparedSecretValuesForRunner(
@@ -955,11 +952,11 @@ function preparedSecretValuesForRunner(
       !storedContext.environment ||
       !Object.hasOwn(storedContext.environment, key)
     ) {
-      return { status: "fallback", reason: "invalid_keys" };
+      return { status: "invalid-keys" };
     }
     const value = storedContext.environment[key];
     if (typeof value !== "string") {
-      return { status: "fallback", reason: "invalid_keys" };
+      return { status: "invalid-keys" };
     }
     secretValues.push(value);
   }
@@ -975,25 +972,22 @@ async function secretValuesForRunner(
     return prepared.secretValues;
   }
 
-  return await timing.measureSecretMaterialization(
-    prepared.reason,
-    async () => {
-      const secretsMap = await decryptPersistentSecretsMap(
-        storedContext.encryptedSecrets,
-        {},
-      );
-      if (!secretsMap) {
-        return null;
-      }
+  return await timing.measureInvalidKeySecretMaterialization(async () => {
+    const secretsMap = await decryptPersistentSecretsMap(
+      storedContext.encryptedSecrets,
+      {},
+    );
+    if (!secretsMap) {
+      return null;
+    }
 
-      const envValues = storedContext.environment
-        ? new Set(Object.values(storedContext.environment))
-        : new Set<string>();
-      return Object.values(secretsMap).filter((value) => {
-        return envValues.has(value);
-      });
-    },
-  );
+    const envValues = storedContext.environment
+      ? new Set(Object.values(storedContext.environment))
+      : new Set<string>();
+    return Object.values(secretsMap).filter((value) => {
+      return envValues.has(value);
+    });
+  });
 }
 
 async function agentIdForRun(

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -361,10 +361,10 @@ export const storedExecutionContextSchema = z.object({
   storageManifest: storageManifestSchema.nullable(),
   environment: z.record(z.string(), z.string()).nullable(),
   // API-only references used to reconstruct runner masking values from the
-  // stored environment. Missing means legacy/stripped data, null means no
-  // persistent secret map, and array order/repetition follows secret-map values.
+  // stored environment. Null means no persistent secret map, and array
+  // order/repetition follows secret-map values.
   // This field must not be included in the runner-facing ExecutionContext.
-  secretValueEnvironmentKeys: z.array(z.string()).nullable().optional(),
+  secretValueEnvironmentKeys: z.array(z.string()).nullable(),
   // Connector-owned runtime vars used by proxy/firewall template resolution.
   // User-provided run vars stay in agent_runs.vars and are merged at claim time.
   vars: z.record(z.string(), z.string()).nullable().optional(),


### PR DESCRIPTION
## Summary

- require API-owned `secretValueEnvironmentKeys` in stored runner execution contexts while preserving `null` and array semantics
- route a missing field through the existing invalid stored-context failure path instead of legacy KMS materialization
- retain the all-or-nothing `invalid_keys` KMS safety fallback and keep the private field out of runner responses

## Rollout decision

- #20942 merged in #20968 at 2026-07-10 10:44:29 UTC.
- The first successful production API deployment containing that merge completed at 2026-07-10 11:39:43 UTC (`api-v1.261.1`); the current production API deployment also contains it.
- More than 5.5 hours elapsed between that deployment and this implementation, exceeding the two-hour lifetime of both direct and delayed runner queue records.
- The maintainer confirmed that rollback to a pre-#20942 API is no longer supported and approved this compatibility cleanup.
- #20942 already separates the fixed low-cardinality `missing_field` and `invalid_keys` fallback reasons. The maintainer go-ahead covers the rollout observation and claim-health decision; this workspace does not have the production `AXIOM_TOKEN`, so the production aggregate was not independently re-run here.

## Preserved behavior

- `null`, valid prepared lists, ordering, duplicates, delayed queue promotion, network-policy freshness, resume sessions, claim ownership, and response-build-before-transition ordering remain unchanged.
- A present list with any unresolvable key still falls back to complete KMS materialization and cannot return a partial masking list.
- `encryptedSecrets`, the runner protocol, Rust types, firewall/proxy behavior, and composite-secret selection semantics are unchanged.

## Validation

- `pnpm -F @vm0/db db:migrate`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F @vm0/api-contracts exec vitest run src/contracts/__tests__/runners.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest --maxWorkers=1 --reporter=dot` (594 files passed, 1 skipped; 7,288 tests passed, 1 skipped)
- `pnpm knip`

The unsharded local parallel suite exceeded unrelated five-second test timeouts while the 12-core workspace was CPU-saturated; no changed test failed. The complete suite passed with one worker after `scripts/prepare.sh`, and all sharded API, app, CLI, and other test jobs passed in CI.

Closes #20955
