### PR TITLE
refactor: serve connector secret display from api

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/auth-org-agents.bdd.test.ts
@@ -264,6 +264,10 @@ describe("AUTH-02 and AUTH-03", () => {
       description: "BDD secret",
       type: "user",
     });
+    await api.setSecret(admin, {
+      name: "GITHUB_ACCESS_TOKEN",
+      value: "github-user-secret-value",
+    });
 
     const invalidSecret = await api.requestSetSecret(
       admin,
@@ -276,8 +280,20 @@ describe("AUTH-02 and AUTH-03", () => {
     const listedSecret = secrets.secrets.find((candidate) => {
       return candidate.name === secretName;
     });
-    expect(listedSecret).toBeDefined();
+    expect(listedSecret).toMatchObject({ connectorDisplay: null });
+    expect(
+      secrets.secrets.find((candidate) => {
+        return candidate.name === "GITHUB_ACCESS_TOKEN";
+      }),
+    ).toMatchObject({
+      type: "user",
+      connectorDisplay: {
+        label: "GitHub",
+        environmentNames: ["GH_TOKEN", "GITHUB_TOKEN"],
+      },
+    });
     expect(JSON.stringify(secrets)).not.toContain("super-secret-value");
+    expect(JSON.stringify(secrets)).not.toContain("github-user-secret-value");
 
     const variableName = upperName("BDD_VARIABLE");
     const variable = await api.setVariable(admin, {
@@ -315,11 +331,15 @@ describe("AUTH-02 and AUTH-03", () => {
     expect(readBack).toStrictEqual(preferences);
 
     await api.deleteSecret(admin, secretName);
+    await api.deleteSecret(admin, "GITHUB_ACCESS_TOKEN");
     await api.deleteVariable(admin, variableName);
     const afterSecretDelete = await api.listSecrets(admin);
     expect(
       afterSecretDelete.secrets.some((candidate) => {
-        return candidate.name === secretName;
+        return (
+          candidate.name === secretName ||
+          candidate.name === "GITHUB_ACCESS_TOKEN"
+        );
       }),
     ).toBeFalsy();
     const afterVariableDelete = await api.listVariables(admin);

--- a/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/connectors.bdd.test.ts
@@ -23,6 +23,7 @@ import {
   expectApiError,
   type ApiTestUser,
 } from "./helpers/api-bdd";
+import { createAuthOrgAgentsBddApi } from "./helpers/api-bdd-auth-org";
 import {
   createConnectorBddApi,
   mockBase44OAuthProvider,
@@ -39,6 +40,7 @@ import {
 
 const context = testContext();
 const connectorsApi = createConnectorBddApi(context);
+const authOrgApi = createAuthOrgAgentsBddApi(context);
 
 function uniqueSlug(prefix: string): string {
   return `${prefix}-${randomUUID().replace(/-/g, "").slice(0, 12)}`;
@@ -187,6 +189,20 @@ describe("CONN-01 and CHAIN-CONNECTOR: connector discovery and manual grant life
         name: "OPENAI_TOKEN",
       }),
     );
+
+    const secretList = await authOrgApi.listSecrets(actor);
+    expect(
+      secretList.secrets.find((secret) => {
+        return secret.name === "OPENAI_TOKEN";
+      }),
+    ).toMatchObject({
+      type: "connector",
+      connectorDisplay: {
+        label: "OpenAI",
+        environmentNames: ["OPENAI_TOKEN"],
+      },
+    });
+    expectNoVisibleSecret(secretList, "sk-bdd-manual-secret");
 
     await expect(
       connectorsApi.readScopeDiff(actor, "openai"),

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-me-model-providers-upsert.test.ts
@@ -6,6 +6,7 @@ import {
   zeroPersonalModelProvidersByTypeContract,
   zeroPersonalModelProvidersMainContract,
 } from "@vm0/api-contracts/contracts/zero-personal-model-providers";
+import { zeroSecretsContract } from "@vm0/api-contracts/contracts/zero-secrets";
 
 import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -135,6 +136,20 @@ describe("POST /api/zero/me/model-providers (upsert)", () => {
       },
       created: true,
     });
+
+    const secretClient = setupApp({ context })(zeroSecretsContract);
+    const secretList = await accept(
+      secretClient.list({
+        headers: { authorization: "Bearer clerk-session" },
+      }),
+      [200],
+    );
+    expect(
+      secretList.body.secrets.find((secret) => {
+        return secret.type === "model-provider";
+      }),
+    ).toMatchObject({ connectorDisplay: null });
+    expect(JSON.stringify(secretList.body)).not.toContain("sk-ant-test");
   });
 
   it("updates an existing personal provider with 200", async () => {

--- a/turbo/apps/api/src/signals/routes/zero-secrets.ts
+++ b/turbo/apps/api/src/signals/routes/zero-secrets.ts
@@ -3,6 +3,8 @@ import {
   zeroSecretsContract,
   zeroVariablesContract,
 } from "@vm0/api-contracts/contracts/zero-secrets";
+import type { SecretListResponse } from "@vm0/api-contracts/contracts/secrets";
+import { getConnectorStoredSecretDisplayInfo } from "@vm0/connectors/connector-utils";
 
 import { organizationAuthContext$ } from "../auth/auth-context";
 import { authRoute } from "../auth/auth-route";
@@ -21,9 +23,26 @@ const setSecretBody$ = bodyResultOf(zeroSecretsContract.set);
 
 const listSecretsInner$ = computed(async (get): Promise<unknown> => {
   const auth = get(organizationAuthContext$);
-  const body = await get(
+  const storedSecrets = await get(
     userSecrets({ orgId: auth.orgId, userId: auth.userId }),
   );
+  const body: SecretListResponse = {
+    secrets: storedSecrets.secrets.map((secret) => {
+      const display =
+        secret.type === "connector" || secret.type === "user"
+          ? getConnectorStoredSecretDisplayInfo(secret.name)
+          : null;
+      return {
+        ...secret,
+        connectorDisplay: display
+          ? {
+              label: display.connectorLabel,
+              environmentNames: display.envNames,
+            }
+          : null,
+      };
+    }),
+  };
   return {
     status: 200 as const,
     body,

--- a/turbo/apps/api/src/signals/services/zero-user-data.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-user-data.service.ts
@@ -14,7 +14,6 @@ import type {
 } from "@vm0/api-contracts/contracts/zero-user-model-preference";
 import { isSupportedRunModel } from "@vm0/api-contracts/contracts/model-providers";
 import type {
-  SecretListResponse,
   SecretResponse,
   SetSecretRequest,
   SecretType,
@@ -417,8 +416,8 @@ export const setUserVariable$ = command(
 export function userSecrets({
   orgId,
   userId,
-}: UserScopedQuery): Computed<Promise<SecretListResponse>> {
-  return computed(async (get): Promise<SecretListResponse> => {
+}: UserScopedQuery): Computed<Promise<{ readonly secrets: SecretResponse[] }>> {
+  return computed(async (get) => {
     const db = get(db$);
     const rows = await db
       .select({

--- a/turbo/apps/cli/src/commands/zero/secret/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/__tests__/list.test.ts
@@ -4,7 +4,7 @@
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
  * - Mock (external): Web API via MSW
- * - Real (internal): All CLI code, formatters, validators, connector display lookups
+ * - Real (internal): All CLI code, formatters, and validators
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -39,11 +39,13 @@ describe("zero secret list command", () => {
                 description: "API key for service",
                 type: "user",
                 updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: null,
               },
               {
                 name: "DB_PASSWORD",
                 type: "user",
                 updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: null,
               },
             ],
           });
@@ -76,7 +78,59 @@ describe("zero secret list command", () => {
   });
 
   describe("connector secrets", () => {
-    it("should display connector secret with derived environment names", async () => {
+    it("should display connector metadata authored by the server", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "SERVER_ONLY_ACCESS_TOKEN",
+                type: "connector",
+                updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: {
+                  label: "Server-only Connector",
+                  environmentNames: ["SERVER_ONLY_TOKEN"],
+                },
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("SERVER_ONLY_ACCESS_TOKEN");
+      expect(logCalls).toContain("[Server-only Connector connector]");
+      expect(logCalls).toContain("Available as: SERVER_ONLY_TOKEN");
+    });
+
+    it("should not infer connector metadata when the server returns null", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "GITHUB_ACCESS_TOKEN",
+                type: "connector",
+                updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: null,
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("GITHUB_ACCESS_TOKEN");
+      expect(logCalls).toContain("[connector]");
+      expect(logCalls).not.toContain("GitHub connector");
+      expect(logCalls).not.toContain("Available as:");
+    });
+
+    it("should use generic display when an older server omits metadata", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/secrets", () => {
           return HttpResponse.json({
@@ -94,20 +148,24 @@ describe("zero secret list command", () => {
       await listCommand.parseAsync(["node", "cli"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("GITHUB_ACCESS_TOKEN");
-      expect(logCalls).toContain("[GitHub connector]");
-      expect(logCalls).toContain("Available as: GH_TOKEN, GITHUB_TOKEN");
+      expect(logCalls).toContain("GITHUB_ACCESS_TOKEN [connector]");
+      expect(logCalls).not.toContain("GitHub connector");
+      expect(logCalls).not.toContain("Available as:");
     });
 
-    it("should display connector secret without derived names when no mapping found", async () => {
+    it("should display connector metadata for a matching user secret", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/secrets", () => {
           return HttpResponse.json({
             secrets: [
               {
-                name: "UNKNOWN_CONNECTOR_SECRET",
-                type: "connector",
+                name: "PRIVATE_CREDENTIAL",
+                type: "user",
                 updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: {
+                  label: "Server-only Connector",
+                  environmentNames: ["SERVER_ONLY_TOKEN"],
+                },
               },
             ],
           });
@@ -117,9 +175,10 @@ describe("zero secret list command", () => {
       await listCommand.parseAsync(["node", "cli"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("UNKNOWN_CONNECTOR_SECRET");
-      expect(logCalls).toContain("[connector]");
-      expect(logCalls).not.toContain("Available as:");
+      expect(logCalls).toContain(
+        "PRIVATE_CREDENTIAL [Server-only Connector connector]",
+      );
+      expect(logCalls).toContain("Available as: SERVER_ONLY_TOKEN");
     });
 
     it("should display model-provider type indicator", async () => {
@@ -131,6 +190,7 @@ describe("zero secret list command", () => {
                 name: "ANTHROPIC_API_KEY",
                 type: "model-provider",
                 updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: null,
               },
             ],
           });
@@ -154,16 +214,22 @@ describe("zero secret list command", () => {
                 description: "User secret",
                 type: "user",
                 updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: null,
               },
               {
                 name: "ANTHROPIC_API_KEY",
                 type: "model-provider",
                 updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: null,
               },
               {
                 name: "GITHUB_ACCESS_TOKEN",
                 type: "connector",
                 updatedAt: "2025-01-01T00:00:00Z",
+                connectorDisplay: {
+                  label: "GitHub",
+                  environmentNames: ["GH_TOKEN", "GITHUB_TOKEN"],
+                },
               },
             ],
           });

--- a/turbo/apps/cli/src/commands/zero/secret/list.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/list.ts
@@ -1,6 +1,5 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { getConnectorStoredSecretDisplayInfo } from "@vm0/connectors/connector-utils";
 import { listZeroSecrets } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 
@@ -29,24 +28,15 @@ export const listCommand = new Command()
 
         if (secret.type === "model-provider") {
           typeIndicator = chalk.dim(" [model-provider]");
+        } else if (secret.connectorDisplay) {
+          typeIndicator = chalk.dim(
+            ` [${secret.connectorDisplay.label} connector]`,
+          );
+          derivedLine = chalk.dim(
+            `Available as: ${secret.connectorDisplay.environmentNames.join(", ")}`,
+          );
         } else if (secret.type === "connector") {
-          const derived = getConnectorStoredSecretDisplayInfo(secret.name);
-          if (derived) {
-            typeIndicator = chalk.dim(` [${derived.connectorLabel} connector]`);
-            derivedLine = chalk.dim(
-              `Available as: ${derived.envNames.join(", ")}`,
-            );
-          } else {
-            typeIndicator = chalk.dim(" [connector]");
-          }
-        } else if (secret.type === "user") {
-          const derived = getConnectorStoredSecretDisplayInfo(secret.name);
-          if (derived) {
-            typeIndicator = chalk.dim(` [${derived.connectorLabel} connector]`);
-            derivedLine = chalk.dim(
-              `Available as: ${derived.envNames.join(", ")}`,
-            );
-          }
+          typeIndicator = chalk.dim(" [connector]");
         }
 
         console.log(`  ${chalk.cyan(secret.name)}${typeIndicator}`);

--- a/turbo/packages/api-contracts/src/contracts/secrets.ts
+++ b/turbo/packages/api-contracts/src/contracts/secrets.ts
@@ -38,11 +38,20 @@ export const secretResponseSchema = z.object({
 
 export type SecretResponse = z.infer<typeof secretResponseSchema>;
 
+const secretListItemResponseSchema = secretResponseSchema.extend({
+  connectorDisplay: z
+    .object({
+      label: z.string(),
+      environmentNames: z.array(z.string()),
+    })
+    .nullable(),
+});
+
 /**
  * List secrets response
  */
 export const secretListResponseSchema = z.object({
-  secrets: z.array(secretResponseSchema),
+  secrets: z.array(secretListItemResponseSchema),
 });
 
 export type SecretListResponse = z.infer<typeof secretListResponseSchema>;


### PR DESCRIPTION
# Summary

- add a required, nullable `connectorDisplay` object to each secret-list item
- derive connector labels and environment aliases in the API list route without loading secret values
- make `vm0 zero secret list` render server-authored metadata and remove its local connector lookup

# Compatibility

- older CLI versions ignore the additive response field
- the current CLI degrades to the generic connector display when an older API omits the field
- the set-secret response and the generic stored-secret service shape are unchanged

# Exclusions

- runtime permission-deny and connector-check diagnostics remain in the follow-up child issues
- this does not move connector catalog storage or loading out of the vm0 repository

# Validation

- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm format`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only`
- `pnpm knip`

Closes #21216

Parent delivery issue: #21140
