### PR TITLE
fix(mitm-addon): hand off runner flushes during shutdown

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -110,6 +110,7 @@ _AUTH_BASE_BODYLESS_METHODS = frozenset(("GET", "HEAD"))
 _HTTP_RESPONSE_BODYLESS_METHODS = frozenset(("CONNECT", "HEAD"))
 _WEBSOCKET_KEY_BYTES = 16
 _AuthBaseBodyCheckKind = Literal["ok", "too_large", "length_required"]
+_UsageFlushPhase = Literal["running", "draining", "closed"]
 
 
 @dataclass(frozen=True)
@@ -135,6 +136,9 @@ class _AuthBaseBodyCheck:
 _RUNNER_USAGE_FLUSH_SIGNAL = signal.SIGUSR1
 _usage_flush_requested = threading.Event()
 _usage_flush_signal_lock = threading.Lock()
+# Running workers own requests under the lock. During shutdown, done() changes
+# the phase before waiting for that lock and becomes the sole draining owner.
+_usage_flush_phase: _UsageFlushPhase = "running"
 _jsonl_flush_state_write_lock = threading.Lock()
 _last_jsonl_flush_request_id: str | None = None
 _JSONL_FLUSH_REQUEST_FILE = "jsonl-flush-request"
@@ -224,6 +228,8 @@ def _handle_runner_usage_flush_signal(signum: int, _frame: object) -> None:
     file I/O, usage flushing, and JSONL flushing.
     """
     del signum
+    if _usage_flush_phase == "closed":
+        return
     _usage_flush_requested.set()
     _start_usage_flush_worker()
 
@@ -247,12 +253,13 @@ def wait_for_runner_usage_flush_worker_to_stop_for_tests(timeout: float = 1.0) -
 
 
 def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
-    global _last_jsonl_flush_request_id
+    global _last_jsonl_flush_request_id, _usage_flush_phase
 
     acquired = _usage_flush_signal_lock.acquire(timeout=timeout)
     if not acquired:
         raise AssertionError("runner usage flush worker did not stop")
     try:
+        _usage_flush_phase = "running"
         _usage_flush_requested.clear()
         _last_jsonl_flush_request_id = None
     finally:
@@ -261,7 +268,12 @@ def reset_runner_usage_flush_state_for_tests(timeout: float = 1.0) -> None:
 
 def _start_usage_flush_worker() -> None:
     """Start one flush worker, coalescing repeated signals while active."""
+    if _usage_flush_phase != "running":
+        return
     if not _usage_flush_signal_lock.acquire(blocking=False):
+        return
+    if _usage_flush_phase != "running":
+        _usage_flush_signal_lock.release()
         return
 
     thread = threading.Thread(
@@ -282,20 +294,23 @@ def _run_usage_flush_worker() -> None:
     """Drain coalesced runner flush requests under the worker lock.
 
     The event can be set again while a flush is running. Loop until no request
-    is pending, and restart after releasing the lock if a signal arrives during
-    the worker exit path.
+    is pending. After releasing the lock, restart for a running-phase signal;
+    draining-phase requests belong to ``done()``.
     """
     try:
-        while True:
-            _usage_flush_requested.clear()
-            _flush_usage_for_runner_request()
-            _flush_jsonl_for_runner_request()
-            if not _usage_flush_requested.is_set():
-                return
+        _drain_runner_usage_flush_requests()
     finally:
         _usage_flush_signal_lock.release()
         if _usage_flush_requested.is_set():
             _start_usage_flush_worker()
+
+
+def _drain_runner_usage_flush_requests() -> None:
+    """Drain coalesced runner requests while the caller owns the signal lock."""
+    while _usage_flush_requested.is_set():
+        _usage_flush_requested.clear()
+        _flush_usage_for_runner_request()
+        _flush_jsonl_for_runner_request()
 
 
 def _flush_usage_for_runner_request() -> None:
@@ -1559,17 +1574,28 @@ def done():
     Runner-triggered flush workers and shutdown flush share
     ``_usage_flush_signal_lock``. Waiting here keeps shutdown from closing the
     executor while a SIGUSR1 worker is still converting buffered usage into
-    webhook reports. After that, ``shutdown(wait=True)`` drains submitted
-    webhook futures during graceful stop. Auth.base forwarding does not need
-    to finish running work during shutdown, so its worker shutdown stops new
-    forwards and best-effort closes active upstream sockets without waiting for
-    slow upstream responses.
+    webhook reports. Shutdown then owns signals received before the request
+    cutoff and acknowledges them before ``shutdown(wait=True)`` drains submitted
+    webhook futures. Auth.base forwarding does not need to finish running work
+    during shutdown, so its worker shutdown stops new forwards and best-effort
+    closes active upstream sockets without waiting for slow upstream responses.
     """
