### PR TITLE
chore(rust): update uuid and zmij lockfile versions

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3690,9 +3690,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4263,9 +4263,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "bd2f034a4bebf216c9e4b7083603e024cf930873fd67830cfb083c9fa33129d9"
 
 [[package]]
 name = "zstd"


### PR DESCRIPTION
## Summary

- Refresh the Rust workspace lockfile with the latest compatible dependency releases.
- Update `uuid` from `1.23.4` to `1.23.5`.
- Update `zmij` from `1.0.21` to `1.0.22`.

## Dependencies not updated

- `generic-array` remains at `0.14.7` although `0.14.9` is available. `crypto-common 0.1.7` pins it exactly to `=0.14.7`, and the pin is transitive rather than a direct workspace constraint.

## Manual version bumps

- None. All direct workspace constraints already allow the latest compatible versions selected by Cargo.

## Test status

- `cargo test --workspace`: could not complete in the automation runner because the filesystem ran out of space while compiling/linking the workspace (`aws-lc-sys` and the `runner` test binary).
- Retried with incremental compilation disabled, debug information removed, and one build job; the runner still exhausted disk space while linking `runner`.
- `cargo test --workspace --exclude runner`: also could not complete because the filesystem ran out of space while linking the `guest-agent` integration test.
- No Rust compilation or test assertion failure was observed before the environment resource failures.
- `git diff --check`: passed.