### PR TITLE
refactor(mitm-addon): make request classifications valid by construction

### DIFF
--- a/crates/runner/mitm-addon/src/connector_diagnostics.py
+++ b/crates/runner/mitm-addon/src/connector_diagnostics.py
@@ -110,22 +110,19 @@ _AUTH_SCHEMES_REQUIRING_CREDENTIAL = frozenset(
 
 def record_allow_context(
     flow: http.HTTPFlow,
-    classification: request_classification.RequestClassification,
+    classification: request_classification.Allow,
 ) -> None:
     """Pin diagnostic lookup context for an eligible ordinary allow flow.
 
     Request-header callers use this before carrying a streamed ``allow``
     classification into ``request()``; request callers use it before immediate
-    or deferred diagnostic resolution. A non-allow classification, browser
-    flow, existing diagnostic, or incomplete VM/original-URL context is a
-    no-op.
+    or deferred diagnostic resolution. A browser flow, existing diagnostic, or
+    incomplete original-URL context is a no-op.
 
     On success, the flow records diagnostic eligibility, active firewall names,
     and one classification-compatible catalog snapshot. Response and error
     phases resolve candidates only from that pinned snapshot.
     """
-    if classification.kind != "allow":
-        return
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
         return
     if metadata_keys.CONNECTOR_DIAGNOSTIC_TYPE in flow.metadata:
@@ -133,7 +130,7 @@ def record_allow_context(
 
     vm_info = classification.vm_info
     original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-    if vm_info is None or not isinstance(original_url, str):
+    if not isinstance(original_url, str):
         return
 
     flow.metadata[_CONNECTOR_DIAGNOSTIC_ELIGIBLE] = True
@@ -186,7 +183,7 @@ def maybe_make_local_response(
 
 def maybe_make_firewall_allow_local_response(
     flow: http.HTTPFlow,
-    classification: request_classification.RequestClassification,
+    classification: request_classification.FirewallAllow,
     *,
     commit: bool,
 ) -> bool:
@@ -208,14 +205,12 @@ def maybe_make_firewall_allow_local_response(
     and recording the selected candidate and ownership metadata. The caller
     must stop normal request dispatch on ``True``.
     """
-    if classification.kind != "firewall_allow":
-        return False
     if _is_browser_diagnostic_skip(flow):
         return False
 
     allow = classification.firewall_allow
     vm_info = classification.vm_info
-    if allow is None or vm_info is None or not _firewall_allow_is_unknown_endpoint(allow):
+    if not _firewall_allow_is_unknown_endpoint(allow):
         return False
 
     original_url = flow_metadata.original_url(flow.metadata)
@@ -480,7 +475,9 @@ def _diagnostic_snapshot_from_flow(
 
 def _select_diagnostic_snapshot(
     flow: http.HTTPFlow,
-    classification: request_classification.RequestClassification | None = None,
+    classification: request_classification.Allow
+    | request_classification.FirewallAllow
+    | None = None,
 ) -> builtin_connector_diagnostics.DiagnosticCatalogSnapshot:
     pinned = _diagnostic_snapshot_from_flow(flow)
     if pinned is not None:
@@ -493,7 +490,9 @@ def _select_diagnostic_snapshot(
 
 def _pin_diagnostic_snapshot(
     flow: http.HTTPFlow,
-    classification: request_classification.RequestClassification | None = None,
+    classification: request_classification.Allow
+    | request_classification.FirewallAllow
+    | None = None,
 ) -> builtin_connector_diagnostics.DiagnosticCatalogSnapshot:
     snapshot = _select_diagnostic_snapshot(flow, classification)
     flow.metadata[_CONNECTOR_DIAGNOSTIC_CATALOG_SNAPSHOT] = snapshot

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -24,7 +24,7 @@ from collections.abc import Awaitable
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NoReturn
 
 from mitmproxy import connection, ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
@@ -467,7 +467,7 @@ def _prebind_requestheaders_upstream_destination(
     if classification.kind != "firewall_allow":
         return
     allow = classification.firewall_allow
-    if allow is None or not _firewall_allow_injects_ordinary_upstream_credentials(allow):
+    if not _firewall_allow_injects_ordinary_upstream_credentials(allow):
         return
     upstream_admission.ensure_bound_destination(
         flow,
@@ -812,59 +812,13 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         flow,
         defer_unresolved_public_destination=True,
     )
-    allow = classification.firewall_allow
-    vm_info = classification.vm_info
-    auth_base = _firewall_allow_auth_base(allow) if allow is not None else None
     if classification.kind == "public_destination_denied":
-        public_destination_denial = classification.public_destination_denial
-        if public_destination_denial is not None:
-            _start_request_timing(flow)
-            _block_public_destination_denied(
-                flow,
-                public_destination_denial,
-                send_response=False,
-            )
-            flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-            upstream_admission.forget_server_binding(flow.server_conn)
-            flow.kill()
-        return None
-
-    if connector_diagnostics.maybe_make_firewall_allow_local_response(
-        flow,
-        classification,
-        commit=False,
-    ):
-        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
-        upstream_admission.forget_server_binding(flow.server_conn)
-        return None
-
-    _prebind_requestheaders_upstream_destination(flow, classification)
-    if (
-        classification.kind == "firewall_allow"
-        and allow is not None
-        and vm_info is not None
-        and body_check.kind != "ok"
-        and auth_base
-    ):
         _start_request_timing(flow)
-        prepare_firewall_metadata(flow, allow, vm_info)
-        proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
-        firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
-        if body_check.kind == "too_large":
-            mark_auth_base_request_too_large(
-                flow,
-                proxy_log_path=proxy_log_path,
-                firewall_base=firewall_base,
-                observed_size=body_check.observed_size,
-            )
-        else:
-            mark_auth_base_request_length_required(
-                flow,
-                proxy_log_path=proxy_log_path,
-                firewall_base=firewall_base,
-                reason=body_check.reason,
-            )
-        request_classification.pop_cached_classification(flow)
+        _block_public_destination_denied(
+            flow,
+            classification.public_destination_denial,
+            send_response=False,
+        )
         flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
         upstream_admission.forget_server_binding(flow.server_conn)
         flow.kill()
@@ -872,42 +826,83 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
 
     if (
         classification.kind == "firewall_allow"
-        and allow is not None
-        and vm_info is not None
-        and auth_base
-        and body_check.kind == "ok"
+        and connector_diagnostics.maybe_make_firewall_allow_local_response(
+            flow,
+            classification,
+            commit=False,
+        )
     ):
-        try:
-            admission = auth_base_forwarder.reserve_forward_request_admission(
-                body_check.observed_size
-            )
-        except (
-            auth_base_forwarder.AuthBaseForwardingSaturatedError,
-            RuntimeError,
-        ):
+        flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+        upstream_admission.forget_server_binding(flow.server_conn)
+        return None
+
+    _prebind_requestheaders_upstream_destination(flow, classification)
+    if classification.kind == "firewall_allow":
+        allow = classification.firewall_allow
+        vm_info = classification.vm_info
+        auth_base = _firewall_allow_auth_base(allow)
+        if body_check.kind != "ok" and auth_base:
             _start_request_timing(flow)
             prepare_firewall_metadata(flow, allow, vm_info)
             proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
             firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
-            mark_auth_base_forwarding_saturated(
-                flow,
-                proxy_log_path=proxy_log_path,
-                firewall_base=firewall_base,
-            )
+            if body_check.kind == "too_large":
+                mark_auth_base_request_too_large(
+                    flow,
+                    proxy_log_path=proxy_log_path,
+                    firewall_base=firewall_base,
+                    observed_size=body_check.observed_size,
+                )
+            else:
+                mark_auth_base_request_length_required(
+                    flow,
+                    proxy_log_path=proxy_log_path,
+                    firewall_base=firewall_base,
+                    reason=body_check.reason,
+                )
             request_classification.pop_cached_classification(flow)
             flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
             upstream_admission.forget_server_binding(flow.server_conn)
             flow.kill()
             return None
-        try:
-            auth_base_forwarder.attach_forward_request_admission_to_flow(flow, admission)
-        except BaseException:
-            auth_base_forwarder.release_forward_request_admission(admission)
-            raise
-        request_classification.cache_classification(flow, classification)
-        return None
 
-    if request_classification.should_stream_capture_request(classification):
+        if auth_base and body_check.kind == "ok":
+            try:
+                admission = auth_base_forwarder.reserve_forward_request_admission(
+                    body_check.observed_size
+                )
+            except (
+                auth_base_forwarder.AuthBaseForwardingSaturatedError,
+                RuntimeError,
+            ):
+                _start_request_timing(flow)
+                prepare_firewall_metadata(flow, allow, vm_info)
+                proxy_log_path = flow_metadata.proxy_log_path(flow.metadata)
+                firewall_base = flow.metadata[metadata_keys.FIREWALL_BASE]
+                mark_auth_base_forwarding_saturated(
+                    flow,
+                    proxy_log_path=proxy_log_path,
+                    firewall_base=firewall_base,
+                )
+                request_classification.pop_cached_classification(flow)
+                flow.metadata[_REQUEST_HEADERS_TERMINATED] = True
+                upstream_admission.forget_server_binding(flow.server_conn)
+                flow.kill()
+                return None
+            try:
+                auth_base_forwarder.attach_forward_request_admission_to_flow(flow, admission)
+            except BaseException:
+                auth_base_forwarder.release_forward_request_admission(admission)
+                raise
+            request_classification.cache_classification(flow, classification)
+            return None
+
+    if isinstance(
+        classification,
+        request_classification.ApiAllow
+        | request_classification.BrowserAllow
+        | request_classification.Allow,
+    ) and request_classification.should_stream_capture_request(classification):
         if classification.kind == "api_allow" and not upstream_admission.ensure_bound_destination(
             flow,
             kind="api_allow",
@@ -915,13 +910,17 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
         ):
             _restore_request_headers_probe_metadata(flow, metadata_snapshot)
             return None
-        connector_diagnostics.record_allow_context(flow, classification)
+        if classification.kind == "allow":
+            connector_diagnostics.record_allow_context(flow, classification)
         request_classification.cache_classification(flow, classification)
         _start_request_timing(flow)
         request_streaming.configure_request_stream(flow)
         return None
 
-    if request_classification.should_try_firewall_stream_capture_request(classification):
+    if (
+        classification.kind == "firewall_allow"
+        and request_classification.should_try_firewall_stream_capture_request(classification)
+    ):
         return _try_firewall_request_stream_capture_from_headers(
             flow,
             classification=classification,
@@ -935,14 +934,11 @@ def requestheaders(flow: http.HTTPFlow) -> Awaitable[None] | None:
 async def _try_firewall_request_stream_capture_from_headers(
     flow: http.HTTPFlow,
     *,
-    classification: request_classification.RequestClassification,
+    classification: request_classification.FirewallAllow,
     metadata_snapshot: dict[str, object],
 ) -> None:
     allow = classification.firewall_allow
     vm_info = classification.vm_info
-    if allow is None or vm_info is None:
-        _restore_request_headers_probe_metadata(flow, metadata_snapshot)
-        return
     if _firewall_allow_injects_ordinary_upstream_credentials(
         allow
     ) and not upstream_admission.ensure_bound_destination(
@@ -1006,6 +1002,10 @@ def _block_public_destination_denied(
     )
 
 
+def _unhandled_request_classification(classification: NoReturn) -> NoReturn:
+    raise AssertionError(f"Unhandled request classification: {classification!r}")
+
+
 async def request(flow: http.HTTPFlow) -> None:
     """
     Intercept request: inject firewall auth headers for configured firewall rules.
@@ -1042,24 +1042,18 @@ async def request(flow: http.HTTPFlow) -> None:
             ctx.log.warn("No client IP available, passing through")
             return
         if classification.kind == "registry_unavailable":
-            unavailable = classification.registry_unavailable
-            if unavailable is not None:
-                _block_registry_unavailable(flow, unavailable)
+            _block_registry_unavailable(flow, classification.registry_unavailable)
             return
         if classification.kind == "stale_tls_admission":
             _block_stale_tls_admission(flow, reason=classification.stale_tls_reason)
             return
         if classification.kind == "invalid_registry_vm":
-            invalid_vm = classification.invalid_vm
-            if invalid_vm is not None:
-                _block_invalid_registry_vm(flow, invalid_vm)
+            _block_invalid_registry_vm(flow, classification.invalid_vm)
             return
         if classification.kind == "pass_through":
             return
         if classification.kind == "authority_denied":
-            authority_error = classification.authority_error
-            if authority_error is not None:
-                _block_authority_validation_error(flow, authority_error)
+            _block_authority_validation_error(flow, classification.authority_error)
             return
         if classification.kind == "api_allow":
             if not upstream_admission.ensure_bound_destination(
@@ -1079,25 +1073,17 @@ async def request(flow: http.HTTPFlow) -> None:
             flow.metadata[metadata_keys.FIREWALL_BILLABLE] = False
             return
         if classification.kind == "firewall_ambiguous":
-            firewall_ambiguous = classification.firewall_ambiguous
-            if firewall_ambiguous is not None:
-                _set_firewall_ambiguous_response(flow, firewall_ambiguous)
+            _set_firewall_ambiguous_response(flow, classification.firewall_ambiguous)
             return
         if classification.kind == "firewall_block":
-            firewall_block = classification.firewall_block
-            if firewall_block is not None:
-                _set_firewall_block_response(flow, firewall_block)
+            _set_firewall_block_response(flow, classification.firewall_block)
             return
         if classification.kind == "public_destination_denied":
-            public_destination_denial = classification.public_destination_denial
-            if public_destination_denial is not None:
-                _block_public_destination_denied(flow, public_destination_denial)
+            _block_public_destination_denied(flow, classification.public_destination_denial)
             return
         if classification.kind == "firewall_allow":
             allow = classification.firewall_allow
             vm_info = classification.vm_info
-            if allow is None or vm_info is None:
-                return
             public_destination_denial = request_classification.current_public_destination_denial(
                 flow,
                 allow,
@@ -1151,18 +1137,21 @@ async def request(flow: http.HTTPFlow) -> None:
                 terminal_usage.release_tracked_flow(flow)
             return
 
-        vm_info = classification.vm_info
-        if vm_info is None:
+        if classification.kind == "allow":
+            connector_diagnostics.record_allow_context(flow, classification)
+            if request_streaming.streamed_request_size(flow) is None:
+                original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
+                if isinstance(
+                    original_url, str
+                ) and connector_diagnostics.maybe_make_local_response(
+                    flow,
+                    original_url=original_url,
+                ):
+                    return
+            flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
             return
-        connector_diagnostics.record_allow_context(flow, classification)
-        if request_streaming.streamed_request_size(flow) is None:
-            original_url = flow.metadata.get(metadata_keys.ORIGINAL_URL)
-            if isinstance(original_url, str) and connector_diagnostics.maybe_make_local_response(
-                flow,
-                original_url=original_url,
-            ):
-                return
-        flow_metadata.set_firewall_decision(flow.metadata, "ALLOW")
+
+        _unhandled_request_classification(classification)
     except (asyncio.CancelledError, Exception):
         flow.metadata.pop(metadata_keys.HTTP_REQUEST_START_MONOTONIC, None)
         auth_base_forwarder.release_forward_request_admission_from_flow(flow)

--- a/crates/runner/mitm-addon/src/request_classification.py
+++ b/crates/runner/mitm-addon/src/request_classification.py
@@ -14,8 +14,8 @@ stale decisions cannot leak into later hook handling for the same flow.
 """
 
 import urllib.parse
-from dataclasses import dataclass
-from typing import Literal, Protocol
+from dataclasses import dataclass, field
+from typing import Literal, Protocol, TypeAlias
 
 from mitmproxy import http
 
@@ -62,20 +62,11 @@ _BROWSER_USER_AGENT_MARKERS = (
     " safari/",
 )
 
-RequestClassificationKind = Literal[
-    "no_client_ip",
-    "pass_through",
-    "registry_unavailable",
-    "stale_tls_admission",
-    "invalid_registry_vm",
-    "authority_denied",
-    "api_allow",
-    "browser_allow",
-    "firewall_ambiguous",
-    "firewall_block",
-    "firewall_allow",
-    "public_destination_denied",
-    "allow",
+StaleTlsAdmissionReason: TypeAlias = Literal[
+    "client_ip_missing",
+    "client_ip_mismatch",
+    "registry_entry_missing",
+    "run_id_mismatch",
 ]
 
 
@@ -103,42 +94,106 @@ class PublicDestinationDenial:
 
 
 @dataclass(frozen=True)
-class RequestClassification:
-    """Classification result and the payload field valid for each kind.
+class NoClientIp:
+    kind: Literal["no_client_ip"] = field(init=False, default="no_client_ip")
 
-    Payload fields are tied to `kind`; optional fields are not independent
-    facts. The expected payloads are:
 
-    - `registry_unavailable`: `registry_unavailable`.
-    - `invalid_registry_vm`: `invalid_vm`.
-    - `authority_denied`: `vm_info` and `authority_error`.
-    - `firewall_block`: `vm_info` and `firewall_block`.
-    - `firewall_ambiguous`: `vm_info` and `firewall_ambiguous`.
-    - `firewall_allow`: `vm_info` and `firewall_allow`.
-    - `public_destination_denied`: `vm_info` and
-      `public_destination_denial`.
-    - `api_allow`, `browser_allow`, and `allow`: `vm_info`.
-    - `firewall_allow` and `allow` may also carry
-      `builtin_firewall_catalog_snapshot` when registry compilation depended on
-      a catalog snapshot.
-    - `stale_tls_admission`: `stale_tls_reason`; `vm_info` is present only
-      when the stale admission is detected after a VM entry is found.
-    - `no_client_ip` and `pass_through`: no additional payload.
-    """
+@dataclass(frozen=True)
+class PassThrough:
+    kind: Literal["pass_through"] = field(init=False, default="pass_through")
 
-    kind: RequestClassificationKind
-    vm_info: dict | None = None
-    registry_unavailable: registry.RegistryUnavailable | None = None
-    invalid_vm: registry.InvalidVmEntry | None = None
-    authority_error: AuthorityValidationError | None = None
-    firewall_ambiguous: matching.FirewallAmbiguous | None = None
-    firewall_block: matching.FirewallBlock | None = None
-    firewall_allow: matching.FirewallAllow | None = None
-    public_destination_denial: PublicDestinationDenial | None = None
-    builtin_firewall_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None = (
-        None
+
+@dataclass(frozen=True)
+class RegistryUnavailable:
+    registry_unavailable: registry.RegistryUnavailable
+    kind: Literal["registry_unavailable"] = field(init=False, default="registry_unavailable")
+
+
+@dataclass(frozen=True)
+class StaleTlsAdmission:
+    stale_tls_reason: StaleTlsAdmissionReason
+    kind: Literal["stale_tls_admission"] = field(init=False, default="stale_tls_admission")
+
+
+@dataclass(frozen=True)
+class InvalidRegistryVm:
+    invalid_vm: registry.InvalidVmEntry
+    kind: Literal["invalid_registry_vm"] = field(init=False, default="invalid_registry_vm")
+
+
+@dataclass(frozen=True)
+class AuthorityDenied:
+    vm_info: dict
+    authority_error: AuthorityValidationError
+    kind: Literal["authority_denied"] = field(init=False, default="authority_denied")
+
+
+@dataclass(frozen=True)
+class ApiAllow:
+    vm_info: dict
+    kind: Literal["api_allow"] = field(init=False, default="api_allow")
+
+
+@dataclass(frozen=True)
+class BrowserAllow:
+    vm_info: dict
+    kind: Literal["browser_allow"] = field(init=False, default="browser_allow")
+
+
+@dataclass(frozen=True)
+class FirewallAmbiguous:
+    vm_info: dict
+    firewall_ambiguous: matching.FirewallAmbiguous
+    kind: Literal["firewall_ambiguous"] = field(init=False, default="firewall_ambiguous")
+
+
+@dataclass(frozen=True)
+class FirewallBlock:
+    vm_info: dict
+    firewall_block: matching.FirewallBlock
+    kind: Literal["firewall_block"] = field(init=False, default="firewall_block")
+
+
+@dataclass(frozen=True)
+class FirewallAllow:
+    vm_info: dict
+    firewall_allow: matching.FirewallAllow
+    builtin_firewall_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None
+    kind: Literal["firewall_allow"] = field(init=False, default="firewall_allow")
+
+
+@dataclass(frozen=True)
+class PublicDestinationDenied:
+    vm_info: dict
+    public_destination_denial: PublicDestinationDenial
+    kind: Literal["public_destination_denied"] = field(
+        init=False,
+        default="public_destination_denied",
     )
-    stale_tls_reason: str = ""
+
+
+@dataclass(frozen=True)
+class Allow:
+    vm_info: dict
+    builtin_firewall_catalog_snapshot: registry_firewalls.BuiltinFirewallCatalogSnapshot | None
+    kind: Literal["allow"] = field(init=False, default="allow")
+
+
+RequestClassification: TypeAlias = (
+    NoClientIp
+    | PassThrough
+    | RegistryUnavailable
+    | StaleTlsAdmission
+    | InvalidRegistryVm
+    | AuthorityDenied
+    | ApiAllow
+    | BrowserAllow
+    | FirewallAmbiguous
+    | FirewallBlock
+    | FirewallAllow
+    | PublicDestinationDenied
+    | Allow
+)
 
 
 def cache_classification(flow: http.HTTPFlow, classification: RequestClassification) -> None:
@@ -223,22 +278,19 @@ def classify_request(
 
     if not client_ip:
         if tls_admission is not None:
-            return RequestClassification(
-                kind="stale_tls_admission",
+            return StaleTlsAdmission(
                 stale_tls_reason="client_ip_missing",
             )
-        return RequestClassification(kind="no_client_ip")
+        return NoClientIp()
 
     registry_state = registry.load_registry_state(registry_path)
     if isinstance(registry_state, registry.RegistryUnavailable):
-        return RequestClassification(
-            kind="registry_unavailable",
+        return RegistryUnavailable(
             registry_unavailable=registry_state,
         )
 
     if tls_admission is not None and tls_admission.client_ip != client_ip:
-        return RequestClassification(
-            kind="stale_tls_admission",
+        return StaleTlsAdmission(
             stale_tls_reason="client_ip_mismatch",
         )
 
@@ -246,16 +298,14 @@ def classify_request(
     if vm_info is None:
         invalid_vm = registry_state.invalid_vms.get(client_ip)
         if invalid_vm is not None:
-            return RequestClassification(
-                kind="invalid_registry_vm",
+            return InvalidRegistryVm(
                 invalid_vm=invalid_vm,
             )
         if tls_admission is not None:
-            return RequestClassification(
-                kind="stale_tls_admission",
+            return StaleTlsAdmission(
                 stale_tls_reason="registry_entry_missing",
             )
-        return RequestClassification(kind="pass_through")
+        return PassThrough()
 
     run_id = vm_info.get("runId", "")
     if (
@@ -263,9 +313,7 @@ def classify_request(
         and tls_admission.run_id is not None
         and tls_admission.run_id != run_id
     ):
-        return RequestClassification(
-            kind="stale_tls_admission",
-            vm_info=vm_info,
+        return StaleTlsAdmission(
             stale_tls_reason="run_id_mismatch",
         )
 
@@ -277,8 +325,7 @@ def classify_request(
     try:
         trusted_authority = get_trusted_authority(flow)
     except AuthorityValidationError as e:
-        return RequestClassification(
-            kind="authority_denied",
+        return AuthorityDenied(
             vm_info=vm_info,
             authority_error=e,
         )
@@ -293,10 +340,10 @@ def classify_request(
 
     hostname = trusted_authority.host.lower()
     if _api_hostname_matches(api_url, hostname) and not flow.request.path.startswith("/api/test/"):
-        return RequestClassification(kind="api_allow", vm_info=vm_info)
+        return ApiAllow(vm_info=vm_info)
 
     if flow.metadata.get(metadata_keys.BROWSER_USER_AGENT):
-        return RequestClassification(kind="browser_allow", vm_info=vm_info)
+        return BrowserAllow(vm_info=vm_info)
 
     compiled_firewalls = registry_state.compiled_firewalls.get(client_ip)
     compiled_network_policies = registry_state.compiled_network_policies[client_ip]
@@ -309,14 +356,12 @@ def classify_request(
             connector_intent.from_flow(flow),
         )
         if isinstance(result, matching.FirewallAmbiguous):
-            return RequestClassification(
-                kind="firewall_ambiguous",
+            return FirewallAmbiguous(
                 vm_info=vm_info,
                 firewall_ambiguous=result,
             )
         if isinstance(result, matching.FirewallBlock):
-            return RequestClassification(
-                kind="firewall_block",
+            return FirewallBlock(
                 vm_info=vm_info,
                 firewall_block=result,
             )
@@ -328,13 +373,11 @@ def classify_request(
                 defer_unresolved_hostnames=defer_unresolved_public_destination,
             )
             if public_destination_denial is not None:
-                return RequestClassification(
-                    kind="public_destination_denied",
+                return PublicDestinationDenied(
                     vm_info=vm_info,
                     public_destination_denial=public_destination_denial,
                 )
-            return RequestClassification(
-                kind="firewall_allow",
+            return FirewallAllow(
                 vm_info=vm_info,
                 firewall_allow=result,
                 builtin_firewall_catalog_snapshot=(
@@ -342,8 +385,7 @@ def classify_request(
                 ),
             )
 
-    return RequestClassification(
-        kind="allow",
+    return Allow(
         vm_info=vm_info,
         builtin_firewall_catalog_snapshot=registry_state.builtin_firewall_catalog_snapshot,
     )
@@ -363,20 +405,18 @@ def classification_needs_request_timing(classification: RequestClassification) -
 
 
 def should_stream_capture_request(classification: RequestClassification) -> bool:
-    if classification.kind not in ("api_allow", "browser_allow", "allow"):
+    if not isinstance(classification, ApiAllow | BrowserAllow | Allow):
         return False
-    vm_info = classification.vm_info
-    return isinstance(vm_info, dict) and bool(vm_info.get("captureNetworkBodies", False))
+    return bool(classification.vm_info.get("captureNetworkBodies", False))
 
 
 def should_try_firewall_stream_capture_request(classification: RequestClassification) -> bool:
-    if classification.kind != "firewall_allow":
+    if not isinstance(classification, FirewallAllow):
         return False
     allow = classification.firewall_allow
-    if allow is None or firewall_allow_uses_public_destination(allow):
+    if firewall_allow_uses_public_destination(allow):
         return False
-    vm_info = classification.vm_info
-    return isinstance(vm_info, dict) and bool(vm_info.get("captureNetworkBodies", False))
+    return bool(classification.vm_info.get("captureNetworkBodies", False))
 
 
 def firewall_allow_uses_public_destination(allow: matching.FirewallAllow) -> bool:

--- a/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_passthrough.py
@@ -7,6 +7,7 @@ import pytest
 import flow_metadata_keys as metadata_keys
 import mitm_addon
 import registry
+import request_classification
 import upstream_destination_binding
 import usage
 from tests.auth_state_helpers import auth_cache_key, has_auth_state
@@ -96,6 +97,26 @@ async def test_registry_unavailable_blocks_vm0_api_auto_allow(registry_file, rea
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
     assert flow.metadata[metadata_keys.FIREWALL_ERROR] == "registry_unavailable"
     assert metadata_keys.VM_RUN_ID not in flow.metadata
+
+
+async def test_unknown_cached_classification_does_not_bypass_registry_gate(
+    tmp_path,
+    real_flow,
+    mitm_ctx,
+):
+    reg_path = tmp_path / "proxy-registry.json"
+    reg_path.write_text("{ broken registry")
+    flow = real_flow(with_response=False, host="api.vm0.ai")
+    flow.metadata[request_classification.REQUEST_CLASSIFICATION_METADATA_KEY] = object()
+
+    with mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 503
+    assert json.loads(flow.response.content)["error"] == "registry_unavailable"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "BLOCK"
+    assert request_classification.REQUEST_CLASSIFICATION_METADATA_KEY not in flow.metadata
 
 
 async def test_vm0_api_test_paths_skip_auto_allow(


### PR DESCRIPTION
## Summary

- replace the shared optional-payload request classification record with 13 immutable, discriminated variants
- narrow request-header, request, streaming, cache, and connector diagnostic consumers to the exact variants they handle
- make ordinary allow explicit, add a static exhaustiveness guard, and cover unknown cached metadata through the real request hook

## Why

The previous model allowed terminal denial kinds to exist without the payload needed to construct their local response. Several consumers silently returned in that state, which could turn a future internal construction or cache regression into upstream continuation. The new closed union makes required payloads non-optional and incompatible fields unavailable to basedpyright and normal constructors.

## Compatibility

This changes only in-process Python objects scoped to one mitmproxy flow. It does not change persisted data, database schemas, files, external APIs, runner protocols, deployment payloads, or behavior for valid classifications.

## Validation

- `.venv/bin/ruff format .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright -p .`
- `PYTHONPATH=src:scripts .venv/bin/python scripts/check-flow-metadata-keys.py`
- targeted classification, request-header, firewall, public-destination, and connector diagnostic pytest suites (`287 passed`)
- `.venv/bin/python -m pytest tests/test_request_handler_passthrough.py` (`40 passed`)
- `.venv/bin/python -m pytest tests/` (`3861 passed`)

Closes #21258
