### PR TITLE
perf(api): attribute runner notification latency

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -8397,15 +8397,14 @@ describe("CHAIN-RUN: sandbox snapshot and telemetry reporting through run webhoo
         }),
       ],
     );
-    const sandboxOperationIngestCall =
-      context.mocks.axiom.sdkIngest.mock.calls.find(([dataset]) => {
-        return dataset === "vm0-sandbox-op-log-dev";
-      });
-    expect(sandboxOperationIngestCall?.[1]).toStrictEqual([
-      expect.not.objectContaining({
-        session_history_ref_hash: "should-not-forward",
-      }),
-    ]);
+    const sessionHistoryDownloadEvents = sandboxOperationEventsForRunByAction(
+      created.runId,
+      "session_history_download",
+    );
+    expect(sessionHistoryDownloadEvents).toHaveLength(1);
+    expect(sessionHistoryDownloadEvents[0]).not.toHaveProperty(
+      "session_history_ref_hash",
+    );
 
     const observed = await webhooks.requestAgentModelUsageObservation(
       {

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -576,6 +576,15 @@ function sandboxOperationEventsForRun(
   });
 }
 
+function sandboxOperationEventsForRunByAction(
+  runId: string,
+  actionType: string,
+): readonly Record<string, unknown>[] {
+  return sandboxOperationEventsForRun(runId).filter((event) => {
+    return event.op_type === actionType;
+  });
+}
+
 function sandboxOperationDurationForRun(
   runId: string,
   actionType: string,
@@ -2749,6 +2758,30 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     expect(apiToRunnerQueueMs + runnerQueueToClaimRequestMs).toBe(
       apiToClaimRequestMs,
     );
+    for (const actionType of [
+      "runner_notification_queue_to_entry",
+      "runner_notification_affinity_lookup",
+      "runner_notification_queue_to_publish_start",
+    ]) {
+      const events = sandboxOperationEventsForRunByAction(
+        protectedFollowUp.runId,
+        actionType,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          op_type: actionType,
+          sandbox_type: "runner",
+          duration_ms: 0,
+          success: true,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          notification_target: "broadcast",
+          session_affinity: "protected",
+        }),
+      );
+    }
     await api.requestCancelRun(actor, protectedFollowUp.runId, [200]);
 
     const expiredFollowUp = await api.createRun(actor, {
@@ -3134,6 +3167,30 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
     expect(apiToRunnerQueueMs + runnerQueueToClaimRequestMs).toBe(
       apiToClaimRequestMs,
     );
+    for (const actionType of [
+      "runner_notification_queue_to_entry",
+      "runner_notification_affinity_lookup",
+      "runner_notification_queue_to_publish_start",
+    ]) {
+      const events = sandboxOperationEventsForRunByAction(
+        third.runId,
+        actionType,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toStrictEqual(
+        expect.objectContaining({
+          source: "api",
+          op_type: actionType,
+          sandbox_type: "runner",
+          duration_ms: 0,
+          success: true,
+          runner_group: runnerGroup,
+          profile: "vm0/default",
+          notification_target: "broadcast",
+          session_affinity: "no_session",
+        }),
+      );
+    }
     await expect(readAutomationsFakeKmsDecryptCallCount(context)).resolves.toBe(
       decryptCountBeforeClaim,
     );

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -1,6 +1,6 @@
 import { publishRunnerJobNotification } from "../external/realtime";
 import { recordSandboxOperations } from "../external/sandbox-op-log";
-import { now, nowDate } from "../external/time";
+import { now } from "../external/time";
 import { logger } from "../../lib/log";
 import type { Db } from "../external/db";
 import {
@@ -21,7 +21,8 @@ export async function notifyRunnerJob(
     readonly createdAt: Date;
   },
 ): Promise<boolean> {
-  const currentDate = nowDate();
+  const notificationEnteredAt = now();
+  const currentDate = new Date(notificationEnteredAt);
   const affinityResult = await settle(
     runnerSessionAffinityProtection({
       db,
@@ -32,6 +33,7 @@ export async function notifyRunnerJob(
       currentDate,
     }),
   );
+  const affinityFinishedAt = now();
   const affinity = affinityResult.ok
     ? affinityResult.value
     : runnerSessionAffinityLookupError();
@@ -61,7 +63,33 @@ export async function notifyRunnerJob(
     notification_target: "broadcast",
     session_affinity: affinity.status,
   };
+  // Queue-relative actions are cumulative boundaries. Affinity and publish
+  // durations are nested children and must not be added to those boundaries.
   recordSandboxOperations([
+    {
+      sandboxType: "runner",
+      actionType: "runner_notification_queue_to_entry",
+      durationMs: Math.max(0, notificationEnteredAt - args.createdAt.getTime()),
+      success: true,
+      runId: args.runId,
+      dimensions,
+    },
+    {
+      sandboxType: "runner",
+      actionType: "runner_notification_affinity_lookup",
+      durationMs: Math.max(0, affinityFinishedAt - notificationEnteredAt),
+      success: affinityResult.ok,
+      runId: args.runId,
+      dimensions,
+    },
+    {
+      sandboxType: "runner",
+      actionType: "runner_notification_queue_to_publish_start",
+      durationMs: Math.max(0, publishStartedAt - args.createdAt.getTime()),
+      success: true,
+      runId: args.runId,
+      dimensions,
+    },
     {
       sandboxType: "runner",
       actionType: "runner_notification_realtime_publish",


### PR DESCRIPTION
## Summary

- add queue-to-entry, affinity lookup, and queue-to-publish-start timings to runner notification telemetry
- preserve the existing realtime publish timing and low-cardinality dimensions
- cover protected direct dispatch and no-session queued promotion paths

## Scope

- additive telemetry only; notification ordering, affinity behavior, and publish behavior are unchanged
- no schema, persisted-data, queue-payload, API/runner protocol, or guest protocol changes

## Timing hierarchy

- `runner_notification_queue_to_entry` and `runner_notification_queue_to_publish_start` are cumulative queue-relative boundaries
- `runner_notification_affinity_lookup` and `runner_notification_realtime_publish` are nested durations and must not be added to the cumulative boundaries
- each action retains the existing runner group, profile, notification target, and session affinity dimensions

## Compatibility and rollback

- old and new API instances can overlap safely: old instances omit the three additive operations, while all instances preserve existing queue, discovery, claim, and publish records
- rollback removes only the new telemetry records and does not require data cleanup or coordinated runner deployment

## Post-deployment validation

Derive intervals per run before aggregation:

- queue to discovery = `runner_queue_to_claim_request - job_discovered_to_claim_request`
- publish start to discovery = queue to discovery minus `runner_notification_queue_to_publish_start`
- other entry-to-publish residual = queue to publish start minus queue to entry minus affinity lookup

After deployment and drain, report operation coverage, p50/p90/p95/p99/max, and negative derived-interval incidence. Do not subtract aggregate percentiles or silently clamp offline residuals. Select a behavior optimization only after these measurements identify the owner.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip`
- pre-commit hooks: prettier, knip, check-types, and commitlint

Closes #21156

Parent: #18746
