### PR TITLE
test: remove deferred finally cleanup

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -1844,20 +1844,16 @@ describe("chat composer models", () => {
       await Promise.resolve();
     });
 
-    try {
-      expect(
-        screen.getByRole("combobox", {
-          hidden: true,
-          name: "Kimi K2.7 Code",
-        }),
-      ).toBeInTheDocument();
-      expect(screen.getByRole("listbox")).toBeInTheDocument();
-      expect(
-        screen.getByRole("option", { name: /Claude Sonnet 4\.6/ }),
-      ).toBeInTheDocument();
-    } finally {
-      pendingPreferenceReload.resolve();
-    }
+    expect(
+      screen.getByRole("combobox", {
+        hidden: true,
+        name: "Kimi K2.7 Code",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /Claude Sonnet 4\.6/ }),
+    ).toBeInTheDocument();
   });
 
   it("shows thread override over user and workspace defaults, then remains editable", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx
@@ -372,17 +372,13 @@ describe("zero chat thread IndexedDB fallback", () => {
       return respond(200, { messages: [], hasHistoryBefore: false });
     });
 
-    try {
-      detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-      await waitFor(() => {
-        expect(messageListRequests).toBeGreaterThan(0);
-        expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
-      });
-      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
-    } finally {
-      initialMessageList.resolve();
-    }
+    await waitFor(() => {
+      expect(messageListRequests).toBeGreaterThan(0);
+      expect(document.querySelector("[data-chat-skeleton]")).toBeNull();
+    });
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
   });
 
   it("keeps model and voice actions visible while uncached messages are blocked", async () => {
@@ -408,34 +404,30 @@ describe("zero chat thread IndexedDB fallback", () => {
       return never();
     });
 
-    try {
-      detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-      await waitFor(() => {
-        expect(messageListRequests).toBeGreaterThan(0);
-        expect(screen.getAllByText(THREAD_TITLE).length).toBeGreaterThan(0);
-      });
+    await waitFor(() => {
+      expect(messageListRequests).toBeGreaterThan(0);
+      expect(screen.getAllByText(THREAD_TITLE).length).toBeGreaterThan(0);
+    });
 
-      const composer = document.querySelector("[data-chat-composer]");
-      expect(composer).toBeInstanceOf(HTMLElement);
-      expect(
-        (composer as HTMLElement).querySelector(".animate-pulse"),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.getByRole("combobox", { name: THREAD_MODEL_LABEL }),
-      ).toBeInTheDocument();
-      expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
-      const sendButton = queryAllByRoleFast(
-        "button",
-        composer as HTMLElement,
-      ).find((button) => {
-        return button.getAttribute("aria-label") === "Send";
-      });
-      expect(sendButton).toBeInstanceOf(HTMLButtonElement);
-      expect(sendButton).toBeDisabled();
-    } finally {
-      initialMessageList.resolve();
-    }
+    const composer = document.querySelector("[data-chat-composer]");
+    expect(composer).toBeInstanceOf(HTMLElement);
+    expect(
+      (composer as HTMLElement).querySelector(".animate-pulse"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: THREAD_MODEL_LABEL }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
+    const sendButton = queryAllByRoleFast(
+      "button",
+      composer as HTMLElement,
+    ).find((button) => {
+      return button.getAttribute("aria-label") === "Send";
+    });
+    expect(sendButton).toBeInstanceOf(HTMLButtonElement);
+    expect(sendButton).toBeDisabled();
   });
 
   it("hides the model picker when an uncached thread has no selected model", async () => {
@@ -461,19 +453,15 @@ describe("zero chat thread IndexedDB fallback", () => {
       return never();
     });
 
-    try {
-      detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
+    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
 
-      await waitFor(() => {
-        expect(messageListRequests).toBeGreaterThan(0);
-        expect(screen.getAllByText(THREAD_TITLE).length).toBeGreaterThan(0);
-      });
+    await waitFor(() => {
+      expect(messageListRequests).toBeGreaterThan(0);
+      expect(screen.getAllByText(THREAD_TITLE).length).toBeGreaterThan(0);
+    });
 
-      expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
-      expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
-    } finally {
-      initialMessageList.resolve();
-    }
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Voice input")).toBeInTheDocument();
   });
 
   it("renders cached sidebar and chat messages while chat thread data APIs are blocked", async () => {


### PR DESCRIPTION
## Summary

Remove four cleanup-only `finally` blocks that manually resolved same-file `context.mocks.deferred()` gates. The test bodies now remain directly in their cases, avoiding cleanup behavior that is unnecessary after the assertions complete.

## Scan details

- Scan timestamp: `2026-07-13T03:02:08.830Z`
- Base commit: `80851d4728b5403a5d6c7efb1082ffed004c01d1`
- Tracked TypeScript/TSX test files scanned: 664
- Matched cleanup-only `finally` blocks: 4
- Files changed: 2
- Ambiguous matches skipped: 0

## Files changed

- `turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx`

## Verification

- `git diff --check`
- Prettier check on both changed files
- Oxlint, type-aware Oxlint, and ESLint on both changed files
- `pnpm vitest --run apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx` (62 passed)
- `pnpm vitest --run apps/platform/src/views/zero-page/__tests__/zero-chat-thread-idb.test.tsx` (5 passed)

Only high-confidence cleanup-only patterns identified by the workflow codemod were changed.
