### PR TITLE
chore: ignore codex work directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,4 +206,5 @@ junit.xml
 e2e/results/
 turbo/apps/desktop/desktop-runtime-config.json
 .codex
+codex-work/
 .agents/


### PR DESCRIPTION
## Summary

- Ignore the repository-local `codex-work/` directory.
- Keep Codex workflow artifacts out of Git status and commits.

## Scope

- This changes only `.gitignore`; it has no runtime behavior impact.

## Validation

- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `cd turbo && pnpm knip`
