### PR TITLE
fix(vsock-guest): contain exec descendants with cgroups

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1152,8 +1152,17 @@ jobs:
             || fail "wrapper-first detach command failed"
           DETACHED_PID=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- cat /tmp/vm0-cgroup-detached.pid) \
             || fail "detached pid was not recorded"
-          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c \
-            "! kill -0 $DETACHED_PID 2>/dev/null" \
+          WAIT_FOR_PID_EXIT_SCRIPT=$(cat <<'GUEST_SCRIPT'
+          pid=$1
+          for _ in $(seq 1 100); do
+            kill -0 "$pid" 2>/dev/null || exit 0
+            sleep 0.02
+          done
+          exit 1
+          GUEST_SCRIPT
+          )
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- \
+            sh -c "$WAIT_FOR_PID_EXIT_SCRIPT" sh "$DETACHED_PID" \
             || fail "detached descendant survived successful wrapper exit"
 
           SUDO_TIMEOUT_SCRIPT=$(cat <<'GUEST_SCRIPT'
@@ -1168,8 +1177,8 @@ jobs:
           fi
           SUDO_PID=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- cat /tmp/vm0-cgroup-sudo.pid) \
             || fail "sudo descendant pid was not recorded"
-          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- sh -c \
-            "! kill -0 $SUDO_PID 2>/dev/null" \
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- \
+            sh -c "$WAIT_FOR_PID_EXIT_SCRIPT" sh "$SUDO_PID" \
             || fail "ordinary sudo descendant survived timeout"
 
           [ -S "/run/vm0/sock/$SANDBOX_ID/control.sock" ] \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1079,7 +1079,7 @@ jobs:
             >/dev/null &
           UNRELATED_EXEC_PID=$!
           UNRELATED_READY=""
-          for _ in $(seq 1 100); do
+          for _ in $(seq 1 30); do
             if sudo "$BIN_DIR/runner" exec --timeout 2 --sandbox "$SANDBOX_ID" -- \
               test -e /tmp/vm0-cgroup-unrelated.ready >/dev/null 2>&1; then
               UNRELATED_READY=1

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1061,6 +1061,93 @@ jobs:
           echo "$OUTPUT" | grep -q "hello-from-exec" || fail "expected 'hello-from-exec', got: $OUTPUT"
           echo "PASS: basic exec"
 
+          # Test: every release exec is owned by one recursive cgroup.
+          echo "--- Test: exec descendant containment ---"
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- sh -c \
+            'findmnt -n -t cgroup2 /sys/fs/cgroup >/dev/null && test -d /sys/fs/cgroup/vm0-exec' \
+            || fail "guest cgroup v2 hierarchy is unavailable"
+
+          TIMEOUT_SCRIPT=$(cat <<'GUEST_SCRIPT'
+          rm -f /tmp/vm0-cgroup-sibling-1.pid /tmp/vm0-cgroup-sibling-2.pid /tmp/vm0-cgroup-nested.pid
+          setsid sh -c '
+            echo $$ > /tmp/vm0-cgroup-sibling-1.pid
+            setsid sh -c "echo \$\$ > /tmp/vm0-cgroup-nested.pid; sleep 60" &
+            sleep 60
+          ' &
+          setsid sh -c 'echo $$ > /tmp/vm0-cgroup-sibling-2.pid; sleep 60' &
+          for _ in $(seq 1 100); do
+            [ -s /tmp/vm0-cgroup-sibling-1.pid ] && \
+              [ -s /tmp/vm0-cgroup-sibling-2.pid ] && \
+              [ -s /tmp/vm0-cgroup-nested.pid ] && break
+            sleep 0.02
+          done
+          [ -s /tmp/vm0-cgroup-sibling-1.pid ] && \
+            [ -s /tmp/vm0-cgroup-sibling-2.pid ] && \
+            [ -s /tmp/vm0-cgroup-nested.pid ]
+          wait
+          GUEST_SCRIPT
+          )
+          if sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --timeout 1 -- sh -c "$TIMEOUT_SCRIPT"; then
+            fail "descendant containment command should time out"
+          fi
+
+          VERIFY_GONE_SCRIPT=$(cat <<'GUEST_SCRIPT'
+          for _ in $(seq 1 100); do
+            alive=0
+            for file in /tmp/vm0-cgroup-sibling-1.pid /tmp/vm0-cgroup-sibling-2.pid /tmp/vm0-cgroup-nested.pid; do
+              pid=$(cat "$file") || exit 1
+              kill -0 "$pid" 2>/dev/null && alive=1
+            done
+            [ "$alive" = 0 ] && exit 0
+            sleep 0.02
+          done
+          exit 1
+          GUEST_SCRIPT
+          )
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$VERIFY_GONE_SCRIPT" \
+            || fail "sibling or nested setsid descendant survived timeout"
+
+          DETACH_SCRIPT=$(cat <<'GUEST_SCRIPT'
+          rm -f /tmp/vm0-cgroup-detached.pid
+          setsid sh -c 'echo $$ > /tmp/vm0-cgroup-detached.pid; sleep 60' >/dev/null 2>&1 &
+          for _ in $(seq 1 100); do
+            [ -s /tmp/vm0-cgroup-detached.pid ] && exit 0
+            sleep 0.02
+          done
+          exit 1
+          GUEST_SCRIPT
+          )
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$DETACH_SCRIPT" \
+            || fail "wrapper-first detach command failed"
+          DETACHED_PID=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- cat /tmp/vm0-cgroup-detached.pid) \
+            || fail "detached pid was not recorded"
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c \
+            "! kill -0 $DETACHED_PID 2>/dev/null" \
+            || fail "detached descendant survived successful wrapper exit"
+
+          SUDO_TIMEOUT_SCRIPT=$(cat <<'GUEST_SCRIPT'
+          rm -f /tmp/vm0-cgroup-sudo.pid
+          setsid sh -c 'echo $$ > /tmp/vm0-cgroup-sudo.pid; sleep 60' &
+          while [ ! -s /tmp/vm0-cgroup-sudo.pid ]; do sleep 0.02; done
+          wait
+          GUEST_SCRIPT
+          )
+          if sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo --timeout 1 -- sh -c "$SUDO_TIMEOUT_SCRIPT"; then
+            fail "sudo descendant containment command should time out"
+          fi
+          SUDO_PID=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- cat /tmp/vm0-cgroup-sudo.pid) \
+            || fail "sudo descendant pid was not recorded"
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- sh -c \
+            "! kill -0 $SUDO_PID 2>/dev/null" \
+            || fail "ordinary sudo descendant survived timeout"
+
+          [ -S "/run/vm0/sock/$SANDBOX_ID/control.sock" ] \
+            || fail "unrelated main agent sandbox stopped during side-exec cleanup"
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- echo containment-isolated)
+          [ "$OUTPUT" = "containment-isolated" ] \
+            || fail "unrelated concurrent exec was affected: $OUTPUT"
+          echo "PASS: exec descendant containment"
+
           # Test 3: exit code propagation
           echo "--- Test: exit code propagation ---"
           sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- false && fail "expected non-zero exit"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -998,6 +998,7 @@ jobs:
           SVC="${JOB_REF}-exec"
           GROUP="vm0/exec-${JOB_REF}"
           SUBMIT_PID=""
+          UNRELATED_EXEC_PID=""
 
           fail() { echo "FAIL: $1"; exit 1; }
 
@@ -1011,6 +1012,7 @@ jobs:
           cleanup() {
             echo "--- Cleanup ---"
             sudo "$BIN_DIR/runner" service stop --name "$SVC" --force || true
+            cleanup_submit_pid "$UNRELATED_EXEC_PID"
             cleanup_submit_pid "$SUBMIT_PID"
           }
           trap cleanup EXIT
@@ -1067,6 +1069,26 @@ jobs:
             'findmnt -n -t cgroup2 /sys/fs/cgroup >/dev/null && test -d /sys/fs/cgroup/vm0-exec' \
             || fail "guest cgroup v2 hierarchy is unavailable"
 
+          UNRELATED_SCRIPT=$(cat <<'GUEST_SCRIPT'
+          rm -f /tmp/vm0-cgroup-unrelated.ready /tmp/vm0-cgroup-unrelated.release
+          touch /tmp/vm0-cgroup-unrelated.ready
+          while [ ! -e /tmp/vm0-cgroup-unrelated.release ]; do sleep 0.02; done
+          GUEST_SCRIPT
+          )
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$UNRELATED_SCRIPT" \
+            >/dev/null &
+          UNRELATED_EXEC_PID=$!
+          UNRELATED_READY=""
+          for _ in $(seq 1 100); do
+            if sudo "$BIN_DIR/runner" exec --timeout 2 --sandbox "$SANDBOX_ID" -- \
+              test -e /tmp/vm0-cgroup-unrelated.ready >/dev/null 2>&1; then
+              UNRELATED_READY=1
+              break
+            fi
+            sleep 0.02
+          done
+          [ -n "$UNRELATED_READY" ] || fail "unrelated concurrent exec did not become ready"
+
           TIMEOUT_SCRIPT=$(cat <<'GUEST_SCRIPT'
           rm -f /tmp/vm0-cgroup-sibling-1.pid /tmp/vm0-cgroup-sibling-2.pid /tmp/vm0-cgroup-nested.pid
           setsid sh -c '
@@ -1106,6 +1128,15 @@ jobs:
           )
           sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- sh -c "$VERIFY_GONE_SCRIPT" \
             || fail "sibling or nested setsid descendant survived timeout"
+          kill -0 "$UNRELATED_EXEC_PID" 2>/dev/null \
+            || fail "unrelated concurrent exec was terminated by target cleanup"
+          sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- \
+            touch /tmp/vm0-cgroup-unrelated.release \
+            || fail "failed to release unrelated concurrent exec"
+          if ! wait "$UNRELATED_EXEC_PID"; then
+            fail "unrelated concurrent exec failed after target cleanup"
+          fi
+          UNRELATED_EXEC_PID=""
 
           DETACH_SCRIPT=$(cat <<'GUEST_SCRIPT'
           rm -f /tmp/vm0-cgroup-detached.pid
@@ -1145,7 +1176,7 @@ jobs:
             || fail "unrelated main agent sandbox stopped during side-exec cleanup"
           OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- echo containment-isolated)
           [ "$OUTPUT" = "containment-isolated" ] \
-            || fail "unrelated concurrent exec was affected: $OUTPUT"
+            || fail "subsequent exec was affected: $OUTPUT"
           echo "PASS: exec descendant containment"
 
           # Test 3: exit code propagation

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -4,11 +4,15 @@
 //! auto-mounts devtmpfs on `/dev` (`CONFIG_DEVTMPFS_MOUNT=y`).
 //!
 //! This module handles the remaining setup:
-//! 1. Mount virtual filesystems (/proc, /sys)
+//! 1. Mount virtual filesystems (/proc, /sys, cgroup v2)
 //! 2. Configure TCP keepalive and environment variables
 
 use nix::mount::{MsFlags, mount};
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+const CGROUP_MOUNT_PATH: &str = "/sys/fs/cgroup";
+const EXEC_CGROUP_ROOT: &str = "/sys/fs/cgroup/vm0-exec";
 
 /// Initialize virtual filesystems and environment.
 ///
@@ -56,6 +60,32 @@ pub fn init_filesystem() -> Result<(), InitError> {
         source: e,
     })?;
 
