### PR TITLE
test(mitm-addon): cover malformed base url vars

### DIFF
--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -128,6 +128,38 @@ class TestRegistryBuiltinBaseUrlVars:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["base"] == "https://acme.zendesk.com"
 
+    @pytest.mark.parametrize(
+        ("base_url_vars", "expected_message"),
+        [
+            ([], "baseUrlVars must be an object"),
+            ({"ZENDESK_SUBDOMAIN": 1}, "baseUrlVars must contain string values"),
+        ],
+    )
+    def test_malformed_base_url_vars_reject_vm(
+        self, tmp_path, base_url_vars: object, expected_message: str
+    ) -> None:
+        path = tmp_path / "registry.json"
+        write_builtin_firewall_registry(
+            path,
+            run_id="run-zendesk",
+            name="zendesk",
+            base_url_vars={"ZENDESK_SUBDOMAIN": "acme"},
+        )
+        data = json.loads(path.read_text())
+        data["vms"]["10.200.0.1"]["firewalls"][0]["baseUrlVars"] = base_url_vars
+        path.write_text(json.dumps(data))
+
+        with patch.object(registry.ctx, "log", MagicMock(), create=True):
+            context = registry.get_vm_context("10.200.0.1", str(path))
+            state = registry.load_registry_state(str(path))
+
+        assert context is None
+        assert not isinstance(state, registry.RegistryUnavailable)
+        assert "10.200.0.1" not in state.vms
+        invalid_vm = state.invalid_vms["10.200.0.1"]
+        assert invalid_vm.reason == "invalid_firewalls"
+        assert invalid_vm.message == expected_message
+
     def test_builtin_fixed_provider_suffix_rejects_authority_escape(self, tmp_path):
         path = tmp_path / "registry.json"
         write_builtin_firewall_registry(

--- a/crates/runner/mitm-addon/tests/test_registry_context_state.py
+++ b/crates/runner/mitm-addon/tests/test_registry_context_state.py
@@ -228,8 +228,6 @@ class TestRegistryContextState:
             [0],
             [{"kind": "inline"}],
             [{"kind": "builtin", "name": ""}],
-            [{"kind": "builtin", "name": "zendesk", "baseUrlVars": []}],
-            [{"kind": "builtin", "name": "zendesk", "baseUrlVars": {"ZENDESK_SUBDOMAIN": 1}}],
             [{"name": "github", "apis": []}],
             [{"kind": "unknown", "name": "github"}],
             [{"kind": "unknown", "name": "github", "apis": []}],


### PR DESCRIPTION
## Summary

- move malformed `baseUrlVars` coverage into the dedicated builtin base URL integration suite
- build a valid trusted catalog fixture before mutating only the registry payload under test
- assert VM rejection and the exact diagnostics for non-object values and non-string record values

## Scope

- test-only change; production registry behavior is unchanged
- no schema, persisted data, API, protocol, or deployment compatibility changes

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- `.venv/bin/python -m pytest tests/ -q` (3833 passed)
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7391 passed, 1 existing skipped benchmark)
- `pnpm knip`

Closes #21154
