### PR TITLE
fix(api): preserve run agent identity across shared versions

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-runs-automations.ts
@@ -6,7 +6,10 @@ import {
   apiKeysByIdContract,
   apiKeysContract,
 } from "@vm0/api-contracts/contracts/api-keys";
-import { composesMainContract } from "@vm0/api-contracts/contracts/composes";
+import {
+  composesMainContract,
+  type ZeroCapability,
+} from "@vm0/api-contracts/contracts/composes";
 import { onboardingSetupContract } from "@vm0/api-contracts/contracts/onboarding";
 import { runsMainContract } from "@vm0/api-contracts/contracts/runs";
 import { webhookStripeContract } from "@vm0/api-contracts/contracts/webhooks";
@@ -50,7 +53,10 @@ import { setupAppWithRoutes } from "../../../../__tests__/test-app";
 import { accept, type TestContext } from "../../../../__tests__/test-context";
 import { mockEnv, mockOptionalEnv } from "../../../../lib/env";
 import { now } from "../../../../lib/time";
-import { generateSandboxToken } from "../../../auth/tokens";
+import {
+  generateSandboxToken,
+  signSandboxJwtForTests,
+} from "../../../auth/tokens";
 import { mockStripeClient } from "../../../external/stripe-client";
 import { agentComposesReadRoutes } from "../../agent-composes-read";
 import { agentComposesRoutes } from "../../agent-composes";
@@ -521,6 +527,27 @@ export function createRunsAutomationsApi(context: TestContext) {
         throw new Error("Sandbox run tokens require an org-scoped actor");
       }
       return generateSandboxToken(actor.userId, runId, actor.orgId);
