### PR TITLE
fix: clarify teams setup flow

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -146,7 +146,7 @@ describe("works page", () => {
     });
   });
 
-  it("shows Microsoft Teams admin install controls", async () => {
+  it("shows Microsoft Teams admin install controls before installation", async () => {
     const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
     mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
     mockTeamsAPI({ isConnected: false, isInstalled: false, isAdmin: true });
@@ -155,6 +155,11 @@ describe("works page", () => {
 
     const installButton = await screen.findByTestId("teams-install-button");
     expect(installButton).toHaveTextContent("Install in Teams");
+    expect(
+      screen.getByText(
+        "Connect your Microsoft account, then install the Teams app",
+      ),
+    ).toBeInTheDocument();
     click(installButton);
 
     expect(openSpy).toHaveBeenCalledTimes(1);

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -458,6 +458,9 @@ function teamsCardDescription(args: {
   if (!args.isInstalled && !args.isAdmin) {
     return "Ask your admin to install the Microsoft Teams integration";
   }
+  if (!args.isInstalled && args.isAdmin) {
+    return "Connect your Microsoft account, then install the Teams app";
+  }
   if (args.isInstalled && !args.isConnected) {
     return "Connect your Microsoft account to finish setup";
   }


### PR DESCRIPTION
## Summary
- Rename the pre-install Teams CTA on /works from install-specific copy to setup copy
- Clarify that admins connect their Microsoft account before installing the Teams app
- Update the /works page test to assert the setup copy while preserving the OAuth setup URL behavior

## Tests
- pnpm -C turbo -F @vm0/app exec vitest run src/views/zero-page/__tests__/zero-works-page.test.tsx
- pnpm -C turbo -F @vm0/app check-types
- git diff --check
- pre-commit: prettier, knip, check-types