### PR TITLE
perf(mitm-addon): avoid eager catalog identity checks

### DIFF
--- a/crates/runner/mitm-addon/src/registry.py
+++ b/crates/runner/mitm-addon/src/registry.py
@@ -6,7 +6,7 @@ import stat
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, TypeAlias
+from typing import TypeAlias
 
 from mitmproxy import ctx
 
@@ -19,20 +19,12 @@ VmContext = tuple[
     matching.CompiledFirewallSet | None,
     matching.CompiledNetworkPolicies,
 ]
-_NoBuiltinFirewallCatalogDependency: TypeAlias = Literal["no-builtin-firewall-catalog-dependency"]
-_NO_BUILTIN_FIREWALL_CATALOG_DEPENDENCY: _NoBuiltinFirewallCatalogDependency = (
-    "no-builtin-firewall-catalog-dependency"
-)
-_BuiltinFirewallCatalogDependencyKey: TypeAlias = (
-    registry_firewalls.BuiltinFirewallCatalogFileKey | _NoBuiltinFirewallCatalogDependency | None
-)
-_RegistryCacheKey = tuple[
+_RegistryFileKey: TypeAlias = tuple[
     str,
     int,
     int,
     int,
     int,
-    _BuiltinFirewallCatalogDependencyKey,
 ]
 MAX_REGISTRY_BYTES = 16 * 1024 * 1024
 _READ_CHUNK_BYTES = 1024 * 1024
@@ -57,7 +49,7 @@ class _RegistrySnapshot:
     compiled_firewalls: dict[str, matching.CompiledFirewallSet]
     compiled_network_policies: dict[str, matching.CompiledNetworkPolicies]
     builtin_firewall_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None
-    loaded_key: _RegistryCacheKey | None
+    loaded_key: _RegistryFileKey | None
 
 
 @dataclass(frozen=True)
@@ -84,12 +76,12 @@ class _RegistryCacheState:
     unavailable: RegistryUnavailable | None = None
     # Known-bad decoded registry input. This key should short-circuit until the
     # file changes again, while enforcement continues to see RegistryUnavailable.
-    failed_key: _RegistryCacheKey | None = None
+    failed_key: _RegistryFileKey | None = None
     # Open/stat failures do not provide a key, so use a one-shot guard. Read
     # errors have a key but are retried on every call; track their last warning
     # key only to avoid request-path log spam without poisoning the file state.
     stat_error_logged: bool = False
-    read_error_key: _RegistryCacheKey | None = None
+    read_error_key: _RegistryFileKey | None = None
     builtin_firewall_core_cache: dict[
         registry_firewalls.BuiltinFirewallCoreCacheKey,
         matching.CompiledFirewallCore,
@@ -217,17 +209,6 @@ def _builtin_firewall_catalog_cache_path() -> str | None:
     return registry_firewalls.configured_catalog_cache_path()
 
 
-def _registry_file_key_matches_snapshot_without_catalog_dependency(
-    key: _RegistryCacheKey,
-    snapshot_key: _RegistryCacheKey | None,
-) -> bool:
-    return (
-        snapshot_key is not None
-        and snapshot_key[:-1] == key[:-1]
-        and snapshot_key[-1] == _NO_BUILTIN_FIREWALL_CATALOG_DEPENDENCY
-    )
-
-
 def _classify_registry_vms(
     raw_registry: dict,
     *,
@@ -236,7 +217,6 @@ def _classify_registry_vms(
     dict,
     dict[str, InvalidVmEntry],
     dict[str, tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...]],
-    bool,
     registry_firewalls.BuiltinFirewallCatalogSnapshot | None,
 ]:
     new_registry: dict = {}
@@ -245,7 +225,6 @@ def _classify_registry_vms(
         str,
         tuple[registry_firewalls.BuiltinFirewallCoreCacheKey | None, ...],
     ] = {}
-    uses_builtin_catalog_dependency = False
     builtin_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None = None
     for client_ip, vm in raw_registry.items():
         if not isinstance(vm, dict):
@@ -297,12 +276,10 @@ def _classify_registry_vms(
         vm_uses_builtin_catalog_dependency = isinstance(raw_firewalls, list) and any(
             isinstance(entry, dict) and entry.get("kind") == "builtin" for entry in raw_firewalls
         )
-        if vm_uses_builtin_catalog_dependency:
-            uses_builtin_catalog_dependency = True
-            if builtin_catalog_snapshot is None:
-                builtin_catalog_snapshot = registry_firewalls.load_catalog_snapshot(
-                    builtin_firewall_catalog_cache_path
-                )
+        if vm_uses_builtin_catalog_dependency and builtin_catalog_snapshot is None:
+            builtin_catalog_snapshot = registry_firewalls.load_catalog_snapshot(
+                builtin_firewall_catalog_cache_path
+            )
 
         try:
             resolved_firewalls = registry_firewalls.resolve_firewall_entries(
@@ -326,7 +303,6 @@ def _classify_registry_vms(
         new_registry,
         invalid_vms,
         builtin_cache_keys_by_client_ip,
-        uses_builtin_catalog_dependency,
         builtin_catalog_snapshot,
     )
 
@@ -406,7 +382,6 @@ def load_registry_state(registry_path: str) -> RegistryState:
     path_key = _path_key(path)
     state = _state_for_path(path_key)
     builtin_catalog_cache_path = _builtin_firewall_catalog_cache_path()
-    builtin_catalog_file_key = registry_firewalls.catalog_file_key(builtin_catalog_cache_path)
 
     try:
         fd, st = _open_registry_for_read(path)
@@ -424,16 +399,12 @@ def load_registry_state(registry_path: str) -> RegistryState:
             st.st_ino,
             st.st_mtime_ns,
             st.st_size,
-            builtin_catalog_file_key,
         )
-        if key == state.snapshot.loaded_key:
-            state.unavailable = None
-            state.stat_error_logged = False
-            state.read_error_key = None
-            return state.snapshot
-        if _registry_file_key_matches_snapshot_without_catalog_dependency(
-            key,
-            state.snapshot.loaded_key,
+        loaded_catalog_snapshot = state.snapshot.builtin_firewall_catalog_snapshot
+        if key == state.snapshot.loaded_key and (
+            loaded_catalog_snapshot is None
+            or registry_firewalls.catalog_file_key(builtin_catalog_cache_path)
+            == loaded_catalog_snapshot.dependency_file_key
         ):
             state.unavailable = None
             state.stat_error_logged = False
@@ -468,28 +439,10 @@ def load_registry_state(registry_path: str) -> RegistryState:
         new_registry,
         invalid_vms,
         builtin_cache_keys,
-        uses_builtin_catalog_dependency,
         builtin_catalog_snapshot,
     ) = _classify_registry_vms(
         raw_registry,
         builtin_firewall_catalog_cache_path=builtin_catalog_cache_path,
-    )
-    loaded_builtin_catalog_file_key = (
-        (
-            builtin_catalog_snapshot.dependency_file_key
-            if builtin_catalog_snapshot is not None
-            else None
-        )
-        if uses_builtin_catalog_dependency
-        else _NO_BUILTIN_FIREWALL_CATALOG_DEPENDENCY
-    )
-    loaded_key = (
-        path_key,
-        st.st_dev,
-        st.st_ino,
-        st.st_mtime_ns,
-        st.st_size,
-        loaded_builtin_catalog_file_key,
     )
     if invalid_vms:
         ctx.log.warn(f"Rejected {len(invalid_vms)} invalid proxy registry VM entries")
@@ -508,8 +461,8 @@ def load_registry_state(registry_path: str) -> RegistryState:
         invalid_vms,
         new_compiled_registry,
         new_compiled_policy_registry,
-        builtin_catalog_snapshot if uses_builtin_catalog_dependency else None,
-        loaded_key,
+        builtin_catalog_snapshot,
+        key,
     )
     state.unavailable = None
     state.failed_key = None

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -280,6 +280,123 @@ class TestRegistryBuiltinCache:
         assert compiled_firewalls is not None
         assert vm_info["firewalls"][0]["apis"][0]["id"] == "run-cache-only:0"
 
+    def test_catalog_identity_is_checked_only_for_cached_builtin_registry(self, tmp_path, mitm_ctx):
+        registry_path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={
+                "cache-only": _cache_firewall(
+                    "cache-only",
+                    "https://cache.example.com",
+                )
+            },
+        )
+        original_catalog_file_key = registry_firewalls.catalog_file_key
+
+        with (
+            mitm_ctx(
+                registry_path=str(registry_path),
+                builtin_firewall_catalog_cache_path=str(cache_path),
+            ),
+            patch.object(
+                registry_firewalls,
+                "catalog_file_key",
+                wraps=original_catalog_file_key,
+            ) as catalog_file_key,
+        ):
+            missing_state = registry.load_registry_state(str(registry_path))
+            assert isinstance(missing_state, registry.RegistryUnavailable)
+            assert missing_state.reason == "stat_failed"
+            assert catalog_file_key.call_count == 0
+
+            write_multi_vm_registry(
+                registry_path,
+                {"10.200.0.1": inline_vm("run-inline")},
+            )
+            os.utime(
+                registry_path,
+                ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000),
+            )
+            inline_state = registry.load_registry_state(str(registry_path))
+            cached_inline_state = registry.load_registry_state(str(registry_path))
+
+            assert not isinstance(inline_state, registry.RegistryUnavailable)
+            assert cached_inline_state is inline_state
+            assert inline_state.vms["10.200.0.1"]["runId"] == "run-inline"
+            assert catalog_file_key.call_count == 0
+
+            write_multi_vm_registry(
+                registry_path,
+                {"10.200.0.1": builtin_vm("run-cache-only", "cache-only")},
+            )
+            os.utime(
+                registry_path,
+                ns=(1_700_000_000_000_000_001, 1_700_000_000_000_000_001),
+            )
+            builtin_state = registry.load_registry_state(str(registry_path))
+
+            assert not isinstance(builtin_state, registry.RegistryUnavailable)
+            assert (
+                builtin_state.vms["10.200.0.1"]["firewalls"][0]["apis"][0]["base"]
+                == "https://cache.example.com"
+            )
+            assert catalog_file_key.call_count == 0
+
+            cached_builtin_state = registry.load_registry_state(str(registry_path))
+
+        assert cached_builtin_state is builtin_state
+        assert catalog_file_key.call_count == 1
+
+    def test_malformed_registry_cache_is_independent_of_catalog_identity(self, tmp_path, mitm_ctx):
+        registry_path = tmp_path / "registry.json"
+        cache_path = tmp_path / "builtin-firewall-catalog-cache.json"
+        registry_path.write_text("{ broken")
+        _write_catalog_cache(
+            cache_path,
+            digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            version="catalog-a",
+            firewalls={"unused": _cache_firewall("unused", "https://unused-a.example.com")},
+        )
+        os.utime(
+            cache_path,
+            ns=(1_700_000_000_000_000_000, 1_700_000_000_000_000_000),
+        )
+        original_catalog_file_key = registry_firewalls.catalog_file_key
+
+        with (
+            mitm_ctx(
+                registry_path=str(registry_path),
+                builtin_firewall_catalog_cache_path=str(cache_path),
+            ) as log,
+            patch.object(
+                registry_firewalls,
+                "catalog_file_key",
+                wraps=original_catalog_file_key,
+            ) as catalog_file_key,
+            patch.object(registry.json, "loads", wraps=registry.json.loads) as json_loads,
+        ):
+            first_state = registry.load_registry_state(str(registry_path))
+            _write_catalog_cache(
+                cache_path,
+                digest="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                version="catalog-b",
+                firewalls={"unused": _cache_firewall("unused", "https://unused-b.example.com")},
+            )
+            os.utime(
+                cache_path,
+                ns=(1_700_000_000_000_000_001, 1_700_000_000_000_000_001),
+            )
+            second_state = registry.load_registry_state(str(registry_path))
+
+        assert isinstance(first_state, registry.RegistryUnavailable)
+        assert second_state is first_state
+        assert json_loads.call_count == 1
+        assert catalog_file_key.call_count == 0
+        assert log.warn.call_count == 1
+
     def test_registry_snapshot_uses_actual_loaded_catalog_file_key(
         self, tmp_path, monkeypatch, mitm_ctx
     ):


