### PR TITLE
fix(runner): recover inconsistent proxy ca state

### DIFF
--- a/crates/runner/src/ca.rs
+++ b/crates/runner/src/ca.rs
@@ -1,61 +1,98 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::paths::HomePaths;
+use crate::state_file;
 
 pub(crate) const CA_CERT: &str = "mitmproxy-ca-cert.pem";
 const CA_KEY: &str = "mitmproxy-ca-key.pem";
 const CA_COMBINED: &str = "mitmproxy-ca.pem";
 
+struct CaFiles {
+    cert: PathBuf,
+    key: PathBuf,
+    combined: PathBuf,
+}
+
+impl CaFiles {
+    fn new(ca_dir: &Path) -> Self {
+        Self {
+            cert: ca_dir.join(CA_CERT),
+            key: ca_dir.join(CA_KEY),
+            combined: ca_dir.join(CA_COMBINED),
+        }
+    }
+}
+
+struct CaIdentity {
+    cert: Vec<u8>,
+    key: Vec<u8>,
+}
+
+impl CaIdentity {
+    fn combined(&self) -> Vec<u8> {
+        let mut combined = self.cert.clone();
+        combined.extend_from_slice(&self.key);
+        combined
+    }
+}
+
+/// Holds the CA flock after proxy preparation until mitmdump is ready.
+pub(crate) struct PreparedCa {
+    _lock: nix::fcntl::Flock<std::fs::File>,
+}
+
 /// Ensure CA certificates exist at `/var/lib/vm0-runner/ca/`.
 ///
-/// Generates a self-signed RSA 4096 CA via openssl if the cert or key is
-/// missing. If only the combined PEM is missing (e.g., manual cleanup or
-/// partial disk corruption), rebuilds it from the existing cert + key rather
-/// than rotating the CA — rotation would silently invalidate any running
-/// guests that trust the current cert. Idempotent — safe to call on every
-/// build.
+/// Recovers a valid combined identity first, then a valid standalone identity.
+/// Generates a self-signed RSA 4096 CA via openssl only when neither
+/// representation is recoverable. Idempotent — safe to call on every build.
 ///
 /// Also locks down permissions unconditionally on every call (not just on
 /// first-ever generation) so legacy runners that shipped with looser perms
 /// get migrated automatically.
 pub async fn ensure(home: &HomePaths) -> RunnerResult<()> {
-    // CA generation/repair writes multiple related files. Serialize it before
-    // any filesystem checks so concurrent `runner build` processes cannot
-    // observe or create a mixed cert/key/combined state.
     let _lock = lock::acquire(home.ca_lock()).await?;
-
     let ca_dir = home.ca_dir();
-    let cert = ca_dir.join(CA_CERT);
-    let key = ca_dir.join(CA_KEY);
-    let combined = ca_dir.join(CA_COMBINED);
+    create_ca_dir(&ca_dir).await?;
+    secure_ca_dir(&ca_dir).await?;
+    reconcile(&ca_dir, true).await
+}
 
-    // Create dir with 0o700 on first run. `recursive(true)` is a no-op on an
-    // already-existing dir; we chmod explicitly below to migrate legacy perms.
+/// Validate and recover an existing CA before launching mitmdump.
+///
+/// Unlike [`ensure`], this never generates a replacement identity. The
+/// returned guard keeps the shared CA lock held while mitmdump reads the
+/// reconciled files.
+pub(crate) async fn prepare_for_proxy(
+    ca_dir: &Path,
+    ca_lock_path: &Path,
+) -> RunnerResult<PreparedCa> {
+    let ca_lock = lock::acquire(ca_lock_path.to_path_buf()).await?;
+    secure_ca_dir(ca_dir).await?;
+    reconcile(ca_dir, false).await?;
+    Ok(PreparedCa { _lock: ca_lock })
+}
+
+async fn create_ca_dir(ca_dir: &Path) -> RunnerResult<()> {
     let mut builder = tokio::fs::DirBuilder::new();
     builder.recursive(true);
     #[cfg(unix)]
     builder.mode(0o700);
     builder
-        .create(&ca_dir)
+        .create(ca_dir)
         .await
-        .map_err(|e| RunnerError::Internal(format!("create ca dir: {e}")))?;
+        .map_err(|e| RunnerError::Internal(format!("create ca dir: {e}")))
+}
 
