### PR TITLE
feat(platform): auto-load a virtualized artifacts grid

### DIFF
--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -20,7 +20,7 @@ import { openChatIdb } from "../external/chat-idb-store.ts";
 import { createArtifactItemCacheStores } from "../external/idb-artifact-item-store.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { ROUTES } from "../route-paths.ts";
-import { onRejection } from "../utils.ts";
+import { onRef, onRejection } from "../utils.ts";
 import {
   ensureAgentDraft$,
   loadAgentDraft$,
@@ -36,8 +36,8 @@ const ARTIFACTS_MAX_PAGES = 100;
 // Read the whole locally-cached set back for the cache-first paint.
 const ARTIFACTS_CACHE_READ_LIMIT = ARTIFACTS_PAGE_SIZE * ARTIFACTS_MAX_PAGES;
 
-// Number of cards the grid reveals per window step. The rendered window grows by
-// this amount on each "load more", keeping the DOM bounded for large sets.
+// Number of cards the grid makes available per automatic loading step. Row
+// virtualization keeps the mounted DOM bounded independently of this window.
 const ARTIFACT_WINDOW_STEP = 60;
 
 const internalArtifactsSearch$ = state("");
@@ -49,6 +49,19 @@ const internalArtifactFavoriteOverrides$ = state<
 >({});
 const internalArtifactsReload$ = state(0);
 const internalArtifactsWindow$ = state(ARTIFACT_WINDOW_STEP);
+const internalArtifactsScrollViewport$ = state<HTMLElement | null>(null);
+const internalArtifactsGridElement$ = state<HTMLElement | null>(null);
+const internalArtifactsGridWidth$ = state(0);
+
+interface ArtifactsScrollMetrics {
+  readonly clientHeight: number;
+  readonly scrollTop: number;
+}
+
+const internalArtifactsScrollMetrics$ = state<ArtifactsScrollMetrics>({
+  clientHeight: 0,
+  scrollTop: 0,
+});
 
 interface ArtifactsPageData {
   readonly artifacts: readonly ArtifactItem[];
@@ -76,8 +89,8 @@ export const artifactsFavoritesOnly$ = computed((get) => {
   return get(internalArtifactsFavoritesOnly$);
 });
 
-// How many artifacts the grid currently reveals. Grown by the view's "load
-// more" control and reset to the first window whenever a filter changes.
+// How many artifacts the grid currently makes available. Grown automatically
+// near the scroll boundary and reset to the first window when filters change.
 export const artifactsWindow$ = computed((get) => {
   return get(internalArtifactsWindow$);
 });
@@ -87,6 +100,85 @@ export const growArtifactsWindow$ = command(({ set }) => {
     return count + ARTIFACT_WINDOW_STEP;
   });
 });
