### PR TITLE
refactor: neutralize shared workflow run identifiers

### DIFF
--- a/turbo/apps/api/src/signals/routes/zero-workflows.ts
+++ b/turbo/apps/api/src/signals/routes/zero-workflows.ts
@@ -40,7 +40,7 @@ import { nowDate } from "../../lib/time";
 import { requireAgentPermission } from "../../lib/require-agent-permission";
 import { uploadVolumeServerSide$ } from "../services/storage-volume-upload.service";
 import { dispatchFailedRunCallbacks } from "../services/agent-run-callback.service";
-import { postAutomationUserMessage } from "../services/zero-chat-automation-message.service";
+import { postRunUserMessage } from "../services/zero-chat-run-message.service";
 import { createZeroRun$ } from "../services/zero-runs-create.service";
 import { deleteZeroWorkflow$ } from "../services/zero-workflow-delete.service";
 import { zeroWorkflowDetail } from "../services/zero-workflow-detail.service";
@@ -1134,7 +1134,7 @@ const runWorkflowInner$ = command(async ({ get, set }, signal: AbortSignal) => {
     return result;
   }
 
-  await postAutomationUserMessage({
+  await postRunUserMessage({
     db: writeDb,
     threadId: chatThreadId,
     userId: auth.userId,

--- a/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-run-message.service.ts
@@ -28,10 +28,10 @@ import {
   resolveModelSelectionPin,
 } from "./zero-model-selection.service";
 
-type AutomationChatThreadModelPin = ModelFirstPin;
+type RunChatThreadModelPin = ModelFirstPin;
 
-type AutomationChatThreadModelPinResult =
-  | AutomationChatThreadModelPin
+type RunChatThreadModelPinResult =
+  | RunChatThreadModelPin
   | ReturnType<typeof providerDeleted>
   | ReturnType<typeof badRequestMessage>
   | ReturnType<typeof insufficientCredits>;
@@ -39,7 +39,7 @@ type AutomationChatThreadModelPinResult =
 async function getStoredThreadModelPin(
   db: Db,
   threadId: string,
-): Promise<AutomationChatThreadModelPin | null> {
+): Promise<RunChatThreadModelPin | null> {
   const [thread] = await db
     .select({ selectedModel: chatThreads.selectedModel })
     .from(chatThreads)
@@ -54,7 +54,7 @@ async function getStoredThreadModelPin(
 async function getFirstRunModelPin(
   db: Db,
   threadId: string,
-): Promise<AutomationChatThreadModelPin | null> {
+): Promise<RunChatThreadModelPin | null> {
   const [run] = await db
     .select({ selectedModel: zeroRuns.selectedModel })
     .from(chatMessages)
@@ -78,7 +78,7 @@ async function getFirstRunModelPin(
 async function existingModelFirstThreadPin(
   db: Db,
   threadId: string,
-): Promise<AutomationChatThreadModelPin | null> {
+): Promise<RunChatThreadModelPin | null> {
   return (
     (await getStoredThreadModelPin(db, threadId)) ??
     (await getFirstRunModelPin(db, threadId))
@@ -89,8 +89,8 @@ async function resolveStoredModelFirstPin(params: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
-  readonly pin: AutomationChatThreadModelPin;
-}): Promise<AutomationChatThreadModelPinResult> {
+  readonly pin: RunChatThreadModelPin;
+}): Promise<RunChatThreadModelPinResult> {
   if (!params.pin.selectedModel) {
     return params.pin;
   }
@@ -121,15 +121,15 @@ async function resolveStoredModelFirstPin(params: {
 }
 
 /**
- * Resolve the model pin for a chat-mode automation run from its linked thread:
+ * Resolve the model pin for a chat-mode run from its linked thread:
  * the thread's stored pin, else its first-run pin, else the org default.
  */
-export async function resolveAutomationChatThreadModelPin(params: {
+export async function resolveRunChatThreadModelPin(params: {
   readonly db: Db;
   readonly orgId: string;
   readonly userId: string;
   readonly threadId: string;
-}): Promise<AutomationChatThreadModelPinResult> {
+}): Promise<RunChatThreadModelPinResult> {
   const existing = await existingModelFirstThreadPin(
     params.db,
     params.threadId,
@@ -146,10 +146,10 @@ export async function resolveAutomationChatThreadModelPin(params: {
 }
 
 /**
- * Post an automation run's prompt as a user chat message into its linked
+ * Post a run's prompt as a user chat message into its linked
  * thread and publish realtime signals so the client surfaces the run.
  */
-export async function postAutomationUserMessage(params: {
+export async function postRunUserMessage(params: {
   readonly db: Db;
   readonly threadId: string;
   readonly userId: string;

--- a/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-goal-continuation.service.ts
@@ -11,9 +11,9 @@ import { now } from "../external/time";
 import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
-  postAutomationUserMessage,
-  resolveAutomationChatThreadModelPin,
-} from "./zero-chat-automation-message.service";
+  postRunUserMessage,
+  resolveRunChatThreadModelPin,
+} from "./zero-chat-run-message.service";
 import { hasUnclaimedQueuedUserMessage } from "./zero-chat-queued-message.service";
 import {
   pauseActiveGoalForThread,
@@ -335,7 +335,7 @@ async function resolveModelContext(args: {
   readonly chatThreadId: string;
   readonly signal: AbortSignal;
 }): Promise<ModelContext> {
-  const threadModelPin = await resolveAutomationChatThreadModelPin({
+  const threadModelPin = await resolveRunChatThreadModelPin({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
@@ -449,7 +449,7 @@ const runGoalNow$ = command(
       return { kind: "run_error", response: result };
     }
 
-    await postAutomationUserMessage({
+    await postRunUserMessage({
       db,
       threadId: goal.threadId,
       userId: goal.userId,

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger-run.service.ts
@@ -13,9 +13,9 @@ import { now, nowDate } from "../external/time";
 import type { DispatchFailedRunCallbacks } from "./agent-run-create.service";
 import type { InternalRunCallbackKind } from "./internal-run-callback";
 import {
-  postAutomationUserMessage,
-  resolveAutomationChatThreadModelPin,
-} from "./zero-chat-automation-message.service";
+  postRunUserMessage,
+  resolveRunChatThreadModelPin,
+} from "./zero-chat-run-message.service";
 import {
   resolveModelFirstProviderAdmission,
   type ModelFirstPin,
@@ -202,7 +202,7 @@ async function resolveModelContext(args: {
   readonly chatThreadId: string;
   readonly signal: AbortSignal;
 }): Promise<ModelContext> {
-  const threadModelPin = await resolveAutomationChatThreadModelPin({
+  const threadModelPin = await resolveRunChatThreadModelPin({
     db: args.db,
     orgId: args.orgId,
     userId: args.userId,
@@ -443,7 +443,7 @@ async function recordWorkflowTriggerRunStart(input: {
 }): Promise<void> {
   const { db, args, runId, signal } = input;
   const { trigger, chatThreadId } = args.due;
-  await postAutomationUserMessage({
+  await postRunUserMessage({
     db,
     threadId: chatThreadId,
     userId: trigger.ownerUserId,

--- a/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-workflow-trigger.service.ts
@@ -27,7 +27,7 @@ import {
   type ZeroWorkflowEventType,
   type ZeroWorkflowSchedule,
   type ZeroWorkflowWebhookSecretResponse,
-  type ZeroWorkflowTriggerAutomationEntry,
+  type ZeroWorkflowAutomationEntry,
   type ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
 import { parseScheduledAtTime } from "@vm0/core/timezone";
@@ -783,7 +783,7 @@ export async function listWorkspaceWorkflowTriggers(
     readonly orgId: string;
     readonly member: WorkflowMember;
   },
-): Promise<readonly ZeroWorkflowTriggerAutomationEntry[]> {
+): Promise<readonly ZeroWorkflowAutomationEntry[]> {
   const rows = await db
     .select({
       trigger: zeroWorkflowTriggers,
@@ -824,24 +824,22 @@ export async function listWorkspaceWorkflowTriggers(
     .orderBy(asc(zeroWorkflowTriggers.createdAt), asc(zeroWorkflowTriggers.id));
 
   const entries = await Promise.all(
-    rows.map(
-      async (row): Promise<ZeroWorkflowTriggerAutomationEntry | null> => {
-        const trigger = await rowToPublicSummary(db, row.trigger, {
-          chatThreadId: row.chatThreadId ?? null,
-        });
-        if (!trigger) {
-          return null;
-        }
-        return {
-          workflow: workflowSummary({
-            workflow: row.workflow,
-            agent: row.agent,
-            member: args.member,
-          }),
-          trigger,
-        };
-      },
-    ),
+    rows.map(async (row): Promise<ZeroWorkflowAutomationEntry | null> => {
+      const trigger = await rowToPublicSummary(db, row.trigger, {
+        chatThreadId: row.chatThreadId ?? null,
+      });
+      if (!trigger) {
+        return null;
+      }
+      return {
+        workflow: workflowSummary({
+          workflow: row.workflow,
+          agent: row.agent,
+          member: args.member,
+        }),
+        trigger,
+      };
+    }),
   );
   return entries.flatMap((entry) => {
     return entry ? [entry] : [];

--- a/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-workflows.ts
@@ -6,7 +6,7 @@ import {
   type ChatThreadWorkflowTrigger,
   type ZeroWorkflowDetailResponse,
   type ZeroWorkflowSummary,
-  type ZeroWorkflowTriggerAutomationEntry,
+  type ZeroWorkflowAutomationEntry,
   type ZeroWorkflowTriggerCreateRequest,
   type ZeroWorkflowTriggerSummary,
 } from "@vm0/api-contracts/contracts/zero-workflows";
@@ -398,15 +398,16 @@ function mockScheduleSummary(
 function workflowTriggerListHandlers() {
   return [
     mockApi(zeroWorkflowTriggersContract.listWorkspace, ({ respond }) => {
-      const entries: ZeroWorkflowTriggerAutomationEntry[] =
-        mockWorkflows.flatMap((workflow) => {
+      const entries: ZeroWorkflowAutomationEntry[] = mockWorkflows.flatMap(
+        (workflow) => {
           return workflow.triggers.map((trigger) => {
             return {
               workflow: summary(workflow),
               trigger: publicWorkflowTrigger(trigger),
             };
           });
-        });
+        },
+      );
       return respond(200, entries);
     }),
 

--- a/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
+++ b/turbo/apps/platform/src/signals/workflows-page/workflows-signals.ts
@@ -19,7 +19,7 @@ import {
   type ZeroWorkflowSchedule,
   type ZeroWorkflowWebhookSecretResponse,
   type ZeroWorkflowSummary,
-  type ZeroWorkflowTriggerAutomationEntry,
+  type ZeroWorkflowAutomationEntry,
   type ZeroWorkflowTriggerCreateRequest,
   type ZeroWorkflowTriggerSummary,
   type ZeroWorkflowUpdateRequest,
@@ -93,7 +93,7 @@ type WorkflowWebhookTriggerSummary = Extract<
 >;
 type WorkflowGithubLabelActor =
   GithubLabelAppliedEventConfig["filters"]["actor"]["type"];
-export type WorkflowTriggerAutomationEntry = ZeroWorkflowTriggerAutomationEntry;
+export type WorkflowAutomationEntry = ZeroWorkflowAutomationEntry;
 export const WORKFLOW_DETAIL_FILE_PARAM = "file";
 
 function workflowDetailTabFromRoute(route: RouteKey | null): WorkflowDetailTab {
@@ -693,7 +693,7 @@ export const allVisibleWorkflows$ = computed(
 );
 
 export const allWorkflowTriggerEntries$ = computed(
-  async (get): Promise<readonly WorkflowTriggerAutomationEntry[]> => {
+  async (get): Promise<readonly WorkflowAutomationEntry[]> => {
     get(internalWorkflowReload$);
     const triggerClient = get(zeroClient$)(zeroWorkflowTriggersContract);
     const triggerResult = await accept(triggerClient.listWorkspace(), [200]);

--- a/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
+++ b/turbo/apps/platform/src/views/workflows-page/workflows-page.tsx
@@ -47,7 +47,7 @@ import {
   WORKFLOW_ALL_AGENTS,
   type WorkflowFilter,
   type WorkflowSortMode,
-  type WorkflowTriggerAutomationEntry,
+  type WorkflowAutomationEntry,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
 import { AgentAvatarImg } from "../zero-page/zero-sidebar-shared.tsx";
@@ -65,13 +65,13 @@ import { WorkflowWebhookUpgradeDialog } from "./workflow-webhook-upgrade-dialog.
 
 export type WorkflowTriggerEntryMap = ReadonlyMap<
   string,
-  readonly WorkflowTriggerAutomationEntry[]
+  readonly WorkflowAutomationEntry[]
 >;
 
 export function workflowTriggerEntryMap(
-  entries: readonly WorkflowTriggerAutomationEntry[],
+  entries: readonly WorkflowAutomationEntry[],
 ): WorkflowTriggerEntryMap {
-  const grouped = new Map<string, WorkflowTriggerAutomationEntry[]>();
+  const grouped = new Map<string, WorkflowAutomationEntry[]>();
   for (const entry of entries) {
     const workflowEntries = grouped.get(entry.workflow.id) ?? [];
     workflowEntries.push(entry);
@@ -92,7 +92,7 @@ function initials(label: string): string {
   return (words[0]?.slice(0, 2) || "??").toUpperCase();
 }
 
-function triggerDotClass(entry: WorkflowTriggerAutomationEntry): string {
+function triggerDotClass(entry: WorkflowAutomationEntry): string {
   const trigger = entry.trigger;
   if (trigger.kind === "schedule") {
     return "bg-blue-500";
@@ -102,9 +102,7 @@ function triggerDotClass(entry: WorkflowTriggerAutomationEntry): string {
     : "bg-emerald-500";
 }
 
-function connectorNames(
-  entries: readonly WorkflowTriggerAutomationEntry[],
-): string {
+function connectorNames(entries: readonly WorkflowAutomationEntry[]): string {
   return entries
     .slice(0, 2)
     .map((entry) => {
@@ -197,7 +195,7 @@ function ConnectorPopoverList({
   entries,
   displayTimezone,
 }: {
-  readonly entries: readonly WorkflowTriggerAutomationEntry[];
+  readonly entries: readonly WorkflowAutomationEntry[];
   readonly displayTimezone: string;
 }) {
   return (
@@ -240,7 +238,7 @@ function ConnectorCell({
   entries,
   displayTimezone,
 }: {
-  readonly entries: readonly WorkflowTriggerAutomationEntry[];
+  readonly entries: readonly WorkflowAutomationEntry[];
   readonly displayTimezone: string;
 }) {
   if (entries.length === 0) {
@@ -327,7 +325,7 @@ export function WorkflowHoverContent({
 function WorkflowRowIcon({
   entries,
 }: {
-  readonly entries: readonly WorkflowTriggerAutomationEntry[];
+  readonly entries: readonly WorkflowAutomationEntry[];
 }) {
   const [lead] = entries;
   if (lead) {
@@ -347,7 +345,7 @@ function WorkflowRow({
   showAgentColumn,
 }: {
   readonly workflow: ZeroWorkflowSummary;
-  readonly entries: readonly WorkflowTriggerAutomationEntry[];
+  readonly entries: readonly WorkflowAutomationEntry[];
   readonly displayTimezone: string;
   readonly showAgentColumn: boolean;
 }) {
@@ -507,7 +505,7 @@ function dayKey(date: Date, timezone: string): string {
 }
 
 function workflowNextRunBucket(
-  entries: readonly WorkflowTriggerAutomationEntry[],
+  entries: readonly WorkflowAutomationEntry[],
   now: Date,
   timezone: string,
 ): NextRunBucket {
@@ -656,7 +654,7 @@ export function WorkflowListPanel({
 }) {
   const entriesByWorkflowId =
     triggerEntriesByWorkflowId ??
-    new Map<string, readonly WorkflowTriggerAutomationEntry[]>();
+    new Map<string, readonly WorkflowAutomationEntry[]>();
 
   return (
     <section className="min-h-[520px]">

--- a/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/workflow-trigger-automations-page.tsx
@@ -52,7 +52,7 @@ import { ROUTES } from "../../signals/route-paths.ts";
 import {
   allVisibleWorkflows$,
   setWorkflowTriggerEnabled$,
-  type WorkflowTriggerAutomationEntry,
+  type WorkflowAutomationEntry,
 } from "../../signals/workflows-page/workflows-signals.ts";
 import {
   atTimeInTimezone,
@@ -373,7 +373,7 @@ export function WorkflowTriggerEnabledSwitch({
   entry,
   size = "default",
 }: {
-  readonly entry: WorkflowTriggerAutomationEntry;
+  readonly entry: WorkflowAutomationEntry;
   readonly size?: "default" | "sm";
 }) {
   const pageSignal = useGet(pageSignal$);

--- a/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-workflows.ts
@@ -923,12 +923,12 @@ export const zeroWorkflowListResponseSchema = z.array(
   zeroWorkflowSummarySchema,
 );
 
-export const zeroWorkflowTriggerAutomationEntrySchema = z.object({
+export const zeroWorkflowAutomationEntrySchema = z.object({
   workflow: zeroWorkflowSummarySchema,
   trigger: zeroWorkflowTriggerSummarySchema,
 });
-export const zeroWorkflowTriggerAutomationListResponseSchema = z.array(
-  zeroWorkflowTriggerAutomationEntrySchema,
+export const zeroWorkflowAutomationListResponseSchema = z.array(
+  zeroWorkflowAutomationEntrySchema,
 );
 
 export const zeroWorkflowCreateRequestSchema = z.object({
@@ -1207,7 +1207,7 @@ export const zeroWorkflowTriggersContract = c.router({
     path: "/api/zero/workflow-triggers",
     headers: authHeadersSchema,
     responses: {
-      200: zeroWorkflowTriggerAutomationListResponseSchema,
+      200: zeroWorkflowAutomationListResponseSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
     },
@@ -1383,8 +1383,8 @@ export type ZeroWorkflowChatThreadResponse = z.infer<
 export type ZeroWorkflowRunResponse = z.infer<
   typeof zeroWorkflowRunResponseSchema
 >;
-export type ZeroWorkflowTriggerAutomationEntry = z.infer<
-  typeof zeroWorkflowTriggerAutomationEntrySchema
+export type ZeroWorkflowAutomationEntry = z.infer<
+  typeof zeroWorkflowAutomationEntrySchema
 >;
 export type ZeroWorkflowsCollectionContract =
   typeof zeroWorkflowsCollectionContract;


### PR DESCRIPTION
## Summary

- Rename the shared chat run message and model-pin helpers so manual Workflow runs, Goal continuations, and Workflow Automations no longer inherit Legacy Automation terminology.
- Normalize internal Workflow Automation contract and UI type names while preserving the existing endpoint and response shape.
- Keep this PR behavior-neutral as the first independently deployable step of the Legacy Automation cleanup.

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm -F api check-types`
- `pnpm knip`
- API targeted tests: 18 Workflow tests, 45 Workflow Automation tests, 12 Goal tests
- Platform targeted tests: 44 Workflow page tests

Part of #21184