### PR TITLE
refactor(cli): consume connector permission metadata from catalog api

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/helpers/connector-catalog.ts
@@ -4,6 +4,7 @@ import type {
   PublicConnectorCatalogAuthMethodSummary,
   PublicConnectorCatalogItem,
   PublicConnectorCatalogManualField,
+  PublicConnectorCatalogPermissionDetail,
   PublicConnectorCatalogStatusItem,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 
@@ -123,6 +124,29 @@ export function catalogStatusItem(
   };
 }
 
+export function catalogPermissionDetail(
+  overrides: Partial<PublicConnectorCatalogPermissionDetail> & {
+    readonly connectorRef: string;
+  },
+): PublicConnectorCatalogPermissionDetail {
+  const permissions = overrides.permissions ?? [];
+  return {
+    connectorRef: overrides.connectorRef,
+    label: overrides.label ?? overrides.connectorRef,
+    icon: overrides.icon ?? {
+      url: `https://icons.example.test/${overrides.connectorRef}.svg`,
+      invertInDarkMode: false,
+    },
+    permissionCount: overrides.permissionCount ?? permissions.length,
+    permissions,
+    categories: overrides.categories ?? null,
+    defaultPolicy: overrides.defaultPolicy ?? {
+      permissionDefault: "allow",
+      unknownPolicy: "allow",
+    },
+  };
+}
+
 export function stubConnectorCatalog(
   connectors: readonly PublicConnectorCatalogItem[],
 ) {
@@ -138,6 +162,36 @@ export function stubConnectorCatalogStatus(
     "http://localhost:3000/api/zero/connector-catalog/status",
     () => {
       return HttpResponse.json({ connectors });
+    },
+  );
+}
+
+export function stubConnectorCatalogPermissions(
+  details: readonly PublicConnectorCatalogPermissionDetail[],
+  origin = "http://localhost:3000",
+) {
+  const detailsByRef = new Map(
+    details.map((detail) => {
+      return [detail.connectorRef, detail] as const;
+    }),
+  );
+  return http.get(
+    `${origin}/api/zero/connector-catalog/:connectorRef/permissions`,
+    ({ params }) => {
+      const connectorRef = String(params.connectorRef);
+      const permissions = detailsByRef.get(connectorRef);
+      if (!permissions) {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Connector catalog item not found",
+              code: "NOT_FOUND",
+            },
+          },
+          { status: 404 },
+        );
+      }
+      return HttpResponse.json({ permissions });
     },
   );
 }

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -6,6 +6,10 @@ import * as os from "os";
 import chalk from "chalk";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server";
+import {
+  catalogPermissionDetail,
+  stubConnectorCatalogPermissions,
+} from "./helpers/connector-catalog";
 import { zeroWhoamiCommand } from "../whoami";
 
 // Mock os.homedir to use temp directory for config isolation
@@ -65,11 +69,35 @@ function makePermissionGrant(overrides: Record<string, unknown> = {}) {
   };
 }
 