+    global _usage_flush_phase
+
+    _usage_flush_phase = "draining"
     try:
         # Wait for any in-flight runner-triggered flush before closing the
-        # executor used by webhook report delivery.
+        # executor used by webhook report delivery. Once the lock is ours,
+        # shutdown also owns requests recorded while the final drain runs.
         with _usage_flush_signal_lock:
-            usage.flush_usage_events(trigger="shutdown")
+            try:
+                usage.flush_usage_events(trigger="shutdown")
+                _drain_runner_usage_flush_requests()
+            finally:
+                # Close request admission while still owning the lock, then
+                # consume any event recorded immediately before this cutoff.
+                _usage_flush_phase = "closed"
+                _drain_runner_usage_flush_requests()
     finally:
         try:
             usage.webhook.usage_executor.shutdown(wait=True)

--- a/crates/runner/mitm-addon/tests/test_done_hook.py
+++ b/crates/runner/mitm-addon/tests/test_done_hook.py
@@ -117,15 +117,93 @@ class TestDoneHook:
             "jsonl:shutdown",
         ]
 
+    def test_done_drains_repeated_signal_without_starting_another_worker(self):
+        runner_flush_count = 0
+        calls: list[str] = []
+
+        def flush_usage_events(*, trigger: str) -> int:
+            assert trigger == "shutdown"
+            calls.append("flush:shutdown")
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            return 0
+
+        def flush_usage_for_runner_request() -> None:
+            nonlocal runner_flush_count
+            runner_flush_count += 1
+            calls.append("flush:runner")
+            if runner_flush_count == 1:
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+
+        mock_executor = MagicMock()
+        mock_executor.shutdown.side_effect = lambda *, wait: calls.append(f"shutdown:{wait}")
+
+        with (
+            patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
+            patch.object(
+                mitm_addon,
+                "_flush_usage_for_runner_request",
+                side_effect=flush_usage_for_runner_request,
+            ),
+            patch.object(
+                mitm_addon,
+                "_flush_jsonl_for_runner_request",
+                side_effect=lambda: calls.append("flush:jsonl"),
+            ),
+            patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(
+                mitm_addon.auth_base_forwarder,
+                "shutdown_forward_request_workers",
+                lambda *, wait: calls.append(f"auth-base:shutdown:{wait}"),
+            ),
+            patch.object(mitm_addon, "shutdown_log_writer", lambda: calls.append("jsonl:shutdown")),
+        ):
+            mitm_addon.done()
+
+        assert calls == [
+            "flush:shutdown",
+            "flush:runner",
+            "flush:jsonl",
+            "flush:runner",
+            "flush:jsonl",
+            "shutdown:True",
+            "auth-base:shutdown:False",
+            "jsonl:shutdown",
+        ]
+        assert not mitm_addon._usage_flush_requested.is_set()
+
+    def test_signal_after_done_does_not_start_worker(self):
+        mock_executor = MagicMock()
+
+        with (
+            patch.object(usage, "flush_usage_events"),
+            patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(mitm_addon.auth_base_forwarder, "shutdown_forward_request_workers"),
+            patch.object(mitm_addon, "shutdown_log_writer"),
+        ):
+            mitm_addon.done()
+
+        with patch.object(mitm_addon, "_start_usage_flush_worker") as start_worker:
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+
+        start_worker.assert_not_called()
+        assert not mitm_addon._usage_flush_requested.is_set()
+
     def test_done_shuts_down_executor_when_flush_fails(self):
         mock_executor = MagicMock()
