### PR TITLE
fix(mitm-addon): report non-streamable usage responses

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -68,10 +68,10 @@ def _log_streaming_decode_error(encoding_label: str, exc: Exception) -> None:
         ctx.log.debug(f"Streaming decompression failed ({encoding_label}): {exc}")
 
 
-def _log_streaming_decode_skipped(encoding_label: str, reason: str) -> None:
+def _log_streaming_decode_skipped(reason: str) -> None:
     with contextlib.suppress(AttributeError):
         # ctx.log unavailable outside mitmproxy runtime
-        ctx.log.debug(f"Streaming decompression skipped ({encoding_label}): {reason}")
+        ctx.log.debug(f"Streaming decompression skipped: {reason}")
 
 
 def _feed_chunks(feed: _StreamDecodeFeed, data: bytes, max_decoded_chunk: int) -> None:
@@ -145,13 +145,18 @@ def _stream_decode_skip_reason(encoding: str) -> str | None:
     return "unsupported content encoding"
 
 
+def stream_decode_skip_reason(headers: http.Headers) -> str | None:
+    """Return a fixed reason when usage streams cannot decode the response."""
+    encoding = headers.get("content-encoding", "").strip().lower()
+    return _stream_decode_skip_reason(encoding)
+
+
 def can_stream_decode_usage(headers: http.Headers) -> bool:
     """Return whether usage parsers can safely consume this response stream."""
-    encoding = headers.get("content-encoding", "").strip().lower()
-    reason = _stream_decode_skip_reason(encoding)
+    reason = stream_decode_skip_reason(headers)
     if reason is None:
         return True
-    _log_streaming_decode_skipped(encoding, reason)
+    _log_streaming_decode_skipped(reason)
     return False
 
 

--- a/crates/runner/mitm-addon/src/response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/src/response_encoding_negotiation.py
@@ -16,18 +16,23 @@ _Q_VALUE_PATTERN = re.compile(r"(?:0(?:\.[0-9]{1,3})?|1(?:\.0{1,3})?)")
 _HTTP_OWS_CHARS = " \t"
 
 
-def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool:
-    """Restrict Accept-Encoding to safe values for response-body inspection.
+def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> None:
+    """Best-effort restriction of Accept-Encoding for body inspection.
 
     The proxy inspects selected upstream responses for usage/billing.  For those
     requests, avoid negotiating encodings whose Python streaming decoders cannot
