### PR TITLE
fix: remove ios artifact preview status bar gradient

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -348,10 +348,7 @@
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta
-      name="apple-mobile-web-app-status-bar-style"
-      content="black-translucent"
-    />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Zero" />
     <meta
       name="description"

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -29,6 +29,13 @@ function readGlobalCss(): string {
 }
 
 describe("platform entrypoint safe area behavior", () => {
+  it("keeps iOS system chrome opaque above fullscreen surfaces", () => {
+    expect(indexHtml).toMatch(
+      /<meta\s+name="apple-mobile-web-app-status-bar-style"\s+content="default"\s*\/>/,
+    );
+    expect(indexHtml).not.toContain('content="black-translucent"');
+  });
+
   it("keeps supported viewport hints without unsupported keyboard directives", () => {
     const viewportDirectives = getViewportDirectives();
 


### PR DESCRIPTION
## Summary

- switch the iOS standalone PWA status bar from `black-translucent` to `default`, preventing iOS from drawing its system contrast gradient above fullscreen artifact previews
- keep the existing viewport and four-sided safe-area padding unchanged so controls and content remain outside notches and system gesture regions
- add an entrypoint regression test that rejects `black-translucent` and requires the opaque status-bar contract

## Verification

- `pnpm exec prettier --check apps/platform/index.html apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts`
- `pnpm -F @vm0/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts --maxWorkers=1` (5 passed)
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`

Local dev server was not started per the vm0 PR verification preference. Exact standalone status-bar rendering requires the PR preview on an iOS device.
