### PR TITLE
fix(platform): restore animated thinking indicator at 100 ms cadence

### DIFF
--- a/docs/react-commit.md
+++ b/docs/react-commit.md
@@ -585,6 +585,11 @@ one stable fallback phrase, while the done phrase is derived from messages and
 subscribed only by the finished row. In the final trace, all React work ended by
 1.461 seconds and no timer-driven `ThinkingIndicator` update remained.
 
+A later follow-up restored the thinking text typewriter at a 100 ms interval,
+along with the CSS shimmer, block-pop, and entrance animations. The fallback
+phrase remains stable rather than rotating. The measurements in this section
+therefore document the fully static baseline, not the current animation policy.
+
 The phrase "first-second commits" is only a time bucket, not a causal phase. In
 the traced run, all initial local work finished within 301 ms, followed by no
 labelled scheduler update until 1.194 seconds. In another run, a remote thinking

--- a/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-thread-signals.ts
@@ -122,6 +122,11 @@ export interface ChatThreadSignals {
   blockColors$: Computed<[string, string, string]>;
   thinkingPhrase$: Computed<string>;
   donePhrase$: Computed<Promise<string>>;
+  displayedThinkingText$: Computed<Promise<string>>;
+  setThinkingIndicatorTextRef$: Command<
+    (() => void) | undefined,
+    [HTMLElement | null]
+  >;
   // -- Artifacts ------------------------------------------------------------
   artifacts$: Computed<Promise<ChatThreadArtifactRun[]>>;
   reloadArtifacts$: Command<void, []>;

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -8,11 +8,13 @@ import {
 } from "ccstate";
 import { animationFrame, delay } from "signal-timers";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { IN_VITEST } from "../../env.ts";
 import {
   onRef,
   onRejection,
   resetSignalScope,
   resetSignal,
+  setLoop,
   withCleanup,
 } from "../utils.ts";
 import { setAblyLoop$ } from "../realtime.ts";
@@ -2767,6 +2769,382 @@ function createCancelRunWithQueuedRecall({
 // Sub-factory: thinking phrases
 // ---------------------------------------------------------------------------
 
+const THINKING_TYPEWRITER_INTERVAL_MS = 100;
+const THINKING_TYPEWRITER_LINE_PAUSE_MS = 3000;
+const THINKING_TYPEWRITER_LINE_PAUSE_TICKS = IN_VITEST
+  ? 1
+  : Math.ceil(
+      THINKING_TYPEWRITER_LINE_PAUSE_MS / THINKING_TYPEWRITER_INTERVAL_MS,
+    );
+const THINKING_TYPEWRITER_WIDTH_GUARD_PX = 8;
+const THINKING_TYPEWRITER_OVERFLOW_PREFIX = "...";
+
+interface ThinkingTypewriterLine {
+  readonly startIndex: number;
+  readonly endIndex: number;
+  readonly text: string;
+}
+
+interface ThinkingTypewriterFrame {
+  readonly messageId: string | undefined;
+  readonly text: string;
+  readonly width: number;
+  readonly lineIndex: number;
+  readonly charIndex: number;
+  readonly pauseTicksRemaining: number;
+  readonly displayedText: string;
+  readonly complete: boolean;
+}
+
+function emptyThinkingTypewriterFrame(): ThinkingTypewriterFrame {
+  return {
+    messageId: undefined,
+    text: "",
+    width: 0,
+    lineIndex: 0,
+    charIndex: 0,
+    pauseTicksRemaining: 0,
+    displayedText: "",
+    complete: false,
+  };
+}
+
+function isAssistantTextMessage(message: EnrichedChatMessage): boolean {
+  return (
+    message.role === "assistant" &&
+    (Boolean(message.content) || Boolean(message.error))
+  );
+}
+
+type ThinkingMarkerMessage = EnrichedChatMessage & {
+  readonly role: "assistant";
+  readonly content: null;
+  readonly error?: undefined;
+  readonly runId: string;
+  readonly thinking: string;
+};
+
+function isThinkingMarkerMessage(
+  message: EnrichedChatMessage,
+): message is ThinkingMarkerMessage {
+  return (
+    message.role === "assistant" &&
+    message.content === null &&
+    message.error === undefined &&
+    typeof message.thinking === "string" &&
+    message.thinking.trim().length > 0 &&
+    message.runId !== undefined
+  );
+}
+
+function thinkingTextGraphemes(text: string): string[] {
+  return Array.from(text);
+}
+
+function lastRunThinkingMessageForIndicator(
+  groups: readonly GroupedChatMessageGroup[],
+): ThinkingMarkerMessage | undefined {
+  const messages = groups.flatMap((group) => {
+    return group.messages.filter((message) => {
+      return !message.isQueued;
+    });
+  });
+  const lastMessage = messages[messages.length - 1];
+  if (!lastMessage || !isThinkingMarkerMessage(lastMessage)) {
+    return undefined;
+  }
+
+  const runId = lastMessage.runId;
+  const runHasAssistantText = messages.some((message) => {
+    return message.runId === runId && isAssistantTextMessage(message);
+  });
+  return runHasAssistantText ? undefined : lastMessage;
+}
+
+function thinkingTypewriterStep(width: number): number {
+  if (width >= 520) {
+    return 3;
+  }
+  if (width >= 320) {
+    return 2;
+  }
+  return 1;
+}
+
+function createThinkingTextMeasurer(
+  el: HTMLElement,
+): (value: string) => number | undefined {
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
+  const style = window.getComputedStyle(el);
+  const font =
+    style.font ||
+    [
+      style.fontStyle,
+      style.fontVariant,
+      style.fontWeight,
+      style.fontSize,
+      style.fontFamily,
+    ]
+      .filter(Boolean)
+      .join(" ");
+  const letterSpacing =
+    style.letterSpacing === "normal"
+      ? 0
+      : Number.parseFloat(style.letterSpacing);
+
+  if (!context || !font) {
+    return () => {
+      return undefined;
+    };
+  }
+
+  context.font = font;
+  return (value: string) => {
+    const measured = context.measureText(value).width;
+    if (!Number.isFinite(measured) || measured <= 0) {
+      return undefined;
+    }
+    const spacing =
+      Number.isFinite(letterSpacing) && letterSpacing > 0
+        ? (thinkingTextGraphemes(value).length - 1) * letterSpacing
+        : 0;
+    return measured + spacing;
+  };
+}
+
+function thinkingLabelWidth(el: HTMLElement): number {
+  const elementWidth = Math.max(
+    el.getBoundingClientRect().width,
+    el.clientWidth,
+  );
+  if (elementWidth > 0) {
+    return elementWidth;
+  }
+
+  const parent = el.parentElement;
+  return Math.max(
+    parent?.getBoundingClientRect().width ?? 0,
+    parent?.clientWidth ?? 0,
+  );
+}
+
+function wrapThinkingTextForWidth(args: {
+  readonly graphemes: readonly string[];
+  readonly width: number;
+  readonly measureText: (value: string) => number | undefined;
+}): ThinkingTypewriterLine[] {
+  if (args.graphemes.length === 0) {
+    return [];
+  }
+  if (!Number.isFinite(args.width) || args.width <= 0) {
+    return [
+      {
+        startIndex: 0,
+        endIndex: args.graphemes.length,
+        text: args.graphemes.join(""),
+      },
+    ];
+  }
+
+  const maxWidth = Math.max(1, args.width - THINKING_TYPEWRITER_WIDTH_GUARD_PX);
+  const lines: ThinkingTypewriterLine[] = [];
+  let startIndex = 0;
+  let current: string[] = [];
+
+  for (let index = 0; index < args.graphemes.length; index++) {
+    const grapheme = args.graphemes[index]!;
+    const candidate = [...current, grapheme];
+    const candidateText = candidate.join("");
+    const measured = args.measureText(candidateText);
+    if (measured === undefined) {
+      return [
+        {
+          startIndex: 0,
+          endIndex: args.graphemes.length,
+          text: args.graphemes.join(""),
+        },
+      ];
+    }
+
+    if (measured <= maxWidth || current.length === 0) {
+      current = candidate;
+      continue;
+    }
+
+    lines.push({
+      startIndex,
+      endIndex: index,
+      text: current.join(""),
+    });
+    startIndex = index;
+    current = [grapheme];
+  }
+
+  if (current.length > 0) {
+    lines.push({
+      startIndex,
+      endIndex: args.graphemes.length,
+      text: current.join(""),
+    });
+  }
+
+  return lines;
+}
+
+function displayedSlidingThinkingText(args: {
+  readonly graphemes: readonly string[];
+  readonly startIndex: number;
+  readonly charIndex: number;
+  readonly width: number;
+  readonly measureText: (value: string) => number | undefined;
+}): string {
+  const visibleGraphemes = args.graphemes.slice(
+    args.startIndex,
+    args.charIndex,
+  );
+  const visibleText = visibleGraphemes.join("");
+  if (visibleText.length === 0) {
+    return "";
+  }
+  if (!Number.isFinite(args.width) || args.width <= 0) {
+    return visibleText;
+  }
+
+  const maxWidth = Math.max(1, args.width - THINKING_TYPEWRITER_WIDTH_GUARD_PX);
+  const visibleWidth = args.measureText(visibleText);
+  if (visibleWidth === undefined || visibleWidth <= maxWidth) {
+    return visibleText;
+  }
+
+  let displayedText: string | undefined;
+  for (let start = visibleGraphemes.length - 1; start >= 0; start--) {
+    const candidate = `${THINKING_TYPEWRITER_OVERFLOW_PREFIX}${visibleGraphemes
+      .slice(start)
+      .join("")}`;
+    const measured = args.measureText(candidate);
+    if (measured === undefined) {
+      return visibleText;
+    }
+    if (measured <= maxWidth) {
+      displayedText = candidate;
+      continue;
+    }
+    if (displayedText) {
+      break;
+    }
+  }
+
+  return displayedText ?? visibleGraphemes[visibleGraphemes.length - 1] ?? "";
+}
+
+function nextThinkingTypewriterFrame(args: {
+  readonly messageId: string;
+  readonly text: string;
+  readonly currentFrame: ThinkingTypewriterFrame;
+  readonly width: number;
+  readonly measureText: (value: string) => number | undefined;
+}): ThinkingTypewriterFrame {
+  const width = Math.max(0, Math.floor(args.width));
+  const graphemes = thinkingTextGraphemes(args.text);
+  if (graphemes.length === 0) {
+    return emptyThinkingTypewriterFrame();
+  }
+  const lines = wrapThinkingTextForWidth({
+    graphemes,
+    width,
+    measureText: args.measureText,
+  });
+  if (lines.length === 0) {
+    return emptyThinkingTypewriterFrame();
+  }
+
+  const currentFrame =
+    args.currentFrame.messageId === args.messageId &&
+    args.currentFrame.text === args.text &&
+    args.currentFrame.width === width
+      ? args.currentFrame
+      : {
+          ...emptyThinkingTypewriterFrame(),
+          messageId: args.messageId,
+          text: args.text,
+          width,
+        };
+  const lineIndex = Math.min(currentFrame.lineIndex, lines.length - 1);
+  const currentLine = lines[lineIndex]!;
+  const nextLine = lines[lineIndex + 1];
+
+  if (currentFrame.pauseTicksRemaining > 0) {
+    return {
+      ...currentFrame,
+      lineIndex,
+      pauseTicksRemaining: currentFrame.pauseTicksRemaining - 1,
+      displayedText: currentLine.text,
+      complete: false,
+    };
+  }
+
+  if (currentFrame.charIndex >= currentLine.endIndex) {
+    if (!nextLine) {
+      return {
+        ...currentFrame,
+        lineIndex,
+        displayedText: currentLine.text,
+        complete: true,
+      };
+    }
+
+    const nextCharIndex = Math.min(
+      nextLine.endIndex,
+      nextLine.startIndex + thinkingTypewriterStep(width),
+    );
+    return {
+      ...currentFrame,
+      lineIndex: lineIndex + 1,
+      charIndex: nextCharIndex,
+      pauseTicksRemaining: 0,
+      displayedText: displayedSlidingThinkingText({
+        graphemes,
+        startIndex: nextLine.startIndex,
+        charIndex: nextCharIndex,
+        width,
+        measureText: args.measureText,
+      }),
+      complete:
+        lineIndex + 1 >= lines.length - 1 && nextCharIndex >= graphemes.length,
+    };
+  }
+
+  const nextCharIndex = Math.min(
+    currentLine.endIndex,
+    currentFrame.charIndex + thinkingTypewriterStep(width),
+  );
+
+  return {
+    ...currentFrame,
+    lineIndex,
+    charIndex: nextCharIndex,
+    pauseTicksRemaining:
+      nextCharIndex >= currentLine.endIndex && nextLine !== undefined
+        ? THINKING_TYPEWRITER_LINE_PAUSE_TICKS
+        : 0,
+    displayedText: displayedSlidingThinkingText({
+      graphemes,
+      startIndex: currentLine.startIndex,
+      charIndex: nextCharIndex,
+      width,
+      measureText: args.measureText,
+    }),
+    complete: nextCharIndex >= graphemes.length,
+  };
+}
+
+function thinkingTypewriterFrameComplete(
+  frame: ThinkingTypewriterFrame,
+): boolean {
+  return frame.complete;
+}
+
 function createThinkingIndicatorSignals(
   groupedChatMessages$: Computed<Promise<GroupedChatMessageGroup[]>>,
 ) {
@@ -2788,11 +3166,58 @@ function createThinkingIndicatorSignals(
         : undefined;
     return formatDonePhrase(lastMessage);
   });
+  const thinkingTypewriterFrame$ = state<ThinkingTypewriterFrame>(
+    emptyThinkingTypewriterFrame(),
+  );
+  const displayedThinkingText$ = computed((get): Promise<string> => {
+    return Promise.resolve(get(thinkingTypewriterFrame$).displayedText);
+  });
+  const resetThinkingTypewriterLoopSignal$ = resetSignal();
+
+  const setThinkingIndicatorTextRef$ = onRef(
+    command(async ({ get, set }, el: HTMLElement, signal: AbortSignal) => {
+      const loopSignal = set(resetThinkingTypewriterLoopSignal$, signal);
+      const measureText = createThinkingTextMeasurer(el);
+      set(thinkingTypewriterFrame$, emptyThinkingTypewriterFrame());
+
+      await setLoop(
+        async (sig) => {
+          const groups = await get(groupedChatMessages$);
+          sig.throwIfAborted();
+
+          const thinkingMessage = lastRunThinkingMessageForIndicator(groups);
+          const text = thinkingMessage?.thinking?.trim() ?? "";
+          if (!thinkingMessage || text.length === 0) {
+            set(thinkingTypewriterFrame$, emptyThinkingTypewriterFrame());
+            return true;
+          }
+
+          const width = thinkingLabelWidth(el);
+          if (width <= 0 && !IN_VITEST) {
+            return false;
+          }
+          const nextFrame = nextThinkingTypewriterFrame({
+            messageId: thinkingMessage.id,
+            text,
+            currentFrame: get(thinkingTypewriterFrame$),
+            width,
+            measureText,
+          });
+          set(thinkingTypewriterFrame$, nextFrame);
+          return thinkingTypewriterFrameComplete(nextFrame);
+        },
+        THINKING_TYPEWRITER_INTERVAL_MS,
+        loopSignal,
+      );
+    }),
+  );
 
   return {
     blockColors$,
     thinkingPhrase$,
     donePhrase$,
+    displayedThinkingText$,
+    setThinkingIndicatorTextRef$,
   };
 }
 

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -214,6 +214,46 @@ body {
   animation: zero-tagline-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
+/* Shimmer text effect for active/thinking states */
+@keyframes zero-shimmer {
+  0% {
+    background-position: 100% center;
+  }
+  100% {
+    background-position: -100% center;
+  }
+}
+.zero-shimmer-text {
+  background: linear-gradient(
+    90deg,
+    hsl(var(--muted-foreground) / 0.8) 0%,
+    hsl(var(--muted-foreground) / 0.8) 35%,
+    hsl(var(--foreground)) 48%,
+    hsl(var(--foreground)) 52%,
+    hsl(var(--muted-foreground) / 0.8) 65%,
+    hsl(var(--muted-foreground) / 0.8) 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: zero-shimmer 3.5s linear infinite;
+}
+
+@keyframes zero-thinking-in {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.zero-thinking-enter {
+  animation: zero-thinking-in 0.3s ease-out;
+}
+
 /* Thinking indicator: 3-block loader */
 .zero-blocks {
   display: inline-grid;
@@ -228,16 +268,30 @@ body {
   background: var(--zb-c1);
   grid-column: 2;
   grid-row: 1;
+  animation: zero-block-pop 1.4s ease-in-out infinite;
 }
 .zero-blocks span:nth-child(2) {
   background: var(--zb-c2);
   grid-column: 1;
   grid-row: 2;
+  animation: zero-block-pop 1.4s ease-in-out 0.2s infinite;
 }
 .zero-blocks span:nth-child(3) {
   background: var(--zb-c3);
   grid-column: 2;
   grid-row: 2;
+  animation: zero-block-pop 1.4s ease-in-out 0.4s infinite;
+}
+@keyframes zero-block-pop {
+  0%,
+  100% {
+    transform: scale(0.8);
+    opacity: 0.5;
+  }
+  50% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 /* Zero app: inherits global cool gray tokens; only card-specific tokens defined here */

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-lifecycle.test.tsx
@@ -757,6 +757,129 @@ function setScrollMetrics(
   });
 }
 
+function mockThinkingTypewriterLayout({
+  text,
+  labelWidth,
+  parentWidth,
+  graphemeWidth,
+  measureTextWidth = (value) => {
+    return Array.from(value).length * graphemeWidth;
+  },
+}: {
+  readonly text: string;
+  readonly labelWidth: number;
+  readonly parentWidth: number;
+  readonly graphemeWidth: number;
+  readonly measureTextWidth?: (value: string) => number;
+}): void {
+  const getContextDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLCanvasElement.prototype,
+    "getContext",
+  );
+  const getBoundingClientRectDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "getBoundingClientRect",
+  );
+  const clientWidthDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "clientWidth",
+  );
+
+  const rectForWidth = (width: number): DOMRect => {
+    return {
+      bottom: 20,
+      height: 20,
+      left: 0,
+      right: width,
+      toJSON: () => {
+        return {};
+      },
+      top: 0,
+      width,
+      x: 0,
+      y: 0,
+    } as DOMRect;
+  };
+  const elementWidth = (el: HTMLElement): number => {
+    if (el.getAttribute("aria-label") === text) {
+      return labelWidth;
+    }
+    if (
+      Array.from(el.children).some((child) => {
+        return child.getAttribute("aria-label") === text;
+      })
+    ) {
+      return parentWidth;
+    }
+    return 0;
+  };
+
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: (contextId: string) => {
+      if (contextId !== "2d") {
+        return null;
+      }
+      return {
+        measureText: (value: string) => {
+          return {
+            width: measureTextWidth(value),
+          } as TextMetrics;
+        },
+      } as CanvasRenderingContext2D;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value(this: HTMLElement) {
+      return rectForWidth(elementWidth(this));
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get(this: HTMLElement) {
+      return elementWidth(this);
+    },
+  });
+
+  context.signal.addEventListener(
+    "abort",
+    () => {
+      if (getContextDescriptor) {
+        Object.defineProperty(
+          HTMLCanvasElement.prototype,
+          "getContext",
+          getContextDescriptor,
+        );
+      }
+      if (!getContextDescriptor) {
+        Reflect.deleteProperty(HTMLCanvasElement.prototype, "getContext");
+      }
+      if (getBoundingClientRectDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "getBoundingClientRect",
+          getBoundingClientRectDescriptor,
+        );
+      }
+      if (!getBoundingClientRectDescriptor) {
+        Reflect.deleteProperty(HTMLElement.prototype, "getBoundingClientRect");
+      }
+      if (clientWidthDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "clientWidth",
+          clientWidthDescriptor,
+        );
+      }
+      if (!clientWidthDescriptor) {
+        Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+      }
+    },
+    { once: true },
+  );
+}
+
 function mockResizeObserver(): { triggerAll: () => void } {
   const originalDescriptor = Object.getOwnPropertyDescriptor(
     globalThis,
@@ -7474,21 +7597,53 @@ describe("initial thinking indicator", () => {
     threadGate.resolve();
   });
 
-  it("renders the full thinking text without incremental animation", async () => {
-    const threadId = "thread-initial-thinking-full-text";
-    const thinking = "Reviewing the complete request";
+  it("restarts on every follow-up line instead of sliding a short tail", async () => {
+    const threadId = "thread-initial-thinking-rollover";
+    const thinking = "ABCDEFG";
+    mockThinkingTypewriterLayout({
+      text: thinking,
+      labelWidth: 38,
+      parentWidth: 160,
+      graphemeWidth: 10,
+      measureTextWidth: (value) => {
+        return (
+          Array.from(value).filter((grapheme) => {
+            return grapheme !== ".";
+          }).length * 10
+        );
+      },
+    });
+    const displayedLabels = new Set<string>();
+    const labelObserver = new MutationObserver(() => {
+      const label = document.querySelector(`[aria-label="${thinking}"]`);
+      if (label?.textContent) {
+        displayedLabels.add(label.textContent);
+      }
+    });
+    labelObserver.observe(document.body, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+    context.signal.addEventListener(
+      "abort",
+      () => {
+        labelObserver.disconnect();
+      },
+      { once: true },
+    );
     mockChatLifecycle(context, {
       threadId,
       chatMessages: [
         {
-          id: "msg-thinking-full-text-user",
+          id: "msg-thinking-rollover-user",
           role: "user",
           content: "Draft a launch checklist",
           runId: "run-active",
           createdAt: "2026-03-10T00:00:00Z",
         },
         {
-          id: "msg-thinking-full-text-marker",
+          id: "msg-thinking-rollover-marker",
           role: "assistant",
           content: null,
           thinking,
@@ -7505,7 +7660,22 @@ describe("initial thinking indicator", () => {
     });
 
     const label = await screen.findByLabelText(thinking);
-    expect(label).toHaveTextContent(thinking);
+    const sawFollowUpLine = () => {
+      if (label.textContent) {
+        displayedLabels.add(label.textContent);
+      }
+      return Array.from(displayedLabels).some((value) => {
+        return value === "D" || value === "DE" || value === "DEF";
+      });
+    };
+    await waitFor(() => {
+      expect(sawFollowUpLine()).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(label).toHaveTextContent(/^G$/);
+    });
+    expect(displayedLabels.has("...EFG")).toBeFalsy();
+    expect(label).not.toHaveTextContent(thinking);
     expect(label.closest("[data-thinking-indicator]")).not.toBeNull();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -4549,6 +4549,9 @@ interface ServerThinkingLabel {
   readonly displayedText: string;
   readonly fullText: string;
   readonly id: string;
+  readonly setRef: (
+    el: HTMLParagraphElement | null,
+  ) => (() => void) | undefined;
 }
 
 function ThinkingLabel({
@@ -4565,7 +4568,7 @@ function ThinkingLabel({
 
   if (isQueued) {
     return (
-      <p className="text-muted-foreground min-w-0 flex-1 text-[0.8125rem] truncate">
+      <p className="zero-shimmer-text min-w-0 flex-1 text-[0.8125rem] truncate">
         Waiting in{" "}
         <button
           type="button"
@@ -4584,7 +4587,8 @@ function ThinkingLabel({
     return (
       <p
         key={serverThinkingLabel.id}
-        className="text-muted-foreground min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem]"
+        ref={serverThinkingLabel.setRef}
+        className="zero-shimmer-text min-w-0 flex-1 overflow-hidden whitespace-nowrap text-[0.8125rem]"
         aria-label={serverThinkingLabel.fullText}
       >
         {serverThinkingLabel.displayedText || "\u00a0"}
@@ -4593,7 +4597,7 @@ function ThinkingLabel({
   }
 
   return (
-    <p className="text-muted-foreground min-w-0 flex-1 text-[0.8125rem] truncate">
+    <p className="zero-shimmer-text min-w-0 flex-1 text-[0.8125rem] truncate">
       {thinkingLabel}
     </p>
   );
@@ -4669,7 +4673,7 @@ function WaitingForAssistantResponse({
     <div
       data-thinking-indicator
       data-role="assistant"
-      className="flex flex-col gap-1"
+      className="zero-thinking-enter flex flex-col gap-1"
     >
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_minmax(0,1fr)] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
         <AssistantBubbleAvatar thread={thread} />
@@ -4839,12 +4843,18 @@ function ThinkingIndicator({
   });
   const thinkingLabel = useGet(thread.thinkingPhrase$);
   const thinkingText = indicatorState.lastThinkingMessage?.thinking.trim();
+  const displayedThinkingText =
+    useLastResolved(thread.displayedThinkingText$) ?? "";
+  const setThinkingIndicatorTextRef = useSet(
+    thread.setThinkingIndicatorTextRef$,
+  );
   const serverThinkingLabel =
     thinkingText && indicatorState.lastThinkingMessage && indicatorState.running
       ? {
-          displayedText: thinkingText,
+          displayedText: displayedThinkingText,
           fullText: thinkingText,
           id: indicatorState.lastThinkingMessage.id,
+          setRef: setThinkingIndicatorTextRef,
         }
       : undefined;
   const recommendedFollowupSource = latestRecommendedFollowups(groups);


### PR DESCRIPTION
## Summary

- restore the thinking label shimmer, three-block pop, and 300 ms entrance animation
- restore the measured-line thinking typewriter with a 100 ms frame interval instead of the previous 28 ms cadence
- keep the fallback thinking phrase stable, so the removed 3.5-second phrase rotation loop does not return
- document that the static profiling baseline no longer describes the current animation policy

## User impact

Active chat runs feel alive again: generated thinking text reveals incrementally, the label shimmers, and the three indicator blocks animate. The slower typewriter cadence limits the React update rate to at most 10 frames per second before semantic equality suppression.

## Verification

- `pnpm exec prettier --check` on all changed platform files
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/chat-lifecycle.test.tsx -t "initial thinking indicator" --reporter=dot` (5 passed)
- local-browser computed-style check against the Vite bundle for the 3.5 s shimmer, staggered 1.4 s block animations, and 300 ms entrance animation

The complete authenticated chat flow was not available locally because the runtime did not have `VITE_CLERK_PUBLISHABLE_KEY`; the typewriter lifecycle is covered by the targeted page test.
