### PR TITLE
test(api): stabilize billing usage aggregation integration test

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/billing-usage-media.bdd.test.ts
@@ -474,8 +474,8 @@ describe("BILL-01: billing status and Stripe-backed actions through public API",
   });
 });
 
-describe("BILL-02: usage, insights, attribution, model stats, and usage cron reads", () => {
-  it("chains empty scoped usage reads and cron aggregation through visible APIs", async () => {
+describe("BILL-02: usage, insights, attribution, and model stats reads", () => {
+  it("chains empty scoped usage, insights, rankings, and attribution through visible APIs", async () => {
     const { api, admin, member } = testActors();
     await completeVisibleOnboarding(api, admin);
 
@@ -540,16 +540,6 @@ describe("BILL-02: usage, insights, attribution, model stats, and usage cron rea
     const modelRankings = await api.readModelRankings();
     expect(modelRankings.body.period).toBe("week");
     expect(Array.isArray(modelRankings.body.rows)).toBeTruthy();
-
-    const processed = await api.processUsageEvents();
-    expect(processed.body.success).toBeTruthy();
-    expect(processed.body.processed).toBeGreaterThanOrEqual(0);
-
-    const aggregatedUsage = await api.aggregateUsage();
-    expect(aggregatedUsage.body.aggregated).toBeGreaterThanOrEqual(0);
-
-    const aggregatedInsights = await api.aggregateInsights();
-    expect(aggregatedInsights.body.users).toBeGreaterThanOrEqual(0);
 
     context.mocks.clerk.users.updateUser.mockResolvedValue({});
     const attribution = await api.recordSignupAttribution(admin);

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-billing-media.ts
@@ -2,11 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type StripeSDK from "stripe";
 import { audioTranscriptionsV1Contract } from "@vm0/api-contracts/contracts/audio-transcriptions-v1";
-import {
-  cronAggregateInsightsContract,
-  cronAggregateUsageContract,
-  cronProcessUsageEventsContract,
-} from "@vm0/api-contracts/contracts/cron";
+import { cronProcessUsageEventsContract } from "@vm0/api-contracts/contracts/cron";
 import { onboardingSetupContract } from "@vm0/api-contracts/contracts/onboarding";
 import { usageContract } from "@vm0/api-contracts/contracts/usage";
 import { zeroAttributionContract } from "@vm0/api-contracts/contracts/zero-attribution";
@@ -558,19 +554,9 @@ export function createBillingMediaApi(context: TestContext) {
       );
     },
 
-    async aggregateUsage() {
-      const client = setupApp({ context })(cronAggregateUsageContract);
-      return await accept(client.aggregate({ headers: cronHeaders() }), [200]);
-    },
-
     async processUsageEvents() {
       const client = setupApp({ context })(cronProcessUsageEventsContract);
       return await accept(client.process({ headers: cronHeaders() }), [200]);
-    },
-
-    async aggregateInsights() {
-      const client = setupApp({ context })(cronAggregateInsightsContract);
-      return await accept(client.aggregate({ headers: cronHeaders() }), [200]);
     },
 
     async recordSignupAttribution(actor: ApiTestUser) {

--- a/turbo/apps/api/src/signals/routes/__tests__/usage.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/usage.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 
+import { cronAggregateUsageContract } from "@vm0/api-contracts/contracts/cron";
 import { usageContract } from "@vm0/api-contracts/contracts/usage";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -16,6 +17,11 @@ const api = createRunsAutomationsApi(context);
 const webhooks = createWebhookCallbackApi(context);
 const mocks = createZeroRouteMocks(context);
 
+/*
+ * This file owns valid aggregate-usage cron coverage. The fixed clock keeps
+ * its previous-day global sweep outside wall-clock windows used by parallel
+ * test files, while unique actors keep user-visible assertions isolated.
+ */
 const FIXED_NOW_ISO = "2026-05-12T12:00:00.000Z";
 
 interface UsageActor {
@@ -35,6 +41,10 @@ function authHeaders() {
 
 function apiClient() {
   return setupApp({ context })(usageContract);
+}
+
+function aggregateUsageClient() {
+  return setupApp({ context })(cronAggregateUsageContract);
 }
 
 async function entitledUsageActor(): Promise<UsageActor> {
@@ -401,5 +411,33 @@ describe("GET /api/usage", () => {
       total_runs: 1,
       total_run_time_ms: 5000,
     });
+  });
+});
+
+describe("GET /api/cron/aggregate-usage", () => {
+  beforeEach(() => {
+    mockNow(new Date(FIXED_NOW_ISO));
+  });
+
+  afterEach(() => {
+    clearMockNow();
+  });
+
+  it("aggregates the previous day's completed runs", async () => {
+    const fixture = await entitledUsageActor();
+    await runFinishedRun(fixture, {
+      createdAt: new Date("2026-05-11T10:00:00.000Z"),
+      durationMs: 5000,
+    });
+
+    const response = await accept(
+      aggregateUsageClient().aggregate({
+        headers: { authorization: "Bearer test-cron-secret" },
+      }),
+      [200],
+    );
+
+    expect(response.body.date).toBe("2026-05-11");
+    expect(response.body.aggregated).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- keep BILL-02 focused on actor-scoped usage, insight, ranking, and attribution reads
- move valid aggregate-usage cron coverage to the focused usage integration suite with an owned previous-day completed run
- remove the unused aggregate-usage and aggregate-insights billing-media test helpers

## Explicit exclusions

- no production behavior, API contract, schema, migration, or persisted-data shape changes
- no timeout increases, sleeps, test skips, direct database fixtures, or internal service mocks
- aggregate-insights and process-usage-events retain their existing focused integration owners

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-usage-media.bdd.test.ts -t "chains empty scoped usage, insights, rankings, and attribution through visible APIs" --reporter=verbose` (three serial passes)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/billing-usage-media.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/usage.test.ts src/signals/routes/__tests__/cron-aggregate-insights.test.ts`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` on a migrated isolated PostgreSQL database (595 files passed, 1 skipped; 7,315 tests passed, 1 skipped)
- `pnpm knip`

Closes #21013
