### PR TITLE
test(nbd-cow): make connection loss test deterministic

### DIFF
--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -671,6 +671,15 @@ async fn connect_device_survives_connection_loss() {
         false
     };
 
+    let opened_device = if connected {
+        // Opening the block device completes the kernel's deferred partition
+        // scan while every connection is healthy. Otherwise the injected loss
+        // can strand an already in-flight scan request on the removed socket.
+        Some(fs::File::open(format!("/dev/nbd{device_index}")))
+    } else {
+        None
+    };
+
     let connection_shutdown_result = if connected {
         // Closing only the userspace server races with the kernel noticing EOF.
         // Shut down the socket retained after connect so I/O assigned to this
@@ -685,14 +694,14 @@ async fn connect_device_survives_connection_loss() {
         lost_server.abort();
         let _ = lost_server.await;
 
-        let device_path = format!("/dev/nbd{device_index}");
+        let device = opened_device.expect("connected device should have an open attempt");
         Some(
             tokio::time::timeout(
                 Duration::from_secs(5),
                 tokio::task::spawn_blocking(move || {
                     use std::os::unix::fs::FileExt;
 
-                    let device = fs::File::open(device_path)?;
+                    let device = device?;
                     let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
                     device.read_exact_at(&mut block, 0)?;
                     Ok::<_, std::io::Error>(block)

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -18,6 +18,7 @@ use std::process::Command;
 use std::time::Duration;
 
 use nix::sys::socket::{Shutdown, shutdown as shutdown_socket};
+use tokio::io::AsyncReadExt;
 
 #[path = "support/nbd_fixture.rs"]
 mod nbd_fixture;
@@ -675,7 +676,7 @@ async fn connect_device_survives_connection_loss() {
         // Opening the block device completes the kernel's deferred partition
         // scan while every connection is healthy. Otherwise the injected loss
         // can strand an already in-flight scan request on the removed socket.
-        Some(fs::File::open(format!("/dev/nbd{device_index}")))
+        Some(tokio::fs::File::open(format!("/dev/nbd{device_index}")).await)
     } else {
         None
     };
@@ -696,17 +697,12 @@ async fn connect_device_survives_connection_loss() {
 
         let device = opened_device.expect("connected device should have an open attempt");
         Some(
-            tokio::time::timeout(
-                Duration::from_secs(5),
-                tokio::task::spawn_blocking(move || {
-                    use std::os::unix::fs::FileExt;
-
-                    let device = device?;
-                    let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
-                    device.read_exact_at(&mut block, 0)?;
-                    Ok::<_, std::io::Error>(block)
-                }),
-            )
+            tokio::time::timeout(Duration::from_secs(5), async move {
+                let mut device = device?;
+                let mut block = vec![1_u8; nbd_cow::BLOCK_SIZE];
+                device.read_exact(&mut block).await?;
+                Ok::<_, std::io::Error>(block)
+            })
             .await,
         )
     } else {
@@ -732,7 +728,6 @@ async fn connect_device_survives_connection_loss() {
     let block = read_after_connection_loss
         .expect("connected device should be read")
         .expect("read after connection loss should not time out")
-        .expect("read task should complete")
         .expect("read after connection loss should succeed");
     assert_eq!(
         block,

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -12,9 +12,12 @@
 //! ```
 
 use std::fs;
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::MetadataExt;
 use std::process::Command;
 use std::time::Duration;
+
+use nix::sys::socket::{Shutdown, shutdown as shutdown_socket};
 
 #[path = "support/nbd_fixture.rs"]
 mod nbd_fixture;
@@ -668,11 +671,19 @@ async fn connect_device_survives_connection_loss() {
         false
     };
 
+    let connection_shutdown_result = if connected {
+        // Closing only the userspace server races with the kernel noticing EOF.
+        // Shut down the socket retained after connect so I/O assigned to this
+        // NBD queue fails and is requeued immediately.
+        Some(shutdown_socket(client_fds[0].as_raw_fd(), Shutdown::Both))
+    } else {
+        None
+    };
+
     let read_after_connection_loss = if connected {
         let lost_server = server_handles.remove(0);
         lost_server.abort();
         let _ = lost_server.await;
-        tokio::task::yield_now().await;
 
         let device_path = format!("/dev/nbd{device_index}");
         Some(
@@ -706,6 +717,9 @@ async fn connect_device_survives_connection_loss() {
 
     connect_result.expect("socketpair setup or connect_device");
     assert!(device_has_correct_size, "device should have correct size");
+    connection_shutdown_result
+        .expect("connected device should lose a connection")
+        .expect("lost client connection should shut down");
     let block = read_after_connection_loss
         .expect("connected device should be read")
         .expect("read after connection loss should not time out")


### PR DESCRIPTION
Follow-up to #21204 and #21232.

## Summary

- open the block device before injecting connection loss so the kernel completes its deferred partition scan while all connections are healthy
- explicitly shut down the kernel-side socket for the connection being removed
- remove the ineffective Tokio scheduler yield while preserving the 5-second prompt-failover assertion

## Root cause

`NBD_CMD_CONNECT` marks the disk for a deferred partition scan. The first block-device open performs that scan synchronously. The original test injected connection loss before its first `File::open`, so the scan could send a request on the socket being removed. Linux marks the socket dead when its receive worker observes the shutdown, but an already in-flight request remains pending until the configured 30-second NBD request timeout. The test therefore expired at 5 seconds.

Shutting down the retained client socket removed the idle-connection detection race but did not eliminate that in-flight partition-scan window. The final test opens and retains the device first, completing the scan with all three connections healthy. It then shuts down one client socket, stops the corresponding userspace server, and reads through the retained file. A post-loss request assigned to the dead queue is immediately routed through a surviving connection.

## Validation

- `cargo test -p nbd-cow`
- `cargo clippy -p nbd-cow --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p nbd-cow --no-deps --all-features`
- `cargo fmt --all -- --check`
- release integration binaries cross-compiled for `aarch64-unknown-linux-musl` and `x86_64-unknown-linux-musl`
- arm64 Linux 6.17 metal host that reproduced CI: exact connection-loss test 50/50, full root-required NBD suite 11/11
- x86_64 Linux 6.17 metal: exact connection-loss test 20/20, full root-required NBD suite 11/11

No production NBD behavior, connection count, schema, persisted state, API, protocol, queue payload, guest image, or module option changes.