+    },
+
+    /** Mints a route-test token without changing production capability issuance. */
+    zeroTokenForRunWithCapabilities(
+      actor: ApiTestUser,
+      runId: string,
+      capabilities: readonly ZeroCapability[],
+    ): string {
+      if (!actor.orgId) {
+        throw new Error("Zero run tokens require an org-scoped actor");
+      }
+      const seconds = Math.floor(now() / 1000);
+      return signSandboxJwtForTests({
+        scope: "zero",
+        userId: actor.userId,
+        orgId: actor.orgId,
+        runId,
+        capabilities: [...capabilities],
+        iat: seconds,
+        exp: seconds + 3600,
+      });
     },
 
     async createCompose(

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -46,6 +46,7 @@ import { createComputerUseBddApi } from "./helpers/api-bdd-computer-use";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
 import { createFirewallApi } from "./helpers/api-bdd-firewall";
 import { createMiscRoutesApi } from "./helpers/api-bdd-misc";
+import { createRunReadsApi } from "./helpers/api-bdd-run-reads";
 import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
 import { storageTextFile } from "./helpers/api-bdd-storage-files";
 import { createStoragesBddApi } from "./helpers/api-bdd-storages";
@@ -5979,6 +5980,164 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     expect(failedRefreshNotification.status).toBe(500);
 
     await api.requestCancelRun(actor, snapshotRun.runId, [200]);
+    const drained = await api.readRunQueue(actor);
+    expect(drained.body.concurrency.active).toBe(0);
+  });
+
+  it("preserves session agent identity when compose versions are shared", async () => {
+    const bdd = createBddApi(context);
+    const authOrg = createAuthOrgAgentsBddApi(context);
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const reads = createRunReadsApi(context);
+    const foreignActor = bdd.user();
+    const actor = bdd.user();
+
+    bdd.acceptAgentStorageWrites();
+    api.acceptStorageDownloads();
+    api.acceptTelemetryIngest();
+    const runnerGroup = api.configureRunnerGroup();
+
+    const foreignStatus = await bdd.requestReadOnboardingStatus(
+      foreignActor,
+      [200],
+    );
+    if (foreignStatus.status !== 200) {
+      throw new Error("Expected foreign onboarding status");
+    }
+    const foreignAgentId = foreignStatus.body.defaultAgentId;
+    if (!foreignAgentId) {
+      throw new Error("Expected foreign default agent bootstrap");
+    }
+
+    const currentStatus = await bdd.requestReadOnboardingStatus(actor, [200]);
+    if (currentStatus.status !== 200) {
+      throw new Error("Expected current onboarding status");
+    }
+    const agentId = currentStatus.body.defaultAgentId;
+    if (!agentId) {
+      throw new Error("Expected current default agent bootstrap");
+    }
+    expect(agentId).not.toBe(foreignAgentId);
+
+    const foreignCompose = await authOrg.readComposeById(
+      foreignActor,
+      foreignAgentId,
+    );
+    const currentCompose = await authOrg.readComposeById(actor, agentId);
+    expect(foreignCompose.headVersionId).toStrictEqual(expect.any(String));
+    expect(currentCompose.headVersionId).toBe(foreignCompose.headVersionId);
+
+    await bdd.updateAgentMetadata(foreignActor, foreignAgentId, {
+      displayName: "Foreign shared agent",
+    });
+    await bdd.updateAgentMetadata(actor, agentId, {
+      displayName: "Current shared agent",
+    });
+
+    await api.grantProEntitlement(actor);
+    await api.ensureOrgModelProvider(actor);
+    await fw.seedTestConnector(actor, {
+      connectorName: "slack",
+      authMethod: "oauth",
+      accessToken: "xoxb-bdd-shared-version",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["slack"]);
+
+    await api.applyUserPermissionGrant(foreignActor, {
+      agentId: foreignAgentId,
+      connectorRef: "slack",
+      permission: "files:write",
+      action: "allow",
+    });
+    await api.applyUserPermissionGrant(actor, {
+      agentId,
+      connectorRef: "slack",
+      permission: "chat:write",
+      action: "allow",
+    });
+
+    await api.heartbeatRunner(runnerGroup);
+    const parent = await api.createRun(actor, {
+      agentId,
+      prompt: "shared version parent run",
+      modelProvider: "anthropic-api-key",
+    });
+    const claim = await api.claimRunnerJob(parent.runId);
+    const claimedPolicy = claim.networkPolicies?.slack;
+    if (!claimedPolicy) {
+      throw new Error("Expected shared-version Slack policy");
+    }
+    expect(claimedPolicy.allow).toContain("chat:write");
+    expect(claimedPolicy.deny).not.toContain("chat:write");
+    expect(claimedPolicy.deny).toContain("files:write");
+    expect(claimedPolicy.allow).not.toContain("files:write");
+
+    const queue = await api.readRunQueue(actor);
+    expect(queue.body.runningTasks).toContainEqual(
+      expect.objectContaining({
+        runId: parent.runId,
+        agentDisplayName: "Current shared agent",
+      }),
+    );
+    expect(queue.body.runningTasks).not.toContainEqual(
+      expect.objectContaining({
+        agentDisplayName: "Foreign shared agent",
+      }),
+    );
+
+    context.mocks.ably.publish.mockClear();
+    await api.applyUserPermissionGrant(actor, {
+      agentId,
+      connectorRef: "slack",
+      permission: "files:write",
+      action: "allow",
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "network-policy-refresh",
+      { runId: parent.runId, connectorRef: "slack" },
+    );
+
+    const refreshed = await api.refreshRunnerNetworkPolicy(
+      parent.runId,
+      "slack",
+    );
+    expect(refreshed.networkPolicy.allow).toContain("chat:write");
+    expect(refreshed.networkPolicy.allow).toContain("files:write");
+    expect(refreshed.networkPolicy.deny).not.toContain("files:write");
+
+    const parentToken = api.zeroTokenForRunWithCapabilities(
+      actor,
+      parent.runId,
+      ["agent-run:write"],
+    );
+    const child = await api.requestCreateRunAs(
+      `Bearer ${parentToken}`,
+      {
+        agentId,
+        prompt: "shared version child run",
+        modelProvider: "anthropic-api-key",
+      },
+      [201],
+    );
+    if (child.status !== 201) {
+      throw new Error("Expected shared-version child run creation");
+    }
+    const childLog = await reads.requestReadLogById(
+      actor,
+      child.body.runId,
+      [200],
+    );
+    expect(childLog.body).toMatchObject({
+      id: child.body.runId,
+      agentId,
+      displayName: "Current shared agent",
+      triggerSource: "agent",
+      triggerAgentName: "Current shared agent",
+    });
+
+    await api.requestCancelRun(actor, child.body.runId, [200]);
+    await api.requestCancelRun(actor, parent.runId, [200]);
     const drained = await api.readRunQueue(actor);
     expect(drained.body.concurrency.active).toBe(0);
   });

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -22,7 +22,7 @@ import {
 } from "@vm0/connectors/firewall-metadata/runner-runtime";
 import { runnerRealtimeTokenContract } from "@vm0/api-contracts/contracts/realtime";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { blobs } from "@vm0/db/schema/blob";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
@@ -585,6 +585,7 @@ interface ClaimedRun {
   readonly id: string;
   readonly userId: string;
   readonly orgId: string;
+  readonly agentId: string;
   readonly prompt: string;
   readonly appendSystemPrompt: string | null;
   readonly agentComposeVersionId: string | null;
@@ -615,13 +616,10 @@ async function getActiveRunNetworkPolicyScope(
       runId: agentRuns.id,
       userId: agentRuns.userId,
       orgId: agentRuns.orgId,
-      agentId: agentComposeVersions.composeId,
+      agentId: agentSessions.agentComposeId,
     })
     .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
-    )
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
     .where(and(eq(agentRuns.id, runId), eq(agentRuns.status, "running")))
     .limit(1);
   signal.throwIfAborted();
@@ -657,6 +655,7 @@ async function getClaimableJob(
         id: agentRuns.id,
         userId: agentRuns.userId,
         orgId: agentRuns.orgId,
+        agentId: agentSessions.agentComposeId,
         prompt: agentRuns.prompt,
         appendSystemPrompt: agentRuns.appendSystemPrompt,
         agentComposeVersionId: agentRuns.agentComposeVersionId,
@@ -666,6 +665,7 @@ async function getClaimableJob(
     })
     .from(runnerJobQueue)
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
     .where(
       and(
         eq(runnerJobQueue.runId, runId),
@@ -1010,22 +1010,6 @@ async function secretValuesForRunner(
   });
 }
 
-async function agentIdForRun(
-  db: Pick<Db, "select">,
-  run: Pick<ClaimedRun, "agentComposeVersionId">,
-): Promise<string | undefined> {
-  if (!run.agentComposeVersionId) {
-    return undefined;
-  }
-
-  const [version] = await db
-    .select({ agentId: agentComposeVersions.composeId })
-    .from(agentComposeVersions)
-    .where(eq(agentComposeVersions.id, run.agentComposeVersionId))
-    .limit(1);
-  return version?.agentId ?? undefined;
-}
-
 async function refreshClaimNetworkPolicies(args: {
   readonly db: Db;
   readonly run: ClaimedRun;
@@ -1043,20 +1027,12 @@ async function refreshClaimNetworkPolicies(args: {
     };
   }
 
-  const agentId = await agentIdForRun(args.db, args.run);
-  if (!agentId) {
-    return {
-      networkPolicies: args.storedContext.networkPolicies,
-      networkPolicyRefreshes: undefined,
-    };
-  }
-
   const refreshes = await resolveActiveNetworkPolicyRefreshes(
     args.db,
     {
       orgId: args.run.orgId,
       userId: args.run.userId,
-      agentId,
+      agentId: args.run.agentId,
     },
     connectorRefs,
   );

--- a/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-aggregate-insights.service.ts
@@ -3,8 +3,8 @@ import {
   loadFirewallPermissionIndex,
   type FirewallServerMetadataConnectorType,
 } from "@vm0/connectors/firewall-metadata/server";
-import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { insightsDaily } from "@vm0/db/schema/insights-daily";
 import { orgMembersCache } from "@vm0/db/schema/org-members-cache";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
@@ -901,11 +901,8 @@ async function queryCompletedRunCounts(
       runs: sql<number>`COUNT(DISTINCT ${agentRuns.id})::int`.as("runs"),
     })
     .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .innerJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
     .where(
       and(
         inArray(agentRuns.orgId, orgIds),
@@ -967,11 +964,8 @@ async function queryUsageEventCreditRows(
       eq(usageAllowanceAllocations.usageEventId, usageEvent.id),
     )
     .leftJoin(agentRuns, eq(usageEvent.runId, agentRuns.id))
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .leftJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .leftJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
     .where(
       and(
         inArray(usageEvent.orgId, orgIds),
@@ -1018,14 +1012,8 @@ async function queryNetworkRunAgentRows(
             ),
         })
         .from(agentRuns)
-        .innerJoin(
-          agentComposeVersions,
-          eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-        )
-        .innerJoin(
-          zeroAgents,
-          eq(agentComposeVersions.composeId, zeroAgents.id),
-        )
+        .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+        .innerJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
         .where(
           and(
             inArray(agentRuns.orgId, orgIds),

--- a/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
+++ b/turbo/apps/api/src/signals/services/cron-cleanup-sandboxes.service.ts
@@ -1,10 +1,8 @@
 import { command } from "ccstate";
-import {
-  agentComposeVersions,
-  agentComposes,
-} from "@vm0/db/schema/agent-compose";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRunCustomConnectorAuthRefs } from "@vm0/db/schema/agent-run-custom-connector-auth-ref";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { exportJobs } from "@vm0/db/schema/export-job";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { and, eq, inArray, isNotNull, lt, sql } from "drizzle-orm";
@@ -530,13 +528,10 @@ export const cleanupSandboxes$ = command(
         composeName: agentComposes.name,
       })
       .from(agentRuns)
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
+      .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
       .leftJoin(
         agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
+        eq(agentSessions.agentComposeId, agentComposes.id),
       )
       .where(inArray(agentRuns.status, ["pending", "running"]));
     signal.throwIfAborted();

--- a/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
+++ b/turbo/apps/api/src/signals/services/diagnostic-bundle.service.ts
@@ -3,11 +3,9 @@ import { randomUUID } from "node:crypto";
 import archiver from "archiver";
 import { eq, or, sql } from "drizzle-orm";
 import type { AxiomNetworkEvent } from "@vm0/api-contracts/contracts/runs";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "@vm0/db/schema/agent-compose";
+import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { computed, type Computed } from "ccstate";
 
@@ -64,9 +62,7 @@ interface RunMeta {
   readonly result: unknown;
 }
 
-interface DiagnosticRunRecord extends RunMeta {
-  readonly agentComposeVersionId: string | null;
-}
+type DiagnosticRunRecord = RunMeta;
 
 interface AgentMeta {
   readonly displayName?: string | null;
@@ -172,7 +168,7 @@ export function submitDiagnosticBundle(
 
     const [connectors, agentConfig, sessionRuns] = await Promise.all([
       get(collectConnectors(orgId, userId)),
-      collectAgentConfig(db, run.agentComposeVersionId),
+      collectAgentConfig(db, runId),
       collectSessionRuns(db, runId, agentSessionId),
     ]);
 
@@ -467,12 +463,8 @@ function uploadDiagnosticZip(params: {
 
 async function collectAgentConfig(
   db: ServiceDb,
-  agentComposeVersionId: string | null,
+  runId: string,
 ): Promise<Record<string, unknown>> {
-  if (!agentComposeVersionId) {
-    return {};
-  }
-
   const [agent] = await db
     .select({
       displayName: zeroAgents.displayName,
@@ -480,13 +472,14 @@ async function collectAgentConfig(
       sound: zeroAgents.sound,
       composeContent: agentComposeVersions.content,
     })
-    .from(agentComposeVersions)
-    .innerJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
+    .from(agentRuns)
+    .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .innerJoin(zeroAgents, eq(zeroAgents.id, agentSessions.agentComposeId))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
     )
-    .innerJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
-    .where(eq(agentComposeVersions.id, agentComposeVersionId))
+    .where(eq(agentRuns.id, runId))
     .limit(1);
 
   if (!agent) {
@@ -515,7 +508,6 @@ function sessionRunSelect() {
     startedAt: agentRuns.startedAt,
     completedAt: agentRuns.completedAt,
     lastEventSequence: agentRuns.lastEventSequence,
-    agentComposeVersionId: agentRuns.agentComposeVersionId,
     runnerGroup: agentRuns.runnerGroup,
     continuedFromSessionId: agentRuns.continuedFromSessionId,
     result: agentRuns.result,

--- a/turbo/apps/api/src/signals/services/zero-developer-support.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-developer-support.service.ts
@@ -60,7 +60,6 @@ export const submitZeroDeveloperSupport$ = command(
         startedAt: agentRuns.startedAt,
         completedAt: agentRuns.completedAt,
         lastEventSequence: agentRuns.lastEventSequence,
-        agentComposeVersionId: agentRuns.agentComposeVersionId,
         runnerGroup: agentRuns.runnerGroup,
         continuedFromSessionId: agentRuns.continuedFromSessionId,
         result: agentRuns.result,

--- a/turbo/apps/api/src/signals/services/zero-goal.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal.service.ts
@@ -3,8 +3,8 @@ import type {
   ZeroGoalResponse,
   ZeroGoalStatus,
 } from "@vm0/api-contracts/contracts/zero-goals";
-import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { chatThreads } from "@vm0/db/schema/chat-thread";
 import { threadGoals, type ThreadGoalStatus } from "@vm0/db/schema/thread-goal";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -109,15 +109,12 @@ async function currentGoalContext(
   const [row] = await db
     .select({
       threadId: zeroRuns.chatThreadId,
-      agentId: agentComposeVersions.composeId,
+      agentId: agentSessions.agentComposeId,
       runGoalId: zeroRuns.goalId,
     })
     .from(zeroRuns)
     .innerJoin(agentRuns, eq(agentRuns.id, zeroRuns.id))
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
-    )
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
     .where(
       and(
         eq(agentRuns.id, auth.runId),

--- a/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-integrations-slack-message.service.ts
@@ -1,7 +1,7 @@
 import { computed, type Computed } from "ccstate";
 import { getModelDisplayName } from "@vm0/core/model-display-name";
-import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { slackOrgConnections } from "@vm0/db/schema/slack-org-connection";
 import { slackOrgInstallations } from "@vm0/db/schema/slack-org-installation";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -21,11 +21,8 @@ async function resolveAgentLabel(
       name: zeroAgents.name,
     })
     .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .innerJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
     .where(eq(agentRuns.id, runId))
     .limit(1);
   if (!row) {

--- a/turbo/apps/api/src/signals/services/zero-report-error.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-report-error.service.ts
@@ -40,7 +40,6 @@ export const submitZeroReportError$ = command(
         startedAt: agentRuns.startedAt,
         completedAt: agentRuns.completedAt,
         lastEventSequence: agentRuns.lastEventSequence,
-        agentComposeVersionId: agentRuns.agentComposeVersionId,
         runnerGroup: agentRuns.runnerGroup,
         continuedFromSessionId: agentRuns.continuedFromSessionId,
         result: agentRuns.result,

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -743,12 +743,9 @@ async function triggerAgentIdForAuth(
   }
 
   const [parentRun] = await db
-    .select({ agentComposeId: agentComposeVersions.composeId })
+    .select({ agentComposeId: agentSessions.agentComposeId })
     .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
-    )
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
     .where(eq(agentRuns.id, auth.runId))
     .limit(1);
 

--- a/turbo/apps/api/src/signals/services/zero-runs.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs.service.ts
@@ -15,11 +15,9 @@ import {
   sandboxReuseResultSchema,
   type SandboxReuseResult,
 } from "@vm0/api-contracts/contracts/webhooks";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "@vm0/db/schema/agent-compose";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { orgMetadata } from "@vm0/db/schema/org-metadata";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
@@ -135,14 +133,8 @@ function queuedRunRows(db: ReadDb, orgId: string): Promise<QueuedRunRow[]> {
     })
     .from(agentRuns)
     .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
+    .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .leftJoin(agentComposes, eq(agentSessions.agentComposeId, agentComposes.id))
     .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(and(eq(agentRuns.orgId, orgId), eq(agentRuns.status, "queued")))
     .orderBy(asc(agentRuns.createdAt));
@@ -158,14 +150,8 @@ function runningRunRows(db: ReadDb, orgId: string): Promise<RunningRunRow[]> {
       agentDisplayName: zeroAgents.displayName,
     })
     .from(agentRuns)
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
+    .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
+    .leftJoin(agentComposes, eq(agentSessions.agentComposeId, agentComposes.id))
     .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(and(eq(agentRuns.orgId, orgId), eq(agentRuns.status, "running")))
     .orderBy(asc(agentRuns.startedAt));
@@ -381,13 +367,10 @@ export function agentRunList(args: {
         composeName: agentComposes.name,
       })
       .from(agentRuns)
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
+      .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
       .leftJoin(
         agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
+        eq(agentSessions.agentComposeId, agentComposes.id),
       )
       .where(and(...conditions))
       .orderBy(desc(agentRuns.createdAt))

--- a/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-telegram-footer.service.ts
@@ -4,11 +4,9 @@ import {
   getFrameworkForType,
   modelProviderTypeSchema,
 } from "@vm0/api-contracts/contracts/model-providers";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "@vm0/db/schema/agent-compose";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { modelProviders } from "@vm0/db/schema/model-provider";
 import { telegramInstallations } from "@vm0/db/schema/telegram-installation";
 import { telegramUserLinks } from "@vm0/db/schema/telegram-user-link";
@@ -175,13 +173,10 @@ async function resolveRunAgentLabel(
       composeName: agentComposes.name,
     })
     .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
+    .innerJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
     .innerJoin(
       agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
+      eq(agentSessions.agentComposeId, agentComposes.id),
     )
     .leftJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
     .where(eq(agentRuns.id, runId))

--- a/turbo/apps/api/src/signals/services/zero-usage.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-usage.service.ts
@@ -6,11 +6,9 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-usage";
 import type { UsageRecordRange } from "@vm0/api-contracts/contracts/zero-usage-record";
 import type { UsageRunsResponse } from "@vm0/api-contracts/contracts/zero-usage-daily";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "@vm0/db/schema/agent-compose";
+import { agentComposes } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { userCache } from "@vm0/db/schema/user-cache";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { zeroRuns } from "@vm0/db/schema/zero-run";
@@ -148,13 +146,10 @@ export const zeroUsageRuns$ = command(
       .select({ total: count() })
       .from(agentRuns)
       .leftJoin(eventUsage, eq(agentRuns.id, eventUsage.runId))
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
+      .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
       .leftJoin(
         agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
+        eq(agentSessions.agentComposeId, agentComposes.id),
       )
       .where(and(...conditions, hasRunUsageTotals(eventUsage)));
     signal.throwIfAborted();
@@ -180,13 +175,10 @@ export const zeroUsageRuns$ = command(
       .from(agentRuns)
       .leftJoin(eventUsage, eq(agentRuns.id, eventUsage.runId))
       .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
+      .leftJoin(agentSessions, eq(agentRuns.sessionId, agentSessions.id))
       .leftJoin(
         agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
+        eq(agentSessions.agentComposeId, agentComposes.id),
       )
       .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
       .where(and(...conditions, hasRunUsageTotals(eventUsage)))

--- a/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-permission-grants.service.ts
@@ -14,7 +14,7 @@ import {
 import { userPermissionGrants } from "@vm0/db/schema/user-permission-grant";
 import { zeroAgents } from "@vm0/db/schema/zero-agent";
 import { agentRuns } from "@vm0/db/schema/agent-run";
-import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
+import { agentSessions } from "@vm0/db/schema/agent-session";
 import { and, asc, eq, gt, inArray, isNotNull, isNull, or } from "drizzle-orm";
 import type {
   ApplyUserPermissionGrantsRequest,
@@ -589,17 +589,14 @@ async function loadActiveNetworkPolicyRefreshRuns(
       runnerGroup: agentRuns.runnerGroup,
     })
     .from(agentRuns)
-    .innerJoin(
-      agentComposeVersions,
-      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
-    )
+    .innerJoin(agentSessions, eq(agentSessions.id, agentRuns.sessionId))
     .where(
       and(
         eq(agentRuns.orgId, scope.orgId),
         eq(agentRuns.userId, scope.userId),
         eq(agentRuns.status, "running"),
         isNotNull(agentRuns.runnerGroup),
-        eq(agentComposeVersions.composeId, scope.agentId),
+        eq(agentSessions.agentComposeId, scope.agentId),
       ),
     );
 }


### PR DESCRIPTION
## Summary

- Resolve an existing run's agent identity through `agent_runs.session_id -> agent_sessions.agent_compose_id` instead of reversing the shared compose version.
- Apply the identity path consistently to runner claim/refresh, queue and run reads, permissions, usage and insights, goals, notifications, cleanup, diagnostics, and child-run attribution.
- Keep compose versions as immutable runtime content and add an integration regression with two agents sharing one version hash.

## Scope

- No schema migration or persisted-data backfill is required.
- No API contract, runner protocol, or production ZERO_TOKEN capability issuance changes.
- Pre-run compose resolution and compose lifecycle isolation remain tracked by #21058.

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `DATABASE_URL=<isolated-test-db> pnpm vitest run --maxWorkers=4 --silent=passed-only` (595 files passed, 7317 tests passed)

Closes #21054
