### PR TITLE
perf(runner): attribute nbd cow creation latency

### DIFF
--- a/crates/nbd-cow/src/device/create.rs
+++ b/crates/nbd-cow/src/device/create.rs
@@ -1,6 +1,6 @@
 use std::os::fd::OwnedFd;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::error::{self, Result};
 use crate::{
@@ -16,6 +16,7 @@ use super::connection::{
     disconnect_connected_if_owned_result_with_lease_critical_section,
     disconnect_device_with_lease_critical_section,
 };
+use super::create_timing::{NbdCowCreateObserver, NbdCowCreateStage, NbdCowCreateTiming};
 
 const MAX_SIZE_RETRIES: u32 = 5;
 const MAX_EBUSY_RETRIES: u32 = 16;
@@ -64,36 +65,46 @@ impl CreateDisconnectStatus {
     }
 }
 
-struct CreateContext<'a> {
+struct CreateContext<'a, 'observer> {
     device_pool: &'a pool::DevicePoolHandle,
     cow_file: &'a Path,
     cow: cow_io::CowIo,
     size: u64,
+    timing: &'a mut NbdCowCreateTiming<'observer>,
 }
 
-impl<'a> CreateContext<'a> {
+impl<'a, 'observer> CreateContext<'a, 'observer> {
     fn new(
         device_pool: &'a pool::DevicePoolHandle,
         cow_file: &'a Path,
         cow: cow_io::CowIo,
         size: u64,
+        timing: &'a mut NbdCowCreateTiming<'observer>,
     ) -> Self {
         Self {
             device_pool,
             cow_file,
             cow,
             size,
+            timing,
         }
     }
 
-    async fn create_with_size_retries(&self) -> Result<(NbdCowDevice, pool::DeviceLease)> {
+    async fn create_with_size_retries(&mut self) -> Result<(NbdCowDevice, pool::DeviceLease)> {
         let mut last_err_idx: u32 = 0;
 
         for size_attempt in 0..=MAX_SIZE_RETRIES {
             let attempt = self.acquire_connected_attempt().await?;
             let device_index = attempt.device_index();
 
-            if netlink::verify_device_size(device_index, self.size).await {
+            let verify_started_at = Instant::now();
+            let size_matches = netlink::verify_device_size(device_index, self.size).await;
+            self.timing.record_stage(
+                NbdCowCreateStage::SizeVerify,
+                verify_started_at,
+                size_matches,
+            );
+            if size_matches {
                 return attempt.into_device(self.cow_file, self.cow.clone());
             }
 
@@ -102,11 +113,18 @@ impl<'a> CreateContext<'a> {
                 attempt = size_attempt + 1,
                 "device size 0 after connect, disconnecting and retrying"
             );
+            let cleanup_started_at = Instant::now();
             attempt.disconnect_and_release().await;
+            self.timing
+                .record_stage(NbdCowCreateStage::RetryCleanup, cleanup_started_at, true);
             last_err_idx = device_index;
 
             if size_attempt < MAX_SIZE_RETRIES {
+                self.timing.record_size_zero_retry();
+                let delay_started_at = Instant::now();
                 tokio::time::sleep(SIZE_RETRY_DELAY).await;
+                self.timing
+                    .record_stage(NbdCowCreateStage::RetryDelay, delay_started_at, true);
             }
         }
 
@@ -117,15 +135,31 @@ impl<'a> CreateContext<'a> {
         ))))
     }
 
-    async fn acquire_connected_attempt(&self) -> Result<CreateAttemptGuard> {
+    async fn acquire_connected_attempt(&mut self) -> Result<CreateAttemptGuard> {
         let mut ebusy_count: u32 = 0;
 
         loop {
-            let lease = self.device_pool.acquire().await?;
+            let acquire_started_at = Instant::now();
+            let acquisition = self.device_pool.acquire().await;
+            self.timing.record_stage(
+                NbdCowCreateStage::DeviceAcquire,
+                acquire_started_at,
+                acquisition.is_ok(),
+            );
+            let acquisition = acquisition?;
+            let (lease, source, scan_duration) = acquisition.into_parts();
+            self.timing.record_acquisition(source, scan_duration);
             let mut attempt = CreateAttemptGuard::new(self.device_pool.clone(), lease);
             let device_index = attempt.device_index();
 
-            let client_fds = match self.setup_dispatch_servers(&mut attempt) {
+            let setup_started_at = Instant::now();
+            let setup_result = self.setup_dispatch_servers(&mut attempt);
+            self.timing.record_stage(
+                NbdCowCreateStage::DispatchSetup,
+                setup_started_at,
+                setup_result.is_ok(),
+            );
+            let client_fds = match setup_result {
                 Ok(client_fds) => client_fds,
                 Err(e) => {
                     // Release device back — connect was never attempted, device
@@ -136,7 +170,14 @@ impl<'a> CreateContext<'a> {
                 }
             };
 
-            match self.connect_attempt(&mut attempt, client_fds).await {
+            let connect_started_at = Instant::now();
+            let connect_result = self.connect_attempt(&mut attempt, client_fds).await;
+            self.timing.record_stage(
+                NbdCowCreateStage::NetlinkConnect,
+                connect_started_at,
+                connect_result.is_ok(),
+            );
+            match connect_result {
                 Ok(connected) => {
                     attempt.mark_connected(connected.connect_tid);
                     return Ok(attempt);
@@ -151,13 +192,26 @@ impl<'a> CreateContext<'a> {
                         "EBUSY on connect, trying next device"
                     );
                     if ebusy_count > MAX_EBUSY_RETRIES {
+                        let cleanup_started_at = Instant::now();
                         attempt.discard().await;
+                        self.timing.record_stage(
+                            NbdCowCreateStage::RetryCleanup,
+                            cleanup_started_at,
+                            true,
+                        );
                         return Err(error::NbdCowError::NoFreeDevice);
                     }
+                    self.timing.record_ebusy_retry();
                     // Device is owned by another process or otherwise busy.
                     // Stop tracking without cooldown; a future demand scan
                     // will rediscover it once it frees.
+                    let cleanup_started_at = Instant::now();
                     attempt.discard().await;
+                    self.timing.record_stage(
+                        NbdCowCreateStage::RetryCleanup,
+                        cleanup_started_at,
+                        true,
+                    );
                 }
                 Err(netlink::ConnectDeviceError::AmbiguousAfterSend {
                     connect_tid,
@@ -203,7 +257,7 @@ impl<'a> CreateContext<'a> {
     }
 
     async fn connect_attempt(
-        &self,
+        &mut self,
         attempt: &mut CreateAttemptGuard,
         client_fds: Vec<OwnedFd>,
     ) -> std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError> {
@@ -639,19 +693,31 @@ impl NbdCowDevice {
         cow_file: &Path,
         size: u64,
         device_pool: &pool::DevicePoolHandle,
+        observer: Option<&mut dyn NbdCowCreateObserver>,
     ) -> Result<(Self, pool::DeviceLease)> {
-        // Create COW layer
-        let cow_layer = cow::CowLayer::new(
-            base_image,
-            cow_file,
-            size,
-            BLOCK_SIZE,
-            DEFAULT_FLUSH_THRESHOLD,
-        )?;
-        let cow = cow_io::CowIo::new(cow_layer);
-        let context = CreateContext::new(device_pool, cow_file, cow, size);
+        let mut timing = NbdCowCreateTiming::new(observer);
+        let result = async {
+            let cow_started_at = Instant::now();
+            let cow_layer = cow::CowLayer::new(
+                base_image,
+                cow_file,
+                size,
+                BLOCK_SIZE,
+                DEFAULT_FLUSH_THRESHOLD,
+            );
+            timing.record_stage(
+                NbdCowCreateStage::CowLayerCreate,
+                cow_started_at,
+                cow_layer.is_ok(),
+            );
+            let cow = cow_io::CowIo::new(cow_layer?);
+            let mut context = CreateContext::new(device_pool, cow_file, cow, size, &mut timing);
 
-        context.create_with_size_retries().await
+            context.create_with_size_retries().await
+        }
+        .await;
+        timing.finish(result.is_ok());
+        result
     }
 }
 

--- a/crates/nbd-cow/src/device/create_timing.rs
+++ b/crates/nbd-cow/src/device/create_timing.rs
@@ -1,0 +1,348 @@
+use std::time::{Duration, Instant};
+
+use crate::pool::DeviceAcquireSource;
+
+const NBD_COW_CREATE_STAGE_COUNT: usize = NbdCowCreateStage::ALL.len();
+
+/// Fixed stages inside one NBD COW device creation.
+///
+/// [`Self::DeviceScan`] is nested inside [`Self::DeviceAcquire`]. Every other
+/// stage is a peer contribution to the enclosing NBD create operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NbdCowCreateStage {
+    CowLayerCreate,
+    DeviceAcquire,
+    DeviceScan,
+    DispatchSetup,
+    NetlinkConnect,
+    SizeVerify,
+    RetryCleanup,
+    RetryDelay,
+}
+
+impl NbdCowCreateStage {
+    /// All stages in stable telemetry order.
+    pub const ALL: [Self; 8] = [
+        Self::CowLayerCreate,
+        Self::DeviceAcquire,
+        Self::DeviceScan,
+        Self::DispatchSetup,
+        Self::NetlinkConnect,
+        Self::SizeVerify,
+        Self::RetryCleanup,
+        Self::RetryDelay,
+    ];
+}
+
+/// Fixed low-cardinality outcomes for one NBD COW device creation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NbdCowCreateOutcome {
+    AcquireSourceDemandScan,
+    AcquireSourceCooledClaim,
+    EbusyRetriesNone,
+    EbusyRetriesOne,
+    EbusyRetriesMultiple,
+    SizeZeroRetriesNone,
+    SizeZeroRetriesOne,
+    SizeZeroRetriesMultiple,
+}
+
+/// Receives aggregate timing and bounded outcomes for one NBD COW create.
+///
+/// Stage records are emitted once when creation returns normally. Retry work is
+/// accumulated into one contribution per stage instead of emitting one sample
+/// per attempt. Cancellation does not invoke observer code from `Drop`.
+pub trait NbdCowCreateObserver: Send {
+    fn record_stage(&mut self, stage: NbdCowCreateStage, duration: Duration, success: bool);
+
+    fn record_outcome(&mut self, outcome: NbdCowCreateOutcome);
+}
+
+#[derive(Clone, Copy, Default)]
+struct StageTiming {
+    duration: Duration,
+    entered: bool,
+}
+
+pub(super) struct NbdCowCreateTiming<'a> {
+    observer: Option<&'a mut dyn NbdCowCreateObserver>,
+    stages: [StageTiming; NBD_COW_CREATE_STAGE_COUNT],
+    failed_stage: Option<NbdCowCreateStage>,
+    used_demand_scan: bool,
+    used_cooled_claim: bool,
+    ebusy_retries: u32,
+    size_zero_retries: u32,
+}
+
+impl<'a> NbdCowCreateTiming<'a> {
+    pub(super) fn new(observer: Option<&'a mut dyn NbdCowCreateObserver>) -> Self {
+        Self {
+            observer,
+            stages: [StageTiming::default(); NBD_COW_CREATE_STAGE_COUNT],
+            failed_stage: None,
+            used_demand_scan: false,
+            used_cooled_claim: false,
+            ebusy_retries: 0,
+            size_zero_retries: 0,
+        }
+    }
+
+    pub(super) fn record_stage(
+        &mut self,
+        stage: NbdCowCreateStage,
+        started_at: Instant,
+        success: bool,
+    ) {
+        self.record_stage_duration(stage, started_at.elapsed(), success);
+    }
+
+    pub(super) fn record_stage_duration(
+        &mut self,
+        stage: NbdCowCreateStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        let timing = self.stage_mut(stage);
+        timing.duration = timing.duration.saturating_add(duration);
+        timing.entered = true;
+        if !success {
+            self.failed_stage = Some(stage);
+        }
+    }
+
+    pub(super) fn record_acquisition(
+        &mut self,
+        source: DeviceAcquireSource,
+        scan_duration: Option<Duration>,
+    ) {
+        match source {
+            DeviceAcquireSource::DemandScan => self.used_demand_scan = true,
+            DeviceAcquireSource::CooledClaim => self.used_cooled_claim = true,
+        }
+        if let Some(duration) = scan_duration {
+            self.record_stage_duration(NbdCowCreateStage::DeviceScan, duration, true);
+        }
+    }
+
+    pub(super) fn record_ebusy_retry(&mut self) {
+        self.ebusy_retries = self.ebusy_retries.saturating_add(1);
+    }
+
+    pub(super) fn record_size_zero_retry(&mut self) {
+        self.size_zero_retries = self.size_zero_retries.saturating_add(1);
+    }
+
+    pub(super) fn finish(mut self, create_success: bool) {
+        let Some(observer) = self.observer.take() else {
+            return;
+        };
+
+        for stage in NbdCowCreateStage::ALL {
+            let timing = self.stage(stage);
+            if !timing.entered {
+                continue;
+            }
+            observer.record_stage(
+                stage,
+                timing.duration,
+                create_success || self.failed_stage != Some(stage),
+            );
+        }
+
+        if self.used_demand_scan {
+            observer.record_outcome(NbdCowCreateOutcome::AcquireSourceDemandScan);
+        }
+        if self.used_cooled_claim {
+            observer.record_outcome(NbdCowCreateOutcome::AcquireSourceCooledClaim);
+        }
+        observer.record_outcome(ebusy_retry_outcome(self.ebusy_retries));
+        observer.record_outcome(size_zero_retry_outcome(self.size_zero_retries));
+    }
+
+    fn stage(&self, stage: NbdCowCreateStage) -> StageTiming {
+        let [
+            cow_layer_create,
+            device_acquire,
+            device_scan,
+            dispatch_setup,
+            netlink_connect,
+            size_verify,
+            retry_cleanup,
+            retry_delay,
+        ] = &self.stages;
+        *match stage {
+            NbdCowCreateStage::CowLayerCreate => cow_layer_create,
+            NbdCowCreateStage::DeviceAcquire => device_acquire,
+            NbdCowCreateStage::DeviceScan => device_scan,
+            NbdCowCreateStage::DispatchSetup => dispatch_setup,
+            NbdCowCreateStage::NetlinkConnect => netlink_connect,
+            NbdCowCreateStage::SizeVerify => size_verify,
+            NbdCowCreateStage::RetryCleanup => retry_cleanup,
+            NbdCowCreateStage::RetryDelay => retry_delay,
+        }
+    }
+
+    fn stage_mut(&mut self, stage: NbdCowCreateStage) -> &mut StageTiming {
+        let [
+            cow_layer_create,
+            device_acquire,
+            device_scan,
+            dispatch_setup,
+            netlink_connect,
+            size_verify,
+            retry_cleanup,
+            retry_delay,
+        ] = &mut self.stages;
+        match stage {
+            NbdCowCreateStage::CowLayerCreate => cow_layer_create,
+            NbdCowCreateStage::DeviceAcquire => device_acquire,
+            NbdCowCreateStage::DeviceScan => device_scan,
+            NbdCowCreateStage::DispatchSetup => dispatch_setup,
+            NbdCowCreateStage::NetlinkConnect => netlink_connect,
+            NbdCowCreateStage::SizeVerify => size_verify,
+            NbdCowCreateStage::RetryCleanup => retry_cleanup,
+            NbdCowCreateStage::RetryDelay => retry_delay,
+        }
+    }
+}
+
+fn ebusy_retry_outcome(count: u32) -> NbdCowCreateOutcome {
+    match count {
+        0 => NbdCowCreateOutcome::EbusyRetriesNone,
+        1 => NbdCowCreateOutcome::EbusyRetriesOne,
+        _ => NbdCowCreateOutcome::EbusyRetriesMultiple,
+    }
+}
+
+fn size_zero_retry_outcome(count: u32) -> NbdCowCreateOutcome {
+    match count {
+        0 => NbdCowCreateOutcome::SizeZeroRetriesNone,
+        1 => NbdCowCreateOutcome::SizeZeroRetriesOne,
+        _ => NbdCowCreateOutcome::SizeZeroRetriesMultiple,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        stages: Vec<(NbdCowCreateStage, Duration, bool)>,
+        outcomes: Vec<NbdCowCreateOutcome>,
+    }
+
+    impl NbdCowCreateObserver for RecordingObserver {
+        fn record_stage(&mut self, stage: NbdCowCreateStage, duration: Duration, success: bool) {
+            self.stages.push((stage, duration, success));
+        }
+
+        fn record_outcome(&mut self, outcome: NbdCowCreateOutcome) {
+            self.outcomes.push(outcome);
+        }
+    }
+
+    #[test]
+    fn timing_aggregates_retries_and_deduplicates_sources() {
+        let mut observer = RecordingObserver::default();
+        let mut timing = NbdCowCreateTiming::new(Some(&mut observer));
+        timing.record_stage_duration(
+            NbdCowCreateStage::DeviceAcquire,
+            Duration::from_millis(7),
+            true,
+        );
+        timing.record_stage_duration(
+            NbdCowCreateStage::DeviceAcquire,
+            Duration::from_millis(11),
+            true,
+        );
+        timing.record_acquisition(
+            DeviceAcquireSource::DemandScan,
+            Some(Duration::from_millis(3)),
+        );
+        timing.record_acquisition(
+            DeviceAcquireSource::DemandScan,
+            Some(Duration::from_millis(5)),
+        );
+        timing.record_acquisition(DeviceAcquireSource::CooledClaim, None);
+        timing.record_ebusy_retry();
+        timing.record_size_zero_retry();
+        timing.record_size_zero_retry();
+        timing.finish(true);
+
+        assert_eq!(
+            observer.stages,
+            vec![
+                (
+                    NbdCowCreateStage::DeviceAcquire,
+                    Duration::from_millis(18),
+                    true,
+                ),
+                (
+                    NbdCowCreateStage::DeviceScan,
+                    Duration::from_millis(8),
+                    true,
+                ),
+            ]
+        );
+        assert_eq!(
+            observer.outcomes,
+            vec![
+                NbdCowCreateOutcome::AcquireSourceDemandScan,
+                NbdCowCreateOutcome::AcquireSourceCooledClaim,
+                NbdCowCreateOutcome::EbusyRetriesOne,
+                NbdCowCreateOutcome::SizeZeroRetriesMultiple,
+            ]
+        );
+    }
+
+    #[test]
+    fn timing_marks_only_terminal_stage_failed() {
+        let mut observer = RecordingObserver::default();
+        let mut timing = NbdCowCreateTiming::new(Some(&mut observer));
+        timing.record_stage_duration(
+            NbdCowCreateStage::DeviceAcquire,
+            Duration::from_millis(4),
+            false,
+        );
+        timing.record_stage_duration(
+            NbdCowCreateStage::RetryCleanup,
+            Duration::from_millis(2),
+            true,
+        );
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(6),
+            false,
+        );
+        timing.finish(false);
+
+        assert_eq!(
+            observer.stages,
+            vec![
+                (
+                    NbdCowCreateStage::DeviceAcquire,
+                    Duration::from_millis(4),
+                    true,
+                ),
+                (
+                    NbdCowCreateStage::NetlinkConnect,
+                    Duration::from_millis(6),
+                    false,
+                ),
+                (
+                    NbdCowCreateStage::RetryCleanup,
+                    Duration::from_millis(2),
+                    true,
+                ),
+            ]
+        );
+        assert_eq!(
+            observer.outcomes,
+            vec![
+                NbdCowCreateOutcome::EbusyRetriesNone,
+                NbdCowCreateOutcome::SizeZeroRetriesNone,
+            ]
+        );
+    }
+}

--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -7,10 +7,12 @@ use tokio_util::sync::CancellationToken;
 
 mod connection;
 mod create;
+mod create_timing;
 mod finalizer;
 mod pooled;
 
 pub use connection::is_our_thread;
+pub use create_timing::{NbdCowCreateObserver, NbdCowCreateOutcome, NbdCowCreateStage};
 pub use pooled::{DestroyRetryPolicy, KeptCow, PooledDestroyError, PooledNbdCowDevice};
 
 use connection::{

--- a/crates/nbd-cow/src/device/pooled.rs
+++ b/crates/nbd-cow/src/device/pooled.rs
@@ -113,7 +113,30 @@ impl pool::DevicePoolHandle {
         cow_file: &Path,
         size: u64,
     ) -> Result<PooledNbdCowDevice> {
-        let (device, lease) = NbdCowDevice::create_inner(base_image, cow_file, size, self).await?;
+        let (device, lease) =
+            NbdCowDevice::create_inner(base_image, cow_file, size, self, None).await?;
+        Ok(PooledNbdCowDevice {
+            device,
+            lease: LeaseGuard::new(lease, self.clone()),
+            pool: self.clone(),
+        })
+    }
+
+    /// Create a pooled NBD COW device and report aggregate creation stages.
+    ///
+    /// The observer receives fixed, low-cardinality records after creation
+    /// returns success or an ordinary error. Cancellation preserves the same
+    /// cleanup behavior as [`Self::create_cow_device`] and does not invoke the
+    /// observer from `Drop`.
+    pub async fn create_cow_device_with_observer(
+        &self,
+        base_image: &Path,
+        cow_file: &Path,
+        size: u64,
+        observer: &mut dyn super::NbdCowCreateObserver,
+    ) -> Result<PooledNbdCowDevice> {
+        let (device, lease) =
+            NbdCowDevice::create_inner(base_image, cow_file, size, self, Some(observer)).await?;
         Ok(PooledNbdCowDevice {
             device,
             lease: LeaseGuard::new(lease, self.clone()),

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -39,8 +39,8 @@ pub mod protocol {
 pub mod server;
 
 pub use device::{
-    DestroyRetryPolicy, KeptCow, NbdCowDevice, PooledDestroyError, PooledNbdCowDevice,
-    is_our_thread,
+    DestroyRetryPolicy, KeptCow, NbdCowCreateObserver, NbdCowCreateOutcome, NbdCowCreateStage,
+    NbdCowDevice, PooledDestroyError, PooledNbdCowDevice, is_our_thread,
 };
 
 /// Default block size: 4KB (matches typical filesystem block size and kernel page size).

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -18,6 +18,8 @@ pub use actor::DevicePoolHandle;
 pub use lease::DeviceLease;
 pub use state::{DevicePool, DevicePoolConfig};
 
+pub(crate) use lease::DeviceAcquireSource;
+
 /// Maximum blocking NBD scans running concurrently.
 const MAX_PENDING: usize = 4;
 

--- a/crates/nbd-cow/src/pool/actor.rs
+++ b/crates/nbd-cow/src/pool/actor.rs
@@ -5,7 +5,8 @@ use crate::error::{NbdCowError, Result};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
 
-use super::lease::DeviceLease;
+use super::lease::{DeviceAcquisition, DeviceLease};
+use super::scan::ScannedDeviceClaim;
 #[cfg(test)]
 use super::state::DevicePoolSnapshot;
 use super::state::{DevicePool, DevicePoolConfig};
@@ -82,7 +83,7 @@ impl LeaseReturnOperation {
 
 pub(super) enum DevicePoolCommand {
     Acquire {
-        respond_to: oneshot::Sender<Result<DeviceLease>>,
+        respond_to: oneshot::Sender<Result<DeviceAcquisition>>,
     },
     ReturnLease {
         action: LeaseReturnAction,
@@ -101,7 +102,7 @@ pub(super) enum DevicePoolCommand {
 struct DevicePoolActor {
     pool: DevicePool,
     commands: mpsc::UnboundedReceiver<DevicePoolCommand>,
-    pending: JoinSet<Result<NbdDeviceClaim>>,
+    pending: JoinSet<Result<ScannedDeviceClaim>>,
 }
 
 impl DevicePoolHandle {
@@ -126,17 +127,20 @@ impl DevicePoolHandle {
     #[cfg(test)]
     pub(super) fn from_pool_with_pending(
         pool: DevicePool,
-        pending: JoinSet<Result<NbdDeviceClaim>>,
+        pending: JoinSet<Result<ScannedDeviceClaim>>,
     ) -> Self {
         Self::spawn_actor(pool, pending)
     }
 
     #[cfg(not(test))]
-    fn from_pool_with_pending(pool: DevicePool, pending: JoinSet<Result<NbdDeviceClaim>>) -> Self {
+    fn from_pool_with_pending(
+        pool: DevicePool,
+        pending: JoinSet<Result<ScannedDeviceClaim>>,
+    ) -> Self {
         Self::spawn_actor(pool, pending)
     }
 
-    fn spawn_actor(mut pool: DevicePool, pending: JoinSet<Result<NbdDeviceClaim>>) -> Self {
+    fn spawn_actor(mut pool: DevicePool, pending: JoinSet<Result<ScannedDeviceClaim>>) -> Self {
         let (commands, command_rx) = mpsc::unbounded_channel();
         pool.set_lease_return(commands.downgrade());
         tokio::spawn(
@@ -182,7 +186,7 @@ impl DevicePoolHandle {
         }
     }
 
-    pub(crate) async fn acquire(&self) -> Result<DeviceLease> {
+    pub(crate) async fn acquire(&self) -> Result<DeviceAcquisition> {
         let (respond_to, response) = oneshot::channel();
         if self
             .commands

--- a/crates/nbd-cow/src/pool/lease.rs
+++ b/crates/nbd-cow/src/pool/lease.rs
@@ -1,10 +1,61 @@
 #[cfg(test)]
 use std::path::Path;
+use std::time::Duration;
 
 use crate::device_lock::NbdDeviceClaim;
 use tokio::sync::{mpsc, oneshot};
 
 use super::actor::{DevicePoolCommand, LeaseReturnAction};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DeviceAcquireSource {
+    DemandScan,
+    CooledClaim,
+}
+
+pub(crate) struct DeviceAcquisition {
+    lease: DeviceLease,
+    source: DeviceAcquireSource,
+    scan_duration: Option<Duration>,
+}
+
+impl DeviceAcquisition {
+    pub(super) fn new(
+        lease: DeviceLease,
+        source: DeviceAcquireSource,
+        scan_duration: Option<Duration>,
+    ) -> Self {
+        Self {
+            lease,
+            source,
+            scan_duration,
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (DeviceLease, DeviceAcquireSource, Option<Duration>) {
+        (self.lease, self.source, self.scan_duration)
+    }
+
+    #[cfg(test)]
+    pub(super) fn index(&self) -> u32 {
+        self.lease.index()
+    }
+
+    #[cfg(test)]
+    pub(super) fn into_lease(self) -> DeviceLease {
+        self.lease
+    }
+
+    #[cfg(test)]
+    pub(super) fn source(&self) -> DeviceAcquireSource {
+        self.source
+    }
+
+    #[cfg(test)]
+    pub(super) fn scan_duration(&self) -> Option<Duration> {
+        self.scan_duration
+    }
+}
 
 /// Owned authority for a checked-out NBD device.
 ///

--- a/crates/nbd-cow/src/pool/scan.rs
+++ b/crates/nbd-cow/src/pool/scan.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use crate::device_lock::{self, NbdDeviceClaim};
 use crate::error::{NbdCowError, Result};
@@ -14,14 +15,31 @@ pub(super) struct ScanRequest {
     pub(super) device_appears_free: DeviceFreeCheck,
 }
 
+pub(super) struct ScannedDeviceClaim {
+    claim: NbdDeviceClaim,
+    duration: Duration,
+}
+
+impl ScannedDeviceClaim {
+    pub(super) fn new(claim: NbdDeviceClaim, duration: Duration) -> Self {
+        Self { claim, duration }
+    }
+
+    pub(super) fn into_parts(self) -> (NbdDeviceClaim, Duration) {
+        (self.claim, self.duration)
+    }
+}
+
 impl ScanRequest {
-    pub(super) fn run(self) -> Result<NbdDeviceClaim> {
-        scan_and_claim_with(
+    pub(super) fn run(self) -> Result<ScannedDeviceClaim> {
+        let started_at = Instant::now();
+        let claim = scan_and_claim_with(
             self.max_devices,
             &self.exclude,
             &self.lock_dir,
             self.device_appears_free,
-        )
+        )?;
+        Ok(ScannedDeviceClaim::new(claim, started_at.elapsed()))
     }
 }
 

--- a/crates/nbd-cow/src/pool/state.rs
+++ b/crates/nbd-cow/src/pool/state.rs
@@ -8,8 +8,8 @@ use crate::netlink;
 use tokio::sync::{mpsc, oneshot};
 
 use super::actor::DevicePoolCommand;
-use super::lease::DeviceLease;
-use super::scan::ScanRequest;
+use super::lease::{DeviceAcquireSource, DeviceAcquisition, DeviceLease};
+use super::scan::{ScanRequest, ScannedDeviceClaim};
 use super::{DEFAULT_COOLDOWN_MS, DeviceFreeCheck, MAX_PENDING};
 
 #[derive(Clone, Copy)]
@@ -93,7 +93,7 @@ pub struct DevicePool {
     /// Acquire errors that raced with still-pending scans.
     pub(super) deferred_acquire_errors: VecDeque<NbdCowError>,
     /// Acquire requests waiting for a scan or an expired cooldown claim.
-    pub(super) waiting_acquires: VecDeque<oneshot::Sender<Result<DeviceLease>>>,
+    pub(super) waiting_acquires: VecDeque<oneshot::Sender<Result<DeviceAcquisition>>>,
     /// Total number of NBD devices (from sysfs nbds_max).
     pub(super) max_devices: u32,
     /// Pool configuration.
@@ -160,7 +160,7 @@ impl DevicePool {
 
     pub(super) fn handle_acquire(
         &mut self,
-        respond_to: oneshot::Sender<Result<DeviceLease>>,
+        respond_to: oneshot::Sender<Result<DeviceAcquisition>>,
         pending_scans: usize,
     ) {
         if !self.active {
@@ -217,17 +217,22 @@ impl DevicePool {
 
     pub(super) fn handle_scan_join(
         &mut self,
-        scan: Option<std::result::Result<Result<NbdDeviceClaim>, tokio::task::JoinError>>,
+        scan: Option<std::result::Result<Result<ScannedDeviceClaim>, tokio::task::JoinError>>,
     ) {
         match scan {
-            Some(Ok(Ok(claim))) => {
+            Some(Ok(Ok(scanned))) => {
+                let (claim, scan_duration) = scanned.into_parts();
                 if self.is_tracked(claim.index()) {
                     tracing::warn!(
                         device_index = claim.index(),
                         "dropping scan result because index is already tracked"
                     );
                 } else {
-                    self.assign_claim_to_waiter(claim);
+                    self.assign_claim_to_waiter(
+                        claim,
+                        DeviceAcquireSource::DemandScan,
+                        Some(scan_duration),
+                    );
                 }
             }
             Some(Ok(Err(e))) => {
@@ -242,15 +247,22 @@ impl DevicePool {
         }
     }
 
-    pub(super) fn assign_claim_to_waiter(&mut self, mut claim: NbdDeviceClaim) -> bool {
+    pub(super) fn assign_claim_to_waiter(
+        &mut self,
+        mut claim: NbdDeviceClaim,
+        source: DeviceAcquireSource,
+        scan_duration: Option<Duration>,
+    ) -> bool {
         let index = claim.index();
         while let Some(respond_to) = self.waiting_acquires.pop_front() {
-            match respond_to.send(Ok(self.lease_for(claim))) {
+            let acquisition = DeviceAcquisition::new(self.lease_for(claim), source, scan_duration);
+            match respond_to.send(Ok(acquisition)) {
                 Ok(()) => {
                     self.in_flight.insert(index);
                     return true;
                 }
-                Err(Ok(lease)) => {
+                Err(Ok(acquisition)) => {
+                    let (lease, _, _) = acquisition.into_parts();
                     let Some(returned_claim) = lease.into_claim() else {
                         return false;
                     };
@@ -414,7 +426,7 @@ impl DevicePool {
             );
             return;
         }
-        self.assign_claim_to_waiter(slot.claim);
+        self.assign_claim_to_waiter(slot.claim, DeviceAcquireSource::CooledClaim, None);
     }
 
     pub(super) fn next_cooldown_deadline(&self) -> Option<Instant> {

--- a/crates/nbd-cow/src/pool/tests.rs
+++ b/crates/nbd-cow/src/pool/tests.rs
@@ -9,7 +9,7 @@ use crate::error::{NbdCowError, Result};
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
 
-use super::scan::scan_and_claim_with;
+use super::scan::{ScannedDeviceClaim, scan_and_claim_with};
 use super::state::CooldownSlot;
 
 fn always_free(_: u32) -> bool {
@@ -34,19 +34,28 @@ fn test_pool(
     )
 }
 
-fn pending_scan_result(result: Result<NbdDeviceClaim>) -> JoinSet<Result<NbdDeviceClaim>> {
+fn scanned(claim: NbdDeviceClaim) -> ScannedDeviceClaim {
+    ScannedDeviceClaim::new(claim, Duration::from_millis(1))
+}
+
+fn pending_scan_result(result: Result<NbdDeviceClaim>) -> JoinSet<Result<ScannedDeviceClaim>> {
     let mut pending = JoinSet::new();
-    pending.spawn(async move { result });
+    pending.spawn(async move { result.map(scanned) });
     pending
 }
 
 fn pending_controlled_scan() -> (
-    JoinSet<Result<NbdDeviceClaim>>,
+    JoinSet<Result<ScannedDeviceClaim>>,
     oneshot::Sender<Result<NbdDeviceClaim>>,
 ) {
     let mut pending = JoinSet::new();
     let (complete, complete_rx) = oneshot::channel();
-    pending.spawn(async move { complete_rx.await.unwrap_or(Err(NbdCowError::NoFreeDevice)) });
+    pending.spawn(async move {
+        complete_rx
+            .await
+            .unwrap_or(Err(NbdCowError::NoFreeDevice))
+            .map(scanned)
+    });
     (pending, complete)
 }
 

--- a/crates/nbd-cow/src/pool/tests/cooldown.rs
+++ b/crates/nbd-cow/src/pool/tests/cooldown.rs
@@ -64,7 +64,9 @@ async fn expired_cooldown_with_waiter_hands_off_same_claim() {
         .expect("acquire task panicked")
         .expect("acquire failed");
     assert_eq!(lease.index(), 3);
-    handle.discard(lease).await;
+    assert_eq!(lease.source(), DeviceAcquireSource::CooledClaim);
+    assert_eq!(lease.scan_duration(), None);
+    handle.discard(lease.into_lease()).await;
     handle.cleanup().await;
 }
 

--- a/crates/nbd-cow/src/pool/tests/lease.rs
+++ b/crates/nbd-cow/src/pool/tests/lease.rs
@@ -96,7 +96,7 @@ async fn discard_releases_in_flight_lease_without_cooldown() {
         .expect("acquire task panicked")
         .expect("acquire failed");
     assert_eq!(lease.index(), 4);
-    handle.discard(lease).await;
+    handle.discard(lease.into_lease()).await;
     handle.cleanup().await;
 }
 

--- a/crates/nbd-cow/src/pool/tests/waiting.rs
+++ b/crates/nbd-cow/src/pool/tests/waiting.rs
@@ -70,7 +70,7 @@ async fn separate_pools_do_not_claim_same_locked_index() {
     let second_result = second.acquire().await;
     assert!(matches!(second_result, Err(NbdCowError::NoFreeDevice)));
 
-    first.discard(first_lease).await;
+    first.discard(first_lease.into_lease()).await;
     first.cleanup().await;
     second.cleanup().await;
 }
@@ -100,6 +100,8 @@ async fn demand_error_waits_for_pending_success_before_failing_waiter() {
 
     let first_lease = first_rx.await.unwrap().unwrap();
     assert_eq!(first_lease.index(), 4);
+    assert_eq!(first_lease.source(), DeviceAcquireSource::DemandScan);
+    assert!(first_lease.scan_duration().is_some());
     assert!(matches!(
         second_rx.await.unwrap(),
         Err(NbdCowError::NoFreeDevice)
@@ -141,10 +143,12 @@ fn scan_success_skips_cancelled_waiter_without_leaking_lock() {
     pool.waiting_acquires.push_back(cancelled_tx);
     pool.waiting_acquires.push_back(active_tx);
 
-    pool.handle_scan_join(Some(Ok(Ok(claim(4, dir.path())))));
+    pool.handle_scan_join(Some(Ok(Ok(scanned(claim(4, dir.path()))))));
 
     let lease = active_rx.try_recv().unwrap().unwrap();
     assert_eq!(lease.index(), 4);
+    assert_eq!(lease.source(), DeviceAcquireSource::DemandScan);
+    assert!(lease.scan_duration().is_some());
     assert!(pool.waiting_acquires.is_empty());
     assert!(pool.in_flight.contains(&4));
 }
@@ -157,7 +161,7 @@ fn cancelled_waiter_after_scan_completion_drops_claim() {
     drop(cancelled_rx);
     pool.waiting_acquires.push_back(cancelled_tx);
 
-    pool.handle_scan_join(Some(Ok(Ok(claim(4, dir.path())))));
+    pool.handle_scan_join(Some(Ok(Ok(scanned(claim(4, dir.path()))))));
 
     assert!(pool.waiting_acquires.is_empty());
     assert!(pool.in_flight.is_empty());
@@ -217,6 +221,6 @@ async fn handle_acquire_waiting_for_scan_does_not_block_release() {
         .expect("acquire task panicked")
         .expect("acquire failed");
     assert_eq!(lease.index(), 4);
-    handle.discard(lease).await;
+    handle.discard(lease.into_lease()).await;
     handle.cleanup().await;
 }

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -21,6 +21,41 @@ mod nbd_fixture;
 
 use nbd_fixture::{NbdTestFixture, default_device_pool};
 
+#[derive(Default)]
+struct RecordingCreateObserver {
+    stages: Vec<(nbd_cow::NbdCowCreateStage, Duration, bool)>,
+    outcomes: Vec<nbd_cow::NbdCowCreateOutcome>,
+}
+
+impl nbd_cow::NbdCowCreateObserver for RecordingCreateObserver {
+    fn record_stage(
+        &mut self,
+        stage: nbd_cow::NbdCowCreateStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        self.stages.push((stage, duration, success));
+    }
+
+    fn record_outcome(&mut self, outcome: nbd_cow::NbdCowCreateOutcome) {
+        self.outcomes.push(outcome);
+    }
+}
+
+impl RecordingCreateObserver {
+    fn stage_duration(&self, expected: nbd_cow::NbdCowCreateStage) -> Duration {
+        let matches: Vec<_> = self
+            .stages
+            .iter()
+            .filter(|(stage, _, _)| *stage == expected)
+            .collect();
+        assert_eq!(matches.len(), 1, "stage {expected:?}: {:?}", self.stages);
+        let (_, duration, success) = matches[0];
+        assert!(*success, "stage {expected:?} should succeed");
+        *duration
+    }
+}
+
 fn nbd_test_available() -> bool {
     if !nix::unistd::getuid().is_root() {
         eprintln!("skipping: requires root");
@@ -85,10 +120,77 @@ async fn create_and_destroy() {
     let cow = fixture.cow_path("cow.img");
 
     let pool = default_device_pool();
+    let mut observer = RecordingCreateObserver::default();
     let device = pool
-        .create_cow_device(fixture.base(), &cow, fixture.size())
+        .create_cow_device_with_observer(fixture.base(), &cow, fixture.size(), &mut observer)
         .await
         .expect("create");
+
+    for stage in [
+        nbd_cow::NbdCowCreateStage::CowLayerCreate,
+        nbd_cow::NbdCowCreateStage::DeviceAcquire,
+        nbd_cow::NbdCowCreateStage::DeviceScan,
+        nbd_cow::NbdCowCreateStage::DispatchSetup,
+        nbd_cow::NbdCowCreateStage::NetlinkConnect,
+        nbd_cow::NbdCowCreateStage::SizeVerify,
+    ] {
+        observer.stage_duration(stage);
+    }
+    assert!(
+        observer.stage_duration(nbd_cow::NbdCowCreateStage::DeviceScan)
+            <= observer.stage_duration(nbd_cow::NbdCowCreateStage::DeviceAcquire),
+        "device scan is nested inside device acquire: {:?}",
+        observer.stages,
+    );
+    assert!(
+        observer
+            .outcomes
+            .contains(&nbd_cow::NbdCowCreateOutcome::AcquireSourceDemandScan)
+    );
+    assert!(
+        observer
+            .outcomes
+            .contains(&nbd_cow::NbdCowCreateOutcome::EbusyRetriesNone)
+    );
+    assert_eq!(
+        observer
+            .outcomes
+            .iter()
+            .filter(|outcome| {
+                matches!(
+                    outcome,
+                    nbd_cow::NbdCowCreateOutcome::EbusyRetriesNone
+                        | nbd_cow::NbdCowCreateOutcome::EbusyRetriesOne
+                        | nbd_cow::NbdCowCreateOutcome::EbusyRetriesMultiple
+                )
+            })
+            .count(),
+        1,
+        "expected one EBUSY retry bucket: {:?}",
+        observer.outcomes,
+    );
+    assert!(
+        observer
+            .outcomes
+            .contains(&nbd_cow::NbdCowCreateOutcome::SizeZeroRetriesNone)
+    );
+    assert_eq!(
+        observer
+            .outcomes
+            .iter()
+            .filter(|outcome| {
+                matches!(
+                    outcome,
+                    nbd_cow::NbdCowCreateOutcome::SizeZeroRetriesNone
+                        | nbd_cow::NbdCowCreateOutcome::SizeZeroRetriesOne
+                        | nbd_cow::NbdCowCreateOutcome::SizeZeroRetriesMultiple
+                )
+            })
+            .count(),
+        1,
+        "expected one size-zero retry bucket: {:?}",
+        observer.outcomes,
+    );
 
     let dev_path = device.device_path().to_owned();
     assert!(dev_path.exists(), "device should exist: {dev_path:?}");

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 use futures_util::FutureExt;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxId,
+    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -65,6 +66,41 @@ const RUNNER_FRESH_SANDBOX_FACTORY_NETNS_ACQUIRE: &str =
     "runner_fresh_sandbox_factory_netns_acquire";
 const RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_CREATE: &str =
     "runner_fresh_sandbox_factory_nbd_cow_create";
+// NBD detail durations are children of `nbd_cow_create`. Device scan is
+// nested again inside device acquire, so downstream queries must not add it to
+// the acquire duration or to a peer-stage sum.
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_LAYER_CREATE: &str =
+    "runner_fresh_sandbox_factory_nbd_cow_layer_create";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_DEVICE_ACQUIRE: &str =
+    "runner_fresh_sandbox_factory_nbd_device_acquire";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_DEVICE_SCAN: &str =
+    "runner_fresh_sandbox_factory_nbd_device_scan";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_DISPATCH_SETUP: &str =
+    "runner_fresh_sandbox_factory_nbd_dispatch_setup";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_CONNECT: &str =
+    "runner_fresh_sandbox_factory_nbd_netlink_connect";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_VERIFY: &str =
+    "runner_fresh_sandbox_factory_nbd_size_verify";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_RETRY_CLEANUP: &str =
+    "runner_fresh_sandbox_factory_nbd_retry_cleanup";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_RETRY_DELAY: &str =
+    "runner_fresh_sandbox_factory_nbd_retry_delay";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_ACQUIRE_SOURCE_DEMAND_SCAN: &str =
+    "runner_fresh_sandbox_factory_nbd_acquire_source_demand_scan";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_ACQUIRE_SOURCE_COOLED_CLAIM: &str =
+    "runner_fresh_sandbox_factory_nbd_acquire_source_cooled_claim";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_EBUSY_RETRIES_NONE: &str =
+    "runner_fresh_sandbox_factory_nbd_ebusy_retries_none";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_EBUSY_RETRIES_ONE: &str =
+    "runner_fresh_sandbox_factory_nbd_ebusy_retries_one";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_EBUSY_RETRIES_MULTIPLE: &str =
+    "runner_fresh_sandbox_factory_nbd_ebusy_retries_multiple";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_NONE: &str =
+    "runner_fresh_sandbox_factory_nbd_size_zero_retries_none";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_ONE: &str =
+    "runner_fresh_sandbox_factory_nbd_size_zero_retries_one";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_MULTIPLE: &str =
+    "runner_fresh_sandbox_factory_nbd_size_zero_retries_multiple";
 const RUNNER_FRESH_SANDBOX_PROXY_REGISTER: &str = "runner_fresh_sandbox_proxy_register";
 const RUNNER_FRESH_SANDBOX_START: &str = "runner_fresh_sandbox_start";
 const RUNNER_FRESH_SANDBOX_RETRY_WITHOUT_WORKSPACE_IMAGE: &str =
@@ -98,6 +134,34 @@ impl SandboxCreateObserver for FreshSandboxFactoryCreateObserver<'_> {
             error,
         );
     }
+
+    fn record_nbd_cow_stage(
+        &mut self,
+        stage: SandboxNbdCowCreateStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        let error = if success {
+            None
+        } else {
+            Some(SANDBOX_FACTORY_CREATE_STAGE_FAILED)
+        };
+        self.telemetry.record(
+            fresh_sandbox_factory_nbd_cow_stage_action(stage),
+            duration,
+            success,
+            error,
+        );
+    }
+
+    fn record_nbd_cow_outcome(&mut self, outcome: SandboxNbdCowCreateOutcome) {
+        self.telemetry.record(
+            fresh_sandbox_factory_nbd_cow_outcome_action(outcome),
+            Duration::ZERO,
+            true,
+            None,
+        );
+    }
 }
 
 fn fresh_sandbox_factory_stage_action(stage: SandboxCreateStage) -> &'static str {
@@ -116,6 +180,54 @@ fn fresh_sandbox_factory_stage_action(stage: SandboxCreateStage) -> &'static str
         SandboxCreateStage::SockDirPrepare => RUNNER_FRESH_SANDBOX_FACTORY_SOCK_DIR_PREPARE,
         SandboxCreateStage::NetnsAcquire => RUNNER_FRESH_SANDBOX_FACTORY_NETNS_ACQUIRE,
         SandboxCreateStage::NbdCowCreate => RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_CREATE,
+    }
+}
+
+fn fresh_sandbox_factory_nbd_cow_stage_action(stage: SandboxNbdCowCreateStage) -> &'static str {
+    match stage {
+        SandboxNbdCowCreateStage::CowLayerCreate => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_LAYER_CREATE
+        }
+        SandboxNbdCowCreateStage::DeviceAcquire => RUNNER_FRESH_SANDBOX_FACTORY_NBD_DEVICE_ACQUIRE,
+        SandboxNbdCowCreateStage::DeviceScan => RUNNER_FRESH_SANDBOX_FACTORY_NBD_DEVICE_SCAN,
+        SandboxNbdCowCreateStage::DispatchSetup => RUNNER_FRESH_SANDBOX_FACTORY_NBD_DISPATCH_SETUP,
+        SandboxNbdCowCreateStage::NetlinkConnect => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_CONNECT
+        }
+        SandboxNbdCowCreateStage::SizeVerify => RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_VERIFY,
+        SandboxNbdCowCreateStage::RetryCleanup => RUNNER_FRESH_SANDBOX_FACTORY_NBD_RETRY_CLEANUP,
+        SandboxNbdCowCreateStage::RetryDelay => RUNNER_FRESH_SANDBOX_FACTORY_NBD_RETRY_DELAY,
+    }
+}
+
+fn fresh_sandbox_factory_nbd_cow_outcome_action(
+    outcome: SandboxNbdCowCreateOutcome,
+) -> &'static str {
+    match outcome {
+        SandboxNbdCowCreateOutcome::AcquireSourceDemandScan => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_ACQUIRE_SOURCE_DEMAND_SCAN
+        }
+        SandboxNbdCowCreateOutcome::AcquireSourceCooledClaim => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_ACQUIRE_SOURCE_COOLED_CLAIM
+        }
+        SandboxNbdCowCreateOutcome::EbusyRetriesNone => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_EBUSY_RETRIES_NONE
+        }
+        SandboxNbdCowCreateOutcome::EbusyRetriesOne => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_EBUSY_RETRIES_ONE
+        }
+        SandboxNbdCowCreateOutcome::EbusyRetriesMultiple => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_EBUSY_RETRIES_MULTIPLE
+        }
+        SandboxNbdCowCreateOutcome::SizeZeroRetriesNone => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_NONE
+        }
+        SandboxNbdCowCreateOutcome::SizeZeroRetriesOne => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_ONE
+        }
+        SandboxNbdCowCreateOutcome::SizeZeroRetriesMultiple => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_ZERO_RETRIES_MULTIPLE
+        }
     }
 }
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use sandbox::{
     ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxCreateObserver,
     SandboxCreateStage, SandboxError, SandboxFactory, SandboxId, SandboxInitializationPhase,
+    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
 };
 use sandbox_mock::MockSandboxFactory;
 
@@ -101,6 +102,7 @@ fn assert_action_outcome(
 struct ObservedMockSandboxFactory {
     inner: MockSandboxFactory,
     failed_stage: Option<SandboxCreateStage>,
+    failed_nbd_cow_stage: Option<SandboxNbdCowCreateStage>,
 }
 
 impl ObservedMockSandboxFactory {
@@ -108,6 +110,7 @@ impl ObservedMockSandboxFactory {
         Self {
             inner: MockSandboxFactory::new(),
             failed_stage: None,
+            failed_nbd_cow_stage: None,
         }
     }
 
@@ -115,6 +118,15 @@ impl ObservedMockSandboxFactory {
         Self {
             inner: MockSandboxFactory::new(),
             failed_stage: Some(stage),
+            failed_nbd_cow_stage: None,
+        }
+    }
+
+    fn with_failed_nbd_cow_stage(stage: SandboxNbdCowCreateStage) -> Self {
+        Self {
+            inner: MockSandboxFactory::new(),
+            failed_stage: None,
+            failed_nbd_cow_stage: Some(stage),
         }
     }
 }
@@ -146,8 +158,31 @@ impl SandboxFactory for ObservedMockSandboxFactory {
             });
         }
 
+        if let Some(stage) = self.failed_nbd_cow_stage {
+            observer.record_nbd_cow_stage(stage, Duration::from_millis(1), false);
+            observer.record_stage(
+                SandboxCreateStage::NbdCowCreate,
+                Duration::from_millis(2),
+                false,
+            );
+            return Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: "observed mock NBD COW detail failure".to_string(),
+            });
+        }
+
         for (index, stage) in SandboxCreateStage::ALL.iter().copied().enumerate() {
             observer.record_stage(stage, Duration::from_millis(index as u64 + 1), true);
+        }
+        for (index, stage) in SandboxNbdCowCreateStage::ALL.iter().copied().enumerate() {
+            observer.record_nbd_cow_stage(stage, Duration::from_millis(index as u64 + 10), true);
+        }
+        for outcome in [
+            SandboxNbdCowCreateOutcome::AcquireSourceDemandScan,
+            SandboxNbdCowCreateOutcome::EbusyRetriesNone,
+            SandboxNbdCowCreateOutcome::SizeZeroRetriesNone,
+        ] {
+            observer.record_nbd_cow_outcome(outcome);
         }
         self.inner.create(config).await
     }
@@ -170,6 +205,23 @@ const FRESH_SANDBOX_FACTORY_STAGE_ACTIONS: &[&str] = &[
     "runner_fresh_sandbox_factory_sock_dir_prepare",
     "runner_fresh_sandbox_factory_netns_acquire",
     "runner_fresh_sandbox_factory_nbd_cow_create",
+];
+
+const FRESH_SANDBOX_FACTORY_NBD_COW_STAGE_ACTIONS: &[&str] = &[
+    "runner_fresh_sandbox_factory_nbd_cow_layer_create",
+    "runner_fresh_sandbox_factory_nbd_device_acquire",
+    "runner_fresh_sandbox_factory_nbd_device_scan",
+    "runner_fresh_sandbox_factory_nbd_dispatch_setup",
+    "runner_fresh_sandbox_factory_nbd_netlink_connect",
+    "runner_fresh_sandbox_factory_nbd_size_verify",
+    "runner_fresh_sandbox_factory_nbd_retry_cleanup",
+    "runner_fresh_sandbox_factory_nbd_retry_delay",
+];
+
+const FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS: &[&str] = &[
+    "runner_fresh_sandbox_factory_nbd_acquire_source_demand_scan",
+    "runner_fresh_sandbox_factory_nbd_ebusy_retries_none",
+    "runner_fresh_sandbox_factory_nbd_size_zero_retries_none",
 ];
 
 const RUNNER_PRE_SPAWN_PHASE_ACTIONS: &[&str] = &[
@@ -359,6 +411,21 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     for action in FRESH_SANDBOX_FACTORY_STAGE_ACTIONS {
         assert_action_success(&telemetry, action, true);
     }
+    for action in FRESH_SANDBOX_FACTORY_NBD_COW_STAGE_ACTIONS {
+        assert_action_success(&telemetry, action, true);
+    }
+    for action in FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS {
+        assert_action_success(&telemetry, action, true);
+    }
+    let operations = telemetry.pending_ops_with_duration_snapshot();
+    for action in FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS {
+        let matching: Vec<_> = operations
+            .iter()
+            .filter(|operation| operation.0 == *action)
+            .collect();
+        assert_eq!(matching.len(), 1, "outcome {action}: {operations:?}");
+        assert_eq!(matching[0].1, 0, "outcome {action} duration");
+    }
     assert_pre_spawn_phase_actions_succeeded(&telemetry);
     assert_lacks_action(&telemetry, "runner_reused_sandbox_prepare");
     assert_lacks_action(&telemetry, "runner_fresh_workspace_image_prepare");
@@ -399,6 +466,48 @@ async fn execute_job_records_failed_fresh_sandbox_factory_stage_timing() {
     );
     assert_action_success(&telemetry, "vm_create", false);
     assert_lacks_action(&telemetry, "runner_fresh_sandbox_start");
+}
+
+#[tokio::test]
+async fn execute_job_records_failed_nbd_cow_detail_and_parent_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = ObservedMockSandboxFactory::with_failed_nbd_cow_stage(
+        SandboxNbdCowCreateStage::NetlinkConnect,
+    );
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, telemetry) = execute_job(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        cancel,
+    )
+    .await;
+
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_factory_nbd_netlink_connect",
+        false,
+        Some("sandbox_factory_create_stage_failed"),
+    );
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_factory_nbd_cow_create",
+        false,
+        Some("sandbox_factory_create_stage_failed"),
+    );
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_factory_create",
+        false,
+        Some("sandbox_factory_create_failed"),
+    );
 }
 
 #[tokio::test]

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 use std::time::{Duration, Instant};
 
-use sandbox::SandboxCreateStage;
+use nbd_cow::{NbdCowCreateOutcome, NbdCowCreateStage};
+use sandbox::{SandboxCreateStage, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage};
 use tracing::{info, warn};
 
 use crate::duration::duration_ms;
@@ -173,6 +174,10 @@ impl<'a> SandboxCreateTiming<'a> {
         self.workspace_seed_image_used = true;
     }
 
+    pub(super) fn has_observer(&self) -> bool {
+        self.observer.is_some()
+    }
+
     pub(super) fn record_stage_result<T, E>(
         &mut self,
         stage: SandboxCreateStage,
@@ -250,6 +255,56 @@ impl<'a> SandboxCreateTiming<'a> {
             return;
         }
         emit_success_summary_event!(warn, self, total_elapsed, "slow sandbox create");
+    }
+}
+
+impl nbd_cow::NbdCowCreateObserver for SandboxCreateTiming<'_> {
+    fn record_stage(&mut self, stage: NbdCowCreateStage, duration: Duration, success: bool) {
+        let Some(observer) = self.observer.as_deref_mut() else {
+            return;
+        };
+        observer.record_nbd_cow_stage(sandbox_nbd_cow_stage(stage), duration, success);
+    }
+
+    fn record_outcome(&mut self, outcome: NbdCowCreateOutcome) {
+        let Some(observer) = self.observer.as_deref_mut() else {
+            return;
+        };
+        observer.record_nbd_cow_outcome(sandbox_nbd_cow_outcome(outcome));
+    }
+}
+
+fn sandbox_nbd_cow_stage(stage: NbdCowCreateStage) -> SandboxNbdCowCreateStage {
+    match stage {
+        NbdCowCreateStage::CowLayerCreate => SandboxNbdCowCreateStage::CowLayerCreate,
+        NbdCowCreateStage::DeviceAcquire => SandboxNbdCowCreateStage::DeviceAcquire,
+        NbdCowCreateStage::DeviceScan => SandboxNbdCowCreateStage::DeviceScan,
+        NbdCowCreateStage::DispatchSetup => SandboxNbdCowCreateStage::DispatchSetup,
+        NbdCowCreateStage::NetlinkConnect => SandboxNbdCowCreateStage::NetlinkConnect,
+        NbdCowCreateStage::SizeVerify => SandboxNbdCowCreateStage::SizeVerify,
+        NbdCowCreateStage::RetryCleanup => SandboxNbdCowCreateStage::RetryCleanup,
+        NbdCowCreateStage::RetryDelay => SandboxNbdCowCreateStage::RetryDelay,
+    }
+}
+
+fn sandbox_nbd_cow_outcome(outcome: NbdCowCreateOutcome) -> SandboxNbdCowCreateOutcome {
+    match outcome {
+        NbdCowCreateOutcome::AcquireSourceDemandScan => {
+            SandboxNbdCowCreateOutcome::AcquireSourceDemandScan
+        }
+        NbdCowCreateOutcome::AcquireSourceCooledClaim => {
+            SandboxNbdCowCreateOutcome::AcquireSourceCooledClaim
+        }
+        NbdCowCreateOutcome::EbusyRetriesNone => SandboxNbdCowCreateOutcome::EbusyRetriesNone,
+        NbdCowCreateOutcome::EbusyRetriesOne => SandboxNbdCowCreateOutcome::EbusyRetriesOne,
+        NbdCowCreateOutcome::EbusyRetriesMultiple => {
+            SandboxNbdCowCreateOutcome::EbusyRetriesMultiple
+        }
+        NbdCowCreateOutcome::SizeZeroRetriesNone => SandboxNbdCowCreateOutcome::SizeZeroRetriesNone,
+        NbdCowCreateOutcome::SizeZeroRetriesOne => SandboxNbdCowCreateOutcome::SizeZeroRetriesOne,
+        NbdCowCreateOutcome::SizeZeroRetriesMultiple => {
+            SandboxNbdCowCreateOutcome::SizeZeroRetriesMultiple
+        }
     }
 }
 
@@ -339,6 +394,8 @@ mod tests {
     #[derive(Default)]
     struct RecordingCreateObserver {
         records: Vec<(sandbox::SandboxCreateStage, Duration, bool)>,
+        nbd_cow_records: Vec<(sandbox::SandboxNbdCowCreateStage, Duration, bool)>,
+        nbd_cow_outcomes: Vec<sandbox::SandboxNbdCowCreateOutcome>,
     }
 
     impl sandbox::SandboxCreateObserver for RecordingCreateObserver {
@@ -349,6 +406,19 @@ mod tests {
             success: bool,
         ) {
             self.records.push((stage, duration, success));
+        }
+
+        fn record_nbd_cow_stage(
+            &mut self,
+            stage: sandbox::SandboxNbdCowCreateStage,
+            duration: Duration,
+            success: bool,
+        ) {
+            self.nbd_cow_records.push((stage, duration, success));
+        }
+
+        fn record_nbd_cow_outcome(&mut self, outcome: sandbox::SandboxNbdCowCreateOutcome) {
+            self.nbd_cow_outcomes.push(outcome);
         }
     }
 
@@ -632,6 +702,65 @@ mod tests {
             ]
         );
         assert!(observer.records.iter().all(|record| record.2));
+    }
+
+    #[test]
+    fn nbd_cow_details_map_to_external_observer() {
+        let mut observer = RecordingCreateObserver::default();
+        {
+            let mut timing = SandboxCreateTiming::new(
+                "sandbox-1".into(),
+                "vm0/default".into(),
+                Some(&mut observer),
+            );
+            for stage in NbdCowCreateStage::ALL {
+                nbd_cow::NbdCowCreateObserver::record_stage(
+                    &mut timing,
+                    stage,
+                    Duration::from_millis(5),
+                    stage != NbdCowCreateStage::NetlinkConnect,
+                );
+            }
+            for outcome in [
+                NbdCowCreateOutcome::AcquireSourceDemandScan,
+                NbdCowCreateOutcome::AcquireSourceCooledClaim,
+                NbdCowCreateOutcome::EbusyRetriesNone,
+                NbdCowCreateOutcome::EbusyRetriesOne,
+                NbdCowCreateOutcome::EbusyRetriesMultiple,
+                NbdCowCreateOutcome::SizeZeroRetriesNone,
+                NbdCowCreateOutcome::SizeZeroRetriesOne,
+                NbdCowCreateOutcome::SizeZeroRetriesMultiple,
+            ] {
+                nbd_cow::NbdCowCreateObserver::record_outcome(&mut timing, outcome);
+            }
+        }
+
+        assert_eq!(
+            observer
+                .nbd_cow_records
+                .iter()
+                .map(|record| record.0)
+                .collect::<Vec<_>>(),
+            SandboxNbdCowCreateStage::ALL,
+        );
+        assert!(
+            observer.nbd_cow_records.iter().all(|record| {
+                record.2 == (record.0 != SandboxNbdCowCreateStage::NetlinkConnect)
+            })
+        );
+        assert_eq!(
+            observer.nbd_cow_outcomes,
+            vec![
+                SandboxNbdCowCreateOutcome::AcquireSourceDemandScan,
+                SandboxNbdCowCreateOutcome::AcquireSourceCooledClaim,
+                SandboxNbdCowCreateOutcome::EbusyRetriesNone,
+                SandboxNbdCowCreateOutcome::EbusyRetriesOne,
+                SandboxNbdCowCreateOutcome::EbusyRetriesMultiple,
+                SandboxNbdCowCreateOutcome::SizeZeroRetriesNone,
+                SandboxNbdCowCreateOutcome::SizeZeroRetriesOne,
+                SandboxNbdCowCreateOutcome::SizeZeroRetriesMultiple,
+            ],
+        );
     }
 
     #[test]

--- a/crates/sandbox-fc/src/factory/mod.rs
+++ b/crates/sandbox-fc/src/factory/mod.rs
@@ -332,11 +332,19 @@ impl FirecrackerFactory {
                 )?;
                 tx.track_network(network);
 
-                // Create NBD COW device (~15ms via netlink, no subprocess).
+                // Create the NBD COW device. Observed runner creates report
+                // fixed child stages beneath the stable parent timing below.
                 let stage_started = Instant::now();
-                let cow_device = timing.record_stage_result(
-                    SandboxCreateStage::NbdCowCreate,
-                    stage_started,
+                let create_cow_result = if timing.has_observer() {
+                    self.device_pool
+                        .create_cow_device_with_observer(
+                            &resources.base_image.path,
+                            &cow_file,
+                            resources.base_image.size,
+                            &mut timing,
+                        )
+                        .await
+                } else {
                     self.device_pool
                         .create_cow_device(
                             &resources.base_image.path,
@@ -344,10 +352,14 @@ impl FirecrackerFactory {
                             resources.base_image.size,
                         )
                         .await
-                        .map_err(|e| SandboxError::Initialization {
-                            phase: SandboxInitializationPhase::SandboxAllocation,
-                            message: format!("create NBD COW device: {e}"),
-                        }),
+                };
+                let cow_device = timing.record_stage_result(
+                    SandboxCreateStage::NbdCowCreate,
+                    stage_started,
+                    create_cow_result.map_err(|e| SandboxError::Initialization {
+                        phase: SandboxInitializationPhase::SandboxAllocation,
+                        message: format!("create NBD COW device: {e}"),
+                    }),
                 )?;
                 tx.track_cow_device(cow_device);
 

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -36,9 +36,64 @@ impl SandboxCreateStage {
     ];
 }
 
+/// Fixed NBD COW details nested under [`SandboxCreateStage::NbdCowCreate`].
+///
+/// [`Self::DeviceScan`] is nested inside [`Self::DeviceAcquire`]. Every other
+/// duration is a peer contribution to the NBD create parent.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxNbdCowCreateStage {
+    CowLayerCreate,
+    DeviceAcquire,
+    DeviceScan,
+    DispatchSetup,
+    NetlinkConnect,
+    SizeVerify,
+    RetryCleanup,
+    RetryDelay,
+}
+
+impl SandboxNbdCowCreateStage {
+    /// All NBD COW detail stages in stable telemetry order.
+    pub const ALL: [Self; 8] = [
+        Self::CowLayerCreate,
+        Self::DeviceAcquire,
+        Self::DeviceScan,
+        Self::DispatchSetup,
+        Self::NetlinkConnect,
+        Self::SizeVerify,
+        Self::RetryCleanup,
+        Self::RetryDelay,
+    ];
+}
+
+/// Fixed low-cardinality NBD COW outcomes for sandbox-create telemetry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxNbdCowCreateOutcome {
+    AcquireSourceDemandScan,
+    AcquireSourceCooledClaim,
+    EbusyRetriesNone,
+    EbusyRetriesOne,
+    EbusyRetriesMultiple,
+    SizeZeroRetriesNone,
+    SizeZeroRetriesOne,
+    SizeZeroRetriesMultiple,
+}
+
 /// Receives low-cardinality sandbox factory create stage timings.
 pub trait SandboxCreateObserver: Send {
     fn record_stage(&mut self, stage: SandboxCreateStage, duration: Duration, success: bool);
+
+    /// Record one aggregate NBD COW detail stage.
+    fn record_nbd_cow_stage(
+        &mut self,
+        _stage: SandboxNbdCowCreateStage,
+        _duration: Duration,
+        _success: bool,
+    ) {
+    }
+
+    /// Record one bounded NBD COW outcome.
+    fn record_nbd_cow_outcome(&mut self, _outcome: SandboxNbdCowCreateOutcome) {}
 }
 
 /// Creates and owns the normal teardown path for sandboxes in one profile.

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -36,7 +36,10 @@ pub use error::{
     Result, SandboxError, SandboxIdleTransition, SandboxInitializationPhase,
     SandboxInvalidStateContext, SandboxOperation, SandboxOperationReason,
 };
-pub use factory::{SandboxCreateObserver, SandboxCreateStage, SandboxFactory};
+pub use factory::{
+    SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxNbdCowCreateOutcome,
+    SandboxNbdCowCreateStage,
+};
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::Sandbox;
 pub use snapshot::{


### PR DESCRIPTION
## Summary

- aggregate fixed NBD COW creation stages across retries inside `nbd-cow`
- attribute device acquisition to demand scans or cooled claims and measure successful scan work separately
- forward bounded stage and retry outcomes through the sandbox observer into the existing runner sandbox-operation telemetry payload
- preserve `runner_fresh_sandbox_factory_nbd_cow_create` as the stable parent series

## Telemetry contract

The new duration actions cover COW layer creation, device acquisition, device scanning, dispatch setup, netlink connection, size verification, retry cleanup, and retry delay. Retry work is aggregated once per create rather than emitted per attempt.

Acquisition-source presence and EBUSY/size-zero retry counts are emitted as fixed zero-duration outcomes. Retry counts use `none`, `one`, and `multiple` buckets.

`runner_fresh_sandbox_factory_nbd_device_scan` is nested inside `runner_fresh_sandbox_factory_nbd_device_acquire`. Downstream queries must not add scan duration to acquire duration or to the peer-stage sum.

## Compatibility and exclusions

- no database schema or persisted-state changes
- no API, telemetry payload, runner/guest protocol, or queue contract changes
- no changes to NBD pool capacity, scan concurrency, cooldown, retry budgets or delays, ownership, or cleanup behavior
- cancellation still avoids observer callbacks from `Drop`; the existing parent lifecycle remains authoritative
- old and new runner versions can overlap and emit independently valid action names

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-targets --all-features`
- `cargo test -p nbd-cow`
- `cargo test -p sandbox`
- `cargo test -p sandbox-fc factory::create_timing`
- `cargo test -p runner executor::tests::telemetry_tests`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,290 passed, 1 skipped)
- `pnpm knip`

The existing privileged metal NBD integration job remains the authoritative real-device validation and now asserts the observed create path.

## Post-deploy validation

Compare the unchanged parent series by runner version, then inspect peer-stage coverage and residual time, acquire versus nested scan work, acquisition-source incidence, retry buckets and retry overhead, and failure/cleanup signals. Use those results to decide whether the next optimization belongs in scanning/acquisition, cooldown recycling, connection/setup, verification/retry handling, or later workspace/NBD overlap work.

Closes #20941

Parent context: #18746
