### PR TITLE
test(runner): bound fifo state-file reads

### DIFF
--- a/crates/runner/src/cmd/service/gate.rs
+++ b/crates/runner/src/cmd/service/gate.rs
@@ -305,29 +305,12 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn read_runner_status_rejects_fifo_without_blocking() {
-        use std::ffi::CString;
-        use std::os::unix::ffi::OsStrExt;
-
+    async fn read_runner_status_rejects_status_directory() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
-        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(
-            result,
-            0,
-            "mkfifo failed: {}",
-            std::io::Error::last_os_error()
-        );
+        std::fs::create_dir(&path).unwrap();
 
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            read_runner_status(dir.path()),
-        )
-        .await;
-
-        assert!(result.is_ok(), "FIFO read should not block");
-        assert!(result.unwrap().is_err(), "FIFO status should be rejected");
+        assert!(read_runner_status(dir.path()).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/runner/src/cmd/start/identity.rs
+++ b/crates/runner/src/cmd/start/identity.rs
@@ -70,32 +70,6 @@ mod tests {
         );
     }
 
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn runner_id_rejects_fifo_without_blocking() {
-        use std::os::unix::ffi::OsStrExt;
-
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("runner_id");
-        let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
-        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(
-            result,
-            0,
-            "mkfifo failed: {}",
-            std::io::Error::last_os_error()
-        );
-
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            load_or_generate_runner_id(dir.path()),
-        )
-        .await
-        .expect("runner_id FIFO should not block");
-
-        assert!(result.is_err());
-    }
-
     #[tokio::test]
     async fn runner_id_rejects_invalid() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/runner/src/config_tests.rs
