### PR TITLE
perf(rust): prebuild guest-agent test mocks once

### DIFF
--- a/.github/scripts/tests/test-rust-wrapper-test.sh
+++ b/.github/scripts/tests/test-rust-wrapper-test.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WRAPPER="${REPO_ROOT}/scripts/test-rust.sh"
+MANIFEST_PATH="${REPO_ROOT}/crates/Cargo.toml"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+FAKE_CARGO="${TEMP_DIR}/cargo"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+cat >"$FAKE_CARGO" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_dir=${FAKE_CARGO_LOG_DIR:?}
+count_file="${log_dir}/count"
+count=0
+if [ -f "$count_file" ]; then
+  read -r count <"$count_file"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$count_file"
+invocation_dir="${log_dir}/$(printf '%02d' "$count")"
+mkdir -p "$invocation_dir"
+printf '%s\0' "$@" >"${invocation_dir}/args"
+printf 'claude=%s\ncodex=%s\n' \
+  "${VM0_TEST_GUEST_MOCK_CLAUDE_PATH:-}" \
+  "${VM0_TEST_GUEST_MOCK_CODEX_PATH:-}" >"${invocation_dir}/env"
+
+emit_artifact() {
+  local name=$1 path=$2
+  jq -nc --arg name "$name" --arg path "$path" '{
+    reason: "compiler-artifact",
+    target: {name: $name, kind: ["bin"]},
+    executable: $path
+  }'
+}
+
+case "${1:-}" in
+  build)
+    if [ "${FAKE_BUILD_EXIT:-0}" -ne 0 ]; then
+      exit "$FAKE_BUILD_EXIT"
+    fi
+    case "${FAKE_ARTIFACT_MODE:-normal}" in
+      normal)
+        emit_artifact guest-mock-claude "$FAKE_MOCK_CLAUDE_PATH"
+        emit_artifact guest-mock-codex "$FAKE_MOCK_CODEX_PATH"
+        ;;
+      missing)
+        emit_artifact guest-mock-claude "$FAKE_MOCK_CLAUDE_PATH"
+        ;;
+      duplicate)
+        emit_artifact guest-mock-claude "$FAKE_MOCK_CLAUDE_PATH"
+        emit_artifact guest-mock-codex "$FAKE_MOCK_CODEX_PATH"
+        emit_artifact guest-mock-codex "$FAKE_DUPLICATE_CODEX_PATH"
+        ;;
+      relative)
+        emit_artifact guest-mock-claude relative/guest-mock-claude
+        emit_artifact guest-mock-codex "$FAKE_MOCK_CODEX_PATH"
+        ;;
+      nonexistent)
+        emit_artifact guest-mock-claude "$FAKE_NONEXISTENT_CLAUDE_PATH"
+        emit_artifact guest-mock-codex "$FAKE_MOCK_CODEX_PATH"
+        ;;
+      *)
+        echo "unknown FAKE_ARTIFACT_MODE: $FAKE_ARTIFACT_MODE" >&2
+        exit 98
+        ;;
+    esac
+    ;;
+  test)
+    exit "${FAKE_TEST_EXIT:-0}"
+    ;;
+  *)
+    echo "unexpected fake Cargo command: $*" >&2
+    exit 99
+    ;;
+esac
+SH
+chmod +x "$FAKE_CARGO"
+
+assert_args() {
+  local args_file=$1
+  shift
+  local actual=()
+  local expected=("$@")
+  local index
+
+  mapfile -d '' -t actual <"$args_file"
+  [ "${#actual[@]}" -eq "${#expected[@]}" ] ||
+    fail "expected ${#expected[@]} args, got ${#actual[@]}"
+  for index in "${!expected[@]}"; do
+    [ "${actual[$index]}" = "${expected[$index]}" ] ||
+      fail "arg ${index}: expected '${expected[$index]}', got '${actual[$index]}'"
+  done
+}
+
+prepare_case() {
+  local name=$1
+  CASE_DIR="${TEMP_DIR}/${name}"
+  LOG_DIR="${CASE_DIR}/log"
+  MOCK_CLAUDE="${CASE_DIR}/guest-mock-claude"
+  MOCK_CODEX="${CASE_DIR}/guest-mock-codex"
+  DUPLICATE_CODEX="${CASE_DIR}/duplicate-guest-mock-codex"
+  mkdir -p "$LOG_DIR"
+  touch "$MOCK_CLAUDE" "$MOCK_CODEX" "$DUPLICATE_CODEX"
+}
+
+run_wrapper() {
+  env \
+    CARGO="$FAKE_CARGO" \
+    FAKE_CARGO_LOG_DIR="$LOG_DIR" \
+    FAKE_MOCK_CLAUDE_PATH="$MOCK_CLAUDE" \
+    FAKE_MOCK_CODEX_PATH="$MOCK_CODEX" \
+    FAKE_DUPLICATE_CODEX_PATH="$DUPLICATE_CODEX" \
+    FAKE_NONEXISTENT_CLAUDE_PATH="${CASE_DIR}/missing-guest-mock-claude" \
+    "${extra_env[@]}" \
+    "$WRAPPER" "$@"
+}
+
+prepare_case split-options
+extra_env=()
+target_dir="${CASE_DIR}/custom target"
+run_wrapper \
+  --release \
+  --target fake-target \
+  --target-dir "$target_dir" \
+  --config net.offline=true \
+  --locked \
+  -p guest-agent \
+  --test cli_child_env \
+  child_env \
+  -- \
+  --nocapture \
+  --test-threads=1
+
+[ "$(<"${LOG_DIR}/count")" = "2" ] || fail "expected build and test invocations"
+assert_args "${LOG_DIR}/01/args" \
+  build --manifest-path "$MANIFEST_PATH" \
+  -p guest-mock-claude -p guest-mock-codex \
+  --release --target fake-target --target-dir "$target_dir" \
+  --config net.offline=true --locked \
+  --message-format=json-render-diagnostics
+assert_args "${LOG_DIR}/02/args" \
+  test --manifest-path "$MANIFEST_PATH" \
+  --release --target fake-target --target-dir "$target_dir" \
+  --config net.offline=true --locked \
+  -p guest-agent --test cli_child_env child_env \
+  -- --nocapture --test-threads=1
+grep -qxF "claude=${MOCK_CLAUDE}" "${LOG_DIR}/02/env" || fail "missing Claude path"
+grep -qxF "codex=${MOCK_CODEX}" "${LOG_DIR}/02/env" || fail "missing Codex path"
+
+prepare_case equals-options
+extra_env=()
+target_dir="${CASE_DIR}/target"
+run_wrapper \
+  --profile=ci \
+  --target=fake-target \
+  --target-dir="$target_dir" \
+  --config=build.incremental=false \
+  --offline \
+  --frozen \
+  --ignore-rust-version \
+  -p guest-agent \
+  --test codex_app_server_backend
+
+assert_args "${LOG_DIR}/01/args" \
+  build --manifest-path "$MANIFEST_PATH" \
+  -p guest-mock-claude -p guest-mock-codex \
+  --profile=ci --target=fake-target --target-dir="$target_dir" \
+  --config=build.incremental=false --offline --frozen --ignore-rust-version \
+  --message-format=json-render-diagnostics
+
+prepare_case missing-artifact
+extra_env=(FAKE_ARTIFACT_MODE=missing)
+if run_wrapper >"${CASE_DIR}/out" 2>"${CASE_DIR}/err"; then
+  fail "expected a missing Codex artifact to fail"
+fi
+[ "$(<"${LOG_DIR}/count")" = "1" ] || fail "missing artifact should stop before tests"
+grep -q "expected one guest-mock-codex executable artifact, found 0" "${CASE_DIR}/err" ||
+  fail "missing artifact error not reported"
+
+prepare_case duplicate-artifact
+extra_env=(FAKE_ARTIFACT_MODE=duplicate)
+if run_wrapper >"${CASE_DIR}/out" 2>"${CASE_DIR}/err"; then
+  fail "expected duplicate Codex artifacts to fail"
+fi
+grep -q "expected one guest-mock-codex executable artifact, found 2" "${CASE_DIR}/err" ||
+  fail "duplicate artifact error not reported"
+
+prepare_case relative-artifact
+extra_env=(FAKE_ARTIFACT_MODE=relative)
+if run_wrapper >"${CASE_DIR}/out" 2>"${CASE_DIR}/err"; then
+  fail "expected a relative Claude artifact to fail"
+fi
+grep -q "Cargo returned a relative guest-mock-claude executable path" "${CASE_DIR}/err" ||
+  fail "relative artifact error not reported"
+
+prepare_case nonexistent-artifact
+extra_env=(FAKE_ARTIFACT_MODE=nonexistent)
+if run_wrapper >"${CASE_DIR}/out" 2>"${CASE_DIR}/err"; then
+  fail "expected a nonexistent Claude artifact to fail"
+fi
+grep -q "guest-mock-claude executable not found" "${CASE_DIR}/err" ||
+  fail "nonexistent artifact error not reported"
+
+prepare_case build-failure
+extra_env=(FAKE_BUILD_EXIT=23)
+set +e
+run_wrapper >"${CASE_DIR}/out" 2>"${CASE_DIR}/err"
+status=$?
+set -e
+[ "$status" = "23" ] || fail "expected build status 23, got ${status}"
+[ "$(<"${LOG_DIR}/count")" = "1" ] || fail "build failure should stop before tests"
+
+prepare_case test-failure
+extra_env=(FAKE_TEST_EXIT=19)
+set +e
+run_wrapper >"${CASE_DIR}/out" 2>"${CASE_DIR}/err"
+status=$?
+set -e
+[ "$status" = "19" ] || fail "expected test status 19, got ${status}"
+[ "$(<"${LOG_DIR}/count")" = "2" ] || fail "test failure should follow one build"
+
+prepare_case managed-manifest
+extra_env=()
+if run_wrapper --manifest-path elsewhere/Cargo.toml >"${CASE_DIR}/out" 2>"${CASE_DIR}/err"; then
+  fail "expected a caller-managed manifest path to fail"
+fi
+[ ! -f "${LOG_DIR}/count" ] || fail "manifest validation should happen before Cargo"
+grep -q -- "--manifest-path is managed by test-rust.sh" "${CASE_DIR}/err" ||
+  fail "managed manifest error not reported"
+
+echo "test-rust-wrapper-test: ok"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -374,7 +374,8 @@ jobs:
       - name: Run tests with coverage
         run: |
           cd crates
