### PR TITLE
chore(rust): refresh sha1, thread_local, and tinyvec lockfile versions

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
  "http 1.4.2",
  "httpdate",
  "mime",
- "sha1 0.10.6",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -3020,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3294,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -3343,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3584,7 +3584,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "thiserror 2.0.18",
 ]
 


### PR DESCRIPTION
## Summary

- Update `sha1` from 0.10.6 to 0.10.7.
- Update `thread_local` from 1.1.9 to 1.1.10.
- Update `tinyvec` from 1.11.0 to 1.12.0.
- Keep the change limited to `crates/Cargo.lock`; no source changes were required.

## Dependencies not updated

- `generic-array` remains at 0.14.7 although 0.14.9 is available because transitive dependency `crypto-common` 0.1.7 requires `generic-array = "=0.14.7"`. This is not a direct workspace constraint.

## Manual version bumps

None. All direct dependency requirements already admit their latest stable compatible versions.

## Test status

- PASS: `cargo test -p ably-subscriber` (186 unit, integration, protocol, and documentation tests passed).
- INCOMPLETE due to runner resource limits: `cargo test --workspace` exhausted the root filesystem during compilation. A retry with debug info disabled and build artifacts moved to the separate 2 GB `/dev/shm` filesystem compiled the updated dependencies but the monolithic `runner` test link was killed with SIGKILL. A grouped per-crate fallback also exhausted that 2 GB filesystem while linking `guest-agent` tests.
- No test assertion failures or update-related compiler errors were observed.