### PR TITLE
docs(ably-subscriber): remove obsolete integration test numbering

### DIFF
--- a/crates/ably-subscriber/tests/integration/auth_token.rs
+++ b/crates/ably-subscriber/tests/integration/auth_token.rs
@@ -129,10 +129,6 @@ async fn token_exchange_dot_segment_key_name_fails_before_request() {
     assert_eq!(token_mock.calls(), 0);
 }
 
-// ---------------------------------------------------------------------------
-// Test 8: token renewal — server receives AUTH after short-TTL token
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn token_renewal() {
     let http = MockServer::start();
@@ -273,10 +269,6 @@ async fn close_during_pending_token_renewal_sends_close() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 9: reconnect after server drops connection
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn server_initiated_auth() {
     let http = MockServer::start();
@@ -394,10 +386,6 @@ async fn close_during_server_requested_pending_token_renewal_sends_close() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 18: get_token callback returns error → subscribe fails
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn get_token_callback_error() {
     let mut config = SubscribeConfig::new(
@@ -414,10 +402,6 @@ async fn get_token_callback_error() {
         Ok(_) => panic!("expected error, got Ok"),
     }
 }
-
-// ---------------------------------------------------------------------------
-// Test 19: heartbeat timeout triggers reconnect (fast with TimingConfig)
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn token_renewal_failures_fatal() {

--- a/crates/ably-subscriber/tests/integration/backpressure.rs
+++ b/crates/ably-subscriber/tests/integration/backpressure.rs
@@ -77,10 +77,6 @@ async fn token_renewal_error_backpressure_closes_socket_before_subscription_clos
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 22: backpressure drops messages when channel is full
-// ---------------------------------------------------------------------------
-
 // current_thread runtime is a determinism requirement: we rely on the
 // subscriber task's synchronous event-loop dispatch processes a batched
 // ProtocolMessage's Vec<AblyMessage> with no await between try_send calls)
@@ -208,10 +204,6 @@ async fn backpressure_drops_messages() {
         other => panic!("expected sentinel Message, got {other:?}"),
     }
 }
-
-// ---------------------------------------------------------------------------
-// Test 23: DETACHED while attaching suspends channel and retries ATTACH
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn close_while_disconnected_event_send_is_backpressured_stops_without_reconnect() {
@@ -620,7 +612,3 @@ async fn channel_error_backpressure_closes_socket_before_subscription_close() {
     sub.close();
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 26: non-positive connection_state_ttl keeps the default resume window
-// ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration/channel_state.rs
+++ b/crates/ably-subscriber/tests/integration/channel_state.rs
@@ -451,10 +451,6 @@ async fn huge_realtime_request_timeout_allows_detached_reattach() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 12: close subscription sends CLOSE to server
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn detached_with_client_error_reattaches() {
     let http = MockServer::start();
@@ -613,10 +609,6 @@ async fn superseded_error_after_attached_without_serial_keeps_resume_intent() {
 
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 16: server sends CLOSED → event loop stops
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn detached_while_attaching_suspends_and_retries_attach() {
@@ -1805,10 +1797,6 @@ async fn reconnect_attach_timeout_retries_channel_on_same_transport() {
 
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 28: detach after reconnect reattaches on the active transport
-// ---------------------------------------------------------------------------
 
 /// Sequence: DETACH → send ATTACH → connection drops → reconnect succeeds →
 /// DETACH on new connection → client should send ATTACH (not open conn-3).

--- a/crates/ably-subscriber/tests/integration/close_drop.rs
+++ b/crates/ably-subscriber/tests/integration/close_drop.rs
@@ -98,10 +98,6 @@ async fn drop_subscription_sends_close() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 13: non-retriable DISCONNECTED still triggers reconnect
-// ---------------------------------------------------------------------------
-
 /// ably-js always reconnects on mid-session DISCONNECTED regardless of
 /// retriability — the server may send 429 or 401 but still expect the
 /// client to backoff-and-retry. Only connection-level ERROR is fatal.
@@ -140,10 +136,6 @@ async fn server_sends_closed() {
         .unwrap();
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 17: server-initiated AUTH (action 17) → client renews token
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn error_during_event_loop() {
@@ -189,10 +181,6 @@ async fn error_during_event_loop() {
         .unwrap();
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 15: DETACHED with a client error still follows ably-js re-attach flow
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn close_during_hanging_reconnect_attempt_closes_socket() {

--- a/crates/ably-subscriber/tests/integration/connection_messages.rs
+++ b/crates/ably-subscriber/tests/integration/connection_messages.rs
@@ -259,10 +259,6 @@ async fn zero_event_channel_capacity_uses_minimum_capacity() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 2: multiple messages received in order
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn multiple_messages() {
     let http = MockServer::start();
@@ -295,10 +291,6 @@ async fn multiple_messages() {
 
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 3: batched messages in a single frame
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn batched_messages_in_single_frame() {
@@ -358,10 +350,6 @@ async fn batched_messages_in_single_frame() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 4: message with json encoding
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn message_with_json_encoding() {
     let http = MockServer::start();
@@ -407,10 +395,6 @@ async fn message_with_json_encoding() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Test 5: server error during handshake
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn server_error_during_handshake() {
     let http = MockServer::start();
@@ -444,10 +428,6 @@ async fn server_error_during_handshake() {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Test 6: connection closed before CONNECTED
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn connection_closed_before_connected() {
     let http = MockServer::start();
@@ -463,7 +443,3 @@ async fn connection_closed_before_connected() {
     let result = subscribe(test_config(ws_port, http.port(), "ch")).await;
     assert!(result.is_err());
 }
-
-// ---------------------------------------------------------------------------
-// Test 7: HTTP token exchange error (500)
-// ---------------------------------------------------------------------------

--- a/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
+++ b/crates/ably-subscriber/tests/integration/heartbeat_timeouts.rs
@@ -135,10 +135,6 @@ async fn zero_max_idle_interval_disables_heartbeat_timeout() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 20: retry continues indefinitely and enters suspended after TTL expiry
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn channel_retry_timers_do_not_extend_heartbeat_deadline() {
     let http = MockServer::start();
@@ -243,10 +239,6 @@ async fn channel_retry_timers_do_not_extend_heartbeat_deadline() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 24: connect_timeout fires when server hangs during handshake
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn connect_timeout_fires() {
     let http = MockServer::start();
@@ -276,10 +268,6 @@ async fn connect_timeout_fires() {
         Ok(_) => panic!("expected error, got Ok"),
     }
 }
-
-// ---------------------------------------------------------------------------
-// Test 25: reconnect_timeout retries until connection state becomes suspended
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn reconnect_timeout_retries_until_suspended() {

--- a/crates/ably-subscriber/tests/integration/reconnect.rs
+++ b/crates/ably-subscriber/tests/integration/reconnect.rs
@@ -87,10 +87,6 @@ async fn reconnect_after_server_drop() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 9b: server sends WebSocket Close frame, client reconnects immediately
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn reconnect_immediately_after_close_frame() {
     let http = MockServer::start();
@@ -176,10 +172,6 @@ async fn reconnect_immediately_after_close_frame() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 9c: server sends Close without a close frame, client reconnects immediately
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn reconnect_immediately_after_close_frame_no_reason() {
     let http = MockServer::start();
@@ -258,10 +250,6 @@ async fn reconnect_immediately_after_close_frame_no_reason() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 9d: server sends Close frame with empty reason
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn reconnect_after_close_frame_empty_reason_reports_code_only() {
     let http = MockServer::start();
@@ -323,10 +311,6 @@ async fn reconnect_after_close_frame_empty_reason_reports_code_only() {
 
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 9e: repeated clean close frames are rate-limited
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn repeated_clean_close_reconnect_is_rate_limited() {
@@ -424,10 +408,6 @@ async fn repeated_clean_close_reconnect_is_rate_limited() {
 
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 10: server sends DISCONNECTED, client reconnects
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn server_sends_disconnected() {
@@ -664,10 +644,6 @@ async fn disconnected_event_is_not_delayed_by_transport_close() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 11: server sends DETACHED, client re-attaches
-// ---------------------------------------------------------------------------
-
 /// ably-js always reconnects on mid-session DISCONNECTED regardless of
 /// retriability — the server may send 429 or 401 but still expect the
 /// client to backoff-and-retry. Only connection-level ERROR is fatal.
@@ -754,10 +730,6 @@ async fn non_retriable_disconnected_triggers_reconnect() {
 
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 14: ERROR during event loop → Event::Error + stop
-// ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn retry_enters_suspended_after_connection_state_ttl() {
@@ -969,10 +941,6 @@ async fn suspended_retry_reconnect_attach_uses_resume_without_serial() {
     join_server_task(server_task, "mock server").await.unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Test 21: token renewal failures become fatal (fast with TimingConfig)
-// ---------------------------------------------------------------------------
-
 #[tokio::test]
 async fn non_positive_ttl_keeps_default_resume_window() {
     let http = MockServer::start();
@@ -1060,10 +1028,6 @@ async fn non_positive_ttl_keeps_default_resume_window() {
     token_mock.assert_calls(1);
     join_server_task(server_task, "mock server").await.unwrap();
 }
-
-// ---------------------------------------------------------------------------
-// Test 27: resumed connection still re-attaches channel
-// ---------------------------------------------------------------------------
 
 /// Regression test: when the server returns the same connection_id (resume),
 /// the client must still send ATTACH. Before the fix, resumed connections


### PR DESCRIPTION
## Summary

- remove all 31 obsolete numbered divider blocks from the seven Ably integration test modules
- preserve all 74 Tokio tests, test declarations, and substantive explanatory comments
- keep the cleanup Ably-specific; runner integration test numbering and runtime behavior are unchanged

Closes #21002

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p ably-subscriber --test integration` (74 passed)
- `cargo clippy --manifest-path crates/Cargo.toml -p ably-subscriber --all-targets --all-features -- -D warnings`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,314 passed; 1 benchmark skipped)
- `pnpm knip`
- static inventory: 0 numbered Ably divider headings, 0 decorative divider lines, and 74 Tokio tests
