### PR TITLE
perf(api): overlap claim response assembly work

### DIFF
--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -1407,34 +1407,48 @@ async function buildClaimResponseBody(args: {
     "claim_route_response_assembly",
     "top_level",
     async () => {
-      const resumeSession = await resolveResumeSessionForClaim({
-        resumeSession: args.storedContext.resumeSession,
-        timing: args.timing,
-        loadIdentityRepresentation(hash: string) {
-          return args.loadIdentityRepresentation(hash);
-        },
-        loadCompressedRepresentation(
-          hash: string,
-          encoding: CompressedSessionHistoryBlobEncoding,
-        ) {
-          return args.loadCompressedRepresentation(hash, encoding);
-        },
-        generateResumeSessionHistoryUrl: args.generateResumeSessionHistoryUrl,
-        generateResumeSessionHistoryObjectUrl:
-          args.generateResumeSessionHistoryObjectUrl,
-      });
+      const [resumeSessionResult, refreshedPoliciesResult] =
+        await Promise.allSettled([
+          resolveResumeSessionForClaim({
+            resumeSession: args.storedContext.resumeSession,
+            timing: args.timing,
+            loadIdentityRepresentation(hash: string) {
+              return args.loadIdentityRepresentation(hash);
+            },
+            loadCompressedRepresentation(
+              hash: string,
+              encoding: CompressedSessionHistoryBlobEncoding,
+            ) {
+              return args.loadCompressedRepresentation(hash, encoding);
+            },
+            generateResumeSessionHistoryUrl:
+              args.generateResumeSessionHistoryUrl,
+            generateResumeSessionHistoryObjectUrl:
+              args.generateResumeSessionHistoryObjectUrl,
+          }),
+          refreshClaimNetworkPolicies({
+            db: args.db,
+            run: args.run,
+            storedContext: args.storedContext,
+            timing: args.timing,
+          }),
+        ]);
+      if (resumeSessionResult.status === "rejected") {
+        const error: unknown = resumeSessionResult.reason;
+        throw error;
+      }
+      const resumeSession = resumeSessionResult.value;
       args.signal.throwIfAborted();
       const sandboxToken = generateSandboxToken(
         args.run.userId,
         args.run.id,
         args.run.orgId,
       );
-      const refreshedPolicies = await refreshClaimNetworkPolicies({
-        db: args.db,
-        run: args.run,
-        storedContext: args.storedContext,
-        timing: args.timing,
-      });
+      if (refreshedPoliciesResult.status === "rejected") {
+        const error: unknown = refreshedPoliciesResult.reason;
+        throw error;
+      }
+      const refreshedPolicies = refreshedPoliciesResult.value;
       args.signal.throwIfAborted();
       const {
         secretValueEnvironmentKeys: _secretValueEnvironmentKeys,


### PR DESCRIPTION
## Summary

- start resume-session reconstruction and network-policy refresh concurrently during runner claim response assembly
- await and observe both operations while preserving resume-session error precedence, sandbox-token generation order, and existing response contents
- reduce the combined-path critical section from sequential latency toward the slower of the two independent operations

## Scope

- does not change claim eligibility, reservation, or completion behavior
- does not change schemas, persisted data, API or runner protocols, or telemetry names
- keeps the existing single-operation paths and response serialization behavior intact

## Validation

- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts` (101 tests passed)
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F @vm0/db test:migration-consistency`
- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm vitest run --maxWorkers=2 --silent=passed-only` (594 files passed, 1 skipped; 7,383 tests passed, 1 skipped)
- `pnpm knip`

## Rollout

- monitor the existing `claim_route_response_assembly` timing and claim error metrics after deployment
- rollback is limited to reverting this commit if combined-path latency or error behavior regresses

Closes #21158

Parent context: #18746
