### PR TITLE
perf(platform): optimize artifact image card thumbnails

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -616,6 +616,86 @@ describe("artifacts page", () => {
     );
   });
 
+  it("loads CDN image cards as thumbnails while preserving original previews", async () => {
+    setupTeam();
+    const scope = testAuthScope("image-thumbnail");
+    const cdnImageUrl =
+      "https://cdn.vm7.io/artifacts/user/image-run/generated.png";
+    const thumbnailUrl =
+      "https://cdn.vm7.io/cdn-cgi/image/width=640,height=640,fit=cover,format=auto,quality=85,metadata=none/artifacts/user/image-run/generated.png";
+    const externalImageUrl =
+      "https://images.example.com/artifacts/external-image.png";
+    const unsupportedCdnImageUrl =
+      "https://cdn.vm7.io/artifacts/user/image-run/legacy.bmp";
+    mockArtifacts([
+      createArtifact({
+        artifactItemId: "image-run:file-1",
+        runId: "image-run",
+        fileId: "image-file",
+        filename: "generated.png",
+        contentType: "image/png",
+        url: cdnImageUrl,
+        artifactKind: undefined,
+      }),
+      createArtifact({
+        artifactItemId: "external-image-run:file-1",
+        runId: "external-image-run",
+        fileId: "external-image-file",
+        filename: "external-image.png",
+        contentType: "image/png",
+        url: externalImageUrl,
+        artifactKind: undefined,
+      }),
+      createArtifact({
+        artifactItemId: "unsupported-image-run:file-1",
+        runId: "unsupported-image-run",
+        fileId: "unsupported-image-file",
+        filename: "legacy.bmp",
+        contentType: "image/bmp",
+        url: unsupportedCdnImageUrl,
+        artifactKind: undefined,
+      }),
+    ]);
+
+    setupArtifactsPage({ scope });
+
+    await screen.findByText("generated.png");
+    await screen.findByText("external-image.png");
+    await screen.findByText("legacy.bmp");
+    const cardImageUrls = Array.from(
+      document.querySelectorAll("article img"),
+      (image) => {
+        return image.getAttribute("src");
+      },
+    );
+    expect(cardImageUrls).toStrictEqual(
+      expect.arrayContaining([
+        thumbnailUrl,
+        externalImageUrl,
+        unsupportedCdnImageUrl,
+      ]),
+    );
+    expect(cardImageUrls).not.toContain(cdnImageUrl);
+
+    click(buttonByLabel("Preview generated.png"));
+    await expect(
+      screen.findByRole("dialog", { name: "generated.png preview" }),
+    ).resolves.toBeInTheDocument();
+    expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
+      "src",
+      cdnImageUrl,
+    );
+
+    click(screen.getByLabelText("Close"));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    click(buttonByLabel("More actions for generated.png"));
+    expect(
+      screen.getByLabelText("Open preview for generated.png"),
+    ).toHaveAttribute("href", cdnImageUrl);
+  });
+
   it("opens previewable artifacts in the lightbox without split view", async () => {
     setupTeam();
     const scope = testAuthScope("preview-lightbox");

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -21,6 +21,7 @@ import {
   IconWorld,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
+import { r2ImageTransformUrl } from "@vm0/core";
 import {
   useGet,
   useLastLoadable,
@@ -107,6 +108,7 @@ const ARTIFACT_GRID_MIN_CARD_WIDTH_PX = 220;
 const ARTIFACT_GRID_OVERSCAN_ROWS = 2;
 const ARTIFACT_GRID_FALLBACK_WIDTH_PX = 900;
 const ARTIFACT_GRID_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
+const ARTIFACT_CARD_IMAGE_SIZE = 640;
 const ARTIFACT_CATEGORY_OPTIONS: readonly {
   readonly ariaLabel: string;
   readonly label: string;
@@ -153,6 +155,17 @@ function artifactPreviewKind(item: ArtifactItem): ArtifactPreviewKind {
     return "video";
   }
   return "file";
+}
+
+function artifactCardImageSupportsTransform(item: ArtifactItem): boolean {
+  const extension = item.filename.split(".").pop()?.toLowerCase();
+  return (
+    extension === "gif" ||
+    extension === "jpeg" ||
+    extension === "jpg" ||
+    extension === "png" ||
+    extension === "webp"
+  );
 }
 
 function artifactTypeIconKind(
@@ -474,10 +487,17 @@ function ArtifactPreview({ item }: { readonly item: ArtifactItem }) {
   }
 
   if (previewKind === "image") {
+    const thumbnailUrl = artifactCardImageSupportsTransform(item)
+      ? r2ImageTransformUrl(previewUrl, {
+          width: ARTIFACT_CARD_IMAGE_SIZE,
+          height: ARTIFACT_CARD_IMAGE_SIZE,
+          fit: "cover",
+        })
+      : previewUrl;
     return (
       <ArtifactPreviewSurface iconKind={iconKind}>
         <img
-          src={previewUrl}
+          src={thumbnailUrl}
           alt=""
           loading="lazy"
           className="h-full w-full object-cover"


### PR DESCRIPTION
## Summary

- load supported artifact image cards through the existing R2 image transform at 640x640 with cover fitting
- keep original URLs for lightbox and new-tab previews while preserving external and unsupported-format fallbacks
- add page-level coverage for transformed, fallback, and original preview URLs

## Test plan

- pnpm exec prettier --write apps/platform/src/views/artifacts-page/artifacts-page.tsx apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx
- pnpm knip --workspace @vm0/app