### PR DESCRIPTION
## Summary

- separate proxy registry file identity from its optional pinned builtin catalog dependency
- read catalog identity only for unchanged successful snapshots that depend on the catalog
- keep initial, changed, missing, and malformed registry validation independent of unrelated catalog metadata
- cover missing-to-inline-to-builtin cache transitions and malformed registry retry identity with real-file regressions

## Compatibility

- no API, CLI option, registry/catalog JSON schema, database, migration, queue payload, persisted data, or runner protocol changes
- catalog-dependent invalidation, actual-opened-snapshot race handling, and missing/malformed catalog fail-closed behavior remain unchanged

## Validation

- `.venv/bin/python -m ruff format src/registry.py tests/test_registry_builtin_cache.py`
- `.venv/bin/python -m ruff check src/registry.py tests/test_registry_builtin_cache.py`
- `.venv/bin/python -m ruff format --check src/registry.py tests/test_registry_builtin_cache.py`
- `.venv/bin/python -m basedpyright` — 0 errors, 0 warnings
- `.venv/bin/python -m pytest -q tests/test_registry_builtin_cache.py tests/test_registry_loading.py` — 75 passed
- `.venv/bin/python -m pytest -q` — 3836 passed
- `git diff --check`
- 100,000 cached no-dependency loads — 0 `catalog_file_key()` calls, 1.956s locally

Closes #21188
