### PR TITLE
perf(guest-agent): avoid directory probes for artifact files

### DIFF
--- a/crates/guest-agent/src/artifact/archive.rs
+++ b/crates/guest-agent/src/artifact/archive.rs
@@ -52,10 +52,17 @@ fn walk_entries(
             continue;
         }
 
-        if let Ok(dir) = current.open_child_dir(&name) {
+        let (try_directory, try_file) = match entry.file_type() {
+            Ok(file_type) => (file_type.is_dir(), file_type.is_file()),
+            Err(_) => (true, true),
+        };
+        if try_directory && let Ok(dir) = current.open_child_dir(&name) {
             let name_str = artifact_path_component(&name, relative)?;
             let rel = relative_artifact_path(relative, name_str);
             walk_dir(&dir, &rel, out)?;
+            continue;
+        }
+        if !try_file {
             continue;
         }
 


### PR DESCRIPTION
## Summary

- route artifact walk entries with `DirEntry::file_type()` so known regular files skip the guaranteed-failing directory probe
- preserve fd-relative `O_NOFOLLOW` typed opens, opened-fd regular-file validation, and the current directory-then-file fallback when classification fails
- skip known symlinks and other non-regular entries before attempting child opens while preserving manifest behavior

## Performance evidence

An `LD_PRELOAD` interceptor ran the exact `guest-agent` test binary for `artifact::archive::tests::walk_dir_handles_hardlinks`, filtering the fixture's two regular child names:

| Path | Failed `O_DIRECTORY` opens with `ENOTDIR` | Successful file opens |
| --- | ---: | ---: |
| Before | 2 | 2 |
| After | 0 | 2 |

The fixture produced the same passing manifest assertions. A separate directional warm-cache microbenchmark of 30,000 empty regular files measured 43.24 ms for the previous directory-first traversal and 29.94 ms with file-type routing. That isolated result is filesystem-dependent and excludes non-empty content hashing, so it is not an end-to-end production latency claim.

This affects artifact checkpoint/run-completion traversal, not VM boot.

## Compatibility

- no API, queue payload, runner protocol, or VAS contract changes
- no schema, persisted-state, or artifact-format migration
- no feature switch or mixed-deployment coordination required
- the no-follow open primitives and artifact best-effort error semantics are unchanged

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent artifact::archive::tests` (33 passed)
- `cargo test --manifest-path crates/Cargo.toml -p guest-agent`
- `cargo clippy --manifest-path crates/Cargo.toml -p guest-agent --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --manifest-path crates/Cargo.toml -p guest-agent --all-features --no-deps`
- `git diff --check`
- pre-commit workspace Rust format, Clippy, and rustdoc hooks

Existing real-filesystem tests cover regular files, recursion, symlinks, FIFOs, hardlinks, exclusions, and non-UTF-8 paths. The syscall regression is verified with deterministic interception rather than a load-sensitive elapsed-time assertion or an internal mock seam.

Closes #21254