+
+export const artifactsScrollViewport$ = computed((get) => {
+  return get(internalArtifactsScrollViewport$);
+});
+
+export const artifactsScrollMetrics$ = computed((get) => {
+  return get(internalArtifactsScrollMetrics$);
+});
+
+export const artifactsGridElement$ = computed((get) => {
+  return get(internalArtifactsGridElement$);
+});
+
+export const artifactsGridWidth$ = computed((get) => {
+  return get(internalArtifactsGridWidth$);
+});
+
+export const syncArtifactsScrollMetrics$ = command(
+  ({ set }, viewport: HTMLElement) => {
+    set(internalArtifactsScrollMetrics$, {
+      clientHeight: viewport.clientHeight,
+      scrollTop: viewport.scrollTop,
+    });
+  },
+);
+
+export const setArtifactsScrollViewportRef$ = onRef(
+  command(({ set }, viewport: HTMLElement, signal: AbortSignal) => {
+    set(internalArtifactsScrollViewport$, viewport);
+    set(syncArtifactsScrollMetrics$, viewport);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            set(syncArtifactsScrollMetrics$, viewport);
+          });
+    resizeObserver?.observe(viewport);
+
+    signal.addEventListener(
+      "abort",
+      () => {
+        resizeObserver?.disconnect();
+        set(internalArtifactsScrollViewport$, null);
+        set(internalArtifactsScrollMetrics$, {
+          clientHeight: 0,
+          scrollTop: 0,
+        });
+      },
+      { once: true },
+    );
+  }),
+);
+
+export const setArtifactsGridRef$ = onRef(
+  command(({ set }, element: HTMLElement, signal: AbortSignal) => {
+    const measure = () => {
+      set(internalArtifactsGridElement$, element);
+      set(internalArtifactsGridWidth$, element.clientWidth);
+    };
+    measure();
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(measure);
+    resizeObserver?.observe(element);
+
+    signal.addEventListener(
+      "abort",
+      () => {
+        resizeObserver?.disconnect();
+        set(internalArtifactsGridElement$, null);
+        set(internalArtifactsGridWidth$, 0);
+      },
+      { once: true },
+    );
+  }),
+);
 
 export const setArtifactsSearch$ = command(({ set }, search: string) => {
   set(internalArtifactsSearch$, search);

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -39,6 +39,8 @@ const ARTIFACTS_CACHE_READ_LIMIT = ARTIFACTS_PAGE_SIZE * ARTIFACTS_MAX_PAGES;
 // Number of cards the grid makes available per automatic loading step. Row
 // virtualization keeps the mounted DOM bounded independently of this window.
 const ARTIFACT_WINDOW_STEP = 60;
+const ARTIFACT_FOCUS_TARGET_SELECTOR =
+  'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 const internalArtifactsSearch$ = state("");
 const internalArtifactsAgentId$ = state<string | null>(null);
@@ -52,6 +54,7 @@ const internalArtifactsWindow$ = state(ARTIFACT_WINDOW_STEP);
 const internalArtifactsScrollViewport$ = state<HTMLElement | null>(null);
 const internalArtifactsGridElement$ = state<HTMLElement | null>(null);
 const internalArtifactsGridWidth$ = state(0);
+const internalArtifactsPendingFocusIndex$ = state<number | null>(null);
 
 interface ArtifactsScrollMetrics {
   readonly clientHeight: number;
@@ -100,6 +103,12 @@ export const growArtifactsWindow$ = command(({ set }) => {
     return count + ARTIFACT_WINDOW_STEP;
   });
 });
+
+export const requestArtifactsKeyboardFocus$ = command(
+  ({ set }, index: number) => {
+    set(internalArtifactsPendingFocusIndex$, index);
+  },
+);
 
 export const artifactsScrollViewport$ = computed((get) => {
   return get(internalArtifactsScrollViewport$);
@@ -178,6 +187,42 @@ export const setArtifactsGridRef$ = onRef(
       { once: true },
     );
   }),
+);
+
+function focusArtifactElement(element: HTMLElement): boolean {
+  const focusTarget = element.matches('[tabindex="0"]')
+    ? element
+    : element.querySelector<HTMLElement>(ARTIFACT_FOCUS_TARGET_SELECTOR);
+  if (!focusTarget) {
+    return false;
+  }
+
+  focusTarget.focus();
+  return document.activeElement === focusTarget;
+}
+
+export const setArtifactCardRef$ = onRef(
+  command(
+    (
+      { get, set },
+      element: HTMLElement | SVGSVGElement,
+      _signal: AbortSignal,
+    ) => {
+      if (!(element instanceof HTMLElement)) {
+        return;
+      }
+      const index = Number(element.dataset.artifactIndex);
+      if (!Number.isInteger(index)) {
+        return;
+      }
+      if (get(internalArtifactsPendingFocusIndex$) !== index) {
+        return;
+      }
+      if (focusArtifactElement(element)) {
+        set(internalArtifactsPendingFocusIndex$, null);
+      }
+    },
+  ),
 );
 
 export const setArtifactsSearch$ = command(({ set }, search: string) => {

--- a/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
+++ b/turbo/apps/platform/src/signals/artifacts-page/artifacts-signals.ts
@@ -189,10 +189,16 @@ export const setArtifactsGridRef$ = onRef(
   }),
 );
 
-function focusArtifactElement(element: HTMLElement): boolean {
-  const focusTarget = element.matches('[tabindex="0"]')
+export function getArtifactFocusTarget(
+  element: HTMLElement,
+): HTMLElement | null {
+  return element.matches('[tabindex="0"]')
     ? element
     : element.querySelector<HTMLElement>(ARTIFACT_FOCUS_TARGET_SELECTOR);
+}
+
+function focusArtifactElement(element: HTMLElement): boolean {
+  const focusTarget = getArtifactFocusTarget(element);
   if (!focusTarget) {
     return false;
   }

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import {
   artifactsContract,
   type ArtifactItem,
@@ -371,6 +371,43 @@ function mockArtifacts(artifacts: readonly ArtifactItem[]): void {
       nextCursor: null,
     });
   });
