### PR TITLE
fix(runner): classify guest download transport errors

### DIFF
--- a/crates/guest-download/src/download.rs
+++ b/crates/guest-download/src/download.rs
@@ -665,10 +665,15 @@ fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError
     let mut last_error = None;
 
     for attempt in 1..=MAX_RETRIES {
+        let attempt_start = Instant::now();
         match download_and_extract(url, target_path) {
             Ok(()) => return Ok(()),
             Err(e) => {
-                log_warn!(LOG_TAG, "Attempt {attempt}/{MAX_RETRIES} failed: {e}");
+                log_warn!(
+                    LOG_TAG,
+                    "Attempt {attempt}/{MAX_RETRIES} failed after {}ms: {e}",
+                    attempt_start.elapsed().as_millis()
+                );
                 let should_break = !e.retriable;
                 last_error = Some(e);
                 if should_break {

--- a/crates/guest-download/src/source.rs
+++ b/crates/guest-download/src/source.rs
@@ -38,16 +38,69 @@ pub(crate) fn open_archive(url: &str) -> Result<ArchiveSource, DownloadError> {
     }
 
     let response = HTTP_AGENT.get(url).call().map_err(|e| {
-        let (retriable, message) = match &e {
-            // Retry on server errors (5xx) and rate limiting (429)
-            ureq::Error::StatusCode(code) => {
-                (*code >= 500 || *code == 429, format!("HTTP status {code}"))
-            }
-            _ => (true, "HTTP transport error".to_string()), // network/timeout errors are retriable
-        };
+        let (retriable, message) = classify_http_error(&e);
         DownloadError::transport(message, retriable)
     })?;
     Ok(ArchiveSource::http(response.into_body().into_reader()))
+}
+
+fn classify_http_error(error: &ureq::Error) -> (bool, String) {
+    // Never render the raw error: URI-bearing variants can expose presigned credentials.
+    match error {
+        // Retry on server errors (5xx) and rate limiting (429).
+        ureq::Error::StatusCode(code) => {
+            (*code >= 500 || *code == 429, format!("HTTP status {code}"))
+        }
+        ureq::Error::HostNotFound => request_error("dns"),
+        ureq::Error::Timeout(timeout) => (
+            true,
+            format!(
+                "HTTP request error (kind=timeout phase={})",
+                timeout_phase(*timeout)
+            ),
+        ),
+        ureq::Error::ConnectionFailed => request_error("connection"),
+        ureq::Error::Io(error) => (
+            true,
+            format!("HTTP request error (kind=io io_kind={:?})", error.kind()),
+        ),
+        ureq::Error::Tls(_)
+        | ureq::Error::Pem(_)
+        | ureq::Error::Rustls(_)
+        | ureq::Error::TlsRequired => request_error("tls"),
+        ureq::Error::InvalidProxyUrl | ureq::Error::ConnectProxyFailed(_) => request_error("proxy"),
+        ureq::Error::Protocol(_)
+        | ureq::Error::RedirectFailed
+        | ureq::Error::BodyExceedsLimit(_)
+        | ureq::Error::TooManyRedirects
+        | ureq::Error::LargeResponseHeader(_, _)
+        | ureq::Error::Decompress(_, _)
+        | ureq::Error::BodyStalled => request_error("protocol"),
+        ureq::Error::Http(_) | ureq::Error::BadUri(_) | ureq::Error::RequireHttpsOnly(_) => {
+            request_error("invalid_request")
+        }
+        ureq::Error::Other(_) => request_error("unknown"),
+        _ => request_error("unknown"),
+    }
+}
+
+fn request_error(kind: &'static str) -> (bool, String) {
+    (true, format!("HTTP request error (kind={kind})"))
+}
+
+fn timeout_phase(timeout: ureq::Timeout) -> &'static str {
+    match timeout {
+        ureq::Timeout::Global => "global",
+        ureq::Timeout::PerCall => "per_call",
+        ureq::Timeout::Resolve => "resolve",
+        ureq::Timeout::Connect => "connect",
+        ureq::Timeout::SendRequest => "send_request",
+        ureq::Timeout::Await100 => "await_100",
+        ureq::Timeout::SendBody => "send_body",
+        ureq::Timeout::RecvResponse => "recv_response",
+        ureq::Timeout::RecvBody => "recv_body",
+        _ => "unknown",
+    }
 }
 
 pub(crate) struct ArchiveSource {

--- a/crates/guest-download/tests/integration/binary_logging/redaction.rs
+++ b/crates/guest-download/tests/integration/binary_logging/redaction.rs
@@ -1,6 +1,86 @@
 use super::{BinaryLoggingFixture, assert_download_total_success_present};
 use crate::support::{assert_does_not_contain_any, create_tar_gz, write_manifest};
 use httpmock::prelude::*;
+use std::io::{self, Read as _};
+use std::net::TcpListener;
+use std::thread;
+use std::time::{Duration, Instant};
+
+const EXPECTED_RETRY_ATTEMPTS: usize = 3;
+const SERVER_DEADLINE: Duration = Duration::from_secs(10);
+
+fn validate_attempt_warning(
+    log_name: &str,
+    log: &str,
+    attempt: usize,
+    expected_error: &str,
+) -> Result<(), String> {
+    let prefix = format!("Attempt {attempt}/{EXPECTED_RETRY_ATTEMPTS} failed after ");
+    let line = log
+        .lines()
+        .find(|line| line.contains(&prefix) && line.contains(expected_error))
+        .ok_or_else(|| {
+            format!("missing {prefix:?} with {expected_error:?} in {log_name}: {log}")
+        })?;
+    let elapsed = line
+        .split_once(&prefix)
+        .and_then(|(_, suffix)| suffix.split_once("ms: "))
+        .map(|(elapsed, _)| elapsed)
+        .ok_or_else(|| format!("malformed attempt warning in {log_name}: {line}"))?;
+    if elapsed.is_empty() || !elapsed.chars().all(|character| character.is_ascii_digit()) {
+        return Err(format!(
+            "invalid elapsed milliseconds in {log_name}: {line}"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_retry_warnings(log_name: &str, log: &str, expected_error: &str) -> Result<(), String> {
+    let warning_count = log.lines().filter(|line| line.contains("Attempt ")).count();
+    if warning_count != EXPECTED_RETRY_ATTEMPTS {
+        return Err(format!(
+            "unexpected attempt warning count in {log_name}: {log}"
+        ));
+    }
+    for attempt in 1..=EXPECTED_RETRY_ATTEMPTS {
+        validate_attempt_warning(log_name, log, attempt, expected_error)?;
+    }
+    Ok(())
+}
+
+fn start_connection_drop_server() -> io::Result<(String, thread::JoinHandle<io::Result<usize>>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    listener.set_nonblocking(true)?;
+    let base_url = format!("http://{}", listener.local_addr()?);
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + SERVER_DEADLINE;
+        let mut accepted = 0;
+        while accepted < EXPECTED_RETRY_ATTEMPTS && Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream.set_read_timeout(Some(Duration::from_secs(1)))?;
+                    let mut request = Vec::new();
+                    let mut buffer = [0_u8; 512];
+                    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        let bytes_read = stream.read(&mut buffer)?;
+                        if bytes_read == 0 {
+                            break;
+                        }
+                        request.extend(buffer.iter().take(bytes_read).copied());
+                    }
+                    accepted += 1;
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(accepted)
+    });
+
+    Ok((base_url, handle))
+}
 
 #[test]
 fn binary_does_not_log_http_archive_url_on_success() {
@@ -92,6 +172,8 @@ fn binary_does_not_log_http_archive_url_on_fatal_status() {
         stderr.contains("HTTP status 404"),
         "unexpected stderr: {stderr}"
     );
+    validate_attempt_warning("stderr", &stderr, 1, "HTTP status 404").unwrap();
+    validate_attempt_warning("system log", &system_log_content, 1, "HTTP status 404").unwrap();
 
     let ops = fixture.ops_entries().unwrap();
     assert!(
@@ -104,6 +186,99 @@ fn binary_does_not_log_http_archive_url_on_fatal_status() {
                         && error.contains("mountPath=")
                         && error.contains("urlScheme=http"))),
         "missing failed storage_download entry: {ops_log_content}"
+    );
+    assert_download_total_success_present(&ops, false);
+}
+
+#[test]
+fn binary_classifies_malformed_http_url_without_logging_it() {
+    let fixture = BinaryLoggingFixture::new("malformed-secret-url").unwrap();
+    let mount = fixture.dir.path().join("mount");
+    let url = "http://invalid host/storage-object/archive.tar.gz?X-Amz-Signature=malformed-secret-token&X-Amz-Credential=malformed-credential";
+    let manifest =
+        write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(url))], None).unwrap();
+
+    let output = fixture.run_manifest_path(&manifest).unwrap();
+
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let system_log_content = fixture.read_system_log().unwrap();
+    let ops_log_content = fixture.read_ops_log().unwrap();
+    let forbidden = [
+        url,
+        "invalid host",
+        "X-Amz-Signature",
+        "malformed-secret-token",
+        "X-Amz-Credential",
+        "malformed-credential",
+    ];
+    assert_does_not_contain_any("stderr", &stderr, &forbidden);
+    assert_does_not_contain_any("system log", &system_log_content, &forbidden);
+    assert_does_not_contain_any("sandbox ops log", &ops_log_content, &forbidden);
+
+    let expected_error = "HTTP request error (kind=invalid_request)";
+    validate_retry_warnings("stderr", &stderr, expected_error).unwrap();
+    validate_retry_warnings("system log", &system_log_content, expected_error).unwrap();
+
+    let ops = fixture.ops_entries().unwrap();
+    assert!(
+        ops.iter()
+            .any(|entry| entry["action_type"] == "storage_download"
+                && entry["success"] == false
+                && entry["error"]
+                    .as_str()
+                    .is_some_and(|error| error.contains(expected_error))),
+        "missing classified storage_download entry: {ops_log_content}"
+    );
+    assert_download_total_success_present(&ops, false);
+}
+
+#[test]
+fn binary_classifies_connection_drop_without_logging_url() {
+    let (base_url, server_handle) = start_connection_drop_server().unwrap();
+    let fixture = BinaryLoggingFixture::new("connection-drop-secret-url").unwrap();
+    let mount = fixture.dir.path().join("mount");
+    let url = format!(
+        "{base_url}/storage-object/archive.tar.gz?X-Amz-Signature=connection-secret-token&X-Amz-Credential=connection-credential"
+    );
+    let manifest =
+        write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let output = fixture.run_manifest_path(&manifest).unwrap();
+    let accepted = server_handle.join().unwrap().unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(accepted, EXPECTED_RETRY_ATTEMPTS);
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let system_log_content = fixture.read_system_log().unwrap();
+    let ops_log_content = fixture.read_ops_log().unwrap();
+    let forbidden = [
+        url.as_str(),
+        "storage-object",
+        "X-Amz-Signature",
+        "connection-secret-token",
+        "X-Amz-Credential",
+        "connection-credential",
+    ];
+    assert_does_not_contain_any("stderr", &stderr, &forbidden);
+    assert_does_not_contain_any("system log", &system_log_content, &forbidden);
+    assert_does_not_contain_any("sandbox ops log", &ops_log_content, &forbidden);
+
+    let expected_error = "HTTP request error (kind=io io_kind=UnexpectedEof)";
+    validate_retry_warnings("stderr", &stderr, expected_error).unwrap();
+    validate_retry_warnings("system log", &system_log_content, expected_error).unwrap();
+
+    let ops = fixture.ops_entries().unwrap();
+    assert!(
+        ops.iter()
+            .any(|entry| entry["action_type"] == "storage_download"
+                && entry["success"] == false
+                && entry["error"]
+                    .as_str()
+                    .is_some_and(|error| error.contains(expected_error))),
+        "missing classified storage_download entry: {ops_log_content}"
     );
     assert_download_total_success_present(&ops, false);
 }

