### PR TITLE
refactor(mitm-addon): derive metadata key diagnostic path

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/cli.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/cli.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import sys
 
 from flow_metadata_linter.api import repository_metadata_key_violations
+from flow_metadata_linter.paths import ADDON_ROOT, METADATA_KEYS_FILE
 from flow_metadata_linter.registry import duplicate_registered_metadata_keys
 
 
 def main() -> int:
+    metadata_keys_location = METADATA_KEYS_FILE.relative_to(ADDON_ROOT)
     messages: list[str] = []
     for value, names in duplicate_registered_metadata_keys().items():
         messages.append(
-            f"src/flow_metadata_keys.py: duplicate metadata key {value!r}: {', '.join(names)}"
+            f"{metadata_keys_location}: duplicate metadata key {value!r}: {', '.join(names)}"
         )
     messages.extend(repository_metadata_key_violations())
     if not messages:

--- a/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
+++ b/crates/runner/mitm-addon/tests/test_flow_metadata_key_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -41,6 +42,31 @@ def _violations_expected_fixture_name() -> str:
     return "violations.expected.py310.txt"
 
 
+def _run_check_script(
+    check_script: Path, addon_root: Path, executable_dir: Path
+) -> subprocess.CompletedProcess[str]:
+    python3 = executable_dir / "python3"
+    python3.symlink_to(Path(sys.executable).resolve())
+    env = {
+        **os.environ,
+        "LC_ALL": "C",
+        "PATH": f"{executable_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "PYTHONCOERCECLOCALE": "0",
+        "PYTHONUTF8": "0",
+    }
+
+    # Trusted workspace tooling with constant argv; no user-controlled shell input.
+    return subprocess.run(  # noqa: S603
+        [str(check_script)],
+        cwd=addon_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=_CLI_TIMEOUT_SECONDS,
+    )
+
+
 def test_registered_flow_metadata_keys_are_unique():
     assert flow_metadata_key_linter.duplicate_registered_metadata_keys() == {}
 
@@ -50,29 +76,48 @@ def test_registered_flow_metadata_keys_use_registry_constants():
 
 
 def test_check_flow_metadata_keys_cli_passes_current_repository(tmp_path):
-    python3 = tmp_path / "python3"
-    python3.symlink_to(Path(sys.executable).resolve())
-    env = {
-        **os.environ,
-        "LC_ALL": "C",
-        "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
-        "PYTHONCOERCECLOCALE": "0",
-        "PYTHONUTF8": "0",
-    }
-
-    # Trusted workspace tooling with constant argv; no user-controlled shell input.
-    result = subprocess.run(  # noqa: S603
-        [str(_CHECK_SCRIPT)],
-        cwd=_ADDON_ROOT,
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=_CLI_TIMEOUT_SECONDS,
-    )
+    result = _run_check_script(_CHECK_SCRIPT, _ADDON_ROOT, tmp_path)
 
     assert result.returncode == 0
     assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_check_flow_metadata_keys_cli_reports_configured_registry_path(tmp_path):
+    addon_root = tmp_path / "mitm-addon"
+    scripts_root = addon_root / "scripts"
+    scripts_root.mkdir(parents=True)
+    check_script = scripts_root / _CHECK_SCRIPT.name
+    shutil.copy2(_CHECK_SCRIPT, check_script)
+    shutil.copy2(
+        _ADDON_ROOT / "scripts" / "flow_metadata_key_linter.py",
+        scripts_root / "flow_metadata_key_linter.py",
+    )
+    shutil.copytree(
+        _ADDON_ROOT / "scripts" / "flow_metadata_linter",
+        scripts_root / "flow_metadata_linter",
+        ignore=shutil.ignore_patterns("__pycache__"),
+    )
+
+    paths_file = scripts_root / "flow_metadata_linter" / "paths.py"
+    paths_file.write_text(
+        paths_file.read_text(encoding="utf-8").replace(
+            '"flow_metadata_keys.py"', '"renamed_flow_metadata_keys.py"'
+        ),
+        encoding="utf-8",
+    )
+    src_root = addon_root / "src"
+    src_root.mkdir()
+    (src_root / "renamed_flow_metadata_keys.py").write_text(
+        'FIRST = "duplicate"\nSECOND = "duplicate"\n', encoding="utf-8"
+    )
+
+    result = _run_check_script(check_script, addon_root, tmp_path)
+
+    assert result.returncode == 1
+    assert result.stdout == (
+        "src/renamed_flow_metadata_keys.py: duplicate metadata key 'duplicate': FIRST, SECOND\n"
+    )
     assert result.stderr == ""
 
 


### PR DESCRIPTION
## Summary

- derive duplicate flow metadata key diagnostics from the configured registry path
- preserve repository-relative output instead of exposing checkout-specific absolute paths
- cover a renamed registry with duplicate values through the real CLI entry point and temporary filesystem

## Scope

This changes only the flow metadata linter CLI and its integration contract test. It does not change
registry loading, duplicate detection semantics, runtime addon behavior, dependencies, or ordinary
metadata-key violation diagnostics.

Closes #20997

## Validation

- `python3 -m ruff format --check .`
- `python3 -m ruff check .`
- `python3 -m basedpyright -p .`
- `python3 -m pytest tests/test_flow_metadata_key_contract.py -q` (9 passed)
- `python3 -m pytest tests/ -v` (3,765 passed)
- `python3 scripts/check-flow-metadata-keys.py`
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (592 files, 7,290 passed; 1 benchmark skipped)
- `cd turbo && pnpm knip`
- pre-commit and commit-message hooks
