### PR TITLE
fix: prevent gray chrome above mobile artifact previews

### DIFF
--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -79,7 +79,7 @@ describe("platform entrypoint safe area behavior", () => {
       /#root\s*{[\s\S]*position:\s*fixed;[\s\S]*top:\s*0;[\s\S]*right:\s*0;[\s\S]*left:\s*0;/,
     );
     expect(globalCss).toMatch(
-      /#root\s*{[\s\S]*box-sizing:\s*border-box;[\s\S]*padding:\s*var\(--sat\)\s+var\(--sar\)\s+var\(--sab\)\s+var\(--sal\);/,
+      /#root\s*{[\s\S]*box-sizing:\s*border-box;[\s\S]*background-color:\s*hsl\(var\(--background\)\);[\s\S]*padding:\s*var\(--sat\)\s+var\(--sar\)\s+var\(--sab\)\s+var\(--sal\);/,
     );
     expect(globalCss).toMatch(
       /\.zero-viewport-shell\s*{[\s\S]*height:\s*100%;[\s\S]*max-height:\s*100%;[\s\S]*overflow:\s*hidden;/,

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -103,6 +103,8 @@ body {
   top: 0;
   right: 0;
   left: 0;
+  /* Keep the root-owned safe-area padding opaque behind translucent iOS chrome. */
+  background-color: hsl(var(--background));
   padding: var(--sat) var(--sar) var(--sab) var(--sal);
 }
 


### PR DESCRIPTION
## Summary

- paint the root-owned mobile safe-area padding with the active app background so iOS artifact previews no longer expose gray translucent system chrome
- keep the existing four-sided safe-area padding unchanged, so headers, controls, and preview content remain outside notches and system gestures
- extend the platform safe-area regression test to require the opaque root surface

## Verification

- `pnpm exec prettier --check apps/platform/src/views/css/index.css apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts --maxWorkers=1` (4 passed)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`

Local dev server was not started per the vm0 PR verification preference. Exact iOS standalone rendering should be confirmed on the PR preview from an iOS device.
