### PR TITLE
feat(runner): make session affinity admission-aware

### DIFF
--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -245,9 +245,15 @@ fn merge_held_session_states(
         if active_cli_agent_sessions.contains(&state.session_id) {
             continue;
         }
-        match by_session.get(&state.session_id) {
-            Some(existing) if existing.last_completed_at >= state.last_completed_at => {}
-            _ => {
+        match by_session.get_mut(&state.session_id) {
+            Some(existing) => {
+                let reusable_sandbox = existing.reusable_sandbox.take();
+                if state.last_completed_at > existing.last_completed_at {
+                    *existing = state;
+                }
+                existing.reusable_sandbox = reusable_sandbox.or(existing.reusable_sandbox.take());
+            }
+            None => {
                 by_session.insert(state.session_id.clone(), state);
             }
         }
@@ -672,6 +678,7 @@ mod tests {
         let idle = vec![HeldSessionState {
             session_id: "sess-idle".into(),
             last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+            reusable_sandbox: None,
         }];
 
         let cache_states = workspace_cache_held_session_states(Some(&cache)).await;
@@ -707,14 +714,17 @@ mod tests {
                 HeldSessionState {
                     session_id: "sess-cache".into(),
                     last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+                    reusable_sandbox: None,
                 },
                 HeldSessionState {
                     session_id: "sess-claimed".into(),
                     last_completed_at: "2026-06-01T00:00:03.000Z".into(),
+                    reusable_sandbox: None,
                 },
                 HeldSessionState {
                     session_id: "sess-active".into(),
                     last_completed_at: "2026-06-01T00:00:04.000Z".into(),
+                    reusable_sandbox: None,
                 },
             ],
         );
@@ -728,10 +738,12 @@ mod tests {
             HeldSessionState {
                 session_id: "sess-cache".into(),
                 last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+                reusable_sandbox: None,
             },
             HeldSessionState {
                 session_id: "sess-idle".into(),
                 last_completed_at: "2026-06-01T00:00:05.000Z".into(),
+                reusable_sandbox: None,
             },
         ];
 
@@ -747,10 +759,12 @@ mod tests {
                 HeldSessionState {
                     session_id: "sess-cache".into(),
                     last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+                    reusable_sandbox: None,
                 },
                 HeldSessionState {
                     session_id: "sess-idle".into(),
                     last_completed_at: "2026-06-01T00:00:05.000Z".into(),
+                    reusable_sandbox: None,
                 },
             ]
         );
@@ -784,6 +798,7 @@ mod tests {
             vec![HeldSessionState {
                 session_id: "sess-cache".into(),
                 last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+                reusable_sandbox: None,
             }],
         );
         assert!(
@@ -799,6 +814,7 @@ mod tests {
             snapshot.upsert_workspace_cache_state(HeldSessionState {
                 session_id: format!("sess-{index:04}"),
                 last_completed_at: timestamp_for_index(index),
+                reusable_sandbox: None,
             });
         }
 
@@ -826,10 +842,12 @@ mod tests {
         let original = HeldSessionState {
             session_id: "sess-original".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+            reusable_sandbox: None,
         };
         let promoted = HeldSessionState {
             session_id: "sess-promoted".into(),
             last_completed_at: "2026-06-01T00:00:02.000Z".into(),
+            reusable_sandbox: None,
         };
         refresh_snapshot(&snapshot, vec![original.clone()]);
 
@@ -861,10 +879,12 @@ mod tests {
         let idle = vec![HeldSessionState {
             session_id: "sess-active-idle".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+            reusable_sandbox: None,
         }];
         let cache = vec![HeldSessionState {
             session_id: "sess-active".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
+            reusable_sandbox: None,
         }];
         let active = std::collections::HashSet::from([
             "sess-active".to_string(),
@@ -881,10 +901,14 @@ mod tests {
         let idle = vec![HeldSessionState {
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
+            reusable_sandbox: Some(crate::types::ReusableSandboxState {
+                profile: "vm0/default".into(),
+            }),
         }];
         let cache = vec![HeldSessionState {
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
+            reusable_sandbox: None,
         }];
 
         let merged = merge_held_session_states(idle, cache, &std::collections::HashSet::new());
@@ -892,6 +916,13 @@ mod tests {
         assert_eq!(merged.len(), 1);
         assert_eq!(merged[0].session_id, "sess-1");
         assert_eq!(merged[0].last_completed_at, "2026-06-01T00:00:01.000Z");
+        assert_eq!(
+            merged[0]
+                .reusable_sandbox
+                .as_ref()
+                .map(|state| state.profile.as_str()),
+            Some("vm0/default")
+        );
     }
 
     #[test]
@@ -899,10 +930,14 @@ mod tests {
         let idle = vec![HeldSessionState {
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
+            reusable_sandbox: Some(crate::types::ReusableSandboxState {
+                profile: "vm0/default".into(),
+            }),
         }];
         let cache = vec![HeldSessionState {
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
+            reusable_sandbox: None,
         }];
 
         let merged = merge_held_session_states(idle, cache, &std::collections::HashSet::new());

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -17,7 +17,9 @@ use super::active_sessions::ActiveCliAgentSessionGuard;
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
-    add_running_run_with_idle_status_snapshot, spawn_idle_destroy_job,
+    add_running_run_with_idle_status_snapshot, destroy_idle_jobs_and_wait,
+    evict_expired_idle_entries, evict_oldest_idle_entry, set_idle_status_snapshot,
+    spawn_idle_destroy_job,
 };
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
@@ -27,7 +29,10 @@ use crate::executor::{
     validate_resume_session_id,
 };
 use crate::http::HttpClient;
-use crate::idle_pool::{IdlePoolSnapshot, IdleUnparkResult, ReusableIdleSandbox};
+use crate::idle_pool::{
+    DestroyOutcome, IdlePoolSnapshot, IdleUnparkResult, ReservedIdleSandbox,
+    RestoreReservedIdleResult, ReusableIdleSandbox,
+};
 use crate::ids::RunId;
 use crate::paths::short_digest;
 use crate::provider::{ClaimedJob, JobCandidate, PreLocalAdmissionOutcome};
@@ -58,13 +63,18 @@ pub(super) struct DiscoveredJobContext<'a> {
 
 struct LocalAdmission {
     run_id: RunId,
-    budget_lease: BudgetLease,
+    resource: LocalAdmissionResource,
     cancel: RunCancellationHandle,
+}
+
+enum LocalAdmissionResource {
+    Fresh(BudgetLease),
+    Reusable(Box<ReservedIdleSandbox>),
 }
 
 struct AdmittedClaim {
     claimed: ClaimedJob,
-    budget_lease: BudgetLease,
+    resource: LocalAdmissionResource,
     cancel: RunCancellationHandle,
 }
 
@@ -77,21 +87,29 @@ struct ReuseAdmissionRequest<'a> {
     job_lease: BudgetLease,
 }
 
+struct ReservedActivationRequest<'a> {
+    run_id: RunId,
+    profile_name: &'a str,
+    workspace_disk_mb: u32,
+    context: &'a ExecutionContext,
+    resume_session_valid: bool,
+}
+
 impl LocalAdmission {
-    async fn rollback(self, cancel_tokens: &SharedRunCancellationMap) {
+    async fn rollback(self, ctx: &mut DiscoveredJobContext<'_>) {
         let Self {
             run_id,
-            budget_lease,
+            resource,
             cancel: _,
         } = self;
-        cancel_tokens.lock().await.remove(&run_id);
-        drop(budget_lease);
+        ctx.cancel_tokens.lock().await.remove(&run_id);
+        rollback_untracked_resource(resource, ctx).await;
     }
 
     fn into_admitted(self, claimed: ClaimedJob) -> AdmittedClaim {
         AdmittedClaim {
             claimed,
-            budget_lease: self.budget_lease,
+            resource: self.resource,
             cancel: self.cancel,
         }
     }
@@ -113,26 +131,42 @@ pub(super) async fn handle_discovered_job(
     let job_vcpu = profile_config.vcpu;
     let job_memory = profile_config.memory_mb;
     let job_workspace_disk_mb = profile_config.workspace_disk_mb;
+    let device_rate_limits = ctx.spawn_ctx.device_rate_limits.clone();
     // Look up factory for this profile.
     let Some((factory, restore_guest_state)) = ctx.factories.get(&profile_name) else {
         warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
         return false;
     };
 
-    let Some(admission) =
-        claim_with_local_admission(candidate, run_id, job_vcpu, job_memory, &ctx).await
+    let Some(admission) = claim_with_local_admission(
+        candidate,
+        run_id,
+        &profile_name,
+        job_vcpu,
+        job_memory,
+        &device_rate_limits,
+        &mut ctx,
+    )
+    .await
     else {
         return false;
     };
     let AdmittedClaim {
         claimed,
-        budget_lease: job_lease,
+        resource,
         cancel: job_cancel,
     } = admission;
     let mut pre_spawn_timing = RunnerPreSpawnTiming::start_after_claim();
     let started_at = Instant::now();
     let resume_session_valid = validate_resume_session_id(claimed.context()).is_ok();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::ResumeSessionValidation, started_at);
+    info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
+    let started_at = Instant::now();
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::DeviceRateLimits, started_at);
+
+    // Hide the claimed session from heartbeat affinity before unpark or
+    // fallback cleanup can yield. Otherwise a concurrent heartbeat could
+    // briefly advertise stale workspace-cache affinity for an active session.
     let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
         ctx.spawn_ctx.active_cli_agent_sessions.clone(),
         if resume_session_valid {
@@ -141,26 +175,71 @@ pub(super) async fn handle_discovered_job(
             None
         },
     );
-    info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
-    let started_at = Instant::now();
-    let device_rate_limits = ctx.spawn_ctx.device_rate_limits.clone();
-    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::DeviceRateLimits, started_at);
 
     let (reuse_entry, active_lease, reuse_result, idle_snapshot, needs_session_affinity_refresh) =
-        try_reuse_from_pool(
-            run_id,
-            ReuseAdmissionRequest {
-                profile_name: &profile_name,
-                device_rate_limits: &device_rate_limits,
-                workspace_disk_mb: job_workspace_disk_mb,
-                context: claimed.context(),
-                resume_session_valid,
-                job_lease,
-            },
-            &mut ctx,
-            &mut pre_spawn_timing,
-        )
-        .await;
+        match resource {
+            LocalAdmissionResource::Fresh(job_lease) => {
+                try_reuse_from_pool(
+                    run_id,
+                    ReuseAdmissionRequest {
+                        profile_name: &profile_name,
+                        device_rate_limits: &device_rate_limits,
+                        workspace_disk_mb: job_workspace_disk_mb,
+                        context: claimed.context(),
+                        resume_session_valid,
+                        job_lease,
+                    },
+                    &mut ctx,
+                    &mut pre_spawn_timing,
+                )
+                .await
+            }
+            LocalAdmissionResource::Reusable(reservation) => {
+                match activate_reserved_idle(
+                    *reservation,
+                    ReservedActivationRequest {
+                        run_id,
+                        profile_name: &profile_name,
+                        workspace_disk_mb: job_workspace_disk_mb,
+                        context: claimed.context(),
+                        resume_session_valid,
+                    },
+                    &mut ctx,
+                    &mut pre_spawn_timing,
+                )
+                .await
+                {
+                    ReservedActivation::Ready {
+                        reuse_entry,
+                        active_lease,
+                        reuse_result,
+                        idle_snapshot,
+                    } => (
+                        reuse_entry.map(|entry| *entry),
+                        active_lease,
+                        reuse_result,
+                        Some(idle_snapshot),
+                        true,
+                    ),
+                    ReservedActivation::CannotStart {
+                        budget_lease,
+                        reuse_result,
+                        error,
+                    } => {
+                        fail_claimed_without_sandbox(
+                            claimed,
+                            job_cancel,
+                            budget_lease,
+                            reuse_result,
+                            error,
+                            &ctx,
+                        )
+                        .await;
+                        return true;
+                    }
+                }
+            }
+        };
 
     let session_history_restore_plan = build_session_history_restore_plan(
         &ctx.spawn_ctx.exec_config.http,
@@ -330,16 +409,34 @@ async fn publish_active_run_status(
 async fn claim_with_local_admission(
     candidate: JobCandidate,
     run_id: RunId,
+    profile_name: &str,
     job_vcpu: u32,
     job_memory: u32,
-    ctx: &DiscoveredJobContext<'_>,
+    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
+    ctx: &mut DiscoveredJobContext<'_>,
 ) -> Option<AdmittedClaim> {
-    let mut candidate = prepare_affinity_protected_candidate(candidate, ctx).await?;
+    let mut candidate = prepare_affinity_protected_candidate(
+        candidate,
+        profile_name,
+        job_vcpu,
+        job_memory,
+        device_rate_limits,
+        ctx,
+    )
+    .await?;
     candidate.mark_local_admission_started();
 
-    // Reserve resources before claiming so we don't waste a job that another
-    // runner could handle.
-    let job_lease = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory)?;
+    // Reserve either the exact reusable sandbox or fresh capacity before
+    // claiming so a losing claim can restore all local ownership.
+    let resource = acquire_local_admission_resource(
+        &candidate,
+        profile_name,
+        job_vcpu,
+        job_memory,
+        device_rate_limits,
+        ctx,
+    )
+    .await?;
 
     // Insert cancel token before claiming so provider-side cancel channels
     // (Ably supervisor for ApiProvider, `.cancel` scan for LocalProvider) can
@@ -349,7 +446,11 @@ async fn claim_with_local_admission(
     {
         let mut tokens = ctx.cancel_tokens.lock().await;
         match tokens.entry(run_id) {
-            Entry::Occupied(_) => return None,
+            Entry::Occupied(_) => {
+                drop(tokens);
+                rollback_untracked_resource(resource, ctx).await;
+                return None;
+            }
             Entry::Vacant(entry) => {
                 entry.insert(job_cancel.clone());
             }
@@ -358,7 +459,7 @@ async fn claim_with_local_admission(
 
     let admission = LocalAdmission {
         run_id,
-        budget_lease: job_lease,
+        resource,
         cancel: job_cancel,
     };
 
@@ -369,18 +470,18 @@ async fn claim_with_local_admission(
     match mode {
         RunnerMode::Running => {}
         RunnerMode::Starting => {
-            admission.rollback(ctx.cancel_tokens).await;
+            admission.rollback(ctx).await;
             return None;
         }
         RunnerMode::Draining => {
-            admission.rollback(ctx.cancel_tokens).await;
+            admission.rollback(ctx).await;
             return None;
         }
         RunnerMode::Stopping => {
             admission.cancel.cancel().await;
         }
         RunnerMode::Stopped => {
-            admission.rollback(ctx.cancel_tokens).await;
+            admission.rollback(ctx).await;
             return None;
         }
     }
@@ -390,7 +491,7 @@ async fn claim_with_local_admission(
         // None means the job won't run here: either lost the race to another
         // runner, or the provider rejected the job. Release the reservation and
         // cancel token so the runner can continue.
-        admission.rollback(ctx.cancel_tokens).await;
+        admission.rollback(ctx).await;
         return None;
     };
     if claimed.context().run_id != run_id {
@@ -399,7 +500,7 @@ async fn claim_with_local_admission(
             context_run_id = %claimed.context().run_id,
             "provider returned claimed job with mismatched run_id"
         );
-        admission.rollback(ctx.cancel_tokens).await;
+        admission.rollback(ctx).await;
         return None;
     }
 
@@ -408,6 +509,10 @@ async fn claim_with_local_admission(
 
 async fn prepare_affinity_protected_candidate(
     candidate: JobCandidate,
+    profile_name: &str,
+    job_vcpu: u32,
+    job_memory: u32,
+    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &DiscoveredJobContext<'_>,
 ) -> Option<JobCandidate> {
     if !candidate.is_affinity_protected() {
@@ -422,11 +527,17 @@ async fn prepare_affinity_protected_candidate(
         );
     };
 
+    let has_exact_reusable = ctx.idle_pool.lock().await.has_reusable(
+        &cli_agent_session_id,
+        profile_name,
+        device_rate_limits,
+    );
     let held_session_states = current_local_held_session_states(ctx).await;
-    if held_session_states
-        .iter()
-        .any(|state| state.session_id == cli_agent_session_id)
-    {
+    let has_fresh_affinity = ctx.budget.can_afford(job_vcpu, job_memory)
+        && held_session_states
+            .iter()
+            .any(|state| state.session_id == cli_agent_session_id);
+    if has_exact_reusable || has_fresh_affinity {
         return Some(
             candidate.with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder),
         );
@@ -460,6 +571,266 @@ async fn current_local_held_session_states(
     ctx.spawn_ctx
         .held_session_snapshot
         .current_held_session_states(idle_states, &ctx.spawn_ctx.active_cli_agent_sessions, None)
+}
+
+async fn acquire_local_admission_resource(
+    candidate: &JobCandidate,
+    profile_name: &str,
+    job_vcpu: u32,
+    job_memory: u32,
+    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
+    ctx: &mut DiscoveredJobContext<'_>,
+) -> Option<LocalAdmissionResource> {
+    loop {
+        if let Some(session_id) = candidate.cli_agent_session_id()
+            && let Some(reservation) =
+                reserve_reusable_idle(session_id, profile_name, device_rate_limits, ctx).await
+        {
+            return Some(LocalAdmissionResource::Reusable(Box::new(reservation)));
+        }
+
+        if let Some(lease) = ResourceBudget::try_reserve_lease(ctx.budget, job_vcpu, job_memory) {
+            return Some(LocalAdmissionResource::Fresh(lease));
+        }
+
+        let expired = evict_expired_idle_entries(ctx.idle_pool, ctx.status).await;
+        if !expired.is_empty() {
+            info!(
+                run_id = %candidate.run_id(),
+                count = expired.len(),
+                "reclaiming expired idle VMs for candidate admission"
+            );
+            destroy_idle_jobs_and_wait(expired, "candidate_admission_expired").await;
+            ctx.spawn_ctx.park_notify.notify_one();
+            continue;
+        }
+
+        let evicted = evict_oldest_idle_entry(ctx.idle_pool, ctx.status).await?;
+        info!(
+            run_id = %candidate.run_id(),
+            session_id = %evicted.cli_agent_session_id(),
+            profile = %evicted.profile_name(),
+            vcpu = evicted.budget_vcpu(),
+            memory_mb = evicted.budget_memory_mb(),
+            "evicting idle VM for candidate admission"
+        );
+        destroy_idle_jobs_and_wait(vec![evicted], "candidate_admission_oldest").await;
+        ctx.spawn_ctx.park_notify.notify_one();
+    }
+}
+
+async fn reserve_reusable_idle(
+    session_id: &str,
+    profile_name: &str,
+    device_rate_limits: &Option<sandbox::DeviceRateLimits>,
+    ctx: &DiscoveredJobContext<'_>,
+) -> Option<ReservedIdleSandbox> {
+    let (reservation, snapshot) = {
+        let mut pool = ctx.idle_pool.lock().await;
+        let reservation = pool.reserve_reusable(session_id, profile_name, device_rate_limits)?;
+        let snapshot = pool.status_snapshot();
+        (reservation, snapshot)
+    };
+    set_idle_status_snapshot(ctx.status, snapshot).await;
+    Some(reservation)
+}
+
+async fn rollback_untracked_resource(
+    resource: LocalAdmissionResource,
+    ctx: &mut DiscoveredJobContext<'_>,
+) {
+    match resource {
+        LocalAdmissionResource::Fresh(budget_lease) => drop(budget_lease),
+        LocalAdmissionResource::Reusable(reservation) => {
+            let (restore_result, snapshot) = {
+                let mut pool = ctx.idle_pool.lock().await;
+                let restore_result = pool.restore_reserved(*reservation);
+                let snapshot = pool.status_snapshot();
+                (restore_result, snapshot)
+            };
+            set_idle_status_snapshot(ctx.status, snapshot).await;
+            if let RestoreReservedIdleResult::Rejected(destroy_job) = restore_result {
+                spawn_idle_destroy_job(
+                    ctx.destroy_tasks,
+                    *destroy_job,
+                    "reserved_idle_rollback_rejected",
+                );
+                ctx.spawn_ctx.park_notify.notify_one();
+            }
+        }
+    }
+}
+
+enum ReservedActivation {
+    Ready {
+        reuse_entry: Option<Box<ReusableIdleSandbox>>,
+        active_lease: BudgetLease,
+        reuse_result: SandboxReuseResult,
+        idle_snapshot: IdlePoolSnapshot,
+    },
+    CannotStart {
+        budget_lease: BudgetLease,
+        reuse_result: SandboxReuseResult,
+        error: String,
+    },
+}
+
+async fn activate_reserved_idle(
+    reservation: ReservedIdleSandbox,
+    request: ReservedActivationRequest<'_>,
+    ctx: &mut DiscoveredJobContext<'_>,
+    pre_spawn_timing: &mut RunnerPreSpawnTiming,
+) -> ReservedActivation {
+    let ReservedActivationRequest {
+        run_id,
+        profile_name,
+        workspace_disk_mb,
+        context,
+        resume_session_valid,
+    } = request;
+    let started_at = Instant::now();
+    let requested_session_id = context.cli_agent_session_id();
+    let reserved_session_id = reservation.cli_agent_session_id().to_owned();
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
+
+    if !resume_session_valid || requested_session_id != Some(reserved_session_id.as_str()) {
+        let reuse_result = if requested_session_id.is_none() || !resume_session_valid {
+            SandboxReuseResult::NoSessionId
+        } else {
+            SandboxReuseResult::PoolMiss
+        };
+        warn!(
+            run_id = %run_id,
+            reserved_session_id = %reserved_session_id,
+            claimed_session_id = ?requested_session_id,
+            "claimed session does not match reserved idle VM, destroying before fresh fallback"
+        );
+        return cleanup_reserved_for_fresh_fallback(
+            reservation.into_destroy_job(),
+            reuse_result,
+            "reserved_reuse_session_mismatch",
+            ctx,
+        )
+        .await;
+    }
+
+    if let Some(cache) = ctx.spawn_ctx.exec_config.workspace_cache.as_ref() {
+        let started_at = Instant::now();
+        let validation = reservation.validate_workspace_promotion_identity(
+            cache,
+            CANONICAL_WORKING_DIR,
+            u64::from(workspace_disk_mb) * 1024 * 1024,
+        );
+        pre_spawn_timing.record_phase_elapsed(
+            RunnerPreSpawnPhase::WorkspacePromotionValidation,
+            started_at,
+        );
+        if let Err(mismatch) = validation {
+            warn!(
+                run_id = %run_id,
+                session_id = %reserved_session_id,
+                profile = %profile_name,
+                mismatch = mismatch.as_str(),
+                "workspace promotion identity mismatch, destroying reserved idle VM before fresh fallback"
+            );
+            return cleanup_reserved_for_fresh_fallback(
+                reservation.into_destroy_job_without_workspace_promotion_for_mismatch(),
+                SandboxReuseResult::PoolMiss,
+                "reserved_reuse_workspace_promotion_mismatch",
+                ctx,
+            )
+            .await;
+        }
+    }
+
+    let started_at = Instant::now();
+    let unpark_result = reservation.try_unpark().await;
+    pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleUnpark, started_at);
+    match unpark_result {
+        IdleUnparkResult::Reused {
+            sandbox,
+            budget_lease,
+        } => {
+            info!(
+                run_id = %run_id,
+                session_id = %reserved_session_id,
+                "reusing pre-claim reserved idle VM for session"
+            );
+            let idle_snapshot = ctx.idle_pool.lock().await.status_snapshot();
+            ReservedActivation::Ready {
+                reuse_entry: Some(sandbox),
+                active_lease: budget_lease,
+                reuse_result: SandboxReuseResult::Reused,
+                idle_snapshot,
+            }
+        }
+        IdleUnparkResult::Failed { destroy_job, error } => {
+            warn!(
+                run_id = %run_id,
+                session_id = %reserved_session_id,
+                error = %error,
+                "reserved idle VM unpark failed, destroying before fresh fallback"
+            );
+            cleanup_reserved_for_fresh_fallback(
+                *destroy_job,
+                SandboxReuseResult::UnparkFailed,
+                "reserved_reuse_unpark_failed",
+                ctx,
+            )
+            .await
+        }
+    }
+}
+
+async fn cleanup_reserved_for_fresh_fallback(
+    destroy_job: crate::idle_pool::IdleDestroyJob,
+    reuse_result: SandboxReuseResult,
+    cleanup_context: &'static str,
+    ctx: &DiscoveredJobContext<'_>,
+) -> ReservedActivation {
+    let cleanup = destroy_job.run_retaining_lease(cleanup_context).await;
+    match cleanup.outcome {
+        DestroyOutcome::Completed => ReservedActivation::Ready {
+            reuse_entry: None,
+            active_lease: cleanup.budget_lease,
+            reuse_result,
+            idle_snapshot: ctx.idle_pool.lock().await.status_snapshot(),
+        },
+        DestroyOutcome::Uncertain => ReservedActivation::CannotStart {
+            budget_lease: cleanup.budget_lease,
+            reuse_result,
+            error: "reserved idle sandbox cleanup was uncertain; fresh replacement was not started"
+                .to_string(),
+        },
+    }
+}
+
+async fn fail_claimed_without_sandbox(
+    claimed: ClaimedJob,
+    cancel: RunCancellationHandle,
+    budget_lease: BudgetLease,
+    reuse_result: SandboxReuseResult,
+    error: String,
+    ctx: &DiscoveredJobContext<'_>,
+) {
+    let (context, completion_auth, active_input_source) = claimed.into_parts();
+    let run_id = context.run_id;
+    let failure = crate::executor::ExecutionFailure::from_error(error);
+    drop(active_input_source);
+    ctx.spawn_ctx
+        .provider
+        .complete(
+            run_id,
+            failure.exit_code,
+            Some(&failure.error),
+            None,
+            Some(reuse_result),
+            completion_auth,
+        )
+        .await;
+    ctx.cancel_tokens.lock().await.remove(&run_id);
+    drop(cancel);
+    drop(budget_lease);
 }
 
 async fn try_reuse_from_pool(

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -58,7 +58,7 @@ use crate::network_log_manager::NetworkLogManager;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
 use crate::prefetch;
 use crate::provider::{
-    ApiProvider, BuiltinFirewallCatalogCachePaths, JobProvider, LocalProvider,
+    ApiProvider, ApiProviderConfig, BuiltinFirewallCatalogCachePaths, JobProvider, LocalProvider,
     NetworkPolicyRefreshHandle,
 };
 use crate::proxy;
@@ -91,7 +91,7 @@ use heartbeat::{
 use identity::load_or_generate_runner_id;
 use idle_lifecycle::{
     SharedIdlePool, cleanup_expired_idle_entries, destroy_idle_jobs_and_wait, drain_idle_pool,
-    evict_expired_idle_entries, evict_oldest_idle_entry, spawn_idle_destroy_job,
+    evict_expired_idle_entries, spawn_idle_destroy_job,
 };
 use job_discovery::{DiscoveredJob, DiscoveredJobContext, handle_discovered_job};
 use job_spawn::{SpawnContext, handle_job_result};
@@ -629,8 +629,11 @@ async fn run_start_with_home(
         let provider = ApiProvider::new(
             http.clone(),
             server.token,
-            group,
-            profiles,
+            ApiProviderConfig {
+                runner_id: runner_id.clone(),
+                group,
+                supported_profiles: profiles,
+            },
             BuiltinFirewallCatalogCachePaths {
                 cache_path: paths.builtin_firewall_catalog_cache(),
                 lock_path: paths.builtin_firewall_catalog_cache_lock(),
@@ -1424,32 +1427,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     }
                     continue;
                 }
-
-                // If budget is still exhausted, try evicting an idle VM before
-                // parking discovery. NOTE: evict_oldest is session-blind — it
-                // may destroy the VM the next job wants to reuse. A proper fix
-                // requires knowing session_id before claim, tracked separately.
-                if let Some(evicted) =
-                    evict_oldest_idle_entry(&shared.idle_pool, &shared.status).await
-                {
-                    info!(
-                        session_id = %evicted.cli_agent_session_id(),
-                        profile = %evicted.profile_name(),
-                        vcpu = evicted.budget_vcpu(),
-                        memory_mb = evicted.budget_memory_mb(),
-                        "evicting idle VM for resource pressure"
-                    );
-                    // Wait for the destroy task so the idle VM's lease is
-                    // dropped before the loop re-checks can_afford().
-                    if destroy_idle_jobs_and_wait(vec![evicted], "budget_pressure_oldest").await {
-                        park_notify.notify_one();
-                    }
-                    continue;
-                }
             }
             capacity
                 .budget
                 .can_afford(capacity.min_vcpu, capacity.min_memory_mb)
+                || shared.idle_pool.lock().await.len() > 0
         } else {
             false
         };
@@ -1489,6 +1471,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     if !capacity
                         .budget
                         .can_afford(capacity.min_vcpu, capacity.min_memory_mb)
+                        && shared.idle_pool.lock().await.len() == 0
                     {
                         break;
                     }

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -67,6 +67,7 @@ fn mark_workspace_cache_snapshot_promoted(
         snapshot.upsert_workspace_cache_state(HeldSessionState {
             session_id: session_id.to_owned(),
             last_completed_at: completed_at.to_owned(),
+            reusable_sandbox: None,
         });
     }
     promoted

--- a/crates/runner/src/cmd/start/tests/budget.rs
+++ b/crates/runner/src/cmd/start/tests/budget.rs
@@ -362,7 +362,7 @@ async fn budget_exhausted_evicts_oldest_when_expired_reclaim_insufficient() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn budget_pressure_eviction_clears_status_json_idle_vms() {
+async fn idle_vm_is_reclaimed_only_after_candidate_discovery() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 2);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
@@ -383,13 +383,41 @@ async fn budget_pressure_eviction_clears_status_json_idle_vms() {
     assert!(completion.is_some(), "job should complete and park");
     assert_eq!(completion.unwrap().exit_code, 0);
 
-    // The single parked VM fills the whole budget, so the Running loop's
-    // pressure path evicts it even without another pending job.
+    // The single parked VM fills the whole budget. It must remain reusable
+    // until a concrete candidate proves that generic capacity is needed.
+    wait_budget_count(&budget, 1, Duration::from_secs(5)).await;
+    assert_eq!(
+        idle_pool.lock().await.len(),
+        1,
+        "idle VM should be retained"
+    );
+    assert_eq!(
+        status_idle_sessions(&status_path).await,
+        vec!["sess-pressure-status".to_string()],
+        "status.json should retain the reusable idle VM"
+    );
+
+    let generic_run_id = RunId::new_v4();
+    push_job(
+        &env,
+        generic_run_id,
+        "vm0/default",
+        Some(minimal_context(generic_run_id)),
+    );
+    let generic_completion = env
+        .handle
+        .wait_completion(generic_run_id, Duration::from_secs(5))
+        .await;
+    assert!(
+        generic_completion.is_some(),
+        "generic job should run after candidate-aware idle reclamation"
+    );
+
     wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
     assert_eq!(idle_pool.lock().await.len(), 0, "idle pool should be empty");
     assert!(
         status_idle_sessions(&status_path).await.is_empty(),
-        "status.json should clear the pressure-evicted idle VM"
+        "status.json should clear the candidate-reclaimed idle VM"
     );
 
     shutdown(&env, run_handle).await;

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -7,6 +7,15 @@ use super::super::support::{
 
 use crate::types::SandboxReuseResult;
 
+const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
+
+fn reusable_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
+    crate::provider::JobCandidate::new(run_id, "vm0/default".into()).with_affinity_metadata(
+        Some(session_id.to_string()),
+        Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
+    )
+}
+
 /// When the runner takes a sandbox out of the idle pool for reuse and
 /// `Sandbox::unpark()` returns an error, the idle entry is destroyed
 /// and the runner falls through to a fresh sandbox create.
@@ -22,7 +31,7 @@ async fn unpark_failure_destroys_idle_entry_and_falls_through() {
         transition: sandbox::SandboxIdleTransition::Unpark,
         message: "simulated unpark failure".into(),
     }));
-    let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
 
@@ -39,18 +48,24 @@ async fn unpark_failure_destroys_idle_entry_and_falls_through() {
     )
     .await;
     assert_eq!(idle_pool.lock().await.len(), 1, "pool seeded");
+    assert!(
+        !budget.can_afford(2, 4096),
+        "the idle lease should exhaust fresh admission capacity"
+    );
 
     let run_handle = tokio::spawn(run(config));
 
     // Push a job for the same session — runner will try to reuse,
     // unpark() will fail, idle entry gets destroyed, fresh create runs.
     let run_id = RunId::new_v4();
-    push_job(
-        &env,
+    env.provider.set_claim_result(
         run_id,
-        "vm0/default",
         Some(context_with_session(run_id, "sess-unpark-fail")),
     );
+    env.handle
+        .discover_tx
+        .send(reusable_candidate(run_id, "sess-unpark-fail"))
+        .unwrap();
 
     let c = env
         .handle
@@ -191,6 +206,68 @@ async fn unpark_panic_destroys_idle_entry_and_falls_through() {
     assert_eq!(counter.unpark_call_count(), 1);
     assert_eq!(counter.park_call_count(), 1);
     assert_eq!(idle_pool.lock().await.len(), 1);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn uncertain_reserved_cleanup_fails_claim_without_starting_replacement() {
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let counter = Arc::clone(&overrides);
+    overrides.push_unpark_result(Err(sandbox::SandboxError::IdleTransition {
+        transition: sandbox::SandboxIdleTransition::Unpark,
+        message: "simulated unpark failure".into(),
+    }));
+    overrides.push_destroy_panic("simulated destroy panic");
+    let (config, env) = mock_run_config_with_overrides(test_profiles(), 2, 4096, 1, overrides);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let session_id = "sess-uncertain-cleanup";
+
+    seed_idle_pool_with_overrides(
+        &idle_pool,
+        &budget,
+        &counter,
+        session_id,
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    env.handle
+        .discover_tx
+        .send(reusable_candidate(run_id, session_id))
+        .unwrap();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("uncertain cleanup should fail the claimed run");
+    assert_eq!(completion.exit_code, 1);
+    assert_eq!(completion.sandbox_id, None);
+    assert_eq!(
+        completion.reuse_result,
+        Some(SandboxReuseResult::UnparkFailed)
+    );
+    assert_eq!(
+        completion.error.as_deref(),
+        Some("reserved idle sandbox cleanup was uncertain; fresh replacement was not started")
+    );
+    assert!(
+        counter.start_process_calls().is_empty(),
+        "uncertain cleanup must not start a fresh sandbox"
+    );
+    assert_eq!(counter.park_call_count(), 0);
+    assert_eq!(counter.unpark_call_count(), 1);
+    assert_eq!(counter.destroy_call_count(), 1);
+    assert_eq!(idle_pool.lock().await.len(), 0);
+    wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -14,6 +14,19 @@ use crate::paths::RunnerPaths;
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
+const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
+
+fn reusable_candidate(
+    run_id: RunId,
+    profile_name: &str,
+    session_id: &str,
+) -> crate::provider::JobCandidate {
+    crate::provider::JobCandidate::new(run_id, profile_name.to_string()).with_affinity_metadata(
+        Some(session_id.to_string()),
+        Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
+    )
+}
+
 // -----------------------------------------------------------------------
 // Test 9: idle pool park/take is gated on session ID availability
 //
@@ -420,7 +433,7 @@ async fn session_affinity_reuses_idle_vm() {
 
 #[tokio::test(start_paused = true)]
 async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates() {
-    let (mut config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (mut config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let idle_pool = Arc::clone(&config.shared.idle_pool);
     let budget = Arc::clone(&config.capacity.budget);
     let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
@@ -450,12 +463,12 @@ async fn workspace_promotion_mismatch_destroys_stale_idle_vm_and_fresh_creates()
 
     let run_handle = tokio::spawn(run(config));
     let run_id = RunId::new_v4();
-    push_job(
-        &env,
-        run_id,
-        "vm0/default",
-        Some(context_with_session(run_id, session_id)),
-    );
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    env.handle
+        .discover_tx
+        .send(reusable_candidate(run_id, "vm0/default", session_id))
+        .unwrap();
 
     let completion = env
         .handle

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -9,6 +9,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
+use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
@@ -220,6 +221,56 @@ async fn claim_run_id_mismatch_rolls_back_local_state() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn exact_idle_reservation_is_restored_after_claim_conflict() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&env.idle_pool);
+    let session_id = "sess-conflict-restore";
+    seed_idle_pool(&idle_pool, &budget, session_id, "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let conflict_run_id = RunId::new_v4();
+    env.provider.set_claim_result(conflict_run_id, None);
+    env.handle
+        .discover_tx
+        .send(affinity_protected_candidate(conflict_run_id, session_id))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    wait_cancel_token_removed(&env.cancel_tokens, conflict_run_id, Duration::from_secs(5)).await;
+    assert_eq!(
+        idle_pool.lock().await.held_sessions(),
+        vec![session_id.to_string()],
+        "claim conflict should restore the exact idle reservation"
+    );
+    assert_eq!(
+        budget.allocated(),
+        (2, 4096, 1),
+        "restored reservation should retain its original budget lease"
+    );
+
+    let followup_run_id = RunId::new_v4();
+    env.provider.set_claim_result(
+        followup_run_id,
+        Some(context_with_session(followup_run_id, session_id)),
+    );
+    env.handle
+        .discover_tx
+        .send(affinity_protected_candidate(followup_run_id, session_id))
+        .unwrap();
+    let completion = env
+        .handle
+        .wait_completion(followup_run_id, Duration::from_secs(5))
+        .await
+        .expect("restored idle reservation should serve the next claim");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
 async fn affinity_protected_candidate_without_local_session_defers_before_claim() {
     let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
@@ -402,7 +453,7 @@ async fn ready_direct_drain_continues_after_claim_conflict() {
 
 #[tokio::test(start_paused = true)]
 async fn affinity_protected_candidate_with_local_session_claims() {
-    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
     let budget = Arc::clone(&config.capacity.budget);
     let idle_pool = Arc::clone(&env.idle_pool);
     seed_idle_pool(
@@ -414,6 +465,10 @@ async fn affinity_protected_candidate_with_local_session_claims() {
         4096,
     )
     .await;
+    assert!(
+        !budget.can_afford(2, 4096),
+        "the parked sandbox should exhaust all fresh admission capacity"
+    );
 
     let run_handle = tokio::spawn(run(config));
 
@@ -432,11 +487,9 @@ async fn affinity_protected_candidate_with_local_session_claims() {
     let completion = env
         .handle
         .wait_completion(run_id, Duration::from_secs(5))
-        .await;
-    assert!(
-        completion.is_some(),
-        "runner holding the protected session should claim and execute the job"
-    );
+        .await
+        .expect("runner holding the protected session should claim and execute the job");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::Reused));
 
     let claim_candidates = env.handle.claim_candidates();
     let claimed_candidate = claim_candidates
@@ -531,6 +584,73 @@ async fn affinity_protected_candidate_with_workspace_cache_session_claims_from_s
         env.handle.deferred_poll_delays().is_empty(),
         "snapshot-backed local holders should not defer before claim"
     );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test]
+async fn saturated_cache_only_holder_defers_before_reclaiming_unrelated_idle() {
+    let session_id = "sess-cache-saturated";
+    let image_size_bytes = 1024 * 1024;
+    let mut profiles = test_profiles();
+    profiles.get_mut("vm0/default").unwrap().workspace_disk_mb = 1;
+    let (mut config, env) = mock_run_config(profiles, 2, 4096, 1);
+    let runner_paths = RunnerPaths::new(config.paths.base_dir.clone());
+    let workspace_cache = SessionWorkspaceCache::shared(
+        runner_paths.clone(),
+        &config.paths.home,
+        &config.runner.group,
+    );
+    seed_workspace_cache_state(
+        &workspace_cache,
+        &runner_paths,
+        session_id,
+        "vm0/default",
+        image_size_bytes,
+    )
+    .await;
+    Arc::get_mut(&mut config.exec_config)
+        .unwrap()
+        .workspace_cache = Some(workspace_cache);
+
+    let budget = Arc::clone(&config.capacity.budget);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    seed_idle_pool(
+        &idle_pool,
+        &budget,
+        "sess-unrelated-idle",
+        "vm0/default",
+        2,
+        4096,
+    )
+    .await;
+    let run_handle = tokio::spawn(run(config));
+    wait_discover_entered(&env, Duration::from_secs(2)).await;
+
+    let run_id = RunId::new_v4();
+    env.provider
+        .set_claim_result(run_id, Some(context_with_session(run_id, session_id)));
+    env.handle
+        .discover_tx
+        .send(affinity_protected_candidate(run_id, session_id))
+        .unwrap();
+
+    wait_discover_entered(&env, Duration::from_secs(5)).await;
+    assert!(
+        env.handle.claim_candidates().is_empty(),
+        "cache-only affinity must not bypass exhausted fresh admission"
+    );
+    assert_eq!(
+        env.handle.deferred_poll_delays().len(),
+        1,
+        "protected cache-only work should wait for the exact reusable holder"
+    );
+    assert_eq!(
+        idle_pool.lock().await.held_sessions(),
+        vec!["sess-unrelated-idle".to_string()],
+        "affinity deferral must happen before candidate-aware reclamation"
+    );
+    assert_eq!(budget.allocated(), (2, 4096, 1));
 
     shutdown(&env, run_handle).await;
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -14,7 +14,7 @@ use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::status::IdleVm;
 use crate::storage_fingerprints::StorageFingerprints;
-use crate::types::HeldSessionState;
+use crate::types::{HeldSessionState, ReusableSandboxState};
 use crate::workspace_image_cache::{
     SessionWorkspaceCache, WorkspaceImagePromotionContext, WorkspaceImagePromotionIdentityMismatch,
     WorkspaceImagePromotionIdentityRequest,
@@ -460,6 +460,16 @@ pub struct IdleEntry {
     idle_timeout: Duration,
 }
 
+#[must_use = "reserved idle sandboxes must be activated, restored, or destroyed"]
+pub struct ReservedIdleSandbox {
+    entry: IdleEntry,
+}
+
+pub enum RestoreReservedIdleResult {
+    Restored,
+    Rejected(Box<IdleDestroyJob>),
+}
+
 /// Idle pool status snapshot paired with a monotonic mutation revision.
 ///
 /// Status writes happen after dropping the pool lock, so an older snapshot can
@@ -549,6 +559,12 @@ pub(crate) struct IdleDestroyResult {
     pub(crate) workspace_cache_promoted: bool,
 }
 
+pub(crate) struct RetainedIdleDestroyResult {
+    pub(crate) outcome: DestroyOutcome,
+    pub(crate) workspace_cache_promoted: bool,
+    pub(crate) budget_lease: BudgetLease,
+}
+
 impl IdleDestroyPayload {
     /// Stop the sandbox and destroy it via its factory.
     #[cfg(test)]
@@ -629,6 +645,15 @@ impl IdleDestroyJob {
     }
 
     pub async fn run_with_context(self, context: &'static str) -> bool {
+        let result = self.run_retaining_lease(context).await;
+        drop(result.budget_lease);
+        result.workspace_cache_promoted
+    }
+
+    pub(crate) async fn run_retaining_lease(
+        self,
+        context: &'static str,
+    ) -> RetainedIdleDestroyResult {
         let Self {
             payload,
             budget_lease,
@@ -636,8 +661,11 @@ impl IdleDestroyJob {
             profile_name: _,
         } = self;
         let result = payload.promote_then_stop_and_destroy(context).await;
-        drop(budget_lease);
-        result.workspace_cache_promoted
+        RetainedIdleDestroyResult {
+            outcome: result.outcome,
+            workspace_cache_promoted: result.workspace_cache_promoted,
+            budget_lease,
+        }
     }
 
     pub fn cli_agent_session_id(&self) -> &str {
@@ -689,6 +717,10 @@ pub enum IdleUnparkResult {
 }
 
 impl IdleEntry {
+    fn cli_agent_session_id(&self) -> &str {
+        self.metadata.cli_agent_session_id()
+    }
+
     pub fn profile_name(&self) -> &str {
         &self.metadata.profile_name
     }
@@ -823,6 +855,35 @@ impl IdleEntry {
     }
 }
 
+impl ReservedIdleSandbox {
+    pub fn cli_agent_session_id(&self) -> &str {
+        self.entry.cli_agent_session_id()
+    }
+
+    pub fn validate_workspace_promotion_identity(
+        &self,
+        cache: &SessionWorkspaceCache,
+        working_dir: &str,
+        image_size_bytes: u64,
+    ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
+        self.entry
+            .validate_workspace_promotion_identity(cache, working_dir, image_size_bytes)
+    }
+
+    pub async fn try_unpark(self) -> IdleUnparkResult {
+        self.entry.try_unpark().await
+    }
+
+    pub fn into_destroy_job(self) -> IdleDestroyJob {
+        self.entry.into_destroy_job()
+    }
+
+    pub fn into_destroy_job_without_workspace_promotion_for_mismatch(self) -> IdleDestroyJob {
+        self.entry
+            .into_destroy_job_without_workspace_promotion_for_mismatch()
+    }
+}
+
 /// Pool of idle sandboxes keyed by session ID.
 ///
 /// After a job completes successfully, its sandbox can be parked here
@@ -901,6 +962,53 @@ impl IdlePool {
             self.bump_revision();
         }
         entry
+    }
+
+    pub fn has_reusable(
+        &self,
+        session_id: &str,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+    ) -> bool {
+        self.entries.get(session_id).is_some_and(|entry| {
+            !entry.is_expired_at(Instant::now())
+                && entry.profile_name() == profile_name
+                && entry.device_rate_limits() == device_rate_limits
+        })
+    }
+
+    pub fn reserve_reusable(
+        &mut self,
+        session_id: &str,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+    ) -> Option<ReservedIdleSandbox> {
+        if !self.has_reusable(session_id, profile_name, device_rate_limits) {
+            return None;
+        }
+        let entry = self.entries.remove(session_id)?;
+        self.bump_revision();
+        Some(ReservedIdleSandbox { entry })
+    }
+
+    pub fn restore_reserved(
+        &mut self,
+        reservation: ReservedIdleSandbox,
+    ) -> RestoreReservedIdleResult {
+        let entry = reservation.entry;
+        let session_id = entry.cli_agent_session_id().to_owned();
+        let has_capacity = self.config.max_idle == 0 || self.entries.len() < self.config.max_idle;
+        if !self.parking_gate.is_open()
+            || entry.is_expired_at(Instant::now())
+            || !has_capacity
+            || self.entries.contains_key(&session_id)
+        {
+            return RestoreReservedIdleResult::Rejected(Box::new(entry.into_destroy_job()));
+        }
+
+        self.entries.insert(session_id, entry);
+        self.bump_revision();
+        RestoreReservedIdleResult::Restored
     }
 
     /// Remove and return all entries that have exceeded their idle timeout.
@@ -991,6 +1099,9 @@ impl IdlePool {
                     .map(|last_completed_at| HeldSessionState {
                         session_id: session_id.clone(),
                         last_completed_at: last_completed_at.clone(),
+                        reusable_sandbox: Some(ReusableSandboxState {
+                            profile: entry.metadata.profile_name.clone(),
+                        }),
                     })
             })
             .collect();
@@ -1326,6 +1437,85 @@ mod tests {
     }
 
     #[test]
+    fn reusable_reservation_is_exclusive_and_restorable() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let candidate = make_candidate_for("session-reserved", 2, 2048);
+        let sandbox_id = candidate.sandbox_id();
+        assert!(matches!(pool.park(candidate), ParkResult::Parked));
+        let parked_revision = pool.status_snapshot().revision;
+
+        assert!(
+            pool.reserve_reusable("session-reserved", "vm0/large", &None)
+                .is_none(),
+            "profile mismatch must not reserve the idle entry"
+        );
+        let reservation = pool
+            .reserve_reusable("session-reserved", "vm0/default", &None)
+            .expect("matching idle entry should be reserved");
+        assert_eq!(pool.len(), 0);
+        assert_eq!(pool.status_snapshot().revision, parked_revision + 1);
+        assert!(
+            pool.reserve_reusable("session-reserved", "vm0/default", &None)
+                .is_none(),
+            "a removed reservation cannot be acquired twice"
+        );
+
+        assert!(matches!(
+            pool.restore_reserved(reservation),
+            RestoreReservedIdleResult::Restored
+        ));
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.status_snapshot().revision, parked_revision + 2);
+        assert_eq!(pool.status_snapshot().idle_vms[0].sandbox_id, sandbox_id);
+    }
+
+    #[tokio::test]
+    async fn reserved_restore_preserves_newer_same_session_entry() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let old = make_candidate_for("session-collision", 2, 2048);
+        let old_sandbox_id = old.sandbox_id();
+        assert!(matches!(pool.park(old), ParkResult::Parked));
+        let reservation = pool
+            .reserve_reusable("session-collision", "vm0/default", &None)
+            .expect("old entry should reserve");
+
+        let replacement = make_candidate_for("session-collision", 2, 2048);
+        let replacement_sandbox_id = replacement.sandbox_id();
+        assert!(matches!(pool.park(replacement), ParkResult::Parked));
+        let RestoreReservedIdleResult::Rejected(rejected) = pool.restore_reserved(reservation)
+        else {
+            panic!("collision must reject the older reservation");
+        };
+        assert_eq!(
+            pool.status_snapshot().idle_vms[0].sandbox_id,
+            replacement_sandbox_id
+        );
+        assert_ne!(old_sandbox_id, replacement_sandbox_id);
+        rejected.run().await;
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn reserved_restore_rejects_after_parking_closes() {
+        let mut pool = IdlePool::new(pool_config(0));
+        assert!(matches!(
+            pool.park(make_candidate_for("session-closed", 2, 2048)),
+            ParkResult::Parked
+        ));
+        let reservation = pool
+            .reserve_reusable("session-closed", "vm0/default", &None)
+            .expect("entry should reserve");
+        pool.parking_gate().close();
+
+        let RestoreReservedIdleResult::Rejected(rejected) = pool.restore_reserved(reservation)
+        else {
+            panic!("closed parking must reject reservation restore");
+        };
+        rejected.run().await;
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
     fn park_uses_candidate_session_as_pool_key() {
         let mut pool = IdlePool::new(pool_config(0));
         let result = pool.park(make_candidate_for("candidate-session", 2, 2048));
@@ -1593,10 +1783,16 @@ mod tests {
                 HeldSessionState {
                     session_id: "sess-a".to_string(),
                     last_completed_at: "2026-05-28T00:00:00.000Z".to_string(),
+                    reusable_sandbox: Some(ReusableSandboxState {
+                        profile: "vm0/default".to_string(),
+                    }),
                 },
                 HeldSessionState {
                     session_id: "sess-b".to_string(),
                     last_completed_at: "2026-05-28T00:00:01.000Z".to_string(),
+                    reusable_sandbox: Some(ReusableSandboxState {
+                        profile: "vm0/default".to_string(),
+                    }),
                 },
             ],
         );

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -111,6 +111,7 @@ enum DiscoveryWakeup {
 /// - **Complete**: `POST /api/webhooks/agent/complete` with per-job sandbox token
 pub struct ApiProvider {
     api: ApiClient,
+    runner_id: String,
     group: String,
     /// Profile names this runner supports (e.g., ["vm0/default"]).
     /// Sent in poll requests so the server only returns jobs this runner can handle.
@@ -133,17 +134,27 @@ pub struct BuiltinFirewallCatalogCachePaths {
     pub lock_path: PathBuf,
 }
 
+pub struct ApiProviderConfig {
+    pub runner_id: String,
+    pub group: String,
+    pub supported_profiles: Vec<String>,
+}
+
 impl ApiProvider {
     /// Create a new API-backed provider.
     pub fn new(
         http: HttpClient,
         token: String,
-        group: String,
-        supported_profiles: Vec<String>,
+        config: ApiProviderConfig,
         builtin_firewall_catalog_cache_paths: BuiltinFirewallCatalogCachePaths,
         cancel: CancellationToken,
         cancel_tokens: SharedRunCancellationMap,
     ) -> Arc<Self> {
+        let ApiProviderConfig {
+            runner_id,
+            group,
+            supported_profiles,
+        } = config;
         let api = ApiClient::new(http, token);
         let network_policy_refresh = NetworkPolicyRefreshHandle::new(api.clone());
         let builtin_firewall_catalog_refresh = BuiltinFirewallCatalogRefreshController::new(
@@ -160,6 +171,7 @@ impl ApiProvider {
 
         Arc::new(Self {
             api,
+            runner_id,
             group,
             supported_profiles,
             poll_wakeups,
@@ -313,7 +325,12 @@ impl JobProvider for ApiProvider {
                     }
                     return None;
                 }
-                result = self.api.poll(&self.group, &self.supported_profiles, reason) => result,
+                result = self.api.poll(
+                    &self.runner_id,
+                    &self.group,
+                    &self.supported_profiles,
+                    reason,
+                ) => result,
             };
 
             match poll_result {
@@ -591,11 +608,12 @@ impl ApiClient {
     /// Poll for a pending job. The response contains `job: None` when no work is available.
     async fn poll(
         &self,
+        runner_id: &str,
         group: &str,
         supported_profiles: &[String],
         reason: PollReason,
     ) -> RunnerResult<PollApiResult> {
-        let body = poll_request_body(group, supported_profiles, reason);
+        let body = poll_request_body(runner_id, group, supported_profiles, reason);
         let poll_started_at = Instant::now();
         let resp = send_api(
             self.http
@@ -836,11 +854,13 @@ fn claim_telemetry_duration_ms(duration: Duration) -> u64 {
 }
 
 fn poll_request_body(
+    runner_id: &str,
     group: &str,
     supported_profiles: &[String],
     reason: PollReason,
 ) -> serde_json::Value {
     serde_json::json!({
+        "runnerId": runner_id,
         "group": group,
         "supportedProfiles": supported_profiles,
         "telemetry": {
@@ -1352,6 +1372,7 @@ mod tests {
             network_policy_refresh: NetworkPolicyRefreshHandle::new(api.clone()),
             builtin_firewall_catalog_refresh: BuiltinFirewallCatalogRefreshController::disabled(),
             api,
+            runner_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
             group: "default".to_string(),
             supported_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             poll_wakeups,
@@ -1413,6 +1434,7 @@ mod tests {
             held_session_states: vec![crate::types::HeldSessionState {
                 session_id: "held-session-test".to_string(),
                 last_completed_at: "2026-07-08T00:00:00.000Z".to_string(),
+                reusable_sandbox: None,
             }],
             mode: "running".to_string(),
         }
@@ -1580,8 +1602,14 @@ mod tests {
     #[test]
     fn poll_request_body_serializes_poll_reason_telemetry() {
         let profiles = vec![crate::profile::DEFAULT_PROFILE.to_string()];
-        let body = poll_request_body("vm0/test", &profiles, PollReason::Immediate);
+        let body = poll_request_body(
+            "550e8400-e29b-41d4-a716-446655440000",
+            "vm0/test",
+            &profiles,
+            PollReason::Immediate,
+        );
 
+        assert_eq!(body["runnerId"], "550e8400-e29b-41d4-a716-446655440000");
         assert_eq!(body["group"], "vm0/test");
         assert_eq!(
             body["supportedProfiles"][0],
@@ -1983,6 +2011,7 @@ mod tests {
                 when.method(POST)
                     .path(routes::runners::poll::POLL.path)
                     .json_body(serde_json::json!({
+                        "runnerId": "550e8400-e29b-41d4-a716-446655440000",
                         "group": "default",
                         "supportedProfiles": [crate::profile::DEFAULT_PROFILE],
                         "telemetry": {
@@ -2051,6 +2080,7 @@ mod tests {
                 when.method(POST)
                     .path(routes::runners::poll::POLL.path)
                     .json_body(serde_json::json!({
+                        "runnerId": "550e8400-e29b-41d4-a716-446655440000",
                         "group": "default",
                         "supportedProfiles": [crate::profile::DEFAULT_PROFILE],
                         "telemetry": {
@@ -2223,7 +2253,12 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let err = api
-            .poll("default", &[], PollReason::Immediate)
+            .poll(
+                "550e8400-e29b-41d4-a716-446655440000",
+                "default",
+                &[],
+                PollReason::Immediate,
+            )
             .await
             .unwrap_err();
 
@@ -2248,7 +2283,12 @@ mod tests {
         let api = api_client_for_server(&server);
 
         let err = api
-            .poll("default", &[], PollReason::Immediate)
+            .poll(
+                "550e8400-e29b-41d4-a716-446655440000",
+                "default",
+                &[],
+                PollReason::Immediate,
+            )
             .await
             .unwrap_err();
 
@@ -2498,6 +2538,7 @@ mod tests {
 
         let err = api
             .poll(
+                "550e8400-e29b-41d4-a716-446655440000",
                 "default",
                 &[crate::profile::DEFAULT_PROFILE.to_string()],
                 PollReason::Immediate,

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -13,7 +13,7 @@ mod local;
 pub mod mock;
 mod network_policy_refresh;
 
-pub use api::{ApiProvider, BuiltinFirewallCatalogCachePaths};
+pub use api::{ApiProvider, ApiProviderConfig, BuiltinFirewallCatalogCachePaths};
 pub use local::LocalProvider;
 pub(crate) use network_policy_refresh::{
     NetworkPolicyRefreshHandle, NetworkPolicyRefreshRegistration,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1167,6 +1167,12 @@ impl ExecutionContext {
 // Heartbeat
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReusableSandboxState {
+    pub profile: String,
+}
+
 /// Runner state snapshot sent to the server via heartbeat.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -1175,6 +1181,8 @@ pub struct HeldSessionState {
     /// Claude/Codex CLI agent session id used for sandbox reuse affinity.
     pub session_id: String,
     pub last_completed_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reusable_sandbox: Option<ReusableSandboxState>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1871,6 +1879,9 @@ mod tests {
             held_session_states: vec![HeldSessionState {
                 session_id: "session-abc".into(),
                 last_completed_at: "2026-05-28T00:00:00.000Z".into(),
+                reusable_sandbox: Some(ReusableSandboxState {
+                    profile: "vm0/default".into(),
+                }),
             }],
             mode: "running".into(),
         };
@@ -1890,9 +1901,25 @@ mod tests {
             json["heldSessionStates"],
             json!([{
                 "sessionId": "session-abc",
-                "lastCompletedAt": "2026-05-28T00:00:00.000Z"
+                "lastCompletedAt": "2026-05-28T00:00:00.000Z",
+                "reusableSandbox": {
+                    "profile": "vm0/default"
+                }
             }])
         );
         assert_eq!(json["mode"], "running");
+    }
+
+    #[test]
+    fn held_session_state_accepts_legacy_shape_and_omits_absent_capability() {
+        let state: HeldSessionState = serde_json::from_value(json!({
+            "sessionId": "session-legacy",
+            "lastCompletedAt": "2026-05-28T00:00:00.000Z"
+        }))
+        .unwrap();
+        assert!(state.reusable_sandbox.is_none());
+
+        let serialized = serde_json::to_value(state).unwrap();
+        assert!(serialized.get("reusableSandbox").is_none());
     }
 }

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -603,6 +603,7 @@ impl SessionWorkspaceCache {
                 states.push(HeldSessionState {
                     session_id: metadata.session_id,
                     last_completed_at: metadata.last_completed_at,
+                    reusable_sandbox: None,
                 });
             }
             drop(lock);

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -1053,11 +1053,13 @@ fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
         .map(|index| HeldSessionState {
             session_id: format!("sess-{index:04}"),
             last_completed_at: timestamp_for_index(index),
+            reusable_sandbox: None,
         })
         .collect();
     states.push(HeldSessionState {
         session_id: "sess-0001".into(),
         last_completed_at: timestamp_for_index(MAX_HELD_SESSION_STATES + 1),
+        reusable_sandbox: None,
     });
 
     let capped = cap_workspace_held_session_states(states);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2444,6 +2444,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     async function heartbeatHolder(args: {
       readonly admittableProfiles?: string[];
       readonly mode?: "starting" | "running" | "draining" | "stopping";
+      readonly reusableSandbox?: { readonly profile: string };
     }): Promise<void> {
       await api.requestHeartbeatRunner(true, [200], {
         runnerId: affinityRunnerId,
@@ -2453,6 +2454,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
           {
             sessionId: cliAgentSessionId,
             lastCompletedAt: nowDate().toISOString(),
+            ...(args.reusableSandbox
+              ? { reusableSandbox: args.reusableSandbox }
+              : {}),
           },
         ],
         mode: args.mode,
@@ -2576,7 +2580,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     onTestFinished(() => {
       clearMockNow();
     });
-    await heartbeatHolder({ admittableProfiles: ["vm0/default"] });
+    await heartbeatHolder({
+      admittableProfiles: [],
+      reusableSandbox: { profile: "vm0/default" },
+    });
     clearMockNow();
     const staleHolder = await pollFollowUp(
       "continue after holder heartbeat is stale",
@@ -2585,7 +2592,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(staleHolder.job?.affinityProtectedUntil).toBeNull();
 
     await heartbeatHolder({
-      admittableProfiles: ["vm0/large"],
+      admittableProfiles: [],
+      reusableSandbox: { profile: "vm0/large" },
     });
     const profileIncompatibleHolder = await pollFollowUp(
       "continue when holder cannot run requested profile",
@@ -2596,7 +2604,8 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(profileIncompatibleHolder.job?.affinityProtectedUntil).toBeNull();
 
     await heartbeatHolder({
-      admittableProfiles: ["vm0/default"],
+      admittableProfiles: [],
+      reusableSandbox: { profile: "vm0/default" },
       mode: "draining",
     });
     const drainingHolder = await pollFollowUp(
@@ -2696,6 +2705,132 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue after affinity protection expires",
     );
     await api.requestCancelRun(actor, expiredFollowUp.runId, [200]);
+  });
+
+  it("prioritizes exact reusable work only for its runner and protection window", async () => {
+    const api = createRunsAutomationsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: "start reusable-priority session",
+      modelProvider: "anthropic-api-key",
+    });
+    const firstClaim = await api.claimRunnerJob(first.runId);
+    const cliAgentSessionId = `bdd-reusable-priority-${first.runId}`;
+    const history = `bdd reusable priority history ${first.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    mockSessionHistoryBlob(historyHash, history);
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: first.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      { authorization: `Bearer ${firstClaim.sandboxToken}` },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
+      { authorization: `Bearer ${firstClaim.sandboxToken}` },
+      [200],
+    );
+
+    const affinityRunnerId = randomUUID();
+    const priorityBase = now();
+    mockNow(priorityBase);
+    onTestFinished(() => {
+      clearMockNow();
+    });
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: affinityRunnerId,
+      group: runnerGroup,
+      admittableProfiles: [],
+      heldSessionStates: [
+        {
+          sessionId: cliAgentSessionId,
+          lastCompletedAt: nowDate().toISOString(),
+          reusableSandbox: { profile: "vm0/default" },
+        },
+      ],
+    });
+
+    const protectedFollowUp = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: "verify reusable holder protection",
+      modelProvider: "anthropic-api-key",
+    });
+    const protectedPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (protectedPoll.status !== 200) {
+      throw new Error("Expected reusable-holder poll to return 200");
+    }
+    expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
+    expect(protectedPoll.body.job?.affinityProtectedUntil).toStrictEqual(
+      expect.any(String),
+    );
+    await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
+
+    const olderGeneric = await api.createRun(actor, {
+      agentId,
+      prompt: "older generic FIFO work",
+      modelProvider: "anthropic-api-key",
+    });
+    mockNow(priorityBase + 1);
+    const newerReusable = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: "newer exact reusable work",
+      modelProvider: "anthropic-api-key",
+    });
+
+    const legacyPriorityPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (legacyPriorityPoll.status !== 200) {
+      throw new Error("Expected legacy FIFO poll to return 200");
+    }
+    expect(legacyPriorityPoll.body.job?.runId).toBe(olderGeneric.runId);
+
+    const reusablePriorityPoll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: affinityRunnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (reusablePriorityPoll.status !== 200) {
+      throw new Error("Expected reusable-priority poll to return 200");
+    }
+    expect(reusablePriorityPoll.body.job?.runId).toBe(newerReusable.runId);
+
+    mockNow(priorityBase + 60_000);
+    const expiredPriorityPoll = await api.requestPollRunner(
+      true,
+      {
+        runnerId: affinityRunnerId,
+        group: runnerGroup,
+        supportedProfiles: ["vm0/default"],
+      },
+      [200],
+    );
+    if (expiredPriorityPoll.status !== 200) {
+      throw new Error("Expected expired reusable-priority poll to return 200");
+    }
+    expect(expiredPriorityPoll.body.job?.runId).toBe(olderGeneric.runId);
+
+    await api.requestCancelRun(actor, newerReusable.runId, [200]);
+    await api.requestCancelRun(actor, olderGeneric.runId, [200]);
   });
 });
 

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -26,7 +26,7 @@ import { agentSessions } from "@vm0/db/schema/agent-session";
 import { blobs } from "@vm0/db/schema/blob";
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
-import { and, eq, gt, inArray, lt, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, lt, sql, type SQL } from "drizzle-orm";
 
 import { runnerAuth$, type RunnerAuthContext } from "../auth/runner-auth";
 import { authorization$ } from "../context/hono";
@@ -65,6 +65,7 @@ import {
   tryNormalizeSessionHistoryBlobEncoding,
 } from "../services/session-history-blobs";
 import {
+  runnerReusableSessionPollPriority,
   runnerSessionAffinityLookupError,
   runnerSessionAffinityProtection,
 } from "../services/runner-session-affinity";
@@ -313,6 +314,13 @@ function canonicalizeHeldSessionStates(
     return {
       sessionId: cliAgentSessionId,
       lastCompletedAt: new Date(state.lastCompletedAt).toISOString(),
+      ...(state.reusableSandbox
+        ? {
+            reusableSandbox: {
+              profile: state.reusableSandbox.profile,
+            },
+          }
+        : {}),
     };
   });
 }
@@ -485,6 +493,18 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
   whereConditions.push(inArray(runnerJobQueue.profile, supportedProfiles));
   const db = set(writeDb$);
   const pendingJobLookupStartedAtMs = now();
+  const currentDate = nowDate();
+  const reusableSessionPriorityOrder = body.data.runnerId
+    ? [
+        desc(
+          runnerReusableSessionPollPriority({
+            runnerId: body.data.runnerId,
+            runnerGroup: group,
+            currentDate,
+          }),
+        ),
+      ]
+    : [];
   const [pendingJob] = await db
     .select({
       runId: runnerJobQueue.runId,
@@ -500,7 +520,11 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     .from(runnerJobQueue)
     .innerJoin(agentRuns, eq(runnerJobQueue.runId, agentRuns.id))
     .where(and(...whereConditions))
-    .orderBy(runnerJobQueue.createdAt, runnerJobQueue.runId)
+    .orderBy(
+      ...reusableSessionPriorityOrder,
+      runnerJobQueue.createdAt,
+      runnerJobQueue.runId,
+    )
     .limit(1);
   signal.throwIfAborted();
   const pendingJobLookupFinishedAtMs = now();
@@ -516,7 +540,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       profile: pendingJob.profile,
       cliAgentSessionId: pendingJob.cliAgentSessionId,
       createdAt: pendingJob.createdAt,
-      currentDate: nowDate(),
+      currentDate,
     }),
     signal,
   );

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -1,10 +1,47 @@
+import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, eq, gt, or, sql, type SQL } from "drizzle-orm";
 
 import type { Db } from "../external/db";
 
 const RUNNER_SESSION_AFFINITY_PROTECTION_MS = 2000;
 const RUNNER_SESSION_AFFINITY_HOLDER_FRESH_MS = 30_000;
+
+function runnerSessionAffinityHolderFreshAfter(currentDate: Date): Date {
+  return new Date(
+    currentDate.getTime() - RUNNER_SESSION_AFFINITY_HOLDER_FRESH_MS,
+  );
+}
+
+export function runnerReusableSessionPollPriority(args: {
+  readonly runnerId: string;
+  readonly runnerGroup: string;
+  readonly currentDate: Date;
+}): SQL<number> {
+  const protectedAfter = new Date(
+    args.currentDate.getTime() - RUNNER_SESSION_AFFINITY_PROTECTION_MS,
+  );
+  const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
+  return sql<number>`CASE WHEN
+    ${runnerJobQueue.createdAt} > ${protectedAfter}
+    AND EXISTS (
+      SELECT 1
+      FROM ${runnerState}
+      WHERE ${runnerState.runnerId} = ${args.runnerId}
+        AND ${runnerState.runnerGroup} = ${args.runnerGroup}
+        AND ${runnerState.mode} = 'running'
+        AND ${runnerState.lastSeenAt} > ${freshAfter}
+        AND ${runnerState.heldSessionStates} @> jsonb_build_array(
+          jsonb_build_object(
+            'sessionId', ${runnerJobQueue.cliAgentSessionId},
+            'reusableSandbox', jsonb_build_object(
+              'profile', ${runnerJobQueue.profile}
+            )
+          )
+        )
+    )
+    THEN 1 ELSE 0 END`;
+}
 
 type RunnerSessionAffinityStatus =
   | "no_session"
@@ -54,11 +91,15 @@ export async function runnerSessionAffinityProtection(args: {
     return { protectedUntil: null, status: "expired" };
   }
 
-  const freshAfter = new Date(
-    args.currentDate.getTime() - RUNNER_SESSION_AFFINITY_HOLDER_FRESH_MS,
-  );
+  const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
   const heldSessionProbe = JSON.stringify([
     { sessionId: args.cliAgentSessionId },
+  ]);
+  const reusableSessionProbe = JSON.stringify([
+    {
+      sessionId: args.cliAgentSessionId,
+      reusableSandbox: { profile: args.profile },
+    },
   ]);
   const admittableProfileProbe = JSON.stringify([args.profile]);
   const [holder] = await args.db
@@ -69,8 +110,13 @@ export async function runnerSessionAffinityProtection(args: {
         eq(runnerState.runnerGroup, args.runnerGroup),
         eq(runnerState.mode, "running"),
         gt(runnerState.lastSeenAt, freshAfter),
-        sql`${runnerState.heldSessionStates} @> ${heldSessionProbe}::jsonb`,
-        sql`${runnerState.admittableProfiles} @> ${admittableProfileProbe}::jsonb`,
+        or(
+          and(
+            sql`${runnerState.heldSessionStates} @> ${heldSessionProbe}::jsonb`,
+            sql`${runnerState.admittableProfiles} @> ${admittableProfileProbe}::jsonb`,
+          ),
+          sql`${runnerState.heldSessionStates} @> ${reusableSessionProbe}::jsonb`,
+        ),
       ),
     )
     .limit(1);

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -145,6 +145,7 @@ export const runnerGroupSchema = z
   );
 
 const runnersPollBodySchema = z.object({
+  runnerId: z.uuid().optional(),
   group: runnerGroupSchema,
   supportedProfiles: runnerSupportedProfileListSchema,
   telemetry: runnerPollTelemetrySchema.optional(),
@@ -174,6 +175,11 @@ export const heldSessionStateSchema = z.object({
   // session id used to route work toward a runner with a reusable sandbox.
   sessionId: z.string(),
   lastCompletedAt: z.string().datetime({ offset: true }),
+  reusableSandbox: z
+    .object({
+      profile: z.string(),
+    })
+    .optional(),
 });
 
 /**

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -5,6 +5,9 @@ export interface RunnerHeldSessionState {
   // id that keys runner sandbox reuse affinity.
   readonly sessionId: string;
   readonly lastCompletedAt: string;
+  readonly reusableSandbox?: {
+    readonly profile: string;
+  };
 }
 
 export type RunnerHeldSessionStates = RunnerHeldSessionState[];


### PR DESCRIPTION
## Summary

- Advertise an optional reusable-sandbox profile in runner heartbeat state and identify the polling runner.
- Prioritize exact reusable continuation work for its holder during the existing affinity window while preserving stable FIFO fallback.
- Reserve exact idle sandboxes before claim, restore them after claim loss, reclaim idle capacity only for a known candidate, and fail safely when cleanup cannot prove teardown.

## Compatibility and exclusions

- New heartbeat and poll fields are optional, so old and new API/runner versions remain interoperable during rollout.
- No relational schema migration or persisted-data backfill is required; existing JSONB heartbeat rows remain valid.
- Existing affinity timing, runner-group policy, and profile admission policy are unchanged.

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,320 passed; 1 skipped)
- `pnpm knip`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner --all-targets` (2,614 passed; 7 ignored)

Closes #20159
