### PR TITLE
chore(api): stop returning legacy chat automation metadata

### DIFF
--- a/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
+++ b/turbo/apps/api/src/signals/services/zero-chat-thread.service.ts
@@ -31,7 +31,6 @@ import {
   type ChatMessageAttachFileMetadata,
   type ChatMessageGenerationTemplate,
   type ChatMessageRecommendedFollowups,
-  type ChatMessageAutomationSnapshot,
   type ChatMessageGoalEvent,
   type ChatMessageGoalSnapshot,
 } from "@vm0/db/schema/chat-message";
@@ -108,11 +107,8 @@ type ChatMessageRow = {
   readonly attachFileMetadata: readonly ChatMessageAttachFileMetadata[] | null;
   readonly generationTemplate: ChatMessageGenerationTemplate | null;
   readonly recommendedFollowups: ChatMessageRecommendedFollowups | null;
-  readonly automationSnapshot: ChatMessageAutomationSnapshot | null;
   readonly revokesMessageId: string | null;
   readonly interruptsRunId: string | null;
-  readonly automationId: string | null;
-  readonly automationTitle: string | null;
   readonly workflowName: string | null;
   readonly workflowDisplayName: string | null;
   readonly workflowDescription: string | null;
@@ -220,11 +216,8 @@ const messageColumns = {
   attachFileMetadata: chatMessages.attachFileMetadata,
   generationTemplate: chatMessages.generationTemplate,
   recommendedFollowups: chatMessages.recommendedFollowups,
-  automationSnapshot: chatMessages.automationSnapshot,
   revokesMessageId: chatMessages.revokesMessageId,
   interruptsRunId: chatMessages.interruptsRunId,
-  automationId: chatMessages.automationId,
-  automationTitle: chatMessages.automationTitle,
   workflowId: sql<string | null>`(
     SELECT "zero_workflows"."id"
     FROM "zero_runs"
@@ -657,9 +650,6 @@ function toPagedMessage(
       return {
         ...message,
         role: "user" as const,
-        automationId: row.automationId ?? undefined,
-        automationTitle: row.automationTitle ?? undefined,
-        automationSnapshot: row.automationSnapshot ?? undefined,
       };
     }
     const recommendedFollowups = normalizeRecommendedFollowups(

--- a/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
+++ b/turbo/packages/api-contracts/src/contracts/__tests__/chat-threads.test.ts
@@ -10,6 +10,7 @@ import {
   chatThreadsContract,
   generationTemplateRequestSchema,
   MODEL_FIRST_SELECTION_PROVIDER_ID,
+  pagedChatMessageSchema,
 } from "../chat-threads";
 
 const legacyModelSelection = {
@@ -21,6 +22,26 @@ const legacyProviderPinnedModelSelection = {
   modelProviderId: "11111111-1111-4111-8111-111111111111",
   selectedModel: "claude-sonnet-4-6",
 };
+
+describe("chat message response contract", () => {
+  it("rejects legacy automation metadata", () => {
+    const parsed = pagedChatMessageSchema.safeParse({
+      id: "message-1",
+      role: "user",
+      content: "Run the workflow",
+      createdAt: "2026-07-13T00:00:00.000Z",
+      automationId: "legacy-automation-id",
+      automationTitle: "Legacy automation",
+      automationSnapshot: {
+        id: "legacy-automation-id",
+        title: "Legacy automation",
+        description: null,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});
 
 describe("chat thread model request compatibility", () => {
   it("normalizes legacy thread create modelSelection bodies to model", () => {

--- a/turbo/packages/api-contracts/src/contracts/chat-threads.ts
+++ b/turbo/packages/api-contracts/src/contracts/chat-threads.ts
@@ -287,17 +287,6 @@ const pagedChatMessageBaseSchema = z.object({
   attachFiles: z.array(resolvedAttachFileSchema).optional(),
   generationTemplate: generationTemplateRequestSchema.optional(),
   sequenceNumber: z.number().nullable().optional(),
-  // Deprecated legacy schedule automation metadata. Migration 0545 clears
-  // existing values; new message writes no longer populate these fields.
-  automationId: z.string().optional(),
-  automationTitle: z.string().optional(),
-  automationSnapshot: z
-    .object({
-      id: z.string(),
-      title: z.string(),
-      description: z.string().nullable(),
-    })
-    .optional(),
   workflowSnapshot: z
     .object({
       id: z.string().uuid().optional(),


### PR DESCRIPTION
## Summary

- stop selecting `chat_messages.automation_id`, `automation_title`, and `automation_snapshot` in Chat thread message reads
- remove the three optional legacy fields from the paged Chat message API contract and response mapping
- keep the physical database columns and `ChatMessageAutomationSnapshot` type unchanged so this release remains compatible with the current production schema
- add contract coverage proving user-message responses reject the removed legacy metadata

## User-visible impact

Chat message responses no longer expose metadata from the deleted standalone Legacy Automation system. Current Workflow and Workflow Automation message metadata is unchanged.

## Deployment compatibility

This is the read-removal half of the two-release Chat column cleanup. It intentionally contains no database migration. This PR must be released to production and verified healthy before the later #21184 slice drops the three physical columns, because production migrations run before new API traffic is promoted.

## Verification

- API contracts tests: 397 passed
- Chat message pagination integration case: 1 passed, 22 skipped
- API contracts lint: passed
- API lint: passed
- API contracts type-check: passed
- API type-check with 4 GB Node heap: passed
- pre-commit: Prettier, Knip, and all 13 repository type-check tasks passed

The complete local `chat-threads.bdd.test.ts` file reached 11/23 passing after local DB setup; 11 failures stopped at the existing runner queue fixture with `Job not found in queue`, and one failed on shared event-cursor count pollution. The directly affected message pagination case passed in isolation. CI remains authoritative for the full integration matrix.

Part of #21184.
