### PR TITLE
test(mitm-addon): make builtin catalog cache tests independent of umask

### DIFF
--- a/crates/runner/mitm-addon/tests/registry_helpers.py
+++ b/crates/runner/mitm-addon/tests/registry_helpers.py
@@ -2,8 +2,14 @@
 
 import json
 import os
+from pathlib import Path
 
 _FIXED_MTIME_NS = 1_700_000_000_000_000_000
+
+
+def write_trusted_catalog_cache_text(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o600)
 
 
 def write_simple_registry(path, *, run_id="run-one"):

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -10,6 +10,9 @@ import registry
 from tests.registry_helpers import (
     write_builtin_firewall_registry as _write_builtin_firewall_registry,
 )
+from tests.registry_helpers import (
+    write_trusted_catalog_cache_text,
+)
 
 _TEST_BUILTIN_FIREWALLS: dict[str, dict] = {}
 
@@ -48,7 +51,8 @@ def _cache_path_for_registry(path):
 
 
 def _write_catalog_cache(path, firewalls: dict[str, dict]) -> None:
-    path.write_text(
+    write_trusted_catalog_cache_text(
+        path,
         json.dumps(
             {
                 "schemaVersion": 1,
@@ -60,7 +64,7 @@ def _write_catalog_cache(path, firewalls: dict[str, dict]) -> None:
                 "firewalls": firewalls,
             },
             sort_keys=True,
-        )
+        ),
     )
 
 

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -69,14 +70,20 @@ def _zendesk_cache_firewall() -> dict:
     }
 
 
+def _write_trusted_catalog_cache_text(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o600)
+
+
 def _write_catalog_cache(
-    path,
+    path: Path,
     *,
     digest: str,
     version: str,
     firewalls: dict[str, dict],
 ) -> None:
-    path.write_text(
+    _write_trusted_catalog_cache_text(
+        path,
         json.dumps(
             {
                 "schemaVersion": 1,
@@ -86,7 +93,7 @@ def _write_catalog_cache(
                 "firewalls": firewalls,
             },
             sort_keys=True,
-        )
+        ),
     )
 
 
@@ -554,7 +561,7 @@ class TestRegistryBuiltinCache:
     def test_malformed_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        cache_path.write_text('{"schemaVersion":1}')
+        _write_trusted_catalog_cache_text(cache_path, '{"schemaVersion":1}')
         write_multi_vm_registry(
             registry_path,
             {"10.200.0.1": builtin_vm("run-fallback", "fallback")},

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,6 +14,7 @@ from tests.registry_helpers import (
     builtin_vm,
     inline_vm,
     write_multi_vm_registry,
+    write_trusted_catalog_cache_text,
 )
 
 
@@ -70,19 +70,14 @@ def _zendesk_cache_firewall() -> dict:
     }
 
 
-def _write_trusted_catalog_cache_text(path: Path, content: str) -> None:
-    path.write_text(content)
-    path.chmod(0o600)
-
-
 def _write_catalog_cache(
-    path: Path,
+    path,
     *,
     digest: str,
     version: str,
     firewalls: dict[str, dict],
 ) -> None:
-    _write_trusted_catalog_cache_text(
+    write_trusted_catalog_cache_text(
         path,
         json.dumps(
             {
@@ -561,7 +556,7 @@ class TestRegistryBuiltinCache:
     def test_malformed_runner_catalog_cache_fails_closed(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
         cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
-        _write_trusted_catalog_cache_text(cache_path, '{"schemaVersion":1}')
+        write_trusted_catalog_cache_text(cache_path, '{"schemaVersion":1}')
         write_multi_vm_registry(
             registry_path,
             {"10.200.0.1": builtin_vm("run-fallback", "fallback")},


### PR DESCRIPTION
## Summary

- add a shared test-only helper that writes trusted builtin catalog cache fixtures with mode `0600`
- use it for both registry cache and builtin base URL integration suites, including malformed caches that must reach content validation
- preserve the explicit group/world-writable fixtures that exercise `cache_untrusted`

## Scope

This changes test fixture setup only. It does not change the production cache reader or Rust writer, weaken the permission trust boundary, set a process-global umask, or modify CI configuration, schemas, APIs, protocols, or persisted state.

## Validation

- `ruff check .`
- `ruff format --check .`
- `basedpyright -p .`
- `umask 0002; python3 -m pytest -q tests/test_registry_builtin_cache.py tests/test_registry_builtin_base_url_vars.py` (97 passed)
- `umask 0022; python3 -m pytest -q tests/test_registry_builtin_cache.py tests/test_registry_builtin_base_url_vars.py` (97 passed)
- `umask 0002; python3 -m pytest -q tests/` (3833 passed)
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (7391 passed, 1 existing benchmark skipped)
- `pnpm knip`

Closes #20829
