### PR TITLE
fix(runner): bind sandbox reuse to application sessions

### DIFF
--- a/crates/runner/src/cmd/start/active_sessions.rs
+++ b/crates/runner/src/cmd/start/active_sessions.rs
@@ -3,25 +3,25 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::sandbox_reuse_identity::{SandboxReuseIdentity, SandboxReuseScope};
 
-pub(super) type ActiveCliAgentSessions = Arc<Mutex<HashMap<SandboxReuseIdentity, usize>>>;
+pub(super) type ActiveSandboxReuseIdentityCounts = Arc<Mutex<HashMap<SandboxReuseIdentity, usize>>>;
 
-pub(super) fn new_active_cli_agent_sessions() -> ActiveCliAgentSessions {
+pub(super) fn new_active_sandbox_reuse_identities() -> ActiveSandboxReuseIdentityCounts {
     Arc::new(Mutex::new(HashMap::new()))
 }
 
-pub(super) fn insert_active_cli_agent_session(
-    active_cli_agent_sessions: &ActiveCliAgentSessions,
+pub(super) fn insert_active_sandbox_reuse_identity(
+    active_sandbox_reuse_identities: &ActiveSandboxReuseIdentityCounts,
     identity: &SandboxReuseIdentity,
 ) {
-    let mut counts = lock_counts(active_cli_agent_sessions);
+    let mut counts = lock_counts(active_sandbox_reuse_identities);
     *counts.entry(identity.clone()).or_insert(0) += 1;
 }
 
-pub(super) fn remove_active_cli_agent_session(
-    active_cli_agent_sessions: &ActiveCliAgentSessions,
+pub(super) fn remove_active_sandbox_reuse_identity(
+    active_sandbox_reuse_identities: &ActiveSandboxReuseIdentityCounts,
     identity: &SandboxReuseIdentity,
 ) {
-    let mut counts = lock_counts(active_cli_agent_sessions);
+    let mut counts = lock_counts(active_sandbox_reuse_identities);
     let Some(count) = counts.get_mut(identity) else {
         return;
     };
@@ -31,34 +31,34 @@ pub(super) fn remove_active_cli_agent_session(
     }
 }
 
-pub(super) fn active_cli_agent_session_ids(
-    active_cli_agent_sessions: &ActiveCliAgentSessions,
+pub(super) fn active_sandbox_reuse_identity_set(
+    active_sandbox_reuse_identities: &ActiveSandboxReuseIdentityCounts,
 ) -> HashSet<SandboxReuseIdentity> {
-    lock_counts(active_cli_agent_sessions)
+    lock_counts(active_sandbox_reuse_identities)
         .keys()
         .cloned()
         .collect()
 }
 
-pub(super) struct ActiveCliAgentSessionGuard {
-    active_cli_agent_sessions: ActiveCliAgentSessions,
+pub(super) struct ActiveSandboxReuseIdentityGuard {
+    active_sandbox_reuse_identities: ActiveSandboxReuseIdentityCounts,
     sandbox_reuse_scope: Option<SandboxReuseScope>,
     sandbox_reuse_identity: Option<SandboxReuseIdentity>,
 }
 
-impl ActiveCliAgentSessionGuard {
+impl ActiveSandboxReuseIdentityGuard {
     pub(super) fn new(
-        active_cli_agent_sessions: ActiveCliAgentSessions,
+        active_sandbox_reuse_identities: ActiveSandboxReuseIdentityCounts,
         sandbox_reuse_scope: Option<SandboxReuseScope>,
         cli_agent_session_id: Option<String>,
     ) -> Self {
         let sandbox_reuse_identity = sandbox_reuse_scope
             .and_then(|scope| scope.with_cli_agent_session_id(cli_agent_session_id.as_deref()?));
         if let Some(identity) = sandbox_reuse_identity.as_ref() {
-            insert_active_cli_agent_session(&active_cli_agent_sessions, identity);
+            insert_active_sandbox_reuse_identity(&active_sandbox_reuse_identities, identity);
         }
         Self {
-            active_cli_agent_sessions,
+            active_sandbox_reuse_identities,
             sandbox_reuse_scope,
             sandbox_reuse_identity,
         }
@@ -74,23 +74,23 @@ impl ActiveCliAgentSessionGuard {
         else {
             return;
         };
-        insert_active_cli_agent_session(&self.active_cli_agent_sessions, &identity);
+        insert_active_sandbox_reuse_identity(&self.active_sandbox_reuse_identities, &identity);
         self.sandbox_reuse_identity = Some(identity);
     }
 }
 
-impl Drop for ActiveCliAgentSessionGuard {
+impl Drop for ActiveSandboxReuseIdentityGuard {
     fn drop(&mut self) {
         if let Some(identity) = self.sandbox_reuse_identity.as_ref() {
-            remove_active_cli_agent_session(&self.active_cli_agent_sessions, identity);
+            remove_active_sandbox_reuse_identity(&self.active_sandbox_reuse_identities, identity);
         }
     }
 }
 
 fn lock_counts(
-    active_cli_agent_sessions: &ActiveCliAgentSessions,
+    active_sandbox_reuse_identities: &ActiveSandboxReuseIdentityCounts,
 ) -> MutexGuard<'_, HashMap<SandboxReuseIdentity, usize>> {
-    active_cli_agent_sessions
+    active_sandbox_reuse_identities
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
@@ -102,41 +102,41 @@ mod tests {
 
     #[test]
     fn active_sessions_are_ref_counted() {
-        let active_sessions = new_active_cli_agent_sessions();
+        let active_sessions = new_active_sandbox_reuse_identities();
         let identity = sandbox_reuse_identity_for_test("sess-1");
-        insert_active_cli_agent_session(&active_sessions, &identity);
-        insert_active_cli_agent_session(&active_sessions, &identity);
+        insert_active_sandbox_reuse_identity(&active_sessions, &identity);
+        insert_active_sandbox_reuse_identity(&active_sessions, &identity);
 
-        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
+        assert!(active_sandbox_reuse_identity_set(&active_sessions).contains(&identity));
 
-        remove_active_cli_agent_session(&active_sessions, &identity);
-        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
+        remove_active_sandbox_reuse_identity(&active_sessions, &identity);
+        assert!(active_sandbox_reuse_identity_set(&active_sessions).contains(&identity));
 
-        remove_active_cli_agent_session(&active_sessions, &identity);
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&identity));
+        remove_active_sandbox_reuse_identity(&active_sessions, &identity);
+        assert!(!active_sandbox_reuse_identity_set(&active_sessions).contains(&identity));
     }
 
     #[test]
-    fn active_cli_agent_session_guard_registers_and_unregisters_initial_session() {
-        let active_sessions = new_active_cli_agent_sessions();
+    fn active_sandbox_reuse_identity_guard_registers_and_unregisters_initial_session() {
+        let active_sessions = new_active_sandbox_reuse_identities();
         let identity = sandbox_reuse_identity_for_test("sess-1");
-        let guard = ActiveCliAgentSessionGuard::new(
+        let guard = ActiveSandboxReuseIdentityGuard::new(
             Arc::clone(&active_sessions),
             Some(identity.scope()),
             Some("sess-1".into()),
         );
 
-        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
+        assert!(active_sandbox_reuse_identity_set(&active_sessions).contains(&identity));
 
         drop(guard);
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&identity));
+        assert!(!active_sandbox_reuse_identity_set(&active_sessions).contains(&identity));
     }
 
     #[test]
-    fn active_cli_agent_session_guard_can_mark_late_discovered_session_active() {
-        let active_sessions = new_active_cli_agent_sessions();
+    fn active_sandbox_reuse_identity_guard_can_mark_late_discovered_session_active() {
+        let active_sessions = new_active_sandbox_reuse_identities();
         let identity = sandbox_reuse_identity_for_test("sess-late");
-        let mut guard = ActiveCliAgentSessionGuard::new(
+        let mut guard = ActiveSandboxReuseIdentityGuard::new(
             Arc::clone(&active_sessions),
             Some(identity.scope()),
             None,
@@ -144,17 +144,17 @@ mod tests {
 
         guard.activate_late("sess-late");
 
-        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
+        assert!(active_sandbox_reuse_identity_set(&active_sessions).contains(&identity));
         drop(guard);
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&identity));
+        assert!(!active_sandbox_reuse_identity_set(&active_sessions).contains(&identity));
     }
 
     #[test]
-    fn active_cli_agent_session_guard_keeps_original_session_when_late_id_is_seen() {
-        let active_sessions = new_active_cli_agent_sessions();
+    fn active_sandbox_reuse_identity_guard_keeps_original_session_when_late_id_is_seen() {
+        let active_sessions = new_active_sandbox_reuse_identities();
         let original = sandbox_reuse_identity_for_test("sess-original");
         let late = sandbox_reuse_identity_for_test("sess-late");
-        let mut guard = ActiveCliAgentSessionGuard::new(
+        let mut guard = ActiveSandboxReuseIdentityGuard::new(
             Arc::clone(&active_sessions),
             Some(original.scope()),
             Some("sess-original".into()),
@@ -162,10 +162,10 @@ mod tests {
 
         guard.activate_late("sess-late");
 
-        let ids = active_cli_agent_session_ids(&active_sessions);
+        let ids = active_sandbox_reuse_identity_set(&active_sessions);
         assert!(ids.contains(&original));
         assert!(!ids.contains(&late));
         drop(guard);
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&original));
+        assert!(!active_sandbox_reuse_identity_set(&active_sessions).contains(&original));
     }
 }

--- a/crates/runner/src/cmd/start/active_sessions.rs
+++ b/crates/runner/src/cmd/start/active_sessions.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, MutexGuard};
 
-pub(super) type ActiveCliAgentSessions = Arc<Mutex<HashMap<String, usize>>>;
+use crate::sandbox_reuse_identity::{SandboxReuseIdentity, SandboxReuseScope};
+
+pub(super) type ActiveCliAgentSessions = Arc<Mutex<HashMap<SandboxReuseIdentity, usize>>>;
 
 pub(super) fn new_active_cli_agent_sessions() -> ActiveCliAgentSessions {
     Arc::new(Mutex::new(HashMap::new()))
@@ -9,29 +11,29 @@ pub(super) fn new_active_cli_agent_sessions() -> ActiveCliAgentSessions {
 
 pub(super) fn insert_active_cli_agent_session(
     active_cli_agent_sessions: &ActiveCliAgentSessions,
-    cli_agent_session_id: &str,
+    identity: &SandboxReuseIdentity,
 ) {
     let mut counts = lock_counts(active_cli_agent_sessions);
-    *counts.entry(cli_agent_session_id.to_owned()).or_insert(0) += 1;
+    *counts.entry(identity.clone()).or_insert(0) += 1;
 }
 
 pub(super) fn remove_active_cli_agent_session(
     active_cli_agent_sessions: &ActiveCliAgentSessions,
-    cli_agent_session_id: &str,
+    identity: &SandboxReuseIdentity,
 ) {
     let mut counts = lock_counts(active_cli_agent_sessions);
-    let Some(count) = counts.get_mut(cli_agent_session_id) else {
+    let Some(count) = counts.get_mut(identity) else {
         return;
     };
     *count = count.saturating_sub(1);
     if *count == 0 {
-        counts.remove(cli_agent_session_id);
+        counts.remove(identity);
     }
 }
 
 pub(super) fn active_cli_agent_session_ids(
     active_cli_agent_sessions: &ActiveCliAgentSessions,
-) -> HashSet<String> {
+) -> HashSet<SandboxReuseIdentity> {
     lock_counts(active_cli_agent_sessions)
         .keys()
         .cloned()
@@ -40,46 +42,54 @@ pub(super) fn active_cli_agent_session_ids(
 
 pub(super) struct ActiveCliAgentSessionGuard {
     active_cli_agent_sessions: ActiveCliAgentSessions,
-    cli_agent_session_id: Option<String>,
+    sandbox_reuse_scope: Option<SandboxReuseScope>,
+    sandbox_reuse_identity: Option<SandboxReuseIdentity>,
 }
 
 impl ActiveCliAgentSessionGuard {
     pub(super) fn new(
         active_cli_agent_sessions: ActiveCliAgentSessions,
+        sandbox_reuse_scope: Option<SandboxReuseScope>,
         cli_agent_session_id: Option<String>,
     ) -> Self {
-        if let Some(cli_agent_session_id) = cli_agent_session_id.as_deref() {
-            insert_active_cli_agent_session(&active_cli_agent_sessions, cli_agent_session_id);
+        let sandbox_reuse_identity = sandbox_reuse_scope
+            .and_then(|scope| scope.with_cli_agent_session_id(cli_agent_session_id.as_deref()?));
+        if let Some(identity) = sandbox_reuse_identity.as_ref() {
+            insert_active_cli_agent_session(&active_cli_agent_sessions, identity);
         }
         Self {
             active_cli_agent_sessions,
-            cli_agent_session_id,
+            sandbox_reuse_scope,
+            sandbox_reuse_identity,
         }
     }
 
     pub(super) fn activate_late(&mut self, discovered_cli_agent_session_id: &str) {
-        if self.cli_agent_session_id.is_some() {
+        if self.sandbox_reuse_identity.is_some() {
             return;
         }
-        insert_active_cli_agent_session(
-            &self.active_cli_agent_sessions,
-            discovered_cli_agent_session_id,
-        );
-        self.cli_agent_session_id = Some(discovered_cli_agent_session_id.to_owned());
+        let Some(identity) = self
+            .sandbox_reuse_scope
+            .and_then(|scope| scope.with_cli_agent_session_id(discovered_cli_agent_session_id))
+        else {
+            return;
+        };
+        insert_active_cli_agent_session(&self.active_cli_agent_sessions, &identity);
+        self.sandbox_reuse_identity = Some(identity);
     }
 }
 
 impl Drop for ActiveCliAgentSessionGuard {
     fn drop(&mut self) {
-        if let Some(cli_agent_session_id) = self.cli_agent_session_id.as_deref() {
-            remove_active_cli_agent_session(&self.active_cli_agent_sessions, cli_agent_session_id);
+        if let Some(identity) = self.sandbox_reuse_identity.as_ref() {
+            remove_active_cli_agent_session(&self.active_cli_agent_sessions, identity);
         }
     }
 }
 
 fn lock_counts(
     active_cli_agent_sessions: &ActiveCliAgentSessions,
-) -> MutexGuard<'_, HashMap<String, usize>> {
+) -> MutexGuard<'_, HashMap<SandboxReuseIdentity, usize>> {
     active_cli_agent_sessions
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -88,60 +98,74 @@ fn lock_counts(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::sandbox_reuse_identity_for_test;
 
     #[test]
     fn active_sessions_are_ref_counted() {
         let active_sessions = new_active_cli_agent_sessions();
-        insert_active_cli_agent_session(&active_sessions, "sess-1");
-        insert_active_cli_agent_session(&active_sessions, "sess-1");
+        let identity = sandbox_reuse_identity_for_test("sess-1");
+        insert_active_cli_agent_session(&active_sessions, &identity);
+        insert_active_cli_agent_session(&active_sessions, &identity);
 
-        assert!(active_cli_agent_session_ids(&active_sessions).contains("sess-1"));
+        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
 
-        remove_active_cli_agent_session(&active_sessions, "sess-1");
-        assert!(active_cli_agent_session_ids(&active_sessions).contains("sess-1"));
+        remove_active_cli_agent_session(&active_sessions, &identity);
+        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
 
-        remove_active_cli_agent_session(&active_sessions, "sess-1");
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains("sess-1"));
+        remove_active_cli_agent_session(&active_sessions, &identity);
+        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&identity));
     }
 
     #[test]
     fn active_cli_agent_session_guard_registers_and_unregisters_initial_session() {
         let active_sessions = new_active_cli_agent_sessions();
-        let guard =
-            ActiveCliAgentSessionGuard::new(Arc::clone(&active_sessions), Some("sess-1".into()));
+        let identity = sandbox_reuse_identity_for_test("sess-1");
+        let guard = ActiveCliAgentSessionGuard::new(
+            Arc::clone(&active_sessions),
+            Some(identity.scope()),
+            Some("sess-1".into()),
+        );
 
-        assert!(active_cli_agent_session_ids(&active_sessions).contains("sess-1"));
+        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
 
         drop(guard);
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains("sess-1"));
+        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&identity));
     }
 
     #[test]
     fn active_cli_agent_session_guard_can_mark_late_discovered_session_active() {
         let active_sessions = new_active_cli_agent_sessions();
-        let mut guard = ActiveCliAgentSessionGuard::new(Arc::clone(&active_sessions), None);
+        let identity = sandbox_reuse_identity_for_test("sess-late");
+        let mut guard = ActiveCliAgentSessionGuard::new(
+            Arc::clone(&active_sessions),
+            Some(identity.scope()),
+            None,
+        );
 
         guard.activate_late("sess-late");
 
-        assert!(active_cli_agent_session_ids(&active_sessions).contains("sess-late"));
+        assert!(active_cli_agent_session_ids(&active_sessions).contains(&identity));
         drop(guard);
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains("sess-late"));
+        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&identity));
     }
 
     #[test]
     fn active_cli_agent_session_guard_keeps_original_session_when_late_id_is_seen() {
         let active_sessions = new_active_cli_agent_sessions();
+        let original = sandbox_reuse_identity_for_test("sess-original");
+        let late = sandbox_reuse_identity_for_test("sess-late");
         let mut guard = ActiveCliAgentSessionGuard::new(
             Arc::clone(&active_sessions),
+            Some(original.scope()),
             Some("sess-original".into()),
         );
 
         guard.activate_late("sess-late");
 
         let ids = active_cli_agent_session_ids(&active_sessions);
-        assert!(ids.contains("sess-original"));
-        assert!(!ids.contains("sess-late"));
+        assert!(ids.contains(&original));
+        assert!(!ids.contains(&late));
         drop(guard);
-        assert!(!active_cli_agent_session_ids(&active_sessions).contains("sess-original"));
+        assert!(!active_cli_agent_session_ids(&active_sessions).contains(&original));
     }
 }

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use tracing::{debug, info};
 
-use super::active_sessions::{ActiveCliAgentSessions, active_cli_agent_session_ids};
+use super::active_sessions::{ActiveSandboxReuseIdentityCounts, active_sandbox_reuse_identity_set};
 use crate::config::ProfileConfig;
 use crate::idle_pool::IdlePool;
 use crate::provider::JobProvider;
@@ -30,7 +30,7 @@ pub(super) struct HeartbeatContext<'a> {
     budget: &'a ResourceBudget,
     provider: &'a dyn JobProvider,
     workspace_cache: Option<SessionWorkspaceCache>,
-    active_cli_agent_sessions: &'a ActiveCliAgentSessions,
+    active_sandbox_reuse_identities: &'a ActiveSandboxReuseIdentityCounts,
     held_session_snapshot: HeldSessionStateSnapshot,
 }
 
@@ -43,7 +43,7 @@ pub(super) struct HeartbeatContextInit<'a> {
     pub(super) budget: &'a ResourceBudget,
     pub(super) provider: &'a dyn JobProvider,
     pub(super) workspace_cache: Option<SessionWorkspaceCache>,
-    pub(super) active_cli_agent_sessions: &'a ActiveCliAgentSessions,
+    pub(super) active_sandbox_reuse_identities: &'a ActiveSandboxReuseIdentityCounts,
     pub(super) held_session_snapshot: HeldSessionStateSnapshot,
 }
 
@@ -58,7 +58,7 @@ impl<'a> HeartbeatContext<'a> {
             budget: init.budget,
             provider: init.provider,
             workspace_cache: init.workspace_cache,
-            active_cli_agent_sessions: init.active_cli_agent_sessions,
+            active_sandbox_reuse_identities: init.active_sandbox_reuse_identities,
             held_session_snapshot: init.held_session_snapshot,
         }
     }
@@ -147,14 +147,14 @@ impl HeldSessionStateSnapshot {
     pub(super) fn current_held_session_states(
         &self,
         idle_states: Vec<HeldSessionState>,
-        active_cli_agent_sessions: &ActiveCliAgentSessions,
+        active_sandbox_reuse_identities: &ActiveSandboxReuseIdentityCounts,
         extra_active_session: Option<&SandboxReuseIdentity>,
     ) -> Vec<HeldSessionState> {
         let workspace_cache_states = self.lock_inner().workspace_cache_states.clone();
         merge_current_held_session_states(
             idle_states,
             workspace_cache_states,
-            active_cli_agent_sessions,
+            active_sandbox_reuse_identities,
             extra_active_session,
         )
     }
@@ -188,7 +188,7 @@ pub(super) async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) 
     state.held_session_states = merge_current_held_session_states(
         state.held_session_states,
         workspace_cache_states,
-        hb.active_cli_agent_sessions,
+        hb.active_sandbox_reuse_identities,
         None,
     );
     info!(
@@ -226,20 +226,21 @@ async fn workspace_cache_held_session_states(
 fn merge_current_held_session_states(
     idle_states: Vec<HeldSessionState>,
     cache_states: Vec<HeldSessionState>,
-    active_cli_agent_sessions: &ActiveCliAgentSessions,
+    active_sandbox_reuse_identities: &ActiveSandboxReuseIdentityCounts,
     extra_active_session: Option<&SandboxReuseIdentity>,
 ) -> Vec<HeldSessionState> {
-    let mut active_cli_agent_sessions = active_cli_agent_session_ids(active_cli_agent_sessions);
+    let mut active_sandbox_reuse_identities =
+        active_sandbox_reuse_identity_set(active_sandbox_reuse_identities);
     if let Some(identity) = extra_active_session {
-        active_cli_agent_sessions.insert(identity.clone());
+        active_sandbox_reuse_identities.insert(identity.clone());
     }
-    merge_held_session_states(idle_states, cache_states, &active_cli_agent_sessions)
+    merge_held_session_states(idle_states, cache_states, &active_sandbox_reuse_identities)
 }
 
 fn merge_held_session_states(
     idle_states: Vec<HeldSessionState>,
     cache_states: Vec<HeldSessionState>,
-    active_cli_agent_sessions: &std::collections::HashSet<SandboxReuseIdentity>,
+    active_sandbox_reuse_identities: &std::collections::HashSet<SandboxReuseIdentity>,
 ) -> Vec<HeldSessionState> {
     let mut by_session =
         std::collections::BTreeMap::<SandboxReuseIdentity, HeldSessionState>::new();
@@ -247,7 +248,7 @@ fn merge_held_session_states(
         let Some(identity) = state.sandbox_reuse_identity() else {
             continue;
         };
-        if active_cli_agent_sessions.contains(&identity) {
+        if active_sandbox_reuse_identities.contains(&identity) {
             continue;
         }
         by_session.insert(identity, state);
@@ -256,7 +257,7 @@ fn merge_held_session_states(
         let Some(identity) = state.sandbox_reuse_identity() else {
             continue;
         };
-        if active_cli_agent_sessions.contains(&identity) {
+        if active_sandbox_reuse_identities.contains(&identity) {
             continue;
         }
         match by_session.get_mut(&identity) {
@@ -659,8 +660,8 @@ mod tests {
         seed_workspace_cache_state(&cache, &paths, session_id, "2026-06-01T00:00:00.000Z").await;
         let profiles = test_profiles();
         let budget = ResourceBudget::new(8, 32768, 1.0, 4);
-        let active_cli_agent_sessions =
-            super::super::active_sessions::new_active_cli_agent_sessions();
+        let active_sandbox_reuse_identities =
+            super::super::active_sessions::new_active_sandbox_reuse_identities();
         let (provider, _) = MockJobProvider::new(tokio_util::sync::CancellationToken::new());
         let held_session_snapshot = HeldSessionStateSnapshot::new();
         let hb = HeartbeatContext::new(HeartbeatContextInit {
@@ -672,7 +673,7 @@ mod tests {
             budget: &budget,
             provider: provider.as_ref(),
             workspace_cache: Some(cache),
-            active_cli_agent_sessions: &active_cli_agent_sessions,
+            active_sandbox_reuse_identities: &active_sandbox_reuse_identities,
             held_session_snapshot: held_session_snapshot.clone(),
         });
 
@@ -693,7 +694,7 @@ mod tests {
         }
         let cached_states = held_session_snapshot.current_held_session_states(
             Vec::new(),
-            &active_cli_agent_sessions,
+            &active_sandbox_reuse_identities,
             None,
         );
         assert_eq!(cached_states.len(), 1);
@@ -709,8 +710,8 @@ mod tests {
         seed_workspace_cache_state(&cache, &paths, "sess-cache", "2026-06-01T00:00:00.000Z").await;
         seed_workspace_cache_state(&cache, &paths, "sess-claimed", "2026-06-01T00:00:01.000Z")
             .await;
-        let active_cli_agent_sessions =
-            super::super::active_sessions::new_active_cli_agent_sessions();
+        let active_sandbox_reuse_identities =
+            super::super::active_sessions::new_active_sandbox_reuse_identities();
         let idle = vec![HeldSessionState {
             sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-idle".into(),
@@ -723,7 +724,7 @@ mod tests {
         let states = merge_current_held_session_states(
             idle,
             cache_states,
-            &active_cli_agent_sessions,
+            &active_sandbox_reuse_identities,
             Some(&claimed_identity),
         );
 
@@ -769,10 +770,10 @@ mod tests {
                 },
             ],
         );
-        let active_cli_agent_sessions =
-            super::super::active_sessions::new_active_cli_agent_sessions();
-        super::super::active_sessions::insert_active_cli_agent_session(
-            &active_cli_agent_sessions,
+        let active_sandbox_reuse_identities =
+            super::super::active_sessions::new_active_sandbox_reuse_identities();
+        super::super::active_sessions::insert_active_sandbox_reuse_identity(
+            &active_sandbox_reuse_identities,
             &test_identity("sess-active"),
         );
         let idle = vec![
@@ -793,7 +794,7 @@ mod tests {
         let claimed_identity = test_identity("sess-claimed");
         let states = snapshot.current_held_session_states(
             idle,
-            &active_cli_agent_sessions,
+            &active_sandbox_reuse_identities,
             Some(&claimed_identity),
         );
 
@@ -867,10 +868,13 @@ mod tests {
             });
         }
 
-        let active_cli_agent_sessions =
-            super::super::active_sessions::new_active_cli_agent_sessions();
-        let states =
-            snapshot.current_held_session_states(Vec::new(), &active_cli_agent_sessions, None);
+        let active_sandbox_reuse_identities =
+            super::super::active_sessions::new_active_sandbox_reuse_identities();
+        let states = snapshot.current_held_session_states(
+            Vec::new(),
+            &active_sandbox_reuse_identities,
+            None,
+        );
 
         assert_eq!(states.len(), MAX_HELD_SESSION_STATES);
         assert!(
@@ -907,17 +911,23 @@ mod tests {
         let refreshed = snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
         assert_eq!(refreshed, vec![original.clone(), promoted.clone()]);
 
-        let active_cli_agent_sessions =
-            super::super::active_sessions::new_active_cli_agent_sessions();
-        let states =
-            snapshot.current_held_session_states(Vec::new(), &active_cli_agent_sessions, None);
+        let active_sandbox_reuse_identities =
+            super::super::active_sessions::new_active_sandbox_reuse_identities();
+        let states = snapshot.current_held_session_states(
+            Vec::new(),
+            &active_sandbox_reuse_identities,
+            None,
+        );
         assert_eq!(states, vec![original.clone(), promoted]);
 
         let refresh = snapshot.begin_workspace_cache_refresh();
         snapshot.finish_workspace_cache_refresh(refresh, vec![original.clone()]);
 
-        let states =
-            snapshot.current_held_session_states(Vec::new(), &active_cli_agent_sessions, None);
+        let states = snapshot.current_held_session_states(
+            Vec::new(),
+            &active_sandbox_reuse_identities,
+            None,
+        );
         assert_eq!(states, vec![original]);
     }
 

--- a/crates/runner/src/cmd/start/heartbeat.rs
+++ b/crates/runner/src/cmd/start/heartbeat.rs
@@ -9,6 +9,7 @@ use crate::config::ProfileConfig;
 use crate::idle_pool::IdlePool;
 use crate::provider::JobProvider;
 use crate::resource_budget::ResourceBudget;
+use crate::sandbox_reuse_identity::SandboxReuseIdentity;
 use crate::status::RunnerMode;
 use crate::types::{HeartbeatState, HeldSessionState, MAX_HELD_SESSION_STATES};
 use crate::workspace_image_cache::SessionWorkspaceCache;
@@ -113,12 +114,15 @@ impl HeldSessionStateSnapshot {
     }
 
     pub(super) fn upsert_workspace_cache_state(&self, state: HeldSessionState) {
+        let Some(identity) = state.sandbox_reuse_identity() else {
+            return;
+        };
         let mut inner = self.lock_inner();
         inner.workspace_cache_loaded = true;
         match inner
             .workspace_cache_states
             .iter_mut()
-            .find(|existing| existing.session_id == state.session_id)
+            .find(|existing| existing.sandbox_reuse_identity().as_ref() == Some(&identity))
         {
             Some(existing) if existing.last_completed_at >= state.last_completed_at => {}
             Some(existing) => *existing = state,
@@ -128,20 +132,23 @@ impl HeldSessionStateSnapshot {
         inner.workspace_cache_revision = inner.workspace_cache_revision.wrapping_add(1);
     }
 
-    pub(super) fn might_contain_workspace_cache_session(&self, session_id: &str) -> bool {
+    pub(super) fn might_contain_workspace_cache_session(
+        &self,
+        identity: &SandboxReuseIdentity,
+    ) -> bool {
         let inner = self.lock_inner();
         !inner.workspace_cache_loaded
             || inner
                 .workspace_cache_states
                 .iter()
-                .any(|state| state.session_id == session_id)
+                .any(|state| state.sandbox_reuse_identity().as_ref() == Some(identity))
     }
 
     pub(super) fn current_held_session_states(
         &self,
         idle_states: Vec<HeldSessionState>,
         active_cli_agent_sessions: &ActiveCliAgentSessions,
-        extra_active_session: Option<&str>,
+        extra_active_session: Option<&SandboxReuseIdentity>,
     ) -> Vec<HeldSessionState> {
         let workspace_cache_states = self.lock_inner().workspace_cache_states.clone();
         merge_current_held_session_states(
@@ -220,11 +227,11 @@ fn merge_current_held_session_states(
     idle_states: Vec<HeldSessionState>,
     cache_states: Vec<HeldSessionState>,
     active_cli_agent_sessions: &ActiveCliAgentSessions,
-    extra_active_session: Option<&str>,
+    extra_active_session: Option<&SandboxReuseIdentity>,
 ) -> Vec<HeldSessionState> {
     let mut active_cli_agent_sessions = active_cli_agent_session_ids(active_cli_agent_sessions);
-    if let Some(session_id) = extra_active_session {
-        active_cli_agent_sessions.insert(session_id.to_owned());
+    if let Some(identity) = extra_active_session {
+        active_cli_agent_sessions.insert(identity.clone());
     }
     merge_held_session_states(idle_states, cache_states, &active_cli_agent_sessions)
 }
@@ -232,20 +239,27 @@ fn merge_current_held_session_states(
 fn merge_held_session_states(
     idle_states: Vec<HeldSessionState>,
     cache_states: Vec<HeldSessionState>,
-    active_cli_agent_sessions: &std::collections::HashSet<String>,
+    active_cli_agent_sessions: &std::collections::HashSet<SandboxReuseIdentity>,
 ) -> Vec<HeldSessionState> {
-    let mut by_session = std::collections::BTreeMap::<String, HeldSessionState>::new();
+    let mut by_session =
+        std::collections::BTreeMap::<SandboxReuseIdentity, HeldSessionState>::new();
     for state in idle_states {
-        if active_cli_agent_sessions.contains(&state.session_id) {
+        let Some(identity) = state.sandbox_reuse_identity() else {
+            continue;
+        };
+        if active_cli_agent_sessions.contains(&identity) {
             continue;
         }
-        by_session.insert(state.session_id.clone(), state);
+        by_session.insert(identity, state);
     }
     for state in cache_states {
-        if active_cli_agent_sessions.contains(&state.session_id) {
+        let Some(identity) = state.sandbox_reuse_identity() else {
+            continue;
+        };
+        if active_cli_agent_sessions.contains(&identity) {
             continue;
         }
-        match by_session.get_mut(&state.session_id) {
+        match by_session.get_mut(&identity) {
             Some(existing) => {
                 let reusable_sandbox = existing.reusable_sandbox.take();
                 if state.last_completed_at > existing.last_completed_at {
@@ -254,7 +268,7 @@ fn merge_held_session_states(
                 existing.reusable_sandbox = reusable_sandbox.or(existing.reusable_sandbox.take());
             }
             None => {
-                by_session.insert(state.session_id.clone(), state);
+                by_session.insert(identity, state);
             }
         }
     }
@@ -263,9 +277,14 @@ fn merge_held_session_states(
         b.last_completed_at
             .cmp(&a.last_completed_at)
             .then_with(|| a.session_id.cmp(&b.session_id))
+            .then_with(|| a.sandbox_reuse_scope.cmp(&b.sandbox_reuse_scope))
     });
     states.truncate(MAX_HELD_SESSION_STATES);
-    states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+    states.sort_unstable_by(|a, b| {
+        a.session_id
+            .cmp(&b.session_id)
+            .then_with(|| a.sandbox_reuse_scope.cmp(&b.sandbox_reuse_scope))
+    });
     states
 }
 
@@ -273,12 +292,16 @@ fn merge_workspace_cache_snapshot_states(
     existing_states: Vec<HeldSessionState>,
     refreshed_states: Vec<HeldSessionState>,
 ) -> Vec<HeldSessionState> {
-    let mut by_session = std::collections::BTreeMap::<String, HeldSessionState>::new();
+    let mut by_session =
+        std::collections::BTreeMap::<SandboxReuseIdentity, HeldSessionState>::new();
     for state in refreshed_states.into_iter().chain(existing_states) {
-        match by_session.get(&state.session_id) {
+        let Some(identity) = state.sandbox_reuse_identity() else {
+            continue;
+        };
+        match by_session.get(&identity) {
             Some(existing) if existing.last_completed_at >= state.last_completed_at => {}
             _ => {
-                by_session.insert(state.session_id.clone(), state);
+                by_session.insert(identity, state);
             }
         }
     }
@@ -293,9 +316,14 @@ fn cap_workspace_cache_snapshot_states(states: &mut Vec<HeldSessionState>) {
         b.last_completed_at
             .cmp(&a.last_completed_at)
             .then_with(|| a.session_id.cmp(&b.session_id))
+            .then_with(|| a.sandbox_reuse_scope.cmp(&b.sandbox_reuse_scope))
     });
     states.truncate(MAX_HELD_SESSION_STATES);
-    states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+    states.sort_unstable_by(|a, b| {
+        a.session_id
+            .cmp(&b.session_id)
+            .then_with(|| a.sandbox_reuse_scope.cmp(&b.sandbox_reuse_scope))
+    });
 }
 
 fn admittable_profiles_for_heartbeat(
@@ -396,6 +424,14 @@ mod tests {
         m
     }
 
+    fn test_identity(session_id: &str) -> SandboxReuseIdentity {
+        crate::test_fixtures::sandbox_reuse_identity_for_test(session_id)
+    }
+
+    fn test_scope_wire() -> Option<String> {
+        Some(crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE.to_owned())
+    }
+
     fn make_synthetic_parked_candidate(session_id: &str) -> ParkedIdleCandidate {
         let budget = Arc::new(ResourceBudget::new(1, 1, 1.0, 0));
         ParkedIdleCandidateBuilder::new(
@@ -420,7 +456,7 @@ mod tests {
         let run_id = crate::ids::RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let lease = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -676,17 +712,19 @@ mod tests {
         let active_cli_agent_sessions =
             super::super::active_sessions::new_active_cli_agent_sessions();
         let idle = vec![HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-idle".into(),
             last_completed_at: "2026-06-01T00:00:02.000Z".into(),
             reusable_sandbox: None,
         }];
 
         let cache_states = workspace_cache_held_session_states(Some(&cache)).await;
+        let claimed_identity = test_identity("sess-claimed");
         let states = merge_current_held_session_states(
             idle,
             cache_states,
             &active_cli_agent_sessions,
-            Some("sess-claimed"),
+            Some(&claimed_identity),
         );
 
         assert!(
@@ -712,16 +750,19 @@ mod tests {
             &snapshot,
             vec![
                 HeldSessionState {
+                    sandbox_reuse_scope: test_scope_wire(),
                     session_id: "sess-cache".into(),
                     last_completed_at: "2026-06-01T00:00:02.000Z".into(),
                     reusable_sandbox: None,
                 },
                 HeldSessionState {
+                    sandbox_reuse_scope: test_scope_wire(),
                     session_id: "sess-claimed".into(),
                     last_completed_at: "2026-06-01T00:00:03.000Z".into(),
                     reusable_sandbox: None,
                 },
                 HeldSessionState {
+                    sandbox_reuse_scope: test_scope_wire(),
                     session_id: "sess-active".into(),
                     last_completed_at: "2026-06-01T00:00:04.000Z".into(),
                     reusable_sandbox: None,
@@ -732,36 +773,41 @@ mod tests {
             super::super::active_sessions::new_active_cli_agent_sessions();
         super::super::active_sessions::insert_active_cli_agent_session(
             &active_cli_agent_sessions,
-            "sess-active",
+            &test_identity("sess-active"),
         );
         let idle = vec![
             HeldSessionState {
+                sandbox_reuse_scope: test_scope_wire(),
                 session_id: "sess-cache".into(),
                 last_completed_at: "2026-06-01T00:00:01.000Z".into(),
                 reusable_sandbox: None,
             },
             HeldSessionState {
+                sandbox_reuse_scope: test_scope_wire(),
                 session_id: "sess-idle".into(),
                 last_completed_at: "2026-06-01T00:00:05.000Z".into(),
                 reusable_sandbox: None,
             },
         ];
 
+        let claimed_identity = test_identity("sess-claimed");
         let states = snapshot.current_held_session_states(
             idle,
             &active_cli_agent_sessions,
-            Some("sess-claimed"),
+            Some(&claimed_identity),
         );
 
         assert_eq!(
             states,
             vec![
                 HeldSessionState {
+                    sandbox_reuse_scope: test_scope_wire(),
                     session_id: "sess-cache".into(),
                     last_completed_at: "2026-06-01T00:00:02.000Z".into(),
                     reusable_sandbox: None,
                 },
                 HeldSessionState {
+                    sandbox_reuse_scope: test_scope_wire(),
                     session_id: "sess-idle".into(),
                     last_completed_at: "2026-06-01T00:00:05.000Z".into(),
                     reusable_sandbox: None,
@@ -773,13 +819,14 @@ mod tests {
     #[test]
     fn held_session_snapshot_treats_unloaded_workspace_cache_as_unknown() {
         let snapshot = HeldSessionStateSnapshot::new();
+        let identity = test_identity("sess-cache");
 
         assert!(
             !snapshot.workspace_cache_loaded(),
             "new snapshot should start with unknown workspace-cache state"
         );
         assert!(
-            snapshot.might_contain_workspace_cache_session("sess-cache"),
+            snapshot.might_contain_workspace_cache_session(&identity),
             "unloaded snapshot should trigger one refresh for cache-enabled runners"
         );
 
@@ -789,20 +836,21 @@ mod tests {
             "refresh should mark workspace-cache state loaded even when empty"
         );
         assert!(
-            !snapshot.might_contain_workspace_cache_session("sess-cache"),
+            !snapshot.might_contain_workspace_cache_session(&identity),
             "loaded empty snapshot should not keep triggering cache refreshes"
         );
 
         refresh_snapshot(
             &snapshot,
             vec![HeldSessionState {
+                sandbox_reuse_scope: test_scope_wire(),
                 session_id: "sess-cache".into(),
                 last_completed_at: "2026-06-01T00:00:02.000Z".into(),
                 reusable_sandbox: None,
             }],
         );
         assert!(
-            snapshot.might_contain_workspace_cache_session("sess-cache"),
+            snapshot.might_contain_workspace_cache_session(&identity),
             "loaded matching snapshot should trigger refresh when that session is claimed"
         );
     }
@@ -812,6 +860,7 @@ mod tests {
         let snapshot = HeldSessionStateSnapshot::new();
         for index in 0..=MAX_HELD_SESSION_STATES {
             snapshot.upsert_workspace_cache_state(HeldSessionState {
+                sandbox_reuse_scope: test_scope_wire(),
                 session_id: format!("sess-{index:04}"),
                 last_completed_at: timestamp_for_index(index),
                 reusable_sandbox: None,
@@ -840,11 +889,13 @@ mod tests {
     fn held_session_snapshot_refresh_preserves_concurrent_upsert() {
         let snapshot = HeldSessionStateSnapshot::new();
         let original = HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-original".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
             reusable_sandbox: None,
         };
         let promoted = HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-promoted".into(),
             last_completed_at: "2026-06-01T00:00:02.000Z".into(),
             reusable_sandbox: None,
@@ -877,18 +928,20 @@ mod tests {
     #[test]
     fn merge_held_session_states_filters_active_sessions() {
         let idle = vec![HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-active-idle".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
             reusable_sandbox: None,
         }];
         let cache = vec![HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-active".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: None,
         }];
         let active = std::collections::HashSet::from([
-            "sess-active".to_string(),
-            "sess-active-idle".to_string(),
+            test_identity("sess-active"),
+            test_identity("sess-active-idle"),
         ]);
 
         let merged = merge_held_session_states(idle, cache, &active);
@@ -899,6 +952,7 @@ mod tests {
     #[test]
     fn merge_held_session_states_keeps_newest_duplicate() {
         let idle = vec![HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: Some(crate::types::ReusableSandboxState {
@@ -906,6 +960,7 @@ mod tests {
             }),
         }];
         let cache = vec![HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:01.000Z".into(),
             reusable_sandbox: None,
@@ -928,6 +983,7 @@ mod tests {
     #[test]
     fn merge_held_session_states_prefers_idle_on_equal_timestamp() {
         let idle = vec![HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: Some(crate::types::ReusableSandboxState {
@@ -935,6 +991,7 @@ mod tests {
             }),
         }];
         let cache = vec![HeldSessionState {
+            sandbox_reuse_scope: test_scope_wire(),
             session_id: "sess-1".into(),
             last_completed_at: "2026-06-01T00:00:00.000Z".into(),
             reusable_sandbox: None,

--- a/crates/runner/src/cmd/start/idle_lifecycle.rs
+++ b/crates/runner/src/cmd/start/idle_lifecycle.rs
@@ -243,7 +243,9 @@ mod tests {
         let request = IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
             factory,
-            cli_agent_session_id: fixture.session_id.clone(),
+            sandbox_reuse_identity: crate::test_fixtures::sandbox_reuse_identity_for_test(
+                &fixture.session_id,
+            ),
             sandbox_id: fixture.sandbox_id,
             profile_name: "vm0/default".into(),
             device_rate_limits: None,

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -34,13 +34,13 @@ use crate::idle_pool::{
     RestoreReservedIdleResult, ReusableIdleSandbox,
 };
 use crate::ids::RunId;
-use crate::paths::short_digest;
 use crate::provider::{ClaimedJob, JobCandidate, PreLocalAdmissionOutcome};
 use crate::resource_budget::{BudgetLease, ResourceBudget};
 use crate::restored_session_identity::{
     RestoredSessionIdentity, RestoredSessionIdentityMismatchReason,
 };
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::sandbox_reuse_identity::SandboxReuseIdentity;
 use crate::status::{RunnerMode, StatusTracker};
 use crate::types::{ExecutionContext, HeldSessionState, SandboxReuseResult};
 
@@ -169,6 +169,7 @@ pub(super) async fn handle_discovered_job(
     // briefly advertise stale workspace-cache affinity for an active session.
     let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
         ctx.spawn_ctx.active_cli_agent_sessions.clone(),
+        claimed.context().sandbox_reuse_scope(),
         if resume_session_valid {
             claimed.context().cli_agent_session_id().map(str::to_owned)
         } else {
@@ -522,7 +523,7 @@ async fn prepare_affinity_protected_candidate(
             candidate.with_pre_local_admission_outcome(PreLocalAdmissionOutcome::NotProtected),
         );
     }
-    let Some(cli_agent_session_id) = candidate.cli_agent_session_id().map(str::to_owned) else {
+    let Some(sandbox_reuse_identity) = candidate.sandbox_reuse_identity().cloned() else {
         return Some(
             candidate
                 .with_pre_local_admission_outcome(PreLocalAdmissionOutcome::MissingSessionMetadata),
@@ -530,7 +531,7 @@ async fn prepare_affinity_protected_candidate(
     };
 
     let has_exact_reusable = ctx.idle_pool.lock().await.has_reusable(
-        &cli_agent_session_id,
+        &sandbox_reuse_identity,
         profile_name,
         device_rate_limits,
     );
@@ -538,7 +539,7 @@ async fn prepare_affinity_protected_candidate(
     let has_fresh_affinity = ctx.budget.can_afford(job_vcpu, job_memory)
         && held_session_states
             .iter()
-            .any(|state| state.session_id == cli_agent_session_id);
+            .any(|state| state.sandbox_reuse_identity() == Some(sandbox_reuse_identity.clone()));
     if has_exact_reusable || has_fresh_affinity {
         return Some(
             candidate.with_pre_local_admission_outcome(PreLocalAdmissionOutcome::LocalHolder),
@@ -548,7 +549,7 @@ async fn prepare_affinity_protected_candidate(
     let delay = candidate
         .affinity_protection_remaining()
         .unwrap_or_default();
-    let session_fingerprint = diagnostic_session_fingerprint(&cli_agent_session_id);
+    let session_fingerprint = sandbox_reuse_identity.diagnostic_fingerprint();
     info!(
         run_id = %candidate.run_id(),
         session_fingerprint = %session_fingerprint,
@@ -557,10 +558,6 @@ async fn prepare_affinity_protected_candidate(
     );
     ctx.spawn_ctx.provider.defer_poll_after(delay).await;
     None
-}
-
-fn diagnostic_session_fingerprint(session_id: &str) -> String {
-    short_digest(session_id)
 }
 
 async fn current_local_held_session_states(
@@ -584,9 +581,9 @@ async fn acquire_local_admission_resource(
     ctx: &mut DiscoveredJobContext<'_>,
 ) -> Option<LocalAdmissionResource> {
     loop {
-        if let Some(session_id) = candidate.cli_agent_session_id()
+        if let Some(identity) = candidate.sandbox_reuse_identity()
             && let Some(reservation) =
-                reserve_reusable_idle(session_id, profile_name, device_rate_limits, ctx).await
+                reserve_reusable_idle(identity, profile_name, device_rate_limits, ctx).await
         {
             return Some(LocalAdmissionResource::Reusable(Box::new(reservation)));
         }
@@ -622,14 +619,14 @@ async fn acquire_local_admission_resource(
 }
 
 async fn reserve_reusable_idle(
-    session_id: &str,
+    identity: &SandboxReuseIdentity,
     profile_name: &str,
     device_rate_limits: &Option<sandbox::DeviceRateLimits>,
     ctx: &DiscoveredJobContext<'_>,
 ) -> Option<ReservedIdleSandbox> {
     let (reservation, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
-        let reservation = pool.reserve_reusable(session_id, profile_name, device_rate_limits)?;
+        let reservation = pool.reserve_reusable(identity, profile_name, device_rate_limits)?;
         let snapshot = pool.status_snapshot();
         (reservation, snapshot)
     };
@@ -691,12 +688,13 @@ async fn activate_reserved_idle(
         resume_session_valid,
     } = request;
     let started_at = Instant::now();
-    let requested_session_id = context.cli_agent_session_id();
+    let requested_identity = context.sandbox_reuse_identity();
     let reserved_session_id = reservation.cli_agent_session_id().to_owned();
+    let reserved_identity = reservation.sandbox_reuse_identity().clone();
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
 
-    if !resume_session_valid || requested_session_id != Some(reserved_session_id.as_str()) {
-        let reuse_result = if requested_session_id.is_none() || !resume_session_valid {
+    if !resume_session_valid || requested_identity.as_ref() != Some(&reserved_identity) {
+        let reuse_result = if requested_identity.is_none() || !resume_session_valid {
             SandboxReuseResult::NoSessionId
         } else {
             SandboxReuseResult::PoolMiss
@@ -704,8 +702,8 @@ async fn activate_reserved_idle(
         warn!(
             run_id = %run_id,
             reserved_session_id = %reserved_session_id,
-            claimed_session_id = ?requested_session_id,
-            "claimed session does not match reserved idle VM, destroying before fresh fallback"
+            claimed_identity = ?requested_identity,
+            "claimed reuse identity does not match reserved idle VM, destroying before fresh fallback"
         );
         return cleanup_reserved_for_fresh_fallback(
             reservation.into_destroy_job(),
@@ -867,7 +865,7 @@ async fn try_reuse_from_pool(
             false,
         );
     }
-    let Some(cli_agent_session_id) = context.cli_agent_session_id() else {
+    let Some(sandbox_reuse_identity) = context.sandbox_reuse_identity() else {
         pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::IdleReuseLookup, started_at);
         return (
             None,
@@ -881,7 +879,7 @@ async fn try_reuse_from_pool(
     // so unpark does not block other take/park operations.
     let (taken, snapshot) = {
         let mut pool = ctx.idle_pool.lock().await;
-        let taken = pool.take(cli_agent_session_id);
+        let taken = pool.take(&sandbox_reuse_identity);
         let snapshot = taken.as_ref().map(|_| pool.status_snapshot());
         (taken, snapshot)
     };
@@ -892,7 +890,7 @@ async fn try_reuse_from_pool(
         && ctx
             .spawn_ctx
             .held_session_snapshot
-            .might_contain_workspace_cache_session(cli_agent_session_id);
+            .might_contain_workspace_cache_session(&sandbox_reuse_identity);
     pre_spawn_timing.record_phase_elapsed(RunnerPreSpawnPhase::HeldSessionStateRefresh, started_at);
     let needs_session_affinity_refresh = took_idle_session || claimed_workspace_cache_session;
     match taken {
@@ -914,7 +912,7 @@ async fn try_reuse_from_pool(
                 if let Err(mismatch) = validation {
                     warn!(
                         run_id = %run_id,
-                        session_id = %cli_agent_session_id,
+                        session_id = %sandbox_reuse_identity.cli_agent_session_id(),
                         profile = %profile_name,
                         mismatch = mismatch.as_str(),
                         "workspace promotion identity mismatch, destroying idle VM and falling through to fresh create"
@@ -943,7 +941,7 @@ async fn try_reuse_from_pool(
                 } => {
                     info!(
                         run_id = %run_id,
-                        session_id = %cli_agent_session_id,
+                        session_id = %sandbox_reuse_identity.cli_agent_session_id(),
                         "reusing idle VM for session"
                     );
                     // Idle entry already holds budget. Drop the speculative
@@ -961,7 +959,7 @@ async fn try_reuse_from_pool(
                 IdleUnparkResult::Failed { destroy_job, error } => {
                     warn!(
                         run_id = %run_id,
-                        session_id = %cli_agent_session_id,
+                        session_id = %sandbox_reuse_identity.cli_agent_session_id(),
                         error = %error,
                         "unpark failed, destroying idle VM and falling through to fresh create"
                     );
@@ -979,7 +977,7 @@ async fn try_reuse_from_pool(
         Some(stale) if stale.profile_name() == profile_name => {
             info!(
                 run_id = %run_id,
-                session_id = %cli_agent_session_id,
+                session_id = %sandbox_reuse_identity.cli_agent_session_id(),
                 profile = %profile_name,
                 "idle VM device rate limiter mismatch, destroying"
             );
@@ -999,7 +997,7 @@ async fn try_reuse_from_pool(
         Some(stale) => {
             info!(
                 run_id = %run_id,
-                session_id = %cli_agent_session_id,
+                session_id = %sandbox_reuse_identity.cli_agent_session_id(),
                 old_profile = %stale.profile_name(),
                 new_profile = %profile_name,
                 "idle VM profile mismatch, destroying"
@@ -1020,7 +1018,7 @@ async fn try_reuse_from_pool(
         None => {
             info!(
                 run_id = %run_id,
-                session_id = %cli_agent_session_id,
+                session_id = %sandbox_reuse_identity.cli_agent_session_id(),
                 "no idle VM found for session"
             );
             (
@@ -1130,7 +1128,7 @@ mod tests {
         });
         assert!(matches!(pool.park(candidate), ParkResult::Parked));
         let entry = pool
-            .take("sess-restore-plan")
+            .take_for_test("sess-restore-plan")
             .expect("idle entry should exist");
         let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
             panic!("idle entry should unpark");
@@ -1178,6 +1176,10 @@ mod tests {
                 run_id,
                 sandbox_id,
                 profile_name: "vm0/default".into(),
+                sandbox_reuse_scope: Some(
+                    crate::test_fixtures::sandbox_reuse_identity_for_test("sess-restore-plan")
+                        .scope(),
+                ),
                 cli_agent_session_id: Some("sess-restore-plan".into()),
                 discovered_cli_agent_session_id: None,
                 restored_session_identity,
@@ -1206,7 +1208,7 @@ mod tests {
         let entry = idle_pool
             .lock()
             .await
-            .take("sess-restore-plan")
+            .take_for_test("sess-restore-plan")
             .expect("finalizer should park reusable sandbox");
         let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
             panic!("finalized idle entry should unpark");

--- a/crates/runner/src/cmd/start/job_discovery.rs
+++ b/crates/runner/src/cmd/start/job_discovery.rs
@@ -13,7 +13,7 @@ use sandbox::SandboxId;
 use tokio::task::JoinSet;
 use tracing::{info, warn};
 
-use super::active_sessions::ActiveCliAgentSessionGuard;
+use super::active_sessions::ActiveSandboxReuseIdentityGuard;
 use super::factory_lifecycle::SharedFactory;
 use super::idle_lifecycle::{
     SharedIdlePool, add_preparing_run_with_idle_status_snapshot,
@@ -167,8 +167,8 @@ pub(super) async fn handle_discovered_job(
     // Hide the claimed session from heartbeat affinity before unpark or
     // fallback cleanup can yield. Otherwise a concurrent heartbeat could
     // briefly advertise stale workspace-cache affinity for an active session.
-    let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
-        ctx.spawn_ctx.active_cli_agent_sessions.clone(),
+    let active_sandbox_reuse_identity_guard = ActiveSandboxReuseIdentityGuard::new(
+        ctx.spawn_ctx.active_sandbox_reuse_identities.clone(),
         claimed.context().sandbox_reuse_scope(),
         if resume_session_valid {
             claimed.context().cli_agent_session_id().map(str::to_owned)
@@ -297,7 +297,7 @@ pub(super) async fn handle_discovered_job(
             reuse_result,
             pre_spawn_timing,
             session_history_restore_plan,
-            active_cli_agent_session_guard,
+            active_sandbox_reuse_identity_guard,
         },
         ctx.spawn_ctx,
         ctx.jobs,
@@ -569,7 +569,11 @@ async fn current_local_held_session_states(
     };
     ctx.spawn_ctx
         .held_session_snapshot
-        .current_held_session_states(idle_states, &ctx.spawn_ctx.active_cli_agent_sessions, None)
+        .current_held_session_states(
+            idle_states,
+            &ctx.spawn_ctx.active_sandbox_reuse_identities,
+            None,
+        )
 }
 
 async fn acquire_local_admission_resource(

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -19,7 +19,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use super::active_sessions::{ActiveCliAgentSessionGuard, ActiveCliAgentSessions};
+use super::active_sessions::{ActiveSandboxReuseIdentityCounts, ActiveSandboxReuseIdentityGuard};
 use super::factory_lifecycle::SharedFactory;
 use super::heartbeat::HeldSessionStateSnapshot;
 use super::idle_lifecycle::SharedIdlePool;
@@ -80,7 +80,7 @@ pub(super) struct SpawnContext {
     pub(super) park_notify: Arc<tokio::sync::Notify>,
     /// Best-effort signal for the main loop to ask mitmproxy to flush usage.
     pub(super) usage_flush_tx: mpsc::Sender<()>,
-    pub(super) active_cli_agent_sessions: ActiveCliAgentSessions,
+    pub(super) active_sandbox_reuse_identities: ActiveSandboxReuseIdentityCounts,
     pub(super) held_session_snapshot: HeldSessionStateSnapshot,
     pub(super) device_rate_limits: Option<sandbox::DeviceRateLimits>,
     #[cfg(test)]
@@ -97,7 +97,7 @@ pub(super) struct SpawnJobRequest {
     pub(super) reuse_result: SandboxReuseResult,
     pub(super) pre_spawn_timing: RunnerPreSpawnTiming,
     pub(super) session_history_restore_plan: SessionHistoryRestorePlan,
-    pub(super) active_cli_agent_session_guard: ActiveCliAgentSessionGuard,
+    pub(super) active_sandbox_reuse_identity_guard: ActiveSandboxReuseIdentityGuard,
 }
 
 struct ExecutorInvocation {
@@ -390,7 +390,7 @@ struct CompletionPhase {
     status: Arc<StatusTracker>,
     usage_flush_tx: mpsc::Sender<()>,
     park_notify: Arc<tokio::sync::Notify>,
-    active_cli_agent_session_guard: ActiveCliAgentSessionGuard,
+    active_sandbox_reuse_identity_guard: ActiveSandboxReuseIdentityGuard,
     cleanup_state: RunCleanupState,
 }
 
@@ -402,7 +402,7 @@ impl CompletionPhase {
             status,
             usage_flush_tx,
             park_notify,
-            active_cli_agent_session_guard,
+            active_sandbox_reuse_identity_guard,
             cleanup_state,
         } = self;
 
@@ -413,7 +413,7 @@ impl CompletionPhase {
         completion_ready
             .complete_and_release(provider.as_ref(), &ownership, &cleanup_state)
             .await;
-        drop(active_cli_agent_session_guard);
+        drop(active_sandbox_reuse_identity_guard);
         if session_affinity_changed {
             park_notify.notify_one();
         }
@@ -495,7 +495,7 @@ pub(super) fn spawn_job(
         reuse_result,
         pre_spawn_timing,
         session_history_restore_plan,
-        active_cli_agent_session_guard,
+        active_sandbox_reuse_identity_guard,
     } = request;
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     let run_id = context.run_id;
@@ -629,7 +629,7 @@ pub(super) fn spawn_job(
         .record_phase_elapsed(RunnerPreSpawnPhase::SpawnJobSetup, started_at);
     executor.pre_spawn_timing.mark_task_enqueued();
     jobs.spawn(async move {
-        let mut active_cli_agent_session_guard = active_cli_agent_session_guard;
+        let mut active_sandbox_reuse_identity_guard = active_sandbox_reuse_identity_guard;
         let body = async move {
             #[cfg(test)]
             maybe_panic_outer_job(outer_job_panic, OuterJobPanicPoint::ActiveOrUnknown, run_id);
@@ -640,7 +640,7 @@ pub(super) fn spawn_job(
                 .discovered_cli_agent_session_id
                 .as_deref()
             {
-                active_cli_agent_session_guard.activate_late(discovered_cli_agent_session_id);
+                active_sandbox_reuse_identity_guard.activate_late(discovered_cli_agent_session_id);
             }
             let cancelled_for_log = job_cancel.is_cancelled();
             log_terminal_job_outcome(
@@ -661,7 +661,7 @@ pub(super) fn spawn_job(
                 status,
                 usage_flush_tx,
                 park_notify,
-                active_cli_agent_session_guard,
+                active_sandbox_reuse_identity_guard,
                 cleanup_state: cleanup_state_for_body,
             }
             .complete(completion_ready)
@@ -1365,8 +1365,8 @@ mod tests {
             "finalizer should send the early park refresh"
         );
 
-        let active_sessions = super::super::active_sessions::new_active_cli_agent_sessions();
-        let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
+        let active_sessions = super::super::active_sessions::new_active_sandbox_reuse_identities();
+        let active_sandbox_reuse_identity_guard = ActiveSandboxReuseIdentityGuard::new(
             Arc::clone(&active_sessions),
             Some(crate::test_fixtures::sandbox_reuse_identity_for_test(session_id).scope()),
             Some(session_id.to_owned()),
@@ -1379,14 +1379,14 @@ mod tests {
             status: Arc::clone(&fixture.status),
             usage_flush_tx,
             park_notify: Arc::clone(&fixture.park_notify),
-            active_cli_agent_session_guard,
+            active_sandbox_reuse_identity_guard,
             cleanup_state: RunCleanupState::new(),
         }
         .complete(finalized.completion_ready)
         .await;
 
         assert!(
-            super::super::active_sessions::active_cli_agent_session_ids(&active_sessions)
+            super::super::active_sessions::active_sandbox_reuse_identity_set(&active_sessions)
                 .is_empty(),
             "completion should release the active session guard before notifying"
         );

--- a/crates/runner/src/cmd/start/job_spawn.rs
+++ b/crates/runner/src/cmd/start/job_spawn.rs
@@ -42,6 +42,7 @@ use crate::network_logs;
 use crate::provider::{ClaimedJob, CompletionAuth, JobProvider};
 use crate::resource_budget::BudgetLease;
 use crate::run_cancellation::{RunCancellationHandle, SharedRunCancellationMap};
+use crate::sandbox_reuse_identity::SandboxReuseScope;
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::telemetry::JobTelemetry;
@@ -238,6 +239,7 @@ struct FinalizationPhase {
     reuse_result: SandboxReuseResult,
     workspace_disk_mb: u32,
     profile_name: String,
+    sandbox_reuse_scope: Option<SandboxReuseScope>,
     cli_agent_session_id: Option<String>,
     storage_fingerprints: StorageFingerprints,
     device_rate_limits: Option<sandbox::DeviceRateLimits>,
@@ -271,6 +273,7 @@ impl FinalizationPhase {
             reuse_result,
             workspace_disk_mb,
             profile_name,
+            sandbox_reuse_scope,
             cli_agent_session_id,
             storage_fingerprints,
             device_rate_limits,
@@ -325,6 +328,7 @@ impl FinalizationPhase {
                 run_id,
                 sandbox_id,
                 profile_name,
+                sandbox_reuse_scope,
                 cli_agent_session_id,
                 discovered_cli_agent_session_id,
                 restored_session_identity,
@@ -495,6 +499,7 @@ pub(super) fn spawn_job(
     } = request;
     let (context, completion_auth, active_input_source) = claimed.into_parts();
     let run_id = context.run_id;
+    let sandbox_reuse_scope = context.sandbox_reuse_scope();
     let cli_agent_session_id = if executor::validate_resume_session_id(&context).is_ok() {
         context.cli_agent_session_id().map(String::from)
     } else {
@@ -595,6 +600,7 @@ pub(super) fn spawn_job(
         reuse_result,
         workspace_disk_mb,
         profile_name,
+        sandbox_reuse_scope,
         cli_agent_session_id,
         storage_fingerprints,
         device_rate_limits: job_device_rate_limits,
@@ -1167,6 +1173,9 @@ mod tests {
                 reuse_result: SandboxReuseResult::PoolMiss,
                 workspace_disk_mb: 0,
                 profile_name: "vm0/default".into(),
+                sandbox_reuse_scope: Some(
+                    crate::test_fixtures::sandbox_reuse_identity_for_test(session_id).scope(),
+                ),
                 cli_agent_session_id: Some(session_id.into()),
                 storage_fingerprints: StorageFingerprints::default(),
                 device_rate_limits: None,
@@ -1277,7 +1286,7 @@ mod tests {
             .idle_pool
             .lock()
             .await
-            .take("sess-restore-plan")
+            .take_for_test("sess-restore-plan")
             .expect("parked sandbox should be in idle pool");
         let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
             panic!("parked sandbox should unpark");
@@ -1321,7 +1330,7 @@ mod tests {
             .idle_pool
             .lock()
             .await
-            .take(session_id)
+            .take_for_test(session_id)
             .expect("parked sandbox should be in idle pool");
         let IdleUnparkResult::Reused { sandbox, .. } = entry.try_unpark().await else {
             panic!("parked sandbox should unpark");
@@ -1359,6 +1368,7 @@ mod tests {
         let active_sessions = super::super::active_sessions::new_active_cli_agent_sessions();
         let active_cli_agent_session_guard = ActiveCliAgentSessionGuard::new(
             Arc::clone(&active_sessions),
+            Some(crate::test_fixtures::sandbox_reuse_identity_for_test(session_id).scope()),
             Some(session_id.to_owned()),
         );
         let (usage_flush_tx, _usage_flush_rx) = mpsc::channel(1);

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -82,7 +82,7 @@ mod ownership;
 mod sandbox_finalization;
 mod signals;
 
-use active_sessions::new_active_cli_agent_sessions;
+use active_sessions::new_active_sandbox_reuse_identities;
 use factory_lifecycle::{shutdown_factories, start_factories};
 use heartbeat::{
     HEARTBEAT_PERIOD, HeartbeatContext, HeartbeatContextInit, HeldSessionStateSnapshot,
@@ -1314,7 +1314,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // for the next 10-second tick.
     let park_notify = Arc::new(tokio::sync::Notify::new());
     let orphaned_active_runs = OrphanedActiveRuns::new();
-    let active_cli_agent_sessions = new_active_cli_agent_sessions();
+    let active_sandbox_reuse_identities = new_active_sandbox_reuse_identities();
     let held_session_snapshot = HeldSessionStateSnapshot::new();
     let mut orphan_reap_tick = tokio::time::interval_at(
         tokio::time::Instant::now() + Duration::from_secs(10),
@@ -1331,7 +1331,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         budget: &capacity.budget,
         provider: &*provider_state.provider,
         workspace_cache: exec_config.workspace_cache.clone(),
-        active_cli_agent_sessions: &active_cli_agent_sessions,
+        active_sandbox_reuse_identities: &active_sandbox_reuse_identities,
         held_session_snapshot: held_session_snapshot.clone(),
     });
     refresh_workspace_cache_held_session_snapshot(
@@ -1358,7 +1358,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         parking_gate: shared.parking_gate.clone(),
         park_notify: Arc::clone(&park_notify),
         usage_flush_tx,
-        active_cli_agent_sessions: active_cli_agent_sessions.clone(),
+        active_sandbox_reuse_identities: active_sandbox_reuse_identities.clone(),
         held_session_snapshot,
         device_rate_limits: capacity.device_rate_limits.clone(),
         #[cfg(test)]

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -1302,7 +1302,7 @@ mod tests {
         let cache_states = cache.held_session_states().await;
         assert_eq!(cache_states.len(), 1);
         assert_eq!(cache_states[0].session_id, session_id);
-        let active_sessions = super::super::active_sessions::new_active_cli_agent_sessions();
+        let active_sessions = super::super::active_sessions::new_active_sandbox_reuse_identities();
         let snapshot_states =
             held_session_snapshot.current_held_session_states(Vec::new(), &active_sessions, None);
         assert_eq!(snapshot_states.len(), 1);

--- a/crates/runner/src/cmd/start/sandbox_finalization.rs
+++ b/crates/runner/src/cmd/start/sandbox_finalization.rs
@@ -34,6 +34,7 @@ use crate::provider::CompletionAuth;
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
 use crate::run_cancellation::RunCancellationHandle;
+use crate::sandbox_reuse_identity::{SandboxReuseIdentity, SandboxReuseScope};
 use crate::status::StatusTracker;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::HeldSessionState;
@@ -59,13 +60,14 @@ fn mark_session_affinity_refresh(
 
 fn mark_workspace_cache_snapshot_promoted(
     snapshot: &HeldSessionStateSnapshot,
-    session_id: Option<&str>,
+    identity: Option<&SandboxReuseIdentity>,
     completed_at: &str,
     promoted: bool,
 ) -> bool {
-    if promoted && let Some(session_id) = session_id {
+    if promoted && let Some(identity) = identity {
         snapshot.upsert_workspace_cache_state(HeldSessionState {
-            session_id: session_id.to_owned(),
+            sandbox_reuse_scope: identity.api_scope_wire_value(),
+            session_id: identity.cli_agent_session_id().to_owned(),
             last_completed_at: completed_at.to_owned(),
             reusable_sandbox: None,
         });
@@ -77,6 +79,7 @@ pub(super) struct FinalizeContext {
     pub(super) run_id: RunId,
     pub(super) sandbox_id: SandboxId,
     pub(super) profile_name: String,
+    pub(super) sandbox_reuse_scope: Option<SandboxReuseScope>,
     pub(super) cli_agent_session_id: Option<String>,
     pub(super) discovered_cli_agent_session_id: Option<String>,
     pub(super) restored_session_identity: Option<RestoredSessionIdentity>,
@@ -116,6 +119,7 @@ pub(super) async fn finalize_sandbox_for_completion(
         run_id,
         sandbox_id,
         profile_name,
+        sandbox_reuse_scope,
         cli_agent_session_id,
         discovered_cli_agent_session_id,
         restored_session_identity,
@@ -154,8 +158,11 @@ pub(super) async fn finalize_sandbox_for_completion(
     let resolved_cli_agent_session_id = cli_agent_session_id
         .as_deref()
         .or(discovered_cli_agent_session_id.as_deref());
-    let parkable_cli_agent_session_id = if exit_code == 0 && !cancelled && parking_gate.is_open() {
-        resolved_cli_agent_session_id.map(str::to_owned)
+    let resolved_sandbox_reuse_identity = sandbox_reuse_scope
+        .and_then(|scope| scope.with_cli_agent_session_id(resolved_cli_agent_session_id?));
+    let parkable_sandbox_reuse_identity = if exit_code == 0 && !cancelled && parking_gate.is_open()
+    {
+        resolved_sandbox_reuse_identity.clone()
     } else {
         None
     };
@@ -170,19 +177,19 @@ pub(super) async fn finalize_sandbox_for_completion(
             storage_fingerprints: storage_fingerprints.clone(),
         })
     });
-    let workspace_promotion_session_id = workspace_promotion
+    let workspace_promotion_identity = workspace_promotion
         .as_ref()
-        .map(|promotion| promotion.cli_agent_session_id().to_owned());
-
+        .map(|promotion| promotion.sandbox_reuse_identity().clone());
     let mut session_affinity_changed = false;
-    let budget = if let Some(cli_agent_session_id) = parkable_cli_agent_session_id {
+    let budget = if let Some(sandbox_reuse_identity) = parkable_sandbox_reuse_identity {
+        let cli_agent_session_id = sandbox_reuse_identity.cli_agent_session_id().to_owned();
         // Inflate the guest balloon BEFORE acquiring the pool lock —
         // the HTTP call to Firecracker can take milliseconds, and we
         // must not block other take/park operations on it.
         let park_request = IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
             factory: Arc::clone(&factory),
-            cli_agent_session_id: cli_agent_session_id.clone(),
+            sandbox_reuse_identity: sandbox_reuse_identity.clone(),
             sandbox_id,
             profile_name: profile_name.clone(),
             device_rate_limits: device_rate_limits.clone(),
@@ -211,7 +218,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                 );
                 let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
                     &held_session_snapshot,
-                    Some(&cli_agent_session_id),
+                    Some(&sandbox_reuse_identity),
                     &completed_at,
                     promote_workspace_image_from_active_sandbox(
                         sandbox.as_ref(),
@@ -263,7 +270,7 @@ pub(super) async fn finalize_sandbox_for_completion(
             .await;
             session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
                 &held_session_snapshot,
-                Some(&cli_agent_session_id),
+                Some(&sandbox_reuse_identity),
                 &completed_at,
                 destroy_result.workspace_cache_promoted,
             );
@@ -298,7 +305,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         .await;
                         let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
                             &held_session_snapshot,
-                            Some(&cli_agent_session_id),
+                            Some(&sandbox_reuse_identity),
                             &completed_at,
                             destroy_result.workspace_cache_promoted,
                         );
@@ -328,7 +335,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                     .await;
                     let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
                         &held_session_snapshot,
-                        Some(&cli_agent_session_id),
+                        Some(&sandbox_reuse_identity),
                         &completed_at,
                         destroy_result.workspace_cache_promoted,
                     );
@@ -414,7 +421,7 @@ pub(super) async fn finalize_sandbox_for_completion(
                         .await;
                         session_affinity_changed |= mark_workspace_cache_snapshot_promoted(
                             &held_session_snapshot,
-                            Some(&cli_agent_session_id),
+                            Some(&sandbox_reuse_identity),
                             &completed_at,
                             destroy_result.workspace_cache_promoted,
                         );
@@ -425,11 +432,11 @@ pub(super) async fn finalize_sandbox_for_completion(
         }
     } else {
         // No parkable session — stop + destroy.
-        let workspace_cache_snapshot_session_id =
-            resolved_cli_agent_session_id.or(workspace_promotion_session_id.as_deref());
         let workspace_cache_promoted = mark_workspace_cache_snapshot_promoted(
             &held_session_snapshot,
-            workspace_cache_snapshot_session_id,
+            resolved_sandbox_reuse_identity
+                .as_ref()
+                .or(workspace_promotion_identity.as_ref()),
             &completed_at,
             promote_workspace_image_from_active_sandbox(
                 sandbox.as_ref(),
@@ -718,6 +725,9 @@ mod tests {
                 run_id,
                 sandbox_id,
                 profile_name: "vm0/default".into(),
+                sandbox_reuse_scope: Some(
+                    crate::test_fixtures::sandbox_reuse_identity_for_test(session_id).scope(),
+                ),
                 cli_agent_session_id: Some(session_id.into()),
                 discovered_cli_agent_session_id: None,
                 restored_session_identity: None,
@@ -751,7 +761,7 @@ mod tests {
         session_id: &str,
     ) -> WorkspaceImageLease {
         let lease = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -1023,7 +1033,7 @@ mod tests {
 
             assert!(promoted);
             let checkout = cache
-                .prepare(WorkspaceImagePrepareRequest {
+                .prepare_for_test(WorkspaceImagePrepareRequest {
                     identity: WorkspaceImageLeaseIdentity {
                         run_id: RunId::new_v4(),
                         sandbox_id: SandboxId::new_v4(),
@@ -1102,7 +1112,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -1169,7 +1179,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -1241,7 +1251,7 @@ mod tests {
         let sandbox_id = SandboxId::new_v4();
         let session_id = "sess-lease-only";
         let workspace_image = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -1321,7 +1331,7 @@ mod tests {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -1422,7 +1432,9 @@ mod tests {
             source_ip: existing_sandbox.source_ip().to_owned(),
             sandbox: existing_sandbox,
             factory: existing_factory,
-            cli_agent_session_id: session_id.into(),
+            sandbox_reuse_identity: crate::test_fixtures::sandbox_reuse_identity_for_test(
+                session_id,
+            ),
             sandbox_id: old_sandbox_id,
             profile_name: "vm0/default".into(),
             device_rate_limits: None,

--- a/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
+++ b/crates/runner/src/cmd/start/tests/failure_recovery/reuse_failure.rs
@@ -5,12 +5,14 @@ use super::super::support::{
     wait_budget_count, wait_idle_pool_len, wait_status_idle_empty_with_active_run,
 };
 
+use crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE;
 use crate::types::SandboxReuseResult;
 
 const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
 
 fn reusable_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, "vm0/default".into()).with_affinity_metadata(
+        Some(TEST_SANDBOX_REUSE_SCOPE.to_string()),
         Some(session_id.to_string()),
         Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
     )

--- a/crates/runner/src/cmd/start/tests/idle_reuse.rs
+++ b/crates/runner/src/cmd/start/tests/idle_reuse.rs
@@ -11,6 +11,7 @@ use super::support::{
 
 use crate::idle_pool::ParkingState;
 use crate::paths::RunnerPaths;
+use crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE;
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
@@ -22,6 +23,7 @@ fn reusable_candidate(
     session_id: &str,
 ) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, profile_name.to_string()).with_affinity_metadata(
+        Some(TEST_SANDBOX_REUSE_SCOPE.to_string()),
         Some(session_id.to_string()),
         Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
     )
@@ -109,6 +111,44 @@ async fn job_with_session_parks_vm() {
     assert_eq!(pool.len(), 1, "VM should be parked when session is present");
     assert!(pool.held_sessions().contains(&"sess-1".to_string()));
     drop(pool);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn api_session_without_valid_reuse_scope_runs_fresh_and_never_parks() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let budget = Arc::clone(&config.capacity.budget);
+    let run_handle = tokio::spawn(run(config));
+
+    for (scope, session_id) in [(None, "sess-missing"), (Some("invalid"), "sess-malformed")] {
+        let run_id = RunId::new_v4();
+        let mut ctx = context_with_session_opt(run_id, Some(session_id));
+        ctx.sandbox_reuse_scope = scope.map(str::to_owned);
+        push_job(&env, run_id, "vm0/default", Some(ctx));
+
+        let completion = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await
+            .expect("job should complete");
+        assert_eq!(completion.exit_code, 0);
+        assert_eq!(
+            completion.reuse_result,
+            Some(SandboxReuseResult::NoSessionId)
+        );
+    }
+
+    wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
+    assert_eq!(env.idle_pool.lock().await.len(), 0);
+    assert!(
+        env.handle
+            .heartbeats
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .iter()
+            .all(|heartbeat| heartbeat.held_session_states.is_empty())
+    );
 
     shutdown(&env, run_handle).await;
 }
@@ -426,6 +466,71 @@ async fn session_affinity_reuses_idle_vm() {
         budget.allocated().2,
         1,
         "budget should remain at 1 (reused, not additive)"
+    );
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn identical_cli_session_in_another_api_scope_does_not_reuse_or_replace_idle_vm() {
+    let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let seeded_sandbox_id =
+        seed_idle_pool(&idle_pool, &budget, "shared-cli", "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+    let run_id = RunId::new_v4();
+    let mut context = context_with_session(run_id, "shared-cli");
+    context.sandbox_reuse_scope = Some("01980a13-532f-7000-8000-000000000002".to_owned());
+
+    push_job(&env, run_id, "vm0/default", Some(context));
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("job should complete");
+
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_ne!(completion.sandbox_id, Some(seeded_sandbox_id));
+    wait_idle_pool_len(&idle_pool, 2, Duration::from_secs(5)).await;
+    let states = idle_pool.lock().await.held_session_states();
+    assert_eq!(states.len(), 2);
+    assert!(states.iter().all(|state| state.session_id == "shared-cli"));
+    assert_ne!(states[0].sandbox_reuse_scope, states[1].sandbox_reuse_scope);
+
+    shutdown(&env, run_handle).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn candidate_and_claim_scope_mismatch_destroys_reservation_and_runs_fresh() {
+    let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
+    let idle_pool = Arc::clone(&config.shared.idle_pool);
+    let budget = Arc::clone(&config.capacity.budget);
+    let seeded_sandbox_id =
+        seed_idle_pool(&idle_pool, &budget, "shared-cli", "vm0/default", 2, 4096).await;
+    let run_handle = tokio::spawn(run(config));
+    let run_id = RunId::new_v4();
+    let mut claimed_context = context_with_session(run_id, "shared-cli");
+    claimed_context.sandbox_reuse_scope = Some("01980a13-532f-7000-8000-000000000002".to_owned());
+    env.provider.set_claim_result(run_id, Some(claimed_context));
+    env.handle
+        .discover_tx
+        .send(reusable_candidate(run_id, "vm0/default", "shared-cli"))
+        .unwrap();
+
+    let completion = env
+        .handle
+        .wait_completion(run_id, Duration::from_secs(5))
+        .await
+        .expect("mismatched claim should run fresh");
+    assert_eq!(completion.reuse_result, Some(SandboxReuseResult::PoolMiss));
+    assert_ne!(completion.sandbox_id, Some(seeded_sandbox_id));
+    wait_idle_pool_len(&idle_pool, 1, Duration::from_secs(5)).await;
+    let states = idle_pool.lock().await.held_session_states();
+    assert_eq!(states.len(), 1);
+    assert_eq!(
+        states[0].sandbox_reuse_scope.as_deref(),
+        Some("01980a13-532f-7000-8000-000000000002")
     );
 
     shutdown(&env, run_handle).await;
@@ -1337,6 +1442,11 @@ async fn park_evicts_via_discovered_cli_agent_session_id() {
         pool.held_sessions(),
         vec!["sess-evict"],
         "parked session should match discovered_cli_agent_session_id"
+    );
+    assert_eq!(
+        pool.held_session_states()[0].sandbox_reuse_scope.as_deref(),
+        Some(TEST_SANDBOX_REUSE_SCOPE),
+        "first-turn discovery must retain the server-provided scope",
     );
     drop(pool);
 

--- a/crates/runner/src/cmd/start/tests/main_loop/admission.rs
+++ b/crates/runner/src/cmd/start/tests/main_loop/admission.rs
@@ -9,6 +9,7 @@ use api_contracts::generated::constants::runners::paths::CANONICAL_WORKING_DIR;
 use std::sync::Arc;
 
 use crate::paths::RunnerPaths;
+use crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE;
 use crate::types::SandboxReuseResult;
 use crate::workspace_image_cache::SessionWorkspaceCache;
 
@@ -16,6 +17,7 @@ const FUTURE_AFFINITY_PROTECTED_UNTIL: &str = "2999-01-01T00:00:00Z";
 
 fn affinity_protected_candidate(run_id: RunId, session_id: &str) -> crate::provider::JobCandidate {
     crate::provider::JobCandidate::new(run_id, "vm0/default".into()).with_affinity_metadata(
+        Some(TEST_SANDBOX_REUSE_SCOPE.to_string()),
         Some(session_id.to_string()),
         Some(FUTURE_AFFINITY_PROTECTED_UNTIL.to_string()),
     )

--- a/crates/runner/src/cmd/start/tests/support/idle_pool.rs
+++ b/crates/runner/src/cmd/start/tests/support/idle_pool.rs
@@ -114,7 +114,7 @@ pub(in super::super) async fn seed_idle_pool_with_workspace_promotion(
     let run_id = RunId::new_v4();
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -169,7 +169,7 @@ pub(in super::super) async fn seed_workspace_cache_state(
     let run_id = RunId::new_v4();
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -544,7 +544,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     let sandbox_id = idle_sandbox.sandbox_id();
     let ReusableIdleSandboxParts {
         sandbox,
-        cli_agent_session_id: idle_cli_agent_session_id,
+        sandbox_reuse_identity: idle_sandbox_reuse_identity,
         source_ip,
         storage_fingerprints: prev_storage,
         restored_session_identity: _restored_session_identity,
@@ -560,7 +560,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                     run_id,
                     sandbox_id,
                     params,
-                    &idle_cli_agent_session_id,
+                    Some(&idle_sandbox_reuse_identity),
                 ) {
                     Ok(lease) => Some(lease),
                     Err(identity_failure) => {
@@ -637,16 +637,13 @@ pub(crate) async fn execute_job_reuse_with_hooks(
     let workspace_image = match config.workspace_cache.as_ref() {
         Some(cache) => Some(match workspace_promotion {
             Some(promotion) => {
-                let expected_session_id = context
-                    .cli_agent_session_id()
-                    .unwrap_or(idle_cli_agent_session_id.as_str());
                 match reused_promotion_into_active_lease(
                     cache,
                     promotion,
                     run_id,
                     sandbox_id,
                     params,
-                    expected_session_id,
+                    Some(&idle_sandbox_reuse_identity),
                 ) {
                     Ok(lease) => lease,
                     Err(identity_failure) => {
@@ -682,17 +679,20 @@ pub(crate) async fn execute_job_reuse_with_hooks(
             }
             None => {
                 cache
-                    .lease_active(WorkspaceImageActiveLeaseRequest {
-                        identity: WorkspaceImageLeaseIdentity {
-                            run_id,
-                            sandbox_id,
-                            profile_name: &params.profile_name,
-                            cli_agent_session_id: context.cli_agent_session_id(),
-                            working_dir: CANONICAL_WORKING_DIR,
-                            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                    .lease_active(
+                        WorkspaceImageActiveLeaseRequest {
+                            identity: WorkspaceImageLeaseIdentity {
+                                run_id,
+                                sandbox_id,
+                                profile_name: &params.profile_name,
+                                cli_agent_session_id: context.cli_agent_session_id(),
+                                working_dir: CANONICAL_WORKING_DIR,
+                                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+                            },
+                            workspace_drive_available: true,
                         },
-                        workspace_drive_available: true,
-                    })
+                        context.sandbox_reuse_scope(),
+                    )
                     .await
             }
         }),
@@ -766,16 +766,25 @@ fn reused_promotion_into_active_lease(
     run_id: RunId,
     sandbox_id: SandboxId,
     params: &JobParams,
-    cli_agent_session_id: &str,
+    sandbox_reuse_identity: Option<&crate::sandbox_reuse_identity::SandboxReuseIdentity>,
 ) -> Result<WorkspaceImageLease, Box<WorkspaceImagePromotionIdentityFailure>> {
+    let Some(sandbox_reuse_identity) = sandbox_reuse_identity else {
+        return Err(Box::new(WorkspaceImagePromotionIdentityFailure {
+            promotion,
+            mismatch: WorkspaceImagePromotionIdentityMismatch::SandboxReuseScope,
+        }));
+    };
     let expected = match cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
-            sandbox_id,
-            profile_name: &params.profile_name,
-            cli_agent_session_id,
-            working_dir: CANONICAL_WORKING_DIR,
-            image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
-        })
+        .expected_promotion_identity(
+            WorkspaceImagePromotionIdentityRequest {
+                sandbox_id,
+                profile_name: &params.profile_name,
+                cli_agent_session_id: sandbox_reuse_identity.cli_agent_session_id(),
+                working_dir: CANONICAL_WORKING_DIR,
+                image_size_bytes: u64::from(params.workspace_disk_mb) * 1024 * 1024,
+            },
+            sandbox_reuse_identity,
+        )
         .inspect_err(|mismatch| {
             tracing::warn!(
                 run_id = %run_id,

--- a/crates/runner/src/executor/mod.rs
+++ b/crates/runner/src/executor/mod.rs
@@ -560,7 +560,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                     run_id,
                     sandbox_id,
                     params,
-                    Some(&idle_sandbox_reuse_identity),
+                    &idle_sandbox_reuse_identity,
                 ) {
                     Ok(lease) => Some(lease),
                     Err(identity_failure) => {
@@ -643,7 +643,7 @@ pub(crate) async fn execute_job_reuse_with_hooks(
                     run_id,
                     sandbox_id,
                     params,
-                    Some(&idle_sandbox_reuse_identity),
+                    &idle_sandbox_reuse_identity,
                 ) {
                     Ok(lease) => lease,
                     Err(identity_failure) => {
@@ -766,14 +766,8 @@ fn reused_promotion_into_active_lease(
     run_id: RunId,
     sandbox_id: SandboxId,
     params: &JobParams,
-    sandbox_reuse_identity: Option<&crate::sandbox_reuse_identity::SandboxReuseIdentity>,
+    sandbox_reuse_identity: &crate::sandbox_reuse_identity::SandboxReuseIdentity,
 ) -> Result<WorkspaceImageLease, Box<WorkspaceImagePromotionIdentityFailure>> {
-    let Some(sandbox_reuse_identity) = sandbox_reuse_identity else {
-        return Err(Box::new(WorkspaceImagePromotionIdentityFailure {
-            promotion,
-            mismatch: WorkspaceImagePromotionIdentityMismatch::SandboxReuseScope,
-        }));
-    };
     let expected = match cache
         .expected_promotion_identity(
             WorkspaceImagePromotionIdentityRequest {

--- a/crates/runner/src/executor/sandbox_run.rs
+++ b/crates/runner/src/executor/sandbox_run.rs
@@ -499,17 +499,20 @@ pub(super) async fn prepare_workspace_image(
     let cache = config.workspace_cache.as_ref()?;
     let prepare_started = Instant::now();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
-            identity: WorkspaceImageLeaseIdentity {
-                run_id: context.run_id,
-                sandbox_id,
-                profile_name,
-                cli_agent_session_id: context.cli_agent_session_id(),
-                working_dir: CANONICAL_WORKING_DIR,
-                image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
+        .prepare(
+            WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id: context.run_id,
+                    sandbox_id,
+                    profile_name,
+                    cli_agent_session_id: context.cli_agent_session_id(),
+                    working_dir: CANONICAL_WORKING_DIR,
+                    image_size_bytes: u64::from(workspace_disk_mb) * 1024 * 1024,
+                },
+                workspace_drive_required: true,
             },
-            workspace_drive_required: true,
-        })
+            context.sandbox_reuse_scope(),
+        )
         .await;
     let prepare_error = workspace_image_prepare_error(lease.result());
     telemetry.record(

--- a/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/idle_pool.rs
@@ -43,7 +43,9 @@ async fn idle_pool_park_and_reuse_cycle() {
     assert_eq!(pool.len(), 1);
 
     // Take from pool for reuse
-    let reuse_entry = pool.take("test-session").expect("should find session");
+    let reuse_entry = pool
+        .take_for_test("test-session")
+        .expect("should find session");
     assert_eq!(pool.len(), 0);
     assert_eq!(reuse_entry.profile_name(), "vm0/default");
 
@@ -86,7 +88,7 @@ async fn idle_pool_profile_mismatch_returns_none() {
     let _ = pool.park(entry);
 
     // Take and verify profile
-    let taken = pool.take("test-session").expect("should find");
+    let taken = pool.take_for_test("test-session").expect("should find");
     assert_eq!(taken.profile_name(), "vm0/default");
 
     // Simulate caller checking profile mismatch

--- a/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/sandbox_run_tests/workspace_cache.rs
@@ -348,7 +348,7 @@ async fn execute_job_reuse_uses_workspace_cache_when_configured() {
     assert!(reuse_outcome.workspace_image.is_some());
 
     let checkout = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
@@ -412,7 +412,7 @@ async fn cached_reuse_workspace_promotion_identity_mismatch_stops_before_agent()
         "identity mismatch must explicitly abandon the consumed cache hit"
     );
     let checkout = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
@@ -454,7 +454,7 @@ async fn execute_job_reuse_without_workspace_cache_config_invalidates_held_cache
     assert_eq!(reuse_outcome.exit_code(), 0);
 
     let checkout = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
@@ -630,7 +630,7 @@ async fn cached_reuse_validation_failure_keeps_workspace_cache_hidden() {
     );
 
     let checkout = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
@@ -688,7 +688,7 @@ async fn cached_reuse_invalid_resume_session_keeps_existing_workspace_cache_hidd
     );
 
     let checkout = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),
@@ -729,7 +729,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
     let run_id = RunId::new_v4();
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -776,7 +776,7 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
     let candidate = IdleParkRequest::new(IdleParkRequestParts {
         sandbox,
         factory,
-        cli_agent_session_id: session_id.to_owned(),
+        sandbox_reuse_identity: crate::test_fixtures::sandbox_reuse_identity_for_test(session_id),
         sandbox_id,
         profile_name: params.profile_name.clone(),
         device_rate_limits: params.device_rate_limits.clone(),
@@ -800,7 +800,9 @@ async fn reusable_idle_sandbox_with_workspace_promotion(
         max_idle: 0,
     });
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
-    let entry = pool.take(session_id).expect("idle entry should exist");
+    let entry = pool
+        .take_for_test(session_id)
+        .expect("idle entry should exist");
     let idle_sandbox = match entry.try_unpark().await {
         IdleUnparkResult::Reused { sandbox, .. } => *sandbox,
         IdleUnparkResult::Failed { error, .. } => {
@@ -829,7 +831,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
     let run_id = RunId::new_v4();
     let sandbox_id = SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -883,7 +885,7 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
     let candidate = IdleParkRequest::new(IdleParkRequestParts {
         sandbox,
         factory,
-        cli_agent_session_id: session_id.to_owned(),
+        sandbox_reuse_identity: crate::test_fixtures::sandbox_reuse_identity_for_test(session_id),
         sandbox_id,
         profile_name: params.profile_name.clone(),
         device_rate_limits: params.device_rate_limits.clone(),
@@ -907,7 +909,9 @@ async fn reusable_idle_sandbox_with_unlocked_workspace_promotion(
         max_idle: 0,
     });
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
-    let entry = pool.take(session_id).expect("idle entry should exist");
+    let entry = pool
+        .take_for_test(session_id)
+        .expect("idle entry should exist");
     let idle_sandbox = match entry.try_unpark().await {
         IdleUnparkResult::Reused { sandbox, .. } => *sandbox,
         IdleUnparkResult::Failed { error, .. } => {

--- a/crates/runner/src/executor/tests/support/config.rs
+++ b/crates/runner/src/executor/tests/support/config.rs
@@ -92,7 +92,9 @@ pub(in crate::executor::tests) async fn make_reusable_idle_sandbox(
         .with_source_ip(source_ip)
         .build();
     assert!(matches!(pool.park(candidate), ParkResult::Parked));
-    let entry = pool.take(session_id).expect("idle entry should exist");
+    let entry = pool
+        .take_for_test(session_id)
+        .expect("idle entry should exist");
     match entry.try_unpark().await {
         IdleUnparkResult::Reused {
             sandbox,

--- a/crates/runner/src/executor/tests/support/workspace_cache.rs
+++ b/crates/runner/src/executor/tests/support/workspace_cache.rs
@@ -19,7 +19,7 @@ pub(in crate::executor::tests) async fn seed_workspace_image_cache(
     let sandbox_id = SandboxId::new_v4();
     let run_id = RunId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -12,6 +12,7 @@ use sandbox::{DeviceRateLimits, Sandbox, SandboxFactory, SandboxId};
 
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
+use crate::sandbox_reuse_identity::SandboxReuseIdentity;
 use crate::status::IdleVm;
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{HeldSessionState, ReusableSandboxState};
@@ -137,7 +138,7 @@ pub(crate) struct IdleParkRequest {
 pub(crate) struct IdleParkRequestParts {
     pub(crate) sandbox: Box<dyn Sandbox>,
     pub(crate) factory: Arc<Box<dyn SandboxFactory>>,
-    pub(crate) cli_agent_session_id: String,
+    pub(crate) sandbox_reuse_identity: SandboxReuseIdentity,
     pub(crate) sandbox_id: SandboxId,
     pub(crate) profile_name: String,
     pub(crate) device_rate_limits: Option<DeviceRateLimits>,
@@ -150,7 +151,7 @@ pub(crate) struct IdleParkRequestParts {
 }
 
 struct IdleSandboxMetadata {
-    cli_agent_session_id: String,
+    sandbox_reuse_identity: SandboxReuseIdentity,
     /// Identity of the parked sandbox. Survives reuse (next job's `run_id`
     /// differs, but `sandbox_id` stays the same) and is the join key for
     /// doctor / kill / workspace-dir naming.
@@ -173,7 +174,7 @@ struct IdleSandboxMetadata {
 
 impl IdleSandboxMetadata {
     fn new(
-        cli_agent_session_id: String,
+        sandbox_reuse_identity: SandboxReuseIdentity,
         sandbox_id: SandboxId,
         profile_name: String,
         device_rate_limits: Option<DeviceRateLimits>,
@@ -182,7 +183,7 @@ impl IdleSandboxMetadata {
         restored_session_identity: Option<RestoredSessionIdentity>,
     ) -> Self {
         Self {
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             sandbox_id,
             profile_name,
             device_rate_limits,
@@ -194,7 +195,11 @@ impl IdleSandboxMetadata {
     }
 
     fn cli_agent_session_id(&self) -> &str {
-        &self.cli_agent_session_id
+        self.sandbox_reuse_identity.cli_agent_session_id()
+    }
+
+    fn sandbox_reuse_identity(&self) -> &SandboxReuseIdentity {
+        &self.sandbox_reuse_identity
     }
 
     fn with_last_completed_at(mut self, last_completed_at: String) -> Self {
@@ -276,7 +281,7 @@ impl IdleParkRequest {
         let IdleParkRequestParts {
             mut sandbox,
             factory,
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             sandbox_id,
             profile_name,
             device_rate_limits,
@@ -289,7 +294,7 @@ impl IdleParkRequest {
         } = self.parts;
 
         let metadata = IdleSandboxMetadata::new(
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             sandbox_id,
             profile_name,
             device_rate_limits,
@@ -299,14 +304,16 @@ impl IdleParkRequest {
         );
 
         if let Some(promotion) = workspace_promotion.as_ref()
-            && let Err(mismatch) =
-                promotion.validate_stored_cache_identity(WorkspaceImagePromotionIdentityRequest {
+            && let Err(mismatch) = promotion.validate_stored_cache_identity(
+                WorkspaceImagePromotionIdentityRequest {
                     sandbox_id: metadata.sandbox_id,
                     profile_name: &metadata.profile_name,
                     cli_agent_session_id: metadata.cli_agent_session_id(),
                     working_dir: CANONICAL_WORKING_DIR,
                     image_size_bytes: workspace_image_size_bytes,
-                })
+                },
+                metadata.sandbox_reuse_identity(),
+            )
         {
             tracing::warn!(
                 sandbox_id = %metadata.sandbox_id,
@@ -392,8 +399,13 @@ impl IdleParkFailure {
 }
 
 impl ParkedIdleCandidate {
+    #[cfg(test)]
     fn cli_agent_session_id(&self) -> &str {
         self.metadata.cli_agent_session_id()
+    }
+
+    fn sandbox_reuse_identity(&self) -> &SandboxReuseIdentity {
+        self.metadata.sandbox_reuse_identity()
     }
 
     #[cfg(test)]
@@ -504,7 +516,7 @@ pub struct ReusableIdleSandbox {
 
 pub struct ReusableIdleSandboxParts {
     pub sandbox: Box<dyn Sandbox>,
-    pub cli_agent_session_id: String,
+    pub sandbox_reuse_identity: SandboxReuseIdentity,
     pub source_ip: String,
     pub storage_fingerprints: StorageFingerprints,
     pub restored_session_identity: Option<RestoredSessionIdentity>,
@@ -527,7 +539,7 @@ impl ReusableIdleSandbox {
             workspace_promotion,
         } = self;
         let IdleSandboxMetadata {
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             sandbox_id: _,
             profile_name: _,
             device_rate_limits: _,
@@ -539,7 +551,7 @@ impl ReusableIdleSandbox {
 
         ReusableIdleSandboxParts {
             sandbox,
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             source_ip,
             storage_fingerprints,
             restored_session_identity,
@@ -634,7 +646,7 @@ impl IdleDestroyPayload {
 pub struct IdleDestroyJob {
     payload: IdleDestroyPayload,
     budget_lease: BudgetLease,
-    cli_agent_session_id: String,
+    sandbox_reuse_identity: SandboxReuseIdentity,
     profile_name: String,
 }
 
@@ -657,7 +669,7 @@ impl IdleDestroyJob {
         let Self {
             payload,
             budget_lease,
-            cli_agent_session_id: _,
+            sandbox_reuse_identity: _,
             profile_name: _,
         } = self;
         let result = payload.promote_then_stop_and_destroy(context).await;
@@ -669,7 +681,7 @@ impl IdleDestroyJob {
     }
 
     pub fn cli_agent_session_id(&self) -> &str {
-        &self.cli_agent_session_id
+        self.sandbox_reuse_identity.cli_agent_session_id()
     }
 
     pub fn profile_name(&self) -> &str {
@@ -818,6 +830,7 @@ impl IdleEntry {
                 working_dir,
                 image_size_bytes,
             },
+            self.metadata.sandbox_reuse_identity(),
         )
     }
 
@@ -841,7 +854,7 @@ impl IdleEntry {
             ..
         } = self;
         let IdleSandboxMetadata {
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             profile_name,
             ..
         } = metadata;
@@ -849,13 +862,17 @@ impl IdleEntry {
         IdleDestroyJob {
             payload: resources.into_destroy_payload(workspace_promotion_policy),
             budget_lease,
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             profile_name,
         }
     }
 }
 
 impl ReservedIdleSandbox {
+    pub(crate) fn sandbox_reuse_identity(&self) -> &SandboxReuseIdentity {
+        self.entry.metadata.sandbox_reuse_identity()
+    }
+
     pub fn cli_agent_session_id(&self) -> &str {
         self.entry.cli_agent_session_id()
     }
@@ -884,13 +901,13 @@ impl ReservedIdleSandbox {
     }
 }
 
-/// Pool of idle sandboxes keyed by session ID.
+/// Pool of idle sandboxes keyed by server scope and CLI agent session ID.
 ///
 /// After a job completes successfully, its sandbox can be parked here
 /// instead of being destroyed. A subsequent job for the same session
 /// can reuse the parked sandbox, skipping VM creation and startup.
 pub struct IdlePool {
-    entries: HashMap<String, IdleEntry>,
+    entries: HashMap<SandboxReuseIdentity, IdleEntry>,
     config: IdlePoolConfig,
     revision: u64,
     /// Shared lifecycle gate. The signal/main-loop lifecycle controller updates
@@ -937,18 +954,18 @@ impl IdlePool {
         parked_at: Instant,
         idle_timeout: Duration,
     ) -> ParkResult {
-        let cli_agent_session_id = candidate.cli_agent_session_id().to_string();
+        let sandbox_reuse_identity = candidate.sandbox_reuse_identity().clone();
         if !self.parking_gate.is_open() {
             return ParkResult::Rejected(candidate.into_rejected());
         }
         if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
             // At capacity and this session has no existing entry to replace.
-            if !self.entries.contains_key(&cli_agent_session_id) {
+            if !self.entries.contains_key(&sandbox_reuse_identity) {
                 return ParkResult::Rejected(candidate.into_rejected());
             }
         }
         let entry = candidate.into_idle_entry(parked_at, idle_timeout);
-        let result = match self.entries.insert(cli_agent_session_id, entry) {
+        let result = match self.entries.insert(sandbox_reuse_identity, entry) {
             Some(evicted) => ParkResult::Replaced(evicted.into_destroy_job()),
             None => ParkResult::Parked,
         };
@@ -956,21 +973,28 @@ impl IdlePool {
         result
     }
 
-    pub fn take(&mut self, session_id: &str) -> Option<IdleEntry> {
-        let entry = self.entries.remove(session_id);
+    pub fn take(&mut self, identity: &SandboxReuseIdentity) -> Option<IdleEntry> {
+        let entry = self.entries.remove(identity);
         if entry.is_some() {
             self.bump_revision();
         }
         entry
     }
 
+    #[cfg(test)]
+    pub fn take_for_test(&mut self, session_id: &str) -> Option<IdleEntry> {
+        self.take(&crate::test_fixtures::sandbox_reuse_identity_for_test(
+            session_id,
+        ))
+    }
+
     pub fn has_reusable(
         &self,
-        session_id: &str,
+        identity: &SandboxReuseIdentity,
         profile_name: &str,
         device_rate_limits: &Option<DeviceRateLimits>,
     ) -> bool {
-        self.entries.get(session_id).is_some_and(|entry| {
+        self.entries.get(identity).is_some_and(|entry| {
             !entry.is_expired_at(Instant::now())
                 && entry.profile_name() == profile_name
                 && entry.device_rate_limits() == device_rate_limits
@@ -979,16 +1003,30 @@ impl IdlePool {
 
     pub fn reserve_reusable(
         &mut self,
+        identity: &SandboxReuseIdentity,
+        profile_name: &str,
+        device_rate_limits: &Option<DeviceRateLimits>,
+    ) -> Option<ReservedIdleSandbox> {
+        if !self.has_reusable(identity, profile_name, device_rate_limits) {
+            return None;
+        }
+        let entry = self.entries.remove(identity)?;
+        self.bump_revision();
+        Some(ReservedIdleSandbox { entry })
+    }
+
+    #[cfg(test)]
+    pub fn reserve_reusable_for_test(
+        &mut self,
         session_id: &str,
         profile_name: &str,
         device_rate_limits: &Option<DeviceRateLimits>,
     ) -> Option<ReservedIdleSandbox> {
-        if !self.has_reusable(session_id, profile_name, device_rate_limits) {
-            return None;
-        }
-        let entry = self.entries.remove(session_id)?;
-        self.bump_revision();
-        Some(ReservedIdleSandbox { entry })
+        self.reserve_reusable(
+            &crate::test_fixtures::sandbox_reuse_identity_for_test(session_id),
+            profile_name,
+            device_rate_limits,
+        )
     }
 
     pub fn restore_reserved(
@@ -996,17 +1034,17 @@ impl IdlePool {
         reservation: ReservedIdleSandbox,
     ) -> RestoreReservedIdleResult {
         let entry = reservation.entry;
-        let session_id = entry.cli_agent_session_id().to_owned();
+        let identity = entry.metadata.sandbox_reuse_identity().clone();
         let has_capacity = self.config.max_idle == 0 || self.entries.len() < self.config.max_idle;
         if !self.parking_gate.is_open()
             || entry.is_expired_at(Instant::now())
             || !has_capacity
-            || self.entries.contains_key(&session_id)
+            || self.entries.contains_key(&identity)
         {
             return RestoreReservedIdleResult::Rejected(Box::new(entry.into_destroy_job()));
         }
 
-        self.entries.insert(session_id, entry);
+        self.entries.insert(identity, entry);
         self.bump_revision();
         RestoreReservedIdleResult::Restored
     }
@@ -1058,9 +1096,13 @@ impl IdlePool {
         let mut vms: Vec<IdleVm> = self
             .entries
             .iter()
-            .map(|(session_id, entry)| idle_vm_for_entry(session_id, entry))
+            .map(|(identity, entry)| idle_vm_for_entry(identity, entry))
             .collect();
-        vms.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+        vms.sort_unstable_by(|a, b| {
+            a.session_id
+                .cmp(&b.session_id)
+                .then_with(|| a.sandbox_id.cmp(&b.sandbox_id))
+        });
         IdlePoolSnapshot {
             revision: self.revision,
             idle_vms: vms,
@@ -1091,13 +1133,14 @@ impl IdlePool {
         let mut states: Vec<HeldSessionState> = self
             .entries
             .iter()
-            .filter_map(|(session_id, entry)| {
+            .filter_map(|(identity, entry)| {
                 entry
                     .metadata
                     .last_completed_at
                     .as_ref()
                     .map(|last_completed_at| HeldSessionState {
-                        session_id: session_id.clone(),
+                        sandbox_reuse_scope: identity.api_scope_wire_value(),
+                        session_id: identity.cli_agent_session_id().to_owned(),
                         last_completed_at: last_completed_at.clone(),
                         reusable_sandbox: Some(ReusableSandboxState {
                             profile: entry.metadata.profile_name.clone(),
@@ -1105,13 +1148,21 @@ impl IdlePool {
                     })
             })
             .collect();
-        states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+        states.sort_unstable_by(|a, b| {
+            a.session_id
+                .cmp(&b.session_id)
+                .then_with(|| a.sandbox_reuse_scope.cmp(&b.sandbox_reuse_scope))
+        });
         states
     }
 
     #[cfg(test)]
     pub fn held_sessions(&self) -> Vec<String> {
-        let mut sessions: Vec<String> = self.entries.keys().cloned().collect();
+        let mut sessions: Vec<String> = self
+            .entries
+            .keys()
+            .map(|identity| identity.cli_agent_session_id().to_owned())
+            .collect();
         sessions.sort_unstable();
         sessions
     }
@@ -1153,9 +1204,9 @@ impl IdlePool {
     }
 }
 
-fn idle_vm_for_entry(session_id: &str, entry: &IdleEntry) -> IdleVm {
+fn idle_vm_for_entry(identity: &SandboxReuseIdentity, entry: &IdleEntry) -> IdleVm {
     IdleVm {
-        session_id: session_id.to_owned(),
+        session_id: identity.cli_agent_session_id().to_owned(),
         sandbox_id: entry.metadata.sandbox_id,
     }
 }
@@ -1223,6 +1274,77 @@ mod tests {
         }
     }
 
+    #[test]
+    fn identical_cli_sessions_in_different_api_scopes_remain_isolated() {
+        let first_identity = crate::test_fixtures::sandbox_reuse_identity_for_test("shared-cli");
+        let second_identity = crate::sandbox_reuse_identity::SandboxReuseScope::api(
+            "01980a13-532f-7000-8000-000000000002",
+        )
+        .and_then(|scope| scope.with_cli_agent_session_id("shared-cli"))
+        .unwrap();
+        let first_sandbox_id = SandboxId::new_v4();
+        let second_sandbox_id = SandboxId::new_v4();
+        let first = ParkedIdleCandidateBuilder::new("shared-cli", make_budget_lease(2, 2048))
+            .with_sandbox_id(first_sandbox_id)
+            .with_sandbox_reuse_identity(first_identity.clone())
+            .with_last_completed_at("2026-07-13T00:00:00.000Z")
+            .build();
+        let second = ParkedIdleCandidateBuilder::new("shared-cli", make_budget_lease(2, 2048))
+            .with_sandbox_id(second_sandbox_id)
+            .with_sandbox_reuse_identity(second_identity.clone())
+            .with_last_completed_at("2026-07-13T00:00:01.000Z")
+            .build();
+        let mut pool = IdlePool::new(pool_config(0));
+
+        assert!(matches!(pool.park(first), ParkResult::Parked));
+        assert!(matches!(pool.park(second), ParkResult::Parked));
+        assert_eq!(
+            pool.len(),
+            2,
+            "different scopes must not replace each other"
+        );
+        assert!(pool.has_reusable(&first_identity, "vm0/default", &None));
+        assert!(pool.has_reusable(&second_identity, "vm0/default", &None));
+
+        let held_states = pool.held_session_states();
+        assert_eq!(held_states.len(), 2);
+        assert!(
+            held_states
+                .iter()
+                .all(|state| state.session_id == "shared-cli")
+        );
+        let mut actual_scopes = held_states
+            .iter()
+            .map(|state| state.sandbox_reuse_scope.clone())
+            .collect::<Vec<_>>();
+        actual_scopes.sort_unstable();
+        let mut expected_scopes = vec![
+            first_identity.api_scope_wire_value(),
+            second_identity.api_scope_wire_value(),
+        ];
+        expected_scopes.sort_unstable();
+        assert_eq!(actual_scopes, expected_scopes);
+
+        let reservation = pool
+            .reserve_reusable(&first_identity, "vm0/default", &None)
+            .expect("first scope reservation");
+        assert!(pool.has_reusable(&second_identity, "vm0/default", &None));
+        assert!(matches!(
+            pool.restore_reserved(reservation),
+            RestoreReservedIdleResult::Restored
+        ));
+
+        let snapshot = pool.status_snapshot();
+        assert_eq!(snapshot.idle_vms.len(), 2);
+        assert!(
+            snapshot
+                .idle_vms
+                .iter()
+                .all(|vm| vm.session_id == "shared-cli")
+        );
+        assert!(snapshot.idle_vms[0].sandbox_id < snapshot.idle_vms[1].sandbox_id);
+    }
+
     async fn make_idle_park_request(
         overrides: Arc<MockSandboxOverrides>,
         session_id: &str,
@@ -1246,7 +1368,9 @@ mod tests {
         IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
             factory,
-            cli_agent_session_id: session_id.into(),
+            sandbox_reuse_identity: crate::test_fixtures::sandbox_reuse_identity_for_test(
+                session_id,
+            ),
             sandbox_id,
             profile_name: "vm0/default".into(),
             device_rate_limits: None,
@@ -1317,7 +1441,9 @@ mod tests {
         let request = IdleParkRequest::new(IdleParkRequestParts {
             sandbox,
             factory,
-            cli_agent_session_id: session_id.into(),
+            sandbox_reuse_identity: crate::test_fixtures::sandbox_reuse_identity_for_test(
+                session_id,
+            ),
             sandbox_id,
             profile_name: profile_name.into(),
             device_rate_limits: None,
@@ -1341,7 +1467,9 @@ mod tests {
 
         let mut pool = IdlePool::new(pool_config(0));
         assert!(matches!(pool.park(candidate), ParkResult::Parked));
-        let entry = pool.take(session_id).expect("idle entry should be parked");
+        let entry = pool
+            .take_for_test(session_id)
+            .expect("idle entry should be parked");
         assert_eq!(entry.profile_name(), profile_name);
 
         let IdleUnparkResult::Reused {
@@ -1354,7 +1482,6 @@ mod tests {
         let sandbox = *sandbox;
         assert_eq!(sandbox.sandbox_id(), sandbox_id);
         let reused_parts = sandbox.into_parts();
-        assert_eq!(reused_parts.cli_agent_session_id, session_id);
         assert_eq!(reused_parts.source_ip, source_ip);
         assert_eq!(
             reused_parts.restored_session_identity,
@@ -1430,7 +1557,7 @@ mod tests {
         assert!(matches!(result, ParkResult::Parked));
         assert_eq!(pool.len(), 1);
 
-        let entry = pool.take("session-1").unwrap();
+        let entry = pool.take_for_test("session-1").unwrap();
         assert_eq!(entry.budget_vcpu(), 2);
         assert_eq!(entry.budget_memory_mb(), 2048);
         assert_eq!(pool.len(), 0);
@@ -1445,17 +1572,17 @@ mod tests {
         let parked_revision = pool.status_snapshot().revision;
 
         assert!(
-            pool.reserve_reusable("session-reserved", "vm0/large", &None)
+            pool.reserve_reusable_for_test("session-reserved", "vm0/large", &None)
                 .is_none(),
             "profile mismatch must not reserve the idle entry"
         );
         let reservation = pool
-            .reserve_reusable("session-reserved", "vm0/default", &None)
+            .reserve_reusable_for_test("session-reserved", "vm0/default", &None)
             .expect("matching idle entry should be reserved");
         assert_eq!(pool.len(), 0);
         assert_eq!(pool.status_snapshot().revision, parked_revision + 1);
         assert!(
-            pool.reserve_reusable("session-reserved", "vm0/default", &None)
+            pool.reserve_reusable_for_test("session-reserved", "vm0/default", &None)
                 .is_none(),
             "a removed reservation cannot be acquired twice"
         );
@@ -1476,7 +1603,7 @@ mod tests {
         let old_sandbox_id = old.sandbox_id();
         assert!(matches!(pool.park(old), ParkResult::Parked));
         let reservation = pool
-            .reserve_reusable("session-collision", "vm0/default", &None)
+            .reserve_reusable_for_test("session-collision", "vm0/default", &None)
             .expect("old entry should reserve");
 
         let replacement = make_candidate_for("session-collision", 2, 2048);
@@ -1503,7 +1630,7 @@ mod tests {
             ParkResult::Parked
         ));
         let reservation = pool
-            .reserve_reusable("session-closed", "vm0/default", &None)
+            .reserve_reusable_for_test("session-closed", "vm0/default", &None)
             .expect("entry should reserve");
         pool.parking_gate().close();
 
@@ -1522,16 +1649,16 @@ mod tests {
         assert!(matches!(result, ParkResult::Parked));
 
         assert!(
-            pool.take("caller-provided-session").is_none(),
+            pool.take_for_test("caller-provided-session").is_none(),
             "park no longer accepts a separate session key"
         );
-        assert!(pool.take("candidate-session").is_some());
+        assert!(pool.take_for_test("candidate-session").is_some());
     }
 
     #[test]
     fn take_missing_returns_none() {
         let mut pool = IdlePool::new(pool_config(0));
-        assert!(pool.take("nonexistent").is_none());
+        assert!(pool.take_for_test("nonexistent").is_none());
     }
 
     #[test]
@@ -1550,7 +1677,7 @@ mod tests {
         }
 
         assert_eq!(pool.len(), 1);
-        let entry = pool.take("session-1").unwrap();
+        let entry = pool.take_for_test("session-1").unwrap();
         assert_eq!(entry.budget_vcpu(), 4);
     }
 
@@ -1626,7 +1753,7 @@ mod tests {
         let evicted = pool.evict_expired();
         assert_eq!(evicted.len(), 1);
         assert_eq!(pool.len(), 1);
-        assert!(pool.take("fresh").is_some());
+        assert!(pool.take_for_test("fresh").is_some());
     }
 
     #[test]
@@ -1745,7 +1872,7 @@ mod tests {
         let evicted = pool.evict_oldest().unwrap();
         assert_eq!(evicted.budget_vcpu(), 2); // the old one
         assert_eq!(pool.len(), 1);
-        assert!(pool.take("new").is_some());
+        assert!(pool.take_for_test("new").is_some());
     }
 
     #[test]
@@ -1781,6 +1908,9 @@ mod tests {
             pool.held_session_states(),
             vec![
                 HeldSessionState {
+                    sandbox_reuse_scope: Some(
+                        crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE.to_owned(),
+                    ),
                     session_id: "sess-a".to_string(),
                     last_completed_at: "2026-05-28T00:00:00.000Z".to_string(),
                     reusable_sandbox: Some(ReusableSandboxState {
@@ -1788,6 +1918,9 @@ mod tests {
                     }),
                 },
                 HeldSessionState {
+                    sandbox_reuse_scope: Some(
+                        crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE.to_owned(),
+                    ),
                     session_id: "sess-b".to_string(),
                     last_completed_at: "2026-05-28T00:00:01.000Z".to_string(),
                     reusable_sandbox: Some(ReusableSandboxState {
@@ -1833,7 +1966,7 @@ mod tests {
         assert!(matches!(pool.park(candidate), ParkResult::Parked));
         assert!(pool.contains_sandbox_id(sandbox_id));
 
-        assert!(pool.take("s1").is_some());
+        assert!(pool.take_for_test("s1").is_some());
         assert!(!pool.contains_sandbox_id(sandbox_id));
     }
 
@@ -1845,7 +1978,7 @@ mod tests {
         let _ = pool.park(make_candidate_for("s1", 2, 2048));
         assert_eq!(pool.status_snapshot().revision, 1);
 
-        assert!(pool.take("s1").is_some());
+        assert!(pool.take_for_test("s1").is_some());
         assert_eq!(pool.status_snapshot().revision, 2);
 
         let drained = pool.drain();
@@ -1994,7 +2127,7 @@ mod tests {
         assert_eq!(evicted.len(), 1);
         assert_eq!(evicted[0].budget_vcpu(), 2); // only the short-timeout entry
         assert_eq!(pool.len(), 1);
-        assert!(pool.take("long").is_some());
+        assert!(pool.take_for_test("long").is_some());
     }
 
     #[test]
@@ -2013,7 +2146,7 @@ mod tests {
         let result = pool.park(make_candidate_for("s1", 8, 8192));
         assert!(matches!(result, ParkResult::Replaced(_)));
         assert_eq!(pool.len(), 1);
-        let entry = pool.take("s1").unwrap();
+        let entry = pool.take_for_test("s1").unwrap();
         assert_eq!(entry.budget_vcpu(), 8);
     }
 }

--- a/crates/runner/src/idle_pool/destroy_tests.rs
+++ b/crates/runner/src/idle_pool/destroy_tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use std::sync::Arc;
 
 use crate::resource_budget::ResourceBudget;
+use crate::test_fixtures::sandbox_reuse_identity_for_test;
 use crate::workspace_image_cache::WorkspaceImagePromotionContext;
 use crate::workspace_promotion::test_support::WorkspacePromotionFixture;
 use sandbox::{ResourceLimits, SandboxConfig};
@@ -65,7 +66,7 @@ async fn make_idle_destroy_job_for(
     IdleDestroyJob {
         payload: make_idle_destroy_payload_for(sandbox_id, overrides, workspace_promotion).await,
         budget_lease,
-        cli_agent_session_id: "sess-destroy".into(),
+        sandbox_reuse_identity: sandbox_reuse_identity_for_test("sess-destroy"),
         profile_name: "vm0/default".into(),
     }
 }

--- a/crates/runner/src/idle_pool/test_support.rs
+++ b/crates/runner/src/idle_pool/test_support.rs
@@ -5,7 +5,9 @@ use sandbox_mock::{MockSandbox, MockSandboxFactory};
 
 use crate::resource_budget::BudgetLease;
 use crate::restored_session_identity::RestoredSessionIdentity;
+use crate::sandbox_reuse_identity::SandboxReuseIdentity;
 use crate::storage_fingerprints::StorageFingerprints;
+use crate::test_fixtures::sandbox_reuse_identity_for_test;
 use crate::workspace_image_cache::WorkspaceImagePromotionContext;
 
 use super::{IdleSandboxMetadata, IdleSandboxResources, ParkedIdleCandidate};
@@ -17,7 +19,7 @@ const DEFAULT_SANDBOX_NAME: &str = "idle-test";
 pub(crate) struct ParkedIdleCandidateBuilder {
     sandbox: Box<dyn Sandbox>,
     factory: Arc<Box<dyn SandboxFactory>>,
-    cli_agent_session_id: String,
+    sandbox_reuse_identity: SandboxReuseIdentity,
     sandbox_id: SandboxId,
     profile_name: String,
     device_rate_limits: Option<DeviceRateLimits>,
@@ -34,10 +36,11 @@ impl ParkedIdleCandidateBuilder {
         session_id: impl Into<String>,
         budget_lease: BudgetLease,
     ) -> ParkedIdleCandidateBuilder {
+        let session_id = session_id.into();
         Self {
             sandbox: Box::new(MockSandbox::new(DEFAULT_SANDBOX_NAME)),
             factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
-            cli_agent_session_id: session_id.into(),
+            sandbox_reuse_identity: sandbox_reuse_identity_for_test(&session_id),
             sandbox_id: SandboxId::new_v4(),
             profile_name: DEFAULT_PROFILE_NAME.into(),
             device_rate_limits: None,
@@ -67,6 +70,14 @@ impl ParkedIdleCandidateBuilder {
 
     pub(crate) fn with_sandbox_id(mut self, sandbox_id: SandboxId) -> Self {
         self.sandbox_id = sandbox_id;
+        self
+    }
+
+    pub(crate) fn with_sandbox_reuse_identity(
+        mut self,
+        sandbox_reuse_identity: SandboxReuseIdentity,
+    ) -> Self {
+        self.sandbox_reuse_identity = sandbox_reuse_identity;
         self
     }
 
@@ -105,7 +116,7 @@ impl ParkedIdleCandidateBuilder {
         let Self {
             sandbox,
             factory,
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             sandbox_id,
             profile_name,
             device_rate_limits,
@@ -117,7 +128,7 @@ impl ParkedIdleCandidateBuilder {
             workspace_promotion,
         } = self;
         let mut metadata = IdleSandboxMetadata::new(
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             sandbox_id,
             profile_name,
             device_rate_limits,

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -42,6 +42,7 @@ mod run_cancellation;
 mod run_resolution;
 mod runner_dirname;
 mod runtime_overrides;
+mod sandbox_reuse_identity;
 mod state_file;
 mod status;
 mod status_file;

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -59,8 +59,9 @@ pub(crate) fn base_dir_lock_name(base_dir: &Path) -> String {
 /// The raw CLI session id is untrusted and must not be embedded directly in
 /// host paths. The working-dir argument is intentionally ignored: workspace
 /// image cache identity is based on canonical workspace semantics. The key
-/// includes the cache scope, profile, drive layout version, and logical image
-/// size so incompatible workspace images never share a host entry.
+/// includes the runner cache scope, profile, sandbox-reuse scope, CLI agent
+/// session id, drive layout version, and logical image size so incompatible or
+/// differently owned workspace images never share a host entry.
 #[cfg(test)]
 pub(crate) fn session_workspace_cache_key(session_id: &str, working_dir: &str) -> String {
     let identity = crate::test_fixtures::sandbox_reuse_identity_for_test(session_id);

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -23,6 +23,7 @@ use sha2::{Digest, Sha256};
 
 use crate::error::RunnerResult;
 use crate::ids::RunId;
+use crate::sandbox_reuse_identity::SandboxReuseIdentity;
 
 /// Short hex digests for storage name and version components, used when
 /// building filesystem paths from untrusted manifest fields.
@@ -62,9 +63,11 @@ pub(crate) fn base_dir_lock_name(base_dir: &Path) -> String {
 /// size so incompatible workspace images never share a host entry.
 #[cfg(test)]
 pub(crate) fn session_workspace_cache_key(session_id: &str, working_dir: &str) -> String {
-    scoped_session_workspace_cache_key("", "vm0/default", session_id, working_dir, 5)
+    let identity = crate::test_fixtures::sandbox_reuse_identity_for_test(session_id);
+    scoped_sandbox_reuse_workspace_cache_key("", "vm0/default", &identity, working_dir, 5)
 }
 
+#[cfg(test)]
 pub(crate) fn scoped_session_workspace_cache_key(
     cache_scope: &str,
     profile_name: &str,
@@ -72,15 +75,34 @@ pub(crate) fn scoped_session_workspace_cache_key(
     _working_dir: &str,
     image_size_bytes: u64,
 ) -> String {
+    let identity = crate::test_fixtures::sandbox_reuse_identity_for_test(session_id);
+    scoped_sandbox_reuse_workspace_cache_key(
+        cache_scope,
+        profile_name,
+        &identity,
+        _working_dir,
+        image_size_bytes,
+    )
+}
+
+pub(crate) fn scoped_sandbox_reuse_workspace_cache_key(
+    cache_scope: &str,
+    profile_name: &str,
+    identity: &SandboxReuseIdentity,
+    _working_dir: &str,
+    image_size_bytes: u64,
+) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"session-workspace-cache:v3\0");
+    hasher.update(b"session-workspace-cache:v4\0");
     hasher.update(cache_scope.as_bytes());
     hasher.update(b"\0");
     hasher.update(profile_name.as_bytes());
     hasher.update(b"\0workspace-drive-v1\0");
     hasher.update(image_size_bytes.to_le_bytes());
     hasher.update(b"\0");
-    hasher.update(session_id.as_bytes());
+    hasher.update(identity.scope().cache_key_namespace().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(identity.cli_agent_session_id().as_bytes());
     hex::encode(hasher.finalize())
 }
 

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -356,6 +356,7 @@ impl JobProvider for ApiProvider {
                     // Fall back to default profile when server doesn't send one
                     // (backwards compat with pre-profile API).
                     let run_id = job.run_id;
+                    let sandbox_reuse_scope = job.sandbox_reuse_scope;
                     let cli_agent_session_id = job.cli_agent_session_id;
                     let affinity_protected_until = job.affinity_protected_until;
                     let profile = job
@@ -363,7 +364,11 @@ impl JobProvider for ApiProvider {
                         .unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
                     info!(run_id = %run_id, %profile, poll_reason = ?reason, "poll: job found");
                     let mut candidate = JobCandidate::new(run_id, profile)
-                        .with_affinity_metadata(cli_agent_session_id, affinity_protected_until)
+                        .with_affinity_metadata(
+                            sandbox_reuse_scope,
+                            cli_agent_session_id,
+                            affinity_protected_until,
+                        )
                         .with_discovery_source(JobDiscoverySource::Poll)
                         .with_poll_reason(poll_reason_value(reason))
                         .with_poll_timing(poll_due_started_at.elapsed(), http_request_elapsed);
@@ -1432,6 +1437,9 @@ mod tests {
             running_count: 1,
             admittable_profiles: vec![crate::profile::DEFAULT_PROFILE.to_string()],
             held_session_states: vec![crate::types::HeldSessionState {
+                sandbox_reuse_scope: Some(
+                    crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE.to_owned(),
+                ),
                 session_id: "held-session-test".to_string(),
                 last_completed_at: "2026-07-08T00:00:00.000Z".to_string(),
                 reusable_sandbox: None,
@@ -1877,6 +1885,7 @@ mod tests {
                     "job": {
                         "runId": run_id,
                         "experimentalProfile": "vm0/default",
+                        "sandboxReuseScope": crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE,
                         "cliAgentSessionId": "sess-poll",
                         "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
                     }
@@ -1897,6 +1906,12 @@ mod tests {
         assert_eq!(discovered.run_id(), run_id);
         assert_eq!(discovered.profile_name(), "vm0/default");
         assert_eq!(discovered.cli_agent_session_id(), Some("sess-poll"));
+        assert_eq!(
+            discovered.sandbox_reuse_identity(),
+            Some(&crate::test_fixtures::sandbox_reuse_identity_for_test(
+                "sess-poll"
+            ))
+        );
         assert!(discovered.is_affinity_protected());
         assert_eq!(
             discovered.discovery_source(),
@@ -2626,6 +2641,12 @@ mod tests {
         );
         assert_eq!(context.storage_manifest.as_ref().unwrap().storages.len(), 1);
         assert_eq!(context.cli_agent_session_id(), Some("fixture-session-id"));
+        assert_eq!(
+            context.sandbox_reuse_identity(),
+            Some(crate::test_fixtures::sandbox_reuse_identity_for_test(
+                "fixture-session-id"
+            ))
+        );
         assert_eq!(
             context.environment.as_ref().unwrap()["FIXTURE_MODEL"],
             "fixture-model"

--- a/crates/runner/src/provider/api_ably_supervisor.rs
+++ b/crates/runner/src/provider/api_ably_supervisor.rs
@@ -682,6 +682,7 @@ async fn handle_ably_message_with_network_policy_refresh(
                     notif.run_id,
                     profile.to_owned(),
                     notification_received_at,
+                    notif.sandbox_reuse_scope.map(str::to_owned),
                     notif.cli_agent_session_id.map(str::to_owned),
                     notif.affinity_protected_until.map(str::to_owned),
                 ))
@@ -722,6 +723,7 @@ enum JobNotificationAction {
 struct JobNotification<'a> {
     run_id: RunId,
     profile: Option<&'a str>,
+    sandbox_reuse_scope: Option<&'a str>,
     cli_agent_session_id: Option<&'a str>,
     affinity_protected_until: Option<&'a str>,
 }
@@ -862,6 +864,11 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
         .get("profile")
         .and_then(|v| v.as_str())
         .filter(|value| !value.is_empty());
+    let sandbox_reuse_scope = msg
+        .data
+        .get("sandboxReuseScope")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.is_empty());
     let cli_agent_session_id = msg
         .data
         .get("cliAgentSessionId")
@@ -875,6 +882,7 @@ fn parse_job_notification(msg: &ably_subscriber::Message) -> Option<JobNotificat
     Some(JobNotification {
         run_id,
         profile,
+        sandbox_reuse_scope,
         cli_agent_session_id,
         affinity_protected_until,
     })
@@ -1724,6 +1732,7 @@ mod tests {
             serde_json::json!({
                 "runId": "00000000-0000-0000-0000-000000000001",
                 "profile": "vm0/default",
+                "sandboxReuseScope": crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE,
                 "cliAgentSessionId": "sess-ably",
                 "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
             }),
@@ -1739,6 +1748,12 @@ mod tests {
         assert_eq!(candidate.profile_name(), "vm0/default");
         let candidate = candidate.into_job_candidate();
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-ably"));
+        assert_eq!(
+            candidate.sandbox_reuse_identity(),
+            Some(&crate::test_fixtures::sandbox_reuse_identity_for_test(
+                "sess-ably"
+            ))
+        );
         assert!(candidate.is_affinity_protected());
         assert_no_direct_candidate(&direct_candidates).await;
         assert!(!wakeups.snapshot().await.poll_now);
@@ -2187,12 +2202,17 @@ mod tests {
                 "runId": "00000000-0000-0000-0000-000000000001",
                 "profile": "vm0/default",
                 "targetRunnerId": "00000000-0000-0000-0000-000000000099",
+                "sandboxReuseScope": crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE,
                 "cliAgentSessionId": "sess-target",
                 "affinityProtectedUntil": "2999-01-01T00:00:00.000Z"
             }),
         );
         let notif = parse_job_notification(&msg).unwrap();
         assert_eq!(notif.profile, Some("vm0/default"));
+        assert_eq!(
+            notif.sandbox_reuse_scope,
+            Some(crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE)
+        );
         assert_eq!(notif.cli_agent_session_id, Some("sess-target"));
         assert_eq!(
             notif.affinity_protected_until,

--- a/crates/runner/src/provider/api_direct_candidates.rs
+++ b/crates/runner/src/provider/api_direct_candidates.rs
@@ -17,6 +17,7 @@ pub(super) struct DirectJobCandidate {
     profile_name: String,
     discovered_at: StdInstant,
     enqueued_at: Option<StdInstant>,
+    sandbox_reuse_scope: Option<String>,
     cli_agent_session_id: Option<String>,
     affinity_protected_until: Option<String>,
 }
@@ -33,7 +34,7 @@ impl DirectJobCandidate {
         profile_name: String,
         discovered_at: StdInstant,
     ) -> Self {
-        Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None)
+        Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None, None)
     }
 
     #[cfg(test)]
@@ -44,7 +45,7 @@ impl DirectJobCandidate {
         enqueued_at: StdInstant,
     ) -> Self {
         let mut candidate =
-            Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None);
+            Self::new_with_affinity_metadata(run_id, profile_name, discovered_at, None, None, None);
         candidate.enqueued_at = Some(enqueued_at);
         candidate
     }
@@ -53,6 +54,7 @@ impl DirectJobCandidate {
         run_id: RunId,
         profile_name: String,
         discovered_at: StdInstant,
+        sandbox_reuse_scope: Option<String>,
         cli_agent_session_id: Option<String>,
         affinity_protected_until: Option<String>,
     ) -> Self {
@@ -61,6 +63,7 @@ impl DirectJobCandidate {
             profile_name,
             discovered_at,
             enqueued_at: None,
+            sandbox_reuse_scope,
             cli_agent_session_id,
             affinity_protected_until,
         }
@@ -99,7 +102,11 @@ impl DirectJobCandidate {
             .enqueued_at
             .map(|enqueued_at| dequeued_at.saturating_duration_since(enqueued_at));
         JobCandidate::new_with_discovered_at(self.run_id, self.profile_name, self.discovered_at)
-            .with_affinity_metadata(self.cli_agent_session_id, self.affinity_protected_until)
+            .with_affinity_metadata(
+                self.sandbox_reuse_scope,
+                self.cli_agent_session_id,
+                self.affinity_protected_until,
+            )
             .with_discovery_source(JobDiscoverySource::Ably)
             .with_direct_candidate_timing(notification_to_enqueue_elapsed, inbox_wait_elapsed)
     }
@@ -114,7 +121,8 @@ impl DirectJobCandidate {
             );
             return;
         }
-        if candidate.cli_agent_session_id.is_some() {
+        if candidate.sandbox_reuse_scope.is_some() && candidate.cli_agent_session_id.is_some() {
+            self.sandbox_reuse_scope = candidate.sandbox_reuse_scope;
             self.cli_agent_session_id = candidate.cli_agent_session_id;
         }
         if candidate.affinity_protected_until.is_some() {
@@ -393,6 +401,7 @@ mod tests {
                 run_id,
                 "vm0/default".to_string(),
                 first_discovered_at,
+                Some(crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE.to_string()),
                 Some("sess-1".to_string()),
                 None,
             ))
@@ -410,6 +419,7 @@ mod tests {
                 run_id,
                 "vm0/default".to_string(),
                 second_discovered_at,
+                None,
                 None,
                 Some("2999-01-01T00:00:00.000Z".to_string()),
             ))
@@ -430,6 +440,12 @@ mod tests {
         assert!(candidate.enqueued_at().is_some());
         let candidate = candidate.into_job_candidate();
         assert_eq!(candidate.cli_agent_session_id(), Some("sess-1"));
+        assert_eq!(
+            candidate.sandbox_reuse_identity(),
+            Some(&crate::test_fixtures::sandbox_reuse_identity_for_test(
+                "sess-1"
+            ))
+        );
         assert!(candidate.is_affinity_protected());
         assert!(
             candidate

--- a/crates/runner/src/provider/local/mod.rs
+++ b/crates/runner/src/provider/local/mod.rs
@@ -166,6 +166,8 @@ impl JobProvider for LocalProvider {
 
         let context = ExecutionContext {
             run_id,
+            sandbox_reuse_scope: None,
+            local_sandbox_reuse: true,
             prompt: req.prompt,
             append_system_prompt: None,
             vars: req.vars,

--- a/crates/runner/src/provider/local/tests/discovery.rs
+++ b/crates/runner/src/provider/local/tests/discovery.rs
@@ -20,6 +20,10 @@ async fn discover_claim_complete() {
     let ctx = claimed.context();
     assert_eq!(ctx.run_id, job_id);
     assert_eq!(ctx.prompt, "hello world");
+    assert_eq!(
+        ctx.sandbox_reuse_scope(),
+        Some(crate::sandbox_reuse_identity::SandboxReuseScope::local())
+    );
 
     provider
         .complete(job_id, 0, None, None, None, CompletionAuth::local())

--- a/crates/runner/src/provider/mod.rs
+++ b/crates/runner/src/provider/mod.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 use crate::active_input::ActiveInputSource;
 use crate::error::RunnerResult;
 use crate::ids::RunId;
+use crate::sandbox_reuse_identity::{SandboxReuseIdentity, SandboxReuseScope};
 use crate::types::{ExecutionContext, HeartbeatState, SandboxReuseResult};
 
 /// Low-cardinality source that first discovered a job candidate.
@@ -81,7 +82,7 @@ pub struct JobCandidate {
     poll_reason: Option<String>,
     poll_due_to_job_discovered_elapsed: Option<Duration>,
     poll_http_request_elapsed: Option<Duration>,
-    cli_agent_session_id: Option<String>,
+    sandbox_reuse_identity: Option<SandboxReuseIdentity>,
     affinity_protected_until: Option<DateTime<Utc>>,
 }
 
@@ -112,7 +113,7 @@ impl JobCandidate {
             poll_reason: None,
             poll_due_to_job_discovered_elapsed: None,
             poll_http_request_elapsed: None,
-            cli_agent_session_id: None,
+            sandbox_reuse_identity: None,
             affinity_protected_until: None,
         }
     }
@@ -203,8 +204,15 @@ impl JobCandidate {
         self.poll_http_request_elapsed
     }
 
+    #[cfg(test)]
     pub(crate) fn cli_agent_session_id(&self) -> Option<&str> {
-        self.cli_agent_session_id.as_deref()
+        self.sandbox_reuse_identity
+            .as_ref()
+            .map(SandboxReuseIdentity::cli_agent_session_id)
+    }
+
+    pub(crate) fn sandbox_reuse_identity(&self) -> Option<&SandboxReuseIdentity> {
+        self.sandbox_reuse_identity.as_ref()
     }
 
     pub(crate) fn affinity_protection_remaining(&self) -> Option<Duration> {
@@ -217,17 +225,22 @@ impl JobCandidate {
     }
 
     pub(crate) fn is_affinity_protected(&self) -> bool {
-        self.affinity_protection_remaining()
-            .is_some_and(|remaining| !remaining.is_zero())
+        self.sandbox_reuse_identity.is_some()
+            && self
+                .affinity_protection_remaining()
+                .is_some_and(|remaining| !remaining.is_zero())
     }
 
     pub(crate) fn with_affinity_metadata(
         mut self,
+        sandbox_reuse_scope: Option<String>,
         cli_agent_session_id: Option<String>,
         affinity_protected_until: Option<String>,
     ) -> Self {
-        self.cli_agent_session_id =
-            cli_agent_session_id.filter(|session_id| !session_id.is_empty());
+        self.sandbox_reuse_identity = sandbox_reuse_scope
+            .as_deref()
+            .and_then(SandboxReuseScope::api)
+            .and_then(|scope| scope.with_cli_agent_session_id(cli_agent_session_id.as_deref()?));
         self.affinity_protected_until = affinity_protected_until
             .as_deref()
             .and_then(parse_affinity_protected_until);

--- a/crates/runner/src/sandbox_reuse_identity.rs
+++ b/crates/runner/src/sandbox_reuse_identity.rs
@@ -128,4 +128,32 @@ mod tests {
         assert_ne!(first, local);
         assert_ne!(second, local);
     }
+
+    #[test]
+    fn local_scope_stays_internal_and_diagnostics_hide_raw_identity() {
+        let raw_api_scope = "01980a13-532f-7000-8000-000000000001";
+        let cli_agent_session_id = "sensitive-cli-session";
+        let api_scope = SandboxReuseScope::api(raw_api_scope).unwrap();
+        let local_scope = SandboxReuseScope::local();
+        let api_identity = api_scope
+            .with_cli_agent_session_id(cli_agent_session_id)
+            .unwrap();
+        let local_identity = local_scope
+            .with_cli_agent_session_id(cli_agent_session_id)
+            .unwrap();
+
+        assert_eq!(api_scope.api_wire_value().as_deref(), Some(raw_api_scope));
+        assert_eq!(local_scope.api_wire_value(), None);
+        assert_ne!(
+            api_scope.cache_key_namespace(),
+            local_scope.cache_key_namespace()
+        );
+        assert_eq!(format!("{api_scope:?}"), "Api");
+        assert_eq!(format!("{local_scope:?}"), "Local");
+
+        for diagnostic in [format!("{api_identity:?}"), format!("{local_identity:?}")] {
+            assert!(!diagnostic.contains(raw_api_scope));
+            assert!(!diagnostic.contains(cli_agent_session_id));
+        }
+    }
 }

--- a/crates/runner/src/sandbox_reuse_identity.rs
+++ b/crates/runner/src/sandbox_reuse_identity.rs
@@ -62,8 +62,7 @@ impl SandboxReuseScope {
 }
 
 /// Complete authorization identity for idle VM and workspace-cache reuse.
-#[derive(Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct SandboxReuseIdentity {
     scope: SandboxReuseScope,
     cli_agent_session_id: String,

--- a/crates/runner/src/sandbox_reuse_identity.rs
+++ b/crates/runner/src/sandbox_reuse_identity.rs
@@ -1,0 +1,132 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Runner-owned namespace for reusable sandbox state.
+///
+/// API scope values originate from `agent_runs.session_id`. `Local` is an
+/// internal trust marker and cannot be selected through API JSON.
+#[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub(crate) enum SandboxReuseScope {
+    Api { id: Uuid },
+    Local,
+}
+
+impl fmt::Debug for SandboxReuseScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Api { .. } => f.write_str("Api"),
+            Self::Local => f.write_str("Local"),
+        }
+    }
+}
+
+impl SandboxReuseScope {
+    pub(crate) fn api(raw: &str) -> Option<Self> {
+        Uuid::parse_str(raw).ok().map(|id| Self::Api { id })
+    }
+
+    pub(crate) const fn local() -> Self {
+        Self::Local
+    }
+
+    pub(crate) fn api_wire_value(self) -> Option<String> {
+        match self {
+            Self::Api { id } => Some(id.to_string()),
+            Self::Local => None,
+        }
+    }
+
+    pub(crate) fn cache_key_namespace(self) -> String {
+        match self {
+            Self::Api { id } => format!("api:{id}"),
+            Self::Local => "local".to_string(),
+        }
+    }
+
+    pub(crate) fn with_cli_agent_session_id(
+        self,
+        cli_agent_session_id: impl Into<String>,
+    ) -> Option<SandboxReuseIdentity> {
+        let cli_agent_session_id = cli_agent_session_id.into();
+        if cli_agent_session_id.is_empty() {
+            return None;
+        }
+        Some(SandboxReuseIdentity {
+            scope: self,
+            cli_agent_session_id,
+        })
+    }
+}
+
+/// Complete authorization identity for idle VM and workspace-cache reuse.
+#[derive(Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SandboxReuseIdentity {
+    scope: SandboxReuseScope,
+    cli_agent_session_id: String,
+}
+
+impl SandboxReuseIdentity {
+    pub(crate) fn scope(&self) -> SandboxReuseScope {
+        self.scope
+    }
+
+    pub(crate) fn cli_agent_session_id(&self) -> &str {
+        &self.cli_agent_session_id
+    }
+
+    pub(crate) fn api_scope_wire_value(&self) -> Option<String> {
+        self.scope.api_wire_value()
+    }
+
+    pub(crate) fn diagnostic_fingerprint(&self) -> String {
+        let scope = match self.scope {
+            SandboxReuseScope::Api { id } => format!("api:{id}"),
+            SandboxReuseScope::Local => "local".to_string(),
+        };
+        crate::paths::short_digest(&format!("{scope}\0{}", self.cli_agent_session_id))
+    }
+}
+
+impl fmt::Debug for SandboxReuseIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SandboxReuseIdentity")
+            .field("fingerprint", &self.diagnostic_fingerprint())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_identity_requires_valid_scope_and_non_empty_cli_id() {
+        let scope = SandboxReuseScope::api("01980a13-532f-7000-8000-000000000001").unwrap();
+        assert!(scope.with_cli_agent_session_id("session-1").is_some());
+        assert!(scope.with_cli_agent_session_id("").is_none());
+        assert!(SandboxReuseScope::api("not-a-uuid").is_none());
+    }
+
+    #[test]
+    fn equal_cli_ids_in_different_scopes_are_distinct() {
+        let first = SandboxReuseScope::api("01980a13-532f-7000-8000-000000000001")
+            .unwrap()
+            .with_cli_agent_session_id("shared-session")
+            .unwrap();
+        let second = SandboxReuseScope::api("01980a13-532f-7000-8000-000000000002")
+            .unwrap()
+            .with_cli_agent_session_id("shared-session")
+            .unwrap();
+        let local = SandboxReuseScope::local()
+            .with_cli_agent_session_id("shared-session")
+            .unwrap();
+
+        assert_ne!(first, second);
+        assert_ne!(first, local);
+        assert_ne!(second, local);
+    }
+}

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -77,10 +77,12 @@ struct ActiveRunState {
     phase_started_at: DateTime<Utc>,
 }
 
-/// One parked (idle) sandbox's identity: the `session_id` it's keyed by in
-/// the idle pool and the `sandbox_id` of the Firecracker VM kept alive for
-/// reuse. Pairing these as a struct (rather than parallel arrays) matches
-/// `ActiveRun` and avoids the "indexed-by-position" bug class.
+/// Diagnostic projection of one parked sandbox. `session_id` is the CLI agent
+/// session component of the pool's internal scoped reuse identity, so separate
+/// scopes may legitimately project the same value. `sandbox_id` identifies the
+/// Firecracker VM kept alive for reuse. Pairing them as a struct (rather than
+/// parallel arrays) matches `ActiveRun` and avoids the "indexed-by-position"
+/// bug class.
 #[derive(Debug, Clone, Serialize)]
 pub struct IdleVm {
     pub session_id: String,

--- a/crates/runner/src/test_fixtures.rs
+++ b/crates/runner/src/test_fixtures.rs
@@ -210,9 +210,21 @@ async fn serve_session_history_once(
     Ok(())
 }
 
+pub(crate) const TEST_SANDBOX_REUSE_SCOPE: &str = "01980a13-532f-7000-8000-000000000001";
+
+pub(crate) fn sandbox_reuse_identity_for_test(
+    cli_agent_session_id: &str,
+) -> crate::sandbox_reuse_identity::SandboxReuseIdentity {
+    crate::sandbox_reuse_identity::SandboxReuseScope::api(TEST_SANDBOX_REUSE_SCOPE)
+        .and_then(|scope| scope.with_cli_agent_session_id(cli_agent_session_id))
+        .expect("test sandbox reuse identity")
+}
+
 pub(crate) fn execution_context_for_test(run_id: RunId) -> ExecutionContext {
     ExecutionContext {
         run_id,
+        sandbox_reuse_scope: Some(TEST_SANDBOX_REUSE_SCOPE.into()),
+        local_sandbox_reuse: false,
         prompt: "test".into(),
         append_system_prompt: None,
         vars: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -1222,7 +1222,8 @@ pub struct HeldSessionState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox_reuse_scope: Option<String>,
     /// Compatibility wire name is `sessionId`; semantically this is the
-    /// Claude/Codex CLI agent session id used for sandbox reuse affinity.
+    /// CLI agent session component of scoped reuse affinity and is not
+    /// authoritative without `sandbox_reuse_scope`.
     pub session_id: String,
     pub last_completed_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -9,6 +9,7 @@ use unicode_normalization::UnicodeNormalization;
 use api_contracts::generated::types::runners::storage::StorageManifest;
 
 use crate::ids::RunId;
+use crate::sandbox_reuse_identity::{SandboxReuseIdentity, SandboxReuseScope};
 
 pub(crate) const MAX_HELD_SESSION_STATES: usize = 1024;
 
@@ -30,6 +31,8 @@ pub struct PollResponse {
 #[serde(rename_all = "camelCase")]
 pub struct Job {
     pub run_id: RunId,
+    #[serde(default)]
+    pub sandbox_reuse_scope: Option<String>,
     #[serde(default)]
     pub experimental_profile: Option<String>,
     #[serde(default)]
@@ -53,6 +56,12 @@ pub struct Job {
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionContext {
     pub run_id: RunId,
+    #[serde(default)]
+    pub sandbox_reuse_scope: Option<String>,
+    // Local submit explicitly authorizes caller-provided reuse identity. This
+    // marker is internal and cannot be selected through API claim JSON.
+    #[serde(default, skip)]
+    pub local_sandbox_reuse: bool,
     pub prompt: String,
     #[serde(default)]
     pub append_system_prompt: Option<String>,
@@ -1180,6 +1189,20 @@ impl ExecutionContext {
             .as_ref()
             .map(|r| r.cli_agent_session_id.as_str())
     }
+
+    pub(crate) fn sandbox_reuse_scope(&self) -> Option<SandboxReuseScope> {
+        if self.local_sandbox_reuse {
+            return Some(SandboxReuseScope::local());
+        }
+        self.sandbox_reuse_scope
+            .as_deref()
+            .and_then(SandboxReuseScope::api)
+    }
+
+    pub(crate) fn sandbox_reuse_identity(&self) -> Option<SandboxReuseIdentity> {
+        self.sandbox_reuse_scope()?
+            .with_cli_agent_session_id(self.cli_agent_session_id()?)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1196,12 +1219,21 @@ pub struct ReusableSandboxState {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct HeldSessionState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_reuse_scope: Option<String>,
     /// Compatibility wire name is `sessionId`; semantically this is the
     /// Claude/Codex CLI agent session id used for sandbox reuse affinity.
     pub session_id: String,
     pub last_completed_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reusable_sandbox: Option<ReusableSandboxState>,
+}
+
+impl HeldSessionState {
+    pub(crate) fn sandbox_reuse_identity(&self) -> Option<SandboxReuseIdentity> {
+        SandboxReuseScope::api(self.sandbox_reuse_scope.as_deref()?)?
+            .with_cli_agent_session_id(self.session_id.clone())
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1306,6 +1338,7 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(job.experimental_profile.as_deref(), Some("browser"));
+        assert!(job.sandbox_reuse_scope.is_none());
     }
 
     #[test]
@@ -1322,6 +1355,36 @@ mod tests {
         });
         let job: Job = serde_json::from_value(json).unwrap();
         assert!(job.experimental_profile.is_none());
+    }
+
+    #[test]
+    fn legacy_and_malformed_api_scopes_deserialize_without_authorizing_reuse() {
+        let legacy: ExecutionContext = serde_json::from_value(json!({
+            "runId": "11111111-1111-4111-8111-111111111111",
+            "prompt": "hello",
+            "sandboxToken": "tok",
+            "cliAgentType": "claude-code",
+            "resumeSession": {
+                "sessionId": "cli-session",
+                "sessionHistory": "{}"
+            }
+        }))
+        .unwrap();
+        assert!(legacy.sandbox_reuse_identity().is_none());
+
+        let malformed: ExecutionContext = serde_json::from_value(json!({
+            "runId": "11111111-1111-4111-8111-111111111111",
+            "sandboxReuseScope": "not-a-uuid",
+            "prompt": "hello",
+            "sandboxToken": "tok",
+            "cliAgentType": "claude-code",
+            "resumeSession": {
+                "sessionId": "cli-session",
+                "sessionHistory": "{}"
+            }
+        }))
+        .unwrap();
+        assert!(malformed.sandbox_reuse_identity().is_none());
     }
 
     #[test]
@@ -1900,6 +1963,9 @@ mod tests {
             running_count: 2,
             admittable_profiles: vec!["vm0/default".into()],
             held_session_states: vec![HeldSessionState {
+                sandbox_reuse_scope: Some(
+                    crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE.to_owned(),
+                ),
                 session_id: "session-abc".into(),
                 last_completed_at: "2026-05-28T00:00:00.000Z".into(),
                 reusable_sandbox: Some(ReusableSandboxState {
@@ -1923,6 +1989,7 @@ mod tests {
         assert_eq!(
             json["heldSessionStates"],
             json!([{
+                "sandboxReuseScope": crate::test_fixtures::TEST_SANDBOX_REUSE_SCOPE,
                 "sessionId": "session-abc",
                 "lastCompletedAt": "2026-05-28T00:00:00.000Z",
                 "reusableSandbox": {
@@ -1940,6 +2007,7 @@ mod tests {
             "lastCompletedAt": "2026-05-28T00:00:00.000Z"
         }))
         .unwrap();
+        assert!(state.sandbox_reuse_identity().is_none());
         assert!(state.reusable_sandbox.is_none());
 
         let serialized = serde_json::to_value(state).unwrap();

--- a/crates/runner/src/workspace_image_cache/entry.rs
+++ b/crates/runner/src/workspace_image_cache/entry.rs
@@ -2,9 +2,10 @@ use std::path::{Path, PathBuf};
 
 use crate::ids::RunId;
 use crate::paths::{
-    scoped_session_workspace_cache_key, workspace_image_cache_capacity_lock_path,
+    scoped_sandbox_reuse_workspace_cache_key, workspace_image_cache_capacity_lock_path,
     workspace_image_cache_lock_path,
 };
+use crate::sandbox_reuse_identity::SandboxReuseIdentity;
 
 use super::SessionWorkspaceCache;
 use super::metadata::WorkspaceCacheMetadata;
@@ -116,6 +117,23 @@ impl SessionWorkspaceCache {
             .tmp_session_history_sidecar_metadata(run_id)
     }
 
+    pub(super) fn scoped_identity_cache_key(
+        &self,
+        profile_name: &str,
+        identity: &SandboxReuseIdentity,
+        working_dir: &str,
+        image_size_bytes: u64,
+    ) -> String {
+        scoped_sandbox_reuse_workspace_cache_key(
+            &self.inner.cache_scope,
+            profile_name,
+            identity,
+            working_dir,
+            image_size_bytes,
+        )
+    }
+
+    #[cfg(test)]
     pub(super) fn scoped_cache_key(
         &self,
         profile_name: &str,
@@ -123,10 +141,9 @@ impl SessionWorkspaceCache {
         working_dir: &str,
         image_size_bytes: u64,
     ) -> String {
-        scoped_session_workspace_cache_key(
-            &self.inner.cache_scope,
+        self.scoped_identity_cache_key(
             profile_name,
-            session_id,
+            &crate::test_fixtures::sandbox_reuse_identity_for_test(session_id),
             working_dir,
             image_size_bytes,
         )
@@ -137,10 +154,13 @@ impl SessionWorkspaceCache {
         cache_key: &str,
         metadata: &WorkspaceCacheMetadata,
     ) -> bool {
-        scoped_session_workspace_cache_key(
+        let Some(identity) = metadata.sandbox_reuse_identity() else {
+            return false;
+        };
+        scoped_sandbox_reuse_workspace_cache_key(
             &metadata.cache_scope,
             &metadata.profile_name,
-            &metadata.session_id,
+            &identity,
             &metadata.working_dir,
             metadata.logical_image_size_bytes,
         ) == cache_key

--- a/crates/runner/src/workspace_image_cache/lifecycle.rs
+++ b/crates/runner/src/workspace_image_cache/lifecycle.rs
@@ -9,6 +9,7 @@ use tracing::{info, warn};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
+use crate::sandbox_reuse_identity::{SandboxReuseIdentity, SandboxReuseScope};
 use crate::storage_fingerprints::StorageFingerprints;
 use crate::types::{HeldSessionState, MAX_HELD_SESSION_STATES};
 
@@ -40,6 +41,7 @@ pub(crate) struct WorkspaceImageLease {
     cache: SessionWorkspaceCache,
     pub(super) cache_key: Option<String>,
     profile_name: String,
+    sandbox_reuse_scope: Option<SandboxReuseScope>,
     cli_agent_session_id: Option<String>,
     working_dir: String,
     active_image: PathBuf,
@@ -59,7 +61,7 @@ pub(crate) struct WorkspaceImagePromotionContext {
     run_id: RunId,
     sandbox_id: sandbox::SandboxId,
     profile_name: String,
-    cli_agent_session_id: String,
+    sandbox_reuse_identity: SandboxReuseIdentity,
     working_dir: String,
     active_image: PathBuf,
     image_size_bytes: u64,
@@ -86,7 +88,7 @@ struct WorkspaceImagePromotionInput<'a> {
     run_id: RunId,
     cache_key: &'a str,
     profile_name: &'a str,
-    cli_agent_session_id: &'a str,
+    sandbox_reuse_identity: &'a SandboxReuseIdentity,
     working_dir: &'a str,
     active_image: &'a Path,
     image_size_bytes: u64,
@@ -98,12 +100,13 @@ struct WorkspaceImagePromotionInput<'a> {
 
 struct WorkspaceImagePromotionTarget {
     cache_key: String,
-    cli_agent_session_id: String,
+    sandbox_reuse_identity: SandboxReuseIdentity,
 }
 
 struct WorkspaceImageLeaseCommon<'a> {
     run_id: RunId,
     profile_name: &'a str,
+    sandbox_reuse_scope: Option<SandboxReuseScope>,
     cli_agent_session_id: Option<&'a str>,
     raw_working_dir: &'a str,
     normalized_working_dir: Option<String>,
@@ -114,6 +117,7 @@ struct WorkspaceImageLeaseCommon<'a> {
 struct WorkspaceImageLeaseBase {
     cache: SessionWorkspaceCache,
     profile_name: String,
+    sandbox_reuse_scope: Option<SandboxReuseScope>,
     cli_agent_session_id: Option<String>,
     working_dir: String,
     active_image: PathBuf,
@@ -136,10 +140,15 @@ fn workspace_image_size_mb(image_size_bytes: u64) -> u32 {
 }
 
 impl<'a> WorkspaceImageLeaseCommon<'a> {
-    fn new(cache: &SessionWorkspaceCache, identity: WorkspaceImageLeaseIdentity<'a>) -> Self {
+    fn new(
+        cache: &SessionWorkspaceCache,
+        identity: WorkspaceImageLeaseIdentity<'a>,
+        sandbox_reuse_scope: Option<SandboxReuseScope>,
+    ) -> Self {
         Self {
             run_id: identity.run_id,
             profile_name: identity.profile_name,
+            sandbox_reuse_scope,
             cli_agent_session_id: identity.cli_agent_session_id,
             raw_working_dir: identity.working_dir,
             normalized_working_dir: normalize_safe_guest_working_dir(identity.working_dir),
@@ -159,21 +168,27 @@ impl<'a> WorkspaceImageLeaseCommon<'a> {
     fn cache_key(
         &self,
         cache: &SessionWorkspaceCache,
-        cli_agent_session_id: &str,
+        identity: &SandboxReuseIdentity,
         working_dir: &str,
     ) -> String {
-        cache.scoped_cache_key(
+        cache.scoped_identity_cache_key(
             self.profile_name,
-            cli_agent_session_id,
+            identity,
             working_dir,
             self.image_size_bytes,
         )
+    }
+
+    fn sandbox_reuse_identity(&self) -> Option<SandboxReuseIdentity> {
+        self.sandbox_reuse_scope?
+            .with_cli_agent_session_id(self.cli_agent_session_id?)
     }
 
     fn lease_base(&self, cache: &SessionWorkspaceCache) -> WorkspaceImageLeaseBase {
         WorkspaceImageLeaseBase {
             cache: cache.clone(),
             profile_name: self.profile_name.to_owned(),
+            sandbox_reuse_scope: self.sandbox_reuse_scope,
             cli_agent_session_id: self.cli_agent_session_id.map(str::to_owned),
             working_dir: self.lease_working_dir().to_owned(),
             active_image: self.active_image.clone(),
@@ -188,6 +203,7 @@ impl WorkspaceImageLease {
             cache: base.cache,
             cache_key: state.cache_key,
             profile_name: base.profile_name,
+            sandbox_reuse_scope: base.sandbox_reuse_scope,
             cli_agent_session_id: base.cli_agent_session_id,
             working_dir: base.working_dir,
             active_image: base.active_image,
@@ -203,16 +219,30 @@ impl WorkspaceImageLease {
 }
 
 impl SessionWorkspaceCache {
+    #[cfg(test)]
+    pub(crate) fn expected_promotion_identity_for_test(
+        &self,
+        request: WorkspaceImagePromotionIdentityRequest<'_>,
+    ) -> Result<WorkspaceImagePromotionIdentity, WorkspaceImagePromotionIdentityMismatch> {
+        let identity =
+            crate::test_fixtures::sandbox_reuse_identity_for_test(request.cli_agent_session_id);
+        self.expected_promotion_identity(request, &identity)
+    }
+
     pub(crate) fn expected_promotion_identity(
         &self,
         request: WorkspaceImagePromotionIdentityRequest<'_>,
+        identity: &SandboxReuseIdentity,
     ) -> Result<WorkspaceImagePromotionIdentity, WorkspaceImagePromotionIdentityMismatch> {
         let Some(working_dir) = normalize_safe_guest_working_dir(request.working_dir) else {
             return Err(WorkspaceImagePromotionIdentityMismatch::UnsafeWorkingDir);
         };
-        let cache_key = self.scoped_cache_key(
+        if request.cli_agent_session_id != identity.cli_agent_session_id() {
+            return Err(WorkspaceImagePromotionIdentityMismatch::CliAgentSessionId);
+        }
+        let cache_key = self.scoped_identity_cache_key(
             request.profile_name,
-            request.cli_agent_session_id,
+            identity,
             &working_dir,
             request.image_size_bytes,
         );
@@ -220,6 +250,7 @@ impl SessionWorkspaceCache {
         Ok(WorkspaceImagePromotionIdentity {
             sandbox_id: request.sandbox_id,
             profile_name: request.profile_name.to_owned(),
+            sandbox_reuse_scope: identity.scope(),
             cli_agent_session_id: request.cli_agent_session_id.to_owned(),
             working_dir,
             image_size_bytes: request.image_size_bytes,
@@ -228,11 +259,24 @@ impl SessionWorkspaceCache {
         })
     }
 
-    pub(crate) async fn lease_active(
+    #[cfg(test)]
+    pub(crate) async fn lease_active_for_test(
         &self,
         request: WorkspaceImageActiveLeaseRequest<'_>,
     ) -> WorkspaceImageLease {
-        let common = WorkspaceImageLeaseCommon::new(self, request.identity);
+        self.lease_active(
+            request,
+            Some(crate::test_fixtures::sandbox_reuse_identity_for_test("scope").scope()),
+        )
+        .await
+    }
+
+    pub(crate) async fn lease_active(
+        &self,
+        request: WorkspaceImageActiveLeaseRequest<'_>,
+        sandbox_reuse_scope: Option<SandboxReuseScope>,
+    ) -> WorkspaceImageLease {
+        let common = WorkspaceImageLeaseCommon::new(self, request.identity, sandbox_reuse_scope);
         let active_lease = |result, entry_lock, cache_key| {
             WorkspaceImageLease::from_parts(
                 common.lease_base(self),
@@ -256,11 +300,11 @@ impl SessionWorkspaceCache {
             );
             return active_lease(WorkspaceCacheCheckoutResult::InvalidWorkingDir, None, None);
         };
-        let Some(cli_agent_session_id) = common.cli_agent_session_id else {
+        let Some(identity) = common.sandbox_reuse_identity() else {
             return active_lease(WorkspaceCacheCheckoutResult::NoSession, None, None);
         };
 
-        let cache_key = common.cache_key(self, cli_agent_session_id, working_dir);
+        let cache_key = common.cache_key(self, &identity, working_dir);
         match crate::lock::try_acquire(self.entry_lock_path(&cache_key)).await {
             Ok(lock) => active_lease(
                 WorkspaceCacheCheckoutResult::Miss,
@@ -279,11 +323,24 @@ impl SessionWorkspaceCache {
         }
     }
 
-    pub(crate) async fn prepare(
+    #[cfg(test)]
+    pub(crate) async fn prepare_for_test(
         &self,
         request: WorkspaceImagePrepareRequest<'_>,
     ) -> WorkspaceImageLease {
-        let common = WorkspaceImageLeaseCommon::new(self, request.identity);
+        self.prepare(
+            request,
+            Some(crate::test_fixtures::sandbox_reuse_identity_for_test("scope").scope()),
+        )
+        .await
+    }
+
+    pub(crate) async fn prepare(
+        &self,
+        request: WorkspaceImagePrepareRequest<'_>,
+        sandbox_reuse_scope: Option<SandboxReuseScope>,
+    ) -> WorkspaceImageLease {
+        let common = WorkspaceImageLeaseCommon::new(self, request.identity, sandbox_reuse_scope);
         let workspace_drive = |result,
                                source_image: Option<PathBuf>,
                                previous_storage: Option<StorageFingerprints>,
@@ -321,7 +378,7 @@ impl SessionWorkspaceCache {
                 request.workspace_drive_required,
             );
         };
-        let Some(cli_agent_session_id) = common.cli_agent_session_id else {
+        let Some(identity) = common.sandbox_reuse_identity() else {
             return workspace_drive(
                 WorkspaceCacheCheckoutResult::NoSession,
                 None,
@@ -384,7 +441,7 @@ impl SessionWorkspaceCache {
             );
         }
 
-        let cache_key = common.cache_key(self, cli_agent_session_id, working_dir);
+        let cache_key = common.cache_key(self, &identity, working_dir);
         let lock_path = self.entry_lock_path(&cache_key);
         let lock = match crate::lock::try_acquire(lock_path).await {
             Ok(lock) => lock,
@@ -450,7 +507,7 @@ impl SessionWorkspaceCache {
             .read_valid_metadata(
                 &metadata_path,
                 common.profile_name,
-                cli_agent_session_id,
+                &identity,
                 working_dir,
                 common.image_size_bytes,
             )
@@ -601,6 +658,7 @@ impl SessionWorkspaceCache {
                 .await
             {
                 states.push(HeldSessionState {
+                    sandbox_reuse_scope: metadata.sandbox_reuse_scope.api_wire_value(),
                     session_id: metadata.session_id,
                     last_completed_at: metadata.last_completed_at,
                     reusable_sandbox: None,
@@ -670,7 +728,7 @@ impl SessionWorkspaceCache {
             .read_valid_metadata(
                 &metadata_path,
                 input.profile_name,
-                input.cli_agent_session_id,
+                input.sandbox_reuse_identity,
                 input.working_dir,
                 input.image_size_bytes,
             )
@@ -885,7 +943,11 @@ impl SessionWorkspaceCache {
             key_version: CACHE_KEY_VERSION,
             cache_scope: self.inner.cache_scope.clone(),
             profile_name: input.profile_name.to_owned(),
-            session_id: input.cli_agent_session_id.to_owned(),
+            sandbox_reuse_scope: input.sandbox_reuse_identity.scope(),
+            session_id: input
+                .sandbox_reuse_identity
+                .cli_agent_session_id()
+                .to_owned(),
             working_dir: input.working_dir.to_owned(),
             last_completed_at: input.completed_at.to_owned(),
             last_used_at: local_timestamp(),
@@ -1028,25 +1090,30 @@ impl WorkspaceImageLease {
 
         match self.result {
             WorkspaceCacheCheckoutResult::Hit | WorkspaceCacheCheckoutResult::Miss => {
+                let sandbox_reuse_identity = self
+                    .sandbox_reuse_scope?
+                    .with_cli_agent_session_id(self.cli_agent_session_id.as_deref()?)?;
                 Some(WorkspaceImagePromotionTarget {
                     cache_key: self.cache_key.clone()?,
-                    cli_agent_session_id: self.cli_agent_session_id.clone()?,
+                    sandbox_reuse_identity,
                 })
             }
             WorkspaceCacheCheckoutResult::NoSession => {
                 if self.cli_agent_session_id.is_some() {
                     return None;
                 }
-                let cli_agent_session_id = cli_agent_session_id_override?.to_owned();
-                let cache_key = self.cache.scoped_cache_key(
+                let sandbox_reuse_identity = self
+                    .sandbox_reuse_scope?
+                    .with_cli_agent_session_id(cli_agent_session_id_override?)?;
+                let cache_key = self.cache.scoped_identity_cache_key(
                     &self.profile_name,
-                    &cli_agent_session_id,
+                    &sandbox_reuse_identity,
                     &self.working_dir,
                     self.image_size_bytes,
                 );
                 Some(WorkspaceImagePromotionTarget {
                     cache_key,
-                    cli_agent_session_id,
+                    sandbox_reuse_identity,
                 })
             }
             WorkspaceCacheCheckoutResult::InvalidWorkingDir
@@ -1069,7 +1136,7 @@ impl WorkspaceImageLease {
             run_id: request.run_id,
             sandbox_id: request.sandbox_id,
             profile_name: self.profile_name.clone(),
-            cli_agent_session_id: target.cli_agent_session_id,
+            sandbox_reuse_identity: target.sandbox_reuse_identity,
             working_dir: self.working_dir.clone(),
             active_image: self.active_image.clone(),
             image_size_bytes: self.image_size_bytes,
@@ -1096,7 +1163,11 @@ impl WorkspaceImagePromotionContext {
     }
 
     pub(crate) fn cli_agent_session_id(&self) -> &str {
-        &self.cli_agent_session_id
+        self.sandbox_reuse_identity.cli_agent_session_id()
+    }
+
+    pub(crate) fn sandbox_reuse_identity(&self) -> &SandboxReuseIdentity {
+        &self.sandbox_reuse_identity
     }
 
     pub(crate) fn restored_session_identity(
@@ -1143,7 +1214,10 @@ impl WorkspaceImagePromotionContext {
         if self.profile_name != expected.profile_name {
             return Err(WorkspaceImagePromotionIdentityMismatch::ProfileName);
         }
-        if self.cli_agent_session_id != expected.cli_agent_session_id {
+        if self.sandbox_reuse_identity.scope() != expected.sandbox_reuse_scope {
+            return Err(WorkspaceImagePromotionIdentityMismatch::SandboxReuseScope);
+        }
+        if self.sandbox_reuse_identity.cli_agent_session_id() != expected.cli_agent_session_id {
             return Err(WorkspaceImagePromotionIdentityMismatch::CliAgentSessionId);
         }
         if self.working_dir != expected.working_dir {
@@ -1165,16 +1239,18 @@ impl WorkspaceImagePromotionContext {
         &self,
         cache: &SessionWorkspaceCache,
         request: WorkspaceImagePromotionIdentityRequest<'_>,
+        identity: &SandboxReuseIdentity,
     ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
-        let expected = cache.expected_promotion_identity(request)?;
+        let expected = cache.expected_promotion_identity(request, identity)?;
         self.validate_identity(&expected)
     }
 
     pub(crate) fn validate_stored_cache_identity(
         &self,
         request: WorkspaceImagePromotionIdentityRequest<'_>,
+        identity: &SandboxReuseIdentity,
     ) -> Result<(), WorkspaceImagePromotionIdentityMismatch> {
-        self.validate_expected_identity(&self.cache, request)
+        self.validate_expected_identity(&self.cache, request, identity)
     }
 
     #[cfg(test)]
@@ -1218,7 +1294,7 @@ impl WorkspaceImagePromotionContext {
                 run_id: self.run_id,
                 cache_key: &self.cache_key,
                 profile_name: &self.profile_name,
-                cli_agent_session_id: &self.cli_agent_session_id,
+                sandbox_reuse_identity: &self.sandbox_reuse_identity,
                 working_dir: &self.working_dir,
                 active_image: &self.active_image,
                 image_size_bytes: self.image_size_bytes,
@@ -1238,7 +1314,7 @@ impl WorkspaceImagePromotionContext {
             run_id,
             sandbox_id,
             profile_name,
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             consumed_cache_hit,
             ..
         } = self;
@@ -1247,7 +1323,7 @@ impl WorkspaceImagePromotionContext {
                 run_id = %run_id,
                 sandbox_id = %sandbox_id,
                 profile_name,
-                session_id = %cli_agent_session_id,
+                session_id = %sandbox_reuse_identity.cli_agent_session_id(),
                 cache_key,
                 reason,
                 "workspace image cache promotion context abandoned without entry lock"
@@ -1335,7 +1411,7 @@ impl WorkspaceImagePromotionContext {
             run_id: _,
             sandbox_id: _,
             profile_name,
-            cli_agent_session_id,
+            sandbox_reuse_identity,
             working_dir,
             active_image,
             image_size_bytes,
@@ -1348,7 +1424,8 @@ impl WorkspaceImagePromotionContext {
         let base = WorkspaceImageLeaseBase {
             cache,
             profile_name,
-            cli_agent_session_id: Some(cli_agent_session_id),
+            sandbox_reuse_scope: Some(sandbox_reuse_identity.scope()),
+            cli_agent_session_id: Some(sandbox_reuse_identity.cli_agent_session_id().to_owned()),
             working_dir,
             active_image,
             image_size_bytes,
@@ -1371,15 +1448,18 @@ impl WorkspaceImagePromotionContext {
 pub(super) fn cap_workspace_held_session_states(
     states: Vec<HeldSessionState>,
 ) -> Vec<HeldSessionState> {
-    let mut newest_by_session = BTreeMap::<String, HeldSessionState>::new();
+    let mut newest_by_session = BTreeMap::<SandboxReuseIdentity, HeldSessionState>::new();
     for state in states {
-        match newest_by_session.get_mut(&state.session_id) {
+        let Some(identity) = state.sandbox_reuse_identity() else {
+            continue;
+        };
+        match newest_by_session.get_mut(&identity) {
             Some(existing) if state.last_completed_at > existing.last_completed_at => {
                 *existing = state;
             }
             Some(_) => {}
             None => {
-                newest_by_session.insert(state.session_id.clone(), state);
+                newest_by_session.insert(identity, state);
             }
         }
     }
@@ -1390,9 +1470,14 @@ pub(super) fn cap_workspace_held_session_states(
             b.last_completed_at
                 .cmp(&a.last_completed_at)
                 .then_with(|| a.session_id.cmp(&b.session_id))
+                .then_with(|| a.sandbox_reuse_scope.cmp(&b.sandbox_reuse_scope))
         });
         states.truncate(MAX_HELD_SESSION_STATES);
     }
-    states.sort_unstable_by(|a, b| a.session_id.cmp(&b.session_id));
+    states.sort_unstable_by(|a, b| {
+        a.session_id
+            .cmp(&b.session_id)
+            .then_with(|| a.sandbox_reuse_scope.cmp(&b.sandbox_reuse_scope))
+    });
     states
 }

--- a/crates/runner/src/workspace_image_cache/metadata.rs
+++ b/crates/runner/src/workspace_image_cache/metadata.rs
@@ -7,6 +7,7 @@ use tracing::info;
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::ids::RunId;
+use crate::sandbox_reuse_identity::{SandboxReuseIdentity, SandboxReuseScope};
 use crate::storage_fingerprints::StorageFingerprints;
 
 use super::fs::{
@@ -38,6 +39,7 @@ pub(super) struct WorkspaceCacheMetadata {
     pub(super) key_version: u32,
     pub(super) cache_scope: String,
     pub(super) profile_name: String,
+    pub(super) sandbox_reuse_scope: SandboxReuseScope,
     pub(super) session_id: String,
     pub(super) working_dir: String,
     pub(super) last_completed_at: String,
@@ -50,6 +52,13 @@ pub(super) struct WorkspaceCacheMetadata {
     pub(super) drive_layout: String,
     pub(super) storage_fingerprints: StorageFingerprints,
     pub(super) state: WorkspaceCacheState,
+}
+
+impl WorkspaceCacheMetadata {
+    pub(super) fn sandbox_reuse_identity(&self) -> Option<SandboxReuseIdentity> {
+        self.sandbox_reuse_scope
+            .with_cli_agent_session_id(self.session_id.clone())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,7 +84,7 @@ impl SessionWorkspaceCache {
         &self,
         metadata_path: &Path,
         profile_name: &str,
-        session_id: &str,
+        identity: &SandboxReuseIdentity,
         working_dir: &str,
         image_size_bytes: u64,
     ) -> RunnerResult<Option<WorkspaceCacheMetadata>> {
@@ -86,12 +95,9 @@ impl SessionWorkspaceCache {
             }
             Err(e) => return Err(e),
         };
-        let current_path = self.session_workspace_cache_current_image(&self.scoped_cache_key(
-            profile_name,
-            session_id,
-            working_dir,
-            image_size_bytes,
-        ));
+        let current_path = self.session_workspace_cache_current_image(
+            &self.scoped_identity_cache_key(profile_name, identity, working_dir, image_size_bytes),
+        );
         let current_metadata = match fs::symlink_metadata(&current_path).await {
             Ok(metadata) => metadata,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -101,13 +107,32 @@ impl SessionWorkspaceCache {
             &metadata,
             &self.inner.cache_scope,
             profile_name,
-            session_id,
+            identity,
             working_dir,
             image_size_bytes,
         )?;
         validate_current_image_identity(&metadata, &current_metadata)?;
         metadata.allocated_bytes = allocated_bytes(&current_metadata);
         Ok(Some(metadata))
+    }
+
+    #[cfg(test)]
+    pub(super) async fn read_valid_metadata_for_test(
+        &self,
+        metadata_path: &Path,
+        profile_name: &str,
+        session_id: &str,
+        working_dir: &str,
+        image_size_bytes: u64,
+    ) -> RunnerResult<Option<WorkspaceCacheMetadata>> {
+        self.read_valid_metadata(
+            metadata_path,
+            profile_name,
+            &crate::test_fixtures::sandbox_reuse_identity_for_test(session_id),
+            working_dir,
+            image_size_bytes,
+        )
+        .await
     }
 
     pub(super) async fn metadata_matches_current_image(
@@ -188,7 +213,7 @@ fn validate_metadata(
     metadata: &WorkspaceCacheMetadata,
     cache_scope: &str,
     profile_name: &str,
-    session_id: &str,
+    identity: &SandboxReuseIdentity,
     working_dir: &str,
     image_size_bytes: u64,
 ) -> RunnerResult<()> {
@@ -214,9 +239,9 @@ fn validate_metadata(
             "workspace metadata profile mismatch".into(),
         ));
     }
-    if metadata.session_id != session_id {
+    if metadata.sandbox_reuse_identity().as_ref() != Some(identity) {
         return Err(RunnerError::Internal(
-            "workspace metadata session id mismatch".into(),
+            "workspace metadata sandbox reuse identity mismatch".into(),
         ));
     }
     if metadata.working_dir != working_dir {

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -60,8 +60,8 @@ pub(crate) use types::{
     WorkspaceSessionHistorySidecarRepresentation,
 };
 
-const CACHE_FORMAT_VERSION: u32 = 1;
-const CACHE_KEY_VERSION: u32 = 1;
+const CACHE_FORMAT_VERSION: u32 = 2;
+const CACHE_KEY_VERSION: u32 = 2;
 const WORKSPACE_DRIVE_LAYOUT: &str = "workspace-drive-v1";
 const GIB: u64 = 1024 * 1024 * 1024;
 const MIN_FREE_BYTES_FLOOR: u64 = 50 * GIB;

--- a/crates/runner/src/workspace_image_cache/mod.rs
+++ b/crates/runner/src/workspace_image_cache/mod.rs
@@ -1,11 +1,12 @@
 //! Local session workspace image cache.
 //!
 //! This cache stores reusable workspace drive images for session-backed runs.
-//! Each cache entry is keyed by cache scope, profile, session id, and logical
-//! workspace image size. The normalized working directory is still stored in
-//! metadata and validated at promotion/reuse boundaries; the hash key itself
-//! follows the canonical-workspace semantics in `paths.rs`. A cache entry
-//! contains a `metadata.json` file and a `current.ext4` image file.
+//! Each cache entry is keyed by runner cache scope, profile, sandbox-reuse
+//! scope, CLI agent session id, and logical workspace image size. The
+//! normalized working directory is still stored in metadata and validated at
+//! promotion/reuse boundaries; the hash key itself follows the
+//! canonical-workspace semantics in `paths.rs`. A cache entry contains a
+//! `metadata.json` file and a `current.ext4` image file.
 //!
 //! ## Invariants
 //!

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -3413,6 +3413,28 @@ async fn promotion_context_validates_expected_identity() {
         Err(WorkspaceImagePromotionIdentityMismatch::CliAgentSessionId),
     );
 
+    let wrong_scope_identity = crate::sandbox_reuse_identity::SandboxReuseScope::api(
+        "01980a13-532f-7000-8000-000000000002",
+    )
+    .and_then(|scope| scope.with_cli_agent_session_id(session_id))
+    .unwrap();
+    let wrong_scope = cache
+        .expected_promotion_identity(
+            WorkspaceImagePromotionIdentityRequest {
+                sandbox_id,
+                profile_name: TEST_PROFILE_NAME,
+                cli_agent_session_id: session_id,
+                working_dir: "/workspace/repo",
+                image_size_bytes,
+            },
+            &wrong_scope_identity,
+        )
+        .unwrap();
+    assert_eq!(
+        promotion.validate_identity(&wrong_scope),
+        Err(WorkspaceImagePromotionIdentityMismatch::SandboxReuseScope),
+    );
+
     let wrong_size = cache
         .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,

--- a/crates/runner/src/workspace_image_cache/tests/mod.rs
+++ b/crates/runner/src/workspace_image_cache/tests/mod.rs
@@ -24,11 +24,16 @@ use crate::paths::{RunnerPaths, scoped_session_workspace_cache_key, session_work
 use crate::restored_session_identity::{RestoredSessionFramework, RestoredSessionIdentity};
 use crate::storage_fingerprints::StorageFingerprint;
 use crate::storage_fingerprints::StorageFingerprints;
+use crate::test_fixtures::{TEST_SANDBOX_REUSE_SCOPE, sandbox_reuse_identity_for_test};
 use crate::types::{HeldSessionState, MAX_HELD_SESSION_STATES, ResumeSessionHistoryRefKind};
 use sha2::{Digest, Sha256};
 use tokio::fs;
 
 const TEST_PROFILE_NAME: &str = "vm0/default";
+
+fn test_sandbox_reuse_scope() -> crate::sandbox_reuse_identity::SandboxReuseScope {
+    sandbox_reuse_identity_for_test("scope").scope()
+}
 
 fn timestamp_for_index(index: usize) -> String {
     format!("2026-05-01T00:{:02}:{:02}.000Z", index / 60, index % 60)
@@ -64,6 +69,7 @@ async fn write_current_cache_entry(
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: cache.inner.cache_scope.clone(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: session_id.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: last_completed_at.into(),
@@ -126,7 +132,7 @@ async fn promote_current_cache_entry(
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -164,6 +170,121 @@ async fn promote_current_cache_entry(
 }
 
 #[tokio::test]
+async fn identical_cli_sessions_in_different_api_scopes_use_distinct_cache_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let session_id = "shared-cli";
+    let first_identity = sandbox_reuse_identity_for_test(session_id);
+    let second_scope = crate::sandbox_reuse_identity::SandboxReuseScope::api(
+        "01980a13-532f-7000-8000-000000000002",
+    )
+    .unwrap();
+    let second_identity = second_scope.with_cli_agent_session_id(session_id).unwrap();
+    let image = b"scoped-workspace";
+    let first_run_id = RunId::new_v4();
+    let first_sandbox_id = sandbox::SandboxId::new_v4();
+
+    let first_lease = cache
+        .prepare(
+            WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id: first_run_id,
+                    sandbox_id: first_sandbox_id,
+                    profile_name: TEST_PROFILE_NAME,
+                    cli_agent_session_id: Some(session_id),
+                    working_dir: "/workspace",
+                    image_size_bytes: image.len() as u64,
+                },
+                workspace_drive_required: false,
+            },
+            Some(first_identity.scope()),
+        )
+        .await;
+    assert_eq!(first_lease.result(), WorkspaceCacheCheckoutResult::Miss);
+    let active_image = paths.active_workspace_image(&first_sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&active_image, image).await.unwrap();
+    assert!(
+        first_lease
+            .promote(
+                first_run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                "2026-07-13T00:00:00.000Z".into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap()
+    );
+
+    let second_run_id = RunId::new_v4();
+    let second_sandbox_id = sandbox::SandboxId::new_v4();
+    let second_lease = cache
+        .prepare(
+            WorkspaceImagePrepareRequest {
+                identity: WorkspaceImageLeaseIdentity {
+                    run_id: second_run_id,
+                    sandbox_id: second_sandbox_id,
+                    profile_name: TEST_PROFILE_NAME,
+                    cli_agent_session_id: Some(session_id),
+                    working_dir: "/workspace",
+                    image_size_bytes: image.len() as u64,
+                },
+                workspace_drive_required: false,
+            },
+            Some(second_scope),
+        )
+        .await;
+    assert_eq!(second_lease.result(), WorkspaceCacheCheckoutResult::Miss);
+    let active_image = paths.active_workspace_image(&second_sandbox_id);
+    tokio::fs::create_dir_all(active_image.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&active_image, image).await.unwrap();
+    assert!(
+        second_lease
+            .promote(
+                second_run_id,
+                None,
+                WorkspaceCacheTerminalStatus::Success,
+                "2026-07-13T00:00:01.000Z".into(),
+                &StorageFingerprints::default(),
+            )
+            .await
+            .unwrap()
+    );
+    assert_ne!(
+        cache.scoped_identity_cache_key(
+            TEST_PROFILE_NAME,
+            &first_identity,
+            "/workspace",
+            image.len() as u64,
+        ),
+        cache.scoped_identity_cache_key(
+            TEST_PROFILE_NAME,
+            &second_identity,
+            "/workspace",
+            image.len() as u64,
+        )
+    );
+
+    let held = cache.held_session_states().await;
+    assert_eq!(held.len(), 2);
+    let held_identities = held
+        .iter()
+        .filter_map(HeldSessionState::sandbox_reuse_identity)
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(
+        held_identities,
+        std::collections::HashSet::from([first_identity, second_identity])
+    );
+}
+
+#[tokio::test]
 async fn promotion_does_not_overwrite_newer_cache_entry() {
     let dir = tempfile::tempdir().unwrap();
     let paths = RunnerPaths::new(dir.path().join("runner"));
@@ -175,7 +296,7 @@ async fn promotion_does_not_overwrite_newer_cache_entry() {
     let stale_run_id = RunId::new_v4();
     let stale_sandbox_id = sandbox::SandboxId::new_v4();
     let stale_lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: stale_run_id,
                 sandbox_id: stale_sandbox_id,
@@ -241,7 +362,7 @@ async fn promotion_does_not_overwrite_same_completed_at_cache_entry() {
     let competing_run_id = RunId::new_v4();
     let competing_sandbox_id = sandbox::SandboxId::new_v4();
     let competing_lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: competing_run_id,
                 sandbox_id: competing_sandbox_id,
@@ -313,7 +434,7 @@ async fn promotion_overwrites_older_cache_entry() {
     let newer_run_id = RunId::new_v4();
     let newer_sandbox_id = sandbox::SandboxId::new_v4();
     let newer_lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: newer_run_id,
                 sandbox_id: newer_sandbox_id,
@@ -449,6 +570,7 @@ async fn inspect_reports_reusable_entry_with_storage_counts() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -515,6 +637,7 @@ async fn inspect_reports_invalid_metadata_reason() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "other-session".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -571,6 +694,7 @@ async fn inspect_rejects_symlink_current_image() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -625,6 +749,7 @@ async fn inspect_reports_current_directory_as_invalid() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: session_id.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -924,6 +1049,7 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
         key_version: CACHE_KEY_VERSION,
         cache_scope: cache.inner.cache_scope.clone(),
         profile_name: TEST_PROFILE_NAME.into(),
+        sandbox_reuse_scope: test_sandbox_reuse_scope(),
         session_id: session_id.into(),
         working_dir: "/workspace".into(),
         last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -950,7 +1076,7 @@ async fn prepare_removes_symlink_cache_entry_without_following_it() {
     std::os::unix::fs::symlink(&outside_entry, &entry_dir).unwrap();
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -1051,12 +1177,14 @@ fn workspace_scoped_fingerprints_do_not_match_prefix_traps() {
 fn cap_workspace_held_session_states_dedupes_and_keeps_newest() {
     let mut states: Vec<HeldSessionState> = (0..=MAX_HELD_SESSION_STATES)
         .map(|index| HeldSessionState {
+            sandbox_reuse_scope: Some(TEST_SANDBOX_REUSE_SCOPE.to_owned()),
             session_id: format!("sess-{index:04}"),
             last_completed_at: timestamp_for_index(index),
             reusable_sandbox: None,
         })
         .collect();
     states.push(HeldSessionState {
+        sandbox_reuse_scope: Some(TEST_SANDBOX_REUSE_SCOPE.to_owned()),
         session_id: "sess-0001".into(),
         last_completed_at: timestamp_for_index(MAX_HELD_SESSION_STATES + 1),
         reusable_sandbox: None,
@@ -1106,7 +1234,7 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
     let cache = SessionWorkspaceCache::new(paths);
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1126,7 +1254,7 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
     assert!(lease.workspace_drive_config().is_none());
 
     let no_session_lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1146,7 +1274,7 @@ async fn invalid_working_dir_allocates_only_required_workspace_drive() {
     assert!(no_session_lease.workspace_drive_config().is_none());
 
     let snapshot_restore_lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1189,7 +1317,7 @@ async fn prepare_normalizes_working_dir_for_cache_identity() {
     let sandbox_id = sandbox::SandboxId::new_v4();
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -1228,7 +1356,7 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
     let sandbox_id = sandbox::SandboxId::new_v4();
 
     let lease = cache_a
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -1260,7 +1388,7 @@ async fn shared_cache_is_reusable_across_runner_base_dirs() {
     );
 
     let checkout = cache_b
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1317,7 +1445,7 @@ async fn cache_hit_removes_metadata_and_returns_move_seed() {
     let image_size = fs::metadata(&current).await.unwrap().len();
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id,
@@ -1367,7 +1495,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -1411,7 +1539,7 @@ async fn abandoned_cache_hit_promotion_context_invalidates_consumed_entry() {
     );
 
     let next = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1446,7 +1574,7 @@ async fn promotion_context_preserves_existing_newer_cache_entry() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -1702,7 +1830,7 @@ async fn no_lock_promotion_context_abandonment_preserves_existing_entry() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -1760,7 +1888,7 @@ async fn metadata_missing_current_present_is_not_a_cache_hit() {
         .unwrap();
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1804,7 +1932,7 @@ async fn consumed_cache_hit_promotion_copies_active_image_back_to_cache() {
     let active_image = paths.active_workspace_image(&sandbox_id);
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -1874,7 +2002,7 @@ async fn consumed_cache_hit_invalidation_tolerates_missing_current() {
     let image_size = fs::metadata(&current).await.unwrap().len();
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1917,7 +2045,7 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
     let cache_b = SessionWorkspaceCache::shared(runner_b, &home, "test-group");
 
     let lease_a = cache_a
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1932,7 +2060,7 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
     assert_eq!(lease_a.result(), WorkspaceCacheCheckoutResult::Miss);
 
     let blocked_checkout = cache_b
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1958,7 +2086,7 @@ async fn shared_cache_same_key_lock_blocks_other_runner_without_deadlock() {
 
     drop(lease_a);
     let checkout_after_drop = cache_b
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -1998,7 +2126,7 @@ async fn shared_cache_is_scoped_by_runner_group() {
     let sandbox_id = sandbox::SandboxId::new_v4();
 
     let lease = cache_a
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -2030,7 +2158,7 @@ async fn shared_cache_is_scoped_by_runner_group() {
     );
 
     let checkout = cache_b
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -2072,7 +2200,7 @@ async fn global_gc_preserves_other_group_cache_entries_when_under_budget() {
     let sandbox_id = sandbox::SandboxId::new_v4();
 
     let lease = cache_a
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -2378,6 +2506,7 @@ async fn metadata_validation_rejects_metadata_mismatch() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "other".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
@@ -2396,7 +2525,7 @@ async fn metadata_validation_rejects_metadata_mismatch() {
         .unwrap();
 
     let err = cache
-        .read_valid_metadata(
+        .read_valid_metadata_for_test(
             &paths.session_workspace_cache_metadata(&key),
             TEST_PROFILE_NAME,
             "sess-1",
@@ -2405,7 +2534,11 @@ async fn metadata_validation_rejects_metadata_mismatch() {
         )
         .await;
 
-    assert!(err.unwrap_err().to_string().contains("session id mismatch"));
+    assert!(
+        err.unwrap_err()
+            .to_string()
+            .contains("sandbox reuse identity mismatch")
+    );
 }
 
 #[tokio::test]
@@ -2438,6 +2571,7 @@ async fn write_metadata_replaces_stale_tmp_symlink_without_following_it() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -2489,6 +2623,7 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "other".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
@@ -2507,7 +2642,7 @@ async fn prepare_removes_invalid_metadata_entry_and_allows_repromotion() {
         .unwrap();
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -2579,6 +2714,7 @@ async fn held_session_states_rejects_metadata_under_wrong_cache_key() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-other".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
@@ -2624,6 +2760,7 @@ async fn held_session_states_rejects_unsafe_working_dir_metadata() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/".into(),
                 last_completed_at: local_timestamp(),
@@ -2674,6 +2811,7 @@ async fn metadata_validation_rejects_replaced_current_image() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
@@ -2697,7 +2835,7 @@ async fn metadata_validation_rejects_replaced_current_image() {
     fs::rename(&replacement, &current).await.unwrap();
 
     let err = cache
-        .read_valid_metadata(
+        .read_valid_metadata_for_test(
             &paths.session_workspace_cache_metadata(&key),
             TEST_PROFILE_NAME,
             "sess-1",
@@ -2743,6 +2881,7 @@ async fn metadata_validation_rejects_symlink_current_image() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: local_timestamp(),
@@ -2761,7 +2900,7 @@ async fn metadata_validation_rejects_symlink_current_image() {
         .unwrap();
 
     let err = cache
-        .read_valid_metadata(
+        .read_valid_metadata_for_test(
             &paths.session_workspace_cache_metadata(&key),
             TEST_PROFILE_NAME,
             "sess-1",
@@ -2902,6 +3041,7 @@ async fn cache_hit_checkout_does_not_require_copy_headroom() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -2932,7 +3072,7 @@ async fn cache_hit_checkout_does_not_require_copy_headroom() {
     );
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -3001,7 +3141,7 @@ async fn lock_busy_checkout_cannot_promote_without_entry_lock() {
         .unwrap();
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -3057,6 +3197,7 @@ async fn active_lease_hides_cached_session_until_dropped() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -3077,7 +3218,7 @@ async fn active_lease_hides_cached_session_until_dropped() {
     assert_eq!(cache.held_session_states().await.len(), 1);
 
     let lease = cache
-        .lease_active(WorkspaceImageActiveLeaseRequest {
+        .lease_active_for_test(WorkspaceImageActiveLeaseRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -3107,7 +3248,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
     let image_size_bytes = 16 * 1024 * 1024;
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -3134,7 +3275,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
         .unwrap();
 
     let blocked_by_context = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -3152,7 +3293,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
     );
 
     let expected = cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: session_id,
@@ -3163,7 +3304,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
     let active_lease = promotion.try_into_active_lease(&expected, true).unwrap();
 
     let blocked_by_active_lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -3182,7 +3323,7 @@ async fn promotion_context_keeps_entry_locked_until_reused_active_lease_drops() 
 
     drop(active_lease);
     let after_drop = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: sandbox::SandboxId::new_v4(),
@@ -3209,7 +3350,7 @@ async fn promotion_context_validates_expected_identity() {
     let image_size_bytes = 16 * 1024 * 1024;
 
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -3234,7 +3375,7 @@ async fn promotion_context_validates_expected_identity() {
         .unwrap();
 
     let expected = cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: session_id,
@@ -3245,7 +3386,7 @@ async fn promotion_context_validates_expected_identity() {
     assert_eq!(promotion.validate_identity(&expected), Ok(()));
 
     let wrong_sandbox = cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id: sandbox::SandboxId::new_v4(),
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: session_id,
@@ -3259,7 +3400,7 @@ async fn promotion_context_validates_expected_identity() {
     );
 
     let wrong_session = cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: "sess-other",
@@ -3273,7 +3414,7 @@ async fn promotion_context_validates_expected_identity() {
     );
 
     let wrong_size = cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: session_id,
@@ -3293,7 +3434,7 @@ async fn promotion_context_validates_expected_identity() {
         "other-scope",
     );
     let wrong_cache_key = scoped_cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: session_id,
@@ -3307,7 +3448,7 @@ async fn promotion_context_validates_expected_identity() {
     );
 
     assert_eq!(
-        cache.expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        cache.expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: session_id,
@@ -3340,6 +3481,7 @@ async fn gc_candidate_detects_replaced_image_with_same_timestamp() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: String::new(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: "sess-1".into(),
                 working_dir: "/workspace".into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -3504,6 +3646,63 @@ async fn gc_removes_unusable_current_entry_without_metadata() {
     assert!(
         !paths.session_workspace_cache_entry_dir(&key).exists(),
         "current images without metadata are not reusable and should not accumulate"
+    );
+}
+
+#[tokio::test]
+async fn legacy_unscoped_workspace_cache_entry_is_not_advertised_and_is_removed() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = RunnerPaths::new(dir.path().join("runner"));
+    tokio::fs::create_dir_all(paths.base_dir()).await.unwrap();
+    let cache = SessionWorkspaceCache::new(paths.clone());
+    let session_id = "sess-legacy";
+    let working_dir = "/workspace";
+    let key = session_workspace_cache_key(session_id, working_dir);
+    tokio::fs::create_dir_all(paths.session_workspace_cache_entry_dir(&key))
+        .await
+        .unwrap();
+    let current = paths.session_workspace_cache_current_image(&key);
+    tokio::fs::write(&current, b"legacy image").await.unwrap();
+    let current_metadata = tokio::fs::metadata(&current).await.unwrap();
+    let metadata = WorkspaceCacheMetadata {
+        format_version: 1,
+        key_version: 1,
+        cache_scope: cache.inner.cache_scope.clone(),
+        profile_name: TEST_PROFILE_NAME.into(),
+        sandbox_reuse_scope: test_sandbox_reuse_scope(),
+        session_id: session_id.into(),
+        working_dir: working_dir.into(),
+        last_completed_at: "2026-05-01T00:00:00.000Z".into(),
+        last_used_at: "2026-05-01T00:00:00.000Z".into(),
+        last_terminal_status: WorkspaceCacheTerminalStatus::Success,
+        workspace_trust: WorkspaceTrust::Clean,
+        logical_image_size_bytes: current_metadata.len(),
+        allocated_bytes: allocated_bytes(&current_metadata),
+        current_image: WorkspaceImageFileIdentity::from_metadata(&current_metadata),
+        drive_layout: WORKSPACE_DRIVE_LAYOUT.into(),
+        storage_fingerprints: StorageFingerprints::default(),
+        state: WorkspaceCacheState::Current,
+    };
+    let mut legacy_metadata = serde_json::to_value(metadata).unwrap();
+    legacy_metadata
+        .as_object_mut()
+        .unwrap()
+        .remove("sandboxReuseScope");
+    tokio::fs::write(
+        paths.session_workspace_cache_metadata(&key),
+        serde_json::to_vec(&legacy_metadata).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    assert!(cache.held_session_states().await.is_empty());
+
+    let freed = cache.gc(false).await.unwrap();
+
+    assert!(freed > 0);
+    assert!(
+        !paths.session_workspace_cache_entry_dir(&key).exists(),
+        "legacy cache entries without a reuse scope must not remain reusable"
     );
 }
 
@@ -3740,6 +3939,7 @@ async fn gc_removes_current_directory_even_when_metadata_matches() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: cache.inner.cache_scope.clone(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: session_id.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -3796,6 +3996,7 @@ async fn gc_counts_nested_current_directory_bytes() {
                 key_version: CACHE_KEY_VERSION,
                 cache_scope: cache.inner.cache_scope.clone(),
                 profile_name: TEST_PROFILE_NAME.into(),
+                sandbox_reuse_scope: test_sandbox_reuse_scope(),
                 session_id: session_id.into(),
                 working_dir: working_dir.into(),
                 last_completed_at: "2026-05-01T00:00:00.000Z".into(),
@@ -4046,7 +4247,7 @@ async fn promote_skips_symlink_active_image_without_following_it() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let session_id = "sess-active-symlink";
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4104,7 +4305,7 @@ async fn promote_replaces_symlink_cache_entry_dir_without_following_it() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let session_id = "sess-promote-entry-symlink";
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4170,7 +4371,7 @@ async fn promote_removes_current_image_when_metadata_write_fails() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4231,7 +4432,7 @@ async fn promote_removes_stale_temporary_directory_before_copy() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4282,7 +4483,7 @@ async fn promote_replaces_stale_current_directory_before_rename() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4333,7 +4534,7 @@ async fn promote_skips_copied_image_with_unexpected_logical_size() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4382,7 +4583,7 @@ async fn promote_skips_when_capacity_lock_is_busy() {
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4434,7 +4635,7 @@ async fn no_session_checkout_without_late_cli_agent_session_id_has_no_promotion_
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4473,7 +4674,7 @@ async fn no_session_checkout_can_promote_with_late_discovered_cli_agent_session_
     let run_id = RunId::new_v4();
     let sandbox_id = sandbox::SandboxId::new_v4();
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4531,7 +4732,7 @@ async fn late_session_promotion_skips_when_entry_lock_is_busy() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let session_id = "sess-late-lock-busy";
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4588,7 +4789,7 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
     let sandbox_id = sandbox::SandboxId::new_v4();
     let session_id = "sess-reused-late-context";
     let lease = cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id,
                 sandbox_id,
@@ -4613,7 +4814,7 @@ async fn no_lock_promotion_context_survives_reuse_active_lease() {
         .unwrap();
 
     let expected = cache
-        .expected_promotion_identity(WorkspaceImagePromotionIdentityRequest {
+        .expected_promotion_identity_for_test(WorkspaceImagePromotionIdentityRequest {
             sandbox_id,
             profile_name: TEST_PROFILE_NAME,
             cli_agent_session_id: session_id,

--- a/crates/runner/src/workspace_image_cache/types.rs
+++ b/crates/runner/src/workspace_image_cache/types.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::ids::RunId;
+use crate::sandbox_reuse_identity::SandboxReuseScope;
 use crate::storage_fingerprints::StorageFingerprints;
 
 use super::{MAX_ENTRY_BYTES_CAP, MIN_FREE_BYTES_FLOOR};
@@ -61,6 +62,7 @@ pub(crate) struct WorkspaceImagePromotionIdentityRequest<'a> {
 pub(crate) struct WorkspaceImagePromotionIdentity {
     pub(crate) sandbox_id: sandbox::SandboxId,
     pub(crate) profile_name: String,
+    pub(crate) sandbox_reuse_scope: SandboxReuseScope,
     pub(crate) cli_agent_session_id: String,
     pub(crate) working_dir: String,
     pub(crate) image_size_bytes: u64,
@@ -73,6 +75,7 @@ pub(crate) enum WorkspaceImagePromotionIdentityMismatch {
     UnsafeWorkingDir,
     SandboxId,
     ProfileName,
+    SandboxReuseScope,
     CliAgentSessionId,
     WorkingDir,
     ImageSizeBytes,
@@ -86,6 +89,7 @@ impl WorkspaceImagePromotionIdentityMismatch {
             Self::UnsafeWorkingDir => "unsafe working directory",
             Self::SandboxId => "sandbox id mismatch",
             Self::ProfileName => "profile mismatch",
+            Self::SandboxReuseScope => "sandbox reuse scope mismatch",
             Self::CliAgentSessionId => "cli agent session id mismatch",
             Self::WorkingDir => "working directory mismatch",
             Self::ImageSizeBytes => "image size mismatch",

--- a/crates/runner/src/workspace_promotion/test_support.rs
+++ b/crates/runner/src/workspace_promotion/test_support.rs
@@ -39,7 +39,7 @@ impl WorkspacePromotionFixture {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -99,7 +99,7 @@ impl WorkspacePromotionFixture {
         let run_id = RunId::new_v4();
         let sandbox_id = SandboxId::new_v4();
         let workspace_image = cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id,
                     sandbox_id,
@@ -138,7 +138,7 @@ impl WorkspacePromotionFixture {
         session_id: &str,
     ) -> WorkspaceCacheCheckoutResult {
         cache
-            .prepare(WorkspaceImagePrepareRequest {
+            .prepare_for_test(WorkspaceImagePrepareRequest {
                 identity: WorkspaceImageLeaseIdentity {
                     run_id: RunId::new_v4(),
                     sandbox_id: SandboxId::new_v4(),

--- a/crates/runner/src/workspace_promotion/tests.rs
+++ b/crates/runner/src/workspace_promotion/tests.rs
@@ -215,7 +215,7 @@ async fn active_workspace_promotion_exports_session_history_sidecar() {
 
     let lease = fixture
         .cache
-        .prepare(WorkspaceImagePrepareRequest {
+        .prepare_for_test(WorkspaceImagePrepareRequest {
             identity: WorkspaceImageLeaseIdentity {
                 run_id: RunId::new_v4(),
                 sandbox_id: SandboxId::new_v4(),

--- a/turbo/apps/api/src/signals/external/realtime.ts
+++ b/turbo/apps/api/src/signals/external/realtime.ts
@@ -235,7 +235,8 @@ export async function publishRunnerJobNotification(
   group: string,
   runId: string,
   profile: string,
-  affinity?: {
+  affinity: {
+    readonly sandboxReuseScope: string;
     readonly cliAgentSessionId: string | null;
     readonly affinityProtectedUntil: string | null;
   },
@@ -246,7 +247,8 @@ export async function publishRunnerJobNotification(
       await channel.publish("job", {
         runId,
         profile,
-        ...(affinity?.cliAgentSessionId
+        sandboxReuseScope: affinity.sandboxReuseScope,
+        ...(affinity.cliAgentSessionId
           ? { cliAgentSessionId: affinity.cliAgentSessionId }
           : {}),
         ...(affinity?.affinityProtectedUntil

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2479,6 +2479,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     });
     expect(first).toMatchObject({ status: "pending" });
     const firstClaim = await api.claimRunnerJob(first.runId);
+    expect(firstClaim.sandboxReuseScope).toBe(first.sessionId);
     const cliAgentSessionId = `bdd-affinity-cli-${first.runId}`;
     const affinityRunnerId = randomUUID();
     const history = `bdd affinity history ${first.runId}`;
@@ -2511,6 +2512,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
         admittableProfiles: args.admittableProfiles,
         heldSessionStates: [
           {
+            sandboxReuseScope: first.sessionId,
             sessionId: cliAgentSessionId,
             lastCompletedAt: nowDate().toISOString(),
             ...(args.reusableSandbox
@@ -2537,7 +2539,10 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       if (poll.status !== 200) {
         throw new Error("Expected affinity poll to return 200");
       }
-      expect(poll.body.job?.runId).toBe(run.runId);
+      expect(poll.body.job).toMatchObject({
+        runId: run.runId,
+        sandboxReuseScope: first.sessionId,
+      });
       if (cancelAfterPoll) {
         await api.requestCancelRun(actor, run.runId, [200]);
       }
@@ -2606,9 +2611,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       "continue when final heartbeat includes extra legacy fields",
     );
     expect(finalHeartbeatHolder.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(finalHeartbeatHolder.job?.affinityProtectedUntil).toStrictEqual(
-      expect.any(String),
-    );
+    expect(finalHeartbeatHolder.job?.affinityProtectedUntil).toBeNull();
 
     await heartbeatHolder({
       admittableProfiles: ["vm0/default"],
@@ -2718,13 +2721,15 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     if (protectedPoll.status !== 200) {
       throw new Error("Expected affinity poll to return 200");
     }
-    expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
-    expect(protectedPoll.body.job?.cliAgentSessionId).toBe(cliAgentSessionId);
-    expect(protectedPoll.body.job?.affinityProtectedUntil).toBe(
-      new Date(queueInsertedAt + 2000).toISOString(),
-    );
+    expect(protectedPoll.body.job).toMatchObject({
+      runId: protectedFollowUp.runId,
+      sandboxReuseScope: first.sessionId,
+      cliAgentSessionId,
+      affinityProtectedUntil: new Date(queueInsertedAt + 2000).toISOString(),
+    });
 
     const protectedClaim = await api.claimRunnerJob(protectedFollowUp.runId);
+    expect(protectedClaim.sandboxReuseScope).toBe(first.sessionId);
     expect(protectedClaim.prompt).toBe("continue affinity-protected session");
     const apiToRunnerQueueMs = sandboxOperationDurationForRun(
       protectedFollowUp.runId,
@@ -2790,6 +2795,124 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
     await api.requestCancelRun(actor, expiredFollowUp.runId, [200]);
   });
 
+  it("isolates identical CLI session IDs across application session scopes", async () => {
+    const api = createRunsAutomationsApi(context);
+    const webhooks = createWebhookCallbackApi(context);
+    const { actor, agentId, runnerGroup } = await entitledRunActor();
+    const cliAgentSessionId = `bdd-shared-cli-${randomUUID()}`;
+
+    async function completeFirstTurn(prompt: string) {
+      const run = await api.createRun(actor, {
+        agentId,
+        prompt,
+        modelProvider: "anthropic-api-key",
+      });
+      const claim = await api.claimRunnerJob(run.runId);
+      expect(claim.sandboxReuseScope).toBe(run.sessionId);
+      const history = `${prompt} history`;
+      const historyHash = createHash("sha256").update(history).digest("hex");
+      mockSessionHistoryBlob(historyHash, history);
+      await webhooks.requestAgentCheckpoint(
+        {
+          runId: run.runId,
+          cliAgentType: "claude-code",
+          cliAgentSessionId,
+          cliAgentSessionHistoryHash: historyHash,
+        },
+        { authorization: `Bearer ${claim.sandboxToken}` },
+        [200],
+      );
+      await webhooks.requestAgentComplete(
+        { runId: run.runId, exitCode: 0, lastEventSequence: 0 },
+        { authorization: `Bearer ${claim.sandboxToken}` },
+        [200],
+      );
+      return run;
+    }
+
+    const first = await completeFirstTurn("first scoped conversation");
+    const second = await completeFirstTurn("second scoped conversation");
+    expect(second.sessionId).not.toBe(first.sessionId);
+
+    await api.requestHeartbeatRunner(true, [200], {
+      runnerId: randomUUID(),
+      group: runnerGroup,
+      admittableProfiles: ["vm0/default"],
+      heldSessionStates: [
+        {
+          sandboxReuseScope: first.sessionId,
+          sessionId: cliAgentSessionId,
+          lastCompletedAt: nowDate().toISOString(),
+        },
+      ],
+    });
+
+    context.mocks.ably.publish.mockClear();
+    const secondFollowUp = await api.createRun(actor, {
+      agentId,
+      sessionId: second.sessionId,
+      prompt: "continue second scope",
+      modelProvider: "anthropic-api-key",
+    });
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: secondFollowUp.runId,
+        sandboxReuseScope: second.sessionId,
+        cliAgentSessionId,
+      }),
+    );
+    const secondNotification = context.mocks.ably.publish.mock.calls.find(
+      ([topic, payload]) => {
+        return (
+          topic === "job" &&
+          isRecord(payload) &&
+          payload.runId === secondFollowUp.runId
+        );
+      },
+    );
+    expect(secondNotification?.[1]).not.toHaveProperty(
+      "affinityProtectedUntil",
+    );
+    const secondPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (secondPoll.status !== 200) {
+      throw new Error("Expected second-scope poll to succeed");
+    }
+    expect(secondPoll.body.job).toMatchObject({
+      runId: secondFollowUp.runId,
+      sandboxReuseScope: second.sessionId,
+      cliAgentSessionId,
+      affinityProtectedUntil: null,
+    });
+    await api.requestCancelRun(actor, secondFollowUp.runId, [200]);
+
+    const firstFollowUp = await api.createRun(actor, {
+      agentId,
+      sessionId: first.sessionId,
+      prompt: "continue first scope",
+      modelProvider: "anthropic-api-key",
+    });
+    const firstPoll = await api.requestPollRunner(
+      true,
+      { group: runnerGroup, supportedProfiles: ["vm0/default"] },
+      [200],
+    );
+    if (firstPoll.status !== 200) {
+      throw new Error("Expected first-scope poll to succeed");
+    }
+    expect(firstPoll.body.job).toMatchObject({
+      runId: firstFollowUp.runId,
+      sandboxReuseScope: first.sessionId,
+      cliAgentSessionId,
+      affinityProtectedUntil: expect.any(String),
+    });
+    await api.requestCancelRun(actor, firstFollowUp.runId, [200]);
+  });
+
   it("prioritizes exact reusable work only for its runner and protection window", async () => {
     const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
@@ -2801,6 +2924,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       modelProvider: "anthropic-api-key",
     });
     const firstClaim = await api.claimRunnerJob(first.runId);
+    expect(firstClaim.sandboxReuseScope).toBe(first.sessionId);
     const cliAgentSessionId = `bdd-reusable-priority-${first.runId}`;
     const history = `bdd reusable priority history ${first.runId}`;
     const historyHash = createHash("sha256").update(history).digest("hex");
@@ -2833,6 +2957,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       admittableProfiles: [],
       heldSessionStates: [
         {
+          sandboxReuseScope: first.sessionId,
           sessionId: cliAgentSessionId,
           lastCompletedAt: nowDate().toISOString(),
           reusableSandbox: { profile: "vm0/default" },
@@ -2855,6 +2980,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected reusable-holder poll to return 200");
     }
     expect(protectedPoll.body.job?.runId).toBe(protectedFollowUp.runId);
+    expect(protectedPoll.body.job?.sandboxReuseScope).toBe(first.sessionId);
     expect(protectedPoll.body.job?.affinityProtectedUntil).toStrictEqual(
       expect.any(String),
     );
@@ -2896,6 +3022,9 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
       throw new Error("Expected reusable-priority poll to return 200");
     }
     expect(reusablePriorityPoll.body.job?.runId).toBe(newerReusable.runId);
+    expect(reusablePriorityPoll.body.job?.sandboxReuseScope).toBe(
+      first.sessionId,
+    );
 
     mockNow(priorityBase + 60_000);
     const expiredPriorityPoll = await api.requestPollRunner(
@@ -3306,6 +3435,13 @@ describe("RUN-01: admission boundaries beyond request validation", () => {
         );
       })
       .toBe(true);
+    expect(context.mocks.ably.publish).toHaveBeenCalledWith(
+      "job",
+      expect.objectContaining({
+        runId: queued.runId,
+        sandboxReuseScope: queued.sessionId,
+      }),
+    );
 
     await api.requestCancelRun(actor, second.runId, [200]);
     await api.requestCancelRun(actor, queued.runId, [200]);

--- a/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/run-lifecycle.bdd.test.ts
@@ -2796,7 +2796,7 @@ describe("CHAIN-RUN: entitled run lifecycle through runner and sandbox webhooks"
   });
 
   it("isolates identical CLI session IDs across application session scopes", async () => {
-    const api = createRunsAutomationsApi(context);
+    const api = createRunsApi(context);
     const webhooks = createWebhookCallbackApi(context);
     const { actor, agentId, runnerGroup } = await entitledRunActor();
     const cliAgentSessionId = `bdd-shared-cli-${randomUUID()}`;

--- a/turbo/apps/api/src/signals/routes/runners.ts
+++ b/turbo/apps/api/src/signals/routes/runners.ts
@@ -314,6 +314,9 @@ function canonicalizeHeldSessionStates(
   return states?.map((state) => {
     const cliAgentSessionId = state.sessionId;
     return {
+      ...(state.sandboxReuseScope
+        ? { sandboxReuseScope: state.sandboxReuseScope }
+        : {}),
       sessionId: cliAgentSessionId,
       lastCompletedAt: new Date(state.lastCompletedAt).toISOString(),
       ...(state.reusableSandbox
@@ -515,6 +518,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       agentComposeVersionId: agentRuns.agentComposeVersionId,
       vars: agentRuns.vars,
       resumedFromCheckpointId: agentRuns.resumedFromCheckpointId,
+      sandboxReuseScope: agentRuns.sessionId,
       profile: runnerJobQueue.profile,
       cliAgentSessionId: runnerJobQueue.cliAgentSessionId,
       createdAt: runnerJobQueue.createdAt,
@@ -540,6 +544,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
       db,
       runnerGroup: group,
       profile: pendingJob.profile,
+      sandboxReuseScope: pendingJob.sandboxReuseScope,
       cliAgentSessionId: pendingJob.cliAgentSessionId,
       createdAt: pendingJob.createdAt,
       currentDate,
@@ -584,6 +589,7 @@ const pollInner$ = command(async ({ get, set }, signal: AbortSignal) => {
         vars: (pendingJob.vars as Record<string, string>) ?? null,
         checkpointId: pendingJob.resumedFromCheckpointId ?? null,
         experimentalProfile: pendingJob.profile,
+        sandboxReuseScope: pendingJob.sandboxReuseScope,
         cliAgentSessionId: pendingJob.cliAgentSessionId,
         affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
       },
@@ -609,6 +615,7 @@ interface ClaimableJob {
 
 interface ClaimedRun {
   readonly id: string;
+  readonly sandboxReuseScope: string;
   readonly userId: string;
   readonly orgId: string;
   readonly agentId: string;
@@ -679,6 +686,7 @@ async function getClaimableJob(
       },
       run: {
         id: agentRuns.id,
+        sandboxReuseScope: agentRuns.sessionId,
         userId: agentRuns.userId,
         orgId: agentRuns.orgId,
         agentId: agentSessions.agentComposeId,
@@ -1457,6 +1465,7 @@ async function buildClaimResponseBody(args: {
       return {
         ...runnerStoredContext,
         runId: args.run.id,
+        sandboxReuseScope: args.run.sandboxReuseScope,
         prompt: args.run.prompt,
         appendSystemPrompt: args.run.appendSystemPrompt,
         agentComposeVersionId: args.run.agentComposeVersionId,

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -384,7 +384,9 @@ interface ExplicitConnectorScope {
 // - agentSessionId is the vm0 application session (`agent_sessions.id`) used
 //   for product-level continuation and future correctness checks.
 // - cliAgentSessionId is the Claude/Codex CLI agent session stored on
-//   `conversations.cli_agent_session_id`; runner sandbox reuse is keyed by it.
+//   `conversations.cli_agent_session_id`. Runner sandbox reuse combines it with
+//   the application-session-derived `sandboxReuseScope`; it is not sufficient
+//   for reuse authorization by itself.
 // Existing API/runner wire fields named `sessionId` are preserved for
 // compatibility and normalized to these semantic names at the boundary.
 

--- a/turbo/apps/api/src/signals/services/agent-run-create.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-create.service.ts
@@ -5320,7 +5320,8 @@ function buildRunnerJobPayload(
 }
 
 type BuildRunnerJobPayloadArgs = Parameters<typeof buildRunnerJobPayload>[1];
-type DispatchRunArgs = BuildRunnerJobPayloadArgs & {
+type DispatchRunArgs = Omit<BuildRunnerJobPayloadArgs, "run"> & {
+  readonly run: Pick<RunRecord, "id" | "sessionId">;
   readonly timing: ApiDispatchTimingCollector;
   readonly timingDimensions: ApiDispatchTimingDimensions | undefined;
 };
@@ -5526,6 +5527,7 @@ function dispatchRun(
         runnerGroup: payload.runnerGroup,
         runId: args.run.id,
         profile: payload.profile,
+        sandboxReuseScope: args.run.sessionId,
         cliAgentSessionId: payload.cliAgentSessionId,
         createdAt: persisted.runnerJobCreatedAt,
       });
@@ -7137,6 +7139,7 @@ async function committedAtomicLaunchResponse(args: {
     runnerGroup: args.committed.runnerJobPayload.runnerGroup,
     runId: args.committed.run.id,
     profile: args.committed.runnerJobPayload.profile,
+    sandboxReuseScope: args.committed.run.sessionId,
     cliAgentSessionId: args.committed.runnerJobPayload.cliAgentSessionId,
     createdAt: args.committed.runnerJobCreatedAt,
   });

--- a/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-queue-payload.service.ts
@@ -17,7 +17,9 @@ const queuedRunnerJobPayloadWireSchema = z.object({
   runnerGroup: z.string(),
   profile: z.string(),
   // Wire/backing payload compatibility field. Semantically this is the
-  // Claude/Codex CLI agent session id used for runner sandbox reuse affinity.
+  // CLI component of runner sandbox reuse affinity. The API derives the
+  // authoritative scope from agent_runs at dispatch/claim time rather than
+  // persisting it in this queued payload.
   sessionId: z.string().nullable(),
   executionContext: storedExecutionContextSchema,
 });

--- a/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
+++ b/turbo/apps/api/src/signals/services/runner-dispatch.service.ts
@@ -17,6 +17,7 @@ export async function notifyRunnerJob(
     readonly runnerGroup: string;
     readonly runId: string;
     readonly profile: string;
+    readonly sandboxReuseScope: string;
     readonly cliAgentSessionId: string | null;
     readonly createdAt: Date;
   },
@@ -28,6 +29,7 @@ export async function notifyRunnerJob(
       db,
       runnerGroup: args.runnerGroup,
       profile: args.profile,
+      sandboxReuseScope: args.sandboxReuseScope,
       cliAgentSessionId: args.cliAgentSessionId,
       createdAt: args.createdAt,
       currentDate,
@@ -51,6 +53,7 @@ export async function notifyRunnerJob(
     args.runId,
     args.profile,
     {
+      sandboxReuseScope: args.sandboxReuseScope,
       cliAgentSessionId: args.cliAgentSessionId,
       affinityProtectedUntil: affinity.protectedUntil?.toISOString() ?? null,
     },

--- a/turbo/apps/api/src/signals/services/runner-session-affinity.ts
+++ b/turbo/apps/api/src/signals/services/runner-session-affinity.ts
@@ -1,5 +1,6 @@
 import { runnerJobQueue } from "@vm0/db/schema/runner-job-queue";
 import { runnerState } from "@vm0/db/schema/runner-state";
+import { agentRuns } from "@vm0/db/schema/agent-run";
 import { and, eq, gt, or, sql, type SQL } from "drizzle-orm";
 
 import type { Db } from "../external/db";
@@ -33,6 +34,7 @@ export function runnerReusableSessionPollPriority(args: {
         AND ${runnerState.lastSeenAt} > ${freshAfter}
         AND ${runnerState.heldSessionStates} @> jsonb_build_array(
           jsonb_build_object(
+            'sandboxReuseScope', ${agentRuns.sessionId},
             'sessionId', ${runnerJobQueue.cliAgentSessionId},
             'reusableSandbox', jsonb_build_object(
               'profile', ${runnerJobQueue.profile}
@@ -76,6 +78,7 @@ export async function runnerSessionAffinityProtection(args: {
   readonly db: Pick<Db, "select">;
   readonly runnerGroup: string;
   readonly profile: string;
+  readonly sandboxReuseScope: string;
   readonly cliAgentSessionId: string | null;
   readonly createdAt: Date;
   readonly currentDate: Date;
@@ -93,10 +96,14 @@ export async function runnerSessionAffinityProtection(args: {
 
   const freshAfter = runnerSessionAffinityHolderFreshAfter(args.currentDate);
   const heldSessionProbe = JSON.stringify([
-    { sessionId: args.cliAgentSessionId },
+    {
+      sandboxReuseScope: args.sandboxReuseScope,
+      sessionId: args.cliAgentSessionId,
+    },
   ]);
   const reusableSessionProbe = JSON.stringify([
     {
+      sandboxReuseScope: args.sandboxReuseScope,
       sessionId: args.cliAgentSessionId,
       reusableSandbox: { profile: args.profile },
     },

--- a/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-run-queue.service.ts
@@ -78,6 +78,7 @@ interface RunnerNotification {
   readonly runId: string;
   readonly runnerGroup: string;
   readonly profile: string;
+  readonly sandboxReuseScope: string;
   readonly cliAgentSessionId: string | null;
   readonly createdAt: Date;
 }
@@ -113,6 +114,7 @@ interface QueuedRunMaintenanceResult {
 
 interface LockedQueueRunRow extends Record<string, unknown> {
   readonly status: string;
+  readonly sandboxReuseScope: string;
 }
 
 async function timedOutQueuedRunsWithMarkerNotifications(
@@ -272,7 +274,9 @@ async function promoteQueuedCandidate(
     }
 
     const lockedRunRows = await tx.execute<LockedQueueRunRow>(sql`
-      SELECT ${agentRuns.status} AS "status"
+      SELECT
+        ${agentRuns.status} AS "status",
+        ${agentRuns.sessionId} AS "sandboxReuseScope"
       FROM ${agentRuns}
       WHERE ${agentRuns.id} = ${args.row.runId}
       FOR UPDATE
@@ -359,6 +363,7 @@ async function promoteQueuedCandidate(
         runId: args.row.runId,
         runnerGroup: args.payload.runnerGroup,
         profile: args.payload.profile,
+        sandboxReuseScope: lockedRun.sandboxReuseScope,
         cliAgentSessionId: args.payload.cliAgentSessionId,
         createdAt: runnerJobCreatedAt,
       },

--- a/turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/fixtures/runner-claim-response.json
@@ -1,5 +1,6 @@
 {
   "runId": "00000000-0000-4000-8000-000000020985",
+  "sandboxReuseScope": "01980a13-532f-7000-8000-000000000001",
   "prompt": "Inspect the fixture repository",
   "appendSystemPrompt": "Use the shared contract fixture",
   "agentComposeVersionId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/runners.test.ts
@@ -33,6 +33,7 @@ describe("runner claim response contract", () => {
 
     expect(context).toMatchObject({
       runId: "00000000-0000-4000-8000-000000020985",
+      sandboxReuseScope: "01980a13-532f-7000-8000-000000000001",
       agentComposeVersionId:
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       checkpointId: "11111111-1111-4111-8111-111111111111",

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -177,7 +177,8 @@ export const heldSessionStateSchema = z.object({
   // but never treated as authoritative reuse affinity.
   sandboxReuseScope: z.uuid().optional(),
   // Compatibility wire name. Semantically this is the Claude/Codex CLI agent
-  // session id used to route work toward a runner with a reusable sandbox.
+  // session component of scoped reuse affinity; it is not authoritative
+  // without sandboxReuseScope.
   sessionId: z.string(),
   lastCompletedAt: z.string().datetime({ offset: true }),
   reusableSandbox: z

--- a/turbo/packages/api-contracts/src/contracts/runners.ts
+++ b/turbo/packages/api-contracts/src/contracts/runners.ts
@@ -162,6 +162,7 @@ export const jobSchema = z.object({
   vars: z.record(z.string(), z.string()).nullable(),
   checkpointId: z.uuid().nullable(),
   experimentalProfile: z.string().optional(),
+  sandboxReuseScope: z.uuid(),
   cliAgentSessionId: z.string().nullable().optional(),
   affinityProtectedUntil: z
     .string()
@@ -171,6 +172,10 @@ export const jobSchema = z.object({
 });
 
 export const heldSessionStateSchema = z.object({
+  // Server-authoritative vm0 application session scope. Intentionally optional
+  // at this compatibility boundary; unscoped legacy heartbeats are accepted
+  // but never treated as authoritative reuse affinity.
+  sandboxReuseScope: z.uuid().optional(),
   // Compatibility wire name. Semantically this is the Claude/Codex CLI agent
   // session id used to route work toward a runner with a reusable sandbox.
   sessionId: z.string(),
@@ -436,6 +441,7 @@ export const storedExecutionContextSchema = z.object({
  */
 export const executionContextSchema = z.object({
   runId: z.uuid(),
+  sandboxReuseScope: z.uuid(),
   prompt: z.string(),
   appendSystemPrompt: z.string().nullable(),
   agentComposeVersionId: z.string().nullable(),

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -1,6 +1,10 @@
 export type RunnerAdmittableProfiles = string[];
 
 export interface RunnerHeldSessionState {
+  // Intentionally optional for persisted pre-scope rows and rolling runner/API
+  // compatibility. Scoped affinity ignores states that omit this
+  // server-authoritative application session id.
+  readonly sandboxReuseScope?: string;
   // Compatibility JSON field name. Semantically this is the CLI agent session
   // id that keys runner sandbox reuse affinity.
   readonly sessionId: string;

--- a/turbo/packages/db/src/jsonb-contracts/runner-state.ts
+++ b/turbo/packages/db/src/jsonb-contracts/runner-state.ts
@@ -6,7 +6,8 @@ export interface RunnerHeldSessionState {
   // server-authoritative application session id.
   readonly sandboxReuseScope?: string;
   // Compatibility JSON field name. Semantically this is the CLI agent session
-  // id that keys runner sandbox reuse affinity.
+  // component of the scoped runner reuse identity and is not authoritative by
+  // itself.
   readonly sessionId: string;
   readonly lastCompletedAt: string;
   readonly reusableSandbox?: {


### PR DESCRIPTION
## Summary

- Bind idle VM, active-session suppression, runner affinity, and workspace-cache reuse to a typed `(application session UUID, CLI agent session ID)` identity.
- Send the server-owned `sandboxReuseScope` through runner poll, direct notifications, queued promotion, and claim responses; require the same scope in authoritative heartbeat affinity.
- Fail closed when an API scope is missing or malformed, while preserving explicit local-provider reuse and mixed-version rollout compatibility.
- Version scoped workspace-cache keys and metadata so legacy unscoped entries are ignored and garbage-collected.

## Compatibility and rollout

- Deploy the API first, then the runner, and confirm every old runner has drained before treating the security boundary as fully active.
- Old runners ignore the additive API fields; the new API accepts their unscoped heartbeats but does not use them for affinity.
- New runners talking to an old API run fresh and do not park, promote, or advertise unscoped reusable state.
- Rolling back to an old runner reopens the legacy behavior; new scoped cache entries remain unreadable to it.

## Explicit exclusions

- No relational database migration or new column.
- No change to persisted runner-job queue execution-context JSON.
- No change to the `status.json` schema and no scope forwarded into the guest.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p runner --all-targets --all-features -- -D warnings`
- `cargo doc -p runner --all-features --no-deps`
- `cargo test -p runner --quiet` (2,655 passed, 9 ignored)
- changed-file Prettier check
- `pnpm turbo run lint --filter=api --filter=@vm0/api-contracts --filter=@vm0/db`
- `pnpm turbo run check-types --filter=api --filter=@vm0/api-contracts --filter=@vm0/db --concurrency=1`
- `pnpm knip`
- `pnpm -F @vm0/api-contracts exec vitest run` (396 passed)
- `pnpm -F @vm0/db exec vitest run` (12 passed)
- `pnpm -F api exec vitest run src/signals/routes/__tests__/run-lifecycle.bdd.test.ts --maxWorkers=4 --silent=passed-only` (102 passed)

Closes #21153
