### PR TITLE
refactor(platform): restructure agent delete dialog into two-column split layout

### DIFF
--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -934,7 +934,7 @@ describe("team page navigation", () => {
     const deleteDialog = await screen.findByRole("dialog");
     expect(
       within(deleteDialog).getByText(
-        /including automations and chats other people created/u,
+        /Deletes the agent, its workflows, automations, and everyone.s chat history/u,
       ),
     ).toBeInTheDocument();
 
@@ -1018,7 +1018,7 @@ describe("team page navigation", () => {
     // The delete dialog offers to rescue each bound workflow by copying it.
     await waitFor(() => {
       expect(
-        within(deleteDialog).getByText("Keep any of these workflows?"),
+        within(deleteDialog).getByText("Keep any workflows?"),
       ).toBeInTheDocument();
       expect(
         within(deleteDialog).getByText("Sales Research"),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -422,7 +422,7 @@ describe("zero settings tab", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(
         screen.getByText(
-          /including automations and chats other people created/u,
+          /Deletes the agent, its workflows, automations, and everyone.s chat history/u,
         ),
       ).toBeInTheDocument();
     });
@@ -432,7 +432,7 @@ describe("zero settings tab", () => {
     await waitFor(() => {
       expect(
         screen.queryByText(
-          /including automations and chats other people created/u,
+          /Deletes the agent, its workflows, automations, and everyone.s chat history/u,
         ),
       ).not.toBeInTheDocument();
     });

--- a/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
@@ -42,6 +42,182 @@ export interface AgentDeleteCopyTarget {
 /** Sentinel Select value meaning "let this workflow be deleted with the agent". */
 const DELETE_WITH_AGENT = "__delete_with_agent__";
 
+function DeleteDangerHeader({ agentName }: { agentName: string }) {
+  return (
+    <>
+      <DialogHeader className="space-y-0 text-left">
+        <div className="flex items-center gap-2">
+          <IconAlertTriangle
+            size={20}
+            stroke={1.5}
+            className="shrink-0 text-destructive"
+          />
+          <DialogTitle>Delete {agentName}?</DialogTitle>
+        </div>
+        <DialogDescription className="mt-3">
+          Deletes the agent, its workflows, automations, and everyone&apos;s
+          chat history.
+        </DialogDescription>
+      </DialogHeader>
+      <p className="mt-3 text-sm font-semibold text-foreground">
+        This can&apos;t be undone.
+      </p>
+    </>
+  );
+}
+
+interface DeleteConfirmButtonProps {
+  deleting: boolean;
+  copying: boolean;
+  onDelete: () => void;
+  className?: string;
+}
+
+function DeleteConfirmButton({
+  deleting,
+  copying,
+  onDelete,
+  className,
+}: DeleteConfirmButtonProps) {
+  const label = copying ? "Copying…" : deleting ? "Deleting…" : "Delete agent";
+  return (
+    <Button
+      variant="destructive"
+      size="sm"
+      className={className}
+      disabled={deleting || copying}
+      onClick={onDelete}
+    >
+      {label}
+    </Button>
+  );
+}
+
+interface AgentDeleteReconcileViewProps {
+  agentName: string;
+  deleting: boolean;
+  copying: boolean;
+  onDelete: () => void;
+  deleteWorkflows: readonly AgentDeleteWorkflow[];
+  deleteCopyTargets: readonly AgentDeleteCopyTarget[];
+  copyChoices: Record<string, string>;
+  setCopyChoices: (choices: Record<string, string>) => void;
+}
+
+function AgentDeleteReconcileView({
+  agentName,
+  deleting,
+  copying,
+  onDelete,
+  deleteWorkflows,
+  deleteCopyTargets,
+  copyChoices,
+  setCopyChoices,
+}: AgentDeleteReconcileViewProps) {
+  return (
+    <div className="grid grid-cols-[264px_1fr]">
+      <div className="flex flex-col border-r border-[hsl(var(--gray-400))]/40 bg-muted/40 px-6 py-6">
+        <DeleteDangerHeader agentName={agentName} />
+        <div className="mt-auto flex flex-col gap-2 pt-8">
+          <DeleteConfirmButton
+            deleting={deleting}
+            copying={copying}
+            onDelete={onDelete}
+            className="w-full"
+          />
+          <DialogClose asChild>
+            <Button variant="outline" size="sm" className="w-full">
+              Cancel
+            </Button>
+          </DialogClose>
+        </div>
+      </div>
+      <div className="flex flex-col px-6 py-6">
+        <p className="text-sm font-medium text-foreground">
+          Keep any workflows?
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Copy a workflow to another agent to keep it. Anything left is deleted.
+        </p>
+        <div className="mt-3 flex max-h-[320px] flex-col gap-1 overflow-y-auto">
+          {deleteWorkflows.map((workflow) => {
+            return (
+              <div
+                key={workflow.id}
+                className="grid grid-cols-[1fr_200px] items-center gap-6"
+              >
+                <span
+                  className="min-w-0 truncate text-sm text-foreground"
+                  title={workflow.title}
+                >
+                  {workflow.title}
+                </span>
+                <Select
+                  value={copyChoices[workflow.id] ?? DELETE_WITH_AGENT}
+                  onValueChange={(value) => {
+                    setCopyChoices({ ...copyChoices, [workflow.id]: value });
+                  }}
+                >
+                  <SelectTrigger
+                    className="w-full"
+                    aria-label={`Handle workflow ${workflow.title}`}
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={DELETE_WITH_AGENT}>
+                      Delete with agent
+                    </SelectItem>
+                    {deleteCopyTargets.map((target) => {
+                      return (
+                        <SelectItem key={target.id} value={target.id}>
+                          Copy to {target.displayName ?? target.id}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface AgentDeleteSimpleViewProps {
+  agentName: string;
+  deleting: boolean;
+  copying: boolean;
+  onDelete: () => void;
+}
+
+function AgentDeleteSimpleView({
+  agentName,
+  deleting,
+  copying,
+  onDelete,
+}: AgentDeleteSimpleViewProps) {
+  return (
+    <div className="flex flex-col px-6 py-6">
+      <DeleteDangerHeader agentName={agentName} />
+      <DialogFooter className="mt-6">
+        <DialogClose asChild>
+          <Button variant="outline" size="sm">
+            Cancel
+          </Button>
+        </DialogClose>
+        <DeleteConfirmButton
+          deleting={deleting}
+          copying={copying}
+          onDelete={onDelete}
+        />
+      </DialogFooter>
+    </div>
+  );
+}
+
 interface AgentDeleteDialogProps {
   /** Agent name shown in the confirmation copy. */
   resolvedAgentName: string;
@@ -111,34 +287,6 @@ export function AgentDeleteDialog({
     );
   };
 
-  const deleteButtonLabel = copying
-    ? "Copying…"
-    : deleting
-      ? "Deleting…"
-      : "Delete agent";
-
-  const deleteDangerHeader = (
-    <>
-      <DialogHeader className="space-y-0 text-left">
-        <div className="flex items-center gap-2">
-          <IconAlertTriangle
-            size={20}
-            stroke={1.5}
-            className="shrink-0 text-destructive"
-          />
-          <DialogTitle>Delete {resolvedAgentName}?</DialogTitle>
-        </div>
-        <DialogDescription className="mt-3">
-          Deletes the agent, its workflows, automations, and everyone&apos;s
-          chat history.
-        </DialogDescription>
-      </DialogHeader>
-      <p className="mt-3 text-sm font-semibold text-foreground">
-        This can&apos;t be undone.
-      </p>
-    </>
-  );
-
   return (
     <Card className="zero-card overflow-hidden border-destructive/20 mt-4">
       <CardContent className="p-4 sm:p-5">
@@ -164,110 +312,23 @@ export function AgentDeleteDialog({
               </DialogTrigger>
               <DialogContent className="max-w-3xl gap-0 overflow-hidden p-0">
                 {canReconcile ? (
-                  <div className="grid grid-cols-[264px_1fr]">
-                    <div className="flex flex-col border-r border-[hsl(var(--gray-400))]/40 bg-muted/40 px-6 py-6">
-                      {deleteDangerHeader}
-                      <div className="mt-auto flex flex-col gap-2 pt-8">
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          className="w-full"
-                          disabled={deleting || copying}
-                          onClick={handleDelete}
-                        >
-                          {deleteButtonLabel}
-                        </Button>
-                        <DialogClose asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="w-full"
-                          >
-                            Cancel
-                          </Button>
-                        </DialogClose>
-                      </div>
-                    </div>
-                    <div className="flex flex-col px-6 py-6">
-                      <p className="text-sm font-medium text-foreground">
-                        Keep any workflows?
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Copy a workflow to another agent to keep it. Anything
-                        left is deleted.
-                      </p>
-                      <div className="mt-3 flex max-h-[320px] flex-col gap-1 overflow-y-auto">
-                        {deleteWorkflows.map((workflow) => {
-                          return (
-                            <div
-                              key={workflow.id}
-                              className="grid grid-cols-[1fr_200px] items-center gap-6"
-                            >
-                              <span
-                                className="min-w-0 truncate text-sm text-foreground"
-                                title={workflow.title}
-                              >
-                                {workflow.title}
-                              </span>
-                              <Select
-                                value={
-                                  copyChoices[workflow.id] ?? DELETE_WITH_AGENT
-                                }
-                                onValueChange={(value) => {
-                                  setCopyChoices({
-                                    ...copyChoices,
-                                    [workflow.id]: value,
-                                  });
-                                }}
-                              >
-                                <SelectTrigger
-                                  className="w-full"
-                                  aria-label={`Handle workflow ${workflow.title}`}
-                                >
-                                  <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                  <SelectItem value={DELETE_WITH_AGENT}>
-                                    Delete with agent
-                                  </SelectItem>
-                                  {deleteCopyTargets.map((target) => {
-                                    return (
-                                      <SelectItem
-                                        key={target.id}
-                                        value={target.id}
-                                      >
-                                        Copy to{" "}
-                                        {target.displayName ?? target.id}
-                                      </SelectItem>
-                                    );
-                                  })}
-                                </SelectContent>
-                              </Select>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
+                  <AgentDeleteReconcileView
+                    agentName={resolvedAgentName}
+                    deleting={deleting}
+                    copying={copying}
+                    onDelete={handleDelete}
+                    deleteWorkflows={deleteWorkflows}
+                    deleteCopyTargets={deleteCopyTargets}
+                    copyChoices={copyChoices}
+                    setCopyChoices={setCopyChoices}
+                  />
                 ) : (
-                  <div className="flex flex-col px-6 py-6">
-                    {deleteDangerHeader}
-                    <DialogFooter className="mt-6">
-                      <DialogClose asChild>
-                        <Button variant="outline" size="sm">
-                          Cancel
-                        </Button>
-                      </DialogClose>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        disabled={deleting || copying}
-                        onClick={handleDelete}
-                      >
-                        {deleteButtonLabel}
-                      </Button>
-                    </DialogFooter>
-                  </div>
+                  <AgentDeleteSimpleView
+                    agentName={resolvedAgentName}
+                    deleting={deleting}
+                    copying={copying}
+                    onDelete={handleDelete}
+                  />
                 )}
               </DialogContent>
             </Dialog>

--- a/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/zero-delete-agent-dialog.tsx
@@ -1,0 +1,279 @@
+import { useGet, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
+import {
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui";
+import { IconAlertTriangle, IconTrash } from "@tabler/icons-react";
+import { pageSignal$ } from "../../../signals/page-signal.ts";
+import { detach, Reason } from "../../../signals/utils.ts";
+import {
+  deleteAgent$,
+  agentDeleteCopyChoices$,
+  setAgentDeleteCopyChoices$,
+  agentDeleteCopying$,
+  setAgentDeleteCopying$,
+} from "../../../signals/zero-page/settings/settings-tab.ts";
+
+export interface AgentDeleteWorkflow {
+  readonly id: string;
+  readonly title: string;
+}
+
+export interface AgentDeleteCopyTarget {
+  readonly id: string;
+  readonly displayName: string | null;
+}
+
+/** Sentinel Select value meaning "let this workflow be deleted with the agent". */
+const DELETE_WITH_AGENT = "__delete_with_agent__";
+
+interface AgentDeleteDialogProps {
+  /** Agent name shown in the confirmation copy. */
+  resolvedAgentName: string;
+  /** Callback to delete the agent. */
+  onDelete: () => Promise<void>;
+  /** Workflows bound to this agent, offered for rescue in the delete dialog. */
+  deleteWorkflows?: readonly AgentDeleteWorkflow[];
+  /** Agents the caller can copy a workflow onto before deleting this agent. */
+  deleteCopyTargets?: readonly AgentDeleteCopyTarget[];
+  /** Copy a workflow onto another agent before the agent is deleted. */
+  onCopyWorkflowBeforeDelete?: (
+    workflowId: string,
+    toAgentId: string,
+  ) => Promise<void>;
+}
+
+export function AgentDeleteDialog({
+  resolvedAgentName,
+  onDelete,
+  deleteWorkflows = [],
+  deleteCopyTargets = [],
+  onCopyWorkflowBeforeDelete,
+}: AgentDeleteDialogProps) {
+  const pageSignal = useGet(pageSignal$);
+
+  const [deleteLoadable, deleteAgentFn] = useLoadableSet(deleteAgent$);
+  const deleting = deleteLoadable.state === "loading";
+
+  // Delete reconcile: each bound workflow maps to a Select value that is either
+  // DELETE_WITH_AGENT (default) or a target agent id to copy it onto first.
+  const copyChoices = useGet(agentDeleteCopyChoices$);
+  const setCopyChoices = useSet(setAgentDeleteCopyChoices$);
+  const copying = useGet(agentDeleteCopying$);
+  const setCopying = useSet(setAgentDeleteCopying$);
+  const canReconcile =
+    deleteWorkflows.length > 0 &&
+    deleteCopyTargets.length > 0 &&
+    onCopyWorkflowBeforeDelete !== undefined;
+
+  const handleDelete = () => {
+    // Scope rescues to this agent's workflows so stale choices from a
+    // previously opened delete dialog never trigger an unrelated copy.
+    const currentWorkflowIds = new Set(
+      deleteWorkflows.map((workflow) => {
+        return workflow.id;
+      }),
+    );
+    const rescues = Object.entries(copyChoices).filter(
+      ([workflowId, target]) => {
+        return (
+          target !== DELETE_WITH_AGENT && currentWorkflowIds.has(workflowId)
+        );
+      },
+    );
+    detach(
+      (async () => {
+        if (rescues.length > 0 && onCopyWorkflowBeforeDelete) {
+          setCopying(true);
+          for (const [workflowId, toAgentId] of rescues) {
+            await onCopyWorkflowBeforeDelete(workflowId, toAgentId);
+          }
+          setCopying(false);
+        }
+        await deleteAgentFn(onDelete, pageSignal);
+      })(),
+      Reason.DomCallback,
+    );
+  };
+
+  const deleteButtonLabel = copying
+    ? "Copying…"
+    : deleting
+      ? "Deleting…"
+      : "Delete agent";
+
+  const deleteDangerHeader = (
+    <>
+      <DialogHeader className="space-y-0 text-left">
+        <div className="flex items-center gap-2">
+          <IconAlertTriangle
+            size={20}
+            stroke={1.5}
+            className="shrink-0 text-destructive"
+          />
+          <DialogTitle>Delete {resolvedAgentName}?</DialogTitle>
+        </div>
+        <DialogDescription className="mt-3">
+          Deletes the agent, its workflows, automations, and everyone&apos;s
+          chat history.
+        </DialogDescription>
+      </DialogHeader>
+      <p className="mt-3 text-sm font-semibold text-foreground">
+        This can&apos;t be undone.
+      </p>
+    </>
+  );
+
+  return (
+    <Card className="zero-card overflow-hidden border-destructive/20 mt-4">
+      <CardContent className="p-4 sm:p-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+          <div className="min-w-0 sm:max-w-[46%]">
+            <h3 className="text-sm font-medium text-foreground">Danger zone</h3>
+            <p className="text-xs text-muted-foreground mt-1 leading-snug">
+              Permanently remove this agent and all its data. This action cannot
+              be undone.
+            </p>
+          </div>
+          <div className="flex w-full shrink-0 justify-end sm:w-auto">
+            <Dialog>
+              <DialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-9 gap-2 rounded-lg border-destructive/40 px-4 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                >
+                  <IconTrash size={14} stroke={1.5} />
+                  Delete agent
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-3xl gap-0 overflow-hidden p-0">
+                {canReconcile ? (
+                  <div className="grid grid-cols-[264px_1fr]">
+                    <div className="flex flex-col border-r border-[hsl(var(--gray-400))]/40 bg-muted/40 px-6 py-6">
+                      {deleteDangerHeader}
+                      <div className="mt-auto flex flex-col gap-2 pt-8">
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          className="w-full"
+                          disabled={deleting || copying}
+                          onClick={handleDelete}
+                        >
+                          {deleteButtonLabel}
+                        </Button>
+                        <DialogClose asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="w-full"
+                          >
+                            Cancel
+                          </Button>
+                        </DialogClose>
+                      </div>
+                    </div>
+                    <div className="flex flex-col px-6 py-6">
+                      <p className="text-sm font-medium text-foreground">
+                        Keep any workflows?
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Copy a workflow to another agent to keep it. Anything
+                        left is deleted.
+                      </p>
+                      <div className="mt-3 flex max-h-[320px] flex-col gap-1 overflow-y-auto">
+                        {deleteWorkflows.map((workflow) => {
+                          return (
+                            <div
+                              key={workflow.id}
+                              className="grid grid-cols-[1fr_200px] items-center gap-6"
+                            >
+                              <span
+                                className="min-w-0 truncate text-sm text-foreground"
+                                title={workflow.title}
+                              >
+                                {workflow.title}
+                              </span>
+                              <Select
+                                value={
+                                  copyChoices[workflow.id] ?? DELETE_WITH_AGENT
+                                }
+                                onValueChange={(value) => {
+                                  setCopyChoices({
+                                    ...copyChoices,
+                                    [workflow.id]: value,
+                                  });
+                                }}
+                              >
+                                <SelectTrigger
+                                  className="w-full"
+                                  aria-label={`Handle workflow ${workflow.title}`}
+                                >
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value={DELETE_WITH_AGENT}>
+                                    Delete with agent
+                                  </SelectItem>
+                                  {deleteCopyTargets.map((target) => {
+                                    return (
+                                      <SelectItem
+                                        key={target.id}
+                                        value={target.id}
+                                      >
+                                        Copy to{" "}
+                                        {target.displayName ?? target.id}
+                                      </SelectItem>
+                                    );
+                                  })}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-col px-6 py-6">
+                    {deleteDangerHeader}
+                    <DialogFooter className="mt-6">
+                      <DialogClose asChild>
+                        <Button variant="outline" size="sm">
+                          Cancel
+                        </Button>
+                      </DialogClose>
+                      <Button
+                        variant="destructive"
+                        size="sm"
+                        disabled={deleting || copying}
+                        onClick={handleDelete}
+                      >
+                        {deleteButtonLabel}
+                      </Button>
+                    </DialogFooter>
+                  </div>
+                )}
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -8,23 +8,16 @@ import {
   Card,
   CardContent,
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
   Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Switch,
   cn,
 } from "@vm0/ui";
-import { IconAlertTriangle, IconTrash } from "@tabler/icons-react";
+import { IconAlertTriangle } from "@tabler/icons-react";
 import {
   Alert,
   AlertDescription,
@@ -41,6 +34,11 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
 import type { Command } from "ccstate";
 import { InlineSettingsRow } from "./components/zero-inline-settings-row.tsx";
+import {
+  AgentDeleteDialog,
+  type AgentDeleteWorkflow,
+  type AgentDeleteCopyTarget,
+} from "./components/zero-delete-agent-dialog.tsx";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { serializeAvatarSvgConfig } from "./avatar-svg-utils.ts";
 import { resolveAvatarSvgConfig } from "./avatar-utils.ts";
@@ -59,29 +57,13 @@ import {
   initSettingsForm$,
   resetSettingsForm$,
   markSettingsSaved$,
-  deleteAgent$,
   settingsVisibility$,
   setSettingsVisibility$,
   agentDemoteConfirmOpen$,
   setAgentDemoteConfirmOpen$,
-  agentDeleteCopyChoices$,
-  setAgentDeleteCopyChoices$,
-  agentDeleteCopying$,
-  setAgentDeleteCopying$,
 } from "../../signals/zero-page/settings/settings-tab.ts";
 
-export interface AgentDeleteWorkflow {
-  readonly id: string;
-  readonly title: string;
-}
-
-export interface AgentDeleteCopyTarget {
-  readonly id: string;
-  readonly displayName: string | null;
-}
-
-/** Sentinel Select value meaning "let this workflow be deleted with the agent". */
-const DELETE_WITH_AGENT = "__delete_with_agent__";
+export type { AgentDeleteWorkflow, AgentDeleteCopyTarget };
 
 interface ZeroSettingsTabProps {
   displayName: string;
@@ -156,9 +138,6 @@ export function ZeroSettingsTab({
   const resetForm = useSet(resetSettingsForm$);
   const markSaved = useSet(markSettingsSaved$);
 
-  const [deleteLoadable, deleteAgentFn] = useLoadableSet(deleteAgent$);
-  const deleting = deleteLoadable.state === "loading";
-
   const [settingsLoadable, triggerUpdateSettings] =
     useLoadableSet(updateSettings$);
   const saving = settingsLoadable.state === "loading";
@@ -201,72 +180,6 @@ export function ZeroSettingsTab({
     }
     runSaveSettings();
   };
-
-  // Delete reconcile: each bound workflow maps to a Select value that is either
-  // DELETE_WITH_AGENT (default) or a target agent id to copy it onto first.
-  const copyChoices = useGet(agentDeleteCopyChoices$);
-  const setCopyChoices = useSet(setAgentDeleteCopyChoices$);
-  const copying = useGet(agentDeleteCopying$);
-  const setCopying = useSet(setAgentDeleteCopying$);
-  const canReconcile =
-    deleteWorkflows.length > 0 &&
-    deleteCopyTargets.length > 0 &&
-    onCopyWorkflowBeforeDelete !== undefined;
-
-  const handleDelete = () => {
-    if (!onDelete) {
-      return;
-    }
-    // Scope rescues to this agent's workflows so stale choices from a
-    // previously opened delete dialog never trigger an unrelated copy.
-    const currentWorkflowIds = new Set(
-      deleteWorkflows.map((workflow) => {
-        return workflow.id;
-      }),
-    );
-    const rescues = Object.entries(copyChoices).filter(
-      ([workflowId, target]) => {
-        return (
-          target !== DELETE_WITH_AGENT && currentWorkflowIds.has(workflowId)
-        );
-      },
-    );
-    detach(
-      (async () => {
-        if (rescues.length > 0 && onCopyWorkflowBeforeDelete) {
-          setCopying(true);
-          for (const [workflowId, toAgentId] of rescues) {
-            await onCopyWorkflowBeforeDelete(workflowId, toAgentId);
-          }
-          setCopying(false);
-        }
-        await deleteAgentFn(onDelete, pageSignal);
-      })(),
-      Reason.DomCallback,
-    );
-  };
-
-  const deleteDangerHeader = (
-    <>
-      <DialogHeader className="space-y-0 text-left">
-        <div className="flex items-center gap-2">
-          <IconAlertTriangle
-            size={20}
-            stroke={1.5}
-            className="shrink-0 text-destructive"
-          />
-          <DialogTitle>Delete {resolvedAgentName}?</DialogTitle>
-        </div>
-        <DialogDescription className="mt-3">
-          Deletes the agent, its workflows, automations, and everyone&apos;s
-          chat history.
-        </DialogDescription>
-      </DialogHeader>
-      <p className="mt-3 text-sm font-semibold text-foreground">
-        This can&apos;t be undone.
-      </p>
-    </>
-  );
 
   return (
     <>
@@ -431,152 +344,13 @@ export function ZeroSettingsTab({
         </Card>
 
         {!isDefaultAgent && onDelete && (
-          <Card className="zero-card overflow-hidden border-destructive/20 mt-4">
-            <CardContent className="p-4 sm:p-5">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
-                <div className="min-w-0 sm:max-w-[46%]">
-                  <h3 className="text-sm font-medium text-foreground">
-                    Danger zone
-                  </h3>
-                  <p className="text-xs text-muted-foreground mt-1 leading-snug">
-                    Permanently remove this agent and all its data. This action
-                    cannot be undone.
-                  </p>
-                </div>
-                <div className="flex w-full shrink-0 justify-end sm:w-auto">
-                  <Dialog>
-                    <DialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-9 gap-2 rounded-lg border-destructive/40 px-4 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                      >
-                        <IconTrash size={14} stroke={1.5} />
-                        Delete agent
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent className="max-w-3xl gap-0 overflow-hidden p-0">
-                      {canReconcile ? (
-                        <div className="grid grid-cols-[264px_1fr]">
-                          <div className="flex flex-col border-r border-[hsl(var(--gray-400))]/40 bg-muted/40 px-6 py-6">
-                            {deleteDangerHeader}
-                            <div className="mt-auto flex flex-col gap-2 pt-8">
-                              <Button
-                                variant="destructive"
-                                size="sm"
-                                className="w-full"
-                                disabled={deleting || copying}
-                                onClick={handleDelete}
-                              >
-                                {copying
-                                  ? "Copying…"
-                                  : deleting
-                                    ? "Deleting…"
-                                    : "Delete agent"}
-                              </Button>
-                              <DialogClose asChild>
-                                <Button
-                                  variant="outline"
-                                  size="sm"
-                                  className="w-full"
-                                >
-                                  Cancel
-                                </Button>
-                              </DialogClose>
-                            </div>
-                          </div>
-                          <div className="flex flex-col px-6 py-6">
-                            <p className="text-sm font-medium text-foreground">
-                              Keep any workflows?
-                            </p>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              Copy a workflow to another agent to keep it.
-                              Anything left is deleted.
-                            </p>
-                            <div className="mt-3 flex max-h-[320px] flex-col gap-1 overflow-y-auto">
-                              {deleteWorkflows.map((workflow) => {
-                                return (
-                                  <div
-                                    key={workflow.id}
-                                    className="grid grid-cols-[1fr_200px] items-center gap-6"
-                                  >
-                                    <span
-                                      className="min-w-0 truncate text-sm text-foreground"
-                                      title={workflow.title}
-                                    >
-                                      {workflow.title}
-                                    </span>
-                                    <Select
-                                      value={
-                                        copyChoices[workflow.id] ??
-                                        DELETE_WITH_AGENT
-                                      }
-                                      onValueChange={(value) => {
-                                        setCopyChoices({
-                                          ...copyChoices,
-                                          [workflow.id]: value,
-                                        });
-                                      }}
-                                    >
-                                      <SelectTrigger
-                                        className="w-full"
-                                        aria-label={`Handle workflow ${workflow.title}`}
-                                      >
-                                        <SelectValue />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value={DELETE_WITH_AGENT}>
-                                          Delete with agent
-                                        </SelectItem>
-                                        {deleteCopyTargets.map((target) => {
-                                          return (
-                                            <SelectItem
-                                              key={target.id}
-                                              value={target.id}
-                                            >
-                                              Copy to{" "}
-                                              {target.displayName ?? target.id}
-                                            </SelectItem>
-                                          );
-                                        })}
-                                      </SelectContent>
-                                    </Select>
-                                  </div>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="flex flex-col px-6 py-6">
-                          {deleteDangerHeader}
-                          <DialogFooter className="mt-6">
-                            <DialogClose asChild>
-                              <Button variant="outline" size="sm">
-                                Cancel
-                              </Button>
-                            </DialogClose>
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              disabled={deleting || copying}
-                              onClick={handleDelete}
-                            >
-                              {copying
-                                ? "Copying…"
-                                : deleting
-                                  ? "Deleting…"
-                                  : "Delete agent"}
-                            </Button>
-                          </DialogFooter>
-                        </div>
-                      )}
-                    </DialogContent>
-                  </Dialog>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <AgentDeleteDialog
+            resolvedAgentName={resolvedAgentName}
+            onDelete={onDelete}
+            deleteWorkflows={deleteWorkflows}
+            deleteCopyTargets={deleteCopyTargets}
+            onCopyWorkflowBeforeDelete={onCopyWorkflowBeforeDelete}
+          />
         )}
       </div>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -246,6 +246,28 @@ export function ZeroSettingsTab({
     );
   };
 
+  const deleteDangerHeader = (
+    <>
+      <DialogHeader className="space-y-0 text-left">
+        <div className="flex items-center gap-2">
+          <IconAlertTriangle
+            size={20}
+            stroke={1.5}
+            className="shrink-0 text-destructive"
+          />
+          <DialogTitle>Delete {resolvedAgentName}?</DialogTitle>
+        </div>
+        <DialogDescription className="mt-3">
+          Deletes the agent, its workflows, automations, and everyone&apos;s
+          chat history.
+        </DialogDescription>
+      </DialogHeader>
+      <p className="mt-3 text-sm font-semibold text-foreground">
+        This can&apos;t be undone.
+      </p>
+    </>
+  );
+
   return (
     <>
       <div className="mx-auto max-w-[900px]">
@@ -433,109 +455,122 @@ export function ZeroSettingsTab({
                         Delete agent
                       </Button>
                     </DialogTrigger>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>Delete {resolvedAgentName}?</DialogTitle>
-                        <DialogDescription>
-                          This is a dangerous operation. Deleting this agent
-                          also permanently deletes every workflow bound to it
-                          and every member&apos;s chat history under it,
-                          including automations and chats other people created.
-                          This action cannot be undone.
-                        </DialogDescription>
-                      </DialogHeader>
-                      <Alert variant="destructive">
-                        <IconAlertTriangle size={16} stroke={1.5} />
-                        <AlertTitle>This can&apos;t be undone</AlertTitle>
-                        <AlertDescription>
-                          {resolvedAgentName} and every member&apos;s workflows,
-                          automations, and chat history under it will be
-                          permanently deleted.
-                        </AlertDescription>
-                      </Alert>
-                      {canReconcile && (
-                        <div className="space-y-2">
-                          <p className="text-sm font-medium text-foreground">
-                            Keep any of these workflows?
-                          </p>
-                          <p className="text-xs text-muted-foreground">
-                            Copy a workflow to another agent to keep it.
-                            Anything left as &quot;Delete with agent&quot; is
-                            removed.
-                          </p>
-                          <div className="flex flex-col gap-2">
-                            {deleteWorkflows.map((workflow) => {
-                              return (
-                                <div
-                                  key={workflow.id}
-                                  className="flex items-center justify-between gap-3"
+                    <DialogContent className="max-w-3xl gap-0 overflow-hidden p-0">
+                      {canReconcile ? (
+                        <div className="grid grid-cols-[264px_1fr]">
+                          <div className="flex flex-col border-r border-[hsl(var(--gray-400))]/40 bg-muted/40 px-6 py-6">
+                            {deleteDangerHeader}
+                            <div className="mt-auto flex flex-col gap-2 pt-8">
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                className="w-full"
+                                disabled={deleting || copying}
+                                onClick={handleDelete}
+                              >
+                                {copying
+                                  ? "Copying…"
+                                  : deleting
+                                    ? "Deleting…"
+                                    : "Delete agent"}
+                              </Button>
+                              <DialogClose asChild>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  className="w-full"
                                 >
-                                  <span
-                                    className="min-w-0 truncate text-sm text-foreground"
-                                    title={workflow.title}
+                                  Cancel
+                                </Button>
+                              </DialogClose>
+                            </div>
+                          </div>
+                          <div className="flex flex-col px-6 py-6">
+                            <p className="text-sm font-medium text-foreground">
+                              Keep any workflows?
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Copy a workflow to another agent to keep it.
+                              Anything left is deleted.
+                            </p>
+                            <div className="mt-3 flex max-h-[320px] flex-col gap-1 overflow-y-auto">
+                              {deleteWorkflows.map((workflow) => {
+                                return (
+                                  <div
+                                    key={workflow.id}
+                                    className="grid grid-cols-[1fr_200px] items-center gap-6"
                                   >
-                                    {workflow.title}
-                                  </span>
-                                  <Select
-                                    value={
-                                      copyChoices[workflow.id] ??
-                                      DELETE_WITH_AGENT
-                                    }
-                                    onValueChange={(value) => {
-                                      setCopyChoices({
-                                        ...copyChoices,
-                                        [workflow.id]: value,
-                                      });
-                                    }}
-                                  >
-                                    <SelectTrigger
-                                      className="h-8 w-[210px] shrink-0"
-                                      aria-label={`Handle workflow ${workflow.title}`}
+                                    <span
+                                      className="min-w-0 truncate text-sm text-foreground"
+                                      title={workflow.title}
                                     >
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                      <SelectItem value={DELETE_WITH_AGENT}>
-                                        Delete with agent
-                                      </SelectItem>
-                                      {deleteCopyTargets.map((target) => {
-                                        return (
-                                          <SelectItem
-                                            key={target.id}
-                                            value={target.id}
-                                          >
-                                            Copy to{" "}
-                                            {target.displayName ?? target.id}
-                                          </SelectItem>
-                                        );
-                                      })}
-                                    </SelectContent>
-                                  </Select>
-                                </div>
-                              );
-                            })}
+                                      {workflow.title}
+                                    </span>
+                                    <Select
+                                      value={
+                                        copyChoices[workflow.id] ??
+                                        DELETE_WITH_AGENT
+                                      }
+                                      onValueChange={(value) => {
+                                        setCopyChoices({
+                                          ...copyChoices,
+                                          [workflow.id]: value,
+                                        });
+                                      }}
+                                    >
+                                      <SelectTrigger
+                                        className="w-full"
+                                        aria-label={`Handle workflow ${workflow.title}`}
+                                      >
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value={DELETE_WITH_AGENT}>
+                                          Delete with agent
+                                        </SelectItem>
+                                        {deleteCopyTargets.map((target) => {
+                                          return (
+                                            <SelectItem
+                                              key={target.id}
+                                              value={target.id}
+                                            >
+                                              Copy to{" "}
+                                              {target.displayName ?? target.id}
+                                            </SelectItem>
+                                          );
+                                        })}
+                                      </SelectContent>
+                                    </Select>
+                                  </div>
+                                );
+                              })}
+                            </div>
                           </div>
                         </div>
+                      ) : (
+                        <div className="flex flex-col px-6 py-6">
+                          {deleteDangerHeader}
+                          <DialogFooter className="mt-6">
+                            <DialogClose asChild>
+                              <Button variant="outline" size="sm">
+                                Cancel
+                              </Button>
+                            </DialogClose>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              disabled={deleting || copying}
+                              onClick={handleDelete}
+                            >
+                              {copying
+                                ? "Copying…"
+                                : deleting
+                                  ? "Deleting…"
+                                  : "Delete agent"}
+                            </Button>
+                          </DialogFooter>
+                        </div>
                       )}
-                      <DialogFooter>
-                        <DialogClose asChild>
-                          <Button variant="outline" size="sm">
-                            Cancel
-                          </Button>
-                        </DialogClose>
-                        <Button
-                          variant="destructive"
-                          size="sm"
-                          disabled={deleting || copying}
-                          onClick={handleDelete}
-                        >
-                          {copying
-                            ? "Copying…"
-                            : deleting
-                              ? "Deleting…"
-                              : "Delete agent"}
-                        </Button>
-                      </DialogFooter>
                     </DialogContent>
                   </Dialog>
                 </div>


### PR DESCRIPTION
## What changed

Restructures the **agent delete confirmation dialog** in `zero-settings-tab.tsx` into a two-column split layout, while keeping every signal, handler, state, and behavior exactly as-is. This is a **presentational refactor only**.

### Split layout (when there are bound workflows to triage — `canReconcile`)
- **Left panel** (bordered gray column): a red `IconAlertTriangle` inline with the `Delete {agent}?` title, a shortened description ("Deletes the agent, its workflows, automations, and everyone's chat history."), and a bold "This can't be undone." line. The destructive **Delete agent** button and an outline **Cancel** are stacked full-width and pinned to the bottom of the panel (Delete on top, Cancel below).
- **Right panel**: "Keep any workflows?" with the per-workflow copy/keep triage — the same `Select` per workflow (values, `onValueChange`, `copyChoices`, `DELETE_WITH_AGENT`, copy targets, and the `Handle workflow …` aria-labels are all unchanged). The dropdown trigger now uses the component default height and full width; the list scrolls at `max-h-[320px]`.

### Single-column fallback (no workflows)
- Same danger header, with a normal `DialogFooter` (outline Cancel, then destructive Delete).

### Other
- The shared danger header is extracted into a single local `deleteDangerHeader` to avoid duplicating it across the two branches (DRY).
- The old `<Alert variant="destructive">` block is dropped from this dialog, but `Alert`/`AlertTitle`/`AlertDescription`/`IconAlertTriangle` imports are kept — they're still used by the "Make {agent} private?" demote dialog in the same file.
- `DialogContent` now uses `max-w-3xl gap-0 overflow-hidden p-0`; the built-in top-right close button is retained (no custom X added).

## Behavior

Unchanged. The copy-before-delete rescue logic, `handleDelete`, disabled/label states (`Copying…` / `Deleting…` / `Delete agent`), and all state wiring are identical. Buttons use the real `Button` variants and dropdowns use the real `Select` component.

## Tests

Retargeted the changed copy literals only (no weakened assertions; role/aria-label queries unchanged):
- `team-page/__tests__/team-navigation.test.tsx` — delete description regex and "Keep any workflows?" text.
- `zero-page/__tests__/zero-settings-tab.test.tsx` — delete description regex (both open/close assertions).

## Verification

Touched files formatted with the repo-pinned Prettier 3.8.1 (no diff). Type-check and full test suite left to CI per project policy.