### PR TITLE
feat(api): add connector permission-deny diagnostics

### DIFF
--- a/turbo/apps/api/src/signals/route.ts
+++ b/turbo/apps/api/src/signals/route.ts
@@ -94,6 +94,7 @@ import { zeroComputerUseAuthorizationRoutes } from "./routes/zero-computer-use-a
 import { zeroComputerUseRoutes } from "./routes/zero-computer-use";
 import { zeroCodexDeviceAuthRoutes } from "./routes/zero-codex-device-auth";
 import { zeroConnectorCatalogRoutes } from "./routes/zero-connector-catalog";
+import { zeroConnectorPermissionDenyRoutes } from "./routes/zero-connector-permission-deny";
 import { zeroConnectorsExternalCodeRoutes } from "./routes/zero-connectors-external-code";
 import { zeroConnectorsOauthDeviceAuthRoutes } from "./routes/zero-connectors-oauth-device-auth";
 import { zeroConnectorsRoutes } from "./routes/zero-connectors";
@@ -289,6 +290,7 @@ export const ROUTES: readonly RouteEntry[] = [
   ...zeroComputerUseRoutes,
   ...zeroCodexDeviceAuthRoutes,
   ...zeroConnectorCatalogRoutes,
+  ...zeroConnectorPermissionDenyRoutes,
   ...zeroConnectorsExternalCodeRoutes,
   ...zeroConnectorsOauthDeviceAuthRoutes,
   ...zeroConnectorsRoutes,

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-permission-deny.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-permission-deny.test.ts
@@ -1,0 +1,558 @@
+import { randomUUID } from "node:crypto";
+
+import { zeroConnectorPermissionDenyContract } from "@vm0/api-contracts/contracts/zero-connector-permission-deny";
+import { createStore } from "ccstate";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { accept, setupApp, testContext } from "../../../__tests__/test-helpers";
+import { createApp } from "../../../app-factory";
+import { now } from "../../../lib/time";
+import { signSandboxJwtForTests } from "../../auth/tokens";
+import { createAuthDeviceApiActions } from "./helpers/api-bdd-auth-device";
+import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
+import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
+import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
+import {
+  deleteOrgMembership$,
+  seedOrgMembership$,
+  type OrgMembershipFixture,
+} from "./helpers/zero-org-membership";
+import {
+  createFixtureTracker,
+  createZeroRouteMocks,
+} from "./helpers/zero-route-test";
+
+const context = testContext();
+const mocks = createZeroRouteMocks(context);
+const bdd = createBddApi(context);
+const connectorsApi = createConnectorBddApi(context);
+const authDevice = createAuthDeviceApiActions(context);
+const runsApi = createRunsAutomationsApi(context);
+const store = createStore();
+
+interface DiagnosticBody {
+  readonly method: string;
+  readonly url: string;
+}
+
+interface ConnectedFixture {
+  readonly actor: ApiTestUser;
+  readonly type: "reap";
+}
+
+const trackConnectedFixture = createFixtureTracker<ConnectedFixture>(
+  async (fixture) => {
+    await connectorsApi.deleteConnectorByType(fixture.actor, fixture.type);
+  },
+);
+const trackOrgMembershipFixture = createFixtureTracker<OrgMembershipFixture>(
+  async (fixture) => {
+    await store.set(deleteOrgMembership$, fixture, context.signal);
+  },
+);
+
+function client() {
+  return setupApp({ context })(zeroConnectorPermissionDenyContract);
+}
+
+function currentSecond(): number {
+  return Math.floor(now() / 1000);
+}
+
+function requireOrgId(actor: ApiTestUser): string {
+  if (!actor.orgId) {
+    throw new Error("Expected an organization-scoped actor");
+  }
+  return actor.orgId;
+}
+
+async function diagnoseWithSession(
+  actor: ApiTestUser,
+  connectorRef: string,
+  body: DiagnosticBody,
+) {
+  mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+  return await accept(
+    client().diagnose({
+      params: { connectorRef },
+      headers: { authorization: "Bearer clerk-session" },
+      body,
+    }),
+    [200],
+  );
+}
+
+async function diagnoseWithToken(
+  token: string,
+  connectorRef: string,
+  body: DiagnosticBody,
+) {
+  return await accept(
+    client().diagnose({
+      params: { connectorRef },
+      headers: { authorization: `Bearer ${token}` },
+      body,
+    }),
+    [200],
+  );
+}
+
+async function issueDevicePat(actor: ApiTestUser): Promise<string> {
+  const started = await authDevice.startCliDevice();
+  const approved = await authDevice.requestCliApproval(
+    actor,
+    { device_code: started.device_code },
+    [200],
+  );
+  expect(approved.body).toStrictEqual({ success: true });
+
+  const token = await authDevice.requestCliToken(started.device_code, [200]);
+  if (token.status !== 200) {
+    throw new Error(`Expected CLI token exchange, got ${token.status}`);
+  }
+  return token.body.access_token;
+}
+
+async function seedZeroMembership(actor: ApiTestUser): Promise<void> {
+  await trackOrgMembershipFixture(
+    store.set(
+      seedOrgMembership$,
+      {
+        orgId: requireOrgId(actor),
+        userId: actor.userId,
+        role: "admin",
+      },
+      context.signal,
+    ),
+  );
+}
+
+function zeroToken(
+  actor: ApiTestUser,
+  runId: string,
+  capabilities: readonly string[],
+): string {
+  const seconds = currentSecond();
+  return signSandboxJwtForTests({
+    scope: "zero",
+    userId: actor.userId,
+    orgId: requireOrgId(actor),
+    runId,
+    capabilities,
+    iat: seconds,
+    exp: seconds + 600,
+  });
+}
+
+async function connectReap(
+  actor: ApiTestUser,
+  apiBaseUrl: string,
+): Promise<void> {
+  await connectorsApi.connectManualGrant(actor, "reap", "api-token", {
+    apiKey: "reap-test-api-key",
+    apiBaseUrl,
+  });
+  await trackConnectedFixture(Promise.resolve({ actor, type: "reap" }));
+}
+
+async function createOwnedRun(actor: ApiTestUser): Promise<string> {
+  bdd.acceptAgentStorageWrites();
+  runsApi.acceptStorageDownloads();
+  runsApi.acceptTelemetryIngest();
+  runsApi.configureRunnerGroup();
+  await runsApi.grantProEntitlement(actor);
+  await runsApi.ensureOrgModelProvider(actor);
+  const agent = await bdd.createAgent(actor, {
+    displayName: `Permission diagnostics ${randomUUID()}`,
+    visibility: "private",
+  });
+  const run = await runsApi.createRun(actor, {
+    agentId: agent.agentId,
+    prompt: "Create a permission diagnostic fixture",
+    modelProvider: "anthropic-api-key",
+  });
+  return run.runId;
+}
+
+beforeEach(() => {
+  context.mocks.clerk.authenticateRequest.mockResolvedValue({
+    isAuthenticated: false,
+  });
+  context.mocks.axiom.query.mockResolvedValue([]);
+});
+
+describe("POST /api/zero/connectors/:connectorRef/diagnostics/permission-deny", () => {
+  it("requires organization auth and the connector:read Zero capability", async () => {
+    const unauthenticated = await accept(
+      client().diagnose({
+        params: { connectorRef: "slack" },
+        headers: {},
+        body: {
+          method: "POST",
+          url: "https://slack.com/api/chat.postMessage",
+        },
+      }),
+      [401],
+    );
+    expect(unauthenticated.body.error.code).toBe("UNAUTHORIZED");
+
+    mocks.clerk.session(`user_${randomUUID()}`, null);
+    const withoutOrganization = await accept(
+      client().diagnose({
+        params: { connectorRef: "slack" },
+        headers: { authorization: "Bearer clerk-session" },
+        body: {
+          method: "POST",
+          url: "https://slack.com/api/chat.postMessage",
+        },
+      }),
+      [401],
+    );
+    expect(withoutOrganization.body.error.code).toBe("UNAUTHORIZED");
+
+    const actor = bdd.user();
+    await seedZeroMembership(actor);
+    const runId = `run_${randomUUID()}`;
+    const forbidden = await accept(
+      client().diagnose({
+        params: { connectorRef: "slack" },
+        headers: {
+          authorization: `Bearer ${zeroToken(actor, runId, [])}`,
+        },
+        body: {
+          method: "POST",
+          url: "https://slack.com/api/chat.postMessage",
+        },
+      }),
+      [403],
+    );
+    expect(forbidden.body.error).toStrictEqual({
+      code: "FORBIDDEN",
+      message: "Missing required capability: connector:read",
+    });
+
+    const allowed = await diagnoseWithToken(
+      zeroToken(actor, runId, ["connector:read"]),
+      "slack",
+      {
+        method: "POST",
+        url: "https://slack.com/api/chat.postMessage",
+      },
+    );
+    expect(allowed.body).toStrictEqual({
+      outcome: "matched",
+      label: "Slack",
+      base: "https://slack.com/api",
+      relativePath: "/chat.postMessage",
+      permissions: ["chat:write"],
+    });
+  });
+
+  it("accepts a real CLI personal access token", async () => {
+    const actor = bdd.user();
+    const token = await issueDevicePat(actor);
+
+    const response = await diagnoseWithToken(token, "slack", {
+      method: "POST",
+      url: "https://slack.com/api/chat.postMessage",
+    });
+
+    expect(response.body).toMatchObject({
+      outcome: "matched",
+      permissions: ["chat:write"],
+    });
+  });
+
+  it("rejects malformed bodies at the contract boundary", async () => {
+    const actor = bdd.user();
+    mocks.clerk.session(actor.userId, actor.orgId, actor.orgRole);
+    const response = await createApp({ signal: context.signal }).request(
+      "/api/zero/connectors/slack/diagnostics/permission-deny",
+      {
+        method: "POST",
+        headers: {
+          authorization: "Bearer clerk-session",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          method: "POST",
+          url: "https://slack.com/api/chat.postMessage",
+          unexpected: true,
+        }),
+      },
+    );
+
+    expect(response.status).toBe(400);
+
+    const invalidRef = await createApp({
+      signal: context.signal,
+    }).request("/api/zero/connectors/invalid_ref/diagnostics/permission-deny", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer clerk-session",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        method: "POST",
+        url: "https://slack.com/api/chat.postMessage",
+      }),
+    });
+    expect(invalidRef.status).toBe(400);
+  });
+
+  it("returns closed semantic outcomes for unsafe methods, URLs, and paths", async () => {
+    const actor = bdd.user();
+    const invalidUrls = [
+      "slack.com/api/chat.postMessage",
+      "https://user@example.com/path",
+      "https://api%2eexample.com/path",
+      "https://例子.example/path",
+      String.raw`https://example.com\path`,
+      "https://example.com/has whitespace",
+    ];
+
+    const invalidMethod = await diagnoseWithSession(actor, "slack", {
+      method: "TRACE",
+      url: "https://slack.com/api/chat.postMessage",
+    });
+    expect(invalidMethod.body).toStrictEqual({
+      outcome: "unsafe-input",
+      reason: "invalid-method",
+    });
+
+    for (const url of invalidUrls) {
+      const invalidUrl = await diagnoseWithSession(actor, "slack", {
+        method: "GET",
+        url,
+      });
+      expect(invalidUrl.body).toStrictEqual({
+        outcome: "unsafe-input",
+        reason: "invalid-url",
+      });
+    }
+
+    const unsafePath = await diagnoseWithSession(actor, "slack", {
+      method: "GET",
+      url: "https://slack.com/api/%2e%2e/admin",
+    });
+    expect(unsafePath.body).toStrictEqual({
+      outcome: "unsafe-input",
+      reason: "unsafe-path",
+    });
+  });
+
+  it("distinguishes unknown connectors, bases, and endpoints", async () => {
+    const actor = bdd.user();
+
+    const unknownConnector = await diagnoseWithSession(
+      actor,
+      "missing-connector",
+      { method: "GET", url: "https://example.com/path" },
+    );
+    expect(unknownConnector.body).toStrictEqual({
+      outcome: "unknown-connector",
+    });
+
+    const noMatchingBase = await diagnoseWithSession(actor, "slack", {
+      method: "GET",
+      url: "https://example.com/api/not.real",
+    });
+    expect(noMatchingBase.body).toStrictEqual({
+      outcome: "no-matching-base",
+      label: "Slack",
+    });
+
+    const unknownEndpoint = await diagnoseWithSession(actor, "slack", {
+      method: "GET",
+      url: "https://slack.com/api/not.real",
+    });
+    expect(unknownEndpoint.body).toStrictEqual({
+      outcome: "unknown-endpoint",
+      label: "Slack",
+      base: "https://slack.com/api",
+      relativePath: "/not.real",
+    });
+  });
+
+  it("uses the most specific base and never echoes query or fragment data", async () => {
+    const actor = bdd.user();
+    const response = await diagnoseWithSession(actor, "youtube", {
+      method: "PUT",
+      url: "https://youtube.googleapis.com/upload/youtube/v3/videos?token=query-sentinel#fragment-sentinel",
+    });
+
+    expect(response.body).toStrictEqual({
+      outcome: "matched",
+      label: "YouTube",
+      base: "https://youtube.googleapis.com/upload/youtube",
+      relativePath: "/v3/videos",
+      permissions: ["videos.create"],
+    });
+    expect(JSON.stringify(response.body)).not.toContain("query-sentinel");
+    expect(JSON.stringify(response.body)).not.toContain("fragment-sentinel");
+  });
+
+  it("matches structural dynamic bases without persisted connector state", async () => {
+    const actor = bdd.user();
+
+    const quickBooks = await diagnoseWithSession(actor, "quickbooks", {
+      method: "GET",
+      url: "https://quickbooks.api.intuit.com/v3/company/realm-123/query",
+    });
+    expect(quickBooks.body).toStrictEqual({
+      outcome: "matched",
+      label: "QuickBooks",
+      base: `https://quickbooks.api.intuit.com/v3/company/\${{ vars.QUICKBOOKS_REALM_ID }}`,
+      relativePath: "/query",
+      permissions: ["query"],
+    });
+
+    const internalConnector = await diagnoseWithSession(actor, "test-oauth", {
+      method: "GET",
+      url: "https://tenant.preview.vm6.ai/api/test/oauth-provider/echo",
+    });
+    expect(internalConnector.body).toStrictEqual({
+      outcome: "matched",
+      label: "Test OAuth (internal)",
+      base: `https://\${{ vars.TEST_OAUTH_TENANT_ID }}.{pr}.vm6.ai/api/test/oauth-provider`,
+      relativePath: "/echo",
+      permissions: ["echo"],
+    });
+  });
+
+  it("resolves opaque bases from the selected connector and isolates user and organization state", async () => {
+    const owner = bdd.user();
+    const orgId = requireOrgId(owner);
+    const sameOrgOtherUser = bdd.user({ orgId });
+    const sameUserOtherOrg = bdd.user({ userId: owner.userId });
+    const storedBase = "https://sandbox.api.reap.global/v1";
+
+    const unresolved = await diagnoseWithSession(owner, "reap", {
+      method: "GET",
+      url: `${storedBase}/users`,
+    });
+    expect(unresolved.body).toStrictEqual({
+      outcome: "unresolved-dynamic-base",
+      label: "Reap",
+    });
+
+    await connectReap(owner, storedBase);
+
+    const matched = await diagnoseWithSession(owner, "reap", {
+      method: "GET",
+      url: `${storedBase}/users`,
+    });
+    expect(matched.body).toStrictEqual({
+      outcome: "matched",
+      label: "Reap",
+      base: storedBase,
+      relativePath: "/users",
+      permissions: ["read"],
+    });
+
+    const otherBase = await diagnoseWithSession(owner, "reap", {
+      method: "GET",
+      url: "https://prod.api.reap.global/v1/users",
+    });
+    expect(otherBase.body).toStrictEqual({
+      outcome: "no-matching-base",
+      label: "Reap",
+    });
+
+    for (const actor of [sameOrgOtherUser, sameUserOtherOrg]) {
+      const isolated = await diagnoseWithSession(actor, "reap", {
+        method: "GET",
+        url: `${storedBase}/users`,
+      });
+      expect(isolated.body).toStrictEqual({
+        outcome: "unresolved-dynamic-base",
+        label: "Reap",
+      });
+    }
+  });
+
+  it("merges routes from exact duplicate catalog bases", async () => {
+    const actor = bdd.user();
+    const response = await diagnoseWithSession(actor, "cloudflare", {
+      method: "POST",
+      url: "https://api.cloudflare.com/client/v4/pages/assets/check-missing",
+    });
+
+    expect(response.body).toStrictEqual({
+      outcome: "matched",
+      label: "Cloudflare",
+      base: "https://api.cloudflare.com/client",
+      relativePath: "/v4/pages/assets/check-missing",
+      permissions: ["page.write"],
+    });
+  });
+
+  it("uses only the owned run snapshot for Zero calls and never falls back to stored state", async () => {
+    const actor = bdd.user();
+    const storedBase = "https://sandbox.api.reap.global/v1";
+    const runBase = "https://prod.api.reap.global/v1";
+    await connectReap(actor, storedBase);
+    const runId = await createOwnedRun(actor);
+    await seedZeroMembership(actor);
+    const token = zeroToken(actor, runId, ["connector:read"]);
+
+    context.mocks.axiom.query.mockResolvedValue([
+      {
+        runId,
+        firewalls: [
+          {
+            kind: "builtin",
+            name: "reap",
+            baseUrlVars: { REAP_API_BASE_URL: runBase },
+          },
+        ],
+      },
+    ]);
+
+    const runMatch = await diagnoseWithToken(token, "reap", {
+      method: "GET",
+      url: `${runBase}/users`,
+    });
+    expect(runMatch.body).toStrictEqual({
+      outcome: "matched",
+      label: "Reap",
+      base: runBase,
+      relativePath: "/users",
+      permissions: ["read"],
+    });
+
+    const storedStateIgnored = await diagnoseWithToken(token, "reap", {
+      method: "GET",
+      url: `${storedBase}/users`,
+    });
+    expect(storedStateIgnored.body).toStrictEqual({
+      outcome: "no-matching-base",
+      label: "Reap",
+    });
+
+    const sameOrgOtherUser = bdd.user({ orgId: requireOrgId(actor) });
+    const sameUserOtherOrg = bdd.user({ userId: actor.userId });
+    for (const intruder of [sameOrgOtherUser, sameUserOtherOrg]) {
+      await seedZeroMembership(intruder);
+      const isolated = await diagnoseWithToken(
+        zeroToken(intruder, runId, ["connector:read"]),
+        "reap",
+        { method: "GET", url: `${runBase}/users` },
+      );
+      expect(isolated.body).toStrictEqual({
+        outcome: "unresolved-dynamic-base",
+        label: "Reap",
+      });
+    }
+
+    context.mocks.axiom.query.mockResolvedValue([]);
+    const missingSnapshot = await diagnoseWithToken(token, "reap", {
+      method: "GET",
+      url: `${storedBase}/users`,
+    });
+    expect(missingSnapshot.body).toStrictEqual({
+      outcome: "unresolved-dynamic-base",
+      label: "Reap",
+    });
+  });
+});

