### PR TITLE
docs(runner): correct mitm_ctx fixture description

### DIFF
--- a/crates/runner/mitm-addon/tests/conftest.py
+++ b/crates/runner/mitm-addon/tests/conftest.py
@@ -332,11 +332,11 @@ def mitm_ctx(tmp_path):
     """Stub ``mitmproxy.ctx.options`` and ``ctx.log`` for a test block.
 
     Returns a context-manager factory: calling ``mitm_ctx(registry_path=...)``
-    patches in a stub ``Options`` object exposing the two addon-specific
-    settings plus a ``MagicMock`` log.  The log stays on MagicMock so tests
-    that need to assert on warn/debug calls can do so; ``options`` doesn't
-    get that treatment because the addon only ever reads two named
-    attributes from it.
+    patches in a concrete options stub for the addon-specific settings modeled
+    by these tests, plus a ``MagicMock`` log. The log stays on ``MagicMock`` so
+    tests that need to assert on warn/debug calls can do so; ``options`` stays
+    concrete so unexpected attribute access fails instead of silently creating
+    another mock.
 
     When the caller omits ``registry_path`` the default comes from pytest's
     per-test ``tmp_path`` fixture, so tests never share a /tmp path that


### PR DESCRIPTION
## Summary

- remove the stale claim that the `mitm_ctx` options stub exposes only two addon-specific settings
- describe the fixture by its stable role: a concrete options stub for the settings modeled by the tests
- retain the rationale for keeping `ctx.log` on `MagicMock` while making unexpected option access fail fast

## Scope

This is a documentation-only correction. It does not change the fixture implementation, modeled options, addon behavior, or tests.

## Validation

Passed:

- `crates/runner/mitm-addon/.venv/bin/ruff check .`
- `crates/runner/mitm-addon/.venv/bin/ruff format --check .`
- `crates/runner/mitm-addon/.venv/bin/basedpyright -p .`
- `crates/runner/mitm-addon/.venv/bin/python -m pytest tests/ -v` (3,799 passed)
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`

The full `pnpm vitest run --maxWorkers=2 --silent=passed-only` run completed with 7,334 passing tests and one unrelated pre-existing async race in the platform permission action card tests. The affected file passes in isolation (17/17); the flake is tracked separately in #21130.

Closes #21112
