### PR TITLE
perf: attribute nbd netlink connect latency

### DIFF
--- a/crates/nbd-cow/src/device/connection.rs
+++ b/crates/nbd-cow/src/device/connection.rs
@@ -1,5 +1,15 @@
+use std::time::{Duration, Instant};
+
 use crate::error::{self, Result};
 use crate::{netlink, pool};
+
+use super::create_timing::{NbdNetlinkConnectStage, NbdNetlinkConnectTiming};
+
+struct NetlinkCriticalSectionResult<T> {
+    queue_duration: Duration,
+    queue_success: bool,
+    result: Result<T>,
+}
 
 pub(super) async fn run_netlink_critical_section<T>(
     operation: &'static str,
@@ -8,12 +18,38 @@ pub(super) async fn run_netlink_critical_section<T>(
 where
     T: Send + 'static,
 {
-    match tokio::task::spawn_blocking(f).await {
-        Ok(value) => Ok(value),
+    run_netlink_critical_section_with_queue_timing(operation, f)
+        .await
+        .result
+}
+
+async fn run_netlink_critical_section_with_queue_timing<T>(
+    operation: &'static str,
+    f: impl FnOnce() -> T + Send + 'static,
+) -> NetlinkCriticalSectionResult<T>
+where
+    T: Send + 'static,
+{
+    let submitted_at = Instant::now();
+    match tokio::task::spawn_blocking(move || {
+        let queue_duration = submitted_at.elapsed();
+        (queue_duration, f())
+    })
+    .await
+    {
+        Ok((queue_duration, value)) => NetlinkCriticalSectionResult {
+            queue_duration,
+            queue_success: true,
+            result: Ok(value),
+        },
         Err(e) if e.is_panic() => std::panic::resume_unwind(e.into_panic()),
-        Err(e) => Err(error::NbdCowError::Io(std::io::Error::other(format!(
-            "{operation} task was cancelled: {e}",
-        )))),
+        Err(e) => NetlinkCriticalSectionResult {
+            queue_duration: submitted_at.elapsed(),
+            queue_success: false,
+            result: Err(error::NbdCowError::Io(std::io::Error::other(format!(
+                "{operation} task was cancelled: {e}",
+            )))),
+        },
     }
 }
 
@@ -47,6 +83,22 @@ pub(super) struct ConnectDeviceOutcome {
     device_index: u32,
     lease: DeferredLease,
     result: Option<std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>>,
+}
+
+pub(super) struct ConnectDeviceCriticalSectionResult {
+    timing: NbdNetlinkConnectTiming,
+    result: std::result::Result<ConnectDeviceOutcome, netlink::ConnectDeviceError>,
+}
+
+impl ConnectDeviceCriticalSectionResult {
+    pub(super) fn into_parts(
+        self,
+    ) -> (
+        NbdNetlinkConnectTiming,
+        std::result::Result<ConnectDeviceOutcome, netlink::ConnectDeviceError>,
+    ) {
+        (self.timing, self.result)
+    }
 }
 
 impl ConnectDeviceOutcome {
@@ -124,19 +176,41 @@ pub(super) async fn connect_device_with_state_critical_section(
     block_size: u64,
     pool: pool::DevicePoolHandle,
     lease: pool::DeviceLease,
-) -> std::result::Result<ConnectDeviceOutcome, netlink::ConnectDeviceError> {
+) -> ConnectDeviceCriticalSectionResult {
     let deferred_lease = DeferredLease::new(pool, lease);
-    let outcome = run_netlink_critical_section("NBD connect", move || {
-        ConnectDeviceOutcome::new(
-            device_index,
-            deferred_lease,
-            netlink::connect_device_with_state(device_index, &client_fds, size, block_size),
-        )
-    })
-    .await
-    .map_err(|source| netlink::ConnectDeviceError::NotSent { source })?;
+    let critical_section =
+        run_netlink_critical_section_with_queue_timing("NBD connect", move || {
+            let (result, timing) = netlink::connect_device_with_state_timing(
+                device_index,
+                &client_fds,
+                size,
+                block_size,
+            );
+            (
+                ConnectDeviceOutcome::new(device_index, deferred_lease, result),
+                timing,
+            )
+        })
+        .await;
 
-    Ok(outcome)
+    let mut timing;
+    let result = match critical_section.result {
+        Ok((outcome, inner_timing)) => {
+            timing = inner_timing;
+            Ok(outcome)
+        }
+        Err(source) => {
+            timing = NbdNetlinkConnectTiming::default();
+            Err(netlink::ConnectDeviceError::NotSent { source })
+        }
+    };
+    timing.record_stage_duration(
+        NbdNetlinkConnectStage::BlockingTaskQueue,
+        critical_section.queue_duration,
+        critical_section.queue_success,
+    );
+
+    ConnectDeviceCriticalSectionResult { timing, result }
 }
 
 pub(super) struct DisconnectOutcome {
@@ -392,6 +466,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(value, "connected");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn timed_netlink_critical_section_records_queue_start() {
+        let outcome = run_netlink_critical_section_with_queue_timing(
+            "test netlink operation",
+            || "connected",
+        )
+        .await;
+
+        assert!(outcome.queue_success);
+        assert_eq!(outcome.result.unwrap(), "connected");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/nbd-cow/src/device/connection.rs
+++ b/crates/nbd-cow/src/device/connection.rs
@@ -468,16 +468,43 @@ mod tests {
         assert_eq!(value, "connected");
     }
 
-    #[tokio::test(flavor = "current_thread")]
-    async fn timed_netlink_critical_section_records_queue_start() {
-        let outcome = run_netlink_critical_section_with_queue_timing(
-            "test netlink operation",
-            || "connected",
-        )
-        .await;
+    #[test]
+    fn timed_netlink_critical_section_records_queued_start() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .max_blocking_threads(1)
+            .enable_time()
+            .build()
+            .unwrap();
 
-        assert!(outcome.queue_success);
-        assert_eq!(outcome.result.unwrap(), "connected");
+        runtime.block_on(async {
+            let (blocker_started_tx, blocker_started_rx) = tokio::sync::oneshot::channel();
+            let (release_blocker_tx, release_blocker_rx) = std::sync::mpsc::channel();
+            let blocker = tokio::task::spawn_blocking(move || {
+                let _ = blocker_started_tx.send(());
+                release_blocker_rx.recv().unwrap();
+            });
+            blocker_started_rx.await.unwrap();
+
+            let mut future = Box::pin(run_netlink_critical_section_with_queue_timing(
+                "test netlink operation",
+                || "connected",
+            ));
+            let waker = std::task::Waker::noop();
+            let mut cx = std::task::Context::from_waker(waker);
+            assert!(matches!(
+                future.as_mut().poll(&mut cx),
+                std::task::Poll::Pending
+            ));
+
+            release_blocker_tx.send(()).unwrap();
+            blocker.await.unwrap();
+            let outcome = future.await;
+
+            assert!(outcome.queue_success);
+            assert!(outcome.queue_duration > Duration::ZERO);
+            assert_eq!(outcome.result.unwrap(), "connected");
+        });
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/nbd-cow/src/device/create.rs
+++ b/crates/nbd-cow/src/device/create.rs
@@ -16,7 +16,9 @@ use super::connection::{
     disconnect_connected_if_owned_result_with_lease_critical_section,
     disconnect_device_with_lease_critical_section,
 };
-use super::create_timing::{NbdCowCreateObserver, NbdCowCreateStage, NbdCowCreateTiming};
+use super::create_timing::{
+    NbdCowCreateObserver, NbdCowCreateStage, NbdCowCreateTiming, NbdNetlinkConnectTiming,
+};
 
 const MAX_SIZE_RETRIES: u32 = 5;
 const MAX_EBUSY_RETRIES: u32 = 16;
@@ -41,6 +43,11 @@ enum CreateDisconnectCleanupMode {
 enum CreateDisconnectStatus {
     Disconnected,
     Uncertain,
+}
+
+struct ConnectAttemptResult {
+    timing: NbdNetlinkConnectTiming,
+    result: std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError>,
 }
 
 impl CreateDisconnectStatus {
@@ -171,12 +178,17 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
             };
 
             let connect_started_at = Instant::now();
-            let connect_result = self.connect_attempt(&mut attempt, client_fds).await;
+            let connect_attempt = self.connect_attempt(&mut attempt, client_fds).await;
+            // End the existing parent before merging child timing so its
+            // before/after boundary remains comparable.
             self.timing.record_stage(
                 NbdCowCreateStage::NetlinkConnect,
                 connect_started_at,
-                connect_result.is_ok(),
+                connect_attempt.result.is_ok(),
             );
+            self.timing
+                .record_netlink_connect_timing(connect_attempt.timing);
+            let connect_result = connect_attempt.result;
             match connect_result {
                 Ok(connected) => {
                     attempt.mark_connected(connected.connect_tid);
@@ -260,17 +272,20 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
         &mut self,
         attempt: &mut CreateAttemptGuard,
         client_fds: Vec<OwnedFd>,
-    ) -> std::result::Result<netlink::ConnectDeviceSuccess, netlink::ConnectDeviceError> {
+    ) -> ConnectAttemptResult {
         let device_index = attempt.device_index();
         let Some(lease) = attempt.take_lease() else {
-            return Err(netlink::ConnectDeviceError::NotSent {
-                source: error::NbdCowError::Io(std::io::Error::other(
-                    "pool lease missing during NBD connect",
-                )),
-            });
+            return ConnectAttemptResult {
+                timing: NbdNetlinkConnectTiming::default(),
+                result: Err(netlink::ConnectDeviceError::NotSent {
+                    source: error::NbdCowError::Io(std::io::Error::other(
+                        "pool lease missing during NBD connect",
+                    )),
+                }),
+            };
         };
 
-        match connect_device_with_state_critical_section(
+        let critical_section = connect_device_with_state_critical_section(
             device_index,
             client_fds,
             self.size,
@@ -278,8 +293,9 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
             self.device_pool.clone(),
             lease,
         )
-        .await
-        {
+        .await;
+        let (timing, critical_result) = critical_section.into_parts();
+        let result = match critical_result {
             Ok(outcome) => match outcome.into_parts() {
                 Ok((lease, result)) => {
                     attempt.restore_lease(lease);
@@ -288,7 +304,9 @@ impl<'a, 'observer> CreateContext<'a, 'observer> {
                 Err(e) => Err(e),
             },
             Err(e) => Err(e),
-        }
+        };
+
+        ConnectAttemptResult { timing, result }
     }
 }
 

--- a/crates/nbd-cow/src/device/create_timing.rs
+++ b/crates/nbd-cow/src/device/create_timing.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use crate::pool::DeviceAcquireSource;
 
 const NBD_COW_CREATE_STAGE_COUNT: usize = NbdCowCreateStage::ALL.len();
+const NBD_NETLINK_CONNECT_STAGE_COUNT: usize = NbdNetlinkConnectStage::ALL.len();
 
 /// Fixed stages inside one NBD COW device creation.
 ///
@@ -34,6 +35,25 @@ impl NbdCowCreateStage {
     ];
 }
 
+/// Fixed stages nested inside [`NbdCowCreateStage::NetlinkConnect`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NbdNetlinkConnectStage {
+    BlockingTaskQueue,
+    SocketSetup,
+    FamilyResolve,
+    ConnectCommand,
+}
+
+impl NbdNetlinkConnectStage {
+    /// All netlink connect stages in stable telemetry order.
+    pub const ALL: [Self; 4] = [
+        Self::BlockingTaskQueue,
+        Self::SocketSetup,
+        Self::FamilyResolve,
+        Self::ConnectCommand,
+    ];
+}
+
 /// Fixed low-cardinality outcomes for one NBD COW device creation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NbdCowCreateOutcome {
@@ -55,6 +75,15 @@ pub enum NbdCowCreateOutcome {
 pub trait NbdCowCreateObserver: Send {
     fn record_stage(&mut self, stage: NbdCowCreateStage, duration: Duration, success: bool);
 
+    /// Record one aggregate stage nested inside netlink connect.
+    fn record_netlink_connect_stage(
+        &mut self,
+        _stage: NbdNetlinkConnectStage,
+        _duration: Duration,
+        _success: bool,
+    ) {
+    }
+
     fn record_outcome(&mut self, outcome: NbdCowCreateOutcome);
 }
 
@@ -64,10 +93,73 @@ struct StageTiming {
     entered: bool,
 }
 
+#[derive(Default)]
+pub(crate) struct NbdNetlinkConnectTiming {
+    stages: [StageTiming; NBD_NETLINK_CONNECT_STAGE_COUNT],
+    failed_stage: Option<NbdNetlinkConnectStage>,
+}
+
+impl NbdNetlinkConnectTiming {
+    pub(crate) fn record_stage(
+        &mut self,
+        stage: NbdNetlinkConnectStage,
+        started_at: Instant,
+        success: bool,
+    ) {
+        self.record_stage_duration(stage, started_at.elapsed(), success);
+    }
+
+    pub(crate) fn record_stage_duration(
+        &mut self,
+        stage: NbdNetlinkConnectStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        let timing = self.stage_mut(stage);
+        timing.duration = timing.duration.saturating_add(duration);
+        timing.entered = true;
+        if !success {
+            self.failed_stage = Some(stage);
+        }
+    }
+
+    fn stage(&self, stage: NbdNetlinkConnectStage) -> StageTiming {
+        let [
+            blocking_task_queue,
+            socket_setup,
+            family_resolve,
+            connect_command,
+        ] = &self.stages;
+        *match stage {
+            NbdNetlinkConnectStage::BlockingTaskQueue => blocking_task_queue,
+            NbdNetlinkConnectStage::SocketSetup => socket_setup,
+            NbdNetlinkConnectStage::FamilyResolve => family_resolve,
+            NbdNetlinkConnectStage::ConnectCommand => connect_command,
+        }
+    }
+
+    fn stage_mut(&mut self, stage: NbdNetlinkConnectStage) -> &mut StageTiming {
+        let [
+            blocking_task_queue,
+            socket_setup,
+            family_resolve,
+            connect_command,
+        ] = &mut self.stages;
+        match stage {
+            NbdNetlinkConnectStage::BlockingTaskQueue => blocking_task_queue,
+            NbdNetlinkConnectStage::SocketSetup => socket_setup,
+            NbdNetlinkConnectStage::FamilyResolve => family_resolve,
+            NbdNetlinkConnectStage::ConnectCommand => connect_command,
+        }
+    }
+}
+
 pub(super) struct NbdCowCreateTiming<'a> {
     observer: Option<&'a mut dyn NbdCowCreateObserver>,
     stages: [StageTiming; NBD_COW_CREATE_STAGE_COUNT],
     failed_stage: Option<NbdCowCreateStage>,
+    netlink_connect_stages: [StageTiming; NBD_NETLINK_CONNECT_STAGE_COUNT],
+    failed_netlink_connect_stage: Option<NbdNetlinkConnectStage>,
     used_demand_scan: bool,
     used_cooled_claim: bool,
     ebusy_retries: u32,
@@ -80,6 +172,8 @@ impl<'a> NbdCowCreateTiming<'a> {
             observer,
             stages: [StageTiming::default(); NBD_COW_CREATE_STAGE_COUNT],
             failed_stage: None,
+            netlink_connect_stages: [StageTiming::default(); NBD_NETLINK_CONNECT_STAGE_COUNT],
+            failed_netlink_connect_stage: None,
             used_demand_scan: false,
             used_cooled_claim: false,
             ebusy_retries: 0,
@@ -124,6 +218,26 @@ impl<'a> NbdCowCreateTiming<'a> {
         }
     }
 
+    pub(super) fn record_netlink_connect_timing(&mut self, timing: NbdNetlinkConnectTiming) {
+        for stage in NbdNetlinkConnectStage::ALL {
+            let attempt_timing = timing.stage(stage);
+            if !attempt_timing.entered {
+                continue;
+            }
+
+            let aggregate_timing = self.netlink_connect_stage_mut(stage);
+            aggregate_timing.duration = aggregate_timing
+                .duration
+                .saturating_add(attempt_timing.duration);
+            aggregate_timing.entered = true;
+        }
+
+        // Failure attribution belongs to the latest connect attempt. Clearing
+        // a recovered or childless attempt prevents an earlier retry failure
+        // from being reported as the terminal child.
+        self.failed_netlink_connect_stage = timing.failed_stage;
+    }
+
     pub(super) fn record_ebusy_retry(&mut self) {
         self.ebusy_retries = self.ebusy_retries.saturating_add(1);
     }
@@ -146,6 +260,24 @@ impl<'a> NbdCowCreateTiming<'a> {
                 stage,
                 timing.duration,
                 create_success || self.failed_stage != Some(stage),
+            );
+        }
+
+        let failed_netlink_connect_stage =
+            if !create_success && self.failed_stage == Some(NbdCowCreateStage::NetlinkConnect) {
+                self.failed_netlink_connect_stage
+            } else {
+                None
+            };
+        for stage in NbdNetlinkConnectStage::ALL {
+            let timing = self.netlink_connect_stage(stage);
+            if !timing.entered {
+                continue;
+            }
+            observer.record_netlink_connect_stage(
+                stage,
+                timing.duration,
+                failed_netlink_connect_stage != Some(stage),
             );
         }
 
@@ -204,6 +336,36 @@ impl<'a> NbdCowCreateTiming<'a> {
             NbdCowCreateStage::RetryDelay => retry_delay,
         }
     }
+
+    fn netlink_connect_stage(&self, stage: NbdNetlinkConnectStage) -> StageTiming {
+        let [
+            blocking_task_queue,
+            socket_setup,
+            family_resolve,
+            connect_command,
+        ] = &self.netlink_connect_stages;
+        *match stage {
+            NbdNetlinkConnectStage::BlockingTaskQueue => blocking_task_queue,
+            NbdNetlinkConnectStage::SocketSetup => socket_setup,
+            NbdNetlinkConnectStage::FamilyResolve => family_resolve,
+            NbdNetlinkConnectStage::ConnectCommand => connect_command,
+        }
+    }
+
+    fn netlink_connect_stage_mut(&mut self, stage: NbdNetlinkConnectStage) -> &mut StageTiming {
+        let [
+            blocking_task_queue,
+            socket_setup,
+            family_resolve,
+            connect_command,
+        ] = &mut self.netlink_connect_stages;
+        match stage {
+            NbdNetlinkConnectStage::BlockingTaskQueue => blocking_task_queue,
+            NbdNetlinkConnectStage::SocketSetup => socket_setup,
+            NbdNetlinkConnectStage::FamilyResolve => family_resolve,
+            NbdNetlinkConnectStage::ConnectCommand => connect_command,
+        }
+    }
 }
 
 fn ebusy_retry_outcome(count: u32) -> NbdCowCreateOutcome {
@@ -229,6 +391,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingObserver {
         stages: Vec<(NbdCowCreateStage, Duration, bool)>,
+        netlink_connect_stages: Vec<(NbdNetlinkConnectStage, Duration, bool)>,
         outcomes: Vec<NbdCowCreateOutcome>,
     }
 
@@ -237,9 +400,26 @@ mod tests {
             self.stages.push((stage, duration, success));
         }
 
+        fn record_netlink_connect_stage(
+            &mut self,
+            stage: NbdNetlinkConnectStage,
+            duration: Duration,
+            success: bool,
+        ) {
+            self.netlink_connect_stages.push((stage, duration, success));
+        }
+
         fn record_outcome(&mut self, outcome: NbdCowCreateOutcome) {
             self.outcomes.push(outcome);
         }
+    }
+
+    fn netlink_timing(records: &[(NbdNetlinkConnectStage, u64, bool)]) -> NbdNetlinkConnectTiming {
+        let mut timing = NbdNetlinkConnectTiming::default();
+        for &(stage, duration_ms, success) in records {
+            timing.record_stage_duration(stage, Duration::from_millis(duration_ms), success);
+        }
+        timing
     }
 
     #[test]
@@ -343,6 +523,178 @@ mod tests {
                 NbdCowCreateOutcome::EbusyRetriesNone,
                 NbdCowCreateOutcome::SizeZeroRetriesNone,
             ]
+        );
+    }
+
+    #[test]
+    fn netlink_timing_aggregates_recovered_attempts_once() {
+        let mut observer = RecordingObserver::default();
+        let mut timing = NbdCowCreateTiming::new(Some(&mut observer));
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(17),
+            false,
+        );
+        timing.record_netlink_connect_timing(netlink_timing(&[
+            (NbdNetlinkConnectStage::BlockingTaskQueue, 2, true),
+            (NbdNetlinkConnectStage::SocketSetup, 3, true),
+            (NbdNetlinkConnectStage::FamilyResolve, 5, true),
+            (NbdNetlinkConnectStage::ConnectCommand, 7, false),
+        ]));
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(60),
+            true,
+        );
+        timing.record_netlink_connect_timing(netlink_timing(&[
+            (NbdNetlinkConnectStage::BlockingTaskQueue, 11, true),
+            (NbdNetlinkConnectStage::SocketSetup, 13, true),
+            (NbdNetlinkConnectStage::FamilyResolve, 17, true),
+            (NbdNetlinkConnectStage::ConnectCommand, 19, true),
+        ]));
+        timing.finish(true);
+
+        assert_eq!(
+            observer.netlink_connect_stages,
+            vec![
+                (
+                    NbdNetlinkConnectStage::BlockingTaskQueue,
+                    Duration::from_millis(13),
+                    true,
+                ),
+                (
+                    NbdNetlinkConnectStage::SocketSetup,
+                    Duration::from_millis(16),
+                    true,
+                ),
+                (
+                    NbdNetlinkConnectStage::FamilyResolve,
+                    Duration::from_millis(22),
+                    true,
+                ),
+                (
+                    NbdNetlinkConnectStage::ConnectCommand,
+                    Duration::from_millis(26),
+                    true,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn netlink_timing_marks_only_latest_terminal_child_failed() {
+        let mut observer = RecordingObserver::default();
+        let mut timing = NbdCowCreateTiming::new(Some(&mut observer));
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(17),
+            false,
+        );
+        timing.record_netlink_connect_timing(netlink_timing(&[
+            (NbdNetlinkConnectStage::BlockingTaskQueue, 2, true),
+            (NbdNetlinkConnectStage::SocketSetup, 3, true),
+            (NbdNetlinkConnectStage::FamilyResolve, 5, true),
+            (NbdNetlinkConnectStage::ConnectCommand, 7, false),
+        ]));
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(49),
+            false,
+        );
+        timing.record_netlink_connect_timing(netlink_timing(&[
+            (NbdNetlinkConnectStage::BlockingTaskQueue, 11, true),
+            (NbdNetlinkConnectStage::SocketSetup, 13, true),
+            (NbdNetlinkConnectStage::FamilyResolve, 17, false),
+        ]));
+        timing.finish(false);
+
+        assert_eq!(
+            observer.netlink_connect_stages,
+            vec![
+                (
+                    NbdNetlinkConnectStage::BlockingTaskQueue,
+                    Duration::from_millis(13),
+                    true,
+                ),
+                (
+                    NbdNetlinkConnectStage::SocketSetup,
+                    Duration::from_millis(16),
+                    true,
+                ),
+                (
+                    NbdNetlinkConnectStage::FamilyResolve,
+                    Duration::from_millis(22),
+                    false,
+                ),
+                (
+                    NbdNetlinkConnectStage::ConnectCommand,
+                    Duration::from_millis(7),
+                    true,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn netlink_timing_clears_recovered_child_before_childless_failure() {
+        let mut observer = RecordingObserver::default();
+        let mut timing = NbdCowCreateTiming::new(Some(&mut observer));
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(7),
+            false,
+        );
+        timing.record_netlink_connect_timing(netlink_timing(&[(
+            NbdNetlinkConnectStage::ConnectCommand,
+            7,
+            false,
+        )]));
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(1),
+            false,
+        );
+        timing.record_netlink_connect_timing(NbdNetlinkConnectTiming::default());
+        timing.finish(false);
+
+        assert_eq!(
+            observer.netlink_connect_stages,
+            vec![(
+                NbdNetlinkConnectStage::ConnectCommand,
+                Duration::from_millis(7),
+                true,
+            )]
+        );
+    }
+
+    #[test]
+    fn netlink_timing_keeps_children_successful_for_other_terminal_parent() {
+        let mut observer = RecordingObserver::default();
+        let mut timing = NbdCowCreateTiming::new(Some(&mut observer));
+        timing.record_stage_duration(
+            NbdCowCreateStage::NetlinkConnect,
+            Duration::from_millis(7),
+            false,
+        );
+        timing.record_netlink_connect_timing(netlink_timing(&[(
+            NbdNetlinkConnectStage::ConnectCommand,
+            7,
+            false,
+        )]));
+        timing.record_stage_duration(
+            NbdCowCreateStage::SizeVerify,
+            Duration::from_millis(5),
+            false,
+        );
+        timing.finish(false);
+
+        assert_eq!(
+            observer.netlink_connect_stages,
+            vec![(
+                NbdNetlinkConnectStage::ConnectCommand,
+                Duration::from_millis(7),
+                true,
+            )]
         );
     }
 }

--- a/crates/nbd-cow/src/device/mod.rs
+++ b/crates/nbd-cow/src/device/mod.rs
@@ -12,7 +12,10 @@ mod finalizer;
 mod pooled;
 
 pub use connection::is_our_thread;
-pub use create_timing::{NbdCowCreateObserver, NbdCowCreateOutcome, NbdCowCreateStage};
+pub(crate) use create_timing::NbdNetlinkConnectTiming;
+pub use create_timing::{
+    NbdCowCreateObserver, NbdCowCreateOutcome, NbdCowCreateStage, NbdNetlinkConnectStage,
+};
 pub use pooled::{DestroyRetryPolicy, KeptCow, PooledDestroyError, PooledNbdCowDevice};
 
 use connection::{

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -40,7 +40,7 @@ pub mod server;
 
 pub use device::{
     DestroyRetryPolicy, KeptCow, NbdCowCreateObserver, NbdCowCreateOutcome, NbdCowCreateStage,
-    NbdCowDevice, PooledDestroyError, PooledNbdCowDevice, is_our_thread,
+    NbdCowDevice, NbdNetlinkConnectStage, PooledDestroyError, PooledNbdCowDevice, is_our_thread,
 };
 
 /// Default block size: 4KB (matches typical filesystem block size and kernel page size).

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -16,9 +16,11 @@
 
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::path::Path;
+use std::time::Instant;
 
 use nix::sys::socket::{AddressFamily, SockFlag, SockType, socketpair};
 
+use crate::device::{NbdNetlinkConnectStage, NbdNetlinkConnectTiming};
 use crate::error::{NbdCowError, Result};
 
 mod socket;
@@ -190,13 +192,50 @@ pub(crate) fn connect_device_with_state(
     size: u64,
     block_size: u64,
 ) -> std::result::Result<ConnectDeviceSuccess, ConnectDeviceError> {
-    let sockets_payload_len = validate_connect_socket_count(client_fds.len())?;
+    connect_device_with_state_timing(device_index, client_fds, size, block_size).0
+}
 
-    let sock =
-        socket::open_genl_socket().map_err(|source| ConnectDeviceError::NotSent { source })?;
-    let family_id =
-        resolve_nbd_family(&sock).map_err(|source| ConnectDeviceError::NotSent { source })?;
+pub(crate) fn connect_device_with_state_timing(
+    device_index: u32,
+    client_fds: &[OwnedFd],
+    size: u64,
+    block_size: u64,
+) -> (
+    std::result::Result<ConnectDeviceSuccess, ConnectDeviceError>,
+    NbdNetlinkConnectTiming,
+) {
+    let setup_started_at = Instant::now();
+    let mut timing = NbdNetlinkConnectTiming::default();
+    let setup_result = (|| {
+        let sockets_payload_len = validate_connect_socket_count(client_fds.len())?;
+        let sock =
+            socket::open_genl_socket().map_err(|source| ConnectDeviceError::NotSent { source })?;
+        Ok((sockets_payload_len, sock))
+    })();
+    timing.record_stage(
+        NbdNetlinkConnectStage::SocketSetup,
+        setup_started_at,
+        setup_result.is_ok(),
+    );
+    let (sockets_payload_len, sock) = match setup_result {
+        Ok(setup) => setup,
+        Err(error) => return (Err(error), timing),
+    };
 
+    let family_started_at = Instant::now();
+    let family_result =
+        resolve_nbd_family(&sock).map_err(|source| ConnectDeviceError::NotSent { source });
+    timing.record_stage(
+        NbdNetlinkConnectStage::FamilyResolve,
+        family_started_at,
+        family_result.is_ok(),
+    );
+    let family_id = match family_result {
+        Ok(family_id) => family_id,
+        Err(error) => return (Err(error), timing),
+    };
+
+    let command_started_at = Instant::now();
     let sockets_nla = build_sockets_nla(client_fds, sockets_payload_len);
     let flags =
         NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_TRIM | NBD_FLAG_CAN_MULTI_CONN;
@@ -228,10 +267,17 @@ pub(crate) fn connect_device_with_state(
     // The kernel records the sending task's TID in /sys/block/nbdN/pid on
     // successful connect. Capture it before crossing the netlink send boundary.
     let connect_tid = unsafe { libc::gettid() } as u32;
-    let seq = send_nbd_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)
-        .map_err(|source| ConnectDeviceError::NotSent { source })?;
+    let result = match send_nbd_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs) {
+        Ok(seq) => finish_connect_after_send(&sock, seq, connect_tid),
+        Err(source) => Err(ConnectDeviceError::NotSent { source }),
+    };
+    timing.record_stage(
+        NbdNetlinkConnectStage::ConnectCommand,
+        command_started_at,
+        result.is_ok(),
+    );
 
-    finish_connect_after_send(&sock, seq, connect_tid)
+    (result, timing)
 }
 
 /// Check whether the device has the expected size via sysfs.

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -24,6 +24,7 @@ use nbd_fixture::{NbdTestFixture, default_device_pool};
 #[derive(Default)]
 struct RecordingCreateObserver {
     stages: Vec<(nbd_cow::NbdCowCreateStage, Duration, bool)>,
+    netlink_connect_stages: Vec<(nbd_cow::NbdNetlinkConnectStage, Duration, bool)>,
     outcomes: Vec<nbd_cow::NbdCowCreateOutcome>,
 }
 
@@ -35,6 +36,15 @@ impl nbd_cow::NbdCowCreateObserver for RecordingCreateObserver {
         success: bool,
     ) {
         self.stages.push((stage, duration, success));
+    }
+
+    fn record_netlink_connect_stage(
+        &mut self,
+        stage: nbd_cow::NbdNetlinkConnectStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        self.netlink_connect_stages.push((stage, duration, success));
     }
 
     fn record_outcome(&mut self, outcome: nbd_cow::NbdCowCreateOutcome) {
@@ -52,6 +62,29 @@ impl RecordingCreateObserver {
         assert_eq!(matches.len(), 1, "stage {expected:?}: {:?}", self.stages);
         let (_, duration, success) = matches[0];
         assert!(*success, "stage {expected:?} should succeed");
+        *duration
+    }
+
+    fn netlink_connect_stage_duration(
+        &self,
+        expected: nbd_cow::NbdNetlinkConnectStage,
+    ) -> Duration {
+        let matches: Vec<_> = self
+            .netlink_connect_stages
+            .iter()
+            .filter(|(stage, _, _)| *stage == expected)
+            .collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "netlink connect stage {expected:?}: {:?}",
+            self.netlink_connect_stages,
+        );
+        let (_, duration, success) = matches[0];
+        assert!(
+            *success,
+            "netlink connect stage {expected:?} should succeed"
+        );
         *duration
     }
 }
@@ -141,6 +174,16 @@ async fn create_and_destroy() {
             <= observer.stage_duration(nbd_cow::NbdCowCreateStage::DeviceAcquire),
         "device scan is nested inside device acquire: {:?}",
         observer.stages,
+    );
+    let netlink_child_duration: Duration = nbd_cow::NbdNetlinkConnectStage::ALL
+        .into_iter()
+        .map(|stage| observer.netlink_connect_stage_duration(stage))
+        .sum();
+    assert!(
+        netlink_child_duration
+            <= observer.stage_duration(nbd_cow::NbdCowCreateStage::NetlinkConnect),
+        "netlink connect children are nested inside their parent: {:?}",
+        observer.netlink_connect_stages,
     );
     assert!(
         observer

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use futures_util::FutureExt;
 use sandbox::{
     Sandbox, SandboxConfig, SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxId,
-    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
+    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
@@ -66,9 +66,9 @@ const RUNNER_FRESH_SANDBOX_FACTORY_NETNS_ACQUIRE: &str =
     "runner_fresh_sandbox_factory_netns_acquire";
 const RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_CREATE: &str =
     "runner_fresh_sandbox_factory_nbd_cow_create";
-// NBD detail durations are children of `nbd_cow_create`. Device scan is
-// nested again inside device acquire, so downstream queries must not add it to
-// the acquire duration or to a peer-stage sum.
+// NBD detail durations are children of `nbd_cow_create`. Device scan is nested
+// again inside device acquire, and netlink details are nested inside netlink
+// connect. Downstream queries must not add nested durations to their parents.
 const RUNNER_FRESH_SANDBOX_FACTORY_NBD_COW_LAYER_CREATE: &str =
     "runner_fresh_sandbox_factory_nbd_cow_layer_create";
 const RUNNER_FRESH_SANDBOX_FACTORY_NBD_DEVICE_ACQUIRE: &str =
@@ -79,6 +79,14 @@ const RUNNER_FRESH_SANDBOX_FACTORY_NBD_DISPATCH_SETUP: &str =
     "runner_fresh_sandbox_factory_nbd_dispatch_setup";
 const RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_CONNECT: &str =
     "runner_fresh_sandbox_factory_nbd_netlink_connect";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_BLOCKING_TASK_QUEUE: &str =
+    "runner_fresh_sandbox_factory_nbd_netlink_blocking_task_queue";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_SOCKET_SETUP: &str =
+    "runner_fresh_sandbox_factory_nbd_netlink_socket_setup";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_FAMILY_RESOLVE: &str =
+    "runner_fresh_sandbox_factory_nbd_netlink_family_resolve";
+const RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_CONNECT_COMMAND: &str =
+    "runner_fresh_sandbox_factory_nbd_netlink_connect_command";
 const RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_VERIFY: &str =
     "runner_fresh_sandbox_factory_nbd_size_verify";
 const RUNNER_FRESH_SANDBOX_FACTORY_NBD_RETRY_CLEANUP: &str =
@@ -154,6 +162,25 @@ impl SandboxCreateObserver for FreshSandboxFactoryCreateObserver<'_> {
         );
     }
 
+    fn record_nbd_netlink_connect_stage(
+        &mut self,
+        stage: SandboxNbdNetlinkConnectStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        let error = if success {
+            None
+        } else {
+            Some(SANDBOX_FACTORY_CREATE_STAGE_FAILED)
+        };
+        self.telemetry.record(
+            fresh_sandbox_factory_nbd_netlink_connect_stage_action(stage),
+            duration,
+            success,
+            error,
+        );
+    }
+
     fn record_nbd_cow_outcome(&mut self, outcome: SandboxNbdCowCreateOutcome) {
         self.telemetry.record(
             fresh_sandbox_factory_nbd_cow_outcome_action(outcome),
@@ -197,6 +224,25 @@ fn fresh_sandbox_factory_nbd_cow_stage_action(stage: SandboxNbdCowCreateStage) -
         SandboxNbdCowCreateStage::SizeVerify => RUNNER_FRESH_SANDBOX_FACTORY_NBD_SIZE_VERIFY,
         SandboxNbdCowCreateStage::RetryCleanup => RUNNER_FRESH_SANDBOX_FACTORY_NBD_RETRY_CLEANUP,
         SandboxNbdCowCreateStage::RetryDelay => RUNNER_FRESH_SANDBOX_FACTORY_NBD_RETRY_DELAY,
+    }
+}
+
+fn fresh_sandbox_factory_nbd_netlink_connect_stage_action(
+    stage: SandboxNbdNetlinkConnectStage,
+) -> &'static str {
+    match stage {
+        SandboxNbdNetlinkConnectStage::BlockingTaskQueue => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_BLOCKING_TASK_QUEUE
+        }
+        SandboxNbdNetlinkConnectStage::SocketSetup => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_SOCKET_SETUP
+        }
+        SandboxNbdNetlinkConnectStage::FamilyResolve => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_FAMILY_RESOLVE
+        }
+        SandboxNbdNetlinkConnectStage::ConnectCommand => {
+            RUNNER_FRESH_SANDBOX_FACTORY_NBD_NETLINK_CONNECT_COMMAND
+        }
     }
 }
 

--- a/crates/runner/src/executor/tests/telemetry_tests.rs
+++ b/crates/runner/src/executor/tests/telemetry_tests.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use sandbox::{
     ProcessOutputChunk, ProcessOutputMode, Sandbox, SandboxConfig, SandboxCreateObserver,
     SandboxCreateStage, SandboxError, SandboxFactory, SandboxId, SandboxInitializationPhase,
-    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
+    SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
 };
 use sandbox_mock::MockSandboxFactory;
 
@@ -103,6 +103,7 @@ struct ObservedMockSandboxFactory {
     inner: MockSandboxFactory,
     failed_stage: Option<SandboxCreateStage>,
     failed_nbd_cow_stage: Option<SandboxNbdCowCreateStage>,
+    failed_nbd_netlink_connect_stage: Option<SandboxNbdNetlinkConnectStage>,
 }
 
 impl ObservedMockSandboxFactory {
@@ -111,6 +112,7 @@ impl ObservedMockSandboxFactory {
             inner: MockSandboxFactory::new(),
             failed_stage: None,
             failed_nbd_cow_stage: None,
+            failed_nbd_netlink_connect_stage: None,
         }
     }
 
@@ -119,6 +121,7 @@ impl ObservedMockSandboxFactory {
             inner: MockSandboxFactory::new(),
             failed_stage: Some(stage),
             failed_nbd_cow_stage: None,
+            failed_nbd_netlink_connect_stage: None,
         }
     }
 
