### PR TITLE
fix: load webhook automations in chat threads

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -533,6 +533,60 @@ describe("zero workflow triggers", () => {
     ]);
   });
 
+  it("lists thread-bound webhook triggers", async () => {
+    const { fixture, workflowId } = await setupFixture("team");
+    await enableWebhookWorkflowTriggers(fixture);
+
+    const created = await accept(
+      triggersClient().create({
+        headers: authHeaders(),
+        params: { workflowId },
+        body: { kind: "event", eventType: "webhook-received" },
+      }),
+      [201],
+    );
+    if (
+      created.body.kind !== "event" ||
+      created.body.eventType !== "webhook-received" ||
+      !created.body.chatThreadId
+    ) {
+      throw new Error("Expected a thread-bound webhook trigger");
+    }
+
+    const listed = await accept(
+      triggersClient().listForChatThread({
+        headers: authHeaders(),
+        params: { threadId: created.body.chatThreadId },
+      }),
+      [200],
+    );
+    const [listedTrigger] = listed.body;
+    expect(listedTrigger).toMatchObject({
+      id: created.body.id,
+      kind: "event",
+      eventType: "webhook-received",
+      eventConfig: {
+        provider: "webhook",
+        event: "received",
+        auth: { mode: "hmac-sha256" },
+      },
+      chatThreadId: created.body.chatThreadId,
+      secretLastFour: created.body.secretLastFour,
+      disabledReason: null,
+      lastReceivedAt: null,
+      workflow: expect.objectContaining({ id: workflowId }),
+    });
+    if (
+      !listedTrigger ||
+      listedTrigger.kind !== "event" ||
+      listedTrigger.eventType !== "webhook-received"
+    ) {
+      throw new Error("Expected the webhook trigger to be listed");
+    }
+    expect(listedTrigger.webhookUrl).toBeUndefined();
+    expect(listedTrigger.webhookSecret).toBeUndefined();
+  });
+
   it("stores trigger chat threads at the workflow-user level", async () => {
     const { workflowId } = await setupFixture();
     const first = await accept(

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -857,43 +857,18 @@ function chatThreadTriggerFromSummary(args: {
   if (!summary || chatThreadId === null) {
     return [];
   }
-  const base = {
-    id: summary.id,
-    enabled: summary.enabled,
-    chatThreadId,
-    nextRunAt: summary.nextRunAt,
-    lastRunAt: summary.lastRunAt,
-    ownerUserId: summary.ownerUserId,
-    workflow: {
-      id: workflow.id,
-      agentId: workflow.agentId,
-      name: workflow.name,
-      displayName: workflow.displayName,
-      description: workflow.description,
-    },
-  };
-  if (summary.kind === "schedule") {
-    return [
-      {
-        ...base,
-        kind: "schedule",
-        schedule: summary.schedule,
-        scheduleSummary: summary.scheduleSummary,
-      },
-    ];
-  }
-  if (summary.kind !== "event") {
-    return [];
-  }
   return [
     {
-      ...base,
-      kind: "event",
-      eventType: summary.eventType,
-      eventConfig: summary.eventConfig,
-      schedule: null,
-      scheduleSummary: null,
-    } as ChatThreadWorkflowTrigger,
+      ...summary,
+      chatThreadId,
+      workflow: {
+        id: workflow.id,
+        agentId: workflow.agentId,
+        name: workflow.name,
+        displayName: workflow.displayName,
+        description: workflow.description,
+      },
+    },
   ];
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -36,6 +36,7 @@ import { zeroGoalsContract } from "@vm0/api-contracts/contracts/zero-goals";
 import {
   zeroWorkflowsCollectionContract,
   zeroWorkflowTriggersContract,
+  type ChatThreadWorkflowTrigger,
   type ZeroWorkflowTriggerUpdateRequest,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import {
@@ -4633,6 +4634,44 @@ describe("chat lifecycle", () => {
     expect(
       within(editDialog).queryByLabelText("Interval seconds"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows webhook automations in the sidebar without edit controls", async () => {
+    const trigger: ChatThreadWorkflowTrigger = {
+      id: "e0000001-0000-4000-a000-000000000006",
+      ownerUserId: "test-user-123",
+      enabled: true,
+      chatThreadId: AUTOMATION_THREAD_ID,
+      nextRunAt: null,
+      lastRunAt: null,
+      workflow: {
+        id: "a0000001-0000-4000-a000-000000000006",
+        agentId: AGENT_ID,
+        name: "webhook-sync",
+        displayName: "Webhook sync",
+        description: "Sync external webhook events",
+      },
+      kind: "event",
+      eventType: "webhook-received",
+      eventConfig: {
+        provider: "webhook",
+        event: "received",
+        auth: { mode: "hmac-sha256" },
+      },
+      schedule: null,
+      scheduleSummary: null,
+      secretLastFour: "cafe",
+      disabledReason: null,
+      lastReceivedAt: null,
+    };
+
+    const sidebar = await openAutomationSidebarWithWorkflowTrigger(trigger);
+
+    expect(within(sidebar).getByText("Webhook sync")).toBeInTheDocument();
+    expect(within(sidebar).getByText("Webhook automation")).toBeInTheDocument();
+    expect(within(sidebar).getByText("View")).toBeInTheDocument();
+    expect(within(sidebar).getByText("Run now")).toBeInTheDocument();
+    expect(within(sidebar).queryByText("Edit")).not.toBeInTheDocument();
   });
 
   it("updates a schedule workflow automation from the sidebar", async () => {

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -697,6 +697,13 @@ export const chatThreadWorkflowNotionPageContentUpdatedTriggerSchema =
     scheduleSummary: z.null(),
   });
 
+export const chatThreadWorkflowWebhookReceivedTriggerSchema =
+  zeroWorkflowWebhookReceivedTriggerSummarySchema.extend({
+    id: z.string().uuid(),
+    chatThreadId: z.string().min(1),
+    workflow: chatThreadWorkflowSchema,
+  });
+
 export const chatThreadWorkflowTriggerSchema = z.union([
   chatThreadWorkflowScheduleTriggerSchema,
   chatThreadWorkflowGmailNewMessageTriggerSchema,
@@ -709,6 +716,7 @@ export const chatThreadWorkflowTriggerSchema = z.union([
   chatThreadWorkflowNotionChildPageCreatedTriggerSchema,
   chatThreadWorkflowNotionDatabaseItemCreatedTriggerSchema,
   chatThreadWorkflowNotionPageContentUpdatedTriggerSchema,
+  chatThreadWorkflowWebhookReceivedTriggerSchema,
 ]);
 export type ChatThreadWorkflowTrigger = z.infer<
   typeof chatThreadWorkflowTriggerSchema


### PR DESCRIPTION
## Summary

- accept `webhook-received` in the chat-thread workflow-trigger response using the full public webhook summary shape
- preserve webhook summary metadata through the chat projection and remove the unsafe `as ChatThreadWorkflowTrigger` assertion
- keep webhook cards visible in the chat Automation panel with `View` and `Run now`, without an edit control
- add API and page-level regression coverage for webhook trigger listing and rendering

## User impact

Chat threads backed by webhook workflows no longer fail with HTTP 500 during response validation. Their webhook automation now loads in the chat sidebar without exposing the webhook URL or secret.

## Verification

- Prettier 3.8.1 check on all changed files
- `@vm0/api-contracts` type-check
- API type-check with a 4 GB Node heap
- Platform production and test type-check with a 4 GB Node heap
- package-scoped ESLint on all changed files
- targeted Platform Vitest: webhook automation sidebar behavior
- targeted API Vitest was attempted, but the local test database was unavailable (`ECONNREFUSED` during the onboarding fixture); CI will run the integration test with its database service

Fixes #21141

Follow-up to the incomplete, closed attempt in #20975.