### PR TITLE
perf(mitm-addon): aggregate jsonl batch completion

### DIFF
--- a/crates/runner/mitm-addon/src/jsonl_writer.py
+++ b/crates/runner/mitm-addon/src/jsonl_writer.py
@@ -12,7 +12,6 @@ from mitmproxy import ctx
 
 MAX_PENDING_JSONL_WRITES = 4096
 MAX_PENDING_JSONL_BYTES = 32 * 1024 * 1024
-JSONL_CONTROL_QUEUE_SLOTS = 1
 SHUTDOWN_JOIN_TIMEOUT_SECONDS = 1.0
 
 
@@ -27,9 +26,7 @@ class _WriteItem:
 _STOP = object()
 _lock = threading.Lock()
 _condition = threading.Condition(_lock)
-_queue: queue.Queue[_WriteItem | object] = queue.Queue(
-    maxsize=MAX_PENDING_JSONL_WRITES + JSONL_CONTROL_QUEUE_SLOTS
-)
+_queue: queue.SimpleQueue[_WriteItem | object] = queue.SimpleQueue()
 _worker: threading.Thread | None = None
 _shutdown = False
 _stop_enqueued = False
@@ -69,14 +66,10 @@ def write_jsonl_line(log_path: str, line: bytes, log_name: str) -> None:
                 log_name=log_name,
                 sequence=sequence,
             )
-            try:
-                _queue.put_nowait(item)
-            except queue.Full:
-                dropped = True
-            else:
-                _accepted_by_path[log_path] = sequence
-                _pending_bytes += line_size
-                _queued_writes += 1
+            _queue.put_nowait(item)
+            _accepted_by_path[log_path] = sequence
+            _pending_bytes += line_size
+            _queued_writes += 1
 
     if dropped:
         _warn_drop_once(log_name)
@@ -127,7 +120,6 @@ def shutdown_writer(*, timeout: float | None = SHUTDOWN_JOIN_TIMEOUT_SECONDS) ->
     """Drain accepted writes and stop the background writer."""
     global _worker, _shutdown, _stop_enqueued
 
-    failed_to_signal_stop = False
     with _condition:
         worker = _worker
         if worker is None:
@@ -136,15 +128,9 @@ def shutdown_writer(*, timeout: float | None = SHUTDOWN_JOIN_TIMEOUT_SECONDS) ->
         _shutdown = True
         should_signal_stop = not _stop_enqueued
         if should_signal_stop:
-            try:
-                _queue.put_nowait(_STOP)
-            except queue.Full:
-                failed_to_signal_stop = True
-            else:
-                _stop_enqueued = True
+            _queue.put_nowait(_STOP)
+            _stop_enqueued = True
 
-    if failed_to_signal_stop:
-        _warn("Failed to signal JSONL writer shutdown because the control queue is full")
     if worker is not threading.current_thread():
         worker.join(timeout=timeout)
         if worker.is_alive():
@@ -166,7 +152,7 @@ def reset_for_tests() -> None:
 
     shutdown_writer(timeout=None)
     with _condition:
-        _queue = queue.Queue(maxsize=MAX_PENDING_JSONL_WRITES + JSONL_CONTROL_QUEUE_SLOTS)
+        _queue = queue.SimpleQueue()
         _worker = None
         _shutdown = False
         _stop_enqueued = False
@@ -202,7 +188,6 @@ def _run_writer() -> None:
     while True:
         item = _queue.get()
         if item is _STOP:
-            _queue.task_done()
             return
 
         batch = [item]
@@ -213,16 +198,12 @@ def _run_writer() -> None:
             except queue.Empty:
                 break
             if next_item is _STOP:
-                _queue.task_done()
                 should_stop = True
                 break
             batch.append(next_item)
 
         _write_batch(batch)
-        for completed in batch:
-            if isinstance(completed, _WriteItem):
-                _complete_item(completed)
-            _queue.task_done()
+        _complete_batch(batch)
 
         if should_stop:
             return
@@ -257,17 +238,32 @@ def _append_lines(log_path: str, content: bytes) -> None:
         os.close(fd)
 
 
-def _complete_item(item: _WriteItem) -> None:
+def _complete_batch(items: list[object]) -> None:
     global _pending_bytes, _queued_writes
 
