### PR TITLE
fix(runner): bound setup artifact resources

### DIFF
--- a/crates/runner/src/cmd/setup/artifacts.rs
+++ b/crates/runner/src/cmd/setup/artifacts.rs
@@ -1,48 +1,74 @@
 use std::path::PathBuf;
 
 use crate::deps::{
-    FIRECRACKER_SHA256_AARCH64, FIRECRACKER_SHA256_X86_64, FIRECRACKER_VERSION,
-    KERNEL_SHA256_AARCH64, KERNEL_SHA256_X86_64, KERNEL_VERSION, MITMDUMP_SHA256_AARCH64,
-    MITMDUMP_SHA256_X86_64, MITMDUMP_TAR_ENTRY, MITMPROXY_VERSION, firecracker_tar_entry,
-    firecracker_url, kernel_url, mitmdump_url,
+    FIRECRACKER_ARCHIVE_SHA256_AARCH64, FIRECRACKER_ARCHIVE_SHA256_X86_64,
+    FIRECRACKER_ARCHIVE_SIZE_AARCH64, FIRECRACKER_ARCHIVE_SIZE_X86_64, FIRECRACKER_SHA256_AARCH64,
+    FIRECRACKER_SHA256_X86_64, FIRECRACKER_SIZE_AARCH64, FIRECRACKER_SIZE_X86_64,
+    FIRECRACKER_VERSION, KERNEL_SHA256_AARCH64, KERNEL_SHA256_X86_64, KERNEL_SIZE_AARCH64,
+    KERNEL_SIZE_X86_64, KERNEL_VERSION, MITMDUMP_SHA256_AARCH64, MITMDUMP_SHA256_X86_64,
+    MITMDUMP_SIZE_AARCH64, MITMDUMP_SIZE_X86_64, MITMDUMP_TAR_ENTRY,
+    MITMPROXY_ARCHIVE_SHA256_AARCH64, MITMPROXY_ARCHIVE_SHA256_X86_64,
+    MITMPROXY_ARCHIVE_SIZE_AARCH64, MITMPROXY_ARCHIVE_SIZE_X86_64, MITMPROXY_VERSION,
+    firecracker_tar_entry, firecracker_url, kernel_url, mitmdump_url,
 };
 use crate::error::RunnerResult;
 use crate::paths::HomePaths;
 
 use super::{
-    SETUP_EXECUTABLE_ARTIFACT_MODE, SETUP_KERNEL_ARTIFACT_MODE, download_and_extract,
-    download_to_temp, ensure_artifact_installed, select_sha, verify_and_install,
+    SETUP_EXECUTABLE_ARTIFACT_MODE, SETUP_KERNEL_ARTIFACT_MODE, SetupArtifactIdentity,
+    download_and_extract, download_to_temp, ensure_artifact_installed, select_sha, select_size,
+    verify_and_install,
 };
 
 enum SetupArtifactSource {
     Direct,
-    TarEntry { entry_name: String },
+    TarEntry {
+        entry_name: String,
+        archive: SetupArtifactIdentity,
+    },
 }
 
 struct SetupArtifact {
     label: &'static str,
     display_name: String,
     target: PathBuf,
-    expected_sha: String,
+    installed: SetupArtifactIdentity,
     mode: u32,
     url: String,
     source: SetupArtifactSource,
 }
 