-    // Symlink guard + unconditional chmod to migrate legacy `0o755` dirs.
-    // The symlink check prevents an attacker-placed symlink from redirecting
-    // our chmod at an arbitrary path.
-    //
-    // TOCTOU note: there's a tiny window between `symlink_metadata` and
-    // `set_permissions` where `ca_dir` could in principle be swapped for a
-    // symlink. We accept this because the parent dir (`/var/lib/vm0-runner/`)
-    // is runner-owned in deployed configurations — a local attacker who can
-    // write to the parent has already escalated past the trust boundary this
-    // check is defending.
+async fn secure_ca_dir(ca_dir: &Path) -> RunnerResult<()> {
+    // Refuse to chmod through a directory symlink. The runner-owned parent is
+    // the trust boundary for the small metadata-to-chmod TOCTOU window.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let meta = tokio::fs::symlink_metadata(&ca_dir)
+        let meta = tokio::fs::symlink_metadata(ca_dir)
             .await
             .map_err(|e| RunnerError::Internal(format!("stat ca dir: {e}")))?;
         if !meta.file_type().is_dir() {
@@ -64,45 +101,82 @@ pub async fn ensure(home: &HomePaths) -> RunnerResult<()> {
                 ca_dir.display()
             )));
         }
-        tokio::fs::set_permissions(&ca_dir, std::fs::Permissions::from_mode(0o700))
+        tokio::fs::set_permissions(ca_dir, std::fs::Permissions::from_mode(0o700))
             .await
             .map_err(|e| RunnerError::Internal(format!("chmod ca dir: {e}")))?;
     }
+    Ok(())
+}
 
