### PR TITLE
fix(platform): paint fullscreen artifacts under ios status bar

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -348,7 +348,10 @@
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
     <meta name="apple-mobile-web-app-title" content="Zero" />
     <meta
       name="description"

--- a/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
+++ b/turbo/apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
@@ -29,11 +29,11 @@ function readGlobalCss(): string {
 }
 
 describe("platform entrypoint safe area behavior", () => {
-  it("keeps iOS system chrome opaque above fullscreen surfaces", () => {
+  it("lets fullscreen surfaces paint under translucent iOS system chrome", () => {
     expect(indexHtml).toMatch(
-      /<meta\s+name="apple-mobile-web-app-status-bar-style"\s+content="default"\s*\/>/,
+      /<meta\s+name="apple-mobile-web-app-status-bar-style"\s+content="black-translucent"\s*\/>/,
     );
-    expect(indexHtml).not.toContain('content="black-translucent"');
+    expect(indexHtml).not.toContain('content="default"');
   });
 
   it("keeps supported viewport hints without unsupported keyboard directives", () => {


### PR DESCRIPTION
## Summary

- let fullscreen artifact surfaces paint beneath the translucent iOS standalone status bar
- update entrypoint safe-area coverage for the status bar mode

## Testing

- pnpm -C turbo exec prettier --check apps/platform/index.html apps/platform/src/views/css/__tests__/entrypoint-safe-area.test.ts
- pnpm -C turbo -F @vm0/app lint
- pnpm -C turbo -F @vm0/app check-types
- pnpm -C turbo -F @vm0/app exec vitest run src/views/css/__tests__/entrypoint-safe-area.test.ts --maxWorkers=4 --silent=passed-only
- pnpm -C turbo knip --workspace @vm0/app