### PR TITLE
test(connectors): cover unsupported stored identities

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-catalog.test.ts
@@ -8,9 +8,11 @@ import {
 import { zeroFeatureSwitchesContract } from "@vm0/api-contracts/contracts/zero-feature-switches";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { createStore } from "ccstate";
+import { sql } from "drizzle-orm";
 import { afterEach } from "vitest";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { db } from "../../../lib/db";
 import { now } from "../../../lib/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
 import {
@@ -33,6 +35,9 @@ const bdd = createBddApi(context);
 const connectorsApi = createConnectorBddApi(context);
 const authDevice = createAuthDeviceApiActions(context);
 const store = createStore();
+const REMOVED_CONNECTOR_TYPE = "removed-connector";
+const REMOVED_AUTH_CONNECTOR_TYPE = "github";
+const MISMATCHED_AUTH_CONNECTOR_TYPE = "gitlab";
 
 async function enableFeatureSwitches(
   orgId: string,
@@ -136,6 +141,10 @@ describe("GET /api/zero/connector-catalog", () => {
     readonly userId: string;
   }[] = [];
   const seededOrgs: OrgMembershipFixture[] = [];
+  const historicalConnectorFixtures: {
+    readonly orgId: string;
+    readonly userId: string;
+  }[] = [];
 
   async function enableConnectorFeatureSwitches(
     orgId: string,
@@ -157,6 +166,21 @@ describe("GET /api/zero/connector-catalog", () => {
       const fixture = seededOrgs.pop();
       if (fixture) {
         await store.set(deleteOrgMembership$, fixture, context.signal);
+      }
+    }
+    while (historicalConnectorFixtures.length > 0) {
+      const fixture = historicalConnectorFixtures.pop();
+      if (fixture) {
+        await db().execute(sql`
+          DELETE FROM connectors
+          WHERE org_id = ${fixture.orgId}
+            AND user_id = ${fixture.userId}
+            AND type IN (
+              ${REMOVED_CONNECTOR_TYPE},
+              ${REMOVED_AUTH_CONNECTOR_TYPE},
+              ${MISMATCHED_AUTH_CONNECTOR_TYPE}
+            )
+        `);
       }
     }
   });
@@ -639,6 +663,77 @@ describe("GET /api/zero/connector-catalog", () => {
     expect(openai?.connection).not.toHaveProperty("externalId");
     expect(openai?.connection).not.toHaveProperty("createdAt");
     expect(openai?.connection).not.toHaveProperty("updatedAt");
+  });
+
+  it("ignores unsupported historical connector identities", async () => {
+    const actor = bdd.user();
+    if (!actor.orgId) {
+      throw new Error("Historical connector fixture requires an organization");
+    }
+    await connectorsApi.connectManualGrant(actor, "openai", "api-token", {
+      apiKey: "sk-public-status",
+    });
+
+    // These rows model identities accepted by an older registry. The current
+    // production API cannot construct these historical states.
+    await db().execute(sql`
+      INSERT INTO connectors (type, auth_method, user_id, org_id)
+      VALUES
+        (${REMOVED_CONNECTOR_TYPE}, 'api-token', ${actor.userId}, ${actor.orgId}),
+        (${REMOVED_AUTH_CONNECTOR_TYPE}, 'removed-auth-method', ${actor.userId}, ${actor.orgId}),
+        (${MISMATCHED_AUTH_CONNECTOR_TYPE}, 'oauth', ${actor.userId}, ${actor.orgId})
+    `);
+    historicalConnectorFixtures.push({
+      orgId: actor.orgId,
+      userId: actor.userId,
+    });
+
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const client = setupApp({ context })(zeroConnectorCatalogContract);
+    const response = await accept(
+      client.status({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+
+    const openai = response.body.connectors.find((connector) => {
+      return connector.connectorRef === "openai";
+    });
+    expect(openai).toMatchObject({
+      connected: true,
+      connectionStatus: "connected",
+    });
+    const github = response.body.connectors.find((connector) => {
+      return connector.connectorRef === REMOVED_AUTH_CONNECTOR_TYPE;
+    });
+    expect(github).toMatchObject({
+      connected: false,
+      connection: null,
+      connectionStatus: "not-connected",
+    });
+    const gitlab = response.body.connectors.find((connector) => {
+      return connector.connectorRef === MISMATCHED_AUTH_CONNECTOR_TYPE;
+    });
+    expect(gitlab).toMatchObject({
+      connected: false,
+      connection: null,
+      connectionStatus: "not-connected",
+    });
+
+    const removedAuthConnector = await connectorsApi.requestReadConnectorByType(
+      actor,
+      REMOVED_AUTH_CONNECTOR_TYPE,
+      [404],
+    );
+    expect(removedAuthConnector.status).toBe(404);
+    const mismatchedAuthConnector =
+      await connectorsApi.requestReadConnectorByType(
+        actor,
+        MISMATCHED_AUTH_CONNECTOR_TYPE,
+        [404],
+      );
+    expect(mismatchedAuthConnector.status).toBe(404);
   });
 
   it("returns connected auth-code status without exposing stored scopes", async () => {

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-integrations-slack.test.ts
@@ -6,10 +6,12 @@ import type {
   TestSlackStateResponse,
 } from "@vm0/api-contracts/contracts/test-slack-state";
 import { zeroIntegrationsSlackContract } from "@vm0/api-contracts/contracts/zero-integrations-slack";
+import { sql } from "drizzle-orm";
 import { http, HttpResponse } from "msw";
 
 import { createApp } from "../../../app-factory";
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { db } from "../../../lib/db";
 import { server } from "../../../mocks/server";
 import { now } from "../../external/time";
 import { signSandboxJwtForTests } from "../../auth/tokens";
@@ -31,6 +33,9 @@ import {
 const context = testContext();
 const store = createStore();
 const SLACK_STATE_ROUTE = "/api/test/slack-state";
+const REMOVED_CONNECTOR_TYPE = "removed-connector";
+const REMOVED_AUTH_CONNECTOR_TYPE = "github";
+const MISMATCHED_AUTH_CONNECTOR_TYPE = "gitlab";
 
 interface SlackFixture {
   readonly userId: string;
@@ -134,12 +139,28 @@ async function deleteSlackConnection(fixture: SlackFixture): Promise<void> {
 
 describe("GET /api/zero/integrations/slack", () => {
   let fixture: SlackFixture;
+  const historicalConnectorFixtures: SlackFixture[] = [];
 
   beforeEach(async () => {
     fixture = await seedSlackFixture();
   });
 
   afterEach(async () => {
+    while (historicalConnectorFixtures.length > 0) {
+      const historicalFixture = historicalConnectorFixtures.pop();
+      if (historicalFixture) {
+        await db().execute(sql`
+          DELETE FROM connectors
+          WHERE org_id = ${historicalFixture.orgId}
+            AND user_id = ${historicalFixture.userId}
+            AND type IN (
+              ${REMOVED_CONNECTOR_TYPE},
+              ${REMOVED_AUTH_CONNECTOR_TYPE},
+              ${MISMATCHED_AUTH_CONNECTOR_TYPE}
+            )
+        `);
+      }
+    }
     await cleanupSlackFixture(fixture);
   });
 
@@ -344,6 +365,42 @@ describe("GET /api/zero/integrations/slack", () => {
         "SEC_A",
       ]);
       expect(response.body.environment!.missingVars).toStrictEqual(["VAR_A"]);
+    });
+
+    it("ignores unsupported historical connectors when loading environment", async () => {
+      await seedEnvironmentVersion();
+
+      // These rows model identities accepted by an older registry. The current
+      // production API cannot construct these historical states.
+      await db().execute(sql`
+        INSERT INTO connectors (type, auth_method, user_id, org_id)
+        VALUES
+          (${REMOVED_CONNECTOR_TYPE}, 'api-token', ${fixture.userId}, ${fixture.orgId}),
+          (${REMOVED_AUTH_CONNECTOR_TYPE}, 'removed-auth-method', ${fixture.userId}, ${fixture.orgId}),
+          (${MISMATCHED_AUTH_CONNECTOR_TYPE}, 'oauth', ${fixture.userId}, ${fixture.orgId})
+      `);
+      historicalConnectorFixtures.push(fixture);
+
+      mockAdminAuth();
+
+      const client = setupApp({ context })(zeroIntegrationsSlackContract);
+      const response = await accept(
+        client.getStatus({
+          headers: { authorization: "Bearer clerk-session" },
+        }),
+        [200],
+      );
+
+      expect(response.body).toMatchObject({
+        isConnected: true,
+        defaultAgentName: "Slack Bot",
+        environment: {
+          requiredSecrets: ["SEC_A"],
+          requiredVars: ["VAR_A"],
+          missingSecrets: ["SEC_A"],
+          missingVars: ["VAR_A"],
+        },
+      });
     });
 
     it("omits environment when isConnected is false", async () => {


### PR DESCRIPTION
## Summary

- add regression coverage for historical connector rows that the current production API cannot create
- verify connector catalog status, connector-by-type lookup, and Slack status/environment loading stay available
- cover a removed connector type, a removed authentication method, and an authentication method valid for a different connector
- keep this as a test-only follow-up to #21163 with no production behavior or data changes

Relates to #21159.

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-catalog.test.ts src/signals/routes/__tests__/zero-integrations-slack.test.ts --silent=passed-only` (54 tests passed)
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (594 files and 7390 tests passed; 1 existing benchmark file/test skipped)
- `pnpm knip`
- pre-commit formatting, Knip, type checks, file-size checks, and commitlint