-pub(super) async fn install_firecracker(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
-    install_setup_artifact(firecracker_artifact(paths, arch)).await
+pub(super) async fn install_firecracker(
+    client: &reqwest::Client,
+    paths: &HomePaths,
+    arch: &str,
+) -> RunnerResult<()> {
+    install_setup_artifact(client, firecracker_artifact(paths, arch)).await
 }
 
-pub(super) async fn install_kernel(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
-    install_setup_artifact(kernel_artifact(paths, arch)).await
+pub(super) async fn install_kernel(
+    client: &reqwest::Client,
+    paths: &HomePaths,
+    arch: &str,
+) -> RunnerResult<()> {
+    install_setup_artifact(client, kernel_artifact(paths, arch)).await
 }
 
-pub(super) async fn install_mitmdump(paths: &HomePaths, arch: &str) -> RunnerResult<()> {
-    install_setup_artifact(mitmdump_artifact(paths, arch)).await
+pub(super) async fn install_mitmdump(
+    client: &reqwest::Client,
+    paths: &HomePaths,
+    arch: &str,
+) -> RunnerResult<()> {
+    install_setup_artifact(client, mitmdump_artifact(paths, arch)).await
 }
 
-async fn install_setup_artifact(artifact: SetupArtifact) -> RunnerResult<()> {
-    if ensure_artifact_installed(&artifact.target, &artifact.expected_sha, artifact.mode).await? {
+async fn install_setup_artifact(
+    client: &reqwest::Client,
+    artifact: SetupArtifact,
+) -> RunnerResult<()> {
+    if ensure_artifact_installed(&artifact.target, &artifact.installed.sha256, artifact.mode)
+        .await?
+    {
         tracing::info!(
             "[OK] {} already installed, skipping download",
             artifact.display_name
@@ -54,17 +80,36 @@ async fn install_setup_artifact(artifact: SetupArtifact) -> RunnerResult<()> {
 
     let produced = match &artifact.source {
         SetupArtifactSource::Direct => {
-            download_to_temp(&artifact.url, &artifact.target, "download", artifact.label).await?
+            download_to_temp(
+                client,
+                &artifact.url,
+                &artifact.target,
+                "download",
+                artifact.label,
+                &artifact.installed,
+            )
+            .await?
         }
-        SetupArtifactSource::TarEntry { entry_name } => {
-            download_and_extract(&artifact.url, artifact.label, entry_name, &artifact.target)
-                .await?
+        SetupArtifactSource::TarEntry {
+            entry_name,
+            archive,
+        } => {
+            download_and_extract(
+                client,
+                &artifact.url,
+                artifact.label,
+                entry_name,
+                &artifact.target,
+                archive,
+                &artifact.installed,
+            )
+            .await?
         }
     };
 
     verify_and_install(
         produced,
-        &artifact.expected_sha,
+        &artifact.installed.sha256,
         artifact.label,
         &artifact.target,
         artifact.mode,
@@ -74,17 +119,38 @@ async fn install_setup_artifact(artifact: SetupArtifact) -> RunnerResult<()> {
     Ok(())
 }
 
+fn setup_artifact_identity(size: u64, sha256: &str) -> SetupArtifactIdentity {
+    SetupArtifactIdentity {
+        size,
+        sha256: sha256.to_owned(),
+    }
+}
+
 fn firecracker_artifact(paths: &HomePaths, arch: &str) -> SetupArtifact {
     SetupArtifact {
         label: "firecracker",
         display_name: format!("firecracker {FIRECRACKER_VERSION}"),
         target: paths.firecracker_bin(FIRECRACKER_VERSION),
-        expected_sha: select_sha(arch, FIRECRACKER_SHA256_X86_64, FIRECRACKER_SHA256_AARCH64)
-            .to_owned(),
+        installed: setup_artifact_identity(
+            select_size(arch, FIRECRACKER_SIZE_X86_64, FIRECRACKER_SIZE_AARCH64),
+            select_sha(arch, FIRECRACKER_SHA256_X86_64, FIRECRACKER_SHA256_AARCH64),
+        ),
         mode: SETUP_EXECUTABLE_ARTIFACT_MODE,
         url: firecracker_url(arch),
         source: SetupArtifactSource::TarEntry {
             entry_name: firecracker_tar_entry(arch),
+            archive: setup_artifact_identity(
+                select_size(
+                    arch,
+                    FIRECRACKER_ARCHIVE_SIZE_X86_64,
+                    FIRECRACKER_ARCHIVE_SIZE_AARCH64,
+                ),
+                select_sha(
+                    arch,
+                    FIRECRACKER_ARCHIVE_SHA256_X86_64,
+                    FIRECRACKER_ARCHIVE_SHA256_AARCH64,
+                ),
+            ),
         },
     }
 }
@@ -94,7 +160,10 @@ fn kernel_artifact(paths: &HomePaths, arch: &str) -> SetupArtifact {
         label: "kernel",
         display_name: format!("kernel vmlinux-{KERNEL_VERSION}"),
         target: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
-        expected_sha: select_sha(arch, KERNEL_SHA256_X86_64, KERNEL_SHA256_AARCH64).to_owned(),
+        installed: setup_artifact_identity(
+            select_size(arch, KERNEL_SIZE_X86_64, KERNEL_SIZE_AARCH64),
+            select_sha(arch, KERNEL_SHA256_X86_64, KERNEL_SHA256_AARCH64),
+        ),
         mode: SETUP_KERNEL_ARTIFACT_MODE,
         url: kernel_url(arch),
         source: SetupArtifactSource::Direct,
@@ -106,11 +175,26 @@ fn mitmdump_artifact(paths: &HomePaths, arch: &str) -> SetupArtifact {
         label: "mitmdump",
         display_name: format!("mitmdump {MITMPROXY_VERSION}"),
         target: paths.mitmdump_bin(MITMPROXY_VERSION),
-        expected_sha: select_sha(arch, MITMDUMP_SHA256_X86_64, MITMDUMP_SHA256_AARCH64).to_owned(),
+        installed: setup_artifact_identity(
+            select_size(arch, MITMDUMP_SIZE_X86_64, MITMDUMP_SIZE_AARCH64),
+            select_sha(arch, MITMDUMP_SHA256_X86_64, MITMDUMP_SHA256_AARCH64),
+        ),
         mode: SETUP_EXECUTABLE_ARTIFACT_MODE,
         url: mitmdump_url(arch),
         source: SetupArtifactSource::TarEntry {
             entry_name: MITMDUMP_TAR_ENTRY.to_owned(),
+            archive: setup_artifact_identity(
+                select_size(
+                    arch,
+                    MITMPROXY_ARCHIVE_SIZE_X86_64,
+                    MITMPROXY_ARCHIVE_SIZE_AARCH64,
+                ),
+                select_sha(
+                    arch,
+                    MITMPROXY_ARCHIVE_SHA256_X86_64,
+                    MITMPROXY_ARCHIVE_SHA256_AARCH64,
+                ),
+            ),
         },
     }
 }
@@ -118,18 +202,33 @@ fn mitmdump_artifact(paths: &HomePaths, arch: &str) -> SetupArtifact {
 #[cfg(test)]
 mod tests {
     use std::os::unix::fs::PermissionsExt;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     use flate2::Compression;
     use flate2::write::GzEncoder;
     use httpmock::Method::GET;
     use httpmock::MockServer;
     use sha2::{Digest, Sha256};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
 
     use super::*;
 
     fn sha256_hex(content: &[u8]) -> String {
         hex::encode(Sha256::digest(content))
+    }
+
+    fn content_identity(content: &[u8]) -> SetupArtifactIdentity {
+        SetupArtifactIdentity {
+            size: u64::try_from(content.len()).unwrap(),
+            sha256: sha256_hex(content),
+        }
+    }
+
+    fn test_client() -> reqwest::Client {
+        reqwest::Client::builder().build().unwrap()
     }
 
     fn mode(path: &std::path::Path) -> u32 {
@@ -149,6 +248,75 @@ mod tests {
         builder.into_inner().unwrap().finish().unwrap()
     }
 
+    fn assert_identity(identity: &SetupArtifactIdentity, size: u64, sha256: &str) {
+        assert_eq!(identity.size, size);
+        assert_eq!(identity.sha256, sha256);
+    }
+
+    fn assert_tar_source(
+        source: &SetupArtifactSource,
+        expected_entry: &str,
+        archive_size: u64,
+        archive_sha256: &str,
+    ) {
+        let SetupArtifactSource::TarEntry {
+            entry_name,
+            archive,
+        } = source
+        else {
+            panic!("expected tar entry source");
+        };
+        assert_eq!(entry_name, expected_entry);
+        assert_identity(archive, archive_size, archive_sha256);
+    }
+
+    async fn spawn_http_response(response: Vec<u8>) -> (String, JoinHandle<std::io::Result<()>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await?;
+            let mut request = [0_u8; 1024];
+            let request_size = stream.read(&mut request).await?;
+            if request_size == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "setup fixture received an empty request",
+                ));
+            }
+            stream.write_all(&response).await
+        });
+        (format!("http://{address}/artifact"), task)
+    }
+
+    async fn finish_http_response(task: JoinHandle<std::io::Result<()>>) {
+        tokio::time::timeout(Duration::from_secs(2), task)
+            .await
+            .expect("setup fixture timed out")
+            .expect("setup fixture task failed")
+            .expect("setup fixture response failed");
+    }
+
+    fn setup_temp_files(root: &Path) -> Vec<PathBuf> {
+        if !root.exists() {
+            return Vec::new();
+        }
+
+        let mut pending = vec![root.to_owned()];
+        let mut temp_files = Vec::new();
+        while let Some(directory) = pending.pop() {
+            for entry in std::fs::read_dir(directory).unwrap() {
+                let entry = entry.unwrap();
+                let file_type = entry.file_type().unwrap();
+                if file_type.is_dir() {
+                    pending.push(entry.path());
+                } else if entry.file_name().to_string_lossy().ends_with(".tmp") {
+                    temp_files.push(entry.path());
+                }
+            }
+        }
+        temp_files
+    }
+
     #[test]
     fn artifact_descriptors_preserve_metadata_by_arch() {
         let paths = HomePaths::with_root(PathBuf::from("/setup-root"));
@@ -159,22 +327,32 @@ mod tests {
             paths.firecracker_bin(FIRECRACKER_VERSION)
         );
         assert_eq!(firecracker_x86.mode, SETUP_EXECUTABLE_ARTIFACT_MODE);
-        assert_eq!(firecracker_x86.expected_sha, FIRECRACKER_SHA256_X86_64);
+        assert_identity(
+            &firecracker_x86.installed,
+            FIRECRACKER_SIZE_X86_64,
+            FIRECRACKER_SHA256_X86_64,
+        );
         assert_eq!(firecracker_x86.url, firecracker_url("x86_64"));
-        assert!(matches!(
+        assert_tar_source(
             &firecracker_x86.source,
-            SetupArtifactSource::TarEntry { entry_name }
-                if entry_name == &firecracker_tar_entry("x86_64")
-        ));
+            &firecracker_tar_entry("x86_64"),
+            FIRECRACKER_ARCHIVE_SIZE_X86_64,
+            FIRECRACKER_ARCHIVE_SHA256_X86_64,
+        );
 
         let firecracker_aarch64 = firecracker_artifact(&paths, "aarch64");
-        assert_eq!(firecracker_aarch64.expected_sha, FIRECRACKER_SHA256_AARCH64);
+        assert_identity(
+            &firecracker_aarch64.installed,
+            FIRECRACKER_SIZE_AARCH64,
+            FIRECRACKER_SHA256_AARCH64,
+        );
         assert_eq!(firecracker_aarch64.url, firecracker_url("aarch64"));
-        assert!(matches!(
+        assert_tar_source(
             &firecracker_aarch64.source,
-            SetupArtifactSource::TarEntry { entry_name }
-                if entry_name == &firecracker_tar_entry("aarch64")
-        ));
+            &firecracker_tar_entry("aarch64"),
+            FIRECRACKER_ARCHIVE_SIZE_AARCH64,
+            FIRECRACKER_ARCHIVE_SHA256_AARCH64,
+        );
 
         let kernel_x86 = kernel_artifact(&paths, "x86_64");
         assert_eq!(
@@ -182,27 +360,52 @@ mod tests {
             paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION)
         );
         assert_eq!(kernel_x86.mode, SETUP_KERNEL_ARTIFACT_MODE);
-        assert_eq!(kernel_x86.expected_sha, KERNEL_SHA256_X86_64);
+        assert_identity(
+            &kernel_x86.installed,
+            KERNEL_SIZE_X86_64,
+            KERNEL_SHA256_X86_64,
+        );
         assert_eq!(kernel_x86.url, kernel_url("x86_64"));
         assert!(matches!(kernel_x86.source, SetupArtifactSource::Direct));
 
         let kernel_aarch64 = kernel_artifact(&paths, "aarch64");
-        assert_eq!(kernel_aarch64.expected_sha, KERNEL_SHA256_AARCH64);
+        assert_identity(
+            &kernel_aarch64.installed,
+            KERNEL_SIZE_AARCH64,
+            KERNEL_SHA256_AARCH64,
+        );
         assert_eq!(kernel_aarch64.url, kernel_url("aarch64"));
+        assert!(matches!(kernel_aarch64.source, SetupArtifactSource::Direct));
 
         let mitmdump_x86 = mitmdump_artifact(&paths, "x86_64");
         assert_eq!(mitmdump_x86.target, paths.mitmdump_bin(MITMPROXY_VERSION));
         assert_eq!(mitmdump_x86.mode, SETUP_EXECUTABLE_ARTIFACT_MODE);
-        assert_eq!(mitmdump_x86.expected_sha, MITMDUMP_SHA256_X86_64);
+        assert_identity(
+            &mitmdump_x86.installed,
+            MITMDUMP_SIZE_X86_64,
+            MITMDUMP_SHA256_X86_64,
+        );
         assert_eq!(mitmdump_x86.url, mitmdump_url("x86_64"));
-        assert!(matches!(
+        assert_tar_source(
             &mitmdump_x86.source,
-            SetupArtifactSource::TarEntry { entry_name } if entry_name.as_str() == MITMDUMP_TAR_ENTRY
-        ));
+            MITMDUMP_TAR_ENTRY,
+            MITMPROXY_ARCHIVE_SIZE_X86_64,
+            MITMPROXY_ARCHIVE_SHA256_X86_64,
+        );
 
         let mitmdump_aarch64 = mitmdump_artifact(&paths, "aarch64");
-        assert_eq!(mitmdump_aarch64.expected_sha, MITMDUMP_SHA256_AARCH64);
+        assert_identity(
+            &mitmdump_aarch64.installed,
+            MITMDUMP_SIZE_AARCH64,
+            MITMDUMP_SHA256_AARCH64,
+        );
         assert_eq!(mitmdump_aarch64.url, mitmdump_url("aarch64"));
+        assert_tar_source(
+            &mitmdump_aarch64.source,
+            MITMDUMP_TAR_ENTRY,
+            MITMPROXY_ARCHIVE_SIZE_AARCH64,
+            MITMPROXY_ARCHIVE_SHA256_AARCH64,
+        );
     }
 
     #[tokio::test]
@@ -228,13 +431,14 @@ mod tests {
             label: "test",
             display_name: "test artifact".to_owned(),
             target: target.clone(),
-            expected_sha: sha256_hex(content),
+            installed: content_identity(content),
             mode: SETUP_EXECUTABLE_ARTIFACT_MODE,
             url: server.url("/artifact.bin"),
             source: SetupArtifactSource::Direct,
         };
+        let client = test_client();
 
-        install_setup_artifact(artifact).await.unwrap();
+        install_setup_artifact(&client, artifact).await.unwrap();
 
         download.assert_calls_async(0).await;
         assert_eq!(std::fs::read(&target).unwrap(), content);
@@ -257,13 +461,14 @@ mod tests {
             label: "direct",
             display_name: "direct artifact".to_owned(),
             target: target.clone(),
-            expected_sha: sha256_hex(&content),
+            installed: content_identity(&content),
             mode: SETUP_KERNEL_ARTIFACT_MODE,
             url: server.url("/direct.bin"),
             source: SetupArtifactSource::Direct,
         };
+        let client = test_client();
 
-        install_setup_artifact(artifact).await.unwrap();
+        install_setup_artifact(&client, artifact).await.unwrap();
 
         download.assert_calls_async(1).await;
         assert_eq!(std::fs::read(&target).unwrap(), content);
@@ -287,18 +492,195 @@ mod tests {
             label: "tar-entry",
             display_name: "tar entry artifact".to_owned(),
             target: target.clone(),
-            expected_sha: sha256_hex(&content),
+            installed: content_identity(&content),
             mode: SETUP_EXECUTABLE_ARTIFACT_MODE,
             url: server.url("/archive.tar.gz"),
             source: SetupArtifactSource::TarEntry {
                 entry_name: "tool".to_owned(),
+                archive: content_identity(&tarball),
             },
         };
+        let client = test_client();
 
-        install_setup_artifact(artifact).await.unwrap();
+        install_setup_artifact(&client, artifact).await.unwrap();
 
         download.assert_calls_async(1).await;
         assert_eq!(std::fs::read(&target).unwrap(), content);
         assert_eq!(mode(&target), SETUP_EXECUTABLE_ARTIFACT_MODE);
+    }
+
+    #[tokio::test]
+    async fn known_oversized_body_is_rejected_before_temp_creation() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockServer::start_async().await;
+        let body = b"larger body".to_vec();
+        let download = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/oversized.bin");
+                then.status(200).body(body.clone());
+            })
+            .await;
+        let expected = b"small";
+        let target = dir.path().join("nested").join("artifact.bin");
+        let artifact = SetupArtifact {
+            label: "direct",
+            display_name: "direct artifact".to_owned(),
+            target: target.clone(),
+            installed: content_identity(expected),
+            mode: SETUP_KERNEL_ARTIFACT_MODE,
+            url: server.url("/oversized.bin"),
+            source: SetupArtifactSource::Direct,
+        };
+        let client = test_client();
+
+        let error = install_setup_artifact(&client, artifact).await.unwrap_err();
+
+        download.assert_calls_async(1).await;
+        assert!(
+            error.to_string().contains("source size mismatch"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.exists());
+        assert!(!target.parent().unwrap().exists());
+        assert!(setup_temp_files(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_length_oversized_body_stops_before_excess_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let response = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n6\r\nabcdef\r\n0\r\n\r\n".to_vec();
+        let (url, server_task) = spawn_http_response(response).await;
+        let target = dir.path().join("artifact.bin");
+        let artifact = SetupArtifact {
+            label: "direct",
+            display_name: "direct artifact".to_owned(),
+            target: target.clone(),
+            installed: content_identity(b"abc"),
+            mode: SETUP_KERNEL_ARTIFACT_MODE,
+            url,
+            source: SetupArtifactSource::Direct,
+        };
+        let client = test_client();
+
+        let error = install_setup_artifact(&client, artifact).await.unwrap_err();
+        finish_http_response(server_task).await;
+
+        assert!(
+            error.to_string().contains("exceeds expected size"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.exists());
+        assert!(setup_temp_files(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_length_short_body_is_rejected_and_cleaned_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let response = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nabc".to_vec();
+        let (url, server_task) = spawn_http_response(response).await;
+        let target = dir.path().join("artifact.bin");
+        let artifact = SetupArtifact {
+            label: "direct",
+            display_name: "direct artifact".to_owned(),
+            target: target.clone(),
+            installed: content_identity(b"abcde"),
+            mode: SETUP_KERNEL_ARTIFACT_MODE,
+            url,
+            source: SetupArtifactSource::Direct,
+        };
+        let client = test_client();
+
+        let error = install_setup_artifact(&client, artifact).await.unwrap_err();
+        finish_http_response(server_task).await;
+
+        assert!(
+            error.to_string().contains("source size mismatch"),
+            "unexpected error: {error}"
+        );
+        assert!(error.to_string().contains("got 3 bytes"));
+        assert!(!target.exists());
+        assert!(setup_temp_files(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn tar_archive_sha_mismatch_is_rejected_before_extraction() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockServer::start_async().await;
+        let content = b"tar entry artifact".to_vec();
+        let tarball = tarball_with_entry("tool", &content);
+        let download = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/archive.tar.gz");
+                then.status(200).body(tarball.clone());
+            })
+            .await;
+        let target = dir.path().join("tool");
+        let artifact = SetupArtifact {
+            label: "tar-entry",
+            display_name: "tar entry artifact".to_owned(),
+            target: target.clone(),
+            installed: content_identity(&content),
+            mode: SETUP_EXECUTABLE_ARTIFACT_MODE,
+            url: server.url("/archive.tar.gz"),
+            source: SetupArtifactSource::TarEntry {
+                entry_name: "tool".to_owned(),
+                archive: SetupArtifactIdentity {
+                    size: u64::try_from(tarball.len()).unwrap(),
+                    sha256: sha256_hex(b"different archive"),
+                },
+            },
+        };
+        let client = test_client();
+
+        let error = install_setup_artifact(&client, artifact).await.unwrap_err();
+
+        download.assert_calls_async(1).await;
+        assert!(
+            error.to_string().contains("source SHA256 mismatch"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.exists());
+        assert!(setup_temp_files(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn tar_entry_declared_size_mismatch_is_rejected_before_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockServer::start_async().await;
+        let content = b"tar entry artifact".to_vec();
+        let tarball = tarball_with_entry("tool", &content);
+        let download = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/archive.tar.gz");
+                then.status(200).body(tarball.clone());
+            })
+            .await;
+        let target = dir.path().join("tool");
+        let artifact = SetupArtifact {
+            label: "tar-entry",
+            display_name: "tar entry artifact".to_owned(),
+            target: target.clone(),
+            installed: SetupArtifactIdentity {
+                size: u64::try_from(content.len()).unwrap() + 1,
+                sha256: sha256_hex(&content),
+            },
+            mode: SETUP_EXECUTABLE_ARTIFACT_MODE,
+            url: server.url("/archive.tar.gz"),
+            source: SetupArtifactSource::TarEntry {
+                entry_name: "tool".to_owned(),
+                archive: content_identity(&tarball),
+            },
+        };
+        let client = test_client();
+
+        let error = install_setup_artifact(&client, artifact).await.unwrap_err();
+
+        download.assert_calls_async(1).await;
+        assert!(
+            error.to_string().contains("entry size mismatch"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.exists());
+        assert!(setup_temp_files(dir.path()).is_empty());
     }
 }

--- a/crates/runner/src/cmd/setup/artifacts.rs
+++ b/crates/runner/src/cmd/setup/artifacts.rs
@@ -234,7 +234,15 @@ mod tests {
     }
 
     fn tarball_with_entry(entry_name: &str, content: &[u8]) -> Vec<u8> {
-        let encoder = GzEncoder::new(Vec::new(), Compression::default());
+        tarball_with_entry_compression(entry_name, content, Compression::default())
+    }
+
+    fn tarball_with_entry_compression(
+        entry_name: &str,
+        content: &[u8],
+        compression: Compression,
+    ) -> Vec<u8> {
+        let encoder = GzEncoder::new(Vec::new(), compression);
         let mut builder = tar::Builder::new(encoder);
         let mut header = tar::Header::new_gnu();
         header.set_size(content.len() as u64);
@@ -676,6 +684,45 @@ mod tests {
         download.assert_calls_async(1).await;
         assert!(
             error.to_string().contains("entry size mismatch"),
+            "unexpected error: {error}"
+        );
+        assert!(!target.exists());
+        assert!(setup_temp_files(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn truncated_tar_entry_read_error_cleans_temps() {
+        let dir = tempfile::tempdir().unwrap();
+        let server = MockServer::start_async().await;
+        let content = vec![b'x'; 128 * 1024];
+        let mut tarball = tarball_with_entry_compression("tool", &content, Compression::none());
+        tarball.truncate(tarball.len() - 64 * 1024);
+        let download = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/truncated.tar.gz");
+                then.status(200).body(tarball.clone());
+            })
+            .await;
+        let target = dir.path().join("tool");
+        let artifact = SetupArtifact {
+            label: "tar-entry",
+            display_name: "tar entry artifact".to_owned(),
+            target: target.clone(),
+            installed: content_identity(&content),
+            mode: SETUP_EXECUTABLE_ARTIFACT_MODE,
+            url: server.url("/truncated.tar.gz"),
+            source: SetupArtifactSource::TarEntry {
+                entry_name: "tool".to_owned(),
+                archive: content_identity(&tarball),
+            },
+        };
+        let client = test_client();
+
+        let error = install_setup_artifact(&client, artifact).await.unwrap_err();
+
+        download.assert_calls_async(1).await;
+        assert!(
+            error.to_string().contains("read tar entry"),
             "unexpected error: {error}"
         );
         assert!(!target.exists());

--- a/crates/runner/src/cmd/setup/artifacts.rs
+++ b/crates/runner/src/cmd/setup/artifacts.rs
@@ -66,9 +66,7 @@ async fn install_setup_artifact(
     client: &reqwest::Client,
     artifact: SetupArtifact,
 ) -> RunnerResult<()> {
-    if ensure_artifact_installed(&artifact.target, &artifact.installed.sha256, artifact.mode)
-        .await?
-    {
+    if ensure_artifact_installed(&artifact.target, &artifact.installed, artifact.mode).await? {
         tracing::info!(
             "[OK] {} already installed, skipping download",
             artifact.display_name
@@ -109,7 +107,7 @@ async fn install_setup_artifact(
 
     verify_and_install(
         produced,
-        &artifact.installed.sha256,
+        &artifact.installed,
         artifact.label,
         &artifact.target,
         artifact.mode,

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -522,7 +522,7 @@ fn install_produced_artifact(
 
 fn ensure_artifact_installed_blocking(
     path: &Path,
-    expected_sha: &str,
+    expected: &SetupArtifactIdentity,
     mode: u32,
 ) -> RunnerResult<bool> {
     let Some(mut file) = open_existing_setup_artifact(path)? else {
@@ -540,7 +540,11 @@ fn ensure_artifact_installed_blocking(
         return Ok(false);
     }
 
-    if file_sha256_open(&mut file, path)? != expected_sha {
+    if setup_artifact_file_size(&stat, path, "setup artifact")? != expected.size {
+        return Ok(false);
+    }
+
+    if file_sha256_open(&mut file, path)? != expected.sha256 {
         return Ok(false);
     }
 
@@ -550,7 +554,10 @@ fn ensure_artifact_installed_blocking(
         if (repaired.st_mode & 0o7777) != mode {
             return Ok(false);
         }
-        if file_sha256_open(&mut file, path)? != expected_sha {
+        if setup_artifact_file_size(&repaired, path, "setup artifact")? != expected.size {
+            return Ok(false);
+        }
+        if file_sha256_open(&mut file, path)? != expected.sha256 {
             return Ok(false);
         }
     }
@@ -633,6 +640,12 @@ fn setup_file_stat<Fd: AsRawFd>(file: &Fd, path: &Path, context: &str) -> Runner
     }
     // SAFETY: successful `fstat` initialized the full struct.
     Ok(unsafe { stat.assume_init() })
+}
+
+fn setup_artifact_file_size(stat: &libc::stat, path: &Path, context: &str) -> RunnerResult<u64> {
+    u64::try_from(stat.st_size).map_err(|e| {
+        RunnerError::Internal(format!("read {context} size for {}: {e}", path.display()))
+    })
 }
 
 fn validate_same_setup_file_identity(
@@ -973,19 +986,31 @@ async fn extract_tar_entry(
 /// A failed rename only counts as a concurrent install if the target verifies.
 async fn verify_and_install(
     artifact: ProducedSetupArtifact,
-    expected_sha: &str,
+    expected: &SetupArtifactIdentity,
     label: &str,
     target: &Path,
     mode: u32,
 ) -> RunnerResult<()> {
-    if let Err(e) = verify_sha256(&artifact.sha256, expected_sha, label) {
+    let verification = (|| {
+        let stat = setup_file_stat(&artifact.file, &artifact.path, "produced setup artifact")?;
+        let actual_size =
+            setup_artifact_file_size(&stat, &artifact.path, "produced setup artifact")?;
+        if actual_size != expected.size {
+            return Err(RunnerError::Internal(format!(
+                "{label} size mismatch: expected {} bytes, got {actual_size} bytes",
+                expected.size
+            )));
+        }
+        verify_sha256(&artifact.sha256, &expected.sha256, label)
+    })();
+    if let Err(e) = verification {
         let _ = tokio::fs::remove_file(&artifact.path).await;
         return Err(e);
     }
 
     match atomic_install_produced(artifact, target, mode).await {
         Ok(()) => Ok(()),
-        Err(e) => match ensure_artifact_installed(target, expected_sha, mode).await {
+        Err(e) => match ensure_artifact_installed(target, expected, mode).await {
             Ok(true) => {
                 tracing::info!("[OK] {label} verified after another install attempt");
                 Ok(())
@@ -1069,19 +1094,20 @@ async fn file_sha256(path: &Path) -> RunnerResult<String> {
     .map_err(|e| RunnerError::Internal(format!("sha256 task failed: {e}")))?
 }
 
-/// Ensure an existing setup artifact matches its pinned SHA and usable mode.
+/// Ensure an existing setup artifact matches its pinned identity and usable mode.
 async fn ensure_artifact_installed(
     path: &Path,
-    expected_sha: &str,
+    expected: &SetupArtifactIdentity,
     mode: u32,
 ) -> RunnerResult<bool> {
     let path = path.to_owned();
-    let expected_sha = expected_sha.to_owned();
-    tokio::task::spawn_blocking(move || {
-        ensure_artifact_installed_blocking(&path, &expected_sha, mode)
-    })
-    .await
-    .map_err(|e| RunnerError::Internal(format!("artifact validation task failed: {e}")))?
+    let expected = SetupArtifactIdentity {
+        size: expected.size,
+        sha256: expected.sha256.clone(),
+    };
+    tokio::task::spawn_blocking(move || ensure_artifact_installed_blocking(&path, &expected, mode))
+        .await
+        .map_err(|e| RunnerError::Internal(format!("artifact validation task failed: {e}")))?
 }
 
 // ---------------------------------------------------------------------------
@@ -1136,6 +1162,13 @@ mod tests {
         ProducedSetupArtifact {
             path: path.to_owned(),
             file,
+            sha256: hex::encode(Sha256::digest(content)),
+        }
+    }
+
+    fn artifact_identity(content: &[u8]) -> SetupArtifactIdentity {
+        SetupArtifactIdentity {
+            size: u64::try_from(content.len()).unwrap(),
             sha256: hex::encode(Sha256::digest(content)),
         }
     }
@@ -1321,8 +1354,9 @@ mod tests {
     async fn ensure_artifact_installed_returns_false_for_missing() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("nonexistent");
+        let expected = artifact_identity(b"anything");
         assert!(
-            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
+            !ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1333,8 +1367,27 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.bin");
         std::fs::write(&path, b"content").unwrap();
+        let expected = SetupArtifactIdentity {
+            size: u64::try_from(b"content".len()).unwrap(),
+            sha256: "wrong_sha".to_owned(),
+        };
         assert!(
-            !ensure_artifact_installed(&path, "wrong_sha", SETUP_EXECUTABLE_ARTIFACT_MODE)
+            !ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_artifact_installed_returns_false_for_wrong_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file.bin");
+        std::fs::write(&path, b"content").unwrap();
+        let mut expected = artifact_identity(b"content");
+        expected.size += 1;
+
+        assert!(
+            !ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1350,9 +1403,9 @@ mod tests {
             std::fs::Permissions::from_mode(SETUP_KERNEL_ARTIFACT_MODE),
         )
         .unwrap();
-        let sha = file_sha256(&path).await.unwrap();
+        let expected = artifact_identity(b"content");
         assert!(
-            ensure_artifact_installed(&path, &sha, SETUP_KERNEL_ARTIFACT_MODE)
+            ensure_artifact_installed(&path, &expected, SETUP_KERNEL_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1364,10 +1417,10 @@ mod tests {
         let path = dir.path().join("file.bin");
         std::fs::write(&path, b"content").unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let sha = file_sha256(&path).await.unwrap();
+        let expected = artifact_identity(b"content");
 
         assert!(
-            ensure_artifact_installed(&path, &sha, SETUP_EXECUTABLE_ARTIFACT_MODE)
+            ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1379,10 +1432,10 @@ mod tests {
         let path = dir.path().join("file.bin");
         std::fs::write(&path, b"content").unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
-        let sha = file_sha256(&path).await.unwrap();
+        let expected = artifact_identity(b"content");
 
         assert!(
-            ensure_artifact_installed(&path, &sha, SETUP_EXECUTABLE_ARTIFACT_MODE)
+            ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1395,10 +1448,10 @@ mod tests {
         let path = dir.path().join("file.bin");
         std::fs::write(&path, b"content").unwrap();
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444)).unwrap();
-        let sha = file_sha256(&path).await.unwrap();
+        let expected = artifact_identity(b"content");
 
         assert!(
-            ensure_artifact_installed(&path, &sha, SETUP_KERNEL_ARTIFACT_MODE)
+            ensure_artifact_installed(&path, &expected, SETUP_KERNEL_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1412,10 +1465,10 @@ mod tests {
         let link = dir.path().join("file.bin");
         std::fs::write(&outside, b"content").unwrap();
         symlink(&outside, &link).unwrap();
-        let sha = file_sha256(&outside).await.unwrap();
+        let expected = artifact_identity(b"content");
 
         assert!(
-            !ensure_artifact_installed(&link, &sha, SETUP_EXECUTABLE_ARTIFACT_MODE)
+            !ensure_artifact_installed(&link, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1427,9 +1480,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.bin");
         nix::unistd::mkfifo(&path, Mode::from_bits_truncate(0o600)).unwrap();
+        let expected = artifact_identity(b"anything");
 
         assert!(
-            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
+            !ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1440,9 +1494,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.bin");
         let _listener = UnixListener::bind(&path).unwrap();
+        let expected = artifact_identity(b"anything");
 
         assert!(
-            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
+            !ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1453,9 +1508,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file.bin");
         std::fs::create_dir(&path).unwrap();
+        let expected = artifact_identity(b"anything");
 
         assert!(
-            !ensure_artifact_installed(&path, "anything", SETUP_EXECUTABLE_ARTIFACT_MODE)
+            !ensure_artifact_installed(&path, &expected, SETUP_EXECUTABLE_ARTIFACT_MODE)
                 .await
                 .unwrap()
         );
@@ -1506,11 +1562,11 @@ mod tests {
         let tmp_path = dir.path().join("tmp.bin");
         let target = dir.path().join("target.bin");
         let artifact = produced_artifact(&tmp_path, b"content");
-        let sha = artifact.sha256.clone();
+        let expected = artifact_identity(b"content");
 
         verify_and_install(
             artifact,
-            &sha,
+            &expected,
             "test",
             &target,
             SETUP_EXECUTABLE_ARTIFACT_MODE,
@@ -1529,10 +1585,14 @@ mod tests {
         let tmp_path = dir.path().join("tmp.bin");
         let target = dir.path().join("target.bin");
         let artifact = produced_artifact(&tmp_path, b"content");
+        let expected = SetupArtifactIdentity {
+            size: u64::try_from(b"content".len()).unwrap(),
+            sha256: "wrong_sha".to_owned(),
+        };
 
         let result = verify_and_install(
             artifact,
-            "wrong_sha",
+            &expected,
             "test",
             &target,
             SETUP_EXECUTABLE_ARTIFACT_MODE,
@@ -1545,18 +1605,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn verify_and_install_removes_produced_artifact_on_wrong_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let tmp_path = dir.path().join("tmp.bin");
+        let target = dir.path().join("target.bin");
+        let artifact = produced_artifact(&tmp_path, b"content");
+        let mut expected = artifact_identity(b"content");
+        expected.size += 1;
+
+        let result = verify_and_install(
+            artifact,
+            &expected,
+            "test",
+            &target,
+            SETUP_EXECUTABLE_ARTIFACT_MODE,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(!tmp_path.exists(), "size mismatch should clean temp file");
+        assert!(!target.exists());
+    }
+
+    #[tokio::test]
     async fn verify_and_install_rejects_replaced_temp_path() {
         let dir = tempfile::tempdir().unwrap();
         let tmp_path = dir.path().join("tmp.bin");
         let target = dir.path().join("target.bin");
         let artifact = produced_artifact(&tmp_path, b"content");
-        let sha = artifact.sha256.clone();
+        let expected = artifact_identity(b"content");
         std::fs::remove_file(&tmp_path).unwrap();
         std::fs::write(&tmp_path, b"replacement").unwrap();
 
         let result = verify_and_install(
             artifact,
-            &sha,
+            &expected,
             "test",
             &target,
             SETUP_EXECUTABLE_ARTIFACT_MODE,
@@ -1577,12 +1660,12 @@ mod tests {
         let tmp_path = dir.path().join("tmp.bin");
         let target = dir.path().join("target.bin");
         let artifact = produced_artifact(&tmp_path, b"content");
-        let sha = artifact.sha256.clone();
+        let expected = artifact_identity(b"content");
         std::fs::create_dir(&target).unwrap();
 
         let result = verify_and_install(
             artifact,
-            &sha,
+            &expected,
             "test",
             &target,
             SETUP_EXECUTABLE_ARTIFACT_MODE,
@@ -1600,12 +1683,12 @@ mod tests {
         let tmp_path = dir.path().join("tmp.bin");
         let target = dir.path().join("target.bin");
         let artifact = produced_artifact(&tmp_path, b"new content");
-        let sha = artifact.sha256.clone();
+        let expected = artifact_identity(b"new content");
         std::fs::write(&target, b"old content").unwrap();
 
         verify_and_install(
             artifact,
-            &sha,
+            &expected,
             "test",
             &target,
             SETUP_EXECUTABLE_ARTIFACT_MODE,
@@ -1628,13 +1711,13 @@ mod tests {
             std::fs::Permissions::from_mode(SETUP_EXECUTABLE_ARTIFACT_MODE),
         )
         .unwrap();
-        let sha = file_sha256(&target).await.unwrap();
+        let expected = artifact_identity(b"content");
         let artifact = produced_artifact(&tmp_path, b"content");
         std::fs::remove_file(&tmp_path).unwrap();
 
         verify_and_install(
             artifact,
-            &sha,
+            &expected,
             "test",
             &target,
             SETUP_EXECUTABLE_ARTIFACT_MODE,

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -925,44 +925,46 @@ async fn extract_tar_entry(
                 }
 
                 let (tmp, mut out) = create_setup_temp_file(&target, "extract")?;
-                let mut hasher = Sha256::new();
-                let mut buf = [0u8; 64 * 1024];
-                let mut observed_size = 0_u64;
-                let result = loop {
-                    let n = entry
-                        .read(&mut buf)
-                        .map_err(|e| RunnerError::Internal(format!("read tar entry: {e}")))?;
-                    if n == 0 {
-                        if observed_size != expected_size {
-                            break Err(RunnerError::Internal(format!(
-                                "{label} entry size mismatch: expected {expected_size} bytes, got {observed_size} bytes"
+                let result = (|| {
+                    let mut hasher = Sha256::new();
+                    let mut buf = [0u8; 64 * 1024];
+                    let mut observed_size = 0_u64;
+                    loop {
+                        let n = entry
+                            .read(&mut buf)
+                            .map_err(|e| RunnerError::Internal(format!("read tar entry: {e}")))?;
+                        if n == 0 {
+                            if observed_size != expected_size {
+                                return Err(RunnerError::Internal(format!(
+                                    "{label} entry size mismatch: expected {expected_size} bytes, got {observed_size} bytes"
+                                )));
+                            }
+                            std::io::Write::flush(&mut out)
+                                .map_err(|e| RunnerError::Internal(format!("flush binary: {e}")))?;
+                            return Ok(hex::encode(hasher.finalize()));
+                        }
+                        let chunk = buf.get(..n).ok_or_else(|| {
+                            RunnerError::Internal("read returned invalid length".into())
+                        })?;
+                        let chunk_size = u64::try_from(chunk.len()).map_err(|e| {
+                            RunnerError::Internal(format!("measure {label} tar entry chunk: {e}"))
+                        })?;
+                        let next_size = observed_size.checked_add(chunk_size).ok_or_else(|| {
+                            RunnerError::Internal(format!(
+                                "{label} entry size overflow while extracting"
+                            ))
+                        })?;
+                        if next_size > expected_size {
+                            return Err(RunnerError::Internal(format!(
+                                "{label} entry exceeds expected size of {expected_size} bytes (read at least {next_size} bytes)"
                             )));
                         }
-                        std::io::Write::flush(&mut out)
-                            .map_err(|e| RunnerError::Internal(format!("flush binary: {e}")))?;
-                        break Ok(hex::encode(hasher.finalize()));
+                        hasher.update(chunk);
+                        std::io::Write::write_all(&mut out, chunk)
+                            .map_err(|e| RunnerError::Internal(format!("write binary: {e}")))?;
+                        observed_size = next_size;
                     }
-                    let chunk = buf.get(..n).ok_or_else(|| {
-                        RunnerError::Internal("read returned invalid length".into())
-                    })?;
-                    let chunk_size = u64::try_from(chunk.len()).map_err(|e| {
-                        RunnerError::Internal(format!("measure {label} tar entry chunk: {e}"))
-                    })?;
-                    let next_size = observed_size.checked_add(chunk_size).ok_or_else(|| {
-                        RunnerError::Internal(format!(
-                            "{label} entry size overflow while extracting"
-                        ))
-                    })?;
-                    if next_size > expected_size {
-                        break Err(RunnerError::Internal(format!(
-                            "{label} entry exceeds expected size of {expected_size} bytes (read at least {next_size} bytes)"
-                        )));
-                    }
-                    hasher.update(chunk);
-                    std::io::Write::write_all(&mut out, chunk)
-                        .map_err(|e| RunnerError::Internal(format!("write binary: {e}")))?;
-                    observed_size = next_size;
-                };
+                })();
                 if result.is_err() {
                     let _ = std::fs::remove_file(&tmp);
                 }

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -12,6 +12,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Component, Path, PathBuf};
+use std::time::Duration;
 
 use nix::fcntl::{OFlag, open, openat};
 use nix::sys::stat::{Mode, SFlag, fstat, mkdirat};
@@ -27,6 +28,9 @@ const SETUP_TEMP_ARTIFACT_MODE: u32 = 0o600;
 const SETUP_EXECUTABLE_ARTIFACT_MODE: u32 = 0o755;
 const SETUP_KERNEL_ARTIFACT_MODE: u32 = 0o644;
 const SETUP_TEMP_CREATE_ATTEMPTS: usize = 16;
+const SETUP_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const SETUP_READ_TIMEOUT: Duration = Duration::from_secs(60);
+const SETUP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
@@ -34,6 +38,11 @@ const STICKY_BIT: u32 = 0o1000;
 struct ProducedSetupArtifact {
     path: PathBuf,
     file: File,
+    sha256: String,
+}
+
+struct SetupArtifactIdentity {
+    size: u64,
     sha256: String,
 }
 
@@ -49,9 +58,15 @@ pub async fn run_setup() -> RunnerResult<()> {
 
     let paths = HomePaths::new()?;
     create_directories(&paths).await?;
-    artifacts::install_firecracker(&paths, arch).await?;
-    artifacts::install_kernel(&paths, arch).await?;
-    artifacts::install_mitmdump(&paths, arch).await?;
+    let http_client = reqwest::Client::builder()
+        .connect_timeout(SETUP_CONNECT_TIMEOUT)
+        .read_timeout(SETUP_READ_TIMEOUT)
+        .timeout(SETUP_REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| RunnerError::Internal(format!("build setup HTTP client: {e}")))?;
+    artifacts::install_firecracker(&http_client, &paths, arch).await?;
+    artifacts::install_kernel(&http_client, &paths, arch).await?;
+    artifacts::install_mitmdump(&http_client, &paths, arch).await?;
     check_system_ca_bundle()?;
     check_kvm();
 
@@ -711,24 +726,46 @@ fn file_parent(path: &Path) -> &Path {
 // Shared download helpers
 // ---------------------------------------------------------------------------
 
-/// Stream an HTTP response to an opened temp file, computing SHA256 incrementally.
-/// Returns the written file and hex-encoded digest.
+/// Stream an HTTP response to an opened temp file, enforcing its exact identity.
 async fn stream_to_file(
     mut response: reqwest::Response,
     mut file: tokio::fs::File,
     path: &Path,
+    expected: &SetupArtifactIdentity,
+    label: &str,
 ) -> RunnerResult<(File, String)> {
     let mut hasher = Sha256::new();
+    let mut observed_size = 0_u64;
 
     while let Some(chunk) = response
         .chunk()
         .await
-        .map_err(|e| RunnerError::Internal(format!("read response chunk: {e}")))?
+        .map_err(|e| RunnerError::Internal(format!("read {label} response chunk: {e}")))?
     {
+        let chunk_size = u64::try_from(chunk.len())
+            .map_err(|e| RunnerError::Internal(format!("measure {label} response chunk: {e}")))?;
+        let next_size = observed_size.checked_add(chunk_size).ok_or_else(|| {
+            RunnerError::Internal(format!("{label} source size overflow while downloading"))
+        })?;
+        if next_size > expected.size {
+            return Err(RunnerError::Internal(format!(
+                "{label} source exceeds expected size of {} bytes (received at least {next_size} bytes)",
+                expected.size
+            )));
+        }
+
         hasher.update(&chunk);
         file.write_all(&chunk)
             .await
             .map_err(|e| RunnerError::Internal(format!("write {}: {e}", path.display())))?;
+        observed_size = next_size;
+    }
+
+    if observed_size != expected.size {
+        return Err(RunnerError::Internal(format!(
+            "{label} source size mismatch: expected {} bytes, got {observed_size} bytes",
+            expected.size
+        )));
     }
 
     file.flush()
@@ -740,25 +777,47 @@ async fn stream_to_file(
 
 /// Download a URL to a temp file. Cleans up on failure.
 async fn download_to_temp(
+    client: &reqwest::Client,
     url: &str,
     target: &Path,
     kind: &str,
     label: &str,
+    expected: &SetupArtifactIdentity,
 ) -> RunnerResult<ProducedSetupArtifact> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| RunnerError::Internal(format!("download {label}: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(RunnerError::Internal(format!(
+            "download {label}: HTTP {}",
+            response.status()
+        )));
+    }
+
+    if let Some(content_length) = response.content_length()
+        && content_length != expected.size
+    {
+        return Err(RunnerError::Internal(format!(
+            "{label} source size mismatch: expected {} bytes, got {content_length} bytes",
+            expected.size
+        )));
+    }
+
     let (tmp_path, file) = create_setup_temp_file(target, kind)?;
     let result = async {
-        let response = reqwest::get(url)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("download {label}: {e}")))?;
-
-        if !response.status().is_success() {
-            return Err(RunnerError::Internal(format!(
-                "download {label}: HTTP {}",
-                response.status()
-            )));
-        }
-
-        stream_to_file(response, tokio::fs::File::from_std(file), &tmp_path).await
+        let (file, sha256) = stream_to_file(
+            response,
+            tokio::fs::File::from_std(file),
+            &tmp_path,
+            expected,
+            label,
+        )
+        .await?;
+        verify_sha256(&sha256, &expected.sha256, &format!("{label} source"))?;
+        Ok((file, sha256))
     }
     .await;
 
@@ -777,20 +836,29 @@ async fn download_to_temp(
 
 /// Download a tarball, extract a named entry. Cleans up tarball after extraction.
 async fn download_and_extract(
+    client: &reqwest::Client,
     url: &str,
     label: &str,
     entry_name: &str,
     target: &Path,
+    archive_identity: &SetupArtifactIdentity,
+    installed_identity: &SetupArtifactIdentity,
 ) -> RunnerResult<ProducedSetupArtifact> {
-    // Tarball SHA is intentionally discarded — we verify the extracted binary's SHA instead.
     let ProducedSetupArtifact {
         path: tarball_path,
         file: tarball_file,
         sha256: _,
-    } = download_to_temp(url, target, "tarball", label).await?;
-    drop(tarball_file);
+    } = download_to_temp(client, url, target, "tarball", label, archive_identity).await?;
 
-    let result = extract_tar_entry(&tarball_path, target, entry_name).await;
+    let result = extract_tar_entry(
+        tarball_file,
+        &tarball_path,
+        target,
+        entry_name,
+        label,
+        installed_identity,
+    )
+    .await;
     let _ = tokio::fs::remove_file(&tarball_path).await;
     result
 }
@@ -798,18 +866,24 @@ async fn download_and_extract(
 /// Extract a named entry from a gzipped tarball, writing to tmp_path.
 /// Matches by file_name (last path component).
 async fn extract_tar_entry(
+    mut tarball_file: File,
     tarball_path: &Path,
     target: &Path,
     entry_name: &str,
+    label: &str,
+    installed_identity: &SetupArtifactIdentity,
 ) -> RunnerResult<ProducedSetupArtifact> {
     let tarball = tarball_path.to_owned();
     let target = target.to_owned();
     let entry_name = entry_name.to_owned();
+    let label = label.to_owned();
+    let expected_size = installed_identity.size;
 
     tokio::task::spawn_blocking(move || {
-        let file = std::fs::File::open(&tarball)
-            .map_err(|e| RunnerError::Internal(format!("open tarball: {e}")))?;
-        let decoder = flate2::read::GzDecoder::new(file);
+        tarball_file.seek(SeekFrom::Start(0)).map_err(|e| {
+            RunnerError::Internal(format!("seek verified tarball {}: {e}", tarball.display()))
+        })?;
+        let decoder = flate2::read::GzDecoder::new(tarball_file);
         let mut archive = tar::Archive::new(decoder);
 
         let entries = archive
@@ -830,14 +904,27 @@ async fn extract_tar_entry(
                 .unwrap_or_default();
 
             if file_name == entry_name {
+                let declared_size = entry.size();
+                if declared_size != expected_size {
+                    return Err(RunnerError::Internal(format!(
+                        "{label} entry size mismatch: expected {expected_size} bytes, got {declared_size} bytes"
+                    )));
+                }
+
                 let (tmp, mut out) = create_setup_temp_file(&target, "extract")?;
                 let mut hasher = Sha256::new();
                 let mut buf = [0u8; 64 * 1024];
+                let mut observed_size = 0_u64;
                 let result = loop {
                     let n = entry
                         .read(&mut buf)
                         .map_err(|e| RunnerError::Internal(format!("read tar entry: {e}")))?;
                     if n == 0 {
+                        if observed_size != expected_size {
+                            break Err(RunnerError::Internal(format!(
+                                "{label} entry size mismatch: expected {expected_size} bytes, got {observed_size} bytes"
+                            )));
+                        }
                         std::io::Write::flush(&mut out)
                             .map_err(|e| RunnerError::Internal(format!("flush binary: {e}")))?;
                         break Ok(hex::encode(hasher.finalize()));
@@ -845,9 +932,23 @@ async fn extract_tar_entry(
                     let chunk = buf.get(..n).ok_or_else(|| {
                         RunnerError::Internal("read returned invalid length".into())
                     })?;
+                    let chunk_size = u64::try_from(chunk.len()).map_err(|e| {
+                        RunnerError::Internal(format!("measure {label} tar entry chunk: {e}"))
+                    })?;
+                    let next_size = observed_size.checked_add(chunk_size).ok_or_else(|| {
+                        RunnerError::Internal(format!(
+                            "{label} entry size overflow while extracting"
+                        ))
+                    })?;
+                    if next_size > expected_size {
+                        break Err(RunnerError::Internal(format!(
+                            "{label} entry exceeds expected size of {expected_size} bytes (read at least {next_size} bytes)"
+                        )));
+                    }
                     hasher.update(chunk);
                     std::io::Write::write_all(&mut out, chunk)
                         .map_err(|e| RunnerError::Internal(format!("write binary: {e}")))?;
+                    observed_size = next_size;
                 };
                 if result.is_err() {
                     let _ = std::fs::remove_file(&tmp);
@@ -919,6 +1020,15 @@ async fn atomic_install_produced(
 
 #[allow(clippy::unreachable)] // arch validated by check_architecture
 fn select_sha<'a>(arch: &str, x86_64: &'a str, aarch64: &'a str) -> &'a str {
+    match arch {
+        "x86_64" => x86_64,
+        "aarch64" => aarch64,
+        _ => unreachable!(),
+    }
+}
+
+#[allow(clippy::unreachable)] // arch validated by check_architecture
+fn select_size(arch: &str, x86_64: u64, aarch64: u64) -> u64 {
     match arch {
         "x86_64" => x86_64,
         "aarch64" => aarch64,

--- a/crates/runner/src/deps.rs
+++ b/crates/runner/src/deps.rs
@@ -4,19 +4,39 @@ pub const FIRECRACKER_VERSION: &str = "v1.15.1";
 pub const KERNEL_VERSION: &str = "6.1.155";
 pub const MITMPROXY_VERSION: &str = "12.2.2";
 
-// SHA256 checksums for installed artifacts, keyed by arch.
+// Exact identities for installed artifacts, keyed by arch.
+pub const FIRECRACKER_SIZE_X86_64: u64 = 3_417_392;
+pub const FIRECRACKER_SIZE_AARCH64: u64 = 3_119_984;
 pub const FIRECRACKER_SHA256_X86_64: &str =
     "7e8b57e88c459396d4680d83dcdd8c7f72305447cb55b11f4ac98ad70a3f7825";
 pub const FIRECRACKER_SHA256_AARCH64: &str =
     "e9ce7466c3b0d879d7a9158f4bf710dd5e131bbc5e580e5269fec66d5b5a0f0a";
+pub const KERNEL_SIZE_X86_64: u64 = 44_279_576;
+pub const KERNEL_SIZE_AARCH64: u64 = 17_111_552;
 pub const KERNEL_SHA256_X86_64: &str =
     "e20e46d0c36c55c0d1014eb20576171b3f3d922260d9f792017aeff53af3d4f2";
 pub const KERNEL_SHA256_AARCH64: &str =
     "e3544b10603acbf3db492cb52e000d22ba202cb4b63b9add027565683e11c591";
+pub const MITMDUMP_SIZE_X86_64: u64 = 39_174_744;
+pub const MITMDUMP_SIZE_AARCH64: u64 = 36_913_888;
 pub const MITMDUMP_SHA256_X86_64: &str =
     "06732d2f9ebb9d86456220267613c6771ed68010a7a8bbe7bc4d55f3a09e2880";
 pub const MITMDUMP_SHA256_AARCH64: &str =
     "0afdc07ff487c26caf737c004d870e0957da4645f6d525a6d7d14ccf20a560fc";
+
+// Exact identities for compressed source archives, keyed by arch.
+pub const FIRECRACKER_ARCHIVE_SIZE_X86_64: u64 = 7_622_285;
+pub const FIRECRACKER_ARCHIVE_SIZE_AARCH64: u64 = 7_422_699;
+pub const FIRECRACKER_ARCHIVE_SHA256_X86_64: &str =
+    "d4a32ab2322d887ca1bc4a4e7afa9cc35393e6362dfc2b3becb389d362e4275a";
+pub const FIRECRACKER_ARCHIVE_SHA256_AARCH64: &str =
+    "00654ac1e702a22744121ea9f10a4f792ebd7c3a744cba587dfac9fcb79b41a5";
+pub const MITMPROXY_ARCHIVE_SIZE_X86_64: u64 = 119_221_654;
+pub const MITMPROXY_ARCHIVE_SIZE_AARCH64: u64 = 112_710_933;
+pub const MITMPROXY_ARCHIVE_SHA256_X86_64: &str =
+    "fe6c6996535918bfc62590bc62c4bd5c46b7f243a98fe06730b385ecff40160c";
+pub const MITMPROXY_ARCHIVE_SHA256_AARCH64: &str =
+    "09adaf908e92243c4d3b967eb084116c5d2b28ffef02bd1b582e5816df5b64bd";
 
 /// System CA certificate bundle path. The standalone mitmproxy binary bundles its
 /// own (incomplete) certifi CA store; we override it with the host's system store.
@@ -93,10 +113,14 @@ mod tests {
         for sha in [
             FIRECRACKER_SHA256_X86_64,
             FIRECRACKER_SHA256_AARCH64,
+            FIRECRACKER_ARCHIVE_SHA256_X86_64,
+            FIRECRACKER_ARCHIVE_SHA256_AARCH64,
             KERNEL_SHA256_X86_64,
             KERNEL_SHA256_AARCH64,
             MITMDUMP_SHA256_X86_64,
             MITMDUMP_SHA256_AARCH64,
+            MITMPROXY_ARCHIVE_SHA256_X86_64,
+            MITMPROXY_ARCHIVE_SHA256_AARCH64,
         ] {
             assert_eq!(sha.len(), 64, "SHA256 hex should be 64 chars: {sha}");
             assert!(


### PR DESCRIPTION
## Summary

- pin exact source and installed `size + SHA-256` identities for every setup artifact and architecture
- reuse a setup-local Reqwest client with bounded connection, read-stall, and total request lifetimes
- reject known or streamed source-size mismatches before excess persistence and authenticate archives before decompression
- extract from the same verified archive file descriptor while independently bounding the selected tar entry
- preserve existing private temp files, cleanup, final checksum, permissions, atomic installation, and concurrent-install convergence

## Scope

This changes only the Rust runner setup path. It does not add retries, configuration, feature switches, dependencies, schemas, persisted-state migrations, API/protocol changes, or deployment workflow changes.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all --check`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::setup`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml -p runner`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `git diff --check`

Closes #21179
