### PR TITLE
perf(platform): reduce chat render work

### DIFF
--- a/docs/react-commit.md
+++ b/docs/react-commit.md
@@ -52,9 +52,13 @@ scenario more than once and retain the raw results.
 
 ## Instrument React Commits
 
-The React DevTools global hook can observe commits without adding permanent
-profiling components to the application. Install the following script from the
-browser console after the page has loaded:
+The React DevTools global hook can count root commits without adding permanent
+profiling components to the application. Keep this instrumentation deliberately
+small: the hook is reliable for root commit boundaries, but a traversal of
+private Fiber fields is not a reliable component execution log.
+
+Install the following script from the browser console after the page has
+loaded:
 
 ```js
 (() => {
@@ -62,53 +66,12 @@ browser console after the page has loaded:
   if (!hook) throw new Error("React DevTools hook is unavailable");
   if (window.__vm0ReactCommitProfiler) return;
 
-  const starts = new WeakMap();
   const state = {
-    root: null,
     profile: null,
   };
   const originalOnCommitFiberRoot = hook.onCommitFiberRoot;
 
-  function componentName(fiber) {
-    const type = fiber.type;
-    if (typeof type === "string") return type;
-    if (typeof type === "function") {
-      return type.displayName || type.name || "Anonymous";
-    }
-    if (type && typeof type === "object") {
-      return (
-        type.displayName ||
-        type.render?.displayName ||
-        type.render?.name ||
-        type.type?.displayName ||
-        type.type?.name ||
-        null
-      );
-    }
-    return null;
-  }
-
-  function visit(rootFiber, callback) {
-    const stack = [rootFiber];
-    while (stack.length > 0) {
-      const fiber = stack.pop();
-      callback(fiber);
-      if (fiber.child) stack.push(fiber.child);
-      if (fiber.sibling) stack.push(fiber.sibling);
-    }
-  }
-
-  function rememberTree(rootFiber) {
-    visit(rootFiber, (fiber) => {
-      starts.set(fiber, fiber.actualStartTime);
-      if (fiber.alternate) {
-        starts.set(fiber.alternate, fiber.alternate.actualStartTime);
-      }
-    });
-  }
-
   hook.onCommitFiberRoot = function onCommitFiberRoot(id, root) {
-    state.root = root;
     const profile = state.profile;
 
     if (profile) {
@@ -117,104 +80,102 @@ browser console after the page has loaded:
       if (typeof duration === "number" && Number.isFinite(duration)) {
         profile.duration += duration;
       }
-
-      visit(root.current, (fiber) => {
-        const previousStart = starts.get(fiber);
-        const rendered =
-          previousStart === undefined ||
-          previousStart !== fiber.actualStartTime;
-
-        if (rendered) {
-          const name = componentName(fiber);
-          if (name) {
-            profile.components[name] = (profile.components[name] || 0) + 1;
-          }
-        }
-
-        starts.set(fiber, fiber.actualStartTime);
+      profile.timeline.push({
+        atMs: performance.now() - profile.startedAt,
+        duration,
       });
-    } else {
-      rememberTree(root.current);
     }
 
-    return originalOnCommitFiberRoot.apply(this, arguments);
+    return originalOnCommitFiberRoot?.apply(this, arguments);
   };
 
   window.__vm0ReactCommitProfiler = {
     start() {
-      if (!state.root) {
-        throw new Error("Trigger one warm-up commit before profiling");
-      }
-      rememberTree(state.root.current);
-      state.profile = { commits: 0, duration: 0, components: {} };
+      state.profile = {
+        startedAt: performance.now(),
+        commits: 0,
+        duration: 0,
+        timeline: [],
+      };
     },
     stop() {
       const result = state.profile;
       state.profile = null;
       return result;
     },
+    uninstall() {
+      hook.onCommitFiberRoot = originalOnCommitFiberRoot;
+      delete window.__vm0ReactCommitProfiler;
+    },
   };
 })();
 ```
 
-Trigger one harmless warm-up update, such as entering the prompt, and then
-start the measurement:
+Start immediately before the measured action:
 
 ```js
 window.__vm0ReactCommitProfiler.start();
 ```
 
-After the run finishes:
+After the run finishes, retain both the total and timeline:
 
 ```js
 const result = window.__vm0ReactCommitProfiler.stop();
-console.table(
-  Object.entries(result.components)
-    .sort((left, right) => right[1] - left[1])
-    .slice(0, 50),
-);
 result;
 ```
 
-The script is intended for local development diagnostics. Fiber fields are
-React internals and may change between React versions. Revalidate the profiler
-after a React upgrade.
+Call `uninstall()` after the investigation so a later console session does not
+stack another wrapper around the hook. `actualDuration` is a private React
+field and development-only relative metric; revalidate the script after a
+React upgrade.
 
-### Complement Commit Counts with a CPU Profile
+### Use React Performance Tracks for Attribution
 
-The repository includes scripts for analyzing component render samples and
-high-frequency function calls from a V8 CPU profile. Capture the same bounded
-interaction with `agent-browser`:
+Capture the same bounded interaction with `agent-browser`:
 
 ```bash
 agent-browser profiler start
 # Perform the measured interaction in the browser.
-agent-browser profiler stop tmp/chat-send.cpuprofile
-
-cd turbo
-node scripts/analyze-react-renders.mjs ../tmp/chat-send.cpuprofile --top 50
-node scripts/analyze-call-frequency.mjs ../tmp/chat-send.cpuprofile --top 50
+agent-browser profiler stop tmp/chat-send.trace.json
 ```
 
-Adjust the profile path when running the commands from a different directory.
-CPU profiles are sample-based: they are useful for finding expensive or
-frequently called functions, but they do not provide an exact React commit
-count. Use the DevTools hook for exact commits and the CPU profile to explain
-where the sampled time went.
+The resulting file is a Chrome trace containing React Performance tracks, not
+a raw V8 `.cpuprofile`. Load it in the Chrome Performance panel and inspect:
+
+- `Update` and `Cascading Update` events in `Scheduler ⚛` for the component
+  and hook that scheduled work;
+- component spans in `Components ⚛` for changed props, referentially unequal
+  closures, and deeply equal objects;
+- the span duration for the expensive subtree, while remembering that parent
+  and child durations are inclusive and must not be added together.
+
+The repository's `analyze-react-renders.mjs` and
+`analyze-call-frequency.mjs` scripts accept a raw V8 CPU profile. Do not pass
+the Chrome trace container to those scripts. Capture a raw CPU profile or
+extract its `Profile` and `ProfileChunk` events first when sampled JavaScript
+stacks are needed.
 
 ## Avoid Fiber Counting False Positives
 
-Two tempting approaches overcount component executions:
+Do not infer component executions by traversing every Fiber after a root
+commit. The following approaches all overcount in current React builds:
 
 - Counting every fiber with the `PerformedWork` flag. Flags can remain visible
   on reused or bailed-out subtrees after a commit.
 - Comparing `fiber.actualStartTime` directly with
   `fiber.alternate.actualStartTime`. React alternates between two fiber objects,
   so this can count historical work from the other buffer.
+- Keeping a `WeakMap` of each Fiber's previous `actualStartTime`. React can
+  retain or copy timing data while traversing an ancestor or bailed-out
+  subtree, so a changed value is still not proof that the component function
+  executed.
 
-Keep a `WeakMap` of the last observed `actualStartTime` for each fiber object
-across commits. Establish the baseline before starting the measurement. This
-distinguishes new executions from values retained on an alternate tree.
+In one chat sample, the `WeakMap` technique reported 76 sidebar executions.
+The React Performance track for the same trace showed no execution spans for
+`SidebarLayout`, `ZeroSidebar`, or `ChatThreadsContent`; the only visible
+sidebar update initiator was one `ChatThreadItem`. Use the root hook for exact
+commit boundaries and React Performance tracks or a deliberately placed React
+`Profiler` for component attribution.
 
 Also account for these sources of noise:
 
@@ -223,8 +184,8 @@ Also account for these sources of noise:
 - Hot module replacement invalidates the current sample.
 - Opening a popover, typing, scrolling, or changing focus adds unrelated work.
 - Development-mode `actualDuration` is useful for relative comparisons only.
-- A newly mounted component has no historical fiber value and should count as
-  work.
+- A newly mounted component legitimately appears as work and should be
+  separated from repeated updates.
 
 ## Divide the Page into Regions
 
@@ -486,6 +447,263 @@ The same optimized sample still executed `ChatThreadContent` and
 `ChatThreadComposer` 13 times. Those components consume real message, run, and
 composer primitives, so collection equality alone cannot eliminate their work.
 Continue by attributing each execution to a specific primitive transition.