+    fs::create_dir_all(CGROUP_MOUNT_PATH).map_err(|e| InitError::Filesystem {
+        path: CGROUP_MOUNT_PATH.into(),
+        source: e,
+    })?;
+    mount(
+        Some("cgroup2"),
+        CGROUP_MOUNT_PATH,
+        Some("cgroup2"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC,
+        None::<&str>,
+    )
+    .map_err(|e| InitError::Mount {
+        target: CGROUP_MOUNT_PATH.into(),
+        source: e,
+    })?;
+    fs::create_dir(EXEC_CGROUP_ROOT).map_err(|e| InitError::Filesystem {
+        path: EXEC_CGROUP_ROOT.into(),
+        source: e,
+    })?;
+    fs::set_permissions(EXEC_CGROUP_ROOT, fs::Permissions::from_mode(0o700)).map_err(|e| {
+        InitError::Filesystem {
+            path: EXEC_CGROUP_ROOT.into(),
+            source: e,
+        }
+    })?;
+
     // Mount tmpfs on /dev/shm — required by Chromium for shared memory.
     // devtmpfs (CONFIG_DEVTMPFS_MOUNT=y) doesn't create /dev/shm.
     let _ = fs::create_dir_all("/dev/shm");
@@ -100,7 +130,14 @@ pub fn init_filesystem() -> Result<(), InitError> {
 /// Errors that can occur during filesystem initialization
 #[derive(Debug)]
 pub enum InitError {
-    Mount { target: String, source: nix::Error },
+    Mount {
+        target: String,
+        source: nix::Error,
+    },
+    Filesystem {
+        path: String,
+        source: std::io::Error,
+    },
 }
 
 impl std::fmt::Display for InitError {
@@ -108,6 +145,9 @@ impl std::fmt::Display for InitError {
         match self {
             InitError::Mount { target, source } => {
                 write!(f, "Failed to mount {}: {}", target, source)
+            }
+            InitError::Filesystem { path, source } => {
+                write!(f, "Failed to initialize {path}: {source}")
             }
         }
     }

--- a/crates/vsock-guest/src/connection.rs
+++ b/crates/vsock-guest/src/connection.rs
@@ -141,6 +141,11 @@ fn acquire_operation_guard(
             send_error_response(seq, "guest operations are quiescing", writer)?;
             Ok(None)
         }
+        Err(AcquireOperationError::Fatal) => {
+            send_error_response(seq, "guest runtime is unhealthy", writer)?;
+            writer.shutdown();
+            Ok(None)
+        }
     }
 }
 
@@ -149,7 +154,11 @@ fn reject_operation_if_quiescing(
     seq: u32,
     writer: &GuestWriter,
 ) -> io::Result<bool> {
-    if operation_state.is_quiescing() {
+    if operation_state.is_fatal() {
+        send_error_response(seq, "guest runtime is unhealthy", writer)?;
+        writer.shutdown();
+        Ok(true)
+    } else if operation_state.is_quiescing() {
         send_error_response(seq, "guest operations are quiescing", writer)?;
         Ok(true)
     } else {
@@ -216,6 +225,11 @@ fn handle_quiesce_operations(
             &format!("guest operations still pending: {pending}"),
             writer,
         ),
+        QuiesceResult::Fatal => {
+            let result = send_error_response(seq, "guest runtime is unhealthy", writer);
+            writer.shutdown();
+            result
+        }
     }
 }
 
@@ -234,8 +248,14 @@ fn handle_resume_operations(
         return Ok(());
     }
 
-    operation_state.resume();
-    send_empty_response(MSG_OPERATIONS_RESUMED, seq, writer)
+    match operation_state.resume() {
+        Ok(()) => send_empty_response(MSG_OPERATIONS_RESUMED, seq, writer),
+        Err(_) => {
+            let result = send_error_response(seq, "guest runtime is unhealthy", writer);
+            writer.shutdown();
+            result
+        }
+    }
 }
 
 struct ConnectionDispatcher {
@@ -247,13 +267,17 @@ struct ConnectionDispatcher {
 }
 
 impl ConnectionDispatcher {
-    fn new(writer: GuestWriter, connection_cancel: Arc<AtomicBool>) -> Self {
+    fn new(
+        writer: GuestWriter,
+        connection_cancel: Arc<AtomicBool>,
+        operation_state: OperationState,
+    ) -> Self {
         Self {
             writer,
             connection_cancel,
             exec_operation_registry: ExecOperationRegistry::default(),
             exec_control_registry: ExecControlRegistry::default(),
-            operation_state: OperationState::default(),
+            operation_state,
         }
     }
 
@@ -385,10 +409,22 @@ impl ConnectionDispatcher {
         else {
             return Ok(());
         };
-        let response = handle_decoded_write_file_message(msg.seq, decoded)?;
-        self.writer.write_frame_after_lock(&response, || {
+        let response = match handle_decoded_write_file_message(msg.seq, decoded, &operation_guard) {
+            Ok(response) => response,
+            Err(error) => {
+                if self.operation_state.is_fatal() {
+                    operation_guard.shutdown_transports();
+                }
+                return Err(error);
+            }
+        };
+        let result = self.writer.write_frame_after_lock(&response.frame, || {
             operation_guard.release();
-        })
+        });
+        if response.fatal {
+            operation_guard.shutdown_transports();
+        }
+        result
     }
 
     fn handle_write_files(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
@@ -410,10 +446,23 @@ impl ConnectionDispatcher {
         else {
             return Ok(());
         };
-        let response = handle_decoded_write_files_message(msg.seq, decoded)?;
-        self.writer.write_frame_after_lock(&response, || {
+        let response = match handle_decoded_write_files_message(msg.seq, decoded, &operation_guard)
+        {
+            Ok(response) => response,
+            Err(error) => {
+                if self.operation_state.is_fatal() {
+                    operation_guard.shutdown_transports();
+                }
+                return Err(error);
+            }
+        };
+        let result = self.writer.write_frame_after_lock(&response.frame, || {
             operation_guard.release();
-        })
+        });
+        if response.fatal {
+            operation_guard.shutdown_transports();
+        }
+        result
     }
 
     fn handle_quiesce_operations(&self, msg: BorrowedRawMessage<'_>) -> io::Result<()> {
@@ -497,17 +546,32 @@ pub fn connect_unix(path: &str) -> io::Result<UnixStream> {
 /// Handle connection - the main event loop
 /// Uses separate reader/writer to avoid deadlock between main loop and background threads
 pub fn handle_connection(stream: UnixStream) -> io::Result<()> {
-    match handle_connection_with_outcome(stream) {
+    match handle_connection_with_outcome(stream, OperationState::default()) {
         Ok(_) => Ok(()),
         Err(failure) => Err(failure.error),
     }
 }
 
-fn handle_connection_with_outcome(stream: UnixStream) -> Result<ConnectionEnd, ConnectionFailure> {
+#[cfg(any(debug_assertions, feature = "test-support"))]
+pub fn handle_connection_with_cgroup_fixture(
+    stream: UnixStream,
+    root: std::path::PathBuf,
+) -> io::Result<()> {
+    match handle_connection_with_outcome(stream, OperationState::with_cgroup_fixture(root)) {
+        Ok(_) => Ok(()),
+        Err(failure) => Err(failure.error),
+    }
+}
+
+fn handle_connection_with_outcome(
+    stream: UnixStream,
+    operation_state: OperationState,
+) -> Result<ConnectionEnd, ConnectionFailure> {
     // Clone the stream to get separate reader and writer
     // This avoids deadlock: reader can block while worker threads write results.
     let mut reader = stream.try_clone().map_err(unstable_connection_failure)?;
     let writer = GuestWriter::new(stream);
+    operation_state.register_transport(writer.shutdown_handle());
     let connection_cancel = Arc::new(AtomicBool::new(false));
     let _cancel_on_drop = ConnectionCancelGuard(connection_cancel.clone());
 
@@ -525,7 +589,7 @@ fn handle_connection_with_outcome(stream: UnixStream) -> Result<ConnectionEnd, C
     log("INFO", "Sent ready signal");
 
     let mut session = ConnectionSession::new();
-    let dispatcher = ConnectionDispatcher::new(writer, connection_cancel.clone());
+    let dispatcher = ConnectionDispatcher::new(writer, connection_cancel.clone(), operation_state);
     let mut buf = [0u8; READ_BUFFER_SIZE];
     loop {
         // Read from stream (reader is separate, no lock needed)
@@ -637,7 +701,25 @@ fn retry_or_fail(failure: ReconnectFailure, attempts: u32) -> io::Result<()> {
 /// Includes reconnection logic for snapshot restore scenarios where
 /// the connection is lost when VM is paused and resumed.
 pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
+    run_with_operation_state(unix_socket, OperationState::default())
+}
+
+#[cfg(any(debug_assertions, feature = "test-support"))]
+pub fn run_with_cgroup_fixture(
+    unix_socket: Option<&str>,
+    root: std::path::PathBuf,
+) -> io::Result<()> {
+    run_with_operation_state(unix_socket, OperationState::with_cgroup_fixture(root))
+}
+
+fn run_with_operation_state(
+    unix_socket: Option<&str>,
+    operation_state: OperationState,
+) -> io::Result<()> {
     log("INFO", "Starting vsock guest...");
+    operation_state.audit_containment().map_err(|error| {
+        io::Error::other(format!("guest exec containment is not reusable: {error}"))
+    })?;
 
     let mut attempts = 0u32;
 
@@ -648,7 +730,7 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream)
+                    handle_connection_with_outcome(stream, operation_state.clone())
                 })
         } else {
             log("INFO", "Connecting to host (CID=2)...");
@@ -656,9 +738,13 @@ pub fn run(unix_socket: Option<&str>) -> io::Result<()> {
                 .map_err(unstable_connection_failure)
                 .and_then(|stream| {
                     log("INFO", "Connected");
-                    handle_connection_with_outcome(stream)
+                    handle_connection_with_outcome(stream, operation_state.clone())
                 })
         };
+
+        if operation_state.is_fatal() {
+            return Err(io::Error::other("guest runtime is unhealthy"));
+        }
 
         match result {
             Ok(ConnectionEnd::Shutdown) => return Ok(()),

--- a/crates/vsock-guest/src/containment.rs
+++ b/crates/vsock-guest/src/containment.rs
@@ -1,0 +1,388 @@
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::fs::OpenOptionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::process::{
+    ProcessTreeKillTarget, kill_process_tree_target, process_tree_kill_target,
+    refresh_process_tree_kill_target,
+};
+
+pub(crate) const EXEC_CGROUP_ROOT: &str = "/sys/fs/cgroup/vm0-exec";
+pub(crate) const CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const EVENTS_BUFFER_SIZE: usize = 4096;
+
+#[derive(Clone)]
+pub(crate) struct ContainmentManager {
+    backend: Arc<ContainmentBackend>,
+}
+
+enum ContainmentBackend {
+    Cgroup(CgroupManager),
+    ProcessGroup,
+}
+
+struct CgroupManager {
+    root: PathBuf,
+    next_id: AtomicU64,
+    fixture_files: bool,
+}
+
+pub(crate) enum PreparedContainment {
+    Cgroup(CgroupLeaf),
+    ProcessGroup,
+}
+
+pub(crate) enum ProcessContainment {
+    Cgroup { leaf: CgroupLeaf, child_id: u32 },
+    ProcessGroup(Option<ProcessTreeKillTarget>),
+}
+
+pub(crate) struct CgroupLeaf {
+    path: PathBuf,
+    procs: File,
+    kill: File,
+    events: File,
+    fixture_files: bool,
+}
+
+impl Default for ContainmentManager {
+    fn default() -> Self {
+        if cfg!(debug_assertions) {
+            Self {
+                backend: Arc::new(ContainmentBackend::ProcessGroup),
+            }
+        } else {
+            Self::cgroup(PathBuf::from(EXEC_CGROUP_ROOT), false)
+        }
+    }
+}
+
+impl ContainmentManager {
+    fn cgroup(root: PathBuf, fixture_files: bool) -> Self {
+        Self {
+            backend: Arc::new(ContainmentBackend::Cgroup(CgroupManager {
+                root,
+                next_id: AtomicU64::new(1),
+                fixture_files,
+            })),
+        }
+    }
+
+    #[cfg(any(debug_assertions, feature = "test-support"))]
+    pub(crate) fn fixture(root: PathBuf) -> Self {
+        Self::cgroup(root, true)
+    }
+
+    pub(crate) fn prepare(&self) -> io::Result<PreparedContainment> {
+        match self.backend.as_ref() {
+            ContainmentBackend::Cgroup(manager) => {
+                manager.prepare().map(PreparedContainment::Cgroup)
+            }
+            ContainmentBackend::ProcessGroup => Ok(PreparedContainment::ProcessGroup),
+        }
+    }
+
+    pub(crate) fn audit(&self) -> io::Result<()> {
+        let ContainmentBackend::Cgroup(manager) = self.backend.as_ref() else {
+            return Ok(());
+        };
+        manager.audit()
+    }
+}
+
+impl CgroupManager {
+    fn prepare(&self) -> io::Result<CgroupLeaf> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let path = self.root.join(format!("exec-{}-{id}", std::process::id()));
+        fs::create_dir(&path)?;
+
+        if self.fixture_files {
+            fs::write(path.join("cgroup.procs"), [])?;
+            fs::write(path.join("cgroup.kill"), [])?;
+            fs::write(path.join("cgroup.events"), b"populated 0\nfrozen 0\n")?;
+        }
+
+        let opened = CgroupLeaf::open(path.clone(), self.fixture_files);
+        if opened.is_err() {
+            remove_leaf_path(&path, self.fixture_files);
+        }
+        opened
+    }
+
+    fn audit(&self) -> io::Result<()> {
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let path = entry.path();
+            let events = match open_control(&path.join("cgroup.events"), false) {
+                Ok(events) => events,
+                Err(error) if error.kind() == io::ErrorKind::NotFound && !path.exists() => {
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            if read_populated(&events)? {
+                return Err(io::Error::other(format!(
+                    "exec containment remains populated: {}",
+                    path.display()
+                )));
+            }
+            drop(events);
+            match remove_leaf(&path, self.fixture_files) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound && !path.exists() => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
+    }
+}
+
+impl PreparedContainment {
+    pub(crate) fn register_pre_exec(&self, command: &mut Command) {
+        let Self::Cgroup(leaf) = self else {
+            return;
+        };
+        let procs_fd = leaf.procs.as_raw_fd();
+        // SAFETY: the closure only invokes async-signal-safe write(2) on an
+        // already-open close-on-exec cgroup.procs descriptor.
+        unsafe {
+            command.pre_exec(move || write_current_process(procs_fd));
+        }
+    }
+
+    pub(crate) fn finish(self, child_id: u32) -> ProcessContainment {
+        match self {
+            Self::Cgroup(leaf) => ProcessContainment::Cgroup { leaf, child_id },
+            Self::ProcessGroup => {
+                ProcessContainment::ProcessGroup(Some(process_tree_kill_target(child_id)))
+            }
+        }
+    }
+
+    pub(crate) fn discard(self) {
+        if let Self::Cgroup(leaf) = self {
+            let path = leaf.path.clone();
+            let fixture_files = leaf.fixture_files;
+            drop(leaf);
+            remove_leaf_path(&path, fixture_files);
+        }
+    }
+}
+
+impl ProcessContainment {
+    pub(crate) fn kill(&mut self) -> io::Result<bool> {
+        match self {
+            Self::Cgroup { leaf, child_id } => {
+                write_control(leaf.kill.as_raw_fd(), b"1")?;
+                if leaf.fixture_files {
+                    let mut target = process_tree_kill_target(*child_id);
+                    refresh_process_tree_kill_target(&mut target);
+                    // SAFETY: fixture containment is used only while the
+                    // direct child remains owned and unreaped by the caller.
+                    let _ = unsafe { kill_process_tree_target(target) };
+                }
+                Ok(true)
+            }
+            Self::ProcessGroup(target) => {
+                let Some(mut target) = target.take() else {
+                    return Ok(false);
+                };
+                refresh_process_tree_kill_target(&mut target);
+                // SAFETY: the wait owner retains the unreaped direct child.
+                Ok(unsafe { kill_process_tree_target(target) })
+            }
+        }
+    }
+
+    pub(crate) fn populated(&self) -> io::Result<bool> {
+        match self {
+            Self::Cgroup { leaf, .. } => read_populated(&leaf.events),
+            Self::ProcessGroup(_) => Ok(false),
+        }
+    }
+
+    pub(crate) fn wait_empty_until(&self, deadline: Instant) -> io::Result<bool> {
+        loop {
+            if !self.populated()? {
+                return Ok(true);
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Ok(false);
+            }
+            std::thread::sleep(remaining.min(Duration::from_millis(10)));
+        }
+    }
+
+    pub(crate) fn remove(self) -> io::Result<()> {
+        let Self::Cgroup { leaf, .. } = self else {
+            return Ok(());
+        };
+        let path = leaf.path.clone();
+        let fixture_files = leaf.fixture_files;
+        drop(leaf);
+        remove_leaf(&path, fixture_files)
+    }
+
+    pub(crate) fn is_cgroup(&self) -> bool {
+        matches!(self, Self::Cgroup { .. })
+    }
+}
+
+impl CgroupLeaf {
+    fn open(path: PathBuf, fixture_files: bool) -> io::Result<Self> {
+        Ok(Self {
+            procs: open_control(&path.join("cgroup.procs"), true)?,
+            kill: open_control(&path.join("cgroup.kill"), true)?,
+            events: open_control(&path.join("cgroup.events"), false)?,
+            path,
+            fixture_files,
+        })
+    }
+}
+
+fn open_control(path: &Path, write: bool) -> io::Result<File> {
+    let mut options = OpenOptions::new();
+    options
+        .read(!write)
+        .write(write)
+        .custom_flags(libc::O_CLOEXEC);
+    options.open(path)
+}
+
+fn write_current_process(fd: RawFd) -> io::Result<()> {
+    let bytes = b"0";
+    // SAFETY: fd is the inherited cgroup.procs descriptor and bytes remains
+    // valid for the duration of this syscall.
+    let written = unsafe { libc::write(fd, bytes.as_ptr().cast(), bytes.len()) };
+    if written == bytes.len() as isize {
+        Ok(())
+    } else if written < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "short write while attaching exec cgroup",
+        ))
+    }
+}
+
+fn write_control(fd: RawFd, bytes: &[u8]) -> io::Result<()> {
+    // SAFETY: fd is a newly opened cgroup control descriptor and bytes is
+    // valid for the duration of write(2). Each control is written once.
+    let written = unsafe { libc::write(fd, bytes.as_ptr().cast(), bytes.len()) };
+    if written == bytes.len() as isize {
+        Ok(())
+    } else if written < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::WriteZero,
+            "short write to exec cgroup control",
+        ))
+    }
+}
+
+fn read_populated(events: &File) -> io::Result<bool> {
+    let mut bytes = [0_u8; EVENTS_BUFFER_SIZE];
+    // SAFETY: bytes is a valid writable buffer and events is an open
+    // cgroup.events descriptor.
+    let read = unsafe {
+        libc::pread(
+            events.as_raw_fd(),
+            bytes.as_mut_ptr().cast(),
+            bytes.len(),
+            0,
+        )
+    };
+    if read < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if read as usize == bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "cgroup.events exceeds supported size",
+        ));
+    }
+    let content = bytes
+        .get(..read as usize)
+        .ok_or_else(|| io::Error::other("cgroup.events read exceeded buffer"))?;
+    let content = std::str::from_utf8(content).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("cgroup.events is not UTF-8: {error}"),
+        )
+    })?;
+    parse_populated(content)
+}
+
+fn parse_populated(content: &str) -> io::Result<bool> {
+    let mut populated = None;
+    for line in content.lines() {
+        let mut fields = line.split_whitespace();
+        let key = fields.next().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "empty cgroup.events line")
+        })?;
+        let value = fields.next().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "missing cgroup.events value")
+        })?;
+        if fields.next().is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected cgroup.events fields",
+            ));
+        }
+        if key == "populated" {
+            if populated.is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "duplicate populated entry in cgroup.events",
+                ));
+            }
+            populated = match value {
+                "0" => Some(false),
+                "1" => Some(true),
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid populated value in cgroup.events",
+                    ));
+                }
+            };
+        }
+    }
+    populated.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "missing populated entry in cgroup.events",
+        )
+    })
+}
+
+fn remove_leaf(path: &Path, fixture_files: bool) -> io::Result<()> {
+    if fixture_files {
+        for name in ["cgroup.procs", "cgroup.kill", "cgroup.events"] {
+            fs::remove_file(path.join(name))?;
+        }
+    }
+    fs::remove_dir(path)
+}
+
+fn remove_leaf_path(path: &Path, fixture_files: bool) {
+    if fixture_files {
+        for name in ["cgroup.procs", "cgroup.kill", "cgroup.events"] {
+            let _ = fs::remove_file(path.join(name));
+        }
+    }
+    let _ = fs::remove_dir(path);
+}

