### PR TITLE
fix(platform): keep mobile chat above the composer after keyboard resize

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auto-scroll.test.ts
@@ -16,12 +16,30 @@ function setScrollMetrics(
 function createScrollContainer(): HTMLElement {
   const container = document.createElement("section");
   const content = document.createElement("div");
+  let scrollTop = 0;
+  Object.defineProperty(container, "scrollTop", {
+    configurable: true,
+    get: () => {
+      return scrollTop;
+    },
+    set: (value: number) => {
+      const maxScrollTop = Math.max(
+        0,
+        container.scrollHeight - container.clientHeight,
+      );
+      scrollTop = Math.max(0, Math.min(value, maxScrollTop));
+    },
+  });
   container.appendChild(content);
   document.body.appendChild(container);
   return container;
 }
 
-function mockResizeObserver(): { restore: () => void; triggerAll: () => void } {
+function mockResizeObserver(): {
+  restore: () => void;
+  trigger: (target: Element) => void;
+  triggerAll: () => void;
+} {
   const originalDescriptor = Object.getOwnPropertyDescriptor(
     globalThis,
     "ResizeObserver",
@@ -29,40 +47,43 @@ function mockResizeObserver(): { restore: () => void; triggerAll: () => void } {
   const observers: TestResizeObserver[] = [];
 
   class TestResizeObserver implements ResizeObserver {
-    private observedTarget: Element | null = null;
+    private observedTargets = new Set<Element>();
 
     constructor(private readonly callback: ResizeObserverCallback) {
       observers.push(this);
     }
 
     observe(target: Element): void {
-      this.observedTarget = target;
+      this.observedTargets.add(target);
     }
 
     unobserve(target: Element): void {
-      if (this.observedTarget === target) {
-        this.observedTarget = null;
-      }
+      this.observedTargets.delete(target);
     }
 
     disconnect(): void {
-      this.observedTarget = null;
+      this.observedTargets = new Set<Element>();
     }
 
-    trigger(): void {
-      if (!this.observedTarget) {
+    trigger(target?: Element): void {
+      const targets = target
+        ? this.observedTargets.has(target)
+          ? [target]
+          : []
+        : [...this.observedTargets];
+      if (targets.length === 0) {
         return;
       }
       this.callback(
-        [
-          {
-            target: this.observedTarget,
-            contentRect: this.observedTarget.getBoundingClientRect(),
+        targets.map((observedTarget) => {
+          return {
+            target: observedTarget,
+            contentRect: observedTarget.getBoundingClientRect(),
             borderBoxSize: [],
             contentBoxSize: [],
             devicePixelContentBoxSize: [],
-          } as unknown as ResizeObserverEntry,
-        ],
+          } as unknown as ResizeObserverEntry;
+        }),
         this,
       );
     }
@@ -88,6 +109,11 @@ function mockResizeObserver(): { restore: () => void; triggerAll: () => void } {
 
   return {
     restore,
+    trigger: (target) => {
+      for (const observer of observers) {
+        observer.trigger(target);
+      }
+    },
     triggerAll: () => {
       for (const observer of observers) {
         observer.trigger();
@@ -111,10 +137,14 @@ describe("auto-scroll", () => {
     }
   }
 
-  function installResizeObserver(): { triggerAll: () => void } {
+  function installResizeObserver(): {
+    trigger: (target: Element) => void;
+    triggerAll: () => void;
+  } {
     const resizeObserver = mockResizeObserver();
     resizeObserverCleanups.push(resizeObserver.restore);
     return {
+      trigger: resizeObserver.trigger,
       triggerAll: resizeObserver.triggerAll,
     };
   }
@@ -210,5 +240,81 @@ describe("auto-scroll", () => {
     resizeObserver.triggerAll();
 
     expect(scrollContainer.scrollTop).toBe(480);
+  });
+
+  it("keeps a mobile chat at the bottom when its viewport becomes shorter", () => {
+    const resizeObserver = installResizeObserver();
+    ctx.mocks.browser.matchMedia((query) => {
+      return query === "(pointer: coarse)";
+    });
+    const scroll = createScrollSignals("mobile-viewport-resize", {
+      observeViewportResizeOnMobile: true,
+    });
+    const scrollContainer = createScrollContainer();
+    setScrollMetrics(scrollContainer, {
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    scrollContainer.scrollTop = 700;
+
+    bindScrollContainer(scroll, scrollContainer);
+    setScrollMetrics(scrollContainer, {
+      scrollHeight: 1000,
+      clientHeight: 180,
+    });
+    resizeObserver.trigger(scrollContainer);
+
+    expect(scrollContainer.scrollTop).toBe(820);
+  });
+
+  it("preserves a mobile history-reading position when the viewport becomes shorter", () => {
+    const resizeObserver = installResizeObserver();
+    ctx.mocks.browser.matchMedia((query) => {
+      return query === "(pointer: coarse)";
+    });
+    const scroll = createScrollSignals("mobile-history-resize", {
+      observeViewportResizeOnMobile: true,
+    });
+    const scrollContainer = createScrollContainer();
+    setScrollMetrics(scrollContainer, {
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    scrollContainer.scrollTop = 700;
+
+    bindScrollContainer(scroll, scrollContainer);
+    scrollContainer.dispatchEvent(new Event("pointerdown"));
+    scrollContainer.scrollTop = 400;
+    scrollContainer.dispatchEvent(new Event("scroll"));
+    setScrollMetrics(scrollContainer, {
+      scrollHeight: 1000,
+      clientHeight: 180,
+    });
+    resizeObserver.trigger(scrollContainer);
+
+    expect(scrollContainer.scrollTop).toBe(400);
+  });
+
+  it("does not observe the chat viewport resize on desktop", () => {
+    const resizeObserver = installResizeObserver();
+    ctx.mocks.browser.matchMedia(false);
+    const scroll = createScrollSignals("desktop-viewport-resize", {
+      observeViewportResizeOnMobile: true,
+    });
+    const scrollContainer = createScrollContainer();
+    setScrollMetrics(scrollContainer, {
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    scrollContainer.scrollTop = 700;
+
+    bindScrollContainer(scroll, scrollContainer);
+    setScrollMetrics(scrollContainer, {
+      scrollHeight: 1000,
+      clientHeight: 180,
+    });
+    resizeObserver.trigger(scrollContainer);
+
+    expect(scrollContainer.scrollTop).toBe(700);
   });
 });

--- a/turbo/apps/platform/src/signals/auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/auto-scroll.ts
@@ -6,6 +6,7 @@ const L = logger("AutoScroll");
 const AT_BOTTOM_THRESHOLD = 10;
 const USER_INPUT_WINDOW_MS = 200;
 const KEY_SCROLL_STEP_PX = 72;
+const COARSE_POINTER_QUERY = "(pointer: coarse)";
 
 export type ScrollStepDirection = "up" | "down";
 export type PrependScrollCompensationToken = symbol;
@@ -14,6 +15,10 @@ interface PendingPrependScrollRecord {
   readonly token: PrependScrollCompensationToken;
   scrollHeight: number;
   scrollTop: number;
+}
+
+interface ScrollSignalOptions {
+  observeViewportResizeOnMobile?: boolean;
 }
 
 // Persists a user's last non-bottom scroll position across container
@@ -107,9 +112,19 @@ function observeContainerResize(
   el: HTMLElement,
   onResize: () => void,
   signal: AbortSignal,
+  observeViewportResizeOnMobile: boolean,
 ) {
   const resizeObserver = new ResizeObserver(onResize);
-  resizeObserver.observe(el.firstElementChild ?? el);
+  const content = el.firstElementChild ?? el;
+  resizeObserver.observe(content);
+  const win = el.ownerDocument.defaultView;
+  if (
+    observeViewportResizeOnMobile &&
+    content !== el &&
+    win?.matchMedia(COARSE_POINTER_QUERY).matches === true
+  ) {
+    resizeObserver.observe(el);
+  }
   signal.addEventListener("abort", () => {
     resizeObserver.disconnect();
   });
@@ -386,6 +401,7 @@ interface SetScrollContainerCommandDeps {
   lastKnownScrollTop: { v: number };
   lastUserInputAt: { v: number };
   markUserInput: () => void;
+  observeViewportResizeOnMobile: boolean;
 }
 
 function createSetScrollContainerCommand(deps: SetScrollContainerCommandDeps) {
@@ -451,7 +467,12 @@ function createSetScrollContainerCommand(deps: SetScrollContainerCommandDeps) {
       const onResize = buildResizeHandler(ctx);
 
       attachUserInputListeners(el, deps.markUserInput, onScroll, signal);
-      observeContainerResize(el, onResize, signal);
+      observeContainerResize(
+        el,
+        onResize,
+        signal,
+        deps.observeViewportResizeOnMobile,
+      );
 
       signal.addEventListener("abort", () => {
         L.debug("container unbound (abort)");
@@ -484,7 +505,10 @@ function createSetScrollContainerCommand(deps: SetScrollContainerCommandDeps) {
  * a chance to invoke `scrollToBottom$`. The cache is cleared once the user
  * scrolls back to the bottom.
  */
-export function createScrollSignals(id?: string) {
+export function createScrollSignals(
+  id?: string,
+  options: ScrollSignalOptions = {},
+) {
   const internalScrollContainer$ = state<HTMLElement | null>(null);
   const autoScrollDisabled$ = state(false);
   // Readable "scrolled away from the bottom" flag for UI (the scroll-to-bottom
@@ -516,6 +540,8 @@ export function createScrollSignals(id?: string) {
     lastKnownScrollTop,
     lastUserInputAt,
     markUserInput,
+    observeViewportResizeOnMobile:
+      options.observeViewportResizeOnMobile === true,
   });
 
   const autoScroll$ = command(({ get }) => {

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -121,7 +121,9 @@ const uuidPattern =
 const QUEUED_RUN_MARKER_EVENT_ID = "queue:queued";
 
 function createChatThreadScrollSignals(threadId: string) {
-  return createScrollSignals(threadId);
+  return createScrollSignals(threadId, {
+    observeViewportResizeOnMobile: true,
+  });
 }
 
 function isRecallControlMessage(msg: PagedChatMessage): boolean {


### PR DESCRIPTION
## Summary

- keep a bottom-following mobile chat pinned to its new bottom when the keyboard or composer reduces the message viewport height
- observe the scroll viewport only for coarse-pointer chat threads, leaving desktop scrolling and non-chat scroll consumers unchanged
- preserve manual history-reading positions while restoring the existing bottom safety spacing for chats that were already following the latest content

## Implementation

- extend the shared scroll signals with an opt-in mobile viewport-resize observation mode
- enable that mode only for chat thread scroll signals
- retain the existing content resize observer and bottom-following state machine

## Verification

- `pnpm exec prettier --check apps/platform/src/signals/auto-scroll.ts apps/platform/src/signals/chat-page/create-chat-thread.ts apps/platform/src/signals/__tests__/auto-scroll.test.ts`
- `pnpm -F @vm0/app lint`
- `pnpm -F @vm0/app check-types`
- `pnpm -F @vm0/app exec vitest run src/signals/__tests__/auto-scroll.test.ts --maxWorkers=1` (6 passed)

The local dev server was not started per the vm0 PR verification preference. The exact standalone iOS keyboard transition should be verified on the PR preview.
