### PR TITLE
perf(sandbox-fc): reduce fresh workspace image writes

### DIFF
--- a/crates/sandbox-fc/src/workspace_drive_image.rs
+++ b/crates/sandbox-fc/src/workspace_drive_image.rs
@@ -69,6 +69,9 @@ pub(crate) async fn prepare_workspace_drive_image(
         None => {}
     }
 
+    // Lazy journal initialization is safe only on this fresh path: create
+    // truncates the regular file, and extending it makes the new range read as
+    // zero. Seed images return above and must not use this formatting option.
     let file = tokio::fs::File::create(path)
         .await
         .map_err(|e| SandboxError::Initialization {
@@ -90,7 +93,7 @@ pub(crate) async fn prepare_workspace_drive_image(
     let stage_started = Instant::now();
     let result = command::exec_status_with_timeout(
         "mkfs.ext4",
-        &["-F", "-q", path_str],
+        &["-F", "-q", "-E", "lazy_journal_init=1", path_str],
         Duration::from_secs(60),
     )
     .await
@@ -261,6 +264,7 @@ fn record_stage_result(
 mod tests {
     use super::*;
     use std::io::SeekFrom;
+    use std::process::Command;
     use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
     #[derive(Default)]
@@ -296,10 +300,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prepare_workspace_drive_image_without_seed_formats_fresh_image() {
+    async fn prepare_workspace_drive_image_without_seed_truncates_and_formats_fresh_image() {
         let tmp = tempfile::tempdir().unwrap();
         let target = tmp.path().join("nested").join("workspace.ext4");
         let mut observer = RecordingObserver::default();
+
+        tokio::fs::create_dir_all(target.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&target, vec![0xff; 4096]).await.unwrap();
 
         prepare_workspace_drive_image(
             &target,
@@ -319,6 +328,41 @@ mod tests {
         assert_eq!(
             observer.stages,
             vec![WorkspaceDriveImagePrepareStage::FreshFormat]
+        );
+
+        let fsck = Command::new("e2fsck")
+            .args(["-f", "-n"])
+            .arg(&target)
+            .output()
+            .unwrap();
+        assert!(
+            fsck.status.success(),
+            "e2fsck failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&fsck.stdout),
+            String::from_utf8_lossy(&fsck.stderr)
+        );
+
+        let tune2fs = Command::new("tune2fs")
+            .arg("-l")
+            .arg(&target)
+            .env("LC_ALL", "C")
+            .output()
+            .unwrap();
+        assert!(
+            tune2fs.status.success(),
+            "tune2fs failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&tune2fs.stdout),
+            String::from_utf8_lossy(&tune2fs.stderr)
+        );
+        let tune2fs_stdout = String::from_utf8(tune2fs.stdout).unwrap();
+        let features = tune2fs_stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("Filesystem features:"))
+            .expect("tune2fs output should contain filesystem features");
+        assert!(
+            features
+                .split_whitespace()
+                .any(|feature| feature == "has_journal")
         );
     }
 


### PR DESCRIPTION
## Summary

- enable `lazy_journal_init=1` only when formatting a newly truncated workspace image
- leave seeded workspace images, image sizing, stage timing, error propagation, and the serial create lifecycle unchanged
- exercise the production entry point with real ext4 tools to verify truncation, filesystem integrity, and journal preservation

## Why this approach

The fresh path creates/truncates the regular file and extends it before `mkfs.ext4`, so the image starts from a zero-readable backing file. Lazy journal initialization can therefore avoid eagerly writing the 128 MiB journal without exposing stale data. Seed images return before this path and deliberately keep their existing filesystem contents and formatting behavior.

This PR does not change workspace/NBD concurrency, NBD allocation behavior, schemas, APIs, runner protocols, or persisted state. It also does not add a fallback/version probe: the deployed e2fsprogs version supports the option, and a formatting failure remains an explicit sandbox creation failure.

## Validation evidence

### Local mechanism comparison

Using e2fsprogs 1.47.0 with otherwise identical 16 GiB images:

- default formatting allocated 270,872 512-byte blocks (138,686,464 bytes)
- lazy journal formatting allocated 8,736 512-byte blocks (4,472,832 bytes)
- both images retained the same logical size, ext4 feature set, inode/block geometry, 128 MiB journal, and clean `e2fsck -fn` result

### Metal runner

Validated on the aarch64 local metal runner with the production sandbox path:

- two fresh, non-seeded workspaces completed successfully after deployment and after runner restart
- diagnostics reported `workspace_seed_image_used=false`; fresh formatting took 28-29 ms and total sandbox creation took 118-123 ms
- the 16 GiB workspace image allocated 8,824 512-byte blocks (4,517,888 bytes) while retaining the expected ext4 geometry and 128 MiB journal
- the guest mounted ext4, wrote and synced a marker, and exited successfully
- after forced runner termination, offline journal recovery succeeded; a read-only loop mount retained the marker and the final forced read-only `e2fsck` was clean
- the runner was restored to active API mode after validation

## Rollout

- compare `workspace_fresh_format_ms` and overall sandbox-create percentiles before and after deployment
- monitor workspace format/mount failures, recovery/cleanup errors, and host writeback pressure
- remeasure #20943 and continue the broader lifecycle work in #20941 before considering overlap or NBD changes
- roll back the formatter option if format, mount, recovery, or cleanup regressions appear

## Tests

- `cargo test -p sandbox-fc workspace_drive_image`
- `cargo test -p sandbox-fc`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest`
- `cd turbo && pnpm knip`

Closes #20940
