### PR TITLE
fix(sandbox-fc): route tcp dns through dnsmasq

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1258,7 +1258,7 @@ jobs:
           # valid response proves PREROUTING redirected the connection to the
           # runner-managed dnsmasq instead of mitmproxy raw TCP passthrough.
           TCP_DNS_SCRIPT="import socket,struct; q=bytes.fromhex('123401000001000000000000077463702d646e7307696e76616c69640000010001'); s=socket.create_connection(('192.0.2.1',53),5); s.sendall(struct.pack('!H',len(q))+q); f=s.makefile('rb'); h=f.read(2); assert len(h)==2; n=struct.unpack('!H',h)[0]; r=f.read(n); assert len(r)==n and r[:2]==q[:2] and r[2]&128; print('TCP_DNS_OK=true')"
-          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "$TCP_DNS_SCRIPT" 2>&1) \
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "$TCP_DNS_SCRIPT") \
             || fail "TCP DNS resolution failed: $OUTPUT"
           [ "$OUTPUT" = "TCP_DNS_OK=true" ] || fail "unexpected TCP DNS output: $OUTPUT"
           echo "  tcp: $OUTPUT"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1253,6 +1253,45 @@ jobs:
           OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" --sudo -- getent hosts example.com 2>&1) \
             || fail "root DNS resolution failed: $OUTPUT"
           echo "  root: $OUTPUT"
+
+          # Force DNS over TCP to a TEST-NET destination with no resolver. A
+          # valid response proves PREROUTING redirected the connection to the
+          # runner-managed dnsmasq instead of mitmproxy raw TCP passthrough.
+          TCP_DNS_SCRIPT="import socket,struct; q=bytes.fromhex('123401000001000000000000077463702d646e7307696e76616c69640000010001'); s=socket.create_connection(('192.0.2.1',53),5); s.sendall(struct.pack('!H',len(q))+q); f=s.makefile('rb'); h=f.read(2); assert len(h)==2; n=struct.unpack('!H',h)[0]; r=f.read(n); assert len(r)==n and r[:2]==q[:2] and r[2]&128; print('TCP_DNS_OK=true')"
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec --sandbox "$SANDBOX_ID" -- python3 -c "$TCP_DNS_SCRIPT" 2>&1) \
+            || fail "TCP DNS resolution failed: $OUTPUT"
+          [ "$OUTPUT" = "TCP_DNS_OK=true" ] || fail "unexpected TCP DNS output: $OUTPUT"
+          echo "  tcp: $OUTPUT"
+
+          # Inspect the actual rules installed for this runner. Matching by its
+          # unique proxy and DNS ports avoids parallel CI runners on the host.
+          PROXY_PORT=$(sudo jq -r '.proxy_port // empty' "$RUNNER_DIR/status.json")
+          DNS_PORT=$(sudo jq -r '.dns_port // empty' "$RUNNER_DIR/status.json")
+          [ -n "$PROXY_PORT" ] || fail "proxy port missing from runner status"
+          [ -n "$DNS_PORT" ] || fail "DNS port missing from runner status"
+          NAT_RULES=$(sudo iptables-save -t nat) || fail "failed to read nat rules"
+          FILTER_RULES=$(sudo iptables-save -t filter) || fail "failed to read filter rules"
+
+          PROXY_RULES=$(printf '%s\n' "$NAT_RULES" \
+            | grep -E -- "--to-ports? ${PROXY_PORT}([[:space:]]|$)" || true)
+          [ -n "$PROXY_RULES" ] || fail "generic TCP proxy rules not found"
+          if printf '%s\n' "$PROXY_RULES" \
+            | grep -Fv -- "-m multiport ! --dports 53,853" >/dev/null; then
+            fail "generic TCP proxy rule does not exclude ports 53 and 853"
+          fi
+
+          DNS_TCP_RULES=$(printf '%s\n' "$NAT_RULES" \
+            | grep -E -- "--to-ports? ${DNS_PORT}([[:space:]]|$)" \
+            | grep -F -- "-p tcp" \
+            | grep -F -- "--dport 53" || true)
+          [ -n "$DNS_TCP_RULES" ] || fail "TCP/53 dnsmasq redirect rule not found"
+
+          printf '%s\n' "$FILTER_RULES" \
+            | grep -E -- "-A FORWARD .* -p tcp .*--dport 53 .* -j DROP" >/dev/null \
+            || fail "TCP/53 FORWARD drop rule not found"
+          printf '%s\n' "$FILTER_RULES" \
+            | grep -E -- "-A FORWARD .* -p tcp .*--dport 853 .* -j DROP" >/dev/null \
+            || fail "TCP/853 FORWARD drop rule not found"
           echo "PASS: DNS resolution"
 
           # Stop transient service (kills sandbox, submit terminates naturally)

