### PR TITLE
refactor: fully roll out artifact video previews

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/artifacts.bdd.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { cronArtifactPreviewContract } from "@vm0/api-contracts/contracts/cron";
 import { FeatureSwitchKey } from "@vm0/connectors/feature-switch-key";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it, onTestFinished } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { mockEnv, mockOptionalEnv } from "../../../lib/env";
 import { server } from "../../../mocks/server";
@@ -527,18 +527,6 @@ describe("GET /api/cron/artifact-preview", () => {
         context,
         ordinaryVideoUpload,
       );
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        userId: owner.actor.userId,
-        orgId: owner.actor.orgId,
-        orgRole: owner.actor.orgRole,
-      },
-      {
-        [FeatureSwitchKey.ArtifactVideoPreview]: true,
-      },
-    );
-
     const generated = await accept(
       cronClient().generate({ headers: cronHeaders() }),
       [200],
@@ -573,57 +561,6 @@ describe("GET /api/cron/artifact-preview", () => {
     expect(ordinaryArtifact).not.toHaveProperty("previewImageUrl");
   }, 180_000);
 
-  it("does not render video posters when the video preview switch is disabled", async () => {
-    const owner = await artifactActor("Artifacts API video preview off agent");
-    if (!owner.actor.orgId) {
-      throw new Error(
-        "Expected video preview disabled test actor to have an org",
-      );
-    }
-    mockEnv("CRON_SECRET", CRON_SECRET);
-    const frameRequests = mockCloudflareVideoFrame(owner.actor.userId);
-
-    const videoArtifact = await createRunUploadedFile({
-      owner,
-      prompt: "create disabled generated video artifact",
-      filename: "disabled-video.mp4",
-      contentType: "video/mp4",
-    });
-    await markHostedArtifactEligibleForPreviewCron(context, videoArtifact, {
-      generatedBy: "zero-official-video",
-    });
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        userId: owner.actor.userId,
-        orgId: owner.actor.orgId,
-        orgRole: owner.actor.orgRole,
-      },
-      {
-        [FeatureSwitchKey.ArtifactVideoPreview]: false,
-      },
-    );
-
-    const generated = await accept(
-      cronClient().generate({ headers: cronHeaders() }),
-      [200],
-    );
-    expect(generated.body).toStrictEqual({ generated: 0 });
-    expect(frameRequests).toHaveLength(0);
-    expect(
-      owner.objectStore.puts.some((put) => {
-        return put.key.endsWith("/poster.jpg");
-      }),
-    ).toBeFalsy();
-
-    const response = await chat.listArtifacts(owner.actor);
-    const disabledArtifact = response.artifacts.find((item) => {
-      return item.fileId === videoArtifact.fileId;
-    });
-    expect(disabledArtifact).toBeDefined();
-    expect(disabledArtifact).not.toHaveProperty("previewImageUrl");
-  }, 180_000);
-
   it("leaves video preview empty when media frame extraction fails", async () => {
     const owner = await artifactActor("Artifacts API video preview fail agent");
     if (!owner.actor.orgId) {
@@ -643,27 +580,6 @@ describe("GET /api/cron/artifact-preview", () => {
     await markHostedArtifactEligibleForPreviewCron(context, videoArtifact, {
       generatedBy: "zero-official-video",
     });
-    await updateFeatureSwitchesForUser(
-      context,
-      {
-        userId: owner.actor.userId,
-        orgId: owner.actor.orgId,
-        orgRole: owner.actor.orgRole,
-      },
-      {
-        [FeatureSwitchKey.ArtifactVideoPreview]: true,
-      },
-    );
-    onTestFinished(async () => {
-      await updateFeatureSwitchesForUser(
-        context,
-        featureSwitchActor(owner.actor),
-        {
-          [FeatureSwitchKey.ArtifactVideoPreview]: false,
-        },
-      );
-    });
-
     const generated = await accept(
       cronClient().generate({ headers: cronHeaders() }),
       [200],

--- a/turbo/apps/api/src/signals/services/artifact-preview.service.ts
+++ b/turbo/apps/api/src/signals/services/artifact-preview.service.ts
@@ -89,14 +89,6 @@ function isVideoContentType(contentType: string | null): boolean {
   return contentType?.startsWith("video/") ?? false;
 }
 
-// The switch that gates this artifact's preview: video posters and HTML
-// screenshots roll out independently.
-function previewFeatureSwitchKey(contentType: string | null): FeatureSwitchKey {
-  return isVideoContentType(contentType)
-    ? FeatureSwitchKey.ArtifactVideoPreview
-    : FeatureSwitchKey.ArtifactPreviewImage;
-}
-
 // Extract a poster frame from a video via Cloudflare Media Transformations.
 // This is a public transform URL on the artifacts CDN (no auth), the video
 // sibling of the `/cdn-cgi/image/` resizing already used for images.
@@ -115,12 +107,11 @@ async function extractVideoPoster(
   return Buffer.from(await response.arrayBuffer());
 }
 
-async function isArtifactPreviewEnabledForOwner(
+async function isHtmlArtifactPreviewEnabledForOwner(
   db: ReadonlyDb,
   args: {
     readonly orgId: string | null;
     readonly userId: string;
-    readonly switchKey: FeatureSwitchKey;
   },
 ): Promise<boolean> {
   const featureCtx = await loadUserFeatureSwitchContext(
@@ -128,7 +119,7 @@ async function isArtifactPreviewEnabledForOwner(
     args.orgId ?? "",
     args.userId,
   );
-  return isFeatureEnabled(args.switchKey, featureCtx);
+  return isFeatureEnabled(FeatureSwitchKey.ArtifactPreviewImage, featureCtx);
 }
 
 function previewCandidateWhere(cursor?: PreviewCandidateCursor) {
@@ -273,23 +264,25 @@ const renderAndStoreArtifactPreview$ = command(
     args: RenderArtifactPreviewArgs,
     signal: AbortSignal,
   ): Promise<boolean> => {
-    // Resolve the switch against the artifact owner's context including their
-    // per-user Lab overrides, so a user can opt in without a code change. Video
-    // posters gate on a separate switch from HTML screenshots.
-    const featureCtx = await get(
-      userFeatureSwitchContext(args.orgId ?? "", args.userId),
-    );
-    signal.throwIfAborted();
-    if (
-      !isFeatureEnabled(previewFeatureSwitchKey(args.contentType), featureCtx)
-    ) {
-      return false;
+    const isVideo = isVideoContentType(args.contentType);
+    if (!isVideo) {
+      // Resolve the HTML preview switch against the artifact owner's context,
+      // including per-user Lab overrides. Video posters are fully rolled out.
+      const featureCtx = await get(
+        userFeatureSwitchContext(args.orgId ?? "", args.userId),
+      );
+      signal.throwIfAborted();
+      if (
+        !isFeatureEnabled(FeatureSwitchKey.ArtifactPreviewImage, featureCtx)
+      ) {
+        return false;
+      }
     }
 
     let image: Buffer;
     let filename: string;
     let contentType: string;
-    if (isVideoContentType(args.contentType)) {
+    if (isVideo) {
       image = await extractVideoPoster(args.url, signal);
       filename = VIDEO_POSTER_FILENAME;
       contentType = VIDEO_POSTER_CONTENT_TYPE;
@@ -372,7 +365,7 @@ export const generateArtifactPreviews$ = command(
     const db = set(writeDb$);
     let generated = 0;
     let cursor: PreviewCandidateCursor | undefined;
-    const ownerFeatureEnabled = new Map<string, boolean>();
+    const htmlPreviewEnabledByOwner = new Map<string, boolean>();
 
     while (generated < PREVIEW_BATCH_SIZE) {
       const rows = await db
@@ -403,22 +396,21 @@ export const generateArtifactPreviews$ = command(
           continue;
         }
 
-        // Gate on the switch matching this artifact's kind (video/HTML roll out
-        // independently), cached per owner + switch.
-        const switchKey = previewFeatureSwitchKey(row.contentType);
-        const featureKey = `${row.orgId ?? ""}:${row.userId}:${switchKey}`;
-        let enabled = ownerFeatureEnabled.get(featureKey);
-        if (enabled === undefined) {
-          enabled = await isArtifactPreviewEnabledForOwner(db, {
-            orgId: row.orgId,
-            userId: row.userId,
-            switchKey,
-          });
-          ownerFeatureEnabled.set(featureKey, enabled);
-          signal.throwIfAborted();
-        }
-        if (!enabled) {
-          continue;
+        if (!isVideoContentType(row.contentType)) {
+          // HTML preview generation remains gated and is cached per owner.
+          const ownerKey = `${row.orgId ?? ""}:${row.userId}`;
+          let enabled = htmlPreviewEnabledByOwner.get(ownerKey);
+          if (enabled === undefined) {
+            enabled = await isHtmlArtifactPreviewEnabledForOwner(db, {
+              orgId: row.orgId,
+              userId: row.userId,
+            });
+            htmlPreviewEnabledByOwner.set(ownerKey, enabled);
+            signal.throwIfAborted();
+          }
+          if (!enabled) {
+            continue;
+          }
         }
 
         const succeeded = await tapError(

--- a/turbo/packages/connectors/src/feature-switch-key.ts
+++ b/turbo/packages/connectors/src/feature-switch-key.ts
@@ -70,7 +70,6 @@ export enum FeatureSwitchKey {
   Artifacts = "artifacts",
   ArtifactFavorites = "artifactFavorites",
   ArtifactPreviewImage = "artifactPreviewImage",
-  ArtifactVideoPreview = "artifactVideoPreview",
   WorkflowTemplateCatalog = "workflowTemplateCatalog",
   WebsiteTemplates = "websiteTemplates",
   WorkflowQueue = "workflowQueue",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -424,13 +424,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.ArtifactVideoPreview]: {
-    maintainer: "bingjie@vm0.ai",
-    description:
-      "Extract a static poster frame for video artifacts (via Cloudflare Media Transformations) so the artifacts grid shows an image instead of loading each video.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.WorkflowTemplateCatalog]: {
     maintainer: "ming@vm0.ai",
     description:


### PR DESCRIPTION
## Summary

- make generated-video poster extraction unconditional for both deploy-time rendering and cron backfill
- keep HTML artifact preview generation behind the independent `artifactPreviewImage` switch
- remove the retired `artifactVideoPreview` switch key, registry entry, and disabled-switch coverage
- update video preview integration coverage to exercise the always-on behavior

## Verification

- Prettier on changed files
- targeted Oxlint and ESLint for the API changes
- full lint for `@vm0/core` and `@vm0/connectors`
- type checks for `@vm0/core` and `@vm0/connectors`
- API type check attempted but exceeded the local Node.js heap limit; PR CI will run it
- targeted API integration test was not run because the local PostgreSQL installation lacks the `vector` extension; PR CI will cover it