### PR TITLE
perf(ably-subscriber): bound drop warning emission

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tracing-subscriber",
+ "tracing-test-support",
  "url",
 ]
 

--- a/crates/ably-subscriber/Cargo.toml
+++ b/crates/ably-subscriber/Cargo.toml
@@ -23,6 +23,7 @@ httpmock = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util", "net"] }
 tracing-subscriber = { workspace = true }
+tracing-test-support = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ably-subscriber/src/connection/event_loop.rs
+++ b/crates/ably-subscriber/src/connection/event_loop.rs
@@ -28,6 +28,69 @@ use crate::protocol::{
 };
 use crate::types::{Event, Message, TimingConfig, TokenDetails, TokenFuture};
 
+const DROP_WARNING_INTERVAL: Duration = Duration::from_secs(60);
+
+#[derive(Default)]
+pub(crate) struct DropWarningState {
+    total_dropped: u64,
+    reported_dropped: u64,
+    last_reported_at: Option<Instant>,
+    report_at: Option<Instant>,
+}
+
+struct DropWarningReport {
+    dropped_since_last: u64,
+    total_dropped: u64,
+}
+
+impl DropWarningState {
+    fn record_drop(&mut self) -> Option<DropWarningReport> {
+        self.total_dropped += 1;
+        if self.report_at.is_some() {
+            return None;
+        }
+
+        let now = Instant::now();
+        let Some(last_reported_at) = self.last_reported_at else {
+            return Some(self.take_report(now));
+        };
+        let report_at = last_reported_at + DROP_WARNING_INTERVAL;
+        if now >= report_at {
+            return Some(self.take_report(now));
+        }
+
+        self.report_at = Some(report_at);
+        None
+    }
+
+    fn report_at(&self) -> Option<Instant> {
+        self.report_at
+    }
+
+    fn take_due_report(&mut self) -> DropWarningReport {
+        self.take_report(Instant::now())
+    }
+
+    fn take_report(&mut self, now: Instant) -> DropWarningReport {
+        let report = DropWarningReport {
+            dropped_since_last: self.total_dropped - self.reported_dropped,
+            total_dropped: self.total_dropped,
+        };
+        self.reported_dropped = self.total_dropped;
+        self.last_reported_at = Some(now);
+        self.report_at = None;
+        report
+    }
+}
+
+fn warn_dropped_messages(report: DropWarningReport) {
+    tracing::warn!(
+        dropped_since_last = report.dropped_since_last,
+        total_dropped = report.total_dropped,
+        "event channel full, dropping message"
+    );
+}
+
 pub(crate) struct EventLoopState {
     pub transport: Option<WsTransport>,
     pub event_tx: mpsc::Sender<Event>,
@@ -39,7 +102,7 @@ pub(crate) struct EventLoopState {
     pub http: reqwest::Client,
     pub get_token: Box<dyn Fn() -> TokenFuture + Send + Sync>,
     pub timing: TimingConfig,
-    pub dropped_messages: u64,
+    pub drop_warnings: DropWarningState,
 }
 
 async fn sleep_until_optional(deadline: Option<Instant>) {
@@ -210,6 +273,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                 }
             }
 