+++ b/crates/runner/src/config_tests.rs
@@ -255,29 +255,6 @@ async fn diagnostic_config_read_rejects_symlink() {
 
 #[cfg(unix)]
 #[tokio::test]
-async fn diagnostic_config_read_rejects_fifo_without_blocking() {
-    let dir = tempfile::tempdir().unwrap();
-    let fifo = dir.path().join("runner.yaml");
-    let c_path = std::ffi::CString::new(fifo.to_string_lossy().as_bytes()).unwrap();
-    // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
-    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-    assert_eq!(
-        result,
-        0,
-        "mkfifo failed: {}",
-        std::io::Error::last_os_error()
-    );
-
-    let error = read_diagnostic_config_to_string(&fifo).await.unwrap_err();
-
-    assert!(
-        error.to_string().contains("not a regular state file"),
-        "unexpected error: {error}"
-    );
-}
-
-#[cfg(unix)]
-#[tokio::test]
 async fn diagnostic_config_read_rejects_directory() {
     let dir = tempfile::tempdir().unwrap();
     let config_dir = dir.path().join("runner.yaml");

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -722,10 +722,53 @@ fn normalize_path_lexically(path: &Path) -> PathBuf {
 #[cfg(unix)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+    use std::time::Duration;
+
+    const FIFO_READ_CHILD_ENV: (&str, &str) = ("VM0_RUN_PRIVATE_FILE_FIFO_READ_CHILD", "1");
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[tokio::test]
+    async fn read_private_file_rejects_fifo_without_blocking() {
+        run_ignored_child_test(
+            "private_fs::tests::read_private_file_rejects_fifo_without_blocking_child",
+            FIFO_READ_CHILD_ENV,
+            Duration::from_secs(10),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "spawned by read_private_file_rejects_fifo_without_blocking"]
+    async fn read_private_file_rejects_fifo_without_blocking_child() {
+        if !ignored_child_test_env_guard_enabled(FIFO_READ_CHILD_ENV) {
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runner_id");
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
+        let result = unsafe { nix::libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(
+            result,
+            0,
+            "mkfifo failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let error = read_private_file_to_string(&path).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("not a regular private file"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -728,7 +728,7 @@ mod tests {
     use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
     use std::time::Duration;
 
-    const FIFO_READ_CHILD_ENV: (&str, &str) = ("VM0_RUN_PRIVATE_FILE_FIFO_READ_CHILD", "1");
+    const FIFO_READ_CHILD_PATH_ENV: &str = "VM0_RUN_PRIVATE_FILE_FIFO_READ_CHILD_PATH";
 
     fn mode(path: &Path) -> u32 {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
@@ -736,9 +736,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_private_file_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runner_id");
+        let fifo_path = path.to_str().expect("temporary FIFO path must be UTF-8");
         run_ignored_child_test(
             "private_fs::tests::read_private_file_rejects_fifo_without_blocking_child",
-            FIFO_READ_CHILD_ENV,
+            (FIFO_READ_CHILD_PATH_ENV, fifo_path),
             Duration::from_secs(10),
         )
         .await;
@@ -747,12 +750,14 @@ mod tests {
     #[tokio::test]
     #[ignore = "spawned by read_private_file_rejects_fifo_without_blocking"]
     async fn read_private_file_rejects_fifo_without_blocking_child() {
-        if !ignored_child_test_env_guard_enabled(FIFO_READ_CHILD_ENV) {
+        let Ok(path) = std::env::var(FIFO_READ_CHILD_PATH_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((FIFO_READ_CHILD_PATH_ENV, &path)) {
             return;
         }
 
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("runner_id");
+        let path = PathBuf::from(path);
         let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
         // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
         let result = unsafe { nix::libc::mkfifo(c_path.as_ptr(), 0o600) };

--- a/crates/runner/src/proxy/flush.rs
+++ b/crates/runner/src/proxy/flush.rs
@@ -664,18 +664,6 @@ mod tests {
     use tracing_subscriber::prelude::*;
     use tracing_test_support::{CapturedEvent, CapturedEvents};
 
-    fn make_fifo(path: &Path) {
-        let c_path = std::ffi::CString::new(path.to_string_lossy().as_bytes()).unwrap();
-        // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
-        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(
-            result,
-            0,
-            "mkfifo failed: {}",
-            std::io::Error::last_os_error()
-        );
-    }
-
     async fn capture_async_log_events<F>(future: F) -> (F::Output, Vec<CapturedEvent>)
     where
         F: std::future::Future,
@@ -943,16 +931,6 @@ mod tests {
         let outside = dir.path().join("outside-jsonl-flush-state");
         std::fs::write(&outside, jsonl_state(&log_path, 0)).unwrap();
         std::os::unix::fs::symlink(&outside, dir.path().join("jsonl-flush-state")).unwrap();
-
-        assert!(!wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn wait_jsonl_flush_rejects_fifo_state_without_blocking() {
-        let dir = tempfile::tempdir().unwrap();
-        let log_path = dir.path().join("network.jsonl");
-        let request = jsonl_request(&log_path);
-        make_fifo(&dir.path().join("jsonl-flush-state"));
 
         assert!(!wait_jsonl_flush(dir.path(), Duration::from_millis(50), &request).await);
     }
@@ -1340,15 +1318,6 @@ mod tests {
         let outside = dir.path().join("outside-usage-pending");
         std::fs::write(&outside, usage_state(0, 0, 0)).unwrap();
         std::os::unix::fs::symlink(&outside, dir.path().join("usage-pending")).unwrap();
-
-        assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &request).await);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn wait_usage_flush_rejects_fifo_state_without_blocking() {
-        let dir = tempfile::tempdir().unwrap();
-        let request = usage_request();
-        make_fifo(&dir.path().join("usage-pending"));
 
         assert!(!wait_usage_flush(dir.path(), Duration::from_millis(50), &request).await);
     }

--- a/crates/runner/src/proxy/registry.rs
+++ b/crates/runner/src/proxy/registry.rs
@@ -330,18 +330,6 @@ mod tests {
     use crate::types::{Firewall, FirewallApi, FirewallAuth, FirewallEntry, FirewallPermission};
     use std::os::unix::fs::PermissionsExt;
 
-    fn make_fifo(path: &Path) {
-        let c_path = std::ffi::CString::new(path.to_string_lossy().as_bytes()).unwrap();
-        // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
-        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(
-            result,
-            0,
-            "mkfifo failed: {}",
-            std::io::Error::last_os_error()
-        );
-    }
-
     struct RegistryHarness {
         _dir: tempfile::TempDir,
         registry_path: PathBuf,
@@ -582,23 +570,6 @@ mod tests {
 
         assert!(
             error.to_string().contains("open state file"),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn read_registry_rejects_fifo_without_blocking() {
-        let dir = tempfile::tempdir().unwrap();
-        let registry_path = dir.path().join("proxy-registry.json");
-        make_fifo(&registry_path);
-
-        let error = read_registry(&registry_path)
-            .await
-            .err()
-            .expect("expected fifo registry rejection");
-
-        assert!(
-            error.to_string().contains("not a regular state file"),
             "unexpected error: {error}"
         );
     }

--- a/crates/runner/src/run_resolution.rs
+++ b/crates/runner/src/run_resolution.rs
@@ -273,29 +273,12 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn read_active_runs_rejects_fifo_without_blocking() {
-        use std::ffi::CString;
-        use std::os::unix::ffi::OsStrExt;
-
+    async fn read_active_runs_skips_status_directory() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("status.json");
-        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
-        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(
-            result,
-            0,
-            "mkfifo failed: {}",
-            std::io::Error::last_os_error()
-        );
+        std::fs::create_dir(&path).unwrap();
 
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            read_active_runs(dir.path()),
-        )
-        .await;
-
-        assert!(result.is_ok(), "FIFO read should not block");
-        assert!(result.unwrap().is_none(), "FIFO status should be rejected");
+        assert!(read_active_runs(dir.path()).await.is_none());
     }
 
     #[tokio::test]

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -291,8 +291,12 @@ fn chmod_private_file_fd<Fd: std::os::fd::AsRawFd>(file: &Fd, path: &Path) -> Ru
 #[cfg(unix)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
     use std::ffi::CString;
     use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::time::Duration;
+
+    const FIFO_READ_CHILD_ENV: (&str, &str) = ("VM0_RUN_STATE_FILE_FIFO_READ_CHILD", "1");
 
     #[tokio::test]
     async fn read_to_string_rejects_symlink_without_reading_target() {
@@ -314,6 +318,21 @@ mod tests {
 
     #[tokio::test]
     async fn read_to_string_rejects_fifo_without_blocking() {
+        run_ignored_child_test(
+            "state_file::tests::read_to_string_rejects_fifo_without_blocking_child",
+            FIFO_READ_CHILD_ENV,
+            Duration::from_secs(10),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "spawned by read_to_string_rejects_fifo_without_blocking"]
+    async fn read_to_string_rejects_fifo_without_blocking_child() {
+        if !ignored_child_test_env_guard_enabled(FIFO_READ_CHILD_ENV) {
+            return;
+        }
+
         let dir = tempfile::tempdir().unwrap();
         let fifo = dir.path().join("fifo");
         let c_path = CString::new(fifo.to_string_lossy().as_bytes()).unwrap();

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -294,9 +294,10 @@ mod tests {
     use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
     use std::ffi::CString;
     use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::path::PathBuf;
     use std::time::Duration;
 
-    const FIFO_READ_CHILD_ENV: (&str, &str) = ("VM0_RUN_STATE_FILE_FIFO_READ_CHILD", "1");
+    const FIFO_READ_CHILD_PATH_ENV: &str = "VM0_RUN_STATE_FILE_FIFO_READ_CHILD_PATH";
 
     #[tokio::test]
     async fn read_to_string_rejects_symlink_without_reading_target() {
@@ -318,9 +319,12 @@ mod tests {
 
     #[tokio::test]
     async fn read_to_string_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("fifo");
+        let fifo_path = fifo.to_str().expect("temporary FIFO path must be UTF-8");
         run_ignored_child_test(
             "state_file::tests::read_to_string_rejects_fifo_without_blocking_child",
-            FIFO_READ_CHILD_ENV,
+            (FIFO_READ_CHILD_PATH_ENV, fifo_path),
             Duration::from_secs(10),
         )
         .await;
@@ -329,12 +333,14 @@ mod tests {
     #[tokio::test]
     #[ignore = "spawned by read_to_string_rejects_fifo_without_blocking"]
     async fn read_to_string_rejects_fifo_without_blocking_child() {
-        if !ignored_child_test_env_guard_enabled(FIFO_READ_CHILD_ENV) {
+        let Ok(fifo_path) = std::env::var(FIFO_READ_CHILD_PATH_ENV) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((FIFO_READ_CHILD_PATH_ENV, &fifo_path)) {
             return;
         }
 
-        let dir = tempfile::tempdir().unwrap();
-        let fifo = dir.path().join("fifo");
+        let fifo = PathBuf::from(fifo_path);
         let c_path = CString::new(fifo.to_string_lossy().as_bytes()).unwrap();
         // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
         let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };

--- a/crates/runner/src/status_file.rs
+++ b/crates/runner/src/status_file.rs
@@ -338,28 +338,21 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn read_rejects_fifo_without_blocking() {
-        use std::ffi::CString;
-        use std::os::unix::ffi::OsStrExt;
+    async fn read_rejects_symlink_to_valid_status() {
+        use std::os::unix::fs::symlink;
 
         let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("outside-status.json");
         let path = dir.path().join("status.json");
-        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
-        let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-        assert_eq!(
-            result,
-            0,
-            "mkfifo failed: {}",
-            std::io::Error::last_os_error()
-        );
-
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            read_as::<StatusForGate>(dir.path()),
+        std::fs::write(
+            &target,
+            r#"{"mode":"running","active_runs":[],"started_at":"2026-04-13T00:00:00.000Z"}"#,
         )
-        .await;
+        .unwrap();
+        symlink(&target, &path).unwrap();
 
-        assert!(result.is_ok(), "FIFO read should not block");
-        assert!(result.unwrap().is_err(), "FIFO status should be rejected");
+        let error = read_as::<StatusForGate>(dir.path()).await.unwrap_err();
+
+        assert!(matches!(error, StatusFileReadError::Read { .. }));
     }
 }

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::os::unix::fs::MetadataExt;
-use std::path::Path;
 
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
@@ -33,18 +32,6 @@ const TEST_PROFILE_NAME: &str = "vm0/default";
 
 fn timestamp_for_index(index: usize) -> String {
     format!("2026-05-01T00:{:02}:{:02}.000Z", index / 60, index % 60)
-}
-
-fn make_fifo(path: &Path) {
-    let c_path = std::ffi::CString::new(path.to_string_lossy().as_bytes()).unwrap();
-    // SAFETY: `c_path` is a valid nul-terminated path for `mkfifo`.
-    let result = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
-    assert_eq!(
-        result,
-        0,
-        "mkfifo failed: {}",
-        std::io::Error::last_os_error()
-    );
 }
 
 async fn write_current_cache_entry(
@@ -868,38 +855,19 @@ async fn inspect_rejects_metadata_symlink_without_following_it() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
     let cache = SessionWorkspaceCache::new(paths.clone());
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
-        .await
-        .unwrap();
-    fs::write(paths.session_workspace_cache_current_image(&key), b"image")
-        .await
-        .unwrap();
+    let key = write_current_cache_entry(
+        &cache,
+        RunId::new_v4(),
+        "sess-1",
+        "/workspace",
+        "2026-05-01T00:00:00.000Z",
+        "2026-05-01T00:00:00.000Z",
+    )
+    .await;
+    let metadata_path = paths.session_workspace_cache_metadata(&key);
     let outside = dir.path().join("outside-metadata.json");
-    fs::write(&outside, b"{\"unexpected\":true}").await.unwrap();
-    std::os::unix::fs::symlink(&outside, paths.session_workspace_cache_metadata(&key)).unwrap();
-
-    let inspection = cache.inspect().await.unwrap();
-
-    assert_eq!(inspection.summary.invalid_entries, 1);
-    let entry = &inspection.entries[0];
-    assert_eq!(entry.status, WorkspaceImageCacheInspectionStatus::Invalid);
-    assert_eq!(entry.reason.as_deref(), Some("missing or invalid metadata"));
-}
-
-#[tokio::test]
-async fn inspect_rejects_fifo_metadata_without_blocking() {
-    let dir = tempfile::tempdir().unwrap();
-    let paths = RunnerPaths::new(dir.path().join("runner"));
-    let cache = SessionWorkspaceCache::new(paths.clone());
-    let key = session_workspace_cache_key("sess-1", "/workspace");
-    fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
-        .await
-        .unwrap();
-    fs::write(paths.session_workspace_cache_current_image(&key), b"image")
-        .await
-        .unwrap();
-    make_fifo(&paths.session_workspace_cache_metadata(&key));
+    fs::rename(&metadata_path, &outside).await.unwrap();
+    std::os::unix::fs::symlink(&outside, &metadata_path).unwrap();
 
     let inspection = cache.inspect().await.unwrap();
 


### PR DESCRIPTION
## Summary

- run the two shared async state-file FIFO contracts in isolated ignored child test processes with a 10-second parent deadline
- keep FIFO fixture directories parent-owned so killing a blocked child still cleans up the filesystem
- remove redundant caller-level FIFO cases that could hang the whole runner test process while preserving caller error-path coverage with symlink, directory, oversized-file, and invalid-content cases
- strengthen the workspace image cache symlink test so following the valid target would make the test fail

## Scope

- test code only
- no runtime behavior, schema, migration, persisted-data format, API, queue payload, or runner protocol changes

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2,601 passed, 7 ignored child entry points)
- focused state-file, private-file, and caller contract tests
- fault injection: each parent test fails on timeout when `O_NONBLOCK` is removed and fails immediately when FIFO type rejection is removed
- fault injection cleanup: killed child processes leave no FIFO fixture directories behind
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` against a fresh migrated temporary database (7,291 passed, 1 existing benchmark skipped)
- `cd turbo && pnpm knip`

Closes #21010
