### PR TITLE
feat(platform): graduate image artifact keyboard navigation

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-artifact-sidebar.test.tsx
@@ -1517,9 +1517,6 @@ describe("zero artifact sidebar", () => {
         },
       ],
       content: "Image artifacts are ready.",
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
       path: `${THREAD_PATH}?artifact=${encodeURIComponent(firstImageUrl)}`,
     });
 
@@ -1657,9 +1654,6 @@ describe("zero artifact sidebar", () => {
         },
       ],
       content: "Image artifacts are ready.",
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
       path: `${THREAD_PATH}?artifact=${encodeURIComponent(firstImageUrl)}`,
     });
 
@@ -1727,9 +1721,6 @@ describe("zero artifact sidebar", () => {
         },
       ],
       content: "Image artifacts are ready.",
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
       path: `${THREAD_PATH}?artifact=${encodeURIComponent(firstImageUrl)}`,
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-attachment-chips.test.tsx
@@ -1216,9 +1216,6 @@ describe("zero attachment chips", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
     });
 
     click(await screen.findByLabelText("Preview first.png"));
@@ -1318,9 +1315,6 @@ describe("zero attachment chips", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
     });
 
     const bodyImage = await screen.findByAltText("first.png");
@@ -1410,9 +1404,6 @@ describe("zero attachment chips", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
     });
 
     const bodyImage = await screen.findByAltText("first.png");
@@ -1490,9 +1481,6 @@ describe("zero attachment chips", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
     });
 
     const bodyImage = await screen.findByAltText("First render");
@@ -1563,9 +1551,6 @@ describe("zero attachment chips", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
     });
 
     click(await screen.findByLabelText("Preview first.png"));
