### PR TITLE
fix(platform): keep slash workflow footer link clickable

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx
@@ -51,6 +51,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 import { reloadUserModelPreference$ } from "../../../signals/external/user-model-preference.ts";
 import { localStorageSignals } from "../../../signals/external/local-storage.ts";
+import { pathname } from "../../../signals/location.ts";
 import { CODEX_FAST_MODE_LOCAL_DEFAULT_STORAGE_KEY } from "../../../signals/zero-page/codex-fast-local-default.ts";
 import { resetChatPageModelSelection$ } from "../../../signals/zero-page/zero-chat-page.ts";
 import { templateCardThemeIdBySlug$ } from "../../../signals/zero-page/zero-chat-composer.ts";
@@ -1206,6 +1207,8 @@ describe("chat composer models", () => {
     const link = linkByText("View all workflows");
     expect(link).toHaveAttribute("href", "/workflows");
     expect(link.parentElement).toHaveClass("shrink-0", "border-t");
+    await user.click(link);
+    expect(pathname()).toBe("/workflows");
   });
 
   it("scrolls the slash workflow picker with keyboard selection", async () => {

--- a/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
+++ b/turbo/apps/platform/src/views/zero-page/slash-workflow.tsx
@@ -131,6 +131,10 @@ export function SlashWorkflowMenu({
         <div className="shrink-0 border-t border-border/60 bg-popover/95 p-1.5">
           <Link
             pathname={ROUTES.workflows}
+            onMouseDown={(event) => {
+              // Keep the composer focused until Link handles the click.
+              event.preventDefault();
+            }}
             className="flex h-9 w-full items-center justify-between rounded px-2 text-sm font-medium text-popover-foreground transition-colors hover:bg-accent"
           >
             <span className="flex min-w-0 items-center gap-2">


### PR DESCRIPTION
## Summary

- keep the Agent Chat composer focused while pressing the Slash workflow menu footer so the controlled popover remains mounted until the link handles the click
- preserve the existing `/workflows` router navigation path and modifier-key behavior
- replace the href-only regression assertion with a real user click and pathname verification

## User-visible impact

Clicking **View all workflows** from the `/` workflow suggestion menu now opens the workflows page instead of closing the menu without navigating.

## Verification

- `npx -y prettier@3.8.1 --check turbo/apps/platform/src/views/zero-page/slash-workflow.tsx turbo/apps/platform/src/views/zero-page/__tests__/chat-composer-models-and-templates.test.tsx`
- `git diff --check`
- full checks delegated to the PR pipeline per repository policy
