### PR TITLE
refactor(mitm-addon): centralize builtin host policy parsing

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -3,6 +3,7 @@
 import ipaddress
 import re
 import urllib.parse
+from dataclasses import dataclass
 
 import public_destination
 from authority_utils import (
@@ -48,6 +49,21 @@ class BuiltinRuntimeHostPolicyError(ValueError):
         self.message = message
 
 
+@dataclass(frozen=True)
+class _ProviderOwnedHostPolicy:
+    exact_hosts: tuple[str, ...]
+    suffixes: tuple[str, ...]
+    allow_non_default_port: bool
+
+
+@dataclass(frozen=True)
+class _PublicDestinationHostPolicy:
+    pass
+
+
+_ParsedHostPolicy = _ProviderOwnedHostPolicy | _PublicDestinationHostPolicy | None
+
+
 def validate_credentialed_builtin_base(
     *,
     firewall_name: str,
@@ -70,10 +86,14 @@ def validate_credentialed_builtin_base(
         raise _invalid_resolved_base_url(firewall_name)
     if authority_has_empty_port(parsed.netloc):
         raise _invalid_resolved_base_url(firewall_name)
+    parsed_host_policy = _parse_host_policy(
+        firewall_name=firewall_name,
+        host_policy=host_policy,
+    )
     _validate_builtin_base_host_policy(
         firewall_name=firewall_name,
         parsed=parsed,
-        host_policy=host_policy,
+        host_policy=parsed_host_policy,
     )
 
 
@@ -89,11 +109,15 @@ def validate_credentialed_builtin_request_destination(
     if not auth_config_injects_ordinary_upstream_credentials(auth_config):
         return
     try:
+        parsed_host_policy = _parse_host_policy(
+            firewall_name=firewall_name,
+            host_policy=host_policy,
+        )
         _validate_builtin_runtime_host_policy(
             firewall_name=firewall_name,
             trusted_host=trusted_host,
             trusted_port=trusted_port,
-            host_policy=host_policy,
+            host_policy=parsed_host_policy,
             upstream_endpoint=upstream_endpoint,
         )
     except BuiltinHostPolicyError as e:
@@ -260,22 +284,74 @@ def _host_policy_host_has_fixed_ownership(
     return len(labels) >= _MIN_FIXED_HOST_OWNERSHIP_LABELS and all(labels)
 
 
+def _parse_host_policy(
+    *,
+    firewall_name: str,
+    host_policy: object,
+) -> _ParsedHostPolicy:
+    if host_policy is None:
+        return None
+    if not isinstance(host_policy, dict):
+        raise BuiltinHostPolicyError(
+            f'builtin firewall "{firewall_name}" hostPolicy must be an object'
+        )
+    kind = host_policy.get("kind")
+    if kind == "providerOwned":
+        _validate_host_policy_keys(
+            firewall_name=firewall_name,
+            policy=host_policy,
+            allowed_keys=_PROVIDER_OWNED_HOST_POLICY_KEYS,
+        )
+        exact_hosts = _host_policy_string_list(host_policy, "exactHosts")
+        suffixes = _host_policy_string_list(host_policy, "suffixes")
+        allow_non_default_port = _host_policy_optional_bool(
+            firewall_name=firewall_name,
+            policy=host_policy,
+            key="allowNonDefaultPort",
+        )
+        if not exact_hosts and not suffixes:
+            raise BuiltinHostPolicyError(
+                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
+                "requires exactHosts or suffixes"
+            )
+        for exact_host in exact_hosts:
+            if not _host_policy_host_has_fixed_ownership(exact_host, allow_leading_dot=False):
+                raise BuiltinHostPolicyError(
+                    f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
+                    "exactHosts must be fixed hostnames with at least two labels"
+                )
+        for suffix in suffixes:
+            if not _host_policy_host_has_fixed_ownership(suffix, allow_leading_dot=True):
+                raise BuiltinHostPolicyError(
+                    f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
+                    "suffixes must be fixed hostnames with at least two labels"
+                )
+        return _ProviderOwnedHostPolicy(
+            exact_hosts=tuple(_normalize_host_policy_hostname(host) for host in exact_hosts),
+            suffixes=tuple(_normalize_host_policy_suffix(suffix) for suffix in suffixes),
+            allow_non_default_port=allow_non_default_port,
+        )
+    if kind == "publicDestination":
+        _validate_host_policy_keys(
+            firewall_name=firewall_name,
+            policy=host_policy,
+            allowed_keys=_PUBLIC_DESTINATION_HOST_POLICY_KEYS,
+        )
+        return _PublicDestinationHostPolicy()
+    raise BuiltinHostPolicyError(f'builtin firewall "{firewall_name}" hostPolicy kind is invalid')
+
+
 def _provider_owned_host_matches(
     hostname: str,
     *,
-    exact_hosts: list[str],
-    suffixes: list[str],
+    exact_hosts: tuple[str, ...],
+    suffixes: tuple[str, ...],
 ) -> bool:
     for exact_host in exact_hosts:
-        if hostname == _normalize_host_policy_hostname(exact_host):
+        if hostname == exact_host:
             return True
     for suffix in suffixes:
-        normalized_suffix = _normalize_host_policy_suffix(suffix)
-        if (
-            normalized_suffix
-            and len(hostname) > len(normalized_suffix)
-            and hostname.endswith(f".{normalized_suffix}")
-        ):
+        if len(hostname) > len(suffix) and hostname.endswith(f".{suffix}"):
             return True
     return False
 
@@ -284,46 +360,22 @@ def _validate_provider_owned_host_policy(
     *,
     firewall_name: str,
     parsed: urllib.parse.SplitResult,
-    policy: dict,
+    policy: _ProviderOwnedHostPolicy,
 ) -> None:
     hostname = _normalize_host_policy_hostname(
         _provider_owned_base_hostname(firewall_name=firewall_name, parsed=parsed)
     )
-    exact_hosts = _host_policy_string_list(policy, "exactHosts")
-    suffixes = _host_policy_string_list(policy, "suffixes")
-    allow_non_default_port = _host_policy_optional_bool(
-        firewall_name=firewall_name,
-        policy=policy,
-        key="allowNonDefaultPort",
-    )
-    if not exact_hosts and not suffixes:
-        raise BuiltinHostPolicyError(
-            f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-            "requires exactHosts or suffixes"
-        )
-    for exact_host in exact_hosts:
-        if not _host_policy_host_has_fixed_ownership(exact_host, allow_leading_dot=False):
-            raise BuiltinHostPolicyError(
-                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-                "exactHosts must be fixed hostnames with at least two labels"
-            )
-    for suffix in suffixes:
-        if not _host_policy_host_has_fixed_ownership(suffix, allow_leading_dot=True):
-            raise BuiltinHostPolicyError(
-                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-                "suffixes must be fixed hostnames with at least two labels"
-            )
     if not _provider_owned_host_matches(
         hostname,
-        exact_hosts=exact_hosts,
-        suffixes=suffixes,
+        exact_hosts=policy.exact_hosts,
+        suffixes=policy.suffixes,
     ):
         raise BuiltinHostPolicyError(
             f'builtin firewall "{firewall_name}" host policy does not allow '
             f'resolved host "{hostname}"'
         )
     if (
-        not allow_non_default_port
+        not policy.allow_non_default_port
         and (parsed_port := _parsed_port(firewall_name=firewall_name, parsed=parsed)) is not None
         and parsed_port != _DEFAULT_HTTPS_PORT
     ):
@@ -352,52 +404,10 @@ def validate_host_policy_shape_for_cache(
     host_policy: object,
 ) -> None:
     """Validate cache-level hostPolicy shape without binding it to a resolved base."""
-    if host_policy is None:
-        return
-    if not isinstance(host_policy, dict):
-        raise BuiltinHostPolicyError(
-            f'builtin firewall "{firewall_name}" hostPolicy must be an object'
-        )
-    kind = host_policy.get("kind")
-    if kind == "providerOwned":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PROVIDER_OWNED_HOST_POLICY_KEYS,
-        )
-        exact_hosts = _host_policy_string_list(host_policy, "exactHosts")
-        suffixes = _host_policy_string_list(host_policy, "suffixes")
-        _host_policy_optional_bool(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            key="allowNonDefaultPort",
-        )
-        if not exact_hosts and not suffixes:
-            raise BuiltinHostPolicyError(
-                f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-                "requires exactHosts or suffixes"
-            )
-        for exact_host in exact_hosts:
-            if not _host_policy_host_has_fixed_ownership(exact_host, allow_leading_dot=False):
-                raise BuiltinHostPolicyError(
-                    f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-                    "exactHosts must be fixed hostnames with at least two labels"
-                )
-        for suffix in suffixes:
-            if not _host_policy_host_has_fixed_ownership(suffix, allow_leading_dot=True):
-                raise BuiltinHostPolicyError(
-                    f'builtin firewall "{firewall_name}" providerOwned hostPolicy '
-                    "suffixes must be fixed hostnames with at least two labels"
-                )
-        return
-    if kind == "publicDestination":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PUBLIC_DESTINATION_HOST_POLICY_KEYS,
-        )
-        return
-    raise BuiltinHostPolicyError(f'builtin firewall "{firewall_name}" hostPolicy kind is invalid')
+    _parse_host_policy(
+        firewall_name=firewall_name,
+        host_policy=host_policy,
+    )
 
 
 def _runtime_host_policy_error(
@@ -417,27 +427,20 @@ def _validate_provider_owned_runtime_host_policy(
     firewall_name: str,
     trusted_host: str,
     trusted_port: int,
-    policy: dict,
+    policy: _ProviderOwnedHostPolicy,
 ) -> None:
     hostname = _normalize_host_policy_hostname(trusted_host)
-    exact_hosts = _host_policy_string_list(policy, "exactHosts")
-    suffixes = _host_policy_string_list(policy, "suffixes")
-    allow_non_default_port = _host_policy_optional_bool(
-        firewall_name=firewall_name,
-        policy=policy,
-        key="allowNonDefaultPort",
-    )
     if not _provider_owned_host_matches(
         hostname,
-        exact_hosts=exact_hosts,
-        suffixes=suffixes,
+        exact_hosts=policy.exact_hosts,
+        suffixes=policy.suffixes,
     ):
         raise _runtime_host_policy_error(
             reason="provider_host_not_allowed",
             firewall_name=firewall_name,
             message=f'host policy does not allow request host "{hostname}"',
         )
-    if not allow_non_default_port and trusted_port != _DEFAULT_HTTPS_PORT:
+    if not policy.allow_non_default_port and trusted_port != _DEFAULT_HTTPS_PORT:
         raise _runtime_host_policy_error(
             reason="provider_non_default_port",
             firewall_name=firewall_name,
@@ -476,24 +479,12 @@ def _validate_builtin_runtime_host_policy(
     firewall_name: str,
     trusted_host: str,
     trusted_port: int,
-    host_policy: object,
+    host_policy: _ParsedHostPolicy,
     upstream_endpoint: tuple[str, int] | None,
 ) -> None:
     if host_policy is None:
         return
-    if not isinstance(host_policy, dict):
-        raise _runtime_host_policy_error(
-            reason="invalid_host_policy",
-            firewall_name=firewall_name,
-            message="hostPolicy must be an object",
-        )
-    kind = host_policy.get("kind")
-    if kind == "providerOwned":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PROVIDER_OWNED_HOST_POLICY_KEYS,
-        )
+    if isinstance(host_policy, _ProviderOwnedHostPolicy):
         _validate_provider_owned_runtime_host_policy(
             firewall_name=firewall_name,
             trusted_host=trusted_host,
@@ -501,22 +492,10 @@ def _validate_builtin_runtime_host_policy(
             policy=host_policy,
         )
         return
-    if kind == "publicDestination":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PUBLIC_DESTINATION_HOST_POLICY_KEYS,
-        )
-        _validate_public_destination_runtime_host_policy(
-            firewall_name=firewall_name,
-            trusted_host=trusted_host,
-            upstream_endpoint=upstream_endpoint,
-        )
-        return
-    raise _runtime_host_policy_error(
-        reason="invalid_host_policy",
+    _validate_public_destination_runtime_host_policy(
         firewall_name=firewall_name,
-        message="hostPolicy kind is invalid",
+        trusted_host=trusted_host,
+        upstream_endpoint=upstream_endpoint,
     )
 
 
@@ -524,36 +503,18 @@ def _validate_builtin_base_host_policy(
     *,
     firewall_name: str,
     parsed: urllib.parse.SplitResult,
-    host_policy: object,
+    host_policy: _ParsedHostPolicy,
 ) -> None:
     if host_policy is None:
         return
-    if not isinstance(host_policy, dict):
-        raise BuiltinHostPolicyError(
-            f'builtin firewall "{firewall_name}" hostPolicy must be an object'
-        )
-    kind = host_policy.get("kind")
-    if kind == "providerOwned":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PROVIDER_OWNED_HOST_POLICY_KEYS,
-        )
+    if isinstance(host_policy, _ProviderOwnedHostPolicy):
         _validate_provider_owned_host_policy(
             firewall_name=firewall_name,
             parsed=parsed,
             policy=host_policy,
         )
         return
-    if kind == "publicDestination":
-        _validate_host_policy_keys(
-            firewall_name=firewall_name,
-            policy=host_policy,
-            allowed_keys=_PUBLIC_DESTINATION_HOST_POLICY_KEYS,
-        )
-        _validate_public_destination_host_policy(
-            firewall_name=firewall_name,
-            parsed=parsed,
-        )
-        return
-    raise BuiltinHostPolicyError(f'builtin firewall "{firewall_name}" hostPolicy kind is invalid')
+    _validate_public_destination_host_policy(
+        firewall_name=firewall_name,
+        parsed=parsed,
+    )

--- a/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
+++ b/crates/runner/mitm-addon/tests/test_builtin_host_policy_contract.py
@@ -1,0 +1,102 @@
+"""Cross-stage contracts for malformed builtin host policies."""
+
+import pytest
+
+import builtin_host_policy
+
+_AUTH_CONFIG: dict[str, object] = {
+    "headers": {"Authorization": "Bearer x"},
+}
+
+
+@pytest.mark.parametrize(
+    ("host_policy", "base", "trusted_host"),
+    [
+        pytest.param(
+            {"kind": "providerOwned", "suffixes": ["com"]},
+            "https://api.com",
+            "api.com",
+            id="one-label-suffix",
+        ),
+        pytest.param(
+            {"kind": "providerOwned", "exactHosts": ["0177.0.0.1"]},
+            "https://0177.0.0.1",
+            "0177.0.0.1",
+            id="ipv4-like-exact-host",
+        ),
+        pytest.param(
+            {"kind": "providerOwned"},
+            "https://api.example.com",
+            "api.example.com",
+            id="empty-provider-ownership",
+        ),
+        pytest.param(
+            {
+                "kind": "providerOwned",
+                "suffixes": ["example.com"],
+                "extra": True,
+            },
+            "https://api.example.com",
+            "api.example.com",
+            id="unsupported-key",
+        ),
+        pytest.param(
+            {"kind": "providerOwned", "exactHosts": "api.example.com"},
+            "https://api.example.com",
+            "api.example.com",
+            id="invalid-list-type",
+        ),
+        pytest.param(
+            {
+                "kind": "providerOwned",
+                "suffixes": ["example.com"],
+                "allowNonDefaultPort": "false",
+            },
+            "https://api.example.com",
+            "api.example.com",
+            id="invalid-boolean-type",
+        ),
+        pytest.param(
+            {"kind": "unsupported"},
+            "https://api.example.com",
+            "api.example.com",
+            id="invalid-kind",
+        ),
+        pytest.param(
+            ["providerOwned"],
+            "https://api.example.com",
+            "api.example.com",
+            id="non-object-policy",
+        ),
+    ],
+)
+def test_malformed_policy_is_rejected_by_every_validation_stage(
+    host_policy: object,
+    base: str,
+    trusted_host: str,
+) -> None:
+    with pytest.raises(builtin_host_policy.BuiltinHostPolicyError):
+        builtin_host_policy.validate_host_policy_shape_for_cache(
+            firewall_name="contract-test",
+            host_policy=host_policy,
+        )
+
+    with pytest.raises(builtin_host_policy.BuiltinHostPolicyError):
+        builtin_host_policy.validate_credentialed_builtin_base(
+            firewall_name="contract-test",
+            base=base,
+            auth_config=_AUTH_CONFIG,
+            host_policy=host_policy,
+        )
+
+    with pytest.raises(builtin_host_policy.BuiltinRuntimeHostPolicyError) as error:
+        builtin_host_policy.validate_credentialed_builtin_request_destination(
+            firewall_name="contract-test",
+            trusted_host=trusted_host,
+            trusted_port=443,
+            auth_config=_AUTH_CONFIG,
+            host_policy=host_policy,
+            upstream_endpoint=None,
+        )
+
+    assert error.value.reason == "invalid_host_policy"

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -276,6 +276,39 @@ async def test_runtime_host_policy_enforces_inline_public_destination_policy(
     assert "Authorization" not in flow.request.headers
 
 
+async def test_runtime_host_policy_rejects_malformed_provider_policy(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="malformed-provider",
+        base="https://api.com",
+        host_policy={"kind": "providerOwned", "suffixes": ["com"]},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="api.com",
+        path="/v1/items",
+        request_headers=headers(("Host", "api.com")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "builtin_host_policy_denied"
+    assert body["reason"] == "invalid_host_policy"
+    auth_fetch.assert_not_called()
+    assert "Authorization" not in flow.request.headers
+
+
 @pytest.mark.parametrize(
     ("base", "host_header", "sni", "port", "expected_reason"),
     [

--- a/docs/testing/mitm-addon-testing.md
+++ b/docs/testing/mitm-addon-testing.md
@@ -29,6 +29,7 @@ Pre-commit hooks run `pytest` on staged Python files in the addon.
 | File | Tests |
 |------|-------|
 | `test_addon_configuration.py` | Addon option registration and configuration updates |
+| `test_builtin_host_policy_contract.py` | Cross-stage malformed built-in host policy contracts |
 | `test_request_handler_passthrough.py` | Request pass-through, auto-allow, and browser user-agent passthrough decisions |
 | `test_request_handler_authority_validation.py` | HTTPS authority validation before firewall auth |
 | `test_request_handler_firewall_dispatch.py` | Core firewall dispatch, permission blocks, malformed config/policy handling, block responses, and unsafe-path blocks |


### PR DESCRIPTION
## Summary

- centralize raw builtin host policy validation into an immutable parsed representation shared by cache, base-host, and runtime checks
- reject malformed runtime policies as `invalid_host_policy` before credential injection
- add a cross-stage malformed-policy contract matrix and a request-hook regression test

## Compatibility

- preserve valid policy matching, authentication gates, destination reasons, raw policy JSON, the validation marker, and routing identity
- make no API, database, cache schema, registry payload, persistence, or migration changes

## Validation

- `.venv/bin/ruff format .`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/basedpyright -p .`
- focused policy and request-handler tests (`160 passed`)
- `.venv/bin/python -m pytest tests/` (`3843 passed`)

Closes #21186
