### PR TITLE
perf(guest-agent): export sidecars from one history snapshot

### DIFF
--- a/crates/guest-agent/src/session_history.rs
+++ b/crates/guest-agent/src/session_history.rs
@@ -125,6 +125,27 @@ pub(crate) enum SessionHistoryCheckpointSource {
     CodexZstd { encoded: Vec<u8> },
 }
 
+pub(crate) struct PreparedSessionHistorySidecar {
+    pub(crate) digest: SessionHistoryDigest,
+    source: PreparedSessionHistorySidecarSource,
+}
+
+enum PreparedSessionHistorySidecarSource {
+    Exportable(SessionHistoryCheckpointSource),
+    RawTooLarge { max_bytes: u64 },
+}
+
+impl PreparedSessionHistorySidecar {
+    pub(crate) fn into_source(self) -> Result<SessionHistoryCheckpointSource, AgentError> {
+        match self.source {
+            PreparedSessionHistorySidecarSource::Exportable(source) => Ok(source),
+            PreparedSessionHistorySidecarSource::RawTooLarge { max_bytes } => {
+                Err(session_history_exceeds_max_error(max_bytes))
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum SessionHistoryDigestError {
     Read(AgentError),
@@ -163,6 +184,34 @@ pub(crate) fn read_session_history_checkpoint_source_from_payload_bounded(
         source => source
             .read(Some(max_bytes))
             .map(SessionHistoryCheckpointSource::Decoded),
+    }
+}
+
+pub(crate) fn prepare_session_history_sidecar_from_payload_bounded(
+    payload: &str,
+    max_decoded_bytes: u64,
+    max_sidecar_bytes: u64,
+) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
+    match resolve_session_history_source(payload)? {
+        ResolvedSessionHistorySource::Codex(session) if session.is_zstd() => {
+            if session.encoded_len()? <= max_sidecar_bytes {
+                let encoded = session.into_zstd_bytes(max_sidecar_bytes)?;
+                let digest = digest_zstd_session_history_bytes(&encoded, max_decoded_bytes)?;
+                Ok(PreparedSessionHistorySidecar {
+                    digest,
+                    source: PreparedSessionHistorySidecarSource::Exportable(
+                        SessionHistoryCheckpointSource::CodexZstd { encoded },
+                    ),
+                })
+            } else {
+                ResolvedSessionHistorySource::Codex(session)
+                    .open_decoded_reader()?
+                    .prepare_sidecar(max_decoded_bytes, max_sidecar_bytes)
+            }
+        }
+        source => source
+            .open_decoded_reader()?
+            .prepare_sidecar(max_decoded_bytes, max_sidecar_bytes),
     }
 }
 
@@ -707,6 +756,27 @@ impl DecodedSessionHistoryReader {
             }
         }
     }
+
+    fn prepare_sidecar(
+        self,
+        max_decoded_bytes: u64,
+        max_sidecar_bytes: u64,
+    ) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
+        match self {
+            Self::Plain { path, reader } => prepare_session_history_sidecar_reader(
+                reader,
+                max_decoded_bytes,
+                max_sidecar_bytes,
+                |error| read_history_error(&path, error),
+            ),
+            Self::Zstd(reader) => prepare_session_history_sidecar_reader(
+                reader,
+                max_decoded_bytes,
+                max_sidecar_bytes,
+                zstd_session_history_error,
+            ),
+        }
+    }
 }
 
 fn zstd_session_history_error(source: io::Error) -> AgentError {
@@ -767,15 +837,81 @@ fn digest_history_reader(
         if size_bytes > max_bytes {
             return Err(SessionHistoryDigestError::ExceedsMaxBytes);
         }
-        let chunk = buffer
-            .get(..bytes_read)
-            .ok_or(SessionHistoryDigestError::ExceedsMaxBytes)?;
+        let chunk = buffer.get(..bytes_read).ok_or_else(|| {
+            SessionHistoryDigestError::Read(map_error(io::Error::other(
+                "session history reader returned more bytes than the provided buffer",
+            )))
+        })?;
         hasher.update(chunk);
     }
 
     Ok(SessionHistoryDigest {
         size_bytes,
         sha256_hex: hex::encode(hasher.finalize()),
+    })
+}
+
+fn digest_zstd_session_history_bytes(
+    encoded: &[u8],
+    max_bytes: u64,
+) -> Result<SessionHistoryDigest, SessionHistoryDigestError> {
+    let reader = zstd::stream::read::Decoder::new(encoded).map_err(zstd_session_history_error)?;
+    digest_history_reader(reader, max_bytes, zstd_session_history_error)
+}
+
+fn prepare_session_history_sidecar_reader(
+    mut reader: impl Read,
+    max_decoded_bytes: u64,
+    max_sidecar_bytes: u64,
+    map_error: impl Fn(io::Error) -> AgentError,
+) -> Result<PreparedSessionHistorySidecar, SessionHistoryDigestError> {
+    let mut hasher = Sha256::new();
+    let mut size_bytes = 0u64;
+    let mut raw_bytes = Some(Vec::new());
+    let mut buffer = [0u8; 8192];
+
+    loop {
+        let bytes_read = reader
+            .read(&mut buffer)
+            .map_err(|error| SessionHistoryDigestError::Read(map_error(error)))?;
+        if bytes_read == 0 {
+            break;
+        }
+        size_bytes = size_bytes
+            .checked_add(bytes_read as u64)
+            .ok_or(SessionHistoryDigestError::ExceedsMaxBytes)?;
+        if size_bytes > max_decoded_bytes {
+            return Err(SessionHistoryDigestError::ExceedsMaxBytes);
+        }
+        let chunk = buffer.get(..bytes_read).ok_or_else(|| {
+            SessionHistoryDigestError::Read(map_error(io::Error::other(
+                "session history reader returned more bytes than the provided buffer",
+            )))
+        })?;
+        hasher.update(chunk);
+        if size_bytes <= max_sidecar_bytes {
+            if let Some(raw_bytes) = raw_bytes.as_mut() {
+                raw_bytes.extend_from_slice(chunk);
+            }
+        } else {
+            raw_bytes = None;
+        }
+    }
+
+    let source = match raw_bytes {
+        Some(raw_bytes) => PreparedSessionHistorySidecarSource::Exportable(
+            SessionHistoryCheckpointSource::Decoded(raw_bytes),
+        ),
+        None => PreparedSessionHistorySidecarSource::RawTooLarge {
+            max_bytes: max_sidecar_bytes,
+        },
+    };
+    Ok(PreparedSessionHistorySidecar {
+        digest: SessionHistoryDigest {
+            size_bytes,
+            sha256_hex: hex::encode(hasher.finalize()),
+        },
+        source,
     })
 }
 
