### PR TITLE
perf: redesign runtime profile retrieval

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -27,7 +27,6 @@ import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { clearMockNow, mockNow, now, nowDate } from "../../../lib/time";
 import { testContext } from "../../../__tests__/test-context";
 import { server } from "../../../mocks/server";
-import { seedLexicalRelationshipMemory } from "../../../test-fixtures/relationship-memory";
 import {
   deleteUsagePricingRows,
   seedOrgMetadata,
@@ -234,7 +233,7 @@ const API_DISPATCH_ZERO_MEMORY_PROFILE_ACTION_TYPES = [
   "api_dispatch_pre_create_zero_memory_profile_static",
   "api_dispatch_pre_create_zero_memory_profile_dynamic",
   "api_dispatch_pre_create_zero_memory_profile_search",
-  "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+  "api_dispatch_pre_create_zero_memory_profile_search_exact_identity",
   "api_dispatch_pre_create_zero_memory_profile_search_semantic_embedding",
   "api_dispatch_pre_create_zero_memory_profile_search_semantic_query",
   "api_dispatch_pre_create_zero_memory_profile_search_graph_expansion",
@@ -254,7 +253,7 @@ const ZERO_MEMORY_TIMING_BUCKET_DIMENSION_KEYS = [
   "memory_profile_static_result_count_bucket",
   "memory_profile_dynamic_result_count_bucket",
   "memory_profile_search_result_count_bucket",
-  "memory_profile_lexical_candidate_count_bucket",
+  "memory_profile_exact_identity_candidate_count_bucket",
   "memory_profile_semantic_candidate_count_bucket",
   "memory_profile_expansion_candidate_count_bucket",
   "memory_profile_seed_ranked_count_bucket",
@@ -1089,8 +1088,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     if (!actor.orgId) {
       throw new Error("Memory runtime timing test requires an org");
     }
-    const prompt = "security review answer";
-    const seededMemoryText = "Send the security review answer to the customer.";
+    const prompt = "find customer@example.com security review";
     await updateFeatureSwitchesForUser(
       context,
       { userId: actor.userId, orgId: actor.orgId, orgRole: "org:admin" },
@@ -1099,12 +1097,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
       },
     );
-    const seeded = await seedLexicalRelationshipMemory({
-      fixture: { orgId: actor.orgId, userId: actor.userId },
-      displayName: "Security Review",
-      kind: "preference",
-      text: seededMemoryText,
-    });
     mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
 
     const created = await api.createRun(actor, {
@@ -1169,12 +1161,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       singleApiDispatchEvent(
         timingEvents,
-        "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+        "api_dispatch_pre_create_zero_memory_profile_search_exact_identity",
       ),
     ).toStrictEqual(
       expect.objectContaining({
-        memory_profile_lexical_candidate_count_bucket: "1",
-        memory_profile_lexical_query_eligible: "true",
+        memory_profile_exact_identity_candidate_count_bucket: "0",
+        memory_profile_exact_identity_query_eligible: "true",
       }),
     );
     expect(
@@ -1203,9 +1195,6 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       agentId,
       actor.userId,
       actor.orgId,
-      seeded.entityId,
-      seeded.memoryId,
-      seededMemoryText,
       "vm0-ai/vm0",
       "source-search-fixture",
       "https://github.com/vm0-ai/vm0/issues/1",
@@ -1215,7 +1204,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
-  it("skips runtime memory lexical search for long noisy zero run prompts", async () => {
+  it("skips exact identity lookup for long noisy zero run prompts", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
     if (!actor.orgId) {
@@ -1261,12 +1250,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       singleApiDispatchEvent(
         timingEvents,
-        "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+        "api_dispatch_pre_create_zero_memory_profile_search_exact_identity",
       ),
     ).toStrictEqual(
       expect.objectContaining({
-        memory_profile_lexical_candidate_count_bucket: "0",
-        memory_profile_lexical_query_eligible: "false",
+        memory_profile_exact_identity_candidate_count_bucket: "0",
+        memory_profile_exact_identity_query_eligible: "false",
       }),
     );
     expect(
@@ -1293,7 +1282,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, created.runId, [200]);
   });
 
-  it("keeps short Unicode runtime memory queries eligible for lexical search", async () => {
+  it("does not treat short Unicode runtime queries as exact identities", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId } = await entitledRunActor();
     if (!actor.orgId) {
@@ -1331,12 +1320,12 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(
       singleApiDispatchEvent(
         timingEvents,
-        "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+        "api_dispatch_pre_create_zero_memory_profile_search_exact_identity",
       ),
     ).toStrictEqual(
       expect.objectContaining({
-        memory_profile_lexical_candidate_count_bucket: "0",
-        memory_profile_lexical_query_eligible: "true",
+        memory_profile_exact_identity_candidate_count_bucket: "0",
+        memory_profile_exact_identity_query_eligible: "false",
       }),
     );
 

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-memory-recall.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-memory-recall.test.ts
@@ -15,9 +15,7 @@ import { now } from "../../../lib/time";
 import { server } from "../../../mocks/server";
 import {
   seedGraphExpansionMemories,
-  seedLexicalRelationshipMemory,
   seedMemoryDocumentChunk,
-  seedSemanticRecallMemory,
 } from "../../../test-fixtures/relationship-memory";
 import {
   createConnectorBddApi,
@@ -34,6 +32,7 @@ const mocks = createZeroRouteMocks(context);
 const connectorsApi = createConnectorBddApi(context);
 const GMAIL_TOPIC_NAME = "projects/vm0-ai-488909/topics/gmail-events";
 const CRON_SECRET = "test-cron-secret";
+const OPENAI_EMBEDDINGS_URL = "https://api.openai.com/v1/embeddings";
 
 interface RelationshipFixture {
   readonly orgId: string;
@@ -58,6 +57,37 @@ function cronClient() {
 
 function cronHeaders() {
   return { authorization: `Bearer ${CRON_SECRET}` };
+}
+
+function testMemoryEmbedding(): readonly number[] {
+  return Array.from({ length: 1536 }, (_value, index) => {
+    return index === 0 ? 1 : 0;
+  });
+}
+
+function configureMemoryEmbeddingMock(): void {
+  mockEnv("VITEST", "false");
+  mockEnv("OPENAI_API_KEY", "test-openai-key");
+  server.use(
+    http.post(OPENAI_EMBEDDINGS_URL, () => {
+      return HttpResponse.json({
+        data: [{ embedding: testMemoryEmbedding() }],
+      });
+    }),
+  );
+}
+
+function configureMemoryEmbeddingFailure(): void {
+  mockEnv("VITEST", "false");
+  mockEnv("OPENAI_API_KEY", "test-openai-key");
+  server.use(
+    http.post(OPENAI_EMBEDDINGS_URL, () => {
+      return HttpResponse.json(
+        { error: { message: "embedding unavailable" } },
+        { status: 503 },
+      );
+    }),
+  );
 }
 
 function fixtureActor(fixture: RelationshipFixture): ApiTestUser {
@@ -204,6 +234,7 @@ async function seedRelationshipMemory(): Promise<RelationshipFixture> {
   const fixture = await seedRelationshipFixture();
   const gmailEmail = `relationship-${randomUUID()}@example.com`;
   const accessToken = `gmail-access-token-${randomUUID()}`;
+  configureMemoryEmbeddingMock();
   configureGmailMocks(gmailEmail, accessToken);
   await connectGmail(fixture, gmailEmail, accessToken);
   mocks.clerk.session(fixture.userId, fixture.orgId);
@@ -220,14 +251,14 @@ async function seedRelationshipMemory(): Promise<RelationshipFixture> {
   await expect
     .poll(async () => {
       await accept(cronClient().drain({ headers: cronHeaders() }), [200]);
-      const recalled = await accept(
-        memoryClient().recall({
+      const resolved = await accept(
+        relationshipsClient().resolve({
           headers: authHeaders(),
-          query: { q: "security review", limit: 5 },
+          query: { email: "customer@example.com" },
         }),
         [200],
       );
-      return recalled.body.memories.length;
+      return resolved.body.relationship?.items.length ?? 0;
     })
     .toBeGreaterThanOrEqual(1);
   return fixture;
@@ -299,35 +330,89 @@ describe("GET /api/zero/memory/recall", () => {
     );
   });
 
-  it("recalls matching structured relationship memory", async () => {
+  it("recalls indexed email and domain identities when embedding fails", async () => {
     await seedRelationshipMemory();
 
-    const response = await accept(
+    const overlap = await accept(
       memoryClient().recall({
         headers: authHeaders(),
-        query: { q: "security review", limit: 5 },
+        query: {
+          q: "what should I do for customer@example.com today?",
+          limit: 10,
+        },
       }),
       [200],
     );
+    expect(
+      new Set(
+        overlap.body.memories.map((memory) => {
+          return memory.id;
+        }),
+      ).size,
+    ).toBe(overlap.body.memories.length);
 
-    expect(response.body.query).toBe("security review");
-    expect(response.body.memories.length).toBeGreaterThanOrEqual(1);
-    expect(response.body.memories[0]).toMatchObject({
-      kind: "open_loop",
-      relationship: {
-        entity: {
-          primaryEmail: "customer@example.com",
-          type: "person",
+    configureMemoryEmbeddingFailure();
+    const emailResponse = await accept(
+      memoryClient().recall({
+        headers: authHeaders(),
+        query: {
+          q: "what should I do for customer@example.com today?",
+          limit: 5,
         },
-      },
-    });
+      }),
+      [200],
+    );
+    expect(emailResponse.body.memories).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "open_loop",
+          relationship: expect.objectContaining({
+            entity: expect.objectContaining({
+              primaryEmail: "customer@example.com",
+              type: "person",
+            }),
+          }),
+        }),
+      ]),
+    );
+
+    const domainResponse = await accept(
+      memoryClient().recall({
+        headers: authHeaders(),
+        query: { q: "summarize the relationship with example.com.", limit: 5 },
+      }),
+      [200],
+    );
+    expect(domainResponse.body.memories).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          relationship: expect.objectContaining({
+            entity: expect.objectContaining({
+              domain: "example.com",
+              type: "organization",
+            }),
+          }),
+        }),
+      ]),
+    );
   });
 
   it("recalls semantic memory without lexical overlap", async () => {
-    const fixture = await seedRelationshipFixture();
+    await seedRelationshipFixture();
+    configureMemoryEmbeddingMock();
     const query = "cash management sweep fund";
-    await seedSemanticRecallMemory(fixture, query);
-    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    await accept(
+      memoryClient().createMemory({
+        headers: authHeaders(),
+        body: {
+          text: "The user prefers JPM IJTXX Treasury allocation.",
+          kind: "preference",
+          confidence: 95,
+          entityDisplayName: "Portfolio Settings",
+        },
+      }),
+      [200],
+    );
 
     const response = await accept(
       memoryClient().recall({
@@ -348,6 +433,84 @@ describe("GET /api/zero/memory/recall", () => {
         },
       },
     });
+
+    const multilingual = await accept(
+      memoryClient().recall({
+        headers: authHeaders(),
+        query: { q: "现金管理偏好", limit: 5 },
+      }),
+      [200],
+    );
+    expect(multilingual.body.memories[0]?.text).toBe(
+      "The user prefers JPM IJTXX Treasury allocation.",
+    );
+  });
+
+  it("uses literal score to rerank bounded semantic candidates", async () => {
+    await seedRelationshipFixture();
+    configureMemoryEmbeddingMock();
+    const exact = await accept(
+      memoryClient().createMemory({
+        headers: authHeaders(),
+        body: {
+          text: "The launch budget sequence is blue.",
+          kind: "key_fact",
+          confidence: 90,
+          entityDisplayName: "Launch planning",
+        },
+      }),
+      [200],
+    );
+    await accept(
+      memoryClient().createMemory({
+        headers: authHeaders(),
+        body: {
+          text: "The support rotation begins next week.",
+          kind: "key_fact",
+          confidence: 90,
+          entityDisplayName: "Launch planning",
+        },
+      }),
+      [200],
+    );
+
+    const response = await accept(
+      memoryClient().recall({
+        headers: authHeaders(),
+        query: { q: "launch budget sequence", limit: 2 },
+      }),
+      [200],
+    );
+
+    expect(response.body.memories[0]?.id).toBe(exact.body.memory.id);
+  });
+
+  it("does not use generic literal recall when embedding fails", async () => {
+    await seedRelationshipFixture();
+    configureMemoryEmbeddingMock();
+    await accept(
+      memoryClient().createMemory({
+        headers: authHeaders(),
+        body: {
+          text: "Remember the cobalt fallback phrase.",
+          kind: "key_fact",
+          confidence: 90,
+          entityDisplayName: "Fallback behavior",
+        },
+      }),
+      [200],
+    );
+    configureMemoryEmbeddingFailure();
+
+    const response = await accept(
+      memoryClient().recall({
+        headers: authHeaders(),
+        query: { q: "cobalt fallback phrase", limit: 5 },
+      }),
+      [200],
+    );
+
+    expect(response.body.memories).toStrictEqual([]);
   });
 
   it("expands semantic recall through related graph memories", async () => {
@@ -395,13 +558,24 @@ describe("GET /api/zero/memory/recall", () => {
   });
 
   it("packs profile memory into runtime context", async () => {
-    const fixture = await seedRelationshipFixture({
+    await seedRelationshipFixture({
       relationshipMemoryEnabled: true,
       runtimeInjectionEnabled: true,
     });
+    configureMemoryEmbeddingMock();
     const query = "cash management sweep fund";
-    await seedSemanticRecallMemory(fixture, query);
-    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    await accept(
+      memoryClient().createMemory({
+        headers: authHeaders(),
+        body: {
+          text: "The user prefers JPM IJTXX Treasury allocation.",
+          kind: "preference",
+          confidence: 95,
+          entityDisplayName: "Portfolio Settings",
+        },
+      }),
+      [200],
+    );
 
     const response = await accept(
       memoryClient().injectionPreview({
@@ -453,12 +627,22 @@ describe("GET /api/zero/memory/recall", () => {
   });
 
   it("does not inject memory for whitespace-only runtime prompts", async () => {
-    const fixture = await seedRelationshipFixture({
+    await seedRelationshipFixture({
       relationshipMemoryEnabled: true,
       runtimeInjectionEnabled: true,
     });
-    await seedSemanticRecallMemory(fixture, "cash management sweep fund");
-    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    await accept(
+      memoryClient().createMemory({
+        headers: authHeaders(),
+        body: {
+          text: "The user prefers concise summaries.",
+          kind: "preference",
+          confidence: 95,
+          entityDisplayName: "Runtime preferences",
+        },
+      }),
+      [200],
+    );
 
     const response = await accept(
       memoryClient().injectionPreview({
@@ -556,13 +740,19 @@ describe("GET /api/zero/memory/search", () => {
   it("returns durable memories without locally persisted document chunks", async () => {
     const fixture = await seedRelationshipFixture();
     const text = "Use the launch checklist for the security review.";
-    await seedLexicalRelationshipMemory({
-      fixture,
-      displayName: "Security review",
-      kind: "key_fact",
-      text,
-      query: "launch checklist",
-    });
+    configureMemoryEmbeddingMock();
+    await accept(
+      memoryClient().createMemory({
+        headers: authHeaders(),
+        body: {
+          text,
+          kind: "key_fact",
+          confidence: 91,
+          entityDisplayName: "Security review",
+        },
+      }),
+      [200],
+    );
     await seedMemoryDocumentChunk({
       fixture,
       title: "Security review checklist",

--- a/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/api-dispatch-timing.service.ts
@@ -34,7 +34,7 @@ export type ApiDispatchTimingActionType =
   | "api_dispatch_pre_create_zero_memory_profile_static"
   | "api_dispatch_pre_create_zero_memory_profile_dynamic"
   | "api_dispatch_pre_create_zero_memory_profile_search"
-  | "api_dispatch_pre_create_zero_memory_profile_search_lexical"
+  | "api_dispatch_pre_create_zero_memory_profile_search_exact_identity"
   | "api_dispatch_pre_create_zero_memory_profile_search_semantic_embedding"
   | "api_dispatch_pre_create_zero_memory_profile_search_semantic_query"
   | "api_dispatch_pre_create_zero_memory_profile_search_graph_expansion"

--- a/turbo/apps/api/src/signals/services/zero-memory-embedding.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-embedding.service.ts
@@ -18,7 +18,7 @@ const openAiEmbeddingResponseSchema = z.object({
     .min(1),
 });
 
-interface MemoryEmbeddingResult {
+export interface MemoryEmbeddingResult {
   readonly model: string;
   readonly embedding: readonly number[];
 }

--- a/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
@@ -225,8 +225,10 @@ function containsQuery(value: string | null, query: string): boolean {
   return normalizedValue.length > 0 && normalizedValue.includes(query);
 }
 
-function tokenMatchScore(values: readonly (string | null)[], query: string) {
-  const tokens = tokenize(query);
+function tokenMatchScore(
+  values: readonly (string | null)[],
+  tokens: readonly string[],
+): number {
   if (tokens.length === 0) {
     return 0;
   }
@@ -237,7 +239,11 @@ function tokenMatchScore(values: readonly (string | null)[], query: string) {
   return matched / tokens.length;
 }
 
-function literalScore(row: MemoryProfileRow, normalizedQuery: string): number {
+function literalScore(
+  row: MemoryProfileRow,
+  normalizedQuery: string,
+  queryTokens: readonly string[],
+): number {
   if (containsQuery(row.text, normalizedQuery)) {
     return 1;
   }
@@ -265,7 +271,7 @@ function literalScore(row: MemoryProfileRow, normalizedQuery: string): number {
       row.relationship.summary,
       row.relationship.relationshipType,
     ],
-    normalizedQuery,
+    queryTokens,
   );
 }
 
@@ -988,6 +994,7 @@ async function rankCandidates(
     return candidate.id;
   });
   const rowsById = await loadRowsByIds(db, args, candidateIds);
+  const queryTokens = tokenize(args.normalizedQuery);
   const ranked = args.candidates
     .map((candidate) => {
       const row = rowsById.get(candidate.id);
@@ -1002,7 +1009,7 @@ async function rankCandidates(
             ...candidate,
             lexicalScore: Math.max(
               candidate.lexicalScore,
-              literalScore(row, args.normalizedQuery),
+              literalScore(row, args.normalizedQuery, queryTokens),
             ),
           },
           args.normalizedQuery,

--- a/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-profile.service.ts
@@ -13,7 +13,7 @@ import {
   memorySourceLinks,
   memorySources,
 } from "@vm0/db/schema/memory-substrate";
-import { and, desc, eq, ilike, inArray, or, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, inArray, or, sql, type SQL } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
 import { logger } from "../../lib/log";
@@ -22,6 +22,7 @@ import { nowDate } from "../external/time";
 import { settle } from "../utils";
 import {
   embedZeroMemoryText,
+  type MemoryEmbeddingResult,
   memoryEmbeddingSqlLiteral,
 } from "./zero-memory-embedding.service";
 import {
@@ -34,8 +35,8 @@ import {
 
 const log = logger("zero-memory-profile");
 const SEMANTIC_SCORE_THRESHOLD = 0.24;
-const LEXICAL_QUERY_MAX_CHARACTERS = 128;
-const LEXICAL_QUERY_MAX_TOKENS = 8;
+const EXACT_IDENTITY_LIMIT = 8;
+const EXACT_IDENTITY_ALIAS_SCORE = 0.88;
 
 interface MemoryScope {
   readonly orgId: string;
@@ -105,16 +106,9 @@ interface CandidateScore {
 type MemoryProfileRow = Omit<ZeroMemoryProfileItem, "sources">;
 type MemoryProfilePhase = "static" | "dynamic" | "search";
 
-interface LexicalCandidateRow {
-  readonly id: string;
-  readonly kind: MemoryKind;
-  readonly text: string;
-  readonly confidence: number;
-  readonly lastSeenAt: Date;
-  readonly displayName: string;
-  readonly aliasValue: string | null;
-  readonly relationshipType: string | null;
-  readonly relationshipSummary: string | null;
+interface ExactIdentityAlias {
+  readonly aliasType: "email" | "domain";
+  readonly aliasValue: string;
 }
 
 const relationshipEmailAliases = alias(
@@ -141,8 +135,6 @@ const relationshipLastInteractionProfiles = alias(
   memoryProfiles,
   "profile_relationship_last_interaction_profiles",
 );
-const lexicalAliases = alias(memoryEntityAliases, "profile_lexical_aliases");
-
 function countDimension(
   dimensionName: string,
   count: number,
@@ -219,7 +211,7 @@ function clamp01(value: number): number {
 function tokenize(value: string): readonly string[] {
   return value
     .toLowerCase()
-    .split(/[^\p{L}\p{N}@._-]+/u)
+    .split(/[^\p{L}\p{N}@._%+-]+/u)
     .map((token) => {
       return token.trim();
     })
@@ -245,57 +237,66 @@ function tokenMatchScore(values: readonly (string | null)[], query: string) {
   return matched / tokens.length;
 }
 
-function hasMoreThanCharacters(value: string, maxCharacters: number): boolean {
-  let characterCount = 0;
-  for (const _character of value) {
-    characterCount += 1;
-    if (characterCount > maxCharacters) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function isLexicalQueryEligible(normalizedQuery: string): boolean {
-  if (!normalizedQuery) {
-    return false;
-  }
-  if (hasMoreThanCharacters(normalizedQuery, LEXICAL_QUERY_MAX_CHARACTERS)) {
-    return false;
-  }
-  if (/\r|\n/.test(normalizedQuery)) {
-    return false;
-  }
-  const tokens = tokenize(normalizedQuery);
-  return tokens.length > 0 && tokens.length <= LEXICAL_QUERY_MAX_TOKENS;
-}
-
-function lexicalScore(row: LexicalCandidateRow, normalizedQuery: string) {
+function literalScore(row: MemoryProfileRow, normalizedQuery: string): number {
   if (containsQuery(row.text, normalizedQuery)) {
     return 1;
   }
-  if (containsQuery(row.displayName, normalizedQuery)) {
+  if (containsQuery(row.entity.displayName, normalizedQuery)) {
     return 0.92;
   }
-  if (containsQuery(row.aliasValue, normalizedQuery)) {
+  if (
+    containsQuery(row.entity.primaryEmail, normalizedQuery) ||
+    containsQuery(row.entity.domain, normalizedQuery)
+  ) {
     return 0.88;
   }
-  if (containsQuery(row.relationshipSummary, normalizedQuery)) {
+  if (containsQuery(row.relationship.summary, normalizedQuery)) {
     return 0.76;
   }
-  if (containsQuery(row.relationshipType, normalizedQuery)) {
+  if (containsQuery(row.relationship.relationshipType, normalizedQuery)) {
     return 0.68;
   }
   return tokenMatchScore(
     [
       row.text,
-      row.displayName,
-      row.aliasValue,
-      row.relationshipSummary,
-      row.relationshipType,
+      row.entity.displayName,
+      row.entity.primaryEmail,
+      row.entity.domain,
+      row.relationship.summary,
+      row.relationship.relationshipType,
     ],
     normalizedQuery,
   );
+}
+
+function exactIdentityAliases(query: string): readonly ExactIdentityAlias[] {
+  const emailPattern = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/u;
+  const domainPattern =
+    /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/u;
+  const aliases: ExactIdentityAlias[] = [];
+  const seen = new Set<string>();
+
+  for (const rawToken of query.split(/[^\p{L}\p{N}@._%+-]+/u)) {
+    const token = rawToken.replace(/\.+$/u, "");
+    const aliasType = emailPattern.test(token)
+      ? "email"
+      : domainPattern.test(token)
+        ? "domain"
+        : null;
+    if (!aliasType) {
+      continue;
+    }
+    const key = `${aliasType}:${token}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    aliases.push({ aliasType, aliasValue: token });
+    seen.add(key);
+    if (aliases.length === EXACT_IDENTITY_LIMIT) {
+      break;
+    }
+  }
+  return aliases;
 }
 
 function entityScore(row: MemoryProfileRow, normalizedQuery: string): number {
@@ -455,19 +456,6 @@ function baseMemoryFilters(args: {
     filters.push(inArray(memoryEntities.type, [...args.entityTypes]));
   }
   return filters;
-}
-
-function queryFilter(query: string): SQL {
-  const pattern = `%${query}%`;
-  return (
-    or(
-      ilike(memories.text, pattern),
-      ilike(memoryEntities.displayName, pattern),
-      ilike(lexicalAliases.aliasValue, pattern),
-      ilike(relationshipTypeProfiles.content, pattern),
-      ilike(relationshipSummaryProfiles.content, pattern),
-    ) ?? sql`false`
-  );
 }
 
 function sourceMetadataValue(
@@ -752,42 +740,31 @@ async function loadProfileWindow(
   });
 }
 
-async function loadLexicalCandidates(
+async function loadExactIdentityCandidates(
   db: ReadonlyDb,
-  args: SearchParams & { readonly normalizedQuery: string },
+  args: SearchParams & { readonly aliases: readonly ExactIdentityAlias[] },
 ): Promise<readonly CandidateScore[]> {
-  if (!args.normalizedQuery) {
+  const identityFilter = or(
+    ...args.aliases.map((identity) => {
+      return and(
+        eq(memoryEntityAliases.aliasType, identity.aliasType),
+        eq(memoryEntityAliases.aliasValue, identity.aliasValue),
+      );
+    }),
+  );
+  if (!identityFilter) {
     return [];
   }
   const rows = await db
     .select({
       id: memories.id,
-      kind: memories.kind,
-      text: memories.text,
-      confidence: memories.confidence,
-      lastSeenAt: memories.lastSeenAt,
-      displayName: memoryEntities.displayName,
-      aliasValue: lexicalAliases.aliasValue,
-      relationshipType: relationshipTypeProfiles.content,
-      relationshipSummary: relationshipSummaryProfiles.content,
     })
-    .from(memories)
-    .innerJoin(memoryEntities, eq(memoryEntities.id, memories.entityId))
-    .leftJoin(lexicalAliases, eq(lexicalAliases.entityId, memoryEntities.id))
-    .leftJoin(
-      relationshipTypeProfiles,
-      and(
-        eq(relationshipTypeProfiles.entityId, memoryEntities.id),
-        eq(relationshipTypeProfiles.section, "relationship_type"),
-      ),
+    .from(memoryEntityAliases)
+    .innerJoin(
+      memoryEntities,
+      eq(memoryEntities.id, memoryEntityAliases.entityId),
     )
-    .leftJoin(
-      relationshipSummaryProfiles,
-      and(
-        eq(relationshipSummaryProfiles.entityId, memoryEntities.id),
-        eq(relationshipSummaryProfiles.section, "relationship_summary"),
-      ),
-    )
+    .innerJoin(memories, eq(memories.entityId, memoryEntities.id))
     .where(
       and(
         ...baseMemoryFilters({
@@ -795,7 +772,9 @@ async function loadLexicalCandidates(
           kinds: args.kinds,
           entityTypes: args.entityTypes,
         }),
-        queryFilter(args.normalizedQuery),
+        eq(memoryEntityAliases.orgId, args.orgId),
+        eq(memoryEntityAliases.userId, args.userId),
+        identityFilter,
       ),
     )
     .orderBy(
@@ -807,19 +786,20 @@ async function loadLexicalCandidates(
 
   const candidates = new Map<string, CandidateScore>();
   for (const row of rows) {
-    const score = lexicalScore(row, args.normalizedQuery);
     mergeCandidate(candidates, {
       id: row.id,
       semanticScore: 0,
-      lexicalScore: score,
-      entityScore: 0,
+      lexicalScore: EXACT_IDENTITY_ALIAS_SCORE,
+      entityScore: 1,
       expansionScore: 0,
     });
   }
   return [...candidates.values()];
 }
 
-async function embedQuery(query: string) {
+async function embedQuery(
+  query: string,
+): Promise<MemoryEmbeddingResult | null> {
   const result = await settle(embedZeroMemoryText(query));
   if (result.ok) {
     return result.value;
@@ -828,15 +808,11 @@ async function embedQuery(query: string) {
   return null;
 }
 
-async function loadSemanticCandidates(
-  db: ReadonlyDb,
+async function loadSemanticQueryEmbedding(
   args: SearchParams & { readonly normalizedQuery: string },
-): Promise<readonly CandidateScore[]> {
-  if (!args.normalizedQuery) {
-    return [];
-  }
+): Promise<MemoryEmbeddingResult | null> {
   let embeddingResult = "empty";
-  const embedded = await measureZeroMemoryTiming(
+  return await measureZeroMemoryTiming(
     args.timing,
     "profile_search_semantic_embedding",
     async () => {
@@ -850,15 +826,18 @@ async function loadSemanticCandidates(
       };
     },
   );
-  if (!embedded) {
-    return [];
-  }
+}
+
+async function loadSemanticCandidates(
+  db: ReadonlyDb,
+  args: SearchParams & { readonly embedded: MemoryEmbeddingResult },
+): Promise<readonly CandidateScore[]> {
   return await measureMemoryList(
     args.timing,
     "profile_search_semantic_query",
     "memory_profile_semantic_candidate_count_bucket",
     async () => {
-      const queryVector = sql`${memoryEmbeddingSqlLiteral(embedded.embedding)}::vector`;
+      const queryVector = sql`${memoryEmbeddingSqlLiteral(args.embedded.embedding)}::vector`;
       const distance = sql<number>`${memorySearchEntries.embedding} <=> ${queryVector}`;
       const rows = await db
         .select({
@@ -873,7 +852,7 @@ async function loadSemanticCandidates(
             eq(memorySearchEntries.orgId, args.orgId),
             eq(memorySearchEntries.userId, args.userId),
             eq(memorySearchEntries.status, "active"),
-            eq(memorySearchEntries.embeddingModel, embedded.model),
+            eq(memorySearchEntries.embeddingModel, args.embedded.model),
             eq(memorySearchEntries.entryKind, "memory_text"),
             ...baseMemoryFilters({
               scope: args,
@@ -1017,7 +996,17 @@ async function rankCandidates(
       }
       return {
         row,
-        score: compositeScore(row, candidate, args.normalizedQuery),
+        score: compositeScore(
+          row,
+          {
+            ...candidate,
+            lexicalScore: Math.max(
+              candidate.lexicalScore,
+              literalScore(row, args.normalizedQuery),
+            ),
+          },
+          args.normalizedQuery,
+        ),
       };
     })
     .filter(
@@ -1062,32 +1051,39 @@ async function loadSearchResults(
   }
 
   const candidates = new Map<string, CandidateScore>();
-  const lexicalQueryEligible = isLexicalQueryEligible(normalizedQuery);
-  const lexicalCandidates = await measureMemoryList(
-    args.timing,
-    "profile_search_lexical",
-    "memory_profile_lexical_candidate_count_bucket",
-    async () => {
-      if (!lexicalQueryEligible) {
-        return [];
-      }
-      return await loadLexicalCandidates(db, {
-        ...args,
-        normalizedQuery,
-      });
-    },
-    {
-      memory_profile_lexical_query_eligible: String(lexicalQueryEligible),
-    },
-  );
-  for (const candidate of lexicalCandidates) {
+  const aliases = exactIdentityAliases(normalizedQuery);
+  const [exactIdentityCandidates, embedded] = await Promise.all([
+    measureMemoryList(
+      args.timing,
+      "profile_search_exact_identity",
+      "memory_profile_exact_identity_candidate_count_bucket",
+      async () => {
+        return await loadExactIdentityCandidates(db, {
+          ...args,
+          aliases,
+        });
+      },
+      {
+        memory_profile_exact_identity_query_eligible: String(
+          aliases.length > 0,
+        ),
+      },
+    ),
+    loadSemanticQueryEmbedding({
+      ...args,
+      normalizedQuery,
+    }),
+  ]);
+  for (const candidate of exactIdentityCandidates) {
     mergeCandidate(candidates, candidate);
   }
-  for (const candidate of await loadSemanticCandidates(db, {
-    ...args,
-    normalizedQuery,
-  })) {
-    mergeCandidate(candidates, candidate);
+  if (embedded) {
+    for (const candidate of await loadSemanticCandidates(db, {
+      ...args,
+      embedded,
+    })) {
+      mergeCandidate(candidates, candidate);
+    }
   }
 
   const seedRows = await measureMemoryList(

--- a/turbo/apps/api/src/signals/services/zero-memory-timing.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-memory-timing.service.ts
@@ -8,7 +8,7 @@ export type ZeroMemoryTimingStage =
   | "profile_static"
   | "profile_dynamic"
   | "profile_search"
-  | "profile_search_lexical"
+  | "profile_search_exact_identity"
   | "profile_search_semantic_embedding"
   | "profile_search_semantic_query"
   | "profile_search_graph_expansion"

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -537,8 +537,8 @@ const ZERO_MEMORY_TIMING_ACTION_TYPES = {
   profile_static: "api_dispatch_pre_create_zero_memory_profile_static",
   profile_dynamic: "api_dispatch_pre_create_zero_memory_profile_dynamic",
   profile_search: "api_dispatch_pre_create_zero_memory_profile_search",
-  profile_search_lexical:
-    "api_dispatch_pre_create_zero_memory_profile_search_lexical",
+  profile_search_exact_identity:
+    "api_dispatch_pre_create_zero_memory_profile_search_exact_identity",
   profile_search_semantic_embedding:
     "api_dispatch_pre_create_zero_memory_profile_search_semantic_embedding",
   profile_search_semantic_query:


### PR DESCRIPTION
## Summary

- replace broad runtime profile `%query%` substring scans with scoped email/domain alias equality lookup
- start query embedding alongside exact identity lookup while keeping semantic SQL serialized after the exact database operation
- preserve literal ranking signals on the bounded hydrated candidate set and retain exact identity recall when embedding fails
- rename lexical timing attribution to exact-identity attribution and update privacy-safe route coverage
- construct new retrieval cases through public lifecycle/Gmail APIs and the real embedding HTTP boundary

## Behavior changes

- natural-language retrieval is semantic-first
- canonical email and standalone domain tokens can add exact candidates through the existing alias B-tree
- generic display-name, summary/type, and literal-text matches no longer generate independent candidates when semantic embedding fails
- runtime injection, public recall/context, and injection preview share the new internal retrieval behavior; public response contracts are unchanged

## Excluded

- vector-index or HNSW changes
- trigram/full-text search
- provider-specific identity grammars
- cross-request embedding cache, retries, hedges, or timeouts
- document retrieval restoration

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-memory-recall.test.ts src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4`
- `pnpm -F api check-types`
- `pnpm -F api lint`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip`

Closes #21037

Parent context: #20929
