### PR TITLE
perf(api): correct runner queue timing boundary

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
@@ -142,9 +142,15 @@ export async function readOrgAdmissionLockState(
   const response = await postAction(context, {
     action: "read-org-admission-lock-state",
   });
+  if (
+    response.admission_lock_held === undefined ||
+    response.admission_lock_waiting === undefined
+  ) {
+    throw new Error("readOrgAdmissionLockState missing lock state");
+  }
   return {
-    held: response.admission_lock_held ?? false,
-    waiting: response.admission_lock_waiting ?? false,
+    held: response.admission_lock_held,
+    waiting: response.admission_lock_waiting,
   };
 }
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/automations.ts
@@ -125,3 +125,31 @@ export async function mutateRunnerJobSecretValueEnvironmentKeys(
     mode,
   });
 }
+
+export async function holdOrgAdmissionLock(
+  context: TestContext,
+  orgId: string,
+): Promise<void> {
+  await postAction(context, {
+    action: "hold-org-admission-lock",
+    org_id: orgId,
+  });
+}
+
+export async function readOrgAdmissionLockState(
+  context: TestContext,
+): Promise<{ readonly held: boolean; readonly waiting: boolean }> {
+  const response = await postAction(context, {
+    action: "read-org-admission-lock-state",
+  });
+  return {
+    held: response.admission_lock_held ?? false,
+    waiting: response.admission_lock_waiting ?? false,
+  };
+}
+
+export async function releaseOrgAdmissionLock(
+  context: TestContext,
+): Promise<void> {
+  await postAction(context, { action: "release-org-admission-lock" });
+}

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -54,9 +54,12 @@ import { updateFeatureSwitchesForUser } from "./helpers/zero-feature-switches";
 import {
   deleteVm0ManagedDefaultModelKey,
   enableAutomationsFakeKms,
+  holdOrgAdmissionLock,
   mutateRunnerJobSecretValueEnvironmentKeys,
   readAutomationComposeHeadVersion,
   readAutomationsFakeKmsDecryptCallCount,
+  readOrgAdmissionLockState,
+  releaseOrgAdmissionLock,
   resetAutomationsFakeKms,
   seedVm0ManagedDefaultModelKey as seedVm0ManagedDefaultModelKeyState,
   seedVm0ManagedModelKey as seedVm0ManagedModelKeyState,
@@ -565,6 +568,19 @@ function sandboxOperationEventsForRun(
       return isRecord(event) && event.run_id === runId;
     });
   });
+}
+
+function sandboxOperationDurationForRun(
+  runId: string,
+  actionType: string,
+): number {
+  const event = sandboxOperationEventsForRun(runId).find((candidate) => {
+    return candidate.op_type === actionType;
+  });
+  if (!event || typeof event.duration_ms !== "number") {
+    throw new Error(`Missing ${actionType} duration for run ${runId}`);
+  }
+  return event.duration_ms;
 }
 
 function claimRouteTimingEventsForRun(
@@ -2592,12 +2608,39 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
     });