-          eval "$(cargo llvm-cov show-env --sh)"
+          coverage_env="$(cargo llvm-cov show-env --sh)"
+          eval "$coverage_env"
           cargo llvm-cov clean --workspace
           ../scripts/test-rust.sh --all-targets --all-features
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -374,7 +374,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           cd crates
-          source <(cargo llvm-cov show-env --sh)
+          eval "$(cargo llvm-cov show-env --sh)"
           cargo llvm-cov clean --workspace
           ../scripts/test-rust.sh --all-targets --all-features
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -374,7 +374,10 @@ jobs:
       - name: Run tests with coverage
         run: |
           cd crates
-          cargo llvm-cov --all-targets --all-features --lcov --output-path lcov.info
+          source <(cargo llvm-cov show-env --sh)
+          cargo llvm-cov clean --workspace
+          ../scripts/test-rust.sh --all-targets --all-features
+          cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         if: success() || failure()

--- a/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
+++ b/crates/guest-agent/tests/codex_jsonl_failure_logging.rs
@@ -109,6 +109,7 @@ unsafe fn setup_codex_env(
                 ..guest_contracts::env::RunPayload::default()
             },
         )?;
+        common::set_coverage_user_env_for_test(&runtime_dir)?;
         std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");

--- a/crates/guest-agent/tests/common/mod.rs
+++ b/crates/guest-agent/tests/common/mod.rs
@@ -6,7 +6,8 @@
 //! overrides as setup input. Consolidating scenarios with different prompts or
 //! grace windows into one `#[tokio::test]` binary would make those process-wide
 //! side effects race. Splitting into separate binaries gives each scenario a
