### PR TITLE
perf: drain workflow skill presigned url refresh backlog

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/system-storage-presigned-url-cache.suite.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/system-storage-presigned-url-cache.suite.ts
@@ -419,7 +419,7 @@ describe("system storage presigned URL cache", () => {
         expect(refreshed.body).toStrictEqual({
           success: true,
           system: {
-            due: 3,
+            due: 4,
             refreshed: 3,
             pruned: 0,
           },

--- a/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/workflow-skill-storage-presigned-url-cache.suite.ts
@@ -23,6 +23,7 @@ const context = testContext();
 const CRON_SECRET = "test-cron-secret";
 const BUCKET = "test-user-storages";
 const WORKFLOW_CACHE_TTL_SECONDS = 2 * 60 * 60;
+const WORKFLOW_CACHE_REFRESH_LIMIT = 32;
 const ISOLATED_CACHE_CRON_NOW = Date.parse("2000-01-02T00:00:00.000Z");
 
 interface CacheRow {
@@ -474,8 +475,9 @@ describe("workflow skill storage presigned URL cache", () => {
       const refreshAfter = new Date(now.getTime() - 60 * 1000);
       const inactiveRequestedAt = new Date(now.getTime() - 48 * 60 * 60 * 1000);
 
-      for (let index = 0; index < 5; index += 1) {
-        const versionId = `${index}`.repeat(64).slice(0, 64);
+      const activeRowCount = WORKFLOW_CACHE_REFRESH_LIMIT + 2;
+      for (let index = 0; index < activeRowCount; index += 1) {
+        const versionId = index.toString(36).padStart(2, "0").repeat(32);
         await seedCacheRow({
           bucket: BUCKET,
           objectKey: `${prefix}/${versionId}/archive.tar.gz`,
@@ -530,11 +532,18 @@ describe("workflow skill storage presigned URL cache", () => {
           pruned: expect.any(Number),
         }),
         workflowSkill: {
-          due: 3,
-          refreshed: 3,
+          due: WORKFLOW_CACHE_REFRESH_LIMIT + 1,
+          refreshed: WORKFLOW_CACHE_REFRESH_LIMIT,
           pruned: 2,
         },
       });
+
+      const rowsAfterFirstTick = await readCacheRowsByObjectKeyPrefix(prefix);
+      expect(
+        rowsAfterFirstTick.filter((row) => {
+          return row.presigned_url.includes("?sig=");
+        }),
+      ).toHaveLength(WORKFLOW_CACHE_REFRESH_LIMIT);
 
       const secondTick = await accept(
         cronClient().refresh({ headers: cronHeaders() }),
@@ -547,12 +556,12 @@ describe("workflow skill storage presigned URL cache", () => {
       });
 
       const rows = await readCacheRowsByObjectKeyPrefix(prefix);
-      expect(rows).toHaveLength(6);
+      expect(rows).toHaveLength(activeRowCount + 1);
       expect(
         rows.filter((row) => {
           return row.presigned_url.includes("?sig=");
         }),
-      ).toHaveLength(5);
+      ).toHaveLength(activeRowCount);
       expect(
         rows.find((row) => {
           return row.storage_version_id === inactiveFreshVersionId;

--- a/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
+++ b/turbo/apps/api/src/signals/services/system-storage-presigned-url-cache.service.ts
@@ -26,7 +26,7 @@ export const SYSTEM_STORAGE_PRESIGNED_URL_PRUNE_LIMIT = 100;
 export const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_TTL_SECONDS = 2 * 60 * 60;
 const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_CACHE_POLICY =
   "workflow-skill-storage-url-v1";
-export const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_REFRESH_LIMIT = 3;
+export const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_REFRESH_LIMIT = 32;
 export const WORKFLOW_SKILL_STORAGE_PRESIGNED_URL_PRUNE_LIMIT = 100;
 
 type StoragePresignedUrlCacheStatus =
@@ -511,11 +511,12 @@ async function refreshDueStoragePresignedUrls(args: {
       asc(systemStoragePresignedUrlCache.refreshAfter),
       asc(systemStoragePresignedUrlCache.expiresAt),
     )
-    .limit(args.limit);
+    .limit(args.limit + 1);
   args.signal?.throwIfAborted();
 
+  const rowsToRefresh = rows.slice(0, args.limit);
   const freshValues = await Promise.all(
-    rows.map((row) => {
+    rowsToRefresh.map((row) => {
       return signCacheValue({
         get: args.get,
         cacheKey: row.cacheKey,


### PR DESCRIPTION
## Summary

- increase the workflow skill presigned URL refresh batch from 3 to 32
- fetch one lookahead row so existing `due` and `refreshed` counts expose refresh saturation without changing the response contract
- cover multi-tick backlog draining while preserving pruning and inactive-row behavior

## Explicit exclusions

- keep the system storage refresh batch at 3
- do not change database schema, persisted row shape, cache TTLs, or API contracts
- do not add concurrency or monotonic-upsert changes without production evidence of a correctness issue

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (592 files and 7,290 tests passed; 1 existing benchmark skipped)
- `pnpm knip`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/storage-presigned-url-cache.test.ts`

Closes #21067

Parent context: #18746
