### PR TITLE
fix: trigger api and platform releases

### DIFF
--- a/turbo/apps/api/src/index.ts
+++ b/turbo/apps/api/src/index.ts
@@ -7,7 +7,7 @@ import { createApp } from "./app-factory";
 // realtime relay WebSocket — Epic #12128 pivoted to Plan D (browser-direct
 // to OpenAI), and the WS scaffolding has since been retired.
 //
-// (no-op API release marker refreshed 2026-07-10 to trigger a release)
+// (no-op API release marker refreshed 2026-07-12 to trigger a release)
 
 const app = (() => {
   const instanceAbortController = new AbortController();

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -10,6 +10,8 @@ import { setLogErrorHandler } from "./signals/log.ts";
 import { detach, Reason } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
 
+// (no-op Platform release marker refreshed 2026-07-12 to trigger a release)
+
 // Initialize Sentry before bootstrap so errors during startup are captured
 initSentry();
 initPostHog();


### PR DESCRIPTION
## Summary

- refresh the API no-op release marker
- add a Platform no-op release marker
- trigger patch releases for both independent release-please components

## Exclusions

- no runtime behavior, API contract, schema, or persisted data changes

## Validation

- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `cd turbo && pnpm knip`
