### PR TITLE
fix: classify completion failures before retrying

### DIFF
--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -1,11 +1,16 @@
 use std::time::Duration;
 
+use reqwest::StatusCode;
+
 use crate::ids::RunId;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RunnerError {
     #[error("api error: {0}")]
     Api(String),
+
+    #[error("api error: {0}")]
+    ApiStatus(Box<ApiStatusError>),
 
     #[error("api error: {0}")]
     ApiTransport(Box<ApiTransportError>),
@@ -119,6 +124,19 @@ pub fn format_short_duration(d: Duration) -> String {
 }
 
 pub type RunnerResult<T> = Result<T, RunnerError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApiStatusError {
+    pub endpoint_label: &'static str,
+    pub status: StatusCode,
+    pub body: String,
+}
+
+impl std::fmt::Display for ApiStatusError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}: {}", self.endpoint_label, self.status, self.body)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiRequestContext {

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -28,7 +28,7 @@ use super::{
     PreLocalAdmissionOutcome,
 };
 use crate::duration::duration_ms;
-use crate::error::{RunnerError, RunnerResult};
+use crate::error::{ApiStatusError, RunnerError, RunnerResult};
 use crate::http::{ApiRequestBuilder, HttpClient};
 use crate::ids::RunId;
 use crate::run_cancellation::SharedRunCancellationMap;
@@ -466,12 +466,68 @@ impl JobProvider for ApiProvider {
                 .await
             {
                 Ok(()) => return,
-                Err(e) if attempt < MAX_ATTEMPTS => {
-                    warn!(run_id = %run_id, error = %e, "completion report failed, retrying");
-                    tokio::time::sleep(RETRY_DELAY).await;
-                }
                 Err(e) => {
-                    error!(run_id = %run_id, error = %e, "failed to report completion after retry");
+                    let (retryable, status, failure_kind) = match &e {
+                        RunnerError::ApiStatus(api_error) => {
+                            let status = api_error.status;
+                            (
+                                matches!(
+                                    status,
+                                    StatusCode::REQUEST_TIMEOUT
+                                        | StatusCode::MISDIRECTED_REQUEST
+                                        | StatusCode::TOO_EARLY
+                                        | StatusCode::TOO_MANY_REQUESTS
+                                ) || status.is_server_error(),
+                                api_error.status.as_str(),
+                                "http_status",
+                            )
+                        }
+                        RunnerError::ApiTransport(api_error) => {
+                            (true, "", api_error.failure_kind.as_str())
+                        }
+                        _ => (false, "", "local"),
+                    };
+                    let will_retry = retryable && attempt < MAX_ATTEMPTS;
+
+                    if will_retry {
+                        warn!(
+                            run_id = %run_id,
+                            error = %e,
+                            attempt,
+                            max_attempts = MAX_ATTEMPTS,
+                            will_retry,
+                            status,
+                            failure_kind,
+                            "completion report failed, retrying"
+                        );
+                        tokio::time::sleep(RETRY_DELAY).await;
+                        continue;
+                    }
+
+                    if attempt > 1 {
+                        error!(
+                            run_id = %run_id,
+                            error = %e,
+                            attempt,
+                            max_attempts = MAX_ATTEMPTS,
+                            will_retry,
+                            status,
+                            failure_kind,
+                            "failed to report completion after retry"
+                        );
+                    } else {
+                        error!(
+                            run_id = %run_id,
+                            error = %e,
+                            attempt,
+                            max_attempts = MAX_ATTEMPTS,
+                            will_retry,
+                            status,
+                            failure_kind,
+                            "failed to report completion"
+                        );
+                    }
+                    return;
                 }
             }
         }
@@ -639,11 +695,7 @@ impl ApiClient {
         )
         .await?;
 
-        if !resp.status().is_success() {
-            let (status, body) = read_api_error(resp).await;
-            warn!(status = %status, "complete request failed: {body}");
-            return Err(api_status_error("complete", status, &body));
-        }
+        check_api_status(resp, "complete").await?;
 
         Ok(())
     }
@@ -817,7 +869,7 @@ async fn send_api(req: ApiRequestBuilder, label: &'static str) -> RunnerResult<R
     }
 }
 
