### PR TITLE
test(platform): stabilize permission action card assertions

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-action-cards.test.tsx
@@ -893,6 +893,7 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
+    const confirmButton = await waitForButtonByText("Confirm", permissionCard);
     expect(
       within(permissionCard).getByText("Gmail permissions"),
     ).toBeInTheDocument();
@@ -900,13 +901,12 @@ describe("chat message action cards", () => {
       within(permissionCard).getByText("Allow messages.write"),
     ).toBeInTheDocument();
 
-    await waitForButtonByText("Confirm", permissionCard);
     expect(listRequests).toBe(2);
     expect(
       within(permissionCard).queryByText("Failed to load permissions"),
     ).not.toBeInTheDocument();
 
-    await confirmPermissionAction(user, permissionCard);
+    await user.click(confirmButton);
 
     await waitFor(() => {
       expect(
@@ -1337,6 +1337,7 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
+    const confirmButton = await waitForButtonByText("Confirm", permissionCard);
     expect(
       within(permissionCard).getByText("Cloudflare permissions"),
     ).toBeInTheDocument();
@@ -1344,7 +1345,7 @@ describe("chat message action cards", () => {
       within(permissionCard).getByText(`Allow ${UNKNOWN_PERMISSION_GRANT}`),
     ).toBeInTheDocument();
 
-    await confirmPermissionAction(user, permissionCard);
+    await user.click(confirmButton);
 
     await waitFor(() => {
       expect(
@@ -1431,6 +1432,7 @@ describe("chat message action cards", () => {
     });
 
     const permissionCard = await screen.findByTestId("permission-action-card");
+    const confirmButton = await waitForButtonByText("Confirm", permissionCard);
     expect(
       within(permissionCard).getByText("Slack permissions"),
     ).toBeInTheDocument();
@@ -1438,7 +1440,7 @@ describe("chat message action cards", () => {
       within(permissionCard).getByText("Deny admin.analytics:read"),
     ).toBeInTheDocument();
 
-    await confirmPermissionAction(user, permissionCard);
+    await user.click(confirmButton);
 
     await waitFor(() => {
       expect(


### PR DESCRIPTION
## Summary

- wait for the enabled permission confirmation control before asserting catalog-derived card content
- reuse the synchronized control when submitting allow and deny actions
- cover the Gmail retry, unknown Cloudflare permission, and Slack deny flows

## Scope

This is a test-only synchronization fix. It does not change permission card behavior, production state handling, timeouts, or CI configuration.

## Validation

- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-message-action-cards.test.tsx --maxWorkers=1 --silent=passed-only` (17 passed)
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip`

Closes #21130
