### PR TITLE
fix: harden nintendo parental controls credentials

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors-external-code.bdd.test.ts
@@ -77,6 +77,14 @@ const NINTENDO_SWITCH_PARENTAL_CONTROLS_SCOPES = [
   "moonDailySummary",
   "moonMonthlySummary",
 ] as const;
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN_CODE =
+  "bdd-switch-parental-controls-code";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN_CODE =
+  "bdd-switch-parental-controls-replacement-code";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN =
+  "bdd-switch-parental-controls-session-token";
+const NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN =
+  "bdd-switch-parental-controls-replacement-session-token";
 
 async function awsActor(): Promise<ApiTestUser> {
   const bdd = createBddApi(context);
@@ -151,23 +159,57 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
   readonly federatedSmartDeviceIds: string[];
   readonly federationBodies: unknown[];
   readonly failLogout: () => void;
+  readonly initialIdToken: string;
+  readonly logoutAuthorizations: (string | null)[];
   readonly logoutBodies: unknown[];
+  readonly replacementIdToken: string;
   readonly sessionTokenBodies: URLSearchParams[];
   readonly tokenBodies: Readonly<Record<string, unknown>>[];
 } {
   const federatedSmartDeviceIds: string[] = [];
   const federationBodies: unknown[] = [];
+  const initialIdToken = jwtPayload({
+    sub: "bdd-switch-parental-controls-account-id",
+    preferred_username: "bdd-nintendo-parent",
+    email: "bdd-nintendo-parent@example.test",
+  });
+  const logoutAuthorizations: (string | null)[] = [];
   const logoutBodies: unknown[] = [];
+  const replacementIdToken = jwtPayload({
+    sub: "bdd-switch-parental-controls-replacement-account-id",
+    preferred_username: "bdd-nintendo-replacement-parent",
+    email: "bdd-nintendo-replacement-parent@example.test",
+  });
   const sessionTokenBodies: URLSearchParams[] = [];
   const tokenBodies: Readonly<Record<string, unknown>>[] = [];
   let logoutStatus = 204;
 
   server.use(
     http.post(NINTENDO_STORE_SESSION_TOKEN_URL, async ({ request }) => {
-      sessionTokenBodies.push(new URLSearchParams(await request.text()));
-      return HttpResponse.json({
-        session_token: "bdd-switch-parental-controls-session-token",
-      });
+      const body = new URLSearchParams(await request.text());
+      sessionTokenBodies.push(body);
+      const sessionTokenCode = body.get("session_token_code");
+      if (
+        sessionTokenCode ===
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN_CODE
+      ) {
+        return HttpResponse.json({
+          session_token:
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN,
+        });
+      }
+      if (
+        sessionTokenCode ===
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN_CODE
+      ) {
+        return HttpResponse.json({
+          session_token:
+            NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN,
+        });
+      }
+      throw new Error(
+        `Unexpected Nintendo Switch Parental Controls session token code: ${sessionTokenCode}`,
+      );
     }),
     http.post(NINTENDO_STORE_TOKEN_URL, async ({ request }) => {
       const body: unknown = await request.json();
@@ -177,14 +219,26 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
         );
       }
       tokenBodies.push(body);
+      const sessionToken = body["session_token"];
+      if (
+        sessionToken !==
+          NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN &&
+        sessionToken !==
+          NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN
+      ) {
+        throw new Error(
+          "Expected a known Nintendo Switch Parental Controls session token",
+        );
+      }
+      const isReplacement =
+        sessionToken ===
+        NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN;
       return HttpResponse.json({
-        access_token: "bdd-switch-parental-controls-access-token",
+        access_token: isReplacement
+          ? "bdd-switch-parental-controls-replacement-access-token"
+          : "bdd-switch-parental-controls-access-token",
         expires_in: 3600,
-        id_token: jwtPayload({
-          sub: "bdd-switch-parental-controls-account-id",
-          preferred_username: "bdd-nintendo-parent",
-          email: "bdd-nintendo-parent@example.test",
-        }),
+        id_token: isReplacement ? replacementIdToken : initialIdToken,
         token_type: "Bearer",
         scope: NINTENDO_SWITCH_PARENTAL_CONTROLS_SCOPES.join(" "),
       });
@@ -225,6 +279,7 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
     http.post(
       NINTENDO_SWITCH_PARENTAL_CONTROLS_LOGOUT_URL,
       async ({ request }) => {
+        logoutAuthorizations.push(request.headers.get("authorization"));
         logoutBodies.push(await request.json());
         return logoutStatus === 204
           ? new HttpResponse(null, { status: 204 })
@@ -242,7 +297,10 @@ function mockNintendoSwitchParentalControlsExternalCodeProvider(): {
     failLogout: () => {
       logoutStatus = 503;
     },
+    initialIdToken,
+    logoutAuthorizations,
     logoutBodies,
+    replacementIdToken,
     sessionTokenBodies,
     tokenBodies,
   };
@@ -681,7 +739,7 @@ describe("CONN-02: external-code session lifecycle", () => {
       {
         sessionId: session.sessionId,
         sessionToken: session.sessionToken,
-        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI}#session_token_code=bdd-switch-parental-controls-code&state=${state}`,
+        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI}#session_token_code=${NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN_CODE}&state=${state}`,
       },
     );
 
@@ -692,7 +750,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     expect(provider.tokenBodies).toStrictEqual([
       {
         client_id: NINTENDO_SWITCH_PARENTAL_CONTROLS_CLIENT_ID,
-        session_token: "bdd-switch-parental-controls-session-token",
+        session_token: NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN,
         grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer-session-token",
       },
     ]);
@@ -714,7 +772,7 @@ describe("CONN-02: external-code session lifecycle", () => {
     expect(complete.connector.tokenExpiresAt).not.toBeNull();
     expectNoVisibleSecret(
       complete,
-      "bdd-switch-parental-controls-session-token",
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN,
     );
     expectNoVisibleSecret(
       complete,
@@ -786,7 +844,7 @@ describe("CONN-02: external-code session lifecycle", () => {
       {
         sessionId: replacementSession.sessionId,
         sessionToken: replacementSession.sessionToken,
-        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI}#session_token_code=bdd-switch-parental-controls-replacement-code&state=${replacementState}`,
+        code: `${NINTENDO_SWITCH_PARENTAL_CONTROLS_REDIRECT_URI}#session_token_code=${NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN_CODE}&state=${replacementState}`,
       },
     );
     expect(provider.federatedSmartDeviceIds).toHaveLength(2);
@@ -802,7 +860,20 @@ describe("CONN-02: external-code session lifecycle", () => {
       actor,
       "nintendo-switch-parental-controls",
     );
-    expect(provider.tokenBodies).toHaveLength(4);
+    expect(
+      provider.tokenBodies.map((body) => {
+        return body["session_token"];
+      }),
+    ).toStrictEqual([
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN,
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN,
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_INITIAL_SESSION_TOKEN,
+      NINTENDO_SWITCH_PARENTAL_CONTROLS_REPLACEMENT_SESSION_TOKEN,
+    ]);
+    expect(provider.logoutAuthorizations).toStrictEqual([
+      `Bearer ${provider.initialIdToken}`,
+      `Bearer ${provider.replacementIdToken}`,
+    ]);
     expect(provider.logoutBodies).toStrictEqual([
       { smartDeviceId: provider.federatedSmartDeviceIds[0] },
       { smartDeviceId: provider.federatedSmartDeviceIds[1] },

--- a/turbo/packages/connectors/src/__tests__/firewalls/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/nintendo-switch-parental-controls.test.ts
@@ -243,23 +243,37 @@ describe("Nintendo Switch Parental Controls firewall", () => {
     for (const value of Object.values(placeholders)) {
       expect(value).not.toMatch(/placeholder|fake|dummy|test|example/i);
     }
-    for (const [name, expectedPayload] of [
+    for (const [name, expectedSegmentLengths, expectedPayload] of [
       [
         "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+        [156, 312, 342],
         {
-          at_hash: "CoffeeSafeLocalCoffeeS",
+          country: "US",
           jti: "10ca1c0f-fee5-4afe-8c0f-fee5afe10ca1",
+          exp: 4_102_444_800,
+          at_hash: "CoffeeSafeLocalCoffeeS",
           typ: "id_token",
+          iat: 4_102_443_900,
+          iss: "https://accounts.nintendo.com",
+          sub: "c0ffee5afe10ca1",
+          aud: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
         },
       ],
       [
         "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+        [156, 334, 342],
         {
+          aud: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+          typ: "token",
+          sub: "c0ffee5afe10ca1",
+          iat: 4_102_443_900,
+          iss: "https://accounts.nintendo.com",
+          "ac:grt": 0,
+          exp: 4_102_444_800,
           "ac:scp": [
             0, 8, 17, 320, 321, 325, 322, 323, 324, 326, 327, 328, 329,
           ],
           jti: "afe10ca1-c0ff-4ee5-8afe-10ca1c0ffee5",
-          typ: "token",
         },
       ],
     ] as const) {
@@ -268,6 +282,14 @@ describe("Nintendo Switch Parental Controls firewall", () => {
         token?.split(".") ?? [];
       if (!encodedHeader || !encodedPayload || !signature || extra) {
         throw new Error(`Expected a three-segment Nintendo JWT for ${name}`);
+      }
+      expect(
+        [encodedHeader, encodedPayload, signature].map((segment) => {
+          return segment.length;
+        }),
+      ).toStrictEqual(expectedSegmentLengths);
+      for (const segment of [encodedHeader, encodedPayload, signature]) {
+        expect(segment).toMatch(/^[A-Za-z0-9_-]+$/);
       }
       const header: unknown = JSON.parse(
         Buffer.from(encodedHeader, "base64url").toString(),
@@ -280,14 +302,7 @@ describe("Nintendo Switch Parental Controls firewall", () => {
         kid: "5afe10ca-1c0f-4fee-8afe-10ca1c0ffee5",
         jku: "https://accounts.nintendo.com/1.0.0/certificates",
       });
-      expect(payload).toMatchObject({
-        aud: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
-        exp: 4_102_444_800,
-        iat: 4_102_443_900,
-        iss: "https://accounts.nintendo.com",
-        ...expectedPayload,
-      });
-      expect(signature).toMatch(/^[A-Za-z0-9_-]{342}$/);
+      expect(payload).toStrictEqual(expectedPayload);
     }
     expect(
       placeholders["NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID"],

--- a/turbo/packages/connectors/src/__tests__/firewalls/nintendo-switch-parental-controls.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewalls/nintendo-switch-parental-controls.test.ts
@@ -1,3 +1,5 @@
+import { Buffer } from "node:buffer";
+
 import { beforeAll, describe, expect, it } from "vitest";
 
 import { NINTENDO_SWITCH_PARENTAL_CONTROLS_APP } from "../../connectors/nintendo-switch-parental-controls";
@@ -228,6 +230,70 @@ describe("Nintendo Switch Parental Controls firewall", () => {
       "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
       "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
     ]);
+  });
+
+  it("uses format-correct, non-obvious runtime placeholders", () => {
+    const placeholders = firewall.placeholders;
+    if (!placeholders) {
+      throw new Error(
+        "Expected Nintendo Switch Parental Controls placeholders",
+      );
+    }
+
+    for (const value of Object.values(placeholders)) {
+      expect(value).not.toMatch(/placeholder|fake|dummy|test|example/i);
+    }
+    for (const [name, expectedPayload] of [
+      [
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+        {
+          at_hash: "CoffeeSafeLocalCoffeeS",
+          jti: "10ca1c0f-fee5-4afe-8c0f-fee5afe10ca1",
+          typ: "id_token",
+        },
+      ],
+      [
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+        {
+          "ac:scp": [
+            0, 8, 17, 320, 321, 325, 322, 323, 324, 326, 327, 328, 329,
+          ],
+          jti: "afe10ca1-c0ff-4ee5-8afe-10ca1c0ffee5",
+          typ: "token",
+        },
+      ],
+    ] as const) {
+      const token = placeholders[name];
+      const [encodedHeader, encodedPayload, signature, extra] =
+        token?.split(".") ?? [];
+      if (!encodedHeader || !encodedPayload || !signature || extra) {
+        throw new Error(`Expected a three-segment Nintendo JWT for ${name}`);
+      }
+      const header: unknown = JSON.parse(
+        Buffer.from(encodedHeader, "base64url").toString(),
+      );
+      const payload: unknown = JSON.parse(
+        Buffer.from(encodedPayload, "base64url").toString(),
+      );
+      expect(header).toStrictEqual({
+        alg: "RS256",
+        kid: "5afe10ca-1c0f-4fee-8afe-10ca1c0ffee5",
+        jku: "https://accounts.nintendo.com/1.0.0/certificates",
+      });
+      expect(payload).toMatchObject({
+        aud: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+        exp: 4_102_444_800,
+        iat: 4_102_443_900,
+        iss: "https://accounts.nintendo.com",
+        ...expectedPayload,
+      });
+      expect(signature).toMatch(/^[A-Za-z0-9_-]{342}$/);
+    }
+    expect(
+      placeholders["NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID"],
+    ).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 
   it("covers the account profile and all 45 app action routes exactly", () => {

--- a/turbo/packages/firewalls-generator/src/nintendo-switch-parental-controls.ts
+++ b/turbo/packages/firewalls-generator/src/nintendo-switch-parental-controls.ts
@@ -4,6 +4,8 @@
  * Data source: Nintendo Switch Parental Controls app 2.4.0 (build 660).
  */
 
+import { Buffer } from "node:buffer";
+
 import { NINTENDO_SWITCH_PARENTAL_CONTROLS_APP } from "@vm0/connectors/connectors/nintendo-switch-parental-controls";
 import {
   logStats,
@@ -15,11 +17,57 @@ import {
   type PermissionGroup,
 } from "./codegen";
 
-const ID_TOKEN_PLACEHOLDER =
-  "nintendo_switch_parental_controls_id_token_placeholder";
-const ACCOUNT_TOKEN_PLACEHOLDER =
-  "nintendo_switch_parental_controls_account_token_placeholder";
-const SMART_DEVICE_ID_PLACEHOLDER = "00000000-0000-4000-8000-000000000000";
+const SMART_DEVICE_ID_PLACEHOLDER = "c0ffee5a-fe10-4ca1-8c0f-fee5afe10ca1";
+const NINTENDO_JWT_KEY_ID_PLACEHOLDER = "5afe10ca-1c0f-4fee-8afe-10ca1c0ffee5";
+const NINTENDO_ID_TOKEN_JTI_PLACEHOLDER =
+  "10ca1c0f-fee5-4afe-8c0f-fee5afe10ca1";
+const NINTENDO_ACCESS_TOKEN_JTI_PLACEHOLDER =
+  "afe10ca1-c0ff-4ee5-8afe-10ca1c0ffee5";
+const NINTENDO_JWT_ISSUED_AT = 4_102_443_900;
+const NINTENDO_JWT_EXPIRES_AT = NINTENDO_JWT_ISSUED_AT + 900;
+// Nintendo Account ID and access tokens use RS256 with 2048-bit keys from
+// https://accounts.nintendo.com/1.0.0/certificates.
+const NINTENDO_JWT_SIGNATURE = "CoffeeSafeLocal".repeat(23).slice(0, 342);
+
+function nintendoJwtPlaceholder(
+  payload: Readonly<Record<string, unknown>>,
+): string {
+  const encode = (value: unknown): string => {
+    return Buffer.from(JSON.stringify(value)).toString("base64url");
+  };
+  return [
+    encode({
+      alg: "RS256",
+      kid: NINTENDO_JWT_KEY_ID_PLACEHOLDER,
+      jku: "https://accounts.nintendo.com/1.0.0/certificates",
+    }),
+    encode(payload),
+    NINTENDO_JWT_SIGNATURE,
+  ].join(".");
+}
+
+const ID_TOKEN_PLACEHOLDER = nintendoJwtPlaceholder({
+  country: "US",
+  jti: NINTENDO_ID_TOKEN_JTI_PLACEHOLDER,
+  exp: NINTENDO_JWT_EXPIRES_AT,
+  at_hash: "CoffeeSafeLocalCoffeeS",
+  typ: "id_token",
+  iat: NINTENDO_JWT_ISSUED_AT,
+  iss: "https://accounts.nintendo.com",
+  sub: "c0ffee5afe10ca1",
+  aud: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+});
+const ACCOUNT_TOKEN_PLACEHOLDER = nintendoJwtPlaceholder({
+  aud: NINTENDO_SWITCH_PARENTAL_CONTROLS_APP.clientId,
+  typ: "token",
+  sub: "c0ffee5afe10ca1",
+  iat: NINTENDO_JWT_ISSUED_AT,
+  iss: "https://accounts.nintendo.com",
+  "ac:grt": 0,
+  exp: NINTENDO_JWT_EXPIRES_AT,
+  "ac:scp": [0, 8, 17, 320, 321, 325, 322, 323, 324, 326, 327, 328, 329],
+  jti: NINTENDO_ACCESS_TOKEN_JTI_PLACEHOLDER,
+});
 const RUNTIME_ID_TOKEN_SECRET = "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN";
 const RUNTIME_ACCOUNT_TOKEN_SECRET =
   "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN";


### PR DESCRIPTION
## Summary

- replace obvious Nintendo Switch Parental Controls runtime placeholders with format-correct RS256 JWT and UUID values
- validate the placeholder JWT headers, claims, signature shape, and smart-device identifier in the firewall integration test
- make initial and replacement credentials distinct in the external-code lifecycle test, then assert that replacement cleanup uses the previous ID token before deletion uses the current ID token

## Scope

This is a follow-up to #21016 and addresses the second and third findings from the review on that PR.

It intentionally does not address the shared `GET /2.0.0/users/me` credential-selection ambiguity. That concern remains separate from this focused follow-up.

## Validation

- `pnpm format`
- `pnpm turbo run lint` (12/12 tasks passed)
- `pnpm check-types` (13/13 tasks passed)
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (594 files and 7,308 tests passed; 1 existing file/test skipped)
- `pnpm knip`
- Nintendo Switch Parental Controls firewall generator completed successfully
- focused firewall integration test (6/6 passed)
- focused external-code lifecycle integration test (9/9 passed)

Relates to #20610.
