### PR TITLE
perf(api): overlap runtime memory with run context preparation

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-messages.bdd.test.ts
@@ -1472,7 +1472,29 @@ describe("CHAT-02: admission without spendable credits", () => {
 describe("CHAT-02: model-first provider policies", () => {
   it("adds Codex image upload guidance for web chat Codex sends", async () => {
     const { actor, agentId, runnerGroup } = await entitledChatActor();
+    if (!actor.orgId) {
+      throw new Error("Expected an org-scoped actor for runtime memory");
+    }
     chatCallbacks.failIfChatCallbackRouteIsFetched();
+    mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", "test");
+    onTestFinished(() => {
+      mockOptionalEnv("ZERO_MEMORY_EMBEDDING_PROVIDER", undefined);
+    });
+    await updateFeatureSwitchesForUser(
+      context,
+      { ...actor, orgId: actor.orgId },
+      {
+        [FeatureSwitchKey.RelationshipMemory]: true,
+        [FeatureSwitchKey.RelationshipMemoryRuntimeInjection]: true,
+      },
+    );
+    const memoryText =
+      "The user prefers the aurora-21210 color palette for generated images.";
+    await chat.createMemory(actor, {
+      text: memoryText,
+      kind: "preference",
+      confidence: 95,
+    });
 
     await misc.upsertPersonalModelProvider(
       actor,
@@ -1495,7 +1517,8 @@ describe("CHAT-02: model-first provider policies", () => {
 
     const run = await sendChatRun(actor, {
       agentId,
-      prompt: "generate an image in web chat",
+      prompt:
+        "generate an image in web chat using the aurora-21210 color palette",
       model: "gpt-5.4",
     });
     const { claim } = await claimChatRun(runnerGroup, run.runId);
@@ -1507,6 +1530,20 @@ describe("CHAT-02: model-first provider policies", () => {
     expect(appendSystemPrompt).toContain("zero web upload-file -h");
     expect(appendSystemPrompt).toContain(CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET);
     expect(appendSystemPrompt).not.toContain("When running in Codex");
+    expect(appendSystemPrompt).toContain(memoryText);
+    let previousSectionIndex = -1;
+    for (const section of [
+      "# Agent Identity",
+      "# Agent Tools",
+      "# Current User Info",
+      "# Zero Memory Context",
+      "# Current Integration",
+      CODEX_WEB_IMAGE_UPLOAD_PROMPT_SNIPPET,
+    ]) {
+      const sectionIndex = appendSystemPrompt.indexOf(section);
+      expect(sectionIndex).toBeGreaterThan(previousSectionIndex);
+      previousSectionIndex = sectionIndex;
+    }
     await cancelChatRun(actor, run.runId);
   });
 

--- a/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/helpers/api-bdd-chat-files.ts
@@ -59,7 +59,9 @@ import {
 } from "@vm0/api-contracts/contracts/zero-memory-activity";
 import {
   zeroMemoryContract,
+  type MemoryCreateRequest,
   type MemoryDetailResponse,
+  type MemoryLifecycleMemory,
 } from "@vm0/api-contracts/contracts/zero-memory";
 
 import { setupAppWithRoutes } from "../../../../__tests__/test-app";
@@ -1332,6 +1334,20 @@ export function createChatFilesBddApi(context: TestContext) {
         [200],
       );
       return response.body;
+    },
+
+    async createMemory(
+      actor: ApiTestUser,
+      body: MemoryCreateRequest,
+    ): Promise<MemoryLifecycleMemory> {
+      const response = await accept(
+        memoryClient().createMemory({
+          headers: authenticate(context, actor),
+          body,
+        }),
+        [200],
+      );
+      return response.body.memory;
     },
 
     async requestReadMemory(

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -6701,11 +6701,7 @@ function prepareRunContext(
       if (isRouteError(runtimeContext)) {
         return runtimeContext;
       }
-      const body = withFinalFrameworkAppendSystemPrompt(
-        bodyContext.body,
-        runtimeContext.framework,
-        args.chatThreadId,
-      );
+      const body = bodyContext.body;
 
       const validation = await timing.measure(
         "api_dispatch_prepare_context_validate_environment",
@@ -7293,19 +7289,47 @@ function createAtomicLaunchRun(input: {
   });
 }
 
-export const createAgentRun$ = command(
+interface PreparedAgentRun {
+  readonly args: CreateAgentRunArgs;
+  readonly context: PreparedRunContext;
+  readonly timing: ApiDispatchTimingCollector;
+}
+
+interface PrepareAgentRunArgs {
+  readonly args: CreateAgentRunArgs;
+  readonly timing: ApiDispatchTimingCollector;
+}
+
+interface CompleteAgentRunArgs {
+  readonly prepared: PreparedAgentRun;
+  readonly finalAppendSystemPrompt: CreateRunBody["appendSystemPrompt"];
+}
+
+function finalizePreparedRunContext(
+  prepared: PreparedAgentRun,
+  finalAppendSystemPrompt: CreateRunBody["appendSystemPrompt"],
+): PreparedRunContext {
+  return {
+    ...prepared.context,
+    body: withFinalFrameworkAppendSystemPrompt(
+      {
+        ...prepared.context.body,
+        appendSystemPrompt: finalAppendSystemPrompt,
+      },
+      prepared.context.framework,
+      prepared.args.chatThreadId,
+    ),
+  };
+}
+
+export const prepareAgentRun$ = command(
   async (
     { get, set },
-    args: CreateAgentRunArgs,
+    input: PrepareAgentRunArgs,
     signal: AbortSignal,
-  ): Promise<CreateRunRouteResult> => {
+  ): Promise<PreparedAgentRun | CreateRunErrorResult> => {
+    const { args, timing } = input;
     const db = set(writeDb$);
-    const timing = args.timing ?? new ApiDispatchTimingCollector();
-    timing.recordElapsed(
-      "api_dispatch_pre_create_agent_run",
-      "top_level",
-      args.apiStartTime,
-    );
     const tierGate = await timing.measure(
       "api_dispatch_check_org_tier",
       "top_level",
@@ -7329,6 +7353,24 @@ export const createAgentRun$ = command(
     if (isRouteError(context)) {
       return context;
     }
+
+    return { args, context, timing };
+  },
+);
+
+export const completeAgentRun$ = command(
+  async (
+    { get, set },
+    input: CompleteAgentRunArgs,
+    signal: AbortSignal,
+  ): Promise<CreateRunRouteResult> => {
+    const db = set(writeDb$);
+    const { args, timing } = input.prepared;
+    const context = finalizePreparedRunContext(
+      input.prepared,
+      input.finalAppendSystemPrompt,
+    );
+    signal.throwIfAborted();
 
     const modelTierGate = await checkLimitedFreeRunModelAdmission({
       db,
@@ -7384,6 +7426,33 @@ export const createAgentRun$ = command(
         signal,
         timing,
       }),
+    );
+  },
+);
+
+export const createAgentRun$ = command(
+  async (
+    { set },
+    args: CreateAgentRunArgs,
+    signal: AbortSignal,
+  ): Promise<CreateRunRouteResult> => {
+    const timing = args.timing ?? new ApiDispatchTimingCollector();
+    timing.recordElapsed(
+      "api_dispatch_pre_create_agent_run",
+      "top_level",
+      args.apiStartTime,
+    );
+    const prepared = await set(prepareAgentRun$, { args, timing }, signal);
+    if (isRouteError(prepared)) {
+      return prepared;
+    }
+    return await set(
+      completeAgentRun$,
+      {
+        prepared,
+        finalAppendSystemPrompt: args.body.appendSystemPrompt,
+      },
+      signal,
     );
   },
 );

--- a/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-runs-create.service.ts
@@ -26,7 +26,8 @@ import { badRequestMessage, notFound } from "../../lib/error";
 import type { AuthContext } from "../../types/auth";
 import { writeDb$, type Db } from "../external/db";
 import {
-  createAgentRun$,
+  completeAgentRun$,
+  prepareAgentRun$,
   type BeforeRunDispatch,
   type CreateAgentRunArgs,
   type DispatchFailedRunCallbacks,
@@ -925,38 +926,22 @@ async function resolveZeroRunTriggerPreCreateContext(
   return { triggerAgentId };
 }
 
-async function buildZeroCreateAgentRunArgs(args: {
-  readonly db: Db;
+function buildZeroCreateAgentRunArgs(args: {
   readonly command: CreateZeroRunCommandArgs;
   readonly agent: ZeroAgentRunRecord;
   readonly userInfo: UserInfo;
   readonly relationshipMemoryEnabled: boolean;
-  readonly relationshipMemoryRuntimeInjectionEnabled: boolean;
+  readonly memoryRuntimeAppendSystemPrompt: string | undefined;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly triggerAgentId: string | undefined;
   readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
   readonly allowedConnectorTypes: readonly ConnectorType[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
-}): Promise<CreateAgentRunArgs> {
+}): CreateAgentRunArgs {
   const command = args.command;
   const agentModelProviderId = optionalAgentSetting(args.agent.modelProviderId);
   const agentSelectedModel = optionalAgentSetting(args.agent.selectedModel);
-  const memoryTiming = zeroMemoryTimingObserver(args.timing);
-  const memoryRuntimeAppendSystemPrompt =
-    await loadMemoryRuntimeAppendSystemPrompt(args.db, {
-      enabled: args.relationshipMemoryRuntimeInjectionEnabled,
-      orgId: command.auth.orgId,
-      userId: command.auth.userId,
-      prompt: command.body.prompt,
-      ...(command.memoryRuntimeRetrievalQuery !== undefined
-        ? { retrievalQuery: command.memoryRuntimeRetrievalQuery }
-        : {}),
-      timing: memoryTiming,
-      ...(command.zeroRunMetadata?.goalId
-        ? { goalId: command.zeroRunMetadata.goalId }
-        : {}),
-    });
   return {
     userId: command.auth.userId,
     orgId: command.auth.orgId,
@@ -965,7 +950,7 @@ async function buildZeroCreateAgentRunArgs(args: {
       agent: args.agent,
       userInfo: { ...args.userInfo, ...command.userInfoExtras },
       relationshipMemoryEnabled: args.relationshipMemoryEnabled,
-      memoryRuntimeAppendSystemPrompt,
+      memoryRuntimeAppendSystemPrompt: args.memoryRuntimeAppendSystemPrompt,
       permissionPolicies: args.runPermissionPolicies,
       triggerAgentId: args.triggerAgentId,
       triggerSource: command.triggerSource,
@@ -1013,29 +998,58 @@ async function buildZeroCreateAgentRunArgs(args: {
   };
 }
 
-async function buildZeroIntegrationCreateAgentRunArgs(args: {
+async function buildZeroFinalAppendSystemPrompt(args: {
   readonly db: Db;
-  readonly command: CreateZeroIntegrationRunCommandArgs;
+  readonly command: CreateZeroRunCommandArgs;
   readonly agent: ZeroAgentRunRecord;
   readonly userInfo: UserInfo;
   readonly relationshipMemoryEnabled: boolean;
   readonly relationshipMemoryRuntimeInjectionEnabled: boolean;
   readonly runPermissionPolicies: FirewallPolicies | null | undefined;
+  readonly triggerAgentId: string | undefined;
+  readonly timing: ApiDispatchTimingCollector;
+}): Promise<string> {
+  const command = args.command;
+  const memoryRuntimeAppendSystemPrompt =
+    await loadMemoryRuntimeAppendSystemPrompt(args.db, {
+      enabled: args.relationshipMemoryRuntimeInjectionEnabled,
+      orgId: command.auth.orgId,
+      userId: command.auth.userId,
+      prompt: command.body.prompt,
+      ...(command.memoryRuntimeRetrievalQuery !== undefined
+        ? { retrievalQuery: command.memoryRuntimeRetrievalQuery }
+        : {}),
+      timing: zeroMemoryTimingObserver(args.timing),
+      ...(command.zeroRunMetadata?.goalId
+        ? { goalId: command.zeroRunMetadata.goalId }
+        : {}),
+    });
+  return createRunBody({
+    body: command.body,
+    agent: args.agent,
+    userInfo: { ...args.userInfo, ...command.userInfoExtras },
+    relationshipMemoryEnabled: args.relationshipMemoryEnabled,
+    memoryRuntimeAppendSystemPrompt,
+    permissionPolicies: args.runPermissionPolicies,
+    triggerAgentId: args.triggerAgentId,
+    triggerSource: command.triggerSource,
+    appendSystemPrompt: command.appendSystemPrompt,
+  }).appendSystemPrompt;
+}
+
+function buildZeroIntegrationCreateAgentRunArgs(args: {
+  readonly command: CreateZeroIntegrationRunCommandArgs;
+  readonly agent: ZeroAgentRunRecord;
+  readonly userInfo: UserInfo;
+  readonly relationshipMemoryEnabled: boolean;
+  readonly memoryRuntimeAppendSystemPrompt: string | undefined;
+  readonly runPermissionPolicies: FirewallPolicies | null | undefined;
   readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
   readonly allowedConnectorTypes: readonly ConnectorType[];
   readonly allowedCustomConnectorIds: readonly string[];
   readonly timing: ApiDispatchTimingCollector;
-}): Promise<CreateAgentRunArgs> {
+}): CreateAgentRunArgs {
   const command = args.command;
-  const memoryTiming = zeroMemoryTimingObserver(args.timing);
-  const memoryRuntimeAppendSystemPrompt =
-    await loadMemoryRuntimeAppendSystemPrompt(args.db, {
-      enabled: args.relationshipMemoryRuntimeInjectionEnabled,
-      orgId: command.orgId,
-      userId: command.userId,
-      prompt: command.prompt,
-      timing: memoryTiming,
-    });
   return {
     userId: command.userId,
     orgId: command.orgId,
@@ -1045,7 +1059,7 @@ async function buildZeroIntegrationCreateAgentRunArgs(args: {
       agent: args.agent,
       userInfo: { ...args.userInfo, ...command.userInfoExtras },
       relationshipMemoryEnabled: args.relationshipMemoryEnabled,
-      memoryRuntimeAppendSystemPrompt,
+      memoryRuntimeAppendSystemPrompt: args.memoryRuntimeAppendSystemPrompt,
       permissionPolicies: args.runPermissionPolicies,
       triggerSource: command.triggerSource,
       appendSystemPrompt: command.appendSystemPrompt,
@@ -1070,6 +1084,155 @@ async function buildZeroIntegrationCreateAgentRunArgs(args: {
     timingDimensions: zeroRunTimingDimensions({ origin: "zero_integration" }),
   };
 }
+
+async function buildZeroIntegrationFinalAppendSystemPrompt(args: {
+  readonly db: Db;
+  readonly command: CreateZeroIntegrationRunCommandArgs;
+  readonly agent: ZeroAgentRunRecord;
+  readonly userInfo: UserInfo;
+  readonly relationshipMemoryEnabled: boolean;
+  readonly relationshipMemoryRuntimeInjectionEnabled: boolean;
+  readonly runPermissionPolicies: FirewallPolicies | null | undefined;
+  readonly timing: ApiDispatchTimingCollector;
+}): Promise<string> {
+  const command = args.command;
+  const memoryRuntimeAppendSystemPrompt =
+    await loadMemoryRuntimeAppendSystemPrompt(args.db, {
+      enabled: args.relationshipMemoryRuntimeInjectionEnabled,
+      orgId: command.orgId,
+      userId: command.userId,
+      prompt: command.prompt,
+      timing: zeroMemoryTimingObserver(args.timing),
+    });
+  return createIntegrationRunBody({
+    prompt: command.prompt,
+    sessionId: command.sessionId,
+    agent: args.agent,
+    userInfo: { ...args.userInfo, ...command.userInfoExtras },
+    relationshipMemoryEnabled: args.relationshipMemoryEnabled,
+    memoryRuntimeAppendSystemPrompt,
+    permissionPolicies: args.runPermissionPolicies,
+    triggerSource: command.triggerSource,
+    appendSystemPrompt: command.appendSystemPrompt,
+  }).appendSystemPrompt;
+}
+
+async function settleZeroRunPreparation<T>(
+  finalAppendSystemPromptPromise: Promise<string>,
+  preparedAgentRunPromise: Promise<T>,
+): Promise<readonly [string, PromiseSettledResult<T>]> {
+  const [finalAppendSystemPromptResult, preparedAgentRunResult] =
+    await Promise.allSettled([
+      finalAppendSystemPromptPromise,
+      preparedAgentRunPromise,
+    ]);
+  if (finalAppendSystemPromptResult.status === "rejected") {
+    const error: unknown = finalAppendSystemPromptResult.reason;
+    throw error;
+  }
+  return [finalAppendSystemPromptResult.value, preparedAgentRunResult];
+}
+
+interface ZeroRunAfterPreCreateBase {
+  readonly agent: ZeroAgentRunRecord;
+  readonly userInfo: UserInfo;
+  readonly relationshipMemoryEnabled: boolean;
+  readonly relationshipMemoryRuntimeInjectionEnabled: boolean;
+  readonly runPermissionPolicies: FirewallPolicies | null | undefined;
+  readonly workflows: Awaited<ReturnType<typeof loadWorkflowsForRun>>;
+  readonly allowedConnectorTypes: readonly ConnectorType[];
+  readonly allowedCustomConnectorIds: readonly string[];
+  readonly timing: ApiDispatchTimingCollector;
+}
+
+interface RegularZeroRunAfterPreCreate extends ZeroRunAfterPreCreateBase {
+  readonly kind: "regular";
+  readonly command: CreateZeroRunCommandArgs;
+  readonly triggerAgentId: string | undefined;
+}
+
+interface IntegrationZeroRunAfterPreCreate extends ZeroRunAfterPreCreateBase {
+  readonly kind: "integration";
+  readonly command: CreateZeroIntegrationRunCommandArgs;
+}
+
+type ZeroRunAfterPreCreate =
+  | RegularZeroRunAfterPreCreate
+  | IntegrationZeroRunAfterPreCreate;
+
+function buildProvisionalZeroCreateAgentRunArgs(
+  input: ZeroRunAfterPreCreate,
+): CreateAgentRunArgs {
+  if (input.kind === "regular") {
+    return buildZeroCreateAgentRunArgs({
+      ...input,
+      memoryRuntimeAppendSystemPrompt: undefined,
+    });
+  }
+  return buildZeroIntegrationCreateAgentRunArgs({
+    ...input,
+    memoryRuntimeAppendSystemPrompt: undefined,
+  });
+}
+
+async function buildZeroFinalAppendSystemPromptForKind(
+  db: Db,
+  input: ZeroRunAfterPreCreate,
+): Promise<string> {
+  if (input.kind === "regular") {
+    return await buildZeroFinalAppendSystemPrompt({ db, ...input });
+  }
+  return await buildZeroIntegrationFinalAppendSystemPrompt({ db, ...input });
+}
+
+const createAgentRunAfterZeroPreCreate$ = command(
+  async ({ set }, input: ZeroRunAfterPreCreate, signal: AbortSignal) => {
+    const db = set(writeDb$);
+    const provisionalCreateAgentRunArgs =
+      buildProvisionalZeroCreateAgentRunArgs(input);
+    const finalAppendSystemPromptPromise = (async () => {
+      const finalAppendSystemPrompt = await measureZeroPreCreate(
+        input.timing,
+        "api_dispatch_pre_create_zero_build_create_run_args",
+        async () => {
+          return await buildZeroFinalAppendSystemPromptForKind(db, input);
+        },
+      );
+      signal.throwIfAborted();
+      input.timing.recordElapsed(
+        "api_dispatch_pre_create_agent_run",
+        "top_level",
+        input.command.apiStartTime,
+      );
+      return finalAppendSystemPrompt;
+    })();
+    const preparedAgentRunPromise = set(
+      prepareAgentRun$,
+      { args: provisionalCreateAgentRunArgs, timing: input.timing },
+      signal,
+    );
+    const [finalAppendSystemPrompt, preparedAgentRunResult] =
+      await settleZeroRunPreparation(
+        finalAppendSystemPromptPromise,
+        preparedAgentRunPromise,
+      );
+    signal.throwIfAborted();
+    if (preparedAgentRunResult.status === "rejected") {
+      const error: unknown = preparedAgentRunResult.reason;
+      throw error;
+    }
+    const preparedAgentRun = preparedAgentRunResult.value;
+    if ("status" in preparedAgentRun) {
+      return preparedAgentRun;
+    }
+
+    return await set(
+      completeAgentRun$,
+      { prepared: preparedAgentRun, finalAppendSystemPrompt },
+      signal,
+    );
+  },
+);
 
 export const createZeroIntegrationRun$ = command(
   async (
@@ -1157,28 +1320,23 @@ export const createZeroIntegrationRun$ = command(
     );
     signal.throwIfAborted();
 
-    const createAgentRunArgs = await measureZeroPreCreate(
-      timing,
-      "api_dispatch_pre_create_zero_build_create_run_args",
-      async () => {
-        return await buildZeroIntegrationCreateAgentRunArgs({
-          db,
-          command: args,
-          agent,
-          userInfo,
-          relationshipMemoryEnabled,
-          relationshipMemoryRuntimeInjectionEnabled,
-          runPermissionPolicies,
-          workflows,
-          allowedConnectorTypes,
-          allowedCustomConnectorIds,
-          timing,
-        });
+    return await set(
+      createAgentRunAfterZeroPreCreate$,
+      {
+        kind: "integration",
+        command: args,
+        agent,
+        userInfo,
+        relationshipMemoryEnabled,
+        relationshipMemoryRuntimeInjectionEnabled,
+        runPermissionPolicies,
+        workflows,
+        allowedConnectorTypes,
+        allowedCustomConnectorIds,
+        timing,
       },
+      signal,
     );
-    signal.throwIfAborted();
-
-    return await set(createAgentRun$, createAgentRunArgs, signal);
   },
 );
 
@@ -1293,27 +1451,23 @@ export const createZeroRun$ = command(
     );
     signal.throwIfAborted();
 
-    const createAgentRunArgs = await measureZeroPreCreate(
-      timing,
-      "api_dispatch_pre_create_zero_build_create_run_args",
-      async () => {
-        return await buildZeroCreateAgentRunArgs({
-          db,
-          command: args,
-          agent,
-          userInfo,
-          relationshipMemoryEnabled,
-          relationshipMemoryRuntimeInjectionEnabled,
-          runPermissionPolicies,
-          triggerAgentId,
-          workflows,
-          allowedConnectorTypes,
-          allowedCustomConnectorIds,
-          timing,
-        });
+    return await set(
+      createAgentRunAfterZeroPreCreate$,
+      {
+        kind: "regular",
+        command: args,
+        agent,
+        userInfo,
+        relationshipMemoryEnabled,
+        relationshipMemoryRuntimeInjectionEnabled,
+        runPermissionPolicies,
+        triggerAgentId,
+        workflows,
+        allowedConnectorTypes,
+        allowedCustomConnectorIds,
+        timing,
       },
+      signal,
     );
-    signal.throwIfAborted();
-    return await set(createAgentRun$, createAgentRunArgs, signal);
   },
 );


### PR DESCRIPTION
## Summary

- split agent-run creation into explicit typed prepare and complete stages
- overlap runtime-memory/final-prompt assembly with organization-tier and side-effect-free run-context preparation for regular and integration Zero runs
- preserve the sequential non-Zero interface and finalize the exact prompt before admission, dispatch, or persistence

## Compatibility and scope

- no schema, migration, persisted-state format, public API, queue payload, or runner protocol changes
- runtime memory still starts after the existing authorization, trigger, connector, workflow, permission, and abort gates
- retrieval behavior and all payload/storage work remain unchanged and outside the concurrent preparation boundary

## Validation

- `pnpm format`
- `pnpm turbo run lint`
- `pnpm check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/chat-messages.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/test-telegram-dispatch-probe.test.ts`
- `pnpm vitest run --maxWorkers=4 --silent=passed-only` (594 files passed, 7391 tests passed, 1 existing skip)
- `pnpm knip`
- `git diff --check`

Closes #21210

Parent context: #18746