--- a/crates/vsock-guest/src/exec_operation.rs
+++ b/crates/vsock-guest/src/exec_operation.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::{self, Write};
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
-use std::process::{Child, ChildStderr, ChildStdin, ChildStdout};
+use std::process::{ChildStderr, ChildStdin, ChildStdout};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
@@ -18,10 +18,7 @@ use crate::drain::{BoundedDrainResult, BoundedStreamConfig, drain_bounded_cancel
 use crate::error::to_io_error;
 use crate::exec_control::ExecControlGuard;
 use crate::log::log;
-use crate::process::{
-    ProcessTreeKillTarget, extract_exit_code, kill_and_reap_child_with_target,
-    process_tree_kill_target, refresh_process_tree_kill_target,
-};
+use crate::process::{ContainedChild, extract_exit_code};
 use crate::quiesce::OperationGuard;
 use crate::shell_command::{
     SpawnedShellCommand, format_env_diagnostics, spawn_shell_command_with_pipes,
@@ -29,8 +26,8 @@ use crate::shell_command::{
 };
 use crate::threading::{SystemThreadSpawner, ThreadSpawner};
 use crate::wait::{
-    DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline,
-    wait_with_kill_timeout_or_cancelled_either_with_target,
+    DRAIN_DEADLINE_SECS, WaitOutcome, await_drain_deadline, terminate_contained_child,
+    wait_contained_with_timeout_or_cancelled,
 };
 use crate::writer::GuestWriter;
 
@@ -352,6 +349,18 @@ impl ExecCompletion<'_> {
         );
     }
 
+    fn fatal_wait_failed(&self, diagnostic: &str) {
+        self.operation_guard.poison(diagnostic.to_owned());
+        self.wait_failed(diagnostic);
+        self.operation_guard.shutdown_transports();
+    }
+
+    fn fatal_without_result(&self, diagnostic: &str) {
+        self.operation_guard.poison(diagnostic.to_owned());
+        self.release_without_result();
+        self.operation_guard.shutdown_transports();
+    }
+
     fn finish<'a>(
         &self,
         termination: ExecTermination,
