### PR TITLE
docs(sandbox-mock): clarify exec matcher result semantics

### DIFF
--- a/crates/sandbox-mock/src/call_records.rs
+++ b/crates/sandbox-mock/src/call_records.rs
@@ -4,11 +4,18 @@ use std::time::Duration;
 use ::sandbox::{ExecOutputLimits, ProcessControlMode, ProcessOutputMode};
 
 /// Behavior override applied to exec calls whose command contains the pattern.
+///
+/// The matcher configures an ordinary [`ExecResult`](::sandbox::ExecResult).
+/// The result remains subject to the executing
+/// [`ExecRequest`](::sandbox::ExecRequest)'s output limits.
 pub struct ExecMatcher {
     /// Substring to match against `ExecRequest.cmd`.
     pub pattern: String,
+    /// Exit code reported by the configured `ExecTermination::Exited` result.
     pub exit_code: i32,
+    /// Stdout bytes configured before the request's output limits are applied.
     pub stdout: Vec<u8>,
+    /// Stderr bytes configured before the request's output limits are applied.
     pub stderr: Vec<u8>,
 }
 

--- a/crates/sandbox-mock/src/overrides.rs
+++ b/crates/sandbox-mock/src/overrides.rs
@@ -243,30 +243,26 @@ impl MockSandboxOverrides {
             .push_back(exit);
     }
 
-    /// Register a pattern matcher consumed on first match.
+    /// Register a one-shot pattern matcher for an ordinary exited result.
+    ///
+    /// The first registered matcher whose pattern occurs in a command is
+    /// consumed. The result is constructed with [`ExecResult::new`], then the
+    /// request's [`ExecOutputLimits`] are applied before it is returned.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
         self.exec
             .matchers
             .lock_ignoring_poison()
             .push(ExecMatcherResult {
                 pattern: matcher.pattern,
-                result: ExecResult {
-                    termination: ExecTermination::Exited {
-                        exit_code: matcher.exit_code,
-                    },
-                    stdout: matcher.stdout,
-                    stderr: matcher.stderr,
-                    diagnostic: String::new(),
-                    stdout_truncated: false,
-                    stderr_truncated: false,
-                },
+                result: ExecResult::new(matcher.exit_code, matcher.stdout, matcher.stderr),
             });
     }
 
     /// Register a pattern matcher that returns the supplied full exec result.
     ///
-    /// Use this when a test needs a non-ordinary terminal state such as timeout,
-    /// cancel, start failure, or wait failure.
+    /// Use this when a test needs a non-ordinary terminal state, diagnostic
+    /// text, or pre-existing result metadata. The request's
+    /// [`ExecOutputLimits`] are still applied before the result is returned.
     pub fn add_exec_result_matcher(&self, pattern: impl Into<String>, result: ExecResult) {
         self.exec
             .matchers

--- a/crates/sandbox-mock/src/tests/exec.rs
+++ b/crates/sandbox-mock/src/tests/exec.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn sandbox_default_exec_succeeds() {
@@ -125,4 +126,45 @@ async fn sandbox_exec_applies_mock_capture_budget() {
     assert_eq!(result.stderr, b"stde");
     assert!(result.stderr_truncated);
     assert_eq!(result.termination, ExecTermination::Exited { exit_code: 0 });
+}
+
+#[tokio::test]
+async fn sandbox_exec_matcher_applies_capture_limits_and_is_one_shot() {
+    let overrides = Arc::new(MockSandboxOverrides::new());
+    overrides.add_exec_matcher(ExecMatcher {
+        pattern: "echo hello".into(),
+        exit_code: 42,
+        stdout: b"stdout".to_vec(),
+        stderr: b"stderr".to_vec(),
+    });
+    let factory = MockSandboxFactory::with_overrides(overrides);
+    let sandbox = factory.create(test_sandbox_config()).await.unwrap();
+    let request = ExecRequest {
+        cmd: "echo hello world",
+        timeout: Duration::from_secs(5),
+        env: &[],
+        sudo: false,
+        stdin_bytes: None,
+        output_limits: ExecOutputLimits::separate(3, 4),
+    };
+
+    let matched = sandbox.exec(&request).await.unwrap();
+    assert_eq!(
+        matched.termination,
+        ExecTermination::Exited { exit_code: 42 }
+    );
+    assert_eq!(matched.stdout, b"std");
+    assert!(matched.stdout_truncated);
+    assert_eq!(matched.stderr, b"stde");
+    assert!(matched.stderr_truncated);
+
+    let fallback = sandbox.exec(&request).await.unwrap();
+    assert_eq!(
+        fallback.termination,
+        ExecTermination::Exited { exit_code: 0 }
+    );
+    assert!(fallback.stdout.is_empty());
+    assert!(!fallback.stdout_truncated);
+    assert!(fallback.stderr.is_empty());
+    assert!(!fallback.stderr_truncated);
 }


### PR DESCRIPTION
## Summary

- document that `ExecMatcher` produces an ordinary exited result whose stdout and stderr are configured before request output limits
- construct matcher results through `ExecResult::new` while preserving existing runtime semantics
- cover output truncation and one-shot matcher consumption through the public sandbox interface

## Behavior and scope

This changes the public Rust documentation for `sandbox-mock`; runtime behavior remains unchanged. It does not change schemas, persisted data, API or runner protocols, endpoints, or deployment compatibility.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-mock`
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-mock --all-targets --all-features`
- `cargo doc --manifest-path crates/Cargo.toml -p sandbox-mock --all-features --no-deps`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=1 --silent=passed-only` (7,382 passed; 1 existing benchmark skipped)
- `pnpm knip`

Closes #21144
