### PR TITLE
refactor: reduce fallback slop in desktop mcp errors

### DIFF
--- a/turbo/apps/desktop/src/desktop-mcp-plugin.ts
+++ b/turbo/apps/desktop/src/desktop-mcp-plugin.ts
@@ -428,19 +428,19 @@ export class DesktopMcpPluginManager {
     payload: ComputerUseMcpPluginCallPayload,
     runtime: McpServerRuntime,
   ): Promise<ComputerUseCommandExecutionResult> {
-    if (!runtime.tools.includes(payload.tool)) {
-      const listed = await runtime.client.listTools().catch(() => null);
-      const live = listed?.tools.some((tool) => {
-        return tool.name === payload.tool;
-      });
-      if (!live) {
-        return commandFailure(
-          "unknown_tool",
-          `MCP server ${payload.server} does not expose tool: ${payload.tool}`,
-        );
-      }
-    }
     try {
+      if (!runtime.tools.includes(payload.tool)) {
+        const listed = await runtime.client.listTools();
+        const live = listed.tools.some((tool) => {
+          return tool.name === payload.tool;
+        });
+        if (!live) {
+          return commandFailure(
+            "unknown_tool",
+            `MCP server ${payload.server} does not expose tool: ${payload.tool}`,
+          );
+        }
+      }
       const result = await runtime.client.callTool({
         name: payload.tool,
         arguments: payload.arguments,


### PR DESCRIPTION
## Summary

- Preserve MCP `listTools` failures as `mcp_error` responses instead of silently treating them as missing tools.
- Keep the stale-tool refresh and unknown-tool behavior unchanged when the live tool list succeeds.

## Scan

- Timestamp: `2026-07-11T20:01:33.076Z`
- Base commit: `952768c8a7124fae42581d38a9603e62aa536e30`
- Files scanned: 4,125
- Total matches: 19,310
- Initial scanner high-confidence production actionable total: 237
- Manually confirmed `actionable_total`: 1
- `edit_budget`: 1 (`max(1, ceil(1 * 0.05))`)
- Candidates changed: 1

### Matches by category

- `nullish`: 5,803
- `nullish-chain`: 134
- `field-fallback-chain`: 110
- `optional-prop`: 6,088
- `zod-optional`: 2,207
- `zod-loose-optional`: 4
- `loose-record`: 1,184
- `loose-index-signature`: 3
- `as-any`: 0
- `as-unknown-as`: 33
- `empty-fallback`: 670
- `string-fallback`: 729
- `null-undefined-fallback`: 1,566
- `empty-catch`: 3
- `promise-catch-swallow`: 15
- `rust-unwrap-or`: 616
- `rust-ok-discard`: 145

## Safety

- `turbo/apps/desktop/src/desktop-mcp-plugin.ts`: moves the live MCP tool-list refresh into the method's existing error boundary. A successful list still returns `unknown_tool` when appropriate; a failed list now returns the underlying `mcp_error` through the same path already used for tool-call failures.
- Manual review excluded the remaining scanner candidates because they are documented compatibility paths, presentation fallbacks, test-fixture contracts, or external payload adapters without an unambiguous stricter runtime contract.

## Verification

- `pnpm -F @vm0/desktop lint`
- `pnpm -F @vm0/desktop check-types`
- Desktop Vitest suite: 35 files, 305 tests passed
- `git diff --check`

This workflow intentionally leaves the remaining candidates for later daily runs.
