### PR TITLE
fix(vsock-guest): keep process signaling before child reap

### DIFF
--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -20,7 +20,7 @@ use crate::exec_control::ExecControlGuard;
 use crate::log::log;
 use crate::process::{
     ProcessTreeKillTarget, extract_exit_code, kill_and_reap_child_with_target,
-    kill_process_tree_target, process_tree_kill_target, refresh_process_tree_kill_target,
+    process_tree_kill_target, refresh_process_tree_kill_target,
 };
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{
@@ -597,14 +597,26 @@ impl RunningExec {
         } = self;
 
         refresh_process_tree_kill_target(&mut kill_target);
+        let stdin_writer_pending = || {
+            let Some(writer) = stdin_writer.as_ref() else {
+                return false;
+            };
+            if matches!(writer.done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)) {
+                request_stdin_writer_cancel(writer);
+                true
+            } else {
+                false
+            }
+        };
         let outcome = wait_with_kill_timeout_or_cancelled_either_with_target(
             child,
             kill_target,
             request.timeout.wait_timeout_ms(),
             connection_cancel,
             exec_cancel,
+            stdin_writer_pending,
         );
-        join_stdin_writer_after_wait(stdin_writer, kill_target, request.seq, &request.label);
+        join_stdin_writer_after_wait(stdin_writer, request.seq, &request.label);
         if matches!(outcome, WaitOutcome::Cancelled | WaitOutcome::TimedOut)
             || connection_cancel.load(Ordering::Acquire)
             || exec_cancel.load(Ordering::Acquire)
@@ -1294,12 +1306,7 @@ fn is_stdin_write_cancelled(error: &io::Error) -> bool {
     error.kind() == io::ErrorKind::Interrupted && error.to_string() == STDIN_WRITE_CANCELLED
 }
 