+}
+
+function mockScrollViewport(
+  element: HTMLElement,
+  initial: {
+    readonly clientHeight: number;
+    readonly scrollHeight: number;
+    readonly scrollTop: number;
+  },
+) {
+  let metrics = initial;
+  Object.defineProperties(element, {
+    clientHeight: {
+      configurable: true,
+      get: () => {
+        return metrics.clientHeight;
+      },
+    },
+    scrollHeight: {
+      configurable: true,
+      get: () => {
+        return metrics.scrollHeight;
+      },
+    },
+    scrollTop: {
+      configurable: true,
+      get: () => {
+        return metrics.scrollTop;
+      },
+      set: (scrollTop: number) => {
+        metrics = { ...metrics, scrollTop };
+      },
+    },
+  });
+  return (next: Partial<typeof initial>) => {
+    metrics = { ...metrics, ...next };
+  };
 }
 
 function setupArtifactsPage({
@@ -1254,34 +1291,50 @@ describe("artifacts page", () => {
     await screen.findByText("page-two.html");
   });
 
-  it("windows a large set behind a load more control", async () => {
+  it("virtualizes a large set and loads more near the scroll boundary", async () => {
     setupTeam();
     const scope = testAuthScope("windowed");
-    const many = Array.from({ length: 65 }, (_, index) => {
-      const label = String(index).padStart(2, "0");
+    const many = Array.from({ length: 180 }, (_, index) => {
+      const label = String(index).padStart(3, "0");
       return createArtifact({
         artifactItemId: `windowed-${label}:file`,
         runId: `windowed-${label}`,
         filename: `windowed-${label}.html`,
-        createdAt: `2026-01-01T00:${label}:00Z`,
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
       });
     });
     mockArtifacts(many);
 
     setupArtifactsPage({ scope });
 
-    // The first window renders; the tail stays hidden until "Load more".
-    await screen.findByText("windowed-00.html");
-    expect(screen.queryByText("windowed-64.html")).not.toBeInTheDocument();
+    await screen.findByText("windowed-000.html");
+    expect(screen.queryByText("Load more")).not.toBeInTheDocument();
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
 
-    const loadMoreButton = queryAllByRoleFast("button").find((button) => {
-      return button.textContent?.trim() === "Load more";
+    const scrollViewport = screen.getByRole("main");
+    const setScrollMetrics = mockScrollViewport(scrollViewport, {
+      clientHeight: 800,
+      scrollHeight: 6068,
+      scrollTop: 5300,
     });
-    if (!loadMoreButton) {
-      throw new Error("Load more button not found");
-    }
-    click(loadMoreButton);
+    fireEvent.scroll(scrollViewport);
 
-    await screen.findByText("windowed-64.html");
+    await screen.findByText("windowed-064.html");
+    expect(screen.queryByText("windowed-000.html")).not.toBeInTheDocument();
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
+
+    setScrollMetrics({ scrollHeight: 12_148, scrollTop: 11_400 });
+    fireEvent.scroll(scrollViewport);
+
+    await screen.findByText("windowed-119.html");
+    expect(screen.queryByText("windowed-064.html")).not.toBeInTheDocument();
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
+
+    setScrollMetrics({ scrollHeight: 18_228, scrollTop: 17_400 });
+    fireEvent.scroll(scrollViewport);
+
+    await screen.findByText("windowed-179.html");
+    expect(screen.queryByText("windowed-119.html")).not.toBeInTheDocument();
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
   });
 });

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -1396,5 +1396,23 @@ describe("artifacts page", () => {
       expect(focusedArtifactIndex()).toBe("60");
     });
     await screen.findByText("keyboard-windowed-060.html");
+
+    const firstMountedArtifact = document.querySelector<HTMLElement>(
+      "article[data-artifact-index]",
+    );
+    if (!firstMountedArtifact?.dataset.artifactIndex) {
+      throw new Error("First mounted artifact not found");
+    }
+    const firstMountedIndex = Number(
+      firstMountedArtifact.dataset.artifactIndex,
+    );
+    expect(firstMountedIndex).toBeGreaterThan(0);
+
+    firstMountedArtifact.focus();
+    fireEvent.keyDown(firstMountedArtifact, { key: "Tab", shiftKey: true });
+
+    await waitFor(() => {
+      expect(focusedArtifactIndex()).toBe(String(firstMountedIndex - 1));
+    });
   });
 });

--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -510,6 +510,23 @@ function buttonByLabel(label: string): HTMLElement {
   return button;
 }
 
+function buttonByText(text: string): HTMLElement {
+  const button = queryAllByRoleFast("button").find((candidate) => {
+    return candidate.textContent?.replace(/\s+/g, " ").trim() === text;
+  });
+  if (!button) {
+    throw new Error(`${text} button not found`);
+  }
+  return button;
+}
+
+function focusedArtifactIndex(): string | null {
+  return (
+    document.activeElement?.closest<HTMLElement>("[data-artifact-index]")
+      ?.dataset.artifactIndex ?? null
+  );
+}
+
 describe("artifacts page", () => {
   it("hides the entry and redirects when the feature switch is disabled", async () => {
     setupTeam();
@@ -1336,5 +1353,48 @@ describe("artifacts page", () => {
     await screen.findByText("windowed-179.html");
     expect(screen.queryByText("windowed-119.html")).not.toBeInTheDocument();
     expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
+  });
+
+  it("continues keyboard navigation through virtualized artifacts", async () => {
+    setupTeam();
+    const scope = testAuthScope("keyboard-windowed");
+    const many = Array.from({ length: 120 }, (_, index) => {
+      const label = String(index).padStart(3, "0");
+      return createArtifact({
+        artifactItemId: `keyboard-windowed-${label}:file`,
+        runId: `keyboard-windowed-${label}`,
+        filename: `keyboard-windowed-${label}.html`,
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+      });
+    });
+    mockArtifacts(many);
+
+    setupArtifactsPage({ scope });
+
+    await screen.findByText("keyboard-windowed-000.html");
+    const scrollViewport = screen.getByRole("main");
+    const setScrollMetrics = mockScrollViewport(scrollViewport, {
+      clientHeight: 800,
+      scrollHeight: 6068,
+      scrollTop: 0,
+    });
+
+    fireEvent.focus(buttonByText("Continue browsing artifacts"));
+
+    await waitFor(() => {
+      expect(focusedArtifactIndex()).toBe("15");
+    });
+    await screen.findByText("keyboard-windowed-015.html");
+
+    setScrollMetrics({ scrollHeight: 20_000, scrollTop: 4560 });
+    fireEvent.scroll(scrollViewport);
+    await screen.findByText("keyboard-windowed-059.html");
+
+    fireEvent.focus(buttonByText("Continue browsing artifacts"));
+
+    await waitFor(() => {
+      expect(focusedArtifactIndex()).toBe("60");
+    });
+    await screen.findByText("keyboard-windowed-060.html");
   });
 });

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -55,8 +55,10 @@ import {
   navigateToArtifactThread$,
   reloadArtifacts$,
   remoteArtifacts$,
+  requestArtifactsKeyboardFocus$,
   selectedArtifactsAgentId$,
   selectedArtifactsCategory$,
+  setArtifactCardRef$,
   setArtifactsGridRef$,
   setArtifactsFavoritesOnly$,
   setArtifactsScrollViewportRef$,
@@ -654,6 +656,8 @@ function ArtifactCardActions({
 }
 
 function ArtifactCard({
+  cardRef,
+  index,
   item,
   onOpenChat,
   onOpenPreview,
@@ -661,6 +665,8 @@ function ArtifactCard({
   onToggleFavorite,
   showFavoriteAction,
 }: {
+  readonly cardRef: (element: HTMLElement | null) => void;
+  readonly index: number;
   readonly item: ArtifactItem;
   readonly onOpenChat: (threadId: string) => void;
   readonly onOpenPreview: (item: ArtifactItem) => void;
@@ -675,6 +681,8 @@ function ArtifactCard({
   const favorited = item.isFavorited === true;
   return (
     <article
+      ref={cardRef}
+      data-artifact-index={index}
       role={previewable ? "button" : undefined}
       tabIndex={previewable ? 0 : undefined}
       aria-label={previewable ? `Preview ${item.filename}` : undefined}
@@ -867,12 +875,29 @@ function ArtifactsEmptyState({ filtered }: { readonly filtered: boolean }) {
   );
 }
 
+function ArtifactsKeyboardContinuation({
+  onFocus,
+}: {
+  readonly onFocus: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="sr-only focus:not-sr-only focus:absolute focus:left-0 focus:top-full focus:z-10 focus:mt-2 focus:rounded-md focus:border focus:border-border focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:text-foreground focus:shadow-sm"
+      onFocus={onFocus}
+    >
+      Continue browsing artifacts
+    </button>
+  );
+}
+
 function ArtifactsList({
   artifacts,
   hasFilters,
   loading,
   error,
   visibleCount,
+  onLoadMore,
   onOpenChat,
   onOpenPreview,
   onStartChat,
@@ -884,6 +909,7 @@ function ArtifactsList({
   readonly loading: boolean;
   readonly error: boolean;
   readonly visibleCount: number;
+  readonly onLoadMore: () => void;
   readonly onOpenChat: (threadId: string) => void;
   readonly onOpenPreview: (item: ArtifactItem) => void;
   readonly onStartChat: (item: ArtifactItem) => void;
@@ -895,18 +921,9 @@ function ArtifactsList({
   const gridElement = useGet(artifactsGridElement$);
   const measuredGridWidth = useGet(artifactsGridWidth$);
   const setGridRef = useSet(setArtifactsGridRef$);
-
-  if (loading) {
-    return <ArtifactsLoadingState />;
-  }
-  if (error) {
-    return <ArtifactsErrorState />;
-  }
-  if (artifacts.length === 0) {
-    return <ArtifactsEmptyState filtered={hasFilters} />;
-  }
-  // Auto-loading expands the available window while row virtualization keeps
-  // only the viewport and a small overscan mounted.
+  const syncScrollMetrics = useSet(syncArtifactsScrollMetrics$);
+  const requestKeyboardFocus = useSet(requestArtifactsKeyboardFocus$);
+  const setArtifactCardRef = useSet(setArtifactCardRef$);
   const windowed = artifacts.slice(0, visibleCount);
   const gridWidth =
     measuredGridWidth ||
@@ -932,6 +949,37 @@ function ArtifactsList({
       viewportHeight,
     });
   const virtualized = windowed.slice(startIndex, endIndex);
+  const hasKeyboardContinuation =
+    endIndex < windowed.length || windowed.length < artifacts.length;
+
+  const continueKeyboardNavigation = () => {
+    const nextIndex = endIndex < windowed.length ? endIndex : windowed.length;
+    if (nextIndex >= artifacts.length) {
+      return;
+    }
+
+    requestKeyboardFocus(nextIndex);
+    if (nextIndex >= windowed.length) {
+      onLoadMore();
+    }
+
+    if (!scrollViewport) {
+      return;
+    }
+    const row = Math.floor(nextIndex / columnCount);
+    scrollViewport.scrollTop = scrollMargin + row * rowHeight;
+    syncScrollMetrics(scrollViewport);
+  };
+
+  if (loading) {
+    return <ArtifactsLoadingState />;
+  }
+  if (error) {
+    return <ArtifactsErrorState />;
+  }
+  if (artifacts.length === 0) {
+    return <ArtifactsEmptyState filtered={hasFilters} />;
+  }
 
   return (
     <div
@@ -948,10 +996,13 @@ function ArtifactsList({
           transform: `translateY(${startOffset}px)`,
         }}
       >
-        {virtualized.map((artifact) => {
+        {virtualized.map((artifact, visibleOffset) => {
+          const index = startIndex + visibleOffset;
           return (
             <ArtifactCard
               key={artifact.artifactItemId}
+              cardRef={setArtifactCardRef}
+              index={index}
               item={artifact}
               onOpenChat={onOpenChat}
               onOpenPreview={onOpenPreview}
@@ -962,6 +1013,9 @@ function ArtifactsList({
           );
         })}
       </div>
+      {hasKeyboardContinuation && (
+        <ArtifactsKeyboardContinuation onFocus={continueKeyboardNavigation} />
+      )}
     </div>
   );
 }
@@ -1075,6 +1129,7 @@ export function ArtifactsPage() {
             loading={loading}
             error={error}
             visibleCount={visibleCount}
+            onLoadMore={loadMore}
             onOpenChat={openChat}
             onOpenPreview={openArtifactPreview}
             onStartChat={(item) => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, UIEvent as ReactUIEvent } from "react";
 import type { ArtifactItem } from "@vm0/api-contracts/contracts/chat-threads";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import {
@@ -42,8 +42,12 @@ import { agents$ } from "../../signals/agent.ts";
 import {
   applyArtifactFavoriteOverrides,
   artifactFavoriteOverrides$,
+  artifactsGridElement$,
+  artifactsGridWidth$,
   artifactsFavoritesOnly$,
   artifactsSearch$,
+  artifactsScrollMetrics$,
+  artifactsScrollViewport$,
   artifactsWindow$,
   cachedArtifacts$,
   filterArtifacts,
@@ -53,11 +57,14 @@ import {
   remoteArtifacts$,
   selectedArtifactsAgentId$,
   selectedArtifactsCategory$,
+  setArtifactsGridRef$,
   setArtifactsFavoritesOnly$,
+  setArtifactsScrollViewportRef$,
   setArtifactsSearch$,
   setSelectedArtifactsAgentId$,
   setSelectedArtifactsCategory$,
   startArtifactChat$,
+  syncArtifactsScrollMetrics$,
   toggleArtifactFavorite$,
 } from "../../signals/artifacts-page/artifacts-signals.ts";
 import type { ArtifactCategory } from "../../signals/artifacts-page/artifact-category.ts";
@@ -87,6 +94,12 @@ type ArtifactPreviewKind = "image" | "html" | "pdf" | "video" | "file";
 type ArtifactTypeIconKind = "presentation" | "html" | "image" | "video";
 
 const DESKTOP_ARTIFACT_PREVIEW_SIZE = 1280;
+const ARTIFACT_AUTO_LOAD_THRESHOLD_PX = 800;
+const ARTIFACT_GRID_GAP_PX = 12;
+const ARTIFACT_GRID_MIN_CARD_WIDTH_PX = 220;
+const ARTIFACT_GRID_OVERSCAN_ROWS = 2;
+const ARTIFACT_GRID_FALLBACK_WIDTH_PX = 900;
+const ARTIFACT_GRID_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
 const ARTIFACT_CATEGORY_OPTIONS: readonly {
   readonly ariaLabel: string;
   readonly label: string;
@@ -684,7 +697,7 @@ function ArtifactCard({
           : undefined
       }
       className={cn(
-        "group relative mb-3 aspect-square break-inside-avoid overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-colors hover:border-foreground/20",
+        "group relative aspect-square overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-colors hover:border-foreground/20",
         previewable &&
           "cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       )}
@@ -717,12 +730,15 @@ function ArtifactCard({
 
 function ArtifactsLoadingState() {
   return (
-    <div className="columns-[220px] gap-3" aria-label="Loading artifacts">
+    <div
+      className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3"
+      aria-label="Loading artifacts"
+    >
       {Array.from({ length: 8 }, (_, index) => {
         return (
           <div
             key={index}
-            className="mb-3 aspect-square break-inside-avoid overflow-hidden rounded-lg border border-border bg-card"
+            className="aspect-square overflow-hidden rounded-lg border border-border bg-card"
           >
             <div className="h-full bg-muted/30">
               <div className="flex h-full flex-col justify-end p-3">
@@ -739,6 +755,86 @@ function ArtifactsLoadingState() {
       })}
     </div>
   );
+}
+
+function hasUsableLayoutPosition(rect: DOMRectReadOnly): boolean {
+  return rect.top !== 0 || rect.left !== 0;
+}
+
+function getArtifactsGridScrollMargin(
+  scrollViewport: HTMLElement | null,
+  gridElement: HTMLElement | null,
+): number {
+  if (!scrollViewport || !gridElement) {
+    return 0;
+  }
+
+  const viewportRect = scrollViewport.getBoundingClientRect();
+  const gridRect = gridElement.getBoundingClientRect();
+  if (
+    hasUsableLayoutPosition(viewportRect) ||
+    hasUsableLayoutPosition(gridRect)
+  ) {
+    return Math.max(
+      0,
+      scrollViewport.scrollTop + gridRect.top - viewportRect.top,
+    );
+  }
+
+  return Math.max(0, gridElement.offsetTop - scrollViewport.offsetTop);
+}
+
+function getArtifactGridDimensions(containerWidth: number) {
+  const columnCount = Math.max(
+    1,
+    Math.floor(
+      (containerWidth + ARTIFACT_GRID_GAP_PX) /
+        (ARTIFACT_GRID_MIN_CARD_WIDTH_PX + ARTIFACT_GRID_GAP_PX),
+    ),
+  );
+  const cardSize =
+    (containerWidth - ARTIFACT_GRID_GAP_PX * (columnCount - 1)) / columnCount;
+  return {
+    columnCount,
+    rowHeight: cardSize + ARTIFACT_GRID_GAP_PX,
+  };
+}
+
+function getVirtualArtifactRange({
+  columnCount,
+  itemCount,
+  rowHeight,
+  scrollMargin,
+  scrollTop,
+  viewportHeight,
+}: {
+  readonly columnCount: number;
+  readonly itemCount: number;
+  readonly rowHeight: number;
+  readonly scrollMargin: number;
+  readonly scrollTop: number;
+  readonly viewportHeight: number;
+}) {
+  const rowCount = Math.ceil(itemCount / columnCount);
+  const localScrollTop = Math.max(0, scrollTop - scrollMargin);
+  const firstVisibleRow = Math.min(
+    Math.max(0, rowCount - 1),
+    Math.floor(localScrollTop / rowHeight),
+  );
+  const visibleRowCount = Math.max(1, Math.ceil(viewportHeight / rowHeight));
+  const startRow = Math.max(0, firstVisibleRow - ARTIFACT_GRID_OVERSCAN_ROWS);
+  const endRow = Math.min(
+    rowCount,
+    firstVisibleRow + visibleRowCount + ARTIFACT_GRID_OVERSCAN_ROWS,
+  );
+
+  return {
+    endIndex: Math.min(itemCount, endRow * columnCount),
+    startIndex: startRow * columnCount,
+    startOffset: startRow * rowHeight,
+    totalHeight:
+      rowCount === 0 ? 0 : rowCount * rowHeight - ARTIFACT_GRID_GAP_PX,
+  };
 }
 
 function ArtifactsErrorState() {
@@ -777,7 +873,6 @@ function ArtifactsList({
   loading,
   error,
   visibleCount,
-  onLoadMore,
   onOpenChat,
   onOpenPreview,
   onStartChat,
@@ -789,13 +884,18 @@ function ArtifactsList({
   readonly loading: boolean;
   readonly error: boolean;
   readonly visibleCount: number;
-  readonly onLoadMore: () => void;
   readonly onOpenChat: (threadId: string) => void;
   readonly onOpenPreview: (item: ArtifactItem) => void;
   readonly onStartChat: (item: ArtifactItem) => void;
   readonly onToggleFavorite: (item: ArtifactItem) => void;
   readonly showFavoriteAction: boolean;
 }) {
+  const scrollViewport = useGet(artifactsScrollViewport$);
+  const scrollMetrics = useGet(artifactsScrollMetrics$);
+  const gridElement = useGet(artifactsGridElement$);
+  const measuredGridWidth = useGet(artifactsGridWidth$);
+  const setGridRef = useSet(setArtifactsGridRef$);
+
   if (loading) {
     return <ArtifactsLoadingState />;
   }
@@ -805,14 +905,50 @@ function ArtifactsList({
   if (artifacts.length === 0) {
     return <ArtifactsEmptyState filtered={hasFilters} />;
   }
-  // Render only the current window so a large set never mounts thousands of
-  // cards (and their iframes) at once; "Load more" reveals the next window.
+  // Auto-loading expands the available window while row virtualization keeps
+  // only the viewport and a small overscan mounted.
   const windowed = artifacts.slice(0, visibleCount);
-  const hasMore = windowed.length < artifacts.length;
+  const gridWidth =
+    measuredGridWidth ||
+    gridElement?.clientWidth ||
+    ARTIFACT_GRID_FALLBACK_WIDTH_PX;
+  const viewportHeight =
+    scrollMetrics.clientHeight ||
+    scrollViewport?.clientHeight ||
+    ARTIFACT_GRID_FALLBACK_VIEWPORT_HEIGHT_PX;
+  const scrollTop = scrollMetrics.scrollTop || scrollViewport?.scrollTop || 0;
+  const scrollMargin = getArtifactsGridScrollMargin(
+    scrollViewport,
+    gridElement,
+  );
+  const { columnCount, rowHeight } = getArtifactGridDimensions(gridWidth);
+  const { endIndex, startIndex, startOffset, totalHeight } =
+    getVirtualArtifactRange({
+      columnCount,
+      itemCount: windowed.length,
+      rowHeight,
+      scrollMargin,
+      scrollTop,
+      viewportHeight,
+    });
+  const virtualized = windowed.slice(startIndex, endIndex);
+
   return (
-    <>
-      <div className="columns-[220px] gap-3">
-        {windowed.map((artifact) => {
+    <div
+      ref={setGridRef}
+      className="relative w-full"
+      data-testid="artifacts-virtual-grid"
+      style={{ height: totalHeight }}
+    >
+      <div
+        className="absolute left-0 top-0 grid w-full gap-3"
+        data-testid="artifacts-virtual-grid-items"
+        style={{
+          gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+          transform: `translateY(${startOffset}px)`,
+        }}
+      >
+        {virtualized.map((artifact) => {
           return (
             <ArtifactCard
               key={artifact.artifactItemId}
@@ -826,14 +962,7 @@ function ArtifactsList({
           );
         })}
       </div>
-      {hasMore && (
-        <div className="flex justify-center pt-1">
-          <Button variant="secondary" onClick={onLoadMore}>
-            Load more
-          </Button>
-        </div>
-      )}
-    </>
+    </div>
   );
 }
 
@@ -853,6 +982,8 @@ export function ArtifactsPage() {
   const pageSignal = useGet(pageSignal$);
   const visibleCount = useGet(artifactsWindow$);
   const loadMore = useSet(growArtifactsWindow$);
+  const setScrollViewportRef = useSet(setArtifactsScrollViewportRef$);
+  const syncScrollMetrics = useSet(syncArtifactsScrollMetrics$);
   const openArtifactPreview = useOpenArtifactPreview();
   const lightboxUrl = useGet(lightboxUrl$);
   const remoteLoadable = useLastLoadable(remoteArtifacts$);
@@ -891,6 +1022,18 @@ export function ArtifactsPage() {
     selectedAgentId !== null ||
     selectedCategory !== null ||
     (artifactFavoritesEnabled && favoritesOnly);
+  const handleScroll = (event: ReactUIEvent<HTMLElement>) => {
+    const viewport = event.currentTarget;
+    syncScrollMetrics(viewport);
+    if (visibleCount >= artifacts.length) {
+      return;
+    }
+    const distanceFromBottom =
+      viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    if (distanceFromBottom <= ARTIFACT_AUTO_LOAD_THRESHOLD_PX) {
+      loadMore();
+    }
+  };
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -908,7 +1051,11 @@ export function ArtifactsPage() {
         </div>
       </header>
 
-      <main className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6 [scrollbar-gutter:stable]">
+      <main
+        ref={setScrollViewportRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-auto px-4 pb-8 pt-3 sm:px-6 [scrollbar-gutter:stable]"
+      >
         <div className="mx-auto flex w-full max-w-[900px] flex-col gap-4">
           <ArtifactsToolbar
             search={search}
@@ -928,7 +1075,6 @@ export function ArtifactsPage() {
             loading={loading}
             error={error}
             visibleCount={visibleCount}
-            onLoadMore={loadMore}
             onOpenChat={openChat}
             onOpenPreview={openArtifactPreview}
             onStartChat={(item) => {

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -1,4 +1,8 @@
-import type { ReactNode, UIEvent as ReactUIEvent } from "react";
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactNode,
+  UIEvent as ReactUIEvent,
+} from "react";
 import type { ArtifactItem } from "@vm0/api-contracts/contracts/chat-threads";
 import type { TeamComposeItem } from "@vm0/api-contracts/contracts/zero-team";
 import {
@@ -51,6 +55,7 @@ import {
   artifactsWindow$,
   cachedArtifacts$,
   filterArtifacts,
+  getArtifactFocusTarget,
   growArtifactsWindow$,
   navigateToArtifactThread$,
   reloadArtifacts$,
@@ -891,6 +896,78 @@ function ArtifactsKeyboardContinuation({
   );
 }
 
+function createArtifactsKeyboardNavigation({
+  artifactsLength,
+  columnCount,
+  endIndex,
+  onLoadMore,
+  requestKeyboardFocus,
+  rowHeight,
+  scrollMargin,
+  scrollViewport,
+  startIndex,
+  syncScrollMetrics,
+  windowedLength,
+}: {
+  readonly artifactsLength: number;
+  readonly columnCount: number;
+  readonly endIndex: number;
+  readonly onLoadMore: () => void;
+  readonly requestKeyboardFocus: (index: number) => void;
+  readonly rowHeight: number;
+  readonly scrollMargin: number;
+  readonly scrollViewport: HTMLElement | null;
+  readonly startIndex: number;
+  readonly syncScrollMetrics: (viewport: HTMLElement) => void;
+  readonly windowedLength: number;
+}) {
+  const scrollToIndex = (index: number) => {
+    if (!scrollViewport) {
+      return;
+    }
+    const row = Math.floor(index / columnCount);
+    scrollViewport.scrollTop = scrollMargin + row * rowHeight;
+    syncScrollMetrics(scrollViewport);
+  };
+
+  const continueForward = () => {
+    const nextIndex = endIndex < windowedLength ? endIndex : windowedLength;
+    if (nextIndex >= artifactsLength) {
+      return;
+    }
+    requestKeyboardFocus(nextIndex);
+    if (nextIndex >= windowedLength) {
+      onLoadMore();
+    }
+    scrollToIndex(nextIndex);
+  };
+
+  const handleBackward = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (
+      event.key !== "Tab" ||
+      !event.shiftKey ||
+      startIndex === 0 ||
+      !scrollViewport
+    ) {
+      return;
+    }
+    const firstMountedArtifact = event.currentTarget.querySelector<HTMLElement>(
+      `[data-artifact-index="${startIndex}"]`,
+    );
+    if (
+      !firstMountedArtifact ||
+      event.target !== getArtifactFocusTarget(firstMountedArtifact)
+    ) {
+      return;
+    }
+    event.preventDefault();
+    requestKeyboardFocus(startIndex - 1);
+    scrollToIndex(startIndex - 1);
+  };
+
+  return { continueForward, handleBackward };
+}
+
 function ArtifactsList({
   artifacts,
   hasFilters,
@@ -951,25 +1028,22 @@ function ArtifactsList({
   const virtualized = windowed.slice(startIndex, endIndex);
   const hasKeyboardContinuation =
     endIndex < windowed.length || windowed.length < artifacts.length;
-
-  const continueKeyboardNavigation = () => {
-    const nextIndex = endIndex < windowed.length ? endIndex : windowed.length;
-    if (nextIndex >= artifacts.length) {
-      return;
-    }
-
-    requestKeyboardFocus(nextIndex);
-    if (nextIndex >= windowed.length) {
-      onLoadMore();
-    }
-
-    if (!scrollViewport) {
-      return;
-    }
-    const row = Math.floor(nextIndex / columnCount);
-    scrollViewport.scrollTop = scrollMargin + row * rowHeight;
-    syncScrollMetrics(scrollViewport);
-  };
+  const {
+    continueForward: continueKeyboardNavigation,
+    handleBackward: handleGridKeyDownCapture,
+  } = createArtifactsKeyboardNavigation({
+    artifactsLength: artifacts.length,
+    columnCount,
+    endIndex,
+    onLoadMore,
+    requestKeyboardFocus,
+    rowHeight,
+    scrollMargin,
+    scrollViewport,
+    startIndex,
+    syncScrollMetrics,
+    windowedLength: windowed.length,
+  });
 
   if (loading) {
     return <ArtifactsLoadingState />;
@@ -984,6 +1058,7 @@ function ArtifactsList({
   return (
     <div
       ref={setGridRef}
+      onKeyDownCapture={handleGridKeyDownCapture}
       className="relative w-full"
       data-testid="artifacts-virtual-grid"
       style={{ height: totalHeight }}


### PR DESCRIPTION
## Summary

- replace the artifacts page's multicolumn list with a responsive fixed-row virtual grid that mounts only the visible rows plus two overscan rows
- remove the visible `Load more` control and automatically expand the available artifact window by 60 items within 800px of the scroll boundary
- preserve the existing bulk fetch, IndexedDB cache, filters, card styling, and square previews while keeping the mounted artifact DOM bounded during continuous scrolling
- cover repeated automatic loading and verify that an 800px, three-column viewport mounts no more than 21 artifact cards

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm check-types` (13/13 packages)
- `pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx --silent=passed-only` (17/17 tests)
- browser verification was attempted, but the local app could not leave its startup skeleton because `VITE_CLERK_PUBLISHABLE_KEY` is unavailable in this checkout
