### PR TITLE
docs(vsock-host): document captured exec output

### DIFF
--- a/crates/vsock-host/src/exec_operation/types.rs
+++ b/crates/vsock-host/src/exec_operation/types.rs
@@ -5,6 +5,19 @@ use vsock_proto::{
     ExecControlStatus, ExecOutputPolicy, ExecOutputStream, ExecTermination, ExecTimeoutPolicy,
 };
 
+/// Owned terminal stdout or stderr representation selected by the requested
+/// [`ExecOutputPolicy`](vsock_proto::ExecOutputPolicy).
+///
+/// [`Discard`](vsock_proto::ExecOutputPolicy::Discard) and
+/// [`Stream`](vsock_proto::ExecOutputPolicy::Stream) produce `Discarded`
+/// because they do not retain bytes in the terminal result.
+/// [`Capture`](vsock_proto::ExecOutputPolicy::Capture) and
+/// [`CaptureAndStream`](vsock_proto::ExecOutputPolicy::CaptureAndStream)
+/// produce `Captured`, including when the retained bytes are empty.
+///
+/// The `truncated` field of `Captured` reports guest-side capture-policy
+/// truncation. Host-side loss from the bounded stream queue is reported
+/// separately by [`ExecOperationResult::stream_overflowed`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecOwnedCapturedOutput {
     /// The stream was discarded by policy and therefore has no captured bytes.


### PR DESCRIPTION
## Summary

- document how each exec output policy maps to retained or discarded terminal output
- distinguish captured-but-empty output from output that was not retained
- separate guest-side capture-policy truncation from host stream-queue overflow

## Scope

This is a documentation-only change. It does not change public Rust types, runtime behavior, the host/guest protocol, tests, dependencies, or deployment compatibility.

## Validation

- `cargo fmt --package vsock-host -- --check`
- `cargo clippy -p vsock-host --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-host --no-deps`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vsock-proto -p vsock-host --no-deps`
- `cargo test -p vsock-host` (305 passed)

Closes #21251
