### PR TITLE
fix: align teams oauth connect flow

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-teams-oauth.test.ts
@@ -32,7 +32,6 @@ const MICROSOFT_TOKEN_URL =
 const MICROSOFT_ME_URL = "https://graph.microsoft.com/v1.0/me";
 const TEAMS_APP_ID = "00000000-0000-0000-0000-000000000001";
 const TEAMS_APP_TENANT_ID = "11111111-1111-1111-1111-111111111111";
-const AUTH_HEADERS = { authorization: "Bearer clerk-session" } as const;
 
 async function appRequest(
   path: string,
@@ -151,12 +150,9 @@ describe("Teams OAuth API routes", () => {
     mockEnv("MICROSOFT_OAUTH_CLIENT_SECRET", "test-microsoft-client-secret");
   });
 
-  it("redirects to Microsoft OAuth with connect state", async () => {
-    mocks.clerk.session("user_1", "org_1", "org:member");
-
+  it("redirects to Microsoft OAuth with connect state without a browser session", async () => {
     const response = await appRequest(
       "/api/zero/teams/oauth/connect?orgId=org_1&vm0UserId=user_1",
-      { headers: AUTH_HEADERS },
     );
 
     expect(response.status).toBe(307);
@@ -181,13 +177,11 @@ describe("Teams OAuth API routes", () => {
   });
 
   it("uses the web rewrite origin for callback URLs", async () => {
-    mocks.clerk.session("user_1", "org_1", "org:member");
-
     const response = await appRequest(
       "/api/zero/teams/oauth/connect?orgId=org_1&vm0UserId=user_1",
       {
         origin: API_ORIGIN,
-        headers: { ...AUTH_HEADERS, "x-vm0-web-origin": WEB_ORIGIN },
+        headers: { "x-vm0-web-origin": WEB_ORIGIN },
       },
     );
 
@@ -198,17 +192,12 @@ describe("Teams OAuth API routes", () => {
     );
   });
 
-  it("rejects connect requests for a different signed-in user", async () => {
-    mocks.clerk.session("user_other", "org_1", "org:member");
+  it("rejects connect requests without org and user state", async () => {
+    const response = await appRequest("/api/zero/teams/oauth/connect");
 
-    const response = await appRequest(
-      "/api/zero/teams/oauth/connect?orgId=org_1&vm0UserId=user_1",
-      { headers: AUTH_HEADERS },
-    );
-
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(400);
     await expect(response.json()).resolves.toStrictEqual({
-      error: "Authenticated user does not match Teams connect request",
+      error: "Missing orgId or vm0UserId",
     });
   });
 
@@ -226,7 +215,7 @@ describe("Teams OAuth API routes", () => {
         code: "valid-code",
         state: { orgId: fixture.orgId, vm0UserId: fixture.userId },
       }),
-      { origin: WEB_ORIGIN, headers: AUTH_HEADERS },
+      { origin: WEB_ORIGIN },
     );
 
     expect(response.status).toBe(307);
@@ -278,7 +267,7 @@ describe("Teams OAuth API routes", () => {
         code: "valid-code",
         state: { orgId: fixture.orgId, vm0UserId: fixture.userId },
       }),
-      { origin: WEB_ORIGIN, headers: AUTH_HEADERS },
+      { origin: WEB_ORIGIN },
     );
 
     expect(response.status).toBe(307);
@@ -329,7 +318,7 @@ describe("Teams OAuth API routes", () => {
         code: "valid-code",
         state: { orgId: fixture.orgId, vm0UserId: fixture.userId },
       }),
-      { origin: WEB_ORIGIN, headers: AUTH_HEADERS },
+      { origin: WEB_ORIGIN },
     );
 
     expect(response.status).toBe(307);
@@ -340,17 +329,18 @@ describe("Teams OAuth API routes", () => {
     );
   });
 
-  it("rejects callback state for a different signed-in user", async () => {
+  it("rejects callback state when the vm0 user is not an org member", async () => {
     const fixture = await seedTeamsInstallation(track);
-    await seedMembership(fixture.orgId, fixture.userId, "admin");
-    mocks.clerk.session("user_other", fixture.orgId, "org:admin");
+    context.mocks.clerk.users.getOrganizationMembershipList.mockResolvedValue({
+      data: [],
+    });
 
     const response = await appRequest(
       callbackPath({
         code: "valid-code",
         state: { orgId: fixture.orgId, vm0UserId: fixture.userId },
       }),
-      { origin: WEB_ORIGIN, headers: AUTH_HEADERS },
+      { origin: WEB_ORIGIN },
     );
 
     expect(response.status).toBe(307);

--- a/turbo/apps/api/src/signals/routes/zero-teams-oauth.ts
+++ b/turbo/apps/api/src/signals/routes/zero-teams-oauth.ts
@@ -4,9 +4,9 @@ import { z } from "zod";
 
 import { env } from "../../lib/env";
 import { logger } from "../../lib/log";
-import { requiredAuthContext$ } from "../auth/auth-context";
 import { request$ } from "../context/hono";
 import { queryOf } from "../context/request";
+import { getMemberRoleAndUpdateCache$ } from "../services/auth.service";
 import {
   buildTeamsInstallUrl,
   connectTeamsInstallation$,
@@ -35,10 +35,6 @@ const MICROSOFT_TEAMS_CONNECT_SCOPES = [
   "email",
   "User.Read",
 ] as const;
-const teamsOauthAuthOptions = {
-  requireOrganization: true,
-  missingOrganizationStatus: 401,
-} as const;
 
 interface OAuthState {
   readonly orgId: string | null;
@@ -64,14 +60,6 @@ interface TeamsOauthAuth {
   readonly orgRole: "admin" | "member";
 }
 
-type TeamsOauthAuthResult =
-  | { readonly kind: "ok"; readonly auth: TeamsOauthAuth }
-  | {
-      readonly kind: "error";
-      readonly message: string;
-      readonly status: 400 | 401 | 403;
-    };
-
 function redirectResponse(url: string): Response {
   return new Response(null, {
     status: REDIRECT_STATUS,
@@ -91,13 +79,6 @@ function jsonErrorResponse(error: string, status: number): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
-}
-
-function authJsonErrorResponse(
-  error: string,
-  status: 400 | 401 | 403,
-): Response {
-  return jsonErrorResponse(error, status);
 }
 
 function appUrl(path: string): string {
@@ -141,49 +122,6 @@ function truncatePrompt(prompt: string): string {
 function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
-
-function stateMatchesAuth(state: OAuthState, auth: TeamsOauthAuth): boolean {
-  return state.orgId === auth.orgId && state.vm0UserId === auth.userId;
-}
-
-const resolveTeamsOauthAuth$ = command(
-  async ({ set }, signal: AbortSignal): Promise<TeamsOauthAuthResult> => {
-    const authResult = await set(
-      requiredAuthContext$,
-      teamsOauthAuthOptions,
-      signal,
-    );
-    signal.throwIfAborted();
-
-    if ("status" in authResult) {
-      return {
-        kind: "error",
-        message: authResult.body.error.message,
-        status: authResult.status,
-      };
-    }
-    if (
-      authResult.tokenType !== "session" ||
-      !authResult.orgId ||
-      !authResult.orgRole
-    ) {
-      return {
-        kind: "error",
-        message:
-          "Microsoft Teams OAuth connect requires a signed-in browser session",
-        status: 403,
-      };
-    }
-    return {
-      kind: "ok",
-      auth: {
-        userId: authResult.userId,
-        orgId: authResult.orgId,
-        orgRole: authResult.orgRole,
-      },
-    };
-  },
-);
 
 function parseOAuthState(state: string | undefined): OAuthState {
   if (!state) {
@@ -315,7 +253,37 @@ async function exchangeMicrosoftTeamsOAuthCode(args: {
   };
 }
 
-const connectOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
+const resolveTeamsOauthStateAuth$ = command(
+  async (
+    { set },
+    state: OAuthState,
+    signal: AbortSignal,
+  ): Promise<TeamsOauthAuth | null> => {
+    if (!state.orgId || !state.vm0UserId) {
+      return null;
+    }
+
+    const member = await set(
+      getMemberRoleAndUpdateCache$,
+      state.orgId,
+      state.vm0UserId,
+      signal,
+    );
+    signal.throwIfAborted();
+
+    if (!member) {
+      return null;
+    }
+
+    return {
+      userId: state.vm0UserId,
+      orgId: state.orgId,
+      orgRole: member.role,
+    };
+  },
+);
+
+const connectOauth$ = command(({ get }) => {
   const request = get(request$).raw;
   const canonicalRedirectUrl = getOAuthCanonicalRedirectUrl(request);
   if (canonicalRedirectUrl) {
@@ -336,27 +304,13 @@ const connectOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
     return jsonErrorResponse("Missing orgId or vm0UserId", 400);
   }
 
-  const authResult = await set(resolveTeamsOauthAuth$, signal);
-  if (authResult.kind === "error") {
-    return authJsonErrorResponse(authResult.message, authResult.status);
-  }
-  if (
-    query.orgId !== authResult.auth.orgId ||
-    query.vm0UserId !== authResult.auth.userId
-  ) {
-    return authJsonErrorResponse(
-      "Authenticated user does not match Teams connect request",
-      403,
-    );
-  }
-
   const stateObj: {
     orgId: string;
     vm0UserId: string;
     prompt?: string;
   } = {
-    orgId: authResult.auth.orgId,
-    vm0UserId: authResult.auth.userId,
+    orgId: query.orgId,
+    vm0UserId: query.vm0UserId,
   };
   if (query.prompt) {
     stateObj.prompt = truncatePrompt(query.prompt);
@@ -402,16 +356,8 @@ const callbackOauth$ = command(async ({ get, set }, signal: AbortSignal) => {
     return settingsErrorRedirect("Invalid connect state.");
   }
 
-  const authResult = await set(resolveTeamsOauthAuth$, signal);
-  if (authResult.kind === "error") {
-    const message =
-      authResult.status === 401
-        ? "Please sign in to connect Microsoft Teams."
-        : "Invalid connect state.";
-    return settingsErrorRedirect(message);
-  }
-  const auth = authResult.auth;
-  if (!stateMatchesAuth(state, auth)) {
+  const auth = await set(resolveTeamsOauthStateAuth$, state, signal);
+  if (!auth) {
     return settingsErrorRedirect("Invalid connect state.");
   }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -124,7 +124,7 @@ describe("works page", () => {
     });
   });
 
-  it("falls back to the Microsoft Teams tenant id when names are unavailable", async () => {
+  it("does not show the Microsoft Teams tenant id when names are unavailable", async () => {
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     mockTeamsAPI({
       isConnected: true,
@@ -139,7 +139,10 @@ describe("works page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Microsoft Teams")).toBeInTheDocument();
-      expect(screen.getByText("Connected (tenant-123)")).toBeInTheDocument();
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Connected (tenant-123)"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -447,7 +447,7 @@ function TeamsPermissionWarning({
 function teamsConnectedDetail(
   teamsData: TeamsConnectStatus | null,
 ): string | null | undefined {
-  return teamsData?.teamName ?? teamsData?.tenantName ?? teamsData?.tenantId;
+  return teamsData?.teamName ?? teamsData?.tenantName;
 }
 
 function teamsCardDescription(args: {


### PR DESCRIPTION
## Summary
- allow Microsoft Teams OAuth connect links to start without a signed-in browser session
- validate Teams OAuth callback state against vm0 organization membership before connecting
- stop showing Teams tenant IDs in /works connected labels when names are unavailable

## Tests
- pnpm -F api exec vitest run src/signals/routes/__tests__/zero-teams-oauth.test.ts
- pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-works-page.test.tsx
- pnpm -F @vm0/app lint
- pre-commit: pnpm check-types