+            let drop_warning_deadline = p.drop_warnings.report_at();
             let Some(transport) = p.transport.as_mut() else {
                 tracing::warn!("WebSocket transport missing before receive loop");
                 break;
@@ -224,6 +288,10 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
 
                 _ = sleep_until_optional(p.session.token_renewal_at()), if p.session.token_renewal_at().is_some() => {
                     ReceiveLoopEvent::TokenRenewal
+                }
+
+                _ = sleep_until_optional(drop_warning_deadline), if drop_warning_deadline.is_some() => {
+                    ReceiveLoopEvent::DropWarningDeadline
                 }
 
                 frame = transport.ws_read.next() => {
@@ -266,6 +334,9 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
                     if handle_renewal_result(&mut p, &mut close_rx, result).await {
                         return;
                     }
+                }
+                ReceiveLoopEvent::DropWarningDeadline => {
+                    warn_dropped_messages(p.drop_warnings.take_due_report());
                 }
                 ReceiveLoopEvent::ChannelOperationDeadline => {
                     if let Some(attach_timed_out) =
@@ -510,6 +581,7 @@ pub(crate) async fn run_event_loop(mut p: EventLoopState, mut close_rx: oneshot:
 enum ReceiveLoopEvent {
     CloseRequested,
     TokenRenewal,
+    DropWarningDeadline,
     ChannelOperationDeadline,
     ChannelRetry,
     Frame(Option<Result<tungstenite::Message, tungstenite::Error>>),
@@ -657,11 +729,9 @@ async fn handle_message(
                             }));
                         }
                         Err(mpsc::error::TrySendError::Full(_)) => {
-                            p.dropped_messages += 1;
-                            tracing::warn!(
-                                total_dropped = p.dropped_messages,
-                                "event channel full, dropping message"
-                            );
+                            if let Some(report) = p.drop_warnings.record_drop() {
+                                warn_dropped_messages(report);
+                            }
                         }
                         Err(mpsc::error::TrySendError::Closed(_)) => {
                             return LoopAction::Stop;
@@ -1046,60 +1116,11 @@ async fn attempt_reconnect(p: &mut EventLoopState) -> Result<ReconnectOutcome, E
 mod tests {
     use super::super::state::ConnState;
     use super::*;
-    use std::collections::BTreeMap;
-    use std::fmt;
-    use std::sync::{Arc, Mutex};
 
     use crate::protocol::{AblyMessage, ErrorInfo};
     use crate::types::{TokenDetails, TokenRequest};
-    use tracing::Subscriber;
-    use tracing::field::{Field, Visit};
-    use tracing_subscriber::layer::{Context, Layer};
     use tracing_subscriber::prelude::*;
-
-    #[derive(Clone, Default)]
-    struct CapturedEvents {
-        events: Arc<Mutex<Vec<BTreeMap<String, String>>>>,
-    }
-
-    impl CapturedEvents {
-        fn entries(&self) -> Vec<BTreeMap<String, String>> {
-            self.events.lock().unwrap().clone()
-        }
-    }
-
-    impl<S> Layer<S> for CapturedEvents
-    where
-        S: Subscriber,
-    {
-        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-            let mut visitor = CapturedFields::default();
-            event.record(&mut visitor);
-            self.events.lock().unwrap().push(visitor.fields);
-        }
-    }
-
-    #[derive(Default)]
-    struct CapturedFields {
-        fields: BTreeMap<String, String>,
-    }
-
-    impl Visit for CapturedFields {
-        fn record_str(&mut self, field: &Field, value: &str) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_u64(&mut self, field: &Field, value: u64) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-            self.fields
-                .insert(field.name().to_string(), format!("{value:?}"));
-        }
-    }
+    use tracing_test_support::{CapturedEvent, CapturedEvents};
 
     fn test_event_loop_state(event_tx: mpsc::Sender<Event>) -> EventLoopState {
         let timing = TimingConfig::default();
@@ -1141,7 +1162,7 @@ mod tests {
                 })
             }),
             timing,
-            dropped_messages: 0,
+            drop_warnings: DropWarningState::default(),
         }
     }
 
@@ -1152,10 +1173,10 @@ mod tests {
         );
     }
 