--- a/crates/runner/src/dns/mod.rs
+++ b/crates/runner/src/dns/mod.rs
@@ -6,13 +6,13 @@
 //!
 //! Defense-in-depth:
 //! - Layer 1: iptables REDIRECT → dnsmasq port (working path, preserves source IP)
-//! - Layer 2: iptables DROP external UDP 53 / TCP 853 (bypass prevention)
+//! - Layer 2: iptables DROP external UDP/TCP 53 and TCP 853 (bypass prevention)
 //! - Layer 3: dnsmasq binds to VM-facing veth interfaces instead of external
 //!   host interfaces (listener restriction)
 //!
 //! VM resolv.conf points to an external nameserver (e.g. 8.8.8.8) as a dummy
-//! target. The REDIRECT rule in PREROUTING intercepts all UDP 53 from the VM
-//! subnet and redirects to dnsmasq before the packet reaches FORWARD/POSTROUTING.
+//! target. The REDIRECT rules in PREROUTING intercept UDP and TCP 53 from the
+//! VM subnet and redirect to dnsmasq before packets reach FORWARD/POSTROUTING.
 //!
 //! Log format: dnsmasq `--log-queries=extra` outputs to stderr, parsed by a background
 //! async task that submits per-VM network JSON rows through `NetworkLogManager`.

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -304,29 +304,26 @@ async fn setup_host_iptables(
     Ok(())
 }
 
-/// Add a proxy REDIRECT rule for outbound non-DNS TCP traffic in PREROUTING.
+/// Add a proxy REDIRECT rule for outbound TCP traffic in PREROUTING.
 ///
 /// This rule redirects outbound TCP traffic from the namespace's veth peer IP