@@ -393,8 +402,7 @@ impl ExecCompletion<'_> {
 }
 
 struct ExecSetup {
-    child: Child,
-    kill_target: ProcessTreeKillTarget,
+    process: ContainedChild,
     stdin_writer: Option<StdinWriter>,
     drain_cancel: Arc<AtomicBool>,
     drain_done_tx: mpsc::Sender<()>,
@@ -402,13 +410,11 @@ struct ExecSetup {
 }
 
 impl ExecSetup {
-    fn new(child: Child) -> Self {
-        let kill_target = process_tree_kill_target(child.id());
+    fn new(process: ContainedChild) -> Self {
         let drain_cancel = Arc::new(AtomicBool::new(false));
         let (drain_done_tx, drain_done_rx) = mpsc::channel::<()>();
         Self {
-            child,
-            kill_target,
+            process,
             stdin_writer: None,
             drain_cancel,
             drain_done_tx,
@@ -417,15 +423,19 @@ impl ExecSetup {
     }
 
     fn take_stdout(&mut self) -> Option<ChildStdout> {
-        self.child.stdout.take()
+        self.process.child.stdout.take()
     }
 
     fn take_stderr(&mut self) -> Option<ChildStderr> {
-        self.child.stderr.take()
+        self.process.child.stderr.take()
     }
 
     fn take_stdin(&mut self) -> Option<ChildStdin> {
-        self.child.stdin.take()
+        self.process.child.stdin.take()
+    }
+
+    fn child_id(&self) -> u32 {
+        self.process.child_id()
     }
 
     fn set_stdin_writer(&mut self, writer: StdinWriter) {
@@ -459,8 +469,7 @@ impl ExecSetup {
         diagnostic: &str,
     ) {
         let ExecSetup {
-            child,
-            kill_target,
+            process,
             stdin_writer,
             drain_cancel,
             drain_done_tx: _,
@@ -468,23 +477,31 @@ impl ExecSetup {
         } = self;
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
-        kill_and_reap_child_with_target(child, kill_target);
+        let cleanup = terminate_contained_child(process);
         join_stdin_writer_after_kill(stdin_writer);
-        completion.wait_failed(diagnostic);
+        match cleanup {
+            Ok(()) => completion.wait_failed(diagnostic),
+            Err(error) => completion.fatal_wait_failed(&format!(
+                "{diagnostic}; exec containment cleanup failed: {error}"
+            )),
+        }
     }
 
     fn abort_exec_started_send_failed(self, completion: &ExecCompletion<'_>) {
         debug_assert!(self.stdin_writer.is_none());
         let ExecSetup {
-            child,
-            kill_target,
+            process,
             stdin_writer: _,
             drain_cancel: _,
             drain_done_tx: _,
             drain_done_rx: _,
         } = self;
-        kill_and_reap_child_with_target(child, kill_target);
-        completion.release_without_result();
+        match terminate_contained_child(process) {
+            Ok(()) => completion.release_without_result(),
+            Err(error) => completion.fatal_without_result(&format!(
+                "exec containment cleanup failed after exec_started send failure: {error}"
+            )),
+        }
     }
 }
 
@@ -515,8 +532,7 @@ impl ExecSetupWithStdout {
             stdout_result_rx: _,
         } = self;
         let ExecSetup {
-            child,
-            kill_target,
+            process,
             stdin_writer,
             drain_cancel,
             drain_done_tx: _,
@@ -524,10 +540,15 @@ impl ExecSetupWithStdout {
         } = setup;
         exec_cancel.store(true, Ordering::Release);
         drain_cancel.store(true, Ordering::Release);
-        kill_and_reap_child_with_target(child, kill_target);
+        let cleanup = terminate_contained_child(process);
         join_stdin_writer_after_kill(stdin_writer);
         let _ = stdout_handle.join();
-        completion.wait_failed(diagnostic);
+        match cleanup {
+            Ok(()) => completion.wait_failed(diagnostic),
+            Err(error) => completion.fatal_wait_failed(&format!(
+                "{diagnostic}; exec containment cleanup failed: {error}"
+            )),
+        }
     }
 
     fn into_running(
@@ -541,8 +562,7 @@ impl ExecSetupWithStdout {
             stdout_result_rx,
         } = self;
         let ExecSetup {
-            child,
-            kill_target,
+            process,
             stdin_writer,
             drain_cancel,
             drain_done_tx,
@@ -551,8 +571,7 @@ impl ExecSetupWithStdout {
         drop(drain_done_tx);
 
         RunningExec {
-            child,
-            kill_target,
+            process,
             stdin_writer,
             stdout_handle,
             stdout_result_rx,
@@ -565,8 +584,7 @@ impl ExecSetupWithStdout {
 }
 
 struct RunningExec {
-    child: Child,
-    kill_target: ProcessTreeKillTarget,
+    process: ContainedChild,
     stdin_writer: Option<StdinWriter>,
     stdout_handle: JoinHandle<()>,
     stdout_result_rx: mpsc::Receiver<BoundedDrainResult>,
@@ -585,8 +603,7 @@ impl RunningExec {
         exec_cancel: &AtomicBool,
     ) {
         let RunningExec {
-            child,
-            mut kill_target,
+            process,
             stdin_writer,
             stdout_handle,
             stdout_result_rx,
@@ -596,7 +613,6 @@ impl RunningExec {
             drain_done_rx,
         } = self;
 
-        refresh_process_tree_kill_target(&mut kill_target);
         let prepare_stdin_writer_for_pre_reap = || {
             let Some(writer) = stdin_writer.as_ref() else {
                 return false;
@@ -608,17 +624,22 @@ impl RunningExec {
                 false
             }
         };
-        let outcome = wait_with_kill_timeout_or_cancelled_either_with_target(
-            child,
-            kill_target,
+        let outcome = wait_contained_with_timeout_or_cancelled(
+            process,
             request.timeout.wait_timeout_ms(),
             connection_cancel,
             exec_cancel,
             prepare_stdin_writer_for_pre_reap,
         );
+        let fatal = matches!(&outcome, WaitOutcome::Fatal(_));
+        if let WaitOutcome::Fatal(diagnostic) = &outcome {
+            completion.operation_guard.poison(diagnostic.clone());
+        }
         join_stdin_writer_after_wait(stdin_writer, request.seq, &request.label);
-        if matches!(outcome, WaitOutcome::Cancelled | WaitOutcome::TimedOut)
-            || connection_cancel.load(Ordering::Acquire)
+        if matches!(
+            &outcome,
+            WaitOutcome::Cancelled | WaitOutcome::TimedOut | WaitOutcome::Fatal(_)
+        ) || connection_cancel.load(Ordering::Acquire)
             || exec_cancel.load(Ordering::Acquire)
         {
             exec_cancel.store(true, Ordering::Release);
@@ -655,6 +676,7 @@ impl RunningExec {
                 ExecTermination::WaitFailed,
                 format!("Failed to wait: {msg}"),
             ),
+            WaitOutcome::Fatal(msg) => (ExecTermination::WaitFailed, msg),
         };
 
         log_exec_terminal_if_notable(
@@ -672,6 +694,9 @@ impl RunningExec {
             captured_output(&stderr_result),
             &diagnostic,
         );
+        if fatal {
+            completion.operation_guard.shutdown_transports();
+        }
     }
 }
 
@@ -814,6 +839,7 @@ fn run_exec_operation_worker<S>(
         effective_env,
         request.sudo,
         pipe_stdin,
+        &operation_guard.containment(),
     ) {
         Ok(spawned) => spawned,
         Err(e) => {
@@ -821,17 +847,24 @@ fn run_exec_operation_worker<S>(
                 "Failed to execute: {e} ({})",
                 format_env_diagnostics(&request.command, &env_refs)
             );
-            completion.start_failed(&diagnostic);
+            if e.is_fatal() {
+                completion.fatal_wait_failed(&diagnostic);
+            } else {
+                completion.start_failed(&diagnostic);
+            }
             return;
         }
     };
 
-    let SpawnedShellCommand { child, env_script } = spawned;
+    let SpawnedShellCommand {
+        process,
+        env_script,
+    } = spawned;
     let _env_script = env_script;
-    let mut setup = ExecSetup::new(child);
+    let mut setup = ExecSetup::new(process);
 
     if request.lifecycle == ExecOperationLifecycle::Supervised
-        && let Err(e) = send_exec_started(request.seq, setup.child.id(), &writer)
+        && let Err(e) = send_exec_started(request.seq, setup.child_id(), &writer)
     {
         log(
             "WARN",

--- a/crates/vsock-guest/src/handlers.rs
+++ b/crates/vsock-guest/src/handlers.rs
@@ -1,24 +1,34 @@
 use std::io::{self, Write};
+use std::os::fd::AsRawFd;
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+#[cfg(test)]
+use std::process::Child;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 #[cfg(any(debug_assertions, feature = "test-support"))]
 use std::sync::Mutex;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use vsock_proto::{
     self, BorrowedRawMessage, MSG_ERROR, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_WRITE_FILE_RESULT,
     MSG_WRITE_FILES_RESULT,
 };
 
+use crate::containment::ContainmentManager;
 use crate::drain::drain_into_vec_cancellable;
 use crate::error::to_io_error;
 use crate::log::log;
-use crate::process::{extract_exit_code, kill_and_reap_child, spawn_in_own_process_group};
+use crate::process::{ContainedChild, SpawnContainmentError, extract_exit_code, spawn_contained};
+#[cfg(test)]
+use crate::process::{kill_and_reap_child, spawn_in_own_process_group};
+use crate::quiesce::OperationGuard;
 use crate::shutdown::handle_shutdown;
 use crate::threading::{SystemThreadSpawner, ThreadSpawner, spawn_scoped_named};
 use crate::user::apply_write_file_identity;
-use crate::wait::{WaitOutcome, await_drain_deadline, wait_with_kill_timeout_and_pre_reap_cleanup};
+use crate::wait::{
+    WaitOutcome, await_drain_deadline, terminate_contained_child,
+    wait_contained_with_timeout_and_pre_reap_cleanup,
+};
 
 const THREAD_WRITE_STDERR: &str = "vsock-write-stderr";
 const THREAD_WRITE_STDIN: &str = "vsock-write-stdin";
@@ -46,6 +56,11 @@ pub(crate) struct DecodedWriteFilesMessage<'a> {
     content_bytes: usize,
 }
 
+pub(crate) struct GuardedWriteResponse {
+    pub(crate) frame: Vec<u8>,
+    pub(crate) fatal: bool,
+}
+
 /// Handle write_file message
 fn handle_write_file(
     path: &str,
@@ -53,7 +68,8 @@ fn handle_write_file(
     use_sudo: bool,
     append: bool,
     private: bool,
-) -> (bool, String) {
+    operation_guard: &OperationGuard,
+) -> (bool, String, bool) {
     log(
         "INFO",
         &format!(
@@ -66,28 +82,58 @@ fn handle_write_file(
         ),
     );
 
-    let child = match spawn_write_file_command(path, use_sudo, append, private) {
-        Ok(c) => c,
-        Err(e) => return (false, format!("Failed to spawn write command: {e}")),
+    let process = match spawn_write_file_command(
+        path,
+        use_sudo,
+        append,
+        private,
+        &operation_guard.containment(),
+    ) {
+        Ok(process) => process,
+        Err(error) => {
+            let fatal = error.is_fatal();
+            return (
+                false,
+                format!("Failed to spawn write command: {error}"),
+                fatal,
+            );
+        }
     };
 
-    wait_write_file_child(child, content, SystemThreadSpawner)
+    wait_contained_write_file_child(process, content, SystemThreadSpawner, |diagnostic| {
+        operation_guard.poison(diagnostic.to_owned());
+    })
 }
 
-fn handle_write_files(payload: &[u8], file_count: usize, content_bytes: usize) -> (bool, String) {
+fn handle_write_files(
+    payload: &[u8],
+    file_count: usize,
+    content_bytes: usize,
+    operation_guard: &OperationGuard,
+) -> (bool, String, bool) {
     log(
         "INFO",
         &format!("write_files: files={file_count} content_bytes={content_bytes}"),
     );
 
-    let child = match spawn_write_files_command() {
-        Ok(c) => c,
-        Err(e) => return (false, format!("Failed to spawn batch write command: {e}")),
+    let process = match spawn_write_files_command(&operation_guard.containment()) {
+        Ok(process) => process,
+        Err(error) => {
+            let fatal = error.is_fatal();
+            return (
+                false,
+                format!("Failed to spawn batch write command: {error}"),
+                fatal,
+            );
+        }
     };
 
-    wait_write_file_child(child, payload, SystemThreadSpawner)
+    wait_contained_write_file_child(process, payload, SystemThreadSpawner, |diagnostic| {
+        operation_guard.poison(diagnostic.to_owned());
+    })
 }
 
+#[cfg(test)]
 fn wait_write_file_child<S>(child: Child, content: &[u8], spawner: S) -> (bool, String)
 where
     S: ThreadSpawner,
@@ -95,8 +141,9 @@ where
     wait_write_file_child_with_timeout(child, content, WRITE_TIMEOUT_MS, spawner)
 }
 
+#[cfg(test)]
 fn wait_write_file_child_with_timeout<S>(
-    mut child: Child,
+    child: Child,
     content: &[u8],
     timeout_ms: u32,
     spawner: S,
@@ -104,11 +151,49 @@ fn wait_write_file_child_with_timeout<S>(
 where
     S: ThreadSpawner,
 {
-    let stdin_pipe = match child.stdin.take() {
+    let process = match ContainedChild::from_process_group(child) {
+        Ok(process) => process,
+        Err(error) => return (false, format!("write containment setup failed: {error}")),
+    };
+    let (success, error, _) =
+        wait_contained_write_file_child_with_timeout(process, content, timeout_ms, spawner, |_| {});
+    (success, error)
+}
+
+fn wait_contained_write_file_child<S, F>(
+    process: ContainedChild,
+    content: &[u8],
+    spawner: S,
+    on_fatal: F,
+) -> (bool, String, bool)
+where
+    S: ThreadSpawner,
+    F: Fn(&str),
+{
+    wait_contained_write_file_child_with_timeout(
+        process,
+        content,
+        WRITE_TIMEOUT_MS,
+        spawner,
+        on_fatal,
+    )
+}
+
+fn wait_contained_write_file_child_with_timeout<S, F>(
+    mut process: ContainedChild,
+    content: &[u8],
+    timeout_ms: u32,
+    spawner: S,
+    on_fatal: F,
+) -> (bool, String, bool)
+where
+    S: ThreadSpawner,
+    F: Fn(&str),
+{
+    let stdin_pipe = match process.child.stdin.take() {
         Some(p) => p,
         None => {
-            kill_and_reap_child(child);
-            return (false, "missing stdin pipe".to_string());
+            return cleanup_write_failure(process, "missing stdin pipe");
         }
     };
     // Drain stderr concurrently with wait via the cancellable helper. Stdout
@@ -120,11 +205,10 @@ where
     // its last write returns EPIPE.
     // Defensive: same invariant as the shared drain helper — reap the child if
     // its stderr is somehow already gone, so we don't leave a zombie.
-    let stderr_pipe = match child.stderr.take() {
+    let stderr_pipe = match process.child.stderr.take() {
         Some(p) => p,
         None => {
-            kill_and_reap_child(child);
-            return (false, "missing stderr pipe".to_string());
+            return cleanup_write_failure(process, "missing stderr pipe");
         }
     };
     let cancel = Arc::new(AtomicBool::new(false));
@@ -143,36 +227,62 @@ where
             Err(e) => {
                 cancel.store(true, std::sync::atomic::Ordering::Release);
                 drop(stdin_pipe);
-                kill_and_reap_child(child);
-                return (false, format!("Failed to spawn stderr drain thread: {e}"));
+                return cleanup_write_failure(
+                    process,
+                    &format!("Failed to spawn stderr drain thread: {e}"),
+                );
             }
         }
     };
 
     std::thread::scope(|scope| {
         let (stdin_done_tx, stdin_done_rx) = std::sync::mpsc::channel::<()>();
+        let stdin_cancel = Arc::new(AtomicBool::new(false));
+        let stdin_cancel_worker = stdin_cancel.clone();
         let stdin_handle = match spawn_scoped_named(scope, THREAD_WRITE_STDIN, move || {
             let mut stdin = stdin_pipe;
-            let result = stdin.write_all(content);
+            let result = write_all_cancellable(&mut stdin, content, &stdin_cancel_worker);
             let _ = stdin_done_tx.send(());
             result
         }) {
             Ok(handle) => handle,
             Err(e) => {
                 cancel.store(true, std::sync::atomic::Ordering::Release);
-                kill_and_reap_child(child);
+                let cleanup = terminate_contained_child(process);
                 let _ = await_drain_deadline(&done_rx, 1, &cancel);
                 let _ = stderr_handle.join();
-                return (false, format!("Failed to spawn stdin writer thread: {e}"));
+                return match cleanup {
+                    Ok(()) => (
+                        false,
+                        format!("Failed to spawn stdin writer thread: {e}"),
+                        false,
+                    ),
+                    Err(cleanup_error) => (
+                        false,
+                        format!(
+                            "Failed to spawn stdin writer thread: {e}; exec containment cleanup failed: {cleanup_error}"
+                        ),
+                        true,
+                    ),
+                };
             }
         };
 
-        let outcome = wait_with_kill_timeout_and_pre_reap_cleanup(child, timeout_ms, || {
-            matches!(
+        let outcome = wait_contained_with_timeout_and_pre_reap_cleanup(process, timeout_ms, || {
+            let pending = matches!(
                 stdin_done_rx.try_recv(),
                 Err(std::sync::mpsc::TryRecvError::Empty)
-            )
+            );
+            if pending {
+                stdin_cancel.store(true, Ordering::Release);
+            }
+            pending
         });
+        if let WaitOutcome::Fatal(diagnostic) = &outcome {
+            on_fatal(diagnostic);
+            cancel.store(true, Ordering::Release);
+        }
+        stdin_cancel.store(true, Ordering::Release);
         let stdin_result = match stdin_handle.join() {
             Ok(result) => result,
             Err(panic) => std::panic::resume_unwind(panic),
@@ -182,22 +292,116 @@ where
         let stderr = stderr_handle.join().unwrap_or_default();
 
         match outcome {
-            WaitOutcome::TimedOut => (false, "write timed out".to_string()),
-            WaitOutcome::Cancelled => (false, "write cancelled".to_string()),
-            WaitOutcome::WaitFailed(msg) => (false, format!("write wait failed: {msg}")),
+            WaitOutcome::TimedOut => (false, "write timed out".to_string(), false),
+            WaitOutcome::Cancelled => (false, "write cancelled".to_string(), false),
+            WaitOutcome::WaitFailed(msg) => (false, format!("write wait failed: {msg}"), false),
+            WaitOutcome::Fatal(msg) => (false, msg, true),
             WaitOutcome::Exited(s) => {
                 let exit_code = extract_exit_code(s);
                 if exit_code != 0 {
                     let stderr_str = String::from_utf8_lossy(&stderr);
-                    return (false, format!("write failed: {stderr_str}"));
+                    return (false, format!("write failed: {stderr_str}"), false);
                 }
                 if let Err(e) = stdin_result {
-                    return (false, format!("Failed to write to stdin: {e}"));
+                    return (false, format!("Failed to write to stdin: {e}"), false);
                 }
-                (true, String::new())
+                (true, String::new(), false)
             }
         }
     })
+}
+
+fn write_all_cancellable<W>(writer: &mut W, content: &[u8], cancel: &AtomicBool) -> io::Result<()>
+where
+    W: Write + AsRawFd,
+{
+    let fd = writer.as_raw_fd();
+    set_nonblocking(fd)?;
+    let mut written = 0usize;
+    while written < content.len() {
+        if cancel.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "write cancelled",
+            ));
+        }
+        let remaining = content
+            .get(written..)
+            .ok_or_else(|| io::Error::other("write offset exceeded content length"))?;
+        match writer.write(remaining) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write content",
+                ));
+            }
+            Ok(count) => written += count,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                wait_write_ready(fd, cancel)?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn set_nonblocking(fd: libc::c_int) -> io::Result<()> {
+    // SAFETY: fd is the owned write-helper stdin descriptor.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: F_SETFL updates status flags on the same open descriptor.
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn wait_write_ready(fd: libc::c_int, cancel: &AtomicBool) -> io::Result<()> {
+    loop {
+        if cancel.load(Ordering::Acquire) {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "write cancelled",
+            ));
+        }
+        let mut pollfd = libc::pollfd {
+            fd,
+            events: libc::POLLOUT,
+            revents: 0,
+        };
+        // SAFETY: pollfd points to one initialized descriptor entry.
+        let result = unsafe { libc::poll(&mut pollfd, 1, 50) };
+        if result > 0 {
+            if pollfd.revents & libc::POLLNVAL != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "write-helper stdin descriptor is invalid",
+                ));
+            }
+            if pollfd.revents & (libc::POLLOUT | libc::POLLHUP | libc::POLLERR) != 0 {
+                return Ok(());
+            }
+        } else if result < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
+    }
+}
+
+fn cleanup_write_failure(process: ContainedChild, diagnostic: &str) -> (bool, String, bool) {
+    match terminate_contained_child(process) {
+        Ok(()) => (false, diagnostic.to_owned(), false),
+        Err(error) => (
+            false,
+            format!("{diagnostic}; exec containment cleanup failed: {error}"),
+            true,
+        ),
+    }
 }
 
 fn write_file_command_args(
@@ -229,7 +433,8 @@ fn spawn_write_file_command(
     use_sudo: bool,
     append: bool,
     private: bool,
-) -> io::Result<Child> {
+    containment: &ContainmentManager,
+) -> Result<ContainedChild, SpawnContainmentError> {
     let mut command = Command::new(guest_write_file_path());
     for arg in write_file_command_args(use_sudo, append, private)? {
         command.arg(arg);
@@ -240,19 +445,23 @@ fn spawn_write_file_command(
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
-    apply_write_file_identity(&mut command, use_sudo)?;
-    spawn_in_own_process_group(&mut command)
+    spawn_contained(&mut command, containment, |command| {
+        apply_write_file_identity(command, use_sudo)
+    })
 }
 
-fn spawn_write_files_command() -> io::Result<Child> {
+fn spawn_write_files_command(
+    containment: &ContainmentManager,
+) -> Result<ContainedChild, SpawnContainmentError> {
     let mut command = Command::new(guest_write_file_path());
     command
         .arg("--batch")
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
-    apply_write_file_identity(&mut command, false)?;
-    spawn_in_own_process_group(&mut command)
+    spawn_contained(&mut command, containment, |command| {
+        apply_write_file_identity(command, false)
+    })
 }
 
 fn guest_write_file_path() -> PathBuf {
@@ -306,26 +515,41 @@ pub(crate) fn decode_write_files_message(
 pub(crate) fn handle_decoded_write_file_message(
     seq: u32,
     decoded: DecodedWriteFileMessage<'_>,
-) -> io::Result<Vec<u8>> {
-    let (success, error) = handle_write_file(
+    operation_guard: &OperationGuard,
+) -> io::Result<GuardedWriteResponse> {
+    let (success, error, fatal) = handle_write_file(
         decoded.path,
         decoded.content,
         decoded.use_sudo,
         decoded.append,
         decoded.private,
+        operation_guard,
     );
+    if fatal {
+        operation_guard.poison(error.clone());
+    }
     let payload = vsock_proto::encode_write_file_result(success, &error);
-    vsock_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).map_err(to_io_error)
+    let frame = vsock_proto::encode(MSG_WRITE_FILE_RESULT, seq, &payload).map_err(to_io_error)?;
+    Ok(GuardedWriteResponse { frame, fatal })
 }
 
 pub(crate) fn handle_decoded_write_files_message(
     seq: u32,
     decoded: DecodedWriteFilesMessage<'_>,
-) -> io::Result<Vec<u8>> {
-    let (success, error) =
-        handle_write_files(decoded.payload, decoded.file_count, decoded.content_bytes);
+    operation_guard: &OperationGuard,
+) -> io::Result<GuardedWriteResponse> {
+    let (success, error, fatal) = handle_write_files(
+        decoded.payload,
+        decoded.file_count,
+        decoded.content_bytes,
+        operation_guard,
+    );
+    if fatal {
+        operation_guard.poison(error.clone());
+    }
     let payload = vsock_proto::encode_write_files_result(success, &error);
-    vsock_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).map_err(to_io_error)
+    let frame = vsock_proto::encode(MSG_WRITE_FILES_RESULT, seq, &payload).map_err(to_io_error)?;
+    Ok(GuardedWriteResponse { frame, fatal })
 }
 
 /// Handle basic incoming messages and return the connection-loop outcome.

--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -7,6 +7,7 @@
 //! Protocol encoding/decoding is handled by the `vsock-proto` crate.
 
 mod connection;
+mod containment;
 mod drain;
 mod error;
 mod exec_control;
@@ -24,6 +25,12 @@ mod user;
 mod wait;
 mod writer;
 
+#[cfg(any(debug_assertions, feature = "test-support"))]
+#[doc(hidden)]
+pub use connection::handle_connection_with_cgroup_fixture;
+#[cfg(any(debug_assertions, feature = "test-support"))]
+#[doc(hidden)]
+pub use connection::run_with_cgroup_fixture;
 pub use connection::{connect_unix, connect_vsock, handle_connection, run};
 pub use log::log;
 

--- a/crates/vsock-guest/src/process.rs
+++ b/crates/vsock-guest/src/process.rs
@@ -1,7 +1,210 @@
 use std::io;
+#[cfg(target_os = "linux")]
+use std::os::fd::{FromRawFd, OwnedFd, RawFd};
 use std::process::{Child, Command, ExitStatus};
+use std::time::Instant;
 
+use crate::containment::{CLEANUP_TIMEOUT, ContainmentManager, ProcessContainment};
 use crate::log::log;
+
+pub(crate) struct ContainedChild {
+    pub(crate) child: Child,
+    pub(crate) containment: ProcessContainment,
+    #[cfg(target_os = "linux")]
+    pub(crate) pidfd: OwnedFd,
+}
+
+#[derive(Debug)]
+pub(crate) struct SpawnContainmentError {
+    error: io::Error,
+    fatal: bool,
+}
+
+impl SpawnContainmentError {
+    fn start(error: io::Error) -> Self {
+        Self {
+            error,
+            fatal: false,
+        }
+    }
+
+    fn fatal(error: io::Error) -> Self {
+        Self { error, fatal: true }
+    }
+
+    pub(crate) fn is_fatal(&self) -> bool {
+        self.fatal
+    }
+}
+
+impl std::fmt::Display for SpawnContainmentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(f)
+    }
+}
+
+impl std::error::Error for SpawnContainmentError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+impl From<io::Error> for SpawnContainmentError {
+    fn from(error: io::Error) -> Self {
+        Self::start(error)
+    }
+}
+
+impl ContainedChild {
+    pub(crate) fn child_id(&self) -> u32 {
+        self.child.id()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_process_group(child: Child) -> io::Result<Self> {
+        let child_id = child.id();
+        let target = process_tree_kill_target(child_id);
+        Self::from_process_group_target(child, target)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_process_group_target(
+        child: Child,
+        target: ProcessTreeKillTarget,
+    ) -> io::Result<Self> {
+        let child_id = child.id();
+        #[cfg(target_os = "linux")]
+        let pidfd = match open_pidfd(child_id) {
+            Ok(pidfd) => pidfd,
+            Err(error) => {
+                kill_and_reap_child_with_target(child, target);
+                return Err(error);
+            }
+        };
+        Ok(Self {
+            child,
+            containment: ProcessContainment::ProcessGroup(Some(target)),
+            #[cfg(target_os = "linux")]
+            pidfd,
+        })
+    }
+}
+
+pub(crate) fn spawn_contained<F>(
+    command: &mut Command,
+    manager: &ContainmentManager,
+    configure: F,
+) -> Result<ContainedChild, SpawnContainmentError>
+where
+    F: FnOnce(&mut Command) -> io::Result<()>,
+{
+    use std::os::unix::process::CommandExt;
+
+    let prepared = manager.prepare().map_err(SpawnContainmentError::start)?;
+    prepared.register_pre_exec(command);
+    if let Err(error) = configure(command) {
+        prepared.discard();
+        return Err(SpawnContainmentError::start(error));
+    }
+    command.process_group(0);
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            prepared.discard();
+            return Err(SpawnContainmentError::start(error));
+        }
+    };
+    let child_id = child.id();
+    let mut containment = prepared.finish(child_id);
+
+    #[cfg(target_os = "linux")]
+    let pidfd = match open_pidfd(child_id) {
+        Ok(pidfd) => pidfd,
+        Err(error) => {
+            let diagnostic = format!("failed to open pidfd for child {child_id}: {error}");
+            match cleanup_without_pidfd(&mut child, &mut containment) {
+                Ok(true) => match containment.remove() {
+                    Ok(()) => {
+                        return Err(SpawnContainmentError::start(io::Error::new(
+                            error.kind(),
+                            diagnostic,
+                        )));
+                    }
+                    Err(cleanup_error) => {
+                        return Err(SpawnContainmentError::fatal(io::Error::other(format!(
+                            "{diagnostic}; failed to remove exec containment: {cleanup_error}"
+                        ))));
+                    }
+                },
+                Ok(false) => {
+                    return Err(SpawnContainmentError::fatal(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        format!("{diagnostic}; timed out cleaning the spawned process"),
+                    )));
+                }
+                Err(cleanup_error) => {
+                    return Err(SpawnContainmentError::fatal(io::Error::other(format!(
+                        "{diagnostic}; failed to clean the spawned process: {cleanup_error}"
+                    ))));
+                }
+            }
+        }
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = containment.kill();
+        let _ = child.kill();
+        return Err(SpawnContainmentError::fatal(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "pidfd containment requires Linux",
+        )));
+    }
+
+    #[cfg(target_os = "linux")]
+    Ok(ContainedChild {
+        child,
+        containment,
+        pidfd,
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn open_pidfd(pid: u32) -> io::Result<OwnedFd> {
+    let pid = process_signal_pid(pid)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid child pid"))?;
+    // SAFETY: pidfd_open does not dereference user pointers and returns a new
+    // descriptor on success.
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let fd = RawFd::try_from(fd)
+        .map_err(|_| io::Error::other("pidfd_open returned an invalid descriptor"))?;
+    // SAFETY: fd is newly owned by this process.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+fn cleanup_without_pidfd(
+    child: &mut Child,
+    containment: &mut ProcessContainment,
+) -> io::Result<bool> {
+    let containment_result = containment.kill();
+    let _ = child.kill();
+    let _ = containment_result?;
+    let deadline = Instant::now() + CLEANUP_TIMEOUT;
+    loop {
+        let child_exited = child.try_wait()?.is_some();
+        let containment_empty = containment.wait_empty_until(deadline)?;
+        if child_exited && containment_empty {
+            return Ok(true);
+        }
+        if Instant::now() >= deadline {
+            return Ok(false);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
 
 /// Extract exit code from ExitStatus, mapping signals to 128 + signal number
 #[cfg(unix)]
@@ -21,6 +224,7 @@ pub(crate) fn extract_exit_code(status: ExitStatus) -> i32 {
 ///
 /// Timeout killing targets the process group by child PID, so every child path
 /// that uses the shared wait helpers must preserve this spawn invariant.
+#[cfg(test)]
 pub(crate) fn spawn_in_own_process_group(command: &mut Command) -> io::Result<Child> {
     #[cfg(unix)]
     {
@@ -108,10 +312,6 @@ pub(crate) struct ProcessTreeKillTarget {
 }
 
 impl ProcessTreeKillTarget {
-    pub(crate) fn child_id(&self) -> u32 {
-        self.child_id
-    }
-
     fn child_pgid_to_signal(&self) -> Option<u32> {
         self.child_pgid
             .and_then(|pgid| signalable_child_pgid(self.child_id, pgid))
@@ -194,6 +394,7 @@ pub(crate) unsafe fn kill_process_tree_target(target: ProcessTreeKillTarget) -> 
 }
 
 /// Kill the process tree for a spawned child and reap the direct child.
+#[cfg(test)]
 pub(crate) fn kill_and_reap_child(child: Child) {
     let child_id = child.id();
     let target = process_tree_kill_target(child_id);
@@ -202,6 +403,7 @@ pub(crate) fn kill_and_reap_child(child: Child) {
 
 /// Kill a process tree using a previously snapshotted target and reap the
 /// direct child.
+#[cfg(test)]
 pub(crate) fn kill_and_reap_child_with_target(mut child: Child, mut target: ProcessTreeKillTarget) {
     // Signal before waiting. The direct child may already be a zombie while
     // descendants still live in its process group; reaping first would release

--- a/crates/vsock-guest/src/quiesce.rs
+++ b/crates/vsock-guest/src/quiesce.rs
@@ -1,9 +1,19 @@
+use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-#[derive(Clone, Default)]
+use crate::containment::ContainmentManager;
+use crate::writer::GuestShutdown;
+
+#[derive(Clone)]
 pub(crate) struct OperationState {
-    inner: Arc<Mutex<Inner>>,
+    inner: Arc<OperationStateInner>,
+}
+
+struct OperationStateInner {
+    state: Mutex<Inner>,
+    containment: ContainmentManager,
+    transports: Mutex<Vec<GuestShutdown>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -15,6 +25,7 @@ enum Mode {
 struct Inner {
     mode: Mode,
     pending: usize,
+    fatal_reason: Option<String>,
 }
 
 impl Default for Inner {
@@ -22,6 +33,7 @@ impl Default for Inner {
         Self {
             mode: Mode::Open,
             pending: 0,
+            fatal_reason: None,
         }
     }
 }
@@ -29,12 +41,14 @@ impl Default for Inner {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AcquireOperationError {
     Quiescing,
+    Fatal,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum QuiesceResult {
     Quiesced,
     Busy { pending: usize },
+    Fatal,
 }
 
 #[derive(Clone)]
@@ -48,8 +62,26 @@ struct OperationGuardInner {
 }
 
 impl OperationState {
+    fn new(containment: ContainmentManager) -> Self {
+        Self {
+            inner: Arc::new(OperationStateInner {
+                state: Mutex::new(Inner::default()),
+                containment,
+                transports: Mutex::new(Vec::new()),
+            }),
+        }
+    }
+
+    #[cfg(any(debug_assertions, feature = "test-support"))]
+    pub(crate) fn with_cgroup_fixture(root: std::path::PathBuf) -> Self {
+        Self::new(ContainmentManager::fixture(root))
+    }
+
     pub(crate) fn acquire(&self) -> Result<OperationGuard, AcquireOperationError> {
-        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut inner = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        if inner.fatal_reason.is_some() {
+            return Err(AcquireOperationError::Fatal);
+        }
         if inner.mode == Mode::Quiescing {
             return Err(AcquireOperationError::Quiescing);
         }
@@ -63,33 +95,113 @@ impl OperationState {
     }
 
     pub(crate) fn enter_quiescing(&self) -> QuiesceResult {
-        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
-        inner.mode = Mode::Quiescing;
-        if inner.pending == 0 {
-            QuiesceResult::Quiesced
-        } else {
-            QuiesceResult::Busy {
-                pending: inner.pending,
+        {
+            let mut inner = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+            if inner.fatal_reason.is_some() {
+                return QuiesceResult::Fatal;
+            }
+            inner.mode = Mode::Quiescing;
+            if inner.pending > 0 {
+                return QuiesceResult::Busy {
+                    pending: inner.pending,
+                };
+            }
+        }
+
+        if let Err(error) = self.inner.containment.audit() {
+            self.poison(format!("exec containment audit failed: {error}"));
+            return QuiesceResult::Fatal;
+        }
+        QuiesceResult::Quiesced
+    }
+
+    pub(crate) fn resume(&self) -> Result<(), AcquireOperationError> {
+        let mut inner = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+        if inner.fatal_reason.is_some() {
+            return Err(AcquireOperationError::Fatal);
+        }
+        inner.mode = Mode::Open;
+        Ok(())
+    }
+
+    pub(crate) fn is_quiescing(&self) -> bool {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .mode
+            == Mode::Quiescing
+    }
+
+    pub(crate) fn is_fatal(&self) -> bool {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .fatal_reason
+            .is_some()
+    }
+
+    pub(crate) fn poison(&self, reason: String) {
+        self.mark_fatal(reason);
+        self.shutdown_transports();
+    }
+
+    fn mark_fatal(&self, reason: String) {
+        {
+            let mut inner = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
+            if inner.fatal_reason.is_none() {
+                inner.fatal_reason = Some(reason);
             }
         }
     }
 
-    pub(crate) fn resume(&self) {
-        self.inner.lock().unwrap_or_else(|e| e.into_inner()).mode = Mode::Open;
+    fn shutdown_transports(&self) {
+        let mut transports = self
+            .inner
+            .transports
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        transports.retain(GuestShutdown::is_alive);
+        for transport in transports.iter() {
+            transport.shutdown();
+        }
     }
 
-    pub(crate) fn is_quiescing(&self) -> bool {
-        self.inner.lock().unwrap_or_else(|e| e.into_inner()).mode == Mode::Quiescing
+    pub(crate) fn register_transport(&self, transport: GuestShutdown) {
+        let mut transports = self
+            .inner
+            .transports
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        transports.retain(GuestShutdown::is_alive);
+        transports.push(transport.clone());
+        drop(transports);
+        if self.is_fatal() {
+            transport.shutdown();
+        }
+    }
+
+    pub(crate) fn containment(&self) -> ContainmentManager {
+        self.inner.containment.clone()
+    }
+
+    pub(crate) fn audit_containment(&self) -> io::Result<()> {
+        self.inner.containment.audit()
     }
 
     fn release_one(&self) {
-        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut inner = self.inner.state.lock().unwrap_or_else(|e| e.into_inner());
         inner.pending = inner.pending.saturating_sub(1);
     }
 
     #[cfg(test)]
     pub(crate) fn pending(&self) -> usize {
-        self.inner.lock().unwrap_or_else(|e| e.into_inner()).pending
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .pending
     }
 }
 
@@ -98,6 +210,24 @@ impl OperationGuard {
         if !self.inner.released.swap(true, Ordering::AcqRel) {
             self.inner.state.release_one();
         }
+    }
+
+    pub(crate) fn poison(&self, reason: String) {
+        self.inner.state.mark_fatal(reason);
+    }
+
+    pub(crate) fn shutdown_transports(&self) {
+        self.inner.state.shutdown_transports();
+    }
+
+    pub(crate) fn containment(&self) -> ContainmentManager {
+        self.inner.state.containment()
+    }
+}
+
+impl Default for OperationState {
+    fn default() -> Self {
+        Self::new(ContainmentManager::default())
     }
 }
 
@@ -164,7 +294,7 @@ mod tests {
             state.acquire(),
             Err(AcquireOperationError::Quiescing)
         ));
-        state.resume();
+        state.resume().unwrap();
 
         let guard = state.acquire().unwrap();
         assert_eq!(state.pending(), 1);

--- a/crates/vsock-guest/src/shell_command.rs
+++ b/crates/vsock-guest/src/shell_command.rs
@@ -36,7 +36,7 @@
 use std::fs::{self, DirBuilder, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime};
 
 use std::os::fd::{AsRawFd, RawFd};
@@ -150,7 +150,7 @@ pub(crate) struct PreparedShellCommand {
 }
 
 pub(crate) struct SpawnedShellCommand {
-    pub(crate) child: Child,
+    pub(crate) process: crate::process::ContainedChild,
     pub(crate) env_script: Option<EnvScriptGuard>,
 }
 
@@ -551,7 +551,8 @@ pub(crate) fn spawn_shell_command_with_pipes(
     env: &[(&str, &str)],
     sudo: bool,
     pipe_stdin: bool,
-) -> io::Result<SpawnedShellCommand> {
+    containment: &crate::containment::ContainmentManager,
+) -> Result<SpawnedShellCommand, crate::process::SpawnContainmentError> {
     let PreparedShellCommand {
         mut command,
         env_script,
@@ -560,8 +561,11 @@ pub(crate) fn spawn_shell_command_with_pipes(
     if pipe_stdin {
         command.stdin(Stdio::piped());
     }
-    let child = crate::process::spawn_in_own_process_group(&mut command)?;
-    Ok(SpawnedShellCommand { child, env_script })
+    let process = crate::process::spawn_contained(&mut command, containment, |_| Ok(()))?;
+    Ok(SpawnedShellCommand {
+        process,
+        env_script,
+    })
 }
 
 #[cfg(test)]

--- a/crates/vsock-guest/src/wait.rs
+++ b/crates/vsock-guest/src/wait.rs
@@ -1,15 +1,23 @@
+use std::cmp;
 use std::io;
-use std::process::{Child, ExitStatus};
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, OwnedFd};
+#[cfg(test)]
+use std::process::Child;
+use std::process::ExitStatus;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+#[cfg(test)]
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::containment::CLEANUP_TIMEOUT;
+use crate::process::ContainedChild;
+#[cfg(test)]
 use crate::process::{
-    ProcessTreeKillTarget, kill_and_reap_child_with_target, kill_process_tree_target,
-    process_signal_pid, process_tree_kill_target, refresh_process_tree_kill_target,
+    ProcessTreeKillTarget, kill_process_tree_target, process_tree_kill_target,
+    refresh_process_tree_kill_target,
 };
-use crate::threading::spawn_scoped_named;
 
 /// After the child process exits, continue draining stdout/stderr for this
 /// many seconds. If EOF is not received within this deadline, proceed to
@@ -17,7 +25,6 @@ use crate::threading::spawn_scoped_named;
 /// child processes hold pipe fds open.
 pub(crate) const DRAIN_DEADLINE_SECS: u64 = 5;
 const WAIT_CANCEL_POLL_INTERVAL_MS: u64 = 50;
-const THREAD_WAIT_OBSERVER: &str = "vsock-wait-observer";
 
 /// Outcome of child wait helpers.
 pub(crate) enum WaitOutcome {
@@ -29,6 +36,8 @@ pub(crate) enum WaitOutcome {
     Cancelled,
     /// `wait()` itself failed; carries the error message.
     WaitFailed(String),
+    /// Descendant cleanup could not be proven within the security deadline.
+    Fatal(String),
 }
 
 enum KillReason {
@@ -64,33 +73,22 @@ pub(crate) fn await_drain_deadline(
     completed
 }
 
-/// Wait for `child` with an optional timeout, allowing the caller to request
-/// process-tree cleanup after natural exit is observed but before the direct
-/// child is reaped.
-///
-/// The callback returns `true` when a still-running descendant is holding a
-/// resource that must be released by killing the tracked process tree.
+/// Wait for a debug/test child with the process-group fallback.
+#[cfg(test)]
 pub(crate) fn wait_with_kill_timeout_and_pre_reap_cleanup(
     child: Child,
     timeout_ms: u32,
     pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
-    let kill_target = process_tree_kill_target(child.id());
-    wait_with_kill_timeout_or_cancelled_by(
-        child,
-        kill_target,
-        timeout_ms,
-        || false,
-        pre_reap_cleanup,
-    )
+    let process = match ContainedChild::from_process_group(child) {
+        Ok(process) => process,
+        Err(error) => return WaitOutcome::WaitFailed(error.to_string()),
+    };
+    wait_with_kill_timeout_or_cancelled_by(process, timeout_ms, || false, pre_reap_cleanup)
 }
 
-/// Wait for `child` while observing either cancel flag and using a kill target
-/// snapshotted before entering the wait path.
-///
-/// Exec operations have both connection-level cancellation and request-level
-/// cancellation, and they snapshot process-tree targets before stdio setup can
-/// introduce cleanup races.
+/// Wait for a debug/test child with an already sampled process-group target.
+#[cfg(test)]
 pub(crate) fn wait_with_kill_timeout_or_cancelled_either_with_target(
     child: Child,
     kill_target: ProcessTreeKillTarget,
@@ -99,187 +97,225 @@ pub(crate) fn wait_with_kill_timeout_or_cancelled_either_with_target(
     second_cancel: &AtomicBool,
     pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
+    let process = match ContainedChild::from_process_group_target(child, kill_target) {
+        Ok(process) => process,
+        Err(error) => return WaitOutcome::WaitFailed(error.to_string()),
+    };
     wait_with_kill_timeout_or_cancelled_by(
-        child,
-        kill_target,
+        process,
         timeout_ms,
         || first_cancel.load(Ordering::Acquire) || second_cancel.load(Ordering::Acquire),
         pre_reap_cleanup,
     )
 }
 
+pub(crate) fn wait_contained_with_timeout_or_cancelled(
+    process: ContainedChild,
+    timeout_ms: u32,
+    first_cancel: &AtomicBool,
+    second_cancel: &AtomicBool,
+    pre_reap_cleanup: impl FnMut() -> bool,
+) -> WaitOutcome {
+    wait_with_kill_timeout_or_cancelled_by(
+        process,
+        timeout_ms,
+        || first_cancel.load(Ordering::Acquire) || second_cancel.load(Ordering::Acquire),
+        pre_reap_cleanup,
+    )
+}
+
+pub(crate) fn wait_contained_with_timeout_and_pre_reap_cleanup(
+    process: ContainedChild,
+    timeout_ms: u32,
+    pre_reap_cleanup: impl FnMut() -> bool,
+) -> WaitOutcome {
+    wait_with_kill_timeout_or_cancelled_by(process, timeout_ms, || false, pre_reap_cleanup)
+}
+
+pub(crate) fn terminate_contained_child(mut process: ContainedChild) -> io::Result<()> {
+    kill_contained(&mut process)?;
+    let status = wait_for_killed_process(&mut process)?;
+    process.containment.remove()?;
+    let _ = status;
+    Ok(())
+}
+
 fn wait_with_kill_timeout_or_cancelled_by(
-    mut child: Child,
-    mut kill_target: ProcessTreeKillTarget,
+    mut process: ContainedChild,
     timeout_ms: u32,
     is_cancelled: impl Fn() -> bool,
     mut pre_reap_cleanup: impl FnMut() -> bool,
 ) -> WaitOutcome {
-    let child_id = child.id();
-    debug_assert_eq!(kill_target.child_id(), child_id);
-    refresh_process_tree_kill_target(&mut kill_target);
-    let deadline = if timeout_ms > 0 {
+    let deadline = (timeout_ms > 0).then(|| {
         let now = Instant::now();
-        Some(
-            now.checked_add(Duration::from_millis(u64::from(timeout_ms)))
-                .unwrap_or(now),
-        )
-    } else {
-        None
+        now.checked_add(Duration::from_millis(u64::from(timeout_ms)))
+            .unwrap_or(now)
+    });
+
+    let mut decision = match wait_for_exit_timeout_or_cancelled(&process, deadline, is_cancelled) {
+        Ok(decision) => decision,
+        Err(error) => return fatal_wait(error),
     };
-
-    thread::scope(|scope| {
-        let (observed_tx, observed_rx) = mpsc::channel::<()>();
-        let observer = match spawn_scoped_named(scope, THREAD_WAIT_OBSERVER, move || {
-            let result = wait_for_child_exit_without_reap(child_id);
-            let _ = observed_tx.send(());
-            result
-        }) {
-            Ok(observer) => observer,
-            Err(e) => {
-                // Without a non-reaping observer, natural exit cannot be
-                // distinguished safely from timeout/cancel before reap.
-                kill_and_reap_child_with_target(child, kill_target);
-                return WaitOutcome::WaitFailed(format!("failed to spawn wait observer: {e}"));
-            }
-        };
-
-        let mut decision = wait_for_exit_timeout_or_cancelled(&observed_rx, deadline, is_cancelled);
-        if matches!(&decision, WaitDecision::Kill(_)) {
-            refresh_process_tree_kill_target(&mut kill_target);
-            decision = apply_final_exit_priority(decision, &observed_rx);
+    if matches!(decision, WaitDecision::Kill(_)) {
+        match pidfd_ready(&process, Duration::ZERO) {
+            Ok(true) => decision = WaitDecision::Exited,
+            Ok(false) => {}
+            Err(error) => return fatal_wait(error),
         }
+    }
 
-        match decision {
-            WaitDecision::Exited => {
-                let observed = match observer.join() {
-                    Ok(observed) => observed,
-                    Err(panic) => {
-                        kill_and_reap_child_with_target(child, kill_target);
-                        std::panic::resume_unwind(panic);
-                    }
-                };
-                if let Err(e) = observed {
-                    kill_and_reap_child_with_target(child, kill_target);
-                    return WaitOutcome::WaitFailed(format!(
-                        "failed to observe child exit without reaping: {e}"
-                    ));
-                }
-
-                if pre_reap_cleanup() {
-                    refresh_process_tree_kill_target(&mut kill_target);
-                    // SAFETY: the exit observer used WNOWAIT, so this owner
-                    // still holds the unreaped direct child identity.
-                    let _ = unsafe { kill_process_tree_target(kill_target) };
-                }
-
-                match child.wait() {
-                    Ok(status) => WaitOutcome::Exited(status),
-                    Err(e) => WaitOutcome::WaitFailed(e.to_string()),
-                }
+    match decision {
+        WaitDecision::Exited => finish_natural_exit(process, &mut pre_reap_cleanup),
+        WaitDecision::Kill(reason) => {
+            let killed = match kill_contained(&mut process) {
+                Ok(killed) => killed,
+                Err(error) => return fatal_wait(error),
+            };
+            let status = match wait_for_killed_process(&mut process) {
+                Ok(status) => status,
+                Err(error) => return fatal_wait(error),
+            };
+            if let Err(error) = process.containment.remove() {
+                return fatal_wait(error);
             }
-            WaitDecision::Kill(reason) => {
-                let child_killed = kill_child(&mut child, kill_target);
-                let observed = observer.join();
-                let status = child.wait();
-
-                let observed = match observed {
-                    Ok(observed) => observed,
-                    Err(panic) => std::panic::resume_unwind(panic),
-                };
-                let status = match status {
-                    Ok(status) => status,
-                    Err(e) => return WaitOutcome::WaitFailed(e.to_string()),
-                };
-                if let Err(e) = observed {
-                    return WaitOutcome::WaitFailed(format!(
-                        "failed to observe child exit without reaping: {e}"
-                    ));
-                }
-                if !child_killed {
-                    return WaitOutcome::Exited(status);
-                }
-                match reason {
-                    KillReason::Timeout => WaitOutcome::TimedOut,
-                    KillReason::Cancelled => WaitOutcome::Cancelled,
-                }
+            if !killed {
+                return WaitOutcome::Exited(status);
+            }
+            match reason {
+                KillReason::Timeout => WaitOutcome::TimedOut,
+                KillReason::Cancelled => WaitOutcome::Cancelled,
             }
         }
-    })
+    }
+}
+
+fn finish_natural_exit(
+    mut process: ContainedChild,
+    pre_reap_cleanup: &mut impl FnMut() -> bool,
+) -> WaitOutcome {
+    let requested_cleanup = pre_reap_cleanup();
+    let populated = match process.containment.populated() {
+        Ok(populated) => populated,
+        Err(error) => return fatal_wait(error),
+    };
+    let should_kill = (process.containment.is_cgroup() && populated)
+        || (!process.containment.is_cgroup() && requested_cleanup);
+    if should_kill && let Err(error) = process.containment.kill() {
+        return fatal_wait(error);
+    }
+    if process.containment.is_cgroup() {
+        let deadline = Instant::now() + CLEANUP_TIMEOUT;
+        match process.containment.wait_empty_until(deadline) {
+            Ok(true) => {}
+            Ok(false) => {
+                return fatal_wait(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "timed out waiting for exec cgroup to become empty",
+                ));
+            }
+            Err(error) => return fatal_wait(error),
+        }
+    }
+    if let Err(error) = process.containment.remove() {
+        return fatal_wait(error);
+    }
+    match process.child.wait() {
+        Ok(status) => WaitOutcome::Exited(status),
+        Err(error) => WaitOutcome::WaitFailed(error.to_string()),
+    }
+}
+
+fn kill_contained(process: &mut ContainedChild) -> io::Result<bool> {
+    let containment_result = process.containment.kill();
+    let child_killed = process.child.kill().is_ok();
+    let containment_killed = containment_result?;
+    Ok(containment_killed || child_killed)
+}
+
+fn wait_for_killed_process(process: &mut ContainedChild) -> io::Result<ExitStatus> {
+    let deadline = Instant::now() + CLEANUP_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out waiting for contained child cleanup",
+            ));
+        }
+        let exited = pidfd_ready(process, remaining.min(Duration::from_millis(10)))?;
+        let empty = !process.containment.populated()?;
+        if exited && empty {
+            return process.child.wait();
+        }
+    }
 }
 
 fn wait_for_exit_timeout_or_cancelled(
-    observed_rx: &mpsc::Receiver<()>,
+    process: &ContainedChild,
     deadline: Option<Instant>,
     is_cancelled: impl Fn() -> bool,
-) -> WaitDecision {
+) -> io::Result<WaitDecision> {
     let poll_interval = Duration::from_millis(WAIT_CANCEL_POLL_INTERVAL_MS);
-
     loop {
-        if exit_observed(observed_rx) {
-            return WaitDecision::Exited;
+        if pidfd_ready(process, Duration::ZERO)? {
+            return Ok(WaitDecision::Exited);
         }
-
         let now = Instant::now();
         let wait_for = match deadline {
             Some(deadline) => {
                 let remaining = deadline.saturating_duration_since(now);
                 if remaining.is_zero() {
-                    return WaitDecision::Kill(KillReason::Timeout);
+                    return Ok(WaitDecision::Kill(KillReason::Timeout));
                 }
                 remaining.min(poll_interval)
             }
             None => poll_interval,
         };
-
         if is_cancelled() {
-            return WaitDecision::Kill(KillReason::Cancelled);
+            return Ok(WaitDecision::Kill(KillReason::Cancelled));
         }
-
-        match observed_rx.recv_timeout(wait_for) {
-            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {
-                return WaitDecision::Exited;
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        if pidfd_ready(process, wait_for)? {
+            return Ok(WaitDecision::Exited);
         }
     }
 }
 
-fn exit_observed(observed_rx: &mpsc::Receiver<()>) -> bool {
-    match observed_rx.try_recv() {
-        Ok(()) | Err(mpsc::TryRecvError::Disconnected) => true,
-        Err(mpsc::TryRecvError::Empty) => false,
-    }
+#[cfg(target_os = "linux")]
+fn pidfd_ready(process: &ContainedChild, timeout: Duration) -> io::Result<bool> {
+    poll_pidfd(&process.pidfd, timeout)
 }
 
-fn apply_final_exit_priority(
-    decision: WaitDecision,
-    observed_rx: &mpsc::Receiver<()>,
-) -> WaitDecision {
-    match decision {
-        WaitDecision::Kill(_) if exit_observed(observed_rx) => WaitDecision::Exited,
-        decision => decision,
-    }
+#[cfg(not(target_os = "linux"))]
+fn pidfd_ready(_process: &ContainedChild, _timeout: Duration) -> io::Result<bool> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "pidfd readiness requires Linux",
+    ))
 }
 
-fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
-    let child_id = process_signal_pid(child_id)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "invalid child pid"))?;
-    // SAFETY: zeroed siginfo_t is valid for waitid to fill.
-    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+#[cfg(target_os = "linux")]
+fn poll_pidfd(pidfd: &OwnedFd, timeout: Duration) -> io::Result<bool> {
+    let timeout_ms = if timeout.is_zero() {
+        0
+    } else {
+        cmp::min(cmp::max(timeout.as_millis(), 1), libc::c_int::MAX as u128) as libc::c_int
+    };
     loop {
-        // SAFETY: child_id belongs to a direct child owned by this process.
-        // WNOWAIT observes its terminal state without releasing its PID.
-        let result = unsafe {
-            libc::waitid(
-                libc::P_PID,
-                child_id as libc::id_t,
-                &mut info,
-                libc::WEXITED | libc::WNOWAIT,
-            )
+        let mut pollfd = libc::pollfd {
+            fd: pidfd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
         };
+        // SAFETY: pollfd points to one initialized descriptor entry.
+        let result = unsafe { libc::poll(&mut pollfd, 1, timeout_ms) };
+        if result > 0 {
+            if pollfd.revents & (libc::POLLERR | libc::POLLNVAL) != 0 {
+                return Err(io::Error::other("pidfd became invalid while polling"));
+            }
+            return Ok(pollfd.revents & (libc::POLLIN | libc::POLLHUP) != 0);
+        }
         if result == 0 {
-            return Ok(());
+            return Ok(false);
         }
         let error = io::Error::last_os_error();
         if error.kind() != io::ErrorKind::Interrupted {
@@ -288,9 +324,14 @@ fn wait_for_child_exit_without_reap(child_id: u32) -> io::Result<()> {
     }
 }
 
-fn kill_child(child: &mut Child, kill_target: ProcessTreeKillTarget) -> bool {
-    // SAFETY: this owner has not reaped child, so its PID/process group cannot
-    // have been reused since the owner refreshed kill_target.
+fn fatal_wait(error: io::Error) -> WaitOutcome {
+    WaitOutcome::Fatal(format!("exec containment failed: {error}"))
+}
+
+#[cfg(test)]
+fn kill_child(child: &mut Child, mut kill_target: ProcessTreeKillTarget) -> bool {
+    refresh_process_tree_kill_target(&mut kill_target);
+    // SAFETY: the test owner retains the unreaped child while signaling.
     let tree_killed = unsafe { kill_process_tree_target(kill_target) };
     let child_killed = child.kill().is_ok();
     tree_killed || child_killed
@@ -494,44 +535,6 @@ mod tests {
         );
 
         assert!(matches!(outcome, WaitOutcome::Cancelled));
-    }
-
-    #[test]
-    fn observed_exit_wins_over_elapsed_deadline() {
-        let cancel = AtomicBool::new(false);
-        let (observed_tx, observed_rx) = mpsc::channel::<()>();
-        observed_tx.send(()).unwrap();
-
-        let decision =
-            wait_for_exit_timeout_or_cancelled(&observed_rx, Some(Instant::now()), || {
-                cancel.load(Ordering::Acquire)
-            });
-
-        assert!(matches!(decision, WaitDecision::Exited));
-    }
-
-    #[test]
-    fn observed_exit_wins_over_pre_signalled_cancel() {
-        let cancel = AtomicBool::new(true);
-        let (observed_tx, observed_rx) = mpsc::channel::<()>();
-        observed_tx.send(()).unwrap();
-
-        let decision = wait_for_exit_timeout_or_cancelled(&observed_rx, None, || {
-            cancel.load(Ordering::Acquire)
-        });
-
-        assert!(matches!(decision, WaitDecision::Exited));
-    }
-
-    #[test]
-    fn final_observed_exit_wins_over_pending_kill_decision() {
-        let (observed_tx, observed_rx) = mpsc::channel::<()>();
-        observed_tx.send(()).unwrap();
-
-        let decision =
-            apply_final_exit_priority(WaitDecision::Kill(KillReason::Timeout), &observed_rx);
-
-        assert!(matches!(decision, WaitDecision::Exited));
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/vsock-guest/src/writer.rs
+++ b/crates/vsock-guest/src/writer.rs
@@ -3,24 +3,37 @@ use std::io;
 use std::net::Shutdown;
 use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 const WRITE_DEADLINE: Duration = Duration::from_secs(10);
 
 /// Shared guest-to-host frame writer.
 ///
-/// The mutex is held for exactly one encoded protocol frame, so concurrent
+/// The write lock is held for exactly one encoded protocol frame, so concurrent
 /// producers cannot interleave bytes on the stream.
 #[derive(Clone)]
 pub(crate) struct GuestWriter {
-    stream: Arc<Mutex<UnixStream>>,
+    transport: Arc<GuestTransport>,
+}
+
+struct GuestTransport {
+    stream: UnixStream,
+    write_lock: Mutex<()>,
+}
+
+#[derive(Clone)]
+pub(crate) struct GuestShutdown {
+    transport: Weak<GuestTransport>,
 }
 
 impl GuestWriter {
     pub(crate) fn new(stream: UnixStream) -> Self {
         Self {
-            stream: Arc::new(Mutex::new(stream)),
+            transport: Arc::new(GuestTransport {
+                stream,
+                write_lock: Mutex::new(()),
+            }),
         }
     }
 
@@ -28,11 +41,21 @@ impl GuestWriter {
         self.write_frame_with_deadline(frame, WRITE_DEADLINE)
     }
 
+    pub(crate) fn shutdown(&self) {
+        let _ = self.transport.stream.shutdown(Shutdown::Both);
+    }
+
+    pub(crate) fn shutdown_handle(&self) -> GuestShutdown {
+        GuestShutdown {
+            transport: Arc::downgrade(&self.transport),
+        }
+    }
+
     fn write_frame_with_deadline(&self, frame: &[u8], deadline: Duration) -> io::Result<()> {
         self.write_frame_with_deadline_after_lock(frame, deadline, || {})
     }
 
-    /// Run `after_lock` while holding the writer mutex, immediately before
+    /// Run `after_lock` while holding the writer lock, immediately before
     /// sending `frame`.
     ///
     /// Guarded operations use this to mark themselves complete at the point
@@ -45,7 +68,7 @@ impl GuestWriter {
         self.write_frame_with_deadline_after_lock(frame, WRITE_DEADLINE, after_lock)
     }
 
-    /// Build and send one frame while holding the writer mutex.
+    /// Build and send one frame while holding the writer lock.
     ///
     /// Control paths that derive the response from operation state use this so
     /// the state check and frame ordering are linearized with terminal frames.
@@ -53,11 +76,15 @@ impl GuestWriter {
     where
         F: FnOnce() -> io::Result<Vec<u8>>,
     {
-        let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        let _write_guard = self
+            .transport
+            .write_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let frame = build_frame()?;
-        let result = send_frame(stream.as_raw_fd(), &frame, WRITE_DEADLINE);
+        let result = send_frame(self.transport.stream.as_raw_fd(), &frame, WRITE_DEADLINE);
         if result.is_err() {
-            let _ = stream.shutdown(Shutdown::Both);
+            let _ = self.transport.stream.shutdown(Shutdown::Both);
         }
         result
     }
@@ -71,15 +98,32 @@ impl GuestWriter {
     where
         F: FnOnce(),
     {
-        let stream = self.stream.lock().unwrap_or_else(|e| e.into_inner());
+        let _write_guard = self
+            .transport
+            .write_lock
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         after_lock();
-        let result = send_frame(stream.as_raw_fd(), frame, deadline);
+        let result = send_frame(self.transport.stream.as_raw_fd(), frame, deadline);
         if result.is_err() {
             // The protocol has no resync marker. After a timeout or partial
             // write failure, keep the stream from carrying corrupted frames.
-            let _ = stream.shutdown(Shutdown::Both);
+            let _ = self.transport.stream.shutdown(Shutdown::Both);
         }
         result
+    }
+}
+
+impl GuestShutdown {
+    pub(crate) fn is_alive(&self) -> bool {
+        self.transport.strong_count() > 0
+    }
+
+    pub(crate) fn shutdown(&self) {
+        let Some(transport) = self.transport.upgrade() else {
+            return;
+        };
+        let _ = transport.stream.shutdown(Shutdown::Both);
     }
 }
 

--- a/crates/vsock-guest/tests/connection/containment.rs
+++ b/crates/vsock-guest/tests/connection/containment.rs
@@ -1,0 +1,111 @@
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use vsock_proto::{ExecOutputPolicy, ExecTermination};
+
+use super::support::{
+    finish_guest_connection, read_exec_result, send_exec_cancel, send_exec_start,
+    start_guest_connection_with_cgroup_fixture, unique_tmp_path,
+};
+
+#[test]
+fn exec_enters_and_cleans_its_cgroup_leaf() {
+    let root_guard = unique_tmp_path("exec-cgroup", "");
+    let root = PathBuf::from(root_guard.as_str());
+    fs::create_dir(&root).unwrap();
+    let (handle, mut host_stream) = start_guest_connection_with_cgroup_fixture(root.clone());
+
+    send_exec_start(
+        &mut host_stream,
+        401,
+        "sleep 60",
+        60_000,
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    );
+    let leaf = wait_for_leaf(&root);
+    assert_eq!(fs::read_to_string(leaf.join("cgroup.procs")).unwrap(), "0");
+
+    send_exec_cancel(&mut host_stream, 401);
+    let (_, result) = read_exec_result(&mut host_stream, 401);
+    assert_eq!(result.termination, ExecTermination::Cancelled);
+    wait_for_empty_root(&root);
+
+    finish_guest_connection(handle, host_stream);
+    fs::remove_dir(&root).unwrap();
+}
+
+#[test]
+fn malformed_containment_state_returns_wait_failed_and_closes_transport() {
+    let root_guard = unique_tmp_path("exec-cgroup-fatal", "");
+    let root = PathBuf::from(root_guard.as_str());
+    fs::create_dir(&root).unwrap();
+    let (handle, mut host_stream) = start_guest_connection_with_cgroup_fixture(root.clone());
+
+    send_exec_start(
+        &mut host_stream,
+        402,
+        "sleep 60",
+        60_000,
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    );
+    let leaf = wait_for_leaf(&root);
+    fs::write(leaf.join("cgroup.events"), b"malformed\n").unwrap();
+
+    send_exec_cancel(&mut host_stream, 402);
+    let (_, result) = read_exec_result(&mut host_stream, 402);
+    assert_eq!(result.termination, ExecTermination::WaitFailed);
+    assert!(result.diagnostic.contains("exec containment failed"));
+
+    let mut byte = [0_u8; 1];
+    let transport_closed = match host_stream.read(&mut byte) {
+        Ok(0) => true,
+        Ok(_) => false,
+        Err(error) => matches!(
+            error.kind(),
+            std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::UnexpectedEof
+        ),
+    };
+    assert!(transport_closed, "fatal containment must close transport");
+    drop(host_stream);
+    let _ = handle.join().unwrap();
+    fs::remove_dir_all(&root).unwrap();
+}
+
+fn wait_for_leaf(root: &Path) -> PathBuf {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(path) = fs::read_dir(root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| path.is_dir())
+        {
+            return path;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "exec cgroup leaf was not created"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_empty_root(root: &Path) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if fs::read_dir(root).unwrap().next().is_none() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "exec cgroup leaf was not removed"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}

--- a/crates/vsock-guest/tests/connection/main.rs
+++ b/crates/vsock-guest/tests/connection/main.rs
@@ -8,6 +8,7 @@
 mod support;
 
 mod basic;
+mod containment;
 mod exec_basic;
 mod exec_cancel_cleanup;
 mod exec_control;

--- a/crates/vsock-guest/tests/connection/reconnect.rs
+++ b/crates/vsock-guest/tests/connection/reconnect.rs
@@ -1,17 +1,21 @@
-use std::io::{self, Write};
+use std::fs;
+use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use vsock_guest::run;
+use vsock_guest::{run, run_with_cgroup_fixture};
 use vsock_proto::{
-    self, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_SHUTDOWN, MSG_SHUTDOWN_ACK,
+    self, ExecOutputPolicy, MSG_OPERATIONS_RESUMED, MSG_PING, MSG_PONG, MSG_SHUTDOWN,
+    MSG_SHUTDOWN_ACK,
 };
 
 use super::support::{
-    read_and_discard_message, read_message, send_resume_operations, unique_socket_path,
+    read_and_discard_message, read_message, send_exec_start, send_resume_operations,
+    unique_socket_path, unique_tmp_path,
 };
 
 const EXPECTED_RECONNECT_ATTEMPTS: usize = 50;
@@ -88,6 +92,53 @@ fn run_resets_reconnect_attempts_after_real_host_work() {
     handle.join().unwrap().unwrap();
 }
 
+#[test]
+fn fatal_cleanup_from_old_connection_closes_replacement_transport() {
+    let socket_path = unique_socket_path("reconnect-fatal-containment");
+    let root_guard = unique_tmp_path("reconnect-fatal-containment", "");
+    let root = PathBuf::from(root_guard.as_str());
+    fs::create_dir(&root).unwrap();
+    let listener = UnixListener::bind(socket_path.as_str()).unwrap();
+    let (done_rx, handle) = spawn_run_fixture_thread(socket_path.as_str(), root.clone());
+
+    let mut first = accept_run_connection(&listener, &done_rx, 1);
+    first
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    read_and_discard_message(&mut first);
+    send_exec_start(
+        &mut first,
+        501,
+        "sleep 60",
+        60_000,
+        ExecOutputPolicy::Discard,
+        ExecOutputPolicy::Discard,
+    );
+    let leaf = wait_for_fixture_leaf(&root);
+    fs::write(leaf.join("cgroup.events"), b"populated 1\n").unwrap();
+    drop(first);
+
+    let mut replacement = accept_run_connection(&listener, &done_rx, 2);
+    replacement
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    read_and_discard_message(&mut replacement);
+
+    let report = done_rx.recv_timeout(Duration::from_secs(4)).unwrap();
+    assert_eq!(
+        report,
+        Err((io::ErrorKind::Other, "guest runtime is unhealthy".into()))
+    );
+    let mut byte = [0_u8; 1];
+    assert!(matches!(replacement.read(&mut byte), Ok(0) | Err(_)));
+
+    drop(replacement);
+    drop(listener);
+    let error = handle.join().unwrap().unwrap_err();
+    assert_eq!(error.to_string(), "guest runtime is unhealthy");
+    fs::remove_dir_all(&root).unwrap();
+}
+
 fn assert_run_exhausts_after_short_lived_connections(
     label: &str,
     mut handle_connection: impl FnMut(&mut UnixStream),
@@ -146,6 +197,43 @@ fn spawn_run_thread(socket_path: &str) -> (mpsc::Receiver<RunReport>, JoinHandle
         result
     });
     (done_rx, handle)
+}
+
+fn spawn_run_fixture_thread(
+    socket_path: &str,
+    root: PathBuf,
+) -> (mpsc::Receiver<RunReport>, JoinHandle<io::Result<()>>) {
+    let guest_socket_path = socket_path.to_owned();
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let result = run_with_cgroup_fixture(Some(&guest_socket_path), root);
+        let report = result
+            .as_ref()
+            .map(|_| ())
+            .map_err(|error| (error.kind(), error.to_string()));
+        let _ = done_tx.send(report);
+        result
+    });
+    (done_rx, handle)
+}
+
+fn wait_for_fixture_leaf(root: &Path) -> PathBuf {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(path) = fs::read_dir(root)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| path.is_dir())
+        {
+            return path;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "exec cgroup leaf was not created"
+        );
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 fn accept_run_connection(

--- a/crates/vsock-guest/tests/connection/support/connection.rs
+++ b/crates/vsock-guest/tests/connection/support/connection.rs
@@ -2,7 +2,7 @@ use std::os::unix::net::UnixStream;
 use std::thread;
 use std::time::Duration;
 
-use vsock_guest::handle_connection;
+use vsock_guest::{handle_connection, handle_connection_with_cgroup_fixture};
 
 use super::protocol::read_and_discard_message;
 
@@ -11,6 +11,18 @@ pub(crate) type GuestConnectionHandle = thread::JoinHandle<std::io::Result<()>>;
 pub(crate) fn start_guest_connection() -> (GuestConnectionHandle, UnixStream) {
     let (guest_stream, mut host_stream) = UnixStream::pair().unwrap();
     let handle = thread::spawn(move || handle_connection(guest_stream));
+    read_and_discard_message(&mut host_stream);
+    host_stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    (handle, host_stream)
+}
+
+pub(crate) fn start_guest_connection_with_cgroup_fixture(
+    root: std::path::PathBuf,
+) -> (GuestConnectionHandle, UnixStream) {
+    let (guest_stream, mut host_stream) = UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || handle_connection_with_cgroup_fixture(guest_stream, root));
     read_and_discard_message(&mut host_stream);
     host_stream
         .set_read_timeout(Some(Duration::from_secs(5)))

--- a/crates/vsock-guest/tests/connection/support/mod.rs
+++ b/crates/vsock-guest/tests/connection/support/mod.rs
@@ -6,6 +6,7 @@ mod temp_paths;
 
 pub(crate) use connection::{
     finish_guest_connection, join_guest_connection, start_guest_connection,
+    start_guest_connection_with_cgroup_fixture,
 };
 pub(crate) use exec::{
     DRAIN_DEADLINE_SECS, LARGE_ENV_COMMAND, LONG_RUNNING_EXEC_TIMEOUT_MS, assert_large_env_stdout,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,19 @@ profiles:
     workspace_disk_mb: 16384
 ```
 
+**Guest exec lifecycle**:
+
+- `guest-init` mounts cgroup v2 and gives every guest exec operation its own
+  root-managed cgroup before executable code runs.
+- An exec result is terminal for the whole descendant tree. Background or
+  detached processes are stopped before success, timeout, or cancellation is
+  reported; exec is not a durable-service ownership API.
+- If recursive cleanup cannot be verified, the guest closes its transport and
+  rejects sandbox quiesce/reuse so the runner retires the sandbox.
+- Normal execs run as the sandbox user inside a root-owned hierarchy. `--sudo`
+  receives the same best-effort lifecycle cleanup, but root inside the guest is
+  trusted and can modify cgroups or terminate the guest supervisor.
+
 **Host-local runner overrides**:
 
 - Host-specific capacity belongs in `/etc/vm0-runner/host.env`, not


### PR DESCRIPTION
## Summary

- mount cgroup v2 during guest initialization and create a root-owned exec hierarchy
- place every release exec and write helper in a dedicated cgroup before untrusted code runs
- use pidfds plus recursive `cgroup.kill` cleanup before reporting success, timeout, or cancellation
- make unverified cleanup a process-lifetime fatal state across reconnects, quiesce, and sandbox reuse
- cover cgroup placement, fatal reconnect behavior, and real nested/detached descendants in runner metal CI

## Compatibility and trust boundary

- no host/guest protocol, API, database, or persisted-state format changes
- debug builds retain the process-group fallback; release builds fail closed on missing containment
- `--sudo` commands receive the same cleanup attempt, but guest root remains trusted and can modify its own cgroup membership

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p guest-init -p vsock-guest -p vsock-test --all-targets --all-features -- -D warnings`
- `cargo check --release -p guest-init -p vsock-guest --all-features`
- `cargo doc -p guest-init -p vsock-guest -p vsock-test --all-features --no-deps`
- `cargo test -p guest-init`
- `cargo test -p vsock-guest`
- `cargo test -p vsock-test`
- `pnpm exec prettier --check ../docs/architecture.md ../.github/workflows/crates.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/crates.yml`
- extracted runner-exec remote script: `bash -n`

Closes #21178
