### PR TITLE
fix(connectors): ignore unsupported stored connectors

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -188,6 +188,9 @@ function storedConnectorRowToResponse(
   authMethod: ConnectorAuthMethodId,
   now: Date,
 ): ExecutableConnectorResponse {
+  if (!getConnectorAuthMethod(type, authMethod)) {
+    throw new Error("Invalid stored connector auth method");
+  }
   const credentialStatus = connectorCredentialStatus({
     type,
     authMethod,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -188,9 +188,6 @@ function storedConnectorRowToResponse(
   authMethod: ConnectorAuthMethodId,
   now: Date,
 ): ExecutableConnectorResponse {
-  if (!getConnectorAuthMethod(type, authMethod)) {
-    throw new Error("Invalid stored connector auth method");
-  }
   const credentialStatus = connectorCredentialStatus({
     type,
     authMethod,

--- a/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-connector-data.service.ts
@@ -185,12 +185,9 @@ function parseStoredReconnectReason(
 function storedConnectorRowToResponse(
   row: StoredConnectorRow,
   type: ConnectorType,
+  authMethod: ConnectorAuthMethodId,
   now: Date,
 ): ExecutableConnectorResponse {
-  const authMethod = connectorAuthMethodIdSchema.parse(row.authMethod);
-  if (!getConnectorAuthMethod(type, authMethod)) {
-    throw new Error("Invalid stored connector auth method");
-  }
   const credentialStatus = connectorCredentialStatus({
     type,
     authMethod,
@@ -481,11 +478,25 @@ export function zeroConnectorList(args: {
     const now = nowDate();
     const connectorList: ExecutableConnectorResponse[] = storedRows.flatMap(
       (row) => {
-        const type = connectorTypeSchema.parse(row.type);
-        if (!storedConnectorTypeIsVisible(type, featureStates)) {
+        const type = connectorTypeSchema.safeParse(row.type);
+        if (
+          !type.success ||
+          !storedConnectorTypeIsVisible(type.data, featureStates)
+        ) {
           return [];
         }
-        return [storedConnectorRowToResponse(row, type, now)];
+        const authMethod = connectorAuthMethodIdSchema.safeParse(
+          row.authMethod,
+        );
+        if (
+          !authMethod.success ||
+          !getConnectorAuthMethod(type.data, authMethod.data)
+        ) {
+          return [];
+        }
+        return [
+          storedConnectorRowToResponse(row, type.data, authMethod.data, now),
+        ];
       },
     );
     const connectorProvidedBindings =
@@ -587,7 +598,21 @@ function storedConnectorByType(args: {
 
     const oauthRow = oauthRows[0];
     if (oauthRow) {
-      return storedConnectorRowToResponse(oauthRow, args.type, nowDate());
+      const authMethod = connectorAuthMethodIdSchema.safeParse(
+        oauthRow.authMethod,
+      );
+      if (
+        !authMethod.success ||
+        !getConnectorAuthMethod(args.type, authMethod.data)
+      ) {
+        return null;
+      }
+      return storedConnectorRowToResponse(
+        oauthRow,
+        args.type,
+        authMethod.data,
+        nowDate(),
+      );
     }
 
     return null;
@@ -1360,6 +1385,7 @@ export const connectManualGrantConnector$ = command(
       connector: storedConnectorRowToResponse(
         connectorRow,
         args.type,
+        args.authMethod,
         nowDate(),
       ),
     };
@@ -1435,6 +1461,7 @@ export const connectNoAuthConnector$ = command(
       connector: storedConnectorRowToResponse(
         connectorRow,
         args.type,
+        args.authMethod,
         nowDate(),
       ),
     };
@@ -2152,6 +2179,7 @@ export const upsertConnectorTokenConnection$ = command(
       connector: storedConnectorRowToResponse(
         connectionResult.connectorRow,
         args.type,
+        args.authMethod,
         nowDate(),
       ),
       created:


### PR DESCRIPTION
## Summary

- restore tolerant reads for persisted connector types that are no longer executable
- ignore stale or unsupported stored auth method IDs in list and by-type reads
- keep connector execution and new writes restricted to validated executable identities

## Impact

- prevents historical connector rows from causing request-level 500s in connector catalog status and Slack integration status
- protects every other `zeroConnectorList` consumer from the same data-dependent failure
- does not mutate or delete existing production records

## Explicit exclusions

- no production data cleanup or migration
- no new structured diagnostic event for skipped rows
- no API contract changes

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types` (completed by the pre-commit hook)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/zero-integrations-slack-status.test.ts --silent=passed-only` (2 files, 41 tests)
- `git diff --check`

Relates to #21159.

Regression introduced by #21128.
