### PR TITLE
feat: add nintendo switch parental controls connector

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -148,12 +148,14 @@ function mockNintendoStoreExternalCodeProvider(): {
 }
 
 function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
+  readonly federatedSmartDeviceIds: string[];
   readonly federationBodies: unknown[];
   readonly failLogout: () => void;
   readonly logoutBodies: unknown[];
   readonly sessionTokenBodies: URLSearchParams[];
   readonly tokenBodies: Readonly<Record<string, unknown>>[];
 } {
+  const federatedSmartDeviceIds: string[] = [];
   const federationBodies: unknown[] = [];
   const logoutBodies: unknown[] = [];
   const sessionTokenBodies: URLSearchParams[] = [];
@@ -193,7 +195,16 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
     http.post(
       NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL,
       async ({ request }) => {
-        federationBodies.push(await request.json());
+        const body: unknown = await request.json();
+        if (
+          !isRecord(body) ||
+          !isRecord(body["smartDeviceInfo"]) ||
+          typeof body["smartDeviceInfo"]["id"] !== "string"
+        ) {
+          throw new Error("Expected Nintendo smart-device federation body");
+        }
+        federationBodies.push(body);
+        federatedSmartDeviceIds.push(body["smartDeviceInfo"]["id"]);
         return HttpResponse.json({
           loginInfo: {
             ownedDevices: [
@@ -226,6 +237,7 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
   );
 
   return {
+    federatedSmartDeviceIds,
     federationBodies,
     failLogout: () => {
       logoutStatus = 503;
@@ -624,7 +636,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
-  it("deletes Nintendo Switch Parental Controls locally when remote logout fails", async () => {
+  it("replaces the remote Nintendo registration and keeps local deletion resilient", async () => {
     const provider = mockNintendoSwitchParentalControlsExternalCodeProvider();
     const bdd = createBddApi(context);
     const actor = bdd.user();
@@ -755,16 +767,46 @@ describe("CONN-02: external-code session lifecycle", () => {
       "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
     ]);
 
+    const replacementSession = await connectorsApi.startExternalCode(
+      actor,
+      "nintendo-switch-parental-controls",
+      "api",
+    );
+    const replacementAuthorizationUrl = new URL(
+      replacementSession.authorizationUrl,
+    );
+    const replacementState =
+      replacementAuthorizationUrl.searchParams.get("state");
+    if (!replacementState) {
+      throw new Error("Expected replacement Nintendo authorization state");
+    }
+    await connectorsApi.completeExternalCode(
+      actor,
+      "nintendo-switch-parental-controls",
+      {
+        sessionId: replacementSession.sessionId,
+        sessionToken: replacementSession.sessionToken,
+        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI}#session_token_code=bdd-switch-parental-controls-replacement-code&state=${replacementState}`,
+      },
+    );
+    expect(provider.federatedSmartDeviceIds).toHaveLength(2);
+    expect(provider.federatedSmartDeviceIds[1]).not.toBe(
+      provider.federatedSmartDeviceIds[0],
+    );
+    expect(provider.logoutBodies).toStrictEqual([
+      { smartDeviceId: provider.federatedSmartDeviceIds[0] },
+    ]);
+
     provider.failLogout();
     await connectorsApi.deleteConnectorByType(
       actor,
       "nintendo-switch-parental-controls",
     );
-    expect(provider.tokenBodies).toHaveLength(2);
-    expect(provider.logoutBodies).toHaveLength(1);
-    expect(provider.logoutBodies[0]).toMatchObject({
-      smartDeviceId: expect.any(String),
-    });
+    expect(provider.tokenBodies).toHaveLength(4);
+    expect(provider.logoutBodies).toStrictEqual([
+      { smartDeviceId: provider.federatedSmartDeviceIds[0] },
+      { smartDeviceId: provider.federatedSmartDeviceIds[1] },
+    ]);
     const afterDelete = await connectorsApi.requestReadConnectorByType(
       actor,
       "nintendo-switch-parental-controls",

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -149,6 +149,7 @@ function mockNintendoStoreExternalCodeProvider(): {
 
 function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
   readonly federationBodies: unknown[];
+  readonly failLogout: () => void;
   readonly logoutBodies: unknown[];
   readonly sessionTokenBodies: URLSearchParams[];
   readonly tokenBodies: Readonly<Record<string, unknown>>[];
@@ -157,6 +158,7 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
   const logoutBodies: unknown[] = [];
   const sessionTokenBodies: URLSearchParams[] = [];
   const tokenBodies: Readonly<Record<string, unknown>>[] = [];
+  let logoutStatus = 204;
 
   server.use(
     http.post(NINTENDO_STORE_SESSION_TOKEN_URL, async ({ request }) => {
@@ -213,13 +215,21 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
       NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL,
       async ({ request }) => {
         logoutBodies.push(await request.json());
-        return new HttpResponse(null, { status: 204 });
+        return logoutStatus === 204
+          ? new HttpResponse(null, { status: 204 })
+          : HttpResponse.json(
+              { error: "temporarily unavailable" },
+              { status: logoutStatus },
+            );
       },
     ),
   );
 
   return {
     federationBodies,
+    failLogout: () => {
+      logoutStatus = 503;
+    },
     logoutBodies,
     sessionTokenBodies,
     tokenBodies,
@@ -614,7 +624,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 
-  it("connects and logs out Nintendo Switch Parental Controls through public APIs", async () => {
+  it("deletes Nintendo Switch Parental Controls locally when remote logout fails", async () => {
     const provider = mockNintendoSwitchParentalControlsExternalCodeProvider();
     const bdd = createBddApi(context);
     const actor = bdd.user();
@@ -745,6 +755,7 @@ describe("CONN-02: external-code session lifecycle", () => {
       "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
     ]);
 
+    provider.failLogout();
     await connectorsApi.deleteConnectorByType(
       actor,
       "nintendo-switch-parental-controls",
@@ -754,6 +765,13 @@ describe("CONN-02: external-code session lifecycle", () => {
     expect(provider.logoutBodies[0]).toMatchObject({
       smartDeviceId: expect.any(String),
     });
+    const afterDelete = await connectorsApi.requestReadConnectorByType(
+      actor,
+      "nintendo-switch-parental-controls",
+      [404],
+    );
+    expectApiError(afterDelete.body);
+    expect(afterDelete.body.error.code).toBe("NOT_FOUND");
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -55,6 +55,28 @@ const NINTENDO_STORE_PROFILE_URL =
   "https://api.accounts.nintendo.com/2.0.0/users/me";
 const NINTENDO_STORE_REDIRECT_URI = "npf5c38e31cd085304b://auth";
 const NINTENDO_STORE_CLIENT_ID = "5c38e31cd085304b";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI =
+  "npf54789befb391a838://auth";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_CLIENT_ID = "54789befb391a838";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL =
+  "https://app.lp1.znma.srv.nintendo.net/v3/actions/federation";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL =
+  "https://app.lp1.znma.srv.nintendo.net/v2/actions/logout";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_SCOPES = [
+  "openid",
+  "user",
+  "user.mii",
+  "moonUser:administration",
+  "moonDevice:create",
+  "moonOwnedDevice:administration",
+  "moonParentalControlSetting",
+  "moonParentalControlSetting:update",
+  "moonParentalControlSettingState",
+  "moonPairingState",
+  "moonSmartDevice:administration",
+  "moonDailySummary",
+  "moonMonthlySummary",
+] as const;
 
 async function awsActor(): Promise<ApiTestUser> {
   const bdd = createBddApi(context);
@@ -123,6 +145,85 @@ function mockNintendoStoreExternalCodeProvider(): {
   );
 
   return { sessionTokenBodies, tokenBodies };
+}
+
+function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
+  readonly federationBodies: unknown[];
+  readonly logoutBodies: unknown[];
+  readonly sessionTokenBodies: URLSearchParams[];
+  readonly tokenBodies: Readonly<Record<string, unknown>>[];
+} {
+  const federationBodies: unknown[] = [];
+  const logoutBodies: unknown[] = [];
+  const sessionTokenBodies: URLSearchParams[] = [];
+  const tokenBodies: Readonly<Record<string, unknown>>[] = [];
+
+  server.use(
+    http.post(NINTENDO_STORE_SESSION_TOKEN_URL, async ({ request }) => {
+      sessionTokenBodies.push(new URLSearchParams(await request.text()));
+      return HttpResponse.json({
+        session_token: "bdd-switch-parental-controls-session-token",
+      });
+    }),
+    http.post(NINTENDO_STORE_TOKEN_URL, async ({ request }) => {
+      const body: unknown = await request.json();
+      if (!isRecord(body)) {
+        throw new Error(
+          "Expected Nintendo Switch Parental Controls token body object",
+        );
+      }
+      tokenBodies.push(body);
+      return HttpResponse.json({
+        access_token: "bdd-switch-parental-controls-access-token",
+        expires_in: 3600,
+        id_token: jwtPayload({
+          sub: "bdd-switch-parental-controls-account-id",
+          preferred_username: "bdd-nintendo-parent",
+          email: "bdd-nintendo-parent@example.test",
+        }),
+        token_type: "Bearer",
+        scope: NINTENDO_SWITCH_PARENTAL_CONTROLS_SCOPES.join(" "),
+      });
+    }),
+    http.get(NINTENDO_STORE_PROFILE_URL, () => {
+      return HttpResponse.json({ country: "US", language: "en" });
+    }),
+    http.post(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL,
+      async ({ request }) => {
+        federationBodies.push(await request.json());
+        return HttpResponse.json({
+          loginInfo: {
+            ownedDevices: [
+              {
+                deviceId: "bdd-switch-device-id",
+                label: "Family room",
+                device: {
+                  serialNumber: "bdd-serial-must-not-leak",
+                  synchronizedUnlockCode: "1234",
+                },
+              },
+            ],
+          },
+          nextStep: "COMPLETED",
+        });
+      },
+    ),
+    http.post(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL,
+      async ({ request }) => {
+        logoutBodies.push(await request.json());
+        return new HttpResponse(null, { status: 204 });
+      },
+    ),
+  );
+
+  return {
+    federationBodies,
+    logoutBodies,
+    sessionTokenBodies,
+    tokenBodies,
+  };
 }
 
 describe("CONN-02: external-code session lifecycle", () => {
@@ -510,6 +611,149 @@ describe("CONN-02: external-code session lifecycle", () => {
     expectNoVisibleSecret(secretList, "bdd-nintendo-access-token");
 
     await connectorsApi.deleteConnectorByType(actor, "nintendo-store");
+    await connectorsApi.deleteFeatureSwitches(actor);
+  });
+
+  it("connects and logs out Nintendo Switch Parental Controls through public APIs", async () => {
+    const provider = mockNintendoSwitchParentalControlsExternalCodeProvider();
+    const bdd = createBddApi(context);
+    const actor = bdd.user();
+    context.mocks.ably.publish.mockResolvedValue(undefined);
+    await connectorsApi.updateFeatureSwitches(actor, {
+      [FeatureSwitchKey.NintendoSwitchParentalControlsConnector]: true,
+    });
+
+    const session = await connectorsApi.startExternalCode(
+      actor,
+      "nintendo-switch-parental-controls",
+      "api",
+    );
+    expect(session).toMatchObject({
+      type: "nintendo-switch-parental-controls",
+      status: "pending",
+      expiresIn: 600,
+    });
+    const authorizationUrl = new URL(session.authorizationUrl);
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      NINTENDO_STORE_AUTHORIZE_URL,
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_CLIENT_ID,
+    );
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI,
+    );
+    expect(authorizationUrl.searchParams.get("scope")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_SCOPES.join(" "),
+    );
+    const state = authorizationUrl.searchParams.get("state");
+    if (!state) {
+      throw new Error(
+        "Expected Nintendo Switch Parental Controls authorization state",
+      );
+    }
+
+    const complete = await connectorsApi.completeExternalCode(
+      actor,
+      "nintendo-switch-parental-controls",
+      {
+        sessionId: session.sessionId,
+        sessionToken: session.sessionToken,
+        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI}#session_token_code=bdd-switch-parental-controls-code&state=${state}`,
+      },
+    );
+
+    expect(provider.sessionTokenBodies).toHaveLength(1);
+    expect(provider.sessionTokenBodies[0]?.get("client_id")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_CLIENT_ID,
+    );
+    expect(provider.tokenBodies).toStrictEqual([
+      {
+        client_id: NINTENDO_SWITCH_PARENTAL_CONTROLS_CLIENT_ID,
+        session_token: "bdd-switch-parental-controls-session-token",
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer-session-token",
+      },
+    ]);
+    expect(provider.federationBodies).toHaveLength(1);
+    expect(provider.federationBodies[0]).toMatchObject({
+      smartDeviceInfo: {
+        id: expect.any(String),
+        bundleId: "com.nintendo.znma",
+        notificationToken: null,
+      },
+    });
+    expect(complete.connector).toMatchObject({
+      type: "nintendo-switch-parental-controls",
+      authMethod: "api",
+      externalId: "bdd-switch-parental-controls-account-id",
+      externalUsername: "bdd-nintendo-parent",
+      oauthScopes: NINTENDO_SWITCH_PARENTAL_CONTROLS_SCOPES,
+    });
+    expect(complete.connector.tokenExpiresAt).not.toBeNull();
+    expectNoVisibleSecret(
+      complete,
+      "bdd-switch-parental-controls-session-token",
+    );
+    expectNoVisibleSecret(
+      complete,
+      "bdd-switch-parental-controls-access-token",
+    );
+    expectNoVisibleSecret(complete, "bdd-serial-must-not-leak");
+    expectNoVisibleSecret(complete, "1234");
+
+    const listed = await connectorsApi.listConnectors(actor);
+    for (const name of [
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+    ]) {
+      expect(listed.connectorProvidedBindings).toContainEqual(
+        expect.objectContaining({
+          connectorType: "nintendo-switch-parental-controls",
+          authMethod: "api",
+          namespace: "secrets",
+          name,
+        }),
+      );
+    }
+    for (const name of [
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG",
+    ]) {
+      expect(listed.connectorProvidedBindings).toContainEqual(
+        expect.objectContaining({
+          connectorType: "nintendo-switch-parental-controls",
+          authMethod: "api",
+          namespace: "vars",
+          name,
+        }),
+      );
+    }
+
+    const secretList = await authOrgApi.listSecrets(actor);
+    const connectorSecretNames = secretList.secrets
+      .filter((secret) => {
+        return secret.type === "connector";
+      })
+      .map((secret) => {
+        return secret.name;
+      });
+    expect(connectorSecretNames.sort()).toStrictEqual([
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCESS_TOKEN",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_ID_TOKEN",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+    ]);
+
+    await connectorsApi.deleteConnectorByType(
+      actor,
+      "nintendo-switch-parental-controls",
+    );
+    expect(provider.tokenBodies).toHaveLength(2);
+    expect(provider.logoutBodies).toHaveLength(1);
+    expect(provider.logoutBodies[0]).toMatchObject({
+      smartDeviceId: expect.any(String),
+    });
     await connectorsApi.deleteFeatureSwitches(actor);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -510,6 +510,59 @@ describe("GET /api/zero/connector-catalog", () => {
     ]);
   });
 
+  it("hides Nintendo Switch Parental Controls until its connector switch is enabled", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const hidden = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+    expect(
+      hidden.body.connectors.some((connector) => {
+        return connector.connectorRef === "nintendo-switch-parental-controls";
+      }),
+    ).toBeFalsy();
+
+    await enableConnectorFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.NintendoSwitchParentalControlsConnector]: true,
+    });
+    const visible = await accept(
+      client.status({ headers: { authorization: "Bearer clerk-session" } }),
+      [200],
+    );
+
+    assertPublicConnectorCatalogHasNoPrivateFields(visible.body);
+    const connector = visible.body.connectors.find((entry) => {
+      return entry.connectorRef === "nintendo-switch-parental-controls";
+    });
+    expect(connector).toMatchObject({
+      connectorRef: "nintendo-switch-parental-controls",
+      label: "Nintendo Switch Parental Controls",
+      connected: false,
+      connectionStatus: "not-connected",
+      permissionSummary: {
+        hasPermissions: true,
+        permissionCount: 15,
+        hasCategories: true,
+        hasDefaultPolicyOverrides: true,
+      },
+    });
+    expect(connector?.authMethods).toStrictEqual([
+      {
+        id: "api",
+        label: "Nintendo sign-in",
+        description:
+          "Sign in with the adult Nintendo Account used by the Nintendo Switch Parental Controls app. After signing in, right-click the redirect button and copy its link address, then paste the full `npf...://auth` redirect URL or the `session_token_code` value.",
+        grantKind: "external-code",
+        manualFields: [],
+        startOptions: [],
+      },
+    ]);
+  });
+
   it("returns connected manual grant status from public API-created state", async () => {
     const actor = bdd.user();
     await connectorsApi.connectManualGrant(actor, "openai", "api-token", {

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -282,7 +282,10 @@ async function finalizeConnectorStateChangeAfterCommit(args: {
 }): Promise<void> {
   let postCommitAbort = args.postCommitAbort;
   if (args.pendingTokenRevoke) {
-    await revokePendingConnectorToken({ pending: args.pendingTokenRevoke });
+    await revokePendingConnectorToken({
+      pending: args.pendingTokenRevoke,
+      signal: args.signal,
+    });
     if (args.signal.aborted) {
       postCommitAbort ??= args.signal.reason;
     }
@@ -708,6 +711,7 @@ function resolveTokenRevokeMethodRef(args: {
 
 async function revokePendingConnectorToken(args: {
   readonly pending: PendingConnectorTokenRevoke;
+  readonly signal: AbortSignal;
 }): Promise<void> {
   // Provider revocation is best-effort; local cleanup still owns visible state.
   await bestEffort(
@@ -715,6 +719,7 @@ async function revokePendingConnectorToken(args: {
       type: args.pending.type,
       authMethod: args.pending.authMethod,
       readEnv: optionalEnv,
+      signal: args.signal,
       loadInputs: () => {
         return decryptConnectorRevokeInputs({
           encryptedInputs: args.pending.encryptedInputs,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -709,6 +709,34 @@ function resolveTokenRevokeMethodRef(args: {
     : null;
 }
 
+function resolveReplaceTokenRevokeMethodRef(args: {
+  readonly type: ConnectorType;
+  readonly authMethod: string | null;
+}): TokenRevokeMethodRef | null {
+  if (!args.authMethod) {
+    return null;
+  }
+  const tokenRevokeMethod = resolveTokenRevokeMethodRef({
+    type: args.type,
+    authMethod: args.authMethod,
+  });
+  if (!tokenRevokeMethod) {
+    return null;
+  }
+  const method = getConnectorAuthMethod(
+    tokenRevokeMethod.type,
+    tokenRevokeMethod.authMethod,
+  );
+  if (
+    !method ||
+    method.revoke.kind !== "token-revoke" ||
+    method.revoke.revokePreviousOnReplace !== true
+  ) {
+    return null;
+  }
+  return tokenRevokeMethod;
+}
+
 async function revokePendingConnectorToken(args: {
   readonly pending: PendingConnectorTokenRevoke;
   readonly signal: AbortSignal;
@@ -1944,6 +1972,90 @@ async function deleteObsoleteConnectorScopedStateForTokenConnect(
   });
 }
 
+async function commitConnectorTokenConnection(args: {
+  readonly db: Db;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly type: AuthGrantConnectorType;
+  readonly authMethod: ConnectorAuthMethodId;
+  readonly connectorTokenState: PreparedConnectorTokenState;
+  readonly featureSwitchContext: FeatureSwitchContext;
+  readonly userInfo: ExternalUserInfo;
+  readonly oauthScopes: readonly string[];
+  readonly tokenExpiresAt: Date | null;
+  readonly signal: AbortSignal;
+}): Promise<{
+  readonly connectorRow: StoredConnectorRow;
+  readonly pendingTokenRevoke: PendingConnectorTokenRevoke | null;
+}> {
+  await lockConnectorState(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    type: args.type,
+  });
+  args.signal.throwIfAborted();
+
+  const existingAuthMethod = await loadExistingConnectorAuthMethod(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    type: args.type,
+    signal: args.signal,
+  });
+  const replaceTokenRevokeMethod = resolveReplaceTokenRevokeMethodRef({
+    type: args.type,
+    authMethod: existingAuthMethod,
+  });
+  const pendingTokenRevoke = replaceTokenRevokeMethod
+    ? await loadPendingConnectorTokenRevoke({
+        db: args.db,
+        orgId: args.orgId,
+        userId: args.userId,
+        method: replaceTokenRevokeMethod,
+        featureSwitchContext: args.featureSwitchContext,
+        signal: args.signal,
+      })
+    : null;
+
+  await upsertPreparedConnectorTokenState({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    state: args.connectorTokenState,
+    signal: args.signal,
+  });
+  args.signal.throwIfAborted();
+
+  const connectorRow = await upsertConnectorTokenConnectionRow(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    type: args.type,
+    authMethod: args.authMethod,
+    userInfo: args.userInfo,
+    oauthScopes: args.oauthScopes,
+    tokenExpiresAt: args.tokenExpiresAt,
+    signal: args.signal,
+  });
+
+  await deleteObsoleteConnectorScopedStateForTokenConnect(args.db, {
+    orgId: args.orgId,
+    userId: args.userId,
+    type: args.type,
+    authMethod: args.authMethod,
+    existingAuthMethod,
+    signal: args.signal,
+  });
+  await deleteManualGrantConnectorLocalStateForAuthMethods({
+    db: args.db,
+    orgId: args.orgId,
+    userId: args.userId,
+    type: args.type,
+    authMethods: [existingAuthMethod, args.authMethod],
+    signal: args.signal,
+  });
+
+  return { connectorRow, pendingTokenRevoke };
+}
+
 export const upsertConnectorTokenConnection$ = command(
   async (
     { get, set },
@@ -2001,60 +2113,20 @@ export const upsertConnectorTokenConnection$ = command(
     signal.throwIfAborted();
 
     let postCommitAbort: unknown = null;
-    const connectorRow = await writeDb.transaction(async (tx) => {
-      await lockConnectorState(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
-        type: args.type,
-      });
-      signal.throwIfAborted();
-
-      const existingAuthMethod = await loadExistingConnectorAuthMethod(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
-        type: args.type,
-        signal,
-      });
-
-      await upsertPreparedConnectorTokenState({
+    const connectionResult = await writeDb.transaction(async (tx) => {
+      return await commitConnectorTokenConnection({
         db: tx,
-        orgId: args.orgId,
-        userId: args.userId,
-        state: connectorTokenState,
-        signal,
-      });
-      signal.throwIfAborted();
-
-      const row = await upsertConnectorTokenConnectionRow(tx, {
         orgId: args.orgId,
         userId: args.userId,
         type: args.type,
         authMethod: args.authMethod,
+        connectorTokenState,
+        featureSwitchContext,
         userInfo: args.userInfo,
         oauthScopes: args.oauthScopes,
         tokenExpiresAt,
         signal,
       });
-
-      await deleteObsoleteConnectorScopedStateForTokenConnect(tx, {
-        orgId: args.orgId,
-        userId: args.userId,
-        type: args.type,
-        authMethod: args.authMethod,
-        existingAuthMethod,
-        signal,
-      });
-
-      await deleteManualGrantConnectorLocalStateForAuthMethods({
-        db: tx,
-        orgId: args.orgId,
-        userId: args.userId,
-        type: args.type,
-        authMethods: [existingAuthMethod, args.authMethod],
-        signal,
-      });
-
-      return row;
     });
     if (signal.aborted) {
       postCommitAbort ??= signal.reason;
@@ -2062,7 +2134,7 @@ export const upsertConnectorTokenConnection$ = command(
 
     await finalizeConnectorStateChangeAfterCommit({
       userId: args.userId,
-      pendingTokenRevoke: null,
+      pendingTokenRevoke: connectionResult.pendingTokenRevoke,
       signal,
       postCommitAbort,
     });
@@ -2070,12 +2142,13 @@ export const upsertConnectorTokenConnection$ = command(
 
     return {
       connector: storedConnectorRowToResponse(
-        connectorRow,
+        connectionResult.connectorRow,
         args.type,
         nowDate(),
       ),
       created:
-        connectorRow.createdAt.getTime() === connectorRow.updatedAt.getTime(),
+        connectionResult.connectorRow.createdAt.getTime() ===
+        connectionResult.connectorRow.updatedAt.getTime(),
     };
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -193,6 +193,7 @@ const CONNECTOR_ICON_COLORFUL = {
   n8n: true,
   neon: true,
   netdata: true,
+  "nintendo-switch-parental-controls": true,
   "nintendo-store": true,
   nyne: true,
   openweather: true,

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
@@ -268,6 +268,8 @@ const SETTINGS_ICON_ASSET_PATHS = {
   neon: "views/zero-page/components/settings/icons/neon-2b1aaef0b2de.svg",
   netdata: "views/zero-page/components/settings/icons/netdata-df49d68a3ecd.svg",
   netter: "views/zero-page/components/settings/icons/netter-4c7de538303c.svg",
+  "nintendo-switch-parental-controls":
+    "views/zero-page/components/settings/icons/nintendo-switch-parental-controls-da75b53905d6.svg",
   "nintendo-store":
     "views/zero-page/components/settings/icons/nintendo-store-f3c8ad8b8d85.svg",
   notion: "views/zero-page/components/settings/icons/notion-beeb509915a9.svg",

--- a/turbo/packages/connectors/src/__tests__/connectors.test.ts
+++ b/turbo/packages/connectors/src/__tests__/connectors.test.ts
@@ -1163,6 +1163,7 @@ describe("connector selected auth method capability checks", () => {
         type: "github",
         authMethod: "oauth",
         readEnv,
+        signal: testRefreshSignal(),
         loadInputs: () => {
           return { accessToken: "gh-access-token" };
         },
@@ -1184,6 +1185,7 @@ describe("connector selected auth method capability checks", () => {
         readEnv: () => {
           return undefined;
         },
+        signal: testRefreshSignal(),
         loadInputs: () => {
           loadedInputs = true;
           return { accessToken: "notion-access-token" };
@@ -1203,6 +1205,7 @@ describe("connector selected auth method capability checks", () => {
         readEnv: () => {
           return undefined;
         },
+        signal: testRefreshSignal(),
         loadInputs: () => {
           loadedInputs = true;
           return { accessToken: "gh-access-token" };
@@ -1222,6 +1225,7 @@ describe("connector selected auth method capability checks", () => {
         readEnv: () => {
           return undefined;
         },
+        signal: testRefreshSignal(),
         loadInputs: () => {
           loadedInputs = true;
           return { accessToken: "gh-access-token" };

--- a/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-categories.test.ts
@@ -25,6 +25,7 @@ const EXPECTED_CATEGORIZED_CONNECTORS = [
   "google-meet",
   "google-search-console",
   "google-sheets",
+  "nintendo-switch-parental-controls",
   "slack",
   "stripe",
   "vercel",

--- a/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-rule-validation.test.ts
@@ -42,6 +42,8 @@ const ALLOWED_FIREWALL_BASE_OVERLAPS = new Set([
   "outlook-calendar[0] https://graph.microsoft.com <-> outlook-mail[0] https://graph.microsoft.com",
   // Railway account/workspace and project tokens hit the same public API origin.
   "railway[0] https://backboard.railway.com <-> railway-project[0] https://backboard.railway.com",
+  // Nintendo apps share the Nintendo Account profile endpoint but use separate app tokens.
+  "nintendo-store[0] https://api.accounts.nintendo.com <-> nintendo-switch-parental-controls[0] https://api.accounts.nintendo.com",
 ]);
 
 function firewallWithPermissionName(name: string): FirewallConfig {

--- a/turbo/packages/connectors/src/__tests__/firewalls/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/nintendo-switch-parental-controls.test.ts
@@ -1,0 +1,381 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { NINTENDO_SWITCH_PARENTAL_CONTROLS_APP } from "../../connectors/nintendo-switch-parental-controls";
+import {
+  findMatchingPermissions,
+  matchFirewallRequestDecision,
+} from "../../firewall-rule-matcher";
+import {
+  extractSecretNamesFromApis,
+  type FirewallConfig,
+} from "../../firewall-types";
+import {
+  loadDefaultFirewallPolicies,
+  loadRequiredConnectorFirewall,
+} from "../firewall-test-helpers";
+
+interface ExpectedRoute {
+  readonly apiBase: string;
+  readonly method: "GET" | "POST";
+  readonly path: string;
+  readonly permission: string;
+}
+
+const ACTION_BASE = NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.actionBaseUrl;
+const ACCOUNT_BASE = NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.accountBaseUrl;
+
+function actionRoutes(
+  method: ExpectedRoute["method"],
+  permission: string,
+  paths: readonly string[],
+): ExpectedRoute[] {
+  return paths.map((path) => {
+    return { apiBase: ACTION_BASE, method, path, permission };
+  });
+}
+
+const EXPECTED_ROUTES: readonly ExpectedRoute[] = [
+  {
+    apiBase: ACCOUNT_BASE,
+    method: "GET",
+    path: "/2.0.0/users/me",
+    permission: "nintendo-switch-parental-controls-account-read",
+  },
+  ...actionRoutes("GET", "nintendo-switch-parental-controls-account-read", [
+    "/v2/actions/user/fetchUser",
+  ]),
+  ...actionRoutes(
+    "GET",
+    "nintendo-switch-parental-controls-announcements-read",
+    ["/v2/actions/announcement/fetchAnnouncements"],
+  ),
+  ...actionRoutes("GET", "nintendo-switch-parental-controls-game-chat-read", [
+    "/v2/actions/chat/fetchCameraChatRequests",
+    "/v2/actions/chat/fetchCameraSetting",
+    "/v2/actions/chat/fetchChatRequests",
+    "/v2/actions/chat/fetchChatSetting",
+    "/v2/actions/chat/fetchTermOfUse",
+  ]),
+  ...actionRoutes(
+    "GET",
+    "nintendo-switch-parental-controls-play-summary-read",
+    [
+      "/v2/actions/playSummary/fetchDailySummaries",
+      "/v2/actions/playSummary/fetchLatestMonthlySummary",
+      "/v2/actions/playSummary/fetchMonthlySummary",
+    ],
+  ),
+  ...actionRoutes(
+    "GET",
+    "nintendo-switch-parental-controls-device-credentials-read",
+    [
+      "/v3/actions/device/fetchExtraPlayingTimeState",
+      "/v3/actions/deviceFederation/checkDeviceFederation",
+      "/v3/actions/user/fetchOwnedDevice",
+      "/v3/actions/user/fetchOwnedDevices",
+    ],
+  ),
+  ...actionRoutes(
+    "GET",
+    "nintendo-switch-parental-controls-settings-credentials-read",
+    ["/v3/actions/parentalControlSetting/fetchParentalControlSetting"],
+  ),
+  ...actionRoutes("POST", "nintendo-switch-parental-controls-game-chat-write", [
+    "/v2/actions/chat/acceptCameraChatRequest",
+    "/v2/actions/chat/acceptChatRequest",
+    "/v2/actions/chat/agreeChildTerm",
+    "/v2/actions/chat/checkRelationship",
+    "/v2/actions/chat/rejectCameraChatRequest",
+    "/v2/actions/chat/rejectChatRequest",
+    "/v2/actions/chat/requestRelationshipCorrection",
+    "/v2/actions/chat/suspendCameraChat",
+    "/v2/actions/chat/updateCameraChatSetting",
+    "/v2/actions/chat/updateCameraSetting",
+    "/v2/actions/chat/updateMemo",
+    "/v2/actions/chat/withdrawChatRequest",
+  ]),
+  ...actionRoutes("POST", "nintendo-switch-parental-controls-play-time-write", [
+    "/v2/actions/device/confirmExtraPlayingTime",
+    "/v2/actions/device/updateExtraPlayingTime",
+    "/v3/actions/parentalControlSetting/updatePlayTimer",
+  ]),
+  ...actionRoutes(
+    "POST",
+    "nintendo-switch-parental-controls-device-pairing-write",
+    [
+      "/v2/actions/deviceFederation/startDeviceFederation",
+      "/v2/actions/user/confirmCopiedOwnedDevice",
+      "/v3/actions/federation",
+    ],
+  ),
+  ...actionRoutes("POST", "nintendo-switch-parental-controls-feedback-write", [
+    "/v2/actions/feedback/sendFeedback",
+  ]),
+  ...actionRoutes(
+    "POST",
+    "nintendo-switch-parental-controls-smart-device-write",
+    ["/v2/actions/logout", "/v2/actions/smartDevice/updateNotificationToken"],
+  ),
+  ...actionRoutes("POST", "nintendo-switch-parental-controls-settings-write", [
+    "/v2/actions/parentalControlSetting/updateRestrictionLevel",
+    "/v2/actions/parentalControlSetting/updateUnlockCode",
+  ]),
+  ...actionRoutes("POST", "nintendo-switch-parental-controls-device-write", [
+    "/v3/actions/device/unregisterDevice",
+    "/v3/actions/device/updateDeviceLabel",
+    "/v3/actions/user/updateOwnedDeviceSortOrder",
+  ]),
+  ...actionRoutes(
+    "POST",
+    "nintendo-switch-parental-controls-notifications-write",
+    [
+      "/v2/actions/user/clearAlarmSettingNotice",
+      "/v2/actions/user/updateNotificationSetting",
+    ],
+  ),
+  ...actionRoutes(
+    "POST",
+    "nintendo-switch-parental-controls-summary-acknowledgement-write",
+    [
+      "/v3/actions/user/confirmFirstDailySummary",
+      "/v3/actions/user/confirmNewMonthlySummary",
+    ],
+  ),
+];
+
+const DEFAULT_ALLOWED = new Set([
+  "nintendo-switch-parental-controls-account-read",
+  "nintendo-switch-parental-controls-announcements-read",
+  "nintendo-switch-parental-controls-game-chat-read",
+  "nintendo-switch-parental-controls-play-summary-read",
+]);
+
+let firewall: FirewallConfig;
+
+function matcherNetworkPolicies(
+  policy: Awaited<ReturnType<typeof loadDefaultFirewallPolicies>>,
+) {
+  const allow: string[] = [];
+  const deny: string[] = [];
+  for (const [permissionName, decision] of Object.entries(policy.policies)) {
+    (decision === "allow" ? allow : deny).push(permissionName);
+  }
+  return {
+    "nintendo-switch-parental-controls": {
+      allow,
+      deny,
+      ask: [],
+      unknownPolicy: policy.unknownPolicy,
+    },
+  };
+}
+
+function matchingPermissions(route: ExpectedRoute): string[] {
+  return [
+    ...findMatchingPermissions(route.method, route.path, firewall, {
+      apiBase: route.apiBase,
+    }),
+  ].sort();
+}
+
+describe("Nintendo Switch Parental Controls firewall", () => {
+  beforeAll(async () => {
+    firewall = await loadRequiredConnectorFirewall(
+      "nintendo-switch-parental-controls",
+    );
+  });
+
+  it("injects the correct account and app credentials and app headers", () => {
+    expect(firewall.name).toBe("nintendo-switch-parental-controls");
+    expect(firewall.apis).toHaveLength(2);
+    expect(
+      Object.fromEntries(
+        firewall.apis.map((api) => {
+          return [api.base, api.auth];
+        }),
+      ),
+    ).toStrictEqual({
+      [ACCOUNT_BASE]: {
+        headers: {
+          Authorization:
+            "Bearer ${{ secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN }}",
+          "User-Agent": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.userAgent,
+        },
+      },
+      [ACTION_BASE]: {
+        headers: {
+          Authorization:
+            "Bearer ${{ secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN }}",
+          "User-Agent": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.userAgent,
+          "X-Moon-App-Display-Version": "2.4.0",
+          "X-Moon-App-Id": "com.nintendo.znma",
+          "X-Moon-App-Internal-Version": "660",
+          "X-Moon-App-Language":
+            "${{ vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE }}",
+          "X-Moon-Model": "vm0",
+          "X-Moon-Os": "ANDROID",
+          "X-Moon-Os-Language":
+            "${{ vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE }}",
+          "X-Moon-Os-Version": "35",
+          "X-Moon-Smart-Device-Id":
+            "${{ secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID }}",
+          "X-Moon-TimeZone": "Etc/UTC",
+        },
+      },
+    });
+    expect(extractSecretNamesFromApis([...firewall.apis])).toStrictEqual([
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+      "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+    ]);
+  });
+
+  it("covers the account profile and all 45 app action routes exactly", () => {
+    expect(EXPECTED_ROUTES).toHaveLength(46);
+    expect(
+      EXPECTED_ROUTES.filter((route) => {
+        return route.method === "GET";
+      }),
+    ).toHaveLength(16);
+    expect(
+      EXPECTED_ROUTES.filter((route) => {
+        return route.method === "POST";
+      }),
+    ).toHaveLength(30);
+
+    for (const route of EXPECTED_ROUTES) {
+      expect(
+        matchingPermissions(route),
+        `${route.method} ${route.path}`,
+      ).toEqual([route.permission]);
+    }
+  });
+
+  it("matches representative action query strings through the request matcher", () => {
+    for (const url of [
+      `${ACTION_BASE}/v2/actions/announcement/fetchAnnouncements?appLanguage=en`,
+      `${ACTION_BASE}/v2/actions/chat/fetchCameraSetting?deviceId=device-1&playerId=player-1`,
+      `${ACTION_BASE}/v2/actions/playSummary/fetchMonthlySummary?deviceId=device-1&year=2026&month=7&containLatest=true`,
+      `${ACTION_BASE}/v3/actions/user/fetchOwnedDevice?deviceId=device-1`,
+    ]) {
+      expect(
+        matchFirewallRequestDecision([firewall], "GET", url),
+      ).toMatchObject({
+        kind: "allow",
+        firewallName: "nintendo-switch-parental-controls",
+      });
+    }
+  });
+
+  it("allows ordinary reads and denies credential reads and writes by default", async () => {
+    const policy = await loadDefaultFirewallPolicies(
+      "nintendo-switch-parental-controls",
+    );
+    const networkPolicies = matcherNetworkPolicies(policy);
+    const permissionNames = new Set(
+      EXPECTED_ROUTES.map((route) => {
+        return route.permission;
+      }),
+    );
+
+    expect(permissionNames.size).toBe(15);
+    expect(
+      EXPECTED_ROUTES.filter((route) => {
+        return DEFAULT_ALLOWED.has(route.permission);
+      }),
+    ).toHaveLength(11);
+    expect(
+      EXPECTED_ROUTES.filter((route) => {
+        return route.method === "GET" && !DEFAULT_ALLOWED.has(route.permission);
+      }),
+    ).toHaveLength(5);
+    expect(
+      EXPECTED_ROUTES.filter((route) => {
+        return route.method === "POST";
+      }),
+    ).toHaveLength(30);
+    for (const permissionName of permissionNames) {
+      expect(policy.policies[permissionName], permissionName).toBe(
+        DEFAULT_ALLOWED.has(permissionName) ? "allow" : "deny",
+      );
+    }
+    for (const route of EXPECTED_ROUTES) {
+      const decision = matchFirewallRequestDecision(
+        [firewall],
+        route.method,
+        `${route.apiBase}${route.path}?probe=value`,
+        networkPolicies,
+      );
+      expect(decision, `${route.method} ${route.path}`).toMatchObject(
+        DEFAULT_ALLOWED.has(route.permission)
+          ? {
+              kind: "allow",
+              firewallName: "nintendo-switch-parental-controls",
+              permission: route.permission,
+            }
+          : {
+              kind: "block",
+              firewallName: "nintendo-switch-parental-controls",
+              reason: "permission_denied",
+              permissions: [route.permission],
+            },
+      );
+    }
+    expect(policy.unknownPolicy).toBe("deny");
+  });
+
+  it("denies unknown paths and methods without claiming unsupported hosts", async () => {
+    const policy = await loadDefaultFirewallPolicies(
+      "nintendo-switch-parental-controls",
+    );
+    const networkPolicies = matcherNetworkPolicies(policy);
+    const unknownRoutes: readonly ExpectedRoute[] = [
+      {
+        apiBase: ACTION_BASE,
+        method: "GET",
+        path: "/v2/actions/logout",
+        permission: "",
+      },
+      {
+        apiBase: ACTION_BASE,
+        method: "POST",
+        path: "/v3/actions/user/fetchOwnedDevices",
+        permission: "",
+      },
+      {
+        apiBase: ACTION_BASE,
+        method: "GET",
+        path: "/moon/v1/devices",
+        permission: "",
+      },
+      {
+        apiBase: "https://api-lp1.pctl.srv.nintendo.net",
+        method: "GET",
+        path: "/v2/actions/user/fetchUser",
+        permission: "",
+      },
+    ];
+
+    for (const route of unknownRoutes) {
+      expect(matchingPermissions(route)).toStrictEqual([]);
+      const decision = matchFirewallRequestDecision(
+        [firewall],
+        route.method,
+        `${route.apiBase}${route.path}`,
+        networkPolicies,
+      );
+      expect(decision, `${route.method} ${route.apiBase}${route.path}`).toEqual(
+        route.apiBase === ACTION_BASE
+          ? {
+              kind: "block",
+              firewallName: "nintendo-switch-parental-controls",
+              base: ACTION_BASE,
+              relativePath: route.path,
+              reason: "unknown_endpoint",
+              permissions: [],
+            }
+          : { kind: "no_match" },
+      );
+    }
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connector-auth.ts
+++ b/turbo/packages/connectors/src/auth-providers/connector-auth.ts
@@ -27,7 +27,7 @@ import {
   getConnectorAuthMethodOpenIdAuthGrantConfig,
   getConnectorAuthMethodExternalCodeGrantConfig,
   getConnectorAuthMethodGrantScopes,
-  isStaticConfidentialConnectorAuthClient,
+  isStaticConnectorAuthClient,
   parseConnectorDeviceAuthStartOptions,
   resolveConnectorAuthClientForMethod,
   type ConnectorAuthClientForMethod,
@@ -92,6 +92,7 @@ import { mercuryProvider } from "./connectors/mercury/provider";
 import { microsoft365Provider } from "./connectors/microsoft-365/provider";
 import { mondayProvider } from "./connectors/monday/provider";
 import { neonProvider } from "./connectors/neon/provider";
+import { nintendoSwitchParentalControlsProvider } from "./connectors/nintendo-switch-parental-controls/provider";
 import { nintendoStoreProvider } from "./connectors/nintendo-store/provider";
 import { notionProvider } from "./connectors/notion/provider";
 import { outlookCalendarProvider } from "./connectors/outlook-calendar/provider";
@@ -503,6 +504,28 @@ function externalCodeRefreshProviderEntry<
   });
 }
 
+function externalCodeRefreshTokenRevokeProviderEntry<
+  Type extends ExternalCodeGrantConnectorType &
+    RefreshTokenAccessConnectorType &
+    TokenRevokeConnectorType,
+  Method extends ConnectorExternalCodeGrantAuthMethodId<Type> &
+    ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token"> &
+    ConnectorAuthMethodIdsByRevokeKind<Type, "token-revoke">,
+>(
+  type: Type,
+  authMethod: Method,
+  provider: ExternalCodeConnectorAuthProvider<Type, Method> & {
+    readonly access: RefreshTokenAccessProvider<Type, Method>;
+    readonly revoke: TokenRevokeProvider<Type, Method>;
+  },
+): RuntimeAuthProviderRegistration<Type, Method> {
+  return connectorAuthProviderRegistryEntry(type, authMethod, {
+    grant: provider.grant,
+    access: provider.access,
+    revoke: provider.revoke,
+  });
+}
+
 function refreshProviderEntry<
   Type extends RefreshTokenAccessConnectorType,
   Method extends ConnectorAuthMethodIdsByAccessKind<Type, "refresh-token"> &
@@ -592,6 +615,7 @@ async function revokeTokenRevokeConnectorAccessToken<
   readonly type: T;
   readonly authMethod: Method;
   readonly readEnv: ConnectorEnvReader;
+  readonly signal: AbortSignal;
   readonly loadInputs: () =>
     | ConnectorRevokeInputValues<T, Method>
     | Promise<ConnectorRevokeInputValues<T, Method>>;
@@ -603,13 +627,14 @@ async function revokeTokenRevokeConnectorAccessToken<
     args.authMethod,
     args.readEnv,
   );
-  if (!authClient || !isStaticConfidentialConnectorAuthClient(authClient)) {
+  if (!authClient || !isStaticConnectorAuthClient(authClient)) {
     return { status: "unsupported" };
   }
 
   await revoke.revokeToken({
     authClient,
     inputs: await args.loadInputs(),
+    signal: args.signal,
   });
   return { status: "revoked" };
 }
@@ -686,6 +711,11 @@ const CONNECTOR_AUTH_METHOD_PROVIDER_ENTRIES = [
     "nintendo-store",
     "api",
     nintendoStoreProvider,
+  ),
+  externalCodeRefreshTokenRevokeProviderEntry(
+    "nintendo-switch-parental-controls",
+    "api",
+    nintendoSwitchParentalControlsProvider,
   ),
   authCodeRefreshProviderEntry("notion", "oauth", notionProvider),
   authCodeRefreshProviderEntry(
@@ -1216,6 +1246,7 @@ export async function revokeConnectorAuthMethodAccessToken(args: {
   readonly type: ConnectorType;
   readonly authMethod: string;
   readonly readEnv: ConnectorEnvReader;
+  readonly signal: AbortSignal;
   readonly loadInputs: () =>
     | Readonly<Record<string, string>>
     | Promise<Readonly<Record<string, string>>>;
@@ -1241,6 +1272,7 @@ export async function revokeConnectorAuthMethodAccessToken(args: {
     type: tokenRevokeAuthMethodRef.type,
     authMethod: tokenRevokeAuthMethodRef.authMethod,
     readEnv: args.readEnv,
+    signal: args.signal,
     loadInputs: args.loadInputs,
   });
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/nintendo-switch-parental-controls.test.ts
@@ -1,0 +1,425 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { NINTENDO_SWITCH_PARENTAL_CONTROLS_APP } from "../../../connectors/nintendo-switch-parental-controls";
+import { resolveConnectorAuthClientForMethod } from "../../../connector-utils";
+import {
+  completeConnectorExternalCodeAuthorization,
+  refreshConnectorAuthProviderAccessToken,
+  revokeConnectorAuthMethodAccessToken,
+  startConnectorExternalCodeAuthorization,
+} from "../../connector-auth";
+import { server } from "../../__tests__/test-server";
+import {
+  NINTENDO_SWITCH_PARENTAL_CONTROLS_AUTHORIZATION_URL,
+  NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL,
+  NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL,
+  NINTENDO_SWITCH_PARENTAL_CONTROLS_OWNED_DEVICES_URL,
+  NINTENDO_SWITCH_PARENTAL_CONTROLS_PROFILE_URL,
+  NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN_URL,
+  NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN_URL,
+} from "../nintendo-switch-parental-controls/api";
+
+const NINTENDO_SESSION_TOKEN_GRANT_TYPE =
+  "urn:ietf:params:oauth:grant-type:jwt-bearer-session-token";
+
+function nintendoSwitchParentalControlsAuthClient() {
+  const authClient = resolveConnectorAuthClientForMethod(
+    "nintendo-switch-parental-controls",
+    "api",
+    () => {
+      throw new Error(
+        "Nintendo Switch Parental Controls auth client should not read env",
+      );
+    },
+  );
+  if (
+    !authClient ||
+    authClient.clientRegistration !== "static" ||
+    authClient.clientType !== "public"
+  ) {
+    throw new Error(
+      "Missing Nintendo Switch Parental Controls public auth client",
+    );
+  }
+  return authClient;
+}
+
+function testSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+function jwtPayload(payload: Readonly<Record<string, string>>): string {
+  return [
+    Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".");
+}
+
+function sha256Base64Url(value: string): string {
+  return createHash("sha256").update(value).digest("base64url");
+}
+
+async function startNintendoSwitchParentalControlsSession() {
+  const result = await startConnectorExternalCodeAuthorization({
+    type: "nintendo-switch-parental-controls",
+    authMethod: "api",
+    authClient: nintendoSwitchParentalControlsAuthClient(),
+  });
+  const providerState = JSON.parse(result.providerState) as {
+    readonly version: 1;
+    readonly state: string;
+    readonly codeVerifier: string;
+  };
+  return { result, providerState };
+}
+
+describe("Nintendo Switch Parental Controls external-code provider", () => {
+  it("starts with the app client, redirect, scopes, state, and PKCE", async () => {
+    const { result, providerState } =
+      await startNintendoSwitchParentalControlsSession();
+    const authorizationUrl = new URL(result.authorizationUrl);
+
+    expect(`${authorizationUrl.origin}${authorizationUrl.pathname}`).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_AUTHORIZATION_URL,
+    );
+    expect(authorizationUrl.searchParams.get("client_id")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+    );
+    expect(authorizationUrl.searchParams.get("redirect_uri")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.redirectUri,
+    );
+    expect(authorizationUrl.searchParams.get("response_type")).toBe(
+      "session_token_code",
+    );
+    expect(authorizationUrl.searchParams.get("scope")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.scopes.join(" "),
+    );
+    expect(authorizationUrl.searchParams.get("state")).toBe(
+      providerState.state,
+    );
+    expect(
+      authorizationUrl.searchParams.get("session_token_code_challenge"),
+    ).toBe(sha256Base64Url(providerState.codeVerifier));
+    expect(
+      authorizationUrl.searchParams.get("session_token_code_challenge_method"),
+    ).toBe("S256");
+    expect(result.expiresIn).toBe(600);
+  });
+
+  it("federates a stable smart device and stores only a safe device projection", async () => {
+    const { result: started, providerState } =
+      await startNintendoSwitchParentalControlsSession();
+    const idToken = jwtPayload({
+      sub: "nintendo-account-123",
+      email: "parent@example.com",
+      name: "Nintendo Parent",
+    });
+    const captured: {
+      sessionBody?: URLSearchParams;
+      tokenBody?: unknown;
+      profileHeaders?: Headers;
+      federationBody?: unknown;
+      federationHeaders?: Headers;
+    } = {};
+
+    server.use(
+      http.post(
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN_URL,
+        async ({ request }) => {
+          captured.sessionBody = new URLSearchParams(await request.text());
+          return HttpResponse.json({ session_token: "session-token" });
+        },
+      ),
+      http.post(
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN_URL,
+        async ({ request }) => {
+          captured.tokenBody = await request.json();
+          return HttpResponse.json({
+            access_token: "account-access-token",
+            expires_in: 3600,
+            id_token: idToken,
+            scope: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.scopes.join(" "),
+            token_type: "Bearer",
+          });
+        },
+      ),
+      http.get(NINTENDO_SWITCH_PARENTAL_CONTROLS_PROFILE_URL, ({ request }) => {
+        captured.profileHeaders = request.headers;
+        return HttpResponse.json({ country: "US", language: "en" });
+      }),
+      http.post(
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL,
+        async ({ request }) => {
+          captured.federationHeaders = request.headers;
+          captured.federationBody = await request.json();
+          return HttpResponse.json({
+            loginInfo: {
+              user: { id: "user-id" },
+              smartDevice: { notificationToken: "must-not-leak" },
+              ownedDevices: [
+                {
+                  deviceId: "switch-z",
+                  label: "Bedroom",
+                  device: {
+                    serialNumber: "serial-must-not-leak",
+                    synchronizedUnlockCode: "1111",
+                  },
+                  parentalControlSettingStatus: {
+                    unlockCode: "2222",
+                  },
+                },
+                {
+                  deviceId: "switch-a",
+                  label: "Family room",
+                  pairingCode: "333333",
+                },
+              ],
+              unconfirmedAllCopiedDevicesInfo: null,
+            },
+            nextStep: "COMPLETED",
+          });
+        },
+      ),
+    );
+
+    const completed = await completeConnectorExternalCodeAuthorization({
+      type: "nintendo-switch-parental-controls",
+      authMethod: "api",
+      authClient: nintendoSwitchParentalControlsAuthClient(),
+      providerState: started.providerState,
+      code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.redirectUri}#session_token_code=session-code&state=${providerState.state}`,
+      signal: testSignal(),
+    });
+
+    expect(completed).toMatchObject({
+      outputs: {
+        sessionToken: "session-token",
+        accessToken: "account-access-token",
+        idToken,
+        accountId: "nintendo-account-123",
+        language: "en",
+      },
+      expiresIn: 3600,
+      scopes: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.scopes,
+      userInfo: {
+        id: "nintendo-account-123",
+        username: "Nintendo Parent",
+        email: "parent@example.com",
+      },
+    });
+    const deviceCatalog = completed.outputs.deviceCatalog;
+    const smartDeviceId = completed.outputs.smartDeviceId;
+    if (
+      typeof deviceCatalog !== "string" ||
+      typeof smartDeviceId !== "string"
+    ) {
+      throw new Error("Missing Nintendo Switch Parental Controls outputs");
+    }
+    expect(JSON.parse(deviceCatalog)).toStrictEqual({
+      version: 1,
+      devices: [
+        { deviceId: "switch-a", label: "Family room" },
+        { deviceId: "switch-z", label: "Bedroom" },
+      ],
+    });
+    expect(deviceCatalog).not.toMatch(
+      /serial|unlock|pairing|notification|1111|2222|333333|must-not-leak/iu,
+    );
+    expect(smartDeviceId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+
+    expect(captured.sessionBody?.get("client_id")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+    );
+    expect(captured.sessionBody?.get("session_token_code")).toBe(
+      "session-code",
+    );
+    expect(captured.sessionBody?.get("session_token_code_verifier")).toBe(
+      providerState.codeVerifier,
+    );
+    expect(captured.tokenBody).toStrictEqual({
+      client_id: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+      session_token: "session-token",
+      grant_type: NINTENDO_SESSION_TOKEN_GRANT_TYPE,
+    });
+    expect(captured.profileHeaders?.get("authorization")).toBe(
+      "Bearer account-access-token",
+    );
+    expect(captured.federationHeaders?.get("authorization")).toBe(
+      `Bearer ${idToken}`,
+    );
+    expect(captured.federationHeaders?.get("user-agent")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.userAgent,
+    );
+    expect(captured.federationHeaders?.get("x-moon-app-id")).toBe(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.packageId,
+    );
+    expect(captured.federationHeaders?.get("x-moon-os")).toBe("ANDROID");
+    expect(captured.federationHeaders?.get("x-moon-timezone")).toBe("Etc/UTC");
+    expect(captured.federationHeaders?.get("x-moon-smart-device-id")).toBe(
+      smartDeviceId,
+    );
+    expect(captured.federationBody).toStrictEqual({
+      smartDeviceInfo: {
+        id: smartDeviceId,
+        bundleId: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.packageId,
+        os: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.os,
+        osVersion: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.osVersion,
+        modelName: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.modelName,
+        timeZone: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.timeZone,
+        appVersion: {
+          displayedVersion:
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.displayedVersion,
+          internalVersion:
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.internalVersion,
+        },
+        osLanguage: "en",
+        appLanguage: "en",
+        notificationToken: null,
+      },
+    });
+  });
+
+  it("refreshes both tokens and omits only a transiently unavailable catalog", async () => {
+    let catalogRequests = 0;
+    let tokenRequests = 0;
+    let catalogHeaders: Headers | undefined;
+    server.use(
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN_URL, () => {
+        tokenRequests += 1;
+        return HttpResponse.json({
+          access_token: `access-token-${tokenRequests}`,
+          expires_in: 1800,
+          id_token: `id-token-${tokenRequests}`,
+          token_type: "Bearer",
+        });
+      }),
+      http.get(
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_OWNED_DEVICES_URL,
+        ({ request }) => {
+          catalogRequests += 1;
+          catalogHeaders = request.headers;
+          if (catalogRequests === 2) {
+            return HttpResponse.json(
+              { error: "temporarily unavailable" },
+              {
+                status: 503,
+              },
+            );
+          }
+          return HttpResponse.json({
+            ownedDevices: [
+              {
+                deviceId: "switch-1",
+                label: "Living room",
+                device: { synchronizedUnlockCode: "must-not-leak" },
+              },
+            ],
+          });
+        },
+      ),
+    );
+
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "nintendo-switch-parental-controls",
+        authMethod: "api",
+        authClient: nintendoSwitchParentalControlsAuthClient(),
+        inputs: {
+          sessionToken: "stored-session-token",
+          smartDeviceId: "stored-smart-device-id",
+          language: "fr",
+        },
+        signal: testSignal(),
+      }),
+    ).resolves.toStrictEqual({
+      outputs: {
+        accessToken: "access-token-1",
+        idToken: "id-token-1",
+        deviceCatalog: JSON.stringify({
+          version: 1,
+          devices: [{ deviceId: "switch-1", label: "Living room" }],
+        }),
+      },
+      expiresIn: 1800,
+    });
+    expect(catalogHeaders?.get("authorization")).toBe("Bearer id-token-1");
+    expect(catalogHeaders?.get("x-moon-app-language")).toBe("fr");
+    expect(catalogHeaders?.get("x-moon-smart-device-id")).toBe(
+      "stored-smart-device-id",
+    );
+
+    await expect(
+      refreshConnectorAuthProviderAccessToken({
+        type: "nintendo-switch-parental-controls",
+        authMethod: "api",
+        authClient: nintendoSwitchParentalControlsAuthClient(),
+        inputs: {
+          sessionToken: "stored-session-token",
+          smartDeviceId: "stored-smart-device-id",
+          language: "fr",
+        },
+        signal: testSignal(),
+      }),
+    ).resolves.toStrictEqual({
+      outputs: {
+        accessToken: "access-token-2",
+        idToken: "id-token-2",
+      },
+      expiresIn: 1800,
+    });
+    expect(catalogRequests).toBe(2);
+  });
+
+  it("revokes a static public client by logging out the stored smart device", async () => {
+    let logoutBody: unknown;
+    let logoutHeaders: Headers | undefined;
+    server.use(
+      http.post(NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN_URL, () => {
+        return HttpResponse.json({
+          access_token: "fresh-account-token",
+          id_token: "fresh-id-token",
+          token_type: "Bearer",
+        });
+      }),
+      http.post(
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL,
+        async ({ request }) => {
+          logoutBody = await request.json();
+          logoutHeaders = request.headers;
+          return new HttpResponse(null, { status: 204 });
+        },
+      ),
+    );
+
+    await expect(
+      revokeConnectorAuthMethodAccessToken({
+        type: "nintendo-switch-parental-controls",
+        authMethod: "api",
+        readEnv: () => {
+          throw new Error("Static public revoke must not read env");
+        },
+        signal: testSignal(),
+        loadInputs: () => {
+          return {
+            sessionToken: "stored-session-token",
+            smartDeviceId: "stored-smart-device-id",
+          };
+        },
+      }),
+    ).resolves.toStrictEqual({ status: "revoked" });
+    expect(logoutBody).toStrictEqual({
+      smartDeviceId: "stored-smart-device-id",
+    });
+    expect(logoutHeaders?.get("authorization")).toBe("Bearer fresh-id-token");
+    expect(logoutHeaders?.get("x-moon-smart-device-id")).toBe(
+      "stored-smart-device-id",
+    );
+  });
+});

--- a/turbo/packages/connectors/src/auth-providers/connectors/__tests__/youtube.test.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/__tests__/youtube.test.ts
@@ -209,6 +209,7 @@ describe("connector/providers/youtube", () => {
         inputs: {
           refreshToken: "youtube-refresh-token",
         },
+        signal: testRefreshSignal(),
       });
 
       expect(new URLSearchParams(requestBody).get("token")).toBe(

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-account.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-account.ts
@@ -1,0 +1,371 @@
+import { Buffer } from "node:buffer";
+import { createHash, randomBytes } from "node:crypto";
+
+import { z } from "zod";
+
+import type { ConnectorExternalCodeGrantConfig } from "@vm0/connectors/connectors";
+import type { ConnectorAuthProviderGrantUserInfo } from "../grant-result";
+import { OAuthProviderHttpError, throwOAuthError } from "../oauth/error";
+
+export const NINTENDO_ACCOUNT_AUTHORIZATION_URL =
+  "https://accounts.nintendo.com/connect/1.0.0/authorize";
+export const NINTENDO_ACCOUNT_SESSION_TOKEN_URL =
+  "https://accounts.nintendo.com/connect/1.0.0/api/session_token";
+export const NINTENDO_ACCOUNT_TOKEN_URL =
+  "https://accounts.nintendo.com/connect/1.0.0/api/token";
+export const NINTENDO_ACCOUNT_PROFILE_URL =
+  "https://api.accounts.nintendo.com/2.0.0/users/me";
+
+const NINTENDO_SESSION_TOKEN_GRANT_TYPE =
+  "urn:ietf:params:oauth:grant-type:jwt-bearer-session-token";
+
+export interface NintendoAccountProviderState {
+  readonly version: 1;
+  readonly state: string;
+  readonly codeVerifier: string;
+}
+
+export interface NintendoAccountSessionToken {
+  readonly sessionToken: string;
+}
+
+export interface NintendoAccountToken {
+  readonly accessToken: string;
+  readonly expiresIn?: number;
+  readonly idToken: string;
+  readonly scopes: readonly string[];
+  readonly tokenType: string;
+}
+
+interface NintendoAccountIdentity {
+  readonly accountId: string;
+  readonly username: string | null;
+  readonly email: string | null;
+}
+
+export interface NintendoAccountProfile {
+  readonly country: string;
+  readonly language: string;
+  readonly locale: string;
+}
+
+const nintendoAccountProviderStateSchema = z.object({
+  version: z.literal(1),
+  state: z.string().min(1).max(128),
+  codeVerifier: z.string().min(43).max(128),
+});
+
+const nintendoAccountSessionTokenSchema = z
+  .object({
+    session_token: z.string().min(1),
+  })
+  .passthrough();
+
+const nintendoAccountTokenSchema = z
+  .object({
+    access_token: z.string().min(1),
+    expires_in: z.number().optional(),
+    id_token: z.string().min(1),
+    scope: z.union([z.string(), z.array(z.string())]).optional(),
+    token_type: z.string().optional(),
+  })
+  .passthrough();
+
+const nintendoAccountIdTokenClaimsSchema = z
+  .object({
+    sub: z.string().min(1).optional(),
+    email: z.string().min(1).optional(),
+    name: z.string().min(1).optional(),
+    preferred_username: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+const nintendoAccountProfileSchema = z
+  .object({
+    country: z.string().min(1),
+    language: z.string().min(1),
+  })
+  .passthrough();
+
+function base64UrlRandom(byteLength: number): string {
+  return randomBytes(byteLength).toString("base64url");
+}
+
+function sha256Base64Url(value: string): string {
+  return createHash("sha256").update(value).digest("base64url");
+}
+
+export function createNintendoAccountProviderState(): NintendoAccountProviderState {
+  return {
+    version: 1,
+    state: base64UrlRandom(36),
+    codeVerifier: base64UrlRandom(32),
+  };
+}
+
+export function parseNintendoAccountProviderState(
+  providerState: string,
+): NintendoAccountProviderState {
+  const parsed: unknown = JSON.parse(providerState);
+  return nintendoAccountProviderStateSchema.parse(parsed);
+}
+
+export function buildNintendoAccountAuthorizationUrl(args: {
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly grant: ConnectorExternalCodeGrantConfig;
+  readonly providerState: NintendoAccountProviderState;
+}): string {
+  const params = new URLSearchParams({
+    state: args.providerState.state,
+    client_id: args.clientId,
+    redirect_uri: args.redirectUri,
+    scope: args.grant.scopes.join(" "),
+    response_type: "session_token_code",
+    session_token_code_challenge: sha256Base64Url(
+      args.providerState.codeVerifier,
+    ),
+    session_token_code_challenge_method: "S256",
+    theme: "login_form",
+  });
+
+  return `${NINTENDO_ACCOUNT_AUTHORIZATION_URL}?${params.toString()}`;
+}
+
+function invalidNintendoExternalCodeError(
+  providerLabel: string,
+  message: string,
+): OAuthProviderHttpError {
+  return new OAuthProviderHttpError(
+    `${providerLabel} ${message}`,
+    400,
+    "invalid_grant",
+  );
+}
+
+function hasAsciiControl(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined || codePoint < 0x20 || codePoint === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseParamsFromInput(input: string): URLSearchParams | null {
+  if (input.startsWith("#")) {
+    return new URLSearchParams(input.slice(1));
+  }
+  if (input.startsWith("?")) {
+    return new URLSearchParams(input.slice(1));
+  }
+  if (input.includes("://")) {
+    try {
+      const parsed = new URL(input);
+      const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
+      if (fragmentParams.toString().length > 0) {
+        return fragmentParams;
+      }
+      return parsed.searchParams;
+    } catch {
+      return new URLSearchParams();
+    }
+  }
+  if (input.includes("session_token_code=")) {
+    try {
+      const parsed = new URL(input);
+      const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
+      if (fragmentParams.has("session_token_code")) {
+        return fragmentParams;
+      }
+      return parsed.searchParams;
+    } catch {
+      return new URLSearchParams(input.replace(/^#/u, "").replace(/^\?/u, ""));
+    }
+  }
+  return null;
+}
+
+export function parseNintendoAccountSessionTokenCode(args: {
+  readonly code: string;
+  readonly expectedState: string;
+  readonly providerLabel: string;
+}): string {
+  const trimmed = args.code.trim();
+  if (!trimmed || hasAsciiControl(trimmed)) {
+    throw invalidNintendoExternalCodeError(
+      args.providerLabel,
+      "authorization code is empty or invalid",
+    );
+  }
+
+  const params = parseParamsFromInput(trimmed);
+  if (!params) {
+    return trimmed;
+  }
+
+  const state = params.get("state");
+  if (state !== null && state !== args.expectedState) {
+    throw invalidNintendoExternalCodeError(
+      args.providerLabel,
+      "authorization state mismatch",
+    );
+  }
+
+  const sessionTokenCode = params.get("session_token_code")?.trim();
+  if (!sessionTokenCode || hasAsciiControl(sessionTokenCode)) {
+    throw invalidNintendoExternalCodeError(
+      args.providerLabel,
+      "redirect URL is missing session_token_code",
+    );
+  }
+  return sessionTokenCode;
+}
+
+export async function exchangeNintendoAccountSessionTokenCode(args: {
+  readonly clientId: string;
+  readonly sessionTokenCode: string;
+  readonly codeVerifier: string;
+  readonly userAgent: string;
+  readonly providerLabel: string;
+  readonly signal: AbortSignal;
+}): Promise<NintendoAccountSessionToken> {
+  const response = await fetch(NINTENDO_ACCOUNT_SESSION_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": args.userAgent,
+      Accept: "application/json",
+      "Accept-Language": "en-US",
+    },
+    body: new URLSearchParams({
+      client_id: args.clientId,
+      session_token_code: args.sessionTokenCode,
+      session_token_code_verifier: args.codeVerifier,
+    }),
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    await throwOAuthError(args.providerLabel, "session exchange", response);
+  }
+
+  const raw = nintendoAccountSessionTokenSchema.parse(await response.json());
+  return { sessionToken: raw.session_token };
+}
+
+function normalizeScopes(
+  scope: string | readonly string[] | undefined,
+): readonly string[] {
+  if (typeof scope !== "string") {
+    return scope ?? [];
+  }
+  return scope.split(/\s+/u).filter((value: string) => {
+    return value.length > 0;
+  });
+}
+
+export async function exchangeNintendoAccountSessionToken(args: {
+  readonly clientId: string;
+  readonly sessionToken: string;
+  readonly userAgent: string;
+  readonly providerLabel: string;
+  readonly signal: AbortSignal;
+}): Promise<NintendoAccountToken> {
+  const response = await fetch(NINTENDO_ACCOUNT_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "User-Agent": args.userAgent,
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      client_id: args.clientId,
+      session_token: args.sessionToken,
+      grant_type: NINTENDO_SESSION_TOKEN_GRANT_TYPE,
+    }),
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    await throwOAuthError(args.providerLabel, "token exchange", response);
+  }
+
+  const raw = nintendoAccountTokenSchema.parse(await response.json());
+  return {
+    accessToken: raw.access_token,
+    ...(raw.expires_in === undefined ? {} : { expiresIn: raw.expires_in }),
+    idToken: raw.id_token,
+    scopes: normalizeScopes(raw.scope),
+    tokenType: raw.token_type ?? "Bearer",
+  };
+}
+
+export async function fetchNintendoAccountProfile(args: {
+  readonly accessToken: string;
+  readonly userAgent: string;
+  readonly providerLabel: string;
+  readonly signal: AbortSignal;
+}): Promise<NintendoAccountProfile> {
+  const response = await fetch(NINTENDO_ACCOUNT_PROFILE_URL, {
+    headers: {
+      Authorization: `Bearer ${args.accessToken}`,
+      "User-Agent": args.userAgent,
+      Accept: "application/json",
+    },
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    await throwOAuthError(args.providerLabel, "profile", response);
+  }
+
+  const raw = nintendoAccountProfileSchema.parse(await response.json());
+  return {
+    country: raw.country,
+    language: raw.language,
+    locale: `${raw.language}-${raw.country}`,
+  };
+}
+
+function parseNintendoAccountIdentity(
+  idToken: string,
+  providerLabel: string,
+): NintendoAccountIdentity {
+  const [, payload] = idToken.split(".");
+  if (!payload) {
+    throw new Error(`${providerLabel} ID token is missing a payload`);
+  }
+  const rawClaims: unknown = JSON.parse(
+    Buffer.from(payload, "base64url").toString("utf8"),
+  );
+  const claims = nintendoAccountIdTokenClaimsSchema.parse(rawClaims);
+  if (!claims.sub) {
+    throw new Error(`${providerLabel} ID token is missing a subject`);
+  }
+  return {
+    accountId: claims.sub,
+    username: claims.preferred_username ?? claims.name ?? null,
+    email: claims.email ?? null,
+  };
+}
+
+export function nintendoAccountUserInfo(
+  idToken: string,
+  providerLabel: string,
+): ConnectorAuthProviderGrantUserInfo {
+  const identity = parseNintendoAccountIdentity(idToken, providerLabel);
+  return {
+    id: identity.accountId,
+    username: identity.username,
+    email: identity.email,
+  };
+}
+
+export function nintendoAccountId(
+  idToken: string,
+  providerLabel: string,
+): string {
+  return parseNintendoAccountIdentity(idToken, providerLabel).accountId;
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/api.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/api.ts
@@ -1,103 +1,50 @@
-import { Buffer } from "node:buffer";
-import { createHash, randomBytes } from "node:crypto";
-
-import { z } from "zod";
-
 import type { ConnectorExternalCodeGrantConfig } from "@vm0/connectors/connectors";
 import type { ConnectorAuthProviderGrantUserInfo } from "../../grant-result";
-import { OAuthProviderHttpError, throwOAuthError } from "../../oauth/error";
+import {
+  NINTENDO_ACCOUNT_AUTHORIZATION_URL,
+  NINTENDO_ACCOUNT_PROFILE_URL,
+  NINTENDO_ACCOUNT_SESSION_TOKEN_URL,
+  NINTENDO_ACCOUNT_TOKEN_URL,
+  buildNintendoAccountAuthorizationUrl,
+  createNintendoAccountProviderState,
+  exchangeNintendoAccountSessionToken,
+  exchangeNintendoAccountSessionTokenCode,
+  fetchNintendoAccountProfile,
+  nintendoAccountId,
+  nintendoAccountUserInfo,
+  parseNintendoAccountProviderState,
+  parseNintendoAccountSessionTokenCode,
+  type NintendoAccountProfile,
+  type NintendoAccountProviderState,
+  type NintendoAccountSessionToken,
+  type NintendoAccountToken,
+} from "../nintendo-account";
+
+const NINTENDO_STORE_PROVIDER_LABEL = "Nintendo Store";
 
 export const NINTENDO_STORE_AUTHORIZATION_URL =
-  "https://accounts.nintendo.com/connect/1.0.0/authorize";
+  NINTENDO_ACCOUNT_AUTHORIZATION_URL;
 export const NINTENDO_STORE_SESSION_TOKEN_URL =
-  "https://accounts.nintendo.com/connect/1.0.0/api/session_token";
-export const NINTENDO_STORE_TOKEN_URL =
-  "https://accounts.nintendo.com/connect/1.0.0/api/token";
-export const NINTENDO_STORE_PROFILE_URL =
-  "https://api.accounts.nintendo.com/2.0.0/users/me";
+  NINTENDO_ACCOUNT_SESSION_TOKEN_URL;
+export const NINTENDO_STORE_TOKEN_URL = NINTENDO_ACCOUNT_TOKEN_URL;
+export const NINTENDO_STORE_PROFILE_URL = NINTENDO_ACCOUNT_PROFILE_URL;
 export const NINTENDO_STORE_REDIRECT_URI = "npf5c38e31cd085304b://auth";
 export const NINTENDO_STORE_USER_AGENT =
   "com.nintendo.znej/1.13.0 (Android/7.1.2)";
 
-const NINTENDO_SESSION_TOKEN_GRANT_TYPE =
-  "urn:ietf:params:oauth:grant-type:jwt-bearer-session-token";
-
-export interface NintendoStoreProviderState {
-  readonly version: 1;
-  readonly state: string;
-  readonly codeVerifier: string;
-}
-
-export interface NintendoStoreSessionToken {
-  readonly sessionToken: string;
-}
-
-export interface NintendoStoreToken {
-  readonly accessToken: string;
-  readonly expiresIn?: number;
-  readonly idToken: string;
-  readonly scopes: readonly string[];
-  readonly tokenType: string;
-}
-
-interface NintendoStoreIdentity {
-  readonly accountId: string;
-  readonly username: string | null;
-  readonly email: string | null;
-}
-
-export interface NintendoStoreLocale {
-  readonly country: string;
-  readonly language: string;
-  readonly locale: string;
-}
-
-const nintendoStoreSessionTokenSchema = z
-  .object({
-    session_token: z.string().min(1),
-  })
-  .passthrough();
-
-const nintendoStoreTokenSchema = z
-  .object({
-    access_token: z.string().min(1),
-    expires_in: z.number().optional(),
-    id_token: z.string().min(1),
-    scope: z.union([z.string(), z.array(z.string())]).optional(),
-    token_type: z.string().optional(),
-  })
-  .passthrough();
-
-const nintendoStoreIdTokenClaimsSchema = z
-  .object({
-    sub: z.string().min(1).optional(),
-    email: z.string().min(1).optional(),
-    name: z.string().min(1).optional(),
-    preferred_username: z.string().min(1).optional(),
-  })
-  .passthrough();
-
-const nintendoStoreProfileSchema = z
-  .object({
-    country: z.string().min(1),
-    language: z.string().min(1),
-  })
-  .passthrough();
-
-function base64UrlRandom(byteLength: number): string {
-  return randomBytes(byteLength).toString("base64url");
-}
-
-function sha256Base64Url(value: string): string {
-  return createHash("sha256").update(value).digest("base64url");
-}
+export type NintendoStoreProviderState = NintendoAccountProviderState;
+export type NintendoStoreSessionToken = NintendoAccountSessionToken;
+export type NintendoStoreToken = NintendoAccountToken;
+export type NintendoStoreLocale = NintendoAccountProfile;
 
 export function createNintendoStoreProviderState(): NintendoStoreProviderState {
-  return {
-    version: 1,
-    state: base64UrlRandom(36),
-    codeVerifier: base64UrlRandom(32),
-  };
+  return createNintendoAccountProviderState();
+}
+
+export function parseNintendoStoreProviderState(
+  providerState: string,
+): NintendoStoreProviderState {
+  return parseNintendoAccountProviderState(providerState);
 }
 
 export function buildNintendoStoreAuthorizationUrl(args: {
@@ -105,234 +52,64 @@ export function buildNintendoStoreAuthorizationUrl(args: {
   readonly grant: ConnectorExternalCodeGrantConfig;
   readonly providerState: NintendoStoreProviderState;
 }): string {
-  const params = new URLSearchParams({
-    state: args.providerState.state,
-    client_id: args.clientId,
-    redirect_uri: NINTENDO_STORE_REDIRECT_URI,
-    scope: args.grant.scopes.join(" "),
-    response_type: "session_token_code",
-    session_token_code_challenge: sha256Base64Url(
-      args.providerState.codeVerifier,
-    ),
-    session_token_code_challenge_method: "S256",
-    theme: "login_form",
+  return buildNintendoAccountAuthorizationUrl({
+    ...args,
+    redirectUri: NINTENDO_STORE_REDIRECT_URI,
   });
-
-  return `${NINTENDO_STORE_AUTHORIZATION_URL}?${params.toString()}`;
-}
-
-function invalidNintendoExternalCodeError(
-  message: string,
-): OAuthProviderHttpError {
-  return new OAuthProviderHttpError(message, 400, "invalid_grant");
-}
-
-function hasAsciiControl(value: string): boolean {
-  for (const character of value) {
-    const codePoint = character.codePointAt(0);
-    if (codePoint === undefined || codePoint < 0x20 || codePoint === 0x7f) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function parseParamsFromInput(input: string): URLSearchParams | null {
-  if (input.startsWith("#")) {
-    return new URLSearchParams(input.slice(1));
-  }
-  if (input.startsWith("?")) {
-    return new URLSearchParams(input.slice(1));
-  }
-  if (input.includes("://")) {
-    try {
-      const parsed = new URL(input);
-      const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
-      if (fragmentParams.toString().length > 0) {
-        return fragmentParams;
-      }
-      return parsed.searchParams;
-    } catch {
-      return new URLSearchParams();
-    }
-  }
-  if (input.includes("session_token_code=")) {
-    try {
-      const parsed = new URL(input);
-      const fragmentParams = new URLSearchParams(parsed.hash.slice(1));
-      if (fragmentParams.has("session_token_code")) {
-        return fragmentParams;
-      }
-      return parsed.searchParams;
-    } catch {
-      return new URLSearchParams(input.replace(/^#/u, "").replace(/^\?/u, ""));
-    }
-  }
-  return null;
 }
 
 export function parseNintendoStoreSessionTokenCode(args: {
   readonly code: string;
   readonly expectedState: string;
 }): string {
-  const trimmed = args.code.trim();
-  if (!trimmed || hasAsciiControl(trimmed)) {
-    throw invalidNintendoExternalCodeError(
-      "Nintendo Store authorization code is empty or invalid",
-    );
-  }
-
-  const params = parseParamsFromInput(trimmed);
-  if (!params) {
-    return trimmed;
-  }
-
-  const state = params.get("state");
-  if (state !== null && state !== args.expectedState) {
-    throw invalidNintendoExternalCodeError(
-      "Nintendo Store authorization state mismatch",
-    );
-  }
-
-  const sessionTokenCode = params.get("session_token_code")?.trim();
-  if (!sessionTokenCode || hasAsciiControl(sessionTokenCode)) {
-    throw invalidNintendoExternalCodeError(
-      "Nintendo Store redirect URL is missing session_token_code",
-    );
-  }
-  return sessionTokenCode;
+  return parseNintendoAccountSessionTokenCode({
+    ...args,
+    providerLabel: NINTENDO_STORE_PROVIDER_LABEL,
+  });
 }
 
-export async function exchangeNintendoStoreSessionTokenCode(args: {
+export function exchangeNintendoStoreSessionTokenCode(args: {
   readonly clientId: string;
   readonly sessionTokenCode: string;
   readonly codeVerifier: string;
   readonly signal: AbortSignal;
 }): Promise<NintendoStoreSessionToken> {
-  const response = await fetch(NINTENDO_STORE_SESSION_TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      "User-Agent": NINTENDO_STORE_USER_AGENT,
-      Accept: "application/json",
-      "Accept-Language": "en-US",
-    },
-    body: new URLSearchParams({
-      client_id: args.clientId,
-      session_token_code: args.sessionTokenCode,
-      session_token_code_verifier: args.codeVerifier,
-    }),
-    signal: args.signal,
-  });
-
-  if (!response.ok) {
-    await throwOAuthError("Nintendo Store", "session exchange", response);
-  }
-
-  const raw = nintendoStoreSessionTokenSchema.parse(await response.json());
-  return { sessionToken: raw.session_token };
-}
-
-function normalizeScopes(
-  scope: string | readonly string[] | undefined,
-): readonly string[] {
-  if (typeof scope !== "string") {
-    return scope ?? [];
-  }
-  return scope.split(/\s+/u).filter((value: string) => {
-    return value.length > 0;
+  return exchangeNintendoAccountSessionTokenCode({
+    ...args,
+    userAgent: NINTENDO_STORE_USER_AGENT,
+    providerLabel: NINTENDO_STORE_PROVIDER_LABEL,
   });
 }
 
-export async function exchangeNintendoStoreSessionToken(args: {
+export function exchangeNintendoStoreSessionToken(args: {
   readonly clientId: string;
   readonly sessionToken: string;
   readonly signal: AbortSignal;
 }): Promise<NintendoStoreToken> {
-  const response = await fetch(NINTENDO_STORE_TOKEN_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      "User-Agent": NINTENDO_STORE_USER_AGENT,
-      Accept: "application/json",
-    },
-    body: JSON.stringify({
-      client_id: args.clientId,
-      session_token: args.sessionToken,
-      grant_type: NINTENDO_SESSION_TOKEN_GRANT_TYPE,
-    }),
-    signal: args.signal,
+  return exchangeNintendoAccountSessionToken({
+    ...args,
+    userAgent: NINTENDO_STORE_USER_AGENT,
+    providerLabel: NINTENDO_STORE_PROVIDER_LABEL,
   });
-
-  if (!response.ok) {
-    await throwOAuthError("Nintendo Store", "token exchange", response);
-  }
-
-  const raw = nintendoStoreTokenSchema.parse(await response.json());
-  return {
-    accessToken: raw.access_token,
-    ...(raw.expires_in === undefined ? {} : { expiresIn: raw.expires_in }),
-    idToken: raw.id_token,
-    scopes: normalizeScopes(raw.scope),
-    tokenType: raw.token_type ?? "Bearer",
-  };
 }
 
-export async function fetchNintendoStoreLocale(args: {
+export function fetchNintendoStoreLocale(args: {
   readonly accessToken: string;
   readonly signal: AbortSignal;
 }): Promise<NintendoStoreLocale> {
-  const response = await fetch(NINTENDO_STORE_PROFILE_URL, {
-    headers: {
-      Authorization: `Bearer ${args.accessToken}`,
-      "User-Agent": NINTENDO_STORE_USER_AGENT,
-      Accept: "application/json",
-    },
-    signal: args.signal,
+  return fetchNintendoAccountProfile({
+    ...args,
+    userAgent: NINTENDO_STORE_USER_AGENT,
+    providerLabel: NINTENDO_STORE_PROVIDER_LABEL,
   });
-
-  if (!response.ok) {
-    await throwOAuthError("Nintendo Store", "profile", response);
-  }
-
-  const raw = nintendoStoreProfileSchema.parse(await response.json());
-  return {
-    country: raw.country,
-    language: raw.language,
-    locale: `${raw.language}-${raw.country}`,
-  };
-}
-
-function parseNintendoStoreIdentity(idToken: string): NintendoStoreIdentity {
-  const [, payload] = idToken.split(".");
-  if (!payload) {
-    throw new Error("Nintendo Store ID token is missing a payload");
-  }
-  const rawClaims: unknown = JSON.parse(
-    Buffer.from(payload, "base64url").toString("utf8"),
-  );
-  const claims = nintendoStoreIdTokenClaimsSchema.parse(rawClaims);
-  if (!claims.sub) {
-    throw new Error("Nintendo Store ID token is missing a subject");
-  }
-  return {
-    accountId: claims.sub,
-    username: claims.preferred_username ?? claims.name ?? null,
-    email: claims.email ?? null,
-  };
 }
 
 export function nintendoStoreUserInfo(
   idToken: string,
 ): ConnectorAuthProviderGrantUserInfo {
-  const identity = parseNintendoStoreIdentity(idToken);
-  return {
-    id: identity.accountId,
-    username: identity.username,
-    email: identity.email,
-  };
+  return nintendoAccountUserInfo(idToken, NINTENDO_STORE_PROVIDER_LABEL);
 }
 
 export function nintendoStoreAccountId(idToken: string): string {
-  return parseNintendoStoreIdentity(idToken).accountId;
+  return nintendoAccountId(idToken, NINTENDO_STORE_PROVIDER_LABEL);
 }

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-store/provider.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import type {
   ExternalCodeConnectorAuthProvider,
   RefreshTokenAccessProvider,
@@ -12,21 +10,11 @@ import {
   fetchNintendoStoreLocale,
   nintendoStoreAccountId,
   nintendoStoreUserInfo,
+  parseNintendoStoreProviderState,
   parseNintendoStoreSessionTokenCode,
 } from "./api";
 
 const NINTENDO_STORE_EXTERNAL_CODE_EXPIRES_IN_SECONDS = 10 * 60;
-
-const nintendoStoreProviderStateSchema = z.object({
-  version: z.literal(1),
-  state: z.string().min(1).max(128),
-  codeVerifier: z.string().min(43).max(128),
-});
-
-function parseNintendoStoreProviderState(providerState: string) {
-  const parsed: unknown = JSON.parse(providerState);
-  return nintendoStoreProviderStateSchema.parse(parsed);
-}
 
 function createNintendoStoreExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
   "nintendo-store",

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/api.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/api.ts
@@ -1,0 +1,290 @@
+import { z } from "zod";
+
+import type { ConnectorExternalCodeGrantConfig } from "@vm0/connectors/connectors";
+import { NINTENDO_SWITCH_PARENTAL_CONTROLS_APP } from "../../../connectors/nintendo-switch-parental-controls";
+import type { ConnectorAuthProviderGrantUserInfo } from "../../grant-result";
+import { throwOAuthError } from "../../oauth/error";
+import {
+  NINTENDO_ACCOUNT_AUTHORIZATION_URL,
+  NINTENDO_ACCOUNT_PROFILE_URL,
+  NINTENDO_ACCOUNT_SESSION_TOKEN_URL,
+  NINTENDO_ACCOUNT_TOKEN_URL,
+  buildNintendoAccountAuthorizationUrl,
+  createNintendoAccountProviderState,
+  exchangeNintendoAccountSessionToken,
+  exchangeNintendoAccountSessionTokenCode,
+  fetchNintendoAccountProfile,
+  nintendoAccountId,
+  nintendoAccountUserInfo,
+  parseNintendoAccountProviderState,
+  parseNintendoAccountSessionTokenCode,
+  type NintendoAccountProfile,
+  type NintendoAccountProviderState,
+  type NintendoAccountSessionToken,
+  type NintendoAccountToken,
+} from "../nintendo-account";
+
+const PROVIDER_LABEL = "Nintendo Switch Parental Controls";
+
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_AUTHORIZATION_URL =
+  NINTENDO_ACCOUNT_AUTHORIZATION_URL;
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN_URL =
+  NINTENDO_ACCOUNT_SESSION_TOKEN_URL;
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN_URL =
+  NINTENDO_ACCOUNT_TOKEN_URL;
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_PROFILE_URL =
+  NINTENDO_ACCOUNT_PROFILE_URL;
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL = `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.actionBaseUrl}/v3/actions/federation`;
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_OWNED_DEVICES_URL = `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.actionBaseUrl}/v3/actions/user/fetchOwnedDevices`;
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL = `${NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.actionBaseUrl}/v2/actions/logout`;
+
+export type NintendoSwitchParentalControlsProviderState =
+  NintendoAccountProviderState;
+export type NintendoSwitchParentalControlsSessionToken =
+  NintendoAccountSessionToken;
+export type NintendoSwitchParentalControlsToken = NintendoAccountToken;
+export type NintendoSwitchParentalControlsProfile = NintendoAccountProfile;
+
+interface NintendoSwitchParentalControlsDeviceCatalogEntry {
+  readonly deviceId: string;
+  readonly label: string;
+}
+
+interface NintendoSwitchParentalControlsDeviceCatalog {
+  readonly version: 1;
+  readonly devices: readonly NintendoSwitchParentalControlsDeviceCatalogEntry[];
+}
+
+const ownedDeviceSchema = z
+  .object({
+    deviceId: z.string().min(1).max(128),
+    label: z.string().max(256),
+  })
+  .passthrough();
+
+const ownedDevicesSchema = z.array(ownedDeviceSchema).max(100);
+
+const federationResponseSchema = z
+  .object({
+    loginInfo: z
+      .object({
+        ownedDevices: ownedDevicesSchema,
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const fetchOwnedDevicesResponseSchema = z
+  .object({
+    ownedDevices: ownedDevicesSchema,
+  })
+  .passthrough();
+
+export function createNintendoSwitchParentalControlsProviderState(): NintendoSwitchParentalControlsProviderState {
+  return createNintendoAccountProviderState();
+}
+
+export function parseNintendoSwitchParentalControlsProviderState(
+  providerState: string,
+): NintendoSwitchParentalControlsProviderState {
+  return parseNintendoAccountProviderState(providerState);
+}
+
+export function buildNintendoSwitchParentalControlsAuthorizationUrl(args: {
+  readonly clientId: string;
+  readonly grant: ConnectorExternalCodeGrantConfig;
+  readonly providerState: NintendoSwitchParentalControlsProviderState;
+}): string {
+  return buildNintendoAccountAuthorizationUrl({
+    ...args,
+    redirectUri: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.redirectUri,
+  });
+}
+
+export function parseNintendoSwitchParentalControlsSessionTokenCode(args: {
+  readonly code: string;
+  readonly expectedState: string;
+}): string {
+  return parseNintendoAccountSessionTokenCode({
+    ...args,
+    providerLabel: PROVIDER_LABEL,
+  });
+}
+
+export function exchangeNintendoSwitchParentalControlsSessionTokenCode(args: {
+  readonly clientId: string;
+  readonly sessionTokenCode: string;
+  readonly codeVerifier: string;
+  readonly signal: AbortSignal;
+}): Promise<NintendoSwitchParentalControlsSessionToken> {
+  return exchangeNintendoAccountSessionTokenCode({
+    ...args,
+    userAgent: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.userAgent,
+    providerLabel: PROVIDER_LABEL,
+  });
+}
+
+export function exchangeNintendoSwitchParentalControlsSessionToken(args: {
+  readonly clientId: string;
+  readonly sessionToken: string;
+  readonly signal: AbortSignal;
+}): Promise<NintendoSwitchParentalControlsToken> {
+  return exchangeNintendoAccountSessionToken({
+    ...args,
+    userAgent: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.userAgent,
+    providerLabel: PROVIDER_LABEL,
+  });
+}
+
+export function fetchNintendoSwitchParentalControlsProfile(args: {
+  readonly accessToken: string;
+  readonly signal: AbortSignal;
+}): Promise<NintendoSwitchParentalControlsProfile> {
+  return fetchNintendoAccountProfile({
+    ...args,
+    userAgent: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.userAgent,
+    providerLabel: PROVIDER_LABEL,
+  });
+}
+
+export function nintendoSwitchParentalControlsUserInfo(
+  idToken: string,
+): ConnectorAuthProviderGrantUserInfo {
+  return nintendoAccountUserInfo(idToken, PROVIDER_LABEL);
+}
+
+export function nintendoSwitchParentalControlsAccountId(
+  idToken: string,
+): string {
+  return nintendoAccountId(idToken, PROVIDER_LABEL);
+}
+
+function actionHeaders(args: {
+  readonly idToken: string;
+  readonly smartDeviceId: string;
+  readonly language: string;
+  readonly contentType?: "application/json";
+}): Record<string, string> {
+  return {
+    Authorization: `Bearer ${args.idToken}`,
+    Accept: "application/json",
+    ...(args.contentType === undefined
+      ? {}
+      : { "Content-Type": args.contentType }),
+    "User-Agent": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.userAgent,
+    "X-Moon-App-Id": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.packageId,
+    "X-Moon-Os": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.os,
+    "X-Moon-Os-Version": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.osVersion,
+    "X-Moon-Model": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.modelName,
+    "X-Moon-TimeZone": NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.timeZone,
+    "X-Moon-Os-Language": args.language,
+    "X-Moon-App-Language": args.language,
+    "X-Moon-App-Display-Version":
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.displayedVersion,
+    "X-Moon-App-Internal-Version": String(
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.internalVersion,
+    ),
+    "X-Moon-Smart-Device-Id": args.smartDeviceId,
+  };
+}
+
+function serializeDeviceCatalog(
+  ownedDevices: z.infer<typeof ownedDevicesSchema>,
+): string {
+  const catalog: NintendoSwitchParentalControlsDeviceCatalog = {
+    version: 1,
+    devices: ownedDevices
+      .map((ownedDevice) => {
+        return {
+          deviceId: ownedDevice.deviceId,
+          label: ownedDevice.label,
+        };
+      })
+      .sort((left, right) => {
+        return left.deviceId.localeCompare(right.deviceId);
+      }),
+  };
+  return JSON.stringify(catalog);
+}
+
+export async function federateNintendoSwitchParentalControlsSmartDevice(args: {
+  readonly idToken: string;
+  readonly smartDeviceId: string;
+  readonly language: string;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  const response = await fetch(
+    NINTENDO_SWITCH_PARENTAL_CONTROLS_FEDERATION_URL,
+    {
+      method: "POST",
+      headers: actionHeaders({ ...args, contentType: "application/json" }),
+      body: JSON.stringify({
+        smartDeviceInfo: {
+          id: args.smartDeviceId,
+          bundleId: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.packageId,
+          os: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.os,
+          osVersion: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.osVersion,
+          modelName: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.modelName,
+          timeZone: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.timeZone,
+          appVersion: {
+            displayedVersion:
+              NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.displayedVersion,
+            internalVersion:
+              NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.internalVersion,
+          },
+          osLanguage: args.language,
+          appLanguage: args.language,
+          notificationToken: null,
+        },
+      }),
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok) {
+    await throwOAuthError(PROVIDER_LABEL, "smart-device federation", response);
+  }
+
+  const raw = federationResponseSchema.parse(await response.json());
+  return serializeDeviceCatalog(raw.loginInfo.ownedDevices);
+}
+
+export async function fetchNintendoSwitchParentalControlsDeviceCatalog(args: {
+  readonly idToken: string;
+  readonly smartDeviceId: string;
+  readonly language: string;
+  readonly signal: AbortSignal;
+}): Promise<string> {
+  const response = await fetch(
+    NINTENDO_SWITCH_PARENTAL_CONTROLS_OWNED_DEVICES_URL,
+    {
+      headers: actionHeaders(args),
+      signal: args.signal,
+    },
+  );
+
+  if (!response.ok) {
+    await throwOAuthError(PROVIDER_LABEL, "device catalog", response);
+  }
+
+  const raw = fetchOwnedDevicesResponseSchema.parse(await response.json());
+  return serializeDeviceCatalog(raw.ownedDevices);
+}
+
+export async function logoutNintendoSwitchParentalControlsSmartDevice(args: {
+  readonly idToken: string;
+  readonly smartDeviceId: string;
+  readonly language: string;
+  readonly signal: AbortSignal;
+}): Promise<void> {
+  const response = await fetch(NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL, {
+    method: "POST",
+    headers: actionHeaders({ ...args, contentType: "application/json" }),
+    body: JSON.stringify({ smartDeviceId: args.smartDeviceId }),
+    signal: args.signal,
+  });
+
+  if (!response.ok) {
+    await throwOAuthError(PROVIDER_LABEL, "smart-device logout", response);
+  }
+}

--- a/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
+++ b/turbo/packages/connectors/src/auth-providers/connectors/nintendo-switch-parental-controls/provider.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "node:crypto";
+
+import { ZodError } from "zod";
+
+import type {
+  ExternalCodeConnectorAuthProvider,
+  RefreshTokenAccessProvider,
+  TokenRevokeProvider,
+} from "../../types";
+import { isOAuthProviderHttpError } from "../../oauth/error";
+import {
+  buildNintendoSwitchParentalControlsAuthorizationUrl,
+  createNintendoSwitchParentalControlsProviderState,
+  exchangeNintendoSwitchParentalControlsSessionToken,
+  exchangeNintendoSwitchParentalControlsSessionTokenCode,
+  federateNintendoSwitchParentalControlsSmartDevice,
+  fetchNintendoSwitchParentalControlsDeviceCatalog,
+  fetchNintendoSwitchParentalControlsProfile,
+  logoutNintendoSwitchParentalControlsSmartDevice,
+  nintendoSwitchParentalControlsAccountId,
+  nintendoSwitchParentalControlsUserInfo,
+  parseNintendoSwitchParentalControlsProviderState,
+  parseNintendoSwitchParentalControlsSessionTokenCode,
+} from "./api";
+
+const EXTERNAL_CODE_EXPIRES_IN_SECONDS = 10 * 60;
+
+function createExternalCodeGrantProvider(): ExternalCodeConnectorAuthProvider<
+  "nintendo-switch-parental-controls",
+  "api"
+>["grant"] {
+  return {
+    kind: "external-code",
+    startExternalCodeAuthorization: async (args) => {
+      const providerState = createNintendoSwitchParentalControlsProviderState();
+      return {
+        authorizationUrl: buildNintendoSwitchParentalControlsAuthorizationUrl({
+          clientId: args.authClient.clientId,
+          grant: args.externalCodeGrant,
+          providerState,
+        }),
+        providerState: JSON.stringify(providerState),
+        expiresIn: EXTERNAL_CODE_EXPIRES_IN_SECONDS,
+      };
+    },
+    completeExternalCodeAuthorization: async (args) => {
+      const providerState = parseNintendoSwitchParentalControlsProviderState(
+        args.providerState,
+      );
+      const sessionTokenCode =
+        parseNintendoSwitchParentalControlsSessionTokenCode({
+          code: args.code,
+          expectedState: providerState.state,
+        });
+      const session =
+        await exchangeNintendoSwitchParentalControlsSessionTokenCode({
+          clientId: args.authClient.clientId,
+          sessionTokenCode,
+          codeVerifier: providerState.codeVerifier,
+          signal: args.signal,
+        });
+      const token = await exchangeNintendoSwitchParentalControlsSessionToken({
+        clientId: args.authClient.clientId,
+        sessionToken: session.sessionToken,
+        signal: args.signal,
+      });
+      const profile = await fetchNintendoSwitchParentalControlsProfile({
+        accessToken: token.accessToken,
+        signal: args.signal,
+      });
+      const smartDeviceId = randomUUID();
+      const deviceCatalog =
+        await federateNintendoSwitchParentalControlsSmartDevice({
+          idToken: token.idToken,
+          smartDeviceId,
+          language: profile.language,
+          signal: args.signal,
+        });
+      return {
+        outputs: {
+          sessionToken: session.sessionToken,
+          accessToken: token.accessToken,
+          idToken: token.idToken,
+          smartDeviceId,
+          accountId: nintendoSwitchParentalControlsAccountId(token.idToken),
+          language: profile.language,
+          deviceCatalog,
+        },
+        expiresIn: token.expiresIn,
+        scopes:
+          token.scopes.length > 0
+            ? token.scopes
+            : args.externalCodeGrant.scopes,
+        userInfo: nintendoSwitchParentalControlsUserInfo(token.idToken),
+      };
+    },
+  };
+}
+
+function catalogFailureCanUseStoredValue(error: unknown): boolean {
+  if (error instanceof ZodError || error instanceof SyntaxError) {
+    return true;
+  }
+  if (error instanceof TypeError) {
+    return true;
+  }
+  return (
+    isOAuthProviderHttpError(error) &&
+    (error.status === 429 || error.status >= 500)
+  );
+}
+
+async function refreshDeviceCatalog(args: {
+  readonly idToken: string;
+  readonly smartDeviceId: string;
+  readonly language: string;
+  readonly signal: AbortSignal;
+}): Promise<string | undefined> {
+  try {
+    return await fetchNintendoSwitchParentalControlsDeviceCatalog(args);
+  } catch (error) {
+    args.signal.throwIfAborted();
+    if (catalogFailureCanUseStoredValue(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function createRefreshTokenAccessProvider(): RefreshTokenAccessProvider<
+  "nintendo-switch-parental-controls",
+  "api"
+> {
+  return {
+    kind: "refresh-token",
+    refresh: async (args) => {
+      const token = await exchangeNintendoSwitchParentalControlsSessionToken({
+        clientId: args.authClient.clientId,
+        sessionToken: args.inputs.sessionToken,
+        signal: args.signal,
+      });
+      const deviceCatalog = await refreshDeviceCatalog({
+        idToken: token.idToken,
+        smartDeviceId: args.inputs.smartDeviceId,
+        language: args.inputs.language,
+        signal: args.signal,
+      });
+      return {
+        outputs: {
+          accessToken: token.accessToken,
+          idToken: token.idToken,
+          ...(deviceCatalog === undefined ? {} : { deviceCatalog }),
+        },
+        expiresIn: token.expiresIn,
+      };
+    },
+  };
+}
+
+function createTokenRevokeProvider(): TokenRevokeProvider<
+  "nintendo-switch-parental-controls",
+  "api"
+> {
+  return {
+    kind: "token-revoke",
+    revokeToken: async (args) => {
+      const token = await exchangeNintendoSwitchParentalControlsSessionToken({
+        clientId: args.authClient.clientId,
+        sessionToken: args.inputs.sessionToken,
+        signal: args.signal,
+      });
+      await logoutNintendoSwitchParentalControlsSmartDevice({
+        idToken: token.idToken,
+        smartDeviceId: args.inputs.smartDeviceId,
+        language: "en",
+        signal: args.signal,
+      });
+    },
+  };
+}
+
+export const nintendoSwitchParentalControlsProvider = {
+  grant: createExternalCodeGrantProvider(),
+  access: createRefreshTokenAccessProvider(),
+  revoke: createTokenRevokeProvider(),
+} as const satisfies ExternalCodeConnectorAuthProvider<
+  "nintendo-switch-parental-controls",
+  "api"
+>;

--- a/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
+++ b/turbo/packages/connectors/src/auth-providers/provider-flow-types.ts
@@ -219,6 +219,7 @@ export type ConnectorAuthProviderRevokeArgs<
     ConnectorAuthMethodIdsByRevokeKind<T, "token-revoke">,
 > = ConnectorAuthMethodClientArgs<T, Method> & {
   readonly inputs: ConnectorRevokeInputValues<T, Method>;
+  readonly signal: AbortSignal;
 };
 
 export type ConnectorDeviceAuthorizationStartArgs<

--- a/turbo/packages/connectors/src/connector-config.ts
+++ b/turbo/packages/connectors/src/connector-config.ts
@@ -264,6 +264,12 @@ export type ConnectorRevokeConfig =
   | {
       readonly kind: "token-revoke";
       readonly inputs: ConnectorRevokeInputBindings;
+      /**
+       * Revoke the previous credential after a replacement connection commits.
+       * Only enable this when the revoke inputs identify the old credential or
+       * remote registration without invalidating the replacement connection.
+       */
+      readonly revokePreviousOnReplace?: boolean;
     };
 
 interface ConnectorAuthMethodConfigBase {

--- a/turbo/packages/connectors/src/connectors.ts
+++ b/turbo/packages/connectors/src/connectors.ts
@@ -8,6 +8,7 @@ import type {
   ConnectorGrantKind,
   ConnectorRevokeKind,
   StaticConfidentialConnectorAuthClientConfig,
+  StaticPublicConnectorAuthClientConfig,
 } from "./connector-config";
 import { github } from "./connectors/github";
 import { gmail } from "./connectors/gmail";
@@ -37,6 +38,7 @@ import { googleAds } from "./connectors/google-ads";
 import { googleMaps } from "./connectors/google-maps";
 import { gumroad } from "./connectors/gumroad";
 import { nintendoStore } from "./connectors/nintendo-store";
+import { nintendoSwitchParentalControls } from "./connectors/nintendo-switch-parental-controls";
 import { playstation } from "./connectors/playstation";
 import { spotify } from "./connectors/spotify";
 import { steam } from "./connectors/steam";
@@ -454,6 +456,7 @@ const CONNECTOR_TYPES_DEF = defineConnectors({
   ...googleCloud,
   ...googleMaps,
   ...gumroad,
+  ...nintendoSwitchParentalControls,
   ...nintendoStore,
   ...playstation,
   ...spotify,
@@ -952,11 +955,13 @@ export type RefreshTokenAccessConnectorType =
   ConnectorTypesByAccessKind<"refresh-token">;
 export type TokenRevokeConnectorType =
   ConnectorTypesByRevokeKind<"token-revoke">;
-type TokenRevokeConnectorTypeWithNonConfidentialClient = {
+type TokenRevokeConnectorTypeWithNonStaticClient = {
   [Type in TokenRevokeConnectorType]: {
     [Method in ConnectorAuthMethodIds<Type>]: ConnectorAuthMethodsOf<Type>[Method] extends {
       readonly revoke: { readonly kind: "token-revoke" };
-      readonly client: StaticConfidentialConnectorAuthClientConfig;
+      readonly client:
+        | StaticConfidentialConnectorAuthClientConfig
+        | StaticPublicConnectorAuthClientConfig;
     }
       ? never
       : ConnectorAuthMethodsOf<Type>[Method] extends {
@@ -966,8 +971,8 @@ type TokenRevokeConnectorTypeWithNonConfidentialClient = {
         : never;
   }[ConnectorAuthMethodIds<Type>];
 }[TokenRevokeConnectorType];
-export type TokenRevokeConnectorAuthMethodsUseConfidentialClients =
-  AssertNever<TokenRevokeConnectorTypeWithNonConfidentialClient>;
+export type TokenRevokeConnectorAuthMethodsUseStaticClients =
+  AssertNever<TokenRevokeConnectorTypeWithNonStaticClient>;
 
 export const CONNECTOR_TYPES = CONNECTOR_TYPES_DEF;
 export const CONNECTOR_TYPE_KEYS = Object.freeze(

--- a/turbo/packages/connectors/src/connectors/nintendo-switch-parental-controls.ts
+++ b/turbo/packages/connectors/src/connectors/nintendo-switch-parental-controls.ts
@@ -1,0 +1,134 @@
+import type { ConnectorConfig } from "../connector-config";
+import { FeatureSwitchKey } from "../feature-switch-key";
+
+export const NINTENDO_SWITCH_PARENTAL_CONTROLS_APP = {
+  clientId: "54789befb391a838",
+  redirectUri: "npf54789befb391a838://auth",
+  packageId: "com.nintendo.znma",
+  displayedVersion: "2.4.0",
+  internalVersion: 660,
+  os: "ANDROID",
+  osVersion: "35",
+  modelName: "vm0",
+  timeZone: "Etc/UTC",
+  actionBaseUrl: "https://app.lp1.znma.srv.nintendo.net",
+  accountBaseUrl: "https://api.accounts.nintendo.com",
+  scopes: [
+    "openid",
+    "user",
+    "user.mii",
+    "moonUser:administration",
+    "moonDevice:create",
+    "moonOwnedDevice:administration",
+    "moonParentalControlSetting",
+    "moonParentalControlSetting:update",
+    "moonParentalControlSettingState",
+    "moonPairingState",
+    "moonSmartDevice:administration",
+    "moonDailySummary",
+    "moonMonthlySummary",
+  ],
+  userAgent: "moon_ANDROID/2.4.0 (com.nintendo.znma; build:660; ANDROID 35)",
+} as const;
+
+export const nintendoSwitchParentalControls = {
+  "nintendo-switch-parental-controls": {
+    label: "Nintendo Switch Parental Controls",
+    category: "data-automation-infrastructure",
+    tags: [
+      "gaming",
+      "player",
+      "nintendo",
+      "parental-controls",
+      "playtime",
+      "gamechat",
+    ],
+    helpText:
+      "Connect Nintendo Switch Parental Controls to read household play activity and manage explicitly granted console settings.",
+    authMethods: {
+      api: {
+        featureFlag: FeatureSwitchKey.NintendoSwitchParentalControlsConnector,
+        label: "Nintendo sign-in",
+        helpText:
+          "Sign in with the adult Nintendo Account used by the Nintendo Switch Parental Controls app. After signing in, right-click the redirect button and copy its link address, then paste the full `npf...://auth` redirect URL or the `session_token_code` value.",
+        client: {
+          clientRegistration: "static",
+          clientType: "public",
+          clientId: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+        },
+        storage: {
+          secrets: [
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN",
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCESS_TOKEN",
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_ID_TOKEN",
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+          ],
+          variables: [
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_ID",
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE",
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG",
+          ],
+        },
+        grant: {
+          kind: "external-code",
+          scopes: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.scopes.slice(),
+          outputs: {
+            sessionToken:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN",
+            accessToken:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCESS_TOKEN",
+            idToken: "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_ID_TOKEN",
+            smartDeviceId:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+            accountId: "$vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_ID",
+            language: "$vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE",
+            deviceCatalog:
+              "$vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG",
+          },
+        },
+        access: {
+          kind: "refresh-token",
+          inputs: {
+            sessionToken:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN",
+            smartDeviceId:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+            language: "$vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE",
+          },
+          outputs: {
+            accessToken:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCESS_TOKEN",
+            idToken: "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_ID_TOKEN",
+            deviceCatalog:
+              "$vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG",
+          },
+          refreshableSecrets: [
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCESS_TOKEN",
+            "NINTENDO_SWITCH_PARENTAL_CONTROLS_ID_TOKEN",
+          ],
+          envBindings: {
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_ID_TOKEN",
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCESS_TOKEN",
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE:
+              "$vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE",
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG:
+              "$vars.NINTENDO_SWITCH_PARENTAL_CONTROLS_DEVICE_CATALOG",
+          },
+        },
+        revoke: {
+          kind: "token-revoke",
+          inputs: {
+            sessionToken:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN",
+            smartDeviceId:
+              "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+          },
+        },
+      },
+    },
+  },
+} as const satisfies Record<string, ConnectorConfig>;

--- a/turbo/packages/connectors/src/connectors/nintendo-switch-parental-controls.ts
+++ b/turbo/packages/connectors/src/connectors/nintendo-switch-parental-controls.ts
@@ -121,6 +121,7 @@ export const nintendoSwitchParentalControls = {
         },
         revoke: {
           kind: "token-revoke",
+          revokePreviousOnReplace: true,
           inputs: {
             sessionToken:
               "$secrets.NINTENDO_SWITCH_PARENTAL_CONTROLS_SESSION_TOKEN",

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -26,6 +26,7 @@ export enum FeatureSwitchKey {
   OutlookCalendarConnector = "outlookCalendarConnector",
   TikTokAdsConnector = "tiktokAdsConnector",
   AwsConnector = "awsConnector",
+  NintendoSwitchParentalControlsConnector = "nintendoSwitchParentalControlsConnector",
   NintendoStoreConnector = "nintendoStoreConnector",
   PosthogConnector = "posthogConnector",
   MailchimpConnector = "mailchimpConnector",

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -123,6 +123,9 @@ describe("getAllFeatureStates", () => {
       orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
     });
     expect(staffOrgStates[FeatureSwitchKey.NintendoStoreConnector]).toBe(true);
+    expect(
+      staffOrgStates[FeatureSwitchKey.NintendoSwitchParentalControlsConnector],
+    ).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.Lab]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowWebhookTriggers]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ApiKeys]).toBe(true);
@@ -151,6 +154,9 @@ describe("getAllFeatureStates", () => {
       orgId: "org_nonexistent",
     });
     expect(otherOrgStates[FeatureSwitchKey.NintendoStoreConnector]).toBe(false);
+    expect(
+      otherOrgStates[FeatureSwitchKey.NintendoSwitchParentalControlsConnector],
+    ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.WorkflowWebhookTriggers]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -158,6 +158,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.NintendoSwitchParentalControlsConnector]: {
+    maintainer: "liangyou@vm0.ai",
+    description: "Enable the Nintendo Switch Parental Controls connector",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "yuma@vm0.ai",
     description: "Enable the PostHog analytics connector",

--- a/turbo/packages/firewalls-generator/package.json
+++ b/turbo/packages/firewalls-generator/package.json
@@ -186,6 +186,7 @@
     "generate:neon": "tsx src/index.ts neon",
     "generate:netdata": "tsx src/index.ts netdata",
     "generate:nintendo-store": "tsx src/index.ts nintendo-store",
+    "generate:nintendo-switch-parental-controls": "tsx src/index.ts nintendo-switch-parental-controls",
     "generate:notion": "tsx src/index.ts notion",
     "generate:novita": "tsx src/index.ts novita",
     "generate:onyx": "tsx src/index.ts onyx",

--- a/turbo/packages/firewalls-generator/src/connector-firewall-manifest.ts
+++ b/turbo/packages/firewalls-generator/src/connector-firewall-manifest.ts
@@ -151,6 +151,7 @@ export const FIREWALL_CONNECTOR_TYPES = [
   "neon",
   "netdata",
   "nintendo-store",
+  "nintendo-switch-parental-controls",
   "notion",
   "novita",
   "onyx",

--- a/turbo/packages/firewalls-generator/src/index.ts
+++ b/turbo/packages/firewalls-generator/src/index.ts
@@ -155,6 +155,7 @@ import { generate as generateN8n } from "./n8n";
 import { generate as generateNeon } from "./neon";
 import { generate as generateNetdata } from "./netdata";
 import { generate as generateNintendoStore } from "./nintendo-store";
+import { generate as generateNintendoSwitchParentalControls } from "./nintendo-switch-parental-controls";
 import { generate as generateNotion } from "./notion";
 import { generate as generateNovita } from "./novita";
 import { generate as generateNyne } from "./nyne";
@@ -435,6 +436,7 @@ const GENERATORS: Record<string, () => Promise<void>> = {
   neon: generateNeon,
   netdata: generateNetdata,
   "nintendo-store": generateNintendoStore,
+  "nintendo-switch-parental-controls": generateNintendoSwitchParentalControls,
   notion: generateNotion,
   novita: generateNovita,
   onyx: generateOnyx,

--- a/turbo/packages/firewalls-generator/src/nintendo-switch-parental-controls.ts
+++ b/turbo/packages/firewalls-generator/src/nintendo-switch-parental-controls.ts
@@ -1,0 +1,288 @@
+/**
+ * Generate Nintendo Switch Parental Controls firewall config.
+ *
+ * Data source: Nintendo Switch Parental Controls app 2.4.0 (build 660).
+ */
+
+import { NINTENDO_SWITCH_PARENTAL_CONTROLS_APP } from "@vm0/connectors/connectors/nintendo-switch-parental-controls";
+import {
+  logStats,
+  renderCategories,
+  renderDefaultAllowed,
+  renderDefaultUnknownPolicy,
+  renderPermissions,
+  writeOutput,
+  type PermissionGroup,
+} from "./codegen";
+
+const ID_TOKEN_PLACEHOLDER =
+  "nintendo_switch_parental_controls_id_token_placeholder";
+const ACCOUNT_TOKEN_PLACEHOLDER =
+  "nintendo_switch_parental_controls_account_token_placeholder";
+const SMART_DEVICE_ID_PLACEHOLDER = "00000000-0000-4000-8000-000000000000";
+const RUNTIME_ID_TOKEN_SECRET = "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN";
+const RUNTIME_ACCOUNT_TOKEN_SECRET =
+  "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN";
+const RUNTIME_SMART_DEVICE_ID_SECRET =
+  "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID";
+const RUNTIME_LANGUAGE_VAR = "NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE";
+
+const ACCOUNT_READ: PermissionGroup = {
+  name: "nintendo-switch-parental-controls-account-read",
+  description: "Read the connected Nintendo Account and app user profile",
+  rules: ["GET /2.0.0/users/me"],
+};
+
+const ACTION_PERMISSIONS: readonly PermissionGroup[] = [
+  {
+    name: ACCOUNT_READ.name,
+    description: ACCOUNT_READ.description,
+    rules: ["GET /v2/actions/user/fetchUser"],
+  },
+  {
+    name: "nintendo-switch-parental-controls-announcements-read",
+    description: "Read Nintendo Switch Parental Controls announcements",
+    rules: ["GET /v2/actions/announcement/fetchAnnouncements"],
+  },
+  {
+    name: "nintendo-switch-parental-controls-game-chat-read",
+    description:
+      "Read GameChat settings, requests, relationships, and terms for supervised players",
+    rules: [
+      "GET /v2/actions/chat/fetchCameraChatRequests",
+      "GET /v2/actions/chat/fetchCameraSetting",
+      "GET /v2/actions/chat/fetchChatRequests",
+      "GET /v2/actions/chat/fetchChatSetting",
+      "GET /v2/actions/chat/fetchTermOfUse",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-play-summary-read",
+    description:
+      "Read daily and monthly play summaries for supervised Nintendo Switch devices",
+    rules: [
+      "GET /v2/actions/playSummary/fetchDailySummaries",
+      "GET /v2/actions/playSummary/fetchLatestMonthlySummary",
+      "GET /v2/actions/playSummary/fetchMonthlySummary",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-device-credentials-read",
+    description:
+      "Read device and federation records that may contain serial numbers, synchronized PINs, or pairing state",
+    rules: [
+      "GET /v3/actions/device/fetchExtraPlayingTimeState",
+      "GET /v3/actions/deviceFederation/checkDeviceFederation",
+      "GET /v3/actions/user/fetchOwnedDevice",
+      "GET /v3/actions/user/fetchOwnedDevices",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-settings-credentials-read",
+    description:
+      "Read parental-control settings that may contain the current unlock PIN",
+    rules: [
+      "GET /v3/actions/parentalControlSetting/fetchParentalControlSetting",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-game-chat-write",
+    description:
+      "Accept, reject, suspend, or change GameChat relationships and settings for supervised players",
+    rules: [
+      "POST /v2/actions/chat/acceptCameraChatRequest",
+      "POST /v2/actions/chat/acceptChatRequest",
+      "POST /v2/actions/chat/agreeChildTerm",
+      "POST /v2/actions/chat/checkRelationship",
+      "POST /v2/actions/chat/rejectCameraChatRequest",
+      "POST /v2/actions/chat/rejectChatRequest",
+      "POST /v2/actions/chat/requestRelationshipCorrection",
+      "POST /v2/actions/chat/suspendCameraChat",
+      "POST /v2/actions/chat/updateCameraChatSetting",
+      "POST /v2/actions/chat/updateCameraSetting",
+      "POST /v2/actions/chat/updateMemo",
+      "POST /v2/actions/chat/withdrawChatRequest",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-play-time-write",
+    description:
+      "Confirm or change extra play time and play-timer restrictions for a supervised device",
+    rules: [
+      "POST /v2/actions/device/confirmExtraPlayingTime",
+      "POST /v2/actions/device/updateExtraPlayingTime",
+      "POST /v3/actions/parentalControlSetting/updatePlayTimer",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-device-pairing-write",
+    description:
+      "Start or confirm device federation, which can create or change a supervised-device pairing",
+    rules: [
+      "POST /v2/actions/deviceFederation/startDeviceFederation",
+      "POST /v2/actions/user/confirmCopiedOwnedDevice",
+      "POST /v3/actions/federation",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-feedback-write",
+    description: "Send feedback to Nintendo from the connected account",
+    rules: ["POST /v2/actions/feedback/sendFeedback"],
+  },
+  {
+    name: "nintendo-switch-parental-controls-smart-device-write",
+    description:
+      "Change the registered smart device, including notification-token updates or logout",
+    rules: [
+      "POST /v2/actions/logout",
+      "POST /v2/actions/smartDevice/updateNotificationToken",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-settings-write",
+    description: "Change parental-control restriction levels or the unlock PIN",
+    rules: [
+      "POST /v2/actions/parentalControlSetting/updateRestrictionLevel",
+      "POST /v2/actions/parentalControlSetting/updateUnlockCode",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-device-write",
+    description:
+      "Rename, reorder, or unregister a supervised Nintendo Switch device",
+    rules: [
+      "POST /v3/actions/device/unregisterDevice",
+      "POST /v3/actions/device/updateDeviceLabel",
+      "POST /v3/actions/user/updateOwnedDeviceSortOrder",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-notifications-write",
+    description:
+      "Clear notices or change notification settings for the connected account",
+    rules: [
+      "POST /v2/actions/user/clearAlarmSettingNotice",
+      "POST /v2/actions/user/updateNotificationSetting",
+    ],
+  },
+  {
+    name: "nintendo-switch-parental-controls-summary-acknowledgement-write",
+    description:
+      "Acknowledge first daily or newly available monthly play summaries",
+    rules: [
+      "POST /v3/actions/user/confirmFirstDailySummary",
+      "POST /v3/actions/user/confirmNewMonthlySummary",
+    ],
+  },
+];
+
+const DEFAULT_ALLOWED = [
+  ACCOUNT_READ.name,
+  "nintendo-switch-parental-controls-announcements-read",
+  "nintendo-switch-parental-controls-game-chat-read",
+  "nintendo-switch-parental-controls-play-summary-read",
+];
+
+const CATEGORIES = {
+  categories: {
+    [ACCOUNT_READ.name]: "Read",
+    "nintendo-switch-parental-controls-announcements-read": "Read",
+    "nintendo-switch-parental-controls-game-chat-read": "Read",
+    "nintendo-switch-parental-controls-play-summary-read": "Read",
+    "nintendo-switch-parental-controls-device-credentials-read":
+      "Sensitive read",
+    "nintendo-switch-parental-controls-settings-credentials-read":
+      "Sensitive read",
+    "nintendo-switch-parental-controls-game-chat-write": "Write",
+    "nintendo-switch-parental-controls-play-time-write": "Write",
+    "nintendo-switch-parental-controls-device-pairing-write": "Write",
+    "nintendo-switch-parental-controls-feedback-write": "Write",
+    "nintendo-switch-parental-controls-smart-device-write": "Write",
+    "nintendo-switch-parental-controls-settings-write": "Write",
+    "nintendo-switch-parental-controls-device-write": "Write",
+    "nintendo-switch-parental-controls-notifications-write": "Write",
+    "nintendo-switch-parental-controls-summary-acknowledgement-write": "Write",
+  },
+  displayOrder: ["Read", "Sensitive read", "Write"],
+};
+
+function generateTypeScript(): string {
+  const app = NINTENDO_SWITCH_PARENTAL_CONTROLS_APP;
+  const lines = [
+    "// Auto-generated from Nintendo Switch Parental Controls app 2.4.0 (build 660).",
+    "// Regenerate: cd turbo && pnpm -F @vm0/firewalls-generator generate:nintendo-switch-parental-controls",
+    "//",
+    "// DO NOT EDIT THIS FILE MANUALLY.",
+    "",
+    'import type { FirewallConfig, FirewallPolicyValue, PermissionNamesOf } from "../firewall-types";',
+    "",
+    "export const nintendoSwitchParentalControlsFirewall = {",
+    '  name: "nintendo-switch-parental-controls",',
+    '  description: "Nintendo Switch Parental Controls API",',
+    "  placeholders: {",
+    `    ${RUNTIME_ID_TOKEN_SECRET}: "${ID_TOKEN_PLACEHOLDER}",`,
+    `    ${RUNTIME_ACCOUNT_TOKEN_SECRET}: "${ACCOUNT_TOKEN_PLACEHOLDER}",`,
+    `    ${RUNTIME_SMART_DEVICE_ID_SECRET}: "${SMART_DEVICE_ID_PLACEHOLDER}",`,
+    "  },",
+    "  apis: [",
+    "    {",
+    `      base: "${app.accountBaseUrl}",`,
+    "      auth: {",
+    "        headers: {",
+    `          Authorization: "Bearer \${{ secrets.${RUNTIME_ACCOUNT_TOKEN_SECRET} }}",`,
+    `          "User-Agent": "${app.userAgent}",`,
+    "        },",
+    "      },",
+    "      permissions: [",
+    ...renderPermissions([ACCOUNT_READ]),
+    "      ],",
+    "    },",
+    "    {",
+    `      base: "${app.actionBaseUrl}",`,
+    "      auth: {",
+    "        headers: {",
+    `          Authorization: "Bearer \${{ secrets.${RUNTIME_ID_TOKEN_SECRET} }}",`,
+    `          "User-Agent": "${app.userAgent}",`,
+    `          "X-Moon-App-Id": "${app.packageId}",`,
+    `          "X-Moon-Os": "${app.os}",`,
+    `          "X-Moon-Os-Version": "${app.osVersion}",`,
+    `          "X-Moon-Model": "${app.modelName}",`,
+    `          "X-Moon-TimeZone": "${app.timeZone}",`,
+    `          "X-Moon-Os-Language": "\${{ vars.${RUNTIME_LANGUAGE_VAR} }}",`,
+    `          "X-Moon-App-Language": "\${{ vars.${RUNTIME_LANGUAGE_VAR} }}",`,
+    `          "X-Moon-App-Display-Version": "${app.displayedVersion}",`,
+    `          "X-Moon-App-Internal-Version": "${app.internalVersion}",`,
+    `          "X-Moon-Smart-Device-Id": "\${{ secrets.${RUNTIME_SMART_DEVICE_ID_SECRET} }}",`,
+    "        },",
+    "      },",
+    "      permissions: [",
+    ...renderPermissions([...ACTION_PERMISSIONS]),
+    "      ],",
+    "    },",
+    "  ],",
+    "} as const satisfies FirewallConfig;",
+    ...renderDefaultAllowed(
+      "nintendoSwitchParentalControlsDefaultAllowed",
+      "nintendoSwitchParentalControlsFirewall",
+      DEFAULT_ALLOWED,
+    ),
+    ...renderCategories(
+      "nintendoSwitchParentalControlsCategories",
+      "nintendoSwitchParentalControlsFirewall",
+      CATEGORIES,
+    ),
+    ...renderDefaultUnknownPolicy(
+      "nintendoSwitchParentalControlsDefaultUnknownPolicy",
+      "deny",
+    ),
+  ];
+  return lines.join("\n");
+}
+
+export async function generate(): Promise<void> {
+  console.error(
+    "Generating Nintendo Switch Parental Controls firewall config...",
+  );
+  writeOutput("nintendo-switch-parental-controls", generateTypeScript());
+  logStats([ACCOUNT_READ, ...ACTION_PERMISSIONS]);
+}


### PR DESCRIPTION
## Summary

- add a dedicated, staff-enabled Nintendo Switch Parental Controls connector using the current `znma` external-code, PKCE, session-token, federation, refresh, and smart-device logout flow
- extract the shared Nintendo Account flow from Nintendo Store while preserving Nintendo Store behavior
- catalog all 45 verified app action routes plus the Nintendo Account profile route with generated runner artifacts
- expose only a strictly projected `{ deviceId, label }` catalog to agents and wire the canonical square connector icon

## Security and policy

- keep the session token, access token, ID token, and smart-device ID in encrypted connector storage
- inject the access token only on the Nintendo Account host and the ID token only on the Parental Controls action host
- override the complete reviewed `X-Moon-*` app identity header set at the firewall boundary
- default allow the 11 verified non-credential-bearing reads
- default deny the 5 GET routes whose mixed responses can contain unlock PINs or related device credentials
- default deny all 30 mutations and all unknown endpoints
- retain the last safe device catalog only for narrowly classified transient/schema refresh failures; all other provider failures propagate
- revoke the superseded smart-device registration only after a replacement connection commits, using the old encrypted inputs captured before overwrite
- attempt remote smart-device logout during deletion without allowing an upstream outage to prevent local credential removal

## Cross-repository deliverables

- icon: vm0-ai/static-files#37 — merged and published at the immutable URL used by this PR
- skill: vm0-ai/vm0-skills#300 — open with green validation; documents all 15 permissions and all 46 routes, including exact request fields, reusable call patterns, identifier discovery, response handling, privacy constraints, and lifecycle safety guidance

## Validation

- `pnpm format`
- `pnpm turbo run lint` (12/12 packages)
- `pnpm check-types` (13/13 packages)
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (597 files and 7,330 tests passed; 1 existing skip)
- `pnpm knip`
- mitm-addon: ruff check and format, basedpyright (0 errors), pytest (3,764 passed)
- focused connector/provider, firewall, API lifecycle, replacement cleanup, remote-logout failure cleanup, catalog, and feature-switch tests
- static-files append-only/XML/content-type/hash/shell checks
- vm0-skills validation plus exact permission, route, request-field, and usage-guidance consistency checks

## Validation boundary

The private protocol and route inventory were verified from Nintendo Switch Parental Controls 2.4.0 (build 660). No authorized live adult Nintendo Account was available in this environment, so staff must complete a non-destructive live connect/read/refresh/delete smoke test before broader rollout.

## Follow-up

- #21043 tracks the platform-wide rollback contract for remote grants that succeed before local connector persistence fails; it is intentionally separate because it spans every grant kind and must distinguish pre-commit failure from post-commit notification failure.

Addresses #20610.
