### PR TITLE
docs(rust): fix stale session metadata integration-test path

### DIFF
--- a/crates/guest-agent/src/events.rs
+++ b/crates/guest-agent/src/events.rs
@@ -1771,7 +1771,7 @@ mod tests {
     // Note: end-to-end coverage of session metadata capture (including both
     // the Claude `system/init` branch and the codex `thread.started`
     // branch) lives in the integration test suites:
-    //   - `tests/integration.rs::send_event_extracts_claude_session_id`
+    //   - `tests/integration/events.rs::send_event_extracts_claude_session_id`
     //   - `tests/codex_session_resume.rs` (codex variant)
     // The Claude/Codex helpers are private; their contracts are
     // exercised transitively through `send_event`.


### PR DESCRIPTION
## Summary

- update the Claude session-metadata coverage reference to the current split integration-test file
- preserve the exact `send_event_extracts_claude_session_id` name and the existing Codex suite reference

## Scope

- comment-only documentation correction; no runtime, API, persistence, protocol, or test behavior changes
- no new test or generalized source-comment path checker

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy -p guest-agent --all-targets -- -D warnings`
- `cd crates && cargo test -p guest-agent --test integration events::send_event_extracts_claude_session_id`
- `cd crates && cargo test -p guest-agent --test codex_session_resume`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=1 --silent=passed-only` (7,319 passed; one existing benchmark skipped)
- `cd turbo && pnpm knip`
- pre-commit hooks, including workspace Cargo format, documentation, and Clippy checks

The full Vitest suite used one file worker after four-worker local runs exposed unrelated five-second resource-contention timeouts. No timeout was increased and no test was disabled or omitted.

Closes #21102
