### PR TITLE
feat: expose connector catalog icon descriptors

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -231,6 +231,47 @@ describe("GET /api/zero/connector-catalog", () => {
     expect(openai?.permissionSummary).not.toHaveProperty("permissions");
   });
 
+  it("returns shared public icon descriptors across catalog views", async () => {
+    const userId = `user_${randomUUID()}`;
+    const orgId = `org_${randomUUID()}`;
+    mocks.clerk.session(userId, orgId);
+
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const headers = { authorization: "Bearer clerk-session" };
+    const listResponse = await accept(client.list({ headers }), [200]);
+    const statusResponse = await accept(client.status({ headers }), [200]);
+    const detailResponse = await accept(
+      client.get({ params: { connectorRef: "openai" }, headers }),
+      [200],
+    );
+
+    const openai = listResponse.body.connectors.find((connector) => {
+      return connector.connectorRef === "openai";
+    });
+    const openaiStatus = statusResponse.body.connectors.find((connector) => {
+      return connector.connectorRef === "openai";
+    });
+    expect(openai?.icon).toStrictEqual({
+      url: "https://static.vm0.io/platform/views/zero-page/components/settings/icons/openai-df8a3d9c4274.svg",
+      invertInDarkMode: true,
+    });
+    expect(openaiStatus?.icon).toStrictEqual(openai?.icon);
+    expect(detailResponse.body.connector.icon).toStrictEqual(openai?.icon);
+
+    const slack = listResponse.body.connectors.find((connector) => {
+      return connector.connectorRef === "slack";
+    });
+    const slackWebhook = listResponse.body.connectors.find((connector) => {
+      return connector.connectorRef === "slack-webhook";
+    });
+    expect(slack?.icon).toStrictEqual({
+      url: "https://static.vm0.io/platform/views/zero-page/components/settings/icons/slack-198390069136.svg?v=568fa471",
+      invertInDarkMode: false,
+      scale: 2.2,
+    });
+    expect(slackWebhook?.icon).toStrictEqual(slack?.icon);
+  });
+
   it("accepts a ZERO_TOKEN carrying the connector:read capability", async () => {
     const userId = `user_${randomUUID()}`;
     const orgId = `org_${randomUUID()}`;

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -34,6 +34,7 @@ import {
   type ApiAuthMethodPolicy,
   type ConnectorFeatureStates,
 } from "@vm0/connectors/connector-utils";
+import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
 import {
   getFirewallPermissionSummary,
   loadFirewallPermissionMetadata,
@@ -201,6 +202,7 @@ function connectorCatalogItem(
     connectorRef: type,
     label: config.label,
     description: config.helpText,
+    icon: getStaticConnectorIconMetadata(type),
     category: config.category,
     generation: [...getConnectorGenerationTypes(type)],
     tags: [...getConnectorTags(type)],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -124,6 +124,14 @@ function connectorCardByLabel(label: string): HTMLElement {
   return card;
 }
 
+function connectorIconByLabel(label: string): HTMLImageElement {
+  const icon = connectorCardByLabel(label).querySelector("img");
+  if (!(icon instanceof HTMLImageElement)) {
+    throw new Error(`${label} connector icon not found`);
+  }
+  return icon;
+}
+
 function applyUserConnectorUpdate(
   current: readonly string[],
   body: {
@@ -423,6 +431,33 @@ describe("connectors page", () => {
       aiGroup.compareDocumentPosition(engineeringGroup) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("preserves static connector icon rendering during catalog migration", async () => {
+    mockConnectors([]);
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(queryConnectorCardByLabel("GitHub")).toBeInTheDocument();
+      expect(queryConnectorCardByLabel("Slack")).toBeInTheDocument();
+    });
+
+    const githubIcon = connectorIconByLabel("GitHub");
+    expect(githubIcon).toHaveAttribute(
+      "src",
+      "https://static.vm0.io/platform/views/zero-page/components/settings/icons/github-4a739019d805.svg",
+    );
+    expect(githubIcon).toHaveClass("zero-icon-mono");
+
+    const slackIcon = connectorIconByLabel("Slack");
+    expect(slackIcon).toHaveAttribute(
+      "src",
+      "https://static.vm0.io/platform/views/zero-page/components/settings/icons/slack-198390069136.svg?v=568fa471",
+    );
+    expect(slackIcon).not.toHaveClass("zero-icon-mono");
+    expect(slackIcon).toHaveClass("scale-[2.2]");
+    expect(slackIcon.parentElement).toHaveClass("overflow-hidden");
   });
 
   it("renders server-authored connector categories unknown to the browser", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -1,295 +1,12 @@
+import type { ConnectorType } from "@vm0/connectors/connectors";
 import {
-  CONNECTOR_TYPE_KEYS,
-  type ConnectorType,
-} from "@vm0/connectors/connectors";
+  getStaticConnectorIconMetadata,
+  isStaticConnectorIconType,
+} from "@vm0/connectors/static-connector-icons";
 import { cn } from "@vm0/ui";
-import { maybeSettingsIconAssetUrl } from "./settings-icon-assets.ts";
-
-const CONNECTOR_ICON_ALIASES = {
-  "slack-webhook": "slack",
-  "railway-project": "railway",
-  "test-oauth-device": "test-oauth",
-} as const satisfies Partial<Record<ConnectorType, ConnectorType>>;
-
-const CONNECTOR_ICONS: Readonly<Record<ConnectorType, string>> = Object.freeze(
-  (() => {
-    const connectorKeys = CONNECTOR_TYPE_KEYS;
-    const filtered: Record<string, string> = {};
-    for (const key of connectorKeys) {
-      const iconKey =
-        key in CONNECTOR_ICON_ALIASES
-          ? CONNECTOR_ICON_ALIASES[key as keyof typeof CONNECTOR_ICON_ALIASES]
-          : key;
-      const icon = maybeSettingsIconAssetUrl(iconKey);
-      if (typeof icon !== "string") {
-        throw new Error(
-          `Missing static icon for connector type "${key}". Add the icon to vm0-ai/static-files and update settings-icon-assets.ts for "${iconKey}".`,
-        );
-      }
-      filtered[key] = icon;
-    }
-
-    return filtered as Record<ConnectorType, string>;
-  })(),
-);
-
-/** Official Slack Mark ships with a 270×270 viewBox whose artwork only fills the central ~45%.
- *  Callers render it inside an `overflow-hidden` box at layout size, and we scale the `<img>` up
- *  so the visible mark matches the box. */
-const CONNECTOR_ICON_LOOSE_VIEWBOX = {
-  slack: true,
-  "slack-webhook": true,
-} as const;
-
-function connectorIconHasLooseViewBox(type: ConnectorType): boolean {
-  return type in CONNECTOR_ICON_LOOSE_VIEWBOX;
-}
-
-/**
- * Multi-color, gradient, and distinctive single-color brand marks: skip `zero-icon-mono`
- * so `filter: invert(1)` does not distort their official colors.
- * Dark single-fill logos (e.g. navy) are *not* listed here—they invert for contrast on dark UI.
- */
-const CONNECTOR_ICON_COLORFUL = {
-  adzuna: true,
-  ahrefs: true,
-  agora: true,
-  airtable: true,
-  "altium-365": true,
-  alchemy: true,
-  amadeus: true,
-  amplitude: true,
-  "anthropic-managed-agents": true,
-  apify: true,
-  archer: true,
-  armature: true,
-  asana: true,
-  ashby: true,
-  atlassian: true,
-  aws: true,
-  aviationstack: true,
-  azure: true,
-  base44: true,
-  bedrock: true,
-  "bentolabs-ai": true,
-  bitrefill: true,
-  bitrix: true,
-  bland: true,
-  box: true,
-  bloom: true,
-  "brave-search": true,
-  "bright-data": true,
-  brevo: true,
-  browserbase: true,
-  browserstack: true,
-  "cal-com": true,
-  calendly: true,
-  canva: true,
-  chatglm: true,
-  chatwoot: true,
-  checkr: true,
-  chert: true,
-  "claude-code": true,
-  clearbit: true,
-  clickup: true,
-  close: true,
-  cloudflare: true,
-  cloudinary: true,
-  coda: true,
-  coingecko: true,
-  coresignal: true,
-  cronlytic: true,
-  crustdata: true,
-  cursor: true,
-  "customer-io": true,
-  deepseek: true,
-  defillama: true,
-  doubao: true,
-  dify: true,
-  discord: true,
-  "discord-webhook": true,
-  doppler: true,
-  docusign: true,
-  dropbox: true,
-  "dropbox-sign": true,
-  e2b: true,
-  etherscan: true,
-  etsy: true,
-  exa: true,
-  explorium: true,
-  fal: true,
-  figma: true,
-  firecrawl: true,
-  fireflies: true,
-  flightaware: true,
-  freshdesk: true,
-  gamma: true,
-  "garmin-connect": true,
-  gemini: true,
-  gitlab: true,
-  gmail: true,
-  gong: true,
-  "google-ads": true,
-  "google-analytics": true,
-  "google-calendar": true,
-  "google-cloud": true,
-  "google-docs": true,
-  "google-drive": true,
-  "google-maps": true,
-  "google-meet": true,
-  "google-search-console": true,
-  "google-sheets": true,
-  granola: true,
-  greenhouse: true,
-  groq: true,
-  gumroad: true,
-  helicone: true,
-  heygen: true,
-  hitem3d: true,
-  honcho: true,
-  hubspot: true,
-  "hugging-face": true,
-  hume: true,
-  hunter: true,
-  imgur: true,
-  instagram: true,
-  insforge: true,
-  instantly: true,
-  interfaze: true,
-  "intervals-icu": true,
-  inth: true,
-  ironclad: true,
-  jam: true,
-  jira: true,
-  jotform: true,
-  "keyframe-labs": true,
-  kugelaudio: true,
-  kommo: true,
-  lark: true,
-  langfuse: true,
-  langsmith: true,
-  line: true,
-  linear: true,
-  limrun: true,
-  loops: true,
-  mailchimp: true,
-  mailsac: true,
-  manus: true,
-  maskdb: true,
-  massive: true,
-  meshy: true,
-  "meta-ads": true,
-  "tiktok-ads": true,
-  metabase: true,
-  "microsoft-365": true,
-  minicor: true,
-  minimax: true,
-  minio: true,
-  miro: true,
-  mixpanel: true,
-  modal: true,
-  monday: true,
-  msg9: true,
-  n8n: true,
-  neon: true,
-  netdata: true,
-  "nintendo-switch-parental-controls": true,
-  "nintendo-store": true,
-  nyne: true,
-  openweather: true,
-  "outlook-calendar": true,
-  "outlook-mail": true,
-  pandadoc: true,
-  pdf4me: true,
-  pdfco: true,
-  pdforge: true,
-  "people-data-labs": true,
-  perplexity: true,
-  pexels: true,
-  pika: true,
-  pipedrive: true,
-  pipedream: true,
-  plain: true,
-  plausible: true,
-  playstation: true,
-  podchaser: true,
-  porkbun: true,
-  posthog: true,
-  primitive: true,
-  productlane: true,
-  printful: true,
-  qdrant: true,
-  qiita: true,
-  quickbooks: true,
-  reap: true,
-  recraft: true,
-  reddit: true,
-  reducto: true,
-  render: true,
-  rentahuman: true,
-  rentcast: true,
-  reportei: true,
-  replicas: true,
-  revenuecat: true,
-  salesgraph: true,
-  salesforce: true,
-  scrapeninja: true,
-  segment: true,
-  semrush: true,
-  sendgrid: true,
-  serpapi: true,
-  servicenow: true,
-  shopify: true,
-  shortio: true,
-  silmaril: true,
-  similarweb: true,
-  slack: true,
-  "slack-webhook": true,
-  snowflake: true,
-  "smol-machines": true,
-  sociavault: true,
-  sponge: true,
-  spotify: true,
-  sproutgigs: true,
-  "stability-ai": true,
-  stablebrowse: true,
-  strapi: true,
-  strava: true,
-  streak: true,
-  stripe: true,
-  supabase: true,
-  supadata: true,
-  testerarmy: true,
-  testrail: true,
-  ticketmaster: true,
-  tldv: true,
-  todoist: true,
-  together: true,
-  trellis: true,
-  tripo: true,
-  twenty: true,
-  twilio: true,
-  wandb: true,
-  webflow: true,
-  weread: true,
-  "whale-alert": true,
-  workos: true,
-  wrike: true,
-  xero: true,
-  youtube: true,
-  zapier: true,
-  zapsign: true,
-  zep: true,
-  zeptomail: true,
-  zoom: true,
-} as const;
-
-function connectorIconSkipsDarkInvert(type: ConnectorType): boolean {
-  return type in CONNECTOR_ICON_COLORFUL;
-}
 
 export function isConnectorIconType(type: string): type is ConnectorType {
-  return Object.prototype.hasOwnProperty.call(CONNECTOR_ICONS, type);
+  return isStaticConnectorIconType(type);
 }
 
 /**
@@ -303,24 +20,24 @@ export function ConnectorIcon({
   type: ConnectorType;
   size?: number;
 }) {
-  const icon = CONNECTOR_ICONS[type];
-  const looseViewBox = connectorIconHasLooseViewBox(type);
+  const icon = getStaticConnectorIconMetadata(type);
+  const scaled = icon.scale !== undefined;
   return (
     <span
       className={cn(
         "inline-flex shrink-0 items-center justify-center",
-        looseViewBox && "overflow-hidden",
+        scaled && "overflow-hidden",
       )}
       style={{ width: size, height: size }}
     >
       <img
-        src={icon}
+        src={icon.url}
         alt=""
         decoding="async"
         className={cn(
           "block h-full w-full max-h-full max-w-full object-contain",
-          !connectorIconSkipsDarkInvert(type) && "zero-icon-mono",
-          looseViewBox && "scale-[2.2]",
+          icon.invertInDarkMode && "zero-icon-mono",
+          scaled && "scale-[2.2]",
         )}
       />
     </span>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
@@ -1,474 +1,58 @@
+import {
+  connectorIconAssetUrl,
+  isConnectorIconAssetKey,
+  type ConnectorIconAssetKey,
+} from "@vm0/connectors/static-connector-icons";
+
 import { platformStaticAssetUrl } from "../../../../lib/static-assets.ts";
 
-const SETTINGS_ICON_ASSET_PATHS = {
-  adzuna: "views/zero-page/components/settings/icons/adzuna-dc78789bbbcd.svg",
-  agentmail:
-    "views/zero-page/components/settings/icons/agentmail-aabbd0730098.svg",
-  agora: "views/zero-page/components/settings/icons/agora-e1ad121bb1d3.svg",
-  ahrefs: "views/zero-page/components/settings/icons/ahrefs-f0a1878981ae.svg",
-  airtable:
-    "views/zero-page/components/settings/icons/airtable-eee466f3f35f.svg",
-  alchemy: "views/zero-page/components/settings/icons/alchemy-52305d20dd90.svg",
-  "altium-365":
-    "views/zero-page/components/settings/icons/altium-365-596dd870332f.svg",
-  amadeus: "views/zero-page/components/settings/icons/amadeus-ae8f238ad1d3.svg",
-  amplitude:
-    "views/zero-page/components/settings/icons/amplitude-207cc9e7fc3d.svg",
+const SETTINGS_ONLY_ICON_ASSET_PATHS = {
   anthropic:
     "views/zero-page/components/settings/icons/anthropic-3fcfdf761a69.svg",
-  "anthropic-managed-agents":
-    "views/zero-page/components/settings/icons/anthropic-managed-agents-3fcfdf761a69.svg",
-  apify: "views/zero-page/components/settings/icons/apify-5c05851a5ece.svg",
-  apollo: "views/zero-page/components/settings/icons/apollo-bf8302798dfb.svg",
-  archer: "views/zero-page/components/settings/icons/archer-1f01e618583e.svg",
-  ardent: "views/zero-page/components/settings/icons/ardent-ae05ebe263dc.svg",
-  "arga-labs":
-    "views/zero-page/components/settings/icons/arga-labs-cbf8647380cd.png",
-  armature:
-    "views/zero-page/components/settings/icons/armature-1990741703fa.svg",
-  asana: "views/zero-page/components/settings/icons/asana-693513c4245f.svg",
-  ashby: "views/zero-page/components/settings/icons/ashby-93e690ec6d4c.svg",
-  atlascloud:
-    "views/zero-page/components/settings/icons/atlascloud-fc9fa3a12884.svg",
-  atlassian:
-    "views/zero-page/components/settings/icons/atlassian-316afc512581.svg",
-  attio: "views/zero-page/components/settings/icons/attio-2ccc836df795.svg",
-  aviationstack:
-    "views/zero-page/components/settings/icons/aviationstack-e547c6f73453.svg",
-  aws: "views/zero-page/components/settings/icons/aws-8ec381036030.svg",
-  axiom: "views/zero-page/components/settings/icons/axiom-7657ffc69323.svg",
   azure: "views/zero-page/components/settings/icons/azure-a3fe212c8716.svg",
-  base44: "views/zero-page/components/settings/icons/base44-8cc1e52c1775.svg",
   bedrock: "views/zero-page/components/settings/icons/bedrock-60e2c52cb4a2.svg",
-  "bentolabs-ai":
-    "views/zero-page/components/settings/icons/bentolabs-ai-b3d6223fb7a9.png",
-  bentoml: "views/zero-page/components/settings/icons/bentoml-2f0b56c3ad28.svg",
-  bfl: "views/zero-page/components/settings/icons/bfl-c8dada65dc9e.svg",
-  bitrefill:
-    "views/zero-page/components/settings/icons/bitrefill-b8e5facc9514.svg",
-  bitrix: "views/zero-page/components/settings/icons/bitrix-6bdd38c9a309.svg",
-  bland: "views/zero-page/components/settings/icons/bland-8d7e921c413f.svg",
-  bloom: "views/zero-page/components/settings/icons/bloom-4c6f7ac5f465.svg",
-  box: "views/zero-page/components/settings/icons/box-5658678ffc4b.svg",
-  "brave-search":
-    "views/zero-page/components/settings/icons/brave-search-66814699ff97.svg",
-  brevo: "views/zero-page/components/settings/icons/brevo-e6864f00fca7.svg",
-  brex: "views/zero-page/components/settings/icons/brex-072214bc1f9d.svg",
-  "bright-data":
-    "views/zero-page/components/settings/icons/bright-data-3168ae4200e9.svg",
-  "browser-use":
-    "views/zero-page/components/settings/icons/browser-use-4aa74d615f7c.svg",
-  browserbase:
-    "views/zero-page/components/settings/icons/browserbase-47febbf5088a.svg",
-  browserless:
-    "views/zero-page/components/settings/icons/browserless-ba6f9d5b55fa.svg",
-  browserstack:
-    "views/zero-page/components/settings/icons/browserstack-af1e6416e878.svg",
-  bubblemaps:
-    "views/zero-page/components/settings/icons/bubblemaps-229d049c9345.svg",
-  buffer: "views/zero-page/components/settings/icons/buffer-c08c7f7a0ce3.svg",
-  builtwith:
-    "views/zero-page/components/settings/icons/builtwith-6f78c4278b1c.svg",
-  "cal-com":
-    "views/zero-page/components/settings/icons/cal-com-a02b7c08ed70.svg",
-  calendly:
-    "views/zero-page/components/settings/icons/calendly-a74d2624c450.svg",
-  canva: "views/zero-page/components/settings/icons/canva-0951b8855de4.svg",
   chatglm: "views/zero-page/components/settings/icons/chatglm-7e6a9cb772fa.svg",
-  chatwoot:
-    "views/zero-page/components/settings/icons/chatwoot-6d8e00d88204.svg",
-  checkr: "views/zero-page/components/settings/icons/checkr-87a016320b17.svg",
-  chert: "views/zero-page/components/settings/icons/chert-784986ecd9a9.png",
-  clado: "views/zero-page/components/settings/icons/clado-4e5752a6bccf.svg",
   "claude-code":
     "views/zero-page/components/settings/icons/claude-code-03a5132e24ca.svg",
-  clearbit:
-    "views/zero-page/components/settings/icons/clearbit-a81ec985a7e3.svg",
-  clerk: "views/zero-page/components/settings/icons/clerk-4f05e7088819.svg",
-  clickup: "views/zero-page/components/settings/icons/clickup-92a639a865ec.svg",
-  close: "views/zero-page/components/settings/icons/close-50f27153d806.svg",
-  cloudflare:
-    "views/zero-page/components/settings/icons/cloudflare-c73ea33bdc10.svg",
-  cloudinary:
-    "views/zero-page/components/settings/icons/cloudinary-902003bb0153.svg",
-  coda: "views/zero-page/components/settings/icons/coda-298689264957.svg",
-  coingecko:
-    "views/zero-page/components/settings/icons/coingecko-5267811161ec.svg",
-  coresignal:
-    "views/zero-page/components/settings/icons/coresignal-2b7ff39b9e1a.svg",
-  cronlytic:
-    "views/zero-page/components/settings/icons/cronlytic-76fb40c74299.svg",
-  crustdata:
-    "views/zero-page/components/settings/icons/crustdata-65c7407fca80.svg",
-  cursor: "views/zero-page/components/settings/icons/cursor-0375fe0bba07.svg",
-  "customer-io":
-    "views/zero-page/components/settings/icons/customer-io-3592b474801b.svg",
-  daytona: "views/zero-page/components/settings/icons/daytona-aed50e967460.svg",
-  db9: "views/zero-page/components/settings/icons/db9-0d3f5466120d.svg",
-  deel: "views/zero-page/components/settings/icons/deel-3ab75a49a804.svg",
-  deepseek:
-    "views/zero-page/components/settings/icons/deepseek-a8663c0a81d9.svg",
-  defillama:
-    "views/zero-page/components/settings/icons/defillama-ca6e0436cc1e.svg",
-  devto: "views/zero-page/components/settings/icons/devto-bba6ca399b94.svg",
-  diffbot: "views/zero-page/components/settings/icons/diffbot-182ffd8a6c40.svg",
-  dify: "views/zero-page/components/settings/icons/dify-7f2bef3c9440.svg",
-  discord: "views/zero-page/components/settings/icons/discord-8039c495de67.svg",
-  "discord-webhook":
-    "views/zero-page/components/settings/icons/discord-webhook-8039c495de67.svg",
-  docusign:
-    "views/zero-page/components/settings/icons/docusign-e93dd2ff5e07.svg",
-  doppler: "views/zero-page/components/settings/icons/doppler-6edc501a4dd9.svg",
-  doubao: "views/zero-page/components/settings/icons/doubao-4c8ef236fcf9.svg",
-  drive9: "views/zero-page/components/settings/icons/drive9-4aa08c7836de.svg",
-  dropbox: "views/zero-page/components/settings/icons/dropbox-5866286a0bf3.svg",
-  "dropbox-sign":
-    "views/zero-page/components/settings/icons/dropbox-sign-61a8d3dd3649.svg",
-  duffel: "views/zero-page/components/settings/icons/duffel-2dc83457b099.svg",
-  e2b: "views/zero-page/components/settings/icons/e2b-4a490da5dc7c.svg",
-  elevenlabs:
-    "views/zero-page/components/settings/icons/elevenlabs-027d98a44abc.svg",
-  etherscan:
-    "views/zero-page/components/settings/icons/etherscan-0d8b09b0f756.svg",
-  etsy: "views/zero-page/components/settings/icons/etsy-ac890f8bb332.svg",
-  exa: "views/zero-page/components/settings/icons/exa-9a6e04de6b38.svg",
-  explorium:
-    "views/zero-page/components/settings/icons/explorium-356f27323ba2.svg",
-  faire: "views/zero-page/components/settings/icons/faire-c16be6b57fa8.svg",
-  fal: "views/zero-page/components/settings/icons/fal-01e8e07ab4a6.svg",
-  figma: "views/zero-page/components/settings/icons/figma-2c2a32ced345.svg",
-  firecrawl:
-    "views/zero-page/components/settings/icons/firecrawl-33490f4a10bd.svg",
-  fireflies:
-    "views/zero-page/components/settings/icons/fireflies-ccfade904c3d.svg",
-  flightaware:
-    "views/zero-page/components/settings/icons/flightaware-c44e79efed07.svg",
-  freshdesk:
-    "views/zero-page/components/settings/icons/freshdesk-a5f20e344c7c.svg",
-  gamma: "views/zero-page/components/settings/icons/gamma-b47fa2ead856.svg",
-  "garmin-connect":
-    "views/zero-page/components/settings/icons/garmin-connect-a71a33da8219.svg",
-  gemini: "views/zero-page/components/settings/icons/gemini-46bd52fb85d9.svg",
-  github: "views/zero-page/components/settings/icons/github-4a739019d805.svg",
-  gitlab: "views/zero-page/components/settings/icons/gitlab-3f258ed8cb9a.svg",
-  gmail: "views/zero-page/components/settings/icons/gmail-18f42e2c6f80.svg",
-  gong: "views/zero-page/components/settings/icons/gong-68520f07a7dc.svg",
-  "google-ads":
-    "views/zero-page/components/settings/icons/google-ads-c1e9d7954aa5.svg",
-  "google-analytics":
-    "views/zero-page/components/settings/icons/google-analytics-e867ed328724.svg",
-  "google-calendar":
-    "views/zero-page/components/settings/icons/google-calendar-58ef860565d1.svg",
-  "google-cloud":
-    "views/zero-page/components/settings/icons/google-cloud-0a48e1af4a43.svg",
-  "google-docs":
-    "views/zero-page/components/settings/icons/google-docs-ce8a250ed67f.svg",
-  "google-drive":
-    "views/zero-page/components/settings/icons/google-drive-aa75924aa727.svg",
-  "google-maps":
-    "views/zero-page/components/settings/icons/google-maps-5b06e906e8fc.svg",
-  "google-meet":
-    "views/zero-page/components/settings/icons/google-meet-5243598ff429.svg",
-  "google-search-console":
-    "views/zero-page/components/settings/icons/google-search-console-f48ce6f21ebc.svg",
-  "google-sheets":
-    "views/zero-page/components/settings/icons/google-sheets-dec60c57a097.svg",
-  granola: "views/zero-page/components/settings/icons/granola-fe035645ea19.svg",
-  greenhouse:
-    "views/zero-page/components/settings/icons/greenhouse-714265097838.svg",
-  groq: "views/zero-page/components/settings/icons/groq-62f86752be05.svg",
-  gumroad: "views/zero-page/components/settings/icons/gumroad-2dde63e716df.svg",
-  helicone:
-    "views/zero-page/components/settings/icons/helicone-09ae8b5c924b.svg",
-  heygen: "views/zero-page/components/settings/icons/heygen-a213e9f1b1b0.svg",
-  hitem3d: "views/zero-page/components/settings/icons/hitem3d-1973c58d08a5.svg",
-  honcho: "views/zero-page/components/settings/icons/honcho-36380d300244.svg",
-  htmlcsstoimage:
-    "views/zero-page/components/settings/icons/htmlcsstoimage-c0c45a50f597.svg",
-  hubspot: "views/zero-page/components/settings/icons/hubspot-69b856e1dc1a.svg",
-  "hugging-face":
-    "views/zero-page/components/settings/icons/hugging-face-b3da7fed90dd.svg",
-  hume: "views/zero-page/components/settings/icons/hume-07c995294c6a.svg",
-  hunter: "views/zero-page/components/settings/icons/hunter-c58056025e04.svg",
   imessage:
     "views/zero-page/components/settings/icons/imessage-5275a5a9cb9a.svg",
-  imgur: "views/zero-page/components/settings/icons/imgur-e4b0fb24400e.svg",
-  infisical:
-    "views/zero-page/components/settings/icons/infisical-433116d4de23.svg",
-  insforge:
-    "views/zero-page/components/settings/icons/insforge-e831c2ea14f5.png",
-  instagram:
-    "views/zero-page/components/settings/icons/instagram-b4cfdf33b929.svg",
-  instantly:
-    "views/zero-page/components/settings/icons/instantly-61fa7572e06b.svg",
-  intercom:
-    "views/zero-page/components/settings/icons/intercom-773dd768e0d4.svg",
-  interfaze:
-    "views/zero-page/components/settings/icons/interfaze-f64eecea9b1d.svg",
-  "intervals-icu":
-    "views/zero-page/components/settings/icons/intervals-icu-78d7a557a3a9.svg",
-  inth: "views/zero-page/components/settings/icons/inth-e0c16be84129.png",
-  ironclad:
-    "views/zero-page/components/settings/icons/ironclad-27e516a89b5d.svg",
-  jam: "views/zero-page/components/settings/icons/jam-97b070088e92.svg",
-  jira: "views/zero-page/components/settings/icons/jira-f682013e1302.svg",
-  jotform: "views/zero-page/components/settings/icons/jotform-523706a4c2fc.svg",
-  "keyframe-labs":
-    "views/zero-page/components/settings/icons/keyframe-labs-f9ee16b4ba55.svg",
   kimi: "views/zero-page/components/settings/icons/kimi-bd6d8b8d5390.svg",
-  klaviyo: "views/zero-page/components/settings/icons/klaviyo-e87a373fc59b.svg",
-  kommo: "views/zero-page/components/settings/icons/kommo-739e724879a6.svg",
-  kugelaudio:
-    "views/zero-page/components/settings/icons/kugelaudio-6ce394d192cf.png",
-  langfuse:
-    "views/zero-page/components/settings/icons/langfuse-1ffd2ae0976b.svg",
-  langsmith:
-    "views/zero-page/components/settings/icons/langsmith-cddee9b4b113.svg",
-  lark: "views/zero-page/components/settings/icons/lark-f5fdfb27067a.svg",
-  limrun: "views/zero-page/components/settings/icons/limrun-181966484546.png",
-  line: "views/zero-page/components/settings/icons/line-55235c2f3a58.svg",
-  linear: "views/zero-page/components/settings/icons/linear-aff4bbe00efc.svg",
   "local-agent":
     "views/zero-page/components/settings/icons/local-agent-57c613146fc9.svg",
   "local-browser":
     "views/zero-page/components/settings/icons/local-browser-9a71e5c6fee7.svg",
-  loops: "views/zero-page/components/settings/icons/loops-29d64256a064.svg",
-  luma: "views/zero-page/components/settings/icons/luma-1e0311e88d0f.svg",
-  "luma-ai":
-    "views/zero-page/components/settings/icons/luma-ai-a3776de7b705.svg",
-  mailchimp:
-    "views/zero-page/components/settings/icons/mailchimp-1c208f9c6576.svg",
-  mailsac: "views/zero-page/components/settings/icons/mailsac-1b850a691eba.svg",
-  make: "views/zero-page/components/settings/icons/make-2dac6beecd28.svg",
-  manus: "views/zero-page/components/settings/icons/manus-ecf491ca9a0d.svg",
-  mapbox: "views/zero-page/components/settings/icons/mapbox-34d6827e7949.svg",
-  maskdb: "views/zero-page/components/settings/icons/maskdb-1376653c02a8.svg",
-  massive: "views/zero-page/components/settings/icons/massive-5460a1758365.svg",
-  mathpix: "views/zero-page/components/settings/icons/mathpix-87fd95ee2101.svg",
-  mem0: "views/zero-page/components/settings/icons/mem0-50e7cc80e37a.svg",
-  mercury: "views/zero-page/components/settings/icons/mercury-baf568144ac4.svg",
-  meshy: "views/zero-page/components/settings/icons/meshy-02e71ea6eb0f.svg",
-  "meta-ads":
-    "views/zero-page/components/settings/icons/meta-ads-bdbde15c3cd9.svg",
-  metabase:
-    "views/zero-page/components/settings/icons/metabase-2f00f22e1c88.svg",
-  "microsoft-365":
-    "views/zero-page/components/settings/icons/microsoft-365-ea4d37dcf563.svg",
-  minicor: "views/zero-page/components/settings/icons/minicor-446daaf992e2.png",
-  minimax: "views/zero-page/components/settings/icons/minimax-ec3b12fc26ff.svg",
-  minio: "views/zero-page/components/settings/icons/minio-ecd4eac71afa.svg",
-  miro: "views/zero-page/components/settings/icons/miro-eefd0c4b5f78.svg",
-  mixpanel:
-    "views/zero-page/components/settings/icons/mixpanel-6c0f2e835e5a.svg",
-  modal: "views/zero-page/components/settings/icons/modal-438525a3b676.svg",
-  monday: "views/zero-page/components/settings/icons/monday-d196940958ef.svg",
-  moss: "views/zero-page/components/settings/icons/moss-e756e788ba2d.svg",
-  msg9: "views/zero-page/components/settings/icons/msg9-a65b9b18454c.svg",
-  n8n: "views/zero-page/components/settings/icons/n8n-2355976a50d0.svg",
-  neon: "views/zero-page/components/settings/icons/neon-2b1aaef0b2de.svg",
-  netdata: "views/zero-page/components/settings/icons/netdata-df49d68a3ecd.svg",
-  netter: "views/zero-page/components/settings/icons/netter-4c7de538303c.svg",
-  "nintendo-switch-parental-controls":
-    "views/zero-page/components/settings/icons/nintendo-switch-parental-controls-da75b53905d6.svg",
-  "nintendo-store":
-    "views/zero-page/components/settings/icons/nintendo-store-f3c8ad8b8d85.svg",
-  notion: "views/zero-page/components/settings/icons/notion-beeb509915a9.svg",
-  novita: "views/zero-page/components/settings/icons/novita-3aa7cdf6fd0b.svg",
-  nyne: "views/zero-page/components/settings/icons/nyne-cb5e80de7d46.svg",
-  oddpool: "views/zero-page/components/settings/icons/oddpool-b0416e7d9c21.svg",
-  onyx: "views/zero-page/components/settings/icons/onyx-5db98d1eed15.svg",
-  openai: "views/zero-page/components/settings/icons/openai-df8a3d9c4274.svg",
-  openrouter:
-    "views/zero-page/components/settings/icons/openrouter-82e9dead836b.svg",
-  openweather:
-    "views/zero-page/components/settings/icons/openweather-614f7acfed2b.svg",
-  "outlook-calendar":
-    "views/zero-page/components/settings/icons/outlook-calendar-d67b8bb4bb8d.svg",
-  "outlook-mail":
-    "views/zero-page/components/settings/icons/outlook-mail-d67b8bb4bb8d.svg",
-  pandadoc:
-    "views/zero-page/components/settings/icons/pandadoc-50d5db7dbe0d.svg",
-  parallel:
-    "views/zero-page/components/settings/icons/parallel-8999315ceac1.svg",
-  pdf4me: "views/zero-page/components/settings/icons/pdf4me-72901b68f016.svg",
-  pdfco: "views/zero-page/components/settings/icons/pdfco-3e7abac71518.svg",
-  pdforge: "views/zero-page/components/settings/icons/pdforge-bdafb344440c.svg",
-  "people-data-labs":
-    "views/zero-page/components/settings/icons/people-data-labs-3f5ade20d1f6.svg",
-  perplexity:
-    "views/zero-page/components/settings/icons/perplexity-7f1c9264c825.svg",
-  pexels: "views/zero-page/components/settings/icons/pexels-066fd51404dc.png",
-  pika: "views/zero-page/components/settings/icons/pika-83321d1aa81f.svg",
-  pinecone:
-    "views/zero-page/components/settings/icons/pinecone-5b72ed27b620.svg",
-  pipedream:
-    "views/zero-page/components/settings/icons/pipedream-42dda4b1effa.svg",
-  pipedrive:
-    "views/zero-page/components/settings/icons/pipedrive-4576bea235fe.svg",
-  plain: "views/zero-page/components/settings/icons/plain-a9121ba278e5.svg",
-  plausible:
-    "views/zero-page/components/settings/icons/plausible-ff49eddd163e.svg",
-  playstation:
-    "views/zero-page/components/settings/icons/playstation-93cfdbb255ce.svg",
-  podchaser:
-    "views/zero-page/components/settings/icons/podchaser-86cc6b891620.svg",
-  porkbun: "views/zero-page/components/settings/icons/porkbun-6c11e42ddc44.svg",
-  posthog: "views/zero-page/components/settings/icons/posthog-8bff2e8232f4.svg",
-  primitive:
-    "views/zero-page/components/settings/icons/primitive-9df35a923915.png",
-  printful:
-    "views/zero-page/components/settings/icons/printful-cb359d029305.svg",
-  "prisma-postgres":
-    "views/zero-page/components/settings/icons/prisma-postgres-b0df05d1a65d.svg",
-  productlane:
-    "views/zero-page/components/settings/icons/productlane-bf1482f05bbc.svg",
-  profound:
-    "views/zero-page/components/settings/icons/profound-f169839aa64a.svg",
-  pushinator:
-    "views/zero-page/components/settings/icons/pushinator-06d3705897df.svg",
-  qdrant: "views/zero-page/components/settings/icons/qdrant-378b348e08c5.svg",
-  qiita: "views/zero-page/components/settings/icons/qiita-6c078d974a73.svg",
-  qomplement:
-    "views/zero-page/components/settings/icons/qomplement-b700b0f3d7f3.png",
-  quickbooks:
-    "views/zero-page/components/settings/icons/quickbooks-fcc0886d32c3.svg",
-  railway: "views/zero-page/components/settings/icons/railway-22723db2f4f9.svg",
-  reap: "views/zero-page/components/settings/icons/reap-dd68e029348e.svg",
-  recraft: "views/zero-page/components/settings/icons/recraft-fac1a92b013f.svg",
-  reddit: "views/zero-page/components/settings/icons/reddit-e1ac3f0da2b6.svg",
-  reducto: "views/zero-page/components/settings/icons/reducto-c00c6f16661d.svg",
-  render: "views/zero-page/components/settings/icons/render-4fcb845a3f77.svg",
-  rentahuman:
-    "views/zero-page/components/settings/icons/rentahuman-fec5bd25072b.svg",
-  rentcast:
-    "views/zero-page/components/settings/icons/rentcast-ba9e471c1a7f.svg",
-  replicas:
-    "views/zero-page/components/settings/icons/replicas-70208a17587f.svg",
-  replicate:
-    "views/zero-page/components/settings/icons/replicate-fca98dbfb77f.svg",
-  reportei:
-    "views/zero-page/components/settings/icons/reportei-4bee89a35829.svg",
-  resend: "views/zero-page/components/settings/icons/resend-caa7e78784cb.svg",
-  revenuecat:
-    "views/zero-page/components/settings/icons/revenuecat-ea0c623502d9.svg",
-  "river-markets":
-    "views/zero-page/components/settings/icons/river-markets-fc23a0022420.png",
-  runtime: "views/zero-page/components/settings/icons/runtime-529df4ae1f3f.svg",
-  runway: "views/zero-page/components/settings/icons/runway-453d2365bcc5.svg",
-  salesforce:
-    "views/zero-page/components/settings/icons/salesforce-346f79d05a04.svg",
-  salesgraph:
-    "views/zero-page/components/settings/icons/salesgraph-577ddc49a9cb.svg",
-  scrapeninja:
-    "views/zero-page/components/settings/icons/scrapeninja-dc11f0f32e56.svg",
-  segment: "views/zero-page/components/settings/icons/segment-56b8b0e2ccf0.svg",
-  semrush: "views/zero-page/components/settings/icons/semrush-12a3461815e7.svg",
-  sendgrid:
-    "views/zero-page/components/settings/icons/sendgrid-d3332cf8b59c.svg",
-  sentry: "views/zero-page/components/settings/icons/sentry-93cf192fc6c3.svg",
-  serpapi: "views/zero-page/components/settings/icons/serpapi-b731737f9b72.svg",
-  servicenow:
-    "views/zero-page/components/settings/icons/servicenow-315c79989d29.svg",
-  shopify: "views/zero-page/components/settings/icons/shopify-83cb0271954f.svg",
-  shortio: "views/zero-page/components/settings/icons/shortio-775376bc8c7d.svg",
-  silmaril:
-    "views/zero-page/components/settings/icons/silmaril-2f64fe3445c8.png",
-  similarweb:
-    "views/zero-page/components/settings/icons/similarweb-872d9e66300b.svg",
-  slack:
-    "views/zero-page/components/settings/icons/slack-198390069136.svg?v=568fa471",
-  slock: "views/zero-page/components/settings/icons/slock-f419faf6c6c4.svg",
-  "smol-machines":
-    "views/zero-page/components/settings/icons/smol-machines-41c59d345b00.svg",
-  snowflake:
-    "views/zero-page/components/settings/icons/snowflake-fd2f3b315278.svg",
-  sociavault:
-    "views/zero-page/components/settings/icons/sociavault-44913bcfa5a4.svg",
-  sponge: "views/zero-page/components/settings/icons/sponge-5d9c0211e5bc.svg",
-  spotify: "views/zero-page/components/settings/icons/spotify-e27177df2642.svg",
-  steam: "views/zero-page/components/settings/icons/steam-4e2ba2137237.svg",
-  sproutgigs:
-    "views/zero-page/components/settings/icons/sproutgigs-c1192764dbee.svg",
-  square: "views/zero-page/components/settings/icons/square-b95ac9f46e21.svg",
-  "stability-ai":
-    "views/zero-page/components/settings/icons/stability-ai-0d39725dc8b5.svg",
-  stablebrowse:
-    "views/zero-page/components/settings/icons/stablebrowse-b2fbca350120.png",
-  strapi: "views/zero-page/components/settings/icons/strapi-593e7af16585.svg",
-  strava: "views/zero-page/components/settings/icons/strava-206d8c9aa841.svg",
-  streak: "views/zero-page/components/settings/icons/streak-1455d7cc87e0.svg",
-  stripe: "views/zero-page/components/settings/icons/stripe-4a7793fa96ae.svg",
-  supabase:
-    "views/zero-page/components/settings/icons/supabase-a19a2501b366.svg",
-  supadata:
-    "views/zero-page/components/settings/icons/supadata-08a65918dcdb.svg",
-  supermemory:
-    "views/zero-page/components/settings/icons/supermemory-da72ccb9600c.svg",
-  tavily: "views/zero-page/components/settings/icons/tavily-013555e5fe64.svg",
   teams: "views/zero-page/components/settings/icons/teams-0dc3a5275d31.svg",
   telegram:
     "views/zero-page/components/settings/icons/telegram-2d9ff5d01146.svg",
-  "test-oauth":
-    "views/zero-page/components/settings/icons/test-oauth-1566bca3cb11.svg",
-  testerarmy:
-    "views/zero-page/components/settings/icons/testerarmy-1c5f5ba86505.png",
-  testrail:
-    "views/zero-page/components/settings/icons/testrail-c8c658083c6c.svg",
-  ticketmaster:
-    "views/zero-page/components/settings/icons/ticketmaster-842dc4fa3af6.svg",
-  "tiktok-ads":
-    "views/zero-page/components/settings/icons/tiktok-ads-d837a2f9f550.svg",
-  tldv: "views/zero-page/components/settings/icons/tldv-b92546888050.svg",
-  todoist: "views/zero-page/components/settings/icons/todoist-7ccd1dfa28e5.svg",
-  together:
-    "views/zero-page/components/settings/icons/together-c8adc591dd9e.svg",
-  totalis: "views/zero-page/components/settings/icons/totalis-d97d41cfb7f0.png",
-  trellis: "views/zero-page/components/settings/icons/trellis-3273c8af062d.png",
-  tripo: "views/zero-page/components/settings/icons/tripo-cee4ccd95d55.svg",
-  twenty: "views/zero-page/components/settings/icons/twenty-c793eaf377c4.svg",
-  twilio: "views/zero-page/components/settings/icons/twilio-ec4acea94d58.svg",
-  typeform:
-    "views/zero-page/components/settings/icons/typeform-f164f8538dae.svg",
-  v0: "views/zero-page/components/settings/icons/v0-16752e92fba7.svg",
-  vercel: "views/zero-page/components/settings/icons/vercel-c2c941b10e27.svg",
   vm0: "views/zero-page/components/settings/icons/vm0-0b40ba3af356.svg",
-  voquill: "views/zero-page/components/settings/icons/voquill-2af65d8d8d90.svg",
-  wandb: "views/zero-page/components/settings/icons/wandb-de3acbf6474d.svg",
-  webflow: "views/zero-page/components/settings/icons/webflow-21cb0ee09d17.svg",
-  weread: "views/zero-page/components/settings/icons/weread-8cd219dc2a90.svg",
-  "whale-alert":
-    "views/zero-page/components/settings/icons/whale-alert-98cbb1bbfdf6.png",
-  wix: "views/zero-page/components/settings/icons/wix-53a609ed8e78.svg",
-  workos: "views/zero-page/components/settings/icons/workos-c7ad66d8b5a0.svg",
-  wrike: "views/zero-page/components/settings/icons/wrike-86c509db0d0c.svg",
-  x: "views/zero-page/components/settings/icons/x-c6644387ea39.svg",
-  xero: "views/zero-page/components/settings/icons/xero-39a95d992dd5.svg",
-  youtube: "views/zero-page/components/settings/icons/youtube-7d0026b054c2.svg",
-  zapier: "views/zero-page/components/settings/icons/zapier-53711819f9ee.svg",
-  zapsign: "views/zero-page/components/settings/icons/zapsign-e9e1ddefebed.svg",
-  zendesk: "views/zero-page/components/settings/icons/zendesk-7984da5ed551.svg",
-  zep: "views/zero-page/components/settings/icons/zep-298c7ff5291e.svg",
-  zeptomail:
-    "views/zero-page/components/settings/icons/zeptomail-4469f325f353.svg",
-  zoom: "views/zero-page/components/settings/icons/zoom-69a0c0bc6fe9.svg",
 } as const;
 
-export type SettingsIconAssetKey = keyof typeof SETTINGS_ICON_ASSET_PATHS;
+type SettingsOnlyIconAssetKey = keyof typeof SETTINGS_ONLY_ICON_ASSET_PATHS;
+type SettingsIconAssetKey = ConnectorIconAssetKey | SettingsOnlyIconAssetKey;
 
-export const SETTINGS_ICON_ASSETS: Readonly<
-  Record<SettingsIconAssetKey, string>
-> = Object.freeze(
-  Object.fromEntries(
-    Object.entries(SETTINGS_ICON_ASSET_PATHS).map(([key, path]) => {
-      return [key, platformStaticAssetUrl(path)];
-    }),
-  ) as Record<SettingsIconAssetKey, string>,
-);
+function isSettingsOnlyIconAssetKey(
+  key: string,
+): key is SettingsOnlyIconAssetKey {
+  return Object.prototype.hasOwnProperty.call(
+    SETTINGS_ONLY_ICON_ASSET_PATHS,
+    key,
+  );
+}
 
 export function settingsIconAssetUrl(key: SettingsIconAssetKey): string {
-  return SETTINGS_ICON_ASSETS[key];
+  const url = maybeSettingsIconAssetUrl(key);
+  if (url) {
+    return url;
+  }
+  throw new Error(`Missing settings icon asset for "${key}"`);
 }
 
 export function maybeSettingsIconAssetUrl(key: string): string | undefined {
-  return (SETTINGS_ICON_ASSETS as Readonly<Record<string, string>>)[key];
+  if (isConnectorIconAssetKey(key)) {
+    return connectorIconAssetUrl(key);
+  }
+  if (isSettingsOnlyIconAssetKey(key)) {
+    return platformStaticAssetUrl(SETTINGS_ONLY_ICON_ASSET_PATHS[key]);
+  }
+  return undefined;
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
@@ -41,7 +41,7 @@ function isSettingsOnlyIconAssetKey(
 
 export function settingsIconAssetUrl(key: SettingsIconAssetKey): string {
   const url = maybeSettingsIconAssetUrl(key);
-  if (url) {
+  if (url !== undefined) {
     return url;
   }
   throw new Error(`Missing settings icon asset for "${key}"`);

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -29,6 +29,12 @@ const publicConnectorCatalogPermissionSummarySchema = z.object({
   hasDefaultPolicyOverrides: z.boolean(),
 });
 
+const publicConnectorCatalogIconSchema = z.object({
+  url: z.url({ protocol: /^https$/u }).max(2048),
+  invertInDarkMode: z.boolean(),
+  scale: z.number().min(1).max(3).optional(),
+});
+
 const publicConnectorCatalogCategoryGroupSchema = z.object({
   id: z.string(),
   label: z.string(),
@@ -51,6 +57,7 @@ const publicConnectorCatalogItemSchema = z.object({
   connectorRef: connectorRefSchema,
   label: z.string(),
   description: z.string(),
+  icon: publicConnectorCatalogIconSchema.optional(),
   category: z.string(),
   generation: z.array(z.string()),
   tags: z.array(z.string()),
@@ -171,6 +178,9 @@ export type PublicConnectorCatalogAuthMethodSummary = z.infer<
 >;
 export type PublicConnectorCatalogPermissionSummary = z.infer<
   typeof publicConnectorCatalogPermissionSummarySchema
+>;
+export type PublicConnectorCatalogIcon = z.infer<
+  typeof publicConnectorCatalogIconSchema
 >;
 export type PublicConnectorCatalogCategoryGroup = z.infer<
   typeof publicConnectorCatalogCategoryGroupSchema

--- a/turbo/packages/connectors/package.json
+++ b/turbo/packages/connectors/package.json
@@ -16,6 +16,10 @@
       "import": "./src/connector-search.ts",
       "types": "./src/connector-search.ts"
     },
+    "./static-connector-icons": {
+      "import": "./src/static-connector-icons.ts",
+      "types": "./src/static-connector-icons.ts"
+    },
     "./connectors": {
       "import": "./src/connectors.ts",
       "types": "./src/connectors.ts"

--- a/turbo/packages/connectors/src/__tests__/static-connector-icons.test.ts
+++ b/turbo/packages/connectors/src/__tests__/static-connector-icons.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { CONNECTOR_TYPE_KEYS } from "../connectors";
+import {
+  connectorIconAssetUrl,
+  getStaticConnectorIconMetadata,
+  isConnectorIconAssetKey,
+  isStaticConnectorIconType,
+  parseStaticConnectorIconAssetPath,
+} from "../static-connector-icons";
+
+describe("static connector icons", () => {
+  it("resolves every connector through the public static icon namespace", () => {
+    const urls = new Set<string>();
+
+    for (const type of CONNECTOR_TYPE_KEYS) {
+      const metadata = getStaticConnectorIconMetadata(type);
+      const url = new URL(metadata.url);
+      urls.add(metadata.url);
+
+      expect(url.protocol).toBe("https:");
+      expect(url.origin).toBe("https://static.vm0.io");
+      expect(url.pathname).toMatch(
+        /^\/platform\/views\/zero-page\/components\/settings\/icons\/[a-z0-9]+(?:-[a-z0-9]+)*-[a-f0-9]{12}\.(?:png|svg)$/u,
+      );
+      expect(url.hash).toBe("");
+      expect(["", "?v=568fa471"]).toContain(url.search);
+      if (url.search) {
+        expect(type === "slack" || type === "slack-webhook").toBe(true);
+      }
+      if (metadata.scale !== undefined) {
+        expect(metadata.scale).toBeGreaterThanOrEqual(1);
+        expect(metadata.scale).toBeLessThanOrEqual(3);
+      }
+    }
+
+    expect(urls.size).toBe(299);
+  });
+
+  it("preserves aliases and representative appearance behavior", () => {
+    expect(getStaticConnectorIconMetadata("slack")).toStrictEqual({
+      url: "https://static.vm0.io/platform/views/zero-page/components/settings/icons/slack-198390069136.svg?v=568fa471",
+      invertInDarkMode: false,
+      scale: 2.2,
+    });
+    expect(getStaticConnectorIconMetadata("slack-webhook")).toStrictEqual(
+      getStaticConnectorIconMetadata("slack"),
+    );
+    expect(getStaticConnectorIconMetadata("railway-project").url).toBe(
+      getStaticConnectorIconMetadata("railway").url,
+    );
+    expect(getStaticConnectorIconMetadata("test-oauth-device").url).toBe(
+      getStaticConnectorIconMetadata("test-oauth").url,
+    );
+    expect(getStaticConnectorIconMetadata("airtable").invertInDarkMode).toBe(
+      false,
+    );
+    expect(getStaticConnectorIconMetadata("github").invertInDarkMode).toBe(
+      true,
+    );
+    expect(getStaticConnectorIconMetadata("openai").invertInDarkMode).toBe(
+      true,
+    );
+  });
+
+  it("distinguishes connector types from reusable asset keys", () => {
+    expect(isStaticConnectorIconType("slack-webhook")).toBe(true);
+    expect(isStaticConnectorIconType("unknown")).toBe(false);
+    expect(isConnectorIconAssetKey("slack")).toBe(true);
+    expect(isConnectorIconAssetKey("slack-webhook")).toBe(false);
+    expect(connectorIconAssetUrl("slack")).toContain("/icons/slack-");
+  });
+
+  it.each([
+    "https://evil.example/icon.svg",
+    "../icons/github-150bd47f5db9.svg",
+    "views/zero-page/components/settings/icons/../github-150bd47f5db9.svg",
+    "views/zero-page/components/other/icons/github-150bd47f5db9.svg",
+    "views/zero-page/components/settings/icons/github-150bd47f5db9.html",
+    "views/zero-page/components/settings/icons/github-150bd47f5db9.svg?token=secret",
+    "views/zero-page/components/settings/icons/github-150bd47f5db9.svg#fragment",
+    "views/zero-page/components/settings/icons/slack-198390069136.svg",
+  ])("rejects an unsafe or unsupported asset path: %s", (path) => {
+    expect(() => {
+      parseStaticConnectorIconAssetPath(path);
+    }).toThrow("Invalid static connector icon asset path");
+  });
+});

--- a/turbo/packages/connectors/src/static-connector-icons.ts
+++ b/turbo/packages/connectors/src/static-connector-icons.ts
@@ -5,7 +5,12 @@ const STATIC_CONNECTOR_ICON_PATH_PATTERN =
   /^views\/zero-page\/components\/settings\/icons\/[a-z0-9]+(?:-[a-z0-9]+)*-[a-f0-9]{12}\.(?:png|svg)$/u;
 const SLACK_ICON_PATH =
   "views/zero-page/components/settings/icons/slack-198390069136.svg";
+// The query is part of the published asset URL because the query-free path was
+// cached as missing before the append-only static mirror finished publishing it.
 const SLACK_ICON_PATH_WITH_CACHE_BUSTER = `${SLACK_ICON_PATH}?v=568fa471`;
+// The official mark occupies only the center of its viewBox, so the current UI
+// clips its square slot and enlarges the image to match the other connector marks.
+const SLACK_ICON_SCALE = 2.2 as const;
 
 const CONNECTOR_ICON_ALIASES = {
   "railway-project": "railway",
@@ -687,7 +692,7 @@ const CONNECTOR_ICON_TYPES: ReadonlySet<string> = new Set(CONNECTOR_TYPE_KEYS);
 export interface StaticConnectorIconMetadata {
   readonly url: string;
   readonly invertInDarkMode: boolean;
-  readonly scale?: number;
+  readonly scale?: typeof SLACK_ICON_SCALE;
 }
 
 export function parseStaticConnectorIconAssetPath(path: string): string {
@@ -734,11 +739,13 @@ function connectorIconAssetKey(type: ConnectorType): ConnectorIconAssetKey {
   return type;
 }
 
-function connectorIconScale(type: ConnectorType): number | undefined {
+function connectorIconScale(
+  type: ConnectorType,
+): typeof SLACK_ICON_SCALE | undefined {
   switch (type) {
     case "slack":
     case "slack-webhook":
-      return 2.2;
+      return SLACK_ICON_SCALE;
     default:
       return undefined;
   }
@@ -759,7 +766,7 @@ function validateStaticConnectorIconMetadata(
   }
 }
 
-export function getStaticConnectorIconMetadata(
+function createStaticConnectorIconMetadata(
   type: ConnectorType,
 ): StaticConnectorIconMetadata {
   const scale = connectorIconScale(type);
@@ -775,12 +782,30 @@ export function getStaticConnectorIconMetadata(
           scale,
         };
   validateStaticConnectorIconMetadata(type, metadata);
-  return metadata;
+  return Object.freeze(metadata);
 }
 
-for (const path of Object.values(STATIC_CONNECTOR_ICON_PATHS)) {
-  parseStaticConnectorIconAssetPath(path);
+function buildStaticConnectorIconMetadata(): ReadonlyMap<
+  ConnectorType,
+  StaticConnectorIconMetadata
+> {
+  const icons = new Map<ConnectorType, StaticConnectorIconMetadata>();
+  for (const type of CONNECTOR_TYPE_KEYS) {
+    icons.set(type, createStaticConnectorIconMetadata(type));
+  }
+  return icons;
 }
-for (const type of CONNECTOR_TYPE_KEYS) {
-  getStaticConnectorIconMetadata(type);
+
+const STATIC_CONNECTOR_ICON_METADATA = buildStaticConnectorIconMetadata();
+
+export function getStaticConnectorIconMetadata(
+  type: ConnectorType,
+): StaticConnectorIconMetadata {
+  const metadata = STATIC_CONNECTOR_ICON_METADATA.get(type);
+  if (!metadata) {
+    throw new Error(
+      `Missing static icon metadata for connector type "${type}"`,
+    );
+  }
+  return metadata;
 }

--- a/turbo/packages/connectors/src/static-connector-icons.ts
+++ b/turbo/packages/connectors/src/static-connector-icons.ts
@@ -1,0 +1,786 @@
+import { CONNECTOR_TYPE_KEYS, type ConnectorType } from "./connectors";
+
+const STATIC_CONNECTOR_ICON_BASE_URL = "https://static.vm0.io/platform/";
+const STATIC_CONNECTOR_ICON_PATH_PATTERN =
+  /^views\/zero-page\/components\/settings\/icons\/[a-z0-9]+(?:-[a-z0-9]+)*-[a-f0-9]{12}\.(?:png|svg)$/u;
+const SLACK_ICON_PATH =
+  "views/zero-page/components/settings/icons/slack-198390069136.svg";
+const SLACK_ICON_PATH_WITH_CACHE_BUSTER = `${SLACK_ICON_PATH}?v=568fa471`;
+
+const CONNECTOR_ICON_ALIASES = {
+  "railway-project": "railway",
+  "slack-webhook": "slack",
+  "test-oauth-device": "test-oauth",
+} as const satisfies Partial<Record<ConnectorType, ConnectorType>>;
+
+type ConnectorIconAlias = keyof typeof CONNECTOR_ICON_ALIASES;
+
+export type ConnectorIconAssetKey = Exclude<ConnectorType, ConnectorIconAlias>;
+
+const STATIC_CONNECTOR_ICON_PATHS = {
+  adzuna: "views/zero-page/components/settings/icons/adzuna-dc78789bbbcd.svg",
+  agentmail:
+    "views/zero-page/components/settings/icons/agentmail-aabbd0730098.svg",
+  agora: "views/zero-page/components/settings/icons/agora-e1ad121bb1d3.svg",
+  ahrefs: "views/zero-page/components/settings/icons/ahrefs-f0a1878981ae.svg",
+  airtable:
+    "views/zero-page/components/settings/icons/airtable-eee466f3f35f.svg",
+  alchemy: "views/zero-page/components/settings/icons/alchemy-52305d20dd90.svg",
+  "altium-365":
+    "views/zero-page/components/settings/icons/altium-365-596dd870332f.svg",
+  amadeus: "views/zero-page/components/settings/icons/amadeus-ae8f238ad1d3.svg",
+  amplitude:
+    "views/zero-page/components/settings/icons/amplitude-207cc9e7fc3d.svg",
+  "anthropic-managed-agents":
+    "views/zero-page/components/settings/icons/anthropic-managed-agents-3fcfdf761a69.svg",
+  apify: "views/zero-page/components/settings/icons/apify-5c05851a5ece.svg",
+  apollo: "views/zero-page/components/settings/icons/apollo-bf8302798dfb.svg",
+  archer: "views/zero-page/components/settings/icons/archer-1f01e618583e.svg",
+  ardent: "views/zero-page/components/settings/icons/ardent-ae05ebe263dc.svg",
+  "arga-labs":
+    "views/zero-page/components/settings/icons/arga-labs-cbf8647380cd.png",
+  armature:
+    "views/zero-page/components/settings/icons/armature-1990741703fa.svg",
+  asana: "views/zero-page/components/settings/icons/asana-693513c4245f.svg",
+  ashby: "views/zero-page/components/settings/icons/ashby-93e690ec6d4c.svg",
+  atlascloud:
+    "views/zero-page/components/settings/icons/atlascloud-fc9fa3a12884.svg",
+  atlassian:
+    "views/zero-page/components/settings/icons/atlassian-316afc512581.svg",
+  attio: "views/zero-page/components/settings/icons/attio-2ccc836df795.svg",
+  aviationstack:
+    "views/zero-page/components/settings/icons/aviationstack-e547c6f73453.svg",
+  aws: "views/zero-page/components/settings/icons/aws-8ec381036030.svg",
+  axiom: "views/zero-page/components/settings/icons/axiom-7657ffc69323.svg",
+  base44: "views/zero-page/components/settings/icons/base44-8cc1e52c1775.svg",
+  "bentolabs-ai":
+    "views/zero-page/components/settings/icons/bentolabs-ai-b3d6223fb7a9.png",
+  bentoml: "views/zero-page/components/settings/icons/bentoml-2f0b56c3ad28.svg",
+  bfl: "views/zero-page/components/settings/icons/bfl-c8dada65dc9e.svg",
+  bitrefill:
+    "views/zero-page/components/settings/icons/bitrefill-b8e5facc9514.svg",
+  bitrix: "views/zero-page/components/settings/icons/bitrix-6bdd38c9a309.svg",
+  bland: "views/zero-page/components/settings/icons/bland-8d7e921c413f.svg",
+  bloom: "views/zero-page/components/settings/icons/bloom-4c6f7ac5f465.svg",
+  box: "views/zero-page/components/settings/icons/box-5658678ffc4b.svg",
+  "brave-search":
+    "views/zero-page/components/settings/icons/brave-search-66814699ff97.svg",
+  brevo: "views/zero-page/components/settings/icons/brevo-e6864f00fca7.svg",
+  brex: "views/zero-page/components/settings/icons/brex-072214bc1f9d.svg",
+  "bright-data":
+    "views/zero-page/components/settings/icons/bright-data-3168ae4200e9.svg",
+  "browser-use":
+    "views/zero-page/components/settings/icons/browser-use-4aa74d615f7c.svg",
+  browserbase:
+    "views/zero-page/components/settings/icons/browserbase-47febbf5088a.svg",
+  browserless:
+    "views/zero-page/components/settings/icons/browserless-ba6f9d5b55fa.svg",
+  browserstack:
+    "views/zero-page/components/settings/icons/browserstack-af1e6416e878.svg",
+  bubblemaps:
+    "views/zero-page/components/settings/icons/bubblemaps-229d049c9345.svg",
+  buffer: "views/zero-page/components/settings/icons/buffer-c08c7f7a0ce3.svg",
+  builtwith:
+    "views/zero-page/components/settings/icons/builtwith-6f78c4278b1c.svg",
+  "cal-com":
+    "views/zero-page/components/settings/icons/cal-com-a02b7c08ed70.svg",
+  calendly:
+    "views/zero-page/components/settings/icons/calendly-a74d2624c450.svg",
+  canva: "views/zero-page/components/settings/icons/canva-0951b8855de4.svg",
+  chatwoot:
+    "views/zero-page/components/settings/icons/chatwoot-6d8e00d88204.svg",
+  checkr: "views/zero-page/components/settings/icons/checkr-87a016320b17.svg",
+  chert: "views/zero-page/components/settings/icons/chert-784986ecd9a9.png",
+  clado: "views/zero-page/components/settings/icons/clado-4e5752a6bccf.svg",
+  clearbit:
+    "views/zero-page/components/settings/icons/clearbit-a81ec985a7e3.svg",
+  clerk: "views/zero-page/components/settings/icons/clerk-4f05e7088819.svg",
+  clickup: "views/zero-page/components/settings/icons/clickup-92a639a865ec.svg",
+  close: "views/zero-page/components/settings/icons/close-50f27153d806.svg",
+  cloudflare:
+    "views/zero-page/components/settings/icons/cloudflare-c73ea33bdc10.svg",
+  cloudinary:
+    "views/zero-page/components/settings/icons/cloudinary-902003bb0153.svg",
+  coda: "views/zero-page/components/settings/icons/coda-298689264957.svg",
+  coingecko:
+    "views/zero-page/components/settings/icons/coingecko-5267811161ec.svg",
+  coresignal:
+    "views/zero-page/components/settings/icons/coresignal-2b7ff39b9e1a.svg",
+  cronlytic:
+    "views/zero-page/components/settings/icons/cronlytic-76fb40c74299.svg",
+  crustdata:
+    "views/zero-page/components/settings/icons/crustdata-65c7407fca80.svg",
+  cursor: "views/zero-page/components/settings/icons/cursor-0375fe0bba07.svg",
+  "customer-io":
+    "views/zero-page/components/settings/icons/customer-io-3592b474801b.svg",
+  daytona: "views/zero-page/components/settings/icons/daytona-aed50e967460.svg",
+  db9: "views/zero-page/components/settings/icons/db9-0d3f5466120d.svg",
+  deel: "views/zero-page/components/settings/icons/deel-3ab75a49a804.svg",
+  deepseek:
+    "views/zero-page/components/settings/icons/deepseek-a8663c0a81d9.svg",
+  defillama:
+    "views/zero-page/components/settings/icons/defillama-ca6e0436cc1e.svg",
+  devto: "views/zero-page/components/settings/icons/devto-bba6ca399b94.svg",
+  diffbot: "views/zero-page/components/settings/icons/diffbot-182ffd8a6c40.svg",
+  dify: "views/zero-page/components/settings/icons/dify-7f2bef3c9440.svg",
+  discord: "views/zero-page/components/settings/icons/discord-8039c495de67.svg",
+  "discord-webhook":
+    "views/zero-page/components/settings/icons/discord-webhook-8039c495de67.svg",
+  docusign:
+    "views/zero-page/components/settings/icons/docusign-e93dd2ff5e07.svg",
+  doppler: "views/zero-page/components/settings/icons/doppler-6edc501a4dd9.svg",
+  doubao: "views/zero-page/components/settings/icons/doubao-4c8ef236fcf9.svg",
+  drive9: "views/zero-page/components/settings/icons/drive9-4aa08c7836de.svg",
+  dropbox: "views/zero-page/components/settings/icons/dropbox-5866286a0bf3.svg",
+  "dropbox-sign":
+    "views/zero-page/components/settings/icons/dropbox-sign-61a8d3dd3649.svg",
+  duffel: "views/zero-page/components/settings/icons/duffel-2dc83457b099.svg",
+  e2b: "views/zero-page/components/settings/icons/e2b-4a490da5dc7c.svg",
+  elevenlabs:
+    "views/zero-page/components/settings/icons/elevenlabs-027d98a44abc.svg",
+  etherscan:
+    "views/zero-page/components/settings/icons/etherscan-0d8b09b0f756.svg",
+  etsy: "views/zero-page/components/settings/icons/etsy-ac890f8bb332.svg",
+  exa: "views/zero-page/components/settings/icons/exa-9a6e04de6b38.svg",
+  explorium:
+    "views/zero-page/components/settings/icons/explorium-356f27323ba2.svg",
+  faire: "views/zero-page/components/settings/icons/faire-c16be6b57fa8.svg",
+  fal: "views/zero-page/components/settings/icons/fal-01e8e07ab4a6.svg",
+  figma: "views/zero-page/components/settings/icons/figma-2c2a32ced345.svg",
+  firecrawl:
+    "views/zero-page/components/settings/icons/firecrawl-33490f4a10bd.svg",
+  fireflies:
+    "views/zero-page/components/settings/icons/fireflies-ccfade904c3d.svg",
+  flightaware:
+    "views/zero-page/components/settings/icons/flightaware-c44e79efed07.svg",
+  freshdesk:
+    "views/zero-page/components/settings/icons/freshdesk-a5f20e344c7c.svg",
+  gamma: "views/zero-page/components/settings/icons/gamma-b47fa2ead856.svg",
+  "garmin-connect":
+    "views/zero-page/components/settings/icons/garmin-connect-a71a33da8219.svg",
+  gemini: "views/zero-page/components/settings/icons/gemini-46bd52fb85d9.svg",
+  github: "views/zero-page/components/settings/icons/github-4a739019d805.svg",
+  gitlab: "views/zero-page/components/settings/icons/gitlab-3f258ed8cb9a.svg",
+  gmail: "views/zero-page/components/settings/icons/gmail-18f42e2c6f80.svg",
+  gong: "views/zero-page/components/settings/icons/gong-68520f07a7dc.svg",
+  "google-ads":
+    "views/zero-page/components/settings/icons/google-ads-c1e9d7954aa5.svg",
+  "google-analytics":
+    "views/zero-page/components/settings/icons/google-analytics-e867ed328724.svg",
+  "google-calendar":
+    "views/zero-page/components/settings/icons/google-calendar-58ef860565d1.svg",
+  "google-cloud":
+    "views/zero-page/components/settings/icons/google-cloud-0a48e1af4a43.svg",
+  "google-docs":
+    "views/zero-page/components/settings/icons/google-docs-ce8a250ed67f.svg",
+  "google-drive":
+    "views/zero-page/components/settings/icons/google-drive-aa75924aa727.svg",
+  "google-maps":
+    "views/zero-page/components/settings/icons/google-maps-5b06e906e8fc.svg",
+  "google-meet":
+    "views/zero-page/components/settings/icons/google-meet-5243598ff429.svg",
+  "google-search-console":
+    "views/zero-page/components/settings/icons/google-search-console-f48ce6f21ebc.svg",
+  "google-sheets":
+    "views/zero-page/components/settings/icons/google-sheets-dec60c57a097.svg",
+  granola: "views/zero-page/components/settings/icons/granola-fe035645ea19.svg",
+  greenhouse:
+    "views/zero-page/components/settings/icons/greenhouse-714265097838.svg",
+  groq: "views/zero-page/components/settings/icons/groq-62f86752be05.svg",
+  gumroad: "views/zero-page/components/settings/icons/gumroad-2dde63e716df.svg",
+  helicone:
+    "views/zero-page/components/settings/icons/helicone-09ae8b5c924b.svg",
+  heygen: "views/zero-page/components/settings/icons/heygen-a213e9f1b1b0.svg",
+  hitem3d: "views/zero-page/components/settings/icons/hitem3d-1973c58d08a5.svg",
+  honcho: "views/zero-page/components/settings/icons/honcho-36380d300244.svg",
+  htmlcsstoimage:
+    "views/zero-page/components/settings/icons/htmlcsstoimage-c0c45a50f597.svg",
+  hubspot: "views/zero-page/components/settings/icons/hubspot-69b856e1dc1a.svg",
+  "hugging-face":
+    "views/zero-page/components/settings/icons/hugging-face-b3da7fed90dd.svg",
+  hume: "views/zero-page/components/settings/icons/hume-07c995294c6a.svg",
+  hunter: "views/zero-page/components/settings/icons/hunter-c58056025e04.svg",
+  imgur: "views/zero-page/components/settings/icons/imgur-e4b0fb24400e.svg",
+  infisical:
+    "views/zero-page/components/settings/icons/infisical-433116d4de23.svg",
+  insforge:
+    "views/zero-page/components/settings/icons/insforge-e831c2ea14f5.png",
+  instagram:
+    "views/zero-page/components/settings/icons/instagram-b4cfdf33b929.svg",
+  instantly:
+    "views/zero-page/components/settings/icons/instantly-61fa7572e06b.svg",
+  intercom:
+    "views/zero-page/components/settings/icons/intercom-773dd768e0d4.svg",
+  interfaze:
+    "views/zero-page/components/settings/icons/interfaze-f64eecea9b1d.svg",
+  "intervals-icu":
+    "views/zero-page/components/settings/icons/intervals-icu-78d7a557a3a9.svg",
+  inth: "views/zero-page/components/settings/icons/inth-e0c16be84129.png",
+  ironclad:
+    "views/zero-page/components/settings/icons/ironclad-27e516a89b5d.svg",
+  jam: "views/zero-page/components/settings/icons/jam-97b070088e92.svg",
+  jira: "views/zero-page/components/settings/icons/jira-f682013e1302.svg",
+  jotform: "views/zero-page/components/settings/icons/jotform-523706a4c2fc.svg",
+  "keyframe-labs":
+    "views/zero-page/components/settings/icons/keyframe-labs-f9ee16b4ba55.svg",
+  klaviyo: "views/zero-page/components/settings/icons/klaviyo-e87a373fc59b.svg",
+  kommo: "views/zero-page/components/settings/icons/kommo-739e724879a6.svg",
+  kugelaudio:
+    "views/zero-page/components/settings/icons/kugelaudio-6ce394d192cf.png",
+  langfuse:
+    "views/zero-page/components/settings/icons/langfuse-1ffd2ae0976b.svg",
+  langsmith:
+    "views/zero-page/components/settings/icons/langsmith-cddee9b4b113.svg",
+  lark: "views/zero-page/components/settings/icons/lark-f5fdfb27067a.svg",
+  limrun: "views/zero-page/components/settings/icons/limrun-181966484546.png",
+  line: "views/zero-page/components/settings/icons/line-55235c2f3a58.svg",
+  linear: "views/zero-page/components/settings/icons/linear-aff4bbe00efc.svg",
+  loops: "views/zero-page/components/settings/icons/loops-29d64256a064.svg",
+  luma: "views/zero-page/components/settings/icons/luma-1e0311e88d0f.svg",
+  "luma-ai":
+    "views/zero-page/components/settings/icons/luma-ai-a3776de7b705.svg",
+  mailchimp:
+    "views/zero-page/components/settings/icons/mailchimp-1c208f9c6576.svg",
+  mailsac: "views/zero-page/components/settings/icons/mailsac-1b850a691eba.svg",
+  make: "views/zero-page/components/settings/icons/make-2dac6beecd28.svg",
+  manus: "views/zero-page/components/settings/icons/manus-ecf491ca9a0d.svg",
+  mapbox: "views/zero-page/components/settings/icons/mapbox-34d6827e7949.svg",
+  maskdb: "views/zero-page/components/settings/icons/maskdb-1376653c02a8.svg",
+  massive: "views/zero-page/components/settings/icons/massive-5460a1758365.svg",
+  mathpix: "views/zero-page/components/settings/icons/mathpix-87fd95ee2101.svg",
+  mem0: "views/zero-page/components/settings/icons/mem0-50e7cc80e37a.svg",
+  mercury: "views/zero-page/components/settings/icons/mercury-baf568144ac4.svg",
+  meshy: "views/zero-page/components/settings/icons/meshy-02e71ea6eb0f.svg",
+  "meta-ads":
+    "views/zero-page/components/settings/icons/meta-ads-bdbde15c3cd9.svg",
+  metabase:
+    "views/zero-page/components/settings/icons/metabase-2f00f22e1c88.svg",
+  "microsoft-365":
+    "views/zero-page/components/settings/icons/microsoft-365-ea4d37dcf563.svg",
+  minicor: "views/zero-page/components/settings/icons/minicor-446daaf992e2.png",
+  minimax: "views/zero-page/components/settings/icons/minimax-ec3b12fc26ff.svg",
+  minio: "views/zero-page/components/settings/icons/minio-ecd4eac71afa.svg",
+  miro: "views/zero-page/components/settings/icons/miro-eefd0c4b5f78.svg",
+  mixpanel:
+    "views/zero-page/components/settings/icons/mixpanel-6c0f2e835e5a.svg",
+  modal: "views/zero-page/components/settings/icons/modal-438525a3b676.svg",
+  monday: "views/zero-page/components/settings/icons/monday-d196940958ef.svg",
+  moss: "views/zero-page/components/settings/icons/moss-e756e788ba2d.svg",
+  msg9: "views/zero-page/components/settings/icons/msg9-a65b9b18454c.svg",
+  n8n: "views/zero-page/components/settings/icons/n8n-2355976a50d0.svg",
+  neon: "views/zero-page/components/settings/icons/neon-2b1aaef0b2de.svg",
+  netdata: "views/zero-page/components/settings/icons/netdata-df49d68a3ecd.svg",
+  netter: "views/zero-page/components/settings/icons/netter-4c7de538303c.svg",
+  "nintendo-store":
+    "views/zero-page/components/settings/icons/nintendo-store-f3c8ad8b8d85.svg",
+  "nintendo-switch-parental-controls":
+    "views/zero-page/components/settings/icons/nintendo-switch-parental-controls-da75b53905d6.svg",
+  notion: "views/zero-page/components/settings/icons/notion-beeb509915a9.svg",
+  novita: "views/zero-page/components/settings/icons/novita-3aa7cdf6fd0b.svg",
+  nyne: "views/zero-page/components/settings/icons/nyne-cb5e80de7d46.svg",
+  oddpool: "views/zero-page/components/settings/icons/oddpool-b0416e7d9c21.svg",
+  onyx: "views/zero-page/components/settings/icons/onyx-5db98d1eed15.svg",
+  openai: "views/zero-page/components/settings/icons/openai-df8a3d9c4274.svg",
+  openrouter:
+    "views/zero-page/components/settings/icons/openrouter-82e9dead836b.svg",
+  openweather:
+    "views/zero-page/components/settings/icons/openweather-614f7acfed2b.svg",
+  "outlook-calendar":
+    "views/zero-page/components/settings/icons/outlook-calendar-d67b8bb4bb8d.svg",
+  "outlook-mail":
+    "views/zero-page/components/settings/icons/outlook-mail-d67b8bb4bb8d.svg",
+  pandadoc:
+    "views/zero-page/components/settings/icons/pandadoc-50d5db7dbe0d.svg",
+  parallel:
+    "views/zero-page/components/settings/icons/parallel-8999315ceac1.svg",
+  pdf4me: "views/zero-page/components/settings/icons/pdf4me-72901b68f016.svg",
+  pdfco: "views/zero-page/components/settings/icons/pdfco-3e7abac71518.svg",
+  pdforge: "views/zero-page/components/settings/icons/pdforge-bdafb344440c.svg",
+  "people-data-labs":
+    "views/zero-page/components/settings/icons/people-data-labs-3f5ade20d1f6.svg",
+  perplexity:
+    "views/zero-page/components/settings/icons/perplexity-7f1c9264c825.svg",
+  pexels: "views/zero-page/components/settings/icons/pexels-066fd51404dc.png",
+  pika: "views/zero-page/components/settings/icons/pika-83321d1aa81f.svg",
+  pinecone:
+    "views/zero-page/components/settings/icons/pinecone-5b72ed27b620.svg",
+  pipedream:
+    "views/zero-page/components/settings/icons/pipedream-42dda4b1effa.svg",
+  pipedrive:
+    "views/zero-page/components/settings/icons/pipedrive-4576bea235fe.svg",
+  plain: "views/zero-page/components/settings/icons/plain-a9121ba278e5.svg",
+  plausible:
+    "views/zero-page/components/settings/icons/plausible-ff49eddd163e.svg",
+  playstation:
+    "views/zero-page/components/settings/icons/playstation-93cfdbb255ce.svg",
+  podchaser:
+    "views/zero-page/components/settings/icons/podchaser-86cc6b891620.svg",
+  porkbun: "views/zero-page/components/settings/icons/porkbun-6c11e42ddc44.svg",
+  posthog: "views/zero-page/components/settings/icons/posthog-8bff2e8232f4.svg",
+  primitive:
+    "views/zero-page/components/settings/icons/primitive-9df35a923915.png",
+  printful:
+    "views/zero-page/components/settings/icons/printful-cb359d029305.svg",
+  "prisma-postgres":
+    "views/zero-page/components/settings/icons/prisma-postgres-b0df05d1a65d.svg",
+  productlane:
+    "views/zero-page/components/settings/icons/productlane-bf1482f05bbc.svg",
+  profound:
+    "views/zero-page/components/settings/icons/profound-f169839aa64a.svg",
+  pushinator:
+    "views/zero-page/components/settings/icons/pushinator-06d3705897df.svg",
+  qdrant: "views/zero-page/components/settings/icons/qdrant-378b348e08c5.svg",
+  qiita: "views/zero-page/components/settings/icons/qiita-6c078d974a73.svg",
+  qomplement:
+    "views/zero-page/components/settings/icons/qomplement-b700b0f3d7f3.png",
+  quickbooks:
+    "views/zero-page/components/settings/icons/quickbooks-fcc0886d32c3.svg",
+  railway: "views/zero-page/components/settings/icons/railway-22723db2f4f9.svg",
+  reap: "views/zero-page/components/settings/icons/reap-dd68e029348e.svg",
+  recraft: "views/zero-page/components/settings/icons/recraft-fac1a92b013f.svg",
+  reddit: "views/zero-page/components/settings/icons/reddit-e1ac3f0da2b6.svg",
+  reducto: "views/zero-page/components/settings/icons/reducto-c00c6f16661d.svg",
+  render: "views/zero-page/components/settings/icons/render-4fcb845a3f77.svg",
+  rentahuman:
+    "views/zero-page/components/settings/icons/rentahuman-fec5bd25072b.svg",
+  rentcast:
+    "views/zero-page/components/settings/icons/rentcast-ba9e471c1a7f.svg",
+  replicas:
+    "views/zero-page/components/settings/icons/replicas-70208a17587f.svg",
+  replicate:
+    "views/zero-page/components/settings/icons/replicate-fca98dbfb77f.svg",
+  reportei:
+    "views/zero-page/components/settings/icons/reportei-4bee89a35829.svg",
+  resend: "views/zero-page/components/settings/icons/resend-caa7e78784cb.svg",
+  revenuecat:
+    "views/zero-page/components/settings/icons/revenuecat-ea0c623502d9.svg",
+  "river-markets":
+    "views/zero-page/components/settings/icons/river-markets-fc23a0022420.png",
+  runtime: "views/zero-page/components/settings/icons/runtime-529df4ae1f3f.svg",
+  runway: "views/zero-page/components/settings/icons/runway-453d2365bcc5.svg",
+  salesforce:
+    "views/zero-page/components/settings/icons/salesforce-346f79d05a04.svg",
+  salesgraph:
+    "views/zero-page/components/settings/icons/salesgraph-577ddc49a9cb.svg",
+  scrapeninja:
+    "views/zero-page/components/settings/icons/scrapeninja-dc11f0f32e56.svg",
+  segment: "views/zero-page/components/settings/icons/segment-56b8b0e2ccf0.svg",
+  semrush: "views/zero-page/components/settings/icons/semrush-12a3461815e7.svg",
+  sendgrid:
+    "views/zero-page/components/settings/icons/sendgrid-d3332cf8b59c.svg",
+  sentry: "views/zero-page/components/settings/icons/sentry-93cf192fc6c3.svg",
+  serpapi: "views/zero-page/components/settings/icons/serpapi-b731737f9b72.svg",
+  servicenow:
+    "views/zero-page/components/settings/icons/servicenow-315c79989d29.svg",
+  shopify: "views/zero-page/components/settings/icons/shopify-83cb0271954f.svg",
+  shortio: "views/zero-page/components/settings/icons/shortio-775376bc8c7d.svg",
+  silmaril:
+    "views/zero-page/components/settings/icons/silmaril-2f64fe3445c8.png",
+  similarweb:
+    "views/zero-page/components/settings/icons/similarweb-872d9e66300b.svg",
+  slack:
+    "views/zero-page/components/settings/icons/slack-198390069136.svg?v=568fa471",
+  slock: "views/zero-page/components/settings/icons/slock-f419faf6c6c4.svg",
+  "smol-machines":
+    "views/zero-page/components/settings/icons/smol-machines-41c59d345b00.svg",
+  snowflake:
+    "views/zero-page/components/settings/icons/snowflake-fd2f3b315278.svg",
+  sociavault:
+    "views/zero-page/components/settings/icons/sociavault-44913bcfa5a4.svg",
+  sponge: "views/zero-page/components/settings/icons/sponge-5d9c0211e5bc.svg",
+  spotify: "views/zero-page/components/settings/icons/spotify-e27177df2642.svg",
+  sproutgigs:
+    "views/zero-page/components/settings/icons/sproutgigs-c1192764dbee.svg",
+  square: "views/zero-page/components/settings/icons/square-b95ac9f46e21.svg",
+  "stability-ai":
+    "views/zero-page/components/settings/icons/stability-ai-0d39725dc8b5.svg",
+  stablebrowse:
+    "views/zero-page/components/settings/icons/stablebrowse-b2fbca350120.png",
+  steam: "views/zero-page/components/settings/icons/steam-4e2ba2137237.svg",
+  strapi: "views/zero-page/components/settings/icons/strapi-593e7af16585.svg",
+  strava: "views/zero-page/components/settings/icons/strava-206d8c9aa841.svg",
+  streak: "views/zero-page/components/settings/icons/streak-1455d7cc87e0.svg",
+  stripe: "views/zero-page/components/settings/icons/stripe-4a7793fa96ae.svg",
+  supabase:
+    "views/zero-page/components/settings/icons/supabase-a19a2501b366.svg",
+  supadata:
+    "views/zero-page/components/settings/icons/supadata-08a65918dcdb.svg",
+  supermemory:
+    "views/zero-page/components/settings/icons/supermemory-da72ccb9600c.svg",
+  tavily: "views/zero-page/components/settings/icons/tavily-013555e5fe64.svg",
+  "test-oauth":
+    "views/zero-page/components/settings/icons/test-oauth-1566bca3cb11.svg",
+  testerarmy:
+    "views/zero-page/components/settings/icons/testerarmy-1c5f5ba86505.png",
+  testrail:
+    "views/zero-page/components/settings/icons/testrail-c8c658083c6c.svg",
+  ticketmaster:
+    "views/zero-page/components/settings/icons/ticketmaster-842dc4fa3af6.svg",
+  "tiktok-ads":
+    "views/zero-page/components/settings/icons/tiktok-ads-d837a2f9f550.svg",
+  tldv: "views/zero-page/components/settings/icons/tldv-b92546888050.svg",
+  todoist: "views/zero-page/components/settings/icons/todoist-7ccd1dfa28e5.svg",
+  together:
+    "views/zero-page/components/settings/icons/together-c8adc591dd9e.svg",
+  totalis: "views/zero-page/components/settings/icons/totalis-d97d41cfb7f0.png",
+  trellis: "views/zero-page/components/settings/icons/trellis-3273c8af062d.png",
+  tripo: "views/zero-page/components/settings/icons/tripo-cee4ccd95d55.svg",
+  twenty: "views/zero-page/components/settings/icons/twenty-c793eaf377c4.svg",
+  twilio: "views/zero-page/components/settings/icons/twilio-ec4acea94d58.svg",
+  typeform:
+    "views/zero-page/components/settings/icons/typeform-f164f8538dae.svg",
+  v0: "views/zero-page/components/settings/icons/v0-16752e92fba7.svg",
+  vercel: "views/zero-page/components/settings/icons/vercel-c2c941b10e27.svg",
+  voquill: "views/zero-page/components/settings/icons/voquill-2af65d8d8d90.svg",
+  wandb: "views/zero-page/components/settings/icons/wandb-de3acbf6474d.svg",
+  webflow: "views/zero-page/components/settings/icons/webflow-21cb0ee09d17.svg",
+  weread: "views/zero-page/components/settings/icons/weread-8cd219dc2a90.svg",
+  "whale-alert":
+    "views/zero-page/components/settings/icons/whale-alert-98cbb1bbfdf6.png",
+  wix: "views/zero-page/components/settings/icons/wix-53a609ed8e78.svg",
+  workos: "views/zero-page/components/settings/icons/workos-c7ad66d8b5a0.svg",
+  wrike: "views/zero-page/components/settings/icons/wrike-86c509db0d0c.svg",
+  x: "views/zero-page/components/settings/icons/x-c6644387ea39.svg",
+  xero: "views/zero-page/components/settings/icons/xero-39a95d992dd5.svg",
+  youtube: "views/zero-page/components/settings/icons/youtube-7d0026b054c2.svg",
+  zapier: "views/zero-page/components/settings/icons/zapier-53711819f9ee.svg",
+  zapsign: "views/zero-page/components/settings/icons/zapsign-e9e1ddefebed.svg",
+  zendesk: "views/zero-page/components/settings/icons/zendesk-7984da5ed551.svg",
+  zep: "views/zero-page/components/settings/icons/zep-298c7ff5291e.svg",
+  zeptomail:
+    "views/zero-page/components/settings/icons/zeptomail-4469f325f353.svg",
+  zoom: "views/zero-page/components/settings/icons/zoom-69a0c0bc6fe9.svg",
+} as const satisfies Readonly<Record<ConnectorIconAssetKey, string>>;
+
+const CONNECTOR_ICON_ORIGINAL_COLOR: ReadonlySet<ConnectorType> = new Set([
+  "adzuna",
+  "agora",
+  "ahrefs",
+  "airtable",
+  "alchemy",
+  "altium-365",
+  "amadeus",
+  "amplitude",
+  "anthropic-managed-agents",
+  "apify",
+  "archer",
+  "armature",
+  "asana",
+  "ashby",
+  "atlassian",
+  "aviationstack",
+  "aws",
+  "base44",
+  "bentolabs-ai",
+  "bitrefill",
+  "bitrix",
+  "bland",
+  "bloom",
+  "box",
+  "brave-search",
+  "brevo",
+  "bright-data",
+  "browserbase",
+  "browserstack",
+  "cal-com",
+  "calendly",
+  "canva",
+  "chatwoot",
+  "checkr",
+  "chert",
+  "clearbit",
+  "clickup",
+  "close",
+  "cloudflare",
+  "cloudinary",
+  "coda",
+  "coingecko",
+  "coresignal",
+  "cronlytic",
+  "crustdata",
+  "cursor",
+  "customer-io",
+  "deepseek",
+  "defillama",
+  "dify",
+  "discord",
+  "discord-webhook",
+  "docusign",
+  "doppler",
+  "doubao",
+  "dropbox",
+  "dropbox-sign",
+  "e2b",
+  "etherscan",
+  "etsy",
+  "exa",
+  "explorium",
+  "fal",
+  "figma",
+  "firecrawl",
+  "fireflies",
+  "flightaware",
+  "freshdesk",
+  "gamma",
+  "garmin-connect",
+  "gemini",
+  "gitlab",
+  "gmail",
+  "gong",
+  "google-ads",
+  "google-analytics",
+  "google-calendar",
+  "google-cloud",
+  "google-docs",
+  "google-drive",
+  "google-maps",
+  "google-meet",
+  "google-search-console",
+  "google-sheets",
+  "granola",
+  "greenhouse",
+  "groq",
+  "gumroad",
+  "helicone",
+  "heygen",
+  "hitem3d",
+  "honcho",
+  "hubspot",
+  "hugging-face",
+  "hume",
+  "hunter",
+  "imgur",
+  "insforge",
+  "instagram",
+  "instantly",
+  "interfaze",
+  "intervals-icu",
+  "inth",
+  "ironclad",
+  "jam",
+  "jira",
+  "jotform",
+  "keyframe-labs",
+  "kommo",
+  "kugelaudio",
+  "langfuse",
+  "langsmith",
+  "lark",
+  "limrun",
+  "line",
+  "linear",
+  "loops",
+  "mailchimp",
+  "mailsac",
+  "manus",
+  "maskdb",
+  "massive",
+  "meshy",
+  "meta-ads",
+  "metabase",
+  "microsoft-365",
+  "minicor",
+  "minimax",
+  "minio",
+  "miro",
+  "mixpanel",
+  "modal",
+  "monday",
+  "msg9",
+  "n8n",
+  "neon",
+  "netdata",
+  "nintendo-store",
+  "nintendo-switch-parental-controls",
+  "nyne",
+  "openweather",
+  "outlook-calendar",
+  "outlook-mail",
+  "pandadoc",
+  "pdf4me",
+  "pdfco",
+  "pdforge",
+  "people-data-labs",
+  "perplexity",
+  "pexels",
+  "pika",
+  "pipedream",
+  "pipedrive",
+  "plain",
+  "plausible",
+  "playstation",
+  "podchaser",
+  "porkbun",
+  "posthog",
+  "primitive",
+  "printful",
+  "productlane",
+  "qdrant",
+  "qiita",
+  "quickbooks",
+  "reap",
+  "recraft",
+  "reddit",
+  "reducto",
+  "render",
+  "rentahuman",
+  "rentcast",
+  "replicas",
+  "reportei",
+  "revenuecat",
+  "salesforce",
+  "salesgraph",
+  "scrapeninja",
+  "segment",
+  "semrush",
+  "sendgrid",
+  "serpapi",
+  "servicenow",
+  "shopify",
+  "shortio",
+  "silmaril",
+  "similarweb",
+  "slack",
+  "slack-webhook",
+  "smol-machines",
+  "snowflake",
+  "sociavault",
+  "sponge",
+  "spotify",
+  "sproutgigs",
+  "stability-ai",
+  "stablebrowse",
+  "strapi",
+  "strava",
+  "streak",
+  "stripe",
+  "supabase",
+  "supadata",
+  "testerarmy",
+  "testrail",
+  "ticketmaster",
+  "tiktok-ads",
+  "tldv",
+  "todoist",
+  "together",
+  "trellis",
+  "tripo",
+  "twenty",
+  "twilio",
+  "wandb",
+  "webflow",
+  "weread",
+  "whale-alert",
+  "workos",
+  "wrike",
+  "xero",
+  "youtube",
+  "zapier",
+  "zapsign",
+  "zep",
+  "zeptomail",
+  "zoom",
+]);
+
+const CONNECTOR_ICON_TYPES: ReadonlySet<string> = new Set(CONNECTOR_TYPE_KEYS);
+
+export interface StaticConnectorIconMetadata {
+  readonly url: string;
+  readonly invertInDarkMode: boolean;
+  readonly scale?: number;
+}
+
+export function parseStaticConnectorIconAssetPath(path: string): string {
+  if (
+    path === SLACK_ICON_PATH_WITH_CACHE_BUSTER ||
+    (path !== SLACK_ICON_PATH && STATIC_CONNECTOR_ICON_PATH_PATTERN.test(path))
+  ) {
+    return path;
+  }
+
+  throw new Error(`Invalid static connector icon asset path "${path}"`);
+}
+
+export function isConnectorIconAssetKey(
+  key: string,
+): key is ConnectorIconAssetKey {
+  return Object.prototype.hasOwnProperty.call(STATIC_CONNECTOR_ICON_PATHS, key);
+}
+
+export function connectorIconAssetUrl(key: ConnectorIconAssetKey): string {
+  const path = parseStaticConnectorIconAssetPath(
+    STATIC_CONNECTOR_ICON_PATHS[key],
+  );
+  return `${STATIC_CONNECTOR_ICON_BASE_URL}${path}`;
+}
+
+export function isStaticConnectorIconType(type: string): type is ConnectorType {
+  return CONNECTOR_ICON_TYPES.has(type);
+}
+
+function connectorIconAssetKey(type: ConnectorType): ConnectorIconAssetKey {
+  switch (type) {
+    case "railway-project":
+      return CONNECTOR_ICON_ALIASES["railway-project"];
+    case "slack-webhook":
+      return CONNECTOR_ICON_ALIASES["slack-webhook"];
+    case "test-oauth-device":
+      return CONNECTOR_ICON_ALIASES["test-oauth-device"];
+  }
+
+  if (!isConnectorIconAssetKey(type)) {
+    throw new Error(`Missing static icon for connector type "${type}"`);
+  }
+  return type;
+}
+
+function connectorIconScale(type: ConnectorType): number | undefined {
+  switch (type) {
+    case "slack":
+    case "slack-webhook":
+      return 2.2;
+    default:
+      return undefined;
+  }
+}
+
+function validateStaticConnectorIconMetadata(
+  type: ConnectorType,
+  metadata: StaticConnectorIconMetadata,
+): void {
+  if (metadata.url.length > 2048) {
+    throw new Error(`Static icon URL is too long for connector type "${type}"`);
+  }
+  if (
+    metadata.scale !== undefined &&
+    (metadata.scale < 1 || metadata.scale > 3)
+  ) {
+    throw new Error(`Invalid static icon scale for connector type "${type}"`);
+  }
+}
+
+export function getStaticConnectorIconMetadata(
+  type: ConnectorType,
+): StaticConnectorIconMetadata {
+  const scale = connectorIconScale(type);
+  const metadata: StaticConnectorIconMetadata =
+    scale === undefined
+      ? {
+          url: connectorIconAssetUrl(connectorIconAssetKey(type)),
+          invertInDarkMode: !CONNECTOR_ICON_ORIGINAL_COLOR.has(type),
+        }
+      : {
+          url: connectorIconAssetUrl(connectorIconAssetKey(type)),
+          invertInDarkMode: !CONNECTOR_ICON_ORIGINAL_COLOR.has(type),
+          scale,
+        };
+  validateStaticConnectorIconMetadata(type, metadata);
+  return metadata;
+}
+
+for (const path of Object.values(STATIC_CONNECTOR_ICON_PATHS)) {
+  parseStaticConnectorIconAssetPath(path);
+}
+for (const type of CONNECTOR_TYPE_KEYS) {
+  getStaticConnectorIconMetadata(type);
+}


### PR DESCRIPTION
## Summary

- add an optional HTTPS connector icon descriptor (`url`, `invertInDarkMode`, and bounded `scale`) to public catalog list, detail, and status responses
- move all 299 connector icon asset paths, three aliases, and current appearance metadata into one validated `@vm0/connectors` compatibility projection
- make the API and the current Platform renderer share that projection while preserving every existing connector URL and rendered appearance
- leave only the 12 non-connector settings/provider assets in Platform-owned metadata

## Compatibility and scope

- the response field is optional so old frontends can ignore it and a newer frontend can tolerate an older backend
- hidden and feature-gated connectors still pass through the existing visibility boundary before icon composition
- this PR does not add R2 reads, external catalog publication, a separate icon endpoint, or Platform API consumption; #20245 handles the browser cutover
- delivery parent: https://github.com/vm0-ai/vm0-connectors/issues/1

## Validation

- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (595 files passed, 7320 tests passed)
- `pnpm knip`
- migration semantic comparison across all 302 connector refs (0 URL or appearance differences)

Closes #20244