+const defaultPermissionDetails = [
+  catalogPermissionDetail({
+    connectorRef: "github",
+    label: "GitHub",
+  }),
+  catalogPermissionDetail({
+    connectorRef: "slack",
+    label: "Slack",
+    permissions: [
+      {
+        name: "admin.conversations:read",
+        description: "Read conversations",
+      },
+      { name: "chat:write", description: "Send messages" },
+      { name: "reactions:read", description: "Read reactions" },
+    ],
+    defaultPolicy: {
+      permissionDefault: "allow",
+      unknownPolicy: "allow",
+    },
+  }),
+];
+
 describe("zero whoami command", () => {
   const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
   beforeEach(async () => {
     chalk.level = 0;
+    server.use(stubConnectorCatalogPermissions(defaultPermissionDetails));
 
     // Ensure clean config state
     const configDir = path.join(TEST_HOME, ".vm0");
@@ -561,6 +589,86 @@ describe("zero whoami command", () => {
       ).toBe(true);
     });
 
+    it("should show permissions for a server-authored connector ref", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      const serverOnlyDetail = catalogPermissionDetail({
+        connectorRef: "server-only",
+        label: "Server Only",
+        permissions: [
+          { name: "records.read", description: "Read server records" },
+        ],
+        defaultPolicy: {
+          permissionDefault: "deny",
+          unknownPolicy: "deny",
+        },
+      });
+      server.use(
+        stubConnectorCatalogPermissions([
+          ...defaultPermissionDetails,
+          serverOnlyDetail,
+        ]),
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "server-only",
+                authMethod: "api-token",
+                externalId: "server-user",
+                externalUsername: "server-user",
+                externalEmail: null,
+                oauthScopes: null,
+                connectionStatus: "connected",
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["server-only"],
+            connectorProvidedBindings: [],
+          });
+        }),
+        mockUserPermissionGrantsHandler([
+          makePermissionGrant({
+            connectorRef: "server-only",
+            permission: "records.read",
+            action: "allow",
+          }),
+        ]),
+        http.get(
+          "http://localhost:3000/api/zero/agents/agent-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["server-only"] });
+          },
+        ),
+      );
+
+      await runWhoami(["--permissions"]);
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("server-only") && line.includes("@server-user");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("✓") && line.includes("records.read");
+        }),
+      ).toBe(true);
+    });
+
     it("should show full access with --permissions for connector with null policies", async () => {
       const token = buildZeroToken({
         userId: "user-1",
@@ -694,6 +802,79 @@ describe("zero whoami command", () => {
       expect(
         output.some((line) => {
           return line.includes("full access");
+        }),
+      ).toBe(false);
+    });
+
+    it("should omit supplementary connectors when permission metadata fails", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                connectionStatus: "connected",
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github"],
+            connectorProvidedBindings: [],
+          });
+        }),
+        mockUserPermissionGrantsHandler(),
+        http.get(
+          "http://localhost:3000/api/zero/agents/agent-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get(
+          "http://localhost:3000/api/zero/connector-catalog/github/permissions",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Permission service unavailable",
+                  code: "INTERNAL",
+                },
+              },
+              { status: 500 },
+            );
+          },
+        ),
+      );
+
+      await runWhoami(["--permissions"]);
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("Agent ID:");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("Connectors:");
         }),
       ).toBe(false);
     });

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -10,6 +10,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
+import {
+  catalogPermissionDetail,
+  stubConnectorCatalogPermissions,
+} from "../../__tests__/helpers/connector-catalog";
 import { viewCommand } from "../view";
 import chalk from "chalk";
 
@@ -19,6 +23,26 @@ const mockAgent = {
   description: "A test agent",
   sound: "professional",
 };
+
+const defaultPermissionDetails = [
+  catalogPermissionDetail({
+    connectorRef: "github",
+    label: "GitHub",
+  }),
+  catalogPermissionDetail({
+    connectorRef: "slack",
+    label: "Slack",
+    permissions: [
+      { name: "conversations:read", description: "Read conversations" },
+      { name: "chat:write", description: "Send messages" },
+      { name: "reactions:read", description: "Read reactions" },
+    ],
+    defaultPolicy: {
+      permissionDefault: "allow",
+      unknownPolicy: "allow",
+    },
+  }),
+];
 
 function mockConnectorListHandler(
   connectors: Record<string, unknown>[] = [],
@@ -87,6 +111,7 @@ describe("zero agent view command", () => {
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
     server.use(mockUserPermissionGrantsHandler());
+    server.use(stubConnectorCatalogPermissions(defaultPermissionDetails));
   });
 
   afterEach(() => {
@@ -213,6 +238,46 @@ describe("zero agent view command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("slack");
       expect(logCalls).not.toContain("slack (0/");
+    });
+
+    it("should load a server-authored connector once per unique ref", async () => {
+      let permissionRequests = 0;
+      const serverOnlyDetail = catalogPermissionDetail({
+        connectorRef: "server-only",
+        label: "Server Only",
+        permissions: [
+          { name: "records.read", description: "Read server records" },
+        ],
+        defaultPolicy: {
+          permissionDefault: "deny",
+          unknownPolicy: "deny",
+        },
+      });
+      server.use(
+        http.get(
+          "http://localhost:3000/api/zero/connector-catalog/server-only/permissions",
+          () => {
+            permissionRequests += 1;
+            return HttpResponse.json({ permissions: serverOnlyDetail });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["server-only"] });
+          },
+        ),
+        mockConnectorListHandler(),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("server-only (0/1 allowed)");
+      expect(permissionRequests).toBe(1);
     });
 
     it("should show instructions content with --instructions flag", async () => {
@@ -558,6 +623,43 @@ describe("zero agent view command", () => {
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should fail instead of treating permission API errors as no metadata", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        mockConnectorListHandler(),
+        http.get(
+          "http://localhost:3000/api/zero/connector-catalog/github/permissions",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Permission service unavailable",
+                  code: "INTERNAL",
+                },
+              },
+              { status: 500 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("500: Permission service unavailable"),
+      );
     });
   });
 });

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -8,7 +8,7 @@ import {
   listZeroConnectors,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import type { ConnectorResponse } from "@vm0/api-contracts/contracts/connector-schemas";
 import { policyIcon } from "../../../lib/utils/format-utils";
 import { formatAvatar } from "./avatar";

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
@@ -4,14 +4,40 @@
  * The command always points users at the self-service permission grant page.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HttpResponse, http } from "msw";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { server } from "../../../../mocks/server";
