### PR TITLE
perf(api): attribute database pool acquisition in query spans

### DIFF
--- a/turbo/apps/api/eslint.config.mjs
+++ b/turbo/apps/api/eslint.config.mjs
@@ -76,7 +76,7 @@ const promiseChainAllowlist = [
   // pg/OTel instrumentation: needs .then chains around the wrapped pg.query
   // call to attach span lifecycle without forcing an async wrapper around
   // every callback-style overload.
-  "src/lib/db.ts",
+  "src/lib/db-instrumentation.ts",
   // Logger flush: detached `?.catch(() => {})` on Sentry flush in process exit
   // path; cannot use signals/utils helpers because lib/ must not import them.
   "src/lib/log.ts",

--- a/turbo/apps/api/package.json
+++ b/turbo/apps/api/package.json
@@ -58,6 +58,8 @@
   },
   "devDependencies": {
     "@hono/vite-build": "^1.11.1",
+    "@opentelemetry/context-async-hooks": "2.7.0",
+    "@opentelemetry/sdk-trace-base": "2.7.0",
     "@types/adm-zip": "^0.5.8",
     "@types/archiver": "^7.0.0",
     "@types/html-to-text": "^9.0.4",

--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -149,6 +149,35 @@ describe("instrumentPgPool", () => {
     expectAcquisition(findSpan(queuedStatement), "queued");
   });
 
+  it("reserves idle and new capacity for earlier synchronous queries", async () => {
+    const pool = createPool({ max: 2 });
+    const warmStatement = "SELECT 104 AS warm_pool";
+    const idleStatement = "SELECT 105 AS burst_idle";
+    const newStatement = "SELECT 106 AS burst_new";
+    const queuedStatement = "SELECT 107 AS burst_queued";
+
+    await pool.query(warmStatement);
+    const idleQuery = pool.query(idleStatement);
+    const newQuery = pool.query(newStatement);
+    const queuedQuery = pool.query(queuedStatement);
+    const waitingCount = pool.waitingCount;
+
+    const [idleResult, newResult, queuedResult] = await Promise.all([
+      idleQuery,
+      newQuery,
+      queuedQuery,
+    ]);
+
+    expect(waitingCount).toBe(3);
+    expect(idleResult.rowCount).toBe(1);
+    expect(newResult.rowCount).toBe(1);
+    expect(queuedResult.rowCount).toBe(1);
+    expectAcquisition(findSpan(warmStatement), "new");
+    expectAcquisition(findSpan(idleStatement), "idle");
+    expectAcquisition(findSpan(newStatement), "new");
+    expectAcquisition(findSpan(queuedStatement), "queued");
+  });
+
   it("keeps concurrent queued measurements on their originating traces", async () => {
     const pool = createPool();
     const heldClient = await pool.connect();

--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -1,0 +1,274 @@
+import { context, SpanStatusCode, type Tracer } from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { Pool, type PoolClient, type PoolConfig } from "pg";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { instrumentPgPool } from "../db-instrumentation";
+import { env } from "../env";
+
+const ACQUIRE_DURATION_ATTRIBUTE = "vm0.db.pool.acquire.duration_ms";
+const ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
+
+type AcquirePath = "idle" | "new" | "queued";
+
+function expectAcquisition(span: ReadableSpan, path: AcquirePath): void {
+  expect(span.attributes[ACQUIRE_PATH_ATTRIBUTE]).toBe(path);
+  const duration = span.attributes[ACQUIRE_DURATION_ATTRIBUTE];
+  expect(typeof duration).toBe("number");
+  if (typeof duration !== "number") {
+    throw new Error("Acquisition duration is not numeric");
+  }
+  expect(duration).toBeGreaterThanOrEqual(0);
+}
+
+function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => {
+      return undefined;
+    },
+    (error: unknown) => {
+      return error;
+    },
+  );
+}
+
+describe("instrumentPgPool", () => {
+  let exporter: InMemorySpanExporter;
+  let provider: BasicTracerProvider;
+  let tracer: Tracer;
+  let pools: Pool[];
+
+  function createPool(config: PoolConfig = {}): Pool {
+    const pool = instrumentPgPool(
+      new Pool({
+        allowExitOnIdle: true,
+        connectionString: env("DATABASE_URL"),
+        idleTimeoutMillis: 0,
+        max: 1,
+        ...config,
+      }),
+      tracer,
+    );
+    pools.push(pool);
+    return pool;
+  }
+
+  function findSpan(statement: string): ReadableSpan {
+    const span = exporter.getFinishedSpans().find((candidate) => {
+      return candidate.attributes["db.statement"] === statement;
+    });
+    if (!span) {
+      throw new Error(`No span found for statement: ${statement}`);
+    }
+    return span;
+  }
+
+  function findNamedSpan(name: string): ReadableSpan {
+    const span = exporter.getFinishedSpans().find((candidate) => {
+      return candidate.name === name;
+    });
+    if (!span) {
+      throw new Error(`No span found with name: ${name}`);
+    }
+    return span;
+  }
+
+  function runUnderParent<T>(
+    parentName: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return tracer.startActiveSpan(parentName, (span) => {
+      return operation().finally(() => {
+        span.end();
+      });
+    });
+  }
+
+  beforeAll(() => {
+    const contextManager = new AsyncLocalStorageContextManager().enable();
+    expect(context.setGlobalContextManager(contextManager)).toBeTruthy();
+  });
+
+  beforeEach(() => {
+    exporter = new InMemorySpanExporter();
+    provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(exporter)],
+    });
+    tracer = provider.getTracer("db-instrumentation-test");
+    pools = [];
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      pools.map((pool) => {
+        return pool.end();
+      }),
+    );
+    await provider.shutdown();
+  });
+
+  afterAll(() => {
+    context.disable();
+  });
+
+  it("attributes new, idle, and queued acquisition to each query span", async () => {
+    const pool = createPool();
+    const newStatement = "SELECT 101 AS new_path";
+    const idleStatement = "SELECT 102 AS idle_path";
+    const queuedStatement = "SELECT 103 AS queued_path";
+
+    const newResult = await pool.query(newStatement);
+    const idleResult = await pool.query(idleStatement);
+
+    const heldClient = await pool.connect();
+    const queuedQuery = pool.query(queuedStatement);
+    const waitingCount = pool.waitingCount;
+    heldClient.release();
+    const queuedResult = await queuedQuery;
+
+    expect(waitingCount).toBe(1);
+    expect(newResult.rowCount).toBe(1);
+    expect(idleResult.rowCount).toBe(1);
+    expect(queuedResult.rowCount).toBe(1);
+    expectAcquisition(findSpan(newStatement), "new");
+    expectAcquisition(findSpan(idleStatement), "idle");
+    expectAcquisition(findSpan(queuedStatement), "queued");
+  });
+
+  it("keeps concurrent queued measurements on their originating traces", async () => {
+    const pool = createPool();
+    const heldClient = await pool.connect();
+    const statementA = "SELECT 201 AS queued_a";
+    const statementB = "SELECT 202 AS queued_b";
+
+    const queryA = runUnderParent("parent-a", () => {
+      return pool.query(statementA);
+    });
+    const queryB = runUnderParent("parent-b", () => {
+      return pool.query(statementB);
+    });
+    const waitingCount = pool.waitingCount;
+
+    heldClient.release();
+    await Promise.all([queryA, queryB]);
+
+    expect(waitingCount).toBe(2);
+    const spanA = findSpan(statementA);
+    const spanB = findSpan(statementB);
+    const parentA = findNamedSpan("parent-a");
+    const parentB = findNamedSpan("parent-b");
+    expectAcquisition(spanA, "queued");
+    expectAcquisition(spanB, "queued");
+    expect(spanA.spanContext().traceId).toBe(parentA.spanContext().traceId);
+    expect(spanA.parentSpanContext?.spanId).toBe(parentA.spanContext().spanId);
+    expect(spanB.spanContext().traceId).toBe(parentB.spanContext().traceId);
+    expect(spanB.parentSpanContext?.spanId).toBe(parentB.spanContext().spanId);
+    expect(parentA.spanContext().traceId).not.toBe(
+      parentB.spanContext().traceId,
+    );
+  });
+
+  it("preserves acquisition and query failures and releases clients", async () => {
+    const timeoutPool = createPool({ connectionTimeoutMillis: 25 });
+    const heldClient = await timeoutPool.connect();
+    const timeoutStatement = "SELECT 301 AS acquisition_timeout";
+
+    const timeoutError = await captureRejection(
+      timeoutPool.query(timeoutStatement),
+    );
+    heldClient.release();
+
+    expect(timeoutError).toBeInstanceOf(Error);
+    expect(timeoutError).toHaveProperty(
+      "message",
+      "timeout exceeded when trying to connect",
+    );
+    const timeoutSpan = findSpan(timeoutStatement);
+    expect(timeoutSpan.status.code).toBe(SpanStatusCode.ERROR);
+    expectAcquisition(timeoutSpan, "queued");
+
+    const failurePool = createPool();
+    const invalidStatement =
+      "SELECT * FROM vm0_missing_db_instrumentation_table";
+    const recoveryStatement = "SELECT 302 AS recovered";
+    const queryError = await captureRejection(
+      failurePool.query(invalidStatement),
+    );
+    const recoveryResult = await failurePool.query(recoveryStatement);
+
+    expect(queryError).toBeInstanceOf(Error);
+    expect(recoveryResult.rowCount).toBe(1);
+    const failureSpan = findSpan(invalidStatement);
+    expect(failureSpan.status.code).toBe(SpanStatusCode.ERROR);
+    expectAcquisition(failureSpan, "new");
+    expectAcquisition(findSpan(recoveryStatement), "new");
+  });
+
+  it("preserves direct callbacks and instruments reused clients only once", async () => {
+    const pool = createPool();
+    let callbackError: Error | undefined;
+    let callbackClient: PoolClient | undefined;
+    const callbackReturn = pool.connect((error, client, release) => {
+      if (error) {
+        callbackError = error;
+        return;
+      }
+      if (!client || !release) {
+        callbackError = new Error("Pool callback did not return a client");
+        return;
+      }
+      callbackClient = client;
+      release();
+    });
+
+    const statementA = "SELECT 401 AS reused_a";
+    const statementB = "SELECT 402 AS reused_b";
+    // With max: 1, this checkout cannot resolve until the callback above has
+    // received and released the sole client.
+    const clientA = await pool.connect();
+    const resultA = await clientA.query(statementA);
+    clientA.release();
+
+    const clientB = await pool.connect();
+    const sameClient = clientB === clientA;
+    const resultB = await clientB.query(statementB);
+    clientB.release();
+
+    expect(callbackReturn).toBeUndefined();
+    expect(callbackError).toBeUndefined();
+    expect(callbackClient).toBe(clientA);
+    expect(sameClient).toBeTruthy();
+    expect(resultA.rowCount).toBe(1);
+    expect(resultB.rowCount).toBe(1);
+    expect(
+      exporter.getFinishedSpans().filter((span) => {
+        return span.attributes["db.statement"] === statementA;
+      }),
+    ).toHaveLength(1);
+    expect(
+      exporter.getFinishedSpans().filter((span) => {
+        return span.attributes["db.statement"] === statementB;
+      }),
+    ).toHaveLength(1);
+    expect(
+      findSpan(statementA).attributes[ACQUIRE_PATH_ATTRIBUTE],
+    ).toBeUndefined();
+    expect(
+      findSpan(statementB).attributes[ACQUIRE_PATH_ATTRIBUTE],
+    ).toBeUndefined();
+  });
+});