-fn join_stdin_writer_after_wait(
-    writer: Option<StdinWriter>,
-    kill_target: ProcessTreeKillTarget,
-    seq: u32,
-    label: &str,
-) {
+fn join_stdin_writer_after_wait(writer: Option<StdinWriter>, seq: u32, label: &str) {
     let Some(writer) = writer else {
         return;
     };
@@ -1308,7 +1315,6 @@ fn join_stdin_writer_after_wait(
         // keep stdin open. Stop the writer before joining it so bounded stdin
         // cannot strand this worker thread.
         request_stdin_writer_cancel(&writer);
-        let _ = unsafe { kill_process_tree_target(kill_target) };
     }
     join_stdin_writer(writer, seq, label);
 }

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -597,7 +597,7 @@ impl RunningExec {
         } = self;
 
         refresh_process_tree_kill_target(&mut kill_target);
-        let stdin_writer_pending = || {
+        let prepare_stdin_writer_for_pre_reap = || {
             let Some(writer) = stdin_writer.as_ref() else {
                 return false;
             };
@@ -614,7 +614,7 @@ impl RunningExec {
             request.timeout.wait_timeout_ms(),
             connection_cancel,
             exec_cancel,
-            stdin_writer_pending,
+            prepare_stdin_writer_for_pre_reap,
         );
         join_stdin_writer_after_wait(stdin_writer, request.seq, &request.label);
         if matches!(outcome, WaitOutcome::Cancelled | WaitOutcome::TimedOut)

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -14,13 +14,11 @@ use vsock_proto::{
 use crate::drain::drain_into_vec_cancellable;
 use crate::error::to_io_error;
 use crate::log::log;
-use crate::process::{
-    extract_exit_code, kill_and_reap_child, kill_process_tree, spawn_in_own_process_group,
-};
+use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
 use crate::shutdown::handle_shutdown;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
 use crate::user::apply_write_file_identity;
-use crate::wait::{WaitOutcome, await_drain_deadline, wait_with_kill_timeout};
+use crate::wait::{WaitOutcome, await_drain_deadline, wait_with_kill_timeout_and_pre_reap_cleanup};
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
 const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
@@ -106,7 +104,6 @@ fn wait_write_file_child_with_timeout<S>(
 where
     S: ThreadSpawner,
 {
-    let child_pid = child.id();
     let stdin_pipe = match child.stdin.take() {
         Some(p) => p,
         None => {
@@ -170,19 +167,12 @@ where
             }
         };
 
-        let outcome = wait_with_kill_timeout(child, timeout_ms);
-        if matches!(outcome, WaitOutcome::Exited(_) | WaitOutcome::WaitFailed(_))
-            && matches!(
+        let outcome = wait_with_kill_timeout_and_pre_reap_cleanup(child, timeout_ms, || {
+            matches!(
                 stdin_done_rx.try_recv(),
                 Err(std::sync::mpsc::TryRecvError::Empty)
             )
-        {
-            // The direct helper exited, but a descendant may still hold the
-            // stdin pipe open without reading from it. Kill the helper's
-            // process group before joining the writer, otherwise write_all()
-            // can block forever on a full pipe.
-            let _ = unsafe { kill_process_tree(child_pid) };
-        }
+        });
         let stdin_result = match stdin_handle.join() {
             Ok(result) => result,
             Err(panic) => std::panic::resume_unwind(panic),
@@ -377,6 +367,13 @@ fn encode_error_response(seq: u32, message: &str) -> io::Result<MessageOutcome> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
+    use std::io::{BufRead, BufReader};
+    #[cfg(target_os = "linux")]
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[cfg(target_os = "linux")]
+    use crate::test_support::{kill_pidfd_and_wait, open_pidfd, wait_for_pidfd_exit};
     use crate::threading::test_support::FailingThreadSpawner;
     use std::sync::Mutex;
 
@@ -409,8 +406,7 @@ mod tests {
         let pid = child.id();
 
         let pgid = unsafe { libc::getpgid(pid as libc::pid_t) };
-        let _ = unsafe { crate::process::kill_process_tree(pid) };
-        let _ = wait_with_kill_timeout(child, 100);
+        kill_and_reap_child(child);
 
         assert_eq!(pgid, pid as libc::pid_t);
     }
@@ -468,18 +464,75 @@ mod tests {
         assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn write_file_kills_lingering_process_group_after_parent_exit() {
         let _guard = WRITE_FILE_CHILD_TESTS.lock().unwrap();
-        let child = spawn_write_file_test_child("sleep 60 <&0 >/dev/null 2>/dev/null & exit 0");
+        let fifo_path = std::env::temp_dir().join(format!(
+            "vsock-write-file-stdin-{}-{}.fifo",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg(
+                "mkfifo \"$FIFO\"; \
+                 exec 3<&0; \
+                 sleep 60 <&3 >/dev/null 2>/dev/null & \
+                 printf '%s\\n' \"$!\"; \
+                 exec 3<&-; \
+                 read _ < \"$FIFO\"; \
+                 rm -f \"$FIFO\"; \
+                 exit 0",
+            )
+            .env("FIFO", &fifo_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = spawn_in_own_process_group(&mut command).unwrap();
         let pid = child.id();
+        let stdout = child.stdout.take().unwrap();
+        let mut descendant_pid = String::new();
+        BufReader::new(stdout)
+            .read_line(&mut descendant_pid)
+            .unwrap();
+        let descendant_pid = descendant_pid.trim().parse::<libc::pid_t>().unwrap();
+        let descendant_pidfd = open_pidfd(descendant_pid).unwrap();
+        let mut fifo = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&fifo_path)
+            .unwrap();
+        writeln!(fifo, "exit").unwrap();
+        drop(fifo);
         let content = vec![b'x'; 1024 * 1024];
 
         let (success, error) =
             wait_write_file_child_with_timeout(child, &content, 1_000, SystemThreadSpawner);
+        let _ = std::fs::remove_file(&fifo_path);
 
         assert!(!success);
         assert!(error.contains("Failed to write to stdin"), "got: {error}");
         assert!(!pid_alive(pid), "child pid {pid} should have been reaped");
+        match wait_for_pidfd_exit(&descendant_pidfd, Duration::from_secs(2)) {
+            Ok(true) => {}
+            Ok(false) => {
+                kill_pidfd_and_wait(&descendant_pidfd).unwrap_or_else(|cleanup| {
+                    panic!(
+                        "failed to clean up lingering descendant pid {descendant_pid}: {cleanup}"
+                    )
+                });
+                panic!("lingering descendant pid {descendant_pid} should be terminated");
+            }
+            Err(error) => {
+                let cleanup = kill_pidfd_and_wait(&descendant_pidfd);
+                panic!(
+                    "failed to wait for lingering descendant pid {descendant_pid}: {error}; cleanup={cleanup:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -234,7 +234,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     use crate::test_support::{kill_pidfd_and_wait, open_pidfd, wait_for_pidfd_exit};
-    use crate::wait::{WaitOutcome, wait_with_kill_timeout};
+    use crate::wait::{WaitOutcome, wait_with_kill_timeout_and_pre_reap_cleanup};
 
     struct TempDirGuard(PathBuf);
 
@@ -536,7 +536,8 @@ mod tests {
             }
         };
 
-        let outcome = wait_with_kill_timeout(child.take().unwrap(), 100);
+        let outcome =
+            wait_with_kill_timeout_and_pre_reap_cleanup(child.take().unwrap(), 100, || false);
         if !matches!(outcome, WaitOutcome::TimedOut) {
             kill_pidfd_and_wait(&background_pidfd)
                 .unwrap_or_else(|e| panic!("failed to clean up background pidfd: {e}"));

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -102,18 +102,17 @@ fn find_child_pgid(parent_pid: u32) -> Option<u32> {
     None
 }
 
-#[derive(Clone, Copy)]
 pub(crate) struct ProcessTreeKillTarget {
     child_id: u32,
     child_pgid: Option<u32>,
 }
 
 impl ProcessTreeKillTarget {
-    pub(crate) fn child_id(self) -> u32 {
+    pub(crate) fn child_id(&self) -> u32 {
         self.child_id
     }
 
-    fn child_pgid_to_signal(self) -> Option<u32> {
+    fn child_pgid_to_signal(&self) -> Option<u32> {
         self.child_pgid
             .and_then(|pgid| signalable_child_pgid(self.child_id, pgid))
     }
@@ -139,24 +138,12 @@ pub(crate) fn refresh_process_tree_kill_target(target: &mut ProcessTreeKillTarge
     }
 }
 
-/// Kill a process group and, if `su -` created a child session, also kill
-/// that child's process group.
-///
-/// # Safety
-///
-/// `child_id` must be a valid PID from `Command::spawn()`.
-/// Returns `true` if any targeted process group was signalled.
-pub(crate) unsafe fn kill_process_tree(child_id: u32) -> bool {
-    // Find su's child PGID BEFORE killing — after kill, PPID changes to 1.
-    let target = process_tree_kill_target(child_id);
-    unsafe { kill_process_tree_target(target) }
-}
-
 /// Kill a previously snapshotted process tree target.
 ///
 /// # Safety
 ///
-/// `target.child_id` must come from a PID returned by `Command::spawn()`.
+/// `target.child_id` must come from a PID returned by `Command::spawn()`, and
+/// that direct child must not have been reaped since the target was captured.
 pub(crate) unsafe fn kill_process_tree_target(target: ProcessTreeKillTarget) -> bool {
     // Kill the direct child's process group (the su wrapper).
     let mut signalled = false;
@@ -576,7 +563,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn snapshotted_process_tree_target_kills_setsid_child_after_parent_exit() {
+    fn snapshotted_process_tree_target_kills_setsid_child_before_parent_reap() {
         use std::io::{BufRead, BufReader, Write};
         use std::os::unix::process::CommandExt;
 
@@ -654,6 +641,37 @@ mod tests {
                 panic!("failed to release parent fifo: {e}");
             }
         }
+        let direct_child_id = child.as_ref().unwrap().id();
+        // SAFETY: zeroed siginfo_t is valid for waitid to fill.
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        // SAFETY: direct_child_id belongs to the test-owned direct child.
+        // WNOWAIT proves it exited without releasing its PID before signaling.
+        let waitid_result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                direct_child_id as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if waitid_result != 0 {
+            let waitid_error = std::io::Error::last_os_error();
+            kill_spawned_child(&mut child);
+            kill_pidfd_and_wait(&child_pidfd).unwrap_or_else(|cleanup| {
+                panic!("waitid failed: {waitid_error}; cleanup={cleanup}")
+            });
+            panic!("failed to observe parent shell exit: {waitid_error}");
+        }
+
+        // SAFETY: `target` came from the spawned shell, and WNOWAIT kept its
+        // direct-child identity owned and unreaped.
+        if !unsafe { kill_process_tree_target(target) } {
+            kill_spawned_child(&mut child);
+            kill_pidfd_and_wait(&child_pidfd)
+                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
+            panic!("snapshotted target should signal at least one process group");
+        }
+
         let status = match child.take().unwrap().wait() {
             Ok(status) => status,
             Err(e) => {
@@ -668,12 +686,6 @@ mod tests {
             panic!("parent shell should exit successfully, got {status}");
         }
 
-        // SAFETY: `target` came from the spawned shell before it exited.
-        if !unsafe { kill_process_tree_target(target) } {
-            kill_pidfd_and_wait(&child_pidfd)
-                .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-            panic!("snapshotted target should signal at least one process group");
-        }
         match wait_for_pidfd_exit(&child_pidfd, Duration::from_secs(2)) {
             Ok(true) => {}
             Ok(false) => {

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::process::{Child, ExitStatus};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
@@ -15,8 +16,8 @@ use crate::threading::spawn_scoped_named;
 /// the terminal exec result anyway to prevent indefinite hangs when orphaned
 /// child processes hold pipe fds open.
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
-const WATCHDOG_CANCEL_POLL_INTERVAL_MS: u64 = 50;
-const THREAD_WAIT_WATCHDOG: &str = "vsock-wait-watchdog";
+const WAIT_CANCEL_POLL_INTERVAL_MS: u64 = 50;
+const THREAD_WAIT_OBSERVER: &str = "vsock-wait-observer";
 
 /// Outcome of child wait helpers.
 pub(crate) enum WaitOutcome {
@@ -35,9 +36,14 @@ enum KillReason {
     Cancelled,
 }
 
-struct WatchdogKill {
+struct ChildKill {
     reason: KillReason,
     killed: bool,
+}
+
+enum WaitDecision {
+    Exited,
+    Kill(KillReason),
 }
 
 /// Wait for drain workers to complete within the shared drain deadline, then
@@ -70,6 +76,7 @@ pub(crate) fn await_drain_deadline(
 /// `Child` and drain them concurrently (see [`drain_until_eof_or_cancelled`]),
 /// otherwise a child producing more than the kernel pipe buffer (~64 KB) will
 /// deadlock on its next write while we wait.
+#[cfg(test)]
 pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitOutcome {
     if timeout_ms == 0 {
         return match child.wait() {
@@ -78,8 +85,28 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
         };
     }
 
-    let cancel = AtomicBool::new(false);
-    wait_with_kill_timeout_or_cancelled(child, timeout_ms, &cancel)
+    wait_with_kill_timeout_and_pre_reap_cleanup(child, timeout_ms, || false)
+}
+
+/// Wait for `child` with an optional timeout, allowing the caller to request
+/// process-tree cleanup after natural exit is observed but before the direct
+/// child is reaped.
+///
+/// The callback returns `true` when a still-running descendant is holding a
+/// resource that must be released by killing the tracked process tree.
+pub(crate) fn wait_with_kill_timeout_and_pre_reap_cleanup(
+    child: Child,
+    timeout_ms: u32,
+    pre_reap_cleanup: impl FnMut() -> bool,
+) -> WaitOutcome {
+    let kill_target = process_tree_kill_target(child.id());
+    wait_with_kill_timeout_or_cancelled_by(
+        child,
+        kill_target,
+        timeout_ms,
+        || false,
+        pre_reap_cleanup,
+    )
 }
 
 /// Wait for `child` to exit, killing and reaping it when either the configured
@@ -88,19 +115,24 @@ pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitO
 /// `timeout_ms == 0` still means "no timeout"; cancellation remains active so
 /// work tied to a disconnected host connection cannot outlive that connection
 /// indefinitely.
+#[cfg(test)]
 pub(crate) fn wait_with_kill_timeout_or_cancelled(
     child: Child,
     timeout_ms: u32,
     cancel: &AtomicBool,
 ) -> WaitOutcome {
     let kill_target = process_tree_kill_target(child.id());
-    wait_with_kill_timeout_or_cancelled_by(child, kill_target, timeout_ms, || {
-        cancel.load(Ordering::Acquire)
-    })
+    wait_with_kill_timeout_or_cancelled_by(
+        child,
+        kill_target,
+        timeout_ms,
+        || cancel.load(Ordering::Acquire),
+        || false,
+    )
 }
 
-/// Like [`wait_with_kill_timeout_or_cancelled`], but observes either cancel
-/// flag and uses a kill target snapshotted before entering the wait path.
+/// Wait for `child` while observing either cancel flag and using a kill target
+/// snapshotted before entering the wait path.
 ///
 /// Exec operations have both connection-level cancellation and request-level
 /// cancellation, and they snapshot process-tree targets before stdio setup can
@@ -111,17 +143,23 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled_either_with_target(
     timeout_ms: u32,
     first_cancel: &AtomicBool,
     second_cancel: &AtomicBool,
+    pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
-    wait_with_kill_timeout_or_cancelled_by(child, kill_target, timeout_ms, || {
-        first_cancel.load(Ordering::Acquire) || second_cancel.load(Ordering::Acquire)
-    })
+    wait_with_kill_timeout_or_cancelled_by(
+        child,
+        kill_target,
+        timeout_ms,
+        || first_cancel.load(Ordering::Acquire) || second_cancel.load(Ordering::Acquire),
+        pre_reap_cleanup,
+    )
 }
 
 fn wait_with_kill_timeout_or_cancelled_by(
     mut child: Child,
     mut kill_target: ProcessTreeKillTarget,
     timeout_ms: u32,
-    is_cancelled: impl Fn() -> bool + Copy + Send + Sync,
+    is_cancelled: impl Fn() -> bool,
+    mut pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
     let child_id = child.id();
     debug_assert_eq!(kill_target.child_id(), child_id);
@@ -137,54 +175,89 @@ fn wait_with_kill_timeout_or_cancelled_by(
     };
 
     thread::scope(|scope| {
-        let (done_tx, done_rx) = mpsc::channel::<()>();
-        let watchdog = match spawn_scoped_named(scope, THREAD_WAIT_WATCHDOG, move || {
-            wait_for_done_timeout_or_cancelled(done_rx, deadline, is_cancelled, kill_target)
+        let (observed_tx, observed_rx) = mpsc::channel::<()>();
+        let observer = match spawn_scoped_named(scope, THREAD_WAIT_OBSERVER, move || {
+            let result = wait_for_child_exit_without_reap(child_id);
+            let _ = observed_tx.send(());
+            result
         }) {
-            Ok(watchdog) => watchdog,
+            Ok(observer) => observer,
             Err(e) => {
-                // If the watchdog cannot be created, timeout/cancel can no
-                // longer be enforced. Kill and reap the child instead of
-                // letting it outlive the failed wait helper.
+                // Without a non-reaping observer, natural exit cannot be
+                // distinguished safely from timeout/cancel before reap.
                 kill_and_reap_child_with_target(child, kill_target);
-                return WaitOutcome::WaitFailed(format!("failed to spawn wait watchdog: {e}"));
+                return WaitOutcome::WaitFailed(format!("failed to spawn wait observer: {e}"));
             }
         };
 
-        let status = child.wait();
-        let _ = done_tx.send(());
-        let watchdog_kill = match watchdog.join() {
-            Ok(watchdog_kill) => watchdog_kill,
-            Err(panic) => std::panic::resume_unwind(panic),
-        };
+        match wait_for_exit_timeout_or_cancelled(&observed_rx, deadline, is_cancelled) {
+            WaitDecision::Exited => {
+                let observed = match observer.join() {
+                    Ok(observed) => observed,
+                    Err(panic) => {
+                        kill_and_reap_child_with_target(child, kill_target);
+                        std::panic::resume_unwind(panic);
+                    }
+                };
+                if let Err(e) = observed {
+                    kill_and_reap_child_with_target(child, kill_target);
+                    return WaitOutcome::WaitFailed(format!(
+                        "failed to observe child exit without reaping: {e}"
+                    ));
+                }
 
-        match status {
-            Err(e) => WaitOutcome::WaitFailed(e.to_string()),
-            Ok(status) => match watchdog_kill {
-                Some(WatchdogKill {
-                    reason,
-                    killed: true,
-                }) => match reason {
+                if pre_reap_cleanup() {
+                    refresh_process_tree_kill_target(&mut kill_target);
+                    // SAFETY: the exit observer used WNOWAIT, so this owner
+                    // still holds the unreaped direct child identity.
+                    let _ = unsafe { kill_process_tree_target(kill_target) };
+                }
+
+                match child.wait() {
+                    Ok(status) => WaitOutcome::Exited(status),
+                    Err(e) => WaitOutcome::WaitFailed(e.to_string()),
+                }
+            }
+            WaitDecision::Kill(reason) => {
+                let child_kill = kill_child(&mut child, kill_target, reason);
+                let observed = observer.join();
+                let status = child.wait();
+
+                let observed = match observed {
+                    Ok(observed) => observed,
+                    Err(panic) => std::panic::resume_unwind(panic),
+                };
+                let status = match status {
+                    Ok(status) => status,
+                    Err(e) => return WaitOutcome::WaitFailed(e.to_string()),
+                };
+                if let Err(e) = observed {
+                    return WaitOutcome::WaitFailed(format!(
+                        "failed to observe child exit without reaping: {e}"
+                    ));
+                }
+                if !child_kill.killed {
+                    return WaitOutcome::Exited(status);
+                }
+                match child_kill.reason {
                     KillReason::Timeout => WaitOutcome::TimedOut,
                     KillReason::Cancelled => WaitOutcome::Cancelled,
-                },
-                _ => WaitOutcome::Exited(status),
-            },
+                }
+            }
         }
     })
 }
 
-fn wait_for_done_timeout_or_cancelled(
-    done_rx: mpsc::Receiver<()>,
+fn wait_for_exit_timeout_or_cancelled(
+    observed_rx: &mpsc::Receiver<()>,
     deadline: Option<Instant>,
     is_cancelled: impl Fn() -> bool,
-    kill_target: ProcessTreeKillTarget,
-) -> Option<WatchdogKill> {
-    let poll_interval = Duration::from_millis(WATCHDOG_CANCEL_POLL_INTERVAL_MS);
+) -> WaitDecision {
+    let poll_interval = Duration::from_millis(WAIT_CANCEL_POLL_INTERVAL_MS);
 
     loop {
-        if wait_done(&done_rx) {
-            return None;
+        if exit_observed(observed_rx) {
+            return WaitDecision::Exited;
         }
 
         let now = Instant::now();
@@ -192,7 +265,7 @@ fn wait_for_done_timeout_or_cancelled(
             Some(deadline) => {
                 let remaining = deadline.saturating_duration_since(now);
                 if remaining.is_zero() {
-                    return kill_child_unless_done(&done_rx, kill_target, KillReason::Timeout);
+                    return WaitDecision::Kill(KillReason::Timeout);
                 }
                 remaining.min(poll_interval)
             }
@@ -200,48 +273,63 @@ fn wait_for_done_timeout_or_cancelled(
         };
 
         if is_cancelled() {
-            return kill_child_unless_done(&done_rx, kill_target, KillReason::Cancelled);
+            return WaitDecision::Kill(KillReason::Cancelled);
         }
 
-        match done_rx.recv_timeout(wait_for) {
-            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return None,
+        match observed_rx.recv_timeout(wait_for) {
+            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return WaitDecision::Exited;
+            }
             Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
     }
 }
 
-fn wait_done(done_rx: &mpsc::Receiver<()>) -> bool {
-    match done_rx.try_recv() {
+fn exit_observed(observed_rx: &mpsc::Receiver<()>) -> bool {
+    match observed_rx.try_recv() {
         Ok(()) | Err(mpsc::TryRecvError::Disconnected) => true,
         Err(mpsc::TryRecvError::Empty) => false,
     }
 }
 
-fn kill_child_unless_done(
-    done_rx: &mpsc::Receiver<()>,
-    mut kill_target: ProcessTreeKillTarget,
-    reason: KillReason,
-) -> Option<WatchdogKill> {
-    if wait_done(done_rx) {
-        None
-    } else {
-        refresh_process_tree_kill_target(&mut kill_target);
-        if wait_done(done_rx) {
-            return None;
+fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
+    let child_id = process_signal_pid(child_id)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid child pid"))?;
+    // SAFETY: zeroed siginfo_t is valid for waitid to fill.
+    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    loop {
+        // SAFETY: child_id belongs to a direct child owned by this process.
+        // WNOWAIT observes its terminal state without releasing its PID.
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child_id as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(());
         }
-        Some(kill_child(kill_target, reason))
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
     }
 }
 
-fn kill_child(kill_target: ProcessTreeKillTarget, reason: KillReason) -> WatchdogKill {
-    let child_id = kill_target.child_id();
-    // SAFETY: kill_target comes from a PID returned by Command::spawn.
+fn kill_child(
+    child: &mut Child,
+    mut kill_target: ProcessTreeKillTarget,
+    reason: KillReason,
+) -> ChildKill {
+    refresh_process_tree_kill_target(&mut kill_target);
+    // SAFETY: this owner has not reaped child, so its PID/process group cannot
+    // have been reused since kill_target was captured.
     let tree_killed = unsafe { kill_process_tree_target(kill_target) };
-    let child_killed = process_signal_pid(child_id)
-        // SAFETY: child_id is a process id from Command::spawn and was validated as pid_t.
-        .is_some_and(|pid| unsafe { libc::kill(pid, libc::SIGKILL) == 0 });
+    let child_killed = child.kill().is_ok();
     let killed = tree_killed || child_killed;
-    WatchdogKill { reason, killed }
+    ChildKill { reason, killed }
 }
 
 #[cfg(test)]
@@ -321,9 +409,10 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
-    fn kill_spawned_child_with_watchdog(child: &mut Option<Child>) {
+    fn kill_spawned_child(child: &mut Option<Child>) {
         if let Some(mut child) = child.take() {
-            kill_child(process_tree_kill_target(child.id()), KillReason::Cancelled);
+            let target = process_tree_kill_target(child.id());
+            let _ = kill_child(&mut child, target, KillReason::Cancelled);
             let _ = child.wait();
         }
     }
@@ -362,10 +451,10 @@ mod tests {
 
         let overhead = timed_total.saturating_sub(baseline_total);
         let allowed_overhead =
-            Duration::from_millis(WATCHDOG_CANCEL_POLL_INTERVAL_MS * u64::from(iterations) / 2);
+            Duration::from_millis(WAIT_CANCEL_POLL_INTERVAL_MS * u64::from(iterations) / 2);
         assert!(
             overhead < allowed_overhead,
-            "timed waits should not accumulate the {WATCHDOG_CANCEL_POLL_INTERVAL_MS}ms cancel \
+            "timed waits should not accumulate the {WAIT_CANCEL_POLL_INTERVAL_MS}ms cancel \
              poll interval per child; {iterations} timed waits took {timed_total:?}, baseline \
              waits took {baseline_total:?}, overhead was {overhead:?}",
         );
@@ -418,41 +507,61 @@ mod tests {
     }
 
     #[test]
-    fn watchdog_done_signal_wins_over_elapsed_deadline() {
+    fn observed_exit_wins_over_elapsed_deadline() {
         let cancel = AtomicBool::new(false);
-        let (done_tx, done_rx) = mpsc::channel::<()>();
-        done_tx.send(()).unwrap();
+        let (observed_tx, observed_rx) = mpsc::channel::<()>();
+        observed_tx.send(()).unwrap();
 
-        let outcome = wait_for_done_timeout_or_cancelled(
-            done_rx,
-            Some(Instant::now()),
-            || cancel.load(Ordering::Acquire),
-            process_tree_kill_target(i32::MAX as u32),
-        );
+        let decision =
+            wait_for_exit_timeout_or_cancelled(&observed_rx, Some(Instant::now()), || {
+                cancel.load(Ordering::Acquire)
+            });
 
-        assert!(outcome.is_none());
+        assert!(matches!(decision, WaitDecision::Exited));
     }
 
     #[test]
-    fn watchdog_done_signal_wins_over_pre_signalled_cancel() {
+    fn observed_exit_wins_over_pre_signalled_cancel() {
         let cancel = AtomicBool::new(true);
-        let (done_tx, done_rx) = mpsc::channel::<()>();
-        done_tx.send(()).unwrap();
+        let (observed_tx, observed_rx) = mpsc::channel::<()>();
+        observed_tx.send(()).unwrap();
 
-        let outcome = wait_for_done_timeout_or_cancelled(
-            done_rx,
-            None,
-            || cancel.load(Ordering::Acquire),
-            process_tree_kill_target(i32::MAX as u32),
-        );
+        let decision = wait_for_exit_timeout_or_cancelled(&observed_rx, None, || {
+            cancel.load(Ordering::Acquire)
+        });
 
-        assert!(outcome.is_none());
+        assert!(matches!(decision, WaitDecision::Exited));
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn watchdog_kill_refreshes_stale_process_tree_target_before_signal() {
-        let (dir, _guard) = temp_dir("watchdog-refresh");
+    fn natural_exit_cleanup_runs_before_direct_child_is_reaped() {
+        let mut command = Command::new("true");
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+        command.process_group(0);
+        let child = command.spawn().unwrap();
+        let child_id = child.id();
+        let mut cleanup_called = false;
+
+        let outcome = wait_with_kill_timeout_and_pre_reap_cleanup(child, 30_000, || {
+            cleanup_called = true;
+            let stat = std::fs::read_to_string(format!("/proc/{child_id}/stat"))
+                .expect("unreaped direct child should remain visible in procfs");
+            let state = stat
+                .rsplit_once(") ")
+                .and_then(|(_, fields)| fields.chars().next());
+            assert_eq!(state, Some('Z'), "observed child should be waitable");
+            false
+        });
+
+        assert!(cleanup_called);
+        assert!(matches!(outcome, WaitOutcome::Exited(status) if status.success()));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn owner_kill_refreshes_stale_process_tree_target_before_signal() {
+        let (dir, _guard) = temp_dir("owner-kill-refresh");
         let fifo = dir.join("parent-fifo");
         let ready = dir.join("ready");
         let child_pid_path = dir.join("setsid-child-pid");
@@ -478,7 +587,7 @@ mod tests {
 
         let mut child = Some(command.spawn().unwrap());
         if !wait_for_path(&ready, Duration::from_secs(2)) {
-            kill_spawned_child_with_watchdog(&mut child);
+            kill_spawned_child(&mut child);
             panic!("parent should block before spawning the setsid child");
         }
 
@@ -487,12 +596,12 @@ mod tests {
             let mut fifo_writer = match std::fs::OpenOptions::new().write(true).open(&fifo) {
                 Ok(writer) => writer,
                 Err(e) => {
-                    kill_spawned_child_with_watchdog(&mut child);
+                    kill_spawned_child(&mut child);
                     panic!("failed to open parent fifo: {e}");
                 }
             };
             if let Err(e) = writeln!(fifo_writer, "go") {
-                kill_spawned_child_with_watchdog(&mut child);
+                kill_spawned_child(&mut child);
                 panic!("failed to write parent fifo: {e}");
             }
         }
@@ -503,34 +612,32 @@ mod tests {
                 None => {
                     let child_pid_text =
                         std::fs::read_to_string(&child_pid_path).unwrap_or_default();
-                    kill_spawned_child_with_watchdog(&mut child);
+                    kill_spawned_child(&mut child);
                     panic!("failed to parse setsid child pid {child_pid_text:?}");
                 }
             };
         if child_pid <= 0 {
-            kill_spawned_child_with_watchdog(&mut child);
+            kill_spawned_child(&mut child);
             panic!("setsid child pid should be positive, got {child_pid}");
         }
         let child_pidfd = match open_pidfd(child_pid) {
             Ok(pidfd) => pidfd,
             Err(e) => {
-                kill_spawned_child_with_watchdog(&mut child);
+                kill_spawned_child(&mut child);
                 // SAFETY: best-effort cleanup of a test-owned process.
                 let _ = unsafe { libc::kill(child_pid, libc::SIGKILL) };
                 panic!("failed to open pidfd for setsid child pid {child_pid}: {e}");
             }
         };
 
-        let (_done_tx, done_rx) = mpsc::channel::<()>();
-        let watchdog_kill = kill_child_unless_done(&done_rx, stale_target, KillReason::Timeout)
-            .expect("watchdog should kill when done is not signalled");
-        if !watchdog_kill.killed {
-            kill_spawned_child_with_watchdog(&mut child);
+        let child_kill = kill_child(child.as_mut().unwrap(), stale_target, KillReason::Timeout);
+        if !child_kill.killed {
+            kill_spawned_child(&mut child);
             kill_pidfd_and_wait(&child_pidfd)
                 .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
-            panic!("watchdog kill should signal at least one process target");
+            panic!("owner kill should signal at least one process target");
         }
-        assert!(matches!(watchdog_kill.reason, KillReason::Timeout));
+        assert!(matches!(child_kill.reason, KillReason::Timeout));
         let _ = child.take().unwrap().wait().unwrap();
 
         match wait_for_pidfd_exit(&child_pidfd, Duration::from_secs(2)) {
@@ -539,7 +646,7 @@ mod tests {
                 kill_pidfd_and_wait(&child_pidfd)
                     .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
                 panic!(
-                    "watchdog kill should terminate delayed setsid child pid {child_pid} after refreshing stale target"
+                    "owner kill should terminate delayed setsid child pid {child_pid} after refreshing stale target"
                 );
             }
             Err(e) => {

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -36,11 +36,6 @@ enum KillReason {
     Cancelled,
 }
 
-struct ChildKill {
-    reason: KillReason,
-    killed: bool,
-}
-
 enum WaitDecision {
     Exited,
     Kill(KillReason),
@@ -184,7 +179,7 @@ fn wait_with_kill_timeout_or_cancelled_by(
                 }
             }
             WaitDecision::Kill(reason) => {
-                let child_kill = kill_child(&mut child, kill_target, reason);
+                let child_killed = kill_child(&mut child, kill_target);
                 let observed = observer.join();
                 let status = child.wait();
 
@@ -201,10 +196,10 @@ fn wait_with_kill_timeout_or_cancelled_by(
                         "failed to observe child exit without reaping: {e}"
                     ));
                 }
-                if !child_kill.killed {
+                if !child_killed {
                     return WaitOutcome::Exited(status);
                 }
-                match child_kill.reason {
+                match reason {
                     KillReason::Timeout => WaitOutcome::TimedOut,
                     KillReason::Cancelled => WaitOutcome::Cancelled,
                 }
@@ -293,17 +288,12 @@ fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
     }
 }
 
-fn kill_child(
-    child: &mut Child,
-    kill_target: ProcessTreeKillTarget,
-    reason: KillReason,
-) -> ChildKill {
+fn kill_child(child: &mut Child, kill_target: ProcessTreeKillTarget) -> bool {
     // SAFETY: this owner has not reaped child, so its PID/process group cannot
     // have been reused since the owner refreshed kill_target.
     let tree_killed = unsafe { kill_process_tree_target(kill_target) };
     let child_killed = child.kill().is_ok();
-    let killed = tree_killed || child_killed;
-    ChildKill { reason, killed }
+    tree_killed || child_killed
 }
 
 #[cfg(test)]
@@ -387,7 +377,7 @@ mod tests {
         if let Some(mut child) = child.take() {
             let mut target = process_tree_kill_target(child.id());
             refresh_process_tree_kill_target(&mut target);
-            let _ = kill_child(&mut child, target, KillReason::Cancelled);
+            let _ = kill_child(&mut child, target);
             let _ = child.wait();
         }
     }
@@ -643,18 +633,13 @@ mod tests {
 
         let mut refreshed_target = stale_target;
         refresh_process_tree_kill_target(&mut refreshed_target);
-        let child_kill = kill_child(
-            child.as_mut().unwrap(),
-            refreshed_target,
-            KillReason::Timeout,
-        );
-        if !child_kill.killed {
+        let child_killed = kill_child(child.as_mut().unwrap(), refreshed_target);
+        if !child_killed {
             kill_spawned_child(&mut child);
             kill_pidfd_and_wait(&child_pidfd)
                 .unwrap_or_else(|e| panic!("failed to clean up setsid child pidfd: {e}"));
             panic!("owner kill should signal at least one process target");
         }
-        assert!(matches!(child_kill.reason, KillReason::Timeout));
         let _ = child.take().unwrap().wait().unwrap();
 
         match wait_for_pidfd_exit(&child_pidfd, Duration::from_secs(2)) {

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -190,7 +190,13 @@ fn wait_with_kill_timeout_or_cancelled_by(
             }
         };
 
-        match wait_for_exit_timeout_or_cancelled(&observed_rx, deadline, is_cancelled) {
+        let mut decision = wait_for_exit_timeout_or_cancelled(&observed_rx, deadline, is_cancelled);
+        if matches!(&decision, WaitDecision::Kill(_)) {
+            refresh_process_tree_kill_target(&mut kill_target);
+            decision = apply_final_exit_priority(decision, &observed_rx);
+        }
+
+        match decision {
             WaitDecision::Exited => {
                 let observed = match observer.join() {
                     Ok(observed) => observed,
@@ -292,6 +298,16 @@ fn exit_observed(observed_rx: &mpsc::Receiver<()>) -> bool {
     }
 }
 
+fn apply_final_exit_priority(
+    decision: WaitDecision,
+    observed_rx: &mpsc::Receiver<()>,
+) -> WaitDecision {
+    match decision {
+        WaitDecision::Kill(_) if exit_observed(observed_rx) => WaitDecision::Exited,
+        decision => decision,
+    }
+}
+
 fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
     let child_id = process_signal_pid(child_id)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid child pid"))?;
@@ -320,12 +336,11 @@ fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
 
 fn kill_child(
     child: &mut Child,
-    mut kill_target: ProcessTreeKillTarget,
+    kill_target: ProcessTreeKillTarget,
     reason: KillReason,
 ) -> ChildKill {
-    refresh_process_tree_kill_target(&mut kill_target);
     // SAFETY: this owner has not reaped child, so its PID/process group cannot
-    // have been reused since kill_target was captured.
+    // have been reused since the owner refreshed kill_target.
     let tree_killed = unsafe { kill_process_tree_target(kill_target) };
     let child_killed = child.kill().is_ok();
     let killed = tree_killed || child_killed;
@@ -411,7 +426,8 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn kill_spawned_child(child: &mut Option<Child>) {
         if let Some(mut child) = child.take() {
-            let target = process_tree_kill_target(child.id());
+            let mut target = process_tree_kill_target(child.id());
+            refresh_process_tree_kill_target(&mut target);
             let _ = kill_child(&mut child, target, KillReason::Cancelled);
             let _ = child.wait();
         }
@@ -533,6 +549,17 @@ mod tests {
         assert!(matches!(decision, WaitDecision::Exited));
     }
 
+    #[test]
+    fn final_observed_exit_wins_over_pending_kill_decision() {
+        let (observed_tx, observed_rx) = mpsc::channel::<()>();
+        observed_tx.send(()).unwrap();
+
+        let decision =
+            apply_final_exit_priority(WaitDecision::Kill(KillReason::Timeout), &observed_rx);
+
+        assert!(matches!(decision, WaitDecision::Exited));
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     fn natural_exit_cleanup_runs_before_direct_child_is_reaped() {
@@ -630,7 +657,13 @@ mod tests {
             }
         };
 
-        let child_kill = kill_child(child.as_mut().unwrap(), stale_target, KillReason::Timeout);
+        let mut refreshed_target = stale_target;
+        refresh_process_tree_kill_target(&mut refreshed_target);
+        let child_kill = kill_child(
+            child.as_mut().unwrap(),
+            refreshed_target,
+            KillReason::Timeout,
+        );
         if !child_kill.killed {
             kill_spawned_child(&mut child);
             kill_pidfd_and_wait(&child_pidfd)

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -69,25 +69,6 @@ pub(crate) fn await_drain_deadline(
     completed
 }
 
-/// Wait for `child` to exit, optionally killing it after `timeout_ms`.
-/// `timeout_ms == 0` means "no timeout".
-///
-/// This **does not touch stdout/stderr** — caller must take them off the
-/// `Child` and drain them concurrently (see [`drain_until_eof_or_cancelled`]),
-/// otherwise a child producing more than the kernel pipe buffer (~64 KB) will
-/// deadlock on its next write while we wait.
-#[cfg(test)]
-pub(crate) fn wait_with_kill_timeout(mut child: Child, timeout_ms: u32) -> WaitOutcome {
-    if timeout_ms == 0 {
-        return match child.wait() {
-            Ok(status) => WaitOutcome::Exited(status),
-            Err(e) => WaitOutcome::WaitFailed(e.to_string()),
-        };
-    }
-
-    wait_with_kill_timeout_and_pre_reap_cleanup(child, timeout_ms, || false)
-}
-
 /// Wait for `child` with an optional timeout, allowing the caller to request
 /// process-tree cleanup after natural exit is observed but before the direct
 /// child is reaped.
@@ -106,28 +87,6 @@ pub(crate) fn wait_with_kill_timeout_and_pre_reap_cleanup(
         timeout_ms,
         || false,
         pre_reap_cleanup,
-    )
-}
-
-/// Wait for `child` to exit, killing and reaping it when either the configured
-/// timeout expires or `cancel` is signalled.
-///
-/// `timeout_ms == 0` still means "no timeout"; cancellation remains active so
-/// work tied to a disconnected host connection cannot outlive that connection
-/// indefinitely.
-#[cfg(test)]
-pub(crate) fn wait_with_kill_timeout_or_cancelled(
-    child: Child,
-    timeout_ms: u32,
-    cancel: &AtomicBool,
-) -> WaitOutcome {
-    let kill_target = process_tree_kill_target(child.id());
-    wait_with_kill_timeout_or_cancelled_by(
-        child,
-        kill_target,
-        timeout_ms,
-        || cancel.load(Ordering::Acquire),
-        || false,
     )
 }
 
@@ -440,13 +399,20 @@ mod tests {
         let mut timed_total = Duration::default();
 
         fn wait_for_fast_child(timeout_ms: u32) -> Duration {
-            let child = Command::new("true")
+            let mut child = Command::new("true")
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .spawn()
                 .unwrap();
             let start = Instant::now();
-            let outcome = wait_with_kill_timeout(child, timeout_ms);
+            let outcome = if timeout_ms == 0 {
+                match child.wait() {
+                    Ok(status) => WaitOutcome::Exited(status),
+                    Err(e) => WaitOutcome::WaitFailed(e.to_string()),
+                }
+            } else {
+                wait_with_kill_timeout_and_pre_reap_cleanup(child, timeout_ms, || false)
+            };
             let elapsed = start.elapsed();
             assert!(
                 matches!(outcome, WaitOutcome::Exited(status) if status.success()),
@@ -480,6 +446,7 @@ mod tests {
     fn timeout_zero_child_is_cancelled_by_external_cancel() {
         let cancel = Arc::new(AtomicBool::new(false));
         let cancel_for_thread = Arc::clone(&cancel);
+        let other_cancel = AtomicBool::new(false);
         let mut command = Command::new("sleep");
         command
             .arg("60")
@@ -491,12 +458,20 @@ mod tests {
             command.process_group(0);
         }
         let child = command.spawn().unwrap();
+        let kill_target = process_tree_kill_target(child.id());
 
         let cancel_thread = thread::spawn(move || {
             cancel_for_thread.store(true, Ordering::Release);
         });
 
-        let outcome = wait_with_kill_timeout_or_cancelled(child, 0, &cancel);
+        let outcome = wait_with_kill_timeout_or_cancelled_either_with_target(
+            child,
+            kill_target,
+            0,
+            &cancel,
+            &other_cancel,
+            || false,
+        );
         cancel_thread.join().unwrap();
 
         assert!(matches!(outcome, WaitOutcome::Cancelled));
@@ -505,6 +480,7 @@ mod tests {
     #[test]
     fn nonzero_timeout_child_is_cancelled_by_pre_signalled_cancel() {
         let cancel = AtomicBool::new(true);
+        let other_cancel = AtomicBool::new(false);
         let mut command = Command::new("sleep");
         command
             .arg("60")
@@ -516,8 +492,16 @@ mod tests {
             command.process_group(0);
         }
         let child = command.spawn().unwrap();
+        let kill_target = process_tree_kill_target(child.id());
 
-        let outcome = wait_with_kill_timeout_or_cancelled(child, 30_000, &cancel);
+        let outcome = wait_with_kill_timeout_or_cancelled_either_with_target(
+            child,
+            kill_target,
+            30_000,
+            &cancel,
+            &other_cancel,
+            || false,
+        );
 
         assert!(matches!(outcome, WaitOutcome::Cancelled));
     }

--- a/crates/vsock-guest/tests/connection/exec_stdin.rs
+++ b/crates/vsock-guest/tests/connection/exec_stdin.rs
@@ -115,7 +115,7 @@ fn exec_operation_returns_when_grandchild_holds_stdin_without_reading() {
     let orphan = OrphanProcessGuard::new("orphan-exec-operation-stdin");
     let stdin = vec![b'x'; vsock_proto::MAX_EXEC_STDIN_BYTES];
     let command = format!(
-        "sleep 30 <&0 >/dev/null 2>/dev/null & echo $! > '{}'; printf stdin-orphan-done",
+        "exec 3<&0; sleep 30 <&3 >/dev/null 2>/dev/null & echo $! > '{}'; exec 3<&-; printf stdin-orphan-done",
         orphan.pid_path()
     );
 
@@ -132,7 +132,6 @@ fn exec_operation_returns_when_grandchild_holds_stdin_without_reading() {
         elapsed < Duration::from_secs(DRAIN_DEADLINE_SECS),
         "exec result should not wait for an inherited stdin pipe, took {elapsed:?}",
     );
-
     finish_guest_connection(handle, host_stream);
 }
 


### PR DESCRIPTION
## Summary

- replace the signaling watchdog with a non-reaping `waitid(WNOWAIT)` observer so one owner retains the child, signaling target, and final reap
- make process-tree kill targets non-copyable and move write-helper and exec stdin cleanup before the direct child is reaped
- preserve fast natural exits, timeout/cancellation results, and bounded blocked-stdin cleanup with real-process regression coverage

## Scope

- Closes #21176
- Does not expand descendant process-group discovery; complete detached-group containment remains #21178
- Does not change the separate Codex app-server lifecycle tracked by #21177

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vsock-guest --all-targets --all-features -- -D warnings`
- `cargo doc -p vsock-guest --all-features --no-deps`
- `cargo test -p vsock-guest`
- repository pre-commit and commit-message hooks