--- a/turbo/apps/api/src/signals/routes/__tests__/zero-connector-permission-deny.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-connector-permission-deny.test.ts
@@ -11,7 +11,7 @@ import { signSandboxJwtForTests } from "../../auth/tokens";
 import { createAuthDeviceApiActions } from "./helpers/api-bdd-auth-device";
 import { createBddApi, type ApiTestUser } from "./helpers/api-bdd";
 import { createConnectorBddApi } from "./helpers/api-bdd-connectors";
-import { createRunsAutomationsApi } from "./helpers/api-bdd-runs-automations";
+import { createRunsApi } from "./helpers/api-bdd-runs";
 import {
   deleteOrgMembership$,
   seedOrgMembership$,
@@ -27,7 +27,7 @@ const mocks = createZeroRouteMocks(context);
 const bdd = createBddApi(context);
 const connectorsApi = createConnectorBddApi(context);
 const authDevice = createAuthDeviceApiActions(context);
-const runsApi = createRunsAutomationsApi(context);
+const runsApi = createRunsApi(context);
 const store = createStore();
 
 interface DiagnosticBody {

--- a/turbo/apps/api/src/signals/routes/zero-connector-permission-deny.ts
+++ b/turbo/apps/api/src/signals/routes/zero-connector-permission-deny.ts
@@ -1,0 +1,54 @@
+import { zeroConnectorPermissionDenyContract } from "@vm0/api-contracts/contracts/zero-connector-permission-deny";
+import { command } from "ccstate";
+
+import { organizationAuthContext$ } from "../auth/auth-context";
+import { authRoute } from "../auth/auth-route";
+import { bodyResultOf, pathParamsOf } from "../context/request";
+import type { RouteEntry } from "../route-entry";
+import { resolveConnectorPermissionDeny$ } from "../services/connector-permission-deny.service";
+
+const diagnoseInner$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const auth = get(organizationAuthContext$);
+  const bodyResult = await get(
+    bodyResultOf(zeroConnectorPermissionDenyContract.diagnose),
+  );
+  signal.throwIfAborted();
+  if (!bodyResult.ok) {
+    return bodyResult.response;
+  }
+
+  const params = get(
+    pathParamsOf(zeroConnectorPermissionDenyContract.diagnose),
+  );
+  const result = await set(
+    resolveConnectorPermissionDeny$,
+    {
+      connectorRef: params.connectorRef,
+      method: bodyResult.data.method,
+      url: bodyResult.data.url,
+      orgId: auth.orgId,
+      userId: auth.userId,
+      stateSource:
+        auth.tokenType === "zero"
+          ? { kind: "run", runId: auth.runId }
+          : { kind: "stored" },
+    },
+    signal,
+  );
+  signal.throwIfAborted();
+  return { status: 200 as const, body: result };
+});
+
+export const zeroConnectorPermissionDenyRoutes: readonly RouteEntry[] = [
+  {
+    route: zeroConnectorPermissionDenyContract.diagnose,
+    handler: authRoute(
+      {
+        requireOrganization: true,
+        missingOrganizationStatus: 401,
+        requiredCapability: "connector:read",
+      },
+      diagnoseInner$,
+    ),
+  },
+];