@@ -1660,9 +1645,6 @@ describe("zero attachment chips", () => {
     detachedSetupPage({
       context,
       path: `/chats/${THREAD_ID}`,
-      featureSwitches: {
-        [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: true,
-      },
     });
 
     click(await screen.findByLabelText("Preview first.png"));
@@ -1689,78 +1671,6 @@ describe("zero attachment chips", () => {
     // Navigating between images must not collapse fullscreen.
     expect(screen.getByLabelText("Exit fullscreen")).toBeInTheDocument();
     expect(screen.queryByLabelText("Enter fullscreen")).toBeNull();
-  });
-
-  it("hides image navigation when the feature switch is disabled", async () => {
-    const firstImageUrl =
-      "https://cdn.vm7.io/artifacts/test/navigation-disabled/first.png";
-    const secondImageUrl =
-      "https://cdn.vm7.io/artifacts/test/navigation-disabled/second.png";
-    context.mocks.api(chatThreadArtifactsContract.list, ({ respond }) => {
-      return respond(200, {
-        runs: [
-          {
-            runId: "run-navigation-disabled",
-            files: [
-              artifactFile(firstImageUrl, {
-                id: "artifact-disabled-first-image",
-                filename: "first.png",
-                contentType: "image/png",
-                size: 128,
-              }),
-              artifactFile(secondImageUrl, {
-                id: "artifact-disabled-second-image",
-                filename: "second.png",
-                contentType: "image/png",
-                size: 256,
-              }),
-            ],
-          },
-        ],
-      });
-    });
-    mockChatLifecycle(context, {
-      threadId: THREAD_ID,
-      chatMessages: [
-        {
-          id: "msg-navigation-disabled",
-          role: "user",
-          content: "Review these images",
-          attachFiles: [
-            {
-              id: "artifact-disabled-first-image",
-              filename: "first.png",
-              contentType: "image/png",
-              size: 128,
-              url: firstImageUrl,
-            },
-            {
-              id: "artifact-disabled-second-image",
-              filename: "second.png",
-              contentType: "image/png",
-              size: 256,
-              url: secondImageUrl,
-            },
-          ],
-          runId: "run-navigation-disabled",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-      ],
-    });
-
-    // No featureSwitches override: the switch defaults to off in tests.
-    detachedSetupPage({ context, path: `/chats/${THREAD_ID}` });
-
-    click(await screen.findByLabelText("Preview first.png"));
-    await waitFor(() => {
-      expect(screen.getByTestId("attachment-lightbox-image")).toHaveAttribute(
-        "alt",
-        "first.png",
-      );
-    });
-
-    expect(screen.queryByLabelText("Next image artifact")).toBeNull();
-    expect(screen.queryByLabelText("Previous image artifact")).toBeNull();
   });
 
   it("opens presentation artifact controls from chat message links", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-artifact-sidebar.tsx
@@ -249,10 +249,6 @@ function ArtifactSidebarWithThreadContext({
   const messageGroups = useLastResolved(thread.messageImageGroups$, {
     equalityFn: equalMessageImageGroups,
   });
-  const features = useLastResolved(featureSwitch$);
-  const imageNavigationEnabled = Boolean(
-    features?.[FeatureSwitchKey.ImageArtifactKeyboardNavigation],
-  );
   const navigateArtifactSidebarImage = useSet(navigateArtifactSidebarImage$);
   const reloadArtifacts = useSet(thread.reloadArtifacts$);
   const item =
@@ -260,9 +256,7 @@ function ArtifactSidebarWithThreadContext({
       ? findArtifactItemForUrl(loadable.data, artifactRef.url)
       : undefined;
   const imageNavigation =
-    imageNavigationEnabled &&
-    artifactRef.source === "url" &&
-    loadable.state === "hasData"
+    artifactRef.source === "url" && loadable.state === "hasData"
       ? currentMessageImageArtifactNavigation(
           loadable.data,
           messageGroups ?? [],

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -960,10 +960,6 @@ function ArtifactPreviewDialogThreadResolver({
   const messageGroups = useLastResolved(thread.messageImageGroups$, {
     equalityFn: equalMessageImageGroups,
   });
-  const features = useGet(featureSwitch$);
-  const imageNavigationEnabled = Boolean(
-    features?.[FeatureSwitchKey.ImageArtifactKeyboardNavigation],
-  );
   const navigateImageLightbox = useSet(navigateImageLightbox$);
   const reloadArtifacts = useSet(thread.reloadArtifacts$);
   const item =
@@ -971,9 +967,7 @@ function ArtifactPreviewDialogThreadResolver({
       ? findArtifactDialogItemForUrl(loadable.data, preview.url)
       : undefined;
   const imageNavigation =
-    imageNavigationEnabled &&
-    preview.kind === "image" &&
-    loadable.state === "hasData"
+    preview.kind === "image" && loadable.state === "hasData"
       ? currentMessageImageArtifactNavigation(
           loadable.data,
           messageGroups ?? [],

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -61,7 +61,6 @@ export enum FeatureSwitchKey {
   AgentUnreadIndicators = "agentUnreadIndicators",
   MobileUnreadChatThreadShortcuts = "mobileUnreadChatThreadShortcuts",
   ChatThreadUnifiedSearch = "chatThreadUnifiedSearch",
-  ImageArtifactKeyboardNavigation = "imageArtifactKeyboardNavigation",
   SidebarManageIconCollapse = "sidebarManageIconCollapse",
   SidebarSubscriptionUsage = "sidebarSubscriptionUsage",
   TeamsIntegration = "teamsIntegration",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -362,13 +362,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ImageArtifactKeyboardNavigation]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Enable left/right keyboard and button navigation between image artifacts within the same chat message, in both the lightbox modal and the artifact sidebar.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.SidebarManageIconCollapse]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- make image artifact keyboard and button navigation unconditional in the lightbox and artifact sidebar
- remove the `ImageArtifactKeyboardNavigation` feature-switch key, configuration, and runtime gates
- remove feature-switch setup from navigation tests and delete the obsolete disabled-state test

## Verification

- `pnpm format`
- `pnpm turbo run lint --log-order grouped`
- `pnpm check-types`
- navigation-focused Vitest filters: 3 sidebar tests and 6 lightbox tests passed

Full-file Vitest runs also surfaced unrelated local 5-second timeouts in existing zoom, document, and presentation tests; the PR pipeline will run the complete suite.