@@ -938,6 +1074,112 @@ mod tests {
                 panic!("oversized encoded body should fall back to decoded history")
             }
         }
+    }
+
+    #[test]
+    fn sidecar_preparation_handles_raw_export_boundaries() {
+        let dir = tempfile::tempdir().unwrap();
+        let history = b"abcde";
+        let path = write_history_file(&dir, "history.jsonl", history);
+
+        let prepared = prepare_session_history_sidecar_from_payload_bounded(
+            path.to_str().unwrap(),
+            history.len() as u64,
+            history.len() as u64,
+        )
+        .unwrap();
+        match prepared.into_source().unwrap() {
+            SessionHistoryCheckpointSource::Decoded(bytes) => assert_eq!(bytes, history),
+            SessionHistoryCheckpointSource::CodexZstd { .. } => {
+                panic!("literal history must use the raw representation")
+            }
+        }
+
+        let prepared = prepare_session_history_sidecar_from_payload_bounded(
+            path.to_str().unwrap(),
+            history.len() as u64,
+            (history.len() - 1) as u64,
+        )
+        .unwrap();
+
+        assert_eq!(prepared.digest.size_bytes, history.len() as u64);
+        assert_eq!(
+            prepared.digest.sha256_hex,
+            hex::encode(Sha256::digest(history))
+        );
+        let error = match prepared.into_source() {
+            Ok(_) => panic!("raw body above the export limit must not be exportable"),
+            Err(error) => error,
+        };
+        assert_over_limit(error, (history.len() - 1) as u64);
+
+        let result = prepare_session_history_sidecar_from_payload_bounded(
+            path.to_str().unwrap(),
+            (history.len() - 1) as u64,
+            (history.len() - 1) as u64,
+        );
+        assert!(matches!(
+            result,
+            Err(SessionHistoryDigestError::ExceedsMaxBytes)
+        ));
+    }
+
+    #[test]
+    fn sidecar_preparation_falls_back_to_raw_when_codex_zstd_exceeds_export_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        let day_dir = sessions_dir.join("2026").join("07").join("02");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+        let history = b"a";
+        let compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        assert!(compressed.len() > history.len());
+        let path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
+        std::fs::write(path, compressed).unwrap();
+        let payload = codex_marker_payload(&sessions_dir, thread_id);
+
+        let prepared = prepare_session_history_sidecar_from_payload_bounded(
+            &payload,
+            history.len() as u64,
+            history.len() as u64,
+        )
+        .unwrap();
+
+        assert_eq!(prepared.digest.size_bytes, history.len() as u64);
+        assert_eq!(
+            prepared.digest.sha256_hex,
+            hex::encode(Sha256::digest(history))
+        );
+        match prepared.into_source().unwrap() {
+            SessionHistoryCheckpointSource::Decoded(bytes) => assert_eq!(bytes, history),
+            SessionHistoryCheckpointSource::CodexZstd { .. } => {
+                panic!("encoded body above the export limit must fall back to raw")
+            }
+        }
+    }
+
+    #[test]
+    fn sidecar_preparation_rejects_truncated_retained_codex_zstd() {
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        let day_dir = sessions_dir.join("2026").join("07").join("02");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+        let history = b"retained zstd history";
+        let mut compressed = zstd::encode_all(history.as_slice(), 0).unwrap();
+        compressed.pop().unwrap();
+        let encoded_limit = compressed.len() as u64;
+        let path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
+        std::fs::write(path, compressed).unwrap();
+        let payload = codex_marker_payload(&sessions_dir, thread_id);
+
+        let result = prepare_session_history_sidecar_from_payload_bounded(
+            &payload,
+            history.len() as u64,
+            encoded_limit,
+        );
+
+        assert!(matches!(result, Err(SessionHistoryDigestError::Read(_))));
     }
 
     #[test]

