### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-template.sh
+++ b/crates/runner/scripts/build-template.sh
@@ -118,9 +118,9 @@ CODEX_CLI_VERSION="0.144.1"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.2.2"
 AGENT_BROWSER_VERSION="0.31.1"
-PNPM_VERSION="11.11.0"
-CHROMIUM_VERSION="150.0.7871.100-1~deb12u1"
-CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260709T060000Z"
+PNPM_VERSION="11.12.0"
+CHROMIUM_VERSION="150.0.7871.114-1~deb12u1"
+CHROMIUM_SECURITY_SNAPSHOT_URL="https://snapshot.debian.org/archive/debian-security/20260712T033608Z"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Update pinned rootfs dependency versions in `crates/runner/scripts/build-template.sh`:

- pnpm: `11.11.0` → `11.12.0`
- Chromium (Debian Bookworm security): `150.0.7871.100-1~deb12u1` → `150.0.7871.114-1~deb12u1`
- Chromium security snapshot: `20260709T060000Z` → `20260712T033608Z`

The remaining pinned versions were checked and remain current:

- Go: `1.26.5`
- Claude Code: `2.1.207`
- OpenAI Codex CLI: `0.144.1`
- Google Workspace CLI: `0.22.5`
- xurl: `1.2.2`
- agent-browser: `0.31.1`

## Verification

- `bash -n crates/runner/scripts/build-template.sh`
- `git diff --check`
- Verified the pinned Debian security snapshot contains the Chromium packages for amd64 and arm64.
- Did not run the full rootfs build locally.