--- a/crates/guest-download/tests/integration/binary_logging/redaction.rs
+++ b/crates/guest-download/tests/integration/binary_logging/redaction.rs
@@ -1,13 +1,14 @@
 use super::{BinaryLoggingFixture, assert_download_total_success_present};
-use crate::support::{assert_does_not_contain_any, create_tar_gz, write_manifest};
+use crate::support::{
+    assert_does_not_contain_any, create_tar_gz, read_http_request_path, write_manifest,
+};
 use httpmock::prelude::*;
-use std::io::{self, Read as _};
-use std::net::TcpListener;
+use std::io::{self, Write as _};
+use std::net::{TcpListener, TcpStream};
 use std::thread;
-use std::time::{Duration, Instant};
 
 const EXPECTED_RETRY_ATTEMPTS: usize = 3;
-const SERVER_DEADLINE: Duration = Duration::from_secs(10);
+const SERVER_STOP_PATH: &str = "/__stop";
 
 fn validate_attempt_warning(
     log_name: &str,
@@ -50,36 +51,30 @@ fn validate_retry_warnings(log_name: &str, log: &str, expected_error: &str) -> R
 
 fn start_connection_drop_server() -> io::Result<(String, thread::JoinHandle<io::Result<usize>>)> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
-    listener.set_nonblocking(true)?;
     let base_url = format!("http://{}", listener.local_addr()?);
     let handle = thread::spawn(move || {
-        let deadline = Instant::now() + SERVER_DEADLINE;
         let mut accepted = 0;
-        while accepted < EXPECTED_RETRY_ATTEMPTS && Instant::now() < deadline {
-            match listener.accept() {
-                Ok((mut stream, _)) => {
-                    stream.set_read_timeout(Some(Duration::from_secs(1)))?;
-                    let mut request = Vec::new();
-                    let mut buffer = [0_u8; 512];
-                    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-                        let bytes_read = stream.read(&mut buffer)?;
-                        if bytes_read == 0 {
-                            break;
-                        }
-                        request.extend(buffer.iter().take(bytes_read).copied());
-                    }
-                    accepted += 1;
-                }
-                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Err(error) => return Err(error),
+        loop {
+            let (mut stream, _) = listener.accept()?;
+            if read_http_request_path(&mut stream)? == SERVER_STOP_PATH {
+                return Ok(accepted);
             }
+            accepted += 1;
         }
-        Ok(accepted)
     });
 
     Ok((base_url, handle))
+}
+
+fn stop_connection_drop_server(base_url: &str) -> io::Result<()> {
+    let address = base_url
+        .strip_prefix("http://")
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid server URL"))?;
+    let mut stream = TcpStream::connect(address)?;
+    stream.write_all(
+        format!("GET {SERVER_STOP_PATH} HTTP/1.1\r\nhost: localhost\r\nconnection: close\r\n\r\n")
+            .as_bytes(),
+    )
 }
 
 #[test]
@@ -246,6 +241,7 @@ fn binary_classifies_connection_drop_without_logging_url() {
         write_manifest(&fixture.dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
 
     let output = fixture.run_manifest_path(&manifest).unwrap();
+    stop_connection_drop_server(&base_url).unwrap();
     let accepted = server_handle.join().unwrap().unwrap();
 
     assert!(!output.status.success());

--- a/crates/guest-download/tests/integration/download.rs
+++ b/crates/guest-download/tests/integration/download.rs
@@ -1,10 +1,10 @@
 use crate::support::{
-    TarEntry, create_tar_gz, create_tar_gz_entries, manifest_json, run_guest_download,
-    run_guest_download_manifest_json, write_manifest,
+    TarEntry, create_tar_gz, create_tar_gz_entries, manifest_json, read_http_request_path,
+    run_guest_download, run_guest_download_manifest_json, write_manifest,
 };
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse, Mock};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -112,7 +112,7 @@ fn start_truncated_then_valid_server(
         let mut storage_requests = 0;
         loop {
             let (mut stream, _) = listener.accept()?;
-            let path = read_request_path(&mut stream)?;
+            let path = read_http_request_path(&mut stream)?;
             if path == "/__unblock" {
                 write_response(&mut stream, &[], 0)?;
                 break;
@@ -134,26 +134,6 @@ fn start_truncated_then_valid_server(
     });
 
     Ok((base_url, handle))
-}
-
-fn read_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
-    let mut request = Vec::new();
-    let mut buffer = [0_u8; 512];
-    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-        let bytes_read = stream.read(&mut buffer)?;
-        if bytes_read == 0 {
-            break;
-        }
-        request.extend(buffer.iter().take(bytes_read).copied());
-    }
-
-    let request = String::from_utf8_lossy(&request);
-    Ok(request
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .unwrap_or_default()
-        .to_owned())
 }
 
 fn write_response(

--- a/crates/guest-download/tests/integration/support.rs
+++ b/crates/guest-download/tests/integration/support.rs
@@ -1,12 +1,33 @@
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use serde_json::{Map, Value, json};
-use std::io::Write;
+use std::io::{Read, Write};
+use std::net::TcpStream;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tempfile::TempDir;
 
 static RUN_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn read_http_request_path(stream: &mut TcpStream) -> std::io::Result<String> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 512];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let bytes_read = stream.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        request.extend(buffer.iter().take(bytes_read).copied());
+    }
+
+    let request = String::from_utf8_lossy(&request);
+    Ok(request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or_default()
+        .to_owned())
+}
 
 pub(crate) enum TarEntry<'a> {
     File(&'a str, &'a [u8]),


### PR DESCRIPTION
## Summary

- classify guest HTTP request failures into bounded DNS, timeout, connection, I/O, TLS, proxy, protocol, invalid-request, and unknown categories
- include timeout phase, I/O error kind, and elapsed milliseconds for each failed download attempt
- verify retry preservation and presigned-URL redaction through the built `guest-download` binary

## Scope

- preserves existing HTTP status handling, retry eligibility, retry count, retry delay, and download concurrency
- does not render raw `ureq` error payloads, request URLs, proxy URLs, or presigned credentials
- does not change APIs, schemas, manifests, persisted state, or E2E behavior

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download --test integration`
- `cargo test --manifest-path crates/Cargo.toml -p guest-download`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-download --all-targets --all-features -- -D warnings`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (594 files passed, 7,307 tests passed)
- `cd turbo && pnpm knip`

Closes #21071
