### PR TITLE
test(app): stabilize custom connector dialog interaction

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -2752,6 +2752,9 @@ describe("connectors page", () => {
     click(await screen.findByText("Rename"));
 
     const renameDialog = await screen.findByRole("dialog");
+    await waitFor(() => {
+      expect(renameDialog).toHaveStyle({ pointerEvents: "auto" });
+    });
     await fill(
       within(renameDialog).getByLabelText("Display name"),
       "Acme Billing API",


### PR DESCRIPTION
## Summary

- Wait for the custom connector rename dialog to become pointer-interactive before filling it in the page-level lifecycle test.
- Keep `userEvent` pointer-event validation active, so a permanently locked dialog still fails the test.
- Stabilize the intermittent `test-app (1)` failure observed in [Actions job 86672339909](https://github.com/vm0-ai/vm0/actions/runs/29201022545/job/86672339909).

## Root cause

Selecting **Rename** closes a modal Radix dropdown and opens a sibling dialog. Under CI load, the dialog can be present in the DOM before Radix's DismissableLayer effect promotes it to the active pointer-interactive layer. `findByRole` could therefore resolve during that transient state, and the immediate `userEvent` input inherited `pointer-events: none` from the body.

## Scope

This changes test synchronization only. It does not alter production dropdown/dialog behavior or add the fix to the unrelated #21132 change.

## Validation

- `pnpm vitest run --project=@vm0/app apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx -t 'manages a custom connector from creation through deletion' --reporter=dot --silent=passed-only` (10 consecutive runs)
- `pnpm vitest run --project=@vm0/app apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx --silent=passed-only`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip`
