### PR TITLE
test(runner): align sandbox file error fixtures

### DIFF
--- a/crates/runner/src/executor/tests/agent_run_tests.rs
+++ b/crates/runner/src/executor/tests/agent_run_tests.rs
@@ -47,8 +47,8 @@ use super::super::{
 use super::support::{
     CancelAfterWaitSandbox, RUN_IN_SANDBOX_TEST_TIMEOUT, StartProcessGateSandbox, api_artifact,
     api_storage, create_overridden_sandbox, minimal_context, sandbox_exec_error,
-    spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts, test_executor_config,
-    test_telemetry,
+    sandbox_read_file_error, spawn_run_in_sandbox_test, spawn_run_in_sandbox_test_with_timeouts,
+    test_executor_config, test_telemetry,
 };
 use crate::active_input::ActiveInputSource;
 use crate::local_queue::{ActiveInputEntry, LocalQueue};
@@ -2662,7 +2662,7 @@ async fn run_in_sandbox_records_final_identity_metadata_read_failure_reason() {
     let config = test_executor_config(dir.path()).await;
     let sandbox = sandbox_mock::MockSandbox::new("test");
     let ctx = minimal_context();
-    sandbox.push_read_file_result(Err(sandbox_exec_error("vsock read failed")));
+    sandbox.push_read_file_result(Err(sandbox_read_file_error("guest read failed")));
     let mut telemetry = test_telemetry(&config, &ctx);
 
     let result = run_in_sandbox(

--- a/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/guest_files.rs
@@ -8,7 +8,7 @@ use super::super::super::diagnostics::{
     read_guest_cli_agent_session_id, read_guest_error_file, read_guest_failure_diagnostic_file,
 };
 use super::super::super::{SMALL_GUEST_FILE_MAX_BYTES, guest_runtime_path};
-use super::super::support::sandbox_exec_error;
+use super::super::support::sandbox_read_file_error;
 use crate::ids::RunId;
 
 #[tokio::test]
@@ -47,9 +47,9 @@ async fn read_guest_error_file_returns_none_on_empty_content() {
 }
 
 #[tokio::test]
-async fn read_guest_error_file_returns_none_on_exec_error() {
+async fn read_guest_error_file_returns_none_on_read_error() {
     let sandbox = MockSandbox::new("test");
-    sandbox.push_read_file_result(Err(sandbox_exec_error("vsock timeout")));
+    sandbox.push_read_file_result(Err(sandbox_read_file_error("guest read failed")));
     let msg = read_guest_error_file(&sandbox, RunId::nil()).await;
     assert!(msg.is_none());
 }
@@ -193,7 +193,7 @@ async fn read_guest_failure_diagnostic_file_returns_none_on_unsupported_schema()
 #[tokio::test]
 async fn read_guest_failure_diagnostic_file_returns_none_on_read_error() {
     let sandbox = MockSandbox::new("test");
-    sandbox.push_read_file_result(Err(sandbox_exec_error("vsock timeout")));
+    sandbox.push_read_file_result(Err(sandbox_read_file_error("guest read failed")));
 
     let diagnostic = read_guest_failure_diagnostic_file(&sandbox, RunId::nil()).await;
 

--- a/crates/runner/src/executor/tests/diagnostics_tests/guest_logs.rs
+++ b/crates/runner/src/executor/tests/diagnostics_tests/guest_logs.rs
@@ -11,7 +11,7 @@ use super::super::super::{
     GUEST_LOG_COPY_MAX_BYTES, STDOUT_STREAM_LIMIT_MARKER, STDOUT_STREAM_OVERFLOW_MARKER,
     guest_runtime_path,
 };
-use super::super::support::{minimal_context, sandbox_exec_error, test_executor_config};
+use super::super::support::{minimal_context, sandbox_copy_file_error, test_executor_config};
 use crate::paths::LogPaths;
 
 #[test]
@@ -149,41 +149,37 @@ async fn copy_guest_logs_keeps_existing_logs_when_sandbox_ops_missing() {
 }
 
 #[tokio::test]
-async fn copy_guest_logs_skips_on_nonzero_exit() {
+async fn copy_guest_logs_continues_after_copy_failure() {
     let dir = tempfile::tempdir().unwrap();
     let log_paths = LogPaths::new(dir.path().to_path_buf());
     let sandbox = MockSandbox::new("test");
     let ctx = minimal_context();
 
-    // Copy fails (file doesn't exist in guest).
-    sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
-    sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
-    sandbox.push_copy_file_result(Err(sandbox_exec_error("No such file")));
-
-    copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
-
-    // Host files should not be created
-    assert!(!log_paths.system_log(ctx.run_id).exists());
-    assert!(!log_paths.metrics_log(ctx.run_id).exists());
-    assert!(!log_paths.sandbox_ops_log(ctx.run_id).exists());
-}
-
-#[tokio::test]
-async fn copy_guest_logs_skips_on_exec_error() {
-    let dir = tempfile::tempdir().unwrap();
-    let log_paths = LogPaths::new(dir.path().to_path_buf());
-    let sandbox = MockSandbox::new("test");
-    let ctx = minimal_context();
-
-    sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
-    sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
-    sandbox.push_copy_file_result(Err(sandbox_exec_error("vsock down")));
+    sandbox.push_copy_file_result(Err(sandbox_copy_file_error("guest copy failed")));
+    sandbox.push_copy_file_result(Ok(b"{\"cpu\":0.5}\n".to_vec()));
+    sandbox.push_copy_file_result(Ok(b"{\"action_type\":\"cleanup\"}\n".to_vec()));
 
     copy_guest_logs(&sandbox, &ctx, &log_paths, false).await;
 
     assert!(!log_paths.system_log(ctx.run_id).exists());
-    assert!(!log_paths.metrics_log(ctx.run_id).exists());
-    assert!(!log_paths.sandbox_ops_log(ctx.run_id).exists());
+    assert_eq!(
+        tokio::fs::read_to_string(log_paths.metrics_log(ctx.run_id))
+            .await
+            .unwrap(),
+        "{\"cpu\":0.5}\n"
+    );
+    assert_eq!(
+        tokio::fs::read_to_string(log_paths.sandbox_ops_log(ctx.run_id))
+            .await
+            .unwrap(),
+        "{\"action_type\":\"cleanup\"}\n"
+    );
+
+    let calls = sandbox.copy_file_calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].host_path, log_paths.system_log(ctx.run_id));
+    assert_eq!(calls[1].host_path, log_paths.metrics_log(ctx.run_id));
+    assert_eq!(calls[2].host_path, log_paths.sandbox_ops_log(ctx.run_id));
 }
 
 #[tokio::test]

--- a/crates/runner/src/executor/tests/support/mod.rs
+++ b/crates/runner/src/executor/tests/support/mod.rs
@@ -23,7 +23,8 @@ pub(super) use self::execution::{
 pub(super) use self::manifest::{api_artifact, api_storage};
 pub(super) use self::sandbox::{
     CancelAfterWaitSandbox, DestroyPanicFactory, QueuedCopyFileSandbox, StartProcessGateSandbox,
-    create_overridden_sandbox, sandbox_create_error, sandbox_exec_error, sandbox_write_file_error,
+    create_overridden_sandbox, sandbox_copy_file_error, sandbox_create_error, sandbox_exec_error,
+    sandbox_read_file_error, sandbox_write_file_error,
 };
 pub(super) use self::tracing::{CapturedEvent, CapturedEvents};
 pub(super) use self::workspace_cache::seed_workspace_image_cache;

--- a/crates/runner/src/executor/tests/support/sandbox.rs
+++ b/crates/runner/src/executor/tests/support/sandbox.rs
@@ -49,6 +49,26 @@ pub(in crate::executor::tests) fn sandbox_exec_error(message: impl Into<String>)
     }
 }
 
+pub(in crate::executor::tests) fn sandbox_read_file_error(
+    message: impl Into<String>,
+) -> SandboxError {
+    SandboxError::Operation {
+        operation: SandboxOperation::ReadFile,
+        reason: SandboxOperationReason::Guest,
+        message: message.into(),
+    }
+}
+
+pub(in crate::executor::tests) fn sandbox_copy_file_error(
+    message: impl Into<String>,
+) -> SandboxError {
+    SandboxError::Operation {
+        operation: SandboxOperation::CopyFile,
+        reason: SandboxOperationReason::Guest,
+        message: message.into(),
+    }
+}
+
 pub(in crate::executor::tests) fn sandbox_write_file_error(
     message: impl Into<String>,
 ) -> SandboxError {


### PR DESCRIPTION
## Summary

- add operation-specific `ReadFile` and `CopyFile` error fixtures for runner tests
- replace duplicate legacy guest-log failure tests with coverage that proves later copies continue and publish after the first copy fails
- align the remaining read-file error fixtures and test naming with the invoked sandbox API

## Exclusions

- no production runner behavior changes
- no shared `sandbox-mock` enforcement; current evidence is limited to runner test fixtures
- no duplicate coverage of lower-level copy protocol error categories already tested by `vsock-host`

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p runner` (2644 passed, 9 ignored, 0 failed; guest inventory integration test passed)
- `cargo clippy --all-targets --all-features`
- `cargo doc --workspace --all-features --no-deps`
- targeted audit for copy/read queues receiving `sandbox_exec_error` (no matches)

Closes #21257
