### PR TITLE
refactor: source connector diagnostics from server catalog cache

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -1,17 +1,17 @@
 """Diagnostic-only matching for unavailable built-in connector URLs."""
 
+import re
 from dataclasses import dataclass
 from typing import Final
 
+import builtin_firewall_cache
 import matching
-from generated.builtin_firewalls.diagnostics import (
-    CONNECTOR_DIAGNOSTIC_FIREWALLS,
-    MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS,
-)
 
 _DYNAMIC_BASE_MARKERS: Final = ("{", "}")
 _DIAGNOSTIC_ANY_PERMISSION: Final = "__connector_diagnostic_any__"
 _DIAGNOSTIC_ANY_RULES: Final = ("ANY /", "ANY /{path+}")
+_MODEL_PROVIDER_PREFIX: Final = "model-provider:"
+_REFERENCE_NAME_PATTERN: Final = re.compile(r"\b(?:secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)")
 _SHARED_BASE_MIN_CANDIDATES: Final = 2
 
 
@@ -55,28 +55,62 @@ class _DiagnosticCatalog:
 
 
 @dataclass(frozen=True)
+class DiagnosticCatalogProjection:
+    connector_firewalls: tuple[dict, ...]
+    model_provider_exclusions: tuple[dict, ...]
+    shared_base_keys: frozenset[str]
+
+
+@dataclass(frozen=True)
+class DiagnosticCatalogSnapshot:
+    dependency_file_key: builtin_firewall_cache.CatalogFileKey | None
+    catalog_identity: builtin_firewall_cache.CatalogIdentity | None
+    catalog: _DiagnosticCatalog | None
+    cache_path: str | None
+    unavailable_reason: str | None
+
+
+@dataclass(frozen=True)
 class _OwnershipMatch:
     candidate: ConnectorDiagnosticCandidate
     route_specific: bool
 
 
-_catalog: _DiagnosticCatalog | None = None
+_current_snapshot: DiagnosticCatalogSnapshot | None = None
 
 
 def reset_cache_for_tests() -> None:
-    global _catalog
-    _catalog = None
+    global _current_snapshot
+    _current_snapshot = None
+
+
+def load_diagnostic_snapshot(
+    preferred_catalog_snapshot: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot | None = None,
+) -> DiagnosticCatalogSnapshot:
+    """Load one diagnostic snapshot without moving current state backward."""
+    current_raw_snapshot = builtin_firewall_cache.load_configured_catalog_snapshot()
+    # Publish the actual current state first. A stale registry classification
+    # may still use its preferred snapshot flow-locally, but cannot reinstall it
+    # as the process-wide current generation.
+    current_snapshot = _current_diagnostic_snapshot(current_raw_snapshot)
+    if preferred_catalog_snapshot is None or _raw_snapshots_match(
+        preferred_catalog_snapshot,
+        current_raw_snapshot,
+    ):
+        return current_snapshot
+    return _compile_diagnostic_snapshot(preferred_catalog_snapshot)
 
 
 def find_candidate(
+    diagnostic_snapshot: DiagnosticCatalogSnapshot,
     url: str,
     method: str,
     *,
     active_firewall_names: set[str],
 ) -> ConnectorDiagnosticCandidate | None:
     """Classify a URL against static built-in connector bases without enforcing it."""
-    catalog = _diagnostic_catalog()
-    if catalog.compiled_connector_firewalls is None:
+    catalog = diagnostic_snapshot.catalog
+    if catalog is None or catalog.compiled_connector_firewalls is None:
         return None
 
     # Model-provider firewalls are never diagnostic candidates. They are kept as
