### PR TITLE
fix(runner): reject duplicate member keys atomically in usage buffer

### DIFF
--- a/crates/runner/mitm-addon/src/usage/buffer/state.py
+++ b/crates/runner/mitm-addon/src/usage/buffer/state.py
@@ -81,8 +81,11 @@ class _UsageBufferState:
     ) -> int:
         if atomic_source_key is not None:
             events = tuple(events)
-            if atomic_source_key in self._seen_source_keys or any(
-                event["idempotencyKey"] in self._seen_source_keys for event in events
+            batch_source_keys = {event["idempotencyKey"] for event in events}
+            if (
+                atomic_source_key in self._seen_source_keys
+                or len(batch_source_keys) != len(events)
+                or any(source_key in self._seen_source_keys for source_key in batch_source_keys)
             ):
                 return 0
 

--- a/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
+++ b/crates/runner/mitm-addon/tests/test_usage_buffer_aggregation.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+import pytest
+
 import usage
 import usage.buffer as usage_buffer
 from tests.pending_helpers import assert_current_pending
@@ -236,6 +238,72 @@ def test_source_preserving_atomic_group_rejects_when_member_key_was_seen(tmp_pat
             }
         ],
     }
+
+
+@pytest.mark.parametrize(
+    ("buffer_events", "url"),
+    [
+        pytest.param(
+            usage.buffer_source_usage_events,
+            "https://api.test/api/webhooks/agent/usage-event",
+            id="usage-event",
+        ),
+        pytest.param(
+            usage.buffer_source_model_usage_observations,
+            "https://api.test/api/webhooks/agent/model-usage-observation",
+            id="model-usage-observation",
+        ),
+    ],
+)
+def test_source_preserving_atomic_group_rejects_duplicate_member_keys(tmp_path, buffer_events, url):
+    enqueue = RecordingEnqueue()
+    usage.reset_usage_buffer_for_tests(enqueue_webhook=enqueue)
+    proxy_log_path = str(tmp_path / "proxy.jsonl")
+
+    assert (
+        buffer_events(
+            url,
+            "token-a",
+            "run-1",
+            [
+                event(source_key="source-duplicate", quantity=10),
+                event(
+                    source_key="source-duplicate",
+                    category="tokens.cache_read",
+                    quantity=4,
+                ),
+            ],
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 0
+    )
+    assert usage.flush_usage_events(trigger="test") == 0
+    enqueue.assert_not_called()
+
+    assert (
+        buffer_events(
+            url,
+            "token-a",
+            "run-1",
+            [
+                event(source_key="source-input", quantity=10),
+                event(
+                    source_key="source-cache-read",
+                    category="tokens.cache_read",
+                    quantity=4,
+                ),
+            ],
+            proxy_log_path,
+            atomic_source_key="input-partition-1",
+        )
+        == 2
+    )
+    assert usage.flush_usage_events(trigger="test") == 1
+    enqueue.assert_called_once()
+    assert [
+        flushed_event["idempotencyKey"] for flushed_event in enqueue.last_call.payload["events"]
+    ] == ["source-input", "source-cache-read"]
 
 
 def test_source_preserving_observation_buffer_uses_model_event_shape(tmp_path):


### PR DESCRIPTION
## Summary

- reject atomic source-preserving batches when member idempotency keys repeat within the same batch
- keep rejected batches side-effect free so a corrected retry can reuse the atomic source key
- cover both usage-event and model-usage-observation public buffer wrappers

## Exclusions

- no schema, API, payload, or migration changes
- no changes to non-atomic buffering behavior

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/ -v` (3,801 passed)
- `.venv/bin/python -m pytest tests/test_usage_buffer_aggregation.py -v` (14 passed)
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,334 passed, 1 skipped; one unrelated existing platform test race in `chat-message-action-cards.test.tsx` failed locally on unchanged main code)

Closes #21113