-    fn captured_contains(events: &[BTreeMap<String, String>], needle: &str) -> bool {
+    fn captured_contains(events: &[CapturedEvent], needle: &str) -> bool {
         events
             .iter()
-            .flat_map(BTreeMap::values)
+            .flat_map(|event| event.fields.values())
             .any(|value| value.contains(needle))
     }
 
@@ -1246,7 +1267,7 @@ mod tests {
         .await;
 
         assert_eq!(action, LoopAction::Continue);
-        assert_eq!(state.dropped_messages, 1);
+        assert_eq!(state.drop_warnings.total_dropped, 1);
         assert!(
             matches!(event_rx.try_recv(), Ok(Event::Connected)),
             "expected pre-filled event to remain queued"
@@ -1290,7 +1311,7 @@ mod tests {
         .await;
 
         assert_eq!(action, LoopAction::Stop);
-        assert_eq!(state.dropped_messages, 0);
+        assert_eq!(state.drop_warnings.total_dropped, 0);
         let events = captured.entries();
         assert!(
             !captured_contains(&events, "Failed to decode JSON encoding layer"),

--- a/crates/ably-subscriber/src/connection/mod.rs
+++ b/crates/ably-subscriber/src/connection/mod.rs
@@ -12,7 +12,7 @@ mod transport;
 
 pub(crate) use auth::exchange_token;
 pub(crate) use endpoint::{DEFAULT_REALTIME_HOST, rest_host};
-pub(crate) use event_loop::{EventLoopState, run_event_loop};
+pub(crate) use event_loop::{DropWarningState, EventLoopState, run_event_loop};
 pub(crate) use handshake::connect_and_attach;
 pub(crate) use session::SessionState;
 pub(crate) use transport::WsTransport;

--- a/crates/ably-subscriber/src/subscribe.rs
+++ b/crates/ably-subscriber/src/subscribe.rs
@@ -3,8 +3,8 @@
 use tokio::sync::{mpsc, oneshot};
 
 use crate::connection::{
-    DEFAULT_REALTIME_HOST, EventLoopState, SessionState, WsTransport, connect_and_attach,
-    exchange_token, rest_host, run_event_loop,
+    DEFAULT_REALTIME_HOST, DropWarningState, EventLoopState, SessionState, WsTransport,
+    connect_and_attach, exchange_token, rest_host, run_event_loop,
 };
 use crate::protocol::error_code;
 use crate::types::{Error, Event, SubscribeConfig};
@@ -109,7 +109,7 @@ pub async fn subscribe(config: SubscribeConfig) -> Result<Subscription, Error> {
             http,
             get_token: config.get_token,
             timing,
-            dropped_messages: 0,
+            drop_warnings: DropWarningState::default(),
         },
         close_rx,
     ));

--- a/crates/ably-subscriber/tests/integration/backpressure.rs
+++ b/crates/ably-subscriber/tests/integration/backpressure.rs
@@ -5,6 +5,8 @@ use futures_util::{SinkExt, StreamExt};
 use httpmock::prelude::*;
 use std::time::Duration;
 use tokio_tungstenite::tungstenite;
+use tracing_subscriber::prelude::*;
+use tracing_test_support::CapturedEvents;
 
 #[tokio::test]
 async fn token_renewal_error_backpressure_closes_socket_before_subscription_close() {
@@ -83,24 +85,19 @@ async fn token_renewal_error_backpressure_closes_socket_before_subscription_clos
 // being uninterruptible by the consumer task. On a multi_thread runtime,
 // the consumer on another OS thread could drain the channel between two
 // try_sends, freeing permits and causing more than CAP messages to arrive.
-
-// current_thread runtime is a determinism requirement: we rely on the
-// subscriber task's synchronous event-loop dispatch processes a batched
-// ProtocolMessage's Vec<AblyMessage> with no await between try_send calls)
-// being uninterruptible by the consumer task. On a multi_thread runtime,
-// the consumer on another OS thread could drain the channel between two
-// try_sends, freeing permits and causing more than CAP messages to arrive.
 #[tokio::test(flavor = "current_thread")]
-async fn backpressure_drops_messages() {
+async fn backpressure_counts_drops_and_bounds_warnings() {
     // Deterministically exercise the try_send backpressure path: pack N
     // messages into ONE ProtocolMessage frame. With channel capacity = 2
     // exactly the first 2 enqueue and the rest are dropped.
     //
-    // Two oneshot gates order the mock's sends:
+    // Oneshot gates order the mock's sends:
     //   1. `batch_gate` — mock sends the burst only after the consumer has
     //      drained the Connected event, so the channel is empty when the
     //      burst arrives (otherwise Connected would occupy one of the two slots).
-    //   2. `sentinel_gate` — after the burst drops, mock sends one more
+    //   2. `saturation_processed` — a DETACHED/ATTACH round trip proves the
+    //      subscriber processed the burst and following single-message frames.
+    //   3. `sentinel_gate` — after the burst drops, mock sends one more
     //      message. Receiving it proves the subscriber didn't stall — the
     //      real backpressure contract is "drop when slow, don't hang".
     let http = MockServer::start();
@@ -108,14 +105,25 @@ async fn backpressure_drops_messages() {
     mock_token_endpoint(&http, "testKey.testId");
 
     const BURST: usize = 20;
+    const SINGLE_MESSAGE_FRAMES: usize = 5;
     const CAP: usize = 2;
+    const REPORT_INTERVAL: Duration = Duration::from_secs(60);
+    const EXPECTED_DROPPED: usize = BURST + SINGLE_MESSAGE_FRAMES - CAP;
 
     let ws_port = ws.port;
     let (batch_gate_tx, batch_gate_rx) = tokio::sync::oneshot::channel::<()>();
+    let (saturation_processed_tx, saturation_processed_rx) = tokio::sync::oneshot::channel::<()>();
     let (sentinel_gate_tx, sentinel_gate_rx) = tokio::sync::oneshot::channel::<()>();
     tokio::spawn(async move {
         let mut conn = ws
-            .accept_and_handshake("ch", "conn-1")
+            .accept_and_handshake_with_opts(
+                "ch",
+                "conn-1",
+                HandshakeOptions {
+                    max_idle_interval_ms: 0,
+                    ..Default::default()
+                },
+            )
             .await
             .expect("mock handshake failed");
 
@@ -142,6 +150,62 @@ async fn backpressure_drops_messages() {
         ))
         .await
         .expect("send burst failed");
+
+        for i in 0..SINGLE_MESSAGE_FRAMES {
+            let message = ProtocolMessage {
+                action: action::MESSAGE,
+                channel: Some("ch".into()),
+                channel_serial: Some(format!("serial-extra-{i}")),
+                messages: Some(vec![AblyMessage {
+                    id: Some(format!("extra-{i}")),
+                    name: Some(format!("extra-{i}")),
+                    data: Some(serde_json::json!(i)),
+                    timestamp: Some(now_ms()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            };
+            conn.send(tungstenite::Message::Binary(
+                encode_msg(&message)
+                    .expect("encode single-message frame failed")
+                    .into(),
+            ))
+            .await
+            .expect("send single-message frame failed");
+        }
+
+        let detached = ProtocolMessage {
+            action: action::DETACHED,
+            channel: Some("ch".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&detached)
+                .expect("encode DETACHED failed")
+                .into(),
+        ))
+        .await
+        .expect("send DETACHED failed");
+        let attach = expect_protocol_msg(&mut conn, "client ATTACH after saturation")
+            .await
+            .expect("read client ATTACH after saturation");
+        assert_eq!(attach.action, action::ATTACH);
+        let attached = ProtocolMessage {
+            action: action::ATTACHED,
+            channel: Some("ch".into()),
+            channel_serial: Some("serial-attached".into()),
+            ..Default::default()
+        };
+        conn.send(tungstenite::Message::Binary(
+            encode_msg(&attached)
+                .expect("encode ATTACHED failed")
+                .into(),
+        ))
+        .await
+        .expect("send ATTACHED failed");
+        saturation_processed_tx
+            .send(())
+            .expect("saturation observer dropped");
 
         sentinel_gate_rx
             .await
@@ -172,6 +236,9 @@ async fn backpressure_drops_messages() {
 
     let mut timing = TimingConfig::default();
     timing.event_channel_capacity = CAP;
+    let captured = CapturedEvents::default();
+    let subscriber = tracing_subscriber::registry().with(captured.clone());
+    let _guard = tracing::subscriber::set_default(subscriber);
     let mut sub = subscribe(test_config_with_timing(ws_port, http.port(), "ch", timing))
         .await
         .unwrap();
@@ -180,16 +247,91 @@ async fn backpressure_drops_messages() {
     batch_gate_tx
         .send(())
         .expect("subscription closed before burst");
+    wait_for_test_observation(
+        saturation_processed_rx,
+        "subscriber processing saturated frames",
+    )
+    .await;
+    tokio::time::pause();
+    tokio::time::advance(REPORT_INTERVAL).await;
+    tokio::time::resume();
+
+    let expected_total = EXPECTED_DROPPED.to_string();
+    let drop_warnings = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let warnings = captured
+                .entries()
+                .into_iter()
+                .filter(|event| {
+                    event
+                        .fields
+                        .get("message")
+                        .is_some_and(|message| message == "event channel full, dropping message")
+                })
+                .collect::<Vec<_>>();
+            if warnings.last().is_some_and(|warning| {
+                warning
+                    .fields
+                    .get("total_dropped")
+                    .is_some_and(|total| total == &expected_total)
+            }) {
+                break warnings;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for exact deferred drop warning");
+
+    let expected_since_last = (EXPECTED_DROPPED - 1).to_string();
+    assert_eq!(
+        drop_warnings.len(),
+        2,
+        "expected one immediate and one deferred drop warning: {drop_warnings:#?}"
+    );
+    assert_eq!(
+        drop_warnings[0]
+            .fields
+            .get("dropped_since_last")
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        drop_warnings[0]
+            .fields
+            .get("total_dropped")
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        drop_warnings[1]
+            .fields
+            .get("dropped_since_last")
+            .map(String::as_str),
+        Some(expected_since_last.as_str())
+    );
+    assert_eq!(
+        drop_warnings[1]
+            .fields
+            .get("total_dropped")
+            .map(String::as_str),
+        Some(expected_total.as_str())
+    );
 
     let mut received = 0;
-    while let Ok(Some(Event::Message(_))) =
-        tokio::time::timeout(Duration::from_secs(2), sub.next()).await
-    {
-        received += 1;
+    for _ in 0..CAP {
+        let event = tokio::time::timeout(Duration::from_secs(2), sub.next())
+            .await
+            .expect("timed out waiting for buffered message")
+            .expect("subscription closed before buffered message");
+        match event {
+            Event::Message(_) => received += 1,
+            other => panic!("expected buffered Message, got {other:?}"),
+        }
     }
     assert_eq!(
         received, CAP,
-        "batch of {BURST} into a cap-{CAP} channel should deliver exactly {CAP} and drop the rest, got {received} — if this regressed, check event-loop message dispatch is still synchronous (no .await between try_send calls)"
+        "{BURST} batched and {SINGLE_MESSAGE_FRAMES} single-frame messages into a cap-{CAP} channel should deliver exactly {CAP}, got {received}"
     );
 
     sentinel_gate_tx


### PR DESCRIPTION
## Summary

- keep exact subscription-lifetime counts for messages dropped by Ably backpressure
- emit the first drop warning immediately, then aggregate subsequent drops into at most one warning per 60-second interval
- cover both one large protocol frame and repeated single-message frames with deterministic integration synchronization

## Compatibility

- no public API, wire protocol, schema, or persisted-data changes
- the existing warning message and cumulative `total_dropped` field remain available; aggregate warnings also include `dropped_since_last`

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p ably-subscriber --all-targets --all-features -- -D warnings`
- `cargo test -p ably-subscriber`
- `cargo doc -p ably-subscriber --all-features --no-deps`
- repository pre-commit hooks (workspace Rust formatting, Clippy, and documentation checks)

Closes #21147
