### PR TITLE
refactor(platform): render connector icons from catalog metadata

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -981,9 +981,19 @@ describe("GET /api/zero/connector-catalog", () => {
       }),
       [200],
     );
+    const detailResponse = await accept(
+      client.get({
+        params: { connectorRef: "google-docs" },
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
 
     assertPublicConnectorCatalogHasNoPrivateFields(response.body);
     expect(response.body.permissions.connectorRef).toBe("google-docs");
+    expect(response.body.permissions.icon).toStrictEqual(
+      detailResponse.body.connector.icon,
+    );
     expect(response.body.permissions.permissionCount).toBeGreaterThan(0);
     expect(response.body.permissions.permissions).toHaveLength(
       response.body.permissions.permissionCount,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflows.test.ts
@@ -326,18 +326,30 @@ describe("zero workflows", () => {
       {
         connectorRef: "gmail",
         label: "Gmail",
+        icon: {
+          url: "https://static.vm0.io/platform/views/zero-page/components/settings/icons/gmail-18f42e2c6f80.svg",
+          invertInDarkMode: false,
+        },
         reason: "The workflow reads Gmail messages.",
         status: "not-connected",
       },
       {
         connectorRef: "runtime",
         label: "Runtime",
+        icon: {
+          url: "https://static.vm0.io/platform/views/zero-page/components/settings/icons/runtime-529df4ae1f3f.svg",
+          invertInDarkMode: true,
+        },
         reason: "The workflow reads Runtime jobs.",
         status: "not-enabled-for-agent",
       },
       {
         connectorRef: "gitlab",
         label: "GitLab",
+        icon: {
+          url: "https://static.vm0.io/platform/views/zero-page/components/settings/icons/gitlab-3f258ed8cb9a.svg",
+          invertInDarkMode: false,
+        },
         reason: "The workflow reads GitLab projects.",
         status: "connected",
       },

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -437,6 +437,7 @@ export async function getPublicConnectorCatalogPermissionDetail(
   return {
     connectorRef: args.connectorRef,
     label: metadata.label,
+    icon: getStaticConnectorIconMetadata(args.connectorRef),
     permissionCount: metadata.permissionCount,
     permissions: metadata.permissions.map((permission) => {
       return {

--- a/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-catalog-reader.service.ts
@@ -4,6 +4,7 @@ import type {
   PublicConnectorCatalogConnection,
   PublicConnectorCatalogConnectionStatus,
   PublicConnectorCatalogDetail,
+  PublicConnectorCatalogIcon,
   PublicConnectorCatalogItem,
   PublicConnectorCatalogListResponse,
   PublicConnectorCatalogManualField,
@@ -61,6 +62,12 @@ interface ConnectorCatalogConnectorReadArgs extends ConnectorCatalogReadArgs {
 
 function isConnectorType(connectorRef: string): connectorRef is ConnectorType {
   return Object.prototype.hasOwnProperty.call(CONNECTOR_TYPES, connectorRef);
+}
+
+export function getPublicConnectorCatalogIcon(
+  connectorRef: ConnectorType,
+): PublicConnectorCatalogIcon {
+  return getStaticConnectorIconMetadata(connectorRef);
 }
 
 function availableAuthMethodsForCatalog(
@@ -202,7 +209,7 @@ function connectorCatalogItem(
     connectorRef: type,
     label: config.label,
     description: config.helpText,
-    icon: getStaticConnectorIconMetadata(type),
+    icon: getPublicConnectorCatalogIcon(type),
     category: config.category,
     generation: [...getConnectorGenerationTypes(type)],
     tags: [...getConnectorTags(type)],
@@ -437,7 +444,7 @@ export async function getPublicConnectorCatalogPermissionDetail(
   return {
     connectorRef: args.connectorRef,
     label: metadata.label,
-    icon: getStaticConnectorIconMetadata(args.connectorRef),
+    icon: getPublicConnectorCatalogIcon(args.connectorRef),
     permissionCount: metadata.permissionCount,
     permissions: metadata.permissions.map((permission) => {
       return {

--- a/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
@@ -21,7 +21,10 @@ import { db$, type ReadonlyDb } from "../external/db";
 import { generateText } from "../external/openrouter";
 import { safeJsonParse } from "../utils";
 import { loadAgentConnectorScope } from "./agent-connector-scope.service";
-import { listPublicConnectorCatalogStatus } from "./connector-catalog-reader.service";
+import {
+  getPublicConnectorCatalogIcon,
+  listPublicConnectorCatalogStatus,
+} from "./connector-catalog-reader.service";
 import { zeroConnectorList } from "./zero-connector-data.service";
 
 const CONNECTOR_READINESS_MODEL = "google/gemini-3.1-flash-lite-preview";
@@ -336,6 +339,7 @@ export const detectWorkflowConnectorReadiness$ = command(
         connectors.push({
           connectorRef,
           label: CONNECTOR_TYPES[connectorRef].label,
+          icon: getPublicConnectorCatalogIcon(connectorRef),
           reason,
           status: "unavailable",
         });
@@ -344,7 +348,7 @@ export const detectWorkflowConnectorReadiness$ = command(
       connectors.push({
         connectorRef,
         label: catalogEntry.label,
-        ...(catalogEntry.icon ? { icon: catalogEntry.icon } : {}),
+        icon: catalogEntry.icon,
         reason,
         status: readinessStatus({
           connectionStatus: catalogEntry.connectionStatus,

--- a/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-connector-readiness.service.ts
@@ -344,6 +344,7 @@ export const detectWorkflowConnectorReadiness$ = command(
       connectors.push({
         connectorRef,
         label: catalogEntry.label,
+        ...(catalogEntry.icon ? { icon: catalogEntry.icon } : {}),
         reason,
         status: readinessStatus({
           connectionStatus: catalogEntry.connectionStatus,

--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
@@ -78,6 +78,10 @@ export function catalogItem(
     connectorRef: overrides.connectorRef,
     label: overrides.label ?? overrides.connectorRef,
     description: overrides.description ?? `${overrides.connectorRef} connector`,
+    icon: overrides.icon ?? {
+      url: `https://icons.example.test/${overrides.connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     category: overrides.category ?? "developer-tools",
     generation: overrides.generation ?? [],
     tags: overrides.tags ?? [],
@@ -98,6 +102,10 @@ export function catalogStatusItem(
     connectorRef: overrides.connectorRef,
     label: overrides.label ?? overrides.connectorRef,
     description: overrides.description ?? `${overrides.connectorRef} connector`,
+    icon: overrides.icon ?? {
+      url: `https://icons.example.test/${overrides.connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     category: overrides.category ?? "developer-tools",
     generation: overrides.generation ?? [],
     tags: overrides.tags ?? [],

--- a/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
+++ b/turbo/apps/cli/src/mocks/handlers/api-handlers.ts
@@ -18,6 +18,7 @@ import {
   getConnectorGenerationTypes,
   getConnectorTags,
 } from "@vm0/connectors/connector-utils";
+import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -124,6 +125,7 @@ function defaultPublicCatalogItem(
     connectorRef: type,
     label: config.label,
     description: config.helpText,
+    icon: getStaticConnectorIconMetadata(type),
     category: config.category,
     generation: [...getConnectorGenerationTypes(type)],
     tags: [...getConnectorTags(type)],

--- a/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-connectors.ts
@@ -43,6 +43,7 @@ import {
   getFirewallPermissionSummary,
   loadFirewallPermissionMetadata,
 } from "@vm0/connectors/firewall-metadata";
+import { getStaticConnectorIconMetadata } from "@vm0/connectors/static-connector-icons";
 import { getAllFeatureStates } from "@vm0/core/feature-switch";
 import { mockApi } from "../msw-contract.ts";
 
@@ -228,6 +229,7 @@ async function mockPermissionDetail(
   return {
     connectorRef,
     label: metadata.label,
+    icon: getStaticConnectorIconMetadata(connectorRef),
     permissionCount: metadata.permissionCount,
     permissions: metadata.permissions.map((permission) => {
       return {
@@ -363,6 +365,7 @@ function mockConnectorCatalogStatusItem(
     connectorRef: type,
     label: config.label,
     description: config.helpText,
+    icon: getStaticConnectorIconMetadata(type),
     category: config.category,
     generation: [...getConnectorGenerationTypes(type)],
     tags: [...getConnectorTags(type)],

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -5,6 +5,7 @@ import {
 } from "@vm0/api-contracts/contracts/zero-connectors";
 import {
   zeroConnectorCatalogContract,
+  type PublicConnectorCatalogIcon,
   type PublicConnectorCatalogStatusItem,
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
@@ -18,6 +19,7 @@ export interface ConnectorCatalogDisplayMetadata {
   readonly connectorRef: string;
   readonly label: string;
   readonly helpText: string;
+  readonly icon: PublicConnectorCatalogIcon | undefined;
 }
 
 /**
@@ -72,6 +74,7 @@ function connectorCatalogDisplayMetadata(
     connectorRef: connector.connectorRef,
     label: connector.label,
     helpText: connector.description,
+    icon: connector.icon,
   };
 }
 

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -19,7 +19,7 @@ export interface ConnectorCatalogDisplayMetadata {
   readonly connectorRef: string;
   readonly label: string;
   readonly helpText: string;
-  readonly icon: PublicConnectorCatalogIcon | undefined;
+  readonly icon: PublicConnectorCatalogIcon;
 }
 
 /**

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -35,6 +35,7 @@ import type {
 import type {
   PublicConnectorCatalogAuthMethodDetail,
   PublicConnectorCatalogConnection,
+  PublicConnectorCatalogIcon,
   PublicConnectorCatalogPermissionSummary,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
@@ -89,6 +90,7 @@ export interface ConnectorTypeWithStatus {
   type: ConnectorType;
   label: string;
   helpText: string;
+  icon: PublicConnectorCatalogIcon | undefined;
   category: string;
   /** Lowercase aliases/keywords used by connector search. */
   tags: readonly string[];
@@ -435,6 +437,7 @@ function connectorCatalogStatusItemToConnectorType(
     type: type.data,
     label: item.label,
     helpText: item.description,
+    icon: item.icon,
     category: item.category,
     tags: item.tags,
     connected: item.connected,

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -90,7 +90,7 @@ export interface ConnectorTypeWithStatus {
   type: ConnectorType;
   label: string;
   helpText: string;
-  icon: PublicConnectorCatalogIcon | undefined;
+  icon: PublicConnectorCatalogIcon;
   category: string;
   /** Lowercase aliases/keywords used by connector search. */
   tags: readonly string[];

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-draft-intent.test.ts
@@ -38,6 +38,10 @@ function createMetadata(): PublicConnectorCatalogPermissionDetail {
   return {
     connectorRef: "slack",
     label: "Slack",
+    icon: {
+      url: "https://icons.example.test/slack.svg",
+      invertInDarkMode: false,
+    },
     permissionCount: READ_PERMISSIONS.length,
     permissions: [...READ_PERMISSIONS],
     categories: {

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page.test.tsx
@@ -29,11 +29,15 @@ function publicConnectorStatusItem(
   overrides: Partial<PublicConnectorCatalogStatusItem> &
     Pick<PublicConnectorCatalogStatusItem, "connectorRef" | "label">,
 ): PublicConnectorCatalogStatusItem {
-  const { connectorRef, label, ...rest } = overrides;
+  const { connectorRef, label, icon, ...rest } = overrides;
   return {
     connectorRef,
     label,
     description: `${label} public help text`,
+    icon: icon ?? {
+      url: `https://icons.example.test/${connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     category: "data-automation-infrastructure",
     generation: [],
     tags: [],

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -26,10 +26,14 @@ function catalogPermissionDetail(
       "connectorRef" | "label" | "permissions"
     >,
 ): PublicConnectorCatalogPermissionDetail {
-  const { connectorRef, label, permissions, ...rest } = overrides;
+  const { connectorRef, label, permissions, icon, ...rest } = overrides;
   return {
     connectorRef,
     label,
+    icon: icon ?? {
+      url: `https://icons.example.test/${connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     permissionCount: permissions.length,
     permissions,
     categories: null,

--- a/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/__tests__/permission-allow-page.test.tsx
@@ -89,6 +89,10 @@ describe("permission allow page", () => {
           permissions: catalogPermissionDetail({
             connectorRef: "slack",
             label: "Catalog Slack",
+            icon: {
+              url: "https://icons.example.test/permission-slack.svg",
+              invertInDarkMode: false,
+            },
             permissions: [
               {
                 name: "catalog.analytics:read",
@@ -140,6 +144,11 @@ describe("permission allow page", () => {
     });
     expect(screen.getByText("Research Bot")).toBeInTheDocument();
     expect(screen.getByText("Catalog Slack")).toBeInTheDocument();
+    expect(
+      document.querySelector(
+        'img[src="https://icons.example.test/permission-slack.svg"]',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("Catalog analytics access")).toBeInTheDocument();
     expect(screen.getByText("catalog.analytics:read")).toBeInTheDocument();
     expect(screen.getByText("Duration")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -41,10 +41,7 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { VM0Logo } from "../components/vm0-logo.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
 import { useUserPermissionGrantExpiryTick } from "../user-permission-grant-expiry-tick.ts";
-import {
-  ConnectorIcon,
-  isConnectorIconType,
-} from "../zero-page/components/settings/connector-icons.tsx";
+import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 
 function TargetPill({
@@ -97,12 +94,12 @@ function resolvePermissionGrantTarget({
 }
 
 function ConnectorPermissionCard({
-  connectorRef,
+  icon,
   connectorLabel,
   permission,
   action,
 }: {
-  connectorRef: string;
+  icon: PublicConnectorCatalogPermissionDetail["icon"];
   connectorLabel: string;
   permission: Permission;
   action: "allow" | "deny";
@@ -111,11 +108,9 @@ function ConnectorPermissionCard({
     <div className="w-full rounded-lg border border-border px-4 py-3">
       <div className="flex flex-col gap-2">
         <div className="flex items-center gap-2 border-b border-border/70 pb-4 pt-1">
-          {isConnectorIconType(connectorRef) && (
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-muted/40">
-              <ConnectorIcon type={connectorRef} size={20} />
-            </span>
-          )}
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-muted/40">
+            <ConnectorIcon icon={icon} size={20} />
+          </span>
           <div className="min-w-0 flex-1 flex flex-col gap-1.5">
             <p className="text-sm font-medium text-foreground">
               {connectorLabel}
@@ -312,6 +307,7 @@ function resolveExistingPermissionGrantResult({
 
 function ConfirmGrantCard({
   target,
+  icon,
   connectorRef,
   connectorLabel,
   permission,
@@ -322,6 +318,7 @@ function ConfirmGrantCard({
   applyGrant,
 }: {
   target: PermissionGrantTarget;
+  icon: PublicConnectorCatalogPermissionDetail["icon"];
   connectorRef: string;
   connectorLabel: string;
   permission: Permission;
@@ -386,7 +383,7 @@ function ConfirmGrantCard({
           <div className="w-full flex flex-col gap-3">
             <p className="text-sm font-medium text-foreground">Would like to</p>
             <ConnectorPermissionCard
-              connectorRef={connectorRef}
+              icon={icon}
               connectorLabel={connectorLabel}
               permission={permission}
               action={action}
@@ -530,6 +527,7 @@ function PermissionAllowDoctorPage({
   return (
     <ConfirmGrantCard
       target={targetResult.target}
+      icon={metadata.icon}
       connectorRef={ref}
       connectorLabel={metadata.label}
       permission={focusedPermission}

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -171,6 +171,10 @@ function axiomCatalogStatusItem(
     connectorRef: "axiom",
     label: "Axiom",
     description: "Observability and log analytics",
+    icon: {
+      url: "https://icons.example.test/axiom.svg",
+      invertInDarkMode: false,
+    },
     category: "data-automation-infrastructure",
     generation: [],
     tags: [],

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -362,7 +362,7 @@ function PermissionRow({
   return (
     <>
       <div className="flex items-center gap-3 px-5 py-4 w-full text-left transition-colors">
-        <ConnectorIcon type={connector.type} size={20} />
+        <ConnectorIcon icon={connector.icon} size={20} />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -60,6 +60,13 @@ function workflowDetailPath(tab: WorkflowDetailTestTab): string {
   return `/workflows/${SALES_WORKFLOW_ID}/${tab}`;
 }
 
+function connectorIcon(connectorRef: string) {
+  return {
+    url: `https://icons.example.test/${connectorRef}.svg`,
+    invertInDarkMode: false,
+  };
+}
+
 function detachedSetupWorkflowDetailPage(
   path: string,
   featureSwitches: Partial<Record<FeatureSwitchKey, boolean>> = {},
@@ -1464,24 +1471,28 @@ describe("workflow detail page", () => {
             {
               connectorRef: "google-drive",
               label: "Google Drive",
+              icon: connectorIcon("google-drive"),
               reason: "The workflow reads account documents.",
               status: "connected",
             },
             {
               connectorRef: "github",
               label: "GitHub",
+              icon: connectorIcon("github"),
               reason: "A GitHub trigger requires this connector.",
               status: "unavailable",
             },
             {
               connectorRef: "slack",
               label: "Slack",
+              icon: connectorIcon("slack"),
               reason: "The workflow posts a summary to Slack.",
               status: "not-enabled-for-agent",
             },
             {
               connectorRef: "notion",
               label: "Notion",
+              icon: connectorIcon("notion"),
               reason: "The workflow updates a Notion page.",
               status: "scope-mismatch",
             },
@@ -1499,6 +1510,7 @@ describe("workflow detail page", () => {
             {
               connectorRef: "linear",
               label: "Linear",
+              icon: connectorIcon("linear"),
               reason: "The workflow creates follow-up issues.",
               status: "not-connected",
             },
@@ -1567,12 +1579,13 @@ describe("workflow detail page", () => {
       transform: "scale(1.25)",
     });
 
-    const linearRow = within(readiness).getByText("Linear").closest("li");
-    if (!(linearRow instanceof HTMLElement)) {
-      throw new Error("Linear readiness row not found");
+    const unavailableRow = within(readiness).getByText("GitHub").closest("li");
+    if (!(unavailableRow instanceof HTMLElement)) {
+      throw new Error("Unavailable readiness row not found");
     }
-    expect(within(linearRow).getByRole("img")).toHaveAccessibleName(
-      "Connector icon unavailable",
+    expect(unavailableRow.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://icons.example.test/github.svg",
     );
 
     expect(linkByText("Reconnect Gmail", readiness)).toHaveAttribute(
@@ -1653,6 +1666,7 @@ describe("workflow detail page", () => {
             {
               connectorRef: "gmail",
               label: "Gmail",
+              icon: connectorIcon("gmail"),
               reason: "The workflow reads outreach replies.",
               status: "connected",
             },

--- a/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/__tests__/workflows-page.test.tsx
@@ -1490,6 +1490,11 @@ describe("workflow detail page", () => {
               label: "Gmail",
               reason: "The workflow reads outreach replies.",
               status: "reconnect-required",
+              icon: {
+                url: "https://icons.example.test/gmail.svg",
+                invertInDarkMode: true,
+                scale: 1.25,
+              },
             },
             {
               connectorRef: "linear",
@@ -1548,6 +1553,27 @@ describe("workflow detail page", () => {
       within(readiness).getByText("Currently unavailable"),
     ).toBeInTheDocument();
     expect(within(readiness).getByText("Connected")).toBeInTheDocument();
+
+    const gmailRow = within(readiness).getByText("Gmail").closest("li");
+    if (!(gmailRow instanceof HTMLElement)) {
+      throw new Error("Gmail readiness row not found");
+    }
+    expect(gmailRow.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://icons.example.test/gmail.svg",
+    );
+    expect(gmailRow.querySelector("img")).toHaveClass("zero-icon-mono");
+    expect(gmailRow.querySelector("img")).toHaveStyle({
+      transform: "scale(1.25)",
+    });
+
+    const linearRow = within(readiness).getByText("Linear").closest("li");
+    if (!(linearRow instanceof HTMLElement)) {
+      throw new Error("Linear readiness row not found");
+    }
+    expect(within(linearRow).getByRole("img")).toHaveAccessibleName(
+      "Connector icon unavailable",
+    );
 
     expect(linkByText("Reconnect Gmail", readiness)).toHaveAttribute(
       "href",

--- a/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflow-detail-page.tsx
@@ -1061,7 +1061,7 @@ function WorkflowConnectorReadinessRow({
     <li className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:gap-4 sm:px-5">
       <div className="flex min-w-0 flex-1 items-start gap-3">
         <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-50">
-          <ConnectorIcon type={entry.connectorRef} size={18} />
+          <ConnectorIcon icon={entry.icon} size={18} />
         </span>
         <div className="min-w-0">
           <p className="truncate text-sm font-medium text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -34,10 +34,14 @@ function catalogPermissionDetail(
       "connectorRef" | "label" | "permissions"
     >,
 ): PublicConnectorCatalogPermissionDetail {
-  const { connectorRef, label, permissions, ...rest } = overrides;
+  const { connectorRef, label, permissions, icon, ...rest } = overrides;
   return {
     connectorRef,
     label,
+    icon: icon ?? {
+      url: `https://icons.example.test/${connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     permissionCount: permissions.length,
     permissions,
     categories: null,
@@ -90,11 +94,15 @@ function publicConnectorStatusItem(
   overrides: Partial<PublicConnectorCatalogStatusItem> &
     Pick<PublicConnectorCatalogStatusItem, "connectorRef" | "label">,
 ): PublicConnectorCatalogStatusItem {
-  const { connectorRef, label, ...rest } = overrides;
+  const { connectorRef, label, icon, ...rest } = overrides;
   return {
     connectorRef,
     label,
     description: `${label} public help text`,
+    icon: icon ?? {
+      url: `https://icons.example.test/${connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     category: "data-automation-infrastructure",
     generation: [],
     tags: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -206,6 +206,10 @@ describe("chat message action cards", () => {
         connectorRef: "github",
         label: "Catalog GitHub",
         description: "Catalog GitHub server help text",
+        icon: {
+          url: "https://icons.example.test/action-github.svg",
+          invertInDarkMode: true,
+        },
         connected: true,
         connectionStatus: "connected",
         connection: {
@@ -289,6 +293,10 @@ describe("chat message action cards", () => {
     expect(
       within(connectorCard).getByText("Catalog GitHub server help text"),
     ).toBeInTheDocument();
+    expect(connectorCard.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://icons.example.test/action-github.svg",
+    );
     await user.click(within(connectorCard).getByText("Connect"));
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -259,8 +259,11 @@ function publicStatusItem(args: {
     connectorRef: args.connectorRef,
     label: args.label,
     description: args.description ?? `${args.label} public description`,
+    icon: args.icon ?? {
+      url: `https://icons.example.test/${args.connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     category: args.category ?? "data-automation-infrastructure",
-    ...(args.icon ? { icon: args.icon } : {}),
     generation: [],
     tags: [],
     authMethods: args.authMethods,
@@ -481,27 +484,6 @@ describe("connectors page", () => {
     expect(slackIcon).not.toHaveClass("zero-icon-mono");
     expect(slackIcon).toHaveStyle({ transform: "scale(1.5)" });
     expect(slackIcon.closest(".overflow-hidden")).toBeInTheDocument();
-  });
-
-  it("renders an accessible fallback when a catalog icon is missing", async () => {
-    mockConnectors([]);
-    mockPublicConnectorStatus([
-      publicStatusItem({
-        connectorRef: "github",
-        label: "GitHub",
-        authMethods: [],
-      }),
-    ]);
-
-    detachedSetupPage({ context, path: "/connectors" });
-
-    const githubCard = await waitFor(() => {
-      return connectorCardByLabel("GitHub");
-    });
-    expect(within(githubCard).queryByRole("img")).toHaveAccessibleName(
-      "Connector icon unavailable",
-    );
-    expect(githubCard).toHaveAccessibleName("Connect GitHub");
   });
 
   it("renders server-authored connector categories unknown to the browser", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -250,6 +250,7 @@ function publicStatusItem(args: {
   readonly label: string;
   readonly description?: string;
   readonly category?: string;
+  readonly icon?: PublicConnectorCatalogStatusItem["icon"];
   readonly authMethods: PublicConnectorCatalogStatusItem["authMethods"];
   readonly singleAuthCodeAuthMethodId?: string | null;
   readonly connectNotice?: PublicConnectorCatalogStatusItem["connectNotice"];
@@ -259,6 +260,7 @@ function publicStatusItem(args: {
     label: args.label,
     description: args.description ?? `${args.label} public description`,
     category: args.category ?? "data-automation-infrastructure",
+    ...(args.icon ? { icon: args.icon } : {}),
     generation: [],
     tags: [],
     authMethods: args.authMethods,
@@ -433,8 +435,29 @@ describe("connectors page", () => {
     ).toBeTruthy();
   });
 
-  it("preserves static connector icon rendering during catalog migration", async () => {
+  it("renders connector icons from server-authored catalog descriptors", async () => {
     mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "github",
+        label: "GitHub",
+        icon: {
+          url: "https://icons.example.test/github.svg",
+          invertInDarkMode: true,
+        },
+        authMethods: [],
+      }),
+      publicStatusItem({
+        connectorRef: "slack",
+        label: "Slack",
+        icon: {
+          url: "https://icons.example.test/slack.svg",
+          invertInDarkMode: false,
+          scale: 1.5,
+        },
+        authMethods: [],
+      }),
+    ]);
 
     detachedSetupPage({ context, path: "/connectors" });
 
@@ -446,18 +469,39 @@ describe("connectors page", () => {
     const githubIcon = connectorIconByLabel("GitHub");
     expect(githubIcon).toHaveAttribute(
       "src",
-      "https://static.vm0.io/platform/views/zero-page/components/settings/icons/github-4a739019d805.svg",
+      "https://icons.example.test/github.svg",
     );
     expect(githubIcon).toHaveClass("zero-icon-mono");
 
     const slackIcon = connectorIconByLabel("Slack");
     expect(slackIcon).toHaveAttribute(
       "src",
-      "https://static.vm0.io/platform/views/zero-page/components/settings/icons/slack-198390069136.svg?v=568fa471",
+      "https://icons.example.test/slack.svg",
     );
     expect(slackIcon).not.toHaveClass("zero-icon-mono");
-    expect(slackIcon).toHaveClass("scale-[2.2]");
-    expect(slackIcon.parentElement).toHaveClass("overflow-hidden");
+    expect(slackIcon).toHaveStyle({ transform: "scale(1.5)" });
+    expect(slackIcon.closest(".overflow-hidden")).toBeInTheDocument();
+  });
+
+  it("renders an accessible fallback when a catalog icon is missing", async () => {
+    mockConnectors([]);
+    mockPublicConnectorStatus([
+      publicStatusItem({
+        connectorRef: "github",
+        label: "GitHub",
+        authMethods: [],
+      }),
+    ]);
+
+    detachedSetupPage({ context, path: "/connectors" });
+
+    const githubCard = await waitFor(() => {
+      return connectorCardByLabel("GitHub");
+    });
+    expect(within(githubCard).queryByRole("img")).toHaveAccessibleName(
+      "Connector icon unavailable",
+    );
+    expect(githubCard).toHaveAccessibleName("Connect GitHub");
   });
 
   it("renders server-authored connector categories unknown to the browser", async () => {
@@ -1963,6 +2007,10 @@ describe("connectors page", () => {
       connectorRef: "axiom",
       label: "Public Axiom",
       description: "Public Axiom description",
+      icon: {
+        url: "https://icons.example.test/axiom-v1.svg",
+        invertInDarkMode: false,
+      },
       authMethods: [
         {
           id: "api-token",
@@ -1998,6 +2046,10 @@ describe("connectors page", () => {
         catalogStatusItems = [
           {
             ...disconnectedAxiom,
+            icon: {
+              url: "https://icons.example.test/axiom-v2.svg",
+              invertInDarkMode: true,
+            },
             connection: {
               authMethod: body.authMethod,
               externalUsername: null,
@@ -2033,6 +2085,15 @@ describe("connectors page", () => {
     expect(
       within(connectorCardByLabel("Public Axiom")).queryByText("Connected"),
     ).not.toBeInTheDocument();
+    const initialIcon = connectorIconByLabel("Public Axiom");
+    expect(initialIcon).toHaveAttribute(
+      "src",
+      "https://icons.example.test/axiom-v1.svg",
+    );
+    fireEvent.error(initialIcon);
+    expect(
+      within(connectorCardByLabel("Public Axiom")).getByRole("img"),
+    ).toHaveAccessibleName("Connector icon unavailable");
 
     const abortScope = context.store.set(
       abortAfterManualGrantConnectSignalScope$,
@@ -2068,6 +2129,13 @@ describe("connectors page", () => {
       expect(
         within(connectorCardByLabel("Public Axiom")).getByText("Connected"),
       ).toBeInTheDocument();
+      expect(connectorIconByLabel("Public Axiom")).toHaveAttribute(
+        "src",
+        "https://icons.example.test/axiom-v2.svg",
+      );
+      expect(connectorIconByLabel("Public Axiom")).toHaveClass(
+        "zero-icon-mono",
+      );
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -44,6 +44,10 @@ function publicStatusItem(args: {
     connectorRef: args.connectorRef,
     label: args.label,
     description: args.description ?? `${args.label} public description`,
+    icon: {
+      url: `https://icons.example.test/${args.connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     category: args.category ?? "data-automation-infrastructure",
     generation: [],
     tags: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -27,6 +27,13 @@ const context = testContext();
 const AGENT_ID = "00000000-0000-0000-0000-000000000001";
 const SECOND_AGENT_ID = "00000000-0000-0000-0000-000000000002";
 
+function connectorIcon(connectorRef: string) {
+  return {
+    url: `https://icons.example.test/${connectorRef}.svg`,
+    invertInDarkMode: false,
+  };
+}
+
 function mockPublicConnectorStatus(
   connector: PublicConnectorCatalogStatusItem,
 ): void {
@@ -50,6 +57,7 @@ function publicManualTokenConnectorStatus(args: {
     connectorRef: args.connectorRef,
     label: args.label,
     description: `${args.label} description`,
+    icon: connectorIcon(args.connectorRef),
     category: "data-automation-infrastructure",
     generation: [],
     tags: [],
@@ -97,6 +105,7 @@ function publicOAuthConnectorStatus(args: {
     connectorRef: args.connectorRef,
     label: args.label,
     description: `${args.label} description`,
+    icon: connectorIcon(args.connectorRef),
     category: "engineering-team-execution",
     generation: [],
     tags: [],
@@ -135,6 +144,7 @@ function publicNoAuthConnectorStatus(args: {
     connectorRef: args.connectorRef,
     label: args.label,
     description: `${args.label} description`,
+    icon: connectorIcon(args.connectorRef),
     category: "data-automation-infrastructure",
     generation: [],
     tags: [],
@@ -191,6 +201,7 @@ function steamOpenIdConnectorStatus(): PublicConnectorCatalogStatusItem {
     connectorRef: "steam",
     label: "Public Steam",
     description: "Public Steam description",
+    icon: connectorIcon("steam"),
     category: "data-automation-infrastructure",
     generation: [],
     tags: [],
@@ -290,6 +301,7 @@ describe("directed connector connect page", () => {
       connectorRef: "github",
       label: "Public GitHub",
       description: "Public GitHub description",
+      icon: connectorIcon("github"),
       category: "engineering-team-execution",
       generation: [],
       tags: [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -36,6 +36,10 @@ function publicConnectorStatusItem(
     label: connectorRef,
     description: `${connectorRef} public description`,
     category: "data-automation-infrastructure",
+    icon: {
+      url: `https://icons.example.test/${connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
     generation: [],
     tags: [],
     authMethods: [],
@@ -200,6 +204,9 @@ describe("zero ideation page", () => {
     const card = await cardByTitle("Daily standup report");
 
     expect(card.querySelectorAll("img")).toHaveLength(5);
+    expect(
+      card.querySelector('img[src="https://icons.example.test/github.svg"]'),
+    ).toBeInTheDocument();
   });
 
   it("hides use cases when any required connector is omitted from catalog", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-image-edit.test.tsx
@@ -307,6 +307,10 @@ function xConnectorStatusItem(args?: {
     connectorRef: "x",
     label: "X",
     description: "Connect your X account",
+    icon: {
+      url: "https://icons.example.test/x.svg",
+      invertInDarkMode: false,
+    },
     category: "marketing-content-growth",
     generation: [],
     tags: [],

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@tabler/icons-react";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type { GenerationTemplateRequest } from "@vm0/api-contracts/contracts/chat-threads";
+import type { PublicConnectorCatalogStatusItem } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
   Button,
   Tooltip,
@@ -47,6 +48,7 @@ import { ReplaceComposerDraftDialog } from "./replace-composer-draft-dialog.tsx"
 import { CREATE_WORKFLOW_WITH_CHAT_PROMPT } from "./workflow-chat-prompts.ts";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
 import {
   replaceWorkflowPromptDraftTarget$,
   setReplaceWorkflowPromptDraftTarget$,
@@ -77,10 +79,7 @@ import {
   ZERO_DESKTOP_DOWNLOAD_URL,
 } from "../../signals/zero-page/computer-use-hosts.ts";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
-import {
-  ConnectorIcon,
-  isConnectorIconType,
-} from "./components/settings/connector-icons.tsx";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
@@ -291,12 +290,20 @@ interface SuggestedPrompt {
 
 function SuggestedPromptButton({
   item,
+  connectorStatusByRef,
   onSelectPrompt,
 }: {
   item: SuggestedPrompt;
+  connectorStatusByRef:
+    | ReadonlyMap<string, PublicConnectorCatalogStatusItem>
+    | undefined;
   onSelectPrompt: (prompt: string) => void;
 }) {
-  const connectorIconTypes = item.connectors?.filter(isConnectorIconType) ?? [];
+  const connectors =
+    item.connectors?.flatMap((connectorRef) => {
+      const connector = connectorStatusByRef?.get(connectorRef);
+      return connector ? [{ connectorRef, icon: connector.icon }] : [];
+    }) ?? [];
   return (
     <button
       type="button"
@@ -314,15 +321,15 @@ function SuggestedPromptButton({
       <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
         {item.description}
       </p>
-      {connectorIconTypes.length > 0 && (
+      {connectors.length > 0 && (
         <div className="flex items-center gap-1.5 mt-auto pt-2.5">
-          {connectorIconTypes.map((type) => {
+          {connectors.map((connector) => {
             return (
               <span
-                key={type}
+                key={connector.connectorRef}
                 className="flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background"
               >
-                <ConnectorIcon type={type} size={14} />
+                <ConnectorIcon icon={connector.icon} size={14} />
               </span>
             );
           })}
@@ -432,6 +439,7 @@ function SuggestedPromptsGrid({
 }: {
   onSelectPrompt: (prompt: string) => void;
 }) {
+  const connectorStatusByRef = useLastResolved(connectorCatalogStatusByRef$);
   const unfilteredSuggestedPrompts =
     useLastResolved(unfilteredSuggestedPrompts$) ?? [];
   const suggestedPromptsLoadable = useLoadable(suggestedPrompts$);
@@ -449,6 +457,7 @@ function SuggestedPromptsGrid({
           <SuggestedPromptButton
             key={item.title}
             item={item}
+            connectorStatusByRef={connectorStatusByRef}
             onSelectPrompt={onSelectPrompt}
           />
         );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -1306,7 +1306,7 @@ export function ConnectModal({
         <DialogHeader>
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">
-              <ConnectorIcon type={selectedType} size={20} />
+              <ConnectorIcon icon={item.icon} size={20} />
             </div>
             <DialogTitle>{item.label}</DialogTitle>
           </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-access-management-dialog.tsx
@@ -232,7 +232,6 @@ function LoadingAgents() {
 
 function ConnectorAccessDialog({
   onClose,
-  connectorType,
   connectorLabel,
   rows,
   rowsLoaded,
@@ -244,7 +243,6 @@ function ConnectorAccessDialog({
   onManage,
 }: {
   readonly onClose: () => void;
-  readonly connectorType: ConnectorType;
   readonly connectorLabel: string;
   readonly rows: readonly ConnectorAgentAccessRow[];
   readonly rowsLoaded: boolean;
@@ -269,7 +267,7 @@ function ConnectorAccessDialog({
         <DialogHeader className="shrink-0 gap-2">
           <div className="flex items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
-              <ConnectorIcon type={connectorType} size={22} />
+              <ConnectorIcon icon={metadata?.icon} size={22} />
             </span>
             <div className="min-w-0">
               <DialogTitle className="text-base">
@@ -426,7 +424,6 @@ export function ConnectorAccessManagementDialog({
     <>
       <ConnectorAccessDialog
         onClose={onClose}
-        connectorType={connectorType}
         connectorLabel={connectorLabel}
         rows={filterRows(rows, search)}
         rowsLoaded={rowsLoadable.state === "hasData"}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-icons.tsx
@@ -1,27 +1,36 @@
-import type { ConnectorType } from "@vm0/connectors/connectors";
-import {
-  getStaticConnectorIconMetadata,
-  isStaticConnectorIconType,
-} from "@vm0/connectors/static-connector-icons";
+import { IconPlug } from "@tabler/icons-react";
+import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { cn } from "@vm0/ui";
 
-export function isConnectorIconType(type: string): type is ConnectorType {
-  return isStaticConnectorIconType(type);
+function ConnectorIconFallback({
+  size,
+  hidden = false,
+}: {
+  size: number;
+  hidden?: boolean;
+}) {
+  return (
+    <span
+      hidden={hidden}
+      role="img"
+      aria-label="Connector icon unavailable"
+      className="inline-flex h-full w-full items-center justify-center text-muted-foreground"
+    >
+      <IconPlug size={size * 0.65} stroke={1.5} aria-hidden="true" />
+    </span>
+  );
 }
 
-/**
- * Connector mark in a square slot. The asset scales with `object-contain` so the
- * drawable uses the full `size×size` box (e.g. a 20×28 logo fills height in a 28×28 slot).
- */
+/** Connector mark in a square slot, driven by public catalog display data. */
 export function ConnectorIcon({
-  type,
+  icon,
   size = 28,
 }: {
-  type: ConnectorType;
+  icon: PublicConnectorCatalogIcon | undefined;
   size?: number;
 }) {
-  const icon = getStaticConnectorIconMetadata(type);
-  const scaled = icon.scale !== undefined;
+  const scaled = icon?.scale !== undefined;
+
   return (
     <span
       className={cn(
@@ -30,16 +39,34 @@ export function ConnectorIcon({
       )}
       style={{ width: size, height: size }}
     >
-      <img
-        src={icon.url}
-        alt=""
-        decoding="async"
-        className={cn(
-          "block h-full w-full max-h-full max-w-full object-contain",
-          icon.invertInDarkMode && "zero-icon-mono",
-          scaled && "scale-[2.2]",
-        )}
-      />
+      {icon === undefined ? (
+        <ConnectorIconFallback size={size} />
+      ) : (
+        <span
+          key={icon.url}
+          className="inline-flex h-full w-full items-center justify-center"
+        >
+          <img
+            src={icon.url}
+            alt=""
+            decoding="async"
+            className={cn(
+              "block h-full w-full max-h-full max-w-full object-contain",
+              icon.invertInDarkMode && "zero-icon-mono",
+            )}
+            style={
+              icon.scale === undefined
+                ? undefined
+                : { transform: `scale(${icon.scale})` }
+            }
+            onError={(event) => {
+              event.currentTarget.hidden = true;
+              event.currentTarget.nextElementSibling?.removeAttribute("hidden");
+            }}
+          />
+          <ConnectorIconFallback size={size} hidden />
+        </span>
+      )}
     </span>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/connector-permission-dialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogFooter,
 } from "@vm0/ui/components/ui/dialog";
 import { Button } from "@vm0/ui/components/ui/button";
+import type { PublicConnectorCatalogIcon } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import type { ConnectorType } from "@vm0/connectors/connectors";
 import { agents$ } from "../../../../signals/agent.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
@@ -30,12 +31,14 @@ const VISIBLE_AGENT_COUNT = 16;
 interface ConnectorPermissionDialogProps {
   connectorType: ConnectorType;
   connectorLabel: string;
+  icon: PublicConnectorCatalogIcon | undefined;
   onClose: () => void;
 }
 
 export function ConnectorPermissionDialog({
   connectorType,
   connectorLabel,
+  icon,
   onClose,
 }: ConnectorPermissionDialogProps) {
   const allAgents = useLastResolved(agents$);
@@ -79,7 +82,7 @@ export function ConnectorPermissionDialog({
       >
         <DialogHeader className="mt-5 items-center gap-2.5 text-center">
           <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
-            <ConnectorIcon type={connectorType} size={20} />
+            <ConnectorIcon icon={icon} size={20} />
           </div>
           <DialogTitle className="text-base font-medium">
             {connectorLabel}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -23,7 +23,10 @@ import {
   DropdownMenuItem,
 } from "@vm0/ui";
 import type { ConnectorType } from "@vm0/connectors/connectors";
-import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import type {
+  PublicConnectorCatalogIcon,
+  PublicConnectorCatalogPermissionDetail,
+} from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import { groupFirewallMetadataPermissionsByCategory } from "@vm0/connectors/firewall-metadata/policy";
 import {
   UNKNOWN_PERMISSION_GRANT,
@@ -183,15 +186,16 @@ function buildInitialPermissionDrawerState({
 }
 
 function PermissionsDrawerHeader({
-  connectorType,
+  icon,
   connectorLabel,
   displayName,
   targetKind = "agent",
   surface,
 }: Pick<
   PermissionsDrawerProps,
-  "connectorType" | "connectorLabel" | "displayName" | "targetKind"
+  "connectorLabel" | "displayName" | "targetKind"
 > & {
+  readonly icon: PublicConnectorCatalogIcon | undefined;
   readonly surface: PermissionsSurface;
 }) {
   const title = (
@@ -211,7 +215,7 @@ function PermissionsDrawerHeader({
     return (
       <DialogHeader>
         <div className="flex items-center gap-3">
-          <ConnectorIcon type={connectorType} size={24} />
+          <ConnectorIcon icon={icon} size={24} />
           <DialogTitle className="text-base">{title}</DialogTitle>
         </div>
         <DialogDescription>{description}</DialogDescription>
@@ -222,7 +226,7 @@ function PermissionsDrawerHeader({
   return (
     <SheetHeader>
       <div className="flex items-center gap-3">
-        <ConnectorIcon type={connectorType} size={24} />
+        <ConnectorIcon icon={icon} size={24} />
         <SheetTitle className="text-base">{title}</SheetTitle>
       </div>
       <SheetDescription>{description}</SheetDescription>
@@ -1550,7 +1554,7 @@ function PermissionsContent({
   return (
     <>
       <PermissionsDrawerHeader
-        connectorType={props.connectorType}
+        icon={loadedMetadata?.icon}
         connectorLabel={props.connectorLabel}
         displayName={props.displayName}
         targetKind={props.targetKind}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -33,10 +33,10 @@ export function ScopeReviewModal({
     return null;
   }
 
-  const connectorLabel =
-    connectorTypes?.find((connector) => {
-      return connector.type === connectorType;
-    })?.label ?? connectorType;
+  const connector = connectorTypes?.find((candidate) => {
+    return candidate.type === connectorType;
+  });
+  const connectorLabel = connector?.label ?? connectorType;
 
   return (
     <Dialog
@@ -49,7 +49,7 @@ export function ScopeReviewModal({
         <DialogHeader>
           <div className="flex items-center gap-3">
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">
-              <ConnectorIcon type={connectorType} size={20} />
+              <ConnectorIcon icon={connector?.icon} size={20} />
             </div>
             <DialogTitle>{connectorLabel} permissions update</DialogTitle>
           </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/settings-icon-assets.ts
@@ -1,12 +1,6 @@
-import {
-  connectorIconAssetUrl,
-  isConnectorIconAssetKey,
-  type ConnectorIconAssetKey,
-} from "@vm0/connectors/static-connector-icons";
-
 import { platformStaticAssetUrl } from "../../../../lib/static-assets.ts";
 
-const SETTINGS_ONLY_ICON_ASSET_PATHS = {
+const SETTINGS_ICON_ASSET_PATHS = {
   anthropic:
     "views/zero-page/components/settings/icons/anthropic-3fcfdf761a69.svg",
   azure: "views/zero-page/components/settings/icons/azure-a3fe212c8716.svg",
@@ -14,6 +8,9 @@ const SETTINGS_ONLY_ICON_ASSET_PATHS = {
   chatglm: "views/zero-page/components/settings/icons/chatglm-7e6a9cb772fa.svg",
   "claude-code":
     "views/zero-page/components/settings/icons/claude-code-03a5132e24ca.svg",
+  deepseek:
+    "views/zero-page/components/settings/icons/deepseek-a8663c0a81d9.svg",
+  github: "views/zero-page/components/settings/icons/github-4a739019d805.svg",
   imessage:
     "views/zero-page/components/settings/icons/imessage-5275a5a9cb9a.svg",
   kimi: "views/zero-page/components/settings/icons/kimi-bd6d8b8d5390.svg",
@@ -21,38 +18,21 @@ const SETTINGS_ONLY_ICON_ASSET_PATHS = {
     "views/zero-page/components/settings/icons/local-agent-57c613146fc9.svg",
   "local-browser":
     "views/zero-page/components/settings/icons/local-browser-9a71e5c6fee7.svg",
+  minimax: "views/zero-page/components/settings/icons/minimax-ec3b12fc26ff.svg",
+  openai: "views/zero-page/components/settings/icons/openai-df8a3d9c4274.svg",
+  openrouter:
+    "views/zero-page/components/settings/icons/openrouter-82e9dead836b.svg",
+  slack:
+    "views/zero-page/components/settings/icons/slack-198390069136.svg?v=568fa471",
   teams: "views/zero-page/components/settings/icons/teams-0dc3a5275d31.svg",
   telegram:
     "views/zero-page/components/settings/icons/telegram-2d9ff5d01146.svg",
+  vercel: "views/zero-page/components/settings/icons/vercel-c2c941b10e27.svg",
   vm0: "views/zero-page/components/settings/icons/vm0-0b40ba3af356.svg",
 } as const;
 
-type SettingsOnlyIconAssetKey = keyof typeof SETTINGS_ONLY_ICON_ASSET_PATHS;
-type SettingsIconAssetKey = ConnectorIconAssetKey | SettingsOnlyIconAssetKey;
-
-function isSettingsOnlyIconAssetKey(
-  key: string,
-): key is SettingsOnlyIconAssetKey {
-  return Object.prototype.hasOwnProperty.call(
-    SETTINGS_ONLY_ICON_ASSET_PATHS,
-    key,
-  );
-}
+type SettingsIconAssetKey = keyof typeof SETTINGS_ICON_ASSET_PATHS;
 
 export function settingsIconAssetUrl(key: SettingsIconAssetKey): string {
-  const url = maybeSettingsIconAssetUrl(key);
-  if (url !== undefined) {
-    return url;
-  }
-  throw new Error(`Missing settings icon asset for "${key}"`);
-}
-
-export function maybeSettingsIconAssetUrl(key: string): string | undefined {
-  if (isConnectorIconAssetKey(key)) {
-    return connectorIconAssetUrl(key);
-  }
-  if (isSettingsOnlyIconAssetKey(key)) {
-    return platformStaticAssetUrl(SETTINGS_ONLY_ICON_ASSET_PATHS[key]);
-  }
-  return undefined;
+  return platformStaticAssetUrl(SETTINGS_ICON_ASSET_PATHS[key]);
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -135,10 +135,7 @@ import {
   ModelProviderPicker,
   type ModelProviderSelection,
 } from "./components/model-provider-picker.tsx";
-import {
-  ConnectorIcon,
-  isConnectorIconType,
-} from "./components/settings/connector-icons.tsx";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import {
   allConnectorTypes$,
@@ -419,6 +416,7 @@ interface ComposerConnectorItem {
   type: ConnectorType;
   label: string;
   helpText: string;
+  icon: ConnectorTypeWithStatus["icon"];
   tags: readonly string[];
   connected: boolean;
   authorized: boolean;
@@ -1399,49 +1397,62 @@ function WorkflowTemplateConnectorIcons({
   connectors,
   compact = false,
   limit = compact ? 3 : 5,
+  withDivider = false,
 }: {
-  // Loosely typed: the curated catalog stores connectors as plain strings;
-  // isConnectorIconType narrows to the ones that actually have an icon.
   connectors: readonly string[];
   compact?: boolean;
   limit?: number;
+  withDivider?: boolean;
 }) {
-  const connectorIconTypes = connectors.filter(isConnectorIconType);
-  if (connectorIconTypes.length === 0) {
+  const catalogConnectors = useLastResolved(allConnectorTypes$);
+  const visibleConnectors = connectors.flatMap((connectorRef) => {
+    const connector = catalogConnectors?.find((candidate) => {
+      return candidate.type === connectorRef;
+    });
+    return connector ? [connector] : [];
+  });
+  if (visibleConnectors.length === 0) {
     return null;
   }
 
-  const visibleConnectorTypes = connectorIconTypes.slice(0, limit);
-  const remainingCount =
-    connectorIconTypes.length - visibleConnectorTypes.length;
+  const displayedConnectors = visibleConnectors.slice(0, limit);
+  const remainingCount = visibleConnectors.length - displayedConnectors.length;
   return (
-    <span
-      className={cn("flex min-w-0 items-center", compact ? "gap-1" : "gap-1.5")}
-    >
-      {visibleConnectorTypes.map((type) => {
-        return (
+    <>
+      {withDivider ? (
+        <span className="h-3.5 w-px shrink-0 bg-border/70" />
+      ) : null}
+      <span
+        className={cn(
+          "flex min-w-0 items-center",
+          compact ? "gap-1" : "gap-1.5",
+        )}
+      >
+        {displayedConnectors.map((connector) => {
+          return (
+            <span
+              key={connector.type}
+              className={cn(
+                "flex shrink-0 items-center justify-center border border-border/60 bg-background",
+                compact ? "h-5 w-5 rounded" : "h-7 w-7 rounded-md",
+              )}
+            >
+              <ConnectorIcon icon={connector.icon} size={compact ? 12 : 14} />
+            </span>
+          );
+        })}
+        {remainingCount > 0 ? (
           <span
-            key={type}
             className={cn(
-              "flex shrink-0 items-center justify-center border border-border/60 bg-background",
-              compact ? "h-5 w-5 rounded" : "h-7 w-7 rounded-md",
+              "flex shrink-0 items-center justify-center rounded border border-border/60 bg-background text-[10px] font-medium text-muted-foreground",
+              compact ? "h-5 min-w-5 px-1" : "h-7 min-w-7 px-1.5",
             )}
           >
-            <ConnectorIcon type={type} size={compact ? 12 : 14} />
+            +{remainingCount}
           </span>
-        );
-      })}
-      {remainingCount > 0 ? (
-        <span
-          className={cn(
-            "flex shrink-0 items-center justify-center rounded border border-border/60 bg-background text-[10px] font-medium text-muted-foreground",
-            compact ? "h-5 min-w-5 px-1" : "h-7 min-w-7 px-1.5",
-          )}
-        >
-          +{remainingCount}
-        </span>
-      ) : null}
-    </span>
+        ) : null}
+      </span>
+    </>
   );
 }
 
@@ -5512,7 +5523,6 @@ function SelectedWorkflowTemplateChip({
   onOpen: () => void;
   onRemove: () => void;
 }) {
-  const hasConnectorIcons = item.connectors.some(isConnectorIconType);
   return (
     <div className="px-4 pt-3">
       <div className="flex">
@@ -5533,15 +5543,11 @@ function SelectedWorkflowTemplateChip({
             <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
               Workflow
             </span>
-            {hasConnectorIcons ? (
-              <>
-                <span className="h-3.5 w-px shrink-0 bg-border/70" />
-                <WorkflowTemplateConnectorIcons
-                  connectors={item.connectors}
-                  compact
-                />
-              </>
-            ) : null}
+            <WorkflowTemplateConnectorIcons
+              connectors={item.connectors}
+              compact
+              withDivider
+            />
             <span className="h-3.5 w-px shrink-0 bg-border/70" />
             <span className="min-w-0 truncate text-xs font-medium">
               {item.title}
@@ -5922,7 +5928,7 @@ function ConnectorTriggerIcons({
         return (
           <span key={c.type} className="relative shrink-0">
             <span className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full bg-background zero-border sm:h-7 sm:w-7">
-              <ConnectorIcon type={c.type} size={16} />
+              <ConnectorIcon icon={c.icon} size={16} />
             </span>
           </span>
         );
@@ -5999,7 +6005,7 @@ function AddConnectorsDialog({
                 >
                   <div className="flex items-center gap-2.5 px-4 pt-4 pb-1">
                     <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-                      <ConnectorIcon type={item.type} size={20} />
+                      <ConnectorIcon icon={item.icon} size={20} />
                     </span>
                     <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
                       {item.label}
@@ -6265,7 +6271,7 @@ function ConnectorsPopoverButton({
                       className="flex cursor-pointer items-center gap-2 px-3 py-2 hover:bg-muted/50 transition-colors"
                     >
                       <span className="flex h-4 w-4 shrink-0 items-center justify-center">
-                        <ConnectorIcon type={item.type} size={16} />
+                        <ConnectorIcon icon={item.icon} size={16} />
                       </span>
                       <span className="text-sm flex-1 truncate text-foreground">
                         {item.label}
@@ -7331,6 +7337,7 @@ export function useZeroChatComposer({
       type: c.type,
       label: c.label,
       helpText: c.helpText,
+      icon: c.icon,
       tags: c.tags,
       connected,
       authorized,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -5572,7 +5572,7 @@ function PermissionActionCardContent({
   onClick,
 }: {
   block: PermissionActionBlock;
-  icon: PublicConnectorCatalogPermissionDetail["icon"];
+  icon: PublicConnectorCatalogPermissionDetail["icon"] | undefined;
   connectorLabel: string;
   actionLabel: string;
   permissionName: string;

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -153,10 +153,7 @@ import type { PermissionActionBlock } from "../../signals/chat-page/permission-a
 import type { ComputerUseAuthorizationBlock } from "../../signals/chat-page/computer-use-authorization-block.ts";
 import { AttachmentPreview } from "./zero-attachment-preview.tsx";
 import { FilePreviewIcon } from "./zero-file-preview-icon.tsx";
-import {
-  ConnectorIcon,
-  isConnectorIconType,
-} from "./components/settings/connector-icons.tsx";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { PermissionGrantDurationSelect } from "../components/permission-grant-duration-select.tsx";
 import { lightboxUrl$ as attachmentLightboxUrl$ } from "../../signals/zero-page/zero-attachment-chips.ts";
@@ -5054,11 +5051,7 @@ function ConnectorActionCard({ block }: { block: ConnectorActionBlock }) {
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          {connectorType ? (
-            <ConnectorIcon type={connectorType} size={22} />
-          ) : (
-            <IconPackage size={22} />
-          )}
+          <ConnectorIcon icon={displayMetadata.icon} size={22} />
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
@@ -5567,6 +5560,7 @@ function createPermissionActionHandler(params: {
 
 function PermissionActionCardContent({
   block,
+  icon,
   connectorLabel,
   actionLabel,
   permissionName,
@@ -5578,6 +5572,7 @@ function PermissionActionCardContent({
   onClick,
 }: {
   block: PermissionActionBlock;
+  icon: PublicConnectorCatalogPermissionDetail["icon"];
   connectorLabel: string;
   actionLabel: string;
   permissionName: string;
@@ -5588,11 +5583,6 @@ function PermissionActionCardContent({
   expiresAt: string | null;
   onClick: () => void;
 }) {
-  const connectorIcon = isConnectorIconType(block.connectorRef) ? (
-    <ConnectorIcon type={block.connectorRef} size={22} />
-  ) : (
-    <IconPackage size={22} />
-  );
   const expiryText = expirationAvailable
     ? permissionGrantExpiryText(expiresAt)
     : null;
@@ -5608,7 +5598,7 @@ function PermissionActionCardContent({
     >
       <div className="flex min-w-0 items-center gap-3">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/40">
-          {connectorIcon}
+          <ConnectorIcon icon={icon} size={22} />
         </div>
         <div className="min-w-0">
           <div className="truncate text-[0.9375rem] font-medium text-foreground">
@@ -5704,6 +5694,7 @@ function PermissionActionCardForTarget({
   return (
     <PermissionActionCardContent
       block={block}
+      icon={permissionMetadata?.icon}
       connectorLabel={permissionMetadata?.label ?? block.connectorRef}
       actionLabel={actionState.actionLabel}
       permissionName={actionState.focusedPermission?.name ?? block.permission}

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -683,7 +683,7 @@ function GlobalConnectorCard({
     <div className="zero-card flex flex-col">
       <div className="flex h-14 items-center gap-2.5 px-5">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          <ConnectorIcon type={connector.type} size={20} />
+          <ConnectorIcon icon={connector.icon} size={20} />
         </span>
         <span
           data-testid="connector-card-label"
@@ -775,7 +775,7 @@ function AvailableConnectorCard({
     >
       <div className="flex items-center gap-2.5 px-5 pt-4 pb-1">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-          <ConnectorIcon type={connector.type} size={20} />
+          <ConnectorIcon icon={connector.icon} size={20} />
         </span>
         <span
           data-testid="connector-card-label"
@@ -958,6 +958,11 @@ export function ZeroConnectorsPage() {
       : undefined;
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
+  const permissionDialogConnector = permissionDialog
+    ? allConnectors.find((connector) => {
+        return connector.type === permissionDialog.type;
+      })
+    : undefined;
   const managedConnectorLabel = connectorLabelForType(
     allConnectors,
     managedConnectorType,
@@ -1202,6 +1207,7 @@ export function ZeroConnectorsPage() {
         <ConnectorPermissionDialog
           connectorType={permissionDialog.type}
           connectorLabel={permissionDialog.label}
+          icon={permissionDialogConnector?.icon}
           onClose={closePermissionDialog}
         />
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -184,7 +184,7 @@ function directedAuthorizeConnectModalOpen(
 }
 
 function DirectedAuthorizeCardContent({
-  connectorType,
+  icon,
   connectorLabel,
   connectorDescription,
   agentName,
@@ -194,7 +194,7 @@ function DirectedAuthorizeCardContent({
   canAuthorize,
   onAuthorize,
 }: {
-  readonly connectorType: ConnectorType;
+  readonly icon: ConnectorTypeWithStatus["icon"];
   readonly connectorLabel: string;
   readonly connectorDescription: string;
   readonly agentName: string;
@@ -223,7 +223,7 @@ function DirectedAuthorizeCardContent({
                     : `${agentName} needs ${connectorLabel} to proceed`}
                 </h1>
                 <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
-                  <ConnectorIcon type={connectorType} size={20} />
+                  <ConnectorIcon icon={icon} size={20} />
                 </div>
                 <p className="w-60 text-sm text-muted-foreground">
                   {connectorDescription}
@@ -402,7 +402,7 @@ function DirectedAuthorizeCard() {
   return (
     <>
       <DirectedAuthorizeCardContent
-        connectorType={connectorType}
+        icon={item?.icon}
         connectorLabel={connectorLabel}
         connectorDescription={connectorDescription}
         agentName={agentName}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -194,7 +194,7 @@ function DirectedAuthorizeCardContent({
   canAuthorize,
   onAuthorize,
 }: {
-  readonly icon: ConnectorTypeWithStatus["icon"];
+  readonly icon: ConnectorTypeWithStatus["icon"] | undefined;
   readonly connectorLabel: string;
   readonly connectorDescription: string;
   readonly agentName: string;

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -257,7 +257,7 @@ function ManualGrantDialog({
   onConnected,
 }: {
   type: ConnectorType;
-  icon: ConnectorTypeWithStatus["icon"];
+  icon: ConnectorTypeWithStatus["icon"] | undefined;
   connectorLabel: string;
   manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
   open: boolean;
@@ -369,7 +369,7 @@ function DirectedConnectDialogs({
   setConnectModalOpen,
 }: {
   readonly connectorType: ConnectorType;
-  readonly icon: ConnectorTypeWithStatus["icon"];
+  readonly icon: ConnectorTypeWithStatus["icon"] | undefined;
   readonly connectorLabel: string;
   readonly manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
   readonly manualGrantDialogOpen: boolean;
@@ -485,7 +485,7 @@ function DirectedConnectCardContent({
   canConnect,
   onConnect,
 }: {
-  readonly icon: ConnectorTypeWithStatus["icon"];
+  readonly icon: ConnectorTypeWithStatus["icon"] | undefined;
   readonly connectorLabel: string;
   readonly connectorDescription: string;
   readonly agentName: string;

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -249,6 +249,7 @@ function ManualGrantForm({
 
 function ManualGrantDialog({
   type,
+  icon,
   connectorLabel,
   manualGrantMethod,
   open,
@@ -256,6 +257,7 @@ function ManualGrantDialog({
   onConnected,
 }: {
   type: ConnectorType;
+  icon: ConnectorTypeWithStatus["icon"];
   connectorLabel: string;
   manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
   open: boolean;
@@ -270,7 +272,7 @@ function ManualGrantDialog({
       <DialogContent className="max-w-md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
-            <ConnectorIcon type={type} size={20} />
+            <ConnectorIcon icon={icon} size={20} />
             <DialogTitle>{connectorLabel}</DialogTitle>
           </div>
         </DialogHeader>
@@ -356,6 +358,7 @@ function DirectedConnectModal({
 
 function DirectedConnectDialogs({
   connectorType,
+  icon,
   connectorLabel,
   manualGrantMethod,
   manualGrantDialogOpen,
@@ -366,6 +369,7 @@ function DirectedConnectDialogs({
   setConnectModalOpen,
 }: {
   readonly connectorType: ConnectorType;
+  readonly icon: ConnectorTypeWithStatus["icon"];
   readonly connectorLabel: string;
   readonly manualGrantMethod: ConnectorStatusAuthMethodDetail | null;
   readonly manualGrantDialogOpen: boolean;
@@ -379,6 +383,7 @@ function DirectedConnectDialogs({
     <>
       <ManualGrantDialog
         type={connectorType}
+        icon={icon}
         connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
         open={manualGrantDialogOpen}
@@ -470,7 +475,7 @@ function directedConnectModalOpen(
 }
 
 function DirectedConnectCardContent({
-  connectorType,
+  icon,
   connectorLabel,
   connectorDescription,
   agentName,
@@ -480,7 +485,7 @@ function DirectedConnectCardContent({
   canConnect,
   onConnect,
 }: {
-  readonly connectorType: ConnectorType;
+  readonly icon: ConnectorTypeWithStatus["icon"];
   readonly connectorLabel: string;
   readonly connectorDescription: string;
   readonly agentName: string;
@@ -509,7 +514,7 @@ function DirectedConnectCardContent({
                     : `${agentName} needs ${connectorLabel} to proceed`}
                 </h1>
                 <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
-                  <ConnectorIcon type={connectorType} size={20} />
+                  <ConnectorIcon icon={icon} size={20} />
                 </div>
                 <p className="w-60 text-sm text-muted-foreground">
                   {connectorDescription}
@@ -614,7 +619,7 @@ function DirectedConnectCard() {
   return (
     <>
       <DirectedConnectCardContent
-        connectorType={connectorType}
+        icon={item?.icon}
         connectorLabel={connectorLabel}
         connectorDescription={connectorDescription}
         agentName={agentName}
@@ -626,6 +631,7 @@ function DirectedConnectCard() {
       />
       <DirectedConnectDialogs
         connectorType={connectorType}
+        icon={item?.icon}
         connectorLabel={connectorLabel}
         manualGrantMethod={manualGrantMethod}
         manualGrantDialogOpen={manualGrantDialogOpen}

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -7,10 +7,7 @@ import {
   IconSearch,
 } from "@tabler/icons-react";
 import { Card, CardContent, cn, Input } from "@vm0/ui";
-import {
-  ConnectorIcon,
-  isConnectorIconType,
-} from "./components/settings/connector-icons.tsx";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { getCategories } from "./zero-ideation-data.ts";
 import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 import { connectorCatalogStatusByRef$ } from "../../signals/external/connectors.ts";
@@ -214,9 +211,14 @@ export function ZeroIdeationPage() {
 
                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
                         {category.cases.map((useCase) => {
-                          const connectorIconTypes =
-                            useCase.connectors?.filter(isConnectorIconType) ??
-                            [];
+                          const connectors =
+                            useCase.connectors?.flatMap((connectorRef) => {
+                              const connector =
+                                connectorStatusByRef?.get(connectorRef);
+                              return connector
+                                ? [{ connectorRef, icon: connector.icon }]
+                                : [];
+                            }) ?? [];
                           return (
                             <Card
                               key={useCase.title}
@@ -237,16 +239,16 @@ export function ZeroIdeationPage() {
                                 <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
                                   {useCase.description}
                                 </p>
-                                {connectorIconTypes.length > 0 && (
+                                {connectors.length > 0 && (
                                   <div className="flex items-center gap-1.5 mt-2.5">
-                                    {connectorIconTypes.map((type) => {
+                                    {connectors.map((connector) => {
                                       return (
                                         <span
-                                          key={type}
+                                          key={connector.connectorRef}
                                           className="flex h-7 w-7 items-center justify-center rounded-md border border-border/60 bg-background"
                                         >
                                           <ConnectorIcon
-                                            type={type}
+                                            icon={connector.icon}
                                             size={14}
                                           />
                                         </span>

--- a/turbo/packages/api-contracts/src/contracts/__tests__/zero-workflows.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/zero-workflows.test.ts
@@ -239,6 +239,10 @@ describe("workflow connector readiness contract", () => {
         return {
           connectorRef: entry.connectorRef,
           label: `Connector ${index}`,
+          icon: {
+            url: `https://icons.example.test/${entry.connectorRef}.svg`,
+            invertInDarkMode: false,
+          },
           reason: "The workflow uses this service.",
           status: entry.status,
         };

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1072,6 +1072,7 @@ export {
   type ZeroConnectorsSearchContract,
 } from "./zero-connectors";
 export {
+  publicConnectorCatalogIconSchema,
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogAuthMethodDetail,
   type PublicConnectorCatalogAuthMethodSummary,
@@ -1080,6 +1081,7 @@ export {
   type PublicConnectorCatalogConnection,
   type PublicConnectorCatalogConnectionStatus,
   type PublicConnectorCatalogItem,
+  type PublicConnectorCatalogIcon,
   type PublicConnectorCatalogListResponse,
   type PublicConnectorCatalogManualField,
   type PublicConnectorCatalogPermissionDetail,

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -29,7 +29,7 @@ const publicConnectorCatalogPermissionSummarySchema = z.object({
   hasDefaultPolicyOverrides: z.boolean(),
 });
 
-const publicConnectorCatalogIconSchema = z.object({
+export const publicConnectorCatalogIconSchema = z.object({
   url: z.url({ protocol: /^https$/u }).max(2048),
   invertInDarkMode: z.boolean(),
   scale: z.number().min(1).max(3).optional(),
@@ -159,6 +159,7 @@ const publicConnectorCatalogDefaultPolicySchema = z.object({
 const publicConnectorCatalogPermissionDetailSchema = z.object({
   connectorRef: connectorRefSchema,
   label: z.string(),
+  icon: publicConnectorCatalogIconSchema.optional(),
   permissionCount: z.number().int().nonnegative(),
   permissions: z.array(publicConnectorCatalogPermissionSchema),
   categories: publicConnectorCatalogPermissionCategoriesSchema.nullable(),

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-catalog.ts
@@ -57,7 +57,7 @@ const publicConnectorCatalogItemSchema = z.object({
   connectorRef: connectorRefSchema,
   label: z.string(),
   description: z.string(),
-  icon: publicConnectorCatalogIconSchema.optional(),
+  icon: publicConnectorCatalogIconSchema,
   category: z.string(),
   generation: z.array(z.string()),
   tags: z.array(z.string()),
@@ -159,7 +159,7 @@ const publicConnectorCatalogDefaultPolicySchema = z.object({
 const publicConnectorCatalogPermissionDetailSchema = z.object({
   connectorRef: connectorRefSchema,
   label: z.string(),
-  icon: publicConnectorCatalogIconSchema.optional(),
+  icon: publicConnectorCatalogIconSchema,
   permissionCount: z.number().int().nonnegative(),
   permissions: z.array(publicConnectorCatalogPermissionSchema),
   categories: publicConnectorCatalogPermissionCategoriesSchema.nullable(),

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { connectorTypeSchema } from "@vm0/connectors/connectors";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { publicConnectorCatalogIconSchema } from "./zero-connector-catalog";
 
 const c = initContract();
 
@@ -983,6 +984,7 @@ export const zeroWorkflowConnectorReadinessEntrySchema = z
   .object({
     connectorRef: connectorTypeSchema,
     label: z.string().min(1),
+    icon: publicConnectorCatalogIconSchema.optional(),
     reason: z.string().min(1),
     status: zeroWorkflowConnectorReadinessStatusSchema,
   })

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -984,7 +984,7 @@ export const zeroWorkflowConnectorReadinessEntrySchema = z
   .object({
     connectorRef: connectorTypeSchema,
     label: z.string().min(1),
-    icon: publicConnectorCatalogIconSchema.optional(),
+    icon: publicConnectorCatalogIconSchema,
     reason: z.string().min(1),
     status: zeroWorkflowConnectorReadinessStatusSchema,
   })


### PR DESCRIPTION
## Summary

- render generic Platform connector marks from the validated public catalog icon descriptor instead of the bundled connector registry
- require the descriptor across catalog, permission-detail, and workflow-readiness boundaries, with a generic fallback only for asset loading failure or UI state that has not loaded catalog data yet
- migrate connector, permission, workflow, chat, composer, and ideation surfaces while retaining a bounded local map only for separately owned product/provider marks

## Compatibility

- prerequisite #20244 already made every current API catalog response include an icon; this PR promotes that established response shape to a required contract
- old frontends ignore the additive icon fields, while current UI slots remain tolerant during request loading and recover when an image asset fails or its URL changes
- missing icon metadata now fails response validation; this PR does not add the external catalog/R2 loader, widen connector identity, change connector actions, or redesign custom connector icons

## Validation

- `pnpm format`
- `pnpm turbo run lint` (12/12 tasks)
- `pnpm check-types` (13/13 tasks)
- `pnpm knip`
- focused connector contract and Platform regression: 2 files and 63 tests passed
- focused API catalog/workflow regression: 2 files and 45 tests passed
- focused CLI catalog regression: 4 files and 67 tests passed
- two post-fix `pnpm vitest run --maxWorkers=4 --silent=passed-only` attempts each passed 593 files and 7318 tests, with one unrelated shared-database global-cron race in a different test on each attempt; both affected files pass alone (`zero-workflow-queue`: 4/4, `zero-relationships`: 14/14)

Closes #20245

Parent objective: https://github.com/vm0-ai/vm0-connectors/issues/1
