### PR TITLE
docs(mitm-addon): document flow metadata linter helpers

### DIFF
--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/api.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/api.py
@@ -18,6 +18,12 @@ def _python_files() -> list[Path]:
 
 
 def metadata_key_violations(path: Path) -> list[str]:
+    """Parse the Python source file at ``path`` and return metadata key diagnostics.
+
+    The file is opened with Python source encoding detection and parsed into an AST. Each
+    diagnostic identifies the source location of a registered key literal used in flow metadata
+    access and the ``metadata_keys`` constant to use instead.
+    """
     with tokenize.open(str(path)) as source_file:
         source = source_file.read()
     tree = ast.parse(source, filename=str(path))
@@ -27,4 +33,9 @@ def metadata_key_violations(path: Path) -> list[str]:
 
 
 def repository_metadata_key_violations() -> list[str]:
+    """Return metadata key diagnostics from the addon's source and test trees.
+
+    The scan recursively covers Python files under ``src/`` and ``tests/`` and excludes
+    ``src/flow_metadata_keys.py``. It does not inspect ``scripts/``.
+    """
     return [violation for path in _python_files() for violation in metadata_key_violations(path)]

--- a/crates/runner/mitm-addon/scripts/flow_metadata_linter/api.py
+++ b/crates/runner/mitm-addon/scripts/flow_metadata_linter/api.py
@@ -21,8 +21,8 @@ def metadata_key_violations(path: Path) -> list[str]:
     """Parse the Python source file at ``path`` and return metadata key diagnostics.
 
     The file is opened with Python source encoding detection and parsed into an AST. Each
-    diagnostic identifies the source location of a registered key literal used in flow metadata
-    access and the ``metadata_keys`` constant to use instead.
+    diagnostic identifies the source location of a statically detected registered key used in
+    flow metadata access and the ``metadata_keys`` constant to use instead.
     """
     with tokenize.open(str(path)) as source_file:
         source = source_file.read()


### PR DESCRIPTION
## Summary

- document the single-file flow metadata linter's encoding-aware read, AST parsing, and diagnostic contract
- document the repository helper's recursive `src/` and `tests/` scan boundary and registry exclusion
- keep facade exports, scanner behavior, diagnostics, CLI behavior, and runtime addon behavior unchanged

## Scope

This is documentation-only. It does not change scan roots, diagnostic formatting or ordering,
dependencies, runtime metadata access, or establish a general docstring policy.

Closes #21029

## Validation

- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/basedpyright -p .`
- `./.venv/bin/python -m pytest tests/test_flow_metadata_key_contract.py -q` (9 passed)
- `./.venv/bin/python -m pytest tests/ -q` (3,765 passed)
- `./.venv/bin/python scripts/check-flow-metadata-keys.py`
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (594 files, 7,307 passed; 1 skipped)
- `cd turbo && pnpm knip`
- `git diff --check`
- pre-commit and commit-message hooks
