### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -113,7 +113,7 @@ CACHE_TMP_TAR=""
 
 # Pinned versions (changes here invalidate the template cache via script hash)
 GO_VERSION="1.26.5"
-CLAUDE_CODE_VERSION="2.1.206"
+CLAUDE_CODE_VERSION="2.1.207"
 CODEX_CLI_VERSION="0.144.1"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"


### PR DESCRIPTION
## Summary

- Update Claude Code from `2.1.206` to `2.1.207` in the reusable rootfs template.
- Keep the remaining pinned dependencies unchanged after checking their current stable or LTS releases.

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`