### PR TITLE
fix: show friendly claude overload guidance

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/chat-callbacks.bdd.test.ts
@@ -2843,6 +2843,42 @@ describe("CHAT-02: failed chat callbacks", () => {
     expect(marker?.content).toBe("insufficient_credits");
   }, 90_000);
 
+  it("shows friendly Claude overload guidance while preserving the raw run error", async () => {
+    const { actor, agentId, runnerGroup } = await entitledChatActor();
+    chatCallbacks.failIfChatCallbackRouteIsFetched();
+    const rawOverloadError =
+      "API Error: 529 Overloaded. This is a server-side issue, usually temporary - try again in a moment. If it persists, check https://status.claude.com.";
+
+    const run = await startChatRun(actor, {
+      agentId,
+      prompt: "trigger claude overload",
+      selectedModel: "claude-sonnet-4-6",
+    });
+    const sandboxHeaders = await claimChatRun(runnerGroup, run.runId);
+    await failChatRun(run.runId, sandboxHeaders, rawOverloadError);
+
+    const page = await waitForThreadMessages(
+      actor,
+      run.threadId,
+      (messages) => {
+        return lifecycleMarkers(messages, run.runId, "failed").some(
+          (message) => {
+            return message.error?.includes("Claude Sonnet 4.6") ?? false;
+          },
+        );
+      },
+    );
+    const marker = lifecycleMarkers(page.messages, run.runId, "failed")[0];
+    expect(marker?.error).toBe(
+      "Claude Sonnet 4.6 is overloaded. Please wait a few minutes and try again, or switch to another model.",
+    );
+    expect(marker?.content).toBe(marker?.error);
+    expect(marker?.error).not.toContain("status.claude.com");
+
+    const rawRun = await api.readRun(actor, run.runId);
+    expect(rawRun.error).toBe(rawOverloadError);
+  }, 90_000);
+
   it("shows Claude Code credential recovery guidance for upstream auth 401s", async () => {
     chatCallbacks.failIfChatCallbackRouteIsFetched();
     const upstreamAuthError =

--- a/turbo/apps/api/src/signals/services/agent-run-telemetry.service.ts
+++ b/turbo/apps/api/src/signals/services/agent-run-telemetry.service.ts
@@ -10,8 +10,10 @@ import type {
   RunStatus,
   SystemLogResponse,
 } from "@vm0/api-contracts/contracts/runs";
+import { formatClaudeProviderOverloadedRunError } from "@vm0/api-contracts/contracts/errors";
 import { agentComposeVersions } from "@vm0/db/schema/agent-compose";
 import { agentRuns } from "@vm0/db/schema/agent-run";
+import { zeroRuns } from "@vm0/db/schema/zero-run";
 import { and, eq } from "drizzle-orm";
 
 import { db$ } from "../external/db";
@@ -92,6 +94,7 @@ interface RunWithCompose {
   readonly error: string | null;
   readonly lastEventSequence: number | null;
   readonly composeContent: unknown;
+  readonly selectedModel: string | null;
 }
 
 function extractFramework(composeContent: unknown): string {
@@ -147,7 +150,11 @@ function buildRunState(run: RunWithCompose): RunState {
   }
 
   if (run.status === "failed" && run.error) {
-    state.error = run.error;
+    state.error =
+      formatClaudeProviderOverloadedRunError({
+        message: run.error,
+        selectedModel: run.selectedModel,
+      }) ?? run.error;
   }
 
   if (run.lastEventSequence !== null) {
@@ -190,12 +197,14 @@ export function agentRunEvents(
         error: agentRuns.error,
         lastEventSequence: agentRuns.lastEventSequence,
         composeContent: agentComposeVersions.content,
+        selectedModel: zeroRuns.selectedModel,
       })
       .from(agentRuns)
       .leftJoin(
         agentComposeVersions,
         eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
       )
+      .leftJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
       .where(
         and(
           eq(agentRuns.id, params.runId),

--- a/turbo/apps/api/src/signals/services/run-error-format.service.ts
+++ b/turbo/apps/api/src/signals/services/run-error-format.service.ts
@@ -30,6 +30,7 @@ interface RunErrorProviderContext {
   readonly orgId: string;
   readonly modelProviderType: ModelProviderType | null;
   readonly modelProviderCredentialScope: ModelProviderCredentialScope | null;
+  readonly selectedModel: string | null;
 }
 
 interface FormatRunErrorLikeWebMessageParams {
@@ -38,6 +39,7 @@ interface FormatRunErrorLikeWebMessageParams {
   readonly errorMessage: string;
   readonly modelProviderType?: ModelProviderType | null;
   readonly modelProviderCredentialScope?: ModelProviderCredentialScope | null;
+  readonly selectedModel?: string | null;
   readonly canManageOrgModelProviders?: boolean;
 }
 
@@ -148,6 +150,7 @@ function runErrorProviderContext(
         orgId: agentRuns.orgId,
         modelProviderType: zeroRuns.modelProvider,
         modelProviderCredentialScope: zeroRuns.modelProviderCredentialScope,
+        selectedModel: zeroRuns.selectedModel,
       })
       .from(agentRuns)
       .leftJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
@@ -165,6 +168,7 @@ function runErrorProviderContext(
       modelProviderCredentialScope: formatRunModelProviderCredentialScope(
         run.modelProviderCredentialScope,
       ),
+      selectedModel: run.selectedModel,
     };
   });
 }
@@ -183,7 +187,8 @@ function formatRunErrorLikeWebMessage(
 
     const providerContext =
       params.modelProviderType !== undefined &&
-      params.modelProviderCredentialScope !== undefined
+      params.modelProviderCredentialScope !== undefined &&
+      params.selectedModel !== undefined
         ? undefined
         : await get(runErrorProviderContext(params.runId));
     const modelProviderType =
@@ -194,9 +199,14 @@ function formatRunErrorLikeWebMessage(
       params.modelProviderCredentialScope !== undefined
         ? params.modelProviderCredentialScope
         : providerContext?.modelProviderCredentialScope;
+    const selectedModel =
+      params.selectedModel !== undefined
+        ? params.selectedModel
+        : providerContext?.selectedModel;
     const displayErrorMessage = formatRunErrorForExternalSurface({
       code: "INTERNAL_SERVER_ERROR",
       message: errorMessage,
+      selectedModel,
       claudeCodeCredentialRecovery: {
         modelProviderType,
         modelProviderCredentialScope,
@@ -266,6 +276,7 @@ export const formatRunErrorForRunOwner$ = command(
         modelProviderType: providerContext?.modelProviderType ?? null,
         modelProviderCredentialScope:
           providerContext?.modelProviderCredentialScope ?? null,
+        selectedModel: providerContext?.selectedModel ?? null,
         canManageOrgModelProviders,
       }),
     );

--- a/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/errors.test.ts
@@ -129,6 +129,73 @@ describe("formatRunErrorForExternalSurface", () => {
     expect(isGenericRunErrorForDisplay(modelCapacity)).toBe(false);
   });
 
+  it("shows friendly Claude overload guidance with the selected model label", () => {
+    const rawRunError =
+      "API Error: 529 Overloaded. This is a server-side issue, usually temporary - try again in a moment. If it persists, check https://status.claude.com.";
+
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+        selectedModel: "claude-sonnet-4-6",
+      }),
+    ).toBe(
+      "Claude Sonnet 4.6 is overloaded. Please wait a few minutes and try again, or switch to another model.",
+    );
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message: rawRunError,
+        selectedModel: "anthropic/claude-sonnet-5",
+      }),
+    ).toBe(
+      "Claude Sonnet 5 is overloaded. Please wait a few minutes and try again, or switch to another model.",
+    );
+  });
+
+  it("shows fallback Claude overload guidance when no selected model is available", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message:
+          'API Error: 529 {"type":"error","error":{"type":"overloaded_error","message":"The service is overloaded"}}',
+      }),
+    ).toBe(
+      "Claude Model is overloaded. Please wait a few minutes and try again, or switch to another model.",
+    );
+  });
+
+  it("shows friendly Claude overload guidance for repeated 529 errors", () => {
+    expect(
+      formatRunErrorForExternalSurface({
+        code: "UNKNOWN",
+        message:
+          "API Error: Repeated 529 Overloaded errors. The API is at capacity - this is usually temporary.",
+        selectedModel: "claude-opus-4-8",
+      }),
+    ).toBe(
+      "Claude Opus 4.8 is overloaded. Please wait a few minutes and try again, or switch to another model.",
+    );
+  });
+
+  it("keeps unrelated Claude 529 text generic", () => {
+    for (const rawRunError of [
+      "API Error: 529 upstream failed",
+      "API Error: 529 not overloaded",
+      "API Error: 529 overloadedness check failed",
+      'API Error: 529 {"type":"error","error":{"type":"not_overloaded_error"}}',
+      "API Error: 503 Overloaded",
+    ]) {
+      expect(
+        formatRunErrorForExternalSurface({
+          code: "UNKNOWN",
+          message: rawRunError,
+          selectedModel: "claude-sonnet-4-6",
+        }),
+      ).toBe(CHAT_RUN_TRANSIENT_ERROR_MESSAGE);
+    }
+  });
+
   it("shows Codex ChatGPT account model support errors verbatim", () => {
     const unsupportedModel =
       '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.6-sol\' model is not supported when using Codex with a ChatGPT account."}}';

--- a/turbo/packages/api-contracts/src/contracts/errors.ts
+++ b/turbo/packages/api-contracts/src/contracts/errors.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
-import type {
-  ModelProviderCredentialScope,
-  ModelProviderType,
+import {
+  getCanonicalModelDisplayName,
+  normalizeRunModelId,
+  type ModelProviderCredentialScope,
+  type ModelProviderType,
 } from "./model-providers";
 
 /**
@@ -146,6 +148,10 @@ const CLAUDE_CODE_ANTHROPIC_API_KEY_ADMIN_MESSAGE =
 const CLAUDE_CODE_ANTHROPIC_API_KEY_MEMBER_MESSAGE =
   "Claude Code could not authenticate with the configured Anthropic API key. Ask a workspace admin to update or replace the API key.";
 
+const CLAUDE_PROVIDER_OVERLOADED_FALLBACK_MODEL = "Claude Model";
+const CLAUDE_PROVIDER_OVERLOADED_GUIDANCE =
+  "is overloaded. Please wait a few minutes and try again, or switch to another model.";
+
 const CLAUDE_CODE_LIMIT_SNIPPETS = [
   "usage limit",
   "usage_limit",
@@ -213,6 +219,77 @@ type ClaudeCodeCredentialRecovery = {
   readonly canManageOrgModelProviders: boolean;
   readonly modelProvidersUrl: string | undefined;
 };
+
+function isWordBoundaryChar(char: string | undefined): boolean {
+  return char === undefined || !/[a-z0-9_-]/u.test(char);
+}
+
+function startsWithOverloadedWord(value: string): boolean {
+  return (
+    value.startsWith("overloaded") &&
+    isWordBoundaryChar(value["overloaded".length])
+  );
+}
+
+function containsOverloadedErrorType(value: string): boolean {
+  return /(^|[^a-z0-9_])overloaded_error([^a-z0-9_]|$)/u.test(value);
+}
+
+function claude529ErrorDetail(value: string): string | undefined {
+  const detail = value.trimStart();
+  const repeatedMatch = /^repeated\s+529\b/u.exec(detail);
+  if (repeatedMatch) {
+    return detail.slice(repeatedMatch[0].length).trimStart();
+  }
+
+  const statusMatch = /^529\b/u.exec(detail);
+  if (!statusMatch) {
+    return undefined;
+  }
+  return detail.slice(statusMatch[0].length).trimStart();
+}
+
+function isClaudeProviderOverloadedErrorMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  const marker = "api error:";
+  let markerIndex = normalized.indexOf(marker);
+
+  while (markerIndex !== -1) {
+    const detail = claude529ErrorDetail(
+      normalized.slice(markerIndex + marker.length),
+    );
+    if (
+      detail !== undefined &&
+      (startsWithOverloadedWord(detail) || containsOverloadedErrorType(detail))
+    ) {
+      return true;
+    }
+    markerIndex = normalized.indexOf(marker, markerIndex + marker.length);
+  }
+
+  return false;
+}
+
+function formatClaudeProviderOverloadedMessage(
+  selectedModel: string | null | undefined,
+): string {
+  const trimmedModel = selectedModel?.trim();
+  const modelLabel = trimmedModel
+    ? getCanonicalModelDisplayName(normalizeRunModelId(trimmedModel))
+    : CLAUDE_PROVIDER_OVERLOADED_FALLBACK_MODEL;
+  return `${modelLabel} ${CLAUDE_PROVIDER_OVERLOADED_GUIDANCE}`;
+}
+
+export function formatClaudeProviderOverloadedRunError(params: {
+  readonly message: string;
+  readonly selectedModel?: string | null;
+}): string | undefined {
+  const errorMessage = params.message.trim();
+  if (!isClaudeProviderOverloadedErrorMessage(errorMessage)) {
+    return undefined;
+  }
+  return formatClaudeProviderOverloadedMessage(params.selectedModel);
+}
 
 function isJsonWhitespace(char: string | undefined): boolean {
   return char === " " || char === "\n" || char === "\r" || char === "\t";
@@ -411,6 +488,7 @@ export function isGenericRunErrorForDisplay(errorMessage: string): boolean {
 export function formatRunErrorForExternalSurface(params: {
   readonly code: string;
   readonly message: string;
+  readonly selectedModel?: string | null;
   readonly claudeCodeCredentialRecovery?: ClaudeCodeCredentialRecovery;
   readonly insufficientCredits?:
     | {
@@ -425,6 +503,14 @@ export function formatRunErrorForExternalSurface(params: {
       };
 }): string {
   const errorMessage = params.message.trim() || "Run failed";
+
+  const claudeOverloadedMessage = formatClaudeProviderOverloadedRunError({
+    message: errorMessage,
+    selectedModel: params.selectedModel,
+  });
+  if (claudeOverloadedMessage !== undefined) {
+    return claudeOverloadedMessage;
+  }
 
   if (
     params.claudeCodeCredentialRecovery !== undefined &&


### PR DESCRIPTION
## Summary
- Detect Claude/Anthropic 529 overload provider errors and replace raw provider text with retry/switch-model guidance.
- Include the selected run model label when available, with a Claude Model fallback otherwise.
- Keep raw run errors persisted for diagnostics while formatting chat callbacks and run event responses for user-facing surfaces.

Closes #17976

## Testing
- pnpm -F @vm0/api-contracts exec vitest src/contracts/__tests__/errors.test.ts --run
- pnpm -F api exec vitest src/signals/routes/__tests__/chat-callbacks.bdd.test.ts --run -t "shows friendly Claude overload guidance"
- pnpm -F @vm0/api-contracts check-types
- pnpm -F api check-types
- pnpm format
- pnpm -F @vm0/api-contracts lint
- pnpm -F api lint
- pre-commit: prettier, knip, turbo check-types, commitlint

Note: local `pnpm -F @vm0/db db:migrate` is currently blocked by pending main-branch migrations that require transaction-separated enum/vector setup in this container; I manually advanced the local test DB enough to run the focused API integration test. CI should run against its normal database setup.