### PR TITLE
test(mitm-addon): cover json probe number forms

### DIFF
--- a/crates/runner/mitm-addon/tests/test_json_probe.py
+++ b/crates/runner/mitm-addon/tests/test_json_probe.py
@@ -1,5 +1,7 @@
 """Tests for bounded JSON prefix probing helpers."""
 
+import pytest
+
 from usage.json_probe import probe_top_level_string_field
 
 
@@ -11,6 +13,69 @@ def test_probe_finds_top_level_string_field_without_scanning_rest():
     assert result.status == "found"
     assert result.value == "response.completed"
     assert result.field_seen
+
+
+@pytest.mark.parametrize(
+    "number",
+    [
+        pytest.param(b"0.0", id="zero-fraction"),
+        pytest.param(b"1.25", id="positive-fraction"),
+        pytest.param(b"-2.5e+3", id="negative-fraction-positive-exponent"),
+        pytest.param(b"1e3", id="exponent-without-sign"),
+        pytest.param(b"1E-3", id="uppercase-negative-exponent"),
+    ],
+)
+def test_probe_skips_fractional_and_exponent_numbers_before_field(number: bytes):
+    result = probe_top_level_string_field(b'{"score":' + number + b',"type":"response.completed"}')
+
+    assert result.status == "found"
+    assert result.value == "response.completed"
+    assert result.field_seen
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(
+            b'{"score":1.,"type":"response.completed"}',
+            id="fraction-missing-digit",
+        ),
+        pytest.param(
+            b'{"score":1e,"type":"response.completed"}',
+            id="exponent-missing-digit",
+        ),
+        pytest.param(
+            b'{"score":1e+,"type":"response.completed"}',
+            id="signed-exponent-missing-digit",
+        ),
+        pytest.param(
+            b'{"score":00.5,"type":"response.completed"}',
+            id="leading-zero-fraction",
+        ),
+    ],
+)
+def test_probe_rejects_malformed_fractional_and_exponent_numbers_before_field(body: bytes):
+    result = probe_top_level_string_field(body)
+
+    assert result.status == "invalid"
+    assert result.value is None
+    assert not result.field_seen
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(b'{"score":1.', id="fraction-missing-digit"),
+        pytest.param(b'{"score":1e', id="exponent-missing-digit"),
+        pytest.param(b'{"score":1e+', id="signed-exponent-missing-digit"),
+    ],
+)
+def test_probe_reports_incomplete_fractional_and_exponent_prefixes_before_field(body: bytes):
+    result = probe_top_level_string_field(body)
+
+    assert result.status == "incomplete"
+    assert result.value is None
+    assert not result.field_seen
 
 
 def test_probe_ignores_nested_fields_with_same_name():

--- a/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
+++ b/crates/runner/mitm-addon/tests/test_openai_responses_event_json.py
@@ -245,6 +245,15 @@ def test_non_terminal_prefilter_ignores_nested_types_and_payload_text():
     assert extract_openai_responses_usage_from_event_json(body) is None
 
 
+def test_non_terminal_prefilter_handles_fractional_exponent_number_before_type():
+    body = b'{"score":-2.5e+3,"type":"response.output_text.delta","delta":"ignored"}'
+
+    assert (
+        openai_responses._classify_responses_event_type(body)
+        == openai_responses._RESPONSES_EVENT_KNOWN_NON_USAGE
+    )
+
+
 def test_duplicate_top_level_type_uses_first_type_boundary():
     body = (
         b'{"type":"response.output_text.delta",'


### PR DESCRIPTION
## Summary

- Add table-driven coverage for fractional and exponent JSON numbers that appear before a probed top-level field.
- Distinguish malformed complete numbers (`invalid`) from valid-but-truncated numeric prefixes (`incomplete`).
- Verify the OpenAI Responses event classifier keeps the known-non-usage fast path when an earlier field contains a fractional exponent number.

## Scope

- Test-only change; the current JSON prefix probe already implements the covered number grammar correctly.
- Does not introduce a numeric-token length limit or otherwise change runtime parsing, billing, or fallback behavior.

## Validation

- `ruff format .`
- `ruff check --fix .`
- `ruff format --check .`
- `ruff check .`
- `basedpyright -p . --pythonpath "$(command -v python3)"`
- `pytest -q tests/test_json_probe.py tests/test_openai_responses_event_json.py` (60 passed)
- `pytest -q tests/test_json_probe.py tests/test_openai_responses_event_json.py tests/test_openai_responses_sse.py tests/test_model_provider_sse_usage.py` (124 passed)
- `pytest -q tests/` (3856 passed)
- Mutation proof: temporarily rejecting fractional/exponent continuations made 9 targeted cases fail; the mutation was reverted before commit.

Closes #21192
