### PR TITLE
perf(mitm-addon): avoid rescanning responses sse prefixes

### DIFF
--- a/crates/runner/mitm-addon/src/usage/openai_responses.py
+++ b/crates/runner/mitm-addon/src/usage/openai_responses.py
@@ -131,12 +131,6 @@ def _resolved_data_event_type(
     return event_type
 
 
-def _resolved_data_event_type_from_prefix(
-    prefix: bytearray,
-) -> _ResponsesEventTypeClassification | None:
-    return _resolved_data_event_type(_classify_responses_event_type(bytes(prefix)))
-
-
 def _is_known_terminal_usage_event(value: object) -> bool:
     return isinstance(value, str) and value in _RESPONSES_TERMINAL_USAGE_EVENTS
 
@@ -425,15 +419,17 @@ class _OpenAIResponsesSseUsageHandler:
 
     def on_event_end(self, event_name: str | None) -> None:
         if self._eventless_prefix is not None:
-            self._data_event_type = _resolved_data_event_type_from_prefix(self._eventless_prefix)
-            extractor = self._start_full_extractor(include_type=self._should_include_type_scalar())
-            extractor.feed(bytes(self._eventless_prefix))
+            prefix = bytes(self._eventless_prefix)
             self._eventless_prefix = None
+            event_type = _classify_responses_event_type(prefix)
+            if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
+                self._start_full_extractor_from_prefix(prefix, event_type)
         if self._named_event_prefix is not None and self._data_event_type is None:
-            self._data_event_type = _resolved_data_event_type_from_prefix(self._named_event_prefix)
-            extractor = self._start_full_extractor(include_type=self._should_include_type_scalar())
-            extractor.feed(bytes(self._named_event_prefix))
+            prefix = bytes(self._named_event_prefix)
             self._named_event_prefix = None
+            event_type = _classify_responses_event_type(prefix)
+            if event_type != _RESPONSES_EVENT_KNOWN_NON_USAGE:
+                self._start_full_extractor_from_prefix(prefix, event_type)
         extractor = self._extractor
         data_event_type = self._data_event_type
         self._reset_event_state()
@@ -482,6 +478,15 @@ class _OpenAIResponsesSseUsageHandler:
     def _should_include_type_scalar(self) -> bool:
         return self._data_event_type is None or self._on_parse_error is not None
 
+    def _start_full_extractor_from_prefix(
+        self,
+        prefix: bytes,
+        event_type: _ResponsesEventTypeClassification,
+    ) -> None:
+        self._data_event_type = _resolved_data_event_type(event_type)
+        extractor = self._start_full_extractor(include_type=self._should_include_type_scalar())
+        extractor.feed(prefix)
+
     def _feed_eventless_data(self, chunk: bytes) -> None:
         prefix = self._eventless_prefix
         if prefix is None:
@@ -492,25 +497,20 @@ class _OpenAIResponsesSseUsageHandler:
         if captured_len:
             prefix.extend(chunk[:captured_len])
 
-        event_type = _classify_responses_event_type(bytes(prefix))
+        if (
+            captured_len == len(chunk)
+            and len(prefix) < _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
+        ):
+            return
+
+        prefix_bytes = bytes(prefix)
+        self._eventless_prefix = None
+        event_type = _classify_responses_event_type(prefix_bytes)
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
-            self._eventless_prefix = None
             self._discard_eventless_event = True
             return
 
-        should_fallback = (
-            event_type
-            in (_RESPONSES_EVENT_TERMINAL, _RESPONSES_EVENT_UNKNOWN, _RESPONSES_EVENT_UNRESOLVED)
-            or captured_len < len(chunk)
-            or len(prefix) >= _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
-        )
-        if not should_fallback:
-            return
-
-        self._data_event_type = _resolved_data_event_type(event_type)
-        self._fallback_eventless_prefix_to_full_extractor(
-            include_type=self._should_include_type_scalar()
-        )
+        self._start_full_extractor_from_prefix(prefix_bytes, event_type)
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
 
@@ -524,40 +524,23 @@ class _OpenAIResponsesSseUsageHandler:
         if captured_len:
             prefix.extend(chunk[:captured_len])
 
-        event_type = _classify_responses_event_type(bytes(prefix))
         if (
-            event_type == _RESPONSES_EVENT_PENDING
-            and captured_len == len(chunk)
+            captured_len == len(chunk)
             and len(prefix) < _RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
         ):
             return
 
+        prefix_bytes = bytes(prefix)
+        self._named_event_prefix = None
+        event_type = _classify_responses_event_type(prefix_bytes)
         if event_type == _RESPONSES_EVENT_KNOWN_NON_USAGE:
-            self._named_event_prefix = None
             self._extractor = None
             self._discard_named_event = True
             return
 
-        self._data_event_type = _resolved_data_event_type(event_type)
-        self._fallback_named_prefix_to_full_extractor(
-            include_type=self._should_include_type_scalar()
-        )
+        self._start_full_extractor_from_prefix(prefix_bytes, event_type)
         if self._extractor is not None and captured_len < len(chunk):
             self._extractor.feed(chunk[captured_len:])
-
-    def _fallback_eventless_prefix_to_full_extractor(self, *, include_type: bool) -> None:
-        prefix = self._eventless_prefix
-        self._eventless_prefix = None
-        extractor = self._start_full_extractor(include_type=include_type)
-        if prefix:
-            extractor.feed(bytes(prefix))
-
-    def _fallback_named_prefix_to_full_extractor(self, *, include_type: bool) -> None:
-        prefix = self._named_event_prefix
-        self._named_event_prefix = None
-        extractor = self._start_full_extractor(include_type=include_type)
-        if prefix:
-            extractor.feed(bytes(prefix))
 
 
 class OpenAIResponsesJsonUsageExtractor:

--- a/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_sse.py
@@ -306,6 +306,44 @@ class TestOpenAIResponsesSseUsageExtractor:
         assert usage["model"] == "gpt-5.4"
         assert usage["tokens.output"] == 5
 
+    @pytest.mark.parametrize(
+        "event_prefix",
+        [
+            pytest.param(b"", id="eventless"),
+            pytest.param(b"event: response.completed\n", id="named"),
+        ],
+    )
+    def test_tiny_chunks_classify_late_terminal_type_once(self, event_prefix, monkeypatch):
+        metadata = b",".join(f'"key_{index}":{index}'.encode() for index in range(250))
+        payload = (
+            b"{"
+            + metadata
+            + b',"type":"response.completed","response":{"model":"gpt-5.6",'
+            + b'"usage":{"output_tokens":17}}}'
+        )
+        assert len(payload) < openai_responses._RESPONSES_EVENTLESS_SSE_PREFILTER_MAX_BYTES
+
+        real_classify = openai_responses._classify_responses_event_type
+        classified_prefixes: list[bytes] = []
+
+        def track_classification(body: bytes):
+            classified_prefixes.append(body)
+            return real_classify(body)
+
+        monkeypatch.setattr(
+            openai_responses,
+            "_classify_responses_event_type",
+            track_classification,
+        )
+        parse, usage = create_openai_responses_sse_usage_extractor()
+        parse(event_prefix + b"data: ")
+        for byte in payload:
+            parse(bytes((byte,)))
+        parse(b"\n\n")
+
+        assert usage == {"model": "gpt-5.6", "tokens.output": 17}
+        assert classified_prefixes == [payload]
+
     def test_eventless_incomplete_terminal_reports_parse_error(self):
         parse_errors: list[tuple[str, str]] = []
 


### PR DESCRIPTION
## Summary

- stop reclassifying a growing OpenAI Responses SSE prefix on every decoded chunk
- classify once at the event boundary or the 4096-byte prefilter bound, then reuse that snapshot to seed the full extractor
- cover eventless and named SSE frames split into one-byte chunks while preserving usage extraction

## Exclusions

- no changes to shared SSE framing, response body decoding, JSON probe semantics, or the prefilter size
- no changes to forwarded response chunks or provider-facing behavior

## Validation

- `ruff format --check .` (runner mitm addon)
- `ruff check .` (runner mitm addon)
- `basedpyright -p .` (runner mitm addon)
- `pytest tests/test_openai_responses_sse.py -q` — 44 passed
- `pytest -q` (runner mitm addon) — 3767 passed
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` — 7307 passed; one unrelated `cron-sync-skills` case exceeded its 5-second limit by 75 ms
- focused rerun of that unchanged `cron-sync-skills` case on a clean database — passed in 1.58 seconds

Closes #21031
