### PR TITLE
refactor(mitm-addon): centralize connected endpoint validation

### DIFF
--- a/crates/runner/mitm-addon/src/connection_endpoints.py
+++ b/crates/runner/mitm-addon/src/connection_endpoints.py
@@ -6,18 +6,18 @@ _ADDRESS_PAIR_LENGTH = 2
 
 
 def server_address(server: object) -> tuple[str, int] | None:
-    return _address_pair(getattr(server, "address", None))
+    return address_pair(getattr(server, "address", None))
 
 
 def server_peername(server: object) -> tuple[str, int] | None:
-    return _address_pair(getattr(server, "peername", None))
+    return address_pair(getattr(server, "peername", None))
 
 
 def connection_sockname(connection: object) -> tuple[str, int] | None:
-    return _address_pair(getattr(connection, "sockname", None))
+    return address_pair(getattr(connection, "sockname", None))
 
 
-def _address_pair(address: object) -> tuple[str, int] | None:
+def address_pair(address: object) -> tuple[str, int] | None:
     if not isinstance(address, tuple) or len(address) < _ADDRESS_PAIR_LENGTH:
         return None
     host, port = address[:_ADDRESS_PAIR_LENGTH]
@@ -26,15 +26,18 @@ def _address_pair(address: object) -> tuple[str, int] | None:
     return host, port
 
 
-def _is_authoritative_connected_endpoint(endpoint: tuple[str, int] | None) -> bool:
-    if endpoint is None:
-        return False
-    endpoint_host, _endpoint_port = endpoint
+def authoritative_connected_endpoint(endpoint: object) -> tuple[str, int] | None:
+    endpoint_pair = address_pair(endpoint)
+    if endpoint_pair is None:
+        return None
+    endpoint_host, _endpoint_port = endpoint_pair
     try:
         endpoint_ip = ipaddress.ip_address(endpoint_host)
     except ValueError:
-        return False
-    return not endpoint_ip.is_loopback and not endpoint_ip.is_unspecified
+        return None
+    if endpoint_ip.is_loopback or endpoint_ip.is_unspecified:
+        return None
+    return endpoint_pair
 
 
 def connected_ip_destination_endpoint(
@@ -43,34 +46,17 @@ def connected_ip_destination_endpoint(
     port: int,
     extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
 ) -> tuple[str, int] | None:
-    for peer in _connected_destination_candidate_endpoints(
-        server,
-        extra_endpoints=extra_endpoints,
-    ):
-        if peer is None:
-            continue
+    peername = authoritative_connected_endpoint(server_peername(server))
+    if peername is not None:
+        return peername if peername[1] == port else None
 
-        _peer_host, peer_port = peer
-        if peer_port != port:
-            continue
+    address = authoritative_connected_endpoint(server_address(server))
+    if address is not None:
+        return address if address[1] == port else None
 
-        if _is_authoritative_connected_endpoint(peer):
-            return peer
+    for extra_endpoint in extra_endpoints:
+        endpoint = authoritative_connected_endpoint(extra_endpoint)
+        if endpoint is not None and endpoint[1] == port:
+            return endpoint
 
     return None
-
-
-def _connected_destination_candidate_endpoints(
-    server: object,
-    *,
-    extra_endpoints: tuple[tuple[str, int] | None, ...] = (),
-) -> tuple[tuple[str, int] | None, ...]:
-    peername = server_peername(server)
-    if _is_authoritative_connected_endpoint(peername):
-        return (peername,)
-
-    address = server_address(server)
-    if _is_authoritative_connected_endpoint(address):
-        return (address,)
-
-    return (peername, address, *extra_endpoints)

--- a/crates/runner/mitm-addon/src/upstream_destination_binding.py
+++ b/crates/runner/mitm-addon/src/upstream_destination_binding.py
@@ -19,6 +19,7 @@ from typing import Literal
 
 from mitmproxy import http
 
+import connection_endpoints
 import flow_metadata
 from url_utils import normalize_trusted_hostname
 
@@ -44,7 +45,6 @@ __all__ = (
 # `api_allow` authorizes VM0 API traffic. `connector_auth` authorizes ordinary
 # upstream credential injection for connector firewalls.
 BindingKind = Literal["api_allow", "connector_auth"]
-_ADDRESS_PAIR_LENGTH = 2
 
 
 @dataclass(frozen=True)
@@ -75,15 +75,6 @@ def _connection_id(connection: object) -> str | None:
     return None
 
 
-def _address_pair(address: object) -> tuple[str, int] | None:
-    if not isinstance(address, tuple) or len(address) < _ADDRESS_PAIR_LENGTH:
-        return None
-    host, port = address[:_ADDRESS_PAIR_LENGTH]
-    if not isinstance(host, str) or not isinstance(port, int):
-        return None
-    return host, port
-
-
 def _endpoint_ip_key(host: str) -> str | None:
     try:
         return str(ipaddress.ip_address(host))
@@ -92,7 +83,7 @@ def _endpoint_ip_key(host: str) -> str | None:
 
 
 def _endpoint_matches(left: object, right: tuple[str, int]) -> bool:
-    left_pair = _address_pair(left)
+    left_pair = connection_endpoints.address_pair(left)
     if left_pair is None:
         return False
     left_host, left_port = left_pair
@@ -113,18 +104,6 @@ def _endpoint_matches_any(
         for binding in bindings
         if binding.original_address is not None
     )
-
-
-def _is_authoritative_connected_address(endpoint: object) -> bool:
-    endpoint_pair = _address_pair(endpoint)
-    if endpoint_pair is None:
-        return False
-    endpoint_host, _endpoint_port = endpoint_pair
-    try:
-        endpoint_ip = ipaddress.ip_address(endpoint_host)
-    except ValueError:
-        return False
-    return not endpoint_ip.is_loopback and not endpoint_ip.is_unspecified
 
 
 def _associate_server_with_client(server_id: str, client: object | None) -> None:
@@ -214,8 +193,8 @@ def refresh_server_binding_connected_address_if_matching(
     normalized_host = normalize_trusted_hostname(host)
     if binding.host != normalized_host or binding.port != port:
         return False
-    connected_pair = _address_pair(connected_address)
-    if connected_pair is None or not _is_authoritative_connected_address(connected_pair):
+    connected_pair = connection_endpoints.authoritative_connected_endpoint(connected_address)
+    if connected_pair is None:
         return False
 
     refreshed_binding = UpstreamDestinationBinding(
@@ -274,7 +253,7 @@ def server_binding_original_address(server: object) -> tuple[str, int] | None:
 
 
 def _address_matches(host: str, port: int, address: object) -> bool:
-    address_pair = _address_pair(address)
+    address_pair = connection_endpoints.address_pair(address)
     if address_pair is None:
         return False
     address_host, address_port = address_pair
@@ -300,21 +279,15 @@ def _server_binding_matches_current_destination(
     binding: UpstreamDestinationBinding,
 ) -> bool:
     if bool(getattr(server, "connected", False)):
-        peername = getattr(server, "peername", None)
-        if _is_authoritative_connected_address(peername):
-            return binding.original_address is not None and _endpoint_matches(
-                peername,
-                binding.original_address,
-            )
-
-        server_address = getattr(server, "address", None)
-        if _is_authoritative_connected_address(server_address):
-            return binding.original_address is not None and _endpoint_matches(
-                server_address,
-                binding.original_address,
-            )
-
-        return False
+        connected_endpoint = connection_endpoints.connected_ip_destination_endpoint(
+            server,
+            port=binding.port,
+        )
+        return (
+            binding.original_address is not None
+            and connected_endpoint is not None
+            and _endpoint_matches(connected_endpoint, binding.original_address)
+        )
     return _address_matches(binding.host, binding.port, getattr(server, "address", None))
 
 
@@ -341,50 +314,21 @@ def _matching_client_bindings(
     )
 
 
-def _client_binding_matches_connected_endpoint(
-    *,
-    client: object,
-    server: object,
-    bindings: tuple[UpstreamDestinationBinding, ...],
-) -> bool:
-    peername = getattr(server, "peername", None)
-    if _is_authoritative_connected_address(peername):
-        return _endpoint_matches_any(peername, bindings)
-
-    server_address = getattr(server, "address", None)
-    if _is_authoritative_connected_address(server_address):
-        return _endpoint_matches_any(server_address, bindings)
-
-    client_sockname = getattr(client, "sockname", None)
-    if _is_authoritative_connected_address(client_sockname):
-        return _endpoint_matches_any(client_sockname, bindings)
-    return False
-
-
 def _client_binding_connected_endpoint(
     *,
     client: object,
     server: object,
+    port: int,
     bindings: tuple[UpstreamDestinationBinding, ...],
 ) -> tuple[str, int] | None:
-    peername = getattr(server, "peername", None)
-    if _is_authoritative_connected_address(peername) and _endpoint_matches_any(peername, bindings):
-        return _address_pair(peername)
-
-    server_address = getattr(server, "address", None)
-    if _is_authoritative_connected_address(server_address) and _endpoint_matches_any(
-        server_address,
-        bindings,
-    ):
-        return _address_pair(server_address)
-
-    client_sockname = getattr(client, "sockname", None)
-    if _is_authoritative_connected_address(client_sockname) and _endpoint_matches_any(
-        client_sockname,
-        bindings,
-    ):
-        return _address_pair(client_sockname)
-    return None
+    connected_endpoint = connection_endpoints.connected_ip_destination_endpoint(
+        server,
+        port=port,
+        extra_endpoints=(connection_endpoints.connection_sockname(client),),
+    )
+    if connected_endpoint is None or not _endpoint_matches_any(connected_endpoint, bindings):
+        return None
+    return connected_endpoint
 
 
 def diagnostic_snapshot_for_flow(
@@ -431,10 +375,14 @@ def diagnostic_snapshot_for_flow(
         if normalized_host is not None
         else ()
     )
-    client_binding_endpoint_match = _client_binding_matches_connected_endpoint(
-        client=flow.client_conn,
-        server=server,
-        bindings=matching_client_bindings,
+    client_binding_endpoint_match = (
+        _client_binding_connected_endpoint(
+            client=flow.client_conn,
+            server=server,
+            port=flow.request.port,
+            bindings=matching_client_bindings,
+        )
+        is not None
     )
     return {
         "server_id": server_id or "",
@@ -492,10 +440,14 @@ def flow_matches_bound_destination(
         allowed_kinds=allowed_kinds,
     )
     if bool(getattr(server, "connected", False)):
-        return _client_binding_matches_connected_endpoint(
-            client=flow.client_conn,
-            server=server,
-            bindings=matching_client_bindings,
+        return (
+            _client_binding_connected_endpoint(
+                client=flow.client_conn,
+                server=server,
+                port=port,
+                bindings=matching_client_bindings,
+            )
+            is not None
         )
 
     return _address_matches(normalized_host, port, getattr(server, "address", None))
@@ -545,6 +497,7 @@ def bound_destination_endpoint_for_flow(
         return _client_binding_connected_endpoint(
             client=flow.client_conn,
             server=server,
+            port=port,
             bindings=matching_client_bindings,
         )
     return None

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -1,6 +1,8 @@
 """Authority validation request hook integration tests."""
 
+import ipaddress
 import json
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -889,8 +891,22 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_without_endp
     assert "Authorization" not in flow.request.headers
 
 
-async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_loopback_endpoint(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+@pytest.mark.parametrize(
+    "client_sockname",
+    [
+        pytest.param(cast(tuple[str, int], ("203.0.113.10",)), id="malformed"),
+        pytest.param(("127.0.0.1", 443), id="loopback"),
+        pytest.param((str(ipaddress.IPv4Address(0)), 443), id="unspecified-ipv4"),
+        pytest.param(("::", 443), id="unspecified-ipv6"),
+    ],
+)
+async def test_matching_sni_and_host_blocks_non_authoritative_connected_endpoint(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    client_sockname: tuple[str, int],
 ):
     reg_path = _write_github_firewall_registry(tmp_path)
     flow = real_flow(
@@ -906,7 +922,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_loopbac
         sni="api.github.com",
         server_address=("api.github.com", 443),
         peername=None,
-        client_sockname=("127.0.0.1", 443),
+        client_sockname=client_sockname,
     )
     upstream_destination_binding.record_server_binding(
         flow.server_conn,
@@ -923,7 +939,7 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_loopbac
         patch.object(
             upstream_admission.socket,
             "getaddrinfo",
-            side_effect=AssertionError("unverified loopback endpoint must not use fresh DNS"),
+            side_effect=AssertionError("non-authoritative endpoint must not use fresh DNS"),
         ),
     ):
         await mitm_addon.request(flow)
@@ -933,6 +949,53 @@ async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_loopbac
     assert flow.response.status_code == 403
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "upstream_destination_unbound"
     assert "Authorization" not in flow.request.headers
+
+
+async def test_matching_sni_and_host_allows_equivalent_ipv6_binding_peer(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_github_firewall_registry(tmp_path)
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.github.com",
+        path="/repos",
+        request_headers=headers(("Host", "api.github.com")),
+    )
+    mark_connected_tls_upstream(
+        flow,
+        sni="api.github.com",
+        server_address=("api.github.com", 443),
+        peername=None,
+    )
+    flow.server_conn.peername = cast(
+        tuple[str, int],
+        ("2001:4860:4860:0:0:0:0:8888", 443, 0, 0),
+    )
+    upstream_destination_binding.record_server_binding(
+        flow.server_conn,
+        client=flow.client_conn,
+        host="api.github.com",
+        port=443,
+        kinds=frozenset(("connector_auth",)),
+        original_address=("2001:4860:4860::8888", 443),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+        patch.object(
+            upstream_admission.socket,
+            "getaddrinfo",
+            side_effect=AssertionError("equivalent connected IPv6 peer must not use fresh DNS"),
+        ),
+    ):
+        await mitm_addon.request(flow)
+
+    auth_fetch.assert_awaited_once()
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer x"
 
 
 async def test_matching_sni_and_host_blocks_connected_firewall_auth_with_stale_binding_peer(

--- a/crates/runner/mitm-addon/tests/test_request_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_request_headers_handler.py
@@ -1212,8 +1212,20 @@ async def test_firewall_allow_header_auth_blocks_without_verified_connected_tls(
     assert upstream_destination_binding.binding_snapshot_for_tests() == {}
 
 
+@pytest.mark.parametrize(
+    "peername",
+    [
+        pytest.param(("203.0.113.99", 443), id="ip-mismatch"),
+        pytest.param(("198.18.20.34", 8443), id="port-mismatch"),
+    ],
+)
 async def test_firewall_allow_prior_client_binding_endpoint_mismatch_blocks(
-    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+    fake_firewall_headers,
+    headers,
+    peername: tuple[str, int],
 ):
     reg_path = _write_github_firewall_registry(
         tmp_path,
@@ -1231,8 +1243,8 @@ async def test_firewall_allow_prior_client_binding_endpoint_mismatch_blocks(
             ("Content-Length", str(STREAM_BUFFER_LIMIT + 1)),
         ),
     )
-    flow.server_conn.peername = ("203.0.113.99", 443)
-    flow.server_conn.address = ("203.0.113.99", 443)
+    flow.server_conn.peername = peername
+    flow.server_conn.address = ("api.github.com", 443)
     flow.server_conn.state = connection.ConnectionState.OPEN
     flow.client_conn.sockname = ("198.18.20.34", 443)
 


### PR DESCRIPTION
## Summary

- make `connection_endpoints.py` the single owner of endpoint tuple coercion and authoritative connected-IP validation
- reuse the shared peername, server-address, and optional client-sockname precedence policy from upstream destination binding checks
- preserve fail-closed port precedence while covering malformed, loopback, unspecified, mismatched-port, and equivalent IPv6 endpoint cases

## Scope

- no schema, API, runner protocol, configuration, or documentation changes
- binding lookup and canonical IP equality remain owned by `upstream_destination_binding.py`

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `cd crates/runner/mitm-addon && .venv/bin/pytest`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `cd turbo && pnpm knip`

Closes #21032