--- a/turbo/apps/api/src/signals/services/connector-permission-deny.service.ts
+++ b/turbo/apps/api/src/signals/services/connector-permission-deny.service.ts
@@ -1,0 +1,657 @@
+import type { ConnectorPermissionDenyDiagnosticResult } from "@vm0/api-contracts/contracts/zero-connector-permission-deny";
+import type { RunContextResponse } from "@vm0/api-contracts/contracts/zero-runs";
+import { getConnectorAuthMethodRuntimeMetadata } from "@vm0/connectors/connector-utils";
+import type { ConnectorType } from "@vm0/connectors/connectors";
+import { matchFirewallRequestDecision } from "@vm0/connectors/firewall-rule-matcher";
+import {
+  loadFirewallRoutingMetadata,
+  type FirewallRoutingRouteMetadata,
+} from "@vm0/connectors/firewall-metadata/routing";
+import {
+  getFirewallExecutionMetadata,
+  type FirewallExecutionMetadata,
+} from "@vm0/connectors/firewall-metadata/server";
+import {
+  FirewallBaseUrlResolutionError,
+  hasUnsafeFirewallPath,
+  resolveFirewallBaseUrlTemplate,
+  type Firewall,
+  type FirewallBaseHostPolicy,
+  type NetworkPolicies,
+} from "@vm0/connectors/firewall-types";
+import { connectors } from "@vm0/db/schema/connector";
+import { variables } from "@vm0/db/schema/variable";
+import { command } from "ccstate";
+import { and, eq, inArray, sql } from "drizzle-orm";
+
+import { type Db, writeDb$ } from "../external/db";
+import { safeSync, safeUrlParse } from "../utils";
+import { zeroRunContext } from "./zero-run-detail.service";
+
+const BASE_URL_VAR_PATTERN = /\$\{\{\s*vars\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+interface DiagnosticExecutionTemplate {
+  readonly credentialed: boolean;
+  readonly hostPolicy?: FirewallBaseHostPolicy;
+}
+
+interface DiagnosticCatalogApi {
+  readonly base: string;
+  readonly routes: readonly FirewallRoutingRouteMetadata[];
+  readonly executionTemplate: DiagnosticExecutionTemplate | null;
+}
+
+interface DiagnosticCatalogView {
+  readonly type: ConnectorType;
+  readonly label: string;
+  readonly baseUrlVarNames: readonly string[];
+  readonly apis: readonly DiagnosticCatalogApi[];
+}
+
+interface DiagnosticBaseCandidate {
+  readonly decisionBase: string;
+  readonly displayBase: string;
+  readonly routes: readonly FirewallRoutingRouteMetadata[];
+}
+
+interface DiagnosticDecisionPermission {
+  readonly name: string;
+  readonly rules: string[];
+}
+
+interface ParsedDiagnosticRequest {
+  readonly method: string;
+  readonly url: string;
+}
+
+function isValidMethod(method: string): boolean {
+  return (
+    method === "GET" ||
+    method === "POST" ||
+    method === "PUT" ||
+    method === "PATCH" ||
+    method === "DELETE" ||
+    method === "HEAD" ||
+    method === "OPTIONS"
+  );
+}
+
+type DynamicStateSource =
+  | { readonly kind: "run"; readonly runId: string }
+  | { readonly kind: "stored" };
+
+interface ResolveConnectorPermissionDenyArgs {
+  readonly connectorRef: string;
+  readonly method: string;
+  readonly url: string;
+  readonly orgId: string;
+  readonly userId: string;
+  readonly stateSource: DynamicStateSource;
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function baseKey(value: string): string {
+  return stripTrailingSlash(value);
+}
+
+function baseUrlVarNames(base: string): readonly string[] {
+  return [
+    ...new Set(
+      [...base.matchAll(BASE_URL_VAR_PATTERN)].map((match) => {
+        return match[1]!;
+      }),
+    ),
+  ];
+}
+
+function sameNames(left: readonly string[], right: readonly string[]): boolean {
+  const leftSorted = [...new Set(left)].sort();
+  const rightSorted = [...new Set(right)].sort();
+  return (
+    leftSorted.length === rightSorted.length &&
+    leftSorted.every((name, index) => {
+      return name === rightSorted[index];
+    })
+  );
+}
+
+function executionTemplatesByBase(
+  metadata: FirewallExecutionMetadata,
+): ReadonlyMap<string, DiagnosticExecutionTemplate> {
+  const templates = new Map<string, DiagnosticExecutionTemplate>();
+  for (const template of metadata.baseUrlTemplates) {
+    const key = baseKey(template.base);
+    if (templates.has(key)) {
+      throw new Error(
+        `Duplicate firewall execution base template for ${metadata.type}`,
+      );
+    }
+    templates.set(key, {
+      credentialed: template.credentialed,
+      ...(template.hostPolicy === undefined
+        ? {}
+        : { hostPolicy: template.hostPolicy }),
+    });
+  }
+  return templates;
+}
+
+async function loadDiagnosticCatalogView(
+  connectorRef: string,
+): Promise<DiagnosticCatalogView | null> {
+  const routing = await loadFirewallRoutingMetadata(connectorRef);
+  if (!routing) {
+    return null;
+  }
+
+  const execution = getFirewallExecutionMetadata(routing.type);
+  if (!execution || execution.type !== routing.type) {
+    throw new Error(`Missing firewall execution metadata for ${routing.type}`);
+  }
+
+  const executionTemplates = executionTemplatesByBase(execution);
+  const groupedApis = new Map<
+    string,
+    {
+      readonly base: string;
+      readonly routes: FirewallRoutingRouteMetadata[];
+      readonly executionTemplate: DiagnosticExecutionTemplate | null;
+    }
+  >();
+  const routingBaseUrlVarNames = new Set<string>();
+
+  for (const api of routing.apis) {
+    const names = baseUrlVarNames(api.base);
+    for (const name of names) {
+      routingBaseUrlVarNames.add(name);
+    }
+    const key = baseKey(api.base);
+    const executionTemplate =
+      names.length === 0 ? null : (executionTemplates.get(key) ?? null);
+    if (names.length > 0 && !executionTemplate) {
+      throw new Error(
+        `Missing firewall execution base template for ${routing.type}`,
+      );
+    }
+
+    const existing = groupedApis.get(key);
+    if (existing) {
+      if (existing.executionTemplate !== executionTemplate) {
+        throw new Error(
+          `Conflicting firewall base metadata for ${routing.type}`,
+        );
+      }
+      existing.routes.push(...api.routes);
+      continue;
+    }
+
+    groupedApis.set(key, {
+      base: api.base,
+      routes: [...api.routes],
+      executionTemplate,
+    });
+  }
+
+  const dynamicApiCount = [...groupedApis.values()].filter((api) => {
+    return api.executionTemplate !== null;
+  }).length;
+  if (
+    !sameNames([...routingBaseUrlVarNames], execution.baseUrlVarNames) ||
+    executionTemplates.size !== dynamicApiCount
+  ) {
+    throw new Error(`Mismatched firewall base metadata for ${routing.type}`);
+  }
+
+  return {
+    type: routing.type,
+    label: routing.label,
+    baseUrlVarNames: [...routingBaseUrlVarNames].sort(),
+    apis: [...groupedApis.values()],
+  };
+}
+
+function rawAuthorityFromUrl(url: string): string | null {
+  const schemeEnd = url.indexOf("://");
+  if (schemeEnd === -1) {
+    return null;
+  }
+
+  const authorityStart = schemeEnd + 3;
+  let authorityEnd = url.length;
+  for (const delimiter of ["/", "?", "#"]) {
+    const index = url.indexOf(delimiter, authorityStart);
+    if (index !== -1) {
+      authorityEnd = Math.min(authorityEnd, index);
+    }
+  }
+  return url.slice(authorityStart, authorityEnd);
+}
+
+function rawAuthorityHasUnsafeSyntax(url: string): boolean {
+  const authority = rawAuthorityFromUrl(url);
+  if (authority === null) {
+    return false;
+  }
+  return (
+    authority === "" ||
+    authority.includes("\\") ||
+    authority.includes("%") ||
+    [...authority].some((character) => {
+      return character.charCodeAt(0) > 0x7f;
+    })
+  );
+}
+
+function stripQueryAndFragment(url: string): string {
+  const queryIndex = url.indexOf("?");
+  const fragmentIndex = url.indexOf("#");
+  let end = url.length;
+  if (queryIndex !== -1) {
+    end = Math.min(end, queryIndex);
+  }
+  if (fragmentIndex !== -1) {
+    end = Math.min(end, fragmentIndex);
+  }
+  return url.slice(0, end);
+}
+
+function rawPathFromUrl(url: string): string {
+  const schemeEnd = url.indexOf("://");
+  const authorityStart = schemeEnd === -1 ? 0 : schemeEnd + 3;
+  const pathStart = url.indexOf("/", authorityStart);
+  return pathStart === -1 ? "/" : url.slice(pathStart);
+}
+
+function parseDiagnosticRequest(
+  method: string,
+  url: string,
+): ParsedDiagnosticRequest | ConnectorPermissionDenyDiagnosticResult {
+  const upperMethod = method.toUpperCase();
+  if (!isValidMethod(upperMethod)) {
+    return { outcome: "unsafe-input", reason: "invalid-method" };
+  }
+
+  if (
+    !url.includes("://") ||
+    /\s/u.test(url) ||
+    rawAuthorityHasUnsafeSyntax(url)
+  ) {
+    return { outcome: "unsafe-input", reason: "invalid-url" };
+  }
+
+  const parsed = safeUrlParse(url);
+  if (
+    !parsed ||
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username !== "" ||
+    parsed.password !== ""
+  ) {
+    return { outcome: "unsafe-input", reason: "invalid-url" };
+  }
+
+  const sanitizedUrl = stripQueryAndFragment(url);
+  if (hasUnsafeFirewallPath(rawPathFromUrl(sanitizedUrl))) {
+    return { outcome: "unsafe-input", reason: "unsafe-path" };
+  }
+
+  return { method: upperMethod, url: sanitizedUrl };
+}
+
+async function loadStoredBaseUrlVars(
+  db: Db,
+  args: {
+    readonly type: ConnectorType;
+    readonly orgId: string;
+    readonly userId: string;
+    readonly requiredNames: readonly string[];
+  },
+): Promise<Record<string, string> | null> {
+  return await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`,
+    );
+
+    const [connector] = await tx
+      .select({ authMethod: connectors.authMethod })
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.orgId, args.orgId),
+          eq(connectors.userId, args.userId),
+          eq(connectors.type, args.type),
+        ),
+      )
+      .limit(1);
+    if (!connector) {
+      return null;
+    }
+
+    const runtimeMetadata = getConnectorAuthMethodRuntimeMetadata(
+      args.type,
+      connector.authMethod,
+    );
+    if (!runtimeMetadata) {
+      throw new Error(`Invalid stored auth method for ${args.type}`);
+    }
+
+    const requiredNameSet = new Set(args.requiredNames);
+    const storageNameByRuntimeName = new Map<string, string>();
+    for (const binding of runtimeMetadata.runtimeBindings) {
+      if (
+        requiredNameSet.has(binding.envName) &&
+        binding.source.kind === "connector-variable"
+      ) {
+        storageNameByRuntimeName.set(binding.envName, binding.source.name);
+      }
+    }
+    if (storageNameByRuntimeName.size !== requiredNameSet.size) {
+      return null;
+    }
+
+    const storageNames = [...new Set(storageNameByRuntimeName.values())];
+    const rows = await tx
+      .select({ name: variables.name, value: variables.value })
+      .from(variables)
+      .where(
+        and(
+          eq(variables.orgId, args.orgId),
+          eq(variables.userId, args.userId),
+          eq(variables.type, "connector"),
+          inArray(variables.name, storageNames),
+        ),
+      );
+    const valueByStorageName = new Map(
+      rows.map((row) => {
+        return [row.name, row.value] as const;
+      }),
+    );
+
+    const values: Record<string, string> = {};
+    for (const [runtimeName, storageName] of storageNameByRuntimeName) {
+      const value = valueByStorageName.get(storageName);
+      if (!value) {
+        return null;
+      }
+      values[runtimeName] = value;
+    }
+    return values;
+  });
+}
+
+function baseUrlVarsFromRunContext(
+  firewalls: RunContextResponse["firewalls"],
+  connectorRef: string,
+  requiredNames: readonly string[],
+): Record<string, string> | null {
+  for (const firewall of firewalls) {
+    if (
+      !("kind" in firewall) ||
+      firewall.kind !== "builtin" ||
+      firewall.name !== connectorRef ||
+      !firewall.baseUrlVars
+    ) {
+      continue;
+    }
+
+    const values: Record<string, string> = {};
+    for (const name of requiredNames) {
+      const value = firewall.baseUrlVars[name];
+      if (!value) {
+        return null;
+      }
+      values[name] = value;
+    }
+    return values;
+  }
+  return null;
+}
+
+function dynamicTemplateToPattern(base: string): string | null {
+  const pattern = base.replace(BASE_URL_VAR_PATTERN, (_match, name: string) => {
+    return `{${name}}`;
+  });
+  return pattern.includes("://") ? pattern : null;
+}
+
+function buildBaseCandidates(
+  view: DiagnosticCatalogView,
+  baseUrlVars: Record<string, string> | null,
+): {
+  readonly candidates: readonly DiagnosticBaseCandidate[];
+  readonly hasUnresolvedDynamicBase: boolean;
+} {
+  const candidates: DiagnosticBaseCandidate[] = [];
+  let hasUnresolvedDynamicBase = false;
+
+  for (const api of view.apis) {
+    const names = baseUrlVarNames(api.base);
+    if (names.length === 0) {
+      candidates.push({
+        decisionBase: api.base,
+        displayBase: stripTrailingSlash(api.base),
+        routes: api.routes,
+      });
+      continue;
+    }
+    const executionTemplate = api.executionTemplate;
+    if (!executionTemplate) {
+      throw new Error(`Missing firewall execution base for ${view.type}`);
+    }
+
+    if (baseUrlVars) {
+      const resolution = safeSync(() => {
+        return resolveFirewallBaseUrlTemplate({
+          serviceName: view.type,
+          base: api.base,
+          vars: baseUrlVars,
+          credentialed: executionTemplate.credentialed,
+          ...(executionTemplate.hostPolicy === undefined
+            ? {}
+            : { hostPolicy: executionTemplate.hostPolicy }),
+        });
+      });
+      if ("error" in resolution) {
+        if (!(resolution.error instanceof FirewallBaseUrlResolutionError)) {
+          throw resolution.error;
+        }
+        hasUnresolvedDynamicBase = true;
+        continue;
+      }
+
+      candidates.push({
+        decisionBase: resolution.ok,
+        displayBase: stripTrailingSlash(resolution.ok),
+        routes: api.routes,
+      });
+      continue;
+    }
+
+    const pattern = dynamicTemplateToPattern(api.base);
+    if (!pattern) {
+      hasUnresolvedDynamicBase = true;
+      continue;
+    }
+    candidates.push({
+      decisionBase: pattern,
+      displayBase: stripTrailingSlash(api.base),
+      routes: api.routes,
+    });
+  }
+
+  const seenDecisionBases = new Set<string>();
+  for (const candidate of candidates) {
+    const key = baseKey(candidate.decisionBase);
+    if (seenDecisionBases.has(key)) {
+      throw new Error(`Conflicting resolved firewall bases for ${view.type}`);
+    }
+    seenDecisionBases.add(key);
+  }
+
+  return { candidates, hasUnresolvedDynamicBase };
+}
+
+function decisionPermissions(
+  routes: readonly FirewallRoutingRouteMetadata[],
+): DiagnosticDecisionPermission[] {
+  const rulesByPermission = new Map<string, string[]>();
+  for (const route of routes) {
+    const rules = rulesByPermission.get(route.permissionName);
+    if (rules) {
+      rules.push(route.rule);
+    } else {
+      rulesByPermission.set(route.permissionName, [route.rule]);
+    }
+  }
+  return [...rulesByPermission].map(([name, rules]) => {
+    return { name, rules };
+  });
+}
+
+function matchDiagnosticRequest(
+  view: DiagnosticCatalogView,
+  request: ParsedDiagnosticRequest,
+  candidates: readonly DiagnosticBaseCandidate[],
+  hasUnresolvedDynamicBase: boolean,
+): ConnectorPermissionDenyDiagnosticResult {
+  if (candidates.length === 0) {
+    return hasUnresolvedDynamicBase
+      ? { outcome: "unresolved-dynamic-base", label: view.label }
+      : { outcome: "no-matching-base", label: view.label };
+  }
+
+  const permissionNames = new Set<string>();
+  const displayBaseByDecisionBase = new Map<string, string>();
+  const apis = candidates.map((candidate) => {
+    const permissions = decisionPermissions(candidate.routes);
+    for (const permission of permissions) {
+      permissionNames.add(permission.name);
+    }
+    displayBaseByDecisionBase.set(
+      baseKey(candidate.decisionBase),
+      candidate.displayBase,
+    );
+    return {
+      base: candidate.decisionBase,
+      auth: {},
+      permissions,
+    };
+  });
+  const firewalls: Firewall[] = [{ name: view.type, apis }];
+  const networkPolicies: NetworkPolicies = {
+    [view.type]: {
+      allow: [],
+      deny: [...permissionNames],
+      ask: [],
+      unknownPolicy: "deny",
+    },
+  };
+  const decision = matchFirewallRequestDecision(
+    firewalls,
+    request.method,
+    request.url,
+    networkPolicies,
+    { status: "present", value: view.type },
+  );
+
+  if (decision.kind === "no_match") {
+    return hasUnresolvedDynamicBase
+      ? { outcome: "unresolved-dynamic-base", label: view.label }
+      : { outcome: "no-matching-base", label: view.label };
+  }
+  if (decision.kind === "ambiguous") {
+    throw new Error(`Ambiguous firewall decision for ${view.type}`);
+  }
+  if (decision.kind === "allow") {
+    throw new Error(`Unexpected allowed firewall decision for ${view.type}`);
+  }
+
+  if (decision.reason === "unsafe_path") {
+    return { outcome: "unsafe-input", reason: "unsafe-path" };
+  }
+  if (
+    decision.reason === "malformed_firewall_config" ||
+    decision.reason === "malformed_network_policy"
+  ) {
+    throw new Error(`Invalid firewall decision data for ${view.type}`);
+  }
+
+  const displayBase = displayBaseByDecisionBase.get(baseKey(decision.base));
+  if (!displayBase) {
+    throw new Error(`Missing firewall decision base for ${view.type}`);
+  }
+  if (decision.reason === "unknown_endpoint") {
+    return {
+      outcome: "unknown-endpoint",
+      label: view.label,
+      base: displayBase,
+      relativePath: decision.relativePath,
+    };
+  }
+
+  const permissions = [...new Set(decision.permissions)].sort();
+  if (permissions.length === 0) {
+    throw new Error(`Missing denied firewall permission for ${view.type}`);
+  }
+  return {
+    outcome: "matched",
+    label: view.label,
+    base: displayBase,
+    relativePath: decision.relativePath,
+    permissions,
+  };
+}
+
+export const resolveConnectorPermissionDeny$ = command(
+  async (
+    { get, set },
+    args: ResolveConnectorPermissionDenyArgs,
+    signal: AbortSignal,
+  ): Promise<ConnectorPermissionDenyDiagnosticResult> => {
+    const request = parseDiagnosticRequest(args.method, args.url);
+    if (!("method" in request)) {
+      return request;
+    }
+
+    const view = await loadDiagnosticCatalogView(args.connectorRef);
+    signal.throwIfAborted();
+    if (!view) {
+      return { outcome: "unknown-connector" };
+    }
+
+    let baseUrlVars: Record<string, string> | null = null;
+    if (view.baseUrlVarNames.length > 0) {
+      if (args.stateSource.kind === "run") {
+        const runContext = await get(
+          zeroRunContext(args.stateSource.runId, args.userId, args.orgId),
+        );
+        signal.throwIfAborted();
+        if (runContext.kind === "ok") {
+          baseUrlVars = baseUrlVarsFromRunContext(
+            runContext.context.firewalls,
+            view.type,
+            view.baseUrlVarNames,
+          );
+        }
+      } else {
+        baseUrlVars = await loadStoredBaseUrlVars(set(writeDb$), {
+          type: view.type,
+          orgId: args.orgId,
+          userId: args.userId,
+          requiredNames: view.baseUrlVarNames,
+        });
+        signal.throwIfAborted();
+      }
+    }
+
+    const candidateResult = buildBaseCandidates(view, baseUrlVars);
+    return matchDiagnosticRequest(
+      view,
+      request,
+      candidateResult.candidates,
+      candidateResult.hasUnresolvedDynamicBase,
+    );
+  },
+);

--- a/turbo/packages/api-contracts/src/contracts/index.ts
+++ b/turbo/packages/api-contracts/src/contracts/index.ts
@@ -1081,6 +1081,12 @@ export {
   type PublicConnectorCatalogStatusResponse,
   type ZeroConnectorCatalogContract,
 } from "./zero-connector-catalog";
+export {
+  connectorPermissionDenyDiagnosticResultSchema,
+  zeroConnectorPermissionDenyContract,
+  type ConnectorPermissionDenyDiagnosticResult,
+  type ZeroConnectorPermissionDenyContract,
+} from "./zero-connector-permission-deny";
 export { CONNECTOR_REF_MAX_LENGTH, connectorRefSchema } from "./connector-ref";
 export {
   CONNECTOR_CATALOG_AUTH_METHOD_ID_MAX_LENGTH,

--- a/turbo/packages/api-contracts/src/contracts/zero-connector-permission-deny.ts
+++ b/turbo/packages/api-contracts/src/contracts/zero-connector-permission-deny.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+import { authHeadersSchema, initContract } from "./base";
+import { connectorCatalogRefSchema } from "./connector-identity";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const connectorPermissionDenyRequestSchema = z
+  .object({
+    method: z.string().min(1).max(16),
+    url: z.string().min(1).max(8192),
+  })
+  .strict();
+
+const connectorPermissionDenyMatchedSchema = z
+  .object({
+    outcome: z.literal("matched"),
+    label: z.string().min(1),
+    base: z.string().min(1),
+    relativePath: z.string().min(1),
+    permissions: z.array(z.string().min(1)).min(1),
+  })
+  .strict();
+
+const connectorPermissionDenyUnknownEndpointSchema = z
+  .object({
+    outcome: z.literal("unknown-endpoint"),
+    label: z.string().min(1),
+    base: z.string().min(1),
+    relativePath: z.string().min(1),
+  })
+  .strict();
+
+const connectorPermissionDenyUnknownConnectorSchema = z
+  .object({ outcome: z.literal("unknown-connector") })
+  .strict();
+
+const connectorPermissionDenyNoMatchingBaseSchema = z
+  .object({
+    outcome: z.literal("no-matching-base"),
+    label: z.string().min(1),
+  })
+  .strict();
+
+const connectorPermissionDenyUnresolvedDynamicBaseSchema = z
+  .object({
+    outcome: z.literal("unresolved-dynamic-base"),
+    label: z.string().min(1),
+  })
+  .strict();
+
+const connectorPermissionDenyUnsafeInputSchema = z
+  .object({
+    outcome: z.literal("unsafe-input"),
+    reason: z.enum(["invalid-method", "invalid-url", "unsafe-path"]),
+  })
+  .strict();
+
+export const connectorPermissionDenyDiagnosticResultSchema =
+  z.discriminatedUnion("outcome", [
+    connectorPermissionDenyMatchedSchema,
+    connectorPermissionDenyUnknownEndpointSchema,
+    connectorPermissionDenyUnknownConnectorSchema,
+    connectorPermissionDenyNoMatchingBaseSchema,
+    connectorPermissionDenyUnresolvedDynamicBaseSchema,
+    connectorPermissionDenyUnsafeInputSchema,
+  ]);
+
+export type ConnectorPermissionDenyDiagnosticResult = z.infer<
+  typeof connectorPermissionDenyDiagnosticResultSchema
+>;
+
+export const zeroConnectorPermissionDenyContract = c.router({
+  diagnose: {
+    method: "POST",
+    path: "/api/zero/connectors/:connectorRef/diagnostics/permission-deny",
+    headers: authHeadersSchema,
+    pathParams: z.object({ connectorRef: connectorCatalogRefSchema }),
+    body: connectorPermissionDenyRequestSchema,
+    responses: {
+      200: connectorPermissionDenyDiagnosticResultSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Diagnose a connector permission denial",
+  },
+});
+
+export type ZeroConnectorPermissionDenyContract =
+  typeof zeroConnectorPermissionDenyContract;


### PR DESCRIPTION
## Summary

- add a strict authenticated API contract for resolving one connector permission-deny diagnostic
- resolve fixed, structural, stored, and run-scoped dynamic bases from server-owned metadata and state
- reuse the official firewall matcher for base specificity, endpoint coverage, and denied permissions
- return closed semantic outcomes without echoing request URLs, query strings, fragments, credentials, or private metadata

## Behavior

- Session and PAT calls read the selected connector and required connector variables in one read-only repeatable-read transaction.
- Zero-token calls use only the owned run-context snapshot; a missing snapshot never falls back to current connector state.
- Exact duplicate bases are merged before matching, while catalog conflicts and impossible same-connector ambiguity fail as server errors.
- Opaque dynamic bases without authoritative state return `unresolved-dynamic-base`; fixed and structural catalog bases remain diagnosable without persisted state.

## Out of scope

- no CLI consumer cutover; that remains in #21218
- no database migration, runner protocol change, frontend proxy, catalog version, or generic catalog snapshot abstraction
- no compatibility fallback to client-bundled connector metadata

## Validation

- `pnpm format`
- `pnpm -F @vm0/api-contracts lint`
- `pnpm -F @vm0/api-contracts check-types`
- `pnpm -F api lint`
- `pnpm -F api check-types`
- `pnpm -F api exec vitest run src/signals/routes/__tests__/zero-connector-permission-deny.test.ts --maxWorkers=1`
- `pnpm knip`
- repository pre-commit hooks, including full Turbo type checking

Closes #21217

Delivery parent: #21140
