### PR TITLE
perf(runner): offload and bound session history materialization

### DIFF
--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -24,9 +24,9 @@ use super::idle_lifecycle::{
 use super::job_spawn::{JobProfile, SpawnContext, SpawnJobRequest, spawn_job};
 use crate::config::ProfileConfig;
 use crate::executor::{
-    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryMaterializer, SessionHistoryProbe,
-    SessionHistoryRestoreFallback, SessionHistoryRestorePlan, effective_cli_framework,
-    validate_resume_session_id,
+    RunnerPreSpawnPhase, RunnerPreSpawnTiming, SessionHistoryCpuPool, SessionHistoryMaterializer,
+    SessionHistoryProbe, SessionHistoryRestoreFallback, SessionHistoryRestorePlan,
+    effective_cli_framework, validate_resume_session_id,
 };
 use crate::http::HttpClient;
 use crate::idle_pool::{
@@ -241,18 +241,22 @@ pub(super) async fn handle_discovered_job(
             }
         };
 
-    let session_history_restore_plan = build_session_history_restore_plan(
-        &ctx.spawn_ctx.exec_config.http,
-        claimed.context(),
-        resume_session_valid,
-        &job_cancel,
-        SessionHistoryRestoreReuse {
-            entry: reuse_entry.as_ref(),
-            result: reuse_result,
-        },
-        &mut pre_spawn_timing,
-        Some(&ctx.spawn_ctx.exec_config.session_history_probe),
-    );
+    let session_history_restore_plan = if resume_session_valid {
+        build_session_history_restore_plan(
+            &ctx.spawn_ctx.exec_config.http,
+            &ctx.spawn_ctx.exec_config.session_history_cpu,
+            claimed.context(),
+            &job_cancel,
+            SessionHistoryRestoreReuse {
+                entry: reuse_entry.as_ref(),
+                result: reuse_result,
+            },
+            &mut pre_spawn_timing,
+            Some(&ctx.spawn_ctx.exec_config.session_history_probe),
+        )
+    } else {
+        SessionHistoryRestorePlan::Default
+    };
 
     // Determine sandbox_id after the reuse decision. On reuse, the sandbox keeps
     // its original identity; on a fresh create, allocate a new UUID for the
@@ -307,16 +311,13 @@ struct SessionHistoryRestoreReuse<'a> {
 
 fn build_session_history_restore_plan(
     http: &HttpClient,
+    cpu: &SessionHistoryCpuPool,
     context: &ExecutionContext,
-    resume_session_valid: bool,
     cancel: &RunCancellationHandle,
     reuse: SessionHistoryRestoreReuse<'_>,
     pre_spawn_timing: &mut RunnerPreSpawnTiming,
     probe: Option<&SessionHistoryProbe>,
 ) -> SessionHistoryRestorePlan {
-    if !resume_session_valid {
-        return SessionHistoryRestorePlan::Default;
-    }
     let Some(resume_session) = context.resume_session.as_ref() else {
         return SessionHistoryRestorePlan::Default;
     };
@@ -373,6 +374,7 @@ fn build_session_history_restore_plan(
     let started_at = Instant::now();
     let materializer = SessionHistoryMaterializer::start_cancellable(
         http,
+        cpu,
         Some(resume_session),
         effective_cli_framework(&context.cli_agent_type),
         cancel.token(),
@@ -1275,8 +1277,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1340,8 +1342,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1388,8 +1390,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1418,8 +1420,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1466,8 +1468,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1500,8 +1502,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1532,8 +1534,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1565,8 +1567,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1598,8 +1600,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: None,
@@ -1635,8 +1637,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),
@@ -1677,8 +1679,8 @@ mod tests {
 
         let plan = build_session_history_restore_plan(
             &http,
+            &SessionHistoryCpuPool::with_capacity(1),
             &context,
-            true,
             &cancel,
             SessionHistoryRestoreReuse {
                 entry: Some(&reusable_sandbox),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -47,7 +47,7 @@ use crate::config::{self, ProfileConfig};
 use crate::deps;
 use crate::dns;
 use crate::error::{RunnerError, RunnerResult};
-use crate::executor::{ExecutorConfig, SessionHistoryProbe};
+use crate::executor::{ExecutorConfig, SessionHistoryCpuPool, SessionHistoryProbe};
 use crate::host;
 use crate::http::{HttpClient, HttpClientConfig};
 use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkingGate};
@@ -654,6 +654,7 @@ async fn run_start_with_home(
         network_log_drain,
         mitm_jsonl_flush: Some(mitm.jsonl_flush_handle(usage_flush_tx.clone())),
         network_policy_refresh,
+        session_history_cpu: SessionHistoryCpuPool::for_host_cpus(host_cpus),
         session_history_probe: SessionHistoryProbe::default(),
         home: home.clone(),
         workspace_cache: Some(SessionWorkspaceCache::shared(

--- a/crates/runner/src/cmd/start/tests/support/env.rs
+++ b/crates/runner/src/cmd/start/tests/support/env.rs
@@ -254,6 +254,7 @@ fn build_mock_run_config_with_runtime(
             network_log_drain: NetworkLogDrainCoordinator::noop(),
             mitm_jsonl_flush: None,
             network_policy_refresh: None,
+            session_history_cpu: executor::SessionHistoryCpuPool::with_capacity(1),
             session_history_probe: executor::SessionHistoryProbe::default(),
             home,
             workspace_cache: None,

--- a/crates/runner/src/executor/agent_run.rs
+++ b/crates/runner/src/executor/agent_run.rs
@@ -37,10 +37,10 @@ use super::env::{
     write_user_env_file,
 };
 use super::guest_state::{restore_guest_state, sync_guest_timezone};
+use super::session_history_cpu::SessionHistoryCpuJob;
 use super::session_history_download::{
     SessionHistoryDownloadPhaseTiming, SessionHistoryDownloadTimings,
     SessionHistoryMaterialization, SessionHistoryMaterializer,
-    verify_codex_zstd_session_history_bytes, verify_identity_session_history_bytes,
 };
 use super::session_restore::{MaterializedResumeSession, restore_session};
 use super::storage::download_storages;
@@ -327,35 +327,78 @@ fn record_session_history_restore_fallback(
 async fn materialize_session_history_sidecar(
     context: &ExecutionContext,
     sidecar: &WorkspaceSessionHistorySidecar,
-) -> RunnerResult<MaterializedResumeSession<'static>> {
+    config: &ExecutorConfig,
+    cancel: &CancellationToken,
+) -> RunnerResult<MaterializedResumeSession> {
     let resume_session = context.resume_session.as_ref().ok_or_else(|| {
         RunnerError::Internal("resume session missing for sidecar restore".into())
     })?;
     let history_ref = resume_session.history_ref().ok_or_else(|| {
         RunnerError::Internal("resume session history ref missing for sidecar restore".into())
     })?;
-    let bytes = read_session_history_sidecar_bytes(sidecar).await?;
-    match sidecar.representation {
-        WorkspaceSessionHistorySidecarRepresentation::Raw => {
-            verify_identity_session_history_bytes(&bytes, history_ref.raw_size, &history_ref.hash)?;
-            Ok(MaterializedResumeSession::new(
-                resume_session.cli_agent_session_id.clone(),
-                bytes,
-            ))
+    let bytes = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            return Err(RunnerError::Internal(
+                "session history sidecar materialization cancelled".into(),
+            ));
         }
-        WorkspaceSessionHistorySidecarRepresentation::CodexZstd => {
-            let timestamp = verify_codex_zstd_session_history_bytes(
-                &bytes,
-                history_ref.raw_size,
-                &history_ref.hash,
-            )?;
-            Ok(MaterializedResumeSession::new_codex_zstd(
-                resume_session.cli_agent_session_id.clone(),
-                bytes,
-                timestamp,
-            ))
-        }
+        result = read_session_history_sidecar_bytes(sidecar) => result?,
+    };
+    let job = match sidecar.representation {
+        WorkspaceSessionHistorySidecarRepresentation::Raw => SessionHistoryCpuJob::raw(
+            resume_session.cli_agent_session_id.clone(),
+            bytes,
+            history_ref.raw_size,
+            history_ref.hash.clone(),
+            effective_cli_framework(&context.cli_agent_type),
+        ),
+        WorkspaceSessionHistorySidecarRepresentation::CodexZstd => SessionHistoryCpuJob::zstd(
+            resume_session.cli_agent_session_id.clone(),
+            bytes,
+            history_ref.raw_size,
+            history_ref.hash.clone(),
+            super::cli_framework::EffectiveCliFramework::Codex,
+        ),
+    };
+    config
+        .session_history_cpu
+        .materialize(job, cancel)
+        .await?
+        .result
+}
+
+async fn materialize_inline_resume_session(
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+    cancel: &CancellationToken,
+) -> RunnerResult<Option<MaterializedResumeSession>> {
+    let Some(resume_session) = context.resume_session.as_ref() else {
+        return Ok(None);
+    };
+    let Some(history) = resume_session.shared_session_history() else {
+        return Ok(None);
+    };
+    if effective_cli_framework(&context.cli_agent_type)
+        == super::cli_framework::EffectiveCliFramework::Codex
+    {
+        let outcome = config
+            .session_history_cpu
+            .materialize(
+                SessionHistoryCpuJob::inline_codex(
+                    resume_session.cli_agent_session_id.clone(),
+                    history,
+                ),
+                cancel,
+            )
+            .await?;
+        return outcome.result.map(Some);
     }
+    Ok(Some(MaterializedResumeSession::new_shared(
+        resume_session.cli_agent_session_id.clone(),
+        history,
+        None,
+    )))
 }
 
 async fn read_session_history_sidecar_bytes(
@@ -1040,6 +1083,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     record_session_history_identity_reason(telemetry, reason);
                     Some(SessionHistoryMaterializer::start_cancellable(
                         &config.http,
+                        &config.session_history_cpu,
                         context.resume_session.as_ref(),
                         effective_cli_framework(&context.cli_agent_type),
                         cancel.clone(),
@@ -1052,6 +1096,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
             record_session_history_restore_fallback(telemetry, fallback);
             Some(SessionHistoryMaterializer::start_cancellable(
                 &config.http,
+                &config.session_history_cpu,
                 context.resume_session.as_ref(),
                 effective_cli_framework(&context.cli_agent_type),
                 cancel.clone(),
@@ -1060,6 +1105,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
         }
         SessionHistoryRestorePlan::Default => Some(SessionHistoryMaterializer::start_cancellable(
             &config.http,
+            &config.session_history_cpu,
             context.resume_session.as_ref(),
             effective_cli_framework(&context.cli_agent_type),
             cancel.clone(),
@@ -1080,7 +1126,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
     };
     if let Some(sidecar) = local_session_history_sidecar {
         let restore_started = Instant::now();
-        match materialize_session_history_sidecar(context, &sidecar).await {
+        match materialize_session_history_sidecar(context, &sidecar, config, &cancel).await {
             Ok(session) => match restore_session(sandbox, context, &session).await {
                 Ok(diagnostics) => {
                     telemetry.record(
@@ -1093,6 +1139,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     session_restore_diagnostics = Some(diagnostics);
                 }
                 Err(error) => {
+                    if cancel.is_cancelled() {
+                        return Err(error);
+                    }
                     telemetry.record(
                         "session_history_workspace_cache_restore",
                         restore_started.elapsed(),
@@ -1113,6 +1162,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                     session_history_materializer =
                         Some(SessionHistoryMaterializer::start_cancellable(
                             &config.http,
+                            &config.session_history_cpu,
                             context.resume_session.as_ref(),
                             effective_cli_framework(&context.cli_agent_type),
                             cancel.clone(),
@@ -1121,6 +1171,9 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 }
             },
             Err(error) => {
+                if cancel.is_cancelled() {
+                    return Err(error);
+                }
                 telemetry.record(
                     "session_history_workspace_cache_restore",
                     restore_started.elapsed(),
@@ -1140,6 +1193,7 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 );
                 session_history_materializer = Some(SessionHistoryMaterializer::start_cancellable(
                     &config.http,
+                    &config.session_history_cpu,
                     context.resume_session.as_ref(),
                     effective_cli_framework(&context.cli_agent_type),
                     cancel.clone(),
@@ -1225,18 +1279,13 @@ pub(super) async fn run_in_sandbox_with_process_cancel_timeouts(
                 return Err(error);
             }
         };
-        let resume_session = downloaded_resume_session.map(Ok).or_else(|| {
-            context
-                .resume_session
-                .as_ref()
-                .map(MaterializedResumeSession::from_inline_resume_session)
-        });
+        let resume_session = match downloaded_resume_session {
+            Some(session) => Some(session),
+            None => materialize_inline_resume_session(context, config, &cancel).await?,
+        };
         if let Some(session) = resume_session {
             let t = Instant::now();
-            let result = match session {
-                Ok(session) => restore_session(sandbox, context, &session).await,
-                Err(error) => Err(error),
-            };
+            let result = restore_session(sandbox, context, &session).await;
             let err = result.as_ref().err().map(|e| e.to_string());
             telemetry.record(
                 "session_restore",

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -30,6 +30,7 @@ mod diagnostics;
 mod env;
 mod guest_state;
 mod sandbox_run;
+mod session_history_cpu;
 mod session_history_download;
 mod session_id;
 mod session_restore;
@@ -40,6 +41,7 @@ pub(crate) use crate::restored_session_identity::RestoredSessionIdentity;
 pub(crate) use agent_run::{SessionHistoryRestoreFallback, SessionHistoryRestorePlan};
 pub(crate) use cli_framework::effective_cli_framework;
 pub(crate) use guest_state::{is_valid_guest_timezone_name, restore_guest_state_with_timezone};
+pub(crate) use session_history_cpu::SessionHistoryCpuPool;
 pub(crate) use session_history_download::{SessionHistoryMaterializer, SessionHistoryProbe};
 
 use crate::active_input::ActiveInputSource;
@@ -157,6 +159,7 @@ pub struct ExecutorConfig {
     pub network_log_drain: NetworkLogDrainCoordinator,
     pub mitm_jsonl_flush: Option<MitmJsonlFlushHandle>,
     pub(crate) network_policy_refresh: Option<crate::provider::NetworkPolicyRefreshHandle>,
+    pub(crate) session_history_cpu: SessionHistoryCpuPool,
     pub(crate) session_history_probe: SessionHistoryProbe,
     pub home: HomePaths,
     pub workspace_cache: Option<SessionWorkspaceCache>,

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -618,6 +618,7 @@ fn start_fresh_session_history_materializer(
     let started = Instant::now();
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
+        &config.session_history_cpu,
         context.resume_session.as_ref(),
         effective_cli_framework(&context.cli_agent_type),
         cancel,

--- a/crates/runner/src/executor/session_history_cpu.rs
+++ b/crates/runner/src/executor/session_history_cpu.rs
@@ -1,0 +1,1357 @@
+//! Bounded CPU execution for resume-session history materialization.
+
+use std::io::{self, BufRead, BufReader, Read};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[cfg(test)]
+use std::sync::{Condvar, Mutex};
+
+use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
+use flate2::read::MultiGzDecoder;
+use sha2::{Digest, Sha256};
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+
+use super::cli_framework::EffectiveCliFramework;
+use super::session_restore::MaterializedResumeSession;
+use super::{RunnerError, RunnerResult};
+
+const CPU_CHUNK_BYTES: usize = 64 * 1024;
+const DECODER_BUFFER_BYTES: usize = 8 * 1024;
+const CPU_CANCELLED: &str = "session history materialization cancelled";
+
+#[derive(Clone)]
+pub(crate) struct SessionHistoryCpuPool {
+    permits: Arc<Semaphore>,
+    hooks: SessionHistoryCpuHooks,
+}
+
+#[derive(Clone, Default)]
+struct SessionHistoryCpuHooks {
+    #[cfg(test)]
+    cpu_gate: Option<SessionHistoryCpuTestGate>,
+    #[cfg(test)]
+    reader_gate: Option<SessionHistoryCpuTestGate>,
+}
+
+struct SessionHistoryCpuTaskGuard {
+    cancel: CancellationToken,
+    abort: tokio::task::AbortHandle,
+    armed: bool,
+}
+
+pub(super) enum SessionHistoryCpuJob {
+    Raw {
+        cli_agent_session_id: String,
+        bytes: Vec<u8>,
+        expected_raw_size: u64,
+        expected_hash: String,
+        framework: EffectiveCliFramework,
+    },
+    Gzip {
+        cli_agent_session_id: String,
+        encoded_bytes: Vec<u8>,
+        expected_raw_size: u64,
+        expected_hash: String,
+        framework: EffectiveCliFramework,
+    },
+    Zstd {
+        cli_agent_session_id: String,
+        encoded_bytes: Vec<u8>,
+        expected_raw_size: u64,
+        expected_hash: String,
+        framework: EffectiveCliFramework,
+    },
+    InlineCodex {
+        cli_agent_session_id: String,
+        history: Arc<String>,
+    },
+}
+
+struct CompressedSessionHistoryJob {
+    cli_agent_session_id: String,
+    encoded_bytes: Vec<u8>,
+    expected_raw_size: u64,
+    expected_hash: String,
+    framework: EffectiveCliFramework,
+    encoding: CompressedEncoding,
+}
+
+#[derive(Debug)]
+pub(super) struct SessionHistoryCpuOutcome {
+    pub(super) timings: SessionHistoryCpuTimings,
+    pub(super) result: RunnerResult<MaterializedResumeSession>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct SessionHistoryCpuTimings {
+    validation: Option<SessionHistoryCpuPhaseTiming>,
+    decompression: Option<SessionHistoryCpuPhaseTiming>,
+    hash_verification: Option<SessionHistoryCpuPhaseTiming>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct SessionHistoryCpuPhaseTiming {
+    elapsed: Duration,
+    success: bool,
+}
+
+impl SessionHistoryCpuPool {
+    pub(crate) fn for_host_cpus(host_cpus: usize) -> Self {
+        let capacity = (host_cpus / 2).clamp(1, 4);
+        Self::with_capacity(capacity)
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(capacity.max(1))),
+            hooks: SessionHistoryCpuHooks::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_test_gates(
+        capacity: usize,
+        cpu_gate: Option<SessionHistoryCpuTestGate>,
+        reader_gate: Option<SessionHistoryCpuTestGate>,
+    ) -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(capacity.max(1))),
+            hooks: SessionHistoryCpuHooks {
+                cpu_gate,
+                reader_gate,
+            },
+        }
+    }
+
+    pub(super) async fn materialize(
+        &self,
+        job: SessionHistoryCpuJob,
+        cancel: &CancellationToken,
+    ) -> RunnerResult<SessionHistoryCpuOutcome> {
+        self.hooks.record_submission();
+        let operation_cancel = cancel.child_token();
+        let permit = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Err(cpu_cancelled_error()),
+            permit = Arc::clone(&self.permits).acquire_owned() => permit.map_err(|error| {
+                RunnerError::Internal(format!("acquire session history CPU permit: {error}"))
+            })?,
+        };
+
+        let blocking_cancel = operation_cancel.clone();
+        let hooks = self.hooks.clone();
+        let mut task = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            materialize_blocking(job, &blocking_cancel, &hooks)
+        });
+        let mut task_guard =
+            SessionHistoryCpuTaskGuard::new(operation_cancel.clone(), task.abort_handle());
+        let (joined, cancellation_observed) = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                task_guard.cancel();
+                ((&mut task).await, true)
+            }
+            joined = &mut task => (joined, false),
+        };
+        task_guard.disarm();
+        if cancellation_observed || cancel.is_cancelled() {
+            return Err(cpu_cancelled_error());
+        }
+        let outcome = joined.map_err(|error| {
+            RunnerError::Internal(format!("session history CPU task failed: {error}"))
+        })?;
+        Ok(outcome)
+    }
+}
+
+impl SessionHistoryCpuTaskGuard {
+    fn new(cancel: CancellationToken, abort: tokio::task::AbortHandle) -> Self {
+        Self {
+            cancel,
+            abort,
+            armed: true,
+        }
+    }
+
+    fn cancel(&self) {
+        self.cancel.cancel();
+        self.abort.abort();
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SessionHistoryCpuTaskGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.cancel();
+        }
+    }
+}
+
+impl SessionHistoryCpuHooks {
+    fn record_submission(&self) {
+        #[cfg(test)]
+        if let Some(gate) = &self.cpu_gate {
+            gate.record_submission();
+        }
+    }
+
+    fn enter_cpu(&self, cancel: &CancellationToken) -> RunnerResult<()> {
+        #[cfg(test)]
+        if let Some(gate) = &self.cpu_gate {
+            return gate
+                .enter(cancel)
+                .then_some(())
+                .ok_or_else(cpu_cancelled_error);
+        }
+        let _ = cancel;
+        Ok(())
+    }
+
+    fn reader_checkpoint(&self, cancel: &CancellationToken) -> io::Result<()> {
+        #[cfg(test)]
+        if let Some(gate) = &self.reader_gate
+            && !gate.enter(cancel)
+        {
+            return Err(io::Error::other(CPU_CANCELLED));
+        }
+        let _ = cancel;
+        Ok(())
+    }
+}
+
+impl SessionHistoryCpuJob {
+    pub(super) fn raw(
+        cli_agent_session_id: String,
+        bytes: Vec<u8>,
+        expected_raw_size: u64,
+        expected_hash: String,
+        framework: EffectiveCliFramework,
+    ) -> Self {
+        Self::Raw {
+            cli_agent_session_id,
+            bytes,
+            expected_raw_size,
+            expected_hash,
+            framework,
+        }
+    }
+
+    pub(super) fn gzip(
+        cli_agent_session_id: String,
+        encoded_bytes: Vec<u8>,
+        expected_raw_size: u64,
+        expected_hash: String,
+        framework: EffectiveCliFramework,
+    ) -> Self {
+        Self::Gzip {
+            cli_agent_session_id,
+            encoded_bytes,
+            expected_raw_size,
+            expected_hash,
+            framework,
+        }
+    }
+
+    pub(super) fn zstd(
+        cli_agent_session_id: String,
+        encoded_bytes: Vec<u8>,
+        expected_raw_size: u64,
+        expected_hash: String,
+        framework: EffectiveCliFramework,
+    ) -> Self {
+        Self::Zstd {
+            cli_agent_session_id,
+            encoded_bytes,
+            expected_raw_size,
+            expected_hash,
+            framework,
+        }
+    }
+
+    pub(super) fn inline_codex(cli_agent_session_id: String, history: Arc<String>) -> Self {
+        Self::InlineCodex {
+            cli_agent_session_id,
+            history,
+        }
+    }
+}
+
+impl SessionHistoryCpuTimings {
+    pub(super) fn validation(self) -> Option<SessionHistoryCpuPhaseTiming> {
+        self.validation
+    }
+
+    pub(super) fn decompression(self) -> Option<SessionHistoryCpuPhaseTiming> {
+        self.decompression
+    }
+
+    pub(super) fn hash_verification(self) -> Option<SessionHistoryCpuPhaseTiming> {
+        self.hash_verification
+    }
+
+    fn record_validation(&mut self, elapsed: Duration, success: bool) {
+        self.validation = Some(SessionHistoryCpuPhaseTiming { elapsed, success });
+    }
+
+    fn record_decompression(&mut self, elapsed: Duration, success: bool) {
+        self.decompression = Some(SessionHistoryCpuPhaseTiming { elapsed, success });
+    }
+
+    fn record_hash_verification(&mut self, elapsed: Duration, success: bool) {
+        self.hash_verification = Some(SessionHistoryCpuPhaseTiming { elapsed, success });
+    }
+}
+
+impl SessionHistoryCpuPhaseTiming {
+    pub(super) fn elapsed(self) -> Duration {
+        self.elapsed
+    }
+
+    pub(super) fn success(self) -> bool {
+        self.success
+    }
+}
+
+fn materialize_blocking(
+    job: SessionHistoryCpuJob,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> SessionHistoryCpuOutcome {
+    if let Err(error) = check_cancelled(cancel).and_then(|()| hooks.enter_cpu(cancel)) {
+        return SessionHistoryCpuOutcome {
+            timings: SessionHistoryCpuTimings::default(),
+            result: Err(error),
+        };
+    }
+    match job {
+        SessionHistoryCpuJob::Raw {
+            cli_agent_session_id,
+            bytes,
+            expected_raw_size,
+            expected_hash,
+            framework,
+        } => materialize_raw(
+            cli_agent_session_id,
+            bytes,
+            expected_raw_size,
+            &expected_hash,
+            framework,
+            cancel,
+            hooks,
+        ),
+        SessionHistoryCpuJob::Gzip {
+            cli_agent_session_id,
+            encoded_bytes,
+            expected_raw_size,
+            expected_hash,
+            framework,
+        } => materialize_compressed(
+            CompressedSessionHistoryJob {
+                cli_agent_session_id,
+                encoded_bytes,
+                expected_raw_size,
+                expected_hash,
+                framework,
+                encoding: CompressedEncoding::Gzip,
+            },
+            cancel,
+            hooks,
+        ),
+        SessionHistoryCpuJob::Zstd {
+            cli_agent_session_id,
+            encoded_bytes,
+            expected_raw_size,
+            expected_hash,
+            framework: EffectiveCliFramework::Codex,
+        } => materialize_codex_zstd(
+            cli_agent_session_id,
+            encoded_bytes,
+            expected_raw_size,
+            &expected_hash,
+            cancel,
+            hooks,
+        ),
+        SessionHistoryCpuJob::Zstd {
+            cli_agent_session_id,
+            encoded_bytes,
+            expected_raw_size,
+            expected_hash,
+            framework,
+        } => materialize_compressed(
+            CompressedSessionHistoryJob {
+                cli_agent_session_id,
+                encoded_bytes,
+                expected_raw_size,
+                expected_hash,
+                framework,
+                encoding: CompressedEncoding::Zstd,
+            },
+            cancel,
+            hooks,
+        ),
+        SessionHistoryCpuJob::InlineCodex {
+            cli_agent_session_id,
+            history,
+        } => {
+            let result = scan_valid_utf8_history(&history, cancel, hooks).map(|timestamp| {
+                MaterializedResumeSession::new_shared(cli_agent_session_id, history, timestamp)
+            });
+            SessionHistoryCpuOutcome {
+                timings: SessionHistoryCpuTimings::default(),
+                result,
+            }
+        }
+    }
+}
+
+fn materialize_raw(
+    cli_agent_session_id: String,
+    bytes: Vec<u8>,
+    expected_raw_size: u64,
+    expected_hash: &str,
+    framework: EffectiveCliFramework,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> SessionHistoryCpuOutcome {
+    let mut timings = SessionHistoryCpuTimings::default();
+    let result = (|| {
+        validate_raw_size(&bytes, expected_raw_size, &mut timings)?;
+        verify_hash(&bytes, expected_hash, &mut timings, cancel)?;
+        let timestamp = if framework == EffectiveCliFramework::Codex {
+            scan_raw_codex_history(&bytes, cancel, hooks)?
+        } else {
+            None
+        };
+        Ok(MaterializedResumeSession::new(
+            cli_agent_session_id,
+            bytes,
+            timestamp,
+        ))
+    })();
+    SessionHistoryCpuOutcome { timings, result }
+}
+
+#[derive(Clone, Copy)]
+enum CompressedEncoding {
+    Gzip,
+    Zstd,
+}
+
+impl CompressedEncoding {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Gzip => "gzip",
+            Self::Zstd => "zstd",
+        }
+    }
+}
+
+fn materialize_compressed(
+    job: CompressedSessionHistoryJob,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> SessionHistoryCpuOutcome {
+    let CompressedSessionHistoryJob {
+        cli_agent_session_id,
+        encoded_bytes,
+        expected_raw_size,
+        expected_hash,
+        framework,
+        encoding,
+    } = job;
+    let mut timings = SessionHistoryCpuTimings::default();
+    let result = (|| {
+        validate_compressed_raw_size(expected_raw_size, encoding.label(), &mut timings)?;
+        let decompression_started = Instant::now();
+        let result = decompress_history(&encoded_bytes, expected_raw_size, encoding, cancel, hooks);
+        timings.record_decompression(decompression_started.elapsed(), result.is_ok());
+        let bytes = result?;
+        validate_decompressed_size(&bytes, expected_raw_size, &mut timings)?;
+        verify_hash(&bytes, &expected_hash, &mut timings, cancel)?;
+        let timestamp = if framework == EffectiveCliFramework::Codex {
+            scan_raw_codex_history(&bytes, cancel, hooks)?
+        } else {
+            None
+        };
+        Ok(MaterializedResumeSession::new(
+            cli_agent_session_id,
+            bytes,
+            timestamp,
+        ))
+    })();
+    SessionHistoryCpuOutcome { timings, result }
+}
+
+fn materialize_codex_zstd(
+    cli_agent_session_id: String,
+    encoded_bytes: Vec<u8>,
+    expected_raw_size: u64,
+    expected_hash: &str,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> SessionHistoryCpuOutcome {
+    let mut timings = SessionHistoryCpuTimings::default();
+    let result = (|| {
+        validate_compressed_raw_size(expected_raw_size, "zstd", &mut timings)?;
+        let timestamp = verify_codex_zstd(
+            &encoded_bytes,
+            expected_raw_size,
+            expected_hash,
+            &mut timings,
+            cancel,
+            hooks,
+        )?;
+        Ok(MaterializedResumeSession::new_codex_zstd(
+            cli_agent_session_id,
+            encoded_bytes,
+            timestamp,
+        ))
+    })();
+    SessionHistoryCpuOutcome { timings, result }
+}
+
+fn validate_raw_size(
+    bytes: &[u8],
+    expected_raw_size: u64,
+    timings: &mut SessionHistoryCpuTimings,
+) -> RunnerResult<()> {
+    let started = Instant::now();
+    let error = if expected_raw_size == 0 {
+        Some(RunnerError::Internal(
+            "identity session history rawSize must be positive".into(),
+        ))
+    } else if expected_raw_size > RESUME_SESSION_HISTORY_MAX_BYTES {
+        Some(RunnerError::Internal(format!(
+            "session history is too large: {expected_raw_size} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
+        )))
+    } else if bytes.len() as u64 != expected_raw_size {
+        Some(RunnerError::Internal(format!(
+            "session history size mismatch: expected {expected_raw_size} bytes, got {} bytes",
+            bytes.len()
+        )))
+    } else {
+        None
+    };
+    timings.record_validation(started.elapsed(), error.is_none());
+    match error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn validate_decompressed_size(
+    bytes: &[u8],
+    expected_raw_size: u64,
+    timings: &mut SessionHistoryCpuTimings,
+) -> RunnerResult<()> {
+    let started = Instant::now();
+    let result = if bytes.len() as u64 == expected_raw_size {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "session history size mismatch: expected {expected_raw_size} bytes after decompression, got {} bytes",
+            bytes.len()
+        )))
+    };
+    timings.record_validation(started.elapsed(), result.is_ok());
+    result
+}
+
+fn validate_compressed_raw_size(
+    expected_raw_size: u64,
+    encoding: &str,
+    timings: &mut SessionHistoryCpuTimings,
+) -> RunnerResult<()> {
+    let started = Instant::now();
+    let result = if expected_raw_size == 0 {
+        Err(RunnerError::Internal(format!(
+            "{encoding} session history rawSize must be positive"
+        )))
+    } else if expected_raw_size > RESUME_SESSION_HISTORY_MAX_BYTES {
+        Err(RunnerError::Internal(format!(
+            "session history rawSize is too large: {expected_raw_size} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
+        )))
+    } else {
+        Ok(())
+    };
+    timings.record_validation(started.elapsed(), result.is_ok());
+    result
+}
+
+fn verify_hash(
+    bytes: &[u8],
+    expected_hash: &str,
+    timings: &mut SessionHistoryCpuTimings,
+    cancel: &CancellationToken,
+) -> RunnerResult<()> {
+    let started = Instant::now();
+    let result = (|| {
+        let mut hasher = Sha256::new();
+        update_hash(&mut hasher, bytes, cancel)?;
+        let actual_hash = hex::encode(hasher.finalize());
+        if actual_hash != expected_hash {
+            return Err(RunnerError::Internal(
+                "session history hash mismatch".into(),
+            ));
+        }
+        Ok(())
+    })();
+    timings.record_hash_verification(started.elapsed(), result.is_ok());
+    result
+}
+
+fn update_hash(hasher: &mut Sha256, bytes: &[u8], cancel: &CancellationToken) -> RunnerResult<()> {
+    for chunk in bytes.chunks(CPU_CHUNK_BYTES) {
+        check_cancelled(cancel)?;
+        hasher.update(chunk);
+    }
+    check_cancelled(cancel)
+}
+
+fn decompress_history(
+    encoded_bytes: &[u8],
+    max_raw_bytes: u64,
+    encoding: CompressedEncoding,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> RunnerResult<Vec<u8>> {
+    let input = CancellationReader::new(encoded_bytes, cancel.clone(), hooks.clone());
+    match encoding {
+        CompressedEncoding::Gzip => {
+            let mut decoder = MultiGzDecoder::new(input);
+            read_compressed_history(&mut decoder, max_raw_bytes, encoding.label(), cancel)
+        }
+        CompressedEncoding::Zstd => {
+            let mut decoder = zstd::stream::read::Decoder::new(input).map_err(|error| {
+                RunnerError::Internal(format!("decompress zstd session history: {error}"))
+            })?;
+            read_compressed_history(&mut decoder, max_raw_bytes, encoding.label(), cancel)
+        }
+    }
+}
+
+fn read_compressed_history(
+    decoder: &mut impl Read,
+    max_raw_bytes: u64,
+    encoding: &str,
+    cancel: &CancellationToken,
+) -> RunnerResult<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0u8; DECODER_BUFFER_BYTES];
+    let mut decoded = 0u64;
+    loop {
+        check_cancelled(cancel)?;
+        let read = decoder.read(&mut buffer).map_err(|error| {
+            if cancel.is_cancelled() {
+                cpu_cancelled_error()
+            } else {
+                RunnerError::Internal(format!("decompress {encoding} session history: {error}"))
+            }
+        })?;
+        check_cancelled(cancel)?;
+        if read == 0 {
+            break;
+        }
+        decoded += read as u64;
+        if decoded > max_raw_bytes {
+            return Err(RunnerError::Internal(format!(
+                "session history is too large after decompression: {decoded} bytes exceeds {max_raw_bytes} bytes"
+            )));
+        }
+        let chunk = buffer.get(..read).ok_or_else(|| {
+            RunnerError::Internal(format!("invalid {encoding} read chunk length"))
+        })?;
+        bytes.extend_from_slice(chunk);
+    }
+    Ok(bytes)
+}
+
+fn verify_codex_zstd(
+    encoded_bytes: &[u8],
+    expected_raw_size: u64,
+    expected_hash: &str,
+    timings: &mut SessionHistoryCpuTimings,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
+    let decompression_started = Instant::now();
+    let input = CancellationReader::new(encoded_bytes, cancel.clone(), hooks.clone());
+    let decoder = match zstd::stream::read::Decoder::new(input) {
+        Ok(decoder) => decoder,
+        Err(error) => {
+            timings.record_decompression(decompression_started.elapsed(), false);
+            return Err(RunnerError::Internal(format!(
+                "decompress zstd session history: {error}"
+            )));
+        }
+    };
+    let decoded = decoder.take(expected_raw_size.saturating_add(1));
+    let output = CancellationReader::new(decoded, cancel.clone(), hooks.clone());
+    let mut reader = BufReader::with_capacity(DECODER_BUFFER_BYTES, output);
+    let mut hasher = Sha256::new();
+    let mut decoded_bytes = 0u64;
+    let mut timestamp = None;
+    let mut line = Vec::new();
+
+    loop {
+        check_cancelled(cancel)?;
+        line.clear();
+        let read = match reader.read_until(b'\n', &mut line) {
+            Ok(read) => read,
+            Err(error) => {
+                timings.record_decompression(decompression_started.elapsed(), false);
+                if cancel.is_cancelled() {
+                    return Err(cpu_cancelled_error());
+                }
+                return Err(RunnerError::Internal(format!(
+                    "decompress zstd session history: {error}"
+                )));
+            }
+        };
+        check_cancelled(cancel)?;
+        if read == 0 {
+            break;
+        }
+        decoded_bytes += read as u64;
+        if decoded_bytes > expected_raw_size {
+            timings.record_decompression(decompression_started.elapsed(), false);
+            return Err(RunnerError::Internal(format!(
+                "session history is too large after decompression: {decoded_bytes} bytes exceeds {expected_raw_size} bytes"
+            )));
+        }
+        update_hash(&mut hasher, &line, cancel)?;
+        if timestamp.is_none() {
+            timestamp = parse_codex_timestamp_line(strip_jsonl_line_ending(&line), cancel, hooks)?;
+        }
+    }
+    timings.record_decompression(decompression_started.elapsed(), true);
+
+    let validation_started = Instant::now();
+    let size_result = if decoded_bytes == expected_raw_size {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(format!(
+            "session history size mismatch: expected {expected_raw_size} bytes after decompression, got {decoded_bytes} bytes"
+        )))
+    };
+    timings.record_validation(validation_started.elapsed(), size_result.is_ok());
+    size_result?;
+
+    let hash_started = Instant::now();
+    check_cancelled(cancel)?;
+    let actual_hash = hex::encode(hasher.finalize());
+    let hash_result = if actual_hash == expected_hash {
+        Ok(())
+    } else {
+        Err(RunnerError::Internal(
+            "session history hash mismatch".into(),
+        ))
+    };
+    timings.record_hash_verification(hash_started.elapsed(), hash_result.is_ok());
+    hash_result?;
+    Ok(timestamp)
+}
+
+fn scan_raw_codex_history(
+    history: &[u8],
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
+    if !validate_utf8(history, cancel)? {
+        return Ok(None);
+    }
+    // SAFETY: the complete byte slice was validated immediately above.
+    let history = unsafe { std::str::from_utf8_unchecked(history) };
+    scan_valid_utf8_history(history, cancel, hooks)
+}
+
+#[cfg(test)]
+pub(super) fn codex_timestamp_for_test(history: &[u8]) -> Option<chrono::DateTime<chrono::Utc>> {
+    scan_raw_codex_history(
+        history,
+        &CancellationToken::new(),
+        &SessionHistoryCpuHooks::default(),
+    )
+    .unwrap()
+}
+
+fn scan_valid_utf8_history(
+    history: &str,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
+    for line in history.split('\n') {
+        check_cancelled(cancel)?;
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        if let Some(timestamp) = parse_valid_utf8_codex_timestamp_line(line, cancel, hooks)? {
+            return Ok(Some(timestamp));
+        }
+    }
+    Ok(None)
+}
+
+fn parse_codex_timestamp_line(
+    line: &[u8],
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
+    if !validate_utf8(line, cancel)? {
+        return Ok(None);
+    }
+    // SAFETY: the complete byte slice was validated immediately above.
+    let line = unsafe { std::str::from_utf8_unchecked(line) };
+    parse_valid_utf8_codex_timestamp_line(line, cancel, hooks)
+}
+
+fn parse_valid_utf8_codex_timestamp_line(
+    line: &str,
+    cancel: &CancellationToken,
+    hooks: &SessionHistoryCpuHooks,
+) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
+    let line = trim_unicode_whitespace(line, cancel)?;
+    if line.is_empty() {
+        return Ok(None);
+    }
+
+    let reader = CancellationReader::new(line.as_bytes(), cancel.clone(), hooks.clone());
+    let reader = BufReader::with_capacity(DECODER_BUFFER_BYTES, reader);
+    let value = match serde_json::from_reader::<_, serde_json::Value>(reader) {
+        Ok(value) => value,
+        Err(_) if cancel.is_cancelled() => return Err(cpu_cancelled_error()),
+        Err(_) => return Ok(None),
+    };
+    check_cancelled(cancel)?;
+    if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
+        return Ok(None);
+    }
+
+    Ok(value
+        .get("payload")
+        .and_then(|payload| payload.get("timestamp"))
+        .and_then(|timestamp| timestamp.as_str())
+        .and_then(parse_codex_rollout_timestamp)
+        .or_else(|| {
+            value
+                .get("timestamp")
+                .and_then(|timestamp| timestamp.as_str())
+                .and_then(parse_codex_rollout_timestamp)
+        }))
+}
+
+fn trim_unicode_whitespace<'a>(line: &'a str, cancel: &CancellationToken) -> RunnerResult<&'a str> {
+    let mut start = line.len();
+    let mut last_check = 0usize;
+    for (index, character) in line.char_indices() {
+        if index.saturating_sub(last_check) >= DECODER_BUFFER_BYTES {
+            check_cancelled(cancel)?;
+            last_check = index;
+        }
+        if !character.is_whitespace() {
+            start = index;
+            break;
+        }
+    }
+    if start == line.len() {
+        check_cancelled(cancel)?;
+        return Ok("");
+    }
+
+    let mut end = line.len();
+    last_check = end;
+    for (relative_index, character) in line[start..].char_indices().rev() {
+        let index = start + relative_index;
+        if last_check.saturating_sub(index) >= DECODER_BUFFER_BYTES {
+            check_cancelled(cancel)?;
+            last_check = index;
+        }
+        if !character.is_whitespace() {
+            end = index + character.len_utf8();
+            break;
+        }
+    }
+    check_cancelled(cancel)?;
+    Ok(&line[start..end])
+}
+
+fn validate_utf8(bytes: &[u8], cancel: &CancellationToken) -> RunnerResult<bool> {
+    let mut start = 0usize;
+    while start < bytes.len() {
+        check_cancelled(cancel)?;
+        let mut end = start.saturating_add(CPU_CHUNK_BYTES).min(bytes.len());
+        if bytes.get(end).copied().is_some_and(is_utf8_continuation) {
+            let mut boundary = end;
+            let mut continuation_bytes = 0usize;
+            while boundary > start
+                && bytes
+                    .get(boundary)
+                    .copied()
+                    .is_some_and(is_utf8_continuation)
+                && continuation_bytes <= 3
+            {
+                boundary -= 1;
+                continuation_bytes += 1;
+            }
+            if continuation_bytes > 3 {
+                return Ok(false);
+            }
+            end = boundary;
+        }
+        let Some(chunk) = bytes.get(start..end) else {
+            return Ok(false);
+        };
+        if end == start || std::str::from_utf8(chunk).is_err() {
+            return Ok(false);
+        }
+        start = end;
+    }
+    check_cancelled(cancel)?;
+    Ok(true)
+}
+
+fn is_utf8_continuation(byte: u8) -> bool {
+    byte & 0b1100_0000 == 0b1000_0000
+}
+
+fn strip_jsonl_line_ending(line: &[u8]) -> &[u8] {
+    let line = line.strip_suffix(b"\n").unwrap_or(line);
+    line.strip_suffix(b"\r").unwrap_or(line)
+}
+
+fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H-%M-%S")
+                .ok()
+                .map(|timestamp| {
+                    chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
+                        timestamp,
+                        chrono::Utc,
+                    )
+                })
+        })
+}
+
+fn check_cancelled(cancel: &CancellationToken) -> RunnerResult<()> {
+    if cancel.is_cancelled() {
+        return Err(cpu_cancelled_error());
+    }
+    Ok(())
+}
+
+fn cpu_cancelled_error() -> RunnerError {
+    RunnerError::Internal(CPU_CANCELLED.into())
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct SessionHistoryCpuTestGate {
+    inner: Arc<SessionHistoryCpuTestGateInner>,
+}
+
+#[cfg(test)]
+struct SessionHistoryCpuTestGateInner {
+    mode: SessionHistoryCpuTestGateMode,
+    state: Mutex<SessionHistoryCpuTestGateState>,
+    release: Condvar,
+    submitted: Semaphore,
+    entered: Semaphore,
+    completed: Semaphore,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+enum SessionHistoryCpuTestGateMode {
+    Every,
+    Entry(usize),
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct SessionHistoryCpuTestGateState {
+    entries: usize,
+    releases: usize,
+}
+
+#[cfg(test)]
+impl SessionHistoryCpuTestGate {
+    fn every_entry() -> Self {
+        Self::new(SessionHistoryCpuTestGateMode::Every)
+    }
+
+    fn at_entry(entry: usize) -> Self {
+        Self::new(SessionHistoryCpuTestGateMode::Entry(entry.max(1)))
+    }
+
+    fn new(mode: SessionHistoryCpuTestGateMode) -> Self {
+        Self {
+            inner: Arc::new(SessionHistoryCpuTestGateInner {
+                mode,
+                state: Mutex::new(SessionHistoryCpuTestGateState::default()),
+                release: Condvar::new(),
+                submitted: Semaphore::new(0),
+                entered: Semaphore::new(0),
+                completed: Semaphore::new(0),
+            }),
+        }
+    }
+
+    fn record_submission(&self) {
+        self.inner.submitted.add_permits(1);
+    }
+
+    fn enter(&self, cancel: &CancellationToken) -> bool {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.entries += 1;
+        let entry = state.entries;
+        self.inner.entered.add_permits(1);
+        let should_block = match self.inner.mode {
+            SessionHistoryCpuTestGateMode::Every => true,
+            SessionHistoryCpuTestGateMode::Entry(blocked_entry) => entry == blocked_entry,
+        };
+        while should_block && state.releases == 0 && !cancel.is_cancelled() {
+            let (next_state, _) = self
+                .inner
+                .release
+                .wait_timeout(state, Duration::from_millis(5))
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state = next_state;
+        }
+        if should_block && state.releases > 0 {
+            state.releases -= 1;
+        }
+        drop(state);
+        self.inner.completed.add_permits(1);
+        !cancel.is_cancelled()
+    }
+
+    fn release_one(&self) {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.releases += 1;
+        drop(state);
+        self.inner.release.notify_one();
+    }
+
+    async fn wait_submitted(&self) {
+        self.inner
+            .submitted
+            .acquire()
+            .await
+            .expect("test submission semaphore should remain open")
+            .forget();
+    }
+
+    async fn wait_entered(&self) {
+        self.inner
+            .entered
+            .acquire()
+            .await
+            .expect("test entry semaphore should remain open")
+            .forget();
+    }
+
+    async fn wait_completed(&self) {
+        self.inner
+            .completed
+            .acquire()
+            .await
+            .expect("test completion semaphore should remain open")
+            .forget();
+    }
+
+    fn entry_count(&self) -> usize {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entries
+    }
+}
+
+struct CancellationReader<R> {
+    inner: R,
+    cancel: CancellationToken,
+    hooks: SessionHistoryCpuHooks,
+}
+
+impl<R> CancellationReader<R> {
+    fn new(inner: R, cancel: CancellationToken, hooks: SessionHistoryCpuHooks) -> Self {
+        Self {
+            inner,
+            cancel,
+            hooks,
+        }
+    }
+}
+
+impl<R: Read> Read for CancellationReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if self.cancel.is_cancelled() {
+            return Err(io::Error::other(CPU_CANCELLED));
+        }
+        let read = self.inner.read(buffer)?;
+        self.hooks.reader_checkpoint(&self.cancel)?;
+        if self.cancel.is_cancelled() {
+            return Err(io::Error::other(CPU_CANCELLED));
+        }
+        Ok(read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    fn raw_job(history: Vec<u8>, framework: EffectiveCliFramework) -> SessionHistoryCpuJob {
+        SessionHistoryCpuJob::raw(
+            "sess-123".into(),
+            history.clone(),
+            history.len() as u64,
+            hex::encode(Sha256::digest(&history)),
+            framework,
+        )
+    }
+
+    async fn wait_for<T>(future: impl Future<Output = T>) -> T {
+        tokio::time::timeout(Duration::from_secs(5), future)
+            .await
+            .expect("test synchronization should complete")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn bounded_cpu_work_keeps_runtime_responsive_and_serializes_admission() {
+        let gate = SessionHistoryCpuTestGate::every_entry();
+        let pool = SessionHistoryCpuPool::with_test_gates(1, Some(gate.clone()), None);
+
+        let first_pool = pool.clone();
+        let first = tokio::spawn(async move {
+            first_pool
+                .materialize(
+                    raw_job(b"first".to_vec(), EffectiveCliFramework::ClaudeCode),
+                    &CancellationToken::new(),
+                )
+                .await
+        });
+        wait_for(gate.wait_submitted()).await;
+        wait_for(gate.wait_entered()).await;
+
+        let (runtime_progress_tx, runtime_progress_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let _ = runtime_progress_tx.send(());
+        });
+        wait_for(runtime_progress_rx)
+            .await
+            .expect("unrelated async task should run");
+
+        let second_pool = pool.clone();
+        let second = tokio::spawn(async move {
+            second_pool
+                .materialize(
+                    raw_job(b"second".to_vec(), EffectiveCliFramework::ClaudeCode),
+                    &CancellationToken::new(),
+                )
+                .await
+        });
+        wait_for(gate.wait_submitted()).await;
+        assert_eq!(gate.entry_count(), 1);
+
+        gate.release_one();
+        let first = wait_for(first).await.unwrap().unwrap();
+        first.result.unwrap();
+        wait_for(gate.wait_entered()).await;
+        assert_eq!(gate.entry_count(), 2);
+        gate.release_one();
+        let second = wait_for(second).await.unwrap().unwrap();
+        second.result.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn active_cpu_cancellation_joins_cooperative_work() {
+        let gate = SessionHistoryCpuTestGate::every_entry();
+        let pool = SessionHistoryCpuPool::with_test_gates(1, Some(gate.clone()), None);
+        let cancel = CancellationToken::new();
+        let task_pool = pool.clone();
+        let task_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            task_pool
+                .materialize(
+                    raw_job(b"cancel".to_vec(), EffectiveCliFramework::ClaudeCode),
+                    &task_cancel,
+                )
+                .await
+        });
+        wait_for(gate.wait_submitted()).await;
+        wait_for(gate.wait_entered()).await;
+
+        cancel.cancel();
+        let error = wait_for(task).await.unwrap().unwrap_err();
+        assert!(error.to_string().contains("cancelled"));
+        wait_for(gate.wait_completed()).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropping_cpu_future_signals_blocking_work() {
+        let gate = SessionHistoryCpuTestGate::every_entry();
+        let pool = SessionHistoryCpuPool::with_test_gates(1, Some(gate.clone()), None);
+        let task = tokio::spawn(async move {
+            pool.materialize(
+                raw_job(b"drop".to_vec(), EffectiveCliFramework::ClaudeCode),
+                &CancellationToken::new(),
+            )
+            .await
+        });
+        wait_for(gate.wait_entered()).await;
+
+        task.abort();
+        assert!(wait_for(task).await.unwrap_err().is_cancelled());
+        wait_for(gate.wait_completed()).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancellation_while_waiting_for_cpu_does_not_start_work() {
+        let gate = SessionHistoryCpuTestGate::every_entry();
+        let pool = SessionHistoryCpuPool::with_test_gates(1, Some(gate.clone()), None);
+        let first_pool = pool.clone();
+        let first = tokio::spawn(async move {
+            first_pool
+                .materialize(
+                    raw_job(b"first".to_vec(), EffectiveCliFramework::ClaudeCode),
+                    &CancellationToken::new(),
+                )
+                .await
+        });
+        wait_for(gate.wait_submitted()).await;
+        wait_for(gate.wait_entered()).await;
+
+        let cancel = CancellationToken::new();
+        let second_cancel = cancel.clone();
+        let second_pool = pool.clone();
+        let second = tokio::spawn(async move {
+            second_pool
+                .materialize(
+                    raw_job(b"second".to_vec(), EffectiveCliFramework::ClaudeCode),
+                    &second_cancel,
+                )
+                .await
+        });
+        wait_for(gate.wait_submitted()).await;
+        cancel.cancel();
+        let error = wait_for(second).await.unwrap().unwrap_err();
+        assert!(error.to_string().contains("cancelled"));
+        assert_eq!(gate.entry_count(), 1);
+
+        gate.release_one();
+        wait_for(first).await.unwrap().unwrap().result.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancellation_interrupts_buffered_json_parse_within_large_line() {
+        let reader_gate = SessionHistoryCpuTestGate::at_entry(1);
+        let pool = SessionHistoryCpuPool::with_test_gates(1, None, Some(reader_gate.clone()));
+        let history = Arc::new(format!(
+            "{{\"type\":\"not_meta\",\"padding\":\"{}\"}}",
+            "x".repeat(DECODER_BUFFER_BYTES * 3)
+        ));
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let task = tokio::spawn(async move {
+            pool.materialize(
+                SessionHistoryCpuJob::inline_codex("sess-123".into(), history),
+                &task_cancel,
+            )
+            .await
+        });
+        wait_for(reader_gate.wait_entered()).await;
+
+        cancel.cancel();
+        let error = wait_for(task).await.unwrap().unwrap_err();
+        assert!(error.to_string().contains("cancelled"));
+        wait_for(reader_gate.wait_completed()).await;
+    }
+
+    #[tokio::test]
+    async fn raw_codex_timestamp_scan_handles_utf8_across_chunk_boundary() {
+        let mut history = "x".repeat(CPU_CHUNK_BYTES - 1).into_bytes();
+        history.extend_from_slice("é\n".as_bytes());
+        history.extend_from_slice(
+            br#"{"type":"session_meta","payload":{"timestamp":"2026-07-13T01:02:03Z"}}"#,
+        );
+        let outcome = SessionHistoryCpuPool::with_capacity(1)
+            .materialize(
+                raw_job(history, EffectiveCliFramework::Codex),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        let session = outcome.result.unwrap();
+        assert_eq!(
+            session
+                .codex_timestamp()
+                .map(|timestamp| timestamp.to_rfc3339())
+                .as_deref(),
+            Some("2026-07-13T01:02:03+00:00")
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_codex_timestamp_scan_preserves_whole_payload_utf8_requirement() {
+        let mut history =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-13T01:02:03Z\"}}\n"
+                .to_vec();
+        history.push(0xff);
+        let outcome = SessionHistoryCpuPool::with_capacity(1)
+            .materialize(
+                raw_job(history, EffectiveCliFramework::Codex),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(outcome.result.unwrap().codex_timestamp().is_none());
+    }
+
+    #[tokio::test]
+    async fn compressed_history_rejects_declared_raw_size_above_limit() {
+        let outcome = SessionHistoryCpuPool::with_capacity(1)
+            .materialize(
+                SessionHistoryCpuJob::zstd(
+                    "sess-123".into(),
+                    Vec::new(),
+                    RESUME_SESSION_HISTORY_MAX_BYTES + 1,
+                    String::new(),
+                    EffectiveCliFramework::Codex,
+                ),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            outcome
+                .result
+                .unwrap_err()
+                .to_string()
+                .contains("rawSize is too large")
+        );
+        assert!(!outcome.timings.validation().unwrap().success());
+    }
+}

--- a/crates/runner/src/executor/session_history_download.rs
+++ b/crates/runner/src/executor/session_history_download.rs
@@ -3,8 +3,9 @@
 //! Resume sessions can arrive with no history, inline history, or a hash-backed
 //! history reference. This module owns the hash-backed materializer lifecycle:
 //! no resume session, no download needed, or an in-flight download task. Inline
-//! history stays on the original `ResumeSession`; `agent_run` restores it after
-//! `finish` reports that no download was needed.
+//! history stays on the original `ResumeSession`; `agent_run` routes Codex
+//! timestamp extraction through the shared CPU materializer after `finish`
+//! reports that no download was needed.
 //!
 //! Hash-backed downloads can be started before the final restore point so the
 //! network fetch overlaps sandbox preparation and reuse checks. `finish` is the
@@ -17,19 +18,19 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::io::{BufRead, BufReader, Read};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use api_contracts::generated::constants::runners::RESUME_SESSION_HISTORY_MAX_BYTES;
-use flate2::read::MultiGzDecoder;
 use reqwest::header::{CONTENT_ENCODING, TRANSFER_ENCODING};
-use sha2::{Digest, Sha256};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use super::cli_framework::EffectiveCliFramework;
-use super::session_restore::{MaterializedResumeSession, codex_session_meta_timestamp_line};
+use super::session_history_cpu::{
+    SessionHistoryCpuJob, SessionHistoryCpuPool, SessionHistoryCpuTimings,
+};
+use super::session_restore::MaterializedResumeSession;
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
 use crate::telemetry::{
@@ -101,6 +102,7 @@ enum SessionHistoryMaterializerState {
         started_at: Instant,
         metadata: SessionHistoryTelemetryMetadata,
         probe_registration: Option<SessionHistoryProbeRegistration>,
+        cancel: CancellationToken,
         task: Option<JoinHandle<SessionHistoryDownloadTaskResult>>,
     },
 }
@@ -109,7 +111,7 @@ pub(super) enum SessionHistoryMaterialization {
     Missing,
     NoDownloadNeeded,
     Downloaded {
-        session: MaterializedResumeSession<'static>,
+        session: MaterializedResumeSession,
         elapsed: Duration,
         timings: SessionHistoryDownloadTimings,
     },
@@ -123,7 +125,7 @@ pub(super) enum SessionHistoryMaterialization {
 struct SessionHistoryDownloadTaskResult {
     elapsed: Duration,
     timings: SessionHistoryDownloadTimings,
-    result: RunnerResult<MaterializedResumeSession<'static>>,
+    result: RunnerResult<MaterializedResumeSession>,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -218,6 +220,18 @@ impl SessionHistoryDownloadTimings {
 
     fn add_validation(&mut self, elapsed: Duration, success: bool) {
         merge_phase_timing(&mut self.validation, elapsed, success);
+    }
+
+    fn merge_cpu(&mut self, timings: SessionHistoryCpuTimings) {
+        if let Some(phase) = timings.validation() {
+            self.add_validation(phase.elapsed(), phase.success());
+        }
+        if let Some(phase) = timings.decompression() {
+            self.record_decompression(phase.elapsed(), phase.success());
+        }
+        if let Some(phase) = timings.hash_verification() {
+            self.record_hash_verification(phase.elapsed(), phase.success());
+        }
     }
 }
 
@@ -421,6 +435,7 @@ impl Drop for SessionHistoryProbeGuardInner {
 impl SessionHistoryMaterializer {
     pub(crate) fn start_cancellable(
         http: &HttpClient,
+        cpu: &SessionHistoryCpuPool,
         session: Option<&ResumeSession>,
         framework: EffectiveCliFramework,
         cancel: CancellationToken,
@@ -443,8 +458,11 @@ impl SessionHistoryMaterializer {
         }
 
         let http = http.clone();
+        let cpu = cpu.clone();
         let session = session.clone();
         let started_at = Instant::now();
+        let task_cancel = cancel.child_token();
+        let task_cancel_for_task = task_cancel.clone();
         let task_probe_registration = probe_registration.clone();
         // The spawned task observes cancellation even before `finish` runs, so
         // prestarted downloads do not need to wait for final materialization.
@@ -453,14 +471,17 @@ impl SessionHistoryMaterializer {
                 started_at,
                 metadata,
                 probe_registration,
+                cancel: task_cancel,
                 task: Some(tokio::spawn(async move {
-                    let result = tokio::select! {
-                        biased;
-                        _ = cancel.cancelled() => {
-                            SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
-                        }
-                        result = download_resume_session_history_timed(http, session, framework, metadata) => result,
-                    };
+                    let result = download_resume_session_history_timed(
+                        http,
+                        cpu,
+                        session,
+                        framework,
+                        metadata,
+                        task_cancel_for_task,
+                    )
+                    .await;
                     if let Some(registration) = &task_probe_registration {
                         registration.finish();
                     }
@@ -502,13 +523,14 @@ impl SessionHistoryMaterializer {
                 started_at,
                 metadata,
                 probe_registration,
+                cancel: task_cancel,
                 task,
             } => {
                 let started_at = *started_at;
                 let metadata = *metadata;
-                if cancel.is_cancelled() {
+                if cancel.is_cancelled() || task_cancel.is_cancelled() {
+                    task_cancel.cancel();
                     if let Some(task) = task.take() {
-                        task.abort();
                         let _ = task.await;
                     }
                     finish_session_history_probe(probe_registration);
@@ -528,7 +550,11 @@ impl SessionHistoryMaterializer {
                 let result = tokio::select! {
                     biased;
                     _ = cancel.cancelled() => {
-                        task.abort();
+                        task_cancel.cancel();
+                        let _ = task.await;
+                        SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
+                    }
+                    _ = task_cancel.cancelled() => {
                         let _ = task.await;
                         SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
                     }
@@ -547,7 +573,7 @@ impl SessionHistoryMaterializer {
                 finish_session_history_probe(probe_registration);
                 // Re-check after joining because the task itself can observe
                 // cancellation while still producing a successful result.
-                if cancel.is_cancelled() {
+                if cancel.is_cancelled() || task_cancel.is_cancelled() {
                     return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata)
                         .into_materialization();
                 }
@@ -587,13 +613,16 @@ impl SessionHistoryDownloadTaskResult {
 impl Drop for SessionHistoryMaterializer {
     fn drop(&mut self) {
         if let SessionHistoryMaterializerState::Downloading {
-            task: Some(task), ..
+            cancel,
+            task: Some(task),
+            ..
         } = &mut self.state
         {
             // Dropping means no owner will call `finish`. Abort the task so an
             // abandoned prestarted download does not continue in the background.
             // Probe cleanup is handled by explicit finish paths or by the
             // guard's drop fallback when the task future is gone.
+            cancel.cancel();
             task.abort();
         }
     }
@@ -607,13 +636,23 @@ fn finish_session_history_probe(registration: &Option<SessionHistoryProbeRegistr
 
 async fn download_resume_session_history_timed(
     http: HttpClient,
+    cpu: SessionHistoryCpuPool,
     session: ResumeSession,
     framework: EffectiveCliFramework,
     metadata: SessionHistoryTelemetryMetadata,
+    cancel: CancellationToken,
 ) -> SessionHistoryDownloadTaskResult {
     let started_at = Instant::now();
     let mut timings = SessionHistoryDownloadTimings::for_metadata(metadata);
-    let result = download_resume_session_history(http, session, framework, &mut timings).await;
+    if cancel.is_cancelled() {
+        return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata);
+    }
+    let result =
+        download_resume_session_history(http, &cpu, session, framework, &cancel, &mut timings)
+            .await;
+    if cancel.is_cancelled() {
+        return SessionHistoryDownloadTaskResult::cancelled(started_at, metadata);
+    }
     SessionHistoryDownloadTaskResult {
         elapsed: started_at.elapsed(),
         timings,
@@ -623,10 +662,12 @@ async fn download_resume_session_history_timed(
 
 async fn download_resume_session_history(
     http: HttpClient,
+    cpu: &SessionHistoryCpuPool,
     session: ResumeSession,
     framework: EffectiveCliFramework,
+    cancel: &CancellationToken,
     timings: &mut SessionHistoryDownloadTimings,
-) -> RunnerResult<MaterializedResumeSession<'static>> {
+) -> RunnerResult<MaterializedResumeSession> {
     // The history ref is treated as untrusted input. The request timeout and
     // 128 MiB cap bound resource use; declared size, HTTP content-length, final
     // byte count, and SHA-256 must all agree before the bytes become sandbox
@@ -644,18 +685,24 @@ async fn download_resume_session_history(
         .encoding
         .unwrap_or(ResumeSessionHistoryEncoding::Identity);
 
-    let bytes = match encoding {
+    let job = match encoding {
         ResumeSessionHistoryEncoding::Identity => {
             validate_identity_ref(&history_ref, timings)?;
             let bytes = download_body(
                 &http,
                 &history_ref.url,
                 Some(history_ref.encoded_size),
+                cancel,
                 timings,
             )
             .await?;
-            validate_identity_body_size(&history_ref, bytes.len(), timings)?;
-            bytes
+            SessionHistoryCpuJob::raw(
+                session.cli_agent_session_id,
+                bytes,
+                history_ref.raw_size,
+                history_ref.hash,
+                framework,
+            )
         }
         ResumeSessionHistoryEncoding::Gzip => {
             let raw_size = validate_compressed_ref("gzip", &history_ref, timings)?;
@@ -663,22 +710,17 @@ async fn download_resume_session_history(
                 &http,
                 &history_ref.url,
                 Some(history_ref.encoded_size),
+                cancel,
                 timings,
             )
             .await?;
-            let decompression_started = Instant::now();
-            let raw_bytes = match gunzip_session_history(&encoded_bytes, raw_size) {
-                Ok(raw_bytes) => {
-                    timings.record_decompression(decompression_started.elapsed(), true);
-                    raw_bytes
-                }
-                Err(error) => {
-                    timings.record_decompression(decompression_started.elapsed(), false);
-                    return Err(error);
-                }
-            };
-            validate_decompressed_raw_size(raw_size, raw_bytes.len(), timings)?;
-            raw_bytes
+            SessionHistoryCpuJob::gzip(
+                session.cli_agent_session_id,
+                encoded_bytes,
+                raw_size,
+                history_ref.hash,
+                framework,
+            )
         }
         ResumeSessionHistoryEncoding::Zstd => {
             let raw_size = validate_compressed_ref("zstd", &history_ref, timings)?;
@@ -686,52 +728,22 @@ async fn download_resume_session_history(
                 &http,
                 &history_ref.url,
                 Some(history_ref.encoded_size),
+                cancel,
                 timings,
             )
             .await?;
-            if framework == EffectiveCliFramework::Codex {
-                let timestamp = verify_codex_zstd_session_history(
-                    &encoded_bytes,
-                    raw_size,
-                    &history_ref.hash,
-                    timings,
-                )?;
-                return Ok(MaterializedResumeSession::new_codex_zstd(
-                    session.cli_agent_session_id,
-                    encoded_bytes,
-                    timestamp,
-                ));
-            }
-            let decompression_started = Instant::now();
-            let raw_bytes = match unzstd_session_history(&encoded_bytes, raw_size) {
-                Ok(raw_bytes) => {
-                    timings.record_decompression(decompression_started.elapsed(), true);
-                    raw_bytes
-                }
-                Err(error) => {
-                    timings.record_decompression(decompression_started.elapsed(), false);
-                    return Err(error);
-                }
-            };
-            validate_decompressed_raw_size(raw_size, raw_bytes.len(), timings)?;
-            raw_bytes
+            SessionHistoryCpuJob::zstd(
+                session.cli_agent_session_id,
+                encoded_bytes,
+                raw_size,
+                history_ref.hash,
+                framework,
+            )
         }
     };
-
-    let hash_started = Instant::now();
-    let actual_hash = hex::encode(Sha256::digest(&bytes));
-    if actual_hash != history_ref.hash {
-        timings.record_hash_verification(hash_started.elapsed(), false);
-        return Err(RunnerError::Internal(
-            "session history hash mismatch".into(),
-        ));
-    }
-    timings.record_hash_verification(hash_started.elapsed(), true);
-
-    Ok(MaterializedResumeSession::new(
-        session.cli_agent_session_id,
-        bytes,
-    ))
+    let outcome = cpu.materialize(job, cancel).await?;
+    timings.merge_cpu(outcome.timings);
+    outcome.result
 }
 
 fn validate_identity_ref(
@@ -775,53 +787,6 @@ fn validate_identity_ref(
     Ok(())
 }
 
-fn validate_identity_body_size(
-    history_ref: &ResumeSessionHistoryRef,
-    byte_count: usize,
-    timings: &mut SessionHistoryDownloadTimings,
-) -> RunnerResult<()> {
-    let validation_started = Instant::now();
-    if byte_count as u64 != history_ref.raw_size {
-        timings.add_validation(validation_started.elapsed(), false);
-        return Err(RunnerError::Internal(format!(
-            "session history size mismatch: expected {} bytes, got {byte_count} bytes",
-            history_ref.raw_size
-        )));
-    }
-    timings.add_validation(validation_started.elapsed(), true);
-    Ok(())
-}
-
-pub(super) fn verify_identity_session_history_bytes(
-    bytes: &[u8],
-    expected_raw_size: u64,
-    expected_hash: &str,
-) -> RunnerResult<()> {
-    if expected_raw_size == 0 {
-        return Err(RunnerError::Internal(
-            "identity session history rawSize must be positive".into(),
-        ));
-    }
-    if expected_raw_size > RESUME_SESSION_HISTORY_MAX_BYTES {
-        return Err(RunnerError::Internal(format!(
-            "session history is too large: {expected_raw_size} bytes exceeds {RESUME_SESSION_HISTORY_MAX_BYTES} bytes"
-        )));
-    }
-    if bytes.len() as u64 != expected_raw_size {
-        return Err(RunnerError::Internal(format!(
-            "session history size mismatch: expected {expected_raw_size} bytes, got {} bytes",
-            bytes.len()
-        )));
-    }
-    let actual_hash = hex::encode(Sha256::digest(bytes));
-    if actual_hash != expected_hash {
-        return Err(RunnerError::Internal(
-            "session history hash mismatch".into(),
-        ));
-    }
-    Ok(())
-}
-
 fn validate_compressed_ref(
     encoding: &str,
     history_ref: &ResumeSessionHistoryRef,
@@ -857,157 +822,22 @@ fn validate_compressed_ref(
     Ok(raw_size)
 }
 
-fn validate_decompressed_raw_size(
-    expected_size: u64,
-    byte_count: usize,
-    timings: &mut SessionHistoryDownloadTimings,
-) -> RunnerResult<()> {
-    let validation_started = Instant::now();
-    if byte_count as u64 != expected_size {
-        timings.add_validation(validation_started.elapsed(), false);
-        return Err(RunnerError::Internal(format!(
-            "session history size mismatch: expected {expected_size} bytes after decompression, got {byte_count} bytes"
-        )));
-    }
-    timings.add_validation(validation_started.elapsed(), true);
-    Ok(())
-}
-
-pub(super) fn verify_codex_zstd_session_history_bytes(
-    encoded_bytes: &[u8],
-    expected_raw_size: u64,
-    expected_hash: &str,
-) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
-    let mut timings = SessionHistoryDownloadTimings::default();
-    verify_codex_zstd_session_history(
-        encoded_bytes,
-        expected_raw_size,
-        expected_hash,
-        &mut timings,
-    )
-}
-
-fn verify_codex_zstd_session_history(
-    encoded_bytes: &[u8],
-    expected_raw_size: u64,
-    expected_hash: &str,
-    timings: &mut SessionHistoryDownloadTimings,
-) -> RunnerResult<Option<chrono::DateTime<chrono::Utc>>> {
-    let decompression_started = Instant::now();
-    let decoder = match zstd::stream::read::Decoder::new(encoded_bytes) {
-        Ok(decoder) => decoder,
-        Err(error) => {
-            timings.record_decompression(decompression_started.elapsed(), false);
-            return Err(RunnerError::Internal(format!(
-                "decompress zstd session history: {error}"
-            )));
-        }
-    };
-    let mut reader = BufReader::new(decoder.take(expected_raw_size.saturating_add(1)));
-    let mut hasher = Sha256::new();
-    let mut decoded = 0u64;
-    let mut timestamp = None;
-    let mut line = Vec::new();
-
-    loop {
-        line.clear();
-        let read = match reader.read_until(b'\n', &mut line) {
-            Ok(read) => read,
-            Err(error) => {
-                timings.record_decompression(decompression_started.elapsed(), false);
-                return Err(RunnerError::Internal(format!(
-                    "decompress zstd session history: {error}"
-                )));
-            }
-        };
-        if read == 0 {
-            break;
-        }
-        decoded += read as u64;
-        if decoded > expected_raw_size {
-            timings.record_decompression(decompression_started.elapsed(), false);
-            return Err(RunnerError::Internal(format!(
-                "session history is too large after decompression: {decoded} bytes exceeds {expected_raw_size} bytes"
-            )));
-        }
-        hasher.update(&line);
-        if timestamp.is_none()
-            && let Ok(line) = std::str::from_utf8(strip_jsonl_line_ending(&line))
-        {
-            timestamp = codex_session_meta_timestamp_line(line);
-        }
-    }
-    timings.record_decompression(decompression_started.elapsed(), true);
-
-    validate_decompressed_raw_size(expected_raw_size, decoded as usize, timings)?;
-    let hash_started = Instant::now();
-    let actual_hash = hex::encode(hasher.finalize());
-    if actual_hash != expected_hash {
-        timings.record_hash_verification(hash_started.elapsed(), false);
-        return Err(RunnerError::Internal(
-            "session history hash mismatch".into(),
-        ));
-    }
-    timings.record_hash_verification(hash_started.elapsed(), true);
-    Ok(timestamp)
-}
-
-fn strip_jsonl_line_ending(line: &[u8]) -> &[u8] {
-    let line = line.strip_suffix(b"\n").unwrap_or(line);
-    line.strip_suffix(b"\r").unwrap_or(line)
-}
-
-fn gunzip_session_history(encoded_bytes: &[u8], max_raw_bytes: u64) -> RunnerResult<Vec<u8>> {
-    let mut decoder = MultiGzDecoder::new(encoded_bytes);
-    read_compressed_session_history(&mut decoder, max_raw_bytes, "gzip")
-}
-
-fn unzstd_session_history(encoded_bytes: &[u8], max_raw_bytes: u64) -> RunnerResult<Vec<u8>> {
-    let mut decoder = zstd::stream::read::Decoder::new(encoded_bytes).map_err(|error| {
-        RunnerError::Internal(format!("decompress zstd session history: {error}"))
-    })?;
-    read_compressed_session_history(&mut decoder, max_raw_bytes, "zstd")
-}
-
-fn read_compressed_session_history(
-    decoder: &mut impl Read,
-    max_raw_bytes: u64,
-    encoding: &str,
-) -> RunnerResult<Vec<u8>> {
-    let mut bytes = Vec::new();
-    let mut buffer = [0u8; 8192];
-    let mut decoded = 0u64;
-    loop {
-        let read = decoder.read(&mut buffer).map_err(|error| {
-            RunnerError::Internal(format!("decompress {encoding} session history: {error}"))
-        })?;
-        if read == 0 {
-            break;
-        }
-        decoded += read as u64;
-        if decoded > max_raw_bytes {
-            return Err(RunnerError::Internal(format!(
-                "session history is too large after decompression: {decoded} bytes exceeds {max_raw_bytes} bytes"
-            )));
-        }
-        let chunk = buffer.get(..read).ok_or_else(|| {
-            RunnerError::Internal(format!("invalid {encoding} read chunk length"))
-        })?;
-        bytes.extend_from_slice(chunk);
-    }
-    Ok(bytes)
-}
-
 async fn download_body(
     http: &HttpClient,
     url: &str,
     expected_size: Option<u64>,
+    cancel: &CancellationToken,
     timings: &mut SessionHistoryDownloadTimings,
 ) -> RunnerResult<Vec<u8>> {
     let mut attempt = 1usize;
     loop {
         timings.reset_download_attempt();
-        match download_body_once(http, url, expected_size, timings).await {
+        let result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Err(session_history_download_cancelled_error()),
+            result = download_body_once(http, url, expected_size, timings) => result,
+        };
+        match result {
             Ok(body) => return Ok(body),
             Err(error) => {
                 let should_retry =
@@ -1022,11 +852,21 @@ async fn download_body(
                     failure_kind = error.kind_value(),
                     "retrying session history encoded body download"
                 );
-                sleep_session_history_download_retry_delay().await;
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {
+                        return Err(session_history_download_cancelled_error());
+                    }
+                    _ = sleep_session_history_download_retry_delay() => {}
+                }
                 attempt += 1;
             }
         }
     }
+}
+
+fn session_history_download_cancelled_error() -> RunnerError {
+    RunnerError::Internal("session history download cancelled".into())
 }
 
 async fn download_body_once(
@@ -1344,6 +1184,7 @@ mod tests {
     use std::io::{self, Write};
 
     use flate2::{Compression, write::GzEncoder};
+    use sha2::{Digest, Sha256};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::sync::oneshot;
@@ -1452,6 +1293,7 @@ mod tests {
     ) -> SessionHistoryMaterializer {
         SessionHistoryMaterializer::start_cancellable(
             &http_client(),
+            &SessionHistoryCpuPool::with_capacity(1),
             Some(session),
             framework,
             CancellationToken::new(),
@@ -1786,6 +1628,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_identity_materializer_extracts_raw_timestamp() {
+        let body =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-13T01:02:03Z\"}}\n";
+        let hash = hex::encode(Sha256::digest(body));
+        let server = serve_once("200 OK", body, Some(body.len() as u64)).await;
+        let session = ref_session(server.url(), hash, body.len() as u64, body.len() as u64);
+
+        let result = start_materializer_with_framework(&session, EffectiveCliFramework::Codex)
+            .finish(&CancellationToken::new())
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Downloaded { session, .. } => {
+                assert_eq!(session.history_bytes(), body);
+                assert_eq!(
+                    session
+                        .codex_timestamp()
+                        .map(|timestamp| timestamp.to_rfc3339())
+                        .as_deref(),
+                    Some("2026-07-13T01:02:03+00:00")
+                );
+            }
+            _ => panic!("expected downloaded session"),
+        }
+        server.assert_served().await;
+    }
+
+    #[tokio::test]
     async fn materializer_retries_zstd_body_read_error_then_succeeds() {
         let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
         let compressed = zstd_bytes(body);
@@ -2100,6 +1970,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_gzip_materializer_extracts_raw_timestamp() {
+        let body =
+            b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-07-13T02:03:04Z\"}}\n";
+        let compressed = gzip_bytes(body);
+        let encoded_size = compressed.len() as u64;
+        let hash = hex::encode(Sha256::digest(body));
+        let server = serve_once("200 OK", compressed, None).await;
+        let session = gzip_ref_session(server.url(), hash, body.len() as u64, encoded_size);
+
+        let result = start_materializer_with_framework(&session, EffectiveCliFramework::Codex)
+            .finish(&CancellationToken::new())
+            .await;
+
+        match result {
+            SessionHistoryMaterialization::Downloaded { session, .. } => {
+                assert_eq!(session.history_bytes(), body);
+                assert_eq!(
+                    session
+                        .codex_timestamp()
+                        .map(|timestamp| timestamp.to_rfc3339())
+                        .as_deref(),
+                    Some("2026-07-13T02:03:04+00:00")
+                );
+            }
+            _ => panic!("expected downloaded session"),
+        }
+        server.assert_served().await;
+    }
+
+    #[tokio::test]
     async fn materializer_downloads_decompresses_and_verifies_zstd_hash() {
         let body = b"{\"type\":\"init\"}\n{\"type\":\"user\",\"message\":\"hello\"}\n";
         let compressed = zstd_bytes(body);
@@ -2148,12 +2048,14 @@ mod tests {
             } => {
                 assert_eq!(session.cli_agent_session_id(), "sess-123");
                 assert_eq!(session.history_bytes(), compressed);
-                assert!(session.history_text().is_none());
-                let (_, timestamp) = session
+                session
                     .codex_zstd_history()
                     .expect("codex zstd history should be preserved");
                 assert_eq!(
-                    timestamp.map(|timestamp| timestamp.to_rfc3339()).as_deref(),
+                    session
+                        .codex_timestamp()
+                        .map(|timestamp| timestamp.to_rfc3339())
+                        .as_deref(),
                     Some("2026-07-02T10:00:00+00:00")
                 );
                 assert_phase_success(timings.request_status());
@@ -2687,6 +2589,7 @@ mod tests {
 
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
+            &SessionHistoryCpuPool::with_capacity(1),
             Some(&session),
             EffectiveCliFramework::ClaudeCode,
             CancellationToken::new(),
@@ -2739,6 +2642,7 @@ mod tests {
 
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
+            &SessionHistoryCpuPool::with_capacity(1),
             Some(&session),
             EffectiveCliFramework::ClaudeCode,
             cancel.clone(),
@@ -2792,6 +2696,7 @@ mod tests {
 
         let materializer = SessionHistoryMaterializer::start_cancellable(
             &http_client(),
+            &SessionHistoryCpuPool::with_capacity(1),
             Some(&session),
             EffectiveCliFramework::ClaudeCode,
             cancel.clone(),
@@ -2823,6 +2728,7 @@ mod tests {
                 result: Ok(MaterializedResumeSession::new(
                     "sess-123".to_string(),
                     br#"{"type":"init"}"#.to_vec(),
+                    None,
                 )),
             }
         });
@@ -2836,6 +2742,7 @@ mod tests {
                 started_at: Instant::now(),
                 metadata: identity_metadata(),
                 probe_registration: None,
+                cancel: CancellationToken::new(),
                 task: Some(task),
             },
         };
@@ -2861,6 +2768,7 @@ mod tests {
                 result: Ok(MaterializedResumeSession::new(
                     "sess-123".to_string(),
                     br#"{"type":"init"}"#.to_vec(),
+                    None,
                 )),
             }
         });
@@ -2869,6 +2777,7 @@ mod tests {
                 started_at: Instant::now(),
                 metadata: identity_metadata(),
                 probe_registration: None,
+                cancel: cancel.clone(),
                 task: Some(task),
             },
         };

--- a/crates/runner/src/executor/session_restore.rs
+++ b/crates/runner/src/executor/session_restore.rs
@@ -2,7 +2,7 @@
 
 mod codex;
 
-use std::borrow::Cow;
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use sandbox::Sandbox;
@@ -13,7 +13,7 @@ use super::env::validate_resume_session_id;
 use super::session_id::{canonical_codex_thread_id, is_valid_session_id};
 use super::{RunnerError, RunnerResult};
 use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
-use crate::types::{ExecutionContext, ResumeSession};
+use crate::types::ExecutionContext;
 use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 
 impl RestoredSessionIdentity {
@@ -54,64 +54,55 @@ fn restored_session_framework(framework: EffectiveCliFramework) -> RestoredSessi
     }
 }
 
-pub(super) fn codex_session_meta_timestamp_line(
-    line: &str,
-) -> Option<chrono::DateTime<chrono::Utc>> {
-    codex::codex_session_meta_timestamp_line(line)
+#[derive(Debug)]
+pub(super) struct MaterializedResumeSession {
+    cli_agent_session_id: String,
+    history: MaterializedResumeHistory,
+    codex_timestamp: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug)]
-pub(super) struct MaterializedResumeSession<'a> {
-    cli_agent_session_id: Cow<'a, str>,
-    history: MaterializedResumeHistory<'a>,
-}
-
-#[derive(Debug)]
-enum MaterializedResumeHistory<'a> {
-    InlineText(&'a str),
+enum MaterializedResumeHistory {
+    SharedText(Arc<String>),
     Bytes(Vec<u8>),
-    CodexZstd {
-        bytes: Vec<u8>,
-        timestamp: Option<DateTime<Utc>>,
-    },
+    CodexZstd(Vec<u8>),
 }
 
-impl MaterializedResumeSession<'static> {
-    pub(super) fn new(cli_agent_session_id: String, history_bytes: Vec<u8>) -> Self {
+impl MaterializedResumeSession {
+    pub(super) fn new(
+        cli_agent_session_id: String,
+        history_bytes: Vec<u8>,
+        codex_timestamp: Option<DateTime<Utc>>,
+    ) -> Self {
         Self {
-            cli_agent_session_id: Cow::Owned(cli_agent_session_id),
+            cli_agent_session_id,
             history: MaterializedResumeHistory::Bytes(history_bytes),
+            codex_timestamp,
+        }
+    }
+
+    pub(super) fn new_shared(
+        cli_agent_session_id: String,
+        session_history: Arc<String>,
+        codex_timestamp: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self {
+            cli_agent_session_id,
+            history: MaterializedResumeHistory::SharedText(session_history),
+            codex_timestamp,
         }
     }
 
     pub(super) fn new_codex_zstd(
         cli_agent_session_id: String,
         history_bytes: Vec<u8>,
-        timestamp: Option<DateTime<Utc>>,
+        codex_timestamp: Option<DateTime<Utc>>,
     ) -> Self {
         Self {
-            cli_agent_session_id: Cow::Owned(cli_agent_session_id),
-            history: MaterializedResumeHistory::CodexZstd {
-                bytes: history_bytes,
-                timestamp,
-            },
+            cli_agent_session_id,
+            history: MaterializedResumeHistory::CodexZstd(history_bytes),
+            codex_timestamp,
         }
-    }
-}
-
-impl<'a> MaterializedResumeSession<'a> {
-    pub(super) fn from_inline_resume_session(
-        session: &'a ResumeSession,
-    ) -> RunnerResult<MaterializedResumeSession<'a>> {
-        let Some(session_history) = session.session_history() else {
-            return Err(RunnerError::Internal(
-                "resume session history was not materialized".into(),
-            ));
-        };
-        Ok(Self {
-            cli_agent_session_id: Cow::Borrowed(&session.cli_agent_session_id),
-            history: MaterializedResumeHistory::InlineText(session_history),
-        })
     }
 
     pub(super) fn cli_agent_session_id(&self) -> &str {
@@ -120,26 +111,20 @@ impl<'a> MaterializedResumeSession<'a> {
 
     pub(super) fn history_bytes(&self) -> &[u8] {
         match &self.history {
-            MaterializedResumeHistory::InlineText(session_history) => session_history.as_bytes(),
+            MaterializedResumeHistory::SharedText(session_history) => session_history.as_bytes(),
             MaterializedResumeHistory::Bytes(history_bytes) => history_bytes,
-            MaterializedResumeHistory::CodexZstd { bytes, .. } => bytes,
+            MaterializedResumeHistory::CodexZstd(bytes) => bytes,
         }
     }
 
-    pub(super) fn history_text(&self) -> Option<&str> {
-        match &self.history {
-            MaterializedResumeHistory::InlineText(session_history) => Some(session_history),
-            MaterializedResumeHistory::Bytes(history_bytes) => {
-                std::str::from_utf8(history_bytes).ok()
-            }
-            MaterializedResumeHistory::CodexZstd { .. } => None,
-        }
+    pub(super) fn codex_timestamp(&self) -> Option<DateTime<Utc>> {
+        self.codex_timestamp
     }
 
-    pub(super) fn codex_zstd_history(&self) -> Option<(&[u8], Option<DateTime<Utc>>)> {
+    pub(super) fn codex_zstd_history(&self) -> Option<&[u8]> {
         match &self.history {
-            MaterializedResumeHistory::CodexZstd { bytes, timestamp } => Some((bytes, *timestamp)),
-            MaterializedResumeHistory::InlineText(_) | MaterializedResumeHistory::Bytes(_) => None,
+            MaterializedResumeHistory::CodexZstd(bytes) => Some(bytes),
+            MaterializedResumeHistory::SharedText(_) | MaterializedResumeHistory::Bytes(_) => None,
         }
     }
 }
@@ -154,7 +139,7 @@ pub(super) struct SessionRestoreDiagnostics {
 pub(super) async fn restore_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &MaterializedResumeSession<'_>,
+    session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     // Validate the CLI agent session id to prevent path traversal.
     // Only allow alnum, dash, and underscore.
@@ -185,7 +170,7 @@ pub(super) async fn restore_session(
 pub(super) async fn restore_claude_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &MaterializedResumeSession<'_>,
+    session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     let session_history = session.history_bytes();
     let project_name = CANONICAL_WORKING_DIR

--- a/crates/runner/src/executor/session_restore/codex.rs
+++ b/crates/runner/src/executor/session_restore/codex.rs
@@ -28,74 +28,10 @@ fn codex_restore_rollout_path(
 }
 
 fn codex_restore_rollout_timestamp(
-    session: &MaterializedResumeSession<'_>,
+    session: &MaterializedResumeSession,
     fallback_timestamp: chrono::DateTime<chrono::Utc>,
 ) -> chrono::DateTime<chrono::Utc> {
-    session
-        .codex_zstd_history()
-        .and_then(|(_, timestamp)| timestamp)
-        .or_else(|| {
-            session
-                .history_text()
-                .and_then(codex_session_meta_timestamp)
-        })
-        .unwrap_or(fallback_timestamp)
-}
-
-pub(super) fn codex_session_meta_timestamp(
-    session_history: &str,
-) -> Option<chrono::DateTime<chrono::Utc>> {
-    for line in session_history.lines() {
-        if let Some(timestamp) = codex_session_meta_timestamp_line(line) {
-            return Some(timestamp);
-        }
-    }
-
-    None
-}
-
-pub(super) fn codex_session_meta_timestamp_line(
-    line: &str,
-) -> Option<chrono::DateTime<chrono::Utc>> {
-    let line = line.trim();
-    if line.is_empty() {
-        return None;
-    }
-
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-        return None;
-    };
-    if value.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
-        return None;
-    }
-
-    value
-        .get("payload")
-        .and_then(|payload| payload.get("timestamp"))
-        .and_then(|timestamp| timestamp.as_str())
-        .and_then(parse_codex_rollout_timestamp)
-        .or_else(|| {
-            value
-                .get("timestamp")
-                .and_then(|timestamp| timestamp.as_str())
-                .and_then(parse_codex_rollout_timestamp)
-        })
-}
-
-fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-    chrono::DateTime::parse_from_rfc3339(raw)
-        .ok()
-        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
-        .or_else(|| {
-            chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H-%M-%S")
-                .ok()
-                .map(|timestamp| {
-                    chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(
-                        timestamp,
-                        chrono::Utc,
-                    )
-                })
-        })
+    session.codex_timestamp().unwrap_or(fallback_timestamp)
 }
 
 /// Write a Codex session history file as canonical JSONL or zstd-compressed
@@ -107,7 +43,7 @@ fn parse_codex_rollout_timestamp(raw: &str) -> Option<chrono::DateTime<chrono::U
 pub(super) async fn restore_codex_session(
     sandbox: &dyn Sandbox,
     context: &ExecutionContext,
-    session: &MaterializedResumeSession<'_>,
+    session: &MaterializedResumeSession,
 ) -> RunnerResult<SessionRestoreDiagnostics> {
     let original_session_id = session.cli_agent_session_id();
     let thread_id = CodexThreadId::parse(original_session_id)
@@ -116,7 +52,7 @@ pub(super) async fn restore_codex_session(
     let session_filename_key = thread_id.filename_key();
 
     let timestamp = codex_restore_rollout_timestamp(session, chrono::Utc::now());
-    let (session_history, extension) = if let Some((bytes, _)) = session.codex_zstd_history() {
+    let (session_history, extension) = if let Some(bytes) = session.codex_zstd_history() {
         (bytes, ".jsonl.zst")
     } else {
         (session.history_bytes(), ".jsonl")

--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -1078,6 +1078,7 @@ async fn run_in_sandbox_uses_prestarted_session_history_materializer() {
 
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
+        &config.session_history_cpu,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
@@ -1410,6 +1411,113 @@ async fn run_in_sandbox_restores_codex_zstd_sidecar_with_session_timestamp() {
 }
 
 #[tokio::test]
+async fn run_in_sandbox_restores_codex_raw_sidecar_with_session_timestamp() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let history =
+        b"{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n";
+    let sidecar_path = dir.path().join("session-history.jsonl");
+    tokio::fs::write(&sidecar_path, history).await.unwrap();
+    let server = MockServer::start_async().await;
+    let history_mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/history.blob");
+            then.status(200).body(history);
+        })
+        .await;
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    ctx.resume_session = Some(ResumeSession {
+        cli_agent_session_id: session_id.into(),
+        history: ResumeSessionHistory::Ref {
+            history_ref: ResumeSessionHistoryRef {
+                kind: ResumeSessionHistoryRefKind::Blob,
+                hash: hex::encode(Sha256::digest(history)),
+                url: server.url("/history.blob?token=secret"),
+                encoding: None,
+                raw_size: history.len() as u64,
+                encoded_size: history.len() as u64,
+                download_source: None,
+            },
+        },
+    });
+
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None)
+            .with_session_history_restore_plan(SessionHistoryRestorePlan::LocalSidecar {
+                sidecar: WorkspaceSessionHistorySidecar {
+                    path: sidecar_path,
+                    representation: WorkspaceSessionHistorySidecarRepresentation::Raw,
+                    encoded_size: history.len() as u64,
+                },
+                fallback: None,
+            }),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+    );
+    assert_eq!(writes[0].content, history);
+    history_mock.assert_calls_async(0).await;
+}
+
+#[tokio::test]
+async fn run_in_sandbox_restores_inline_codex_history_with_session_timestamp() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = test_executor_config(dir.path()).await;
+    let sandbox = sandbox_mock::MockSandbox::new("test");
+    let session_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let history =
+        "{\"type\":\"session_meta\",\"payload\":{\"timestamp\":\"2026-06-04T07:18:08Z\"}}\n";
+    let mut ctx = minimal_context();
+    ctx.cli_agent_type = "codex".into();
+    ctx.resume_session = Some(ResumeSession::inline(session_id.into(), history.into()));
+
+    let mut telemetry = test_telemetry(&config, &ctx);
+    let result = run_in_sandbox(
+        &sandbox,
+        &ctx,
+        &config,
+        RunStart {
+            restore_guest_state: false,
+            reuse_result: SandboxReuseResult::PoolMiss,
+            prev_storage: None,
+        },
+        &mut telemetry,
+        RunControls::new(tokio_util::sync::CancellationToken::new(), None),
+    )
+    .await
+    .unwrap();
+
+    assert!(result.failure.is_none());
+    let writes = sandbox.write_file_calls();
+    assert_eq!(writes.len(), 1);
+    assert_eq!(
+        writes[0].path,
+        "/home/user/.codex/sessions/2026/06/04/rollout-2026-06-04T07-18-08-019e9154-c304-70f0-adde-36efb1be1701.jsonl"
+    );
+    assert_eq!(writes[0].content, history.as_bytes());
+}
+
+#[tokio::test]
 async fn run_in_sandbox_records_completed_prestarted_materializer_failure() {
     let dir = tempfile::tempdir().unwrap();
     let config = test_executor_config(dir.path()).await;
@@ -1434,6 +1542,7 @@ async fn run_in_sandbox_records_completed_prestarted_materializer_failure() {
 
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
+        &config.session_history_cpu,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
@@ -1985,6 +2094,7 @@ async fn run_in_sandbox_records_fallback_and_restores_prestarted_history() {
     sandbox.push_read_file_result(Ok(None));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
+        &config.session_history_cpu,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
@@ -2073,6 +2183,7 @@ async fn run_in_sandbox_records_missing_idle_identity_reuse_fallback() {
     sandbox.push_read_file_result(Ok(None));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
+        &config.session_history_cpu,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),
@@ -2165,6 +2276,7 @@ async fn run_in_sandbox_uses_final_identity_when_restored_history_changes_before
     ))));
     let materializer = SessionHistoryMaterializer::start_cancellable(
         &config.http,
+        &config.session_history_cpu,
         ctx.resume_session.as_ref(),
         effective_cli_framework(&ctx.cli_agent_type),
         tokio_util::sync::CancellationToken::new(),

--- a/crates/runner/src/executor/tests/session_restore_tests/mod.rs
+++ b/crates/runner/src/executor/tests/session_restore_tests/mod.rs
@@ -10,6 +10,7 @@ use std::sync::Mutex;
 use tracing_subscriber::prelude::*;
 
 use super::super::DEFAULT_EXEC_TIMEOUT;
+use super::super::session_history_cpu::codex_timestamp_for_test;
 use super::super::session_restore::MaterializedResumeSession;
 use super::support::{CapturedEvent, CapturedEvents, minimal_context};
 use crate::types::{
@@ -31,22 +32,28 @@ const CODEX_CANONICAL_ROLLOUT_FILENAME_SUFFIX: &str = "-019e9154-c304-70f0-adde-
 fn materialized_text_session(
     session_id: impl Into<String>,
     history: impl Into<String>,
-) -> MaterializedResumeSession<'static> {
-    MaterializedResumeSession::new(session_id.into(), history.into().into_bytes())
+) -> MaterializedResumeSession {
+    let history = history.into().into_bytes();
+    let timestamp = codex_timestamp_for_test(&history);
+    MaterializedResumeSession::new(session_id.into(), history, timestamp)
 }
 
 fn materialized_bytes_session(
     session_id: impl Into<String>,
     history: &[u8],
-) -> MaterializedResumeSession<'static> {
-    MaterializedResumeSession::new(session_id.into(), history.to_vec())
+) -> MaterializedResumeSession {
+    MaterializedResumeSession::new(
+        session_id.into(),
+        history.to_vec(),
+        codex_timestamp_for_test(history),
+    )
 }
 
 fn materialized_codex_zstd_session(
     session_id: impl Into<String>,
     history: &[u8],
     timestamp: chrono::DateTime<chrono::Utc>,
-) -> MaterializedResumeSession<'static> {
+) -> MaterializedResumeSession {
     MaterializedResumeSession::new_codex_zstd(session_id.into(), history.to_vec(), Some(timestamp))
 }
 

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -37,6 +37,7 @@ pub(in crate::executor::tests) async fn test_executor_config(dir: &Path) -> Exec
         network_log_drain: NetworkLogDrainCoordinator::noop(),
         mitm_jsonl_flush: None,
         network_policy_refresh: None,
+        session_history_cpu: super::super::super::SessionHistoryCpuPool::with_capacity(1),
         session_history_probe: super::super::super::SessionHistoryProbe::default(),
         home: HomePaths::with_root(dir.to_path_buf()),
         workspace_cache: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
+use std::sync::Arc;
 
 use sandbox::SandboxId;
 use serde::{Deserialize, Serialize};
@@ -1077,7 +1078,8 @@ pub struct ResumeSession {
 pub enum ResumeSessionHistory {
     Inline {
         #[serde(rename = "sessionHistory")]
-        session_history: String,
+        #[serde(deserialize_with = "deserialize_shared_string")]
+        session_history: Arc<String>,
     },
     Ref {
         #[serde(rename = "historyRef")]
@@ -1131,13 +1133,23 @@ impl ResumeSession {
     pub fn inline(cli_agent_session_id: String, session_history: String) -> Self {
         Self {
             cli_agent_session_id,
-            history: ResumeSessionHistory::Inline { session_history },
+            history: ResumeSessionHistory::Inline {
+                session_history: Arc::new(session_history),
+            },
         }
     }
 
+    #[cfg(test)]
     pub fn session_history(&self) -> Option<&str> {
         match &self.history {
             ResumeSessionHistory::Inline { session_history } => Some(session_history),
+            ResumeSessionHistory::Ref { .. } => None,
+        }
+    }
+
+    pub fn shared_session_history(&self) -> Option<Arc<String>> {
+        match &self.history {
+            ResumeSessionHistory::Inline { session_history } => Some(Arc::clone(session_history)),
             ResumeSessionHistory::Ref { .. } => None,
         }
     }
@@ -1148,6 +1160,13 @@ impl ResumeSession {
             ResumeSessionHistory::Ref { history_ref } => Some(history_ref),
         }
     }
+}
+
+fn deserialize_shared_string<'de, D>(deserializer: D) -> Result<Arc<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(Arc::new)
 }
 
 impl ExecutionContext {
@@ -1668,6 +1687,10 @@ mod tests {
             ctx.resume_session.as_ref().unwrap().session_history(),
             Some("{}")
         );
+        let session = ctx.resume_session.as_ref().unwrap();
+        let first = session.shared_session_history().unwrap();
+        let second = session.shared_session_history().unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- move session-history decompression, SHA-256 verification, Codex JSONL scanning, and timestamp extraction off Tokio async workers
- bound all remote, workspace-sidecar, and inline Codex CPU materialization with one runner-scoped semaphore
- preserve payload ownership and carry extracted Codex timestamps into restore so raw histories are not scanned twice
- make download, retry, CPU admission, active blocking work, and abrupt task drop cancellation-aware

## Behavior and compatibility

- preserves the existing 128 MiB remote limits, 64 MiB sidecar limit, validation, hashes, output representations, fallback behavior, redaction, and phase telemetry
- preserves the external `sessionHistory` JSON string while sharing its allocation internally with `Arc<String>`
- uses `(host_cpus / 2).clamp(1, 4)` as the runner-wide CPU concurrency policy

## Exclusions

- no dedicated CPU executor dependency or user-facing tuning knob
- no HTTP streaming pipeline, guest protocol, persisted-state, or filesystem contract changes

## Validation

- `cargo check -p runner --all-targets`
- `cargo fmt --all --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner executor::session_history_cpu::tests`
- `cargo test -p runner executor::session_history_download::tests`
- `cargo test -p runner executor::tests::agent_run_tests`
- `cargo test -p runner executor::tests::session_restore_tests`
- `cargo test -p runner resume_session`
- `cargo test -p runner`

Closes #21149