@@ -127,6 +130,16 @@ impl ObservedMockSandboxFactory {
             inner: MockSandboxFactory::new(),
             failed_stage: None,
             failed_nbd_cow_stage: Some(stage),
+            failed_nbd_netlink_connect_stage: None,
+        }
+    }
+
+    fn with_failed_nbd_netlink_connect_stage(stage: SandboxNbdNetlinkConnectStage) -> Self {
+        Self {
+            inner: MockSandboxFactory::new(),
+            failed_stage: None,
+            failed_nbd_cow_stage: None,
+            failed_nbd_netlink_connect_stage: Some(stage),
         }
     }
 }
@@ -171,11 +184,40 @@ impl SandboxFactory for ObservedMockSandboxFactory {
             });
         }
 
+        if let Some(stage) = self.failed_nbd_netlink_connect_stage {
+            observer.record_nbd_netlink_connect_stage(stage, Duration::from_millis(1), false);
+            observer.record_nbd_cow_stage(
+                SandboxNbdCowCreateStage::NetlinkConnect,
+                Duration::from_millis(2),
+                false,
+            );
+            observer.record_stage(
+                SandboxCreateStage::NbdCowCreate,
+                Duration::from_millis(3),
+                false,
+            );
+            return Err(SandboxError::Initialization {
+                phase: SandboxInitializationPhase::SandboxAllocation,
+                message: "observed mock NBD netlink detail failure".to_string(),
+            });
+        }
+
         for (index, stage) in SandboxCreateStage::ALL.iter().copied().enumerate() {
             observer.record_stage(stage, Duration::from_millis(index as u64 + 1), true);
         }
         for (index, stage) in SandboxNbdCowCreateStage::ALL.iter().copied().enumerate() {
             observer.record_nbd_cow_stage(stage, Duration::from_millis(index as u64 + 10), true);
+        }
+        for (index, stage) in SandboxNbdNetlinkConnectStage::ALL
+            .iter()
+            .copied()
+            .enumerate()
+        {
+            observer.record_nbd_netlink_connect_stage(
+                stage,
+                Duration::from_millis(index as u64 + 20),
+                true,
+            );
         }
         for outcome in [
             SandboxNbdCowCreateOutcome::AcquireSourceDemandScan,
@@ -216,6 +258,13 @@ const FRESH_SANDBOX_FACTORY_NBD_COW_STAGE_ACTIONS: &[&str] = &[
     "runner_fresh_sandbox_factory_nbd_size_verify",
     "runner_fresh_sandbox_factory_nbd_retry_cleanup",
     "runner_fresh_sandbox_factory_nbd_retry_delay",
+];
+
+const FRESH_SANDBOX_FACTORY_NBD_NETLINK_CONNECT_STAGE_ACTIONS: &[&str] = &[
+    "runner_fresh_sandbox_factory_nbd_netlink_blocking_task_queue",
+    "runner_fresh_sandbox_factory_nbd_netlink_socket_setup",
+    "runner_fresh_sandbox_factory_nbd_netlink_family_resolve",
+    "runner_fresh_sandbox_factory_nbd_netlink_connect_command",
 ];
 
 const FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS: &[&str] = &[
@@ -414,6 +463,9 @@ async fn execute_job_records_runner_pre_spawn_and_fresh_path_timing() {
     for action in FRESH_SANDBOX_FACTORY_NBD_COW_STAGE_ACTIONS {
         assert_action_success(&telemetry, action, true);
     }
+    for action in FRESH_SANDBOX_FACTORY_NBD_NETLINK_CONNECT_STAGE_ACTIONS {
+        assert_action_success(&telemetry, action, true);
+    }
     for action in FRESH_SANDBOX_FACTORY_NBD_COW_OUTCOME_ACTIONS {
         assert_action_success(&telemetry, action, true);
     }
@@ -502,6 +554,48 @@ async fn execute_job_records_failed_nbd_cow_detail_and_parent_timing() {
         false,
         Some("sandbox_factory_create_stage_failed"),
     );
+    assert_action_outcome(
+        &telemetry,
+        "runner_fresh_sandbox_factory_create",
+        false,
+        Some("sandbox_factory_create_failed"),
+    );
+}
+
+#[tokio::test]
+async fn execute_job_records_failed_nbd_netlink_detail_and_parent_timing() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let factory = ObservedMockSandboxFactory::with_failed_nbd_netlink_connect_stage(
+        SandboxNbdNetlinkConnectStage::ConnectCommand,
+    );
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let (_outcome, telemetry) = execute_job(
+        &factory,
+        minimal_context(),
+        NewSandboxDispatch {
+            id: SandboxId::new_v4(),
+            reuse_result: SandboxReuseResult::PoolMiss,
+        },
+        &config,
+        &default_params(),
+        cancel,
+    )
+    .await;
+
+    for action in [
+        "runner_fresh_sandbox_factory_nbd_netlink_connect_command",
+        "runner_fresh_sandbox_factory_nbd_netlink_connect",
+        "runner_fresh_sandbox_factory_nbd_cow_create",
+    ] {
+        assert_action_outcome(
+            &telemetry,
+            action,
+            false,
+            Some("sandbox_factory_create_stage_failed"),
+        );
+    }
     assert_action_outcome(
         &telemetry,
         "runner_fresh_sandbox_factory_create",

--- a/crates/sandbox-fc/src/factory/create_timing.rs
+++ b/crates/sandbox-fc/src/factory/create_timing.rs
@@ -1,8 +1,11 @@
 use std::fmt;
 use std::time::{Duration, Instant};
 
-use nbd_cow::{NbdCowCreateOutcome, NbdCowCreateStage};
-use sandbox::{SandboxCreateStage, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage};
+use nbd_cow::{NbdCowCreateOutcome, NbdCowCreateStage, NbdNetlinkConnectStage};
+use sandbox::{
+    SandboxCreateStage, SandboxNbdCowCreateOutcome, SandboxNbdCowCreateStage,
+    SandboxNbdNetlinkConnectStage,
+};
 use tracing::{info, warn};
 
 use crate::duration::duration_ms;
@@ -266,6 +269,22 @@ impl nbd_cow::NbdCowCreateObserver for SandboxCreateTiming<'_> {
         observer.record_nbd_cow_stage(sandbox_nbd_cow_stage(stage), duration, success);
     }
 
+    fn record_netlink_connect_stage(
+        &mut self,
+        stage: NbdNetlinkConnectStage,
+        duration: Duration,
+        success: bool,
+    ) {
+        let Some(observer) = self.observer.as_deref_mut() else {
+            return;
+        };
+        observer.record_nbd_netlink_connect_stage(
+            sandbox_nbd_netlink_connect_stage(stage),
+            duration,
+            success,
+        );
+    }
+
     fn record_outcome(&mut self, outcome: NbdCowCreateOutcome) {
         let Some(observer) = self.observer.as_deref_mut() else {
             return;
@@ -284,6 +303,19 @@ fn sandbox_nbd_cow_stage(stage: NbdCowCreateStage) -> SandboxNbdCowCreateStage {
         NbdCowCreateStage::SizeVerify => SandboxNbdCowCreateStage::SizeVerify,
         NbdCowCreateStage::RetryCleanup => SandboxNbdCowCreateStage::RetryCleanup,
         NbdCowCreateStage::RetryDelay => SandboxNbdCowCreateStage::RetryDelay,
+    }
+}
+
+fn sandbox_nbd_netlink_connect_stage(
+    stage: NbdNetlinkConnectStage,
+) -> SandboxNbdNetlinkConnectStage {
+    match stage {
+        NbdNetlinkConnectStage::BlockingTaskQueue => {
+            SandboxNbdNetlinkConnectStage::BlockingTaskQueue
+        }
+        NbdNetlinkConnectStage::SocketSetup => SandboxNbdNetlinkConnectStage::SocketSetup,
+        NbdNetlinkConnectStage::FamilyResolve => SandboxNbdNetlinkConnectStage::FamilyResolve,
+        NbdNetlinkConnectStage::ConnectCommand => SandboxNbdNetlinkConnectStage::ConnectCommand,
     }
 }
 
@@ -395,6 +427,7 @@ mod tests {
     struct RecordingCreateObserver {
         records: Vec<(sandbox::SandboxCreateStage, Duration, bool)>,
         nbd_cow_records: Vec<(sandbox::SandboxNbdCowCreateStage, Duration, bool)>,
+        nbd_netlink_connect_records: Vec<(sandbox::SandboxNbdNetlinkConnectStage, Duration, bool)>,
         nbd_cow_outcomes: Vec<sandbox::SandboxNbdCowCreateOutcome>,
     }
 
@@ -415,6 +448,16 @@ mod tests {
             success: bool,
         ) {
             self.nbd_cow_records.push((stage, duration, success));
+        }
+
+        fn record_nbd_netlink_connect_stage(
+            &mut self,
+            stage: sandbox::SandboxNbdNetlinkConnectStage,
+            duration: Duration,
+            success: bool,
+        ) {
+            self.nbd_netlink_connect_records
+                .push((stage, duration, success));
         }
 
         fn record_nbd_cow_outcome(&mut self, outcome: sandbox::SandboxNbdCowCreateOutcome) {
@@ -721,6 +764,14 @@ mod tests {
                     stage != NbdCowCreateStage::NetlinkConnect,
                 );
             }
+            for stage in NbdNetlinkConnectStage::ALL {
+                nbd_cow::NbdCowCreateObserver::record_netlink_connect_stage(
+                    &mut timing,
+                    stage,
+                    Duration::from_millis(3),
+                    stage != NbdNetlinkConnectStage::FamilyResolve,
+                );
+            }
             for outcome in [
                 NbdCowCreateOutcome::AcquireSourceDemandScan,
                 NbdCowCreateOutcome::AcquireSourceCooledClaim,
@@ -748,6 +799,17 @@ mod tests {
                 record.2 == (record.0 != SandboxNbdCowCreateStage::NetlinkConnect)
             })
         );
+        assert_eq!(
+            observer
+                .nbd_netlink_connect_records
+                .iter()
+                .map(|record| record.0)
+                .collect::<Vec<_>>(),
+            SandboxNbdNetlinkConnectStage::ALL,
+        );
+        assert!(observer.nbd_netlink_connect_records.iter().all(|record| {
+            record.2 == (record.0 != SandboxNbdNetlinkConnectStage::FamilyResolve)
+        }));
         assert_eq!(
             observer.nbd_cow_outcomes,
             vec![

--- a/crates/sandbox/src/factory.rs
+++ b/crates/sandbox/src/factory.rs
@@ -66,6 +66,25 @@ impl SandboxNbdCowCreateStage {
     ];
 }
 
+/// Fixed details nested under [`SandboxNbdCowCreateStage::NetlinkConnect`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxNbdNetlinkConnectStage {
+    BlockingTaskQueue,
+    SocketSetup,
+    FamilyResolve,
+    ConnectCommand,
+}
+
+impl SandboxNbdNetlinkConnectStage {
+    /// All NBD netlink connect stages in stable telemetry order.
+    pub const ALL: [Self; 4] = [
+        Self::BlockingTaskQueue,
+        Self::SocketSetup,
+        Self::FamilyResolve,
+        Self::ConnectCommand,
+    ];
+}
+
 /// Fixed low-cardinality NBD COW outcomes for sandbox-create telemetry.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SandboxNbdCowCreateOutcome {
@@ -87,6 +106,15 @@ pub trait SandboxCreateObserver: Send {
     fn record_nbd_cow_stage(
         &mut self,
         _stage: SandboxNbdCowCreateStage,
+        _duration: Duration,
+        _success: bool,
+    ) {
+    }
+
+    /// Record one aggregate stage nested inside NBD netlink connect.
+    fn record_nbd_netlink_connect_stage(
+        &mut self,
+        _stage: SandboxNbdNetlinkConnectStage,
         _duration: Duration,
         _success: bool,
     ) {

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -38,7 +38,7 @@ pub use error::{
 };
 pub use factory::{
     SandboxCreateObserver, SandboxCreateStage, SandboxFactory, SandboxNbdCowCreateOutcome,
-    SandboxNbdCowCreateStage,
+    SandboxNbdCowCreateStage, SandboxNbdNetlinkConnectStage,
 };
 pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::Sandbox;


### PR DESCRIPTION
## Summary

- attribute the existing NBD netlink connect parent duration to blocking-task queueing, socket setup, generic-netlink family resolution, and the connect command
- aggregate child durations across retries while marking only the authoritative terminal child as failed
- propagate the additive child stages through sandbox creation observers and emit fixed low-cardinality runner telemetry actions

## Compatibility and exclusions

- preserves the existing netlink connect parent timing boundary and action name
- keeps connect, disconnect, cancellation, panic, lease, and cleanup behavior unchanged
- adds default no-op observer methods for cross-version source compatibility
- does not change schemas, persisted data, APIs, queue payloads, or runner protocols

## Rollout and post-deploy decision

- this PR intentionally adds attribution only; it does not select or implement a netlink behavior optimization
- old and new runner versions can overlap safely because the new action names are additive; reverting the runner returns to parent-only attribution
- the privileged metal NBD job remains a required signal for the real kernel connect path
- after production rollout, update #21110 with the runner release boundary, sample count, p50/p90/p95/p99/max for the parent and each child, child coverage, parent-minus-child residuals, and failure/retry incidence
- consider family reuse, blocking execution changes, socket reuse, or connection-count/kernel work only if its corresponding child dominates; close or defer behavior work if the expanded stages show an immaterial or irreducible kernel floor

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo doc --workspace --no-deps`
- `cargo test -p nbd-cow`
- `cargo test -p sandbox`
- `cargo test -p sandbox-fc factory::create_timing`
- `cargo test -p runner executor::tests::telemetry_tests`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=1 --silent=passed-only` (594 files passed, 1 benchmark file skipped; 7,319 tests passed)
- `cd turbo && pnpm knip`

Closes #21110

Parent context: #18746
