### PR TITLE
test(rust): validate guest exec privilege boundary

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1117,25 +1117,33 @@ jobs:
           [ -z "$SANDBOX_ID" ] && fail "control socket not found after 60s"
           echo "Found sandbox: $SANDBOX_ID"
 
-          # Test 1: basic exec
+          # Test 1: privilege boundary
+          echo "--- Test: privilege boundary ---"
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- id -u)
+          [ "$OUTPUT" = "1000" ] || fail "ordinary exec expected UID 1000, got: $OUTPUT"
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- id -u)
+          [ "$OUTPUT" = "0" ] || fail "privileged exec expected UID 0, got: $OUTPUT"
+          echo "PASS: privilege boundary"
+
+          # Test 2: basic exec
           echo "--- Test: basic exec ---"
           OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- echo hello-from-exec)
           echo "$OUTPUT" | grep -q "hello-from-exec" || fail "expected 'hello-from-exec', got: $OUTPUT"
           echo "PASS: basic exec"
 
-          # Test 2: exit code propagation
+          # Test 3: exit code propagation
           echo "--- Test: exit code propagation ---"
           sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- false && fail "expected non-zero exit"
           echo "PASS: exit code propagation"
 
-          # Test 3: prefix matching
+          # Test 4: prefix matching
           echo "--- Test: prefix matching ---"
           PREFIX=$(echo "$SANDBOX_ID" | cut -c1-8)
           OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$PREFIX" -- hostname)
           [ -n "$OUTPUT" ] || fail "prefix match returned empty output"
           echo "PASS: prefix matching"
 
-          # Test 4: argv boundary preservation — regression guard for #9019.
+          # Test 5: argv boundary preservation — regression guard for #9019.
           # NOTE: each assertion relies on the surrounding bash (this
           # heredoc, running on the metal runner) to tokenise quoted
           # arguments and pass them to runner as separate argv entries.
@@ -1179,7 +1187,7 @@ jobs:
           [ "$OUTPUT" = "root with space" ] || fail "--sudo quoting: got '$OUTPUT'"
           echo "PASS: argv boundary preservation"
 
-          # Test 5: verify pre-installed language runtimes and databases
+          # Test 6: verify pre-installed language runtimes and databases
           echo "--- Test: runtime availability ---"
           for cmd in \
             "node --version" \
@@ -1242,7 +1250,7 @@ jobs:
           echo "  PostgreSQL start/stop: ok"
           echo "PASS: runtime availability"
 
-          # Test 6: verify /etc/environment is loaded for both user and root
+          # Test 7: verify /etc/environment is loaded for both user and root
           # [sync:etc-environment] Keep in sync with: crates/runner/scripts/customize-rootfs.sh
           echo "--- Test: environment variables ---"
           EXPECTED_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -1273,7 +1281,7 @@ jobs:
           check_env "root" "--sudo"
           echo "PASS: environment variables"
 
-          # Test 7: verify HTTPS works through proxy for each runtime
+          # Test 8: verify HTTPS works through proxy for each runtime
           # All traffic goes through mitmproxy, so TLS must trust the proxy CA.
           echo "--- Test: HTTPS through proxy ---"
           TLS_URL="https://www.vm0.ai"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1313,7 +1313,7 @@ jobs:
           echo "  HTTPS go: ok"
           echo "PASS: HTTPS through proxy"
 
-          # Test 8: verify DNS resolution works inside sandbox
+          # Test 9: verify DNS resolution works inside sandbox
           # Uses getent (libc-bin, always available) instead of nslookup (requires dnsutils).
           echo "--- Test: DNS resolution ---"
           OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- getent hosts localhost 2>&1) \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1119,9 +1119,11 @@ jobs:
 
           # Test 1: privilege boundary
           echo "--- Test: privilege boundary ---"
-          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- id -u)
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- id -u) || \
+            fail "ordinary exec failed"
           [ "$OUTPUT" = "1000" ] || fail "ordinary exec expected UID 1000, got: $OUTPUT"
