### PR TITLE
perf(mitm-addon): avoid unused response body buffering

### DIFF
--- a/crates/runner/mitm-addon/src/body_decoding.py
+++ b/crates/runner/mitm-addon/src/body_decoding.py
@@ -160,6 +160,12 @@ def can_stream_decode_usage(headers: http.Headers) -> bool:
     return False
 
 
+def can_decode_json_usage_body(headers: http.Headers) -> bool:
+    """Return whether bounded terminal JSON usage decoding supports the response."""
+    encoding = headers.get("content-encoding", "").strip().lower()
+    return not encoding or encoding == "identity" or encoding in _SUPPORTED_ONE_SHOT_BODY_ENCODINGS
+
+
 def create_stream_decode_session(
     headers: http.Headers,
     feed: _StreamDecodeFeed,

--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -664,6 +664,7 @@ def _replace_response_content(
 ) -> bytes | None:
     if flow.response is None:
         return None
+    flow.metadata.pop(metadata_keys.RESPONSE_STREAM_STATE, None)
     flow.metadata.pop(metadata_keys.STREAM_BUFFER, None)
     flow.metadata.pop(metadata_keys.STREAM_BUFFER_STATE, None)
     for header in ("content-encoding", "content-length", "transfer-encoding"):

--- a/crates/runner/mitm-addon/src/flow_metadata_keys.py
+++ b/crates/runner/mitm-addon/src/flow_metadata_keys.py
@@ -110,13 +110,16 @@ Firewall and auth context
 
 Response streaming
 ------------------
+- ``RESPONSE_STREAM_STATE``: ``dict`` containing ``total_bytes`` for the
+  general response stream callback. Read for exact response-size logging and
+  removed by stream cleanup.
 - ``STREAM_BUFFER``: capped ``bytearray`` written by ``responseheaders()`` via
-  response streaming setup. Read by response logging, body capture, model JSON
-  fallback extraction, and connector fallback parsing. Removed by stream
-  cleanup after terminal hooks.
-- ``STREAM_BUFFER_STATE``: ``dict`` with at least ``truncated`` and
-  ``total_bytes``. Written with ``STREAM_BUFFER`` and read for response size,
-  capture truncation, and connector parsing. Removed by stream cleanup.
+  response streaming setup only when body capture or usage fallback needs raw
+  response bytes. Read by body capture, model JSON fallback extraction, and
+  connector fallback parsing. Removed by stream cleanup after terminal hooks.
+- ``STREAM_BUFFER_STATE``: ``dict`` containing ``truncated``. Written only
+  with ``STREAM_BUFFER`` and read for capture truncation and connector fallback
+  parsing. Removed by stream cleanup.
 
 Request streaming
 -----------------
@@ -209,6 +212,7 @@ MODEL_PROVIDER_USAGE: Final = "model_provider_usage"
 MODEL_PROVIDER_USAGE_SOURCES: Final = "model_provider_usage_sources"
 MODEL_USAGE_PROVIDER: Final = "model_usage_provider"
 MODEL_JSON_USAGE_FINALIZED: Final = "_model_json_usage_finalized"
+RESPONSE_STREAM_STATE: Final = "response_stream_state"
 STREAM_BUFFER: Final = "stream_buffer"
 STREAM_BUFFER_STATE: Final = "stream_buffer_state"
 REQUEST_STREAM_BUFFER: Final = "request_stream_buffer"

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -1452,7 +1452,7 @@ def _handle_response(flow: http.HTTPFlow) -> None:
         not flow.metadata.get(metadata_keys.MODEL_JSON_USAGE_FINALIZED)
         and not flow.metadata.get(metadata_keys.MODEL_PROVIDER_USAGE)
         and stream_buf
-        and usage.is_model_provider_usage_observable(flow)
+        and response_streaming.uses_model_json_fallback(flow)
     ):
         if response_streaming.uses_openai_responses_usage_protocol(flow):
             json_usage, json_error = usage.extract_openai_responses_usage_with_error_from_json(

--- a/crates/runner/mitm-addon/src/response_streaming.py
+++ b/crates/runner/mitm-addon/src/response_streaming.py
@@ -2,8 +2,8 @@
 
 Lifecycle:
 - ``mitm_addon.responseheaders()`` calls ``configure_response_stream()`` to
-  install the streaming callback, capped forensic buffer, and incremental
-  usage parsers.
+  install the streaming callback, exact byte accounting, optional capped body
+  buffer, and incremental usage parsers.
 - ``mitm_addon.websocket_message()`` calls ``feed_model_websocket_usage()`` for
   terminal server-side usage frames on model-provider WebSocket upgrades.
 - ``mitm_addon.response()`` finalizes HTTP model and connector usage before
@@ -12,8 +12,8 @@ Lifecycle:
 - ``mitm_addon.websocket_end()`` is terminal for model-provider WebSocket
   upgrades. HTTP 101 responses defer tracked usage release until that hook.
 - hook cleanup paths call ``release_response_stream_state()`` to remove parser
-  callbacks and stream buffer metadata from ``flow.metadata``. This cleanup is
-  separate from tracked usage release.
+  callbacks, byte accounting, and optional buffer metadata from
+  ``flow.metadata``. This cleanup is separate from tracked usage release.
 """
 
 from collections.abc import Callable
@@ -53,6 +53,11 @@ class CapturedResponseStreamBody(NamedTuple):
     truncated: bool
 
 
+class _ResponseUsageStreamSetup(NamedTuple):
+    parser: _ResponseChunkParser | None
+    needs_buffered_fallback: bool
+
+
 def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
     """Return whether a flow should use OpenAI Responses usage parsing.
 
@@ -61,6 +66,21 @@ def uses_openai_responses_usage_protocol(flow: http.HTTPFlow) -> bool:
     usage protocol, while other model-provider flows use the Anthropic protocol.
     """
     return flow_metadata.cli_agent_type(flow.metadata) == "codex"
+
+
+def uses_model_json_fallback(flow: http.HTTPFlow) -> bool:
+    """Return whether terminal model usage may parse a buffered JSON body."""
+    response = flow.response
+    if (
+        response is None
+        or not _response_can_have_body(flow, response)
+        or not usage.is_model_provider_usage_observable(flow)
+    ):
+        return False
+    content_type = response.headers.get("content-type", "").lower()
+    if "text/event-stream" in content_type:
+        return False
+    return not _is_confirmed_websocket_upgrade_response(flow)
 
 
 def is_model_websocket_usage_enabled(flow: http.HTTPFlow) -> bool:
@@ -143,13 +163,12 @@ def _maybe_log_response_encoding_inspection_risk(
     )
 
 
-def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParser | None:
+def _configure_response_usage_stream(flow: http.HTTPFlow) -> _ResponseUsageStreamSetup:
     # Set up usage extraction for response classes that need body inspection.
-    # The forensic stream_buffer remains capped; usage parsers consume chunks
-    # separately so a large response cannot grow that buffer.
+    # Usage parsers consume chunks separately from the optional capped buffer.
     response = flow.response
     if response is None:
-        return None
+        return _ResponseUsageStreamSetup(None, False)
 
     # Platform-billable firewall flag, sourced from vm_info["billableFirewalls"]
     # via auth.handle_firewall_request.  Gates report_connector_usage (in response())
@@ -165,7 +184,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = {}
         flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE_SOURCES] = {}
         flow.metadata[_MODEL_WEBSOCKET_USAGE_ENABLED] = True
-        return None
+        return _ResponseUsageStreamSetup(None, False)
     if is_observable_model_provider:
         content_type = response.headers.get("content-type", "").lower()
         if "text/event-stream" in content_type:
@@ -190,7 +209,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
             decode_session = _make_response_decode_session(parser_fn, response.headers)
             if decode_session is None:
                 _maybe_log_response_encoding_inspection_risk(flow, response)
-                return None
+                return _ResponseUsageStreamSetup(None, False)
             flow.metadata[metadata_keys.MODEL_PROVIDER_USAGE] = usage_dict
 
             def finish_sse_usage() -> None:
@@ -202,7 +221,7 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
                 parser_fn.finish()
 
             flow.metadata[_MODEL_SSE_USAGE_FINISH] = finish_sse_usage
-            return decode_session.feed
+            return _ResponseUsageStreamSetup(decode_session.feed, False)
 
         if uses_openai_responses_usage_protocol(flow):
             extractor = usage.create_openai_responses_json_usage_extractor()
@@ -211,7 +230,11 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
         decode_session = _make_response_decode_session(extractor.feed, response.headers)
         if decode_session is None:
             _maybe_log_response_encoding_inspection_risk(flow, response)
-            return None
+            return _ResponseUsageStreamSetup(
+                None,
+                uses_model_json_fallback(flow)
+                and body_decoding.can_decode_json_usage_body(response.headers),
+            )
 
         def finish_json_usage() -> tuple[dict | None, str | None]:
             decode_error = decode_session.finish_error()
@@ -220,10 +243,10 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
             return extractor.finish()
 
         flow.metadata[_MODEL_JSON_USAGE_FINISH] = finish_json_usage
-        return decode_session.feed
+        return _ResponseUsageStreamSetup(decode_session.feed, False)
 
     if not is_billable_flow:
-        return None
+        return _ResponseUsageStreamSetup(None, False)
     if not body_decoding.can_stream_decode_usage(response.headers):
         firewall_name = flow_metadata.firewall_name(flow.metadata)
         if (
@@ -231,12 +254,17 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
             and usage.has_connector_response_parser(firewall_name)
         ):
             _maybe_log_response_encoding_inspection_risk(flow, response)
-        return None
+        return _ResponseUsageStreamSetup(
+            None,
+            _response_can_have_body(flow, response)
+            and body_decoding.can_decode_json_usage_body(response.headers)
+            and usage.needs_connector_response_buffer_fallback(flow),
+        )
     connector_parser = usage.create_connector_response_parser(flow)
     if connector_parser is not None:
         decode_session = _make_response_decode_session(connector_parser.feed, response.headers)
         if decode_session is None:
-            return None
+            raise RuntimeError("stream-decodable connector response did not create a decoder")
         if connector_parser.finish is not None or connector_parser.finish_decode_error is not None:
 
             def finish_connector_response() -> None:
@@ -249,9 +277,9 @@ def _configure_response_usage_parser(flow: http.HTTPFlow) -> _ResponseChunkParse
                     connector_parser.finish()
 
             flow.metadata[_CONNECTOR_RESPONSE_FINISH] = finish_connector_response
-        return decode_session.feed
+        return _ResponseUsageStreamSetup(decode_session.feed, False)
 
-    return None
+    return _ResponseUsageStreamSetup(None, False)
 
 
 def _is_confirmed_websocket_upgrade_response(flow: http.HTTPFlow) -> bool:
@@ -294,55 +322,50 @@ def _single_header_value(headers: http.Headers, name: str) -> str | None:
 
 
 def configure_response_stream(flow: http.HTTPFlow) -> None:
-    """
-    Enable response streaming with body buffering.
+    """Enable pass-through response streaming and body consumers.
 
-    Uses a callback to stream response data to the client immediately
-    while accumulating a copy in memory (up to ``STREAM_BUFFER_LIMIT``).
-    Once the limit is exceeded, buffering stops but streaming continues
-    uninterrupted.  The buffered body is available in the ``response()``
-    hook via ``flow.metadata[metadata_keys.STREAM_BUFFER]``.
+    Every configured response records exact streamed bytes. A capped raw-wire
+    body prefix is retained only for network capture or a terminal usage
+    fallback that cannot use incremental decoding.
     """
     if not flow.response:
         return
 
-    buf = bytearray()
-    state = {"truncated": False, "total_bytes": 0}
-    active_parser = _configure_response_usage_parser(flow)
+    metrics = {"total_bytes": 0}
+    usage_parser, needs_buffered_fallback = _configure_response_usage_stream(flow)
+    retain_body = flow_metadata.should_capture_body(flow.metadata) or needs_buffered_fallback
+    buf = bytearray() if retain_body else None
+    buffer_state = {"truncated": False} if retain_body else None
 
-    # Buffer cap policy:
-    # - stream_buffer is only for forensic logging / capture and is always
-    #   capped at STREAM_BUFFER_LIMIT.
-    # - Token usage extraction uses the incremental parsers above.
-    buf_limit = STREAM_BUFFER_LIMIT
-
-    def stream_and_buffer(chunk: bytes) -> bytes:
-        state["total_bytes"] += len(chunk)
-        if not state["truncated"]:
-            remaining = buf_limit - len(buf)
+    def stream_and_observe(chunk: bytes) -> bytes:
+        metrics["total_bytes"] += len(chunk)
+        if buf is not None and buffer_state is not None and not buffer_state["truncated"]:
+            remaining = STREAM_BUFFER_LIMIT - len(buf)
             if len(chunk) <= remaining:
                 buf.extend(chunk)
             else:
                 buf.extend(chunk[:remaining])
-                state["truncated"] = True
-        if active_parser is not None:
-            active_parser(chunk)
+                buffer_state["truncated"] = True
+        if usage_parser is not None:
+            usage_parser(chunk)
         return chunk
 
-    flow.response.stream = stream_and_buffer
-    flow.metadata[metadata_keys.STREAM_BUFFER] = buf
-    flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = state
-    flow.metadata[_RESPONSE_STREAM_CALLBACK] = stream_and_buffer
+    flow.response.stream = stream_and_observe
+    flow.metadata[metadata_keys.RESPONSE_STREAM_STATE] = metrics
+    if buf is not None and buffer_state is not None:
+        flow.metadata[metadata_keys.STREAM_BUFFER] = buf
+        flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = buffer_state
+    flow.metadata[_RESPONSE_STREAM_CALLBACK] = stream_and_observe
 
 
 def streamed_response_size(flow: http.HTTPFlow) -> int | None:
     """Return total bytes observed by the response streaming callback.
 
     Read-only helper used by ``response()`` network logging. Reads
-    ``metadata_keys.STREAM_BUFFER_STATE`` and returns ``None`` when
+    ``metadata_keys.RESPONSE_STREAM_STATE`` and returns ``None`` when
     ``responseheaders()`` did not configure streaming for this flow.
     """
-    state = flow.metadata.get(metadata_keys.STREAM_BUFFER_STATE)
+    state = flow.metadata.get(metadata_keys.RESPONSE_STREAM_STATE)
     if state is None:
         return None
     return int(state["total_bytes"])
@@ -498,12 +521,13 @@ def release_response_stream_state(flow: http.HTTPFlow) -> None:
     ``error()``, and ``websocket_end()``. Safe to call repeatedly. This releases
     stream/parser state even when a 101 response keeps usage tracking alive
     until ``websocket_end()``. Removes ``_RESPONSE_STREAM_CALLBACK``,
-    ``metadata_keys.STREAM_BUFFER``, ``metadata_keys.STREAM_BUFFER_STATE``, and
+    ``metadata_keys.RESPONSE_STREAM_STATE``, optional body-buffer metadata, and
     outstanding model or connector finish callbacks. Preserves externally
-    replaced ``flow.response.stream`` callbacks and only disables the stream
-    callback installed by this module.
+    replaced ``flow.response.stream`` callbacks and only disables the callback
+    installed by this module.
     """
     stream_callback = flow.metadata.pop(_RESPONSE_STREAM_CALLBACK, None)
+    flow.metadata.pop(metadata_keys.RESPONSE_STREAM_STATE, None)
     flow.metadata.pop(metadata_keys.STREAM_BUFFER, None)
     flow.metadata.pop(metadata_keys.STREAM_BUFFER_STATE, None)
     flow.metadata.pop(_MODEL_JSON_USAGE_FINISH, None)

--- a/crates/runner/mitm-addon/src/usage/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/__init__.py
@@ -56,6 +56,7 @@ from .openai_responses import (
 from .providers.connectors import (
     create_connector_response_parser,
     has_connector_response_parser,
+    needs_connector_response_buffer_fallback,
     report_connector_usage,
 )
 from .providers.model_provider import (
@@ -91,6 +92,7 @@ __all__ = [
     "increment_in_flight_flows",
     "is_model_provider_usage_observable",
     "merge_openai_responses_usage_result",
+    "needs_connector_response_buffer_fallback",
     "read_usage_flush_request_id",
     "report_connector_usage",
     "report_model_provider_usage",

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/__init__.py
@@ -28,6 +28,7 @@ from .response_parser import ConnectorResponseParser
 
 _ConnectorUsageHandler = Callable[[http.HTTPFlow, str, str], None]
 _ResponseParserFactory = Callable[[http.HTTPFlow, str], ConnectorResponseParser | None]
+_ResponseBufferFallbackPredicate = Callable[[http.HTTPFlow], bool]
 
 # Map firewall_name → per-connector report_usage handler. A handler is only
 # invoked when ``flow.metadata[metadata_keys.FIREWALL_BILLABLE]`` is True. That
@@ -45,6 +46,10 @@ _HANDLERS: dict[str, _ConnectorUsageHandler] = {
 # parser.
 _RESPONSE_PARSER_FACTORIES: dict[str, _ResponseParserFactory] = {
     "x": x.create_response_parser,
+}
+
+_RESPONSE_BUFFER_FALLBACK_PREDICATES: dict[str, _ResponseBufferFallbackPredicate] = {
+    "x": x.needs_response_buffer_fallback,
 }
 
 # One-shot guard: first time we see a billable firewall_name with no
@@ -122,3 +127,12 @@ def create_connector_response_parser(flow: http.HTTPFlow) -> ConnectorResponsePa
         return None
     original_url = _require_original_url(flow)
     return factory(flow, original_url)
+
+
+def needs_connector_response_buffer_fallback(flow: http.HTTPFlow) -> bool:
+    """Return whether terminal connector billing may consume buffered response bytes."""
+    if not flow_metadata.is_firewall_billable(flow.metadata):
+        return False
+    firewall_name = flow_metadata.firewall_name(flow.metadata)
+    predicate = _RESPONSE_BUFFER_FALLBACK_PREDICATES.get(firewall_name)
+    return predicate(flow) if predicate is not None else False

--- a/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
+++ b/crates/runner/mitm-addon/src/usage/providers/connectors/x.py
@@ -47,11 +47,10 @@ _HTTP_STATUS_REDIRECT_MIN = 300
 
 # X v2 NDJSON streaming endpoint paths (exact match — ``/2/tweets/search/stream/rules``
 # is a regular request/response endpoint for rules management, NOT a stream).
-# Streams deliver one JSON object per line, possibly for hours.  The shared
-# response streaming wrapper remains the mitmproxy stream callback: it keeps the
-# capped forensic stream_buffer and, when a parser is configured, feeds the X
-# NDJSON parser incrementally so billing extraction does not require buffering
-# the full response body.
+# Streams deliver one JSON object per line, possibly for hours. The shared
+# response streaming wrapper feeds the X NDJSON parser incrementally so billing
+# extraction does not retain the response body. Capture mode independently keeps
+# a capped raw-wire prefix.
 _STREAM_ENDPOINTS = frozenset(
     {
         "/2/tweets/search/stream",
@@ -293,6 +292,12 @@ class _NdjsonState(TypedDict):
     """JSON-parseable non-blank lines."""
     lines_failed: int
     """Lines that failed JSON decoding or exceeded the single-line safety cap."""
+
+
+class _ResponseUsageContext(NamedTuple):
+    permission: str
+    request_path: str
+    endpoint_bucket: str
 
 
 class _NdjsonExtractor:
@@ -920,6 +925,26 @@ def _compute_billable_counts(
     return counts
 
 
+def _response_usage_context(flow: http.HTTPFlow) -> _ResponseUsageContext | None:
+    if not flow.response or not (
+        _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
+    ):
+        return None
+    permission = flow_metadata.firewall_permission(flow.metadata)
+    if not permission:
+        return None
+    request_path = _strip_request_target_query(flow.request.path)
+    endpoint_bucket = classify_bucket(permission, flow.request.method, request_path)
+    if endpoint_bucket is None:
+        return None
+    return _ResponseUsageContext(permission, request_path, endpoint_bucket)
+
+
+def needs_response_buffer_fallback(flow: http.HTTPFlow) -> bool:
+    """Return whether X billing may consume a buffered response body."""
+    return _response_usage_context(flow) is not None
+
+
 def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     """Compute billable resource counts and buffer them for upload.
 
@@ -942,22 +967,17 @@ def report_usage(flow: http.HTTPFlow, run_id: str, original_url: str) -> None:
     - ``firewall_permission`` is not mapped to an X billing bucket
       (e.g. the ``"app-only"`` scope for BearerToken-only endpoints)
     """
+    response_context = _response_usage_context(flow)
+    if response_context is None:
+        return
     firewall_name = flow_metadata.firewall_name(flow.metadata)
-    if not flow.response or not (
-        _HTTP_STATUS_OK_MIN <= flow.response.status_code < _HTTP_STATUS_REDIRECT_MIN
-    ):
-        return
-    permission = flow_metadata.firewall_permission(flow.metadata)
-    if not permission:
-        return
+    permission = response_context.permission
     # mitmproxy's ``flow.request.path`` is the raw request-target — it
     # includes the query string.  Strip it without parsing query params so
     # literal-suffix overrides (e.g. ``/2/tweets/{id}/retweeted_by``) still
     # match requests that carry ``?max_results=10`` or similar.
-    request_path = _strip_request_target_query(flow.request.path)
-    endpoint_bucket = classify_bucket(permission, flow.request.method, request_path)
-    if endpoint_bucket is None:
-        return
+    request_path = response_context.request_path
+    endpoint_bucket = response_context.endpoint_bucket
     if bucket_needs_body_refinement(endpoint_bucket, flow.request.method, request_path):
         request_body = billing_body.decode_request_body_for_billing(
             _request_body_for_billing_refinement(flow),

--- a/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
+++ b/crates/runner/mitm-addon/tests/stream_buffer_helpers.py
@@ -18,10 +18,7 @@ def set_response_stream_buffer(
 ) -> None:
     """Seed response stream metadata with the hook-owned key/state shape."""
     flow.metadata[metadata_keys.STREAM_BUFFER] = bytearray(body)
-    flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {
-        "truncated": truncated,
-        "total_bytes": len(body) + 1 if truncated else len(body),
-    }
+    flow.metadata[metadata_keys.STREAM_BUFFER_STATE] = {"truncated": truncated}
 
 
 def set_request_stream_buffer(

--- a/crates/runner/mitm-addon/tests/test_connector_usage.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage.py
@@ -4,7 +4,6 @@ import pytest
 
 import flow_metadata_keys as metadata_keys
 import mitm_addon
-from body_limits import STREAM_BUFFER_LIMIT
 from tests.flow_helpers import header_map, response_stream
 from tests.x_flow_helpers import make_x_response_flow
 
@@ -32,6 +31,8 @@ class TestXStreamPathRouting:
 
         assert metadata_keys.X_NDJSON_STATE in flow.metadata
         assert "connector_response_finish" in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_absolute_form_request_target_registers_ndjson_parser_from_original_url(
         self, real_flow
@@ -72,8 +73,10 @@ class TestXStreamPathRouting:
 
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
-    def test_stream_error_response_uses_bounded_forensic_buffer_only(self, real_flow):
+    def test_stream_error_response_does_not_retain_body_prefix(self, real_flow):
         flow = make_x_response_flow(
             real_flow,
             path="/2/tweets/search/stream",
@@ -86,8 +89,8 @@ class TestXStreamPathRouting:
         assert "connector_response_finish" not in flow.metadata
         callback = response_stream(flow)
         callback(b'{"title":"Unauthorized","detail":"' + b"x" * (200 * 1024) + b'"}')
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     @pytest.mark.parametrize("path", ["/2/tweets", "/2/tweets/search/stream"])
     @pytest.mark.parametrize("firewall_billable", [False, None])
@@ -103,12 +106,12 @@ class TestXStreamPathRouting:
 
         mitm_addon.responseheaders(flow)
 
-        response_stream(flow)(b"x" * (STREAM_BUFFER_LIMIT + 1000))
+        response_stream(flow)(b"x" * (65 * 1024))
 
         assert "connector_response_finish" not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_brotli_stream_path_skips_response_body_parser(self, real_flow, mitm_ctx):
         flow = self._make_x_response_flow(real_flow, "/2/tweets/search/stream")

--- a/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
+++ b/crates/runner/mitm-addon/tests/test_connector_usage_dispatcher.py
@@ -45,14 +45,12 @@ class TestConnectorUsageDispatcher:
             for event in body["events"]
         ]
 
-    def test_x_usage_flow_stream_state_matches_response_stream_contract(self, tmp_path, real_flow):
+    def test_x_usage_flow_buffer_state_matches_response_stream_contract(self, tmp_path, real_flow):
         body = b'{"data":[{"id":"1","text":"hi"}]}'
         flow = self._make_x_flow(real_flow, tmp_path, body=body)
 
         assert flow.metadata[metadata_keys.STREAM_BUFFER] == bytearray(body)
-        stream_state = flow.metadata[metadata_keys.STREAM_BUFFER_STATE]
-        assert stream_state["truncated"] is False
-        assert stream_state["total_bytes"] == len(body)
+        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE] == {"truncated": False}
 
     def test_skips_for_model_provider(self, tmp_path, real_flow):
         """Model-provider flows go through report_model_provider_usage instead.

--- a/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_json_streaming.py
@@ -70,11 +70,13 @@ class TestModelProviderJsonStreaming:
 
         assert "model_json_usage_finish" not in flow.metadata
         assert metadata_keys.MODEL_PROVIDER_USAGE not in flow.metadata
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
-    def test_full_pipeline_large_model_json_uses_bounded_buffer(self, tmp_path, real_flow):
-        """responseheaders + response report model usage without full-body buffering."""
+    def test_full_pipeline_large_model_json_uses_incremental_parser_without_buffer(
+        self, tmp_path, real_flow
+    ):
+        """responseheaders + response report model usage without a body-prefix copy."""
         flow = model_provider_flow(
             real_flow,
             tmp_path,
@@ -91,8 +93,8 @@ class TestModelProviderJsonStreaming:
         callback(b'{"id":"msg_1","model":"claude-sonnet-4-6","content":[{"text":"')
         callback(b"x" * (STREAM_BUFFER_LIMIT + 4096))
         callback(b'"}],"usage":{"input_tokens":50,"output_tokens":200}}')
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
         webhook = run_response(flow, self._usage_webhook_api)
 
@@ -179,6 +181,8 @@ class TestModelProviderJsonStreaming:
         mitm_addon.responseheaders(flow)
         assert "model_json_usage_finish" not in flow.metadata
         response_stream(flow)(compressed)
+        assert metadata_keys.STREAM_BUFFER in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
         webhook = run_response(flow, self._usage_webhook_api)
 
@@ -345,6 +349,8 @@ class TestModelProviderJsonStreaming:
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(compressed)
+        assert metadata_keys.STREAM_BUFFER in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
         webhook = run_response(flow, self._usage_webhook_api)
 

--- a/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_sse_usage.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import Callable
 from pathlib import Path
 
+import brotli
 import pytest
 from mitmproxy import http
 from mitmproxy.flow import Error
@@ -106,6 +107,8 @@ class TestModelProviderSseUsage:
         """response() must flush a trailing SSE usage event before reporting."""
         flow = _openai_responses_sse_flow(tmp_path, real_flow)
         mitm_addon.responseheaders(flow)
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         response_stream(flow)(
             b"event: response.completed\n"
             b'data: {"response":{"model":"gpt-5.5",'
@@ -125,6 +128,36 @@ class TestModelProviderSseUsage:
             "tokens.cache_read": 10,
             "tokens.cache_creation": 15,
         }
+
+    @pytest.mark.parametrize("capture_body", [False, True])
+    def test_brotli_sse_does_not_use_model_json_fallback(self, tmp_path, real_flow, capture_body):
+        flow = _openai_responses_sse_flow(tmp_path, real_flow)
+        assert flow.response is not None
+        flow.response.headers["content-encoding"] = "br"
+        if capture_body:
+            flow.metadata[metadata_keys.CAPTURE_BODY] = True
+        plaintext = (
+            b"event: response.completed\n"
+            b'data: {"response":{"id":"resp_sse_1","model":"gpt-5.5",'
+            b'"usage":{"input_tokens":50,"output_tokens":20}}}\n\n'
+        )
+
+        mitm_addon.responseheaders(flow)
+        response_stream(flow)(brotli.compress(plaintext))
+        assert (metadata_keys.STREAM_BUFFER in flow.metadata) is capture_body
+        assert (metadata_keys.STREAM_BUFFER_STATE in flow.metadata) is capture_body
+
+        webhook = self._run_response(flow)
+
+        assert webhook.request_count == 0
+        proxy_log = Path(flow.metadata[metadata_keys.VM_PROXY_LOG_PATH])
+        entries = (
+            read_jsonl_entries_after_flush(proxy_log) if jsonl_exists_after_flush(proxy_log) else []
+        )
+        assert not any(
+            entry.get("message") == "Model provider JSON usage extraction failed"
+            for entry in entries
+        )
 
     def test_full_pipeline_model_sse_reports_response_incomplete_usage(self, tmp_path, real_flow):
         flow = _openai_responses_sse_flow(tmp_path, real_flow)

--- a/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
+++ b/crates/runner/mitm-addon/tests/test_model_provider_websocket_usage.py
@@ -180,6 +180,8 @@ class TestModelProviderWebSocketUsage:
         assert flow.metadata["model_websocket_usage_enabled"] is True
         assert "model_json_usage_finish" not in flow.metadata
         assert "model_sse_usage_finish" not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
         _set_websocket_message(
             flow,

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -71,6 +71,7 @@ class TestResponseHandler:
                 headers=header_map({"content-type": "text/plain", "content-length": "8"}),
                 content=b"upstream",
             )
+            flow.metadata[metadata_keys.RESPONSE_STREAM_STATE] = {"total_bytes": 8}
             mitm_addon.response(flow)
 
         assert flow.response.status_code == 401
@@ -98,6 +99,8 @@ class TestResponseHandler:
         assert entry["connector_diagnostic_reason"] == "not_configured_for_run"
         assert entry["connector_diagnostic_env_names"] == ["FAL_TOKEN"]
         assert entry["connector_diagnostic_base"] == "https://fal.run"
+        assert entry["response_size"] == len(content)
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         proxy_entry = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")[0]
         assert proxy_entry["type"] == "connector_diagnostic"
         assert proxy_entry["connector"] == "fal"
@@ -1048,10 +1051,10 @@ class TestResponseHandler:
         entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 100
 
-    def test_response_size_tracks_streamed_bytes_when_buffer_truncated(
+    def test_response_size_tracks_large_stream_without_body_buffer(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        """response_size should ignore Content-Length when stream metadata exists."""
+        """A large ordinary response keeps exact size without retaining a prefix."""
         flow = real_flow(with_response=False, host="api.example.com")
         log_path = str(tmp_path / "network.jsonl")
         body = b"x" * (STREAM_BUFFER_LIMIT + 4096)
@@ -1066,10 +1069,10 @@ class TestResponseHandler:
         )
 
         mitm_addon.responseheaders(flow)
-        response_stream(flow)(body[:123])
-        response_stream(flow)(body[123:])
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
+        assert response_stream(flow)(body[:123]) == body[:123]
+        assert response_stream(flow)(body[123:]) == body[123:]
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -1496,7 +1499,7 @@ class TestResponseHandler:
         entry = read_jsonl_entries_after_flush(Path(log_path))[0]
         assert entry["response_size"] == 0
 
-    def test_response_size_tracks_streamed_bytes_when_buffer_truncated_without_length(
+    def test_response_size_tracks_large_unbounded_stream_without_length(
         self, tmp_path, real_flow, mitm_ctx
     ):
         """response_size should not become 0 for chunked large streamed responses."""
@@ -1516,6 +1519,8 @@ class TestResponseHandler:
         mitm_addon.responseheaders(flow)
         response_stream(flow)(body[:123])
         response_stream(flow)(body[123:])
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
         with mitm_ctx():
             mitm_addon.response(flow)
@@ -1793,6 +1798,7 @@ class TestResponseHandler:
             mitm_addon.response(flow)
 
         assert flow.response.stream is False
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata
@@ -1815,6 +1821,7 @@ class TestResponseHandler:
         mitm_addon.response(flow)
 
         assert flow.response.stream is False
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_response_headers_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_headers_handler.py
@@ -10,8 +10,8 @@ from tests.flow_helpers import header_map, response_stream
 class TestResponseHeadersHandler:
     """Tests for the responseheaders() hook contract."""
 
-    def test_enables_streaming_with_buffer(self, real_flow):
-        """All responses should be streamed via a buffer callback."""
+    def test_enables_streaming_without_body_buffer(self, real_flow):
+        """Ordinary responses should stream with metrics but no retained prefix."""
         flow = real_flow(with_response=False, host="api.example.com")
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
@@ -20,9 +20,9 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
-        assert metadata_keys.STREAM_BUFFER in flow.metadata
-        assert isinstance(flow.metadata[metadata_keys.STREAM_BUFFER], bytearray)
-        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
+        assert flow.metadata[metadata_keys.RESPONSE_STREAM_STATE] == {"total_bytes": 0}
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_capture_body_also_streams(self, real_flow):
         """When capture_body is set, streaming should still be enabled."""
@@ -35,6 +35,7 @@ class TestResponseHeadersHandler:
         mitm_addon.responseheaders(flow)
 
         assert callable(response_stream(flow))
+        assert flow.metadata[metadata_keys.RESPONSE_STREAM_STATE] == {"total_bytes": 0}
         assert metadata_keys.STREAM_BUFFER in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
@@ -44,3 +45,5 @@ class TestResponseHeadersHandler:
         flow.response = None
 
         mitm_addon.responseheaders(flow)
+
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_response_streaming.py
+++ b/crates/runner/mitm-addon/tests/test_response_streaming.py
@@ -21,8 +21,16 @@ _OVERSIZED_NDJSON_LINE_BYTES = LARGE_RESPONSE_DECOMPRESS_LIMIT + 1024
 class TestResponseStreamBuffer:
     """Tests for generic response stream buffering behavior."""
 
-    def _json_response_flow(self, real_flow, *, host: str = "api.example.com") -> http.HTTPFlow:
+    def _json_response_flow(
+        self,
+        real_flow,
+        *,
+        host: str = "api.example.com",
+        capture_body: bool = True,
+    ) -> http.HTTPFlow:
         flow = real_flow(with_response=False, host=host)
+        if capture_body:
+            flow.metadata[metadata_keys.CAPTURE_BODY] = True
         flow.response = tutils.tresp(
             status_code=200, headers=header_map({"content-type": "application/json"})
         )
@@ -95,18 +103,28 @@ class TestResponseStreamBuffer:
         callback(b"hello")
         assert bytes(flow.metadata[metadata_keys.STREAM_BUFFER]) == b"hello"
 
-    def test_non_model_provider_buffer_truncated(self, real_flow):
-        flow = self._json_response_flow(real_flow, host="api.github.com")
+    def test_non_capture_response_does_not_retain_body_prefix(self, real_flow):
+        flow = self._json_response_flow(
+            real_flow,
+            host="api.github.com",
+            capture_body=False,
+        )
 
         mitm_addon.responseheaders(flow)
 
-        response_stream(flow)(b"x" * (STREAM_BUFFER_LIMIT + 1000))
+        body = b"x" * (STREAM_BUFFER_LIMIT + 1000)
+        assert response_stream(flow)(body) == body
 
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
+        assert flow.metadata[metadata_keys.RESPONSE_STREAM_STATE]["total_bytes"] == len(body)
 
-    def test_non_x_billable_connector_uses_bounded_forensic_buffer(self, real_flow):
-        flow = self._json_response_flow(real_flow, host="api.gamma.example")
+    def test_billable_connector_without_body_parser_does_not_retain_prefix(self, real_flow):
+        flow = self._json_response_flow(
+            real_flow,
+            host="api.gamma.example",
+            capture_body=False,
+        )
         flow.metadata[metadata_keys.FIREWALL_NAME] = "gamma"
         flow.metadata[metadata_keys.FIREWALL_BILLABLE] = True
 
@@ -114,8 +132,8 @@ class TestResponseStreamBuffer:
 
         response_stream(flow)(b"g" * (STREAM_BUFFER_LIMIT + 1000))
 
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert metadata_keys.X_NDJSON_STATE not in flow.metadata
         assert "connector_response_finish" not in flow.metadata
 
@@ -224,6 +242,8 @@ class TestResponseEncodingInspectionRisk:
         assert "private-encoding-value" not in str(entry)
         assert "private-encoding-value" not in log.debug.call_args.args[0]
         assert entry["decode_skip_reason"] == "unsupported content encoding"
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_stream_safe_model_response_keeps_parser_without_risk(
         self, real_flow, tmp_path, mitm_ctx
@@ -246,6 +266,8 @@ class TestResponseEncodingInspectionRisk:
             mitm_addon.responseheaders(flow)
 
         assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     @pytest.mark.parametrize(
         ("request_method", "response_status"),
@@ -275,6 +297,8 @@ class TestResponseEncodingInspectionRisk:
             mitm_addon.responseheaders(flow)
 
         assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     def test_successful_billable_connector_logs_non_streamable_encoding_risk(
         self, real_flow, tmp_path, mitm_ctx
@@ -291,6 +315,24 @@ class TestResponseEncodingInspectionRisk:
         assert entry["firewall_name"] == "x"
         assert entry["status_code"] == 200
         assert entry["decode_skip_reason"] == "zstd streaming output cannot be hard-bounded"
+
+    def test_unknown_connector_encoding_does_not_retain_unusable_fallback(
+        self, real_flow, tmp_path, mitm_ctx
+    ) -> None:
+        flow = make_x_pipeline_flow(
+            real_flow,
+            tmp_path,
+            content_encoding="private-encoding-value",
+        )
+
+        with mitm_ctx():
+            mitm_addon.responseheaders(flow)
+
+        [entry] = read_jsonl_entries_after_flush(tmp_path / "proxy.jsonl")
+        assert entry["reason"] == "response_encoding_not_stream_decodable"
+        assert entry["decode_skip_reason"] == "unsupported content encoding"
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
     @pytest.mark.parametrize(
         ("firewall_name", "firewall_billable", "response_status"),
@@ -323,13 +365,17 @@ class TestResponseEncodingInspectionRisk:
             mitm_addon.responseheaders(flow)
 
         assert not jsonl_exists_after_flush(tmp_path / "proxy.jsonl")
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
 
 class TestNdjsonExtractor:
     """Tests for X NDJSON extraction through responseheaders (issue #9534)."""
 
-    def _stream_flow(self, real_flow):
+    def _stream_flow(self, real_flow, *, capture_body=False):
         flow = make_x_response_flow(real_flow, path="/2/tweets/search/stream")
+        if capture_body:
+            flow.metadata[metadata_keys.CAPTURE_BODY] = True
         mitm_addon.responseheaders(flow)
         return flow
 
@@ -354,7 +400,7 @@ class TestNdjsonExtractor:
         assert state["lines_parsed"] == 2
 
     def test_forensic_buffer_truncation_does_not_stop_parser(self, real_flow):
-        flow = self._stream_flow(real_flow)
+        flow = self._stream_flow(real_flow, capture_body=True)
         parse = response_stream(flow)
         state = flow.metadata[metadata_keys.X_NDJSON_STATE]
 
@@ -646,6 +692,7 @@ class TestXJsonFinalize:
             path="/2/users/by",
             original_url="https://api.x.com/2/users/by?ids=1,2,3",
         )
+        flow.metadata[metadata_keys.CAPTURE_BODY] = True
         mitm_addon.responseheaders(flow)
 
         callback = response_stream(flow)
@@ -1053,6 +1100,7 @@ class TestReleaseResponseStreamState:
 
         assert flow.response.stream is external_stream
         assert "_vm0_response_stream_callback" not in flow.metadata
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
@@ -1132,6 +1180,7 @@ class TestReleaseResponseStreamState:
         response_streaming.release_response_stream_state(flow)
 
         assert finish_key not in flow.metadata
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert flow.response.stream is False
@@ -1163,6 +1212,7 @@ class TestReleaseResponseStreamState:
 
         assert flow.response.stream is False
         assert "_vm0_response_stream_callback" not in flow.metadata
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
@@ -1185,6 +1235,7 @@ class TestReleaseResponseStreamState:
 
         assert flow.response is None
         assert "_vm0_response_stream_callback" not in flow.metadata
+        assert metadata_keys.RESPONSE_STREAM_STATE not in flow.metadata
         assert metadata_keys.STREAM_BUFFER not in flow.metadata
         assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
         assert "model_json_usage_finish" not in flow.metadata

--- a/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
+++ b/crates/runner/mitm-addon/tests/test_x_connector_pipeline.py
@@ -70,10 +70,10 @@ class TestXConnectorResponsePipeline:
             for event in body["events"]
         ]
 
-    def test_full_response_pipeline_large_x_json_uses_bounded_buffer(
+    def test_full_response_pipeline_large_x_json_uses_incremental_parser_without_buffer(
         self, tmp_path, real_flow, mitm_ctx
     ):
-        """responseheaders + response bill X JSON without full-body buffering."""
+        """responseheaders + response bill X JSON without a body-prefix copy."""
         flow = make_x_pipeline_flow(real_flow, tmp_path, query="expansions=author_id")
 
         mitm_addon.responseheaders(flow)
@@ -81,8 +81,8 @@ class TestXConnectorResponsePipeline:
         callback(b'{"data":[{"id":"1","text":"')
         callback(b"x" * (STREAM_BUFFER_LIMIT + 4096))
         callback(b'"}],"includes":{"users":[{"id":"u1"}]},"meta":{"result_count":1}}')
-        assert len(flow.metadata[metadata_keys.STREAM_BUFFER]) == STREAM_BUFFER_LIMIT
-        assert flow.metadata[metadata_keys.STREAM_BUFFER_STATE]["truncated"] is True
+        assert metadata_keys.STREAM_BUFFER not in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE not in flow.metadata
 
         with self._usage_webhook_api() as webhook:
             mitm_addon.response(flow)
@@ -103,6 +103,8 @@ class TestXConnectorResponsePipeline:
         with mitm_ctx() as log:
             mitm_addon.responseheaders(flow)
         response_stream(flow)(_compress_body(encoding_case, payload))
+        assert metadata_keys.STREAM_BUFFER in flow.metadata
+        assert metadata_keys.STREAM_BUFFER_STATE in flow.metadata
 
         payloads = self._call_and_get_billing(flow)
 
@@ -432,7 +434,6 @@ class TestXConnectorResponsePipeline:
             sandbox_value="tok-xyz",
             rule="GET /2/tweets/search/recent",
         )
-
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"}')
         assert "connector_response_finish" in flow.metadata
@@ -466,6 +467,7 @@ class TestXConnectorResponsePipeline:
             sandbox_value="tok-xyz",
             rule="GET /2/tweets/search/recent",
         )
+        flow.metadata[metadata_keys.CAPTURE_BODY] = True
 
         mitm_addon.responseheaders(flow)
         response_stream(flow)(b'{"data":[{"id":"1"},' + b" " * STREAM_BUFFER_LIMIT)


### PR DESCRIPTION
## Summary

- track exact streamed response bytes independently from optional body retention
- retain the capped response prefix only for explicit body capture or a terminal usage fallback whose bounded decoder can consume it
- centralize model JSON and X connector fallback eligibility so SSE, WebSocket, bodyless, non-billable, error, unknown-encoding, and unrelated connector responses do not allocate a body buffer
- preserve incremental model and X usage extraction, existing pre-buffered fallback diagnostics, and the non-streamable encoding risk signals from #21172
- clean up all ephemeral stream state on terminal paths

## Compatibility

- no persisted data, database schema, API, runner protocol, or deployment contract changes
- the new response stream metrics key is ephemeral per-flow metadata and is removed during existing cleanup

## Validation

- `cd crates/runner/mitm-addon && python3 -m pytest -q` (`3833 passed`)
- `cd crates/runner/mitm-addon && python3 -m ruff check .`
- `cd crates/runner/mitm-addon && python3 -m ruff format --check .`
- `cd crates/runner/mitm-addon && python3 -m basedpyright -p .`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=2 --silent=passed-only --reporter=dot` (`592` files and `7381` tests passed; two unrelated UI tests hit the 5-second timeout)
- `cd turbo && pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx src/views/zero-page/__tests__/zero-attachment-chips.test.tsx --maxWorkers=1 --silent=passed-only --reporter=dot` (`2` files and `107` tests passed)
- `cd turbo && pnpm knip`

Closes #21146