-    const protectedFollowUp = await api.createRun(actor, {
+    if (!actor.orgId) {
+      throw new Error("Expected affinity actor to have an organization");
+    }
+    const requestStartedAt = now();
+    const queueInsertedAt = requestStartedAt + 5000;
+    mockNow(requestStartedAt);
+    const admissionLockRequest = holdOrgAdmissionLock(context, actor.orgId);
+    onTestFinished(async () => {
+      clearMockNow();
+      await releaseOrgAdmissionLock(context);
+      await admissionLockRequest;
+    });
+    await expect
+      .poll(async () => {
+        return (await readOrgAdmissionLockState(context)).held;
+      })
+      .toBe(true);
+
+    const protectedFollowUpRequest = api.createRun(actor, {
       agentId,
       sessionId: first.sessionId,
       prompt: "continue affinity-protected session",
       modelProvider: "anthropic-api-key",
     });
+    await expect
+      .poll(async () => {
+        return (await readOrgAdmissionLockState(context)).waiting;
+      })
+      .toBe(true);
+    mockNow(queueInsertedAt);
+    await releaseOrgAdmissionLock(context);
+    await admissionLockRequest;
+    const protectedFollowUp = await protectedFollowUpRequest;
 
     const protectedPoll = await api.requestPollRunner(
       true,
@@ -2609,12 +2652,29 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     }
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
     expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(protectedPoll.body.job?.affinityProtectedUntil).toStrictEqual(
-      expect.any(String),
+    expect(protectedPoll.body.job?.affinityProtectedUntil).toBe(
+      new Date(queueInsertedAt + 2000).toISOString(),
     );
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
     expect(protectedClaim.prompt).toBe("continue affinity-protected session");
+    const apiToRunnerQueueMs = sandboxOperationDurationForRun(
+      protectedFollowUp.runId,
+      "api_to_runner_queue",
+    );
+    const runnerQueueToClaimRequestMs = sandboxOperationDurationForRun(
+      protectedFollowUp.runId,
+      "runner_queue_to_claim_request",
+    );
+    const apiToClaimRequestMs = sandboxOperationDurationForRun(
+      protectedFollowUp.runId,
+      "api_to_claim_request",
+    );
+    expect(apiToRunnerQueueMs).toBe(queueInsertedAt - requestStartedAt);
+    expect(runnerQueueToClaimRequestMs).toBe(0);
+    expect(apiToRunnerQueueMs + runnerQueueToClaimRequestMs).toBe(
+      apiToClaimRequestMs,
+    );
     await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
 
     const expiredFollowUp = await api.createRun(actor, {
@@ -2735,6 +2795,76 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     await api.requestCancelRun(actor, run.runId, [200]);
   });
 
+  it("keeps runner expiry on the database clock", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    mockNow(now() - 3 * 60 * 60 * 1000);
+
+    const run = await api.createRun(actor, {
+      agentId,
+      prompt: "runner ttl should use the database insertion clock",
+      modelProvider: "anthropic-api-key",
+    });
+
+    const poll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (poll.status !== 200) {
+      throw new Error("Expected runner expiry poll to succeed");
+    }
+    expect(poll.body.job?.runId).toBe(run.runId);
+    await api.claimRunnerJob(run.runId);
+
+    await api.requestCancelRun(actor, run.runId, [200]);
+  });
+
+  it("orders equal runner queue timestamps deterministically", async () => {
+    const api = createRunsAutomationsApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    mockNow(now());
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "same timestamp runner job one",
+      modelProvider: "anthropic-api-key",
+    });
+    const second = await api.createRun(actor, {
+      agentId,
+      prompt: "same timestamp runner job two",
+      modelProvider: "anthropic-api-key",
+    });
+    const orderedRunIds = [first.runId, second.runId].sort();
+
+    const firstPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (firstPoll.status !== 200) {
+      throw new Error("Expected first deterministic runner poll to succeed");
+    }
+    expect(firstPoll.body.job?.runId).toBe(orderedRunIds[0]);
+    if (!orderedRunIds[0]) {
+      throw new Error("Expected a first ordered runner job");
+    }
+    await api.claimRunnerJob(orderedRunIds[0]);
+
+    const secondPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (secondPoll.status !== 200) {
+      throw new Error("Expected second deterministic runner poll to succeed");
+    }
+    expect(secondPoll.body.job?.runId).toBe(orderedRunIds[1]);
+
+    await api.requestCancelRun(actor, first.runId, [200]);
+    await api.requestCancelRun(actor, second.runId, [200]);
+  });
+
   it("queues runs over the concurrency limit and promotes them after cancellation", async () => {
     const api = createRunsAutomationsApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
@@ -2768,6 +2898,8 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(queued.body.queue).toHaveLength(1);
     expect(queued.body.queue[0]?.runId).toBe(third.runId);
 
+    const promotedAt = now() + 5000;
+    mockNow(promotedAt);
     await api.requestCancelRun(actor, first.runId, [200]);
 
     const promoted = await waitForRunStatus(api, actor, third.runId, "pending");
@@ -2785,6 +2917,23 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     }
     expect(thirdClaim.secretValues).toContain(zeroToken);
     expect(thirdClaim).not.toHaveProperty("secretValueEnvironmentKeys");
+    const apiToRunnerQueueMs = sandboxOperationDurationForRun(
+      third.runId,
+      "api_to_runner_queue",
+    );
+    const runnerQueueToClaimRequestMs = sandboxOperationDurationForRun(
+      third.runId,
+      "runner_queue_to_claim_request",
+    );
+    const apiToClaimRequestMs = sandboxOperationDurationForRun(
+      third.runId,
+      "api_to_claim_request",
+    );
+    expect(apiToRunnerQueueMs).toBe(0);
+    expect(runnerQueueToClaimRequestMs).toBe(0);
+    expect(apiToRunnerQueueMs + runnerQueueToClaimRequestMs).toBe(
+      apiToClaimRequestMs,
+    );
     await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
       decryptCountBeforeClaim,
     );

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -500,7 +500,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .from(runnerJobQueue)
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
     .where(and(...whereConditions))
