### PR TITLE
fix(runner): use bash for release asset builds

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1895,7 +1895,6 @@ jobs:
         id: target-metadata
         env:
           TARGET_TRIPLE: ${{ matrix.target }}
-        shell: bash
         run: |
           set -euo pipefail
           . .github/scripts/runner-image-target.sh
@@ -1963,7 +1962,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
           TARGET_TRIPLE: ${{ matrix.target }}
-        shell: bash
         run: |
           set -euo pipefail
           . .github/scripts/runner-image-target.sh

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1877,6 +1877,9 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260622
+    defaults:
+      run:
+        shell: bash
     permissions:
       contents: write
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,10 @@ For detailed patterns and examples, use `/testing`.
 
 **All pull requests must pass CI checks before merging.** These checks are defined in `.github/workflows/turbo.yml` and run automatically on every PR, including lint, test, deploy, and cli-e2e.
 
+### GitHub Actions Shell Compatibility
+
+GitHub Actions container jobs run `run` steps with `sh` by default. Any step that uses Bash syntax or sources a Bash helper must set `shell: bash`, or the job must set `defaults.run.shell: bash`. A sourced script's shebang does not select the shell because the calling shell parses it.
+
 ### Zero Tolerance for Skipping Tests
 
 **NEVER skip tests to make CI pass.** All tests must execute and pass:


### PR DESCRIPTION
## Summary

- run every shell step in the runner release asset container job with Bash
- document that GitHub Actions container jobs default to `sh` and that sourced shebangs do not change the caller shell

## Root cause

PR #21066 introduced a Bash-only guest inventory helper and Bash arrays in two inline release build steps. Container jobs use `sh` for implicit `run` shells, so both architecture matrix legs failed before compilation with `Bad substitution` and an unexpected `(` syntax error.

Before this PR, the job's target-metadata and upload steps explicitly selected Bash and completed successfully, proving Bash is available in the toolchain container. A job-level default makes the shell contract consistent for all current and future commands in this job.

## Release ordering

The pending runner release PR #21088 must merge after this fix is present on `main`; rerunning the old failed workflow would still use the old workflow definition.

## Scope

- no changes to guest inventory contents or build arguments
- no attempt to make the existing Bash helper POSIX-compatible

## Validation

- `bash -n .github/scripts/*.sh .github/scripts/tests/*.sh`
- all `.github/scripts/tests/*.sh`
- actionlint v1.7.12
- Bash execution of both guest and runner argument construction loops
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (594 files passed, 7307 tests passed, 1 file and 1 test skipped)
- `cd turbo && pnpm knip`
