### PR TITLE
fix(mitm-addon): preserve auth fetch across cancellation

### DIFF
--- a/crates/runner/mitm-addon/src/firewall_auth_cache.py
+++ b/crates/runner/mitm-addon/src/firewall_auth_cache.py
@@ -39,7 +39,7 @@ class _FirewallAuthState:
     """Per-auth-identity lifecycle state."""
 
     cache: _FirewallHeaderCacheEntry | None = None
-    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    in_flight: asyncio.Task[dict] | None = None
     force_refresh_pending: bool = False
     last_force_refresh_monotonic_at: float | None = None
 
@@ -254,47 +254,20 @@ def _build_cache_hit(
     return _build_token_meta(cached.payload, cache_hit=True)
 
 
-async def get_firewall_headers(
-    cache_key: FirewallAuthCacheKey,
+def _observe_fetch_task_exception(task: asyncio.Task[dict]) -> None:
+    """Retrieve a detached fetch failure after every waiter is cancelled."""
+    if not task.cancelled():
+        task.exception()
+
+
+async def _fetch_and_cache_firewall_headers(
+    state: _FirewallAuthState,
     request: FirewallAuthRequest,
+    *,
+    force_refresh: bool,
 ) -> dict:
-    """Get firewall auth headers with TTL-based caching.
-
-    Uses per-key locking so that concurrent requests for the same
-    auth identity coalesce into a single HTTP fetch.
-
-    Cache is evicted when:
-    - The run is removed from the registry (see registry.load_registry)
-    - A 401 response is received (see response handler)
-    - The expiresAt timestamp from the auth endpoint has passed
-    """
-    state = _get_auth_state(cache_key)
-
-    # Fast path: cache hit (no lock needed — single-threaded event loop)
-    if state.cache:
-        hit = _build_cache_hit(state.cache, firewall_billable=request.firewall_billable)
-        if hit:
-            return hit
-
-    # Slow path: acquire per-key lock so only one coroutine fetches
-    async with state.lock:
-        # Double-check: another coroutine may have populated cache while we waited
-        if state.cache:
-            hit = _build_cache_hit(state.cache, firewall_billable=request.firewall_billable)
-            if hit:
-                return hit
-
-        # Consume the force-refresh marker inside the lock so concurrent
-        # coroutines for the same auth identity cannot both trigger a
-        # refresh — the one that loses the lock will see the fresh cache
-        # on its double-check above and never reach this path. Record the
-        # consume timestamp so request_force_refresh() suppresses re-marking
-        # within the cooldown window (guards against 401-amplification).
-        force_refresh = state.force_refresh_pending
-        state.force_refresh_pending = False
-        if force_refresh:
-            state.last_force_refresh_monotonic_at = time.monotonic()
-
+    """Own one shared fetch through completion and update its cache state."""
+    try:
         result = await fetch_firewall_headers(
             request,
             force_refresh=force_refresh,
@@ -309,8 +282,8 @@ async def get_firewall_headers(
         )
 
         # A 401 can request a forced refresh while this non-forced fetch is
-        # in flight. Return the current result to this request, but do not let
-        # it repopulate shared cache ahead of the pending forced refresh.
+        # in flight. Return the current result to its initiating request, but
+        # do not let it repopulate shared cache ahead of the pending refresh.
         marker_appeared_during_non_forced_fetch = not force_refresh and state.force_refresh_pending
         if not marker_appeared_during_non_forced_fetch:
             state.cache = cache_entry
@@ -321,3 +294,59 @@ async def get_firewall_headers(
             refreshed_connectors=result.refreshed_connectors,
             refreshed_secrets=result.refreshed_secrets,
         )
+    finally:
+        state.in_flight = None
+
+
+async def get_firewall_headers(
+    cache_key: FirewallAuthCacheKey,
+    request: FirewallAuthRequest,
+) -> dict:
+    """Get firewall auth headers with TTL-based caching.
+
+    Uses a state-owned per-key task so concurrent requests for the same
+    auth identity coalesce even if an individual waiter is cancelled.
+
+    Cache is evicted when:
+    - The run is removed from the registry (see registry.load_registry)
+    - A 401 response is received (see response handler)
+    - The expiresAt timestamp from the auth endpoint has passed
+    """
+    state = _get_auth_state(cache_key)
+
+    while True:
+        # Cache inspection and task selection contain no await, so they are
+        # atomic on mitmproxy's single event loop.
+        if state.cache:
+            hit = _build_cache_hit(state.cache, firewall_billable=request.firewall_billable)
+            if hit:
+                return hit
+
+        fetch_task = state.in_flight
+        created_fetch = fetch_task is None
+        if fetch_task is None:
+            # Consume the marker before creating the task so only this shared
+            # operation can trigger the refresh. Recording before the fetch
+            # preserves the intentional failed-refresh cooldown semantics.
+            force_refresh = state.force_refresh_pending
+            state.force_refresh_pending = False
+            if force_refresh:
+                state.last_force_refresh_monotonic_at = time.monotonic()
+
+            fetch_task = asyncio.create_task(
+                _fetch_and_cache_firewall_headers(
+                    state,
+                    request,
+                    force_refresh=force_refresh,
+                )
+            )
+            state.in_flight = fetch_task
+            fetch_task.add_done_callback(_observe_fetch_task_exception)
+
+        result = await asyncio.shield(fetch_task)
+        if created_fetch:
+            return result
+
+        # Followers observe an ordinary completion through the cache. If the
+        # result was intentionally left uncached after a new 401 marker, the
+        # loop creates the required forced refresh instead.

--- a/crates/runner/mitm-addon/tests/test_auth_cache.py
+++ b/crates/runner/mitm-addon/tests/test_auth_cache.py
@@ -15,8 +15,10 @@ from tests.auth_endpoint_helpers import FakeAuthEndpoint
 from tests.auth_state_helpers import (
     auth_cache_key,
     cached_headers,
+    force_refresh_pending,
     has_auth_state,
     require_cached_headers,
+    require_last_force_refresh_monotonic_at,
     set_cached_headers,
 )
 
@@ -83,6 +85,109 @@ class TestFirewallHeaderCache:
         assert sum(flag is False for flag in cache_hit_flags) == 1
         assert sum(flag is True for flag in cache_hit_flags) == 2
         assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer token"}
+
+    async def test_cancelled_force_refresh_leader_keeps_shared_fetch(self, mitm_ctx):
+        """A cancelled leader must leave its threaded forced fetch available to a waiter."""
+        endpoint = FakeAuthEndpoint()
+        release_response = threading.Event()
+        endpoint.queue_json_response(
+            {
+                "headers": {"Authorization": "Bearer refreshed"},
+                "expiresAt": time.time() + 3600,
+            },
+            release_event=release_response,
+        )
+        cache_key = auth_cache_key()
+        auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
+        auth_cache.request_force_refresh(cache_key)
+        before_fetch = time.monotonic()
+
+        with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+            leader = asyncio.create_task(auth_cache.get_firewall_headers(cache_key, auth_request))
+            waiter = None
+            try:
+                assert await asyncio.to_thread(endpoint.wait_for_request_count, 1)
+                leader.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await leader
+
+                waiter_started = asyncio.Event()
+
+                async def wait_for_headers() -> dict:
+                    waiter_started.set()
+                    return await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+                waiter = asyncio.create_task(wait_for_headers())
+                await waiter_started.wait()
+                release_response.set()
+                result = await waiter
+            finally:
+                release_response.set()
+                tasks = [task for task in (leader, waiter) if task is not None]
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert endpoint.request_count == 1
+        assert endpoint.requests[0].json_body()["forceRefresh"] is True
+        assert result["headers"] == {"Authorization": "Bearer refreshed"}
+        assert result["cache_hit"] is True
+        assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer refreshed"}
+        assert not force_refresh_pending(cache_key)
+        assert require_last_force_refresh_monotonic_at(cache_key) >= before_fetch
+
+    async def test_cancelled_leader_shared_failure_allows_later_retry(self, mitm_ctx):
+        """A failed surviving fetch must fail its waiter and leave the key retryable."""
+        endpoint = FakeAuthEndpoint()
+        release_failure = threading.Event()
+        endpoint.queue_response(500, body=b"not-json", release_event=release_failure)
+        endpoint.queue_json_response(
+            {
+                "headers": {"Authorization": "Bearer retry"},
+                "expiresAt": time.time() + 3600,
+            }
+        )
+        cache_key = auth_cache_key()
+        auth_request = _firewall_auth_request(auth_headers={"Authorization": "template"})
+
+        with endpoint.run(), mitm_ctx(api_url=endpoint.api_url):
+            leader = asyncio.create_task(auth_cache.get_firewall_headers(cache_key, auth_request))
+            waiter = None
+            try:
+                assert await asyncio.to_thread(endpoint.wait_for_request_count, 1)
+                leader.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await leader
+
+                waiter_started = asyncio.Event()
+
+                async def wait_for_headers() -> dict:
+                    waiter_started.set()
+                    return await auth_cache.get_firewall_headers(cache_key, auth_request)
+
+                waiter = asyncio.create_task(wait_for_headers())
+                await waiter_started.wait()
+                release_failure.set()
+                with pytest.raises(urllib.error.HTTPError):
+                    await waiter
+
+                assert endpoint.request_count == 1
+                assert cached_headers(cache_key) is None
+
+                retry = await auth_cache.get_firewall_headers(cache_key, auth_request)
+            finally:
+                release_failure.set()
+                tasks = [task for task in (leader, waiter) if task is not None]
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert endpoint.request_count == 2
+        assert retry["headers"] == {"Authorization": "Bearer retry"}
+        assert retry["cache_hit"] is False
+        assert require_cached_headers(cache_key).headers == {"Authorization": "Bearer retry"}
 
     async def test_different_keys_fetch_independently(self, mitm_ctx):
         """Different auth cache keys should fetch independently."""
@@ -213,8 +318,8 @@ class TestFirewallHeaderCache:
             assert cached["cache_hit"] is True
             assert endpoint.request_count == 2
 
-    def test_registry_eviction_cleans_locks(self, tmp_path, mitm_ctx):
-        """When a run is evicted from registry, its locks should be cleaned up too."""
+    def test_registry_eviction_cleans_auth_state(self, tmp_path, mitm_ctx):
+        """When a run is evicted from the registry, its auth state is removed."""
         cache_key = auth_cache_key(run_id="run-old")
         set_cached_headers(cache_key, headers={}, expires_at=None)
 


### PR DESCRIPTION
## Summary

- keep each firewall-auth fetch owned by per-key cache state so cancelling one caller cannot abandon request coalescing
- shield the shared fetch from waiter cancellation while preserving cache population, force-refresh marker, and cooldown behavior
- cover cancelled-leader success and failure paths with a blocked real threaded auth endpoint

## Scope

- no changes to the firewall auth webhook request or response contract
- no changes to force-refresh cooldown policy or cache identity
- the blocking HTTP request remains non-cancellable; this change keeps it represented as the shared in-flight operation until completion

## Validation

- `cd crates/runner/mitm-addon && .venv/bin/ruff format .`
- `cd crates/runner/mitm-addon && .venv/bin/ruff check .`
- `cd crates/runner/mitm-addon && .venv/bin/basedpyright -p .`
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/test_auth_cache.py -v` (8 passed)
- `cd crates/runner/mitm-addon && .venv/bin/python -m pytest tests/ -v` (3836 passed)

Closes #21187
