### PR TITLE
perf(runner): defer cold cache fill until agent spawn

### DIFF
--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -891,6 +891,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         session_history_restore_plan,
     } = controls;
     let has_active_input_source = active_input_source.is_some();
+    let mut deferred_background_fill = None;
 
     // 1. Fix guest clock and reseed entropy (must happen before HTTPS calls).
     //    Needed after snapshot restore (frozen clock) and after idle reuse (drifted clock).
@@ -985,7 +986,8 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     .then_some(STORAGE_CACHE_POPULATE_FAILED),
             );
             match cache_result {
-                Ok(()) => {
+                Ok(deferred) => {
+                    deferred_background_fill = deferred;
                     let guest_manifest = plan.into_guest_manifest();
                     let download_t = Instant::now();
                     let download_result =
@@ -1425,6 +1427,10 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     let stream_task = handle
         .take_stdout_receiver()
         .map(|stdout_rx| tokio::spawn(drain_stdout_to_file(stdout_rx, host_log_path)));
+
+    if let Some(background_fill) = deferred_background_fill {
+        background_fill.start(telemetry);
+    }
 
     // 6. Wait for exit (or cancellation). On cancel, ask the guest to cancel the
     // supervised process and briefly wait for its terminal status so the vsock

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -24,8 +24,8 @@ use guest_contracts::session_history_identity::{
 };
 use httpmock::prelude::*;
 use sandbox::{
-    ExecResult, ExecTermination, ProcessExit, ProcessOutputChunk, SandboxConfig, SandboxFactory,
-    SandboxId,
+    ExecResult, ExecTermination, ProcessExit, ProcessOutputChunk, ProcessOutputMode, SandboxConfig,
+    SandboxFactory, SandboxId,
 };
 use sandbox_mock::MockSandboxFactory;
 use sha2::{Digest, Sha256};
@@ -38,15 +38,17 @@ use super::super::agent_run::{
 };
 use super::super::diagnostics::AgentStdoutStreamDiagnostics;
 use super::super::storage::guest_download_stdin_command;
+use super::super::telemetry::RunnerSpawnTiming;
 use super::super::{
     EXIT_SIGKILL, PROCESS_CANCEL_WRITE_TIMEOUT, RestoredSessionIdentity,
     SessionHistoryMaterializer, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
     effective_cli_framework,
 };
 use super::support::{
-    CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, api_artifact, api_storage,
-    create_overridden_sandbox, minimal_context, sandbox_exec_error, spawn_run_in_sandbox_test,
-    spawn_run_in_sandbox_test_with_timeouts, test_executor_config, test_telemetry,
+    CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, StartProcessGateSandbox, api_artifact,
+    api_storage, create_overridden_sandbox, minimal_context, sandbox_exec_error,
+    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts, test_executor_config,
+    test_telemetry,
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -82,9 +84,10 @@ async fn serve_history_once(body: &[u8]) -> OneShotSessionHistoryServer {
 
 async fn serve_storage_archive_for_cache(
     body: &'static [u8],
-) -> (String, tokio::task::JoinHandle<()>) {
+) -> (String, tokio::task::JoinHandle<()>, oneshot::Receiver<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();
+    let (request_tx, request_rx) = oneshot::channel();
     let handle = tokio::spawn(async move {
         let probe_response = format!(
             "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes 0-0/{}\r\nContent-Length: 1\r\nConnection: close\r\n\r\nx",
@@ -98,14 +101,22 @@ async fn serve_storage_archive_for_cache(
         .into_bytes();
         full_response.extend_from_slice(body);
 
+        let mut request_tx = Some(request_tx);
         for response in [probe_response, full_response] {
             let (mut stream, _) = listener.accept().await.unwrap();
             let mut request = [0u8; 1024];
             let _ = stream.read(&mut request).await;
+            if let Some(request_tx) = request_tx.take() {
+                let _ = request_tx.send(());
+            }
             stream.write_all(&response).await.unwrap();
         }
     });
-    (format!("http://{address}/archive.tar.gz"), handle)
+    (
+        format!("http://{address}/archive.tar.gz"),
+        handle,
+        request_rx,
+    )
 }
 
 async fn serve_history_once_after_request(
@@ -551,12 +562,20 @@ async fn run_in_sandbox_runs_guest_download_for_cached_instruction_normalization
 }
 
 #[tokio::test]
-async fn run_in_sandbox_storage_cache_miss_passthrough_reaches_guest_download() {
+async fn run_in_sandbox_starts_deferred_cache_fill_after_agent_spawn() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
-    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    let start_process_entered = Arc::new(Notify::new());
+    let start_process_release = Arc::new(Notify::new());
+    let sandbox = StartProcessGateSandbox {
+        inner: create_overridden_sandbox(Arc::clone(&overrides)).await,
+        entered: Arc::clone(&start_process_entered),
+        release: Arc::clone(&start_process_release),
+    };
     let mut ctx = minimal_context();
-    let (archive_url, archive_server) = serve_storage_archive_for_cache(b"cache-archive").await;
+    let (archive_url, archive_server, mut archive_request) =
+        serve_storage_archive_for_cache(b"cache-archive").await;
     let storage = api_storage("instructions", "/home/user/.codex", "v1", &archive_url);
     ctx.storage_manifest = Some(StorageManifest {
         storages: vec![storage],
@@ -564,7 +583,173 @@ async fn run_in_sandbox_storage_cache_miss_passthrough_reaches_guest_download() 
     });
     let mut telemetry = test_telemetry(&config, &ctx);
 
-    run_in_sandbox(
+    {
+        let run = run_in_sandbox(
+            &sandbox,
+            &ctx,
+            &config,
+            RunStart {
+                restore_guest_state: false,
+                reuse_result: SandboxReuseResult::PoolMiss,
+                prev_storage: None,
+            },
+            &mut telemetry,
+            RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+                .with_spawn_timing(RunnerSpawnTiming::start(None)),
+        );
+        tokio::pin!(run);
+
+        tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, async {
+            tokio::select! {
+                result = &mut run => {
+                    let _ = result;
+                    panic!("run finished before the start-process barrier");
+                },
+                () = start_process_entered.notified() => {}
+            }
+        })
+        .await
+        .expect("run should reach the start-process barrier");
+
+        assert!(matches!(
+            archive_request.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
+        ));
+        let exec_calls = overrides.exec_calls();
+        assert!(
+            exec_calls
+                .iter()
+                .any(|call| call.cmd == guest_download_stdin_command()),
+            "cache miss passthrough should reach guest-download before process spawn; calls: {exec_calls:?}"
+        );
+
+        start_process_release.notify_one();
+        run.await.unwrap();
+    }
+
+    tokio::time::timeout(RUN_IN_SANDBOX_TEST_TIMEOUT, &mut archive_request)
+        .await
+        .expect("deferred cache fill should contact the archive after spawn")
+        .expect("archive server should report its first request");
+    tokio::time::timeout(Duration::from_secs(5), archive_server)
+        .await
+        .expect("background cache fill should fetch archive")
+        .expect("background cache fill server task should not panic");
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
+    assert_successful_action_once(&ops, "runner_storage_manifest_cache_populate");
+    assert_successful_action_once(&ops, "runner_storage_manifest_guest_download");
+    assert_successful_action_once(&ops, "runner_storage_manifest_apply");
+    assert_successful_action_once(&ops, "storage_cache_miss_passthrough");
+    assert_successful_action_once(&ops, "storage_cache_background_fill_deferred_count_1");
+    assert_successful_action_once(&ops, "storage_cache_background_fill_deferred_delay");
+    assert_successful_action_once(&ops, "storage_cache_background_fill_scheduled_count_1");
+    assert_successful_action_once(&ops, "runner_agent_start_process");
+    assert_successful_action_once(&ops, "runner_executor_start_to_spawn");
+    assert_no_action(&ops, "storage_cache_miss");
+    assert_no_action(&ops, "storage_cache_download");
+
+    let spawn_index = ops
+        .iter()
+        .position(|op| op.0 == "runner_executor_start_to_spawn")
+        .unwrap();
+    let deferred_start_index = ops
+        .iter()
+        .position(|op| op.0 == "storage_cache_background_fill_deferred_delay")
+        .unwrap();
+    let scheduled_index = ops
+        .iter()
+        .position(|op| op.0 == "storage_cache_background_fill_scheduled_count_1")
+        .unwrap();
+    assert!(spawn_index < deferred_start_index);
+    assert!(deferred_start_index < scheduled_index);
+}
+
+#[tokio::test]
+async fn run_in_sandbox_drops_deferred_cache_fill_when_agent_spawn_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+    overrides.push_start_process_stdout_chunks(
+        (0..=ProcessOutputMode::DEFAULT_QUEUE_CAPACITY)
+            .map(|_| ProcessOutputChunk {
+                bytes: Vec::new(),
+                truncated: false,
+            })
+            .collect(),
+    );
+    let sandbox = create_overridden_sandbox(Arc::clone(&overrides)).await;
+    let mut ctx = minimal_context();
+    let (archive_url, archive_server, mut archive_request) =
+        serve_storage_archive_for_cache(b"cache-archive").await;
+    ctx.storage_manifest = Some(StorageManifest {
+        storages: vec![api_storage(
+            "instructions",
+            "/home/user/.codex",
+            "v1",
+            &archive_url,
+        )],
+        artifacts: vec![],
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
+        sandbox.as_ref(),
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_spawn_timing(RunnerSpawnTiming::start(None)),
+    )
+    .await;
+    assert!(result.is_err());
+    tokio::task::yield_now().await;
+
+    assert!(matches!(
+        archive_request.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+    let ops = telemetry.pending_ops_snapshot();
+    assert_successful_action_once(&ops, "storage_cache_background_fill_deferred_count_1");
+    assert!(
+        ops.iter()
+            .any(|op| op.0 == "runner_agent_start_process" && !op.1),
+        "expected failed process spawn telemetry, got: {ops:?}"
+    );
+    assert_no_action(&ops, "storage_cache_background_fill_deferred_delay");
+    assert_no_action(&ops, "storage_cache_background_fill_scheduled_count_1");
+    assert_no_action(&ops, "runner_executor_start_to_spawn");
+
+    archive_server.abort();
+    let _ = archive_server.await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_drops_deferred_cache_fill_when_guest_download_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    sandbox.push_exec_result(Err(sandbox_exec_error("vsock exec failed")));
+    let mut ctx = minimal_context();
+    let (archive_url, archive_server, mut archive_request) =
+        serve_storage_archive_for_cache(b"cache-archive").await;
+    ctx.storage_manifest = Some(StorageManifest {
+        storages: vec![api_storage(
+            "instructions",
+            "/home/user/.codex",
+            "v1",
+            &archive_url,
+        )],
+        artifacts: vec![],
+    });
+    let mut telemetry = test_telemetry(&config, &ctx);
+
+    let result = run_in_sandbox(
         &sandbox,
         &ctx,
         &config,
@@ -576,28 +761,27 @@ async fn run_in_sandbox_storage_cache_miss_passthrough_reaches_guest_download() 
         &mut telemetry,
         RunControls::new(tokio_util::sync::CancellationToken::new(), None),
     )
-    .await
-    .unwrap();
+    .await;
+    assert!(result.is_err());
+    tokio::task::yield_now().await;
 
-    let exec_calls = sandbox.exec_calls();
-    assert!(
-        exec_calls
-            .iter()
-            .any(|call| call.cmd == guest_download_stdin_command()),
-        "cache miss passthrough should leave work for guest-download; calls: {exec_calls:?}"
-    );
-    tokio::time::timeout(Duration::from_secs(5), archive_server)
-        .await
-        .expect("background cache fill should fetch archive")
-        .expect("background cache fill server task should not panic");
+    assert!(matches!(
+        archive_request.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
     let ops = telemetry.pending_ops_snapshot();
-    assert_successful_action_once(&ops, "runner_storage_manifest_has_work");
-    assert_successful_action_once(&ops, "runner_storage_manifest_cache_populate");
-    assert_successful_action_once(&ops, "runner_storage_manifest_guest_download");
-    assert_successful_action_once(&ops, "runner_storage_manifest_apply");
-    assert_successful_action_once(&ops, "storage_cache_miss_passthrough");
-    assert_no_action(&ops, "storage_cache_miss");
-    assert_no_action(&ops, "storage_cache_download");
+    assert_successful_action_once(&ops, "storage_cache_background_fill_deferred_count_1");
+    assert_no_action(&ops, "storage_cache_background_fill_deferred_delay");
+    assert_no_action(&ops, "storage_cache_background_fill_scheduled_count_1");
+    assert_no_action(&ops, "runner_agent_start_process");
+    assert_failed_action_error_once(
+        &ops,
+        "runner_storage_manifest_guest_download",
+        "storage-download-failed",
+    );
+
+    archive_server.abort();
+    let _ = archive_server.await;
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/support/mod.rs
+++ b/crates/runner/src/executor/tests/support/mod.rs
@@ -22,8 +22,8 @@ pub(super) use self::execution::{
 };
 pub(super) use self::manifest::{api_artifact, api_storage};
 pub(super) use self::sandbox::{
-    CancelAfterWaitSandbox, DestroyPanicFactory, QueuedCopyFileSandbox, create_overridden_sandbox,
-    sandbox_create_error, sandbox_exec_error, sandbox_write_file_error,
+    CancelAfterWaitSandbox, DestroyPanicFactory, QueuedCopyFileSandbox, StartProcessGateSandbox,
+    create_overridden_sandbox, sandbox_create_error, sandbox_exec_error, sandbox_write_file_error,
 };
 pub(super) use self::tracing::{CapturedEvent, CapturedEvents};
 pub(super) use self::workspace_cache::seed_workspace_image_cache;

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -138,6 +138,97 @@ pub(in crate::executor::tests) struct CancelAfterWaitSandbox {
     pub(in crate::executor::tests) cancel: tokio_util::sync::CancellationToken,
 }
 
+pub(in crate::executor::tests) struct StartProcessGateSandbox {
+    pub(in crate::executor::tests) inner: Box<dyn Sandbox>,
+    pub(in crate::executor::tests) entered: Arc<tokio::sync::Notify>,
+    pub(in crate::executor::tests) release: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait]
+impl Sandbox for StartProcessGateSandbox {
+    fn id(&self) -> &str {
+        self.inner.id()
+    }
+
+    fn source_ip(&self) -> &str {
+        self.inner.source_ip()
+    }
+
+    fn host_process_pid(&self) -> Option<u32> {
+        self.inner.host_process_pid()
+    }
+
+    async fn start(&mut self) -> sandbox::Result<()> {
+        self.inner.start().await
+    }
+
+    async fn stop(&mut self) -> sandbox::Result<()> {
+        self.inner.stop().await
+    }
+
+    async fn kill(&mut self) -> sandbox::Result<()> {
+        self.inner.kill().await
+    }
+
+    async fn park(&mut self) -> sandbox::Result<()> {
+        self.inner.park().await
+    }
+
+    async fn unpark(&mut self) -> sandbox::Result<()> {
+        self.inner.unpark().await
+    }
+
+    async fn exec(&self, request: &ExecRequest<'_>) -> sandbox::Result<ExecResult> {
+        self.inner.exec(request).await
+    }
+
+    async fn exec_with_diagnostic_label(
+        &self,
+        request: &ExecRequest<'_>,
+        label: &'static str,
+    ) -> sandbox::Result<ExecResult> {
+        self.inner.exec_with_diagnostic_label(request, label).await
+    }
+
+    async fn read_file(&self, path: &str, max_bytes: u64) -> sandbox::Result<Option<Vec<u8>>> {
+        self.inner.read_file(path, max_bytes).await
+    }
+
+    async fn copy_file(
+        &self,
+        path: &str,
+        host_path: &Path,
+        options: CopyFileOptions,
+    ) -> sandbox::Result<sandbox::CopyFileResult> {
+        self.inner.copy_file(path, host_path, options).await
+    }
+
+    async fn write_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_file(path, content).await
+    }
+
+    async fn write_private_file(&self, path: &str, content: &[u8]) -> sandbox::Result<()> {
+        self.inner.write_private_file(path, content).await
+    }
+
+    async fn start_process(
+        &self,
+        request: &StartProcessRequest<'_>,
+    ) -> sandbox::Result<sandbox::GuestProcessHandle> {
+        self.entered.notify_one();
+        self.release.notified().await;
+        self.inner.start_process(request).await
+    }
+
+    async fn wait_process(
+        &self,
+        handle: sandbox::GuestProcessHandle,
+        timeout: Duration,
+    ) -> sandbox::Result<ProcessExit> {
+        self.inner.wait_process(handle, timeout).await
+    }
+}
+
 #[async_trait]
 impl Sandbox for CancelAfterWaitSandbox {
     fn id(&self) -> &str {

--- a/crates/runner/src/storage_cache.rs
+++ b/crates/runner/src/storage_cache.rs
@@ -4,8 +4,9 @@
 //! For each eligible planned archive, checks a host-local
 //! cache keyed by `(vasStorageName, vasVersionId)`. On hit, reads the cached
 //! tarball from disk and pushes it into the guest via vsock. On miss, leaves
-//! the original URL for the current guest download and starts a background
-//! cache fill for future runs. Once guest staging succeeds, the plan's
+//! the original URL for the current guest download and returns a deferred
+//! cache fill for future runs. The executor starts that fill only after the
+//! agent process has spawned. Once guest staging succeeds, the plan's
 //! archive source is resolved to
 //! `file:///tmp/vm0-storage-cache/<hash(name)>-<hash(version)>.tar.gz`
 //! so `guest-download` reads the guest-local staged archive instead of
@@ -90,6 +91,8 @@ const STORAGE_CACHE_BACKGROUND_FILL_RETRYABLE_SKIPPED: &str =
 const STORAGE_CACHE_BACKGROUND_FILL_SKIPPED: &str = "storage_cache_background_fill_skipped";
 const STORAGE_CACHE_BACKGROUND_FILL_FAILED: &str = "storage_cache_background_fill_failed";
 const STORAGE_CACHE_BACKGROUND_FILL_FAILED_ERROR: &str = "background-fill-failed";
+const STORAGE_CACHE_BACKGROUND_FILL_DEFERRED_DELAY: &str =
+    "storage_cache_background_fill_deferred_delay";
 
 /// Guest-side filename for a cached archive.
 ///
@@ -116,6 +119,39 @@ struct CacheTarget {
 #[derive(Clone)]
 struct CacheTargetGroup {
     targets: Vec<CacheTarget>,
+}
+
+/// Cold cache work selected during storage planning but not yet started.
+///
+/// Before [`Self::start`], this value owns archive URLs but no HTTP client,
+/// task, cache lock, or file, so dropping it on a pre-spawn failure requires
+/// no asynchronous cleanup.
+#[must_use = "deferred storage cache fill must be started after agent spawn or explicitly dropped"]
+pub(crate) struct DeferredBackgroundFill {
+    groups: Vec<CacheTargetGroup>,
+    home: HomePaths,
+    selected_at: Instant,
+}
+
+impl DeferredBackgroundFill {
+    pub(crate) fn start(self, telemetry: &mut JobTelemetry) {
+        telemetry.record(
+            STORAGE_CACHE_BACKGROUND_FILL_DEFERRED_DELAY,
+            self.selected_at.elapsed(),
+            true,
+            None,
+        );
+        telemetry.record(
+            background_fill_scheduled_count_action(self.groups.len()),
+            Duration::ZERO,
+            true,
+            None,
+        );
+        let reporter = telemetry.reporter();
+        tokio::spawn(async move {
+            run_background_fill_groups(self.groups, self.home, reporter).await;
+        });
+    }
 }
 
 enum GroupOutcome {
@@ -616,7 +652,7 @@ impl ForegroundCacheMode {
         }
     }
 
-    fn schedules_background_fill(self) -> bool {
+    fn defers_background_fill(self) -> bool {
         matches!(self, Self::HitOrPassthrough)
     }
 }
@@ -626,7 +662,7 @@ pub async fn populate_cache(
     sandbox: &dyn Sandbox,
     home: &HomePaths,
     telemetry: &mut JobTelemetry,
-) -> RunnerResult<()> {
+) -> RunnerResult<Option<DeferredBackgroundFill>> {
     populate_cache_with_mode(
         plan,
         sandbox,
@@ -644,14 +680,16 @@ async fn populate_cache_passthrough_without_background(
     home: &HomePaths,
     telemetry: &mut JobTelemetry,
 ) -> RunnerResult<()> {
-    populate_cache_with_mode(
+    let deferred = populate_cache_with_mode(
         plan,
         sandbox,
         home,
         telemetry,
         ForegroundCacheMode::HitOrPassthroughWithoutBackgroundFill,
     )
-    .await
+    .await?;
+    assert!(deferred.is_none());
+    Ok(())
 }
 
 #[cfg(test)]
@@ -661,14 +699,16 @@ async fn populate_cache_blocking(
     home: &HomePaths,
     telemetry: &mut JobTelemetry,
 ) -> RunnerResult<()> {
-    populate_cache_with_mode(
+    let deferred = populate_cache_with_mode(
         plan,
         sandbox,
         home,
         telemetry,
         ForegroundCacheMode::BlockingFill,
     )
-    .await
+    .await?;
+    assert!(deferred.is_none());
+    Ok(())
 }
 
 async fn populate_cache_with_mode(
@@ -677,10 +717,10 @@ async fn populate_cache_with_mode(
     home: &HomePaths,
     telemetry: &mut JobTelemetry,
     mode: ForegroundCacheMode,
-) -> RunnerResult<()> {
+) -> RunnerResult<Option<DeferredBackgroundFill>> {
     let targets = collect_targets(plan);
     if targets.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
     let target_groups = group_targets(targets);
 
@@ -793,42 +833,48 @@ async fn populate_cache_with_mode(
     stage_metrics.record_total(telemetry);
     let outcomes = stage_result?;
 
-    if mode.uses_hit_or_passthrough() {
+    let deferred = if mode.uses_hit_or_passthrough() {
         record_passthrough_summary(&outcomes, telemetry);
-        if mode.schedules_background_fill() {
-            spawn_background_fill_groups(&outcomes, home.clone(), telemetry);
+        if mode.defers_background_fill() {
+            defer_background_fill_groups(&outcomes, home.clone(), telemetry)
+        } else {
+            None
         }
-    }
+    } else {
+        None
+    };
     for (group, outcome) in outcomes {
         apply_group_outcome(plan, &group, &outcome, telemetry);
     }
-    Ok(())
+    Ok(deferred)
 }
 
-fn spawn_background_fill_groups(
+fn defer_background_fill_groups(
     outcomes: &[(CacheTargetGroup, GroupOutcome)],
     home: HomePaths,
     telemetry: &mut JobTelemetry,
-) {
+) -> Option<DeferredBackgroundFill> {
     let groups = outcomes
         .iter()
         .filter(|(_, outcome)| should_background_fill(outcome))
         .map(|(group, _)| group.clone())
         .collect::<Vec<_>>();
     if groups.is_empty() {
-        return;
+        return None;
     }
 
+    let selected_at = Instant::now();
     telemetry.record(
-        background_fill_scheduled_count_action(groups.len()),
+        background_fill_deferred_count_action(groups.len()),
         Duration::ZERO,
         true,
         None,
     );
-    let reporter = telemetry.reporter();
-    tokio::spawn(async move {
-        run_background_fill_groups(groups, home, reporter).await;
-    });
+    Some(DeferredBackgroundFill {
+        groups,
+        home,
+        selected_at,
+    })
 }
 
 fn should_background_fill(outcome: &GroupOutcome) -> bool {
@@ -2300,6 +2346,18 @@ fn background_fill_scheduled_count_action(count: usize) -> &'static str {
     }
 }
 
+fn background_fill_deferred_count_action(count: usize) -> &'static str {
+    match count_bucket(count) {
+        CountBucket::Zero => "storage_cache_background_fill_deferred_count_0",
+        CountBucket::One => "storage_cache_background_fill_deferred_count_1",
+        CountBucket::Two => "storage_cache_background_fill_deferred_count_2",
+        CountBucket::ThreeToFour => "storage_cache_background_fill_deferred_count_3_4",
+        CountBucket::FiveToEight => "storage_cache_background_fill_deferred_count_5_8",
+        CountBucket::NineToSixteen => "storage_cache_background_fill_deferred_count_9_16",
+        CountBucket::SeventeenPlus => "storage_cache_background_fill_deferred_count_17_plus",
+    }
+}
+
 fn background_fill_size_bucket_action(size: u64) -> &'static str {
     if size < 64 * 1024 {
         "storage_cache_background_fill_size_lt_64_kib"
@@ -2920,6 +2978,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn production_warm_hit_returns_no_deferred_fill() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+        let name = "production-warm-hit";
+        let version = "v1";
+        write_cached_archive(&home, name, version, &tarball_bytes());
+        let mut manifest = fresh_storage_plan(
+            "https://r2.example.com/never-called.tar.gz".into(),
+            name,
+            version,
+        );
+
+        let deferred = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap();
+
+        assert!(deferred.is_none());
+        assert_eq!(
+            storage_archive_url(&manifest, 0),
+            Some(format!("file://{}", guest_archive_path(name, version)).as_str())
+        );
+        assert_eq!(sandbox.write_files_calls().len(), 1);
+        let ops = telemetry.pending_ops_snapshot();
+        assert_no_op(&ops, "storage_cache_background_fill_deferred_count_1");
+        assert_no_op(&ops, "storage_cache_background_fill_scheduled_count_1");
+    }
+
+    #[tokio::test]
     async fn guarded_hit_path_reads_from_disk_and_rewrites_url() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
@@ -3050,7 +3138,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn miss_passthrough_fills_cache_in_background() {
+    async fn miss_passthrough_defers_cache_fill_until_started() {
         let temp = tempfile::tempdir().unwrap();
         let home = home_at(&temp);
         let sandbox = MockSandbox::new("test");
@@ -3060,12 +3148,17 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let (allow_tx, allow_rx) = tokio::sync::oneshot::channel();
+        let (request_tx, mut request_rx) = tokio::sync::oneshot::channel();
         let server_task = tokio::spawn(async move {
             let mut allow_rx = Some(allow_rx);
+            let mut request_tx = Some(request_tx);
             for response in [partial_content_response(body.len()), ok_response(&body)] {
                 let (mut socket, _) = listener.accept().await?;
                 let mut request = [0u8; 1024];
                 let _ = tokio::io::AsyncReadExt::read(&mut socket, &mut request).await?;
+                if let Some(request_tx) = request_tx.take() {
+                    let _ = request_tx.send(());
+                }
                 if let Some(allow_rx) = allow_rx.take() {
                     let _ = allow_rx.await;
                 }
@@ -3078,11 +3171,16 @@ mod tests {
         let original = format!("http://{addr}/archive.tar.gz");
         let mut manifest = fresh_storage_plan(original.clone(), name, version);
 
-        populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+        let deferred = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("cold miss should return deferred cache fill");
 
         assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
+        assert!(matches!(
+            request_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
         assert!(
             !home
                 .storage_cache_dir(name, version)
@@ -3092,6 +3190,17 @@ mod tests {
         assert!(sandbox.write_file_calls().is_empty());
         assert!(sandbox.write_files_calls().is_empty());
 
+        let ops = telemetry.pending_ops_snapshot();
+        assert_op_error(&ops, STORAGE_CACHE_MISS_PASSTHROUGH, "missing");
+        assert_op(&ops, "storage_cache_background_fill_deferred_count_1", true);
+        assert_no_op(&ops, "storage_cache_background_fill_scheduled_count_1");
+        assert_no_op(&ops, STORAGE_CACHE_BACKGROUND_FILL_DEFERRED_DELAY);
+
+        deferred.start(&mut telemetry);
+        tokio::time::timeout(Duration::from_secs(5), &mut request_rx)
+            .await
+            .expect("started background fill should contact archive server")
+            .expect("archive request sender should remain available");
         allow_tx.send(()).unwrap();
         await_raw_http_sequence(server_task).await;
         assert_eq!(
@@ -3100,14 +3209,59 @@ mod tests {
         );
 
         let ops = telemetry.pending_ops_snapshot();
-        assert_op_error(&ops, STORAGE_CACHE_MISS_PASSTHROUGH, "missing");
         assert_op(
             &ops,
             "storage_cache_background_fill_scheduled_count_1",
             true,
         );
+        assert_op(&ops, STORAGE_CACHE_BACKGROUND_FILL_DEFERRED_DELAY, true);
         assert_no_op(&ops, "storage_cache_miss");
         assert_no_op(&ops, "storage_cache_download");
+    }
+
+    #[tokio::test]
+    async fn dropped_deferred_fill_starts_no_http_or_cache_work() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = home_at(&temp);
+        let sandbox = MockSandbox::new("test");
+        let mut telemetry = new_telemetry();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (request_tx, mut request_rx) = tokio::sync::oneshot::channel();
+        let server_task = tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let _ = request_tx.send(());
+                let _ = socket
+                    .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
+                    .await;
+            }
+        });
+        let name = "dropped-background-miss";
+        let version = "v1";
+        let original = format!("http://{addr}/archive.tar.gz");
+        let mut manifest = fresh_storage_plan(original.clone(), name, version);
+
+        let deferred = populate_cache(&mut manifest, &sandbox, &home, &mut telemetry)
+            .await
+            .unwrap()
+            .expect("cold miss should return deferred cache fill");
+        drop(deferred);
+        tokio::task::yield_now().await;
+
+        assert_eq!(storage_archive_url(&manifest, 0), Some(original.as_str()));
+        assert!(matches!(
+            request_rx.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+        assert!(!home.storage_cache_dir(name, version).exists());
+        assert!(!home.storage_lock(name, version).exists());
+        let ops = telemetry.pending_ops_snapshot();
+        assert_op(&ops, "storage_cache_background_fill_deferred_count_1", true);
+        assert_no_op(&ops, "storage_cache_background_fill_scheduled_count_1");
+        assert_no_op(&ops, STORAGE_CACHE_BACKGROUND_FILL_DEFERRED_DELAY);
+
+        server_task.abort();
+        let _ = server_task.await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- keep cold archive misses on the existing guest-download path while carrying cache-fill work as an inert deferred batch
- start cold archive cache downloads only after the guest agent process has spawned and its startup/output plumbing is established
- drop deferred cache work on pre-spawn failures, while preserving warm-hit staging, background deduplication, retry behavior, and future-run cache population
- add telemetry for deferred batch count and spawn-to-fill delay, plus storage- and executor-level integration coverage

## Scope

- no API, schema, persisted-state, guest protocol, or deployment compatibility changes
- no feature switch; the behavior is runner-internal and failure-safe
- this PR completes #21129 only; #19669 remains the delivery parent for the broader run-startup work

## Validation

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cd crates && cargo test --workspace`
- `cd crates/runner/mitm-addon && python3 -m pytest tests/` (3,799 passed)
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (7,335 passed, 1 benchmark skipped)
- `cd turbo && pnpm knip`

Closes #21129

Parent context: #19669
