### PR TITLE
fix(mitm-addon): preserve invalid bytes at capture boundary

### DIFF
--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -238,8 +238,10 @@ def _set_body_fields(
     content_type: str,
     *,
     already_truncated: bool = False,
+    truncated_at_limit: bool = False,
 ) -> None:
-    truncated = already_truncated or len(body) > BODY_CAPTURE_LIMIT
+    body_exceeds_limit = len(body) > BODY_CAPTURE_LIMIT
+    truncated = already_truncated or truncated_at_limit or body_exceeds_limit
     if truncated:
         # Truncation describes capture completeness, even when no body string is emitted.
         log_entry[f"{side}_body_truncated"] = True
@@ -251,7 +253,8 @@ def _set_body_fields(
     encoded, encoding = _encode_body(
         bounded_body,
         content_type,
-        truncated_at_limit=truncated and len(body) >= BODY_CAPTURE_LIMIT,
+        truncated_at_limit=(truncated_at_limit or body_exceeds_limit)
+        and len(body) >= BODY_CAPTURE_LIMIT,
     )
     if encoded is None:
         log_entry[f"{side}_body_encoding"] = "binary"
@@ -306,7 +309,8 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
                     "request",
                     request_body,
                     req_ct,
-                    already_truncated=request_stream_body.truncated or request_stream_incomplete,
+                    already_truncated=request_stream_incomplete,
+                    truncated_at_limit=request_stream_body.truncated,
                 )
         elif flow.request.raw_content:
             req_ct = flow.request.headers.get("content-type", "")
@@ -350,5 +354,5 @@ def add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             "response",
             body,
             res_ct,
-            already_truncated=stream_truncated,
+            truncated_at_limit=stream_truncated,
         )

--- a/crates/runner/mitm-addon/src/body_capture.py
+++ b/crates/runner/mitm-addon/src/body_capture.py
@@ -16,14 +16,6 @@ from body_limits import BODY_CAPTURE_LIMIT
 
 _REDACTED_HEADER_VALUE = "***"
 