-/// to the specified proxy port on the host. Standard DNS (53) and DNS-over-TLS
-/// (853) are excluded so their dedicated rules cannot be bypassed by
-/// mitmproxy's raw TCP passthrough.
-async fn add_proxy_redirect_rule(name: &str, peer_ip: &str, proxy_port: u16) -> Result<()> {
+/// to the specified proxy port on the host. When the DNS proxy is enabled,
+/// standard DNS (53) and DNS-over-TLS (853) are excluded so their dedicated
+/// rules cannot be bypassed by mitmproxy's raw TCP passthrough. Without a DNS
+/// proxy, all TCP traffic keeps the existing mitmproxy behavior.
+async fn add_proxy_redirect_rule(
+    name: &str,
+    peer_ip: &str,
+    proxy_port: u16,
+    dns_proxy_enabled: bool,
+) -> Result<()> {
     let src = format!("{peer_ip}/30");
     let port_str = proxy_port.to_string();
-    exec_iptables(&[
-        "-t",
-        "nat",
-        "-A",
-        "PREROUTING",
-        "-s",
-        &src,
-        "-p",
-        "tcp",
-        "-m",
-        "multiport",
-        "!",
-        "--dports",
-        "53,853",
+    let mut args: Vec<&str> = vec!["-t", "nat", "-A", "PREROUTING", "-s", &src, "-p", "tcp"];
+    if dns_proxy_enabled {
+        args.extend(["-m", "multiport", "!", "--dports", "53,853"]);
+    }
+    args.extend([
         "-j",
         "REDIRECT",
         "--to-port",
@@ -335,8 +332,8 @@ async fn add_proxy_redirect_rule(name: &str, peer_ip: &str, proxy_port: u16) -> 
         "comment",
         "--comment",
         name,
-    ])
-    .await?;
+    ]);
+    exec_iptables(&args).await?;
     Ok(())
 }
 
@@ -676,7 +673,9 @@ pub(super) async fn create_single_namespace(
     match result {
         Ok(()) => {
             if let Some(port) = proxy_port {
-                if let Err(e) = add_proxy_redirect_rule(&ns_name, &peer_ip, port).await {
+                if let Err(e) =
+                    add_proxy_redirect_rule(&ns_name, &peer_ip, port, dns_port.is_some()).await
+                {
                     error!(name = %ns_name, error = %e, "failed to add proxy rules, cleaning up");
                     delete_namespace_resources(&ns_name, &host_device).await;
                     return Err(e);

--- a/crates/sandbox-fc/src/network/pool/host.rs
+++ b/crates/sandbox-fc/src/network/pool/host.rs
@@ -304,11 +304,12 @@ async fn setup_host_iptables(
     Ok(())
 }
 
-/// Add proxy REDIRECT rule for all outbound TCP traffic in PREROUTING chain.
+/// Add a proxy REDIRECT rule for outbound non-DNS TCP traffic in PREROUTING.
 ///
-/// This rule redirects all outbound TCP traffic from the namespace's
-/// veth peer IP to the specified proxy port on the host. mitmproxy in
-/// transparent mode handles both HTTP/HTTPS and non-HTTP (raw TCP passthrough).
+/// This rule redirects outbound TCP traffic from the namespace's veth peer IP
+/// to the specified proxy port on the host. Standard DNS (53) and DNS-over-TLS
+/// (853) are excluded so their dedicated rules cannot be bypassed by
+/// mitmproxy's raw TCP passthrough.
 async fn add_proxy_redirect_rule(name: &str, peer_ip: &str, proxy_port: u16) -> Result<()> {
     let src = format!("{peer_ip}/30");
     let port_str = proxy_port.to_string();
@@ -321,6 +322,11 @@ async fn add_proxy_redirect_rule(name: &str, peer_ip: &str, proxy_port: u16) -> 
         &src,
         "-p",
         "tcp",
+        "-m",
+        "multiport",
+        "!",
+        "--dports",
+        "53,853",
         "-j",
         "REDIRECT",
         "--to-port",
@@ -377,82 +383,68 @@ async fn add_non_tcp_log_rule(name: &str, peer_ip: &str) -> Result<()> {
     Ok(())
 }
 
-/// Redirect all outbound DNS (UDP 53) to the local dnsmasq port.
+/// Redirect standard outbound DNS (UDP/TCP 53) to the local dnsmasq port.
 ///
 /// VM resolv.conf points to an external nameserver as a dummy target.
-/// This PREROUTING REDIRECT intercepts the packet before FORWARD/MASQUERADE,
-/// preserving the original source IP (peer veth) for per-VM log routing.
-async fn add_dns_redirect_rule(name: &str, peer_ip: &str, dns_port: u16) -> Result<()> {
+/// These PREROUTING REDIRECT rules intercept packets before FORWARD/MASQUERADE,
+/// preserving the original source IP (peer veth) for per-VM log routing. TCP
+/// support covers explicit DNS-over-TCP and fallback after truncated UDP
+/// responses.
+async fn add_dns_redirect_rules(name: &str, peer_ip: &str, dns_port: u16) -> Result<()> {
     let src = format!("{peer_ip}/30");
     let port_str = dns_port.to_string();
-    exec_iptables(&[
-        "-t",
-        "nat",
-        "-A",
-        "PREROUTING",
-        "-s",
-        &src,
-        "-p",
-        "udp",
-        "--dport",
-        "53",
-        "-j",
-        "REDIRECT",
-        "--to-port",
-        &port_str,
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
+    for protocol in ["udp", "tcp"] {
+        exec_iptables(&[
+            "-t",
+            "nat",
+            "-A",
+            "PREROUTING",
+            "-s",
+            &src,
+            "-p",
+            protocol,
+            "--dport",
+            "53",
+            "-j",
+            "REDIRECT",
+            "--to-port",
+            &port_str,
+            "-m",
+            "comment",
+            "--comment",
+            name,
+        ])
+        .await?;
+    }
     Ok(())
 }
 
 /// Drop external DNS traffic that bypasses the REDIRECT rule.
 ///
-/// Blocks UDP 53 and TCP 853 (DNS over TLS) in FORWARD chain.
+/// Blocks UDP/TCP 53 and TCP 853 (DNS over TLS) in FORWARD chain.
 /// DNS over HTTPS (TCP 443) is handled by mitmproxy at HTTP level.
 async fn add_dns_drop_rules(name: &str, peer_ip: &str) -> Result<()> {
     let src = format!("{peer_ip}/30");
-    // Block UDP 53 in FORWARD (catches any traffic not caught by PREROUTING REDIRECT)
-    exec_iptables(&[
-        "-I",
-        "FORWARD",
-        "1",
-        "-s",
-        &src,
-        "-p",
-        "udp",
-        "--dport",
-        "53",
-        "-j",
-        "DROP",
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
-    // Block DNS over TLS (TCP 853)
-    exec_iptables(&[
-        "-I",
-        "FORWARD",
-        "1",
-        "-s",
-        &src,
-        "-p",
-        "tcp",
-        "--dport",
-        "853",
-        "-j",
-        "DROP",
-        "-m",
-        "comment",
-        "--comment",
-        name,
-    ])
-    .await?;
+    for (protocol, port) in [("udp", "53"), ("tcp", "53"), ("tcp", "853")] {
+        exec_iptables(&[
+            "-I",
+            "FORWARD",
+            "1",
+            "-s",
+            &src,
+            "-p",
+            protocol,
+            "--dport",
+            port,
+            "-j",
+            "DROP",
+            "-m",
+            "comment",
+            "--comment",
+            name,
+        ])
+        .await?;
+    }
     Ok(())
 }
 
@@ -696,8 +688,8 @@ pub(super) async fn create_single_namespace(
                 }
             }
             if let Some(port) = dns_port {
-                if let Err(e) = add_dns_redirect_rule(&ns_name, &peer_ip, port).await {
-                    error!(name = %ns_name, error = %e, "failed to add DNS redirect rule, cleaning up");
+                if let Err(e) = add_dns_redirect_rules(&ns_name, &peer_ip, port).await {
+                    error!(name = %ns_name, error = %e, "failed to add DNS redirect rules, cleaning up");
                     delete_namespace_resources(&ns_name, &host_device).await;
                     return Err(e);
                 }

--- a/e2e/tests/03-runner/t45-vm0-network-logging.bats
+++ b/e2e/tests/03-runner/t45-vm0-network-logging.bats
@@ -2,9 +2,9 @@
 
 # Test network traffic logging from sandbox VMs.
 #
-# TCP: All outbound TCP is redirected through mitmproxy (transparent mode).
+# TCP: Outbound non-DNS TCP is redirected through mitmproxy (transparent mode).
 #      Non-HTTP TCP (e.g. SSH) passes through as raw TCP.
-# DNS: Queries intercepted via iptables REDIRECT to dnsmasq, logged as type "dns".
+# DNS: UDP/TCP 53 is redirected to dnsmasq and logged as type "dns".
 # Non-TCP: Logged via iptables LOG + /dev/kmsg (UDP, ICMP, etc).
 # All types are written to the same per-run network JSONL file.
 
@@ -67,15 +67,19 @@ EOF
     wait_for_log "$RUN_ID" --network -- "TCP" ":22" ":443"
 }
 
-@test "t45-1: dns queries logged via dnsmasq" {
+@test "t45-1: udp and tcp dns queries logged via dnsmasq" {
     create_agent
 
-    # DNS queries are intercepted by iptables REDIRECT to dnsmasq and logged
-    # as type "dns". getent triggers a standard libc DNS lookup.
+    # getent exercises standard UDP DNS. The Python query forces DNS over TCP
+    # to a TEST-NET destination with no resolver, so a valid response proves
+    # the packet was transparently redirected to dnsmasq rather than passed
+    # through as generic TCP.
+    local tcp_dns_script="import socket,struct; q=bytes.fromhex('123401000001000000000000077463702d646e7307696e76616c69640000010001'); s=socket.create_connection(('192.0.2.1',53),5); s.sendall(struct.pack('!H',len(q))+q); f=s.makefile('rb'); h=f.read(2); assert len(h)==2; n=struct.unpack('!H',h)[0]; r=f.read(n); assert len(r)==n and r[:2]==q[:2] and r[2]&128; print('TCP_DNS_OK=true')"
     run $VM0_CLI run "$AGENT_NAME" \
         --artifact "$ARTIFACT_NAME:/home/user/workspace" \
-        "getent hosts example.com"
+        "getent hosts example.com >/dev/null && python3 -c \"$tcp_dns_script\""
     assert_success
+    assert_output --partial "TCP_DNS_OK=true"
 
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
     [ -n "$RUN_ID" ] || {
@@ -83,9 +87,13 @@ EOF
         return 1
     }
 
-    # Verify network logs contain DNS entries and at least one DNS result row.
-    # DNS result entries render as: [timestamp] DNS   example.com:53 -> <answer>
-    wait_for_log "$RUN_ID" --network -- "example.com" "DNS" ":53" "->"
+    # The distinct TCP-only name proves dnsmasq parsed and logged the TCP query,
+    # rather than mitmproxy recording only generic connection metadata.
+    wait_for_log "$RUN_ID" --network -- \
+        "example.com" \
+        "tcp-dns.invalid" \
+        "DNS" \
+        ":53"
 }
 
 @test "t45-2: non-dns udp appears in network logs" {


### PR DESCRIPTION
## Summary

- when the runner-managed DNS proxy is enabled, exclude standard DNS and DNS-over-TLS ports from the generic mitmproxy TCP redirect
- redirect both UDP/53 and TCP/53 to dnsmasq, while dropping bypass traffic for TCP/53 and TCP/853
- preserve the existing all-TCP proxy behavior for benchmark and other proxy-only runtimes
- extend metal runner and network-log E2E coverage with a real DNS-over-TCP query and live iptables assertions

## Scope

This changes only host networking rules, DNS documentation, and their integration coverage. It does not change database schemas, persisted data, APIs, runner protocols, or feature switches.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo test --manifest-path crates/Cargo.toml -p sandbox-fc` (689 passed)
- `cargo test --manifest-path crates/Cargo.toml -p runner dns::` (33 passed)
- `cargo clippy --manifest-path crates/Cargo.toml -p sandbox-fc -p runner --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --manifest-path crates/Cargo.toml -p sandbox-fc -p runner --all-features --no-deps`
- `pnpm prettier --check ../.github/workflows/crates.yml`
- `actionlint .github/workflows/crates.yml`
- `e2e/test/libs/bats/bin/bats --count e2e/tests/03-runner/t45-vm0-network-logging.bats`
- extracted runner-exec remote script: `bash -n`
- repository pre-commit hooks, including workspace Cargo format, Clippy, docs, and commitlint

The metal-host behavior checks are part of the required PR CI and cannot run in the local container.

Closes #21263