+
+## Current Chat Send Attribution (2026-07-12)
+
+The initial sample below measured an existing chat thread in a local
+development build before removing the React-driven thinking typewriter. The
+prompt was entered before profiling, and the measurement began immediately
+before Send. The local run produced and fully revealed a thinking message but
+did not emit a final or terminal event, so it was cancelled after profiling.
+The results identify update sources; they are not a send-to-completion
+benchmark.
+
+Two immediately repeated sends with the same thread, model, and prompt provided
+complementary data:
+
+| Sample                                              | Result                                                      |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| Root commit counter, first five seconds             | 62 commits; the final measured commit was at 3.439 seconds  |
+| Root commit counter, first second                   | 20 commits                                                  |
+| Root commit counter, 1.0 through 3.439 seconds      | 42 commits; 45 adjacent intervals were between 20 and 45 ms |
+| React scheduler track, separate equivalent send     | 49 `Update` events and 7 `Cascading Update` events          |
+| Scheduler activity after thinking text was revealed | None before the run was manually cancelled                  |
+
+Scheduler events are update initiators, not commits. React may batch multiple
+initiators into one commit, schedule cascading work from a commit, or commit
+work without a separately labelled scheduler event. Do not add or compare the
+two totals directly.
+
+### Scheduler update sources
+
+The React scheduler track attributed the 56 labelled updates as follows:
+
+| Update initiator              | Count | Interpretation                                                     |
+| ----------------------------- | ----: | ------------------------------------------------------------------ |
+| `ThinkingIndicator`           |    39 | Typewriter frames written at a nominal 28 ms interval              |
+| `AgentListDialog`             |     5 | A closed dialog remained subscribed to changing thread-list data   |
+| `ChatThreadContent`           |     4 | Optimistic message, reconciliation, and remote message projections |
+| `ChatThreadComposer`          |     4 | Send/loading/run-state transitions                                 |
+| `WorkflowComposerPlaceholder` |     1 | Draft/composer transition during Send                              |
+| `ChatThreadHeader`            |     1 | Thread metadata transition                                         |
+| `AssistantBubbleAvatar`       |     1 | Assistant identity became available to the new response row        |
+| `ChatThreadItem`              |     1 | The visible sidebar row changed to its active-run indicator        |
+
+A pre-change ccstate watcher probe showed the same separation. During one sample,
+`displayedThinkingText$` notified its React watcher 42 times, while the main
+message and run projections such as `groupedChatMessages$`,
+`renderedGroupedChatMessages$`, `allFinished$`, `hasChatGroups$`, and
+`lastAssistantCancelled$` each notified watchers about five times. A watcher
+notification is only a computed reevaluation: primitive equality in
+`useLastResolved` can still prevent a React update when its semantic result did
+not change.
+
+### Work by page region
+
+The component track gives a more accurate region picture than Fiber traversal:
+
+| Region            | Observed component work                                                                                               |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Visible sidebar   | One direct `ChatThreadItem` update; no spans for `SidebarLayout`, `ZeroSidebar`, or `ChatThreadsContent`              |
+| Hidden sidebar UI | Five direct `AgentListDialog` updates while the dialog was closed                                                     |
+| Message list      | Four direct `ChatThreadContent` updates; `ChatThreadMessagesMain` and `ChatThreadMessageGroups` each executed 8 times |
+| Composer          | Four direct `ChatThreadComposer` updates; its main leaf slots executed 11 times                                       |
+| Thinking row      | 39 direct `ThinkingIndicator` updates; `WaitingForAssistantResponse` executed 46 times                                |
+
+The direct update component is the root of that scheduled work and may not have
+its own component span. Descendant span counts can therefore be higher than the
+direct update count.
+
+The message-list spans exposed unnecessary identity churn:
+
+- `PagedUserMessage` executed five times. Four executions only received a new,
+  deeply equal `message.blocks`; one was the real optimistic-to-persistent
+  reconciliation.
+- `PagedAssistantMessageItem` executed three times, and all three received new,
+  deeply equal `message.blocks`.
+- `UserMessageActions` executed 14 times with only a new `onCopy` closure.
+
+`createTranscriptMessagesComputed` currently maps the complete raw transcript
+whenever persistent or optimistic messages change. It calls
+`parseBodyRenderBlocks` and `enrichBlocksWithTextPreviews` for every message,
+creating new enriched messages and block arrays. `groupMessagesForDisplay` then
+creates new group and message arrays. The shallow `equalArrays` used by
+`ChatThreadContent` cannot suppress this update because the group objects are
+new even when every old message is semantically unchanged.
+
+The composer spans showed a different hot path:
+
+- `TiptapWorkflowComposer` executed 11 times and consumed about 3.8 ms of
+  inclusive development-mode span time. Ten executions only changed
+  `onDraftChange`, `onKeyDown`, and `onPaste` closure identities; one also
+  changed the semantic `sending` prop.
+- `ComposerModelPickerSlot` also executed 11 times. Its `modelPicker.value` was
+  repeatedly referentially unequal but deeply equal, and its callbacks were
+  recreated.
+- The closed model picker still rendered its select-content tree. The trace
+  contained 176 `SelectItem` executions, and the model-picker slot consumed
+  about 127 ms of inclusive development-mode span time. This was substantially
+  more work than Tiptap in the same sample.
+
+`thread.selectedModel$` already resolves to a primitive model identifier, but
+`useChatComposerModel` immediately wraps it in new `modelSelection` and
+`modelPicker` objects. `useZeroChatComposer` also recreates its event handlers
+and passes them through every composer leaf. This makes otherwise unrelated
+run and message transitions re-execute the closed picker and editor leaves.
+
+Finally, most of the pre-change commit count came from an intentional animation
+policy, not server event volume. `setThinkingIndicatorTextRef$` wrote a new
+`thinkingTypewriterFrame$` every `THINKING_TYPEWRITER_INTERVAL_MS` (28 ms), and
+`ThinkingIndicator` subscribed to the derived primitive
+`displayedThinkingText$`. Primitive equality correctly suppressed identical
+strings, but each typewriter frame was a different string. Each render also
+allocated new `blockStyle` and `serverThinkingLabel` objects, which propagated
+the frame through the waiting-row subtree.
+
+### Result after removing the thinking animations
+
+The typewriter state, 28 ms loop, canvas text measurement, DOM ref command, and
+React subscription were removed. A thinking marker now renders its full text in
+one update. The CSS shimmer, block-pop, and entrance animations were also
+removed so the indicator is fully static. Two repeated sends on the same stable
+thread produced the first two post-change rows below:
+
+| Sample                           | First-second commits | Five-second commits | Last measured commit |
+| -------------------------------- | -------------------: | ------------------: | -------------------: |
+| Without typewriter, first run    |                   11 |                  29 |              3.310 s |
+| Without typewriter, traced run   |                   11 |                  24 |              3.281 s |
+| Without any React thinking loops |                   22 |                  24 |              1.461 s |
+
+The matching pre-change sample had 62 commits in five seconds. The fixed 28 ms
+cadence disappeared completely. The remaining count still varies with remote
+event timing.
+
+The first implementation pass exposed one remaining periodic update at about
+3.3 seconds: `runPhraseLoop$` still rotated the fallback phrase and refreshed a
+done phrase every 3.5 seconds. That loop was also removed. Each thread now picks
+one stable fallback phrase, while the done phrase is derived from messages and
+subscribed only by the finished row. In the final trace, all React work ended by
+1.461 seconds and no timer-driven `ThinkingIndicator` update remained.
+
+The phrase "first-second commits" is only a time bucket, not a causal phase. In
+the traced run, all initial local work finished within 301 ms, followed by no
+labelled scheduler update until 1.194 seconds. In another run, a remote thinking
+event arrived at 0.91 seconds and was counted in the first-second bucket. Split
+profiles into an initial local burst and later remote events instead of treating
+one second as a stable boundary.
+
+The 11 commits in the initial local burst had ten labelled scheduler update
+initiators:
+
+| Update initiator              | Count | Immediate cause                                                      |
+| ----------------------------- | ----: | -------------------------------------------------------------------- |
+| `ChatThreadComposer`          |     3 | Send loadable, run state, and composer-derived lifecycle transitions |
+| `WorkflowComposerPlaceholder` |     1 | The submitted draft was cleared                                      |
+| `ThinkingIndicator`           |     1 | The optimistic user/run projection made the indicator visible        |
+| `ChatThreadHeader`            |     1 | A new `threadMeta$` object reached the header                        |
+| `AssistantBubbleAvatar`       |     1 | The newly mounted waiting row resolved its async `agentId$`          |
+| `MobileTopBar`                |     1 | A new `mobileBreadcrumb$` object reached the hidden mobile header    |
+| `ChatThreadItem`              |     1 | The current sidebar row gained its active-run state                  |
+| `AgentListDialog`             |     1 | The closed dialog observed changing thread-list data                 |
+
+One root commit had no separate scheduler label. Several labelled transitions
+are user-visible and valid, but their descendant work is still much broader
+than necessary:
+
+- The composer leaves executed five times in the first 500 ms.
+  `uploadsReady` changed `true -> false -> true`, while four of five Tiptap
+  executions changed only callback identities. The closed model picker also
+  executed five times, expanded 80 `SelectItem` executions, and occupied about
+  70 ms of inclusive component span time; Tiptap occupied about 1.8 ms.
+- `ChatThreadMessagesMain` and `ChatThreadMessageGroups` each executed three
+  times. Four old user rows and four old assistant rows received new, deeply
+  equal `blocks` arrays during the initial burst.
+- The visible sidebar container still did not execute. Its one row update was
+  semantic; the closed dialog and hidden mobile header were avoidable work.
+
+After the initial burst in the intermediate trace, there were four
+`ChatThreadContent` updates, one composer update, two closed-dialog updates, one
+sidebar-row update, one mobile-header update, and the periodic phrase-loop
+update that prompted the second cleanup.
+
+The final trace contained 20 labelled scheduler updates in total: six from the
+closed `AgentListDialog`, four from `ChatThreadContent`, three from
+`ChatThreadItem`, three from `ChatThreadComposer`, and one each from
+`WorkflowComposerPlaceholder`, the initial `ThinkingIndicator`,
+`AssistantBubbleAvatar`, and the hidden `MobileTopBar`. There were no
+per-character, phrase-rotation, or delayed done-phrase React updates.
+
+### Result after moving subscriptions to leaf components
+
+The next pass removed the object-level `threadMeta$` subscription from the
+header, made title fields and server settlement primitive async computed values,
+and changed `ChatThreadContent` into a subscription-free layout shell. The
+message pane now subscribes to the rendered group window and server settlement,
+while a dedicated thinking leaf subscribes to the complete group list. The
+composer is a sibling of that message pane, so message projection updates no
+longer execute the composer subtree through their parent.
+
+The attachment upload summary object was also replaced with an async readiness
+primitive. React observes only `useLoadableState(attachmentUploadsReady$)`.
+With no attachments the computed returns synchronously, so clearing an already
+empty draft does not create a false `loading -> hasData` transition.
+
+A real-browser trace of the same send shape showed the following component
+execution counts. The runs had different remote event timings and message
+history lengths, so the table is evidence about subtree isolation rather than
+a controlled comparison of total render cost:
+
+| Component or subtree       | Earlier final trace | Leaf-subscription trace |
+| -------------------------- | ------------------: | ----------------------: |
+| `TiptapWorkflowComposer`   |                  11 |                       4 |
+| `ComposerModelPickerSlot`  |                  11 |                       4 |
+| `ChatThreadMessagesMain`   |                   8 |                       3 |
+| `ChatThreadMessageGroups`  |                   8 |                       3 |
+| Closed-picker `SelectItem` |                 176 |                       0 |
+
+The closed picker reached zero items by mounting
+`ModelFirstModelPickerContent` only when a controlled picker is open. The
+trigger and its primitive model subscriptions remain mounted, so opening and
+changing the model retain their normal behavior. Uncontrolled picker callers
+keep the previous mounting behavior.
+
+The final five-second browser sample recorded 23 root commits and about 192 ms
+of cumulative development-mode `actualDuration`. All commits ended within
+1.631 seconds of the first send-triggered commit. Its 18 labelled scheduler
+initiators were:
+
+| Update initiator              | Count |
+| ----------------------------- | ----: |
+| Closed `AgentListDialog`      |     4 |
+| `ChatThreadMessagesPane`      |     3 |
+| `ChatThreadComposer`          |     3 |
+| `ChatThreadItem`              |     2 |
+| Hidden `MobileTopBar`         |     2 |
+| `ChatThreadThinkingIndicator` |     1 |
+| Initial `ThinkingIndicator`   |     1 |
+| `WorkflowComposerPlaceholder` |     1 |
+| `AssistantBubbleAvatar`       |     1 |
+
+`ChatThreadContent` and `ChatThreadHeader` were absent from the scheduler
+update sources. The three composer updates are direct subscriptions for the
+send and run lifecycle; message-list updates no longer cause additional
+composer executions. The message pane and thinking leaf still update when their
+different semantic projections change, which is expected.
+
+### Prioritized follow-up
+
+1. Preserve enriched message and block identity for unchanged raw message
+   objects. Use structural sharing at the transcript projection boundary
+   instead of a recursive deep-equality check in React.
+2. Stabilize the remaining composer callbacks only if a controlled trace shows
+   that their cost is material after the subscription split.
+3. Remove object-level subscriptions from `MobileTopBar` and other leaves that
+   render primitive fields. Split `AgentListDialog` into an always-mounted
+   open-state shell and a body that subscribes to thread-list data only while
+   the dialog is open.
+4. Repeat the measurement with a fixed mocked event sequence that reaches a
+   terminal state. Compare commits per event and retain separate counts for the
+   initial send transition, stream events, and settlement.
 
 ## Memory Leaks Are a Separate Investigation
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -24,7 +24,6 @@ export { chatThreads$ } from "../agent-chat.ts";
 export {
   zeroChatAttachments$,
   uploadZeroAttachment$,
-  zeroChatAttachmentUploadSummary$,
   restoreZeroAttachments$,
   removeZeroAttachment$,
   appendZeroChatInput$,

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-panes.ts
@@ -108,7 +108,6 @@ const resolvePaneThread$ = command(
     await Promise.all([
       set(loadDraft$, thread, isNew, signal),
       set(setupChatThreadInitScroll$, thread, signal),
-      set(thread.runPhraseLoop$, signal),
       set(thread.subscribeChatThread$, signal),
     ]);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -33,8 +33,10 @@ export interface ChatThreadSignals {
   threadDraft$: Computed<Promise<ChatThreadDraft | null>>;
   threadMeta$: Computed<Promise<ThreadMeta | null>>;
   reloadThread$: Command<void, []>;
+  threadTitle$: Computed<Promise<string | null>>;
   threadTitleEmoji$: Computed<Promise<string | null>>;
   threadTitleText$: Computed<Promise<string>>;
+  threadSettledInServer$: Computed<Promise<boolean>>;
   // -- Composer model selection --------------------------------------------
   // Derived from the thread event projection; user edits register optimistic
   // model_selection_updated events and then persist through the thread API.
@@ -118,14 +120,8 @@ export interface ChatThreadSignals {
   subscribeChatThread$: Command<Promise<void>, [AbortSignal]>;
   // -- Thinking indicator ---------------------------------------------------
   blockColors$: Computed<[string, string, string]>;
-  rotatingPhrase$: Computed<string>;
-  donePhrase$: Computed<string>;
-  displayedThinkingText$: Computed<Promise<string>>;
-  setThinkingIndicatorTextRef$: Command<
-    (() => void) | undefined,
-    [HTMLElement | null]
-  >;
-  runPhraseLoop$: Command<Promise<void>, [AbortSignal]>;
+  thinkingPhrase$: Computed<string>;
+  donePhrase$: Computed<Promise<string>>;
   // -- Artifacts ------------------------------------------------------------
   artifacts$: Computed<Promise<ChatThreadArtifactRun[]>>;
   reloadArtifacts$: Command<void, []>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -8,13 +8,11 @@ import {
 } from "ccstate";
 import { animationFrame, delay } from "signal-timers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
-import { IN_VITEST } from "../../env.ts";
 import {
   onRef,
   onRejection,
   resetSignalScope,
   resetSignal,
-  setLoop,
   withCleanup,
 } from "../utils.ts";
 import { setAblyLoop$ } from "../realtime.ts";
@@ -285,8 +283,6 @@ const THINKING_PHRASES = [
   "Tuning in...",
 ] as const;
 
-const PHRASE_INTERVAL_MS = 3500;
-
 const DONE_PHRASES = [
   (t: string) => {
     return `Wrapped up at ${t}`;
@@ -323,7 +319,10 @@ function formatDonePhrase(lastMsg: PagedChatMessage | undefined): string {
         minute: "2-digit",
       })
     : "just now";
-  const pick = DONE_PHRASES[Math.floor(Math.random() * DONE_PHRASES.length)]!;
+  const phraseIndex = lastMsg?.id
+    ? lastMsg.id.charCodeAt(lastMsg.id.length - 1) % DONE_PHRASES.length
+    : 0;
+  const pick = DONE_PHRASES[phraseIndex]!;
   return pick(time);
 }
 
@@ -500,9 +499,11 @@ function createThreadMeta(threadId: string) {
 function createThreadTitleParts(
   threadMeta$: Computed<Promise<ThreadMeta | null>>,
 ) {
+  const threadTitle$ = computed(async (get): Promise<string | null> => {
+    return (await get(threadMeta$))?.title ?? null;
+  });
   const threadTitleParts$ = computed(async (get) => {
-    const threadMeta = await get(threadMeta$);
-    return getChatThreadTitleParts(threadMeta?.title);
+    return getChatThreadTitleParts(await get(threadTitle$));
   });
   const threadTitleEmoji$ = computed(async (get) => {
     return (await get(threadTitleParts$)).emoji;
@@ -510,7 +511,26 @@ function createThreadTitleParts(
   const threadTitleText$ = computed(async (get) => {
     return (await get(threadTitleParts$)).text;
   });
-  return { threadTitleEmoji$, threadTitleText$ };
+  return { threadTitle$, threadTitleEmoji$, threadTitleText$ };
+}
+
+function createThreadSettledInServer(
+  threadId: string,
+  threadMeta$: Computed<Promise<ThreadMeta | null>>,
+) {
+  const optimisticCreateUnsettled$ =
+    optimisticChatThreadCreateUnsettled(threadId);
+  return computed(async (get): Promise<boolean> => {
+    const threadMeta = await get(threadMeta$);
+    const optimisticCreateUnsettled = get(optimisticCreateUnsettled$);
+    if (threadMeta === null) {
+      if (optimisticCreateUnsettled) {
+        return false;
+      }
+      throw new Error("Chat not found");
+    }
+    return !optimisticCreateUnsettled;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -2744,497 +2764,35 @@ function createCancelRunWithQueuedRecall({
 }
 
 // ---------------------------------------------------------------------------
-// Sub-factory: thinking phrase animation
+// Sub-factory: thinking phrases
 // ---------------------------------------------------------------------------
 
-const THINKING_TYPEWRITER_INTERVAL_MS = 28;
-const THINKING_TYPEWRITER_LINE_PAUSE_MS = 3000;
-const THINKING_TYPEWRITER_LINE_PAUSE_TICKS = IN_VITEST
-  ? 1
-  : Math.ceil(
-      THINKING_TYPEWRITER_LINE_PAUSE_MS / THINKING_TYPEWRITER_INTERVAL_MS,
-    );
-const THINKING_TYPEWRITER_WIDTH_GUARD_PX = 8;
-const THINKING_TYPEWRITER_OVERFLOW_PREFIX = "...";
-
-interface ThinkingTypewriterLine {
-  readonly startIndex: number;
-  readonly endIndex: number;
-  readonly text: string;
-}
-
-interface ThinkingTypewriterFrame {
-  readonly messageId: string | undefined;
-  readonly text: string;
-  readonly width: number;
-  readonly lineIndex: number;
-  readonly charIndex: number;
-  readonly pauseTicksRemaining: number;
-  readonly displayedText: string;
-  readonly complete: boolean;
-}
-
-function emptyThinkingTypewriterFrame(): ThinkingTypewriterFrame {
-  return {
-    messageId: undefined,
-    text: "",
-    width: 0,
-    lineIndex: 0,
-    charIndex: 0,
-    pauseTicksRemaining: 0,
-    displayedText: "",
-    complete: false,
-  };
-}
-
-function isAssistantTextMessage(message: EnrichedChatMessage): boolean {
-  return (
-    message.role === "assistant" &&
-    (Boolean(message.content) || Boolean(message.error))
-  );
-}
-
-type ThinkingMarkerMessage = EnrichedChatMessage & {
-  readonly role: "assistant";
-  readonly content: null;
-  readonly error?: undefined;
-  readonly runId: string;
-  readonly thinking: string;
-};
-
-function isThinkingMarkerMessage(
-  message: EnrichedChatMessage,
-): message is ThinkingMarkerMessage {
-  return (
-    message.role === "assistant" &&
-    message.content === null &&
-    message.error === undefined &&
-    typeof message.thinking === "string" &&
-    message.thinking.trim().length > 0 &&
-    message.runId !== undefined
-  );
-}
-
-function thinkingTextGraphemes(text: string): string[] {
-  return Array.from(text);
-}
-
-function lastRunThinkingMessageForIndicator(
-  groups: readonly GroupedChatMessageGroup[],
-): ThinkingMarkerMessage | undefined {
-  const messages = groups.flatMap((group) => {
-    return group.messages.filter((message) => {
-      return !message.isQueued;
-    });
-  });
-  const lastMessage = messages[messages.length - 1];
-  if (!lastMessage || !isThinkingMarkerMessage(lastMessage)) {
-    return undefined;
-  }
-
-  const runId = lastMessage.runId;
-  const runHasAssistantText = messages.some((message) => {
-    return message.runId === runId && isAssistantTextMessage(message);
-  });
-  return runHasAssistantText ? undefined : lastMessage;
-}
-
-function thinkingTypewriterStep(width: number): number {
-  if (width >= 520) {
-    return 3;
-  }
-  if (width >= 320) {
-    return 2;
-  }
-  return 1;
-}
-
-function createThinkingTextMeasurer(
-  el: HTMLElement,
-): (value: string) => number | undefined {
-  const canvas = document.createElement("canvas");
-  const context = canvas.getContext("2d");
-  const style = window.getComputedStyle(el);
-  const font =
-    style.font ||
-    [
-      style.fontStyle,
-      style.fontVariant,
-      style.fontWeight,
-      style.fontSize,
-      style.fontFamily,
-    ]
-      .filter(Boolean)
-      .join(" ");
-  const letterSpacing =
-    style.letterSpacing === "normal"
-      ? 0
-      : Number.parseFloat(style.letterSpacing);
-
-  if (!context || !font) {
-    return () => {
-      return undefined;
-    };
-  }
-
-  context.font = font;
-  return (value: string) => {
-    const measured = context.measureText(value).width;
-    if (!Number.isFinite(measured) || measured <= 0) {
-      return undefined;
-    }
-    const spacing =
-      Number.isFinite(letterSpacing) && letterSpacing > 0
-        ? (thinkingTextGraphemes(value).length - 1) * letterSpacing
-        : 0;
-    return measured + spacing;
-  };
-}
-
-function thinkingLabelWidth(el: HTMLElement): number {
-  const elementWidth = Math.max(
-    el.getBoundingClientRect().width,
-    el.clientWidth,
-  );
-  if (elementWidth > 0) {
-    return elementWidth;
-  }
-
-  const parent = el.parentElement;
-  return Math.max(
-    parent?.getBoundingClientRect().width ?? 0,
-    parent?.clientWidth ?? 0,
-  );
-}
-
-function wrapThinkingTextForWidth(args: {
-  readonly graphemes: readonly string[];
-  readonly width: number;
-  readonly measureText: (value: string) => number | undefined;
-}): ThinkingTypewriterLine[] {
-  if (args.graphemes.length === 0) {
-    return [];
-  }
-  if (!Number.isFinite(args.width) || args.width <= 0) {
-    return [
-      {
-        startIndex: 0,
-        endIndex: args.graphemes.length,
-        text: args.graphemes.join(""),
-      },
-    ];
-  }
-
-  const maxWidth = Math.max(1, args.width - THINKING_TYPEWRITER_WIDTH_GUARD_PX);
-  const lines: ThinkingTypewriterLine[] = [];
-  let startIndex = 0;
-  let current: string[] = [];
-
-  for (let index = 0; index < args.graphemes.length; index++) {
-    const grapheme = args.graphemes[index]!;
-    const candidate = [...current, grapheme];
-    const candidateText = candidate.join("");
-    const measured = args.measureText(candidateText);
-    if (measured === undefined) {
-      return [
-        {
-          startIndex: 0,
-          endIndex: args.graphemes.length,
-          text: args.graphemes.join(""),
-        },
-      ];
-    }
-
-    if (measured <= maxWidth || current.length === 0) {
-      current = candidate;
-      continue;
-    }
-
-    lines.push({
-      startIndex,
-      endIndex: index,
-      text: current.join(""),
-    });
-    startIndex = index;
-    current = [grapheme];
-  }
-
-  if (current.length > 0) {
-    lines.push({
-      startIndex,
-      endIndex: args.graphemes.length,
-      text: current.join(""),
-    });
-  }
-
-  return lines;
-}
-
-function displayedSlidingThinkingText(args: {
-  readonly graphemes: readonly string[];
-  readonly startIndex: number;
-  readonly charIndex: number;
-  readonly width: number;
-  readonly measureText: (value: string) => number | undefined;
-}): string {
-  const visibleGraphemes = args.graphemes.slice(
-    args.startIndex,
-    args.charIndex,
-  );
-  const visibleText = visibleGraphemes.join("");
-  if (visibleText.length === 0) {
-    return "";
-  }
-  if (!Number.isFinite(args.width) || args.width <= 0) {
-    return visibleText;
-  }
-
-  const maxWidth = Math.max(1, args.width - THINKING_TYPEWRITER_WIDTH_GUARD_PX);
-  const visibleWidth = args.measureText(visibleText);
-  if (visibleWidth === undefined || visibleWidth <= maxWidth) {
-    return visibleText;
-  }
-
-  let displayedText: string | undefined;
-  for (let start = visibleGraphemes.length - 1; start >= 0; start--) {
-    const candidate = `${THINKING_TYPEWRITER_OVERFLOW_PREFIX}${visibleGraphemes
-      .slice(start)
-      .join("")}`;
-    const measured = args.measureText(candidate);
-    if (measured === undefined) {
-      return visibleText;
-    }
-    if (measured <= maxWidth) {
-      displayedText = candidate;
-      continue;
-    }
-    if (displayedText) {
-      break;
-    }
-  }
-
-  return displayedText ?? visibleGraphemes[visibleGraphemes.length - 1] ?? "";
-}
-
-function nextThinkingTypewriterFrame(args: {
-  readonly messageId: string;
-  readonly text: string;
-  readonly currentFrame: ThinkingTypewriterFrame;
-  readonly width: number;
-  readonly measureText: (value: string) => number | undefined;
-}): ThinkingTypewriterFrame {
-  const width = Math.max(0, Math.floor(args.width));
-  const graphemes = thinkingTextGraphemes(args.text);
-  if (graphemes.length === 0) {
-    return emptyThinkingTypewriterFrame();
-  }
-  const lines = wrapThinkingTextForWidth({
-    graphemes,
-    width,
-    measureText: args.measureText,
-  });
-  if (lines.length === 0) {
-    return emptyThinkingTypewriterFrame();
-  }
-
-  const currentFrame =
-    args.currentFrame.messageId === args.messageId &&
-    args.currentFrame.text === args.text &&
-    args.currentFrame.width === width
-      ? args.currentFrame
-      : {
-          ...emptyThinkingTypewriterFrame(),
-          messageId: args.messageId,
-          text: args.text,
-          width,
-        };
-  const lineIndex = Math.min(currentFrame.lineIndex, lines.length - 1);
-  const currentLine = lines[lineIndex]!;
-  const nextLine = lines[lineIndex + 1];
-
-  if (currentFrame.pauseTicksRemaining > 0) {
-    return {
-      ...currentFrame,
-      lineIndex,
-      pauseTicksRemaining: currentFrame.pauseTicksRemaining - 1,
-      displayedText: currentLine.text,
-      complete: false,
-    };
-  }
-
-  if (currentFrame.charIndex >= currentLine.endIndex) {
-    if (!nextLine) {
-      return {
-        ...currentFrame,
-        lineIndex,
-        displayedText: currentLine.text,
-        complete: true,
-      };
-    }
-
-    const nextCharIndex = Math.min(
-      nextLine.endIndex,
-      nextLine.startIndex + thinkingTypewriterStep(width),
-    );
-    return {
-      ...currentFrame,
-      lineIndex: lineIndex + 1,
-      charIndex: nextCharIndex,
-      pauseTicksRemaining: 0,
-      displayedText: displayedSlidingThinkingText({
-        graphemes,
-        startIndex: nextLine.startIndex,
-        charIndex: nextCharIndex,
-        width,
-        measureText: args.measureText,
-      }),
-      complete:
-        lineIndex + 1 >= lines.length - 1 && nextCharIndex >= graphemes.length,
-    };
-  }
-
-  const nextCharIndex = Math.min(
-    currentLine.endIndex,
-    currentFrame.charIndex + thinkingTypewriterStep(width),
-  );
-
-  return {
-    ...currentFrame,
-    lineIndex,
-    charIndex: nextCharIndex,
-    pauseTicksRemaining:
-      nextCharIndex >= currentLine.endIndex && nextLine !== undefined
-        ? THINKING_TYPEWRITER_LINE_PAUSE_TICKS
-        : 0,
-    displayedText: displayedSlidingThinkingText({
-      graphemes,
-      startIndex: currentLine.startIndex,
-      charIndex: nextCharIndex,
-      width,
-      measureText: args.measureText,
-    }),
-    complete: nextCharIndex >= graphemes.length,
-  };
-}
-
-function thinkingTypewriterFrameComplete(
-  frame: ThinkingTypewriterFrame,
-): boolean {
-  return frame.complete;
-}
-
-function createPhraseLoop(
+function createThinkingIndicatorSignals(
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>,
-  allFinished$: Computed<Promise<boolean>>,
 ) {
-  const internalBlockColors$ =
-    state<[string, string, string]>(shuffleBlockColors());
-  const blockColors$ = computed((get) => {
-    return get(internalBlockColors$);
+  const blockColors = shuffleBlockColors();
+  const blockColors$ = computed(() => {
+    return blockColors;
   });
-  const phraseIndex$ = state(
-    Math.floor(Math.random() * THINKING_PHRASES.length),
-  );
-  const rotatingPhrase$ = computed((get) => {
-    return THINKING_PHRASES[get(phraseIndex$)]!;
+  const thinkingPhrase =
+    THINKING_PHRASES[Math.floor(Math.random() * THINKING_PHRASES.length)]!;
+  const thinkingPhrase$ = computed(() => {
+    return thinkingPhrase;
   });
-  const internalDonePhrase$ = state<string>(formatDonePhrase(undefined));
-  const donePhrase$ = computed((get) => {
-    return get(internalDonePhrase$);
+  const donePhrase$ = computed(async (get): Promise<string> => {
+    const groups = await get(groupedChatMessages$);
+    const lastGroup = groups[groups.length - 1];
+    const lastMessage =
+      lastGroup?.role === "assistant"
+        ? lastGroup.messages[lastGroup.messages.length - 1]
+        : undefined;
+    return formatDonePhrase(lastMessage);
   });
-  const lastDoneMessageId$ = state<string | undefined>(undefined);
-  const thinkingTypewriterFrame$ = state<ThinkingTypewriterFrame>(
-    emptyThinkingTypewriterFrame(),
-  );
-  const displayedThinkingText$ = computed((get): Promise<string> => {
-    return Promise.resolve(get(thinkingTypewriterFrame$).displayedText);
-  });
-  const resetThinkingTypewriterLoopSignal$ = resetSignal();
-
-  const setThinkingIndicatorTextRef$ = onRef(
-    command(async ({ get, set }, el: HTMLElement, signal: AbortSignal) => {
-      const loopSignal = set(resetThinkingTypewriterLoopSignal$, signal);
-      const measureText = createThinkingTextMeasurer(el);
-      set(thinkingTypewriterFrame$, emptyThinkingTypewriterFrame());
-
-      await setLoop(
-        async (sig) => {
-          const groups = await get(groupedChatMessages$);
-          sig.throwIfAborted();
-
-          const thinkingMessage = lastRunThinkingMessageForIndicator(groups);
-          const text = thinkingMessage?.thinking?.trim() ?? "";
-          if (!thinkingMessage || text.length === 0) {
-            set(thinkingTypewriterFrame$, emptyThinkingTypewriterFrame());
-            return true;
-          }
-
-          const width = thinkingLabelWidth(el);
-          if (width <= 0 && !IN_VITEST) {
-            return false;
-          }
-          const nextFrame = nextThinkingTypewriterFrame({
-            messageId: thinkingMessage.id,
-            text,
-            currentFrame: get(thinkingTypewriterFrame$),
-            width,
-            measureText,
-          });
-          set(thinkingTypewriterFrame$, nextFrame);
-          return thinkingTypewriterFrameComplete(nextFrame);
-        },
-        THINKING_TYPEWRITER_INTERVAL_MS,
-        loopSignal,
-      );
-    }),
-  );
-
-  const runPhraseLoop$ = command(
-    async ({ get, set }, signal: AbortSignal): Promise<void> => {
-      await setLoop(
-        async (sig) => {
-          const groups = await get(groupedChatMessages$);
-          sig.throwIfAborted();
-          const lastGroup = groups[groups.length - 1];
-          const lastIsAssistant = lastGroup?.role === "assistant";
-          const lastMsg =
-            lastIsAssistant && lastGroup
-              ? lastGroup.messages[lastGroup.messages.length - 1]
-              : undefined;
-          if (lastMsg?.id !== get(lastDoneMessageId$)) {
-            set(lastDoneMessageId$, lastMsg?.id);
-            set(internalDonePhrase$, formatDonePhrase(lastMsg));
-          }
-          const allFinished = await get(allFinished$);
-          sig.throwIfAborted();
-          const thinkingMessage = lastRunThinkingMessageForIndicator(groups);
-          if (!thinkingMessage) {
-            set(thinkingTypewriterFrame$, emptyThinkingTypewriterFrame());
-          }
-          if (
-            !thinkingMessage &&
-            (!allFinished || (!!lastGroup && !lastIsAssistant))
-          ) {
-            set(
-              phraseIndex$,
-              (get(phraseIndex$) + 1) % THINKING_PHRASES.length,
-            );
-          }
-          return false;
-        },
-        PHRASE_INTERVAL_MS,
-        signal,
-      );
-    },
-  );
 
   return {
     blockColors$,
-    rotatingPhrase$,
+    thinkingPhrase$,
     donePhrase$,
-    displayedThinkingText$,
-    setThinkingIndicatorTextRef$,
-    runPhraseLoop$,
   };
 }
 
@@ -3250,8 +2808,12 @@ export function createChatThreadSignals(
   const { remoteThreadDetail$, threadDraft$, reloadThread$ } =
     createRemoteThreadDetail(dataSource);
   const threadMeta$ = createThreadMeta(threadId);
-  const { threadTitleEmoji$, threadTitleText$ } =
+  const { threadTitle$, threadTitleEmoji$, threadTitleText$ } =
     createThreadTitleParts(threadMeta$);
+  const threadSettledInServer$ = createThreadSettledInServer(
+    threadId,
+    threadMeta$,
+  );
   const { selectedModel$, setModelSelection$ } = createModelSelection(
     threadId,
     threadMeta$,
@@ -3310,9 +2872,8 @@ export function createChatThreadSignals(
     dataSource,
   });
   const workflowComposer = createWorkflowComposerSignals(draft);
-  const phraseLoop = createPhraseLoop(
+  const thinkingIndicator = createThinkingIndicatorSignals(
     messages.groupedChatMessages$,
-    runTracking.allFinished$,
   );
   const artifact = createArtifacts(threadId, messages.groupedChatMessages$);
   return {
@@ -3321,8 +2882,10 @@ export function createChatThreadSignals(
     threadDraft$,
     threadMeta$,
     reloadThread$,
+    threadTitle$,
     threadTitleEmoji$,
     threadTitleText$,
+    threadSettledInServer$,
     selectedModel$,
     setModelSelection$,
     ...computerUseHostSelection,
@@ -3357,7 +2920,7 @@ export function createChatThreadSignals(
     resetRenderedChatGroupsIfAtBottom$:
       messages.resetRenderedChatGroupsIfAtBottom$,
     subscribeChatThread$: runTracking.subscribeChatThread$,
-    ...phraseLoop,
+    ...thinkingIndicator,
     ...artifact,
   };
 }

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -124,11 +124,6 @@ export interface ZeroChatAttachment {
   upload$: Command<Promise<void>, [AbortSignal]>;
 }
 
-export interface AttachmentUploadSummary {
-  attachmentCount: number;
-  readyCount: number;
-}
-
 function createChatAttachment(file: File): ZeroChatAttachment {
   const contentType = inferUploadContentType(file);
   const resetSignal$ = resetSignal();
@@ -217,7 +212,7 @@ export interface DraftSignals {
     [GenerationTemplateRequest | undefined]
   >;
   attachments$: Computed<ZeroChatAttachment[]>;
-  attachmentUploadSummary$: Computed<Promise<AttachmentUploadSummary>>;
+  attachmentUploadsReady$: Computed<boolean | Promise<boolean>>;
   uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
   restoreAttachments$: Command<void, [PersistedAttachment[]]>;
   removeAttachment$: Command<void, [ZeroChatAttachment]>;
@@ -330,31 +325,38 @@ export function createDraftSignals(): DraftSignals {
     return get(internalAttachments$);
   });
 
-  const attachmentUploadSummary$ = computed(
-    async (get): Promise<AttachmentUploadSummary> => {
+  const attachmentUploadsReady$ = computed(
+    (get): boolean | Promise<boolean> => {
       const attachments = get(internalAttachments$);
-      const infos = await Promise.all(
-        attachments.map((attachment) => {
-          return get(attachment.fileInfo$);
-        }),
-      );
-      return {
-        attachmentCount: attachments.length,
-        readyCount: infos.filter((info) => {
-          return info !== null;
-        }).length,
-      };
+      if (attachments.length === 0) {
+        return true;
+      }
+      const fileInfos = attachments.map((attachment) => {
+        return get(attachment.fileInfo$);
+      });
+      return (async () => {
+        const infos = await Promise.all(fileInfos);
+        if (
+          infos.some((info) => {
+            return info === null;
+          })
+        ) {
+          throw new Error("Attachment upload did not start");
+        }
+        return true;
+      })();
     },
   );
 
   const uploadAttachment$ = command(
     async ({ set }, file: File, signal: AbortSignal) => {
       const attachment = createChatAttachment(file);
+      const upload = set(attachment.upload$, signal);
       set(internalAttachments$, (prev) => {
         return [...prev, attachment];
       });
 
-      await tapError(set(attachment.upload$, signal), () => {
+      await tapError(upload, () => {
         set(internalAttachments$, (prev) => {
           return prev.filter((a) => {
             return a !== attachment;
@@ -399,10 +401,13 @@ export function createDraftSignals(): DraftSignals {
     set(draftInput.setInput$, "");
     set(internalGenerationTemplate$, undefined);
     // Cancel all pending uploads before clearing
-    for (const attachment of get(internalAttachments$)) {
+    const attachments = get(internalAttachments$);
+    for (const attachment of attachments) {
       set(attachment.cancel$);
     }
-    set(internalAttachments$, []);
+    if (attachments.length > 0) {
+      set(internalAttachments$, []);
+    }
     set(internalDragOver$, false);
   });
 
@@ -418,7 +423,7 @@ export function createDraftSignals(): DraftSignals {
     generationTemplate$,
     setGenerationTemplate$,
     attachments$,
-    attachmentUploadSummary$,
+    attachmentUploadsReady$,
     uploadAttachment$,
     restoreAttachments$,
     removeAttachment$,
@@ -466,13 +471,6 @@ const zeroChatInput$ = computed((get) => {
 export const zeroChatAttachments$ = computed((get) => {
   const draft = get(currentDraft$);
   return draft ? get(draft.attachments$) : [];
-});
-
-export const zeroChatAttachmentUploadSummary$ = computed(async (get) => {
-  const draft = get(currentDraft$);
-  return draft
-    ? await get(draft.attachmentUploadSummary$)
-    : { attachmentCount: 0, readyCount: 0 };
 });
 
 export const uploadZeroAttachment$ = command(

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -214,32 +214,6 @@ body {
   animation: zero-tagline-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
-/* Shimmer text effect for active/thinking states */
-@keyframes zero-shimmer {
-  0% {
-    background-position: 100% center;
-  }
-  100% {
-    background-position: -100% center;
-  }
-}
-.zero-shimmer-text {
-  background: linear-gradient(
-    90deg,
-    hsl(var(--muted-foreground) / 0.8) 0%,
-    hsl(var(--muted-foreground) / 0.8) 35%,
-    hsl(var(--foreground)) 48%,
-    hsl(var(--foreground)) 52%,
-    hsl(var(--muted-foreground) / 0.8) 65%,
-    hsl(var(--muted-foreground) / 0.8) 100%
-  );
-  background-size: 200% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  animation: zero-shimmer 3.5s linear infinite;
-}
-
 /* Thinking indicator: 3-block loader */
 .zero-blocks {
   display: inline-grid;
@@ -254,30 +228,16 @@ body {
   background: var(--zb-c1);
   grid-column: 2;
   grid-row: 1;
-  animation: zero-block-pop 1.4s ease-in-out infinite;
 }
 .zero-blocks span:nth-child(2) {
   background: var(--zb-c2);
   grid-column: 1;
   grid-row: 2;
-  animation: zero-block-pop 1.4s ease-in-out 0.2s infinite;
 }
 .zero-blocks span:nth-child(3) {
   background: var(--zb-c3);
   grid-column: 2;
   grid-row: 2;
-  animation: zero-block-pop 1.4s ease-in-out 0.4s infinite;
-}
-@keyframes zero-block-pop {
-  0%,
-  100% {
-    transform: scale(0.8);
-    opacity: 0.5;
-  }
-  50% {
-    transform: scale(1);
-    opacity: 1;
-  }
 }
 
 /* Zero app: inherits global cool gray tokens; only card-specific tokens defined here */

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -756,129 +756,6 @@ function setScrollMetrics(
   });
 }
 
-function mockThinkingTypewriterLayout({
-  text,
-  labelWidth,
-  parentWidth,
-  graphemeWidth,
-  measureTextWidth = (value) => {
-    return Array.from(value).length * graphemeWidth;
-  },
-}: {
-  readonly text: string;
-  readonly labelWidth: number;
-  readonly parentWidth: number;
-  readonly graphemeWidth: number;
-  readonly measureTextWidth?: (value: string) => number;
-}): void {
-  const getContextDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLCanvasElement.prototype,
-    "getContext",
-  );
-  const getBoundingClientRectDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLElement.prototype,
-    "getBoundingClientRect",
-  );
-  const clientWidthDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLElement.prototype,
-    "clientWidth",
-  );
-
-  const rectForWidth = (width: number): DOMRect => {
-    return {
-      bottom: 20,
-      height: 20,
-      left: 0,
-      right: width,
-      toJSON: () => {
-        return {};
-      },
-      top: 0,
-      width,
-      x: 0,
-      y: 0,
-    } as DOMRect;
-  };
-  const elementWidth = (el: HTMLElement): number => {
-    if (el.getAttribute("aria-label") === text) {
-      return labelWidth;
-    }
-    if (
-      Array.from(el.children).some((child) => {
-        return child.getAttribute("aria-label") === text;
-      })
-    ) {
-      return parentWidth;
-    }
-    return 0;
-  };
-
-  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
-    configurable: true,
-    value: (contextId: string) => {
-      if (contextId !== "2d") {
-        return null;
-      }
-      return {
-        measureText: (value: string) => {
-          return {
-            width: measureTextWidth(value),
-          } as TextMetrics;
-        },
-      } as CanvasRenderingContext2D;
-    },
-  });
-  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
-    configurable: true,
-    value(this: HTMLElement) {
-      return rectForWidth(elementWidth(this));
-    },
-  });
-  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
-    configurable: true,
-    get(this: HTMLElement) {
-      return elementWidth(this);
-    },
-  });
-
-  context.signal.addEventListener(
-    "abort",
-    () => {
-      if (getContextDescriptor) {
-        Object.defineProperty(
-          HTMLCanvasElement.prototype,
-          "getContext",
-          getContextDescriptor,
-        );
-      }
-      if (!getContextDescriptor) {
-        Reflect.deleteProperty(HTMLCanvasElement.prototype, "getContext");
-      }
-      if (getBoundingClientRectDescriptor) {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          "getBoundingClientRect",
-          getBoundingClientRectDescriptor,
-        );
-      }
-      if (!getBoundingClientRectDescriptor) {
-        Reflect.deleteProperty(HTMLElement.prototype, "getBoundingClientRect");
-      }
-      if (clientWidthDescriptor) {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          "clientWidth",
-          clientWidthDescriptor,
-        );
-      }
-      if (!clientWidthDescriptor) {
-        Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
-      }
-    },
-    { once: true },
-  );
-}
-
 function mockResizeObserver(): { triggerAll: () => void } {
   const originalDescriptor = Object.getOwnPropertyDescriptor(
     globalThis,
@@ -7523,53 +7400,21 @@ describe("initial thinking indicator", () => {
     threadGate.resolve();
   });
 
-  it("restarts on every follow-up line instead of sliding a short tail", async () => {
-    const threadId = "thread-initial-thinking-rollover";
-    const thinking = "ABCDEFG";
-    mockThinkingTypewriterLayout({
-      text: thinking,
-      labelWidth: 38,
-      parentWidth: 160,
-      graphemeWidth: 10,
-      measureTextWidth: (value) => {
-        return (
-          Array.from(value).filter((grapheme) => {
-            return grapheme !== ".";
-          }).length * 10
-        );
-      },
-    });
-    const displayedLabels = new Set<string>();
-    const labelObserver = new MutationObserver(() => {
-      const label = document.querySelector(`[aria-label="${thinking}"]`);
-      if (label?.textContent) {
-        displayedLabels.add(label.textContent);
-      }
-    });
-    labelObserver.observe(document.body, {
-      childList: true,
-      characterData: true,
-      subtree: true,
-    });
-    context.signal.addEventListener(
-      "abort",
-      () => {
-        labelObserver.disconnect();
-      },
-      { once: true },
-    );
+  it("renders the full thinking text without incremental animation", async () => {
+    const threadId = "thread-initial-thinking-full-text";
+    const thinking = "Reviewing the complete request";
     mockChatLifecycle(context, {
       threadId,
       chatMessages: [
         {
-          id: "msg-thinking-rollover-user",
+          id: "msg-thinking-full-text-user",
           role: "user",
           content: "Draft a launch checklist",
           runId: "run-active",
           createdAt: "2026-03-10T00:00:00Z",
         },
         {
-          id: "msg-thinking-rollover-marker",
+          id: "msg-thinking-full-text-marker",
           role: "assistant",
           content: null,
           thinking,
@@ -7586,22 +7431,7 @@ describe("initial thinking indicator", () => {
     });
 
     const label = await screen.findByLabelText(thinking);
-    const sawFollowUpLine = () => {
-      if (label.textContent) {
-        displayedLabels.add(label.textContent);
-      }
-      return Array.from(displayedLabels).some((value) => {
-        return value === "D" || value === "DE" || value === "DEF";
-      });
-    };
-    await waitFor(() => {
-      expect(sawFollowUpLine()).toBeTruthy();
-    });
-    await waitFor(() => {
-      expect(label).toHaveTextContent(/^G$/);
-    });
-    expect(displayedLabels.has("...EFG")).toBeFalsy();
-    expect(label).not.toHaveTextContent(thinking);
+    expect(label).toHaveTextContent(thinking);
     expect(label.closest("[data-thinking-indicator]")).not.toBeNull();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/model-provider-picker.tsx
@@ -774,17 +774,19 @@ function ModelFirstSelectPicker({
           />
         </SelectValue>
       </SelectTrigger>
-      <ModelFirstModelPickerContent
-        selectValue={state.selectValue}
-        placeholder={placeholder}
-        policies={state.policies}
-        selectableValue={state.selectableValue}
-        limitedFree1={limitedFree1}
-        codexFastModeAvailable={state.codexFastModeAvailable}
-        selectedModel={state.selectedModel}
-        codexServiceTier={state.codexServiceTier}
-        onChange={onChange}
-      />
+      {open !== false && (
+        <ModelFirstModelPickerContent
+          selectValue={state.selectValue}
+          placeholder={placeholder}
+          policies={state.policies}
+          selectableValue={state.selectableValue}
+          limitedFree1={limitedFree1}
+          codexFastModeAvailable={state.codexFastModeAvailable}
+          selectedModel={state.selectedModel}
+          codexServiceTier={state.codexServiceTier}
+          onChange={onChange}
+        />
+      )}
     </Select>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -6728,7 +6728,9 @@ function useResolvedComposerSignals(
     | undefined,
 ) {
   const attachments = useGet(draft.attachments$);
-  const attachmentUploadSummary = useLoadable(draft.attachmentUploadSummary$);
+  const attachmentUploadsState = useLoadableState(
+    draft.attachmentUploadsReady$,
+  );
   const readInput = useSet(draft.readInput$);
   const setInput = useSet(draft.setInput$);
   const uploadAttachment = useSet(draft.uploadAttachment$);
@@ -6748,7 +6750,7 @@ function useResolvedComposerSignals(
     readInput,
     setInput,
     attachments,
-    attachmentUploadSummary,
+    attachmentUploadsState,
     uploadAttachment,
     restoreAttachments,
     removeAttachment,
@@ -7137,7 +7139,7 @@ export function useZeroChatComposer({
     readInput,
     setInput,
     attachments,
-    attachmentUploadSummary,
+    attachmentUploadsState,
     uploadAttachment,
     restoreAttachments,
     removeAttachment,
@@ -7156,10 +7158,7 @@ export function useZeroChatComposer({
     attachments,
     visualAttachmentUnsupported,
   );
-  const uploadsReady =
-    attachmentUploadSummary.state === "hasData" &&
-    attachmentUploadSummary.data.readyCount ===
-      attachmentUploadSummary.data.attachmentCount;
+  const uploadsReady = attachmentUploadsState === "hasData";
 
   // When feedback fragments are present the composer is in "feedback mode": the
   // textarea is replaced by the stacked quote + note rows and Send dispatches

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -255,7 +255,6 @@ import {
   type PagedChatMessage,
 } from "../../signals/chat-page/chat-message.ts";
 import type { ChatThreadSignals } from "../../signals/chat-page/chat-thread-signals.ts";
-import type { ThreadMeta } from "../../signals/chat-page/chat-thread-event-sourcing.ts";
 import {
   applyChatThreadEmoji,
   removeChatThreadEmoji,
@@ -443,7 +442,7 @@ export function AutomationMenuButton({
   );
 }
 function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
-  const threadMetaLoadable = useLastLoadable(thread.threadMeta$);
+  const threadTitleLoadable = useLastLoadable(thread.threadTitle$);
   const threadTitleEmoji = useLastResolved(thread.threadTitleEmoji$);
   const threadTitleText = useLastResolved(thread.threadTitleText$) ?? "";
   const openRenameChatThreadDialog = useSet(
@@ -451,8 +450,8 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   );
   const pageSignal = useGet(pageSignal$);
   const threadTitle =
-    threadMetaLoadable.state === "hasData"
-      ? (threadMetaLoadable.data?.title?.trim() ?? "")
+    threadTitleLoadable.state === "hasData"
+      ? (threadTitleLoadable.data?.trim() ?? "")
       : "";
 
   function openRenameDialog(event: ReactMouseEvent<HTMLSpanElement>) {
@@ -466,7 +465,7 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
       <div className="flex min-w-0 items-center gap-2">
-        {threadMetaLoadable.state === "loading" ? (
+        {threadTitleLoadable.state === "loading" ? (
           <Skeleton className="h-5 w-48 rounded" />
         ) : (
           <>
@@ -2753,24 +2752,18 @@ type LoadableValue<T> =
   | { state: "hasError"; error: unknown };
 
 function resolveSessionError(
-  threadMetaLoadable: LoadableValue<ThreadMeta | null>,
+  threadSettledInServerLoadable: LoadableValue<boolean>,
   groupsLoadable: LoadableValue<GroupedChatMessageGroup[]>,
 ): string | null {
-  if (threadMetaLoadable.state === "hasError") {
-    return threadMetaLoadable.error instanceof Error
-      ? threadMetaLoadable.error.message
+  if (threadSettledInServerLoadable.state === "hasError") {
+    return threadSettledInServerLoadable.error instanceof Error
+      ? threadSettledInServerLoadable.error.message
       : "Failed to load chat";
   }
   if (groupsLoadable.state === "hasError") {
     return groupsLoadable.error instanceof Error
       ? groupsLoadable.error.message
       : "Failed to load messages";
-  }
-  if (
-    threadMetaLoadable.state === "hasData" &&
-    threadMetaLoadable.data === null
-  ) {
-    return "Chat not found";
   }
   return null;
 }
@@ -2781,26 +2774,17 @@ const CHAT_RENDER_LOAD_MORE_TOP_THRESHOLD_PX = 100;
 
 function ChatThreadMessagesMain({
   thread,
-  groups,
-  activeGroups,
   renderedGroups,
   sessionError,
   skeletonVisible,
-  messagesLoading,
+  showEmptyState,
 }: {
   thread: ChatThreadSignals;
-  groups: GroupedChatMessageGroup[];
-  activeGroups: GroupedChatMessageGroup[];
   renderedGroups: GroupedChatMessageGroup[];
   sessionError: string | null;
   skeletonVisible: boolean;
-  messagesLoading: boolean;
+  showEmptyState: boolean;
 }) {
-  const showEmptyState =
-    !sessionError &&
-    groups.length === 0 &&
-    !messagesLoading &&
-    !skeletonVisible;
   const { activeGroups: renderedActiveGroups } =
     splitQueuedMessagesForThinkingIndicator(renderedGroups);
   const runGroupExpandedKeys = useGet(runGroupExpandedKeys$);
@@ -2856,10 +2840,23 @@ function ChatThreadMessagesMain({
           completedWorkExpandedKeys={completedWorkExpandedKeys}
           onToggleCompletedWork={toggleCompletedWorkExpanded}
         />
-        <ThinkingIndicator thread={thread} groups={activeGroups} />
+        <ChatThreadThinkingIndicator thread={thread} />
       </div>
     </main>
   );
+}
+
+function ChatThreadThinkingIndicator({
+  thread,
+}: {
+  thread: ChatThreadSignals;
+}) {
+  const groups =
+    useLastResolved(thread.groupedChatMessages$, {
+      equalityFn: equalArrays,
+    }) ?? [];
+  const { activeGroups } = splitQueuedMessagesForThinkingIndicator(groups);
+  return <ThinkingIndicator thread={thread} groups={activeGroups} />;
 }
 
 function ChatThreadMessageGroups({
@@ -3633,27 +3630,32 @@ function ChatThreadSkeletonOverlay({
   );
 }
 
-function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
-  const groupsLoadable = useLastLoadable(thread.groupedChatMessages$, {
-    equalityFn: equalArrays,
-  });
+function ChatThreadMessagesPane({ thread }: { thread: ChatThreadSignals }) {
   const renderedGroupsLoadable = useLastLoadable(
     thread.renderedGroupedChatMessages$,
     { equalityFn: equalArrays },
   );
-  const threadMetaLoadable = useLastLoadable(thread.threadMeta$);
-  const sessionError = resolveSessionError(threadMetaLoadable, groupsLoadable);
-  const messagesLoading = groupsLoadable.state === "loading";
-  const groups = groupsLoadable.state === "hasData" ? groupsLoadable.data : [];
+  const threadSettledInServerLoadable = useLastLoadable(
+    thread.threadSettledInServer$,
+  );
+  const sessionError = resolveSessionError(
+    threadSettledInServerLoadable,
+    renderedGroupsLoadable,
+  );
   const renderedGroups =
     renderedGroupsLoadable.state === "hasData"
       ? renderedGroupsLoadable.data
       : [];
-  const { activeGroups } = splitQueuedMessagesForThinkingIndicator(groups);
   const setScrollContainer = useSet(thread.setScrollContainer$);
   const loadMoreRenderedChatGroups = useSet(thread.loadMoreRenderedChatGroups$);
   const pageSignal = useGet(pageSignal$);
-  const skeletonVisible = messagesLoading;
+  const skeletonVisible = renderedGroupsLoadable.state === "loading";
+  const showEmptyState =
+    sessionError === null &&
+    threadSettledInServerLoadable.state === "hasData" &&
+    threadSettledInServerLoadable.data &&
+    renderedGroupsLoadable.state === "hasData" &&
+    renderedGroups.length === 0;
 
   const handleScroll = (event: ReactUIEvent<HTMLDivElement>) => {
     if (
@@ -3665,40 +3667,43 @@ function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
   };
 
   return (
+    <div className="flex-1 min-h-0 relative isolate">
+      <div
+        ref={setScrollContainer}
+        data-scroll-container
+        tabIndex={-1}
+        onScroll={handleScroll}
+        className="absolute inset-0 overflow-y-auto focus:outline-none [overflow-anchor:none] [scrollbar-gutter:stable]"
+      >
+        <ChatThreadMessagesMain
+          thread={thread}
+          renderedGroups={renderedGroups}
+          sessionError={sessionError}
+          skeletonVisible={skeletonVisible}
+          showEmptyState={showEmptyState}
+        />
+      </div>
+      <ChatThreadSkeletonOverlay
+        sessionError={sessionError}
+        skeletonVisible={skeletonVisible}
+      />
+      <ScrollToBottomButton
+        thread={thread}
+        skeletonVisible={skeletonVisible}
+        sessionError={sessionError}
+      />
+    </div>
+  );
+}
+
+function ChatThreadContent({ thread }: { thread: ChatThreadSignals }) {
+  return (
     <>
       <ChatThreadHeader thread={thread} />
 
       <div className="relative min-h-0 flex-1">
         <div className="flex h-full min-w-0 flex-col">
-          <div className="flex-1 min-h-0 relative isolate">
-            <div
-              ref={setScrollContainer}
-              data-scroll-container
-              tabIndex={-1}
-              onScroll={handleScroll}
-              className="absolute inset-0 overflow-y-auto focus:outline-none [overflow-anchor:none] [scrollbar-gutter:stable]"
-            >
-              <ChatThreadMessagesMain
-                thread={thread}
-                groups={groups}
-                activeGroups={activeGroups}
-                renderedGroups={renderedGroups}
-                sessionError={sessionError}
-                skeletonVisible={skeletonVisible}
-                messagesLoading={messagesLoading}
-              />
-            </div>
-            <ChatThreadSkeletonOverlay
-              sessionError={sessionError}
-              skeletonVisible={skeletonVisible}
-            />
-            <ScrollToBottomButton
-              thread={thread}
-              skeletonVisible={skeletonVisible}
-              sessionError={sessionError}
-            />
-          </div>
-
+          <ChatThreadMessagesPane thread={thread} />
           <ChatThreadComposer thread={thread} />
         </div>
       </div>
@@ -4544,18 +4549,15 @@ interface ServerThinkingLabel {
   readonly displayedText: string;
   readonly fullText: string;
   readonly id: string;
-  readonly setRef: (
-    el: HTMLParagraphElement | null,
-  ) => (() => void) | undefined;
 }
 
 function ThinkingLabel({
   isQueued,
-  rotatingLabel,
+  thinkingLabel,
   serverThinkingLabel,
 }: {
   isQueued: boolean;
-  rotatingLabel: string;
+  thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
 }) {
   const openQueueDrawer = useSet(openQueueDrawer$);
@@ -4563,7 +4565,7 @@ function ThinkingLabel({
 
   if (isQueued) {
     return (
-      <p className="zero-shimmer-text min-w-0 flex-1 text-[0.8125rem] truncate">
+      <p className="text-muted-foreground min-w-0 flex-1 text-[0.8125rem] truncate">
         Waiting in{" "}
         <button
           type="button"
@@ -4582,8 +4584,7 @@ function ThinkingLabel({
     return (
       <p
         key={serverThinkingLabel.id}
-        ref={serverThinkingLabel.setRef}
-        className="zero-shimmer-text min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem]"
+        className="text-muted-foreground min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem]"
         aria-label={serverThinkingLabel.fullText}
       >
         {serverThinkingLabel.displayedText || "\u00a0"}
@@ -4592,8 +4593,8 @@ function ThinkingLabel({
   }
 
   return (
-    <p className="zero-shimmer-text min-w-0 flex-1 text-[0.8125rem] truncate">
-      {rotatingLabel}
+    <p className="text-muted-foreground min-w-0 flex-1 text-[0.8125rem] truncate">
+      {thinkingLabel}
     </p>
   );
 }
@@ -4601,12 +4602,12 @@ function ThinkingLabel({
 function InlineThinkingRow({
   blockStyle,
   isQueued,
-  rotatingLabel,
+  thinkingLabel,
   serverThinkingLabel,
 }: {
   blockStyle: CSSProperties;
   isQueued: boolean;
-  rotatingLabel: string;
+  thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
 }) {
   return (
@@ -4618,7 +4619,7 @@ function InlineThinkingRow({
       </span>
       <ThinkingLabel
         isQueued={isQueued}
-        rotatingLabel={rotatingLabel}
+        thinkingLabel={thinkingLabel}
         serverThinkingLabel={serverThinkingLabel}
       />
     </div>
@@ -4627,13 +4628,14 @@ function InlineThinkingRow({
 
 function FinishedRunRow({
   thread,
-  label,
   source,
 }: {
   thread: ChatThreadSignals;
-  label: string;
   source: RecommendedFollowupSource | null;
 }) {
+  const donePhrase = useLastResolved(thread.donePhrase$) ?? "Done";
+  const label = source ? "Keep going" : donePhrase;
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex h-5 flex-col justify-center gap-1.5">
@@ -4654,20 +4656,20 @@ function WaitingForAssistantResponse({
   thread,
   blockStyle,
   isQueued,
-  rotatingLabel,
+  thinkingLabel,
   serverThinkingLabel,
 }: {
   thread: ChatThreadSignals;
   blockStyle: CSSProperties;
   isQueued: boolean;
-  rotatingLabel: string;
+  thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
 }) {
   return (
     <div
       data-thinking-indicator
       data-role="assistant"
-      className="flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
+      className="flex flex-col gap-1"
     >
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />
@@ -4680,7 +4682,7 @@ function WaitingForAssistantResponse({
             </span>
             <ThinkingLabel
               isQueued={isQueued}
-              rotatingLabel={rotatingLabel}
+              thinkingLabel={thinkingLabel}
               serverThinkingLabel={serverThinkingLabel}
             />
           </div>
@@ -4701,19 +4703,17 @@ function AssistantThinkingStatusRow({
   running,
   blockStyle,
   isQueued,
-  rotatingLabel,
+  thinkingLabel,
   serverThinkingLabel,
   thread,
-  doneLabel,
   recommendedFollowupSource,
 }: {
   running: boolean;
   blockStyle: CSSProperties;
   isQueued: boolean;
-  rotatingLabel: string;
+  thinkingLabel: string;
   serverThinkingLabel?: ServerThinkingLabel;
   thread: ChatThreadSignals;
-  doneLabel: string;
   recommendedFollowupSource: RecommendedFollowupSource | null;
 }) {
   const thinkingIndicatorProps = running
@@ -4732,15 +4732,11 @@ function AssistantThinkingStatusRow({
           <InlineThinkingRow
             blockStyle={blockStyle}
             isQueued={isQueued}
-            rotatingLabel={rotatingLabel}
+            thinkingLabel={thinkingLabel}
             serverThinkingLabel={serverThinkingLabel}
           />
         ) : (
-          <FinishedRunRow
-            thread={thread}
-            label={doneLabel}
-            source={recommendedFollowupSource}
-          />
+          <FinishedRunRow thread={thread} source={recommendedFollowupSource} />
         )}
       </div>
     </div>
@@ -4841,24 +4837,17 @@ function ThinkingIndicator({
     messageRunIndicatorResolved,
     initialThinkingEnabled: true,
   });
-  const rotatingLabel = useGet(thread.rotatingPhrase$);
-  const donePhrase = useGet(thread.donePhrase$);
-  const displayedThinkingText =
-    useLastResolved(thread.displayedThinkingText$) ?? "";
-  const setThinkingIndicatorTextRef = useSet(
-    thread.setThinkingIndicatorTextRef$,
-  );
+  const thinkingLabel = useGet(thread.thinkingPhrase$);
+  const thinkingText = indicatorState.lastThinkingMessage?.thinking.trim();
   const serverThinkingLabel =
-    indicatorState.lastThinkingMessage && indicatorState.running
+    thinkingText && indicatorState.lastThinkingMessage && indicatorState.running
       ? {
-          displayedText: displayedThinkingText,
-          fullText: indicatorState.lastThinkingMessage.thinking.trim(),
+          displayedText: thinkingText,
+          fullText: thinkingText,
           id: indicatorState.lastThinkingMessage.id,
-          setRef: setThinkingIndicatorTextRef,
         }
       : undefined;
   const recommendedFollowupSource = latestRecommendedFollowups(groups);
-  const doneLabel = recommendedFollowupSource ? "Keep going" : donePhrase;
 
   if (
     !shouldRenderThinkingIndicator({
@@ -4884,10 +4873,9 @@ function ThinkingIndicator({
         running={indicatorState.running}
         blockStyle={blockStyle}
         isQueued={indicatorState.isQueued}
-        rotatingLabel={rotatingLabel}
+        thinkingLabel={thinkingLabel}
         serverThinkingLabel={serverThinkingLabel}
         thread={thread}
-        doneLabel={doneLabel}
         recommendedFollowupSource={recommendedFollowupSource}
       />
     );
@@ -4899,7 +4887,7 @@ function ThinkingIndicator({
       thread={thread}
       blockStyle={blockStyle}
       isQueued={indicatorState.isQueued}
-      rotatingLabel={rotatingLabel}
+      thinkingLabel={thinkingLabel}
       serverThinkingLabel={serverThinkingLabel}
     />
   );


### PR DESCRIPTION
## Summary

- replace timer-driven thinking animations and broad chat subscriptions with stable primitive ccstate signals
- isolate header, message, and composer update boundaries without React memoization, and avoid mounting closed model picker options
- expose primitive attachment upload readiness and document the React commit profiling workflow and results

## Performance verification

- `TiptapWorkflowComposer`: 11 executions to 4
- `ComposerModelPickerSlot`: 11 executions to 4
- message main/groups: 8 executions to 3
- closed picker `SelectItem`: 176 executions to 0
- final browser sample: 23 root commits and about 192 ms cumulative development-mode render duration

The browser sample did not reach a natural terminal run state, so the component isolation results are the reliable comparison rather than the raw commit total.

## Testing

- `pnpm format`
- `pnpm turbo run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types`
- `pnpm knip`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx --reporter=dot` (127 passed)
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx --reporter=dot` (62 passed)
- real-browser React commit and component-track profiling

The full Vitest suite was intentionally not run locally.