-    with _condition:
-        _completed_by_path[item.log_path] = max(
-            _completed_by_path[item.log_path],
+    completed_by_path: dict[str, int] = {}
+    completed_bytes = 0
+    completed_writes = 0
+    for item in items:
+        if not isinstance(item, _WriteItem):
+            continue
+        completed_by_path[item.log_path] = max(
+            completed_by_path.get(item.log_path, 0),
             item.sequence,
         )
-        _pending_bytes = max(0, _pending_bytes - len(item.line))
-        _queued_writes = max(0, _queued_writes - 1)
-        _prune_completed_path_locked(item.log_path, item.sequence)
+        completed_bytes += len(item.line)
+        completed_writes += 1
+
+    with _condition:
+        for log_path, sequence in completed_by_path.items():
+            _completed_by_path[log_path] = max(
+                _completed_by_path[log_path],
+                sequence,
+            )
+        _pending_bytes = max(0, _pending_bytes - completed_bytes)
+        _queued_writes = max(0, _queued_writes - completed_writes)
+        for log_path, sequence in completed_by_path.items():
+            _prune_completed_path_locked(log_path, sequence)
         _condition.notify_all()
 
 

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -1,18 +1,24 @@
 """Tests for the asynchronous JSONL writer state machine."""
 
 import threading
+from collections.abc import Callable
 from unittest.mock import patch
 
 import jsonl_writer
 from tests.thread_helpers import ThreadUnderTest
 
 
-def test_complete_batch_publishes_aggregate_state_once(tmp_path):
+def test_writer_publishes_backlog_completion_once_per_batch(tmp_path):
     class ObservedCondition:
         def __init__(self) -> None:
             self._condition = threading.Condition()
             self.acquisitions = 0
             self.notifications = 0
+            self.accepted_by_path: dict[str, int] = {}
+            self.completed_by_path: dict[str, int] = {}
+            self.flush_waiters_by_path: dict[str, int] = {}
+            self.pending_bytes = 0
+            self.queued_writes = 0
 
         def __enter__(self) -> "ObservedCondition":
             self.acquisitions += 1
@@ -22,49 +28,124 @@ def test_complete_batch_publishes_aggregate_state_once(tmp_path):
         def __exit__(self, *_args: object) -> None:
             self._condition.release()
 
+        def wait(self, timeout: float | None = None) -> bool:
+            return self._condition.wait(timeout)
+
+        def wait_for(
+            self,
+            predicate: Callable[[], bool],
+            timeout: float | None = None,
+        ) -> bool:
+            return self._condition.wait_for(predicate, timeout)
+
+        def reset_observations(self) -> None:
+            with self._condition:
+                self.acquisitions = 0
+                self.notifications = 0
+                self.accepted_by_path = {}
+                self.completed_by_path = {}
+                self.flush_waiters_by_path = {}
+                self.pending_bytes = 0
+                self.queued_writes = 0
+
         def notify_all(self) -> None:
             self.notifications += 1
+            self.accepted_by_path = dict(jsonl_writer._accepted_by_path)
+            self.completed_by_path = dict(jsonl_writer._completed_by_path)
+            self.flush_waiters_by_path = dict(jsonl_writer._flush_waiters_by_path)
+            self.pending_bytes = jsonl_writer._pending_bytes
+            self.queued_writes = jsonl_writer._queued_writes
             self._condition.notify_all()
 
+    gate_path = str(tmp_path / "gate.jsonl")
     pruned_path = str(tmp_path / "pruned.jsonl")
     waiter_path = str(tmp_path / "waiter.jsonl")
     later_write_path = str(tmp_path / "later.jsonl")
-    later_line = b'{"message":"later"}\n'
-    items: list[object] = [
-        jsonl_writer._WriteItem(pruned_path, b"a\n", "proxy", 1),
-        jsonl_writer._WriteItem(pruned_path, b"bb\n", "proxy", 2),
-        jsonl_writer._WriteItem(waiter_path, b"ccc\n", "proxy", 1),
-        jsonl_writer._WriteItem(later_write_path, b"dddd\n", "proxy", 1),
-    ]
-    completed_bytes = sum(
-        len(item.line) for item in items if isinstance(item, jsonl_writer._WriteItem)
-    )
+    gate_started = threading.Event()
+    release_gate = threading.Event()
+    target_batch_started = threading.Event()
+    release_target_batch = threading.Event()
+    later_batch_started = threading.Event()
+    release_later_batch = threading.Event()
     condition = ObservedCondition()
+    waiter_thread: ThreadUnderTest | None = None
+    later_line = b"later-2\n"
+    original_append_lines = jsonl_writer._append_lines
 
-    jsonl_writer._accepted_by_path.update(
-        {
-            pruned_path: 2,
-            waiter_path: 1,
-            later_write_path: 2,
-        }
-    )
-    jsonl_writer._flush_waiters_by_path[waiter_path] = 1
-    jsonl_writer._pending_bytes = completed_bytes + len(later_line)
-    jsonl_writer._queued_writes = len(items) + 1
+    def append_lines(path: str, content: bytes) -> None:
+        if path == gate_path:
+            gate_started.set()
+            release_gate.wait()
+        elif path == pruned_path:
+            target_batch_started.set()
+            release_target_batch.wait()
+        elif path == later_write_path and content == later_line:
+            later_batch_started.set()
+            release_later_batch.wait()
+        original_append_lines(path, content)
 
-    with patch.object(jsonl_writer, "_condition", condition):
-        jsonl_writer._complete_batch(items)
+    def flush_waiter_path() -> None:
+        assert jsonl_writer.flush_log_path(waiter_path)
 
-    assert condition.acquisitions == 1
-    assert condition.notifications == 1
-    assert pruned_path not in jsonl_writer._accepted_by_path
-    assert pruned_path not in jsonl_writer._completed_by_path
-    assert jsonl_writer._accepted_by_path[waiter_path] == 1
-    assert jsonl_writer._completed_by_path[waiter_path] == 1
-    assert jsonl_writer._accepted_by_path[later_write_path] == 2
-    assert jsonl_writer._completed_by_path[later_write_path] == 1
-    assert jsonl_writer._pending_bytes == len(later_line)
-    assert jsonl_writer._queued_writes == 1
+    with (
+        patch.object(jsonl_writer, "_condition", condition),
+        patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
+    ):
+        try:
+            jsonl_writer.write_jsonl_line(gate_path, b"gate\n", "proxy")
+            assert gate_started.wait(timeout=1)
+
+            jsonl_writer.write_jsonl_line(pruned_path, b"pruned-1\n", "proxy")
+            jsonl_writer.write_jsonl_line(pruned_path, b"pruned-2\n", "proxy")
+            jsonl_writer.write_jsonl_line(waiter_path, b"waiter-1\n", "proxy")
+            jsonl_writer.write_jsonl_line(waiter_path, b"waiter-2\n", "proxy")
+            jsonl_writer.write_jsonl_line(later_write_path, b"later-1\n", "proxy")
+
+            waiter_thread = ThreadUnderTest(target=flush_waiter_path, daemon=True)
+            waiter_thread.start()
+            with condition:
+                waiter_registered = condition.wait_for(
+                    lambda: jsonl_writer._flush_waiters_by_path.get(waiter_path, 0) == 1,
+                    timeout=1,
+                )
+            if not waiter_registered:
+                waiter_thread.raise_if_failed()
+            assert waiter_registered
+
+            release_gate.set()
+            assert target_batch_started.wait(timeout=1)
+
+            jsonl_writer.write_jsonl_line(later_write_path, later_line, "proxy")
+            condition.reset_observations()
+            release_target_batch.set()
+            assert later_batch_started.wait(timeout=1)
+
+            assert condition.acquisitions == 1
+            assert condition.notifications == 1
+            assert pruned_path not in condition.accepted_by_path
+            assert pruned_path not in condition.completed_by_path
+            assert condition.accepted_by_path[waiter_path] == 2
+            assert condition.completed_by_path[waiter_path] == 2
+            assert condition.flush_waiters_by_path[waiter_path] == 1
+            assert condition.accepted_by_path[later_write_path] == 2
+            assert condition.completed_by_path[later_write_path] == 1
+            assert condition.pending_bytes == len(later_line)
+            assert condition.queued_writes == 1
+
+            release_later_batch.set()
+            waiter_thread.join_and_raise(timeout=1)
+            jsonl_writer.flush_all_logs()
+
+            assert (tmp_path / "pruned.jsonl").read_bytes() == b"pruned-1\npruned-2\n"
+            assert (tmp_path / "waiter.jsonl").read_bytes() == b"waiter-1\nwaiter-2\n"
+            assert (tmp_path / "later.jsonl").read_bytes() == b"later-1\nlater-2\n"
+        finally:
+            release_gate.set()
+            release_target_batch.set()
+            release_later_batch.set()
+            if waiter_thread is not None:
+                waiter_thread.join(timeout=1)
+            jsonl_writer.shutdown_writer(timeout=None)
 
 
 def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
@@ -227,6 +308,10 @@ def test_shutdown_writer_returns_when_normal_write_backlog_is_full(tmp_path):
             if shutdown_thread is not None:
                 shutdown_thread.join(timeout=2)
             jsonl_writer.reset_for_tests()
+
+    assert len((tmp_path / "net.jsonl").read_bytes().splitlines()) == (
+        jsonl_writer.MAX_PENDING_JSONL_WRITES
+    )
 
 
 def test_flush_log_path_timeout_returns_false_and_cleans_waiter(tmp_path):

--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -7,6 +7,66 @@ import jsonl_writer
 from tests.thread_helpers import ThreadUnderTest
 
 
+def test_complete_batch_publishes_aggregate_state_once(tmp_path):
+    class ObservedCondition:
+        def __init__(self) -> None:
+            self._condition = threading.Condition()
+            self.acquisitions = 0
+            self.notifications = 0
+
+        def __enter__(self) -> "ObservedCondition":
+            self.acquisitions += 1
+            self._condition.acquire()
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            self._condition.release()
+
+        def notify_all(self) -> None:
+            self.notifications += 1
+            self._condition.notify_all()
+
+    pruned_path = str(tmp_path / "pruned.jsonl")
+    waiter_path = str(tmp_path / "waiter.jsonl")
+    later_write_path = str(tmp_path / "later.jsonl")
+    later_line = b'{"message":"later"}\n'
+    items: list[object] = [
+        jsonl_writer._WriteItem(pruned_path, b"a\n", "proxy", 1),
+        jsonl_writer._WriteItem(pruned_path, b"bb\n", "proxy", 2),
+        jsonl_writer._WriteItem(waiter_path, b"ccc\n", "proxy", 1),
+        jsonl_writer._WriteItem(later_write_path, b"dddd\n", "proxy", 1),
+    ]
+    completed_bytes = sum(
+        len(item.line) for item in items if isinstance(item, jsonl_writer._WriteItem)
+    )
+    condition = ObservedCondition()
+
+    jsonl_writer._accepted_by_path.update(
+        {
+            pruned_path: 2,
+            waiter_path: 1,
+            later_write_path: 2,
+        }
+    )
+    jsonl_writer._flush_waiters_by_path[waiter_path] = 1
+    jsonl_writer._pending_bytes = completed_bytes + len(later_line)
+    jsonl_writer._queued_writes = len(items) + 1
+
+    with patch.object(jsonl_writer, "_condition", condition):
+        jsonl_writer._complete_batch(items)
+
+    assert condition.acquisitions == 1
+    assert condition.notifications == 1
+    assert pruned_path not in jsonl_writer._accepted_by_path
+    assert pruned_path not in jsonl_writer._completed_by_path
+    assert jsonl_writer._accepted_by_path[waiter_path] == 1
+    assert jsonl_writer._completed_by_path[waiter_path] == 1
+    assert jsonl_writer._accepted_by_path[later_write_path] == 2
+    assert jsonl_writer._completed_by_path[later_write_path] == 1
+    assert jsonl_writer._pending_bytes == len(later_line)
+    assert jsonl_writer._queued_writes == 1
+
+
 def test_completed_write_prunes_path_state_without_explicit_flush(tmp_path):
     log_path = str(tmp_path / "proxy.jsonl")
 
@@ -126,6 +186,7 @@ def test_concurrent_flushes_prune_after_all_waiters_complete(tmp_path):
 
 def test_shutdown_writer_returns_when_normal_write_backlog_is_full(tmp_path):
     log_path = str(tmp_path / "net.jsonl")
+    line = b'{"action":"ALLOW"}\n'
     append_started = threading.Event()
     release_append = threading.Event()
     shutdown_thread: ThreadUnderTest | None = None
@@ -143,11 +204,15 @@ def test_shutdown_writer_returns_when_normal_write_backlog_is_full(tmp_path):
         patch.object(jsonl_writer, "_append_lines", side_effect=append_lines),
     ):
         try:
-            jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+            jsonl_writer.write_jsonl_line(log_path, line, "network")
             assert append_started.wait(timeout=1)
 
             for _ in range(jsonl_writer.MAX_PENDING_JSONL_WRITES):
-                jsonl_writer.write_jsonl_line(log_path, b'{"action":"ALLOW"}\n', "network")
+                jsonl_writer.write_jsonl_line(log_path, line, "network")
+
+            assert jsonl_writer._accepted_by_path[log_path] == jsonl_writer.MAX_PENDING_JSONL_WRITES
+            assert jsonl_writer._queued_writes == jsonl_writer.MAX_PENDING_JSONL_WRITES
+            assert jsonl_writer._pending_bytes == jsonl_writer.MAX_PENDING_JSONL_WRITES * len(line)
 
             shutdown_thread = ThreadUnderTest(
                 target=shutdown_writer,


### PR DESCRIPTION
## Summary

- replace the bounded transport queue with `SimpleQueue` while preserving count and byte admission limits under the writer condition
- publish completion bookkeeping once per drained batch, preserving per-path flush high-water marks and pruning semantics
- cover aggregate completion publication and shutdown signaling with a fully admitted write backlog

The isolated 4,096-item completion benchmark improved from a 2.057 ms median to 0.640 ms median.

## Explicit exclusions

- no JSONL schema, serialized format, API, runner protocol, or persisted-data changes
- no changes to backlog limits, drop behavior, batch write ordering, or write-error handling

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/pytest tests/ -q` (3,800 passed)
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,335 passed, 1 skipped)
- `cd turbo && pnpm knip`

Closes #21114
