### PR TITLE
perf(api): attribute claim response assembly stages

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -106,6 +106,12 @@ const CLAIM_ROUTE_PREPARED_PATH_OMITTED_ACTION_TYPES = [
   "claim_route_feature_switch_context",
   "claim_route_secret_materialization",
 ] as const;
+const CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES = [
+  "claim_route_response_resume_session",
+  "claim_route_response_network_policy_refresh",
+] as const;
+type ClaimRouteResponseTimingActionType =
+  (typeof CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES)[number];
 const CLAIM_ROUTE_TRANSITION_TIMING_ACTION_TYPES = [
   "claim_route_transition_execute",
 ] as const;
@@ -673,6 +679,46 @@ function singleSandboxOperationEvent(
   });
   expect(matchingEvents).toHaveLength(1);
   return matchingEvents[0]!;
+}
+
+function expectClaimRouteResponseTimingActions(args: {
+  readonly runId: string;
+  readonly expectedActionTypes: readonly ClaimRouteResponseTimingActionType[];
+  readonly forbiddenValues: readonly string[];
+}): void {
+  const events = claimRouteTimingEventsForRun(args.runId);
+  const expectedActionTypes = new Set(args.expectedActionTypes);
+  for (const actionType of CLAIM_ROUTE_RESPONSE_TIMING_ACTION_TYPES) {
+    const matchingEvents = events.filter((event) => {
+      return event.op_type === actionType;
+    });
+    if (!expectedActionTypes.has(actionType)) {
+      expect(matchingEvents).toHaveLength(0);
+      continue;
+    }
+
+    expect(matchingEvents).toHaveLength(1);
+    const event = matchingEvents[0];
+    expect(event).toStrictEqual(
+      expect.objectContaining({
+        source: "api",
+        op_type: actionType,
+        sandbox_type: "runner",
+        success: true,
+        run_id: args.runId,
+        span_kind: "nested",
+      }),
+    );
+    expect(event?.duration_ms).toStrictEqual(expect.any(Number));
+    expect(Number(event?.duration_ms)).toBeGreaterThanOrEqual(0);
+    for (const forbiddenKey of FORBIDDEN_CLAIM_ROUTE_TIMING_KEYS) {
+      expect(event).not.toHaveProperty(forbiddenKey);
+    }
+    const serialized = JSON.stringify(event);
+    for (const forbiddenValue of args.forbiddenValues) {
+      expect(serialized).not.toContain(forbiddenValue);
+    }
+  }
 }
 
 function expectCustomConnectorRuntimePhaseTimingEvents(
@@ -2120,6 +2166,25 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       expect(serialized).not.toContain(historyHash);
       expect(serialized).not.toContain(first.sessionId);
     }
