### PR TITLE
test(runner): isolate environment-dependent tests

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -7061,6 +7061,7 @@ server:
         run_ignored_child_test(
             "cmd::gc::tests::gc_storage_cache_many_candidates_low_fd_child",
             (LOW_FD_STORAGE_GC_CHILD_ENV, "1"),
+            &[],
             Duration::from_secs(60),
         )
         .await;

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -744,11 +744,13 @@ async fn run_submit_with_home(args: SubmitArgs, home: HomePaths) -> RunnerResult
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
     use std::os::unix::fs::{PermissionsExt, symlink};
-    use std::sync::Mutex;
 
-    /// Serialize tests that mutate environment variables to prevent UB.
-    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+    const TIMEZONE_CHILD_SCENARIO: &str = "VM0_RUNNER_TIMEZONE_TEST_SCENARIO";
+    const TIMEZONE_CHILD_TEST: &str = "cmd::local::submit::tests::detect_system_timezone_child";
+    const TIMEZONE_FROM_ENV_SCENARIO: &str = "from-env";
+    const TIMEZONE_EMPTY_ENV_SCENARIO: &str = "empty-env";
     const TEST_QUEUE_WATCH_TIMEOUT: Duration = Duration::from_secs(5);
     const TEST_QUEUE_WATCH_INTERVAL: Duration = Duration::from_millis(1);
 
@@ -767,33 +769,49 @@ mod tests {
         std::fs::metadata(path).unwrap().permissions().mode() & 0o777
     }
 
-    #[test]
-    fn detect_system_timezone_from_env() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        let original = std::env::var("TZ").ok();
-        // SAFETY: ENV_MUTEX ensures no other test mutates env concurrently.
-        unsafe { std::env::set_var("TZ", "America/New_York") };
-        let tz = detect_system_timezone();
-        match original {
-            Some(orig) => unsafe { std::env::set_var("TZ", orig) },
-            None => unsafe { std::env::remove_var("TZ") },
-        }
-        assert_eq!(tz, Some("America/New_York".to_string()));
+    #[tokio::test]
+    async fn detect_system_timezone_from_env() {
+        run_timezone_child(TIMEZONE_FROM_ENV_SCENARIO, "America/New_York").await;
+    }
+
+    #[tokio::test]
+    async fn detect_system_timezone_empty_env() {
+        run_timezone_child(TIMEZONE_EMPTY_ENV_SCENARIO, "").await;
+    }
+
+    async fn run_timezone_child(scenario: &'static str, timezone: &'static str) {
+        run_ignored_child_test(
+            TIMEZONE_CHILD_TEST,
+            (TIMEZONE_CHILD_SCENARIO, scenario),
+            &[("TZ", Some(timezone))],
+            Duration::from_secs(5),
+        )
+        .await;
     }
 
     #[test]
