### PR TITLE
test(runner): cover jsonl worker start failure

### DIFF
--- a/crates/runner/mitm-addon/tests/test_jsonl_writer.py
+++ b/crates/runner/mitm-addon/tests/test_jsonl_writer.py
@@ -8,6 +8,33 @@ import jsonl_writer
 from tests.thread_helpers import ThreadUnderTest
 
 
+def test_worker_start_failure_does_not_publish_or_consume_retry_capacity(tmp_path, mitm_ctx):
+    log_path = tmp_path / "proxy.jsonl"
+    line = b'{"message":"retry"}\n'
+
+    with (
+        patch.object(jsonl_writer, "MAX_PENDING_JSONL_WRITES", 1),
+        patch.object(jsonl_writer, "MAX_PENDING_JSONL_BYTES", len(line)),
+        mitm_ctx() as log,
+    ):
+        with patch.object(
+            jsonl_writer.threading.Thread,
+            "start",
+            side_effect=RuntimeError("can't start new thread"),
+        ):
+            jsonl_writer.write_jsonl_line(str(log_path), line, "proxy")
+
+        assert jsonl_writer.flush_log_path(str(log_path), timeout=0)
+        assert jsonl_writer._worker is None
+        assert not log_path.exists()
+
+        jsonl_writer.write_jsonl_line(str(log_path), line, "proxy")
+        assert jsonl_writer.flush_log_path(str(log_path), timeout=1)
+
+        log.warn.assert_called_once_with("Failed to start JSONL writer for proxy log")
+        assert log_path.read_bytes() == line
+
+
 def test_writer_publishes_backlog_completion_once_per_batch(tmp_path):
     class ObservedCondition:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary

- add a regression test for JSONL writer thread-start failure
- verify a failed start does not publish the worker or consume write/byte backlog capacity
- verify a subsequent write can start a worker, persist the line, and emit only the expected warning

## Scope

- test-only change; production behavior is unchanged
- no schema, migration, API, runner protocol, or feature-switch changes

## Validation

- `cd crates/runner/mitm-addon && python3 -m pytest tests/test_jsonl_writer.py -q` (7 passed)
- `cd crates/runner/mitm-addon && python3 -m pytest tests/ -q` (3834 passed)
- `cd crates/runner/mitm-addon && ruff check .`
- `cd crates/runner/mitm-addon && ruff format --check .`
- `cd crates/runner/mitm-addon && basedpyright -p .`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm format`
- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` (7400 passed, 1 benchmark skipped)
- `cd turbo && pnpm knip`

Closes #21155