-    // Fast path: all three files already exist. Still migrate their perms so
-    // runners upgraded from versions that wrote `0o644` key/combined get fixed.
-    if exists(&cert).await? && exists(&key).await? && exists(&combined).await? {
-        tracing::info!("CA certificates already exist, skipping generation");
-        apply_perms(&cert, &key, &combined).await?;
-        return Ok(());
+async fn reconcile(ca_dir: &Path, allow_generation: bool) -> RunnerResult<()> {
+    let files = CaFiles::new(ca_dir);
+
+    let identity = if let Some(identity) = load_identity(&files.combined, &files.combined).await? {
+        tracing::info!("using valid combined proxy CA identity");
+        identity
+    } else if let Some(identity) = load_identity(&files.cert, &files.key).await? {
+        tracing::info!("recovering combined proxy CA from valid standalone identity");
+        identity
+    } else if allow_generation {
+        tracing::info!("generating proxy CA certificate...");
+        generate_identity(ca_dir).await?
+    } else {
+        return Err(RunnerError::Config(format!(
+            "proxy CA in {} is not recoverable; run `runner build` before starting the proxy",
+            ca_dir.display()
+        )));
+    };
+
+    publish_identity(&files, &identity).await?;
+    apply_perms(&files.cert, &files.key, &files.combined).await?;
+    Ok(())
+}
+
+async fn load_identity(cert: &Path, key: &Path) -> RunnerResult<Option<CaIdentity>> {
+    if !exists(cert).await? || !exists(key).await? {
+        return Ok(None);
     }
 
-    // Recovery path: cert + key exist but combined is missing. Rebuild
-    // combined from them instead of falling through to full generation —
-    // `openssl genrsa` below would otherwise overwrite the existing key,
-    // silently rotating the CA identity and breaking guests that already
-    // trust the current cert.
-    if exists(&cert).await? && exists(&key).await? {
-        tracing::info!("combined CA missing; rebuilding from existing cert + key");
-        build_combined(&cert, &key, &combined).await?;
-        apply_perms(&cert, &key, &combined).await?;
-        return Ok(());
+    let cert_path = cert.to_string_lossy();
+    let key_path = key.to_string_lossy();
+    let Some(cert_pem) =
+        try_openssl(&["x509", "-in", cert_path.as_ref(), "-outform", "PEM"]).await?
+    else {
+        return Ok(None);
+    };
+    let Some(key_pem) = try_openssl(&["pkey", "-in", key_path.as_ref(), "-outform", "PEM"]).await?
+    else {
+        return Ok(None);
+    };
+    let Some(cert_public_key) =
+        try_openssl(&["x509", "-in", cert_path.as_ref(), "-pubkey", "-noout"]).await?
+    else {
+        return Ok(None);
+    };
+    let Some(private_public_key) =
+        try_openssl(&["pkey", "-in", key_path.as_ref(), "-pubout"]).await?
+    else {
+        return Ok(None);
+    };
+    if cert_public_key != private_public_key {
+        return Ok(None);
     }
 
-    tracing::info!("generating proxy CA certificate...");
+    Ok(Some(CaIdentity {
+        cert: cert_pem,
+        key: key_pem,
+    }))
+}
 
-    // Generate RSA 4096 private key. Immediately chmod 0o600 — older openssl
-    // releases don't default to 0600.
-    run_openssl(&["genrsa", "-out", &key.to_string_lossy(), "4096"]).await?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(&key, std::fs::Permissions::from_mode(0o600))
-            .await
-            .map_err(|e| RunnerError::Internal(format!("chmod CA key: {e}")))?;
-    }
+async fn generate_identity(ca_dir: &Path) -> RunnerResult<CaIdentity> {
+    let staging = tempfile::Builder::new()
+        .prefix(".ca-generation-")
+        .tempdir_in(ca_dir)
+        .map_err(|e| RunnerError::Internal(format!("create CA staging directory: {e}")))?;
+    let key = staging.path().join(CA_KEY);
+    let cert = staging.path().join(CA_CERT);
 
-    // Generate self-signed certificate (10 years). Cert is non-sensitive.
+    run_openssl(&["genrsa", "-out", key.to_string_lossy().as_ref(), "4096"]).await?;
     run_openssl(&[
         "req",
         "-new",
@@ -110,9 +184,9 @@ pub async fn ensure(home: &HomePaths) -> RunnerResult<()> {
         "-days",
         "3650",
         "-key",
-        &key.to_string_lossy(),
+        key.to_string_lossy().as_ref(),
         "-out",
-        &cert.to_string_lossy(),
+        cert.to_string_lossy().as_ref(),
         "-subj",
         "/CN=mitmproxy/O=mitmproxy",
         "-addext",
@@ -122,14 +196,9 @@ pub async fn ensure(home: &HomePaths) -> RunnerResult<()> {
     ])
     .await?;
 
-    // Create combined PEM (cert + key) for mitmproxy, then apply perms to
-    // all three files.  The explicit chmod covers the truncation case where
-    // a stale `combined` kept its old (possibly loose) perms.
-    build_combined(&cert, &key, &combined).await?;
-    apply_perms(&cert, &key, &combined).await?;
-
-    tracing::info!("CA certificates generated at {}", ca_dir.display());
-    Ok(())
+    load_identity(&cert, &key).await?.ok_or_else(|| {
+        RunnerError::Internal("generated proxy CA certificate and key do not match".into())
+    })
 }
 
 async fn exists(path: &Path) -> RunnerResult<bool> {
@@ -138,35 +207,26 @@ async fn exists(path: &Path) -> RunnerResult<bool> {
         .map_err(|e| RunnerError::Internal(format!("check {}: {e}", path.display())))
 }
 
-/// Read `cert` + `key` and write their concatenation to `combined` with mode
-/// `0o600` on Unix. `create(true).truncate(true)` (not `create_new`) preserves
-/// idempotence if a stale `combined` file is left from a prior run.
-async fn build_combined(cert: &Path, key: &Path, combined: &Path) -> RunnerResult<()> {
-    let cert_content = tokio::fs::read(cert)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read CA cert: {e}")))?;
-    let key_content = tokio::fs::read(key)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read CA key: {e}")))?;
-    let mut combined_content = cert_content;
-    combined_content.extend_from_slice(&key_content);
-
-    use tokio::io::AsyncWriteExt;
-    let mut opts = tokio::fs::OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
-    opts.mode(0o600);
-    let mut f = opts
-        .open(combined)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("open CA combined: {e}")))?;
-    f.write_all(&combined_content)
-        .await
-        .map_err(|e| RunnerError::Internal(format!("write CA combined: {e}")))?;
-    f.flush()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("flush CA combined: {e}")))?;
+async fn publish_identity(files: &CaFiles, identity: &CaIdentity) -> RunnerResult<()> {
+    write_if_changed(&files.cert, &identity.cert).await?;
+    write_if_changed(&files.key, &identity.key).await?;
+    write_if_changed(&files.combined, &identity.combined()).await?;
     Ok(())
+}
+
+async fn write_if_changed(path: &Path, content: &[u8]) -> RunnerResult<()> {
+    match tokio::fs::read(path).await {
+        Ok(existing) if existing == content => return Ok(()),
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(RunnerError::Internal(format!(
+                "read CA file {}: {e}",
+                path.display()
+            )));
+        }
+    }
+    state_file::write_private_atomic(path, content).await
 }
 
 /// Chmod the three CA files: cert 0o644, key 0o600, combined 0o600.