+    const resumedClaim = await api.claimRunnerJob(resumed.runId);
+    expect(resumedClaim.resumeSession).toMatchObject({
+      sessionId: `bdd-timing-cli-${first.runId}`,
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: expect.any(String),
+      },
+    });
+    expectClaimRouteResponseTimingActions({
+      runId: resumed.runId,
+      expectedActionTypes: ["claim_route_response_resume_session"],
+      forbiddenValues: [
+        history,
+        historyHash,
+        first.sessionId,
+        resumedClaim.sandboxToken,
+      ],
+    });
 
     const checkpointZeroToken = "bdd-checkpoint-zero-token";
     const checkpointRun = await api.createDirectRun(actor, {
@@ -6136,6 +6201,15 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
 
     const grantedContext = await claimSlackContext("granted permissions");
     const granted = grantedContext.policy;
+    expectClaimRouteResponseTimingActions({
+      runId: grantedContext.claim.runId,
+      expectedActionTypes: ["claim_route_response_network_policy_refresh"],
+      forbiddenValues: [
+        "granted permissions",
+        "slack",
+        grantedContext.claim.sandboxToken,
+      ],
+    });
     expect(
       grantedContext.claim.networkPolicyRefreshes?.slack?.nextRefreshAt,
     ).toStrictEqual(expect.any(String));
@@ -6255,6 +6329,88 @@ describe("RUN-02: custom connectors, grants, and network policies", () => {
     await api.requestCancelRun(actor, snapshotRun.runId, [200]);
     const drained = await api.readRunQueue(actor);
     expect(drained.body.concurrency.active).toBe(0);
+  });
+
+  it("records co-occurring resume and policy response timing", async () => {
+    const api = createRunsAutomationsApi(context);
+    const fw = createFirewallApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+
+    await fw.seedTestConnector(actor, {
+      connectorName: "slack",
+      authMethod: "oauth",
+      accessToken: "xoxb-bdd-claim-response-timing",
+    });
+    await api.enableAgentConnectors(actor, agentId, ["slack"]);
+    await api.heartbeatRunner(runnerGroup);
+
+    const firstPrompt = "start combined claim response timing";
+    const first = await api.createRun(actor, {
+      agentId,
+      prompt: firstPrompt,
+      modelProvider: "anthropic-api-key",
+    });
+    const firstClaim = await api.claimRunnerJob(first.runId);
+    expect(firstClaim.networkPolicies?.slack).toBeDefined();
+
+    const history = `bdd combined claim history ${first.runId}`;
+    const historyHash = createHash("sha256").update(history).digest("hex");
+    mockSessionHistoryBlob(historyHash, history);
+    await webhooks.requestAgentCheckpoint(
+      {
+        runId: first.runId,
+        cliAgentType: "claude-code",
+        cliAgentSessionId: `bdd-combined-cli-${first.runId}`,
+        cliAgentSessionHistoryHash: historyHash,
+      },
+      { authorization: `Bearer ${firstClaim.sandboxToken}` },
+      [200],
+    );
+    await webhooks.requestAgentComplete(
+      { runId: first.runId, exitCode: 0, lastEventSequence: 0 },
+      { authorization: `Bearer ${firstClaim.sandboxToken}` },
+      [200],
+    );
+    const completed = await api.readRun(actor, first.runId);
+    expect(completed.status).toBe("completed");
+
+    const resumedPrompt = "continue combined claim response timing";
+    const resumed = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: resumedPrompt,
+      modelProvider: "anthropic-api-key",
+    });
+    const resumedClaim = await api.claimRunnerJob(resumed.runId);
+    expect(resumedClaim.resumeSession).toMatchObject({
+      sessionId: `bdd-combined-cli-${first.runId}`,
+      historyRef: {
+        kind: "blob",
+        hash: historyHash,
+        url: expect.any(String),
+      },
+    });
+    expect(resumedClaim.networkPolicies?.slack).toBeDefined();
+    expectClaimRouteResponseTimingActions({
+      runId: resumed.runId,
+      expectedActionTypes: [
+        "claim_route_response_resume_session",
+        "claim_route_response_network_policy_refresh",
+      ],
+      forbiddenValues: [
+        firstPrompt,
+        resumedPrompt,
+        history,
+        historyHash,
+        first.sessionId,
+        "slack",
+        "xoxb-bdd-claim-response-timing",
+        resumedClaim.sandboxToken,
+      ],
+    });
+
+    await api.requestCancelRun(actor, resumed.runId, [200]);
   });
 
   it("preserves session agent identity when compose versions are shared", async () => {
@@ -6903,6 +7059,11 @@ describe("RUN-03: user-runner protocol and runner authentication", () => {
     }
     expect(claimed.body.prompt).toBe("user runner job one");
     expect(claimed.body.sandboxToken).not.toBe("");
+    expectClaimRouteResponseTimingActions({
+      runId: first.runId,
+      expectedActionTypes: [],
+      forbiddenValues: [firstPrompt, claimed.body.sandboxToken, apiKey.token],
+    });
     const claimRouteTimingEvents = claimRouteTimingEventsForRun(first.runId);
     expect(claimRouteTimingEvents).toHaveLength(
       CLAIM_ROUTE_TIMING_ACTION_TYPES.length,

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -133,6 +133,8 @@ type ClaimRouteTimingActionType =
   | "claim_route_context_parse"
   | "claim_route_secret_materialization"
   | "claim_route_response_assembly"
+  | "claim_route_response_network_policy_refresh"
+  | "claim_route_response_resume_session"
   | "claim_route_transition_running"
   | "claim_route_transition_execute";
 
@@ -1038,6 +1040,7 @@ async function refreshClaimNetworkPolicies(args: {
   readonly db: Db;
   readonly run: ClaimedRun;
   readonly storedContext: StoredExecutionContext;
+  readonly timing: ClaimRouteTimingCollector;
 }): Promise<
   Pick<StoredExecutionContext, "networkPolicies" | "networkPolicyRefreshes">
 > {
@@ -1051,22 +1054,28 @@ async function refreshClaimNetworkPolicies(args: {
     };
   }
 
-  const refreshes = await resolveActiveNetworkPolicyRefreshes(
-    args.db,
-    {
-      orgId: args.run.orgId,
-      userId: args.run.userId,
-      agentId: args.run.agentId,
+  return await args.timing.measure(
+    "claim_route_response_network_policy_refresh",
+    "nested",
+    async () => {
+      const refreshes = await resolveActiveNetworkPolicyRefreshes(
+        args.db,
+        {
+          orgId: args.run.orgId,
+          userId: args.run.userId,
+          agentId: args.run.agentId,
+        },
+        connectorRefs,
+      );
+      return {
+        networkPolicies: mergeNetworkPolicyRefreshes(
+          args.storedContext.networkPolicies,
+          refreshes,
+        ),
+        networkPolicyRefreshes: networkPolicyRefreshesRecord(refreshes),
+      };
     },
-    connectorRefs,
   );
-  return {
-    networkPolicies: mergeNetworkPolicyRefreshes(
-      args.storedContext.networkPolicies,
-      refreshes,
-    ),
-    networkPolicyRefreshes: networkPolicyRefreshesRecord(refreshes),
-  };
 }
 
 type StoredResumeSessionWithHistoryRef = Extract<
@@ -1290,6 +1299,7 @@ const loadIdentityResumeSessionHistoryRepresentation$ = command(
 
 async function resolveResumeSessionForClaim(args: {
   readonly resumeSession: StoredExecutionContext["resumeSession"];
+  readonly timing: ClaimRouteTimingCollector;
   readonly loadIdentityRepresentation: (
     hash: string,
   ) => Promise<IdentityResumeSessionHistoryRepresentation | undefined>;
@@ -1307,63 +1317,67 @@ async function resolveResumeSessionForClaim(args: {
     return resumeSession;
   }
 
-  const { sessionId, historyRef } = resumeSession;
-  const encoding = historyRef.encoding ?? SESSION_HISTORY_ENCODING_IDENTITY;
-  if (encoding !== SESSION_HISTORY_ENCODING_IDENTITY) {
-    const compressedRepresentation = await args.loadCompressedRepresentation(
-      historyRef.hash,
-      encoding,
-    );
-    if (compressedRepresentation === undefined) {
-      throw invalidResumeSessionHistoryError(
-        historyRef.hash,
-        new Error(`${encoding} session history metadata is missing`),
-      );
-    }
-    validateCompressedResumeSessionHistoryRepresentation(
-      historyRef.hash,
-      compressedRepresentation,
-    );
-    const url = await args.generateResumeSessionHistoryObjectUrl(
-      compressedRepresentation.objectKey,
-    );
-    return {
-      sessionId,
-      historyRef: {
-        kind: historyRef.kind,
-        hash: historyRef.hash,
-        url,
-        encoding: compressedRepresentation.encoding,
-        rawSize: compressedRepresentation.rawSize,
-        encodedSize: compressedRepresentation.encodedSize,
-        downloadSource: compressedRepresentation.downloadSource,
-      },
-    };
-  }
+  return await args.timing.measure(
+    "claim_route_response_resume_session",
+    "nested",
+    async () => {
+      const { sessionId, historyRef } = resumeSession;
+      const encoding = historyRef.encoding ?? SESSION_HISTORY_ENCODING_IDENTITY;
+      if (encoding !== SESSION_HISTORY_ENCODING_IDENTITY) {
+        const compressedRepresentation =
+          await args.loadCompressedRepresentation(historyRef.hash, encoding);
+        if (compressedRepresentation === undefined) {
+          throw invalidResumeSessionHistoryError(
+            historyRef.hash,
+            new Error(`${encoding} session history metadata is missing`),
+          );
+        }
+        validateCompressedResumeSessionHistoryRepresentation(
+          historyRef.hash,
+          compressedRepresentation,
+        );
+        const url = await args.generateResumeSessionHistoryObjectUrl(
+          compressedRepresentation.objectKey,
+        );
+        return {
+          sessionId,
+          historyRef: {
+            kind: historyRef.kind,
+            hash: historyRef.hash,
+            url,
+            encoding: compressedRepresentation.encoding,
+            rawSize: compressedRepresentation.rawSize,
+            encodedSize: compressedRepresentation.encodedSize,
+            downloadSource: compressedRepresentation.downloadSource,
+          },
+        };
+      }
 
-  const identityRepresentation = await args.loadIdentityRepresentation(
-    historyRef.hash,
-  );
-  if (identityRepresentation === undefined) {
-    throw new ResumeSessionHistoryLoadError(
-      historyRef.hash,
-      RESUME_SESSION_HISTORY_LOAD_ERROR,
-      new Error("identity session history metadata is missing"),
-    );
-  }
-  const url = await args.generateResumeSessionHistoryUrl(historyRef.hash);
-  return {
-    sessionId,
-    historyRef: {
-      kind: historyRef.kind,
-      hash: historyRef.hash,
-      url,
-      encoding: identityRepresentation.encoding,
-      rawSize: identityRepresentation.rawSize,
-      encodedSize: identityRepresentation.encodedSize,
-      downloadSource: identityRepresentation.downloadSource,
+      const identityRepresentation = await args.loadIdentityRepresentation(
+        historyRef.hash,
+      );
+      if (identityRepresentation === undefined) {
+        throw new ResumeSessionHistoryLoadError(
+          historyRef.hash,
+          RESUME_SESSION_HISTORY_LOAD_ERROR,
+          new Error("identity session history metadata is missing"),
+        );
+      }
+      const url = await args.generateResumeSessionHistoryUrl(historyRef.hash);
+      return {
+        sessionId,
+        historyRef: {
+          kind: historyRef.kind,
+          hash: historyRef.hash,
+          url,
+          encoding: identityRepresentation.encoding,
+          rawSize: identityRepresentation.rawSize,
+          encodedSize: identityRepresentation.encodedSize,
+          downloadSource: identityRepresentation.downloadSource,
+        },
+      };
     },
-  };
+  );
 }
 
 async function buildClaimResponseBody(args: {
@@ -1395,6 +1409,7 @@ async function buildClaimResponseBody(args: {
     async () => {
       const resumeSession = await resolveResumeSessionForClaim({
         resumeSession: args.storedContext.resumeSession,
+        timing: args.timing,
         loadIdentityRepresentation(hash: string) {
           return args.loadIdentityRepresentation(hash);
         },
@@ -1418,6 +1433,7 @@ async function buildClaimResponseBody(args: {
         db: args.db,
         run: args.run,
         storedContext: args.storedContext,
+        timing: args.timing,
       });
       args.signal.throwIfAborted();
       const {


### PR DESCRIPTION
## Summary

- emit nested `claim_route_response_resume_session` timing only when resume-session response work runs
- emit nested `claim_route_response_network_policy_refresh` timing only when connector policy refresh work runs
- retain `claim_route_response_assembly` as the stable per-claim denominator and cover absent, isolated, and co-occurring child actions
- verify telemetry shape and prevent prompts, credentials, session identifiers, hashes, connector names, and sandbox tokens from leaking into timing events

## Scope

This is attribution-only instrumentation. It does not change response assembly order, abort behavior, error propagation, API or runner protocol shapes, database schema, persisted data, telemetry dimensions, or parent action semantics. Parallel response assembly remains deferred until production co-occurrence and stage-cost data justify it.

## Deployment and rollback

The two fixed action names are additive API-internal telemetry. Old and new API instances can overlap during deployment because every instance retains the existing parent action, and runners do not consume these records. Reverting this PR removes only the child series; claim behavior and the comparable parent series remain unchanged.

## Post-deploy decision gates

- wait for the successful API deployment boundary and mixed-version traffic to drain before classifying child absence
- use `claim_route_response_assembly` as the denominator and report parent/child sample counts, p50/p90/p95/p99/max, child coverage, four-way per-run co-occurrence, and parent-minus-child residual
- consider concurrency only if both children frequently co-occur and their measured overlap remains material after database/signing capacity, abort behavior, and sibling failure are reviewed
- split resume or policy work further only if its child owns a material residual; make no behavior change if neither child is material

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/db test:migration-consistency`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (101 passed)
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,334 passed; two unrelated contention-sensitive tests failed in the full run and then passed individually: `cron-summarize-memory.test.ts` 5/5 and `chat-message-persistence.test.tsx` 1/1)

Closes #21120

Parent context: #18746