-    provide the needed bounded-output behavior.  The helper still respects an
-    explicit requester rejection of ``identity``.
+    provide the needed bounded-output behavior.
+
+    The helper preserves explicit requester rejections.  When ``identity`` and
+    every supported compression coding are rejected, the original header remains
+    unchanged and the actual response might not support bounded streaming
+    inspection.  Callers must use the response's ``Content-Encoding`` to decide
+    whether incremental body inspection is available.
     """
     values = headers.get_all(_ACCEPT_ENCODING)
     if not values:
         headers[_ACCEPT_ENCODING] = _IDENTITY
-        return True
+        return
 
     accepted_safe: dict[str, str | None] = {}
     rejected_safe: set[str] = set()
@@ -88,12 +93,13 @@ def normalize_accept_encoding_for_body_inspection(headers: http.Headers) -> bool
         rewritten = ", ".join(
             _format_coding(name, q_text) for name, q_text in accepted_safe.items()
         )
-        return _set_if_changed(headers, values, rewritten)
+        _set_if_changed(headers, values, rewritten)
+        return
 
     if identity_rejected:
-        return False
+        return
 
-    return _set_if_changed(headers, values, _IDENTITY)
+    _set_if_changed(headers, values, _IDENTITY)
 
 
 def _parse_coding(raw_coding: str) -> tuple[str, Decimal | None]:
@@ -156,8 +162,7 @@ def _add_wildcard_safe_compression_encodings(
             accepted_safe[name] = wildcard_q_text
 
 
-def _set_if_changed(headers: http.Headers, original_values: list[str], value: str) -> bool:
+def _set_if_changed(headers: http.Headers, original_values: list[str], value: str) -> None:
     if len(original_values) == 1 and original_values[0] == value:
-        return False
+        return
     headers[_ACCEPT_ENCODING] = value
-    return True

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -32,7 +32,10 @@ from usage.underbilling import log_usage_underbilling
 
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
 _HTTP_STATUS_OK_MIN = 200
+_HTTP_STATUS_NO_CONTENT = 204
+_HTTP_STATUS_RESET_CONTENT = 205
 _HTTP_STATUS_REDIRECT_MIN = 300
+_HTTP_STATUS_NOT_MODIFIED = 304
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
@@ -104,13 +107,29 @@ def _make_model_sse_parse_error_logger(
     return log_parse_error
 
 
-def _log_response_encoding_inspection_risk(
+def _response_can_have_body(flow: http.HTTPFlow, response: http.Response) -> bool:
+    """Return whether HTTP semantics permit content on this response."""
+    status_code = response.status_code
+    if status_code < _HTTP_STATUS_OK_MIN or status_code in (
+        _HTTP_STATUS_NO_CONTENT,
+        _HTTP_STATUS_RESET_CONTENT,
+        _HTTP_STATUS_NOT_MODIFIED,
+    ):
+        return False
+    method = flow.request.method.upper()
+    if method == "HEAD":
+        return False
+    return method != "CONNECT" or status_code >= _HTTP_STATUS_REDIRECT_MIN
+
+
+def _maybe_log_response_encoding_inspection_risk(
     flow: http.HTTPFlow,
-    *,
-    skip_reason: str,
+    response: http.Response,
 ) -> None:
-    response = flow.response
-    if response is None:
+    if not _response_can_have_body(flow, response):
+        return
+    skip_reason = body_decoding.stream_decode_skip_reason(response.headers)
+    if skip_reason is None:
         return
     log_usage_underbilling(
         flow_metadata.proxy_log_path(flow.metadata),
@@ -128,7 +147,8 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
     # Set up usage extraction for response classes that need body inspection.
     # The forensic stream_buffer remains capped; usage parsers consume chunks
     # separately so a large response cannot grow that buffer.
-    if not flow.response:
+    response = flow.response
+    if response is None:
         return None
 
     # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
@@ -147,7 +167,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
         return None
     if is_observable_model_provider:
-        content_type = flow.response.headers.get("content-type", "").lower()
+        content_type = response.headers.get("content-type", "").lower()
         if "text/event-stream" in content_type:
             if uses_openai_responses_usage_protocol(flow):
                 usage_protocol = "openai_responses_sse"
@@ -167,11 +187,9 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
                 parser_fn, usage_dict = usage.create_anthropic_messages_sse_usage_extractor(
                     on_parse_error=log_parse_error
                 )
-            decode_session = _make_response_decode_session(parser_fn, flow.response.headers)
+            decode_session = _make_response_decode_session(parser_fn, response.headers)
             if decode_session is None:
-                skip_reason = body_decoding.stream_decode_skip_reason(flow.response.headers)
-                if skip_reason is not None:
-                    _log_response_encoding_inspection_risk(flow, skip_reason=skip_reason)
+                _maybe_log_response_encoding_inspection_risk(flow, response)
                 return None
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
 
@@ -190,11 +208,9 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
             extractor = usage.create_openai_responses_json_usage_extractor()
         else:
             extractor = usage.create_anthropic_messages_json_usage_extractor()
-        decode_session = _make_response_decode_session(extractor.feed, flow.response.headers)
+        decode_session = _make_response_decode_session(extractor.feed, response.headers)
         if decode_session is None:
-            skip_reason = body_decoding.stream_decode_skip_reason(flow.response.headers)
-            if skip_reason is not None:
-                _log_response_encoding_inspection_risk(flow, skip_reason=skip_reason)
+            _maybe_log_response_encoding_inspection_risk(flow, response)
             return None
 
         def finish_json_usage() -> tuple[dict | None, str | None]:
@@ -208,19 +224,17 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
 
     if not is_billable_flow:
         return None
-    if not body_decoding.can_stream_decode_usage(flow.response.headers):
+    if not body_decoding.can_stream_decode_usage(response.headers):
         firewall_name = flow_metadata.firewall_name(flow.metadata)
         if (
-            _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
+            _HTTP_STATUS_OK_MIN <= response.status_code < _HTTP_STATUS_REDIRECT_MIN
             and usage.has_connector_response_parser(firewall_name)
         ):
-            skip_reason = body_decoding.stream_decode_skip_reason(flow.response.headers)
-            if skip_reason is not None:
-                _log_response_encoding_inspection_risk(flow, skip_reason=skip_reason)
+            _maybe_log_response_encoding_inspection_risk(flow, response)
         return None
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:
-        decode_session = _make_response_decode_session(connector_parser.feed, flow.response.headers)
+        decode_session = _make_response_decode_session(connector_parser.feed, response.headers)
         if decode_session is None:
             return None
         if connector_parser.finish is not None or connector_parser.finish_decode_error is not None:

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -28,8 +28,11 @@ import flow_metadata_keys as metadata_keys
 import usage
 from body_limits import STREAM_BUFFER_LIMIT
 from logging_utils import log_proxy_entry
+from usage.underbilling import log_usage_underbilling
 
 _HTTP_STATUS_SWITCHING_PROTOCOLS = 101
+_HTTP_STATUS_OK_MIN = 200
+_HTTP_STATUS_REDIRECT_MIN = 300
 
 _MODEL_JSON_USAGE_FINISH = "model_json_usage_finish"
 _MODEL_SSE_USAGE_FINISH = "model_sse_usage_finish"
@@ -101,6 +104,26 @@ def _make_model_sse_parse_error_logger(
     return log_parse_error
 
 
+def _log_response_encoding_inspection_risk(
+    flow: http.HTTPFlow,
+    *,
+    skip_reason: str,
+) -> None:
+    response = flow.response
+    if response is None:
+        return
+    log_usage_underbilling(
+        flow_metadata.proxy_log_path(flow.metadata),
+        "Response encoding prevents incremental usage inspection",
+        "response_encoding_not_stream_decodable",
+        "risk",
+        run_id=flow_metadata.run_id(flow.metadata),
+        firewall_name=flow_metadata.firewall_name(flow.metadata),
+        status_code=response.status_code,
+        decode_skip_reason=skip_reason,
+    )
+
+
 def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParser | None:
     # Set up usage extraction for response classes that need body inspection.
     # The forensic stream_buffer remains capped; usage parsers consume chunks
@@ -146,6 +169,9 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
                 )
             decode_session = _make_response_decode_session(parser_fn, flow.response.headers)
             if decode_session is None:
+                skip_reason = body_decoding.stream_decode_skip_reason(flow.response.headers)
+                if skip_reason is not None:
+                    _log_response_encoding_inspection_risk(flow, skip_reason=skip_reason)
                 return None
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
 
@@ -166,6 +192,9 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
             extractor = usage.create_anthropic_messages_json_usage_extractor()
         decode_session = _make_response_decode_session(extractor.feed, flow.response.headers)
         if decode_session is None:
+            skip_reason = body_decoding.stream_decode_skip_reason(flow.response.headers)
+            if skip_reason is not None:
+                _log_response_encoding_inspection_risk(flow, skip_reason=skip_reason)
             return None
 
         def finish_json_usage() -> tuple[dict | None, str | None]:
@@ -180,6 +209,14 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
     if not is_billable_flow:
         return None
     if not body_decoding.can_stream_decode_usage(flow.response.headers):
+        firewall_name = flow_metadata.firewall_name(flow.metadata)
+        if (
+            _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
+            and usage.has_connector_response_parser(firewall_name)
+        ):
+            skip_reason = body_decoding.stream_decode_skip_reason(flow.response.headers)
+            if skip_reason is not None:
+                _log_response_encoding_inspection_risk(flow, skip_reason=skip_reason)
         return None
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -124,7 +124,10 @@ class TestXStreamPathRouting:
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
         assert log.debug.call_count == 1
-        assert "Streaming decompression skipped (br)" in log.debug.call_args[0][0]
+        assert (
+            "Streaming decompression skipped: brotli streaming output cannot be bounded"
+            in log.debug.call_args[0][0]
+        )
 
     def test_unregistered_parser_factory_does_not_require_original_url(self, real_flow):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")

--- a/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
+++ b/crates/runner/mitm-addon/tests/test_response_encoding_negotiation.py
@@ -26,78 +26,76 @@ _BROWSER_USER_AGENT = (
 
 
 @pytest.mark.parametrize(
-    ("header_pairs", "changed", "values"),
+    ("header_pairs", "values"),
     [
-        pytest.param([], True, ["identity"], id="absent"),
+        pytest.param([], ["identity"], id="absent"),
+        pytest.param(
+            [("Accept-Encoding", "identity")],
+            ["identity"],
+            id="identity-already-normalized",
+        ),
+        pytest.param(
+            [("Accept-Encoding", "gzip")],
+            ["gzip"],
+            id="gzip-already-normalized",
+        ),
         pytest.param(
             [("Accept-Encoding", "gzip, zstd, br")],
-            True,
             ["gzip"],
             id="drops-unsafe-keeps-gzip",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0, deflate;q=0.5, identity;q=1")],
-            True,
             ["deflate;q=0.5, identity;q=1"],
             id="drops-safe-q-zero",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip, identity;q=0, zstd")],
-            True,
             ["gzip, identity;q=0"],
             id="preserves-explicit-identity-rejection-with-safe-coding",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip, *;q=0, zstd")],
-            True,
             ["gzip, identity;q=0"],
             id="preserves-wildcard-identity-rejection-with-safe-coding",
         ),
         pytest.param(
             [("Accept-Encoding", "zstd, br, *")],
-            True,
             ["identity"],
             id="unsafe-only-falls-back-to-identity",
         ),
         pytest.param(
             [("Accept-Encoding", "identity;q=0, zstd")],
-            False,
             ["identity;q=0, zstd"],
             id="respects-explicit-identity-rejection",
         ),
         pytest.param(
             [("Accept-Encoding", "*;q=0, zstd")],
-            False,
             ["*;q=0, zstd"],
             id="wildcard-zero-rejects-implicit-identity",
         ),
         pytest.param(
             [("Accept-Encoding", "zstd, br, *;q=0.5, identity;q=0")],
-            True,
             ["gzip;q=0.5, deflate;q=0.5, identity;q=0"],
             id="wildcard-allows-safe-compression-when-identity-rejected",
         ),
         pytest.param(
             [("Accept-Encoding", "zstd, br, *, identity;q=0")],
-            True,
             ["gzip, deflate, identity;q=0"],
             id="wildcard-default-q-allows-safe-compression-when-identity-rejected",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0, zstd, *;q=0.5, identity;q=0")],
-            True,
             ["deflate;q=0.5, identity;q=0"],
             id="wildcard-safe-compression-respects-explicit-safe-rejection",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0.2, zstd, *;q=0.8, identity;q=0")],
-            True,
             ["gzip;q=0.2, deflate;q=0.8, identity;q=0"],
             id="wildcard-adds-missing-safe-compression-after-explicit-safe-coding",
         ),
         pytest.param(
             [("Accept-Encoding", "deflate, br"), ("Accept-Encoding", "*;q=0.5, identity;q=0")],
-            True,
             ["deflate, gzip;q=0.5, identity;q=0"],
             id="wildcard-adds-missing-safe-compression-across-header-fields",
         ),
@@ -108,133 +106,111 @@ _BROWSER_USER_AGENT = (
                     "gzip;q=0, deflate;q=0, zstd, *;q=0.5, identity;q=0",
                 )
             ],
-            False,
             ["gzip;q=0, deflate;q=0, zstd, *;q=0.5, identity;q=0"],
             id="wildcard-keeps-original-when-all-safe-codings-rejected",
         ),
         pytest.param(
             [("Accept-Encoding", "*;q=0.5, *;q=0, identity;q=0, zstd")],
-            False,
             ["*;q=0.5, *;q=0, identity;q=0, zstd"],
             id="duplicate-wildcard-rejection-wins",
         ),
         pytest.param(
             [("Accept-Encoding", "GZip;q=1, zstd"), ("Accept-Encoding", "deflate;q=0.5, br")],
-            True,
             ["gzip;q=1, deflate;q=0.5"],
             id="case-insensitive-and-multiple-fields",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip, gzip;q=0.5, deflate")],
-            True,
             ["gzip, deflate"],
             id="collapses-duplicate-safe-codings",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=1, gzip;q=0, zstd")],
-            True,
             ["identity"],
             id="duplicate-safe-coding-rejection-wins-after-acceptance",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0, gzip;q=1, zstd")],
-            True,
             ["identity"],
             id="duplicate-safe-coding-rejection-wins-before-acceptance",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=1;q=0, zstd")],
-            True,
             ["identity"],
             id="duplicate-q-parameter-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;foo=bar, zstd")],
-            True,
             ["identity"],
             id="non-q-parameter-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0.5;foo=bar, zstd")],
-            True,
             ["identity"],
             id="q-with-extra-parameter-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;, zstd")],
-            True,
             ["identity"],
             id="empty-parameter-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip\u2028, zstd")],
-            True,
             ["identity"],
             id="unicode-whitespace-suffix-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "\u2028gzip, zstd")],
-            True,
             ["identity"],
             id="unicode-whitespace-prefix-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip\v, zstd")],
-            True,
             ["identity"],
             id="vertical-tab-suffix-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip\n, zstd")],
-            True,
             ["identity"],
             id="newline-suffix-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=0.5\u2028, zstd")],
-            True,
             ["identity"],
             id="unicode-whitespace-q-value-is-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip, identity;q=1, identity;q=0, zstd")],
-            True,
             ["gzip, identity;q=0"],
             id="duplicate-identity-rejection-is-preserved-with-safe-coding",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=2, zstd")],
-            True,
             ["identity"],
             id="invalid-q-value-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=1.0000, zstd")],
-            True,
             ["identity"],
             id="q-value-with-too-many-digits-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=.5, zstd")],
-            True,
             ["identity"],
             id="q-value-without-leading-zero-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "gzip;q=1e-1, zstd")],
-            True,
             ["identity"],
             id="exponent-q-value-not-readvertised",
         ),
         pytest.param(
             [("Accept-Encoding", "identity;q=bogus, zstd")],
-            True,
             ["identity"],
             id="malformed-identity-q-is-not-explicit-rejection",
         ),
         pytest.param(
             [("Accept-Encoding", "identity;q=0.0000, zstd")],
-            True,
             ["identity"],
             id="malformed-identity-zero-is-not-explicit-rejection",
         ),
@@ -243,14 +219,13 @@ _BROWSER_USER_AGENT = (
 def test_normalize_accept_encoding_for_body_inspection(
     headers,
     header_pairs: list[tuple[str, str]],
-    changed: bool,
     values: list[str],
 ) -> None:
     request_headers = headers(*header_pairs)
 
     assert (
         response_encoding_negotiation.normalize_accept_encoding_for_body_inspection(request_headers)
-        is changed
+        is None
     )
     assert request_headers.get_all(_ACCEPT_ENCODING) == values
 

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -12,7 +12,8 @@ import mitm_addon
 import response_streaming
 from body_limits import LARGE_RESPONSE_DECOMPRESS_LIMIT, STREAM_BUFFER_LIMIT
 from tests.flow_helpers import header_map, response_stream
-from tests.x_flow_helpers import make_x_response_flow
+from tests.jsonl_log_helpers import jsonl_exists_after_flush, read_jsonl_entries_after_flush
+from tests.x_flow_helpers import make_x_pipeline_flow, make_x_response_flow
 
 _OVERSIZED_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT + 1024
 
@@ -117,6 +118,176 @@ class TestResponseStreamBuffer:
         assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
+
+
+class TestResponseEncodingInspectionRisk:
+    """Tests structured risk signals at the actual response decoder gate."""
+
+    def _model_flow(
+        self,
+        real_flow,
+        tmp_path,
+        *,
+        content_encoding: str,
+        content_type: str = "application/json",
+    ) -> http.HTTPFlow:
+        flow = real_flow(with_response=False, host="api.anthropic.com", path="/v1/messages")
+        flow.response = tutils.tresp(
+            status_code=200,
+            headers=header_map(
+                {
+                    "content-type": content_type,
+                    "content-encoding": content_encoding,
+                }
+            ),
+        )
+        flow.metadata.update(
+            {
+                metadata_keys.VM_RUN_ID: "run-encoding-risk",
+                metadata_keys.VM_PROXY_LOG_PATH: str(tmp_path / "proxy.jsonl"),
+                metadata_keys.FIREWALL_NAME: "model-provider:anthropic-api-key",
+                metadata_keys.FIREWALL_BILLABLE: True,
+                metadata_keys.MODEL_USAGE_PROVIDER: "claude-sonnet-4-6",
+            }
+        )
+        return flow
+
+    @pytest.mark.parametrize(
+        ("content_encoding", "content_type", "decode_skip_reason"),
+        [
+            pytest.param(
+                "zstd",
+                "application/json",
+                "zstd streaming output cannot be hard-bounded",
+                id="model-json-zstd",
+            ),
+            pytest.param(
+                "br",
+                "text/event-stream",
+                "brotli streaming output cannot be bounded",
+                id="model-sse-brotli",
+            ),
+            pytest.param(
+                "private-encoding-value",
+                "application/json",
+                "unsupported content encoding",
+                id="model-json-unknown",
+            ),
+        ],
+    )
+    def test_observable_model_provider_logs_non_streamable_encoding_risk(
+        self,
+        real_flow,
+        tmp_path,
+        mitm_ctx,
+        content_encoding: str,
+        content_type: str,
+        decode_skip_reason: str,
+    ) -> None:
+        flow = self._model_flow(
+            real_flow,
+            tmp_path,
+            content_encoding=content_encoding,
+            content_type=content_type,
+        )
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert entry["type"] == "usage_underbilling"
+        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert entry["underbilling_class"] == "risk"
+        assert entry["component"] == "mitm_addon"
+        assert entry["run_id"] == "run-encoding-risk"
+        assert entry["firewall_name"] == "model-provider:anthropic-api-key"
+        assert entry["status_code"] == 200
+        assert entry["decode_skip_reason"] == decode_skip_reason
+        assert callable(response_stream(flow))
+
+    def test_unknown_encoding_value_is_not_persisted(self, real_flow, tmp_path, mitm_ctx) -> None:
+        flow = self._model_flow(
+            real_flow,
+            tmp_path,
+            content_encoding="private-encoding-value",
+        )
+
+        with mitm_ctx() as log:
+            mitm_addon.responseheaders(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert "private-encoding-value" not in str(entry)
+        assert "private-encoding-value" not in log.debug.call_args.args[0]
+        assert entry["decode_skip_reason"] == "unsupported content encoding"
+
+    def test_stream_safe_model_response_keeps_parser_without_risk(
+        self, real_flow, tmp_path, mitm_ctx
+    ) -> None:
+        flow = self._model_flow(real_flow, tmp_path, content_encoding="gzip")
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        assert "model_json_usage_finish" in flow.metadata
+        assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+
+    def test_non_observable_model_response_does_not_log_encoding_risk(
+        self, real_flow, tmp_path, mitm_ctx
+    ) -> None:
+        flow = self._model_flow(real_flow, tmp_path, content_encoding="zstd")
+        flow.metadata.pop(metadata_keys.MODEL_USAGE_PROVIDER)
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+
+    def test_successful_billable_connector_logs_non_streamable_encoding_risk(
+        self, real_flow, tmp_path, mitm_ctx
+    ) -> None:
+        flow = make_x_pipeline_flow(real_flow, tmp_path, content_encoding="zstd")
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert entry["type"] == "usage_underbilling"
+        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert entry["underbilling_class"] == "risk"
+        assert entry["firewall_name"] == "x"
+        assert entry["status_code"] == 200
+        assert entry["decode_skip_reason"] == "zstd streaming output cannot be hard-bounded"
+
+    @pytest.mark.parametrize(
+        ("firewall_name", "firewall_billable", "response_status"),
+        [
+            pytest.param("x", False, 200, id="non-billable"),
+            pytest.param("stripe", True, 200, id="no-registered-parser"),
+            pytest.param("x", True, 400, id="unsuccessful-response"),
+        ],
+    )
+    def test_non_inspected_connector_does_not_log_encoding_risk(
+        self,
+        real_flow,
+        tmp_path,
+        mitm_ctx,
+        firewall_name: str,
+        firewall_billable: bool,
+        response_status: int,
+    ) -> None:
+        flow = make_x_pipeline_flow(
+            real_flow,
+            tmp_path,
+            response_status=response_status,
+            content_encoding="zstd",
+        )
+        flow.metadata[metadata_keys.FIREWALL_NAME] = firewall_name
+        flow.metadata[metadata_keys.FIREWALL_BILLABLE] = firewall_billable
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
 
 
 class TestNdjsonExtractor:
@@ -554,7 +725,8 @@ class TestResponseHeadersModelJsonParser:
         assert "model_json_usage_finish" not in flow.metadata
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
         assert any(
-            "Streaming decompression skipped (br)" in call.args[0]
+            "Streaming decompression skipped: brotli streaming output cannot be bounded"
+            in call.args[0]
             for call in log.debug.call_args_list
         )
 

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -131,7 +131,12 @@ class TestResponseEncodingInspectionRisk:
         content_encoding: str,
         content_type: str = "application/json",
     ) -> http.HTTPFlow:
-        flow = real_flow(with_response=False, host="api.anthropic.com", path="/v1/messages")
+        flow = real_flow(
+            with_response=False,
+            host="api.anthropic.com",
+            path="/v1/messages",
+            method="POST",
+        )
         flow.response = tutils.tresp(
             status_code=200,
             headers=header_map(
@@ -242,6 +247,35 @@ class TestResponseEncodingInspectionRisk:
 
         assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
 
+    @pytest.mark.parametrize(
+        ("request_method", "response_status"),
+        [
+            pytest.param("GET", 101, id="informational"),
+            pytest.param("GET", 204, id="no-content"),
+            pytest.param("GET", 205, id="reset-content"),
+            pytest.param("GET", 304, id="not-modified"),
+            pytest.param("HEAD", 200, id="head"),
+            pytest.param("CONNECT", 200, id="successful-connect"),
+        ],
+    )
+    def test_bodyless_model_response_does_not_log_encoding_risk(
+        self,
+        real_flow,
+        tmp_path,
+        mitm_ctx,
+        request_method: str,
+        response_status: int,
+    ) -> None:
+        flow = self._model_flow(real_flow, tmp_path, content_encoding="zstd")
+        flow.request.method = request_method
+        assert flow.response is not None
+        flow.response.status_code = response_status
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+
     def test_successful_billable_connector_logs_non_streamable_encoding_risk(
         self, real_flow, tmp_path, mitm_ctx
     ) -> None:
@@ -264,6 +298,7 @@ class TestResponseEncodingInspectionRisk:
             pytest.param("x", False, 200, id="non-billable"),
             pytest.param("stripe", True, 200, id="no-registered-parser"),
             pytest.param("x", True, 400, id="unsuccessful-response"),
+            pytest.param("x", True, 204, id="bodyless-response"),
         ],
     )
     def test_non_inspected_connector_does_not_log_encoding_risk(

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -24,6 +24,11 @@ from tests.x_flow_helpers import (
     make_x_stream_pipeline_flow,
 )
 
+_STREAM_DECODE_SKIP_REASONS = {
+    "br": "brotli streaming output cannot be bounded",
+    "zstd": "zstd streaming output cannot be hard-bounded",
+}
+
 
 def _compress_body(encoding: str, payload: bytes) -> bytes:
     if encoding == "gzip":
@@ -106,7 +111,10 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert log.debug.call_count == 1
-        assert f"Streaming decompression skipped ({encoding_case})" in log.debug.call_args[0][0]
+        assert (
+            f"Streaming decompression skipped: {_STREAM_DECODE_SKIP_REASONS[encoding_case]}"
+            in log.debug.call_args[0][0]
+        )
 
     @pytest.mark.parametrize("encoding_case", ["br", "zstd"])
     def test_responseheaders_unsafe_compressed_x_stream_does_not_leave_parser_state(
@@ -122,7 +130,10 @@ class TestXConnectorResponsePipeline:
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert log.debug.call_count == 1
-        assert f"Streaming decompression skipped ({encoding_case})" in log.debug.call_args[0][0]
+        assert (
+            f"Streaming decompression skipped: {_STREAM_DECODE_SKIP_REASONS[encoding_case]}"
+            in log.debug.call_args[0][0]
+        )
 
     @pytest.mark.parametrize("encoding_case", ["gzip", "deflate", "br", "zstd"])
     def test_full_response_pipeline_truncated_compressed_x_json_does_not_bill(


### PR DESCRIPTION
## Summary

- make request `Accept-Encoding` normalization an explicit best-effort mutation with no ambiguous boolean result
- emit a structured `usage_underbilling` risk when an observable model response or successful billable connector response cannot be decoded incrementally
- keep diagnostic fields bounded and fixed so unknown upstream encoding values are not persisted
- suppress encoding-risk diagnostics for HTTP responses that cannot carry a body

## Exclusions

- no request or response traffic behavior changes
- no billing decision, stream buffering, or one-shot Brotli/zstd fallback changes
- no API, database, queue, or cross-process protocol changes

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff format --check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/` (3830 passed)
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (7382 passed, 1 skipped)
- `cd turbo && pnpm knip`

Closes #21142
