### PR TITLE
docs: scope pre-commit checks by affected code

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -19,7 +19,7 @@ Run both operations together for a complete pre-commit workflow.
 
 ## Scope Selection
 
-1. Read and follow the [Pre-Commit Checks](../../../CLAUDE.md#pre-commit-checks) section.
+1. Read and follow the **Pre-Commit Checks** section in `CLAUDE.md`.
 2. Inspect `git status --short` and `git diff --cached --name-only`.
 3. Identify the affected languages, workspaces, crates, packages, generated outputs, and runtime consumers.
 4. Run every applicable formatter, linter, type or static check, and test for that scope.
@@ -27,11 +27,11 @@ Run both operations together for a complete pre-commit workflow.
 
 Do not run an unrelated language ecosystem's full suite. Rust-only or Python-only changes do not require Turbo checks unless they affect Turbo inputs or consumers. Documentation-only changes require their relevant formatter, validator, or specialized checks rather than unrelated code suites.
 
-The root [lefthook.yml](../../../lefthook.yml) selects formatting and static checks from staged paths. It does not replace manually selecting and running the relevant tests.
+The root `lefthook.yml` selects formatting and static checks from staged paths. It does not replace manually selecting and running the relevant tests.
 
 ## Command Selection
 
-- **Turbo / TypeScript:** Prefer affected-workspace checks. Use the full commands documented in [CLAUDE.md](../../../CLAUDE.md#select-checks-by-affected-scope) when the change crosses workspaces or cannot be isolated safely.
+- **Turbo / TypeScript:** Prefer affected-workspace checks. Use the full commands documented in `CLAUDE.md` when the change crosses workspaces or cannot be isolated safely.
 - **Rust:** From `crates/`, run formatting, Clippy, documentation checks, and tests for the affected crate(s). Use workspace-wide checks for shared or cross-crate changes.
 - **Python (`crates/runner/mitm-addon`):** Run Ruff formatting and linting, basedpyright, and pytest in that package.
 - **Documentation or configuration:** Run the formatter, validator, or specialized tests that consume the changed files.
@@ -210,7 +210,7 @@ For detailed information, read these files:
 
 # Project Standards
 
-From [CLAUDE.md](../../../CLAUDE.md):
+From CLAUDE.md:
 
 - **Never use `any` type** - Use `unknown` with narrowing
 - **Never add eslint-disable** - Fix the root cause

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Complete pre-commit workflow - run quality checks (format, lint, type, test) and validate/create conventional commit messages
+description: Complete pre-commit workflow - select and run applicable quality checks, then validate/create conventional commit messages
 context: fork
 ---
 
@@ -8,7 +8,7 @@ You are a commit specialist for the vm0 project. Your role is to ensure code qua
 
 ## Operations
 
-1. **Check** - Run pre-commit quality checks (format, lint, type, test)
+1. **Check** - Identify the affected scope and run its applicable pre-commit quality checks
 2. **Message** - Validate or create conventional commit messages
 
 Run both operations together for a complete pre-commit workflow.
@@ -17,35 +17,47 @@ Run both operations together for a complete pre-commit workflow.
 
 # Operation 1: Quality Checks
 
-## Commands
+## Scope Selection
 
-```bash
-cd turbo
+1. Read and follow the [Pre-Commit Checks](../../../CLAUDE.md#pre-commit-checks) section.
+2. Inspect `git status --short` and `git diff --cached --name-only`.
+3. Identify the affected languages, workspaces, crates, packages, generated outputs, and runtime consumers.
+4. Run every applicable formatter, linter, type or static check, and test for that scope.
+5. Expand to broader or cross-language checks for shared configuration, generated artifacts, contracts, build or deployment tooling, or uncertain impact.
 
-pnpm format           # Auto-format code
-pnpm lint             # Check for linting issues
-pnpm check-types      # Verify TypeScript type safety
-pnpm test             # Run all tests
-```
+Do not run an unrelated language ecosystem's full suite. Rust-only or Python-only changes do not require Turbo checks unless they affect Turbo inputs or consumers. Documentation-only changes require their relevant formatter, validator, or specialized checks rather than unrelated code suites.
+
+The root [lefthook.yml](../../../lefthook.yml) selects formatting and static checks from staged paths. It does not replace manually selecting and running the relevant tests.
+
+## Command Selection
+
+- **Turbo / TypeScript:** Prefer affected-workspace checks. Use the full commands documented in [CLAUDE.md](../../../CLAUDE.md#select-checks-by-affected-scope) when the change crosses workspaces or cannot be isolated safely.
+- **Rust:** From `crates/`, run formatting, Clippy, documentation checks, and tests for the affected crate(s). Use workspace-wide checks for shared or cross-crate changes.
+- **Python (`crates/runner/mitm-addon`):** Run Ruff formatting and linting, basedpyright, and pytest in that package.
+- **Documentation or configuration:** Run the formatter, validator, or specialized tests that consume the changed files.
 
 ## Execution Order
 
-**IMPORTANT: Run checks sequentially, one at a time.** Each check can take several minutes in this monorepo. Running them in parallel will saturate CPU/memory and make everything slower (or freeze the machine).
+**IMPORTANT: Run selected checks sequentially, one at a time.** Each check can take several minutes in this monorepo. Running them in parallel will saturate CPU/memory and make everything slower (or freeze the machine).
 
-1. **Format** (`pnpm format`) - Auto-fixes formatting
-2. **Lint** (`pnpm lint`) - Auto-fix with `--fix` flag if needed
-3. **Type Check** (`pnpm check-types`) - Requires manual fixes
-4. **Test** (`pnpm test`) - Requires debugging if failed
+Within each affected ecosystem, use this order when the check applies:
+
+1. **Format** - Apply the repository formatter
+2. **Lint / Static Analysis** - Fix underlying issues rather than suppressing them
+3. **Type Check** - Fix type errors without bypasses
+4. **Test** - Run the tests selected from the affected behavior and consumers
+
+Run only one Vitest process at a time. Do not run multiple Cargo checks concurrently.
 
 ## Output Format
 
 ```
 Pre-Commit Check Results
 
-Formatting: [PASSED/FIXED/FAILED]
-Linting: [PASSED/FIXED/FAILED]
-Type Checking: [PASSED/FAILED]
-Tests: [PASSED/FAILED]
+Affected scope: [languages, workspaces, crates, packages, and consumers]
+Checks:
+- [command]: [PASSED/FIXED/FAILED]
+Skipped ecosystems: [ecosystems omitted because they are unrelated]
 
 Summary: [Ready to commit / Issues need attention]
 ```
@@ -164,10 +176,11 @@ Alternatives:
 Complete Pre-Commit Workflow
 
 Step 1: Quality Checks
-   Formatting: PASSED
-   Linting: FIXED (2 issues)
-   Type Checking: PASSED
-   Tests: PASSED (42 tests)
+   Affected scope: turbo/apps/api
+   Checks:
+   - pnpm -F api exec vitest: PASSED (42 tests)
+   - applicable formatting, lint, type, and Knip checks: PASSED
+   Skipped ecosystems: Rust and Python (unrelated)
 
 Step 2: Commit Message
    Changes:
@@ -197,7 +210,7 @@ For detailed information, read these files:
 
 # Project Standards
 
-From CLAUDE.md:
+From [CLAUDE.md](../../../CLAUDE.md):
 
 - **Never use `any` type** - Use `unknown` with narrowing
 - **Never add eslint-disable** - Fix the root cause
@@ -207,7 +220,7 @@ From CLAUDE.md:
 
 ## Best Practices
 
-1. Run checks before every commit
+1. Run all applicable checks before every commit
 2. Auto-fix formatting/lint when possible
 3. Focus on "why" not "what" in messages
 4. Keep commits atomic - one logical change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ The root `lefthook.yml` selects formatting and static checks from staged file pa
    ```
    pnpm -F @vm0/app exec vitest
    ```
-   Replace `@vm0/app` with the workspace name relevant to your changes (e.g. `@vm0/cli`, `@vm0/api`).
+   Replace `@vm0/app` with the workspace name relevant to your changes (e.g. `@vm0/cli`, `api`).
 3. **Limit full-suite worker concurrency** - When an all-workspace run is necessary, cap file workers to avoid resource-contention timeouts:
    ```
    pnpm vitest run --maxWorkers=4 --silent=passed-only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,21 +167,30 @@ For detailed patterns and examples, use `/testing`.
 
 ## Pre-Commit Checks
 
-**All code must pass these checks before committing.** Run these commands from the `/turbo` directory to ensure code quality:
+**Run every check relevant to the files and behavior changed before committing.** Do not run an unrelated language ecosystem's full suite. For example, Rust-only or Python-only changes do not require Turbo checks unless they affect Turbo inputs or consumers. Determine the affected scope from the changed files and their consumers, then expand the scope for shared configuration, generated artifacts, cross-language contracts, build or deployment tooling, and other changes with wider impact.
 
-### Required Checks:
-- **Lint:** `cd turbo && pnpm turbo run lint` - Check for code style and quality issues
-- **Type Check:** `cd turbo && pnpm check-types` - Verify TypeScript type safety
-- **Format:** `cd turbo && pnpm format` - Auto-format code according to project standards
-- **Test:** `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` - Run all tests without overloading local workers
-- **Knip:** `cd turbo && pnpm knip` - Find and fix unused dependencies, exports, and files
+### Select Checks by Affected Scope
+
+- **Turbo / TypeScript:** Run formatting, lint, type checking, Knip, and tests for the affected workspace(s). The full-repository forms below are appropriate when a change crosses workspaces, affects shared Turbo configuration, or cannot be isolated safely:
+  - `cd turbo && pnpm format`
+  - `cd turbo && pnpm turbo run lint`
+  - `cd turbo && pnpm check-types`
+  - `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only`
+  - `cd turbo && pnpm knip`
+- **Rust:** Run `cargo fmt`, Clippy, documentation checks, and tests for the affected crate(s) from `crates/`. Use workspace-wide checks when shared crates, workspace configuration, or cross-crate behavior changes.
+- **Python (`crates/runner/mitm-addon`):** Run Ruff formatting and linting, basedpyright, and pytest in that package.
+- **Documentation or configuration:** Run the formatter, validator, or specialized tests that consume the changed files. Unrelated Turbo, Rust, or Python suites are not required unless those files affect them.
+
+The root `lefthook.yml` selects formatting and static checks from staged file paths. It does not replace running the relevant tests manually.
 
 ### Before Committing:
-1. Run all checks to ensure code quality
-2. Fix any issues that are found
-3. Never commit code that fails any of these checks
-4. Use proper conventional commit message format
-5. These checks help maintain the high standards defined in our design principles
+
+1. Identify the affected languages, workspaces, crates, packages, generated outputs, and runtime consumers
+2. Run all formatting, linting, type checking, static analysis, and tests relevant to that scope
+3. Expand to broader or cross-language checks when the impact is shared or uncertain
+4. Fix any issues that are found
+5. Never commit code that fails an applicable check
+6. Use proper conventional commit message format
 
 ### Running Vitest Correctly
 
@@ -200,7 +209,8 @@ For detailed patterns and examples, use `/testing`.
    Do not increase test timeouts to compensate for excessive local concurrency.
 
 ### CRITICAL: Never run checks in background
-**All pre-commit checks (lint, format, typecheck, test, knip) MUST run in the foreground.** Never use `run_in_background` for these commands. The results must be available immediately so the commit can proceed — background execution defeats this purpose.
+
+**All selected pre-commit checks MUST run in the foreground.** Never use `run_in_background` for these commands. The results must be available immediately so the commit can proceed — background execution defeats this purpose.
 
 ## Code Quality Tools
 
@@ -235,7 +245,8 @@ GitHub Actions container jobs run `run` steps with `sh` by default. Any step tha
 
 ### Zero Tolerance for Skipping Tests
 
-**NEVER skip tests to make CI pass.** All tests must execute and pass:
+**NEVER skip tests to make CI pass.** All tests selected for the affected scope, together with all tests selected by CI, must execute and pass:
+
 - Do not add `skip` flags or environment variables to bypass tests
 - Do not modify CI workflow to skip tests that are timing out or failing
 - If tests are slow or timing out, **fix the underlying issue** - either optimize the tests or fix the code
@@ -243,6 +254,7 @@ GitHub Actions container jobs run `run` steps with `sh` by default. Any step tha
 - Especially critical: **never skip tests for the feature being developed in the PR**
 
 If tests timeout, investigate why:
+
 1. Is there a bug in the code causing infinite loops or hangs?
 2. Are there network issues or external service dependencies?
 3. Is the test itself poorly designed and needs optimization?


### PR DESCRIPTION
## Summary

- replace the unconditional Turbo pre-commit checklist with validation guidance based on affected languages, workspaces, crates, and consumers
- align the repository commit skill so it inspects staged scope and follows the same affected-scope policy instead of always running Turbo commands
- require broader checks for shared configuration, generated artifacts, cross-language contracts, and other changes with wider consumers
- clarify that relevant tests and all CI-selected tests must pass, while Lefthook's file-scoped static checks do not replace manual test selection
- correct the API package name used by the workspace-scoped Vitest example

## Exclusions

- no CI or Git hook behavior changes
- no production code changes

## Validation

- `git diff --check`
- compared the modified `CLAUDE.md` policy sections with Prettier output
- Prettier check for `SKILL.md`
- `pnpm --filter api list --depth -1`
- file-size checks for `CLAUDE.md` and `SKILL.md`
- pre-commit file-size and generated-firewall checks, plus commitlint

Tests were not run because this change only updates project and skill documentation and does not affect executable code or test inputs.
