### PR TITLE
feat(cli): diagnose ambiguous connector routes

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -760,6 +760,79 @@ describe("zero doctor check-connector command", () => {
     });
   });
 
+  describe("option validation", () => {
+    it("should reject --connector without --url", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+          "--connector",
+          "github",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--connector can only be used with --url"),
+      );
+    });
+
+    it("should reject --check-permission with --url", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.github.com/repos/owner/repo",
+          "--check-permission",
+          "contents:read",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--check-permission cannot be used with --url"),
+      );
+    });
+
+    it("should reject an explicit --method without --url", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+          "--method",
+          "POST",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--method can only be used with --url"),
+      );
+    });
+
+    it("should reject unknown connector types without prototype matches", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.github.com/repos/owner/repo",
+          "--connector",
+          "constructor",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unknown connector type: constructor"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("zero connector search 'constructor'"),
+      );
+    });
+  });
+
   describe("re-diagnose hint", () => {
     it("should include re-diagnose hint with check-connector syntax", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
@@ -831,6 +904,469 @@ describe("zero doctor check-connector command", () => {
   });
 
   describe("--url mode", () => {
+    function stubConnectedUrlConnector(type: string, authMethod: string): void {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      server.use(
+        stubAvailableConnectors([type]),
+        http.get(`https://app.vm0.ai/api/zero/connectors/${type}`, () => {
+          return HttpResponse.json({
+            ...connectedResponse,
+            type,
+            authMethod,
+          });
+        }),
+      );
+    }
+
+    it("should report ambiguous generated routes with explicit selection commands", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.accounts.nintendo.com/2.0.0/users/me?code=secret#private",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Multiple connectors match GET https://api.accounts.nintendo.com/2.0.0/users/me",
+        ),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "nintendo-store, nintendo-switch-parental-controls",
+        ),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--connector 'nintendo-switch-parental-controls'",
+        ),
+      );
+      expect(mockConsoleError).not.toHaveBeenCalledWith(
+        expect.stringContaining("code=secret"),
+      );
+    });
+
+    it.each([
+      {
+        order: ["nintendo-store", "nintendo-switch-parental-controls"],
+        selected: "nintendo-store",
+        environmentName: "NINTENDO_STORE_TOKEN",
+      },
+      {
+        order: ["nintendo-switch-parental-controls", "nintendo-store"],
+        selected: "nintendo-store",
+        environmentName: "NINTENDO_STORE_TOKEN",
+      },
+      {
+        order: ["nintendo-store", "nintendo-switch-parental-controls"],
+        selected: "nintendo-switch-parental-controls",
+        environmentName: "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+      },
+      {
+        order: ["nintendo-switch-parental-controls", "nintendo-store"],
+        selected: "nintendo-switch-parental-controls",
+        environmentName: "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+      },
+    ])(
+      "should select $selected from compact run firewalls in either order",
+      async ({ order, selected, environmentName }) => {
+        vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+        vi.stubEnv("VM0_TOKEN", "test-token");
+        vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+        server.use(
+          stubAvailableConnectors([selected]),
+          http.get(`https://app.vm0.ai/api/zero/connectors/${selected}`, () => {
+            return HttpResponse.json({
+              ...connectedResponse,
+              type: selected,
+              authMethod: "api",
+            });
+          }),
+          http.get(
+            "https://app.vm0.ai/api/zero/runs/run-abc-123/context",
+            () => {
+              return HttpResponse.json({
+                ...runContextResponse,
+                firewalls: order.map((name) => {
+                  return { kind: "builtin", name };
+                }),
+                networkPolicies: null,
+              });
+            },
+          ),
+        );
+
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.accounts.nintendo.com/2.0.0/users/me",
+          "--connector",
+          selected,
+        ]);
+
+        const output = getOutput();
+        expect(output).toContain(`type: ${selected}`);
+        expect(output).toContain(`Environment names: [${environmentName}]`);
+      },
+    );
+
+    it("should reject an unsafe shared route before connector diagnosis", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              { kind: "builtin", name: "nintendo-store" },
+              {
+                kind: "builtin",
+                name: "nintendo-switch-parental-controls",
+              },
+            ],
+            networkPolicies: null,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.accounts.nintendo.com/2.0.0/users/%2e%2e/me",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("request path contains unsafe syntax"),
+      );
+      expect(getOutput()).not.toContain("Step 2: Connector configuration");
+    });
+
+    it("should report Railway base-only ownership ambiguity", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://backboard.railway.com/graphql/v2",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("railway, railway-project"),
+      );
+    });
+
+    it.each([
+      ["railway", "RAILWAY_TOKEN"],
+      ["railway-project", "RAILWAY_PROJECT_TOKEN"],
+    ])(
+      "should select the %s base-only owner",
+      async (selected, environmentName) => {
+        stubConnectedUrlConnector(selected, "api-token");
+
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://backboard.railway.com/graphql/v2",
+          "--connector",
+          selected,
+        ]);
+
+        const output = getOutput();
+        expect(output).toContain(`type: ${selected}`);
+        expect(output).toContain(`Environment names: [${environmentName}]`);
+      },
+    );
+
+    it("should select an ambiguous connector and derive its route environment", async () => {
+      stubConnectedUrlConnector("nintendo-switch-parental-controls", "api");
+      vi.stubEnv(
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+        "placeholder",
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.accounts.nintendo.com/2.0.0/users/me",
+        "--connector",
+        "nintendo-switch-parental-controls",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain(
+        "matches the Nintendo Switch Parental Controls connector",
+      );
+      expect(output).toContain(
+        "Environment names: [NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN]",
+      );
+      expect(output).toContain(
+        "Checking process.env.NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN: present",
+      );
+      expect(output).toContain(
+        "--connector 'nintendo-switch-parental-controls'",
+      );
+    });
+
+    it("should derive every environment name used by a unique API route", async () => {
+      stubConnectedUrlConnector("nintendo-switch-parental-controls", "api");
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://app.lp1.znma.srv.nintendo.net/v3/actions/user/fetchOwnedDevices",
+        "--connector",
+        "nintendo-switch-parental-controls",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain(
+        "Environment names: [NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE, NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID, NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN]",
+      );
+      expect(output).toContain(
+        "Matched permissions: [nintendo-switch-parental-controls-device-credentials-read]",
+      );
+    });
+
+    it("should derive environment names from the winning API within one connector", async () => {
+      stubConnectedUrlConnector("cloudflare", "api-token");
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.cloudflare.com/client/v4/pages/assets/upload",
+        "--method",
+        "POST",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("matches the Cloudflare connector");
+      expect(output).toContain("Environment names: []");
+      expect(output).toContain(
+        "The matched API route does not use a sandbox environment name.",
+      );
+      expect(output).toContain("Matched permissions: [page.write]");
+      expect(output).not.toContain("diagnostic-api-");
+    });
+
+    it("should reject an explicit connector that does not own a unique route", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://app.lp1.znma.srv.nintendo.net/v3/actions/user/fetchOwnedDevices",
+          "--connector",
+          "nintendo-store",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Connector nintendo-store does not own GET https://app.lp1.znma.srv.nintendo.net/v3/actions/user/fetchOwnedDevices",
+        ),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "the matching connector is nintendo-switch-parental-controls",
+        ),
+      );
+    });
+
+    it("should reject a base-only selector when another owner has the winning route", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              {
+                name: "slack",
+                apis: [
+                  {
+                    base: "https://api.github.com",
+                    permissions: [],
+                  },
+                ],
+              },
+              {
+                name: "github",
+                apis: [
+                  {
+                    base: "https://api.github.com",
+                    permissions: [
+                      {
+                        name: "repository.read",
+                        rules: ["GET /repos/{owner}/{repo}"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            networkPolicies: null,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.github.com/repos/owner/repo",
+          "--connector",
+          "slack",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("the matching connector is github"),
+      );
+    });
+
+    it("should reject a connector-owned environment from a different API route", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.accounts.nintendo.com/2.0.0/users/me",
+          "--connector",
+          "nintendo-switch-parental-controls",
+          "--env-name",
+          "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN is not used by the matched API route",
+        ),
+      );
+    });
+
+    it.each(["UNKNOWN_ROUTE_TOKEN", "SLACK_TOKEN"])(
+      "should reject URL environment selection %s outside the selected connector",
+      async (environmentName) => {
+        await expect(async () => {
+          await checkConnectorCommand.parseAsync([
+            "node",
+            "cli",
+            "--url",
+            "https://api.github.com/repos/owner/repo",
+            "--env-name",
+            environmentName,
+          ]);
+        }).rejects.toThrow("process.exit called");
+
+        expect(mockConsoleError).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `${environmentName} is not an environment name for the GitHub connector`,
+          ),
+        );
+      },
+    );
+
+    it("should not fall back to generated routes when a run context exists", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [],
+            networkPolicies: null,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.github.com/repos/owner/repo",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("no firewall in the current run matches"),
+      );
+    });
+
+    it("should report unavailable environment metadata for an unmatched inline API", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        stubAvailableConnectors(["github"]),
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              {
+                name: "github",
+                apis: [
+                  {
+                    base: "https://legacy-github.example.com",
+                    permissions: [
+                      {
+                        name: "repository.read",
+                        rules: ["GET /repos/{owner}/{repo}"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            networkPolicies: {
+              github: {
+                allow: ["repository.read"],
+                deny: [],
+                ask: [],
+                unknownPolicy: "deny" as const,
+              },
+            },
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://legacy-github.example.com/repos/owner/repo",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("Environment names: unavailable");
+      expect(output).toContain(
+        "Environment metadata is unavailable for this run's sanitized firewall entry",
+      );
+      expect(output).not.toContain("Checking process.env.GH_TOKEN");
+      expect(output).not.toContain("Checking process.env.GITHUB_TOKEN");
+      expect(output).toContain("Matched permissions: [repository.read]");
+    });
+
     it("should resolve connector from URL and run full diagnostic", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
       vi.stubEnv("VM0_TOKEN", "test-token");
@@ -862,6 +1398,7 @@ describe("zero doctor check-connector command", () => {
       expect(output).toContain("matches the GitHub connector");
       expect(output).toContain("Matched base URL: https://api.github.com");
       expect(output).toContain("Relative path:    /repos/owner/repo");
+      expect(output).toContain("Environment names: [GITHUB_TOKEN]");
       expect(output).toContain("Step 1: Sandbox environment name");
       expect(output).toContain("Step 2: Connector configuration");
       expect(output).toContain(
@@ -870,6 +1407,42 @@ describe("zero doctor check-connector command", () => {
       expect(output).toContain(
         "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo'",
       );
+    });
+
+    it("should accept a sibling environment alias for the matched route", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      vi.stubEnv("GH_TOKEN", "placeholder");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json(runContextResponse);
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.github.com/repos/owner/repo",
+        "--env-name",
+        "GH_TOKEN",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("Environment names: [GH_TOKEN]");
+      expect(output).toContain("Checking process.env.GH_TOKEN: present");
+      expect(output).toContain("--env-name 'GH_TOKEN'");
     });
 
     it("should resolve compact built-in run context firewalls", async () => {
@@ -1600,23 +2173,19 @@ describe("zero doctor check-connector command", () => {
         }),
       );
 
-      await checkConnectorCommand.parseAsync([
-        "node",
-        "cli",
-        "--url",
-        "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/users/%2e%2e/admin",
-      ]);
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://tenant-123.pr-123.vm6.ai/api/test/oauth-provider/users/%2e%2e/admin",
+        ]);
+      }).rejects.toThrow("process.exit called");
 
-      const output = getOutput();
-      expect(output).toContain(
-        "Permission matching could not complete because the request path contains unsafe path syntax.",
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("request path contains unsafe syntax"),
       );
-      expect(output).toContain(
-        "Result: The request path contains unsafe path syntax, so the request is blocked.",
-      );
-      expect(output).not.toContain(
-        "falls through to the unknown-endpoint policy",
-      );
+      expect(getOutput()).not.toContain("Step 2: Connector configuration");
     });
 
     it("should fail for unrecognized URL", async () => {
@@ -1713,6 +2282,30 @@ describe("zero doctor check-connector command", () => {
       expect(output).toContain(
         "zero doctor check-connector --url 'https://api.github.com/repos/owner/repo' --method 'POST'",
       );
+    });
+
+    it("should preserve every URL selector while redacting query and fragment", async () => {
+      stubConnectedUrlConnector("nintendo-switch-parental-controls", "api");
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://app.lp1.znma.srv.nintendo.net/v3/actions/device/updateDeviceLabel?access_token=secret#private",
+        "--connector",
+        "nintendo-switch-parental-controls",
+        "--env-name",
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+        "--method",
+        "post",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain(
+        "zero doctor check-connector --url 'https://app.lp1.znma.srv.nintendo.net/v3/actions/device/updateDeviceLabel' --connector 'nintendo-switch-parental-controls' --env-name 'NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN' --method 'POST'",
+      );
+      expect(output).not.toContain("access_token=secret");
+      expect(output).not.toContain("#private");
     });
   });
 });

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -1161,6 +1161,58 @@ describe("zero doctor check-connector command", () => {
       expect(output).not.toContain("diagnostic-api-");
     });
 
+    it("should not guess inline environment metadata for conflicting same-base APIs", async () => {
+      stubConnectedUrlConnector("cloudflare", "api-token");
+      vi.stubEnv("ZERO_TOKEN", buildZeroToken());
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
+          return HttpResponse.json({
+            ...runContextResponse,
+            firewalls: [
+              {
+                name: "cloudflare",
+                apis: [
+                  {
+                    base: "https://api.cloudflare.com/client",
+                    permissions: [
+                      {
+                        name: "page.write",
+                        rules: ["POST /v4/pages/assets/upload"],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+            networkPolicies: {
+              cloudflare: {
+                allow: ["page.write"],
+                deny: [],
+                ask: [],
+                unknownPolicy: "deny" as const,
+              },
+            },
+          });
+        }),
+      );
+
+      await checkConnectorCommand.parseAsync([
+        "node",
+        "cli",
+        "--url",
+        "https://api.cloudflare.com/client/v4/pages/assets/upload",
+        "--method",
+        "POST",
+      ]);
+
+      const output = getOutput();
+      expect(output).toContain("Environment names: unavailable");
+      expect(output).toContain(
+        "Environment metadata is unavailable for this run's sanitized firewall entry",
+      );
+      expect(output).toContain("Matched permissions: [page.write]");
+    });
+
     it("should reject an explicit connector that does not own a unique route", async () => {
       await expect(async () => {
         await checkConnectorCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -780,6 +780,23 @@ describe("zero doctor check-connector command", () => {
       );
     });
 
+    it("should reject an explicitly empty --connector without --url", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+          "--connector",
+          "",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--connector can only be used with --url"),
+      );
+    });
+
     it("should reject --check-permission with --url", async () => {
       await expect(async () => {
         await checkConnectorCommand.parseAsync([
@@ -795,6 +812,41 @@ describe("zero doctor check-connector command", () => {
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("--check-permission cannot be used with --url"),
       );
+    });
+
+    it("should reject an explicitly empty --check-permission with --url", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--url",
+          "https://api.github.com/repos/owner/repo",
+          "--check-permission",
+          "",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--check-permission cannot be used with --url"),
+      );
+    });
+
+    it("should not ignore an explicitly empty --url", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+          "--url",
+          "",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No connector found for provided URL"),
+      );
+      expect(getOutput()).not.toContain("GH_TOKEN is managed by");
     });
 
     it("should reject an explicit --method without --url", async () => {

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -831,6 +831,25 @@ describe("zero doctor check-connector command", () => {
       );
     });
 
+    it("should reject an empty --check-permission in environment mode", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync([
+          "node",
+          "cli",
+          "--env-name",
+          "GH_TOKEN",
+          "--check-permission",
+          " ",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--check-permission requires a non-empty permission name",
+        ),
+      );
+    });
+
     it("should not ignore an explicitly empty --url", async () => {
       await expect(async () => {
         await checkConnectorCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -157,7 +157,9 @@ describe("zero doctor check-connector command", () => {
 
       const output = getOutput();
       expect(output).toContain("present");
-      expect(output).toContain("placeholder value");
+      expect(output).toContain(
+        "non-secret connector settings or credential placeholders",
+      );
     });
 
     it("should report environment name not present when it is missing", async () => {
@@ -1120,6 +1122,7 @@ describe("zero doctor check-connector command", () => {
 
     it("should derive every environment name used by a unique API route", async () => {
       stubConnectedUrlConnector("nintendo-switch-parental-controls", "api");
+      vi.stubEnv("NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE", "en-US");
 
       await checkConnectorCommand.parseAsync([
         "node",
@@ -1133,6 +1136,12 @@ describe("zero doctor check-connector command", () => {
       const output = getOutput();
       expect(output).toContain(
         "Environment names: [NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE, NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID, NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN]",
+      );
+      expect(output).toContain(
+        "Checking process.env.NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE: present",
+      );
+      expect(output).toContain(
+        "These values may be non-secret connector settings or credential placeholders",
       );
       expect(output).toContain(
         "Matched permissions: [nintendo-switch-parental-controls-device-credentials-read]",

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/check-connector.test.ts
@@ -763,6 +763,16 @@ describe("zero doctor check-connector command", () => {
   });
 
   describe("option validation", () => {
+    it("should require an environment name or URL", async () => {
+      await expect(async () => {
+        await checkConnectorCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Either --env-name or --url is required"),
+      );
+    });
+
     it("should reject --connector without --url", async () => {
       await expect(async () => {
         await checkConnectorCommand.parseAsync([
@@ -1422,7 +1432,7 @@ describe("zero doctor check-connector command", () => {
         http.get("https://app.vm0.ai/api/zero/runs/run-abc-123/context", () => {
           return HttpResponse.json({
             ...runContextResponse,
-            firewalls: [],
+            firewalls: [{ kind: "builtin", name: "unknown-connector" }],
             networkPolicies: null,
           });
         }),

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -680,7 +680,7 @@ function checkEnvironmentNames(ctx: DiagContext): void {
   }
   if (environmentPresent) {
     console.log(
-      "A placeholder value is present in the sandbox environment. This value is not the real credential — it is a stand-in that gets replaced at the network boundary when requests are sent to registered base URLs.",
+      "At least one connector value is present in the sandbox environment. These values may be non-secret connector settings or credential placeholders; real credentials are never injected and are resolved at the network boundary for registered base URLs.",
     );
   } else {
     console.log(

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -1096,6 +1096,9 @@ function validateCheckConnectorOptions(
       "--check-permission cannot be used with --url because the permission is derived from the request. Remove --check-permission.",
     );
   }
+  if (opts.checkPermission?.trim() === "") {
+    throw new Error("--check-permission requires a non-empty permission name.");
+  }
   if (!hasUrl && command.getOptionValueSource("method") === "cli") {
     throw new Error(
       "--method can only be used with --url. Add --url <URL> or remove --method.",

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -1085,22 +1085,23 @@ function validateCheckConnectorOptions(
   opts: CheckConnectorOptions,
   command: Command,
 ): void {
-  if (opts.connector && !opts.url) {
+  const hasUrl = opts.url !== undefined;
+  if (opts.connector !== undefined && !hasUrl) {
     throw new Error(
       "--connector can only be used with --url. Add --url <URL> or remove --connector.",
     );
   }
-  if (opts.checkPermission && opts.url) {
+  if (opts.checkPermission !== undefined && hasUrl) {
     throw new Error(
       "--check-permission cannot be used with --url because the permission is derived from the request. Remove --check-permission.",
     );
   }
-  if (!opts.url && command.getOptionValueSource("method") === "cli") {
+  if (!hasUrl && command.getOptionValueSource("method") === "cli") {
     throw new Error(
       "--method can only be used with --url. Add --url <URL> or remove --method.",
     );
   }
-  if (!opts.envName && !opts.url) {
+  if (opts.envName === undefined && !hasUrl) {
     throw new Error(
       "Either --env-name or --url is required. Use --help for usage.",
     );
@@ -1141,7 +1142,7 @@ async function resolveCheckConnectorInput(
   opts: CheckConnectorOptions,
 ): Promise<ResolvedCheckConnectorInput> {
   const method = opts.method.toUpperCase();
-  if (opts.url) {
+  if (opts.url !== undefined) {
     const requestedConnector = requestedConnectorType(opts.connector);
     const runContext = await getCurrentRunContext();
     const urlDiagnostic = await resolveUrlDiagnostic(
@@ -1167,7 +1168,7 @@ async function resolveCheckConnectorInput(
   }
 
   const environmentName = opts.envName;
-  if (!environmentName) {
+  if (environmentName === undefined) {
     throw new Error(
       "Either --env-name or --url is required. Use --help for usage.",
     );
@@ -1195,21 +1196,21 @@ function printRediagnoseHint(
   method: string,
 ): void {
   const args: string[] = [];
-  if (opts.url) {
+  if (opts.url !== undefined) {
     args.push(`--url ${shellQuoteArg(stripUrlQueryAndFragment(opts.url))}`);
-    if (opts.connector) {
+    if (opts.connector !== undefined) {
       args.push(`--connector ${shellQuoteArg(opts.connector)}`);
     }
-    if (opts.envName) {
+    if (opts.envName !== undefined) {
       args.push(`--env-name ${shellQuoteArg(opts.envName)}`);
     }
     if (method !== "GET") {
       args.push(`--method ${shellQuoteArg(method)}`);
     }
-  } else if (opts.envName) {
+  } else if (opts.envName !== undefined) {
     args.push(`--env-name ${shellQuoteArg(opts.envName)}`);
   }
-  if (opts.checkPermission) {
+  if (opts.checkPermission !== undefined) {
     args.push(`--check-permission ${shellQuoteArg(opts.checkPermission)}`);
   }
   console.log(
@@ -1323,7 +1324,7 @@ How connectors work:
           networkPolicies,
           configuredForRun,
         );
-      } else if (opts.checkPermission) {
+      } else if (opts.checkPermission !== undefined) {
         checkPermissionPolicy(
           connectorType,
           label,

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -47,6 +47,12 @@ interface CheckConnectorOptions {
   checkPermission?: string;
 }
 
+type ValidatedCheckConnectorOptions = CheckConnectorOptions &
+  (
+    | { readonly url: string }
+    | { readonly url?: undefined; readonly envName: string }
+  );
+
 interface DiagContext {
   environmentNames: readonly string[] | null;
   connectorType: ConnectorType;
@@ -259,14 +265,12 @@ function inlineApiEnvironmentNames(
 
 function routingConfigFromInlineRunContext(
   firewall: RunContextInlineFirewall,
+  connectorType: ConnectorType,
   metadata: FirewallRoutingMetadata | null,
-): DiagnosticRoutingConfig | null {
-  if (!isConnectorType(firewall.name)) {
-    return null;
-  }
+): DiagnosticRoutingConfig {
   return {
-    type: firewall.name,
-    label: CONNECTOR_TYPES[firewall.name].label,
+    type: connectorType,
+    label: CONNECTOR_TYPES[connectorType].label,
     apis: firewall.apis.map((api) => {
       return {
         base: api.base,
@@ -283,7 +287,7 @@ async function runContextFirewallRoutingConfig(
   if ("apis" in firewall) {
     if (!isConnectorType(firewall.name)) return null;
     const metadata = await loadFirewallRoutingMetadata(firewall.name);
-    return routingConfigFromInlineRunContext(firewall, metadata);
+    return routingConfigFromInlineRunContext(firewall, firewall.name, metadata);
   }
   if (!isConnectorType(firewall.name)) {
     return null;
@@ -1084,7 +1088,7 @@ type ResolvedCheckConnectorInput =
 function validateCheckConnectorOptions(
   opts: CheckConnectorOptions,
   command: Command,
-): void {
+): asserts opts is ValidatedCheckConnectorOptions {
   const hasUrl = opts.url !== undefined;
   if (opts.connector !== undefined && !hasUrl) {
     throw new Error(
@@ -1142,7 +1146,7 @@ function printUrlDiagnosticSummary(
 }
 
 async function resolveCheckConnectorInput(
-  opts: CheckConnectorOptions,
+  opts: ValidatedCheckConnectorOptions,
 ): Promise<ResolvedCheckConnectorInput> {
   const method = opts.method.toUpperCase();
   if (opts.url !== undefined) {
@@ -1171,11 +1175,6 @@ async function resolveCheckConnectorInput(
   }
 
   const environmentName = opts.envName;
-  if (environmentName === undefined) {
-    throw new Error(
-      "Either --env-name or --url is required. Use --help for usage.",
-    );
-  }
   const connectorType =
     getDiagnosticConnectorTypeForRuntimeEnvName(environmentName);
   if (!connectorType) {

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -1220,7 +1220,7 @@ function printRediagnoseHint(
 export const checkConnectorCommand = new Command()
   .name("check-connector")
   .description(
-    "Diagnose connector health: environment name, connector configuration, and permission policies",
+    "Diagnose connector health: environment names, connector configuration, and permission policies",
   )
   .addOption(
     new Option(
@@ -1231,7 +1231,7 @@ export const checkConnectorCommand = new Command()
   .addOption(
     new Option(
       "--url <URL>",
-      "A full URL to diagnose — auto-detects the connector, environment name, and permission (e.g. https://api.github.com/repos/owner/repo)",
+      "A full URL to diagnose — matches connector ownership, route environment names, and permission (e.g. https://api.github.com/repos/owner/repo)",
     ),
   )
   .addOption(
@@ -1258,7 +1258,7 @@ export const checkConnectorCommand = new Command()
 Examples:
   zero doctor check-connector --env-name GITHUB_TOKEN
   zero doctor check-connector --url https://api.github.com/repos/owner/repo
-  zero doctor check-connector --url https://example.com/api --connector example
+  zero doctor check-connector --url https://api.accounts.nintendo.com/2.0.0/users/me --connector nintendo-store
   zero doctor check-connector --url https://slack.com/api/chat.postMessage --method POST
   zero doctor check-connector --env-name SLACK_TOKEN --check-permission chat:write
 

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -8,7 +8,7 @@ import {
   getDiagnosticConnectorTypeForRuntimeEnvName,
 } from "@vm0/connectors/connector-utils";
 import {
-  type FirewallBaseUrlMatch,
+  type FirewallConnectorIntent,
   type FirewallRequestDecision,
   matchFirewallBaseUrl,
   matchFirewallRequestDecision,
@@ -40,6 +40,7 @@ import { toPlatformUrl } from "./platform-url";
 import { decodeZeroTokenPayload } from "../../../lib/api/zero-token";
 
 interface CheckConnectorOptions {
+  connector?: string;
   envName?: string;
   url?: string;
   method: string;
@@ -47,7 +48,7 @@ interface CheckConnectorOptions {
 }
 
 interface DiagContext {
-  envName: string;
+  environmentNames: readonly string[] | null;
   connectorType: ConnectorType;
   label: string;
   connectorAvailable: boolean;
@@ -60,10 +61,14 @@ interface RunConnectorState {
   readonly configuredForRun: boolean | null;
 }
 
+interface DiagnosticRoutingApi extends FirewallRoutingPermissionApi {
+  readonly environmentNames: readonly string[] | null;
+}
+
 interface DiagnosticRoutingConfig {
-  type: ConnectorType;
-  label: string;
-  apis: readonly FirewallRoutingPermissionApi[];
+  readonly type: ConnectorType;
+  readonly label: string;
+  readonly apis: readonly DiagnosticRoutingApi[];
 }
 
 interface DiagnosticDecisionPermission {
@@ -78,16 +83,20 @@ interface DiagnosticDecisionApi {
 }
 
 interface DiagnosticDecisionFirewall {
-  readonly name: ConnectorType;
+  readonly name: string;
   readonly apis: readonly DiagnosticDecisionApi[];
 }
 
-interface UrlLookupResult {
-  connectorType: ConnectorType;
-  envName: string;
-  matchedBase: string;
-  relativePath: string;
-  routingConfig?: DiagnosticRoutingConfig;
+type SelectedFirewallRequestDecision = Extract<
+  FirewallRequestDecision,
+  { readonly kind: "allow" | "block" }
+>;
+
+interface UrlDiagnosticResult {
+  readonly connectorType: ConnectorType;
+  readonly routingConfig: DiagnosticRoutingConfig;
+  readonly decision: SelectedFirewallRequestDecision;
+  readonly environmentNames: readonly string[] | null;
 }
 
 type RunContextFirewall = RunContextResponse["firewalls"][number];
@@ -100,7 +109,7 @@ type RunContextInlinePermission =
     : never;
 
 function isConnectorType(type: string): type is ConnectorType {
-  return type in CONNECTOR_TYPES;
+  return Object.hasOwn(CONNECTOR_TYPES, type);
 }
 
 async function connectorTypeIsAvailable(type: ConnectorType): Promise<boolean> {
@@ -108,10 +117,6 @@ async function connectorTypeIsAvailable(type: ConnectorType): Promise<boolean> {
   return catalog.connectors.some((connector) => {
     return connector.id === type;
   });
-}
-
-function connectorEnvName(type: ConnectorType): string | null {
-  return getConnectorEnvBindingEntries(type)[0]?.envName ?? null;
 }
 
 function stripUrlQueryAndFragment(url: string): string {
@@ -145,11 +150,11 @@ function routesToDecisionPermissions(
   });
 }
 
-function routingConfigToDecisionFirewalls(
-  config: DiagnosticRoutingConfig,
+function routingConfigsToDecisionFirewalls(
+  configs: readonly DiagnosticRoutingConfig[],
 ): readonly DiagnosticDecisionFirewall[] {
-  return [
-    {
+  return configs.map((config) => {
+    return {
       name: config.type,
       apis: config.apis.map((api) => {
         return {
@@ -158,8 +163,8 @@ function routingConfigToDecisionFirewalls(
           permissions: routesToDecisionPermissions(api.routes),
         };
       }),
-    },
-  ];
+    };
+  });
 }
 
 interface RoutingBaseExecutionTemplate {
@@ -206,6 +211,7 @@ function routingConfigFromMetadata(
             })
           : api.base,
         routes: api.routes,
+        environmentNames: api.environmentNames,
       };
     }),
   };
@@ -229,8 +235,24 @@ function runContextPermissionRoutes(
   return routes;
 }
 
+function inlineApiEnvironmentNames(
+  base: string,
+  metadata: FirewallRoutingMetadata | null,
+): readonly string[] | null {
+  if (!metadata) return null;
+  const names = new Set<string>();
+  let matched = false;
+  for (const api of metadata.apis) {
+    if (api.base !== base) continue;
+    matched = true;
+    for (const name of api.environmentNames) names.add(name);
+  }
+  return matched ? [...names].sort() : null;
+}
+
 function routingConfigFromInlineRunContext(
   firewall: RunContextInlineFirewall,
+  metadata: FirewallRoutingMetadata | null,
 ): DiagnosticRoutingConfig | null {
   if (!isConnectorType(firewall.name)) {
     return null;
@@ -242,45 +264,9 @@ function routingConfigFromInlineRunContext(
       return {
         base: api.base,
         routes: runContextPermissionRoutes(api.permissions),
+        environmentNames: inlineApiEnvironmentNames(api.base, metadata),
       };
     }),
-  };
-}
-
-/**
- * Reverse-lookup a full URL to find which connector handles it.
- * Iterates routing index base URLs and checks if the URL
- * starts with any registered base URL (scheme + host + optional path prefix).
- */
-function resolveConnectorFromUrl(url: string): UrlLookupResult | null {
-  let bestMatch: {
-    connectorType: ConnectorType;
-    match: FirewallBaseUrlMatch;
-  } | null = null;
-
-  for (const metadata of Object.values(FIREWALL_ROUTING_METADATA_INDEX)) {
-    for (const api of metadata.apis) {
-      const match = matchFirewallBaseUrl(url, api.base);
-      if (match !== null) {
-        // Pick the longest (most specific) base URL match
-        if (!bestMatch || match.score > bestMatch.match.score) {
-          bestMatch = { connectorType: metadata.type, match };
-        }
-      }
-    }
-  }
-
-  if (!bestMatch) return null;
-
-  // Derive the environment name from the connector's configured env bindings.
-  const envName = connectorEnvName(bestMatch.connectorType);
-  if (!envName) return null;
-
-  return {
-    connectorType: bestMatch.connectorType,
-    envName,
-    matchedBase: bestMatch.match.displayBase,
-    relativePath: bestMatch.match.relativePath,
   };
 }
 
@@ -288,7 +274,9 @@ async function runContextFirewallRoutingConfig(
   firewall: RunContextFirewall,
 ): Promise<DiagnosticRoutingConfig | null> {
   if ("apis" in firewall) {
-    return routingConfigFromInlineRunContext(firewall);
+    if (!isConnectorType(firewall.name)) return null;
+    const metadata = await loadFirewallRoutingMetadata(firewall.name);
+    return routingConfigFromInlineRunContext(firewall, metadata);
   }
   if (!isConnectorType(firewall.name)) {
     return null;
@@ -298,44 +286,200 @@ async function runContextFirewallRoutingConfig(
   return routingConfigFromMetadata(metadata, firewall.baseUrlVars, true);
 }
 
-async function resolveConnectorFromRunContext(
-  url: string,
-  runContext: RunContextResponse,
-): Promise<UrlLookupResult | null> {
-  let bestMatch: {
-    connectorType: ConnectorType;
-    match: FirewallBaseUrlMatch;
-    routingConfig: DiagnosticRoutingConfig;
-  } | null = null;
+function mergeRoutingConfigs(
+  configs: readonly DiagnosticRoutingConfig[],
+): DiagnosticRoutingConfig[] {
+  const merged = new Map<ConnectorType, DiagnosticRoutingConfig>();
+  for (const config of configs) {
+    const existing = merged.get(config.type);
+    merged.set(config.type, {
+      type: config.type,
+      label: config.label,
+      apis: existing ? [...existing.apis, ...config.apis] : config.apis,
+    });
+  }
+  return [...merged.values()];
+}
 
-  for (const firewall of runContext.firewalls) {
-    if (!isConnectorType(firewall.name)) continue;
-    const routingConfig = await runContextFirewallRoutingConfig(firewall);
-    if (!routingConfig) continue;
-    for (const api of routingConfig.apis) {
+async function loadRunContextRoutingConfigs(
+  runContext: RunContextResponse,
+): Promise<DiagnosticRoutingConfig[]> {
+  const configs = await Promise.all(
+    runContext.firewalls.map(async (firewall) => {
+      return await runContextFirewallRoutingConfig(firewall);
+    }),
+  );
+  return mergeRoutingConfigs(
+    configs.filter((config): config is DiagnosticRoutingConfig => {
+      return config !== null;
+    }),
+  );
+}
+
+async function loadGeneratedRoutingConfigs(
+  url: string,
+): Promise<DiagnosticRoutingConfig[]> {
+  let bestScore: number | null = null;
+  const connectorTypes = new Set<ConnectorType>();
+  for (const metadata of Object.values(FIREWALL_ROUTING_METADATA_INDEX)) {
+    for (const api of metadata.apis) {
       const match = matchFirewallBaseUrl(url, api.base);
       if (match === null) continue;
-      if (!bestMatch || match.score > bestMatch.match.score) {
-        bestMatch = {
-          connectorType: firewall.name,
-          match,
-          routingConfig,
-        };
+      if (bestScore === null || match.score > bestScore) {
+        bestScore = match.score;
+        connectorTypes.clear();
+      }
+      if (match.score === bestScore) {
+        connectorTypes.add(metadata.type);
       }
     }
   }
 
-  if (!bestMatch) return null;
+  const configs = await Promise.all(
+    [...connectorTypes].sort().map(async (type) => {
+      const metadata = await loadFirewallRoutingMetadata(type);
+      return metadata
+        ? routingConfigFromMetadata(metadata, undefined, false)
+        : null;
+    }),
+  );
+  return configs.filter((config): config is DiagnosticRoutingConfig => {
+    return config !== null;
+  });
+}
 
-  const envName = connectorEnvName(bestMatch.connectorType);
-  if (!envName) return null;
+function decisionOwnerNames(
+  decision: FirewallRequestDecision,
+): readonly string[] {
+  if (decision.kind === "ambiguous") return decision.candidates;
+  if (decision.kind === "allow" || decision.kind === "block") {
+    return [decision.firewallName];
+  }
+  return [];
+}
+
+function environmentNamesForWinningApis(
+  config: DiagnosticRoutingConfig,
+  method: string,
+  url: string,
+): readonly string[] | null {
+  const apisByOwner = new Map<string, DiagnosticRoutingApi>();
+  const firewalls = config.apis.map((api, index) => {
+    const name = `diagnostic-api-${index}`;
+    apisByOwner.set(name, api);
+    return {
+      name,
+      apis: [
+        {
+          base: api.base,
+          auth: {},
+          permissions: routesToDecisionPermissions(api.routes),
+        },
+      ],
+    } satisfies DiagnosticDecisionFirewall;
+  });
+  const decision = matchFirewallRequestDecision(firewalls, method, url);
+  const names = new Set<string>();
+  let found = false;
+  for (const owner of decisionOwnerNames(decision)) {
+    const api = apisByOwner.get(owner);
+    if (!api) continue;
+    found = true;
+    if (api.environmentNames === null) return null;
+    for (const name of api.environmentNames) names.add(name);
+  }
+  return found ? [...names].sort() : null;
+}
+
+function connectorSelectionCommand(
+  url: string,
+  method: string,
+  connectorType: string,
+): string {
+  const args = [
+    `--url ${shellQuoteArg(stripUrlQueryAndFragment(url))}`,
+    `--connector ${shellQuoteArg(connectorType)}`,
+  ];
+  if (method !== "GET") args.push(`--method ${shellQuoteArg(method)}`);
+  return `zero doctor check-connector ${args.join(" ")}`;
+}
+
+function ambiguousConnectorError(
+  decision: Extract<FirewallRequestDecision, { readonly kind: "ambiguous" }>,
+  url: string,
+): Error {
+  const candidates = [...decision.candidates].sort();
+  const commands = candidates.map((candidate) => {
+    return `  ${connectorSelectionCommand(url, decision.method, candidate)}`;
+  });
+  return new Error(
+    `Multiple connectors match ${decision.method} ${stripUrlQueryAndFragment(url)} at the same route specificity: ${candidates.join(", ")}\nSelect one explicitly:\n${commands.join("\n")}`,
+  );
+}
+
+async function resolveUrlDiagnostic(
+  url: string,
+  method: string,
+  requestedConnector: ConnectorType | undefined,
+  runContext: RunContextResponse | null,
+): Promise<UrlDiagnosticResult> {
+  const routingConfigs = runContext
+    ? await loadRunContextRoutingConfigs(runContext)
+    : await loadGeneratedRoutingConfigs(url);
+  const connectorIntent: FirewallConnectorIntent = requestedConnector
+    ? { status: "present", value: requestedConnector }
+    : { status: "absent" };
+  const decision = matchFirewallRequestDecision(
+    routingConfigsToDecisionFirewalls(routingConfigs),
+    method,
+    url,
+    runContext?.networkPolicies,
+    connectorIntent,
+  );
+
+  if (decision.kind === "ambiguous") {
+    throw ambiguousConnectorError(decision, url);
+  }
+  if (decision.kind === "no_match") {
+    throw new Error(
+      runContext
+        ? "No connector found for provided URL — no firewall in the current run matches this URL"
+        : "No connector found for provided URL — no registered base URL matches this URL",
+    );
+  }
+  if (decision.kind === "block" && decision.reason === "unsafe_path") {
+    throw new Error(
+      `Cannot diagnose ${method} ${stripUrlQueryAndFragment(url)} because the request path contains unsafe syntax`,
+    );
+  }
+  if (!isConnectorType(decision.firewallName)) {
+    throw new Error("The matched firewall is not a registered connector");
+  }
+  if (
+    requestedConnector !== undefined &&
+    decision.firewallName !== requestedConnector
+  ) {
+    throw new Error(
+      `Connector ${requestedConnector} does not own ${method} ${stripUrlQueryAndFragment(url)}; the matching connector is ${decision.firewallName}\nRun: ${connectorSelectionCommand(url, method, decision.firewallName)}`,
+    );
+  }
+
+  const routingConfig = routingConfigs.find((config) => {
+    return config.type === decision.firewallName;
+  });
+  if (!routingConfig) {
+    throw new Error("The matched connector routing metadata is unavailable");
+  }
 
   return {
-    connectorType: bestMatch.connectorType,
-    envName,
-    matchedBase: bestMatch.match.displayBase,
-    relativePath: bestMatch.match.relativePath,
-    routingConfig: bestMatch.routingConfig,
+    connectorType: decision.firewallName,
+    routingConfig,
+    decision,
+    environmentNames: environmentNamesForWinningApis(
+      routingConfig,
+      method,
+      url,
+    ),
   };
 }
 
@@ -438,24 +582,105 @@ function printConnectorAuthorizationStatus(
   console.log("");
 }
 
-function checkEnvName(ctx: DiagContext): boolean {
+function connectorEnvironmentValueRefs(
+  connectorType: ConnectorType,
+  environmentName: string,
+): ReadonlySet<string> {
+  const refs = new Set<string>();
+  for (const entry of getConnectorEnvBindingEntries(connectorType)) {
+    if (entry.envName === environmentName) refs.add(entry.valueRef);
+  }
+  return refs;
+}
+
+function environmentNameSupportsRoute(
+  connectorType: ConnectorType,
+  environmentName: string,
+  routeEnvironmentNames: readonly string[],
+): boolean {
+  const explicitRefs = connectorEnvironmentValueRefs(
+    connectorType,
+    environmentName,
+  );
+  return routeEnvironmentNames.some((routeEnvironmentName) => {
+    if (routeEnvironmentName === environmentName) return true;
+    const routeRefs = connectorEnvironmentValueRefs(
+      connectorType,
+      routeEnvironmentName,
+    );
+    return [...explicitRefs].some((ref) => {
+      return routeRefs.has(ref);
+    });
+  });
+}
+
+function resolveUrlEnvironmentNames(
+  connectorType: ConnectorType,
+  routeEnvironmentNames: readonly string[] | null,
+  requestedEnvironmentName: string | undefined,
+): readonly string[] | null {
+  if (requestedEnvironmentName === undefined) return routeEnvironmentNames;
+  const ownedByConnector = getConnectorEnvBindingEntries(connectorType).some(
+    (entry) => {
+      return entry.envName === requestedEnvironmentName;
+    },
+  );
+  if (!ownedByConnector) {
+    throw new Error(
+      `${requestedEnvironmentName} is not an environment name for the ${CONNECTOR_TYPES[connectorType].label} connector. Remove --env-name to use the matched route metadata.`,
+    );
+  }
+  if (
+    routeEnvironmentNames !== null &&
+    !environmentNameSupportsRoute(
+      connectorType,
+      requestedEnvironmentName,
+      routeEnvironmentNames,
+    )
+  ) {
+    throw new Error(
+      `${requestedEnvironmentName} is not used by the matched API route. Expected one of: ${routeEnvironmentNames.join(", ") || "none"}. Remove --env-name to use the matched route metadata.`,
+    );
+  }
+  return [requestedEnvironmentName];
+}
+
+function checkEnvironmentNames(ctx: DiagContext): void {
   console.log("## Step 1: Sandbox environment name");
   console.log("");
-  const envPresent = Boolean(process.env[ctx.envName]);
-  console.log(
-    `Checking process.env.${ctx.envName}: ${envPresent ? "present" : "not present"}`,
-  );
-  if (envPresent) {
+  if (ctx.environmentNames === null) {
+    console.log(
+      "Environment metadata is unavailable for this run's sanitized firewall entry, so no environment name was guessed.",
+    );
+    console.log("");
+    return;
+  }
+  if (ctx.environmentNames.length === 0) {
+    console.log(
+      "The matched API route does not use a sandbox environment name.",
+    );
+    console.log("");
+    return;
+  }
+
+  let environmentPresent = false;
+  for (const environmentName of ctx.environmentNames) {
+    const present = Boolean(process.env[environmentName]);
+    environmentPresent ||= present;
+    console.log(
+      `Checking process.env.${environmentName}: ${present ? "present" : "not present"}`,
+    );
+  }
+  if (environmentPresent) {
     console.log(
       "A placeholder value is present in the sandbox environment. This value is not the real credential — it is a stand-in that gets replaced at the network boundary when requests are sent to registered base URLs.",
     );
   } else {
     console.log(
-      "No value found for this environment name. Note: credential replacement at the network boundary is independent of this name — the proxy injects auth headers based on the destination URL.",
+      "No value found for these environment names. Note: credential replacement at the network boundary is independent of these names — the proxy injects auth headers based on the destination URL.",
     );
   }
   console.log("");
-  return envPresent;
 }
 
 async function checkConnectorStatus(ctx: DiagContext): Promise<{
@@ -647,7 +872,7 @@ function unknownPermissionChangeCommand(connectorRef: string): string {
 }
 
 function matchedPermissionsFromDecision(
-  decision: FirewallRequestDecision,
+  decision: SelectedFirewallRequestDecision,
 ): string[] {
   if (decision.kind === "allow") {
     return decision.permission === undefined ? [] : [decision.permission];
@@ -661,7 +886,7 @@ function matchedPermissionsFromDecision(
 function printMatchedPermissionsSummary(
   method: string,
   relativePath: string,
-  decision: FirewallRequestDecision,
+  decision: SelectedFirewallRequestDecision,
 ): void {
   const matchedPermissions = matchedPermissionsFromDecision(decision);
   if (matchedPermissions.length > 0) {
@@ -675,13 +900,6 @@ function printMatchedPermissionsSummary(
   ) {
     console.log(
       `No named permission matches ${method} ${relativePath}. This request falls through to the unknown-endpoint policy.`,
-    );
-    return;
-  }
-
-  if (decision.kind === "no_match") {
-    console.log(
-      "No connector firewall base matched this request during final permission evaluation.",
     );
     return;
   }
@@ -735,7 +953,7 @@ function printDeniedPermissionResult(
 
 function printFirewallDecisionResult(
   connectorType: ConnectorType,
-  decision: FirewallRequestDecision,
+  decision: SelectedFirewallRequestDecision,
   connectorPolicies: NetworkPolicies[string],
 ): void {
   if (decision.kind === "allow") {
@@ -746,11 +964,6 @@ function printFirewallDecisionResult(
       return;
     }
     printAllowedPermissionResult(decision.permission, connectorPolicies);
-    return;
-  }
-
-  if (decision.kind === "no_match") {
-    console.log("Result: No connector firewall base matched this request.");
     return;
   }
 
@@ -786,21 +999,16 @@ function printFirewallDecisionResult(
   }
 }
 
-/**
- * When --url is provided, auto-detect the matching permission by running
- * the URL's relative path against the connector's firewall rules.
- */
-async function resolvePermissionFromUrl(
+function resolvePermissionFromUrl(
   connectorType: ConnectorType,
   label: string,
   method: string,
-  url: string,
   relativePath: string,
   matchedBase: string,
-  routingConfig: DiagnosticRoutingConfig | undefined,
+  decision: SelectedFirewallRequestDecision,
   networkPolicies: NetworkPolicies | null,
   configuredForRun: boolean | null,
-): Promise<void> {
+): void {
   console.log("## Step 3: Permission policy check (auto-detected from URL)");
   console.log("");
   console.log(
@@ -808,27 +1016,6 @@ async function resolvePermissionFromUrl(
   );
   console.log("");
 
-  let config = routingConfig;
-  if (!config) {
-    const metadata = await loadFirewallRoutingMetadata(connectorType);
-    config = metadata
-      ? routingConfigFromMetadata(metadata, undefined, false)
-      : undefined;
-  }
-  if (!config) {
-    console.log(
-      `The ${label} connector does not have permission rules defined.`,
-    );
-    console.log("");
-    return;
-  }
-
-  const decision = matchFirewallRequestDecision(
-    routingConfigToDecisionFirewalls(config),
-    method,
-    url,
-    networkPolicies,
-  );
   printMatchedPermissionsSummary(method, relativePath, decision);
   console.log("");
 
@@ -871,6 +1058,158 @@ async function resolvePermissionFromUrl(
   console.log("");
 }
 
+type ResolvedCheckConnectorInput =
+  | {
+      readonly mode: "url";
+      readonly method: string;
+      readonly connectorType: ConnectorType;
+      readonly environmentNames: readonly string[] | null;
+      readonly urlDiagnostic: UrlDiagnosticResult;
+      readonly runContext: RunContextResponse | null;
+    }
+  | {
+      readonly mode: "environment";
+      readonly method: string;
+      readonly connectorType: ConnectorType;
+      readonly environmentNames: readonly string[];
+    };
+
+function validateCheckConnectorOptions(
+  opts: CheckConnectorOptions,
+  command: Command,
+): void {
+  if (opts.connector && !opts.url) {
+    throw new Error(
+      "--connector can only be used with --url. Add --url <URL> or remove --connector.",
+    );
+  }
+  if (opts.checkPermission && opts.url) {
+    throw new Error(
+      "--check-permission cannot be used with --url because the permission is derived from the request. Remove --check-permission.",
+    );
+  }
+  if (!opts.url && command.getOptionValueSource("method") === "cli") {
+    throw new Error(
+      "--method can only be used with --url. Add --url <URL> or remove --method.",
+    );
+  }
+  if (!opts.envName && !opts.url) {
+    throw new Error(
+      "Either --env-name or --url is required. Use --help for usage.",
+    );
+  }
+}
+
+function requestedConnectorType(
+  value: string | undefined,
+): ConnectorType | undefined {
+  if (value === undefined) return undefined;
+  if (!isConnectorType(value)) {
+    throw new Error(
+      `Unknown connector type: ${value}\nRun: zero connector search ${shellQuoteArg(value)}`,
+    );
+  }
+  return value;
+}
+
+function printUrlDiagnosticSummary(
+  url: string,
+  diagnostic: UrlDiagnosticResult,
+  environmentNames: readonly string[] | null,
+): void {
+  const { connectorType, decision } = diagnostic;
+  console.log(
+    `URL ${stripUrlQueryAndFragment(url)} matches the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
+  );
+  console.log(`  Matched base URL: ${decision.base}`);
+  console.log(`  Relative path:    ${decision.relativePath}`);
+  if (environmentNames === null) {
+    console.log("  Environment names: unavailable");
+  } else {
+    console.log(`  Environment names: [${environmentNames.join(", ")}]`);
+  }
+}
+
+async function resolveCheckConnectorInput(
+  opts: CheckConnectorOptions,
+): Promise<ResolvedCheckConnectorInput> {
+  const method = opts.method.toUpperCase();
+  if (opts.url) {
+    const requestedConnector = requestedConnectorType(opts.connector);
+    const runContext = await getCurrentRunContext();
+    const urlDiagnostic = await resolveUrlDiagnostic(
+      opts.url,
+      method,
+      requestedConnector,
+      runContext,
+    );
+    const environmentNames = resolveUrlEnvironmentNames(
+      urlDiagnostic.connectorType,
+      urlDiagnostic.environmentNames,
+      opts.envName,
+    );
+    printUrlDiagnosticSummary(opts.url, urlDiagnostic, environmentNames);
+    return {
+      mode: "url",
+      method,
+      connectorType: urlDiagnostic.connectorType,
+      environmentNames,
+      urlDiagnostic,
+      runContext,
+    };
+  }
+
+  const environmentName = opts.envName;
+  if (!environmentName) {
+    throw new Error(
+      "Either --env-name or --url is required. Use --help for usage.",
+    );
+  }
+  const connectorType =
+    getDiagnosticConnectorTypeForRuntimeEnvName(environmentName);
+  if (!connectorType) {
+    throw new Error(
+      `Unknown environment name: ${environmentName} — not managed by any connector`,
+    );
+  }
+  console.log(
+    `${environmentName} is managed by the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
+  );
+  return {
+    mode: "environment",
+    method,
+    connectorType,
+    environmentNames: [environmentName],
+  };
+}
+
+function printRediagnoseHint(
+  opts: CheckConnectorOptions,
+  method: string,
+): void {
+  const args: string[] = [];
+  if (opts.url) {
+    args.push(`--url ${shellQuoteArg(stripUrlQueryAndFragment(opts.url))}`);
+    if (opts.connector) {
+      args.push(`--connector ${shellQuoteArg(opts.connector)}`);
+    }
+    if (opts.envName) {
+      args.push(`--env-name ${shellQuoteArg(opts.envName)}`);
+    }
+    if (method !== "GET") {
+      args.push(`--method ${shellQuoteArg(method)}`);
+    }
+  } else if (opts.envName) {
+    args.push(`--env-name ${shellQuoteArg(opts.envName)}`);
+  }
+  if (opts.checkPermission) {
+    args.push(`--check-permission ${shellQuoteArg(opts.checkPermission)}`);
+  }
+  console.log(
+    `To re-diagnose after changes, run: zero doctor check-connector ${args.join(" ")}`,
+  );
+}
+
 export const checkConnectorCommand = new Command()
   .name("check-connector")
   .description(
@@ -886,6 +1225,12 @@ export const checkConnectorCommand = new Command()
     new Option(
       "--url <URL>",
       "A full URL to diagnose — auto-detects the connector, environment name, and permission (e.g. https://api.github.com/repos/owner/repo)",
+    ),
+  )
+  .addOption(
+    new Option(
+      "--connector <type>",
+      "Select the connector when multiple connectors own the same URL route",
     ),
   )
   .addOption(
@@ -906,6 +1251,7 @@ export const checkConnectorCommand = new Command()
 Examples:
   zero doctor check-connector --env-name GITHUB_TOKEN
   zero doctor check-connector --url https://api.github.com/repos/owner/repo
+  zero doctor check-connector --url https://example.com/api --connector example
   zero doctor check-connector --url https://slack.com/api/chat.postMessage --method POST
   zero doctor check-connector --env-name SLACK_TOKEN --check-permission chat:write
 
@@ -918,59 +1264,12 @@ How connectors work:
   This command checks each part of that pipeline and reports what it finds.`,
   )
   .action(
-    withErrorHandler(async (opts: CheckConnectorOptions) => {
-      if (!opts.envName && !opts.url) {
-        throw new Error(
-          "Either --env-name or --url is required. Use --help for usage.",
-        );
-      }
-
-      let envName: string;
-      let connectorType: ConnectorType;
-      let urlLookup: UrlLookupResult | null = null;
-      let runContext: RunContextResponse | null | undefined;
-
-      if (opts.url) {
-        runContext = await getCurrentRunContext();
-        if (runContext) {
-          urlLookup = await resolveConnectorFromRunContext(
-            opts.url,
-            runContext,
-          );
-        }
-        if (!urlLookup) {
-          urlLookup = await resolveConnectorFromUrl(opts.url);
-        }
-        if (!urlLookup) {
-          throw new Error(
-            "No connector found for provided URL — no registered base URL matches this URL",
-          );
-        }
-        const displayUrl = stripUrlQueryAndFragment(opts.url);
-        connectorType = urlLookup.connectorType;
-        envName = opts.envName ?? urlLookup.envName;
-        console.log(
-          `URL ${displayUrl} matches the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
-        );
-        console.log(`  Matched base URL: ${urlLookup.matchedBase}`);
-        console.log(`  Relative path:    ${urlLookup.relativePath}`);
-        console.log(`  Environment name:  ${envName}`);
-      } else {
-        envName = opts.envName!;
-        const resolvedConnectorType =
-          getDiagnosticConnectorTypeForRuntimeEnvName(envName);
-        if (!resolvedConnectorType) {
-          throw new Error(
-            `Unknown environment name: ${envName} — not managed by any connector`,
-          );
-        }
-        connectorType = resolvedConnectorType;
-        console.log(
-          `${envName} is managed by the ${CONNECTOR_TYPES[connectorType].label} connector (type: ${connectorType}).`,
-        );
-      }
+    withErrorHandler(async (opts: CheckConnectorOptions, command: Command) => {
+      validateCheckConnectorOptions(opts, command);
+      const input = await resolveCheckConnectorInput(opts);
       console.log("");
 
+      const { connectorType, environmentNames, method } = input;
       const { label } = CONNECTOR_TYPES[connectorType];
       const [apiUrl, connectorAvailable] = await Promise.all([
         getApiUrl(),
@@ -979,7 +1278,7 @@ How connectors work:
       const platformUrl = toPlatformUrl(apiUrl);
 
       const ctx: DiagContext = {
-        envName,
+        environmentNames,
         connectorType,
         label,
         connectorAvailable,
@@ -987,15 +1286,14 @@ How connectors work:
         agentId: process.env.ZERO_AGENT_ID || undefined,
       };
 
-      checkEnvName(ctx);
+      checkEnvironmentNames(ctx);
       const { isConnected, isExpired, hasPermission } =
         await checkConnectorStatus(ctx);
       const { networkPolicies, configuredForRun } = await checkConnectorDomains(
         ctx,
-        runContext,
+        input.mode === "url" ? input.runContext : undefined,
       );
 
-      // Summary for Step 2
       if (configuredForRun === false) {
         console.log(
           `Steps 1-2 summary: The ${label} connector is not configured for this run. Check the agent authorization settings, then start a new run after updating them.`,
@@ -1007,23 +1305,18 @@ How connectors work:
       }
       console.log("");
 
-      // Step 3: Permission policy check
-      const diagnosedUrl = opts.url;
-      if (urlLookup && diagnosedUrl) {
-        // --url mode: auto-detect permission from URL path
-        await resolvePermissionFromUrl(
+      if (input.mode === "url") {
+        resolvePermissionFromUrl(
           connectorType,
           label,
-          opts.method,
-          diagnosedUrl,
-          urlLookup.relativePath,
-          urlLookup.matchedBase,
-          urlLookup.routingConfig,
+          method,
+          input.urlDiagnostic.decision.relativePath,
+          input.urlDiagnostic.decision.base,
+          input.urlDiagnostic.decision,
           networkPolicies,
           configuredForRun,
         );
       } else if (opts.checkPermission) {
-        // --env-name mode with explicit --check-permission
         checkPermissionPolicy(
           connectorType,
           label,
@@ -1033,21 +1326,6 @@ How connectors work:
         );
       }
 
-      // Re-diagnose hint
-      const args: string[] = [];
-      if (opts.url) {
-        args.push(`--url ${shellQuoteArg(stripUrlQueryAndFragment(opts.url))}`);
-        if (opts.method !== "GET") {
-          args.push(`--method ${shellQuoteArg(opts.method)}`);
-        }
-      } else {
-        args.push(`--env-name ${shellQuoteArg(envName)}`);
-      }
-      if (opts.checkPermission) {
-        args.push(`--check-permission ${shellQuoteArg(opts.checkPermission)}`);
-      }
-      console.log(
-        `To re-diagnose after changes, run: zero doctor check-connector ${args.join(" ")}`,
-      );
+      printRediagnoseHint(opts, method);
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/check-connector.ts
@@ -240,14 +240,21 @@ function inlineApiEnvironmentNames(
   metadata: FirewallRoutingMetadata | null,
 ): readonly string[] | null {
   if (!metadata) return null;
-  const names = new Set<string>();
-  let matched = false;
-  for (const api of metadata.apis) {
-    if (api.base !== base) continue;
-    matched = true;
-    for (const name of api.environmentNames) names.add(name);
+  const [first, ...otherApis] = metadata.apis.filter((api) => {
+    return api.base === base;
+  });
+  if (!first) return null;
+  for (const api of otherApis) {
+    if (
+      api.environmentNames.length !== first.environmentNames.length ||
+      api.environmentNames.some((name, index) => {
+        return name !== first.environmentNames[index];
+      })
+    ) {
+      return null;
+    }
   }
-  return matched ? [...names].sort() : null;
+  return first.environmentNames;
 }
 
 function routingConfigFromInlineRunContext(

--- a/turbo/packages/connectors/src/__tests__/firewall-routing-metadata.test.ts
+++ b/turbo/packages/connectors/src/__tests__/firewall-routing-metadata.test.ts
@@ -13,6 +13,7 @@ import {
 
 const DEFAULT_FIREWALL_SECRET_PLACEHOLDER =
   "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
+const ENVIRONMENT_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
 const FORBIDDEN_ROUTING_METADATA_KEYS = new Set([
   "auth",
   "headers",
@@ -205,6 +206,15 @@ describe("firewall routing metadata", () => {
 
       const apiCounts = new Map<string, number>();
       for (const api of metadata.apis) {
+        expect(api.environmentNames, `${type} ${api.base}`).toStrictEqual(
+          [...new Set(api.environmentNames)].sort(compareStrings),
+        );
+        for (const environmentName of api.environmentNames) {
+          expect(environmentName, `${type} ${api.base}`).toMatch(
+            ENVIRONMENT_NAME_PATTERN,
+          );
+        }
+
         const names = new Set(
           api.routes.map((route) => {
             return route.permissionName;
@@ -229,5 +239,28 @@ describe("firewall routing metadata", () => {
 
     expect(sharedPermissionExample).not.toBeNull();
     expect(sharedPermissionExample!.apiCount).toBeGreaterThan(1);
+  });
+
+  it("keeps Nintendo Parental Controls API environment names route-specific", async () => {
+    const metadata = await loadRequiredRoutingMetadata(
+      "nintendo-switch-parental-controls",
+    );
+
+    expect(
+      Object.fromEntries(
+        metadata.apis.map((api) => {
+          return [api.base, api.environmentNames];
+        }),
+      ),
+    ).toStrictEqual({
+      "https://api.accounts.nintendo.com": [
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_ACCOUNT_TOKEN",
+      ],
+      "https://app.lp1.znma.srv.nintendo.net": [
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_LANGUAGE",
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_SMART_DEVICE_ID",
+        "NINTENDO_SWITCH_PARENTAL_CONTROLS_TOKEN",
+      ],
+    });
   });
 });

--- a/turbo/packages/connectors/src/firewall-metadata/types.ts
+++ b/turbo/packages/connectors/src/firewall-metadata/types.ts
@@ -74,6 +74,7 @@ export interface FirewallRoutingIndexMetadata {
 
 export interface FirewallRoutingApiMetadata {
   readonly base: string;
+  readonly environmentNames: readonly string[];
   readonly routes: readonly FirewallRoutingRouteMetadata[];
 }
 

--- a/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
+++ b/turbo/packages/firewalls-generator/src/__tests__/metadata.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { MODEL_PROVIDER_FIREWALL_CONFIGS } from "@vm0/api-contracts/contracts/model-provider-firewalls";
+import { extractFirewallTemplateReferences } from "@vm0/connectors/firewall-types";
 import {
   generatedFirewallExportName,
   generatedConnectorMetadataFileName,
@@ -124,8 +125,12 @@ function routingMetadataFromSource(source: ConnectorFirewallSource): unknown {
     type: source.type,
     label: source.label,
     apis: source.firewall.apis.map((api) => {
+      const references = extractFirewallTemplateReferences([api]);
       return {
         base: api.base,
+        environmentNames: [
+          ...new Set([...references.secrets, ...references.vars]),
+        ].sort(compareStrings),
         routes: (api.permissions ?? []).flatMap((permission) => {
           return permission.rules.map((rule) => {
             return {
@@ -742,6 +747,7 @@ describe("firewall metadata generator", () => {
     expect(source).toContain('"daytona"');
     expect(source).toContain('"modal"');
     expect(sourceHasObjectKey(source, "base")).toBe(true);
+    expect(sourceHasObjectKey(source, "environmentNames")).toBe(false);
     expect(sourceHasObjectKey(source, "routes")).toBe(false);
     expect(sourceHasObjectKey(source, "permissionName")).toBe(false);
     expect(sourceHasObjectKey(source, "rule")).toBe(false);
@@ -793,6 +799,9 @@ describe("firewall metadata generator", () => {
     expect(slackDetailSource).toContain("JSON.parse");
     expect(slackDetailSource).toContain(
       "firewallRoutingMetadataValue as FirewallRoutingMetadata",
+    );
+    expect(sourceHasObjectKey(slackDetailSource, "environmentNames")).toBe(
+      true,
     );
     expect(slackDetailSource).toContain('\\"base\\"');
     expect(slackDetailSource).toContain('\\"routes\\"');

--- a/turbo/packages/firewalls-generator/src/metadata.ts
+++ b/turbo/packages/firewalls-generator/src/metadata.ts
@@ -15,12 +15,13 @@ import type {
   FirewallRoutingMetadata,
 } from "@vm0/connectors/firewall-metadata/routing";
 import type { FirewallExecutionMetadata } from "@vm0/connectors/firewall-metadata/server";
-import type {
-  FirewallConfig,
-  Firewall,
-  FirewallBaseHostPolicy,
-  FirewallPolicy,
-  FirewallPolicyValue,
+import {
+  extractFirewallTemplateReferences,
+  type FirewallConfig,
+  type Firewall,
+  type FirewallBaseHostPolicy,
+  type FirewallPolicy,
+  type FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
 import type { FirewallConnectorType } from "./connector-firewall-manifest";
 import {
@@ -626,8 +627,13 @@ function buildRoutingMetadata(
     type: source.type as FirewallConnectorType & ConnectorType,
     label: source.label,
     apis: source.firewall.apis.map((api) => {
+      const references = extractFirewallTemplateReferences([api]);
       return {
         base: api.base,
+        environmentNames: sortedStrings([
+          ...references.secrets,
+          ...references.vars,
+        ]),
         routes: (api.permissions ?? []).flatMap((permission) => {
           return permission.rules.map((rule) => {
             return {


### PR DESCRIPTION
## Summary

- make `zero doctor check-connector --url` select connector owners through the shared firewall matcher, including explicit `--connector` disambiguation and authoritative current-run routing
- generate safe per-API environment-name metadata and diagnose the winning API's environment bindings without relying on connector declaration order
- reject conflicting selectors, redact URL query/fragment data from errors and retry commands, and reuse the owner-selected permission decision
- cover Nintendo, Railway, Cloudflare, compact/inline run contexts, route specificity, invalid inputs, and shell-safe remediation through CLI integration tests

## Exclusions

- no runner, proxy, request-header, API contract, database, persisted snapshot, or full runtime-auth metadata changes

## Validation

- `pnpm -F @vm0/firewalls-generator generate:metadata`
- `pnpm -F @vm0/firewalls-generator exec vitest run src/__tests__/metadata.test.ts`
- `pnpm -F @vm0/connectors exec vitest run src/__tests__/firewall-routing-metadata.test.ts src/__tests__/firewall-rule-validation.test.ts`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/check-connector.test.ts`
- `pnpm -F @vm0/cli build`
- `ZERO_STARTUP_BENCH=1 pnpm -F @vm0/cli bench:startup`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,362 passed)
- `pnpm knip`
- `git diff --check`

Closes #21099

Parent context: #21094