--- a/crates/guest-agent/src/session_history_identity.rs
+++ b/crates/guest-agent/src/session_history_identity.rs
@@ -79,12 +79,17 @@ pub fn export_final_session_history_sidecar_file(
     export_path: impl AsRef<Path>,
 ) -> Result<SessionHistorySidecarExportMetadata, FinalSessionHistoryIdentityVerifyError> {
     let identity = read_final_session_history_identity(metadata_path)?;
-    verify_final_session_history_identity(&identity)?;
-    let source = session_history::read_session_history_checkpoint_source_from_payload_bounded(
+    verify_final_session_history_identity_constraints(&identity)?;
+    let prepared = session_history::prepare_session_history_sidecar_from_payload_bounded(
         &identity.history_marker_payload,
+        identity.history_size_bytes,
         SESSION_HISTORY_SIDECAR_MAX_BYTES,
     )
-    .map_err(FinalSessionHistoryIdentityVerifyError::HistoryRead)?;
+    .map_err(map_session_history_digest_error)?;
+    verify_final_session_history_digest(&identity, &prepared.digest)?;
+    let source = prepared
+        .into_source()
+        .map_err(FinalSessionHistoryIdentityVerifyError::HistoryRead)?;
     let (representation, bytes) = match source {
         session_history::SessionHistoryCheckpointSource::Decoded(bytes) => {
             (SessionHistorySidecarRepresentation::Raw, bytes)
@@ -124,6 +129,18 @@ fn read_final_session_history_identity(
 fn verify_final_session_history_identity(
     identity: &FinalSessionHistoryIdentity,
 ) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
+    verify_final_session_history_identity_constraints(identity)?;
+    let digest = session_history::digest_session_history_from_payload_bounded(
+        &identity.history_marker_payload,
+        identity.history_size_bytes,
+    )
+    .map_err(map_session_history_digest_error)?;
+    verify_final_session_history_digest(identity, &digest)
+}
+
+fn verify_final_session_history_identity_constraints(
+    identity: &FinalSessionHistoryIdentity,
+) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
     match identity.framework {
         FinalSessionHistoryFramework::ClaudeCode => {
             if session_history::is_codex_marker(&identity.history_marker_payload) {
@@ -140,18 +157,13 @@ fn verify_final_session_history_identity(
     if identity.history_size_bytes > RESUME_SESSION_HISTORY_MAX_BYTES {
         return Err(FinalSessionHistoryIdentityVerifyError::HistoryTooLarge);
     }
-    let digest = match session_history::digest_session_history_from_payload_bounded(
-        &identity.history_marker_payload,
-        identity.history_size_bytes,
-    ) {
-        Ok(digest) => digest,
-        Err(session_history::SessionHistoryDigestError::Read(error)) => {
-            return Err(FinalSessionHistoryIdentityVerifyError::HistoryRead(error));
-        }
-        Err(session_history::SessionHistoryDigestError::ExceedsMaxBytes) => {
-            return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
-        }
-    };
+    Ok(())
+}
+
+fn verify_final_session_history_digest(
+    identity: &FinalSessionHistoryIdentity,
+    digest: &session_history::SessionHistoryDigest,
+) -> Result<(), FinalSessionHistoryIdentityVerifyError> {
     if digest.size_bytes != identity.history_size_bytes {
         return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
     }
@@ -159,6 +171,19 @@ fn verify_final_session_history_identity(
         return Err(FinalSessionHistoryIdentityVerifyError::HistoryMismatch);
     }
     Ok(())
+}
+
+fn map_session_history_digest_error(
+    error: session_history::SessionHistoryDigestError,
+) -> FinalSessionHistoryIdentityVerifyError {
+    match error {
+        session_history::SessionHistoryDigestError::Read(error) => {
+            FinalSessionHistoryIdentityVerifyError::HistoryRead(error)
+        }
+        session_history::SessionHistoryDigestError::ExceedsMaxBytes => {
+            FinalSessionHistoryIdentityVerifyError::HistoryMismatch
+        }
+    }
 }
 
 /// Error returned while building final identity metadata.
@@ -288,35 +313,6 @@ mod tests {
         let metadata_path = write_metadata(&dir, &identity);
 
         verify_final_session_history_identity_file(metadata_path, None).unwrap();
-    }
-
-    #[test]
-    fn exports_claude_literal_history_sidecar() {
-        let dir = tempfile::tempdir().unwrap();
-        let history = br#"{"type":"system"}"#;
-        let history_path = dir.path().join("history.jsonl");
-        std::fs::write(&history_path, history).unwrap();
-        let identity = FinalSessionHistoryIdentity::new(
-            FinalSessionHistoryFramework::ClaudeCode,
-            "a".repeat(64),
-            FinalSessionHistoryRefKind::Blob,
-            hex::encode(Sha256::digest(history)),
-            history.len() as u64,
-            history_path.to_string_lossy(),
-        )
-        .unwrap();
-        let metadata_path = write_metadata(&dir, &identity);
-        let export_path = dir.path().join("sidecar.blob");
-
-        let export_metadata =
-            export_final_session_history_sidecar_file(metadata_path, &export_path).unwrap();
-
-        assert_eq!(
-            export_metadata.representation,
-            SessionHistorySidecarRepresentation::Raw
-        );
-        assert_eq!(export_metadata.encoded_size, history.len() as u64);
-        assert_eq!(std::fs::read(export_path).unwrap(), history);
     }
 
     #[test]

--- a/crates/guest-agent/tests/session_history_identity_helper.rs
+++ b/crates/guest-agent/tests/session_history_identity_helper.rs
@@ -9,20 +9,60 @@ use guest_contracts::session_history_identity::{
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_ARGS,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_INVALID_METADATA,
     SESSION_HISTORY_IDENTITY_VERIFY_EXIT_METADATA_READ,
-    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS,
+    SESSION_HISTORY_IDENTITY_VERIFY_EXIT_SUCCESS, SessionHistorySidecarExportMetadata,
+    SessionHistorySidecarRepresentation,
 };
+#[cfg(target_os = "linux")]
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use sha2::{Digest, Sha256};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-type TestResult = Result<(), Box<dyn std::error::Error>>;
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 struct VerifyCase {
     name: &'static str,
     metadata_path: PathBuf,
     expectation_args: Vec<OsString>,
     expected_exit_code: i32,
+}
+
+struct SourceOpenWatch {
+    #[cfg(target_os = "linux")]
+    inotify: Inotify,
+}
+
+impl SourceOpenWatch {
+    fn new(path: &Path) -> TestResult<Self> {
+        #[cfg(target_os = "linux")]
+        {
+            let inotify = Inotify::init(InitFlags::IN_CLOEXEC | InitFlags::IN_NONBLOCK)?;
+            let _watch = inotify.add_watch(
+                path,
+                AddWatchFlags::IN_OPEN | AddWatchFlags::IN_CLOSE_NOWRITE,
+            )?;
+            Ok(Self { inotify })
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = path;
+            Ok(Self {})
+        }
+    }
+
+    fn assert_opened_once(self) -> TestResult {
+        #[cfg(target_os = "linux")]
+        {
+            let events = self.inotify.read_events()?;
+            let open_count = events
+                .iter()
+                .filter(|event| event.mask.contains(AddWatchFlags::IN_OPEN))
+                .count();
+            assert_eq!(open_count, 1, "source events: {events:?}");
+        }
+        Ok(())
+    }
 }
 
 #[test]
@@ -178,6 +218,122 @@ fn verify_session_history_identity_returns_stable_exit_codes() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn export_session_history_sidecar_reads_raw_source_once() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let history = br#"{"type":"system"}"#;
+    let history_path = dir.path().join("history.jsonl");
+    std::fs::write(&history_path, history)?;
+    let identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        sha256_hex(history),
+        history.len() as u64,
+        history_path.to_string_lossy(),
+    )?;
+    let metadata_path = write_metadata(dir.path(), "raw-identity.json", &identity)?;
+    let export_path = dir.path().join("raw-sidecar");
+    let source_watch = SourceOpenWatch::new(&history_path)?;
+
+    let output = run_export_helper(&metadata_path, &export_path)?;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    source_watch.assert_opened_once()?;
+    let export_metadata =
+        serde_json::from_slice::<SessionHistorySidecarExportMetadata>(&output.stdout)?;
+    assert_eq!(
+        export_metadata.representation,
+        SessionHistorySidecarRepresentation::Raw
+    );
+    assert_eq!(export_metadata.encoded_size, history.len() as u64);
+    assert_eq!(std::fs::read(export_path)?, history);
+    Ok(())
+}
+
+#[test]
+fn export_session_history_sidecar_reads_native_codex_zstd_once() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let sessions_dir = dir.path().join("sessions");
+    let day_dir = sessions_dir.join("2026").join("07").join("13");
+    std::fs::create_dir_all(&day_dir)?;
+    let thread_id = "019e9154-c304-70f0-adde-36efb1be1701";
+    let history = br#"{"type":"session_meta","timestamp":"2026-07-13T10:00:00Z"}"#;
+    let encoded = zstd::encode_all(history.as_slice(), 0)?;
+    let history_path = day_dir.join("rollout-019e9154c30470f0adde36efb1be1701.jsonl.zst");
+    std::fs::write(&history_path, &encoded)?;
+    let sessions_dir = sessions_dir.to_string_lossy();
+    let marker = format!(
+        "CODEX_SEARCH:{}:{sessions_dir}:{thread_id}",
+        sessions_dir.len()
+    );
+    let identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::Codex,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        sha256_hex(history),
+        history.len() as u64,
+        marker,
+    )?;
+    let metadata_path = write_metadata(dir.path(), "codex-identity.json", &identity)?;
+    let export_path = dir.path().join("codex-sidecar");
+    let source_watch = SourceOpenWatch::new(&history_path)?;
+
+    let output = run_export_helper(&metadata_path, &export_path)?;
+
+    assert!(
+        output.status.success(),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    source_watch.assert_opened_once()?;
+    let export_metadata =
+        serde_json::from_slice::<SessionHistorySidecarExportMetadata>(&output.stdout)?;
+    assert_eq!(
+        export_metadata.representation,
+        SessionHistorySidecarRepresentation::CodexZstd
+    );
+    assert_eq!(export_metadata.encoded_size, encoded.len() as u64);
+    assert_eq!(std::fs::read(export_path)?, encoded);
+    Ok(())
+}
+
+#[test]
+fn export_session_history_sidecar_rejects_history_mismatch() -> TestResult {
+    let dir = tempfile::tempdir()?;
+    let history = b"actual";
+    let history_path = dir.path().join("mismatched-history.jsonl");
+    std::fs::write(&history_path, history)?;
+    let identity = FinalSessionHistoryIdentity::new(
+        FinalSessionHistoryFramework::ClaudeCode,
+        "a".repeat(64),
+        FinalSessionHistoryRefKind::Blob,
+        sha256_hex(b"expect"),
+        history.len() as u64,
+        history_path.to_string_lossy(),
+    )?;
+    let metadata_path = write_metadata(dir.path(), "mismatched-identity.json", &identity)?;
+    let export_path = dir.path().join("mismatched-sidecar");
+
+    let output = run_export_helper(&metadata_path, &export_path)?;
+
+    assert_eq!(
+        output.status.code(),
+        Some(SESSION_HISTORY_IDENTITY_VERIFY_EXIT_HISTORY_MISMATCH),
+        "stdout={}, stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!export_path.exists());
+    Ok(())
+}
+
 fn write_metadata(
     dir: &Path,
     name: &str,
@@ -211,5 +367,14 @@ fn run_helper(case: &VerifyCase) -> Result<Output, std::io::Error> {
         .arg("verify-session-history-identity")
         .arg(&case.metadata_path)
         .args(&case.expectation_args)
+        .output()
+}
+
+fn run_export_helper(metadata_path: &Path, export_path: &Path) -> Result<Output, std::io::Error> {
+    Command::new(env!("CARGO_BIN_EXE_guest-agent"))
+        .env_clear()
+        .arg("export-session-history-sidecar")
+        .arg(metadata_path)
+        .arg(export_path)
         .output()
 }


### PR DESCRIPTION
## Summary

- derive the session-history digest and sidecar representation from one resolved source snapshot
- retain native Codex zstd bytes when they fit, while preserving the existing bounded raw fallback
- keep ordinary identity verification streaming and preserve mismatch/error categories
- cover raw and native-zstd exports through the CLI, including Linux assertions that the source is opened once

## Scope

- no runner or API contract changes
- no persisted sidecar format, size-limit, timeout, or promotion-policy changes

## Validation

Passed:

- `cd crates && cargo fmt --all -- --check`
- `cd crates && cargo clippy --all-targets --all-features -- -D warnings`
- `cd crates && cargo doc --workspace --all-features --no-deps`
- `cd crates && cargo test -p guest-agent`
- `cd crates && cargo test -p guest-agent session_history`
- `cd crates && cargo test -p guest-agent --test session_history_identity_helper`
- `cd turbo && pnpm format`
- `cd turbo && pnpm turbo run lint`
- `cd turbo && pnpm check-types`
- `cd turbo && pnpm knip`

Local diagnostic:

- `cd turbo && pnpm vitest run --maxWorkers=4 --silent=passed-only` hit unrelated API tests' existing 5-second timeout under four-worker load. The first run timed out in one test and the post-`scripts/prepare.sh` run timed out in nine different tests; every timed-out case passed unchanged with the original timeout at one worker.

Closes #21175