-async fn check_api_status(resp: Response, label: &str) -> RunnerResult<Response> {
+async fn check_api_status(resp: Response, label: &'static str) -> RunnerResult<Response> {
     let status = resp.status();
     if !status.is_success() {
         let (status, body) = read_api_error(resp).await;
@@ -840,8 +892,12 @@ async fn read_api_error(resp: Response) -> (StatusCode, String) {
     (status, body)
 }
 
-fn api_status_error(label: &str, status: StatusCode, body: &str) -> RunnerError {
-    RunnerError::Api(format!("{label} {status}: {body}"))
+fn api_status_error(label: &'static str, status: StatusCode, body: &str) -> RunnerError {
+    RunnerError::ApiStatus(Box::new(ApiStatusError {
+        endpoint_label: label,
+        status,
+        body: body.to_string(),
+    }))
 }
 
 fn decode_api_json_bytes<T: DeserializeOwned>(body: &[u8]) -> Result<T, String> {
@@ -1259,11 +1315,25 @@ mod tests {
         mock.assert_async().await;
     }
 
-    fn assert_api_error(err: RunnerError, expected: &str) {
+    fn assert_api_status_error(
+        err: RunnerError,
+        endpoint_label: &'static str,
+        status: StatusCode,
+        body: &str,
+    ) {
+        let display = err.to_string();
         match err {
-            RunnerError::Api(message) => assert_eq!(message, expected),
-            other => panic!("expected RunnerError::Api, got {other:?}"),
+            RunnerError::ApiStatus(error) => {
+                assert_eq!(error.endpoint_label, endpoint_label);
+                assert_eq!(error.status, status);
+                assert_eq!(error.body, body);
+            }
+            other => panic!("expected RunnerError::ApiStatus, got {other:?}"),
         }
+        assert_eq!(
+            display,
+            format!("api error: {endpoint_label} {status}: {body}")
+        );
     }
 
     fn api_provider_for_test(
@@ -1426,8 +1496,8 @@ mod tests {
             for status in statuses {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 let request = read_http_request_text(&mut socket).await;
-                request_tx.send(request).unwrap();
                 write_http_status_response(&mut socket, status).await;
+                request_tx.send(request).unwrap();
             }
         });
         (api_url, request_rx, server_task)
@@ -2159,7 +2229,12 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_api_error(err, "poll 503 Service Unavailable: poll unavailable");
+        assert_api_status_error(
+            err,
+            "poll",
+            StatusCode::SERVICE_UNAVAILABLE,
+            "poll unavailable",
+        );
         mock.assert_async().await;
     }
 
@@ -2463,7 +2538,12 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_api_error(err, "complete 500 Internal Server Error: complete failed");
+        assert_api_status_error(
+            err,
+            "complete",
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "complete failed",
+        );
         mock.assert_async().await;
     }
 
@@ -2909,16 +2989,127 @@ mod tests {
         mock.assert_calls_async(0).await;
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn api_provider_complete_retries_once_after_failure_and_succeeds() {
-        let (api_url, mut requests, server_task) = complete_sequence_server(vec![500, 200]).await;
+    #[tokio::test]
+    async fn api_provider_complete_does_not_retry_permanent_http_failure() {
+        let (api_url, mut requests, server_task) = complete_sequence_server(vec![400]).await;
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
             api_url,
             CancellationToken::new(),
             Arc::new(PollWakeups::new(false)),
         );
+        let ((), events) = tokio::time::timeout(
+            Duration::from_secs(1),
+            capture_api_provider_events(async move {
+                provider
+                    .complete(
+                        run_id,
+                        0,
+                        None,
+                        None,
+                        None,
+                        CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
+                    )
+                    .await;
+            }),
+        )
+        .await
+        .expect("permanent completion failure should not wait for the retry delay");
 
+        let request = next_request(&mut requests).await;
+        assert_complete_authorization(&request, "sandbox-token");
+        server_task.await.unwrap();
+        assert!(
+            requests.recv().await.is_none(),
+            "permanent completion failure should send one request"
+        );
+
+        let run_id = run_id.to_string();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.fields.get("run_id") == Some(&run_id))
+                .count(),
+            1,
+            "one failed request should produce one provider event: {events:#?}"
+        );
+        let event = captured_event(&events, "failed to report completion");
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(event_field(event, "attempt"), "1");
+        assert_eq!(event_field(event, "max_attempts"), "2");
+        assert_eq!(event_field(event, "will_retry"), "false");
+        assert_eq!(event_field(event, "status"), "400");
+        assert_eq!(event_field(event, "failure_kind"), "http_status");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_provider_complete_retries_transient_http_failures() {
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::MISDIRECTED_REQUEST,
+            StatusCode::TOO_EARLY,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let (api_url, mut requests, server_task) =
+                complete_sequence_server(vec![status.as_u16(), 200]).await;
+            let run_id = RunId::nil();
+            let provider = api_provider_for_test(
+                api_url,
+                CancellationToken::new(),
+                Arc::new(PollWakeups::new(false)),
+            );
+            let complete_task = tokio::spawn(async move {
+                provider
+                    .complete(
+                        run_id,
+                        0,
+                        None,
+                        None,
+                        None,
+                        CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
+                    )
+                    .await;
+            });
+
+            let first_request = next_request(&mut requests).await;
+            assert_complete_authorization(&first_request, "sandbox-token");
+            tokio::task::yield_now().await;
+            assert!(
+                requests.try_recv().is_err(),
+                "status {status} should wait before the retry"
+            );
+            tokio::time::advance(Duration::from_secs(2)).await;
+            let second_request = next_request(&mut requests).await;
+            assert_complete_authorization(&second_request, "sandbox-token");
+
+            complete_task.await.unwrap();
+            server_task.await.unwrap();
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_provider_complete_retries_transport_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        let (request_tx, mut requests) = mpsc::unbounded_channel();
+        let server_task = tokio::spawn(async move {
+            let (mut first_socket, _) = listener.accept().await.unwrap();
+            let first_request = read_http_request_text(&mut first_socket).await;
+            drop(first_socket);
+            request_tx.send(first_request).unwrap();
+
+            let (mut second_socket, _) = listener.accept().await.unwrap();
+            let second_request = read_http_request_text(&mut second_socket).await;
+            write_http_status_response(&mut second_socket, 200).await;
+            request_tx.send(second_request).unwrap();
+        });
+        let run_id = RunId::nil();
+        let provider = api_provider_for_test(
+            api_url,
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
         let complete_task = tokio::spawn(async move {
             provider
                 .complete(
@@ -2934,6 +3125,11 @@ mod tests {
 
         let first_request = next_request(&mut requests).await;
         assert_complete_authorization(&first_request, "sandbox-token");
+        tokio::task::yield_now().await;
+        assert!(
+            requests.try_recv().is_err(),
+            "transport failure should wait before the retry"
+        );
         tokio::time::advance(Duration::from_secs(2)).await;
         let second_request = next_request(&mut requests).await;
         assert_complete_authorization(&second_request, "sandbox-token");
@@ -2943,9 +3139,38 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn api_provider_complete_stops_after_two_failures() {
-        let (api_url, mut requests, server_task) =
-            complete_sequence_server(vec![500, 500, 200]).await;
+    async fn api_provider_complete_does_not_retry_local_request_failure() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let api_url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let run_id = RunId::nil();
+        let provider = api_provider_for_test(
+            api_url,
+            CancellationToken::new(),
+            Arc::new(PollWakeups::new(false)),
+        );
+        let ((), events) = capture_api_provider_events(provider.complete(
+            run_id,
+            0,
+            None,
+            None,
+            None,
+            CompletionAuth::sandbox_token(run_id, "invalid\nheader".to_string()),
+        ))
+        .await;
+
+        let event = captured_event(&events, "failed to report completion");
+        assert_eq!(event.level, Level::ERROR);
+        assert_eq!(event_field(event, "attempt"), "1");
+        assert_eq!(event_field(event, "will_retry"), "false");
+        assert_eq!(event_field(event, "status"), "");
+        assert_eq!(event_field(event, "failure_kind"), "local");
+        assert!(event_field(event, "error").contains("build API request"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn api_provider_complete_stops_after_two_transient_failures() {
+        let (api_url, mut requests, server_task) = complete_sequence_server(vec![500, 500]).await;
         let run_id = RunId::nil();
         let provider = api_provider_for_test(
             api_url,
@@ -2954,16 +3179,15 @@ mod tests {
         );
 
         let complete_task = tokio::spawn(async move {
-            provider
-                .complete(
-                    run_id,
-                    1,
-                    Some("boom"),
-                    None,
-                    None,
-                    CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
-                )
-                .await;
+            capture_api_provider_events(provider.complete(
+                run_id,
+                1,
+                Some("boom"),
+                None,
+                None,
+                CompletionAuth::sandbox_token(run_id, "sandbox-token".to_string()),
+            ))
+            .await
         });
 
         let first_request = next_request(&mut requests).await;
@@ -2972,12 +3196,34 @@ mod tests {
         let second_request = next_request(&mut requests).await;
         assert_complete_authorization(&second_request, "sandbox-token");
 
-        complete_task.await.unwrap();
+        let ((), events) = complete_task.await.unwrap();
+        server_task.await.unwrap();
         assert!(
-            requests.try_recv().is_err(),
+            requests.recv().await.is_none(),
             "completion should stop after the retry"
         );
-        server_task.abort();
-        let _ = server_task.await;
+
+        let run_id = run_id.to_string();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.fields.get("run_id") == Some(&run_id))
+                .count(),
+            2,
+            "two failed requests should produce two provider events: {events:#?}"
+        );
+        let retry_event = captured_event(&events, "completion report failed, retrying");
+        assert_eq!(retry_event.level, Level::WARN);
+        assert_eq!(event_field(retry_event, "attempt"), "1");
+        assert_eq!(event_field(retry_event, "will_retry"), "true");
+        assert_eq!(event_field(retry_event, "status"), "500");
+        assert_eq!(event_field(retry_event, "failure_kind"), "http_status");
+
+        let final_event = captured_event(&events, "failed to report completion after retry");
+        assert_eq!(final_event.level, Level::ERROR);
+        assert_eq!(event_field(final_event, "attempt"), "2");
+        assert_eq!(event_field(final_event, "will_retry"), "false");
+        assert_eq!(event_field(final_event, "status"), "500");
+        assert_eq!(event_field(final_event, "failure_kind"), "http_status");
     }
 }

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -7798,7 +7798,7 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
 });
 
 describe("RUN-03: sandbox completion reports against missing checkpoints and settled runs", () => {
-  it("fails a clean exit whose run never reported a checkpoint", async () => {
+  it("acknowledges a clean exit whose missing checkpoint fails the run", async () => {
     const api = createRunsAutomationsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId } = await entitledRunActor();
@@ -7815,10 +7815,14 @@ describe("RUN-03: sandbox completion reports against missing checkpoints and set
     const missing = await webhooks.requestAgentComplete(
       { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
       sandboxHeaders,
-      [404],
+      [200],
     );
-    expectApiError(missing.body);
-    expect(missing.body.error.message).toBe("Checkpoint for run not found");
+    if (missing.status !== 200) {
+      throw new Error(
+        "Expected the missing checkpoint failure to be acknowledged",
+      );
+    }
+    expect(missing.body).toStrictEqual({ success: true, status: "failed" });
     expect(context.mocks.ably.publish).toHaveBeenCalledWith(
       `run:changed:${run.runId}`,
       { status: "failed" },

--- a/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-webhook-complete.service.ts
@@ -266,21 +266,11 @@ async function handleMissingCheckpoint(
   });
   signal.throwIfAborted();
 
-  return {
-    status: 404,
-    body: {
-      error: {
-        message: error,
-        code: "NOT_FOUND",
-      },
-    },
-    sideEffects: {
-      runId: input.body.runId,
-      orgId: run.orgId,
-      status: "failed",
-      error,
-    },
-  };
+  L.warn("Run failed because checkpoint was not found", {
+    runId: input.body.runId,
+    error,
+  });
+  return successResponse(input.body.runId, run.orgId, "failed", error);
 }
 
 async function handleSuccessfulCompletion(


### PR DESCRIPTION
## Summary

- Preserve HTTP response status details in runner API errors and retry completion reports only for transport failures or transient statuses (`408`, `421`, `425`, `429`, and `5xx`).
- Emit one structured provider log for each failed completion attempt, including the attempt, retry decision, status, and failure kind.
- Return `200 { success: true, status: "failed" }` when a clean completion without a checkpoint has already transitioned the run to `failed`, while preserving `404` for a genuinely missing run.
- Cover permanent, transient, transport, and local completion failures plus the applied missing-checkpoint outcome.

## Deployment compatibility

- An old runner with the new API receives a successful acknowledgement for the applied missing-checkpoint transition.
- A new runner with the old API treats the legacy `404` as permanent and does not retry it.
- Request and response schemas are unchanged; frontend, API, and runner deployments can overlap safely.

## Scope

- Keep the existing completion retry budget at two attempts with a two-second delay.
- Do not change run lifecycle rules, database schema, API contracts, or the `404` response for a run that does not exist.

## Validation

- `cargo check -p runner`
- `cargo clippy -p runner --all-targets --all-features`
- `cargo test -p runner`
- `pnpm format`
- `pnpm lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip`

Closes #21006