-          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- id -u)
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- id -u) || \
+            fail "privileged exec failed"
           [ "$OUTPUT" = "0" ] || fail "privileged exec expected UID 0, got: $OUTPUT"
           echo "PASS: privilege boundary"
 

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -79,7 +79,11 @@ fn shell_escape_value(val: &str) -> String {
 /// In debug/test-support builds, local tests run as the current user unless
 /// `sudo` explicitly requests elevation through `sudo sh -c`.
 pub(crate) fn build_shell_command(command: &str, sudo: bool) -> Command {
-    match shell_command_user() {
+    build_shell_command_for_user(command, sudo, shell_command_user())
+}
+
+fn build_shell_command_for_user(command: &str, sudo: bool, user: Option<&str>) -> Command {
+    match user {
         Some(user) => {
             if sudo {
                 // Release: already root — run directly
@@ -992,31 +996,53 @@ mod tests {
         );
     }
 
-    #[test]
-    fn build_shell_command_normal() {
-        let cmd = build_shell_command("echo hello", false);
-        let prog = cmd.get_program().to_string_lossy().to_string();
-        let args: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
-        // In debug builds: sh -c "echo hello"
-        // In release builds: su - user -c "echo hello"
-        assert!(
-            (prog == "sh" && args == ["-c", "echo hello"])
-                || (prog == "su" && args == ["-", "user", "-c", "echo hello"]),
-            "unexpected command: {prog} {args:?}"
+    fn assert_command(command: Command, expected_program: &str, expected_args: &[&str]) {
+        assert_eq!(
+            command.get_program(),
+            std::ffi::OsStr::new(expected_program)
+        );
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            expected_args
+                .iter()
+                .map(std::ffi::OsStr::new)
+                .collect::<Vec<_>>()
         );
     }
 
     #[test]
-    fn build_shell_command_sudo() {
-        let cmd = build_shell_command("reboot", true);
-        let prog = cmd.get_program().to_string_lossy().to_string();
-        let args: Vec<String> = cmd.get_args().map(|a| a.to_string_lossy().into()).collect();
-        // In debug builds: sudo sh -c "reboot"
-        // In release builds: sh -c "reboot"
-        assert!(
-            (prog == "sudo" && args == ["sh", "-c", "reboot"])
-                || (prog == "sh" && args == ["-c", "reboot"]),
-            "unexpected sudo command: {prog} {args:?}"
+    fn build_shell_command_for_local_user() {
+        assert_command(
+            build_shell_command_for_user("echo hello", false, None),
+            "sh",
+            &["-c", "echo hello"],
+        );
+    }
+
+    #[test]
+    fn build_privileged_shell_command_for_local_user() {
+        assert_command(
+            build_shell_command_for_user("reboot", true, None),
+            "sudo",
+            &["sh", "-c", "reboot"],
+        );
+    }
+
+    #[test]
+    fn build_shell_command_for_sandbox_user() {
+        assert_command(
+            build_shell_command_for_user("echo hello", false, Some("sandbox")),
+            "su",
+            &["-", "sandbox", "-c", "echo hello"],
+        );
+    }
+
+    #[test]
+    fn build_privileged_shell_command_for_sandbox_user() {
+        assert_command(
+            build_shell_command_for_user("reboot", true, Some("sandbox")),
+            "sh",
+            &["-c", "reboot"],
         );
     }
 }

--- a/crates/vsock-test/tests/integration/exec.rs
+++ b/crates/vsock-test/tests/integration/exec.rs
@@ -124,23 +124,6 @@ async fn test_exec_sequential() {
     h.finish();
 }
 
-#[tokio::test]
-async fn test_exec_sudo() {
-    let h = Harness::new().await;
-
-    // In debug mode, sudo=true uses `sudo sh -c`, which may fail if sudo is
-    // not installed. We only verify the flag is correctly sent through the
-    // protocol and the guest attempts the right code path (non-panic, returns
-    // a result). In release/production the process runs as root so sudo=true
-    // just uses `sh -c` directly.
-    let result = run_exec(h.host(), "whoami", 5000, &[], true)
-        .await
-        .expect("exec sudo failed");
-    // Don't assert exit_code — depends on whether sudo is available
-    let _ = result;
-    h.finish();
-}
-
 /// Core concurrency test: exec works while supervised exec wait is pending.
 ///
 /// This is the exact production scenario that motivated the VsockHost refactor —


### PR DESCRIPTION
## Summary

- extract a private command-construction seam and assert the exact local/production-style ordinary/privileged policy matrix
- remove the local sudo integration test that accepted every process result
- verify the current guest image runs ordinary exec as UID 1000 and `--sudo` exec as UID 0 in the metal `runner-exec` job

## Scope

This changes test coverage and privately refactors command construction without changing APIs, wire formats, schemas, persisted data, or production behavior.

## Validation

```text
cargo test --manifest-path crates/Cargo.toml -p vsock-guest shell_command::tests
cargo test --manifest-path crates/Cargo.toml -p vsock-test --test integration
cargo fmt --manifest-path crates/Cargo.toml --all -- --check
cargo clippy --manifest-path crates/Cargo.toml -p vsock-guest -p vsock-test --all-targets --all-features -- -D warnings
cargo test --manifest-path crates/Cargo.toml --all-targets --all-features
git diff --check
```

Issue: [#20988](https://github.com/vm0-ai/vm0/issues/20988)

Closes #20988