-# UTF-8 byte-boundary markers (RFC 3629). Continuation bytes match
-# ``0b10xxxxxx`` via ``(byte & 0xC0) == _UTF8_CONT_MARK``. Lead bytes fall
-# into four ranges by ``lead < _UTF8_LEAD_MAX_{N}BYTE`` for N = 1..3.
-_UTF8_CONT_MARK = 0x80
-_UTF8_LEAD_MAX_1BYTE = 0x80  # ASCII: 0xxxxxxx
-_UTF8_LEAD_MAX_2BYTE = 0xE0  # 2-byte lead: 110xxxxx
-_UTF8_LEAD_MAX_3BYTE = 0xF0  # 3-byte lead: 1110xxxx
-
 _TEXT_CONTENT_TYPES = (
     "text/",
     "application/json",
@@ -107,44 +99,28 @@ def _is_text_content(content_type: str) -> bool:
     return any(ct.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES)
 
 
-def _truncate_bytes_utf8_safe(data: bytes, max_size: int) -> bytes:
-    """Truncate bytes at a UTF-8 character boundary.
+def _encode_body(
+    content: bytes,
+    content_type: str,
+    *,
+    truncated_at_limit: bool = False,
+) -> tuple[str | None, str | None]:
+    """Encode an exact bounded body prefix without losing invalid bytes.
 
-    After slicing at *max_size*, checks whether the last character is complete.
-    If not, removes the incomplete trailing bytes (at most 4).
+    A known limit-truncated prefix may omit only a terminal incomplete UTF-8
+    sequence. Every other UTF-8 error preserves the exact prefix as base64.
     """
-    if len(data) <= max_size:
-        return data
-    t = data[:max_size]
-    # Find the start of the last character by scanning backwards past
-    # continuation bytes (10xxxxxx = 0x80..0xBF).
-    i = len(t)
-    while i > 0 and (t[i - 1] & 0xC0) == _UTF8_CONT_MARK:
-        i -= 1
-    if i == 0:
-        return t  # all continuation bytes; should not happen in valid UTF-8
-    lead = t[i - 1]
-    if lead < _UTF8_LEAD_MAX_1BYTE:
-        expected = 1
-    elif lead < _UTF8_LEAD_MAX_2BYTE:
-        expected = 2
-    elif lead < _UTF8_LEAD_MAX_3BYTE:
-        expected = 3
-    else:
-        expected = 4
-    actual = len(t) - (i - 1)
-    if actual < expected:
-        return t[: i - 1]
-    return t
-
-
-def _encode_body(content: bytes, content_type: str) -> tuple[str | None, str | None]:
-    """Encode body content. Returns (encoded_string, encoding_type), or None values."""
     if not _is_text_content(content_type):
         return None, None  # skip binary bodies
     try:
         return content.decode("utf-8"), "utf-8"
-    except UnicodeDecodeError:
+    except UnicodeDecodeError as error:
+        if (
+            truncated_at_limit
+            and error.end == len(content)
+            and error.reason == "unexpected end of data"
+        ):
+            return content[: error.start].decode("utf-8"), "utf-8"
         return base64.b64encode(content).decode("ascii"), "base64"
 
 
@@ -271,9 +247,11 @@ def _set_body_fields(
     if not body:
         return
 
+    bounded_body = body[:BODY_CAPTURE_LIMIT]
     encoded, encoding = _encode_body(
-        _truncate_bytes_utf8_safe(body, BODY_CAPTURE_LIMIT) if truncated else body,
+        bounded_body,
         content_type,
+        truncated_at_limit=truncated and len(body) >= BODY_CAPTURE_LIMIT,
     )
     if encoded is None:
         log_entry[f"{side}_body_encoding"] = "binary"

--- a/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_decompression.py
@@ -1,5 +1,6 @@
 """Tests for capture-level response body decompression behavior."""
 
+import base64
 import gzip
 import zlib
 
@@ -96,7 +97,7 @@ class TestDecompression:
         assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
     def test_brotli_truncation_preserves_utf8_boundary(self, real_flow):
-        original = b"x" * BODY_CAPTURE_LIMIT + "\u20ac".encode("utf-8")
+        original = b"x" * (BODY_CAPTURE_LIMIT - 1) + "€".encode()
         compressed = brotli.compress(original)
         assert len(compressed) < BODY_CAPTURE_LIMIT
         flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
@@ -104,7 +105,18 @@ class TestDecompression:
         add_capture_fields(flow, entry)
         assert entry["response_body_truncated"] is True
         assert entry["response_body_encoding"] == "utf-8"
-        assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
+        assert entry["response_body"] == "x" * (BODY_CAPTURE_LIMIT - 1)
+
+    def test_brotli_invalid_boundary_preserves_truncated_base64(self, real_flow):
+        original = b"x" * (BODY_CAPTURE_LIMIT - 1) + b"\xffz"
+        compressed = brotli.compress(original)
+        assert len(compressed) < BODY_CAPTURE_LIMIT
+        flow = self._make_flow_with_compressed_buffer(real_flow, compressed, "br", "text/plain")
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["response_body_truncated"] is True
+        assert entry["response_body_encoding"] == "base64"
+        assert base64.b64decode(entry["response_body"]) == original[:BODY_CAPTURE_LIMIT]
 
     def test_brotli_large_text_uses_adaptive_chunks(self, real_flow, monkeypatch):
         original = pseudo_random_ascii(BODY_CAPTURE_LIMIT // 2)

--- a/crates/runner/mitm-addon/tests/test_body_capture_encoding.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_encoding.py
@@ -2,7 +2,7 @@
 
 import base64
 
-from body_capture import _encode_body, _is_text_content, _truncate_bytes_utf8_safe
+from body_capture import _encode_body, _is_text_content
 
 
 class TestIsTextContent:
@@ -53,47 +53,3 @@ class TestEncodeBody:
         assert encoding == "base64"
         assert encoded is not None
         assert base64.b64decode(encoded) == body
-
-
-class TestTruncateBytesUtf8Safe:
-    def test_no_truncation_needed(self):
-        data = b"hello"
-        assert _truncate_bytes_utf8_safe(data, 10) == b"hello"
-
-    def test_ascii_truncation(self):
-        data = b"hello world"
-        assert _truncate_bytes_utf8_safe(data, 5) == b"hello"
-
-    def test_truncation_mid_2byte_char(self):
-        # "é" = \xc3\xa9 (2 bytes). Put it at the cut boundary.
-        data = b"aaa\xc3\xa9bbb"  # 3 + 2 + 3 = 8 bytes
-        # Cut at 4 bytes: b"aaa\xc3" — \xc3 is a 2-byte start, incomplete
-        result = _truncate_bytes_utf8_safe(data, 4)
-        assert result == b"aaa"
-
-    def test_truncation_mid_3byte_char(self):
-        # "€" = \xe2\x82\xac (3 bytes)
-        data = b"ab\xe2\x82\xac"  # 2 + 3 = 5 bytes
-        # Cut at 3: b"ab\xe2" — \xe2 is a 3-byte start, incomplete
-        result = _truncate_bytes_utf8_safe(data, 3)
-        assert result == b"ab"
-        # Cut at 4: b"ab\xe2\x82" — continuation byte at end
-        result = _truncate_bytes_utf8_safe(data, 4)
-        assert result == b"ab"
-
-    def test_truncation_mid_4byte_char(self):
-        # "𝄞" (musical symbol) = \xf0\x9d\x84\x9e (4 bytes)
-        data = b"a\xf0\x9d\x84\x9e"  # 1 + 4 = 5 bytes
-        # Cut at 3: b"a\xf0\x9d" — incomplete 4-byte sequence
-        result = _truncate_bytes_utf8_safe(data, 3)
-        assert result == b"a"
-
-    def test_truncation_at_char_boundary(self):
-        # "é" = \xc3\xa9. Cut right after it.
-        data = b"aaa\xc3\xa9bbb"
-        result = _truncate_bytes_utf8_safe(data, 5)
-        assert result == b"aaa\xc3\xa9"
-
-    def test_exact_size(self):
-        data = b"hello"
-        assert _truncate_bytes_utf8_safe(data, 5) == b"hello"

--- a/crates/runner/mitm-addon/tests/test_body_capture_fields.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_fields.py
@@ -3,6 +3,8 @@
 import base64
 import gzip
 
+import pytest
+
 from body_capture import add_capture_fields
 from body_limits import BODY_CAPTURE_LIMIT
 
@@ -459,9 +461,25 @@ class TestAddCaptureFields:
         assert "response_body_truncated" not in entry
         assert len(entry["response_body"]) == BODY_CAPTURE_LIMIT
 
-    def test_truncation_preserves_utf8_boundary(self, real_flow):
-        # Body is BODY_CAPTURE_LIMIT + a 3-byte char "€" (\xe2\x82\xac)
-        body = b"x" * BODY_CAPTURE_LIMIT + "\u20ac".encode("utf-8")
+    def test_complete_body_at_limit_with_incomplete_utf8_uses_base64(self, real_flow):
+        body = b"x" * (BODY_CAPTURE_LIMIT - 1) + b"\xe2"
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            response_content_type="application/json",
+            include_request_id=True,
+            request_body=body,
+            request_content_type="text/plain",
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == body
+        assert "request_body_truncated" not in entry
+
+    @pytest.mark.parametrize("character", ["é", "€", "𝄞"])
+    def test_truncation_preserves_utf8_boundary(self, real_flow, character):
+        body = b"x" * (BODY_CAPTURE_LIMIT - 1) + character.encode()
         flow = real_flow(
             method="POST",
             host="api.example.com",
@@ -473,9 +491,8 @@ class TestAddCaptureFields:
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body_truncated"] is True
-        # Should be valid UTF-8 (truncated at char boundary, not mid-char)
         assert entry["request_body_encoding"] == "utf-8"
-        assert len(entry["request_body"]) == BODY_CAPTURE_LIMIT  # all ASCII before the €
+        assert entry["request_body"] == "x" * (BODY_CAPTURE_LIMIT - 1)
 
     def test_text_request_with_binary_response(self, real_flow):
         flow = real_flow(
@@ -567,3 +584,60 @@ class TestAddCaptureFields:
         assert entry["response_body_encoding"] == "base64"
         assert base64.b64decode(entry["response_body"]) == response_body[:BODY_CAPTURE_LIMIT]
         assert entry["response_body_truncated"] is True
+
+    def test_invalid_boundary_bytes_preserve_truncated_base64(self, real_flow):
+        request_body = b"r" * (BODY_CAPTURE_LIMIT - 1) + b"\xff" + b"x"
+        response_body = b"s" * (BODY_CAPTURE_LIMIT - 1) + b"\xfe" + b"y"
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_body=request_body,
+            request_content_type="text/plain",
+            response_body=response_body,
+            response_content_type="text/plain",
+            include_request_id=True,
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == request_body[:BODY_CAPTURE_LIMIT]
+        assert entry["request_body_truncated"] is True
+        assert entry["response_body_encoding"] == "base64"
+        assert base64.b64decode(entry["response_body"]) == response_body[:BODY_CAPTURE_LIMIT]
+        assert entry["response_body_truncated"] is True
+
+    @pytest.mark.parametrize(
+        "invalid_suffix",
+        [b"\xc0", b"\xf5", b"\xe0\x80", b"\xed\xa0", b"\xf0\x80", b"\xf4\x90"],
+    )
+    def test_invalid_utf8_suffix_preserves_truncated_base64(self, real_flow, invalid_suffix):
+        body = b"x" * (BODY_CAPTURE_LIMIT - len(invalid_suffix)) + invalid_suffix + b"z"
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_body=body,
+            request_content_type="text/plain",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == body[:BODY_CAPTURE_LIMIT]
+        assert entry["request_body_truncated"] is True
+
+    def test_earlier_invalid_byte_preserves_split_utf8_suffix_in_base64(self, real_flow):
+        body = b"\xff" + b"x" * (BODY_CAPTURE_LIMIT - 2) + "€".encode()
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_body=body,
+            request_content_type="text/plain",
+            response_content_type="application/json",
+            include_request_id=True,
+        )
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == body[:BODY_CAPTURE_LIMIT]
+        assert entry["request_body_truncated"] is True

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -1,5 +1,6 @@
 """Tests for body capture request and response stream-buffer contracts."""
 
+import base64
 import gzip
 
 import pytest
@@ -41,6 +42,21 @@ class TestBodyCaptureStreamBuffer:
         entry = {}
         add_capture_fields(flow, entry)
         assert entry["request_body"] == "x" * STREAM_BUFFER_LIMIT
+        assert entry["request_body_encoding"] == "utf-8"
+        assert entry["request_body_truncated"] is True
+
+    def test_truncated_request_stream_buffer_trims_incomplete_utf8(self, real_flow):
+        body = b"x" * (STREAM_BUFFER_LIMIT - 1) + b"\xe2"
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            include_request_id=True,
+        )
+        set_request_stream_buffer(flow, body, truncated=True)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body"] == "x" * (STREAM_BUFFER_LIMIT - 1)
         assert entry["request_body_encoding"] == "utf-8"
         assert entry["request_body_truncated"] is True
 
@@ -356,6 +372,43 @@ class TestBodyCaptureStreamBuffer:
         set_response_stream_buffer(flow, body, truncated=True)
         entry = {}
         add_capture_fields(flow, entry)
+        assert entry["response_body_truncated"] is True
+
+    def test_truncated_response_stream_buffer_trims_incomplete_utf8(self, real_flow):
+        body = b"y" * (STREAM_BUFFER_LIMIT - 2) + "𝄞".encode()[:2]
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="application/json",
+            response_content_type="text/plain",
+            include_request_id=True,
+        )
+        set_response_stream_buffer(flow, body, truncated=True)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["response_body"] == "y" * (STREAM_BUFFER_LIMIT - 2)
+        assert entry["response_body_encoding"] == "utf-8"
+        assert entry["response_body_truncated"] is True
+
+    def test_invalid_stream_boundaries_preserve_truncated_base64(self, real_flow):
+        request_body = b"r" * (STREAM_BUFFER_LIMIT - 1) + b"\xff"
+        response_body = b"s" * (STREAM_BUFFER_LIMIT - 1) + b"\xf5"
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            response_content_type="text/plain",
+            include_request_id=True,
+        )
+        set_request_stream_buffer(flow, request_body, truncated=True)
+        set_response_stream_buffer(flow, response_body, truncated=True)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == request_body
+        assert entry["request_body_truncated"] is True
+        assert entry["response_body_encoding"] == "base64"
+        assert base64.b64decode(entry["response_body"]) == response_body
         assert entry["response_body_truncated"] is True
 
     def test_binary_stream_buffer_exactly_at_limit_not_truncated(self, real_flow):

--- a/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture_stream_buffer.py
@@ -75,6 +75,21 @@ class TestBodyCaptureStreamBuffer:
         assert entry["request_body_encoding"] == "utf-8"
         assert entry["request_body_truncated"] is True
 
+    def test_incomplete_request_at_limit_preserves_partial_utf8(self, real_flow):
+        body = b"x" * (STREAM_BUFFER_LIMIT - 1) + b"\xe2"
+        flow = real_flow(
+            method="POST",
+            host="api.example.com",
+            request_content_type="text/plain",
+            include_request_id=True,
+        )
+        set_request_stream_buffer(flow, body, complete=False)
+        entry = {}
+        add_capture_fields(flow, entry)
+        assert entry["request_body_encoding"] == "base64"
+        assert base64.b64decode(entry["request_body"]) == body
+        assert entry["request_body_truncated"] is True
+
     def test_empty_incomplete_request_stream_buffer_marks_truncation(self, real_flow):
         flow = real_flow(
             method="POST",


### PR DESCRIPTION
## Summary

- preserve the exact bounded body prefix as base64 when strict UTF-8 decoding finds invalid bytes
- trim only a terminal incomplete UTF-8 sequence when the capture is known to have been cut at the body limit
- distinguish confirmed limit truncation from an incomplete request stream so interrupted bytes are never discarded
- apply the same encoding decision to raw, streamed, and decompressed request and response bodies
- cover malformed lead/continuation sequences, earlier invalid bytes, exact-limit bodies, interrupted streams, and split 2/3/4-byte characters

## Exclusions

- no changes to capture or stream-buffer limits
- no network-log schema, billing inspection, API, or UI changes
- no changes to binary content-type handling

## Validation

- `cd crates/runner/mitm-addon && pytest` (3,808 passed)
- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && basedpyright -p .`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=1 --silent=passed-only` (7,335 passed, 1 benchmark skipped)
- `cd turbo && pnpm knip`

Closes #21115