-//! fresh process, paid for by a small cargo build-cache hit (idempotent).
+//! fresh process. The repository Rust test wrapper prepares shared mock
+//! executables before running these processes.
 //!
 //! # Error handling
 //!
@@ -382,8 +383,11 @@ pub fn ensure_canonical_workspace_for_test() -> Result<(), String> {
     Ok(())
 }
 
-/// Build the mock binary (idempotent when up to date) and resolve its
-/// filesystem path.
+const TEST_MOCK_CLAUDE_PATH_ENV: &str = "VM0_TEST_GUEST_MOCK_CLAUDE_PATH";
+const TEST_MOCK_CODEX_PATH_ENV: &str = "VM0_TEST_GUEST_MOCK_CODEX_PATH";
+
+/// Resolve the mock binary prepared by the outer test wrapper, or build it for
+/// compatibility with direct Cargo test commands.
 ///
 /// The subprocess `cargo build` must land the artifact in the same
 /// `target/` directory + profile that the enclosing `cargo test` uses,
@@ -392,16 +396,54 @@ pub fn ensure_canonical_workspace_for_test() -> Result<(), String> {
 /// and under `cargo test --release`. We infer both from the currently-
 /// running test binary's path and forward them to the subprocess.
 pub fn build_and_locate_mock() -> Result<PathBuf, String> {
-    build_and_locate_mock_package("guest-mock-claude", "guest-mock-claude")
+    locate_or_build_mock_package(
+        "guest-mock-claude",
+        "guest-mock-claude",
+        TEST_MOCK_CLAUDE_PATH_ENV,
+    )
 }
 
 /// Build the mock Codex binary and resolve its filesystem path beside the
 /// current test profile.
 pub fn build_and_locate_mock_codex() -> Result<PathBuf, String> {
-    build_and_locate_mock_package("guest-mock-codex", "guest-mock-codex")
+    locate_or_build_mock_package(
+        "guest-mock-codex",
+        "guest-mock-codex",
+        TEST_MOCK_CODEX_PATH_ENV,
+    )
 }
 
-fn build_and_locate_mock_package(package: &str, binary: &str) -> Result<PathBuf, String> {
+fn locate_or_build_mock_package(
+    package: &str,
+    binary: &str,
+    prebuilt_path_env: &str,
+) -> Result<PathBuf, String> {
+    if let Some(value) = std::env::var_os(prebuilt_path_env) {
+        let path = PathBuf::from(value);
+        if path.as_os_str().is_empty() {
+            return Err(format!("{prebuilt_path_env} is empty"));
+        }
+        if !path.is_absolute() {
+            return Err(format!(
+                "{prebuilt_path_env} must be an absolute path: {}",
+                path.display()
+            ));
+        }
+        let metadata = std::fs::metadata(&path).map_err(|error| {
+            format!(
+                "read {prebuilt_path_env} executable metadata at {}: {error}",
+                path.display()
+            )
+        })?;
+        if !metadata.is_file() {
+            return Err(format!(
+                "{prebuilt_path_env} is not a file: {}",
+                path.display()
+            ));
+        }
+        return Ok(path);
+    }
+
     // Test binary:   <target_dir>/<profile>/deps/<name>-<hash>
     //   parent():    <target_dir>/<profile>/deps
     //   parent().parent():  <target_dir>/<profile>   ← target_profile_dir
@@ -555,6 +597,20 @@ pub unsafe fn set_user_env_file_env_for_test(
     Ok(())
 }
 
+/// Forward cargo-llvm-cov's output path through the curated CLI environment so
+/// instrumented mock executables do not fall back to the read-only canonical
+/// workspace.
+///
+/// # Safety
+/// Call before any other test thread reads process environment.
+pub unsafe fn set_coverage_user_env_for_test(runtime_dir: &Path) -> Result<(), String> {
+    let Ok(profile_file) = std::env::var("LLVM_PROFILE_FILE") else {
+        return Ok(());
+    };
+    let user_env = HashMap::from([("LLVM_PROFILE_FILE".to_string(), profile_file)]);
+    unsafe { set_user_env_file_env_for_test(runtime_dir, &user_env) }
+}
+
 /// Configure one test binary for the experimental Codex app-server backend.
 ///
 /// Must be called before building a `GuestRuntime` because runtime bootstrap
@@ -594,6 +650,7 @@ pub unsafe fn setup_codex_app_server_env(
                 ..guest_contracts::env::RunPayload::default()
             },
         )?;
+        set_coverage_user_env_for_test(&runtime_dir)?;
         if let Some(resume_session_id) = config.resume_session_id {
             std::env::set_var("VM0_RESUME_SESSION_ID", resume_session_id);
         } else {
@@ -705,6 +762,7 @@ pub unsafe fn setup_env(
                 ..guest_contracts::env::RunPayload::default()
             },
         )?;
+        set_coverage_user_env_for_test(&runtime_dir)?;
         // Empty API token → has_api() false → no network calls.
         std::env::set_var("VM0_API_URL", "http://127.0.0.1:1");
         std::env::set_var("VM0_API_TOKEN", "");

--- a/crates/guest-agent/tests/execute_cli_api_mode.rs
+++ b/crates/guest-agent/tests/execute_cli_api_mode.rs
@@ -41,6 +41,7 @@ unsafe fn setup_api_env(
                 ..guest_contracts::env::RunPayload::default()
             },
         )?;
+        common::set_coverage_user_env_for_test(&runtime_dir)?;
         std::env::set_var("VM0_API_URL", api_url);
         std::env::set_var("VM0_API_TOKEN", "test-token");
         std::env::set_var("VM0_SANDBOX_ID", "00000000-0000-4000-8000-000000000abc");

--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -7,18 +7,27 @@ Rust crates live in `crates/` and use `cargo test` for testing. The same princip
 ## Running Tests
 
 ```bash
-# All crates
-cargo test --manifest-path crates/Cargo.toml
+# All crates (prepares shared guest mocks once)
+./scripts/test-rust.sh
 
-# Specific crate
-cargo test --manifest-path crates/Cargo.toml -p guest-agent
+# Guest-agent
+./scripts/test-rust.sh -p guest-agent
 
-# Specific test by name
+# Focused guest-agent integration target
+./scripts/test-rust.sh -p guest-agent --test cli_child_env
+
+# Other specific crates can use Cargo directly
 cargo test --manifest-path crates/Cargo.toml -p runner config::tests::load_full_config
 
-# With output (for debugging)
-cargo test --manifest-path crates/Cargo.toml -- --nocapture
+# Guest-agent with output (for debugging)
+./scripts/test-rust.sh -p guest-agent -- --nocapture
 ```
+
+The wrapper builds `guest-mock-claude` and `guest-mock-codex` once and passes
+their Cargo-reported executable paths to the process-isolated guest-agent test
+binaries. Direct guest-agent `cargo test` commands remain supported, but use a
+compatibility fallback that may repeat Cargo freshness checks across test
+processes.
 
 Pre-commit hooks run `cargo-clippy` and `cargo-fmt` on staged Rust files.
 

--- a/scripts/test-rust.sh
+++ b/scripts/test-rust.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MANIFEST_PATH="${REPO_ROOT}/crates/Cargo.toml"
+CARGO_BIN="${CARGO:-cargo}"
+TEST_MOCK_CLAUDE_PATH_ENV="VM0_TEST_GUEST_MOCK_CLAUDE_PATH"
+TEST_MOCK_CODEX_PATH_ENV="VM0_TEST_GUEST_MOCK_CODEX_PATH"
+
+fail() {
+  echo "test-rust: $1" >&2
+  exit 2
+}
+
+command -v "$CARGO_BIN" >/dev/null 2>&1 || fail "Cargo executable not found: ${CARGO_BIN}"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+original_args=("$@")
+build_args=()
+index=0
+
+while [ "$index" -lt "${#original_args[@]}" ]; do
+  arg="${original_args[$index]}"
+  if [ "$arg" = "--" ]; then
+    break
+  fi
+
+  case "$arg" in
+    -r | --release | --locked | --offline | --frozen | --ignore-rust-version)
+      build_args+=("$arg")
+      ;;
+    --profile | --target | --target-dir | --config)
+      index=$((index + 1))
+      if [ "$index" -ge "${#original_args[@]}" ] || [ -z "${original_args[$index]}" ]; then
+        fail "${arg} requires a value"
+      fi
+      build_args+=("$arg" "${original_args[$index]}")
+      ;;
+    --profile=* | --target=* | --target-dir=* | --config=*)
+      [ -n "${arg#*=}" ] || fail "${arg%%=*} requires a value"
+      build_args+=("$arg")
+      ;;
+    --manifest-path | --manifest-path=*)
+      fail "--manifest-path is managed by test-rust.sh"
+      ;;
+  esac
+
+  index=$((index + 1))
+done
+
+build_messages="$(mktemp "${TMPDIR:-/tmp}/vm0-rust-test-build.XXXXXX")"
+cleanup() {
+  rm -f "$build_messages"
+}
+trap cleanup EXIT
+
+set +e
+"$CARGO_BIN" build \
+  --manifest-path "$MANIFEST_PATH" \
+  -p guest-mock-claude \
+  -p guest-mock-codex \
+  "${build_args[@]}" \
+  --message-format=json-render-diagnostics >"$build_messages"
+build_status=$?
+set -e
+
+jq -r 'select(.reason == "compiler-message") | .message.rendered // empty' \
+  "$build_messages" >&2
+
+if [ "$build_status" -ne 0 ]; then
+  exit "$build_status"
+fi
+
+resolve_mock_path() {
+  local target_name=$1
+  local paths=()
+  local path
+
+  mapfile -t paths < <(
+    jq -r --arg target_name "$target_name" '
+      select(
+        .reason == "compiler-artifact"
+        and .target.name == $target_name
+        and ((.target.kind // []) | index("bin"))
+        and .executable != null
+      )
+      | .executable
+    ' "$build_messages" | sort -u
+  )
+
+  if [ "${#paths[@]}" -ne 1 ]; then
+    fail "expected one ${target_name} executable artifact, found ${#paths[@]}"
+  fi
+
+  path="${paths[0]}"
+  [ -n "$path" ] || fail "Cargo returned an empty ${target_name} executable path"
+  [[ "$path" = /* ]] || fail "Cargo returned a relative ${target_name} executable path: ${path}"
+  [ -f "$path" ] || fail "${target_name} executable not found at ${path}"
+
+  printf '%s\n' "$path"
+}
+
+mock_claude_path="$(resolve_mock_path guest-mock-claude)"
+mock_codex_path="$(resolve_mock_path guest-mock-codex)"
+
+cleanup
+trap - EXIT
+
+export "$TEST_MOCK_CLAUDE_PATH_ENV=$mock_claude_path"
+export "$TEST_MOCK_CODEX_PATH_ENV=$mock_codex_path"
+
+exec "$CARGO_BIN" test --manifest-path "$MANIFEST_PATH" "${original_args[@]}"


### PR DESCRIPTION
## Summary

- add a repository Rust test wrapper that builds both guest CLI mocks in one Cargo invocation and resolves their exact executable paths from Cargo JSON artifacts
- pass the prebuilt paths into isolated guest-agent integration-test processes while retaining the existing direct `cargo test` compatibility fallback
- run coverage through cargo-llvm-cov's external-test flow, preserve profile output for instrumented mock children, and document the optimized local commands
- add shell integration coverage for argument forwarding, artifact validation, environment injection, and exit-status propagation

## Result

- warm `guest-agent` suite: 34.275s before, 32.235s after
- Cargo invocations during the suite: 44 nested mock builds before; one combined mock build plus one test command after, with zero runtime nested builds

## Compatibility

No production code, API, schema, persisted data, runner protocol, release package, or deployment behavior changes. Raw and focused `cargo test` commands remain supported.

## Validation

- `bash .github/scripts/tests/test-rust-wrapper-test.sh`
- all `.github/scripts/tests/*.sh` checks
- POSIX `sh -e` cargo-llvm-cov setup and report flow
- actionlint with ShellCheck 0.11
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- focused wrapper tests for debug, release, `ci` profile, explicit target directory, and native target
- raw focused `cargo test` compatibility fallback
- full `guest-agent` suite with exact Cargo invocation counting
- cargo-llvm-cov external-test flow with `--all-targets --all-features` and a nonempty 6,539,797-byte LCOV report
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,290 passed)
- `pnpm knip`

Closes #21007