@@ -130,6 +164,7 @@ def _find_shared_base_candidate(
 
 
 def resolve_shared_base_ownership(
+    diagnostic_snapshot: DiagnosticCatalogSnapshot,
     url: str,
     method: str,
     *,
@@ -144,7 +179,9 @@ def resolve_shared_base_ownership(
     outcomes are represented with ``candidate=None`` so callers can keep normal
     auth injection behavior.
     """
-    catalog = _diagnostic_catalog()
+    catalog = diagnostic_snapshot.catalog
+    if catalog is None:
+        return None
     if _matches_model_provider_exclusion(url, method, catalog):
         return None
 
@@ -282,21 +319,85 @@ def _candidate_from_match(
     )
 
 
-def _diagnostic_catalog() -> _DiagnosticCatalog:
-    global _catalog
-    if _catalog is not None:
-        return _catalog
+def _current_diagnostic_snapshot(
+    raw_snapshot: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
+) -> DiagnosticCatalogSnapshot:
+    global _current_snapshot
+    if _current_snapshot is not None and _compiled_snapshot_matches_raw(
+        _current_snapshot,
+        raw_snapshot,
+    ):
+        return _current_snapshot
+    _current_snapshot = _compile_diagnostic_snapshot(raw_snapshot)
+    return _current_snapshot
 
+
+def _compile_diagnostic_snapshot(
+    raw_snapshot: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
+) -> DiagnosticCatalogSnapshot:
+    raw_catalog = raw_snapshot.catalog
+    if raw_catalog is None:
+        return DiagnosticCatalogSnapshot(
+            dependency_file_key=raw_snapshot.dependency_file_key,
+            catalog_identity=None,
+            catalog=None,
+            cache_path=raw_snapshot.cache_path,
+            unavailable_reason=raw_snapshot.unavailable_reason or "cache_unavailable",
+        )
+    return DiagnosticCatalogSnapshot(
+        dependency_file_key=raw_snapshot.dependency_file_key,
+        catalog_identity=raw_catalog.identity,
+        catalog=_compile_diagnostic_catalog(raw_catalog.firewalls),
+        cache_path=raw_snapshot.cache_path,
+        unavailable_reason=None,
+    )
+
+
+def _compiled_snapshot_matches_raw(
+    compiled_snapshot: DiagnosticCatalogSnapshot,
+    raw_snapshot: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
+) -> bool:
+    raw_catalog = raw_snapshot.catalog
+    return (
+        compiled_snapshot.dependency_file_key == raw_snapshot.dependency_file_key
+        and compiled_snapshot.catalog_identity
+        == (raw_catalog.identity if raw_catalog is not None else None)
+        and compiled_snapshot.cache_path == raw_snapshot.cache_path
+        and compiled_snapshot.unavailable_reason
+        == (
+            None
+            if raw_catalog is not None
+            else raw_snapshot.unavailable_reason or "cache_unavailable"
+        )
+    )
+
+
+def _raw_snapshots_match(
+    left: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
+    right: builtin_firewall_cache.BuiltinFirewallCatalogSnapshot,
+) -> bool:
+    left_catalog = left.catalog
+    right_catalog = right.catalog
+    return (
+        left.dependency_file_key == right.dependency_file_key
+        and (left_catalog.identity if left_catalog is not None else None)
+        == (right_catalog.identity if right_catalog is not None else None)
+        and left.cache_path == right.cache_path
+        and left.unavailable_reason == right.unavailable_reason
+    )
+
+
+def _compile_diagnostic_catalog(firewalls: dict[str, dict]) -> _DiagnosticCatalog:
+    projection = project_diagnostic_catalog(firewalls)
     connector_firewalls: list[dict] = []
     connector_matchers: list[_DiagnosticConnectorMatcher] = []
-    shared_route_aware_base_keys = _shared_route_aware_base_keys(CONNECTOR_DIAGNOSTIC_FIREWALLS)
-    for firewall in CONNECTOR_DIAGNOSTIC_FIREWALLS:
-        diagnostic_firewall = _diagnostic_firewall_from_manifest(firewall)
+    for firewall in projection.connector_firewalls:
+        diagnostic_firewall = _diagnostic_firewall_from_projection(firewall)
         if diagnostic_firewall is not None:
             connector_firewalls.append(diagnostic_firewall)
-        route_aware_firewall = _route_aware_diagnostic_firewall_from_manifest(
+        route_aware_firewall = _route_aware_diagnostic_firewall_from_projection(
             firewall,
-            shared_base_keys=shared_route_aware_base_keys,
+            shared_base_keys=projection.shared_base_keys,
         )
         if route_aware_firewall is not None:
             connector_matchers.append(
@@ -313,12 +414,12 @@ def _diagnostic_catalog() -> _DiagnosticCatalog:
             )
 
     model_provider_exclusions: list[dict] = []
-    for firewall in MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS:
-        model_provider_exclusion = _model_provider_exclusion_firewall_from_manifest(firewall)
+    for firewall in projection.model_provider_exclusions:
+        model_provider_exclusion = _model_provider_exclusion_firewall_from_projection(firewall)
         if model_provider_exclusion is not None:
             model_provider_exclusions.append(model_provider_exclusion)
 
-    _catalog = _DiagnosticCatalog(
+    return _DiagnosticCatalog(
         compiled_connector_firewalls=matching.compile_firewalls(connector_firewalls),
         compiled_network_policies=matching.compile_network_policies(
             _matching_network_policies(connector_firewalls)
@@ -329,7 +430,6 @@ def _diagnostic_catalog() -> _DiagnosticCatalog:
             _matching_network_policies(model_provider_exclusions)
         ),
     )
-    return _catalog
 
 
 def _matches_model_provider_exclusion(
@@ -346,15 +446,37 @@ def _matches_model_provider_exclusion(
     return isinstance(match, matching.FirewallAllow)
 
 
-def _manifest_str_tuple(value: object) -> tuple[str, ...]:
-    if not isinstance(value, (list, tuple)):
+def _diagnostic_reference_names(value: object) -> tuple[str, ...]:
+    names: list[str] = []
+    seen: set[str] = set()
+
+    def visit(nested: object) -> None:
+        if isinstance(nested, str):
+            for match in _REFERENCE_NAME_PATTERN.finditer(nested):
+                name = match.group(1)
+                if name not in seen:
+                    seen.add(name)
+                    names.append(name)
+            return
+        if isinstance(nested, list):
+            for item in nested:
+                visit(item)
+            return
+        if isinstance(nested, dict):
+            for key in sorted(nested):
+                visit(nested[key])
+
+    visit(value)
+    return tuple(names)
+
+
+def _auth_mapping_names(auth: dict, key: str) -> tuple[str, ...]:
+    raw_mapping = auth.get(key)
+    if raw_mapping is None:
         return ()
-    result: list[str] = []
-    for item in value:
-        if not isinstance(item, str):
-            return ()
-        result.append(item)
-    return tuple(result)
+    if not isinstance(raw_mapping, dict):
+        raise TypeError(f"validated catalog auth.{key} must be an object")
+    return tuple(sorted(raw_mapping))
 
 
 def _diagnostic_static_base_key(raw_base: str) -> str | None:
@@ -363,28 +485,22 @@ def _diagnostic_static_base_key(raw_base: str) -> str | None:
     return matching.static_firewall_base_config_key(raw_base)
 
 
-def _shared_route_aware_base_keys(firewalls: object) -> frozenset[str]:
-    if not isinstance(firewalls, (list, tuple)):
-        return frozenset()
+def _shared_route_aware_base_keys(firewalls: dict[str, dict]) -> frozenset[str]:
     connector_names_by_base: dict[str, set[str]] = {}
-    for firewall in firewalls:
-        if not isinstance(firewall, dict):
+    for name in sorted(firewalls):
+        if name.startswith(_MODEL_PROVIDER_PREFIX):
             continue
-        raw_name = firewall.get("name")
-        raw_apis = firewall.get("apis")
-        if not isinstance(raw_name, str) or raw_name == "" or not isinstance(raw_apis, list):
-            continue
+        _, raw_apis = _catalog_firewall_fields(firewalls[name])
         for api in raw_apis:
-            if not isinstance(api, dict):
-                continue
             raw_base = api.get("base")
-            if not isinstance(raw_base, str) or not _manifest_str_tuple(api.get("envNames")):
-                continue
+            auth = api.get("auth")
+            if not isinstance(raw_base, str) or not isinstance(auth, dict):
+                raise TypeError("validated catalog API base/auth shape changed")
             base_key = _diagnostic_static_base_key(raw_base)
-            if base_key is None:
+            if base_key is None or not _diagnostic_reference_names(auth):
                 continue
             connector_names = connector_names_by_base.setdefault(base_key, set())
-            connector_names.add(raw_name)
+            connector_names.add(name)
     return frozenset(
         base_key
         for base_key, connector_names in connector_names_by_base.items()
@@ -409,19 +525,101 @@ def _firewall_base_authorities(firewall: dict) -> frozenset[str]:
     return frozenset(authorities)
 
 
-def _diagnostic_firewall_from_manifest(firewall: object) -> dict | None:
-    if not isinstance(firewall, dict):
-        return None
+def _catalog_firewall_fields(firewall: dict) -> tuple[str, list[dict]]:
     raw_name = firewall.get("name")
-    if not isinstance(raw_name, str) or raw_name == "":
-        return None
     raw_apis = firewall.get("apis")
-    if not isinstance(raw_apis, list):
+    if not isinstance(raw_name, str) or raw_name == "" or not isinstance(raw_apis, list):
+        raise TypeError("validated catalog firewall shape changed")
+    if not all(isinstance(api, dict) for api in raw_apis):
+        raise TypeError("validated catalog firewall API shape changed")
+    return raw_name, raw_apis
+
+
+def project_diagnostic_catalog(firewalls: dict[str, dict]) -> DiagnosticCatalogProjection:
+    shared_base_keys = _shared_route_aware_base_keys(firewalls)
+    connector_firewalls: list[dict] = []
+    model_provider_exclusions: list[dict] = []
+    for name in sorted(firewalls):
+        firewall = firewalls[name]
+        raw_name, raw_apis = _catalog_firewall_fields(firewall)
+        projected_apis: list[dict] = []
+        if name.startswith(_MODEL_PROVIDER_PREFIX):
+            for api in raw_apis:
+                projected_api = _project_model_provider_api(api)
+                if projected_api is not None:
+                    projected_apis.append(projected_api)
+            if projected_apis:
+                model_provider_exclusions.append({"name": raw_name, "apis": projected_apis})
+            continue
+
+        for api in raw_apis:
+            projected_api = _project_connector_api(api, shared_base_keys=shared_base_keys)
+            if projected_api is not None:
+                projected_apis.append(projected_api)
+        if projected_apis:
+            connector_firewalls.append({"name": raw_name, "apis": projected_apis})
+
+    return DiagnosticCatalogProjection(
+        connector_firewalls=tuple(connector_firewalls),
+        model_provider_exclusions=tuple(model_provider_exclusions),
+        shared_base_keys=shared_base_keys,
+    )
+
+
+def _project_connector_api(
+    api: dict,
+    *,
+    shared_base_keys: frozenset[str],
+) -> dict | None:
+    raw_base = api.get("base")
+    auth = api.get("auth")
+    if not isinstance(raw_base, str) or not isinstance(auth, dict):
+        raise TypeError("validated catalog API base/auth shape changed")
+    base_key = _diagnostic_static_base_key(raw_base)
+    if base_key is None:
         return None
+
+    env_names = _diagnostic_reference_names(auth)
+    if not env_names:
+        return None
+
+    projected = {
+        "base": raw_base,
+        "envNames": list(env_names),
+        "authHeaderNames": list(_auth_mapping_names(auth, "headers")),
+        "authQueryParamNames": list(_auth_mapping_names(auth, "query")),
+    }
+    if base_key in shared_base_keys:
+        permissions = _catalog_permissions(api.get("permissions"))
+        if permissions:
+            projected["permissions"] = permissions
+    return projected
+
+
+def _project_model_provider_api(api: dict) -> dict | None:
+    raw_base = api.get("base")
+    if not isinstance(raw_base, str):
+        raise TypeError("validated catalog API base shape changed")
+    if _diagnostic_static_base_key(raw_base) is None:
+        return None
+    return {
+        "base": raw_base,
+        "permissions": _catalog_permissions(api.get("permissions")),
+    }
+
+
+def _projection_str_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise TypeError("diagnostic projection string-list shape changed")
+    return tuple(value)
+
+
+def _diagnostic_firewall_from_projection(firewall: dict) -> dict | None:
+    raw_name, raw_apis = _catalog_firewall_fields(firewall)
 
     apis: list[dict] = []
     for api in raw_apis:
-        diagnostic_api = _diagnostic_api_from_manifest(api)
+        diagnostic_api = _diagnostic_api_from_projection(api)
         if diagnostic_api is not None:
             apis.append(diagnostic_api)
 
@@ -430,23 +628,16 @@ def _diagnostic_firewall_from_manifest(firewall: object) -> dict | None:
     return {"name": raw_name, "apis": apis}
 
 
-def _route_aware_diagnostic_firewall_from_manifest(
-    firewall: object,
+def _route_aware_diagnostic_firewall_from_projection(
+    firewall: dict,
     *,
     shared_base_keys: frozenset[str],
 ) -> dict | None:
-    if not isinstance(firewall, dict):
-        return None
-    raw_name = firewall.get("name")
-    if not isinstance(raw_name, str) or raw_name == "":
-        return None
-    raw_apis = firewall.get("apis")
-    if not isinstance(raw_apis, list):
-        return None
+    raw_name, raw_apis = _catalog_firewall_fields(firewall)
 
     apis: list[dict] = []
     for api in raw_apis:
-        diagnostic_api = _route_aware_diagnostic_api_from_manifest(
+        diagnostic_api = _route_aware_diagnostic_api_from_projection(
             api,
             shared_base_keys=shared_base_keys,
         )
@@ -458,19 +649,12 @@ def _route_aware_diagnostic_firewall_from_manifest(
     return {"name": raw_name, "apis": apis}
 
 
-def _model_provider_exclusion_firewall_from_manifest(firewall: object) -> dict | None:
-    if not isinstance(firewall, dict):
-        return None
-    raw_name = firewall.get("name")
-    if not isinstance(raw_name, str) or raw_name == "":
-        return None
-    raw_apis = firewall.get("apis")
-    if not isinstance(raw_apis, list):
-        return None
+def _model_provider_exclusion_firewall_from_projection(firewall: dict) -> dict | None:
+    raw_name, raw_apis = _catalog_firewall_fields(firewall)
 
     apis: list[dict] = []
     for api in raw_apis:
-        exclusion_api = _model_provider_exclusion_api_from_manifest(api)
+        exclusion_api = _model_provider_exclusion_api_from_projection(api)
         if exclusion_api is not None:
             apis.append(exclusion_api)
 
@@ -479,65 +663,47 @@ def _model_provider_exclusion_firewall_from_manifest(firewall: object) -> dict |
     return {"name": raw_name, "apis": apis}
 
 
-def _diagnostic_api_from_manifest(api: object) -> dict | None:
-    if not isinstance(api, dict):
-        return None
+def _diagnostic_api_from_projection(api: dict) -> dict | None:
     raw_base = api.get("base")
-    if not isinstance(raw_base, str) or _has_dynamic_base_marker(raw_base):
-        return None
-    if not matching.firewall_base_config_is_valid(raw_base):
-        return None
-
-    env_names = _manifest_str_tuple(api.get("envNames"))
-    if not env_names:
-        return None
+    if not isinstance(raw_base, str):
+        raise TypeError("diagnostic projection base shape changed")
 
     return {
         "base": raw_base,
         "auth": {},
         "permissions": _base_match_permissions(),
-        "_diagnostic_env_names": env_names,
-        "_diagnostic_auth_header_names": _manifest_str_tuple(api.get("authHeaderNames")),
-        "_diagnostic_auth_query_param_names": _manifest_str_tuple(api.get("authQueryParamNames")),
+        "_diagnostic_env_names": _projection_str_tuple(api.get("envNames")),
+        "_diagnostic_auth_header_names": _projection_str_tuple(api.get("authHeaderNames")),
+        "_diagnostic_auth_query_param_names": _projection_str_tuple(api.get("authQueryParamNames")),
     }
 
 
-def _route_aware_diagnostic_api_from_manifest(
-    api: object,
+def _route_aware_diagnostic_api_from_projection(
+    api: dict,
     *,
     shared_base_keys: frozenset[str],
 ) -> dict | None:
-    if not isinstance(api, dict):
-        return None
     raw_base = api.get("base")
     if not isinstance(raw_base, str):
-        return None
+        raise TypeError("diagnostic projection base shape changed")
     base_key = _diagnostic_static_base_key(raw_base)
     if base_key is None or base_key not in shared_base_keys:
-        return None
-
-    env_names = _manifest_str_tuple(api.get("envNames"))
-    if not env_names:
         return None
 
     return {
         "base": raw_base,
         "auth": {},
-        "permissions": _manifest_permissions(api.get("permissions")),
-        "_diagnostic_env_names": env_names,
-        "_diagnostic_auth_header_names": _manifest_str_tuple(api.get("authHeaderNames")),
-        "_diagnostic_auth_query_param_names": _manifest_str_tuple(api.get("authQueryParamNames")),
+        "permissions": _catalog_permissions(api.get("permissions")),
+        "_diagnostic_env_names": _projection_str_tuple(api.get("envNames")),
+        "_diagnostic_auth_header_names": _projection_str_tuple(api.get("authHeaderNames")),
+        "_diagnostic_auth_query_param_names": _projection_str_tuple(api.get("authQueryParamNames")),
     }
 
 
-def _model_provider_exclusion_api_from_manifest(api: object) -> dict | None:
-    if not isinstance(api, dict):
-        return None
+def _model_provider_exclusion_api_from_projection(api: dict) -> dict | None:
     raw_base = api.get("base")
-    if not isinstance(raw_base, str) or _has_dynamic_base_marker(raw_base):
-        return None
-    if not matching.firewall_base_config_is_valid(raw_base):
-        return None
+    if not isinstance(raw_base, str):
+        raise TypeError("diagnostic projection base shape changed")
 
     return {
         "base": raw_base,
@@ -546,38 +712,31 @@ def _model_provider_exclusion_api_from_manifest(api: object) -> dict | None:
     }
 
 
-def _manifest_permissions(raw_permissions: object) -> list[dict]:
-    if not isinstance(raw_permissions, (list, tuple)):
+def _catalog_permissions(raw_permissions: object) -> list[dict]:
+    if raw_permissions is None:
         return []
+    if not isinstance(raw_permissions, list):
+        raise TypeError("validated catalog permissions shape changed")
     permissions: list[dict] = []
     for permission in raw_permissions:
         if not isinstance(permission, dict):
-            return []
+            raise TypeError("validated catalog permission shape changed")
         name = permission.get("name")
         rules = permission.get("rules")
         if not isinstance(name, str) or not isinstance(rules, list):
-            return []
+            raise TypeError("validated catalog permission fields changed")
         rule_values: list[str] = []
         for rule in rules:
             if not isinstance(rule, str):
-                return []
+                raise TypeError("validated catalog permission rule shape changed")
             rule_values.append(rule)
         permissions.append({"name": name, "rules": rule_values})
     return permissions
 
 
 def _diagnostic_permissions(raw_permissions: object) -> list[dict]:
-    if isinstance(raw_permissions, (list, tuple)) and raw_permissions:
-        permissions: list[dict] = []
-        for permission in raw_permissions:
-            if isinstance(permission, dict):
-                name = permission.get("name")
-                rules = permission.get("rules")
-                if isinstance(name, str) and isinstance(rules, list):
-                    permissions.append({"name": name, "rules": rules})
-        if permissions:
-            return permissions
-    return _base_match_permissions()
+    permissions = _catalog_permissions(raw_permissions)
+    return permissions or _base_match_permissions()
 
 
 def _base_match_permissions() -> list[dict]:

--- a/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/builtin_connector_diagnostics.py
@@ -56,6 +56,8 @@ class _DiagnosticCatalog:
 
 @dataclass(frozen=True)
 class DiagnosticCatalogProjection:
+    """Diagnostic subset derived deterministically from a validated catalog."""
+
     connector_firewalls: tuple[dict, ...]
     model_provider_exclusions: tuple[dict, ...]
     shared_base_keys: frozenset[str]
@@ -63,6 +65,8 @@ class DiagnosticCatalogProjection:
 
 @dataclass(frozen=True)
 class DiagnosticCatalogSnapshot:
+    """Compiled diagnostic catalog or unavailable outcome selected for a flow."""
+
     dependency_file_key: builtin_firewall_cache.CatalogFileKey | None
     catalog_identity: builtin_firewall_cache.CatalogIdentity | None
     catalog: _DiagnosticCatalog | None

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -115,7 +115,7 @@ def catalog_file_key(cache_path: str | None) -> CatalogFileKey | None:
 
 
 def load_catalog_snapshot(cache_path: str | None) -> BuiltinFirewallCatalogSnapshot:
-    """Load one catalog cache state for a single registry reload."""
+    """Load one trusted catalog snapshot for a consumer pass."""
     if not cache_path:
         return BuiltinFirewallCatalogSnapshot(
             None,

--- a/crates/runner/mitm-addon/src/builtin_firewall_cache.py
+++ b/crates/runner/mitm-addon/src/builtin_firewall_cache.py
@@ -76,6 +76,20 @@ def clear_cache() -> None:
     _cache_state.reset()
 
 
+def configured_catalog_cache_path() -> str | None:
+    """Return the runner-configured builtin catalog cache path."""
+    options = getattr(ctx, "options", None)
+    cache_path = getattr(options, "vm0_builtin_firewall_catalog_cache_path", None)
+    if not isinstance(cache_path, str) or cache_path == "":
+        return None
+    return cache_path
+
+
+def load_configured_catalog_snapshot() -> BuiltinFirewallCatalogSnapshot:
+    """Load the current runner-configured builtin catalog snapshot."""
+    return load_catalog_snapshot(configured_catalog_cache_path())
+
+
 def _path_key(path: Path) -> str:
     return str(path.absolute())
 

--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -29,6 +29,7 @@ REQUEST_HEADERS_PROBE_METADATA_KEYS = (
 
 _CONNECTOR_DIAGNOSTIC_ELIGIBLE = "_connector_diagnostic_eligible"
 _CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES = "_connector_diagnostic_active_firewall_names"
+_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT = "_connector_diagnostic_catalog_snapshot"
 _CONNECTOR_DIAGNOSTIC_LOOKUP_DONE = "_connector_diagnostic_lookup_done"
 _CONNECTOR_DIAGNOSTIC_CANDIDATE = "_connector_diagnostic_candidate"
 _CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES = "_connector_diagnostic_auth_header_names"
@@ -118,6 +119,7 @@ def record_allow_context(
     flow.metadata[_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES] = tuple(
         sorted(_active_firewall_names(vm_info))
     )
+    _pin_diagnostic_snapshot(flow, classification)
 
 
 def maybe_make_local_response(
@@ -152,6 +154,8 @@ def maybe_make_local_response(
 def maybe_make_firewall_allow_local_response(
     flow: http.HTTPFlow,
     classification: request_classification.RequestClassification,
+    *,
+    commit: bool,
 ) -> bool:
     if classification.kind != "firewall_allow":
         return False
@@ -167,7 +171,11 @@ def maybe_make_firewall_allow_local_response(
     if not original_url:
         return False
 
+    diagnostic_snapshot = _select_diagnostic_snapshot(flow, classification)
+    if commit:
+        flow.metadata[_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT] = diagnostic_snapshot
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        diagnostic_snapshot,
         original_url,
         flow.request.method,
         active_firewall_names=_active_firewall_names(vm_info),
@@ -181,6 +189,7 @@ def maybe_make_firewall_allow_local_response(
     if _request_has_auth_material(flow, candidate, original_url):
         return False
 
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT] = diagnostic_snapshot
     flow_metadata.start_request_timing(flow.metadata)
     _set_failure_metadata(flow, candidate)
     flow.metadata[_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON] = resolution.reason
@@ -285,7 +294,17 @@ def maybe_make_error_response(
     )
 
 
-def release_response_stream_state(flow: http.HTTPFlow) -> None:
+def release_flow_state(flow: http.HTTPFlow) -> None:
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_ELIGIBLE, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_ACTIVE_FIREWALL_NAMES, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_CANDIDATE, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_AUTH_HEADER_NAMES, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_AUTH_QUERY_PARAM_NAMES, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_REASON, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_CANDIDATES, None)
+    flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_OWNERSHIP_HINT_STATUS, None)
     stream_callback = flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_CALLBACK, None)
     flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_BODY, None)
     flow.metadata.pop(_CONNECTOR_DIAGNOSTIC_RESPONSE_STREAM_BODY_SENT, None)
@@ -356,6 +375,37 @@ def _cached_candidate_from_flow(
     return None
 
 
+def _diagnostic_snapshot_from_flow(
+    flow: http.HTTPFlow,
+) -> builtin_connector_diagnostics.DiagnosticCatalogSnapshot | None:
+    snapshot = flow.metadata.get(_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT)
+    if isinstance(snapshot, builtin_connector_diagnostics.DiagnosticCatalogSnapshot):
+        return snapshot
+    return None
+
+
+def _select_diagnostic_snapshot(
+    flow: http.HTTPFlow,
+    classification: request_classification.RequestClassification | None = None,
+) -> builtin_connector_diagnostics.DiagnosticCatalogSnapshot:
+    pinned = _diagnostic_snapshot_from_flow(flow)
+    if pinned is not None:
+        return pinned
+    preferred = (
+        classification.builtin_firewall_catalog_snapshot if classification is not None else None
+    )
+    return builtin_connector_diagnostics.load_diagnostic_snapshot(preferred)
+
+
+def _pin_diagnostic_snapshot(
+    flow: http.HTTPFlow,
+    classification: request_classification.RequestClassification | None = None,
+) -> builtin_connector_diagnostics.DiagnosticCatalogSnapshot:
+    snapshot = _select_diagnostic_snapshot(flow, classification)
+    flow.metadata[_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT] = snapshot
+    return snapshot
+
+
 def _resolve_candidate(
     flow: http.HTTPFlow,
     *,
@@ -376,8 +426,12 @@ def _resolve_candidate(
     if _is_browser_diagnostic_skip(flow):
         return None
 
+    diagnostic_snapshot = _diagnostic_snapshot_from_flow(flow)
+    if diagnostic_snapshot is None:
+        return None
     flow.metadata[_CONNECTOR_DIAGNOSTIC_LOOKUP_DONE] = True
     candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         original_url,
         flow.request.method,
         active_firewall_names=set(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1072,8 +1072,6 @@ async def request(flow: http.HTTPFlow) -> None:
                 terminal_usage.release_tracked_flow(flow)
                 _block_public_destination_denied(flow, public_destination_denial)
                 return
-            if flow.metadata.get(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS):
-                return
             if connector_diagnostics.maybe_make_firewall_allow_local_response(
                 flow,
                 classification,
@@ -1081,6 +1079,8 @@ async def request(flow: http.HTTPFlow) -> None:
             ):
                 auth_base_forwarder.release_forward_request_admission_from_flow(flow)
                 terminal_usage.release_tracked_flow(flow)
+                return
+            if flow.metadata.get(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS):
                 return
             if _firewall_allow_injects_ordinary_upstream_credentials(
                 allow

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -806,7 +806,11 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
             flow.kill()
         return None
 
-    if connector_diagnostics.maybe_make_firewall_allow_local_response(flow, classification):
+    if connector_diagnostics.maybe_make_firewall_allow_local_response(
+        flow,
+        classification,
+        commit=False,
+    ):
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         upstream_admission.forget_server_binding(flow.server_conn)
         return None
@@ -1073,6 +1077,7 @@ async def request(flow: http.HTTPFlow) -> None:
             if connector_diagnostics.maybe_make_firewall_allow_local_response(
                 flow,
                 classification,
+                commit=True,
             ):
                 auth_base_forwarder.release_forward_request_admission_from_flow(flow)
                 terminal_usage.release_tracked_flow(flow)
@@ -1322,7 +1327,7 @@ def _release_terminal_flow_state(
     flow.metadata.pop(_FIREWALL_AUTH_APPLIED_IN_REQUESTHEADERS, None)
     flow.metadata.pop(metadata_keys.WEBSOCKET_UPGRADE_REQUEST, None)
     request_streaming.release_request_stream_state(flow)
-    connector_diagnostics.release_response_stream_state(flow)
+    connector_diagnostics.release_flow_state(flow)
     response_streaming.release_response_stream_state(flow)
     auth_base_forwarder.release_forward_request_admission_from_flow(flow)
     if flow.error is not None:

--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -56,6 +56,7 @@ class _RegistrySnapshot:
     invalid_vms: dict[str, InvalidVmEntry]
     compiled_firewalls: dict[str, matching.CompiledFirewallSet]
     compiled_network_policies: dict[str, matching.CompiledNetworkPolicies]
+    builtin_firewall_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None
     loaded_key: _RegistryCacheKey | None
 
 
@@ -71,7 +72,7 @@ RegistryState = _RegistrySnapshot | RegistryUnavailable
 
 
 def _empty_snapshot() -> _RegistrySnapshot:
-    return _RegistrySnapshot({}, {}, {}, {}, None)
+    return _RegistrySnapshot({}, {}, {}, {}, None, None)
 
 
 @dataclass
@@ -213,11 +214,7 @@ def _compile_firewalls_with_builtin_cache(
 
 
 def _builtin_firewall_catalog_cache_path() -> str | None:
-    options = getattr(ctx, "options", None)
-    cache_path = getattr(options, "vm0_builtin_firewall_catalog_cache_path", None)
-    if not isinstance(cache_path, str) or cache_path == "":
-        return None
-    return cache_path
+    return registry_firewalls.configured_catalog_cache_path()
 
 
 def _registry_file_key_matches_snapshot_without_catalog_dependency(
@@ -240,7 +237,7 @@ def _classify_registry_vms(
     dict[str, InvalidVmEntry],
     dict[str, tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...]],
     bool,
-    registry_firewalls.BuiltinFirewallCatalogFileKey | None,
+    registry_firewalls.BuiltinFirewallCatalogSnapshot | None,
 ]:
     new_registry: dict = {}
     invalid_vms: dict[str, InvalidVmEntry] = {}
@@ -330,11 +327,7 @@ def _classify_registry_vms(
         invalid_vms,
         builtin_cache_keys_by_client_ip,
         uses_builtin_catalog_dependency,
-        (
-            builtin_catalog_snapshot.dependency_file_key
-            if builtin_catalog_snapshot is not None
-            else None
-        ),
+        builtin_catalog_snapshot,
     )
 
 
@@ -393,7 +386,6 @@ def _mark_unavailable(
         evict_all_cache_keys()
     state.snapshot = _empty_snapshot()
     state.builtin_firewall_core_cache.clear()
-    registry_firewalls.clear_catalog_cache()
     state.unavailable = RegistryUnavailable(reason, message)
     return state.unavailable
 
@@ -446,7 +438,6 @@ def load_registry_state(registry_path: str) -> RegistryState:
             state.unavailable = None
             state.stat_error_logged = False
             state.read_error_key = None
-            registry_firewalls.clear_catalog_cache()
             return state.snapshot
         if key == state.failed_key:
             return state.unavailable or _mark_unavailable(
@@ -478,18 +469,20 @@ def load_registry_state(registry_path: str) -> RegistryState:
         invalid_vms,
         builtin_cache_keys,
         uses_builtin_catalog_dependency,
-        builtin_catalog_dependency_file_key,
+        builtin_catalog_snapshot,
     ) = _classify_registry_vms(
         raw_registry,
         builtin_firewall_catalog_cache_path=builtin_catalog_cache_path,
     )
     loaded_builtin_catalog_file_key = (
-        builtin_catalog_dependency_file_key
+        (
+            builtin_catalog_snapshot.dependency_file_key
+            if builtin_catalog_snapshot is not None
+            else None
+        )
         if uses_builtin_catalog_dependency
         else _NO_BUILTIN_FIREWALL_CATALOG_DEPENDENCY
     )
-    if not uses_builtin_catalog_dependency:
-        registry_firewalls.clear_catalog_cache()
     loaded_key = (
         path_key,
         st.st_dev,
@@ -515,6 +508,7 @@ def load_registry_state(registry_path: str) -> RegistryState:
         invalid_vms,
         new_compiled_registry,
         new_compiled_policy_registry,
+        builtin_catalog_snapshot if uses_builtin_catalog_dependency else None,
         loaded_key,
     )
     state.unavailable = None

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -66,6 +66,11 @@ def clear_catalog_cache() -> None:
     builtin_firewall_cache.clear_cache()
 
 
+def configured_catalog_cache_path() -> str | None:
+    """Return the runner-configured builtin catalog cache path."""
+    return builtin_firewall_cache.configured_catalog_cache_path()
+
+
 def catalog_file_key(
     cache_path: str | None,
 ) -> builtin_firewall_cache.CatalogFileKey | None:

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -26,6 +26,7 @@ import http_network_log
 import matching
 import public_destination
 import registry
+import registry_firewalls
 import upstream_destination_binding
 from url_utils import AuthorityValidationError, get_trusted_authority, normalize_trusted_hostname
 
@@ -127,6 +128,9 @@ class RequestClassification:
     firewall_block: matching.FirewallBlock | None = None
     firewall_allow: matching.FirewallAllow | None = None
     public_destination_denial: PublicDestinationDenial | None = None
+    builtin_firewall_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None = (
+        None
+    )
     stale_tls_reason: str = ""
 
 
@@ -319,9 +323,16 @@ def classify_request(
                 kind="firewall_allow",
                 vm_info=vm_info,
                 firewall_allow=result,
+                builtin_firewall_catalog_snapshot=(
+                    registry_state.builtin_firewall_catalog_snapshot
+                ),
             )
 
-    return RequestClassification(kind="allow", vm_info=vm_info)
+    return RequestClassification(
+        kind="allow",
+        vm_info=vm_info,
+        builtin_firewall_catalog_snapshot=registry_state.builtin_firewall_catalog_snapshot,
+    )
 
 
 def classification_needs_request_timing(classification: RequestClassification) -> bool:

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -115,6 +115,9 @@ class RequestClassification:
     - `public_destination_denied`: `vm_info` and
       `public_destination_denial`.
     - `api_allow`, `browser_allow`, and `allow`: `vm_info`.
+    - `firewall_allow` and `allow` may also carry
+      `builtin_firewall_catalog_snapshot` when registry compilation depended on
+      a catalog snapshot.
     - `stale_tls_admission`: `stale_tls_reason`; `vm_info` is present only
       when the stale admission is detected after a VM entry is found.
     - `no_client_ip` and `pass_through`: no additional payload.

--- a/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
+++ b/crates/runner/mitm-addon/tests/connector_diagnostic_helpers.py
@@ -1,5 +1,6 @@
 """Helpers for connector diagnostic hook lifecycle tests."""
 
+import json
 from pathlib import Path
 
 from mitmproxy import http
@@ -10,7 +11,87 @@ from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
 CONNECTOR_DIAGNOSTIC_REQUEST_CHUNK = b"partial request"
 
 
+def connector_diagnostic_test_firewalls() -> dict[str, dict]:
+    return {
+        "fal": {
+            "name": "fal",
+            "apis": [
+                {
+                    "base": "https://fal.run",
+                    "hostPolicy": {
+                        "kind": "providerOwned",
+                        "exactHosts": ["fal.run"],
+                    },
+                    "auth": {
+                        "headers": {
+                            "Authorization": "Bearer ${{ secrets.FAL_TOKEN }}",
+                        }
+                    },
+                    "permissions": [
+                        {
+                            "name": "run",
+                            "rules": ["POST /fal-ai/{model}"],
+                        }
+                    ],
+                }
+            ],
+        },
+        "openweather": {
+            "name": "openweather",
+            "apis": [
+                {
+                    "base": "https://api.openweathermap.org",
+                    "hostPolicy": {
+                        "kind": "providerOwned",
+                        "exactHosts": ["api.openweathermap.org"],
+                    },
+                    "auth": {
+                        "query": {
+                            "appid": "${{ secrets.OPENWEATHER_TOKEN }}",
+                        }
+                    },
+                    "permissions": [
+                        {
+                            "name": "read",
+                            "rules": ["GET /{path+}"],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+def write_connector_diagnostic_catalog_cache(
+    tmp_path: Path,
+    *,
+    firewalls: dict[str, dict] | None = None,
+    digest: str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    version: str = "catalog-test",
+) -> Path:
+    cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+    replacement_path = tmp_path / "builtin-firewall-catalog-cache.next.json"
+    replacement_path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "catalogDigest": digest,
+                "catalogVersion": version,
+                "updatedAt": "2026-07-07T00:00:00.000Z",
+                "firewalls": (
+                    connector_diagnostic_test_firewalls() if firewalls is None else firewalls
+                ),
+            },
+            sort_keys=True,
+        )
+    )
+    replacement_path.chmod(0o600)
+    replacement_path.replace(cache_path)
+    return cache_path
+
+
 def write_connector_diagnostic_capture_registry(tmp_path: Path) -> Path:
+    write_connector_diagnostic_catalog_cache(tmp_path)
     return _write_registry(
         tmp_path,
         vm_info=_vm_without_firewalls(

--- a/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_connector_diagnostics.py
@@ -1,38 +1,89 @@
 """Tests for built-in connector diagnostic URL classification."""
 
+import pytest
+
 import builtin_connector_diagnostics
-import generated.builtin_firewalls
+import builtin_firewall_cache
+from generated.builtin_firewalls import BUILTIN_FIREWALLS
+from generated.builtin_firewalls.diagnostics import (
+    CONNECTOR_DIAGNOSTIC_FIREWALLS,
+    MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS,
+)
+
+_TEST_FILE_KEY: builtin_firewall_cache.CatalogFileKey = (
+    "/test/catalog.json",
+    1,
+    1,
+    1,
+    1,
+)
 
 
 def _shared_base_firewall(
-    name,
-    token_name,
+    name: str,
+    token_name: str,
     *,
-    permissions=None,
-    base="https://shared.example.com",
-):
+    permissions: list[dict] | None = None,
+    base: str = "https://shared.example.com",
+) -> dict:
     return {
         "name": name,
         "apis": [
             {
                 "base": base,
-                "envNames": [token_name],
-                "authHeaderNames": ["Authorization"],
-                "authQueryParamNames": [],
+                "auth": {
+                    "headers": {
+                        "Authorization": f"Bearer ${{{{ secrets.{token_name} }}}}",
+                    }
+                },
                 "permissions": permissions or [],
             }
         ],
     }
 
 
-def _patch_connector_diagnostics(monkeypatch, firewalls):
-    monkeypatch.setattr(builtin_connector_diagnostics, "CONNECTOR_DIAGNOSTIC_FIREWALLS", firewalls)
-    monkeypatch.setattr(builtin_connector_diagnostics, "MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS", [])
-    builtin_connector_diagnostics.reset_cache_for_tests()
+def _diagnostic_snapshot(
+    firewalls: dict[str, dict] | list[dict],
+) -> builtin_connector_diagnostics.DiagnosticCatalogSnapshot:
+    firewall_map = (
+        firewalls
+        if isinstance(firewalls, dict)
+        else {firewall["name"]: firewall for firewall in firewalls}
+    )
+    raw_snapshot = builtin_firewall_cache.BuiltinFirewallCatalogSnapshot(
+        dependency_file_key=_TEST_FILE_KEY,
+        catalog=builtin_firewall_cache.BuiltinFirewallCatalog(
+            identity=("cache", "sha256:" + "0" * 64, "test", _TEST_FILE_KEY),
+            firewalls=firewall_map,
+        ),
+        cache_path=_TEST_FILE_KEY[0],
+    )
+    return builtin_connector_diagnostics._compile_diagnostic_snapshot(raw_snapshot)
 
 
-def test_classifies_static_builtin_connector_url():
+@pytest.fixture(scope="module")
+def diagnostic_snapshot() -> builtin_connector_diagnostics.DiagnosticCatalogSnapshot:
+    return _diagnostic_snapshot(dict(BUILTIN_FIREWALLS))
+
+
+def test_server_catalog_projection_matches_generated_diagnostic_oracle():
+    projection = builtin_connector_diagnostics.project_diagnostic_catalog(dict(BUILTIN_FIREWALLS))
+
+    assert len(projection.connector_firewalls) == 246
+    assert sum(len(firewall["apis"]) for firewall in projection.connector_firewalls) == 353
+    assert len(projection.model_provider_exclusions) == 12
+    assert sum(len(firewall["apis"]) for firewall in projection.model_provider_exclusions) == 13
+    assert len(projection.shared_base_keys) == 3
+    assert [firewall["name"] for firewall in projection.connector_firewalls] == sorted(
+        firewall["name"] for firewall in projection.connector_firewalls
+    )
+    assert list(projection.connector_firewalls) == CONNECTOR_DIAGNOSTIC_FIREWALLS
+    assert list(projection.model_provider_exclusions) == MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS
+
+
+def test_classifies_static_builtin_connector_url(diagnostic_snapshot):
     candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         "https://fal.run/fal-ai/nano-banana-pro",
         "POST",
         active_firewall_names=set(),
@@ -47,25 +98,9 @@ def test_classifies_static_builtin_connector_url():
     assert candidate.auth_query_param_names == ()
 
 
-def test_classification_does_not_load_full_builtin_catalog(monkeypatch):
-    def fail_load_json_parts(_name):
-        raise AssertionError("connector diagnostics should not load full firewall JSON")
-
-    monkeypatch.setattr(generated.builtin_firewalls, "load_json_parts", fail_load_json_parts)
-    builtin_connector_diagnostics.reset_cache_for_tests()
-
+def test_skips_active_connector_name(diagnostic_snapshot):
     candidate = builtin_connector_diagnostics.find_candidate(
-        "https://fal.run/fal-ai/nano-banana-pro",
-        "POST",
-        active_firewall_names=set(),
-    )
-
-    assert candidate is not None
-    assert candidate.connector_type == "fal"
-
-
-def test_skips_active_connector_name():
-    candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         "https://fal.run/fal-ai/nano-banana-pro",
         "POST",
         active_firewall_names={"fal"},
@@ -74,8 +109,9 @@ def test_skips_active_connector_name():
     assert candidate is None
 
 
-def test_skips_dynamic_template_base_urls():
+def test_skips_dynamic_template_base_urls(diagnostic_snapshot):
     candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         "https://acme.zendesk.com/api/v2/tickets",
         "GET",
         active_firewall_names=set(),
@@ -84,19 +120,19 @@ def test_skips_dynamic_template_base_urls():
     assert candidate is None
 
 
-def test_classifies_static_base_with_literal_unbalanced_brace(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_classifies_static_base_with_literal_unbalanced_brace():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall(
                 "literal-brace",
                 "LITERAL_BRACE_TOKEN",
                 base="https://literal.example.com/{literal",
             )
-        ],
+        ]
     )
 
     candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
         "https://literal.example.com/{literal/item",
         "GET",
         active_firewall_names=set(),
@@ -107,19 +143,19 @@ def test_classifies_static_base_with_literal_unbalanced_brace(monkeypatch):
     assert candidate.env_names == ("LITERAL_BRACE_TOKEN",)
 
 
-def test_skips_parameterized_manifest_base_urls(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_skips_parameterized_catalog_base_urls():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall(
                 "parameterized",
                 "PARAMETERIZED_TOKEN",
                 base="https://parameterized.example.com/{tenant}",
             )
-        ],
+        ]
     )
 
     candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
         "https://parameterized.example.com/acme/item",
         "GET",
         active_firewall_names=set(),
@@ -128,13 +164,14 @@ def test_skips_parameterized_manifest_base_urls(monkeypatch):
     assert candidate is None
 
 
-def test_skips_parameterized_base_urls():
+def test_skips_parameterized_base_urls(diagnostic_snapshot):
     for url in (
         "https://s3.amazonaws.com/my-bucket/private-object",
         "https://raw.githubusercontent.com/vm0-ai/vm0/main/README.md",
         "https://eth-mainnet.g.alchemy.com/v2/demo",
     ):
         candidate = builtin_connector_diagnostics.find_candidate(
+            diagnostic_snapshot,
             url,
             "GET",
             active_firewall_names=set(),
@@ -143,8 +180,11 @@ def test_skips_parameterized_base_urls():
         assert candidate is None
 
 
-def test_skips_static_connector_urls_without_injectable_auth_references():
+def test_skips_static_connector_urls_without_injectable_auth_references(
+    diagnostic_snapshot,
+):
     candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         "https://test.api.amadeus.com/v1/security/oauth2/token",
         "POST",
         active_firewall_names=set(),
@@ -153,7 +193,7 @@ def test_skips_static_connector_urls_without_injectable_auth_references():
     assert candidate is None
 
 
-def test_skips_model_provider_firewalls():
+def test_skips_model_provider_firewalls(diagnostic_snapshot):
     for url in (
         "https://api.anthropic.com/v1/messages",
         "https://api.openai.com/v1/responses",
@@ -162,6 +202,7 @@ def test_skips_model_provider_firewalls():
         "https://api.minimax.io/anthropic/v1/messages",
     ):
         candidate = builtin_connector_diagnostics.find_candidate(
+            diagnostic_snapshot,
             url,
             "POST",
             active_firewall_names=set(),
@@ -170,8 +211,11 @@ def test_skips_model_provider_firewalls():
         assert candidate is None
 
 
-def test_connector_diagnostic_matches_static_base_without_permission_method_enforcement():
+def test_connector_diagnostic_matches_static_base_without_permission_method_enforcement(
+    diagnostic_snapshot,
+):
     candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         "https://slack.com/api/conversations.list",
         "POST",
         active_firewall_names=set(),
@@ -182,8 +226,11 @@ def test_connector_diagnostic_matches_static_base_without_permission_method_enfo
     assert candidate.base == "https://slack.com/api"
 
 
-def test_classifies_connector_permission_path_on_model_provider_host():
+def test_classifies_connector_permission_path_on_model_provider_host(
+    diagnostic_snapshot,
+):
     candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         "https://api.anthropic.com/v1/agents",
         "GET",
         active_firewall_names=set(),
@@ -194,16 +241,16 @@ def test_classifies_connector_permission_path_on_model_provider_host():
     assert candidate.env_names == ("ANTHROPIC_MANAGED_AGENTS_TOKEN",)
 
 
-def test_find_candidate_suppresses_shared_base_only_candidate(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_find_candidate_suppresses_shared_base_only_candidate():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall("first", "FIRST_TOKEN"),
             _shared_base_firewall("second", "SECOND_TOKEN"),
-        ],
+        ]
     )
 
     candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
         "https://shared.example.com/messages/123",
         "GET",
         active_firewall_names=set(),
@@ -212,9 +259,8 @@ def test_find_candidate_suppresses_shared_base_only_candidate(monkeypatch):
     assert candidate is None
 
 
-def test_find_candidate_selects_shared_base_route_specific_inactive_owner(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_find_candidate_selects_shared_base_route_specific_inactive_owner():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall("active", "ACTIVE_TOKEN"),
             _shared_base_firewall(
@@ -222,10 +268,11 @@ def test_find_candidate_selects_shared_base_route_specific_inactive_owner(monkey
                 "INACTIVE_TOKEN",
                 permissions=[{"name": "inactive-read", "rules": ["GET /messages/{id}"]}],
             ),
-        ],
+        ]
     )
 
     candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
         "https://shared.example.com/messages/123",
         "GET",
         active_firewall_names={"active"},
@@ -236,9 +283,8 @@ def test_find_candidate_selects_shared_base_route_specific_inactive_owner(monkey
     assert candidate.env_names == ("INACTIVE_TOKEN",)
 
 
-def test_find_candidate_suppresses_shared_base_active_route_owner(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_find_candidate_suppresses_shared_base_active_route_owner():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall(
                 "active",
@@ -246,10 +292,11 @@ def test_find_candidate_suppresses_shared_base_active_route_owner(monkeypatch):
                 permissions=[{"name": "active-read", "rules": ["GET /messages/{id}"]}],
             ),
             _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
-        ],
+        ]
     )
 
     candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
         "https://shared.example.com/messages/123",
         "GET",
         active_firewall_names={"active"},
@@ -258,9 +305,8 @@ def test_find_candidate_suppresses_shared_base_active_route_owner(monkeypatch):
     assert candidate is None
 
 
-def test_find_candidate_suppresses_shared_base_multiple_route_owners(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_find_candidate_suppresses_shared_base_multiple_route_owners():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall(
                 "first",
@@ -272,10 +318,11 @@ def test_find_candidate_suppresses_shared_base_multiple_route_owners(monkeypatch
                 "SECOND_TOKEN",
                 permissions=[{"name": "second-read", "rules": ["GET /messages/{id}"]}],
             ),
-        ],
+        ]
     )
 
     candidate = builtin_connector_diagnostics.find_candidate(
+        snapshot,
         "https://shared.example.com/messages/123",
         "GET",
         active_firewall_names=set(),
@@ -284,12 +331,15 @@ def test_find_candidate_suppresses_shared_base_multiple_route_owners(monkeypatch
     assert candidate is None
 
 
-def test_find_candidate_suppresses_current_graph_mail_and_calendar_base_only_diagnostics():
+def test_find_candidate_suppresses_current_graph_mail_and_calendar_base_only_diagnostics(
+    diagnostic_snapshot,
+):
     for url in (
         "https://graph.microsoft.com/v1.0/me/messages",
         "https://graph.microsoft.com/v1.0/me/events",
     ):
         candidate = builtin_connector_diagnostics.find_candidate(
+            diagnostic_snapshot,
             url,
             "GET",
             active_firewall_names=set(),
@@ -298,8 +348,11 @@ def test_find_candidate_suppresses_current_graph_mail_and_calendar_base_only_dia
         assert candidate is None
 
 
-def test_find_candidate_keeps_current_graph_route_specific_microsoft_365_diagnostic():
+def test_find_candidate_keeps_current_graph_route_specific_microsoft_365_diagnostic(
+    diagnostic_snapshot,
+):
     candidate = builtin_connector_diagnostics.find_candidate(
+        diagnostic_snapshot,
         "https://graph.microsoft.com/v1.0/teams",
         "GET",
         active_firewall_names=set(),
@@ -309,12 +362,15 @@ def test_find_candidate_keeps_current_graph_route_specific_microsoft_365_diagnos
     assert candidate.connector_type == "microsoft-365"
 
 
-def test_find_candidate_suppresses_current_shared_base_only_diagnostics():
+def test_find_candidate_suppresses_current_shared_base_only_diagnostics(
+    diagnostic_snapshot,
+):
     for url, method in (
         ("https://backboard.railway.com/graphql/v2", "POST"),
         ("https://graph.facebook.com/v22.0/123/ads_posts", "GET"),
     ):
         candidate = builtin_connector_diagnostics.find_candidate(
+            diagnostic_snapshot,
             url,
             method,
             active_firewall_names=set(),
@@ -323,9 +379,8 @@ def test_find_candidate_suppresses_current_shared_base_only_diagnostics():
         assert candidate is None
 
 
-def test_shared_base_ownership_selects_route_specific_inactive_sibling(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_shared_base_ownership_selects_route_specific_inactive_sibling():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall(
                 "active",
@@ -337,10 +392,11 @@ def test_shared_base_ownership_selects_route_specific_inactive_sibling(monkeypat
                 "INACTIVE_TOKEN",
                 permissions=[{"name": "inactive-read", "rules": ["GET /messages/{id}"]}],
             ),
-        ],
+        ]
     )
 
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        snapshot,
         "https://shared.example.com/messages/123",
         "GET",
         active_firewall_names={"active"},
@@ -355,16 +411,16 @@ def test_shared_base_ownership_selects_route_specific_inactive_sibling(monkeypat
     assert resolution.candidate.env_names == ("INACTIVE_TOKEN",)
 
 
-def test_shared_base_ownership_suppresses_base_only_candidate(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_shared_base_ownership_suppresses_base_only_candidate():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall("active", "ACTIVE_TOKEN"),
             _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
-        ],
+        ]
     )
 
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        snapshot,
         "https://shared.example.com/messages/123",
         "GET",
         active_firewall_names={"active"},
@@ -376,16 +432,16 @@ def test_shared_base_ownership_suppresses_base_only_candidate(monkeypatch):
     assert resolution.reason == "base_only"
 
 
-def test_shared_base_ownership_uses_intent_inside_candidate_set(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_shared_base_ownership_uses_intent_inside_candidate_set():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall("active", "ACTIVE_TOKEN"),
             _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
-        ],
+        ]
     )
 
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        snapshot,
         "https://shared.example.com/graphql/v2",
         "POST",
         active_firewall_names={"active"},
@@ -400,16 +456,16 @@ def test_shared_base_ownership_uses_intent_inside_candidate_set(monkeypatch):
     assert resolution.candidate.connector_type == "inactive"
 
 
-def test_shared_base_ownership_ignores_intent_outside_candidate_set(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_shared_base_ownership_ignores_intent_outside_candidate_set():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall("active", "ACTIVE_TOKEN"),
             _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
-        ],
+        ]
     )
 
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        snapshot,
         "https://shared.example.com/graphql/v2",
         "POST",
         active_firewall_names={"active"},
@@ -423,9 +479,8 @@ def test_shared_base_ownership_ignores_intent_outside_candidate_set(monkeypatch)
     assert resolution.hint_status == "outside_candidate_set"
 
 
-def test_shared_base_ownership_route_specific_active_overrides_conflicting_intent(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_shared_base_ownership_route_specific_active_overrides_conflicting_intent():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall(
                 "active",
@@ -433,10 +488,11 @@ def test_shared_base_ownership_route_specific_active_overrides_conflicting_inten
                 permissions=[{"name": "active-read", "rules": ["GET /active/{id}"]}],
             ),
             _shared_base_firewall("inactive", "INACTIVE_TOKEN"),
-        ],
+        ]
     )
 
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        snapshot,
         "https://shared.example.com/active/123",
         "GET",
         active_firewall_names={"active"},
@@ -450,9 +506,8 @@ def test_shared_base_ownership_route_specific_active_overrides_conflicting_inten
     assert resolution.hint_status == "ignored"
 
 
-def test_shared_base_ownership_normalizes_static_base_keys(monkeypatch):
-    _patch_connector_diagnostics(
-        monkeypatch,
+def test_shared_base_ownership_normalizes_static_base_keys():
+    snapshot = _diagnostic_snapshot(
         [
             _shared_base_firewall(
                 "active",
@@ -466,10 +521,11 @@ def test_shared_base_ownership_normalizes_static_base_keys(monkeypatch):
                 base="https://shared.example.com/api",
                 permissions=[{"name": "inactive-read", "rules": ["GET /messages/{id}"]}],
             ),
-        ],
+        ]
     )
 
     resolution = builtin_connector_diagnostics.resolve_shared_base_ownership(
+        snapshot,
         "https://shared.example.com/api/messages/123",
         "GET",
         active_firewall_names={"active"},

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -16,6 +16,7 @@ from tests.connector_diagnostic_helpers import (
 )
 from tests.flow_helpers import header_map, response_stream
 from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
+from tests.requestheaders_helpers import await_requestheaders_result
 
 
 def _catalog_firewall(
@@ -196,14 +197,16 @@ def _shared_catalog(inactive_name: str, inactive_token: str) -> dict[str, dict]:
     return {"active-shared": active, inactive_name: inactive}
 
 
-def _builtin_shared_registry(tmp_path):
+def _builtin_shared_registry(tmp_path, *, capture_network_bodies: bool = False):
     return _write_registry(
         tmp_path,
         vm_info={
             "runId": "run-shared",
             "sandboxToken": "sandbox-shared",
+            "encryptedSecrets": "iv:tag:data",
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+            "captureNetworkBodies": capture_network_bodies,
             "firewalls": [{"kind": "builtin", "name": "active-shared"}],
             "networkPolicies": {
                 "active-shared": {
@@ -271,6 +274,66 @@ async def test_registry_classification_from_a_cannot_race_into_diagnostic_b(
     assert current_snapshot.catalog_identity is not None
     assert current_snapshot.catalog_identity[2] == "catalog-b"
     assert _response_connector(second_flow) == "inactive-b"
+
+
+async def test_stream_safe_firewall_request_commit_pins_classification_catalog(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+):
+    cache_path = write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls=_shared_catalog("inactive-a", "INACTIVE_A_TOKEN"),
+        version="catalog-a",
+    )
+    registry_path = _builtin_shared_registry(tmp_path, capture_network_bodies=True)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/unowned",
+        method="POST",
+        request_headers=headers(
+            ("Host", "shared.example.com"),
+            ("Content-Length", str(mitm_addon.STREAM_BUFFER_LIMIT + 1)),
+        ),
+    )
+
+    with (
+        mitm_ctx(
+            registry_path=str(registry_path),
+            builtin_firewall_catalog_cache_path=str(cache_path),
+        ),
+        fake_firewall_headers(headers={"Authorization": "Bearer active"}) as auth_fetch,
+    ):
+        requestheaders_result = mitm_addon.requestheaders(flow)
+        await await_requestheaders_result(requestheaders_result)
+        write_connector_diagnostic_catalog_cache(
+            tmp_path,
+            firewalls=_shared_catalog("inactive-b", "INACTIVE_B_TOKEN"),
+            digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            version="catalog-b",
+        )
+
+        await mitm_addon.request(flow)
+
+        pinned_snapshots = [
+            value
+            for value in flow.metadata.values()
+            if isinstance(value, builtin_connector_diagnostics.DiagnosticCatalogSnapshot)
+        ]
+        current_snapshot = builtin_connector_diagnostics.load_diagnostic_snapshot()
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer active"
+    assert len(pinned_snapshots) == 1
+    assert pinned_snapshots[0].catalog_identity is not None
+    assert pinned_snapshots[0].catalog_identity[2] == "catalog-a"
+    assert current_snapshot.catalog_identity is not None
+    assert current_snapshot.catalog_identity[2] == "catalog-b"
 
 
 async def test_unavailable_flow_stays_unavailable_after_cache_recovers(

--- a/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
+++ b/crates/runner/mitm-addon/tests/test_connector_diagnostic_catalog_lifecycle.py
@@ -1,0 +1,364 @@
+"""Integration tests for server-catalog connector diagnostic lifecycles."""
+
+import json
+
+import pytest
+from mitmproxy.flow import Error
+from mitmproxy.test import tutils
+
+import builtin_connector_diagnostics
+import flow_metadata_keys as metadata_keys
+import mitm_addon
+import request_classification
+from tests.connector_diagnostic_helpers import (
+    record_connector_diagnostic_requestheaders_context,
+    write_connector_diagnostic_catalog_cache,
+)
+from tests.flow_helpers import header_map, response_stream
+from tests.request_handler_helpers import _vm_without_firewalls, _write_registry
+
+
+def _catalog_firewall(
+    name: str,
+    token_name: str,
+    *,
+    base: str = "https://catalog.example.com",
+    permissions: list[dict[str, object]] | None = None,
+) -> dict:
+    host = base.removeprefix("https://").split("/", maxsplit=1)[0]
+    return {
+        "name": name,
+        "apis": [
+            {
+                "base": base,
+                "hostPolicy": {
+                    "kind": "providerOwned",
+                    "exactHosts": [host],
+                },
+                "auth": {
+                    "headers": {
+                        "Authorization": f"Bearer ${{{{ secrets.{token_name} }}}}",
+                    }
+                },
+                "permissions": permissions or [{"name": "access", "rules": ["ANY /{path+}"]}],
+            }
+        ],
+    }
+
+
+def _catalog(name: str, token_name: str) -> dict[str, dict]:
+    return {name: _catalog_firewall(name, token_name)}
+
+
+def _capture_registry(tmp_path):
+    return _write_registry(
+        tmp_path,
+        vm_info=_vm_without_firewalls(
+            tmp_path,
+            vm_fields={"captureNetworkBodies": True},
+        ),
+    )
+
+
+def _flow(real_flow, *, host: str = "catalog.example.com"):
+    return real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host=host,
+        path="/items",
+        method="POST",
+    )
+
+
+def _response_connector(flow) -> str:
+    assert flow.response is not None
+    content = flow.response.content
+    assert content is not None
+    body = json.loads(content)
+    connector = body.get("connector")
+    assert isinstance(connector, str)
+    return connector
+
+
+def test_unchanged_cache_reuses_compiled_diagnostic_snapshot(tmp_path, mitm_ctx):
+    cache_path = write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls=_catalog("catalog-a", "CATALOG_A_TOKEN"),
+        version="catalog-a",
+    )
+
+    with mitm_ctx(builtin_firewall_catalog_cache_path=str(cache_path)):
+        first = builtin_connector_diagnostics.load_diagnostic_snapshot()
+        second = builtin_connector_diagnostics.load_diagnostic_snapshot()
+
+    assert first is second
+    assert first.catalog is not None
+    assert first.catalog_identity is not None
+    assert first.catalog_identity[2] == "catalog-a"
+
+
+@pytest.mark.parametrize("terminal_hook", ["response", "stream", "error"])
+def test_pinned_flow_finishes_with_catalog_a_after_atomic_b_replacement(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    terminal_hook,
+):
+    cache_path = write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls=_catalog("catalog-a", "CATALOG_A_TOKEN"),
+        version="catalog-a",
+    )
+    registry_path = _capture_registry(tmp_path)
+    flow = _flow(real_flow)
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_catalog_cache_path=str(cache_path),
+    ):
+        record_connector_diagnostic_requestheaders_context(flow)
+        write_connector_diagnostic_catalog_cache(
+            tmp_path,
+            firewalls=_catalog("catalog-b", "CATALOG_B_TOKEN"),
+            digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            version="catalog-b",
+        )
+
+        streamed_body: bytes | None = None
+        if terminal_hook == "error":
+            flow.error = Error("connection reset by peer")
+            mitm_addon.error(flow)
+        else:
+            flow.response = tutils.tresp(
+                status_code=401,
+                headers=header_map({"content-type": "text/plain"}),
+                content=b"upstream auth error",
+            )
+            if terminal_hook == "stream":
+                mitm_addon.responseheaders(flow)
+                stream = response_stream(flow)
+                assert stream(b"upstream auth error") == ()
+                stream_result = stream(b"")
+                assert isinstance(stream_result, bytes)
+                streamed_body = stream_result
+            mitm_addon.response(flow)
+
+    if streamed_body is not None:
+        assert json.loads(streamed_body)["connector"] == "catalog-a"
+    else:
+        assert _response_connector(flow) == "catalog-a"
+
+
+async def test_later_flow_observes_atomic_catalog_replacement(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    cache_path = write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls=_catalog("catalog-a", "CATALOG_A_TOKEN"),
+        version="catalog-a",
+    )
+    registry_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    first_flow = _flow(real_flow)
+    second_flow = _flow(real_flow)
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_catalog_cache_path=str(cache_path),
+    ):
+        await mitm_addon.request(first_flow)
+        write_connector_diagnostic_catalog_cache(
+            tmp_path,
+            firewalls=_catalog("catalog-b", "CATALOG_B_TOKEN"),
+            digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            version="catalog-b",
+        )
+        await mitm_addon.request(second_flow)
+
+    assert _response_connector(first_flow) == "catalog-a"
+    assert _response_connector(second_flow) == "catalog-b"
+
+
+def _shared_catalog(inactive_name: str, inactive_token: str) -> dict[str, dict]:
+    active = _catalog_firewall(
+        "active-shared",
+        "ACTIVE_TOKEN",
+        base="https://shared.example.com",
+        permissions=[{"name": "active-read", "rules": ["GET /active"]}],
+    )
+    inactive = _catalog_firewall(
+        inactive_name,
+        inactive_token,
+        base="https://shared.example.com",
+        permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
+    )
+    return {"active-shared": active, inactive_name: inactive}
+
+
+def _builtin_shared_registry(tmp_path):
+    return _write_registry(
+        tmp_path,
+        vm_info={
+            "runId": "run-shared",
+            "sandboxToken": "sandbox-shared",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+            "firewalls": [{"kind": "builtin", "name": "active-shared"}],
+            "networkPolicies": {
+                "active-shared": {
+                    "allow": ["active-read"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "allow",
+                }
+            },
+        },
+    )
+
+
+async def test_registry_classification_from_a_cannot_race_into_diagnostic_b(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    cache_path = write_connector_diagnostic_catalog_cache(
+        tmp_path,
+        firewalls=_shared_catalog("inactive-a", "INACTIVE_A_TOKEN"),
+        version="catalog-a",
+    )
+    registry_path = _builtin_shared_registry(tmp_path)
+    first_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/inactive",
+        method="GET",
+    )
+    second_flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="shared.example.com",
+        path="/inactive",
+        method="GET",
+    )
+
+    with mitm_ctx(
+        registry_path=str(registry_path),
+        builtin_firewall_catalog_cache_path=str(cache_path),
+    ):
+        classification = request_classification.classify_request(
+            first_flow,
+            registry_path=str(registry_path),
+            api_url="https://api.vm0.ai",
+            tls_admission=None,
+        )
+        assert classification.kind == "firewall_allow"
+        assert classification.builtin_firewall_catalog_snapshot is not None
+        request_classification.cache_classification(first_flow, classification)
+
+        write_connector_diagnostic_catalog_cache(
+            tmp_path,
+            firewalls=_shared_catalog("inactive-b", "INACTIVE_B_TOKEN"),
+            digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            version="catalog-b",
+        )
+        await mitm_addon.request(first_flow)
+        current_snapshot = builtin_connector_diagnostics.load_diagnostic_snapshot()
+        await mitm_addon.request(second_flow)
+
+    assert _response_connector(first_flow) == "inactive-a"
+    assert current_snapshot.catalog_identity is not None
+    assert current_snapshot.catalog_identity[2] == "catalog-b"
+    assert _response_connector(second_flow) == "inactive-b"
+
+
+async def test_unavailable_flow_stays_unavailable_after_cache_recovers(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    registry_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    unavailable_flow = _flow(real_flow)
+    recovered_flow = _flow(real_flow)
+
+    with mitm_ctx(registry_path=str(registry_path)):
+        await mitm_addon.request(unavailable_flow)
+        assert unavailable_flow.response is None
+
+        write_connector_diagnostic_catalog_cache(
+            tmp_path,
+            firewalls=_catalog("recovered", "RECOVERED_TOKEN"),
+            version="catalog-recovered",
+        )
+        unavailable_flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"upstream auth error",
+        )
+        mitm_addon.response(unavailable_flow)
+        await mitm_addon.request(recovered_flow)
+
+    assert unavailable_flow.response.status_code == 401
+    assert unavailable_flow.response.content == b"upstream auth error"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in unavailable_flow.metadata
+    assert _response_connector(recovered_flow) == "recovered"
+
+
+def _prepare_unavailable_cache(tmp_path, cache_state: str) -> None:
+    cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+    if cache_state == "malformed":
+        cache_path.write_text("{ malformed")
+    elif cache_state == "oversized":
+        cache_path.write_bytes(b"x" * (16 * 1024 * 1024 + 1))
+    elif cache_state == "group-writable":
+        cache_path.write_text("{}")
+        cache_path.chmod(0o620)
+    elif cache_state == "other-writable":
+        cache_path.write_text("{}")
+        cache_path.chmod(0o602)
+    elif cache_state == "symlink":
+        target = tmp_path / "catalog-target.json"
+        target.write_text("{}")
+        target.chmod(0o600)
+        cache_path.symlink_to(target)
+    elif cache_state == "directory":
+        cache_path.mkdir()
+    else:
+        raise AssertionError(f"unknown cache state: {cache_state}")
+
+
+@pytest.mark.parametrize(
+    "cache_state",
+    [
+        "malformed",
+        "oversized",
+        "group-writable",
+        "other-writable",
+        "symlink",
+        "directory",
+    ],
+)
+async def test_untrusted_or_invalid_cache_has_no_generated_diagnostic_fallback(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    cache_state,
+):
+    _prepare_unavailable_cache(tmp_path, cache_state)
+    registry_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
+    flow = _flow(real_flow)
+
+    with mitm_ctx(registry_path=str(registry_path)):
+        await mitm_addon.request(flow)
+        assert flow.response is None
+        flow.response = tutils.tresp(
+            status_code=401,
+            headers=header_map({"content-type": "text/plain"}),
+            content=b"upstream auth error",
+        )
+        mitm_addon.response(flow)
+
+    assert flow.response.status_code == 401
+    assert flow.response.content == b"upstream auth error"
+    assert metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -1104,7 +1104,7 @@ class TestRegistryBuiltinCache:
         second_cache_key = next(iter(registry._registry_state.builtin_firewall_core_cache))
         assert second_cache_key[0] == "cache-b"
 
-    def test_builtin_core_cache_is_cleared_when_registry_becomes_unavailable(
+    def test_registry_unavailable_clears_compiled_core_but_retains_shared_catalog(
         self, tmp_path, mitm_ctx
     ):
         path = tmp_path / "registry.json"
@@ -1124,7 +1124,8 @@ class TestRegistryBuiltinCache:
             context = registry.get_vm_context("10.200.0.1", str(path))
             assert context is not None
             assert len(registry._registry_state.builtin_firewall_core_cache) == 1
-            assert builtin_firewall_cache._cache_state.catalog is not None
+            retained_catalog = builtin_firewall_cache._cache_state.catalog
+            assert retained_catalog is not None
 
             path.write_text("{ broken")
             unavailable = registry.load_registry_state(str(path))
@@ -1132,11 +1133,9 @@ class TestRegistryBuiltinCache:
         assert isinstance(unavailable, registry.RegistryUnavailable)
         assert unavailable.reason == "parse_failed"
         assert registry._registry_state.builtin_firewall_core_cache == {}
-        assert builtin_firewall_cache._cache_state.catalog is None
+        assert builtin_firewall_cache._cache_state.catalog is retained_catalog
 
-    def test_builtin_catalog_cache_is_cleared_when_registry_drops_builtin_entries(
-        self, tmp_path, mitm_ctx
-    ):
+    def test_registry_dropping_builtin_entries_retains_shared_catalog(self, tmp_path, mitm_ctx):
         path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
         _write_catalog_cache(
@@ -1154,16 +1153,17 @@ class TestRegistryBuiltinCache:
         ):
             context = registry.get_vm_context("10.200.0.1", str(path))
             assert context is not None
-            assert builtin_firewall_cache._cache_state.catalog is not None
+            retained_catalog = builtin_firewall_cache._cache_state.catalog
+            assert retained_catalog is not None
 
             write_multi_vm_registry(path, {"10.200.0.1": inline_vm("run-inline")})
             os.utime(path, ns=(1_700_000_000_000_000_001, 1_700_000_000_000_000_001))
             inline_context = registry.get_vm_context("10.200.0.1", str(path))
 
         assert inline_context is not None
-        assert builtin_firewall_cache._cache_state.catalog is None
+        assert builtin_firewall_cache._cache_state.catalog is retained_catalog
 
-    def test_no_builtin_registry_fast_path_clears_catalog_cache(self, tmp_path, mitm_ctx):
+    def test_no_builtin_registry_fast_path_retains_shared_catalog(self, tmp_path, mitm_ctx):
         path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
         _write_catalog_cache(
@@ -1184,12 +1184,13 @@ class TestRegistryBuiltinCache:
 
             snapshot = registry_firewalls.load_catalog_snapshot(str(cache_path))
             assert snapshot.catalog is not None
-            assert builtin_firewall_cache._cache_state.catalog is not None
+            retained_catalog = builtin_firewall_cache._cache_state.catalog
+            assert retained_catalog is snapshot.catalog
 
             second_context = registry.get_vm_context("10.200.0.1", str(path))
 
         assert second_context is not None
-        assert builtin_firewall_cache._cache_state.catalog is None
+        assert builtin_firewall_cache._cache_state.catalog is retained_catalog
 
     def test_inline_firewalls_do_not_share_compiled_core(self, tmp_path):
         path = tmp_path / "registry.json"

--- a/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_connector_diagnostics.py
@@ -4,12 +4,14 @@ import json
 
 import pytest
 
-import builtin_connector_diagnostics
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import request_classification
 import request_streaming
 import upstream_destination_binding
+from tests.connector_diagnostic_helpers import (
+    write_connector_diagnostic_catalog_cache,
+)
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
 from tests.request_handler_helpers import (
     _single_firewall_vm,
@@ -73,96 +75,54 @@ def _write_shared_base_active_firewall_registry(
     )
 
 
-def _shared_base_diagnostic_firewall(
+def _shared_base_catalog_firewall(
     name: str,
     token_name: str,
     *,
     permissions: list[dict[str, object]] | None = None,
-) -> dict[str, object]:
+) -> dict:
     return {
         "name": name,
         "apis": [
             {
                 "base": "https://shared.example.com",
-                "envNames": [token_name],
-                "authHeaderNames": ["Authorization"],
-                "authQueryParamNames": ["api_key"],
+                "hostPolicy": {
+                    "kind": "providerOwned",
+                    "exactHosts": ["shared.example.com"],
+                },
+                "auth": {
+                    "headers": {
+                        "Authorization": f"Bearer ${{{{ secrets.{token_name} }}}}",
+                    },
+                    "query": {
+                        "api_key": f"${{{{ secrets.{token_name} }}}}",
+                    },
+                },
                 "permissions": permissions or [],
             }
         ],
     }
 
 
-def _patch_shared_base_diagnostic_catalog(
-    monkeypatch,
+def _write_shared_base_diagnostic_catalog(
+    tmp_path,
     *,
     active_permissions: list[dict[str, object]] | None = None,
     inactive_permissions: list[dict[str, object]] | None = None,
 ) -> None:
-    monkeypatch.setattr(
-        builtin_connector_diagnostics,
-        "CONNECTOR_DIAGNOSTIC_FIREWALLS",
-        [
-            _shared_base_diagnostic_firewall(
-                "active-shared",
-                "ACTIVE_TOKEN",
-                permissions=active_permissions,
-            ),
-            _shared_base_diagnostic_firewall(
-                "inactive-shared",
-                "INACTIVE_TOKEN",
-                permissions=inactive_permissions,
-            ),
-        ],
-    )
-    monkeypatch.setattr(
-        builtin_connector_diagnostics,
-        "MODEL_PROVIDER_DIAGNOSTIC_EXCLUSIONS",
-        [],
-    )
-    builtin_connector_diagnostics.reset_cache_for_tests()
-
-
-def _write_fal_catalog_cache(tmp_path) -> str:
-    cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-    cache_path.write_text(
-        json.dumps(
-            {
-                "schemaVersion": 1,
-                "catalogDigest": (
-                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                ),
-                "catalogVersion": "catalog-test",
-                "updatedAt": "2026-07-07T00:00:00.000Z",
-                "firewalls": {
-                    "fal": {
-                        "name": "fal",
-                        "apis": [
-                            {
-                                "base": "https://fal.run",
-                                "hostPolicy": {
-                                    "kind": "providerOwned",
-                                    "exactHosts": ["fal.run"],
-                                },
-                                "auth": {
-                                    "headers": {"Authorization": "Bearer ${{ secrets.FAL_TOKEN }}"}
-                                },
-                                "permissions": [
-                                    {
-                                        "name": "run",
-                                        "rules": ["POST /fal-ai/{model}"],
-                                    }
-                                ],
-                            }
-                        ],
-                    }
-                },
-            },
-            sort_keys=True,
-        )
-    )
-    cache_path.chmod(0o600)
-    return str(cache_path)
+    firewalls = {
+        "active-shared": _shared_base_catalog_firewall(
+            "active-shared",
+            "ACTIVE_TOKEN",
+            permissions=active_permissions,
+        ),
+        "inactive-shared": _shared_base_catalog_firewall(
+            "inactive-shared",
+            "INACTIVE_TOKEN",
+            permissions=inactive_permissions,
+        ),
+    }
+    write_connector_diagnostic_catalog_cache(tmp_path, firewalls=firewalls)
 
 
 def _assert_shared_base_inactive_diagnostic(flow):
@@ -190,10 +150,10 @@ def _assert_shared_base_inactive_diagnostic(flow):
 
 
 async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _patch_shared_base_diagnostic_catalog(
-        monkeypatch,
+    _write_shared_base_diagnostic_catalog(
+        tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
     )
@@ -228,9 +188,9 @@ async def test_shared_base_unknown_endpoint_diagnoses_inactive_sibling_before_au
 
 
 async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_before_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _patch_shared_base_diagnostic_catalog(monkeypatch)
+    _write_shared_base_diagnostic_catalog(tmp_path)
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -262,10 +222,10 @@ async def test_shared_base_connector_intent_diagnoses_inside_candidate_set_befor
 
 
 async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_path(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _patch_shared_base_diagnostic_catalog(
-        monkeypatch,
+    _write_shared_base_diagnostic_catalog(
+        tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
     )
@@ -296,9 +256,9 @@ async def test_shared_base_unknown_endpoint_with_user_auth_keeps_active_auth_pat
 
 
 async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _patch_shared_base_diagnostic_catalog(monkeypatch)
+    _write_shared_base_diagnostic_catalog(tmp_path)
     reg_path = _write_shared_base_active_firewall_registry(tmp_path)
     flow = real_flow(
         with_response=False,
@@ -326,10 +286,10 @@ async def test_shared_base_malformed_connector_intent_is_ignored_and_stripped(
 
 
 async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, monkeypatch
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers
 ):
-    _patch_shared_base_diagnostic_catalog(
-        monkeypatch,
+    _write_shared_base_diagnostic_catalog(
+        tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_permissions=[{"name": "inactive-read", "rules": ["GET /inactive"]}],
     )
@@ -356,10 +316,10 @@ async def test_shared_base_known_permission_skips_pre_auth_diagnostic(
 
 
 async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers, monkeypatch
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    _patch_shared_base_diagnostic_catalog(
-        monkeypatch,
+    _write_shared_base_diagnostic_catalog(
+        tmp_path,
         active_permissions=[{"name": "active-read", "rules": ["GET /active"]}],
         inactive_permissions=[{"name": "inactive-write", "rules": ["POST /inactive"]}],
     )
@@ -400,6 +360,7 @@ async def test_shared_base_requestheaders_diagnoses_before_stream_safe_auth(
 async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic(
     tmp_path, real_flow, mitm_ctx
 ):
+    write_connector_diagnostic_catalog_cache(tmp_path)
     reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
     flow = real_flow(
         with_response=False,
@@ -439,6 +400,7 @@ async def test_inactive_builtin_connector_url_without_auth_gets_local_diagnostic
 async def test_inactive_builtin_connector_url_with_empty_auth_gets_local_diagnostic(
     tmp_path, real_flow, mitm_ctx, headers, path, request_header_pairs
 ):
+    write_connector_diagnostic_catalog_cache(tmp_path)
     reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
     flow = real_flow(
         with_response=False,
@@ -461,6 +423,7 @@ async def test_inactive_builtin_connector_url_with_empty_auth_gets_local_diagnos
 async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
     tmp_path, real_flow, mitm_ctx, headers
 ):
+    write_connector_diagnostic_catalog_cache(tmp_path)
     reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
     flow = real_flow(
         with_response=False,
@@ -486,6 +449,7 @@ async def test_inactive_builtin_connector_url_with_user_auth_allows_upstream(
 async def test_streamed_inactive_builtin_connector_request_waits_for_response_fallback(
     tmp_path, real_flow, mitm_ctx
 ):
+    write_connector_diagnostic_catalog_cache(tmp_path)
     reg_path = _write_registry(
         tmp_path,
         vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
@@ -516,6 +480,7 @@ async def test_streamed_inactive_builtin_connector_request_waits_for_response_fa
 async def test_browser_builtin_connector_url_does_not_record_diagnostic_candidate(
     tmp_path, real_flow, mitm_ctx, headers
 ):
+    write_connector_diagnostic_catalog_cache(tmp_path)
     reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
     flow = real_flow(
         with_response=False,
@@ -544,7 +509,7 @@ async def test_browser_builtin_connector_url_does_not_record_diagnostic_candidat
 async def test_active_builtin_connector_url_uses_firewall_path(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers
 ):
-    cache_path = _write_fal_catalog_cache(tmp_path)
+    cache_path = write_connector_diagnostic_catalog_cache(tmp_path)
     reg_path = _write_registry(
         tmp_path,
         vm_info={
@@ -565,7 +530,7 @@ async def test_active_builtin_connector_url_uses_firewall_path(
         mitm_ctx(
             registry_path=str(reg_path),
             api_url="https://api.vm0.ai",
-            builtin_firewall_catalog_cache_path=cache_path,
+            builtin_firewall_catalog_cache_path=str(cache_path),
         ),
         fake_firewall_headers(),
     ):

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -27,6 +27,7 @@ from tests.auth_state_helpers import (
 from tests.connector_diagnostic_helpers import (
     record_connector_diagnostic_requestheaders_context,
     write_connector_diagnostic_capture_registry,
+    write_connector_diagnostic_catalog_cache,
 )
 from tests.flow_helpers import header_map, response_stream
 from tests.jsonl_log_helpers import (
@@ -310,6 +311,7 @@ class TestResponseHandler:
     def test_streamed_connector_401_before_request_gets_diagnostic(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        write_connector_diagnostic_catalog_cache(tmp_path)
         reg_path = _write_registry(
             tmp_path,
             vm_info=_vm_without_firewalls(tmp_path, vm_fields={"captureNetworkBodies": True}),
@@ -750,6 +752,7 @@ class TestResponseHandler:
     async def test_cached_connector_candidate_keeps_specific_query_auth_hint(
         self, tmp_path, real_flow, mitm_ctx
     ):
+        write_connector_diagnostic_catalog_cache(tmp_path)
         reg_path = _write_registry(tmp_path, vm_info=_vm_without_firewalls(tmp_path))
         flow = real_flow(
             with_response=False,


### PR DESCRIPTION
## Summary

- Derive connector diagnostics from the existing trusted schema-v1 server catalog cache instead of generated Python diagnostic constants.
- Share decoded raw catalog ownership with registry classification and pin one immutable valid or unavailable diagnostic snapshot per committed diagnostic-eligible HTTP flow.
- Ensure requests authenticated during `requestheaders` still commit the classification catalog snapshot before the request hook returns.
- Preserve the generated diagnostic projection only as a temporary parity oracle, with real cache-backed coverage for atomic replacement, registry races, recovery, and untrusted inputs.

## Behavior and compatibility

- New HTTP flows use the latest trusted catalog, while an already committed flow keeps one snapshot through response headers, streaming, response, and error handling.
- There is no run-level catalog pin and no API, cache schema, Rust writer, run-context, queue, database, or credential change.
- Local-provider runs without a separately provisioned trusted cache skip synthetic connector diagnostics and preserve ordinary upstream outcomes.
- Generated package and generator lifecycle remain intact for #20893 and #20894.

## Validation

- python3 -m pytest -q: 3798 passed
- ruff check, ruff format --check, and basedpyright: passed
- cargo test -p runner builtin_firewall_catalog: 33 passed
- pnpm turbo run lint: passed
- pnpm check-types: passed
- pnpm format: passed with no unrelated drift
- pnpm vitest --silent=passed-only --reporter=dot: 7288 passed, 1 existing benchmark skipped
- pnpm knip: passed

Closes #20892
