### PR TITLE
test(rust): cover session identity helper exit codes

### DIFF
--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -1,0 +1,215 @@
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
+use guest_contracts::session_history_identity::{
+    FinalSessionHistoryFramework, FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+};
+use sha2::{Digest, Sha256};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+struct VerifyCase {
+    name: &'static str,
+    metadata_path: PathBuf,
+    expectation_args: Vec<OsString>,
+    expected_exit_code: i32,
+}
+
+#[test]
+fn verify_session_history_identity_returns_stable_exit_codes() -> TestResult {
+    let dir = tempfile::tempdir()?;
+
+    let matching_history = br#"{"type":"system"}"#;
+    let matching_history_path = dir.path().join("matching-history.jsonl");
+    std::fs::write(&matching_history_path, matching_history)?;
+    let matching_history_hash = sha256_hex(matching_history);
+    let matching_identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        matching_history_hash.clone(),
+        matching_history.len() as u64,
+        matching_history_path.to_string_lossy(),
+    )?;
+    let matching_metadata_path =
+        write_metadata(dir.path(), "matching-identity.json", &matching_identity)?;
+
+    let invalid_metadata_path = dir.path().join("invalid-identity.json");
+    std::fs::write(&invalid_metadata_path, b"not-json")?;
+
+    let framework_mismatch_identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::Codex,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        matching_history_hash,
+        matching_history.len() as u64,
+        matching_history_path.to_string_lossy(),
+    )?;
+    let framework_mismatch_metadata_path = write_metadata(
+        dir.path(),
+        "framework-mismatch-identity.json",
+        &framework_mismatch_identity,
+    )?;
+
+    let missing_history_path = dir.path().join("missing-history.jsonl");
+    let history_read_identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        "b".repeat(64),
+        1,
+        missing_history_path.to_string_lossy(),
+    )?;
+    let history_read_metadata_path = write_metadata(
+        dir.path(),
+        "history-read-identity.json",
+        &history_read_identity,
+    )?;
+
+    let mismatched_history_path = dir.path().join("mismatched-history.jsonl");
+    std::fs::write(&mismatched_history_path, b"actual!")?;
+    let history_mismatch_identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        sha256_hex(b"expect!"),
+        7,
+        mismatched_history_path.to_string_lossy(),
+    )?;
+    let history_mismatch_metadata_path = write_metadata(
+        dir.path(),
+        "history-mismatch-identity.json",
+        &history_mismatch_identity,
+    )?;
+
+    let history_too_large_identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        "b".repeat(64),
+        RESUME_SESSION_HISTORY_MAX_BYTES + 1,
+        matching_history_path.to_string_lossy(),
+    )?;
+    let history_too_large_metadata_path = write_metadata(
+        dir.path(),
+        "history-too-large-identity.json",
+        &history_too_large_identity,
+    )?;
+
+    let cases = [
+        VerifyCase {
+            name: "success",
+            metadata_path: matching_metadata_path.clone(),
+            expectation_args: Vec::new(),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+        },
+        VerifyCase {
+            name: "invalid arguments",
+            metadata_path: matching_metadata_path.clone(),
+            expectation_args: vec![OsString::from("claude-code")],
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
+        },
+        VerifyCase {
+            name: "metadata read",
+            metadata_path: dir.path().join("missing-identity.json"),
+            expectation_args: Vec::new(),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+        },
+        VerifyCase {
+            name: "invalid metadata",
+            metadata_path: invalid_metadata_path,
+            expectation_args: Vec::new(),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+        },
+        VerifyCase {
+            name: "framework mismatch",
+            metadata_path: framework_mismatch_metadata_path,
+            expectation_args: Vec::new(),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
+        },
+        VerifyCase {
+            name: "expected identity mismatch",
+            metadata_path: matching_metadata_path,
+            expectation_args: expectation_args(&matching_identity, "b".repeat(64)),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+        },
+        VerifyCase {
+            name: "history read",
+            metadata_path: history_read_metadata_path,
+            expectation_args: Vec::new(),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+        },
+        VerifyCase {
+            name: "history mismatch",
+            metadata_path: history_mismatch_metadata_path,
+            expectation_args: Vec::new(),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+        },
+        VerifyCase {
+            name: "history too large",
+            metadata_path: history_too_large_metadata_path,
+            expectation_args: Vec::new(),
+            expected_exit_code: SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+        },
+    ];
+
+    for case in cases {
+        let output = run_helper(&case)?;
+        assert_eq!(
+            output.status.code(),
+            Some(case.expected_exit_code),
+            "{}: stdout={}, stderr={}",
+            case.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(())
+}
+
+fn write_metadata(
+    dir: &Path,
+    name: &str,
+    identity: &FinalSessionHistoryIdentity,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let path = dir.join(name);
+    std::fs::write(&path, identity.to_json_vec()?)?;
+    Ok(path)
+}
+
+fn expectation_args(
+    identity: &FinalSessionHistoryIdentity,
+    session_id_hash: String,
+) -> Vec<OsString> {
+    vec![
+        OsString::from(identity.framework.as_str()),
+        OsString::from(session_id_hash),
+        OsString::from(identity.history_ref_kind.as_str()),
+        OsString::from(&identity.history_hash),
+        OsString::from(identity.history_size_bytes.to_string()),
+    ]
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    hex::encode(Sha256::digest(bytes))
+}
+
+fn run_helper(case: &VerifyCase) -> Result<Output, std::io::Error> {
+    Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+        .env_clear()
+        .arg("verify-session-history-identity")
+        .arg(&case.metadata_path)
+        .args(&case.expectation_args)
+        .output()
+}

--- a/crates/guest-contracts/src/session_history_identity.rs
+++ b/crates/guest-contracts/src/session_history_identity.rs
@@ -372,6 +372,25 @@ fn is_sha256_hex(value: &str) -> bool {
 mod tests {
     use super::*;
 
+    #[test]
+    fn session_history_identity_verify_exit_codes_are_stable() {
+        assert_eq!(
+            [
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+                SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+            ],
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        );
+    }
+
     fn valid_identity() -> FinalSessionHistoryIdentity {
         FinalSessionHistoryIdentity::new(
             FinalSessionHistoryFramework::ClaudeCode,

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -12,8 +12,15 @@ use flate2::{Compression, write::GzEncoder};
 use guest_contracts::session_history_identity::{
     FINAL_SESSION_HISTORY_IDENTITY_MAX_BYTES, FinalSessionHistoryFramework,
     FinalSessionHistoryIdentity, FinalSessionHistoryRefKind,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_TOO_LARGE,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
 };
 use httpmock::prelude::*;
 use sandbox::{
@@ -1604,6 +1611,57 @@ async fn run_in_sandbox_skips_checkpointed_final_session_history_restore() {
             .any(|op| op.0 == "session_history_restore_skip" && op.1),
         "expected checkpointed skip telemetry, got: {ops:?}"
     );
+}
+
+#[tokio::test]
+async fn run_in_sandbox_classifies_checkpointed_final_identity_helper_failure_codes() {
+    let cases = [
+        (
+            "generic",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FAILURE,
+            "session_history_identity_verify_helper_failed",
+        ),
+        (
+            "invalid-args",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
+            "session_history_identity_verify_helper_invalid_args",
+        ),
+        (
+            "metadata-read",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
+            "session_history_identity_verify_helper_metadata_read_failed",
+        ),
+        (
+            "invalid-metadata",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
+            "session_history_identity_verify_helper_invalid_metadata",
+        ),
+        (
+            "framework-mismatch",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_FRAMEWORK_MISMATCH,
+            "session_history_identity_verify_helper_framework_mismatch",
+        ),
+        (
+            "expected-mismatch",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_EXPECTED_MISMATCH,
+            "session_history_identity_verify_helper_expected_mismatch",
+        ),
+        (
+            "history-read",
+            SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_READ,
+            "session_history_identity_verify_helper_history_read_failed",
+        ),
+    ];
+
+    for (name, exit_code, expected_reason_action) in cases {
+        let session_id = format!("sess-final-helper-{name}-123");
+        assert_checkpointed_final_identity_helper_failure_falls_back(
+            &session_id,
+            ExecResult::new(exit_code, Vec::new(), Vec::new()),
+            expected_reason_action,
+        )
+        .await;
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- pin the session-history identity helper exit-code ABI at values 0 through 9
- exercise the real `guest-agent verify-session-history-identity` process for every reachable result category
- cover the runner fallback telemetry mapping for generic and helper-specific failure codes, complementing the existing mismatch and size-limit cases

## Scope

- tests only; no production behavior, API, schema, persisted data, or runner protocol changes
- the generic failure code is covered at the runner boundary because the verifier has no valid input path that intentionally emits it

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml --all-targets --all-features`
- `cargo test --manifest-path crates/Cargo.toml -p guest-contracts`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,290 passed; two attempts each hit a different unrelated shared-state API failure, and both failed cases passed targeted single-worker reruns)

Closes #21027