-    fn detect_system_timezone_empty_env() {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        let original = std::env::var("TZ").ok();
-        // SAFETY: ENV_MUTEX ensures no other test mutates env concurrently.
-        unsafe { std::env::set_var("TZ", "") };
-        let tz = detect_system_timezone();
-        match original {
-            Some(orig) => unsafe { std::env::set_var("TZ", orig) },
-            None => unsafe { std::env::remove_var("TZ") },
+    #[ignore = "spawned by timezone environment scenario tests"]
+    fn detect_system_timezone_child() {
+        let Ok(scenario) = std::env::var(TIMEZONE_CHILD_SCENARIO) else {
+            return;
+        };
+        if !ignored_child_test_env_guard_enabled((TIMEZONE_CHILD_SCENARIO, &scenario)) {
+            return;
         }
-        // Empty TZ falls through to /etc/timezone
-        assert_ne!(tz, Some("".to_string()));
+
+        match scenario.as_str() {
+            TIMEZONE_FROM_ENV_SCENARIO => {
+                assert_eq!(
+                    detect_system_timezone(),
+                    Some("America/New_York".to_string())
+                );
+            }
+            TIMEZONE_EMPTY_ENV_SCENARIO => {
+                // Empty TZ falls through to /etc/timezone.
+                assert_ne!(detect_system_timezone(), Some("".to_string()));
+            }
+            other => panic!("unknown timezone test scenario: {other}"),
+        }
     }
 
     #[test]

--- a/crates/runner/src/host_file.rs
+++ b/crates/runner/src/host_file.rs
@@ -615,6 +615,7 @@ mod tests {
         run_ignored_child_test(
             "host_file::tests::ensure_dir_handles_restrictive_umask_child",
             (RESTRICTIVE_UMASK_CHILD_ENV, "1"),
+            &[],
             Duration::from_secs(60),
         )
         .await;

--- a/crates/runner/src/private_fs.rs
+++ b/crates/runner/src/private_fs.rs
@@ -742,6 +742,7 @@ mod tests {
         run_ignored_child_test(
             "private_fs::tests::read_private_file_rejects_fifo_without_blocking_child",
             (FIFO_READ_CHILD_PATH_ENV, fifo_path),
+            &[],
             Duration::from_secs(10),
         )
         .await;

--- a/crates/runner/src/r2_cache/tests/config.rs
+++ b/crates/runner/src/r2_cache/tests/config.rs
@@ -1,8 +1,22 @@
+use std::time::Duration;
+
+use crate::test_fixtures::{ignored_child_test_env_guard_enabled, run_ignored_child_test};
+
 use super::super::{
     R2Error, R2ImageCache,
     config::ENV_VARS,
     keys::{key_for_hash, key_for_template_hash},
 };
+
+const R2_ENV_CHILD_SCENARIO: &str = "VM0_RUNNER_R2_ENV_TEST_SCENARIO";
+const R2_ENV_CHILD_TEST: &str = "r2_cache::tests::config::from_env_child";
+const R2_ENV_CHILD_TIMEOUT: Duration = Duration::from_secs(10);
+const ALL_MISSING_SCENARIO: &str = "all-missing";
+const ALL_PRESENT_SCENARIO: &str = "all-present";
+const ALL_EMPTY_SCENARIO: &str = "all-empty";
+const PARTIAL_SCENARIO: &str = "partial";
+const PARTIAL_EMPTY_SCENARIO: &str = "partial-empty";
+const DEBUG_REDACTION_SCENARIO: &str = "debug-redaction";
 
 #[test]
 fn key_format() {
@@ -13,175 +27,144 @@ fn key_format() {
     );
 }
 
-/// `from_env` requires all-or-nothing on the four env vars.
-/// Tests use a single var with each scenario via temporary process env;
-/// concurrent execution is safe — `with_clean_r2_env` serializes via
-/// `ENV_LOCK` so the snapshot/mutate/restore window is exclusive.
 #[tokio::test]
 async fn from_env_returns_none_when_all_missing() {
-    with_clean_r2_env(|| async {
-        let result = R2ImageCache::from_env().await.unwrap();
-        assert!(result.is_none(), "all four missing → None");
-    })
-    .await;
+    run_from_env_child(ALL_MISSING_SCENARIO, [None, None, None, None]).await;
 }
 
 #[tokio::test]
 async fn from_env_returns_some_when_all_present() {
-    with_clean_r2_env(|| async {
-        // SAFETY: env mutation is serialized by ENV_LOCK in with_clean_r2_env.
-        unsafe {
-            std::env::set_var("R2_ACCOUNT_ID", "test-account");
-            std::env::set_var("R2_ACCESS_KEY_ID", "test-key");
-            std::env::set_var("R2_SECRET_ACCESS_KEY", "test-secret");
-            std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "test-bucket");
-        }
-        let result = R2ImageCache::from_env().await.unwrap();
-        assert!(result.is_some(), "all four set → Some");
-        assert_eq!(result.unwrap().bucket, "test-bucket");
-    })
+    run_from_env_child(
+        ALL_PRESENT_SCENARIO,
+        [
+            Some("test-account"),
+            Some("test-key"),
+            Some("test-secret"),
+            Some("test-bucket"),
+        ],
+    )
     .await;
 }
 
 #[tokio::test]
 async fn from_env_treats_empty_string_as_unset() {
-    // Callers often substitute "" for missing secrets (e.g.
-    // `${R2_ACCOUNT_ID:-}` in shell, `lookup('env', ...)` in Ansible).
-    // Empty strings are never valid R2 credentials — treat as unset.
-    with_clean_r2_env(|| async {
-        unsafe {
-            for v in &ENV_VARS {
-                std::env::set_var(v, "");
-            }
-        }
-        let result = R2ImageCache::from_env().await.unwrap();
-        assert!(result.is_none(), "all four empty → None, not Some");
-    })
-    .await;
+    run_from_env_child(ALL_EMPTY_SCENARIO, [Some(""), Some(""), Some(""), Some("")]).await;
 }
 
 #[tokio::test]
 async fn from_env_errors_on_partial_config() {
-    // Set 2 of 4 — should return PartialConfig with the right partition.
-    with_clean_r2_env(|| async {
-        unsafe {
-            std::env::set_var("R2_ACCOUNT_ID", "test");
-            std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "test");
-        }
-        let err = R2ImageCache::from_env().await.unwrap_err();
-        match err {
-            R2Error::PartialConfig { present, missing } => {
-                assert_eq!(present.len(), 2);
-                assert_eq!(missing.len(), 2);
-                assert!(present.contains(&"R2_ACCOUNT_ID".to_string()));
-                assert!(present.contains(&"R2_USER_STORAGES_BUCKET_NAME".to_string()));
-                assert!(missing.contains(&"R2_ACCESS_KEY_ID".to_string()));
-                assert!(missing.contains(&"R2_SECRET_ACCESS_KEY".to_string()));
-            }
-            e => panic!("expected PartialConfig, got {e:?}"),
-        }
-    })
-    .await;
-}
-
-/// Process-wide lock that serializes env-mutating tests in this module so
-/// they're correct even when the test harness runs threads in parallel
-/// (CI uses `cargo llvm-cov` without `--test-threads=1`). Held across the
-/// inner `tokio::spawn(...).await` because env vars are process-global —
-/// without the lock, two concurrent tests would clobber each other's
-/// snapshot/restore. Async-aware so holding across await is sound.
-static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
-/// Helper: snapshot and clear all R2 env vars before running, restore after.
-/// Panic-safe: the closure runs in a `tokio::spawn` task so a panic doesn't
-/// skip the restore. SAFETY of `set_var` / `remove_var`: serialized by
-/// `ENV_LOCK` above, so no concurrent env mutation can occur.
-async fn with_clean_r2_env<F, Fut>(f: F)
-where
-    F: FnOnce() -> Fut + Send + 'static,
-    Fut: std::future::Future<Output = ()> + Send + 'static,
-{
-    let _guard = ENV_LOCK.lock().await;
-    let saved: Vec<(&str, Option<String>)> = ENV_VARS
-        .iter()
-        .map(|v| (*v, std::env::var(v).ok()))
-        .collect();
-    unsafe {
-        for v in &ENV_VARS {
-            std::env::remove_var(v);
-        }
-    }
-    let join = tokio::spawn(f()).await;
-    unsafe {
-        for (k, v) in saved {
-            match v {
-                Some(val) => std::env::set_var(k, val),
-                None => std::env::remove_var(k),
-            }
-        }
-    }
-    // Now propagate any panic from the test body so the test fails properly.
-    join.unwrap();
+    run_from_env_child(PARTIAL_SCENARIO, [Some("test"), None, None, Some("test")]).await;
 }
 
 #[tokio::test]
 async fn from_env_errors_on_partial_with_some_empty_strings() {
-    // Real-world misconfiguration: 2 secrets typo'd to empty, 2 set.
-    // Empty counts as unset (per from_env_treats_empty_string_as_unset),
-    // so this should be PartialConfig with present=2, missing=2 — NOT
-    // silently disabled (which would happen if all four were empty).
-    with_clean_r2_env(|| async {
-        unsafe {
-            std::env::set_var("R2_ACCOUNT_ID", "real-value");
-            std::env::set_var("R2_ACCESS_KEY_ID", ""); // typo'd to empty
-            std::env::set_var("R2_SECRET_ACCESS_KEY", ""); // typo'd to empty
-            std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "real-value");
-        }
-        let err = R2ImageCache::from_env().await.unwrap_err();
-        match err {
-            R2Error::PartialConfig { present, missing } => {
-                assert_eq!(present.len(), 2, "two non-empty present");
-                assert_eq!(missing.len(), 2, "two empty treated as missing");
-                assert!(missing.contains(&"R2_ACCESS_KEY_ID".to_string()));
-                assert!(missing.contains(&"R2_SECRET_ACCESS_KEY".to_string()));
-            }
-            e => panic!("expected PartialConfig, got {e:?}"),
-        }
-    })
+    run_from_env_child(
+        PARTIAL_EMPTY_SCENARIO,
+        [Some("real-value"), Some(""), Some(""), Some("real-value")],
+    )
     .await;
 }
 
-/// `R2ImageCache::Debug` must not leak credentials — if logs ever capture
-/// `{:?}` on a cache (e.g. via `tracing` instrumentation), only the
-/// bucket name should appear, not account_id / access_key / secret.
 #[tokio::test]
 async fn debug_format_does_not_leak_credentials() {
-    with_clean_r2_env(|| async {
-        // SAFETY: env mutation is serialized by ENV_LOCK in with_clean_r2_env.
-        unsafe {
-            std::env::set_var("R2_ACCOUNT_ID", "secret-account-id-do-not-leak");
-            std::env::set_var("R2_ACCESS_KEY_ID", "AKIAEXAMPLEDONOTLEAK");
-            std::env::set_var("R2_SECRET_ACCESS_KEY", "secret-key-MUST-NOT-appear-in-logs");
-            std::env::set_var("R2_USER_STORAGES_BUCKET_NAME", "test-bucket");
-        }
-        let cache = R2ImageCache::from_env().await.unwrap().unwrap();
-        let dbg = format!("{cache:?}");
-        assert!(
-            !dbg.contains("secret-account-id-do-not-leak"),
-            "Debug leaked account_id: {dbg}"
-        );
-        assert!(
-            !dbg.contains("AKIAEXAMPLEDONOTLEAK"),
-            "Debug leaked access_key_id: {dbg}"
-        );
-        assert!(
-            !dbg.contains("secret-key-MUST-NOT-appear-in-logs"),
-            "Debug leaked secret_key: {dbg}"
-        );
-        assert!(
-            dbg.contains("test-bucket"),
-            "Debug should still expose bucket for diagnostic value: {dbg}"
-        );
-    })
+    run_from_env_child(
+        DEBUG_REDACTION_SCENARIO,
+        [
+            Some("secret-account-id-do-not-leak"),
+            Some("AKIAEXAMPLEDONOTLEAK"),
+            Some("secret-key-MUST-NOT-appear-in-logs"),
+            Some("test-bucket"),
+        ],
+    )
     .await;
+}
+
+async fn run_from_env_child(scenario: &'static str, values: [Option<&'static str>; 4]) {
+    let child_env = [
+        (ENV_VARS[0], values[0]),
+        (ENV_VARS[1], values[1]),
+        (ENV_VARS[2], values[2]),
+        (ENV_VARS[3], values[3]),
+    ];
+    run_ignored_child_test(
+        R2_ENV_CHILD_TEST,
+        (R2_ENV_CHILD_SCENARIO, scenario),
+        &child_env,
+        R2_ENV_CHILD_TIMEOUT,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "spawned by R2 environment scenario tests"]
+async fn from_env_child() {
+    let Ok(scenario) = std::env::var(R2_ENV_CHILD_SCENARIO) else {
+        return;
+    };
+    if !ignored_child_test_env_guard_enabled((R2_ENV_CHILD_SCENARIO, &scenario)) {
+        return;
+    }
+
+    match scenario.as_str() {
+        ALL_MISSING_SCENARIO => {
+            let result = R2ImageCache::from_env().await.unwrap();
+            assert!(result.is_none(), "all four missing → None");
+        }
+        ALL_PRESENT_SCENARIO => {
+            let result = R2ImageCache::from_env().await.unwrap();
+            assert!(result.is_some(), "all four set → Some");
+            assert_eq!(result.unwrap().bucket, "test-bucket");
+        }
+        ALL_EMPTY_SCENARIO => {
+            let result = R2ImageCache::from_env().await.unwrap();
+            assert!(result.is_none(), "all four empty → None, not Some");
+        }
+        PARTIAL_SCENARIO => {
+            let error = R2ImageCache::from_env().await.unwrap_err();
+            match error {
+                R2Error::PartialConfig { present, missing } => {
+                    assert_eq!(present.len(), 2);
+                    assert_eq!(missing.len(), 2);
+                    assert!(present.contains(&"R2_ACCOUNT_ID".to_string()));
+                    assert!(present.contains(&"R2_USER_STORAGES_BUCKET_NAME".to_string()));
+                    assert!(missing.contains(&"R2_ACCESS_KEY_ID".to_string()));
+                    assert!(missing.contains(&"R2_SECRET_ACCESS_KEY".to_string()));
+                }
+                other => panic!("expected PartialConfig, got {other:?}"),
+            }
+        }
+        PARTIAL_EMPTY_SCENARIO => {
+            let error = R2ImageCache::from_env().await.unwrap_err();
+            match error {
+                R2Error::PartialConfig { present, missing } => {
+                    assert_eq!(present.len(), 2, "two non-empty present");
+                    assert_eq!(missing.len(), 2, "two empty treated as missing");
+                    assert!(missing.contains(&"R2_ACCESS_KEY_ID".to_string()));
+                    assert!(missing.contains(&"R2_SECRET_ACCESS_KEY".to_string()));
+                }
+                other => panic!("expected PartialConfig, got {other:?}"),
+            }
+        }
+        DEBUG_REDACTION_SCENARIO => {
+            let cache = R2ImageCache::from_env().await.unwrap().unwrap();
+            let debug = format!("{cache:?}");
+            assert!(
+                !debug.contains("secret-account-id-do-not-leak"),
+                "Debug leaked account_id: {debug}"
+            );
+            assert!(
+                !debug.contains("AKIAEXAMPLEDONOTLEAK"),
+                "Debug leaked access_key_id: {debug}"
+            );
+            assert!(
+                !debug.contains("secret-key-MUST-NOT-appear-in-logs"),
+                "Debug leaked secret_key: {debug}"
+            );
+            assert!(
+                debug.contains("test-bucket"),
+                "Debug should still expose bucket for diagnostic value: {debug}"
+            );
+        }
+        other => panic!("unknown R2 environment test scenario: {other}"),
+    }
 }

--- a/crates/runner/src/state_file.rs
+++ b/crates/runner/src/state_file.rs
@@ -325,6 +325,7 @@ mod tests {
         run_ignored_child_test(
             "state_file::tests::read_to_string_rejects_fifo_without_blocking_child",
             (FIFO_READ_CHILD_PATH_ENV, fifo_path),
+            &[],
             Duration::from_secs(10),
         )
         .await;

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -246,6 +246,7 @@ pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
 pub(crate) async fn run_ignored_child_test(
     child_test_name: &str,
     env_guard: (&str, &str),
+    child_env: &[(&str, Option<&str>)],
     timeout: Duration,
 ) {
     let (env_guard_key, env_guard_value) = env_guard;
@@ -277,6 +278,16 @@ pub(crate) async fn run_ignored_child_test(
         .stderr(Stdio::piped())
         .kill_on_drop(true);
     command.env(env_guard_key, env_guard_value);
+    for &(key, value) in child_env {
+        match value {
+            Some(value) => {
+                command.env(key, value);
+            }
+            None => {
+                command.env_remove(key);
+            }
+        }
+    }
 
     let mut child = command.spawn().expect("spawn ignored child test");
     let stdout = child
@@ -501,6 +512,7 @@ mod tests {
         run_ignored_child_test(
             "test_fixtures::tests::run_ignored_child_test_large_success_output_child",
             (LARGE_SUCCESS_OUTPUT_CHILD_ENV, "1"),
+            &[],
             Duration::from_secs(5),
         )
         .await;
@@ -522,6 +534,7 @@ mod tests {
         run_ignored_child_test(
             "test_fixtures::tests::run_ignored_child_test_large_output_child",
             (LARGE_OUTPUT_CHILD_ENV, "1"),
+            &[],
             Duration::from_secs(5),
         )
         .await;
@@ -556,6 +569,7 @@ mod tests {
         run_ignored_child_test(
             "test_fixtures::tests::run_ignored_child_test_timeout_child",
             (TIMEOUT_CHILD_ENV, "1"),
+            &[],
             Duration::from_millis(10),
         )
         .await;

--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -90,9 +90,9 @@ async fn post_json_success() {
 
 ### Shared State and Process Environment
 
-Use `std::sync::Mutex` only for Rust-owned shared state when every access participates in the same lock. A Tokio mutex does not coordinate separate `#[tokio::test]` runtimes.
+Use a mutex only for Rust-owned shared state when every access participates in the same lock. Prefer `std::sync::Mutex` when the guard does not cross an `.await`; use an async mutex when it must.
 
-Do not use a mutex to justify `std::env::set_var` or `std::env::remove_var` in a multi-threaded test process. On non-Windows platforms, unrelated standard-library or dependency code may read the environment without taking the project lock, so the lock cannot satisfy those functions' safety contract.
+Neither kind of mutex makes `std::env::set_var` or `std::env::remove_var` safe in a multi-threaded test process. On non-Windows platforms, unrelated standard-library or dependency code may read the environment without taking the project lock, so the lock cannot satisfy those functions' safety contract.
 
 Configure environment-dependent scenarios before spawning a child process instead:
 

--- a/docs/testing/rust-testing.md
+++ b/docs/testing/rust-testing.md
@@ -88,21 +88,28 @@ async fn post_json_success() {
 }
 ```
 
-### Test Serialization
+### Shared State and Process Environment
 
-When tests share mutable state (env vars, global server), use `std::sync::Mutex`:
+Use `std::sync::Mutex` only for Rust-owned shared state when every access participates in the same lock. A Tokio mutex does not coordinate separate `#[tokio::test]` runtimes.
+
+Do not use a mutex to justify `std::env::set_var` or `std::env::remove_var` in a multi-threaded test process. On non-Windows platforms, unrelated standard-library or dependency code may read the environment without taking the project lock, so the lock cannot satisfy those functions' safety contract.
+
+Configure environment-dependent scenarios before spawning a child process instead:
 
 ```rust
-// Use std::sync::Mutex, not tokio::sync::Mutex
-// Each #[tokio::test] runs in its own runtime, so tokio Mutex won't work across tests
-static TEST_MUTEX: Mutex<()> = Mutex::new(());
+use std::path::Path;
+use std::process::Command;
 
-#[tokio::test]
-async fn test_with_shared_state() {
-    let _guard = TEST_MUTEX.lock().unwrap();
-    // ... test body
+fn command_with_test_env(binary: &Path) -> Command {
+    let mut command = Command::new(binary);
+    command
+        .env("TZ", "UTC")
+        .env_remove("R2_SECRET_ACCESS_KEY");
+    command
 }
 ```
+
+For inline runner tests, reuse `run_ignored_child_test` from `crates/runner/src/test_fixtures.rs`. It invokes one exact ignored test in a bounded child process and accepts per-child environment settings and removals.
 
 ### Temp Directories
 


### PR DESCRIPTION
## Summary

- run R2 configuration and timezone detection scenarios in exact ignored child test processes
- extend the runner child-test helper with explicit environment overrides and removals
- document why process environment mutation cannot be made safe with a test-only mutex

## Scope

This changes test execution only. It does not change runner production behavior, APIs, schemas, migrations, deployment configuration, or persisted state.

## Validation

- `cargo test -p runner r2_cache::tests::config::`
- `cargo test -p runner cmd::local::submit::tests::detect_system_timezone`
- `cargo test -p runner test_fixtures::tests::`
- `cargo test -p runner`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm knip`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,306 passed; 76 tests in 29 unrelated files hit the local 5-second timeout under full-suite contention)
- reran all 29 affected files with one worker on a clean database: all 756 tests passed

Closes #21143
