### PR TITLE
fix(runner): enforce guest binary inventory completeness

### DIFF
--- a/.github/scripts/prepare-runner-image.sh
+++ b/.github/scripts/prepare-runner-image.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPT_DIR}/runner-image-target.sh"
+. "${SCRIPT_DIR}/runner-guest-binaries.sh"
 
 require_env() {
   local name=$1
@@ -58,24 +59,24 @@ done
 
 mkdir -p "$(dirname "$MANIFEST_PATH")"
 
+runner_guest_binaries_load
+guest_cargo_args=()
+guest_env=()
+for index in "${!RUNNER_GUEST_PACKAGES[@]}"; do
+  guest_cargo_args+=("-p" "${RUNNER_GUEST_PACKAGES[$index]}")
+  guest_env+=("${RUNNER_GUEST_PATH_ENVS[$index]}=target/$TARGET_TRIPLE/ci/${RUNNER_GUEST_BINARIES[$index]}")
+done
+
 echo "=== Cross-compiling guest binaries for ${TARGET_TRIPLE} ==="
 (
   cd crates
-  cargo build --profile ci --target "$TARGET_TRIPLE" \
-    -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file
+  cargo build --profile ci --target "$TARGET_TRIPLE" "${guest_cargo_args[@]}"
 )
 
 echo "=== Cross-compiling runner with embedded guests for ${TARGET_TRIPLE} ==="
 (
   cd crates
-  GUEST_AGENT_PATH="target/$TARGET_TRIPLE/ci/guest-agent" \
-  GUEST_DOWNLOAD_PATH="target/$TARGET_TRIPLE/ci/guest-download" \
-  GUEST_INIT_PATH="target/$TARGET_TRIPLE/ci/guest-init" \
-  GUEST_MOCK_CLAUDE_PATH="target/$TARGET_TRIPLE/ci/guest-mock-claude" \
-  GUEST_MOCK_CODEX_PATH="target/$TARGET_TRIPLE/ci/guest-mock-codex" \
-  GUEST_RESEED_PATH="target/$TARGET_TRIPLE/ci/guest-reseed" \
-  GUEST_WRITE_FILE_PATH="target/$TARGET_TRIPLE/ci/guest-write-file" \
-  cargo build --profile ci --target "$TARGET_TRIPLE" -p runner
+  env "${guest_env[@]}" cargo build --profile ci --target "$TARGET_TRIPLE" -p runner
 )
 
 sha_file() {
@@ -83,23 +84,11 @@ sha_file() {
 }
 
 runner_sha=$(sha_file "${TARGET_DIR}/runner")
-guest_sha_json=$(jq -n \
-  --arg guest_agent "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-agent")" \
-  --arg guest_download "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-download")" \
-  --arg guest_init "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-init")" \
-  --arg guest_mock_claude "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-mock-claude")" \
-  --arg guest_mock_codex "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-mock-codex")" \
-  --arg guest_reseed "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-reseed")" \
-  --arg guest_write_file "$(sha_file "crates/target/${TARGET_TRIPLE}/ci/guest-write-file")" \
-  '{
-    "guest-agent": $guest_agent,
-    "guest-download": $guest_download,
-    "guest-init": $guest_init,
-    "guest-mock-claude": $guest_mock_claude,
-    "guest-mock-codex": $guest_mock_codex,
-    "guest-reseed": $guest_reseed,
-    "guest-write-file": $guest_write_file
-  }')
+guest_sha_json=$(jq -n '{}')
+for binary in "${RUNNER_GUEST_BINARIES[@]}"; do
+  guest_sha=$(sha_file "crates/target/${TARGET_TRIPLE}/ci/${binary}")
+  guest_sha_json=$(jq -c --arg binary "$binary" --arg sha "$guest_sha" '. + {($binary): $sha}' <<<"$guest_sha_json")
+done
 
 prepare_host() {
   local host=$1

--- a/.github/scripts/runner-guest-binaries.sh
+++ b/.github/scripts/runner-guest-binaries.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+RUNNER_GUEST_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_GUEST_REPO_ROOT="$(cd "${RUNNER_GUEST_HELPER_DIR}/../.." && pwd)"
+RUNNER_GUEST_INVENTORY_PATH="${RUNNER_GUEST_INVENTORY_PATH:-${RUNNER_GUEST_REPO_ROOT}/crates/runner/guest-binaries.json}"
+
+RUNNER_GUEST_PACKAGES=()
+RUNNER_GUEST_BINARIES=()
+RUNNER_GUEST_PATH_ENVS=()
+RUNNER_GUEST_BUNDLED_ENVS=()
+RUNNER_GUEST_DESTINATIONS=()
+
+runner_guest_binaries_load() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to load runner guest binaries" >&2
+    return 2
+  fi
+
+  local rows
+  if ! rows=$(jq -er '
+    if type != "array" or length == 0 then
+      error("runner guest inventory must be a non-empty array")
+    else
+      .[]
+      | [.package, .binary, .pathEnv, .bundledEnv, .destination] as $fields
+      | if any($fields[]; type != "string" or length == 0) then
+          error("runner guest inventory fields must be non-empty strings")
+        else
+          $fields | @tsv
+        end
+    end
+  ' "$RUNNER_GUEST_INVENTORY_PATH"); then
+    return 1
+  fi
+
+  RUNNER_GUEST_PACKAGES=()
+  RUNNER_GUEST_BINARIES=()
+  RUNNER_GUEST_PATH_ENVS=()
+  RUNNER_GUEST_BUNDLED_ENVS=()
+  RUNNER_GUEST_DESTINATIONS=()
+
+  local package binary path_env bundled_env destination
+  while IFS=$'\t' read -r package binary path_env bundled_env destination; do
+    RUNNER_GUEST_PACKAGES+=("$package")
+    RUNNER_GUEST_BINARIES+=("$binary")
+    RUNNER_GUEST_PATH_ENVS+=("$path_env")
+    RUNNER_GUEST_BUNDLED_ENVS+=("$bundled_env")
+    RUNNER_GUEST_DESTINATIONS+=("$destination")
+  done <<<"$rows"
+}

--- a/.github/scripts/runner-guest-binaries.sh
+++ b/.github/scripts/runner-guest-binaries.sh
@@ -7,8 +7,6 @@ RUNNER_GUEST_INVENTORY_PATH="${RUNNER_GUEST_INVENTORY_PATH:-${RUNNER_GUEST_REPO_
 RUNNER_GUEST_PACKAGES=()
 RUNNER_GUEST_BINARIES=()
 RUNNER_GUEST_PATH_ENVS=()
-RUNNER_GUEST_BUNDLED_ENVS=()
-RUNNER_GUEST_DESTINATIONS=()
 
 runner_guest_binaries_load() {
   if ! command -v jq >/dev/null 2>&1; then
@@ -26,7 +24,7 @@ runner_guest_binaries_load() {
       | if any($fields[]; type != "string" or length == 0) then
           error("runner guest inventory fields must be non-empty strings")
         else
-          $fields | @tsv
+          $fields[:3] | @tsv
         end
     end
   ' "$RUNNER_GUEST_INVENTORY_PATH"); then
@@ -36,15 +34,11 @@ runner_guest_binaries_load() {
   RUNNER_GUEST_PACKAGES=()
   RUNNER_GUEST_BINARIES=()
   RUNNER_GUEST_PATH_ENVS=()
-  RUNNER_GUEST_BUNDLED_ENVS=()
-  RUNNER_GUEST_DESTINATIONS=()
 
-  local package binary path_env bundled_env destination
-  while IFS=$'\t' read -r package binary path_env bundled_env destination; do
+  local package binary path_env
+  while IFS=$'\t' read -r package binary path_env; do
     RUNNER_GUEST_PACKAGES+=("$package")
     RUNNER_GUEST_BINARIES+=("$binary")
     RUNNER_GUEST_PATH_ENVS+=("$path_env")
-    RUNNER_GUEST_BUNDLED_ENVS+=("$bundled_env")
-    RUNNER_GUEST_DESTINATIONS+=("$destination")
   done <<<"$rows"
 }

--- a/.github/scripts/runner-image-context.sh
+++ b/.github/scripts/runner-image-context.sh
@@ -257,14 +257,7 @@ turbo_consumer() {
 crates_consumer() {
   local consumer="false"
   if is_true "${CI_CHANGED:-false}" ||
-    is_true "${RUNNER_CHANGED:-false}" ||
-    is_true "${GUEST_INIT_CHANGED:-false}" ||
-    is_true "${GUEST_DOWNLOAD_CHANGED:-false}" ||
-    is_true "${GUEST_AGENT_CHANGED:-false}" ||
-    is_true "${GUEST_MOCK_CLAUDE_CHANGED:-false}" ||
-    is_true "${GUEST_MOCK_CODEX_CHANGED:-false}" ||
-    is_true "${GUEST_RESEED_CHANGED:-false}" ||
-    is_true "${GUEST_WRITE_FILE_CHANGED:-false}"; then
+    is_true "${RUNNER_CHANGED:-false}"; then
     consumer="true"
   fi
 
@@ -273,14 +266,7 @@ crates_consumer() {
 
 image_inputs() {
   local crate_image_inputs_changed="false"
-  if is_true "${RUNNER_CHANGED:-false}" ||
-    is_true "${GUEST_INIT_CHANGED:-false}" ||
-    is_true "${GUEST_DOWNLOAD_CHANGED:-false}" ||
-    is_true "${GUEST_AGENT_CHANGED:-false}" ||
-    is_true "${GUEST_MOCK_CLAUDE_CHANGED:-false}" ||
-    is_true "${GUEST_MOCK_CODEX_CHANGED:-false}" ||
-    is_true "${GUEST_RESEED_CHANGED:-false}" ||
-    is_true "${GUEST_WRITE_FILE_CHANGED:-false}"; then
+  if is_true "${RUNNER_CHANGED:-false}"; then
     crate_image_inputs_changed="true"
   fi
 

--- a/.github/scripts/runner-image-manifest.sh
+++ b/.github/scripts/runner-image-manifest.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPT_DIR}/runner-image-target.sh"
+. "${SCRIPT_DIR}/runner-guest-binaries.sh"
 
 usage() {
   cat <<'USAGE'
@@ -44,6 +45,8 @@ validate() {
   require_env PROFILE
   require_env METAL_HOSTS
 
+  runner_guest_binaries_load
+
   runner_image_validate_target "$TARGET"
 
   if [ ! -f "$MANIFEST_PATH" ]; then
@@ -73,7 +76,7 @@ validate() {
   [ -n "$runner_dir" ] || { echo "manifest missing runnerDir" >&2; exit 1; }
   [ -n "$runner_sha" ] || { echo "manifest missing runnerSha256" >&2; exit 1; }
 
-  for guest in guest-agent guest-download guest-init guest-mock-claude guest-mock-codex guest-reseed guest-write-file; do
+  for guest in "${RUNNER_GUEST_BINARIES[@]}"; do
     actual=$(jq -r --arg guest "$guest" '.guestSha256[$guest] // empty' "$MANIFEST_PATH")
     [ -n "$actual" ] || { echo "manifest missing guestSha256.${guest}" >&2; exit 1; }
   done

--- a/.github/scripts/tests/dev-runner-test.sh
+++ b/.github/scripts/tests/dev-runner-test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 DEV_RUNNER="${REPO_ROOT}/scripts/dev-runner.sh"
 TARGET_HELPER="${REPO_ROOT}/.github/scripts/runner-image-target.sh"
+GUEST_HELPER="${REPO_ROOT}/.github/scripts/runner-guest-binaries.sh"
+GUEST_INVENTORY="${REPO_ROOT}/crates/runner/guest-binaries.json"
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
@@ -19,11 +21,13 @@ setup_test_root() {
     "${root}/scripts" \
     "${root}/.github/scripts" \
     "${root}/.certs" \
-    "${root}/crates" \
+    "${root}/crates/runner" \
     "${root}/bin"
 
   ln -s "$DEV_RUNNER" "${root}/scripts/dev-runner.sh"
   ln -s "$TARGET_HELPER" "${root}/.github/scripts/runner-image-target.sh"
+  ln -s "$GUEST_HELPER" "${root}/.github/scripts/runner-guest-binaries.sh"
+  ln -s "$GUEST_INVENTORY" "${root}/crates/runner/guest-binaries.json"
   touch "${root}/.certs/vm0-metal-local.pem"
 
   cat >"${root}/scripts/.env.local" <<'ENV'
@@ -77,13 +81,20 @@ SH
 set -euo pipefail
 
 target=""
-previous=""
-for arg in "$@"; do
-  if [ "$previous" = "--target" ]; then
-    target="$arg"
-    break
-  fi
-  previous="$arg"
+packages=()
+original_args="$*"
+while (($#)); do
+  case "$1" in
+    --target)
+      target="$2"
+      shift 2
+      ;;
+    -p)
+      packages+=("$2")
+      shift 2
+      ;;
+    *) shift ;;
+  esac
 done
 
 if [ -z "$target" ]; then
@@ -91,9 +102,9 @@ if [ -z "$target" ]; then
   exit 2
 fi
 
-printf '%s\n' "$*" >>"${CARGO_LOG:?}"
+printf '%s\n' "$original_args" >>"${CARGO_LOG:?}"
 mkdir -p "target/${target}/ci"
-for bin in guest-agent guest-download guest-init guest-mock-claude guest-mock-codex guest-reseed guest-write-file runner; do
+for bin in "${packages[@]}"; do
   printf '%s\n' "$bin" >"target/${target}/ci/${bin}"
   chmod +x "target/${target}/ci/${bin}"
 done

--- a/.github/scripts/tests/runner-guest-binaries-test.sh
+++ b/.github/scripts/tests/runner-guest-binaries-test.sh
@@ -38,8 +38,13 @@ runner_guest_binaries_load
 [ "${RUNNER_GUEST_PACKAGES[0]}" = "guest-one" ] || fail "expected first package"
 [ "${RUNNER_GUEST_BINARIES[1]}" = "guest-two" ] || fail "expected second binary"
 [ "${RUNNER_GUEST_PATH_ENVS[0]}" = "GUEST_ONE_PATH" ] || fail "expected first path env"
-[ "${RUNNER_GUEST_BUNDLED_ENVS[1]}" = "BUNDLED_GUEST_TWO" ] || fail "expected second bundled env"
-[ "${RUNNER_GUEST_DESTINATIONS[0]}" = "/usr/local/bin/guest one" ] || fail "expected destination with spaces"
+
+jq '.[0].bundledEnv = ""' "$RUNNER_GUEST_INVENTORY_PATH" >"${TMPDIR}/invalid.json"
+RUNNER_GUEST_INVENTORY_PATH="${TMPDIR}/invalid.json"
+if runner_guest_binaries_load >"${TMPDIR}/invalid.out" 2>"${TMPDIR}/invalid.err"; then
+  fail "expected empty inventory field to fail"
+fi
+grep -q "runner guest inventory fields must be non-empty strings" "${TMPDIR}/invalid.err" || fail "expected invalid field error"
 
 printf '[]\n' >"$RUNNER_GUEST_INVENTORY_PATH"
 if runner_guest_binaries_load >"${TMPDIR}/empty.out" 2>"${TMPDIR}/empty.err"; then

--- a/.github/scripts/tests/runner-guest-binaries-test.sh
+++ b/.github/scripts/tests/runner-guest-binaries-test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+RUNNER_GUEST_INVENTORY_PATH="${TMPDIR}/guests.json"
+. "${SCRIPT_DIR}/runner-guest-binaries.sh"
+
+cat >"$RUNNER_GUEST_INVENTORY_PATH" <<'JSON'
+[
+  {
+    "package": "guest-one",
+    "binary": "guest-one",
+    "pathEnv": "GUEST_ONE_PATH",
+    "bundledEnv": "BUNDLED_GUEST_ONE",
+    "destination": "/usr/local/bin/guest one"
+  },
+  {
+    "package": "guest-two",
+    "binary": "guest-two",
+    "pathEnv": "GUEST_TWO_PATH",
+    "bundledEnv": "BUNDLED_GUEST_TWO",
+    "destination": "/sbin/guest-two"
+  }
+]
+JSON
+
+runner_guest_binaries_load
+
+[ "${#RUNNER_GUEST_PACKAGES[@]}" -eq 2 ] || fail "expected two guest packages"
+[ "${RUNNER_GUEST_PACKAGES[0]}" = "guest-one" ] || fail "expected first package"
+[ "${RUNNER_GUEST_BINARIES[1]}" = "guest-two" ] || fail "expected second binary"
+[ "${RUNNER_GUEST_PATH_ENVS[0]}" = "GUEST_ONE_PATH" ] || fail "expected first path env"
+[ "${RUNNER_GUEST_BUNDLED_ENVS[1]}" = "BUNDLED_GUEST_TWO" ] || fail "expected second bundled env"
+[ "${RUNNER_GUEST_DESTINATIONS[0]}" = "/usr/local/bin/guest one" ] || fail "expected destination with spaces"
+
+printf '[]\n' >"$RUNNER_GUEST_INVENTORY_PATH"
+if runner_guest_binaries_load >"${TMPDIR}/empty.out" 2>"${TMPDIR}/empty.err"; then
+  fail "expected empty inventory to fail"
+fi
+grep -q "runner guest inventory must be a non-empty array" "${TMPDIR}/empty.err" || fail "expected empty inventory error"
+
+echo "runner-guest-binaries-test: ok"

--- a/.github/scripts/tests/runner-image-context-test.sh
+++ b/.github/scripts/tests/runner-image-context-test.sh
@@ -103,16 +103,7 @@ out=$(run_clean \
   "$CONTEXT" turbo-consumer)
 assert_contains "$out" "turbo-runner-consumer-needed=false"
 
-for flag in \
-  CI_CHANGED \
-  RUNNER_CHANGED \
-  GUEST_INIT_CHANGED \
-  GUEST_DOWNLOAD_CHANGED \
-  GUEST_AGENT_CHANGED \
-  GUEST_MOCK_CLAUDE_CHANGED \
-  GUEST_MOCK_CODEX_CHANGED \
-  GUEST_RESEED_CHANGED \
-  GUEST_WRITE_FILE_CHANGED; do
+for flag in CI_CHANGED RUNNER_CHANGED; do
   out=$(run_clean \
     "${flag}=true" \
     "$CONTEXT" crates-consumer)

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -70,13 +70,6 @@ jobs:
       ably-subscriber-changed: ${{ steps.detect.outputs.ably-subscriber-changed }}
       api-contracts-changed: ${{ steps.detect.outputs.api-contracts-changed }}
       runner-changed: ${{ steps.detect.outputs.runner-changed }}
-      guest-init-changed: ${{ steps.detect.outputs.guest-init-changed }}
-      guest-download-changed: ${{ steps.detect.outputs.guest-download-changed }}
-      guest-agent-changed: ${{ steps.detect.outputs.guest-agent-changed }}
-      guest-mock-claude-changed: ${{ steps.detect.outputs.guest-mock-claude-changed }}
-      guest-mock-codex-changed: ${{ steps.detect.outputs.guest-mock-codex-changed }}
-      guest-reseed-changed: ${{ steps.detect.outputs.guest-reseed-changed }}
-      guest-write-file-changed: ${{ steps.detect.outputs.guest-write-file-changed }}
       nbd-cow-changed: ${{ steps.detect.outputs.nbd-cow-changed }}
       vsock-test-changed: ${{ steps.detect.outputs.vsock-test-changed }}
       crates-runner-consumer-needed: ${{ steps.runner-tests.outputs.crates-runner-consumer-needed }}
@@ -123,13 +116,6 @@ jobs:
           check_crate ably-subscriber
           check_crate api-contracts
           check_crate runner
-          check_crate guest-init
-          check_crate guest-download
-          check_crate guest-agent
-          check_crate guest-mock-claude
-          check_crate guest-mock-codex
-          check_crate guest-reseed
-          check_crate guest-write-file
           check_crate nbd-cow
           check_crate vsock-test
 
@@ -189,13 +175,6 @@ jobs:
         env:
           CI_CHANGED: ${{ steps.detect.outputs.ci-changed }}
           RUNNER_CHANGED: ${{ steps.detect.outputs.runner-changed }}
-          GUEST_INIT_CHANGED: ${{ steps.detect.outputs.guest-init-changed }}
-          GUEST_DOWNLOAD_CHANGED: ${{ steps.detect.outputs.guest-download-changed }}
-          GUEST_AGENT_CHANGED: ${{ steps.detect.outputs.guest-agent-changed }}
-          GUEST_MOCK_CLAUDE_CHANGED: ${{ steps.detect.outputs.guest-mock-claude-changed }}
-          GUEST_MOCK_CODEX_CHANGED: ${{ steps.detect.outputs.guest-mock-codex-changed }}
-          GUEST_RESEED_CHANGED: ${{ steps.detect.outputs.guest-reseed-changed }}
-          GUEST_WRITE_FILE_CHANGED: ${{ steps.detect.outputs.guest-write-file-changed }}
         run: .github/scripts/runner-image-context.sh crates-consumer
 
       - name: Select runner job refs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1932,24 +1932,28 @@ jobs:
         env:
           TARGET_TRIPLE: ${{ matrix.target }}
         run: |
+          . .github/scripts/runner-guest-binaries.sh
+          runner_guest_binaries_load
+          guest_cargo_args=()
+          for package in "${RUNNER_GUEST_PACKAGES[@]}"; do
+            guest_cargo_args+=("-p" "$package")
+          done
           cd crates
-          cargo build --release --target "$TARGET_TRIPLE" \
-            -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file
+          cargo build --release --target "$TARGET_TRIPLE" "${guest_cargo_args[@]}"
 
       - name: Cross-compile runner with embedded guests for ${{ matrix.target }}
         env:
           TARGET_TRIPLE: ${{ matrix.target }}
         run: |
+          . .github/scripts/runner-guest-binaries.sh
+          runner_guest_binaries_load
           cd crates
           TARGET_DIR="target/${TARGET_TRIPLE}/release"
-          GUEST_AGENT_PATH="${TARGET_DIR}/guest-agent" \
-          GUEST_DOWNLOAD_PATH="${TARGET_DIR}/guest-download" \
-          GUEST_INIT_PATH="${TARGET_DIR}/guest-init" \
-          GUEST_MOCK_CLAUDE_PATH="${TARGET_DIR}/guest-mock-claude" \
-          GUEST_MOCK_CODEX_PATH="${TARGET_DIR}/guest-mock-codex" \
-          GUEST_RESEED_PATH="${TARGET_DIR}/guest-reseed" \
-          GUEST_WRITE_FILE_PATH="${TARGET_DIR}/guest-write-file" \
-            cargo build --release --target "$TARGET_TRIPLE" -p runner
+          guest_env=()
+          for index in "${!RUNNER_GUEST_BINARIES[@]}"; do
+            guest_env+=("${RUNNER_GUEST_PATH_ENVS[$index]}=${TARGET_DIR}/${RUNNER_GUEST_BINARIES[$index]}")
+          done
+          env "${guest_env[@]}" cargo build --release --target "$TARGET_TRIPLE" -p runner
 
       - name: Upload runner binary to GitHub Release
         env:

--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -136,23 +136,9 @@ jobs:
           }
 
           check_crate runner runner-changed runner_changed
-          check_crate guest-init guest-init-changed guest_init_changed
-          check_crate guest-download guest-download-changed guest_download_changed
-          check_crate guest-agent guest-agent-changed guest_agent_changed
-          check_crate guest-mock-claude guest-mock-claude-changed guest_mock_claude_changed
-          check_crate guest-mock-codex guest-mock-codex-changed guest_mock_codex_changed
-          check_crate guest-reseed guest-reseed-changed guest_reseed_changed
-          check_crate guest-write-file guest-write-file-changed guest_write_file_changed
 
           CI_CHANGED="$ci_changed" \
           RUNNER_CHANGED="$runner_changed" \
-          GUEST_INIT_CHANGED="$guest_init_changed" \
-          GUEST_DOWNLOAD_CHANGED="$guest_download_changed" \
-          GUEST_AGENT_CHANGED="$guest_agent_changed" \
-          GUEST_MOCK_CLAUDE_CHANGED="$guest_mock_claude_changed" \
-          GUEST_MOCK_CODEX_CHANGED="$guest_mock_codex_changed" \
-          GUEST_RESEED_CHANGED="$guest_reseed_changed" \
-          GUEST_WRITE_FILE_CHANGED="$guest_write_file_changed" \
           .github/scripts/runner-image-context.sh crates-consumer
 
       - name: Detect runner image input changes
@@ -169,13 +155,6 @@ jobs:
           fi
 
           RUNNER_CHANGED="${{ steps.crates.outputs.runner-changed }}" \
-          GUEST_INIT_CHANGED="${{ steps.crates.outputs.guest-init-changed }}" \
-          GUEST_DOWNLOAD_CHANGED="${{ steps.crates.outputs.guest-download-changed }}" \
-          GUEST_AGENT_CHANGED="${{ steps.crates.outputs.guest-agent-changed }}" \
-          GUEST_MOCK_CLAUDE_CHANGED="${{ steps.crates.outputs.guest-mock-claude-changed }}" \
-          GUEST_MOCK_CODEX_CHANGED="${{ steps.crates.outputs.guest-mock-codex-changed }}" \
-          GUEST_RESEED_CHANGED="${{ steps.crates.outputs.guest-reseed-changed }}" \
-          GUEST_WRITE_FILE_CHANGED="${{ steps.crates.outputs.guest-write-file-changed }}" \
           RUNNER_IMAGE_CI_CHANGED="$runner_image_ci_changed" \
           .github/scripts/runner-image-context.sh image-inputs
 

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -45,6 +45,10 @@ which = { workspace = true }
 zstd = { workspace = true, features = ["zstdmt"] }
 vsock-proto = { workspace = true }
 
+[build-dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+
 # These dev-dependencies exist solely for release-please version tracking:
 # cargo-workspace plugin includes dev-dependencies in its dependency graph,
 # so runner-rs gets auto-bumped when any guest crate version changes.

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -1,8 +1,23 @@
 // Build scripts are compile-time only — panic/expect/unwrap are appropriate for fatal errors.
 #![allow(clippy::panic, clippy::expect_used, clippy::unwrap_used)]
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::{env, fs};
+
+use serde::Deserialize;
+
+const GUEST_BINARIES_FILE: &str = "guest-binaries.json";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GuestBinary {
+    package: String,
+    binary: String,
+    path_env: String,
+    bundled_env: String,
+    destination: String,
+}
 
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(bundled_guests)");
@@ -16,8 +31,11 @@ fn main() {
     println!("cargo::rerun-if-changed=scripts/mount-workspace-drive.sh");
     println!("cargo::rerun-if-changed=scripts/unmount-workspace-drive.sh");
     println!("cargo::rerun-if-changed=scripts/verify-rootfs.sh");
+    println!("cargo::rerun-if-changed={GUEST_BINARIES_FILE}");
 
     generate_addon_files();
+    let guests = load_guest_binaries();
+    generate_guest_binaries(&guests);
 
     // Build scripts run with cwd=CARGO_MANIFEST_DIR (crates/runner/), but
     // GUEST_*_PATH values are relative to the workspace root (crates/).
@@ -27,33 +45,30 @@ fn main() {
         .expect("CARGO_MANIFEST_DIR should have a parent")
         .to_path_buf();
 
-    let guests = [
-        ("GUEST_AGENT_PATH", "BUNDLED_GUEST_AGENT"),
-        ("GUEST_DOWNLOAD_PATH", "BUNDLED_GUEST_DOWNLOAD"),
-        ("GUEST_INIT_PATH", "BUNDLED_GUEST_INIT"),
-        ("GUEST_MOCK_CLAUDE_PATH", "BUNDLED_GUEST_MOCK_CLAUDE"),
-        ("GUEST_MOCK_CODEX_PATH", "BUNDLED_GUEST_MOCK_CODEX"),
-        ("GUEST_RESEED_PATH", "BUNDLED_GUEST_RESEED"),
-        ("GUEST_WRITE_FILE_PATH", "BUNDLED_GUEST_WRITE_FILE"),
-    ];
-
     // Always rebuild when any of these env vars change.
-    for (env_var, _) in &guests {
-        println!("cargo::rerun-if-env-changed={env_var}");
+    for guest in &guests {
+        println!("cargo::rerun-if-env-changed={}", guest.path_env);
     }
 
     // All-or-nothing: either all GUEST_*_PATH vars are set, or none.
     let paths: Vec<_> = guests
         .iter()
-        .filter_map(|(env_var, _)| std::env::var(env_var).ok().map(|v| (*env_var, v)))
+        .filter_map(|guest| {
+            std::env::var(&guest.path_env)
+                .ok()
+                .map(|value| (guest, value))
+        })
         .collect();
 
     if !paths.is_empty() && paths.len() != guests.len() {
-        let set: Vec<_> = paths.iter().map(|(k, _)| *k).collect();
+        let set: Vec<_> = paths
+            .iter()
+            .map(|(guest, _)| guest.path_env.as_str())
+            .collect();
         let missing: Vec<_> = guests
             .iter()
-            .filter(|(k, _)| !set.contains(k))
-            .map(|(k, _)| *k)
+            .filter(|guest| !set.contains(&guest.path_env.as_str()))
+            .map(|guest| guest.path_env.as_str())
             .collect();
         panic!(
             "partial GUEST_*_PATH env vars: set={set:?}, missing={missing:?} — must set all or none"
@@ -62,21 +77,80 @@ fn main() {
 
     if paths.len() == guests.len() {
         println!("cargo::rustc-cfg=bundled_guests");
-        for ((_, bundled_key), (_, raw_path)) in guests.iter().zip(paths.iter()) {
-            let resolved = if std::path::Path::new(raw_path).is_relative() {
-                workspace_root.join(raw_path)
+        for (guest, raw_path) in paths {
+            let resolved = if std::path::Path::new(raw_path.as_str()).is_relative() {
+                workspace_root.join(raw_path.as_str())
             } else {
-                PathBuf::from(raw_path)
+                PathBuf::from(raw_path.as_str())
             };
             let abs = std::fs::canonicalize(&resolved)
                 .unwrap_or_else(|e| panic!("{raw_path} (resolved to {}): {e}", resolved.display()));
             let abs_str = abs
                 .to_str()
                 .unwrap_or_else(|| panic!("non-UTF-8 path: {}", abs.display()));
-            println!("cargo::rustc-env={bundled_key}={abs_str}");
+            println!("cargo::rustc-env={}={abs_str}", guest.bundled_env);
             println!("cargo::rerun-if-changed={abs_str}");
         }
     }
+}
+
+fn load_guest_binaries() -> Vec<GuestBinary> {
+    let input = fs::read_to_string(GUEST_BINARIES_FILE)
+        .unwrap_or_else(|e| panic!("read {GUEST_BINARIES_FILE}: {e}"));
+    let guests: Vec<GuestBinary> =
+        serde_json::from_str(&input).unwrap_or_else(|e| panic!("parse {GUEST_BINARIES_FILE}: {e}"));
+    if guests.is_empty() {
+        panic!("{GUEST_BINARIES_FILE} must contain at least one guest binary");
+    }
+
+    let unique_fields: [fn(&GuestBinary) -> &str; 5] = [
+        |guest: &GuestBinary| guest.package.as_str(),
+        |guest: &GuestBinary| guest.binary.as_str(),
+        |guest: &GuestBinary| guest.path_env.as_str(),
+        |guest: &GuestBinary| guest.bundled_env.as_str(),
+        |guest: &GuestBinary| guest.destination.as_str(),
+    ];
+    for field in unique_fields {
+        let mut values = HashSet::new();
+        for guest in &guests {
+            let value = field(guest);
+            if !values.insert(value) {
+                panic!("duplicate guest binary inventory value: {value}");
+            }
+        }
+    }
+
+    guests
+}
+
+fn generate_guest_binaries(guests: &[GuestBinary]) {
+    let mut code = String::from("const GUEST_DEFINITIONS: &[GuestDefinition] = &[\n");
+    for guest in guests {
+        code.push_str(&format!(
+            "    GuestDefinition {{ name: {:?}, destination: {:?} }},\n",
+            guest.binary, guest.destination
+        ));
+    }
+    code.push_str("];\n\n#[cfg(bundled_guests)]\nmod embedded {\n");
+    for (index, guest) in guests.iter().enumerate() {
+        code.push_str(&format!(
+            "    pub(super) const GUEST_{index}: &[u8] = include_bytes!(env!({:?}));\n",
+            guest.bundled_env
+        ));
+    }
+    code.push_str("}\n\n#[cfg(bundled_guests)]\nfn bundled_guest(name: &str) -> Option<&'static [u8]> {\n    match name {\n");
+    for (index, guest) in guests.iter().enumerate() {
+        code.push_str(&format!(
+            "        {:?} => Some(embedded::GUEST_{index}),\n",
+            guest.binary
+        ));
+    }
+    code.push_str(
+        "        _ => None,\n    }\n}\n\n#[cfg(not(bundled_guests))]\nfn bundled_guest(_name: &str) -> Option<&'static [u8]> {\n    None\n}\n",
+    );
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    fs::write(out_dir.join("guest_binaries.rs"), code).unwrap();
 }
 
 /// Recursively scan `mitm-addon/src/**` and generate `addon_files.rs` with all

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -19,6 +19,8 @@ struct GuestBinary {
     destination: String,
 }
 
+type GuestField = (&'static str, fn(&GuestBinary) -> &str);
+
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(bundled_guests)");
 
@@ -103,20 +105,35 @@ fn load_guest_binaries() -> Vec<GuestBinary> {
         panic!("{GUEST_BINARIES_FILE} must contain at least one guest binary");
     }
 
-    let unique_fields: [fn(&GuestBinary) -> &str; 5] = [
-        |guest: &GuestBinary| guest.package.as_str(),
-        |guest: &GuestBinary| guest.binary.as_str(),
-        |guest: &GuestBinary| guest.path_env.as_str(),
-        |guest: &GuestBinary| guest.bundled_env.as_str(),
-        |guest: &GuestBinary| guest.destination.as_str(),
+    let unique_fields: [GuestField; 5] = [
+        ("package", |guest: &GuestBinary| guest.package.as_str()),
+        ("binary", |guest: &GuestBinary| guest.binary.as_str()),
+        ("pathEnv", |guest: &GuestBinary| guest.path_env.as_str()),
+        ("bundledEnv", |guest: &GuestBinary| {
+            guest.bundled_env.as_str()
+        }),
+        ("destination", |guest: &GuestBinary| {
+            guest.destination.as_str()
+        }),
     ];
-    for field in unique_fields {
+    for (name, field) in unique_fields {
         let mut values = HashSet::new();
         for guest in &guests {
             let value = field(guest);
-            if !values.insert(value) {
-                panic!("duplicate guest binary inventory value: {value}");
+            if value.is_empty() {
+                panic!("guest binary inventory {name} must not be empty");
             }
+            if !values.insert(value) {
+                panic!("duplicate guest binary inventory {name}: {value}");
+            }
+        }
+    }
+    for guest in &guests {
+        if !Path::new(&guest.destination).is_absolute() {
+            panic!(
+                "guest binary inventory destination must be absolute: {}",
+                guest.destination
+            );
         }
     }
 

--- a/crates/runner/build.rs
+++ b/crates/runner/build.rs
@@ -129,10 +129,15 @@ fn load_guest_binaries() -> Vec<GuestBinary> {
         }
     }
     for guest in &guests {
-        if !Path::new(&guest.destination).is_absolute() {
+        let destination = guest.destination.as_str();
+        let relative = destination.strip_prefix('/').unwrap_or("");
+        if relative.is_empty()
+            || relative
+                .split('/')
+                .any(|component| component.is_empty() || component == "." || component == "..")
+        {
             panic!(
-                "guest binary inventory destination must be absolute: {}",
-                guest.destination
+                "guest binary inventory destination must be an absolute, safe non-root path: {destination}"
             );
         }
     }

--- a/crates/runner/guest-binaries.json
+++ b/crates/runner/guest-binaries.json
@@ -1,0 +1,51 @@
+[
+  {
+    "package": "guest-agent",
+    "binary": "guest-agent",
+    "pathEnv": "GUEST_AGENT_PATH",
+    "bundledEnv": "BUNDLED_GUEST_AGENT",
+    "destination": "/usr/local/bin/guest-agent"
+  },
+  {
+    "package": "guest-download",
+    "binary": "guest-download",
+    "pathEnv": "GUEST_DOWNLOAD_PATH",
+    "bundledEnv": "BUNDLED_GUEST_DOWNLOAD",
+    "destination": "/usr/local/bin/guest-download"
+  },
+  {
+    "package": "guest-init",
+    "binary": "guest-init",
+    "pathEnv": "GUEST_INIT_PATH",
+    "bundledEnv": "BUNDLED_GUEST_INIT",
+    "destination": "/sbin/guest-init"
+  },
+  {
+    "package": "guest-reseed",
+    "binary": "guest-reseed",
+    "pathEnv": "GUEST_RESEED_PATH",
+    "bundledEnv": "BUNDLED_GUEST_RESEED",
+    "destination": "/sbin/guest-reseed"
+  },
+  {
+    "package": "guest-write-file",
+    "binary": "guest-write-file",
+    "pathEnv": "GUEST_WRITE_FILE_PATH",
+    "bundledEnv": "BUNDLED_GUEST_WRITE_FILE",
+    "destination": "/sbin/guest-write-file"
+  },
+  {
+    "package": "guest-mock-claude",
+    "binary": "guest-mock-claude",
+    "pathEnv": "GUEST_MOCK_CLAUDE_PATH",
+    "bundledEnv": "BUNDLED_GUEST_MOCK_CLAUDE",
+    "destination": "/usr/local/bin/guest-mock-claude"
+  },
+  {
+    "package": "guest-mock-codex",
+    "binary": "guest-mock-codex",
+    "pathEnv": "GUEST_MOCK_CODEX_PATH",
+    "bundledEnv": "BUNDLED_GUEST_MOCK_CODEX",
+    "destination": "/usr/local/bin/guest-mock-codex"
+  }
+]

--- a/crates/runner/scripts/customize-rootfs.sh
+++ b/crates/runner/scripts/customize-rootfs.sh
@@ -14,13 +14,8 @@
 #     --rootfs /path/to/rootfs.ext4.staging \
 #     --ca-dir /path/to/ca \
 #     --dns-nameserver 8.8.8.8 \
-#     --guest-agent /path/to/guest-agent \
-#     --guest-download /path/to/guest-download \
-#     --guest-init /path/to/guest-init \
-#     --guest-mock-claude /path/to/guest-mock-claude \
-#     --guest-mock-codex /path/to/guest-mock-codex \
-#     --guest-reseed /path/to/guest-reseed \
-#     --guest-write-file /path/to/guest-write-file
+#     --guest /path/to/guest-agent /usr/local/bin/guest-agent \
+#     [--guest SOURCE DESTINATION ...]
 
 set -euo pipefail
 
@@ -40,13 +35,8 @@ shift
 ROOTFS=""
 CA_DIR=""
 DNS_NAMESERVER=""
-GUEST_AGENT=""
-GUEST_DOWNLOAD=""
-GUEST_INIT=""
-GUEST_MOCK_CLAUDE=""
-GUEST_MOCK_CODEX=""
-GUEST_RESEED=""
-GUEST_WRITE_FILE=""
+GUEST_SOURCES=()
+GUEST_DESTINATIONS=()
 MOUNT_DIR=""
 CHROOT_TMP=""
 CHROOT_TMP_HOST=""
@@ -102,23 +92,25 @@ while [[ $# -gt 0 ]]; do
     --rootfs)             ROOTFS="$2";             shift 2 ;;
     --ca-dir)             CA_DIR="$2";             shift 2 ;;
     --dns-nameserver)     DNS_NAMESERVER="$2";     shift 2 ;;
-    --guest-agent)        GUEST_AGENT="$2";        shift 2 ;;
-    --guest-download)     GUEST_DOWNLOAD="$2";     shift 2 ;;
-    --guest-init)         GUEST_INIT="$2";         shift 2 ;;
-    --guest-mock-claude)  GUEST_MOCK_CLAUDE="$2";  shift 2 ;;
-    --guest-mock-codex)   GUEST_MOCK_CODEX="$2";   shift 2 ;;
-    --guest-reseed)       GUEST_RESEED="$2";       shift 2 ;;
-    --guest-write-file)   GUEST_WRITE_FILE="$2";   shift 2 ;;
+    --guest)
+      GUEST_SOURCES+=("$2")
+      GUEST_DESTINATIONS+=("$3")
+      shift 3
+      ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-for var in ROOTFS CA_DIR DNS_NAMESERVER GUEST_AGENT GUEST_DOWNLOAD GUEST_INIT GUEST_MOCK_CLAUDE GUEST_MOCK_CODEX GUEST_RESEED GUEST_WRITE_FILE; do
+for var in ROOTFS CA_DIR DNS_NAMESERVER; do
   if [[ -z "${!var}" ]]; then
     echo "error: --$(echo "$var" | tr '_' '-' | tr '[:upper:]' '[:lower:]') is required" >&2
     exit 1
   fi
 done
+if [[ ${#GUEST_SOURCES[@]} -eq 0 ]]; then
+  echo "error: at least one --guest SOURCE DESTINATION is required" >&2
+  exit 1
+fi
 
 missing=()
 for cmd in sudo unshare mount umount mountpoint chroot mktemp sed grep; do
@@ -259,13 +251,9 @@ printf '%s\n' \
   "::1 localhost" \
   | install_inline_file "/etc/hosts" 644
 
-install_host_file "$GUEST_AGENT" "/usr/local/bin/guest-agent" 755
-install_host_file "$GUEST_DOWNLOAD" "/usr/local/bin/guest-download" 755
-install_host_file "$GUEST_INIT" "/sbin/guest-init" 755
-install_host_file "$GUEST_MOCK_CLAUDE" "/usr/local/bin/guest-mock-claude" 755
-install_host_file "$GUEST_MOCK_CODEX" "/usr/local/bin/guest-mock-codex" 755
-install_host_file "$GUEST_RESEED" "/sbin/guest-reseed" 755
-install_host_file "$GUEST_WRITE_FILE" "/sbin/guest-write-file" 755
+for index in "${!GUEST_SOURCES[@]}"; do
+  install_host_file "${GUEST_SOURCES[$index]}" "${GUEST_DESTINATIONS[$index]}" 755
+done
 
 install_host_file "$ca_cert" "/${CA_ROOTFS_DEST}" 644
 

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -10,7 +10,8 @@
 # by the kernel if the script is hard-killed before the EXIT trap runs.
 #
 # Usage:
-#   bash verify-rootfs.sh --rootfs /path/to/image.ext4 [--mode template|rootfs]
+#   bash verify-rootfs.sh --rootfs /path/to/image.ext4 [--mode template|rootfs] \
+#     --guest-dest /usr/local/bin/guest-agent [--guest-dest DESTINATION ...]
 
 set -euo pipefail
 
@@ -33,11 +34,13 @@ shift
 
 ROOTFS=""
 MODE="rootfs"
+GUEST_DESTINATIONS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --rootfs) ROOTFS="$2"; shift 2 ;;
     --mode)   MODE="$2";   shift 2 ;;
+    --guest-dest) GUEST_DESTINATIONS+=("$2"); shift 2 ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
@@ -48,6 +51,10 @@ if [[ -z "$ROOTFS" ]]; then
 fi
 if [[ "$MODE" != "template" && "$MODE" != "rootfs" ]]; then
   echo "error: --mode must be template or rootfs" >&2
+  exit 1
+fi
+if [[ ${#GUEST_DESTINATIONS[@]} -eq 0 ]]; then
+  echo "error: at least one --guest-dest is required" >&2
   exit 1
 fi
 
@@ -232,23 +239,14 @@ else
   errors+=("python3 not found at /usr/bin/python3")
 fi
 
-guest_dests=(
-  "/usr/local/bin/guest-agent"
-  "/usr/local/bin/guest-download"
-  "/sbin/guest-init"
-  "/usr/local/bin/guest-mock-claude"
-  "/usr/local/bin/guest-mock-codex"
-  "/sbin/guest-reseed"
-  "/sbin/guest-write-file"
-)
 if [[ "$MODE" == "rootfs" ]]; then
   # Check guest binaries
-  for dest in "${guest_dests[@]}"; do
+  for dest in "${GUEST_DESTINATIONS[@]}"; do
     check_required_executable "$dest" "$dest"
   done
 else
   guest_contamination=0
-  for dest in "${guest_dests[@]}"; do
+  for dest in "${GUEST_DESTINATIONS[@]}"; do
     if [[ -e "${MOUNT_DIR}${dest}" || -L "${MOUNT_DIR}${dest}" ]]; then
       errors+=("template contains rootfs-only guest binary: ${dest}")
       guest_contamination=1

--- a/crates/runner/src/cmd/build/guest.rs
+++ b/crates/runner/src/cmd/build/guest.rs
@@ -4,55 +4,28 @@ use crate::error::{RunnerError, RunnerResult};
 
 use super::BuildArgs;
 
-const GUEST_AGENT_DEST: &str = "/usr/local/bin/guest-agent";
-const GUEST_DOWNLOAD_DEST: &str = "/usr/local/bin/guest-download";
-const GUEST_INIT_DEST: &str = "/sbin/guest-init";
-const GUEST_RESEED_DEST: &str = "/sbin/guest-reseed";
-const GUEST_WRITE_FILE_DEST: &str = "/sbin/guest-write-file";
-const GUEST_MOCK_CLAUDE_DEST: &str = "/usr/local/bin/guest-mock-claude";
-const GUEST_MOCK_CODEX_DEST: &str = "/usr/local/bin/guest-mock-codex";
-
-#[cfg(bundled_guests)]
-mod embedded {
-    pub const GUEST_INIT: &[u8] = include_bytes!(env!("BUNDLED_GUEST_INIT"));
-    pub const GUEST_DOWNLOAD: &[u8] = include_bytes!(env!("BUNDLED_GUEST_DOWNLOAD"));
-    pub const GUEST_AGENT: &[u8] = include_bytes!(env!("BUNDLED_GUEST_AGENT"));
-    pub const GUEST_MOCK_CLAUDE: &[u8] = include_bytes!(env!("BUNDLED_GUEST_MOCK_CLAUDE"));
-    pub const GUEST_MOCK_CODEX: &[u8] = include_bytes!(env!("BUNDLED_GUEST_MOCK_CODEX"));
-    pub const GUEST_RESEED: &[u8] = include_bytes!(env!("BUNDLED_GUEST_RESEED"));
-    pub const GUEST_WRITE_FILE: &[u8] = include_bytes!(env!("BUNDLED_GUEST_WRITE_FILE"));
+#[derive(Clone, Copy)]
+pub(super) struct GuestDefinition {
+    pub(super) name: &'static str,
+    pub(super) destination: &'static str,
 }
 
-#[cfg(bundled_guests)]
-fn bundled_guest(name: &str) -> Option<&'static [u8]> {
-    match name {
-        "guest-agent" => Some(embedded::GUEST_AGENT),
-        "guest-download" => Some(embedded::GUEST_DOWNLOAD),
-        "guest-init" => Some(embedded::GUEST_INIT),
-        "guest-mock-claude" => Some(embedded::GUEST_MOCK_CLAUDE),
-        "guest-mock-codex" => Some(embedded::GUEST_MOCK_CODEX),
-        "guest-reseed" => Some(embedded::GUEST_RESEED),
-        "guest-write-file" => Some(embedded::GUEST_WRITE_FILE),
-        _ => None,
-    }
+include!(concat!(env!("OUT_DIR"), "/guest_binaries.rs"));
+
+pub(super) fn guest_definitions() -> &'static [GuestDefinition] {
+    GUEST_DEFINITIONS
 }
 
-#[cfg(not(bundled_guests))]
-fn bundled_guest(_name: &str) -> Option<&'static [u8]> {
-    None
+pub(super) struct ResolvedGuest {
+    pub(super) definition: &'static GuestDefinition,
+    pub(super) path: PathBuf,
 }
 
 pub(super) struct GuestBinaries {
     // Keeps extracted bundled guest binaries alive for hash computation and
     // customize-rootfs.sh execution.
     pub(super) _temp_dir: tempfile::TempDir,
-    pub(super) guest_agent: PathBuf,
-    pub(super) guest_download: PathBuf,
-    pub(super) guest_init: PathBuf,
-    pub(super) guest_mock_claude: PathBuf,
-    pub(super) guest_mock_codex: PathBuf,
-    pub(super) guest_reseed: PathBuf,
-    pub(super) guest_write_file: PathBuf,
+    pub(super) entries: Vec<ResolvedGuest>,
 }
 
 impl GuestBinaries {
@@ -60,45 +33,32 @@ impl GuestBinaries {
         let temp_dir = tempfile::tempdir()
             .map_err(|e| RunnerError::Internal(format!("create temp dir: {e}")))?;
         let temp_path = temp_dir.path();
-        let guest_agent = resolve_guest(args.guest_agent.take(), "guest-agent", temp_path).await?;
-        let guest_download =
-            resolve_guest(args.guest_download.take(), "guest-download", temp_path).await?;
-        let guest_init = resolve_guest(args.guest_init.take(), "guest-init", temp_path).await?;
-        let guest_mock_claude = resolve_guest(
-            args.guest_mock_claude.take(),
-            "guest-mock-claude",
-            temp_path,
-        )
-        .await?;
-        let guest_mock_codex =
-            resolve_guest(args.guest_mock_codex.take(), "guest-mock-codex", temp_path).await?;
-        let guest_reseed =
-            resolve_guest(args.guest_reseed.take(), "guest-reseed", temp_path).await?;
-        let guest_write_file =
-            resolve_guest(args.guest_write_file.take(), "guest-write-file", temp_path).await?;
+        let mut entries = Vec::with_capacity(GUEST_DEFINITIONS.len());
+        for definition in GUEST_DEFINITIONS {
+            let path = resolve_guest(
+                args.take_guest_path(definition.name),
+                definition.name,
+                temp_path,
+            )
+            .await?;
+            entries.push(ResolvedGuest { definition, path });
+        }
 
         Ok(Self {
             _temp_dir: temp_dir,
-            guest_agent,
-            guest_download,
-            guest_init,
-            guest_mock_claude,
-            guest_mock_codex,
-            guest_reseed,
-            guest_write_file,
+            entries,
         })
     }
 
-    pub(super) fn hash_inputs(&self) -> [(&Path, &str); 7] {
-        [
-            (self.guest_agent.as_path(), GUEST_AGENT_DEST),
-            (self.guest_download.as_path(), GUEST_DOWNLOAD_DEST),
-            (self.guest_init.as_path(), GUEST_INIT_DEST),
-            (self.guest_reseed.as_path(), GUEST_RESEED_DEST),
-            (self.guest_write_file.as_path(), GUEST_WRITE_FILE_DEST),
-            (self.guest_mock_claude.as_path(), GUEST_MOCK_CLAUDE_DEST),
-            (self.guest_mock_codex.as_path(), GUEST_MOCK_CODEX_DEST),
-        ]
+    pub(super) fn hash_inputs(&self) -> Vec<(&Path, &str)> {
+        self.entries
+            .iter()
+            .map(|guest| (guest.path.as_path(), guest.definition.destination))
+            .collect()
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = &ResolvedGuest> {
+        self.entries.iter()
     }
 }
 
@@ -145,41 +105,6 @@ async fn resolve_guest(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn guest_binaries_hash_inputs_preserve_destination_order() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let guest_agent = temp_dir.path().join("guest-agent");
-        let guest_download = temp_dir.path().join("guest-download");
-        let guest_init = temp_dir.path().join("guest-init");
-        let guest_reseed = temp_dir.path().join("guest-reseed");
-        let guest_write_file = temp_dir.path().join("guest-write-file");
-        let guest_mock_claude = temp_dir.path().join("guest-mock-claude");
-        let guest_mock_codex = temp_dir.path().join("guest-mock-codex");
-        let guests = GuestBinaries {
-            _temp_dir: temp_dir,
-            guest_agent: guest_agent.clone(),
-            guest_download: guest_download.clone(),
-            guest_init: guest_init.clone(),
-            guest_mock_claude: guest_mock_claude.clone(),
-            guest_mock_codex: guest_mock_codex.clone(),
-            guest_reseed: guest_reseed.clone(),
-            guest_write_file: guest_write_file.clone(),
-        };
-
-        assert_eq!(
-            guests.hash_inputs(),
-            [
-                (guest_agent.as_path(), GUEST_AGENT_DEST),
-                (guest_download.as_path(), GUEST_DOWNLOAD_DEST),
-                (guest_init.as_path(), GUEST_INIT_DEST),
-                (guest_reseed.as_path(), GUEST_RESEED_DEST),
-                (guest_write_file.as_path(), GUEST_WRITE_FILE_DEST),
-                (guest_mock_claude.as_path(), GUEST_MOCK_CLAUDE_DEST),
-                (guest_mock_codex.as_path(), GUEST_MOCK_CODEX_DEST),
-            ]
-        );
-    }
 
     #[tokio::test]
     async fn resolve_guest_snapshots_cli_binary_into_temp_dir() {

--- a/crates/runner/src/cmd/build/mod.rs
+++ b/crates/runner/src/cmd/build/mod.rs
@@ -20,7 +20,7 @@ mod scripts;
 mod sizes;
 mod snapshot;
 
-use guest::GuestBinaries;
+use guest::{GuestBinaries, guest_definitions};
 use hashes::{
     compute_ca_cert_fingerprint, compute_rootfs_hash, compute_snapshot_hash, compute_template_hash,
 };
@@ -110,6 +110,21 @@ pub struct BuildArgs {
     /// Build or upload only the shared R2 template cache, without creating a snapshot
     #[arg(long)]
     pub warm_rootfs_cache: bool,
+}
+
+impl BuildArgs {
+    fn take_guest_path(&mut self, name: &str) -> Option<PathBuf> {
+        match name {
+            "guest-agent" => self.guest_agent.take(),
+            "guest-download" => self.guest_download.take(),
+            "guest-init" => self.guest_init.take(),
+            "guest-mock-claude" => self.guest_mock_claude.take(),
+            "guest-mock-codex" => self.guest_mock_codex.take(),
+            "guest-reseed" => self.guest_reseed.take(),
+            "guest-write-file" => self.guest_write_file.take(),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -358,9 +373,10 @@ pub async fn run_build(mut args: BuildArgs, provider: &dyn SnapshotProvider) -> 
             // change if this host's CA changes.
             ca::ensure(&paths).await?;
             let ca_fingerprint = compute_ca_cert_fingerprint(&paths).await?;
+            let guest_hash_inputs = guests.hash_inputs();
             let rootfs_hash = compute_rootfs_hash(
                 &template_hash,
-                &guests.hash_inputs(),
+                &guest_hash_inputs,
                 &ca_fingerprint,
                 def.rootfs_disk_mb,
             )
@@ -1016,6 +1032,9 @@ async fn verify_template_file(rootfs: &Path, work_dir: &Path) -> RunnerResult<()
 async fn verify_rootfs_file(rootfs: &Path, work_dir: &Path, mode: &str) -> RunnerResult<()> {
     let mut cmd = rootfs_script_command(&work_dir.join("verify-rootfs.sh"));
     cmd.arg("--rootfs").arg(rootfs).arg("--mode").arg(mode);
+    for definition in guest_definitions() {
+        cmd.arg("--guest-dest").arg(definition.destination);
+    }
     let status = run_rootfs_script(cmd, "verify-rootfs.sh").await?;
 
     if !status.success() {
@@ -1068,21 +1087,12 @@ async fn customize_rootfs_staging(
         .arg("--ca-dir")
         .arg(&ca_dir)
         .arg("--dns-nameserver")
-        .arg(ROOTFS_DNS_NAMESERVER)
-        .arg("--guest-agent")
-        .arg(&input.guests.guest_agent)
-        .arg("--guest-download")
-        .arg(&input.guests.guest_download)
-        .arg("--guest-init")
-        .arg(&input.guests.guest_init)
-        .arg("--guest-mock-claude")
-        .arg(&input.guests.guest_mock_claude)
-        .arg("--guest-mock-codex")
-        .arg(&input.guests.guest_mock_codex)
-        .arg("--guest-reseed")
-        .arg(&input.guests.guest_reseed)
-        .arg("--guest-write-file")
-        .arg(&input.guests.guest_write_file);
+        .arg(ROOTFS_DNS_NAMESERVER);
+    for guest in input.guests.iter() {
+        cmd.arg("--guest")
+            .arg(&guest.path)
+            .arg(guest.definition.destination);
+    }
     let status = run_rootfs_script(cmd, "customize-rootfs.sh").await?;
 
     if !status.success() {

--- a/crates/runner/src/cmd/build/scripts.rs
+++ b/crates/runner/src/cmd/build/scripts.rs
@@ -396,13 +396,7 @@ exit 1
     #[test]
     fn template_build_script_excludes_rootfs_only_inputs() {
         for forbidden in [
-            "--guest-agent",
-            "--guest-download",
-            "--guest-init",
-            "--guest-mock-claude",
-            "--guest-mock-codex",
-            "--guest-reseed",
-            "--guest-write-file",
+            "--guest",
             "--ca-dir",
             "--dns-nameserver",
             "CA_ROOTFS_DEST",
@@ -602,20 +596,32 @@ exit 1
             VERIFY_SCRIPT.contains(r#"check_required_executable "$dest" "$dest""#),
             "verify-rootfs.sh should verify rootfs-only guest binaries are executable"
         );
-        for guest_binary_path in [
-            "/usr/local/bin/guest-agent",
-            "/usr/local/bin/guest-download",
-            "/sbin/guest-init",
-            "/usr/local/bin/guest-mock-claude",
-            "/usr/local/bin/guest-mock-codex",
-            "/sbin/guest-reseed",
-            "/sbin/guest-write-file",
-        ] {
-            assert!(
-                VERIFY_SCRIPT.contains(guest_binary_path),
-                "verify-rootfs.sh should verify {guest_binary_path} in rootfs mode"
-            );
-        }
+        assert!(
+            VERIFY_SCRIPT.contains("--guest-dest)"),
+            "verify-rootfs.sh should accept guest destinations from the runner"
+        );
+        assert!(
+            VERIFY_SCRIPT.contains(r#""${GUEST_DESTINATIONS[@]}""#),
+            "verify-rootfs.sh should iterate every supplied guest destination"
+        );
+    }
+
+    #[test]
+    fn customize_script_installs_supplied_guest_pairs() {
+        assert!(
+            CUSTOMIZE_SCRIPT.contains("--guest)"),
+            "customize-rootfs.sh should accept guest source/destination pairs"
+        );
+        assert!(
+            CUSTOMIZE_SCRIPT.contains(r#""${!GUEST_SOURCES[@]}""#),
+            "customize-rootfs.sh should iterate every supplied guest pair"
+        );
+        assert!(
+            CUSTOMIZE_SCRIPT.contains(
+                r#"install_host_file "${GUEST_SOURCES[$index]}" "${GUEST_DESTINATIONS[$index]}" 755"#
+            ),
+            "customize-rootfs.sh should install each supplied guest pair as executable"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/runner/src/cmd/build/tests/cli.rs
+++ b/crates/runner/src/cmd/build/tests/cli.rs
@@ -1,10 +1,12 @@
 use super::fixtures::*;
 use super::*;
+use clap::CommandFactory;
+use std::collections::BTreeSet;
 
 #[test]
 fn build_args_parse_warm_rootfs_cache_flag() {
-    let mut args = build_args().to_vec();
-    args.push("--warm-rootfs-cache");
+    let mut args = build_args();
+    args.push("--warm-rootfs-cache".to_string());
 
     let cli = <TestBuildCli as clap::Parser>::try_parse_from(args).unwrap();
 
@@ -15,7 +17,7 @@ fn build_args_parse_warm_rootfs_cache_flag() {
 
 #[test]
 fn build_args_parse_warm_rootfs_cache_without_guest_binaries() {
-    let cli = <TestBuildCli as clap::Parser>::try_parse_from([
+    let mut cli = <TestBuildCli as clap::Parser>::try_parse_from([
         "runner-build",
         "--profile",
         "vm0/default",
@@ -24,13 +26,50 @@ fn build_args_parse_warm_rootfs_cache_without_guest_binaries() {
     .unwrap();
 
     assert_eq!(BuildMode::from_args(&cli.args), BuildMode::WarmRootfsCache);
-    assert!(cli.args.guest_agent.is_none());
-    assert!(cli.args.guest_download.is_none());
-    assert!(cli.args.guest_init.is_none());
-    assert!(cli.args.guest_mock_claude.is_none());
-    assert!(cli.args.guest_mock_codex.is_none());
-    assert!(cli.args.guest_reseed.is_none());
-    assert!(cli.args.guest_write_file.is_none());
+    for definition in guest_definitions() {
+        assert!(cli.args.take_guest_path(definition.name).is_none());
+    }
+}
+
+#[test]
+fn guest_cli_flags_match_inventory() {
+    let command = TestBuildCli::command();
+    let actual: BTreeSet<_> = command
+        .get_arguments()
+        .filter_map(|arg| arg.get_long())
+        .filter(|flag| flag.starts_with("guest-"))
+        .map(str::to_owned)
+        .collect();
+    let expected: BTreeSet<_> = guest_definitions()
+        .iter()
+        .map(|definition| definition.name.to_string())
+        .collect();
+
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn explicit_guest_paths_resolve_every_inventory_entry() {
+    let source_dir = tempfile::tempdir().unwrap();
+    let mut argv = vec!["runner-build".to_string()];
+    for definition in guest_definitions() {
+        let source = source_dir.path().join(definition.name);
+        std::fs::write(&source, definition.name).unwrap();
+        argv.push(format!("--{}", definition.name));
+        argv.push(source.to_string_lossy().into_owned());
+    }
+    argv.extend(["--profile".to_string(), "vm0/default".to_string()]);
+
+    let mut cli = <TestBuildCli as clap::Parser>::try_parse_from(argv).unwrap();
+    let guests = GuestBinaries::resolve(&mut cli.args).await.unwrap();
+
+    assert_eq!(guests.entries.len(), guest_definitions().len());
+    for guest in guests.iter() {
+        assert_eq!(
+            std::fs::read_to_string(&guest.path).unwrap(),
+            guest.definition.name
+        );
+    }
 }
 
 #[test]

--- a/crates/runner/src/cmd/build/tests/fixtures.rs
+++ b/crates/runner/src/cmd/build/tests/fixtures.rs
@@ -1,3 +1,4 @@
+use super::super::guest::{ResolvedGuest, guest_definitions};
 use super::*;
 use aws_smithy_mocks::{Rule, RuleMode, mock, mock_client};
 use std::sync::Arc;
@@ -8,26 +9,14 @@ pub(super) struct TestBuildCli {
     pub(super) args: BuildArgs,
 }
 
-pub(super) fn build_args() -> [&'static str; 17] {
-    [
-        "runner-build",
-        "--guest-agent",
-        "/tmp/guest-agent",
-        "--guest-download",
-        "/tmp/guest-download",
-        "--guest-init",
-        "/tmp/guest-init",
-        "--guest-mock-claude",
-        "/tmp/guest-mock-claude",
-        "--guest-mock-codex",
-        "/tmp/guest-mock-codex",
-        "--guest-reseed",
-        "/tmp/guest-reseed",
-        "--guest-write-file",
-        "/tmp/guest-write-file",
-        "--profile",
-        "vm0/default",
-    ]
+pub(super) fn build_args() -> Vec<String> {
+    let mut args = vec!["runner-build".to_string()];
+    for definition in guest_definitions() {
+        args.push(format!("--{}", definition.name));
+        args.push(format!("/tmp/{}", definition.name));
+    }
+    args.extend(["--profile".to_string(), "vm0/default".to_string()]);
+    args
 }
 
 pub(super) fn rootfs_input<'a>(
@@ -52,16 +41,16 @@ pub(super) fn test_guest_binaries() -> GuestBinaries {
     let temp_dir = tempfile::tempdir().unwrap();
     let guest = temp_dir.path().join("guest");
     std::fs::write(&guest, b"guest").unwrap();
-    let guest_write_file = guest.clone();
+    let entries = guest_definitions()
+        .iter()
+        .map(|definition| ResolvedGuest {
+            definition,
+            path: guest.clone(),
+        })
+        .collect();
     GuestBinaries {
         _temp_dir: temp_dir,
-        guest_agent: guest.clone(),
-        guest_download: guest.clone(),
-        guest_init: guest.clone(),
-        guest_mock_claude: guest.clone(),
-        guest_mock_codex: guest.clone(),
-        guest_reseed: guest,
-        guest_write_file,
+        entries,
     }
 }
 

--- a/crates/runner/tests/guest_inventory.rs
+++ b/crates/runner/tests/guest_inventory.rs
@@ -85,11 +85,20 @@ fn delivered_guests_match_cargo_and_release_contracts() {
         "guest destination",
         inventory.iter().map(|guest| guest.destination.as_str()),
     );
-    assert!(
-        inventory
-            .iter()
-            .all(|guest| guest.destination.starts_with('/'))
-    );
+    for guest in &inventory {
+        let relative = guest
+            .destination
+            .strip_prefix('/')
+            .unwrap_or_else(|| panic!("guest destination must be absolute: {}", guest.destination));
+        assert!(
+            !relative.is_empty()
+                && !relative
+                    .split('/')
+                    .any(|component| component.is_empty() || component == "." || component == ".."),
+            "guest destination must be a safe non-root path: {}",
+            guest.destination
+        );
+    }
 
     let output = Command::new(env!("CARGO"))
         .args([

--- a/crates/runner/tests/guest_inventory.rs
+++ b/crates/runner/tests/guest_inventory.rs
@@ -1,0 +1,160 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct GuestBinary {
+    package: String,
+    binary: String,
+    path_env: String,
+    bundled_env: String,
+    destination: String,
+}
+
+#[derive(Deserialize)]
+struct CargoMetadata {
+    packages: Vec<CargoPackage>,
+}
+
+#[derive(Deserialize)]
+struct CargoPackage {
+    name: String,
+    dependencies: Vec<CargoDependency>,
+    targets: Vec<CargoTarget>,
+}
+
+#[derive(Deserialize)]
+struct CargoDependency {
+    name: String,
+    kind: Option<String>,
+    path: Option<PathBuf>,
+}
+
+#[derive(Deserialize)]
+struct CargoTarget {
+    name: String,
+    kind: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct ReleasePleaseConfig {
+    packages: BTreeMap<String, Value>,
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn assert_unique<'a>(label: &str, values: impl IntoIterator<Item = &'a str>) {
+    let mut unique = BTreeSet::new();
+    for value in values {
+        assert!(unique.insert(value), "duplicate {label}: {value}");
+    }
+}
+
+#[test]
+fn delivered_guests_match_cargo_and_release_contracts() {
+    let root = repo_root();
+    let inventory: Vec<GuestBinary> = serde_json::from_slice(
+        &std::fs::read(root.join("crates/runner/guest-binaries.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(!inventory.is_empty());
+
+    assert_unique(
+        "guest package",
+        inventory.iter().map(|guest| guest.package.as_str()),
+    );
+    assert_unique(
+        "guest binary",
+        inventory.iter().map(|guest| guest.binary.as_str()),
+    );
+    assert_unique(
+        "guest path environment key",
+        inventory.iter().map(|guest| guest.path_env.as_str()),
+    );
+    assert_unique(
+        "guest bundled environment key",
+        inventory.iter().map(|guest| guest.bundled_env.as_str()),
+    );
+    assert_unique(
+        "guest destination",
+        inventory.iter().map(|guest| guest.destination.as_str()),
+    );
+    assert!(
+        inventory
+            .iter()
+            .all(|guest| guest.destination.starts_with('/'))
+    );
+
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "metadata",
+            "--manifest-path",
+            "crates/Cargo.toml",
+            "--no-deps",
+            "--format-version",
+            "1",
+        ])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout).unwrap();
+
+    let runner = metadata
+        .packages
+        .iter()
+        .find(|package| package.name == "runner")
+        .unwrap();
+    let inventory_packages: BTreeSet<_> = inventory
+        .iter()
+        .map(|guest| guest.package.as_str())
+        .collect();
+    let runner_guest_dev_dependencies: BTreeSet<_> = runner
+        .dependencies
+        .iter()
+        .filter(|dependency| {
+            dependency.kind.as_deref() == Some("dev")
+                && dependency.path.is_some()
+                && dependency.name.starts_with("guest-")
+        })
+        .map(|dependency| dependency.name.as_str())
+        .collect();
+    assert_eq!(runner_guest_dev_dependencies, inventory_packages);
+
+    for guest in &inventory {
+        let package = metadata
+            .packages
+            .iter()
+            .find(|package| package.name == guest.package)
+            .unwrap_or_else(|| panic!("missing workspace guest package: {}", guest.package));
+        assert!(
+            package.targets.iter().any(|target| {
+                target.name == guest.binary && target.kind.iter().any(|kind| kind == "bin")
+            }),
+            "{} does not expose binary target {}",
+            guest.package,
+            guest.binary
+        );
+    }
+
+    let release_config: ReleasePleaseConfig =
+        serde_json::from_slice(&std::fs::read(root.join("release-please-config.json")).unwrap())
+            .unwrap();
+    for guest in &inventory {
+        let release_path = format!("crates/{}", guest.package);
+        assert!(
+            release_config.packages.contains_key(&release_path),
+            "release-please does not register {release_path}"
+        );
+    }
+}

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -17,6 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CRATES_DIR="$PROJECT_ROOT/crates"
 . "$PROJECT_ROOT/.github/scripts/runner-image-target.sh"
+. "$PROJECT_ROOT/.github/scripts/runner-guest-binaries.sh"
 
 log() { echo "[runner] $1" >&2; }
 
@@ -111,22 +112,23 @@ cmd_deploy() {
   API_URL="https://tunnel-${RUNNER_NAME#local-}-www.vm7.ai"
   log "Runner: $RUNNER_NAME (group: $RUNNER_GROUP, api: $API_URL)"
 
+  runner_guest_binaries_load
+  local guest_cargo_args=()
+  local guest_env=()
+  local index
+  for index in "${!RUNNER_GUEST_PACKAGES[@]}"; do
+    guest_cargo_args+=("-p" "${RUNNER_GUEST_PACKAGES[$index]}")
+    guest_env+=("${RUNNER_GUEST_PATH_ENVS[$index]}=target/$TARGET/ci/${RUNNER_GUEST_BINARIES[$index]}")
+  done
+
   # Build guests
   log "Building guest binaries..."
   cd "$CRATES_DIR"
-  cargo build --profile ci --target "$TARGET" \
-    -p guest-agent -p guest-download -p guest-init -p guest-mock-claude -p guest-mock-codex -p guest-reseed -p guest-write-file
+  cargo build --profile ci --target "$TARGET" "${guest_cargo_args[@]}"
 
   # Build runner
   log "Building runner with embedded guests..."
-  GUEST_AGENT_PATH="target/$TARGET/ci/guest-agent" \
-  GUEST_DOWNLOAD_PATH="target/$TARGET/ci/guest-download" \
-  GUEST_INIT_PATH="target/$TARGET/ci/guest-init" \
-  GUEST_MOCK_CLAUDE_PATH="target/$TARGET/ci/guest-mock-claude" \
-  GUEST_MOCK_CODEX_PATH="target/$TARGET/ci/guest-mock-codex" \
-  GUEST_RESEED_PATH="target/$TARGET/ci/guest-reseed" \
-  GUEST_WRITE_FILE_PATH="target/$TARGET/ci/guest-write-file" \
-  cargo build --profile ci --target "$TARGET" -p runner
+  env "${guest_env[@]}" cargo build --profile ci --target "$TARGET" -p runner
 
   BINARY="$CRATES_DIR/target/$TARGET/ci/runner"
   log "Binary: $BINARY ($(du -h "$BINARY" | cut -f1))"


### PR DESCRIPTION
## Summary

- add a runner-owned guest binary inventory and generate the Rust build/runtime guest definitions from it
- drive local, CI, runner-image, and release builds plus manifest validation from the same inventory
- make rootfs guest installation and verification generic, with integration tests enforcing Cargo and release-please completeness

## Compatibility

- preserves the existing runner CLI flags, guest binary names, install destinations, and guest ordering
- retains every guest crate as a runner dev dependency so release-please continues to bump runner when a guest changes
- does not change APIs, runner protocols, queue payloads, or persisted state
- causes one expected rootfs cache-key rollover because the embedded rootfs scripts change

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets --all-features -- -D warnings`
- bundled runner `cargo check` with every `GUEST_*_PATH` set
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- Bash syntax checks and every `.github/scripts/tests/*.sh` test
- `actionlint`
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `cd turbo && pnpm knip`

Closes #21008