-    .orderBy(runnerJobQueue.createdAt)
+    .orderBy(runnerJobQueue.createdAt, runnerJobQueue.runId)
     .limit(1);
   signal.throwIfAborted();
   const pendingJobLookupFinishedAtMs = now();

--- a/turbo/apps/api/src/signals/routes/test-automations-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-automations-state.ts
@@ -151,7 +151,11 @@ async function readOrgAdmissionLockState(
       ) AS "waiting"
   `);
   signal.throwIfAborted();
-  return result.rows[0] ?? { held: false, waiting: false };
+  const state = result.rows[0];
+  if (!state) {
+    throw new Error("Failed to read org admission lock state");
+  }
+  return state;
 }
 
 async function seedCompose(

--- a/turbo/apps/api/src/signals/routes/test-automations-state.ts
+++ b/turbo/apps/api/src/signals/routes/test-automations-state.ts
@@ -27,6 +27,7 @@ import {
 } from "../../lib/secret-kms-client";
 import { testOverride } from "../../lib/singleton";
 import type { RouteEntry } from "../route-entry";
+import { createDeferredPromise, onRejection } from "../utils";
 import {
   isTestEndpointAllowed,
   testEndpointNotFoundResponse,
@@ -34,8 +35,8 @@ import {
 
 // Test-only support actions. The legacy automation seeding endpoints that
 // used to live here were removed together with the automations tables
-// (#20101); the remaining actions cover generic fixtures (composes, fake KMS,
-// the vm0-managed default model key) still used by the API test suites.
+// (#20101); the remaining actions cover generic infrastructure fixtures still
+// used by the API test suites.
 
 const actionBody$ = bodyResultOf(testAutomationsStateContract.action);
 const fakeKmsDataKey = Buffer.from("0123456789abcdef0123456789abcdef", "utf8");
@@ -44,6 +45,114 @@ const RUN_LIFECYCLE_TEST_VM0_MANAGED_API_KEY =
 const fakeKmsDecryptCallCount = testOverride<number>(() => {
   return 0;
 });
+
+interface OrgAdmissionLockGate {
+  holderPid: number | null;
+  readonly released: ReturnType<typeof createDeferredPromise<void>>;
+  readonly release: () => void;
+}
+
+const orgAdmissionLockGate = testOverride<OrgAdmissionLockGate | null>(() => {
+  return null;
+});
+
+interface OrgAdmissionLockHolderRow extends Record<string, unknown> {
+  readonly holderPid: number;
+}
+
+interface OrgAdmissionLockStateRow extends Record<string, unknown> {
+  readonly held: boolean;
+  readonly waiting: boolean;
+}
+
+function createOrgAdmissionLockGate(signal: AbortSignal): OrgAdmissionLockGate {
+  const released = createDeferredPromise<void>(signal);
+  return {
+    holderPid: null,
+    released,
+    release: () => {
+      if (!released.settled()) {
+        released.resolve(undefined);
+      }
+    },
+  };
+}
+
+function clearOrgAdmissionLockGate(gate: OrgAdmissionLockGate): void {
+  if (orgAdmissionLockGate.get() === gate) {
+    orgAdmissionLockGate.clear();
+  }
+}
+
+async function holdOrgAdmissionLock(
+  db: Db,
+  orgId: string,
+  signal: AbortSignal,
+): Promise<void> {
+  if (orgAdmissionLockGate.get()) {
+    throw new Error("An org admission lock gate is already active");
+  }
+  const gate = createOrgAdmissionLockGate(signal);
+  orgAdmissionLockGate.set(gate);
+  await onRejection(
+    db.transaction(async (tx) => {
+      const result = await tx.execute<OrgAdmissionLockHolderRow>(sql`
+        SELECT
+          pg_backend_pid() AS "holderPid",
+          pg_advisory_xact_lock(hashtext(${orgId}))
+      `);
+      signal.throwIfAborted();
+      const holder = result.rows[0];
+      if (!holder) {
+        throw new Error("Failed to acquire org admission lock");
+      }
+      gate.holderPid = holder.holderPid;
+      await gate.released.promise;
+    }),
+    () => {
+      clearOrgAdmissionLockGate(gate);
+    },
+  );
+  clearOrgAdmissionLockGate(gate);
+}
+
+async function readOrgAdmissionLockState(
+  db: Db,
+  signal: AbortSignal,
+): Promise<{ readonly held: boolean; readonly waiting: boolean }> {
+  const holderPid = orgAdmissionLockGate.get()?.holderPid;
+  if (holderPid === null || holderPid === undefined) {
+    return { held: false, waiting: false };
+  }
+  const result = await db.execute<OrgAdmissionLockStateRow>(sql`
+    SELECT
+      EXISTS (
+        SELECT 1
+        FROM pg_locks held
+        WHERE
+          held.pid = ${holderPid}
+          AND held.locktype = 'advisory'
+          AND held.granted
+      ) AS "held",
+      EXISTS (
+        SELECT 1
+        FROM pg_locks held
+        INNER JOIN pg_locks waiting
+          ON waiting.locktype = held.locktype
+          AND waiting.database IS NOT DISTINCT FROM held.database
+          AND waiting.classid IS NOT DISTINCT FROM held.classid
+          AND waiting.objid IS NOT DISTINCT FROM held.objid
+          AND waiting.objsubid IS NOT DISTINCT FROM held.objsubid
+        WHERE
+          held.pid = ${holderPid}
+          AND held.locktype = 'advisory'
+          AND held.granted
+          AND NOT waiting.granted
+      ) AS "waiting"
+  `);
+  signal.throwIfAborted();
+  return result.rows[0] ?? { held: false, waiting: false };
+}
 
 async function seedCompose(
   db: Db,
@@ -256,6 +365,25 @@ const postAutomationsStateAction$ = command(
           body.mode,
           signal,
         );
+        return { status: 200 as const, body: { ok: true as const } };
+      }
+      case "hold-org-admission-lock": {
+        await holdOrgAdmissionLock(db, body.org_id, signal);
+        return { status: 200 as const, body: { ok: true as const } };
+      }
+      case "read-org-admission-lock-state": {
+        const state = await readOrgAdmissionLockState(db, signal);
+        return {
+          status: 200 as const,
+          body: {
+            ok: true as const,
+            admission_lock_held: state.held,
+            admission_lock_waiting: state.waiting,
+          },
+        };
+      }
+      case "release-org-admission-lock": {
+        orgAdmissionLockGate.get()?.release();
         return { status: 200 as const, body: { ok: true as const } };
       }
     }

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -162,6 +162,7 @@ import {
 import { userFeatureSwitchOverrides } from "./feature-switches.service";
 import { drainOrgQueue$ } from "./zero-run-queue.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
+import { runnerJobQueueTimestamps } from "./runner-job-queue-lifecycle.service";
 import {
   connectorRuntimeCredentialStatus,
   type ConnectorCredentialStatus,
@@ -5351,6 +5352,7 @@ async function insertRunnerJobQueueRow(
     readonly payload: RunnerJobPayload;
   },
 ): Promise<Date> {
+  const timestamps = runnerJobQueueTimestamps();
   const [runnerJob] = await tx
     .insert(runnerJobQueue)
     .values({
@@ -5359,7 +5361,7 @@ async function insertRunnerJobQueueRow(
       profile: args.payload.profile,
       cliAgentSessionId: args.payload.cliAgentSessionId,
       executionContext: args.payload.executionContext,
-      expiresAt: sql`now() + interval '2 hours'`,
+      ...timestamps,
     })
     .returning({ createdAt: runnerJobQueue.createdAt });
   if (!runnerJob) {

--- a/turbo/apps/api/src/signals/services/runner-job-queue-lifecycle.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-job-queue-lifecycle.service.ts
@@ -1,0 +1,21 @@
+import { sql, type SQL } from "drizzle-orm";
+
+import { nowDate } from "../external/time";
+
+interface RunnerJobQueueTimestamps {
+  readonly createdAt: Date;
+  readonly expiresAt: SQL;
+}
+
+/**
+ * Capture the closest safe persisted approximation of queue availability.
+ * The row is committed before notification, so this is insertion time rather
+ * than commit, notification, or runner discovery time. The API clock owns the
+ * telemetry/affinity boundary, while the database clock owns queue expiry.
+ */
+export function runnerJobQueueTimestamps(): RunnerJobQueueTimestamps {
+  return {
+    createdAt: nowDate(),
+    expiresAt: sql`clock_timestamp() AT TIME ZONE 'UTC' + interval '2 hours'`,
+  };
+}

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -17,6 +17,7 @@ import { logger } from "../../lib/log";
 import { activePendingRunPredicate } from "./agent-run-activity.service";
 import { decryptQueuedRunnerJobPayload } from "./agent-run-queue-payload.service";
 import { notifyRunnerJob } from "./runner-dispatch.service";
+import { runnerJobQueueTimestamps } from "./runner-job-queue-lifecycle.service";
 import { recordSandboxOperation } from "../external/sandbox-op-log";
 import {
   revokeQueuedRunAssistantMarkers,
@@ -182,6 +183,7 @@ async function insertPromotedRunnerJob(
     },
   });
 
+  const timestamps = runnerJobQueueTimestamps();
   const [runnerJob] = await tx
     .insert(runnerJobQueue)
     .values({
@@ -193,7 +195,7 @@ async function insertPromotedRunnerJob(
         ...args.payload.executionContext,
         apiStartTime: promotedAt,
       },
-      expiresAt: sql`now() + interval '2 hours'`,
+      ...timestamps,
     })
     .returning({ createdAt: runnerJobQueue.createdAt });
   if (!runnerJob) {

--- a/turbo/packages/api-contracts/src/contracts/test-automations-state.ts
+++ b/turbo/packages/api-contracts/src/contracts/test-automations-state.ts
@@ -49,6 +49,16 @@ export const testAutomationsStateActionBodySchema = z.discriminatedUnion(
       run_id: z.uuid(),
       mode: z.enum(["remove", "invalid"]),
     }),
+    z.object({
+      action: z.literal("hold-org-admission-lock"),
+      org_id: z.string(),
+    }),
+    z.object({
+      action: z.literal("read-org-admission-lock-state"),
+    }),
+    z.object({
+      action: z.literal("release-org-admission-lock"),
+    }),
   ],
 );
 
@@ -58,6 +68,8 @@ export const testAutomationsStateActionResponseSchema = z.object({
   head_version_id: z.string().nullable().optional(),
   selected_model: z.string().optional(),
   decrypt_call_count: z.number().optional(),
+  admission_lock_held: z.boolean().optional(),
+  admission_lock_waiting: z.boolean().optional(),
 });
 
 export const testAutomationsStateContract = c.router({

--- a/turbo/packages/db/src/schema/runner-job-queue.ts
+++ b/turbo/packages/db/src/schema/runner-job-queue.ts
@@ -46,8 +46,10 @@ export const runnerJobQueue = pgTable(
       .$type<RunnerJobQueueExecutionContext>()
       .notNull(),
 
-    // Lifecycle management
+    // Lifecycle management. Current API writers provide an application-clock
+    // insertion time; the default keeps older writers compatible.
     createdAt: timestamp("created_at").defaultNow().notNull(),
+    // Current API writers use the database clock during the insert statement.
     expiresAt: timestamp("expires_at").notNull(), // TTL for auto-cleanup
   },
   (table) => {


### PR DESCRIPTION
## Summary

- record runner queue `created_at` from the API clock immediately before direct and promoted inserts so queue telemetry and affinity no longer inherit PostgreSQL transaction-start time
- compute runner queue TTL from the database statement clock and add a deterministic `run_id` tie-breaker for equal queue timestamps
- cover slow admission transactions, promoted jobs, database-owned expiry, and equal-timestamp ordering with integration tests against real PostgreSQL locking

## Compatibility and exclusions

- no database migration or schema-shape change
- no persisted payload, public API, or runner protocol change
- retain the database `created_at` default for mixed-version writers while current API writers supply the corrected boundary explicitly
- keep TTL comparisons on the database clock so scheduler and historical application clocks cannot expire fresh jobs

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (594 files and 7,309 tests passed; one existing benchmark test skipped)

Closes #21075

Parent: #18746
