### PR TITLE
docs(mitm-addon): document upstream admission contract

### DIFF
--- a/crates/runner/mitm-addon/src/upstream_admission.py
+++ b/crates/runner/mitm-addon/src/upstream_admission.py
@@ -691,6 +691,29 @@ def ensure_bound_destination(
     kind: upstream_destination_binding.BindingKind,
     api_url: str,
 ) -> bool:
+    """Admit the flow's trusted authority for one privileged binding kind.
+
+    ``flow`` must already carry validated trusted-authority metadata and the
+    request, client, and server connection state to bind. ``kind`` selects the
+    privileged purpose, while ``api_url`` identifies the platform API authority
+    where ``connector_auth`` requires the gated test-endpoint bypass before
+    either binding or reusing a destination.
+
+    A direct server binding may be reused, extended with ``kind``, or refreshed
+    only while its authority and current destination remain valid. Otherwise an
+    unconnected server may be retargeted and bound to the normalized authority;
+    a connected server requires current verified upstream TLS and authoritative
+    endpoint evidence rather than fresh DNS. Client-associated matches are not
+    durable proof for the current server connection, so they still pass through
+    the direct binding path.
+
+    Return ``True`` only when the current server connection is directly admitted
+    for the flow authority, port, and requested kind. ``False`` does not create a
+    response and must not be treated as admission: request-header callers may use
+    the attempt for best-effort prebinding or defer the decision, but terminal
+    callers must fail closed before API auto-allow or ordinary connector
+    credential injection.
+    """
     if _flow_requires_platform_connector_auth_bypass(
         flow,
         kind=kind,


### PR DESCRIPTION
## Summary

- document the trusted-authority and connection-state prerequisites for `ensure_bound_destination`
- explain when direct bindings may be reused, extended, refreshed, or created
- clarify that `False` creates no response and terminal callers must fail closed

## Scope

- documentation only; runtime behavior is unchanged
- no schema, migration, persisted-data, API, queue, or runner protocol changes

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/python -m py_compile src/upstream_admission.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check src/upstream_admission.py`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check src/upstream_admission.py`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright`
- `cd crates/runner/mitm-addon && .venv/bin/pytest -q` (3,764 passed)
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && DATABASE_URL=<isolated test database> pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,290 passed, 1 skipped)
- `cd turbo && pnpm knip`

Closes #20998
