### PR TITLE
test(platform): wait for permission metadata before asserting action cards

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -893,12 +893,14 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
-    expect(
-      within(permissionCard).getByText("Gmail permissions"),
-    ).toBeInTheDocument();
-    expect(
-      within(permissionCard).getByText("Allow messages.write"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Gmail permissions"),
+      ).toBeInTheDocument();
+      expect(
+        within(permissionCard).getByText("Allow messages.write"),
+      ).toBeInTheDocument();
+    });
 
     await waitForButtonByText("Confirm", permissionCard);
     expect(listRequests).toBe(2);
@@ -1337,12 +1339,14 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
-    expect(
-      within(permissionCard).getByText("Cloudflare permissions"),
-    ).toBeInTheDocument();
-    expect(
-      within(permissionCard).getByText(`Allow ${UNKNOWN_PERMISSION_GRANT}`),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Cloudflare permissions"),
+      ).toBeInTheDocument();
+      expect(
+        within(permissionCard).getByText(`Allow ${UNKNOWN_PERMISSION_GRANT}`),
+      ).toBeInTheDocument();
+    });
 
     await confirmPermissionAction(user, permissionCard);
 
@@ -1431,12 +1435,14 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
-    expect(
-      within(permissionCard).getByText("Slack permissions"),
-    ).toBeInTheDocument();
-    expect(
-      within(permissionCard).getByText("Deny admin.analytics:read"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        within(permissionCard).getByText("Slack permissions"),
+      ).toBeInTheDocument();
+      expect(
+        within(permissionCard).getByText("Deny admin.analytics:read"),
+      ).toBeInTheDocument();
+    });
 
     await confirmPermissionAction(user, permissionCard);
 


### PR DESCRIPTION
## Summary

- wait for connector permission metadata before asserting final action-card labels
- cover Gmail retry, unknown Cloudflare permission, and Slack deny flows
- preserve the production loading fallback while removing timing-dependent assertions

## User impact

Prevents permission action-card tests from failing when the card renders before asynchronous connector catalog metadata resolves.

## Verification

- `git diff --check`
- local Vitest not run per repository PR preference; CI will validate the focused test change