+
+        def fail_shutdown_flush(*, trigger: str) -> int:
+            assert trigger == "shutdown"
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+            raise RuntimeError("flush failed")
 
         with (
             patch.object(
                 usage,
                 "flush_usage_events",
-                side_effect=RuntimeError("flush failed"),
+                side_effect=fail_shutdown_flush,
             ) as flush_usage_events,
+            patch.object(mitm_addon, "_flush_usage_for_runner_request") as flush_runner_usage,
+            patch.object(mitm_addon, "_flush_jsonl_for_runner_request") as flush_runner_jsonl,
             patch.object(usage.webhook, "usage_executor", mock_executor),
             patch.object(
                 mitm_addon.auth_base_forwarder,
@@ -137,6 +215,13 @@ class TestDoneHook:
             mitm_addon.done()
 
         flush_usage_events.assert_called_once_with(trigger="shutdown")
+        flush_runner_usage.assert_called_once_with()
+        flush_runner_jsonl.assert_called_once_with()
         mock_executor.shutdown.assert_called_once_with(wait=True)
         shutdown_forward_request_workers.assert_called_once_with(wait=False)
         shutdown_log_writer.assert_called_once_with()
+        assert not mitm_addon._usage_flush_requested.is_set()
+
+        with patch.object(mitm_addon, "_start_usage_flush_worker") as start_worker:
+            mitm_addon._handle_runner_usage_flush_signal(0, None)
+        start_worker.assert_not_called()

--- a/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
+++ b/crates/runner/mitm-addon/tests/test_runner_usage_flush_signal.py
@@ -155,6 +155,82 @@ class TestRunnerUsageFlushSignal:
             flush_request_id="request-1",
         )
 
+    def test_done_folds_signal_received_during_shutdown_into_acknowledgements(
+        self, runner_usage_flush_files: RunnerUsageFlushFiles
+    ):
+        shutdown_flush_started = threading.Event()
+        release_shutdown_flush = threading.Event()
+        calls: list[str] = []
+        runner_usage_flush_files.write_usage_flush_request()
+        log_path = runner_usage_flush_files.write_jsonl_flush_request()
+
+        def flush_usage_events(*, trigger: str) -> int:
+            calls.append(f"flush:{trigger}")
+            if trigger == "shutdown":
+                shutdown_flush_started.set()
+                assert release_shutdown_flush.wait(timeout=2)
+            return 0
+
+        def shutdown_usage_executor(*, wait: bool) -> None:
+            calls.append(f"executor:shutdown:{wait}")
+            assert_pending(
+                runner_usage_flush_files.pending_path,
+                flows=0,
+                buffered=0,
+                reports=0,
+                flush_request_id="request-1",
+            )
+            state = json.loads(runner_usage_flush_files.jsonl_flush_state_path.read_text())
+            assert state["flushRequestId"] == "jsonl-request-1"
+            assert state["path"] == str(log_path)
+            assert state["pending"] == 0
+            assert not mitm_addon._usage_flush_requested.is_set()
+
+        mock_executor = MagicMock()
+        mock_executor.shutdown.side_effect = shutdown_usage_executor
+        done_thread = ThreadUnderTest(target=mitm_addon.done)
+
+        with (
+            patch.object(mitm_addon, "__file__", str(runner_usage_flush_files.addon_file)),
+            patch.object(usage, "flush_usage_events", side_effect=flush_usage_events),
+            patch.object(usage.webhook, "usage_executor", mock_executor),
+            patch.object(
+                mitm_addon.auth_base_forwarder,
+                "shutdown_forward_request_workers",
+                lambda *, wait: calls.append(f"auth-base:shutdown:{wait}"),
+            ),
+            patch.object(mitm_addon, "shutdown_log_writer", lambda: calls.append("jsonl:shutdown")),
+        ):
+            try:
+                done_thread.start()
+                wait_for_event(
+                    shutdown_flush_started,
+                    timeout=1,
+                    threads=(done_thread,),
+                    message="done did not start the shutdown usage flush",
+                )
+
+                mitm_addon._handle_runner_usage_flush_signal(0, None)
+                state_before_release = json.loads(runner_usage_flush_files.pending_path.read_text())
+                assert "flushRequestId" not in state_before_release
+                assert not runner_usage_flush_files.jsonl_flush_state_path.exists()
+
+                release_shutdown_flush.set()
+                done_thread.join_and_raise(timeout=1)
+            finally:
+                release_shutdown_flush.set()
+                done_thread.join(timeout=1)
+
+        assert not done_thread.is_alive()
+        assert calls == [
+            "flush:shutdown",
+            "flush:runner",
+            "executor:shutdown:True",
+            "auth-base:shutdown:False",
+            "jsonl:shutdown",
+        ]
+        assert not mitm_addon._usage_flush_requested.is_set()
+
     def test_signal_handler_writes_snapshot_when_flush_fails(
         self, runner_usage_flush_files: RunnerUsageFlushFiles
     ):


### PR DESCRIPTION
## Summary

- add explicit `running`, `draining`, and `closed` ownership phases for runner flush requests
- hand signals received during shutdown to `done()` so usage and JSONL acknowledgements complete before the usage executor closes
- cover repeated shutdown signals, the post-shutdown cutoff, shutdown-flush failures, and real acknowledgement files

## Scope

- no API, runner protocol, queue payload, schema, migration, or persisted data-format changes
- no Rust runtime behavior changes

## Validation

- `pytest tests/` (3,768 passed)
- `ruff format --check .`
- `ruff check .`
- `basedpyright -p .`
- `python -m compileall src scripts tests`
- `cargo fmt --check`
- `cargo clippy -p runner --all-targets -- -D warnings`
- `cargo test -p runner`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=2 --silent=passed-only` (7,308 passed, 1 skipped)
- `pnpm knip`

Closes #21033