@@ -190,31 +250,94 @@ async fn apply_perms(cert: &Path, key: &Path, combined: &Path) -> RunnerResult<(
 }
 
 async fn run_openssl(args: &[&str]) -> RunnerResult<()> {
+    let output = openssl_output(args).await?;
+    if !output.status.success() {
+        return Err(openssl_error(args, &output));
+    }
+    Ok(())
+}
+
+async fn try_openssl(args: &[&str]) -> RunnerResult<Option<Vec<u8>>> {
+    let output = openssl_output(args).await?;
+    Ok(output.status.success().then_some(output.stdout))
+}
+
+async fn openssl_output(args: &[&str]) -> RunnerResult<std::process::Output> {
     let mut cmd = tokio::process::Command::new("openssl");
     cmd.args(args)
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
-    let output = cmd
-        .output()
+    cmd.output()
         .await
-        .map_err(|e| RunnerError::Internal(format!("spawn openssl: {e}")))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(RunnerError::Internal(format!(
-            "openssl {} failed with {}: {stderr}",
-            args.first().unwrap_or(&""),
-            output.status
-        )));
-    }
-    Ok(())
+        .map_err(|e| RunnerError::Internal(format!("spawn openssl: {e}")))
+}
+
+fn openssl_error(args: &[&str], output: &std::process::Output) -> RunnerError {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    RunnerError::Internal(format!(
+        "openssl {} failed with {}: {stderr}",
+        args.first().unwrap_or(&""),
+        output.status
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::paths::HomePaths;
+
+    struct CaBytes {
+        cert: Vec<u8>,
+        key: Vec<u8>,
+        combined: Vec<u8>,
+    }
+
+    fn read_ca(ca_dir: &Path) -> CaBytes {
+        CaBytes {
+            cert: std::fs::read(ca_dir.join(CA_CERT)).unwrap(),
+            key: std::fs::read(ca_dir.join(CA_KEY)).unwrap(),
+            combined: std::fs::read(ca_dir.join(CA_COMBINED)).unwrap(),
+        }
+    }
+
+    async fn generated_ca() -> CaBytes {
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        ensure(&home).await.unwrap();
+        read_ca(&home.ca_dir())
+    }
+
+    fn write_ca(ca_dir: &Path, cert: &[u8], key: &[u8], combined: Option<&[u8]>) {
+        std::fs::create_dir_all(ca_dir).unwrap();
+        std::fs::write(ca_dir.join(CA_CERT), cert).unwrap();
+        std::fs::write(ca_dir.join(CA_KEY), key).unwrap();
+        if let Some(combined) = combined {
+            std::fs::write(ca_dir.join(CA_COMBINED), combined).unwrap();
+        }
+    }
+
+    fn assert_ca_eq(actual: &CaBytes, expected: &CaBytes) {
+        assert!(actual.cert == expected.cert, "certificate identity changed");
+        assert!(actual.key == expected.key, "private key identity changed");
+        assert!(
+            actual.combined == expected.combined,
+            "combined identity changed"
+        );
+    }
+
+    async fn assert_valid_ca(ca_dir: &Path) {
+        let files = CaFiles::new(ca_dir);
+        let identity = load_identity(&files.cert, &files.key)
+            .await
+            .unwrap()
+            .expect("standalone CA should be valid");
+        assert!(
+            std::fs::read(&files.combined).unwrap() == identity.combined(),
+            "combined should exactly contain the standalone certificate and key"
+        );
+    }
 
     #[cfg(unix)]
     fn mode_of(path: &Path) -> u32 {
@@ -239,6 +362,7 @@ mod tests {
         assert!(
             combined.contains("BEGIN PRIVATE KEY") || combined.contains("BEGIN RSA PRIVATE KEY")
         );
+        assert_valid_ca(&ca_dir).await;
     }
 
     #[tokio::test]
@@ -247,11 +371,11 @@ mod tests {
         let home = HomePaths::with_root(dir.path().to_path_buf());
 
         ensure(&home).await.unwrap();
-        let cert1 = std::fs::read(home.ca_dir().join(CA_CERT)).unwrap();
+        let first = read_ca(&home.ca_dir());
 
         ensure(&home).await.unwrap();
-        let cert2 = std::fs::read(home.ca_dir().join(CA_CERT)).unwrap();
-        assert_eq!(cert1, cert2, "cert should not change on second call");
+        let second = read_ca(&home.ca_dir());
+        assert_ca_eq(&second, &first);
     }
 
     #[cfg(unix)]
@@ -275,7 +399,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn ensure_migrates_legacy_loose_permissions() {
+    async fn ensure_regenerates_invalid_legacy_files_and_migrates_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
@@ -312,12 +436,11 @@ mod tests {
             "cert should remain 0644"
         );
 
-        // Contents untouched (no regeneration).
-        assert_eq!(
-            std::fs::read(ca_dir.join(CA_KEY)).unwrap(),
-            b"fake key",
-            "key contents preserved"
+        assert!(
+            std::fs::read(ca_dir.join(CA_KEY)).unwrap() != b"fake key",
+            "invalid legacy key should be replaced"
         );
+        assert_valid_ca(&ca_dir).await;
     }
 
     #[cfg(unix)]
@@ -369,22 +492,19 @@ mod tests {
         // rotate the CA.
         ensure(&home).await.unwrap();
 
-        assert_eq!(
-            std::fs::read(ca_dir.join(CA_KEY)).unwrap(),
-            original_key,
+        assert!(
+            std::fs::read(ca_dir.join(CA_KEY)).unwrap() == original_key,
             "key must not be rotated when only combined is missing"
         );
-        assert_eq!(
-            std::fs::read(ca_dir.join(CA_CERT)).unwrap(),
-            original_cert,
+        assert!(
+            std::fs::read(ca_dir.join(CA_CERT)).unwrap() == original_cert,
             "cert must not be reissued when only combined is missing"
         );
 
         let mut expected_combined = original_cert.clone();
         expected_combined.extend_from_slice(&original_key);
-        assert_eq!(
-            std::fs::read(ca_dir.join(CA_COMBINED)).unwrap(),
-            expected_combined,
+        assert!(
+            std::fs::read(ca_dir.join(CA_COMBINED)).unwrap() == expected_combined,
             "combined should be cert + key concatenation"
         );
         assert_eq!(
@@ -424,5 +544,134 @@ mod tests {
             combined.contains("BEGIN CERTIFICATE"),
             "combined should contain real cert, not stale placeholder"
         );
+        assert_valid_ca(&ca_dir).await;
+    }
+
+    #[tokio::test]
+    async fn ensure_prefers_valid_combined_over_different_standalone_identity() {
+        let combined_identity = generated_ca().await;
+        let standalone_identity = generated_ca().await;
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        write_ca(
+            &home.ca_dir(),
+            &standalone_identity.cert,
+            &standalone_identity.key,
+            Some(&combined_identity.combined),
+        );
+
+        ensure(&home).await.unwrap();
+
+        assert_ca_eq(&read_ca(&home.ca_dir()), &combined_identity);
+    }
+
+    #[tokio::test]
+    async fn ensure_repairs_mismatched_standalone_from_valid_combined() {
+        let committed = generated_ca().await;
+        let other = generated_ca().await;
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        write_ca(
+            &home.ca_dir(),
+            &other.cert,
+            &committed.key,
+            Some(&committed.combined),
+        );
+
+        ensure(&home).await.unwrap();
+
+        assert_ca_eq(&read_ca(&home.ca_dir()), &committed);
+    }
+
+    #[tokio::test]
+    async fn ensure_recovers_missing_standalone_from_valid_combined() {
+        let committed = generated_ca().await;
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        std::fs::create_dir_all(home.ca_dir()).unwrap();
+        let mut mitmproxy_order = committed.key.clone();
+        mitmproxy_order.extend_from_slice(&committed.cert);
+        std::fs::write(home.ca_dir().join(CA_COMBINED), mitmproxy_order).unwrap();
+
+        ensure(&home).await.unwrap();
+
+        assert_ca_eq(&read_ca(&home.ca_dir()), &committed);
+    }
+
+    #[tokio::test]
+    async fn ensure_recovers_invalid_combined_from_valid_standalone() {
+        let standalone = generated_ca().await;
+        let other = generated_ca().await;
+        let mut mismatched_combined = standalone.cert.clone();
+        mismatched_combined.extend_from_slice(&other.key);
+
+        for invalid_combined in [
+            Vec::new(),
+            standalone.cert.clone(),
+            b"not a PEM file".to_vec(),
+            mismatched_combined,
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let home = HomePaths::with_root(dir.path().to_path_buf());
+            write_ca(
+                &home.ca_dir(),
+                &standalone.cert,
+                &standalone.key,
+                Some(&invalid_combined),
+            );
+
+            ensure(&home).await.unwrap();
+
+            assert_ca_eq(&read_ca(&home.ca_dir()), &standalone);
+        }
+    }
+
+    #[tokio::test]
+    async fn ensure_generates_when_no_identity_is_recoverable() {
+        let first = generated_ca().await;
+        let second = generated_ca().await;
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        write_ca(
+            &home.ca_dir(),
+            &first.cert,
+            &second.key,
+            Some(b"partial combined"),
+        );
+
+        ensure(&home).await.unwrap();
+
+        let generated = read_ca(&home.ca_dir());
+        assert!(
+            generated.cert != first.cert,
+            "unrecoverable certificate should be replaced"
+        );
+        assert!(
+            generated.key != second.key,
+            "unrecoverable key should be replaced"
+        );
+        assert_valid_ca(&home.ca_dir()).await;
+    }
+
+    #[tokio::test]
+    async fn ensure_ignores_dangling_staging_file() {
+        let standalone = generated_ca().await;
+        let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().to_path_buf());
+        write_ca(
+            &home.ca_dir(),
+            &standalone.cert,
+            &standalone.key,
+            Some(b"partial combined"),
+        );
+        std::fs::write(
+            home.ca_dir().join(".mitmproxy-ca.pem.interrupted.tmp"),
+            b"staged but unpublished",
+        )
+        .unwrap();
+
+        ensure(&home).await.unwrap();
+
+        assert_ca_eq(&read_ca(&home.ca_dir()), &standalone);
     }
 }

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -136,6 +136,7 @@ pub async fn run_benchmark(
     let (mut mitm, _crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
         mitmdump_bin: home.mitmdump_bin(MITMPROXY_VERSION),
         ca_dir: runner_config.ca_dir.clone(),
+        ca_lock_path: home.ca_lock(),
         addon_dir: runner_paths.mitm_addon_dir(),
         registry_path: runner_paths.proxy_registry(),
         registry_lock_path: runner_paths.proxy_registry_lock(),

--- a/crates/runner/src/cmd/setup/mod.rs
+++ b/crates/runner/src/cmd/setup/mod.rs
@@ -34,6 +34,16 @@ const SETUP_REQUEST_TIMEOUT: Duration = Duration::from_secs(15 * 60);
 const GROUP_OR_OTHER_WRITE_BITS: u32 = 0o022;
 const ROOT_UID: u32 = 0;
 const STICKY_BIT: u32 = 0o1000;
+const START_SYSTEM_DEPENDENCIES: [&str; 7] = [
+    "ip",
+    "iptables",
+    "iptables-save",
+    "sysctl",
+    "dnsmasq",
+    "mkfs.ext4",
+    "openssl",
+];
+const OTHER_COMMAND_SYSTEM_DEPENDENCIES: [&str; 3] = ["pgrep", "debootstrap", "flock"];
 
 struct ProducedSetupArtifact {
     path: PathBuf,
@@ -97,24 +107,12 @@ fn check_architecture() -> RunnerResult<&'static str> {
 
 /// Returns names of missing required dependencies.
 fn check_system_dependencies() -> Vec<&'static str> {
-    // Required by `runner start` (sandbox networking and workspace images).
-    let required = [
-        "ip",
-        "iptables",
-        "iptables-save",
-        "sysctl",
-        "dnsmasq",
-        "mkfs.ext4",
-    ];
-    // Only needed by specific commands (rootfs, build, etc.)
-    let optional = ["pgrep", "debootstrap", "flock", "openssl"];
-
-    let missing_required: Vec<&str> = required
+    let missing_required: Vec<&str> = START_SYSTEM_DEPENDENCIES
         .iter()
         .filter(|dep| which::which(dep).is_err())
         .copied()
         .collect();
-    let missing_optional: Vec<&str> = optional
+    let missing_optional: Vec<&str> = OTHER_COMMAND_SYSTEM_DEPENDENCIES
         .iter()
         .filter(|dep| which::which(dep).is_err())
         .copied()
@@ -1214,20 +1212,18 @@ mod tests {
     #[test]
     fn check_system_dependencies_only_returns_known_deps() {
         let missing = check_system_dependencies();
-        let known = [
-            "ip",
-            "iptables",
-            "iptables-save",
-            "sysctl",
-            "dnsmasq",
-            "mkfs.ext4",
-        ];
         for dep in &missing {
             assert!(
-                known.contains(dep),
+                START_SYSTEM_DEPENDENCIES.contains(dep),
                 "unexpected dependency reported as missing: {dep}"
             );
         }
+    }
+
+    #[test]
+    fn runner_start_dependencies_include_openssl_for_proxy_ca_validation() {
+        assert!(START_SYSTEM_DEPENDENCIES.contains(&"openssl"));
+        assert!(!OTHER_COMMAND_SYSTEM_DEPENDENCIES.contains(&"openssl"));
     }
 
     #[test]

--- a/crates/runner/src/cmd/start/mitm_restart.rs
+++ b/crates/runner/src/cmd/start/mitm_restart.rs
@@ -127,6 +127,7 @@ mod tests {
         let (mitm, rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
             mitmdump_bin: PathBuf::from("true"),
             ca_dir: dir.path().to_path_buf(),
+            ca_lock_path: dir.path().join("ca.lock"),
             addon_dir: dir.path().join("addon"),
             registry_path: dir.path().join("registry.json"),
             registry_lock_path: dir.path().join("registry.lock"),

--- a/crates/runner/src/cmd/start/mod.rs
+++ b/crates/runner/src/cmd/start/mod.rs
@@ -440,6 +440,7 @@ async fn run_start_with_home(
     let (mut mitm, mitm_crash_rx) = proxy::MitmProxy::new(proxy::ProxyConfig {
         mitmdump_bin: home.mitmdump_bin(deps::MITMPROXY_VERSION),
         ca_dir: runner_config.ca_dir.clone(),
+        ca_lock_path: home.ca_lock(),
         addon_dir: paths.mitm_addon_dir(),
         registry_path: paths.proxy_registry(),
         registry_lock_path: paths.proxy_registry_lock(),

--- a/crates/runner/src/proxy/process.rs
+++ b/crates/runner/src/proxy/process.rs
@@ -40,6 +40,8 @@ pub struct ProxyConfig {
     pub mitmdump_bin: PathBuf,
     /// Directory containing mitmproxy CA files (mitmproxy-ca.pem).
     pub ca_dir: PathBuf,
+    /// Lock file coordinating CA reconciliation with runner builds.
+    pub ca_lock_path: PathBuf,
     /// Directory where addon scripts will be written.
     pub addon_dir: PathBuf,
     /// Path where the proxy registry JSON will be written.
@@ -429,6 +431,7 @@ impl MitmProxy {
                 config: ProxyConfig {
                     mitmdump_bin: std::path::PathBuf::new(),
                     ca_dir: std::path::PathBuf::new(),
+                    ca_lock_path: std::path::PathBuf::new(),
                     addon_dir: std::path::PathBuf::new(),
                     registry_path: std::path::PathBuf::new(),
                     registry_lock_path: std::path::PathBuf::new(),
@@ -506,6 +509,7 @@ pub(crate) async fn spawn_mitmdump(
     stopping: &Arc<AtomicBool>,
     usage_state_id: &str,
 ) -> RunnerResult<tokio::process::Child> {
+    let _prepared_ca = crate::ca::prepare_for_proxy(&config.ca_dir, &config.ca_lock_path).await?;
     let mut cmd = tokio::process::Command::new(&config.mitmdump_bin);
     cmd.arg("--mode")
         .arg("transparent")
@@ -733,6 +737,7 @@ fn send_usage_flush_signal(child: &tokio::process::Child) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::paths::HomePaths;
     use std::os::unix::fs::PermissionsExt;
 
     fn write_fake_listening_mitmdump(path: &Path) {
@@ -940,6 +945,7 @@ PY
         let config = ProxyConfig {
             mitmdump_bin: dir.path().join("mitmdump"),
             ca_dir: dir.path().join("ca"),
+            ca_lock_path: dir.path().join("ca.lock"),
             addon_dir: addon_dir.clone(),
             registry_path: dir.path().join("proxy-registry.json"),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
@@ -971,6 +977,7 @@ PY
         let config = ProxyConfig {
             mitmdump_bin: dir.path().join("mitmdump"),
             ca_dir: dir.path().join("ca"),
+            ca_lock_path: dir.path().join("ca.lock"),
             addon_dir: addon_dir.clone(),
             registry_path: registry_path.clone(),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
@@ -1044,6 +1051,10 @@ PY
     #[tokio::test]
     async fn spawn_mitmdump_passes_usage_state_id_option() {
         let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        crate::ca::ensure(&home).await.unwrap();
+        let original_cert = std::fs::read(home.ca_dir().join(crate::ca::CA_CERT)).unwrap();
+        std::fs::remove_file(home.ca_dir().join("mitmproxy-ca.pem")).unwrap();
         let fake_mitmdump = dir.path().join("fake-mitmdump");
         write_fake_listening_mitmdump(&fake_mitmdump);
         let builtin_firewall_catalog_cache_path =
@@ -1051,7 +1062,8 @@ PY
 
         let config = ProxyConfig {
             mitmdump_bin: fake_mitmdump.clone(),
-            ca_dir: dir.path().join("ca"),
+            ca_dir: home.ca_dir(),
+            ca_lock_path: home.ca_lock(),
             addon_dir: dir.path().join("addon"),
             registry_path: dir.path().join("proxy-registry.json"),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),
@@ -1070,6 +1082,14 @@ PY
         let _ = child.kill().await;
 
         let args = std::fs::read_to_string(fake_mitmdump.with_extension("args")).unwrap();
+        assert!(
+            home.ca_dir().join("mitmproxy-ca.pem").is_file(),
+            "proxy preparation should rebuild missing combined CA"
+        );
+        assert!(
+            std::fs::read(home.ca_dir().join(crate::ca::CA_CERT)).unwrap() == original_cert,
+            "proxy preparation must not rotate the standalone identity"
+        );
         assert!(
             args.lines()
                 .any(|arg| arg == "vm0_usage_state_id=usage-state-test"),
@@ -1101,14 +1121,55 @@ PY
     }
 
     #[tokio::test]
+    async fn spawn_mitmdump_rejects_unrecoverable_ca_before_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca_dir = dir.path().join("ca");
+        std::fs::create_dir(&ca_dir).unwrap();
+        let fake_mitmdump = dir.path().join("fake-mitmdump");
+        write_fake_listening_mitmdump(&fake_mitmdump);
+        let config = ProxyConfig {
+            mitmdump_bin: fake_mitmdump.clone(),
+            ca_dir,
+            ca_lock_path: dir.path().join("ca.lock"),
+            addon_dir: dir.path().join("addon"),
+            registry_path: dir.path().join("proxy-registry.json"),
+            registry_lock_path: dir.path().join("proxy-registry.json.lock"),
+            builtin_firewall_catalog_cache_path: dir
+                .path()
+                .join("builtin-firewall-catalog-cache.json"),
+            api_url: None,
+            client_session_id: "runner-session-test".to_string(),
+        };
+        let (crash_tx, _crash_rx) = mpsc::channel(1);
+        let stopping = Arc::new(AtomicBool::new(false));
+        let port = find_available_port().unwrap();
+
+        let error = spawn_mitmdump(&config, port, &crash_tx, &stopping, "usage-state-test")
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("proxy CA") && error.to_string().contains("not recoverable"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !fake_mitmdump.with_extension("args").exists(),
+            "mitmdump must not be spawned for unrecoverable CA state"
+        );
+    }
+
+    #[tokio::test]
     async fn spawn_mitmdump_kills_child_when_handle_is_dropped() {
         let dir = tempfile::tempdir().unwrap();
+        let home = HomePaths::with_root(dir.path().join("home"));
+        crate::ca::ensure(&home).await.unwrap();
         let fake_mitmdump = dir.path().join("fake-mitmdump");
         write_fake_listening_mitmdump(&fake_mitmdump);
 
         let config = ProxyConfig {
             mitmdump_bin: fake_mitmdump,
-            ca_dir: dir.path().join("ca"),
+            ca_dir: home.ca_dir(),
+            ca_lock_path: home.ca_lock(),
             addon_dir: dir.path().join("addon"),
             registry_path: dir.path().join("proxy-registry.json"),
             registry_lock_path: dir.path().join("proxy-registry.json.lock"),


### PR DESCRIPTION
## Summary

- Treat the standalone certificate, standalone key, and combined mitmproxy PEM as one recoverable CA identity instead of trusting file existence.
- Validate candidate certificates and keys with OpenSSL, require matching public keys, and publish repaired files with same-directory atomic replacement.
- Reconcile and lock CA state before every mitmdump launch, including crash restarts and benchmarks, so proxy startup cannot silently rotate an incomplete CA.
- Classify OpenSSL as a required `runner start` dependency so host setup fails early when proxy CA validation cannot run.

## State resolution

1. A valid combined PEM is authoritative and repairs the standalone files.
2. Otherwise, a valid matching standalone certificate and key repair the combined PEM.
3. Runner build generates a new identity only when neither representation is recoverable.
4. Proxy startup never generates a replacement identity; it fails before spawning mitmdump and directs the operator to run runner build.

## Compatibility

- Existing valid CA identities are preserved, including legacy mitmproxy key-first combined PEM files.
- OpenSSL was already required for runner build; because proxy startup now validates the same CA invariant, `runner setup` also enforces it as a start prerequisite.
- No database schema, persisted data model, API, queue payload, runner configuration format, or guest protocol changes.
- No new persisted metadata is introduced.

## Validation

- `cargo check --manifest-path crates/Cargo.toml -p runner`
- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path crates/Cargo.toml -p runner --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p runner --no-deps`
- `cargo test --manifest-path crates/Cargo.toml -p runner cmd::setup::tests` (36 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner` (2653 passed, 9 ignored; guest inventory passed)
- `cargo clippy --all-targets --all-features` from `crates/`
- Pre-commit workspace format, documentation, Clippy, file-size, and generated-firewall checks

Closes #21255