+import {
+  catalogPermissionDetail,
+  stubConnectorCatalogPermissions,
+} from "../../__tests__/helpers/connector-catalog";
 import { permissionChangeCommand } from "../permission-change";
 
 describe("zero doctor permission-change command", () => {
   const SLACK_READ_PERMISSION = "admin.conversations:read";
+  const permissionDetails = [
+    catalogPermissionDetail({
+      connectorRef: "slack",
+      label: "Slack",
+      permissions: [
+        { name: SLACK_READ_PERMISSION, description: "Read conversations" },
+        { name: "chat:write", description: "Send messages" },
+      ],
+    }),
+    catalogPermissionDetail({
+      connectorRef: "gmail",
+      label: "Gmail",
+      permissions: [
+        { name: "messages.send", description: "Send messages" },
+        { name: "drafts.send", description: "Send drafts" },
+      ],
+    }),
+    catalogPermissionDetail({
+      connectorRef: "cloudflare",
+      label: "Cloudflare",
+    }),
+  ];
 
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -20,6 +46,15 @@ describe("zero doctor permission-change command", () => {
   const mockConsoleError = vi
     .spyOn(console, "error")
     .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    server.use(
+      stubConnectorCatalogPermissions(permissionDetails, "https://app.vm0.ai"),
+      stubConnectorCatalogPermissions(permissionDetails, "https://www.vm0.ai"),
+      stubConnectorCatalogPermissions(permissionDetails),
+    );
+  });
 
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -292,12 +327,43 @@ describe("zero doctor permission-change command", () => {
     expect(logCalls).toContain("Only allow this permission below");
   });
 
+  it("validates a server-authored connector absent from the CLI bundle", async () => {
+    vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+    const serverOnlyDetail = catalogPermissionDetail({
+      connectorRef: "server-only",
+      label: "Server Only",
+      permissions: [
+        { name: "records.read", description: "Read server records" },
+      ],
+    });
+    server.use(
+      stubConnectorCatalogPermissions(
+        [...permissionDetails, serverOnlyDetail],
+        "https://app.vm0.ai",
+      ),
+    );
+
+    await permissionChangeCommand.parseAsync([
+      "node",
+      "cli",
+      "server-only",
+      "--permission",
+      "records.read",
+      "--enable",
+    ]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("[Manage Server Only permissions]");
+    expect(logCalls).toContain("ref=server-only");
+    expect(logCalls).toContain("permission=records.read");
+  });
+
   it("exits with an error for an unknown connector type", async () => {
     await expect(async () => {
       await permissionChangeCommand.parseAsync([
         "node",
         "cli",
-        "unknown_service",
+        "unknown-service",
         "--permission",
         "foo",
         "--enable",
@@ -305,7 +371,92 @@ describe("zero doctor permission-change command", () => {
     }).rejects.toThrow("process.exit called");
 
     expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining("Unknown connector type: unknown_service"),
+      expect.stringContaining("Unknown connector type: unknown-service"),
+    );
+  });
+
+  it("exits with authentication guidance when no token is available", async () => {
+    vi.stubEnv("VM0_TOKEN", "");
+    vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+
+    await expect(async () => {
+      await permissionChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "slack",
+        "--permission",
+        SLACK_READ_PERMISSION,
+        "--enable",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Not authenticated"),
+    );
+  });
+
+  it("does not treat permission API authorization failures as missing metadata", async () => {
+    vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+    server.use(
+      http.get(
+        "https://app.vm0.ai/api/zero/connector-catalog/slack/permissions",
+        () => {
+          return HttpResponse.json(
+            { error: { message: "Forbidden", code: "FORBIDDEN" } },
+            { status: 403 },
+          );
+        },
+      ),
+    );
+
+    await expect(async () => {
+      await permissionChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "slack",
+        "--permission",
+        SLACK_READ_PERMISSION,
+        "--enable",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("403: Forbidden"),
+    );
+  });
+
+  it("rejects permission metadata for a different connector ref", async () => {
+    vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+    server.use(
+      http.get(
+        "https://app.vm0.ai/api/zero/connector-catalog/slack/permissions",
+        () => {
+          return HttpResponse.json({
+            permissions: catalogPermissionDetail({
+              connectorRef: "github",
+              label: "GitHub",
+              permissions: [{ name: SLACK_READ_PERMISSION }],
+            }),
+          });
+        },
+      ),
+    );
+
+    await expect(async () => {
+      await permissionChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "slack",
+        "--permission",
+        SLACK_READ_PERMISSION,
+        "--enable",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Permission metadata connectorRef mismatch: expected slack, got github",
+      ),
     );
   });
 

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/permission-change.test.ts
@@ -425,6 +425,33 @@ describe("zero doctor permission-change command", () => {
     );
   });
 
+  it("does not treat permission API network failures as missing metadata", async () => {
+    vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+    server.use(
+      http.get(
+        "https://app.vm0.ai/api/zero/connector-catalog/slack/permissions",
+        () => {
+          return HttpResponse.error();
+        },
+      ),
+    );
+
+    await expect(async () => {
+      await permissionChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "slack",
+        "--permission",
+        SLACK_READ_PERMISSION,
+        "--enable",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    const errorOutput = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorOutput).toContain("Failed to fetch");
+    expect(errorOutput).not.toContain("Unknown connector type");
+  });
+
   it("rejects permission metadata for a different connector ref", async () => {
     vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
     server.use(

--- a/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/permission-change.ts
@@ -1,9 +1,6 @@
 import { Command, Option } from "commander";
 import type { UserPermissionGrantExpiresIn } from "@vm0/api-contracts/contracts/zero-user-permission-grants";
-import {
-  findFirewallMetadataPermission,
-  loadFirewallPermissionMetadata,
-} from "@vm0/connectors/firewall-metadata";
+import { findFirewallMetadataPermission } from "@vm0/connectors/firewall-metadata/policy";
 import { UNKNOWN_PERMISSION_GRANT } from "@vm0/connectors/firewall-types";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "./platform-url";
@@ -14,6 +11,7 @@ import {
 import {
   ApiRequestError,
   createComputerUseAuthorizationRequest,
+  getZeroConnectorCatalogPermissions,
 } from "../../../lib/api";
 
 const DEFAULT_PERMISSION_GRANT_DURATION: UserPermissionGrantExpiresIn = "1h";
@@ -263,7 +261,7 @@ Notes:
           return;
         }
 
-        const metadata = await loadFirewallPermissionMetadata(connectorRef);
+        const metadata = await getZeroConnectorCatalogPermissions(connectorRef);
         if (!metadata) {
           throw new Error(`Unknown connector type: ${connectorRef}`);
         }

--- a/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
+++ b/turbo/apps/cli/src/commands/zero/shared/firewall-permissions.ts
@@ -1,18 +1,16 @@
-import {
-  loadFirewallPermissionMetadata,
-  resolveFirewallMetadataPolicies,
-  type FirewallPermissionDetailMetadata,
-} from "@vm0/connectors/firewall-metadata";
+import type { PublicConnectorCatalogPermissionDetail } from "@vm0/api-contracts/contracts/zero-connector-catalog";
+import { resolveFirewallMetadataPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import type {
   FirewallPolicies,
   FirewallPolicyValue,
 } from "@vm0/connectors/firewall-types";
+import { getZeroConnectorCatalogPermissions } from "../../../lib/api";
 
 export interface ConnectorPermissionInfo {
   readonly type: string;
   readonly hasPermissions: boolean;
   readonly hasPolicyEntry: boolean;
-  readonly permissions: readonly FirewallPermissionDetailMetadata["permissions"][number][];
+  readonly permissions: readonly PublicConnectorCatalogPermissionDetail["permissions"][number][];
   readonly policies: Readonly<Record<string, FirewallPolicyValue>> | null;
   readonly unknownPolicy: FirewallPolicyValue;
   readonly allowed: number;
@@ -21,7 +19,7 @@ export interface ConnectorPermissionInfo {
 
 type PermissionMetadataByType = Map<
   string,
-  FirewallPermissionDetailMetadata | null
+  PublicConnectorCatalogPermissionDetail | null
 >;
 
 async function loadPermissionMetadataByType(
@@ -30,7 +28,7 @@ async function loadPermissionMetadataByType(
   const uniqueTypes = [...new Set(types)];
   const entries = await Promise.all(
     uniqueTypes.map(async (type) => {
-      return [type, await loadFirewallPermissionMetadata(type)] as const;
+      return [type, await getZeroConnectorCatalogPermissions(type)] as const;
     }),
   );
   return new Map(entries);
@@ -38,7 +36,7 @@ async function loadPermissionMetadataByType(
 
 function connectorPermissionInfo(args: {
   readonly type: string;
-  readonly metadata: FirewallPermissionDetailMetadata | null;
+  readonly metadata: PublicConnectorCatalogPermissionDetail | null;
   readonly resolvedPolicies: FirewallPolicies | null;
 }): ConnectorPermissionInfo {
   if (!args.metadata) {
@@ -54,7 +52,7 @@ function connectorPermissionInfo(args: {
     };
   }
 
-  const refPolicy = args.resolvedPolicies?.[args.metadata.type];
+  const refPolicy = args.resolvedPolicies?.[args.metadata.connectorRef];
   const policies =
     refPolicy && Object.keys(refPolicy.policies).length > 0
       ? refPolicy.policies

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -12,7 +12,7 @@ import {
   listZeroUserPermissionGrants,
 } from "../../lib/api";
 import { withErrorHandler } from "../../lib/command";
-import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata";
+import { permissionGrantsToFirewallPolicies } from "@vm0/connectors/firewall-metadata/policy";
 import { policyIcon } from "../../lib/utils/format-utils";
 import {
   loadConnectorPermissionInfos,

--- a/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-connectors.ts
@@ -13,6 +13,7 @@ import {
 import {
   zeroConnectorCatalogContract,
   type PublicConnectorCatalogListResponse,
+  type PublicConnectorCatalogPermissionDetail,
   type PublicConnectorCatalogStatusResponse,
 } from "@vm0/api-contracts/contracts/zero-connector-catalog";
 import {
@@ -88,6 +89,35 @@ export async function listZeroConnectorCatalogStatus(): Promise<PublicConnectorC
   }
 
   handleError(result, "Failed to list connector catalog status");
+}
+
+export async function getZeroConnectorCatalogPermissions(
+  connectorRef: string,
+): Promise<PublicConnectorCatalogPermissionDetail | null> {
+  const config = await getClientConfig();
+  const client = initClient(zeroConnectorCatalogContract, config);
+
+  const result = await client.permissions({
+    params: { connectorRef },
+  });
+
+  if (result.status === 200) {
+    if (result.body.permissions.connectorRef !== connectorRef) {
+      throw new Error(
+        `Permission metadata connectorRef mismatch: expected ${connectorRef}, got ${result.body.permissions.connectorRef}`,
+      );
+    }
+    return result.body.permissions;
+  }
+
+  if (result.status === 404) {
+    return null;
+  }
+
+  handleError(
+    result,
+    `Failed to get connector permission metadata for "${connectorRef}"`,
+  );
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -148,6 +148,7 @@ export {
   listZeroConnectors,
   listZeroConnectorCatalog,
   listZeroConnectorCatalogStatus,
+  getZeroConnectorCatalogPermissions,
   connectZeroConnectorManualGrant,
   listZeroCustomConnectors,
   getZeroCustomConnector,


### PR DESCRIPTION
## Summary

- add typed CLI access to the existing connector catalog permission-detail endpoint
- make `zero doctor permission-change`, `zero agent view`, and `zero whoami --permissions` resolve permission inventory and default policies from server-authored catalog data
- preserve pure local policy overlay logic while treating only 404 as absent metadata and keeping other API failures on the existing command-specific error paths
- cover server-only connector refs, authentication/authorization/network failures, response mismatches, request de-duplication, and supplementary-output failure behavior at CLI entry points

## Exclusions

- no new backend endpoint, catalog contract, batch API, or database migration
- no migration of runtime firewall diagnostics such as `check-connector` or `permission-deny`
- no removal of the generated compatibility source or activation of an external catalog backend

## Validation

- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=1 --silent=passed-only` (594 files passed, 1 benchmark skipped; 7390 tests passed, 1 benchmark skipped)
- `pnpm knip`
- `pnpm -F @vm0/cli lint`
- `pnpm -F @vm0/cli check-types`
- `pnpm -F @vm0/cli exec vitest run src/commands/zero/doctor/__tests__/permission-change.test.ts --maxWorkers=1 --silent=passed-only` (24 tests passed)

Closes #21139

Parent delivery context: vm0-ai/vm0-connectors#1