--- a/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
+++ b/turbo/apps/api/src/lib/__tests__/db-instrumentation.test.ts
@@ -178,6 +178,36 @@ describe("instrumentPgPool", () => {
     expectAcquisition(findSpan(queuedStatement), "queued");
   });
 
+  it("classifies replacement connections while older queries remain queued", async () => {
+    const pool = createPool({ max: 2 });
+    const clientA = await pool.connect();
+    const clientB = await pool.connect();
+    const queuedStatementA = "SELECT 108 AS replacement_queue_a";
+    const queuedStatementB = "SELECT 109 AS replacement_queue_b";
+    const replacementStatement = "SELECT 110 AS replacement_new";
+
+    const queuedQueryA = pool.query(queuedStatementA);
+    const queuedQueryB = pool.query(queuedStatementB);
+    clientA.release(new Error("retire test client"));
+
+    expect(pool.totalCount).toBe(1);
+    expect(pool.idleCount).toBe(0);
+    expect(pool.waitingCount).toBe(2);
+    const replacementQuery = pool.query(replacementStatement);
+    clientB.release();
+
+    const [queuedResultA, queuedResultB, replacementResult] = await Promise.all(
+      [queuedQueryA, queuedQueryB, replacementQuery],
+    );
+
+    expect(queuedResultA.rowCount).toBe(1);
+    expect(queuedResultB.rowCount).toBe(1);
+    expect(replacementResult.rowCount).toBe(1);
+    expectAcquisition(findSpan(queuedStatementA), "queued");
+    expectAcquisition(findSpan(queuedStatementB), "queued");
+    expectAcquisition(findSpan(replacementStatement), "new");
+  });
+
   it("keeps concurrent queued measurements on their originating traces", async () => {
     const pool = createPool();
     const heldClient = await pool.connect();

--- a/turbo/apps/api/src/lib/db-instrumentation.ts
+++ b/turbo/apps/api/src/lib/db-instrumentation.ts
@@ -47,6 +47,13 @@ function extractSql(args: AnyArgs): string {
 }
 
 function acquisitionPath(pool: Pool): PoolAcquirePath {
+  // With no idle client, pg-pool either starts a connection immediately or
+  // queues solely based on whether the pool is full. This can leapfrog older
+  // waiters while a removed client is still closing.
+  if (pool.idleCount === 0) {
+    return pool.totalCount < pool.options.max ? "new" : "queued";
+  }
+
   // Idle delivery is deferred to the next tick, so a synchronous burst can
   // observe the same idle clients before earlier waiters receive them. Treat
   // waitingCount as the new request's zero-based position and reserve both

--- a/turbo/apps/api/src/lib/db-instrumentation.ts
+++ b/turbo/apps/api/src/lib/db-instrumentation.ts
@@ -1,0 +1,192 @@
+import { performance } from "node:perf_hooks";
+
+import {
+  context,
+  createContextKey,
+  SpanKind,
+  SpanStatusCode,
+  type Span,
+  type Tracer,
+} from "@opentelemetry/api";
+import type { Pool, PoolClient } from "pg";
+
+import { deriveSqlSpanName } from "./sql-span-name";
+
+const POOL_QUERY_SPAN_KEY = createContextKey("vm0.pg.pool-query-span");
+const POOL_ACQUIRE_DURATION_ATTRIBUTE = "vm0.db.pool.acquire.duration_ms";
+const POOL_ACQUIRE_PATH_ATTRIBUTE = "vm0.db.pool.acquire.path";
+
+type AnyArgs = readonly unknown[];
+type PgQuery = (...args: AnyArgs) => unknown;
+type PoolAcquirePath = "idle" | "new" | "queued";
+type PoolRelease = (error?: Error | boolean) => void;
+type PoolConnectCallback = (
+  error: Error | undefined,
+  client?: PoolClient,
+  release?: PoolRelease,
+) => void;
+
+class PoolQuerySpan {
+  constructor(readonly span: Span) {}
+}
+
+function extractSql(args: AnyArgs): string {
+  const first = args[0];
+  if (typeof first === "string") {
+    return first;
+  }
+  if (
+    first &&
+    typeof first === "object" &&
+    "text" in first &&
+    typeof first.text === "string"
+  ) {
+    return first.text;
+  }
+  return "pg.query";
+}
+
+function acquisitionPath(pool: Pool): PoolAcquirePath {
+  if (pool.idleCount > 0) {
+    return "idle";
+  }
+  if (pool.totalCount < pool.options.max) {
+    return "new";
+  }
+  return "queued";
+}
+
+function isPoolConnectCallback(value: unknown): value is PoolConnectCallback {
+  return typeof value === "function";
+}
+
+function instrumentQuery(
+  target: object,
+  original: PgQuery,
+  tracer: Tracer,
+  markPoolQuery: boolean,
+): PgQuery {
+  return function instrumentedQuery(this: unknown, ...args: AnyArgs): unknown {
+    // pg query is overloaded: when the caller passes a trailing callback
+    // (pool.query does this internally to drive client.query), the result is
+    // undefined and the callback is the only completion signal. The outer
+    // pool query already produced a span, so pass callback-style client
+    // queries straight through.
+    if (typeof args[args.length - 1] === "function") {
+      return Reflect.apply(original, target, args);
+    }
+
+    const sql = extractSql(args);
+    const spanName = deriveSqlSpanName(sql) ?? "pg.query";
+    return tracer.startActiveSpan(
+      spanName,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          "db.system": "postgresql",
+          "db.statement": sql,
+        },
+      },
+      (span) => {
+        // Pool-level queries mark their exact outer span while pg-pool
+        // synchronously calls connect(callback). The callback may run much
+        // later, so acquisition instrumentation captures this marked span at
+        // connect entry instead of looking up whichever request context is
+        // active when a queued client finally becomes available.
+        const execute = (): Promise<unknown> => {
+          return Reflect.apply(original, target, args) as Promise<unknown>;
+        };
+        const query =
+          markPoolQuery && span.isRecording()
+            ? context.with(
+                context
+                  .active()
+                  .setValue(POOL_QUERY_SPAN_KEY, new PoolQuerySpan(span)),
+                execute,
+              )
+            : execute();
+
+        // The span parents to whatever request span is active when the query
+        // starts. Slice DB spans by route via a trace_id join to the Hono
+        // server span; never copy request-scoped attributes onto pooled
+        // client spans.
+        return query
+          .then(
+            (result) => {
+              span.setStatus({ code: SpanStatusCode.OK });
+              return result;
+            },
+            (error: unknown) => {
+              span.setStatus({
+                code: SpanStatusCode.ERROR,
+                message: error instanceof Error ? error.message : String(error),
+              });
+              span.recordException(
+                error instanceof Error ? error : String(error),
+              );
+              throw error;
+            },
+          )
+          .finally(() => {
+            span.end();
+          });
+      },
+    );
+  } as PgQuery;
+}
+
+export function instrumentPgPool(pool: Pool, tracer: Tracer): Pool {
+  const originalQuery = pool.query.bind(pool) as PgQuery;
+  pool.query = instrumentQuery(
+    pool,
+    originalQuery,
+    tracer,
+    true,
+  ) as Pool["query"];
+
+  const instrumentedClients = new WeakSet<PoolClient>();
+  const originalConnect = pool.connect.bind(pool);
+  pool.connect = function patchedConnect(...args: AnyArgs) {
+    const callback = args[args.length - 1];
+    if (isPoolConnectCallback(callback)) {
+      const markedSpan = context.active().getValue(POOL_QUERY_SPAN_KEY);
+      if (!(markedSpan instanceof PoolQuerySpan)) {
+        return Reflect.apply(originalConnect, pool, args);
+      }
+
+      const startedAt = performance.now();
+      const path = acquisitionPath(pool);
+      const wrappedCallback: PoolConnectCallback = (error, client, release) => {
+        markedSpan.span.setAttributes({
+          [POOL_ACQUIRE_DURATION_ATTRIBUTE]: performance.now() - startedAt,
+          [POOL_ACQUIRE_PATH_ATTRIBUTE]: path,
+        });
+        callback(error, client, release);
+      };
+      const wrappedArgs = [...args.slice(0, -1), wrappedCallback] as const;
+      return Reflect.apply(originalConnect, pool, wrappedArgs);
+    }
+
+    const promise = Reflect.apply(
+      originalConnect,
+      pool,
+      args,
+    ) as Promise<PoolClient>;
+    return promise.then((client) => {
+      if (instrumentedClients.has(client)) {
+        return client;
+      }
+      const clientQuery = client.query.bind(client) as PgQuery;
+      client.query = instrumentQuery(
+        client,
+        clientQuery,
+        tracer,
+        false,
+      ) as PoolClient["query"];
+      instrumentedClients.add(client);
+      return client;
+    });
+  } as Pool["connect"];
+
+  return pool;
+}

--- a/turbo/apps/api/src/lib/db-instrumentation.ts
+++ b/turbo/apps/api/src/lib/db-instrumentation.ts
@@ -47,10 +47,17 @@ function extractSql(args: AnyArgs): string {
 }
 
 function acquisitionPath(pool: Pool): PoolAcquirePath {
-  if (pool.idleCount > 0) {
+  // Idle delivery is deferred to the next tick, so a synchronous burst can
+  // observe the same idle clients before earlier waiters receive them. Treat
+  // waitingCount as the new request's zero-based position and reserve both
+  // idle clients and remaining connection slots for earlier requests.
+  const position = pool.waitingCount;
+  if (position < pool.idleCount) {
     return "idle";
   }
-  if (pool.totalCount < pool.options.max) {
+  const availableClientCount =
+    pool.idleCount + pool.options.max - pool.totalCount;
+  if (position < availableClientCount) {
     return "new";
   }
   return "queued";

--- a/turbo/apps/api/src/lib/db.ts
+++ b/turbo/apps/api/src/lib/db.ts
@@ -1,14 +1,13 @@
-import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
+import { trace } from "@opentelemetry/api";
 import { schema } from "@vm0/db";
-import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
-import { Pool, type PoolClient, type QueryConfig } from "pg";
-
 import { attachDatabasePool } from "@vercel/functions";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
 
+import { instrumentPgPool } from "./db-instrumentation";
 import { env } from "./env";
 import { logger } from "./log";
 import { singleton } from "./singleton";
-import { deriveSqlSpanName } from "./sql-span-name";
 
 const log = logger("api:db");
 
@@ -21,127 +20,12 @@ interface SingletonValue<T> {
 type ApiDb = NodePgDatabase<typeof schema>;
 
 const pool = singleton((): Pool => {
-  // `@opentelemetry/instrumentation-pg` would normally hook `pg.Pool` via
-  // `require-in-the-middle`, but `vercel deploy --prebuilt --archive=tgz`
-  // bundles the api into a single `index.js` so the require hook never fires.
-  // Hook the `Pool` instance ourselves at lazy-init time — bundle-safe and
-  // covers every code path because every drizzle/pg call funnels through this
-  // singleton. `tracer.startActiveSpan` is a no-op when no provider is
-  // registered (i.e. `pnpm dev` / vitest without VERCEL_GIT_COMMIT_SHA), so the
-  // wrap stays cheap when OTel is off.
-  const tracer = trace.getTracer("vm0-api/pg");
-
-  type AnyArgs = readonly unknown[];
-  type PgQuery = (...args: AnyArgs) => unknown;
-
-  function extractSql(args: AnyArgs): string {
-    const first = args[0];
-    if (typeof first === "string") {
-      return first;
-    }
-    if (first && typeof first === "object" && "text" in first) {
-      const config = first as QueryConfig;
-      return config.text;
-    }
-    return "pg.query";
-  }
-
-  function instrumentQuery(target: object, original: PgQuery): PgQuery {
-    return function instrumentedQuery(
-      this: unknown,
-      ...args: AnyArgs
-    ): unknown {
-      // pg's `query()` is overloaded: when the caller passes a trailing
-      // callback (`pool.query` itself does this internally to drive
-      // `client.query`) the result is `undefined` and the user's callback is
-      // the only completion signal. We can't wrap that into a Promise without
-      // intercepting the callback, and pool.query above already produced a
-      // span for the outer call — so just pass it straight through.
-      if (typeof args[args.length - 1] === "function") {
-        return Reflect.apply(original, target, args);
-      }
-
-      const sql = extractSql(args);
-      const spanName = deriveSqlSpanName(sql) ?? "pg.query";
-      return tracer.startActiveSpan(
-        spanName,
-        {
-          kind: SpanKind.CLIENT,
-          attributes: {
-            "db.system": "postgresql",
-            "db.statement": sql,
-          },
-        },
-        (span) => {
-          // The span parents to whatever request span is active when the
-          // query runs (standard OTel context propagation). Slice DB spans by
-          // route via a `trace_id` join to the `@hono/otel` SERVER span — never
-          // by stamping a request-scoped `http.route` onto these pooled CLIENT
-          // spans, which mis-attributes across concurrent requests.
-          //
-          // Promise chain instead of try/catch so this file doesn't have to
-          // opt out of `no-restricted-syntax` (the api package centralises
-          // guarded operations). `.then(onOk, onErr)` covers both branches in
-          // a single pass; `.finally(span.end)` runs whichever branch fired.
-          return (Reflect.apply(original, target, args) as Promise<unknown>)
-            .then(
-              (result) => {
-                span.setStatus({ code: SpanStatusCode.OK });
-                return result;
-              },
-              (error: unknown) => {
-                span.setStatus({
-                  code: SpanStatusCode.ERROR,
-                  message:
-                    error instanceof Error ? error.message : String(error),
-                });
-                span.recordException(error as Error);
-                throw error;
-              },
-            )
-            .finally(() => {
-              span.end();
-            });
-        },
-      );
-    } as PgQuery;
-  }
-
-  function instrumentPool(target: Pool): Pool {
-    const originalQuery = target.query.bind(target) as PgQuery;
-    target.query = instrumentQuery(target, originalQuery) as Pool["query"];
-
-    // pg-pool's `pool.query()` internally calls `pool.connect(callback)` to
-    // acquire a client — that path is already covered by the wrapped
-    // `pool.query` above, so leave callback-style connect alone (replacing
-    // the callback would double-wrap and the callback would never fire).
-    // Promise-style `pool.connect()` is what drizzle uses for transactions —
-    // patch the returned client's `query` so the BEGIN/COMMIT plus every
-    // statement inside the transaction emit CLIENT spans too.
-    const originalConnect = target.connect.bind(target);
-    target.connect = function patchedConnect(...args: AnyArgs) {
-      if (typeof args[args.length - 1] === "function") {
-        return Reflect.apply(originalConnect, target, args);
-      }
-      const promise = Reflect.apply(
-        originalConnect,
-        target,
-        args,
-      ) as Promise<PoolClient>;
-      return promise.then((client) => {
-        const clientQuery = client.query.bind(client) as PgQuery;
-        client.query = instrumentQuery(
-          client,
-          clientQuery,
-        ) as PoolClient["query"];
-        return client;
-      });
-    } as Pool["connect"];
-
-    return target;
-  }
-
-  const pgPool = instrumentPool(
+  // The official pg instrumentation normally hooks Pool through
+  // require-in-the-middle. The single-file Vercel bundle prevents that hook,
+  // so instrument this lazy singleton directly. The tracer is a no-op when no
+  // provider is registered, keeping local development and ordinary tests
+  // lightweight.
+  const pgPool = instrumentPgPool(
     new Pool({
       allowExitOnIdle: true,
       connectionString: env("DATABASE_URL"),
@@ -150,6 +34,7 @@ const pool = singleton((): Pool => {
       idleTimeoutMillis: env("DB_POOL_IDLE_TIMEOUT_MS"),
       connectionTimeoutMillis: env("DB_POOL_CONNECT_TIMEOUT_MS"),
     }),
+    trace.getTracer("vm0-api/pg"),
   );
   pgPool.on("error", (error: Error) => {
     log.warn("idle database client error", { error: error.message });

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -242,6 +242,12 @@ importers:
       '@hono/vite-build':
         specifier: ^1.11.1
         version: 1.11.1(hono@4.12.25)
+      '@opentelemetry/context-async-hooks':
+        specifier: 2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 2.7.0
+        version: 2.7.0(@opentelemetry/api@1.9.1)
       '@types/adm-zip':
         specifier: ^0.5.8
         version: 0.5.8
@@ -2488,6 +2494,12 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.7.0':
+    resolution: {integrity: sha512-MWXggArM+Y11mPS8VOrqxOj+YMGQSRuvhM91eSBX4xFpJa05mpkeVvM8pPux5ElkEjV5RMgrkisrlP/R83SpBQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/core@2.8.0':
     resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
@@ -11427,6 +11439,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.7.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
## Summary

- annotate each existing Promise-style `Pool.query()` span with monotonic client-acquisition duration and a bounded `idle` / `new` / `queued` path
- capture the exact outer query span synchronously at `Pool.connect(callback)` entry so concurrent queued queries cannot cross-attribute acquisition data
- classify synchronous idle-client bursts and replacement connections according to `pg-pool`'s actual deferred-allocation branches
- make Promise-acquired transaction client instrumentation idempotent, preventing reused clients from accumulating nested query wrappers
- add real-PostgreSQL, real-OpenTelemetry integration coverage for immediate, burst, queued, replacement, concurrent, failure, callback, and reused-client behavior

The implementation adds two fixed, low-cardinality attributes and no additional spans:

- `vm0.db.pool.acquire.duration_ms`
- `vm0.db.pool.acquire.path`

## Scope and compatibility

- no pool-size, timeout, retry, SQL, index, schema, retrieval, ranking, prompt, API, runner, queue, or frontend behavior changes
- no query parameters, database values, run/user/org/memory identifiers, or other new identity data
- mixed API revisions are safe: older spans omit the attributes; newer spans include them
- transaction checkout remains unattributed because it has no outer `Pool.query()` span, while its BEGIN/COMMIT/statement spans remain intact

## Validation

Passed after the self-review fixes:

- `pnpm -F api exec vitest run src/lib/__tests__/db-instrumentation.test.ts src/lib/__tests__/sql-span-name.test.ts` — 2 files, 24 tests
- `pnpm -F api lint`
- `pnpm -F api check-types`
- staged-file Prettier, full-workspace type-check, Knip, and commitlint hooks for both follow-up commits

The initial submitted commit also passed full API tests (157 files, 2,049 tests), full lint, API build, format, and Knip. After adding the two self-review regressions, a fresh full API run completed with 154/157 files and 2,048/2,051 tests passing. Its failures were outside the changed instrumentation:

- billing usage aggregation repeatedly reaches the default 5-second timeout even when run alone — #21013
- `zero-workflows.test.ts` accumulates agents in a fixed staff organization across local runs and now receives the seven-agent quota response — #21014
- one workflow-trigger scheduler case timed out in the full run and passed in the immediate focused rerun

Earlier root `pnpm test` attempts also encountered unrelated resource-sensitive 5-second timeouts. No test was skipped and no timeout was increased; fresh PR CI is required for merge.

## Post-deploy validation

Replace `<DEPLOYED_SERVICE_VERSION>` with the deployed commit SHA from `service.version`, then run:

```apl
['vm0-traces-prod']
| where ['service.name'] == "vm0-api"
| where ['service.version'] == "<DEPLOYED_SERVICE_VERSION>"
| where name == "SELECT memory_search_entries"
| where isnotnull(['vm0.db.pool.acquire.duration_ms'])
| extend total_ms = duration / 1ms
| extend acquire_ms = ['vm0.db.pool.acquire.duration_ms']
| extend acquire_path = ['vm0.db.pool.acquire.path']
| extend remaining_ms = total_ms - acquire_ms
| summarize
    samples = count(),
    total_p50_ms = percentile(total_ms, 50),
    total_p90_ms = percentile(total_ms, 90),
    total_p95_ms = percentile(total_ms, 95),
    total_max_ms = max(total_ms),
    acquire_p50_ms = percentile(acquire_ms, 50),
    acquire_p90_ms = percentile(acquire_ms, 90),
    acquire_p95_ms = percentile(acquire_ms, 95),
    acquire_max_ms = max(acquire_ms),
    remaining_p50_ms = percentile(remaining_ms, 50),
    remaining_p90_ms = percentile(remaining_ms, 90),
    remaining_p95_ms = percentile(remaining_ms, 95),
    remaining_max_ms = max(remaining_ms),
    over_1s = countif(total_ms >= 1000),
    over_10s = countif(total_ms >= 10000)
  by acquire_path
| sort by acquire_path asc
```

`remaining_ms` is client-operation time, not pure PostgreSQL execution: it still includes network/row transfer and node-postgres response processing.

Follow-up evidence gate for parent #20929:

- `queued` owns the tail: investigate pool pressure, query fan-out, and connection lifecycle
- `new` owns the tail: investigate connection churn and establishment
- `remaining_ms` owns the tail: collect representative server-side plan/timing evidence before selecting a SQL or index change

Closes #20984
Parent: #20929
