### PR TITLE
feat: enable website templates for staff org

### DIFF
--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -144,7 +144,7 @@ describe("getAllFeatureStates", () => {
     expect(staffOrgStates[FeatureSwitchKey.HtmlArtifactCommentEditing]).toBe(
       true,
     );
-    expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(false);
+    expect(staffOrgStates[FeatureSwitchKey.WebsiteTemplates]).toBe(true);
     expect(staffOrgStates[FeatureSwitchKey.ComposerUploadPopover]).toBe(false);
     expect(staffOrgStates[FeatureSwitchKey.WorkflowConnectorReadiness]).toBe(
       true,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -433,6 +433,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     description:
       "Enable the built-in R2-backed website template picker and generation-template flow.",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.WorkflowQueue]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## Summary
- Make `WebsiteTemplates` visible to the staff org via `STAFF_ORG_ID_HASHES` instead of enabling it globally
- Keep non-staff orgs and no-context evaluations disabled for the website template switch
- Update the core feature-switch test matrix to reflect staff-org visibility

## Verification
- pnpm exec prettier --check packages/core/src/feature-switch.ts packages/core/src/__tests__/feature-switch.test.ts
- pnpm --filter @vm0/core check-types
- pnpm --filter @vm0/core exec vitest run src/__tests__/feature-switch.test.ts

Refs vm0-ai/vm0#20350

Note: this is the org-visible rollout variant and is intentionally separate from the global rollout PR #21203.
