### PR TITLE
perf(nbd-cow): reduce default connection count

### DIFF
--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -47,7 +47,10 @@ pub use device::{
 pub const BLOCK_SIZE: usize = 4096;
 
 /// Default number of connections per NBD device.
-pub const NUM_CONNECTIONS: usize = 4;
+///
+/// Three balances connect latency with steady-state I/O while leaving two
+/// live connections after one connection is lost.
+pub const NUM_CONNECTIONS: usize = 3;
 
 /// Default write buffer flush threshold: 4MB.
 pub const DEFAULT_FLUSH_THRESHOLD: usize = 4 * 1024 * 1024;

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -605,10 +605,10 @@ async fn snapshot_restore_round_trip() {
 // DevicePool-specific tests (require root + nbd module)
 // ---------------------------------------------------------------------------
 
-/// Verify connect_device works with a specific device index.
+/// Verify a specifically connected device remains readable after one connection is lost.
 #[tokio::test(flavor = "multi_thread")]
 #[ignore]
-async fn connect_device_specific_index() {
+async fn connect_device_survives_connection_loss() {
     if !nbd_test_available() {
         return;
     }
@@ -668,6 +668,31 @@ async fn connect_device_specific_index() {
         false
     };
 
+    let read_after_connection_loss = if connected {
+        let lost_server = server_handles.remove(0);
+        lost_server.abort();
+        let _ = lost_server.await;
+        tokio::task::yield_now().await;
+
+        let device_path = format!("/dev/nbd{device_index}");
+        Some(
+            tokio::time::timeout(
+                Duration::from_secs(5),
+                tokio::task::spawn_blocking(move || {
+                    use std::os::unix::fs::FileExt;
+
+                    let device = fs::File::open(device_path)?;
+                    let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
+                    device.read_exact_at(&mut block, 0)?;
+                    Ok::<_, std::io::Error>(block)
+                }),
+            )
+            .await,
+        )
+    } else {
+        None
+    };
+
     // Clean up
     shutdown.cancel();
     for h in server_handles {
@@ -681,6 +706,16 @@ async fn connect_device_specific_index() {
 
     connect_result.expect("socketpair setup or connect_device");
     assert!(device_has_correct_size, "device should have correct size");
+    let block = read_after_connection_loss
+        .expect("connected device should be read")
+        .expect("read after connection loss should not time out")
+        .expect("read task should complete")
+        .expect("read after connection loss should succeed");
+    assert_eq!(
+        block,
+        vec![0_u8; nbd_cow::BLOCK_SIZE],
+        "read after connection loss should return base image data"
+    );
 }
 
 /// After destroy + release, the pool should not hand back the same device


### PR DESCRIPTION
## Summary

- reduce the internal NBD default from four connections to three
- retain two live connections after one connection is lost
- extend the real, root-required NBD integration test to close one server connection and verify bounded block-device I/O

Three was selected from measured candidates. On representative aarch64 metal, 100-cycle median connect time improved from 79.6 ms with four connections to 66.4 ms with three. Ten interleaved runner pairs improved median NBD create from 93 ms to 82 ms and median sandbox create from 128.5 ms to 120 ms. Two connections was rejected because focused random-read testing regressed median IOPS by about 19% versus four.

## Scope and compatibility

- no database schema, persisted state, API, queue payload, wire protocol, guest protocol, image format, kernel-module, or user configuration change
- no telemetry names or dimensions change
- old and new runners can overlap; each ephemeral NBD device keeps the connection set chosen when it is created
- rollback restores the constant to four and affects only newly created devices; no migration or cleanup job is required

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nbd-cow`
- `cargo clippy -p nbd-cow --all-targets --all-features -- -D warnings`
- `cargo test --no-run --release --target aarch64-unknown-linux-musl -p nbd-cow`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p nbd-cow --no-deps --all-features`
- aarch64 metal focused connection-loss test: 1 passed
- aarch64 metal full root-required NBD suite: 11 passed
- `pnpm runner:local` plus a real runner benchmark smoke: guest command succeeded, NBD create 67 ms, sandbox create 103 ms, and cleanup completed

Closes #21204

Parent context: #18746
