### PR TITLE
fix(mitm-addon): redact userinfo from malformed log urls

### DIFF
--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -3,15 +3,16 @@
 import urllib.parse
 
 _URLSPLIT_LEADING_STRIP_CHARACTERS = "".join(chr(codepoint) for codepoint in range(0x21))
-_URLSPLIT_REMOVABLE_CHARACTERS = str.maketrans("", "", "\t\r\n")
+_URLSPLIT_REMOVABLE_CHARACTERS = "\t\r\n"
 _SPECIAL_URL_SCHEMES = ("http", "https")
 
 
 def _normalize_for_urlsplit(value: str) -> str:
     """Apply current URL preprocessing consistently on Python 3.10+."""
-    return value.lstrip(_URLSPLIT_LEADING_STRIP_CHARACTERS).translate(
-        _URLSPLIT_REMOVABLE_CHARACTERS
-    )
+    value = value.lstrip(_URLSPLIT_LEADING_STRIP_CHARACTERS)
+    for character in _URLSPLIT_REMOVABLE_CHARACTERS:
+        value = value.replace(character, "")
+    return value
 
 
 def _sanitize_netloc_for_network_log(netloc: str) -> str:

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -5,6 +5,7 @@ import urllib.parse
 _URLSPLIT_LEADING_STRIP_CHARACTERS = "".join(chr(codepoint) for codepoint in range(0x21))
 _URLSPLIT_REMOVABLE_CHARACTERS = "\t\r\n"
 _SPECIAL_URL_SCHEMES = ("http", "https")
+_SPECIAL_URL_SEPARATORS = "/\\"
 
 
 def _normalize_for_urlsplit(value: str) -> str:
@@ -43,7 +44,9 @@ def _sanitize_url_text_fallback_for_network_log(value: str) -> str:
 def _sanitize_malformed_authority_for_network_log(
     value: str, parts: urllib.parse.SplitResult
 ) -> str | None:
-    if parts.netloc:
+    # A mixed separator run can leave only backslashes in netloc while the
+    # actual authority-like segment lands in path.
+    if parts.netloc.strip(_SPECIAL_URL_SEPARATORS):
         return None
 
     has_special_scheme = parts.scheme in _SPECIAL_URL_SCHEMES
@@ -51,9 +54,11 @@ def _sanitize_malformed_authority_for_network_log(
     if not has_special_scheme and not is_protocol_relative:
         return None
 
-    authority_path = parts.path.lstrip("/\\")
+    authority_path = parts.path.lstrip(_SPECIAL_URL_SEPARATORS)
     cut_points = [
-        index for separator in ("/", "\\") if (index := authority_path.find(separator)) != -1
+        index
+        for separator in _SPECIAL_URL_SEPARATORS
+        if (index := authority_path.find(separator)) != -1
     ]
     if cut_points:
         path_start = min(cut_points)

--- a/crates/runner/mitm-addon/src/network_log_sanitization.py
+++ b/crates/runner/mitm-addon/src/network_log_sanitization.py
@@ -2,6 +2,17 @@
 
 import urllib.parse
 
+_URLSPLIT_LEADING_STRIP_CHARACTERS = "".join(chr(codepoint) for codepoint in range(0x21))
+_URLSPLIT_REMOVABLE_CHARACTERS = str.maketrans("", "", "\t\r\n")
+_SPECIAL_URL_SCHEMES = ("http", "https")
+
+
+def _normalize_for_urlsplit(value: str) -> str:
+    """Apply current URL preprocessing consistently on Python 3.10+."""
+    return value.lstrip(_URLSPLIT_LEADING_STRIP_CHARACTERS).translate(
+        _URLSPLIT_REMOVABLE_CHARACTERS
+    )
+
 
 def _sanitize_netloc_for_network_log(netloc: str) -> str:
     if "@" not in netloc:
@@ -28,17 +39,54 @@ def _sanitize_url_text_fallback_for_network_log(value: str) -> str:
     return value
 
 
+def _sanitize_malformed_authority_for_network_log(
+    value: str, parts: urllib.parse.SplitResult
+) -> str | None:
+    if parts.netloc:
+        return None
+
+    has_special_scheme = parts.scheme in _SPECIAL_URL_SCHEMES
+    is_protocol_relative = not parts.scheme and value.startswith("//")
+    if not has_special_scheme and not is_protocol_relative:
+        return None
+
+    authority_path = parts.path.lstrip("/\\")
+    cut_points = [
+        index for separator in ("/", "\\") if (index := authority_path.find(separator)) != -1
+    ]
+    if cut_points:
+        path_start = min(cut_points)
+        authority = authority_path[:path_start]
+        path = authority_path[path_start:].replace("\\", "/")
+    else:
+        authority = authority_path
+        path = ""
+
+    if "@" not in authority:
+        return None
+
+    netloc = _sanitize_netloc_for_network_log(authority)
+    return urllib.parse.urlunsplit((parts.scheme, netloc, path, "", ""))
+
+
 def sanitize_url_for_network_log(value: str) -> str:
     """Return a primary request/proxy URL string for persistent logs.
 
     Runtime metadata can keep raw URLs because firewall/auth and connector
     billing may need query parameters. Persistent logs do not. This sanitizer
-    still preserves path for request diagnostics and is not appropriate for
-    arbitrary captured header values.
+    also removes userinfo from malformed HTTP(S) authority positions, but it
+    still preserves ordinary paths for request diagnostics. It is not a general
+    sanitizer for arbitrary captured header values or path contents.
     """
+    normalized_value = _normalize_for_urlsplit(value)
     try:
-        parts = urllib.parse.urlsplit(value)
+        parts = urllib.parse.urlsplit(normalized_value)
     except ValueError:
-        return _sanitize_url_text_fallback_for_network_log(value)
+        return _sanitize_url_text_fallback_for_network_log(normalized_value)
+
+    malformed_authority_url = _sanitize_malformed_authority_for_network_log(normalized_value, parts)
+    if malformed_authority_url is not None:
+        return malformed_authority_url
+
     netloc = _sanitize_netloc_for_network_log(parts.netloc)
     return urllib.parse.urlunsplit((parts.scheme, netloc, parts.path, "", ""))

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -207,16 +207,6 @@ class TestLogProxyEntry:
                 "https://example.com/users/alice@example.com",
                 id="at-sign-in-valid-path",
             ),
-            pytest.param(
-                "https:////example.com/users/alice@example.com?token=secret#fragment",
-                "https://example.com/users/alice@example.com",
-                id="at-sign-after-malformed-authority",
-            ),
-            pytest.param(
-                r"https://\/example.com/users/alice@example.com?token=secret#fragment",
-                r"https://\/example.com/users/alice@example.com",
-                id="at-sign-after-separator-only-netloc",
-            ),
         ],
     )
     def test_sanitizes_structured_url_field(self, tmp_path, raw_url, expected_url):
@@ -239,6 +229,28 @@ class TestLogProxyEntry:
         assert "first@" not in serialized
         assert "token=secret" not in serialized
         assert "#fragment" not in serialized
+
+    @pytest.mark.parametrize(
+        "raw_url",
+        [
+            "https:////example.com/users/alice@example.com?token=secret#fragment",
+            r"https://\/example.com/users/alice@example.com?token=secret#fragment",
+        ],
+    )
+    def test_preserves_at_sign_after_malformed_authority(self, tmp_path, raw_url):
+        proxy_path = tmp_path / "proxy-test.jsonl"
+
+        logging_utils.log_proxy_entry(
+            str(proxy_path),
+            "warn",
+            "url diagnostic",
+            url=raw_url,
+        )
+
+        [entry] = read_jsonl_entries_after_flush(proxy_path)
+        assert entry["url"].endswith("example.com/users/alice@example.com")
+        assert "token=secret" not in entry["url"]
+        assert "#fragment" not in entry["url"]
 
     def test_only_sanitizes_exact_url_field(self, tmp_path):
         proxy_path = tmp_path / "proxy-test.jsonl"

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import flow_metadata_keys as metadata_keys
 import logging_utils
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
@@ -112,9 +114,120 @@ class TestLogProxyEntry:
         assert entry["extra_field"] == "value"
         assert_utc_millisecond_timestamp(entry["timestamp"])
 
-    def test_sanitizes_structured_url_field(self, tmp_path):
+    @pytest.mark.parametrize(
+        ("raw_url", "expected_url"),
+        [
+            pytest.param(
+                "https://user:pass@example.com/v1/search?token=secret#fragment",
+                "https://example.com/v1/search",
+                id="absolute",
+            ),
+            pytest.param(
+                "//user:pass@example.com/v1/search?token=secret#fragment",
+                "//example.com/v1/search",
+                id="protocol-relative",
+            ),
+            pytest.param(
+                "https:////user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="extra-slashes",
+            ),
+            pytest.param(
+                "https:///user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="three-slashes",
+            ),
+            pytest.param(
+                "https:/user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="one-slash",
+            ),
+            pytest.param(
+                "https:user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="no-slashes",
+            ),
+            pytest.param(
+                "HTTP:////user:pass@example.com/path?token=secret#fragment",
+                "http://example.com/path",
+                id="case-insensitive-http-scheme",
+            ),
+            pytest.param(
+                r"https:\\user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="reverse-solidus",
+            ),
+            pytest.param(
+                r"https:/\\user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="mixed-separators",
+            ),
+            pytest.param(
+                "///user:pass@example.com/path?token=secret#fragment",
+                "//example.com/path",
+                id="extra-protocol-relative-slash",
+            ),
+            pytest.param(
+                "\x00 https:////user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="leading-c0-and-space",
+            ),
+            pytest.param(
+                "h\tt\rtp\ns:////user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="embedded-urlsplit-controls",
+            ),
+            pytest.param(
+                "https:////first@user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="multiple-at-signs",
+            ),
+            pytest.param(
+                "https:////user:pass@example.com?token=secret#fragment",
+                "https://example.com",
+                id="empty-path",
+            ),
+            pytest.param(
+                "https:////user:pass@example.com/?token=secret#fragment",
+                "https://example.com/",
+                id="root-path",
+            ),
+            pytest.param(
+                "https://example.com/users/alice@example.com?token=secret#fragment",
+                "https://example.com/users/alice@example.com",
+                id="at-sign-in-valid-path",
+            ),
+            pytest.param(
+                "https:////example.com/users/alice@example.com?token=secret#fragment",
+                "https://example.com/users/alice@example.com",
+                id="at-sign-after-malformed-authority",
+            ),
+        ],
+    )
+    def test_sanitizes_structured_url_field(self, tmp_path, raw_url, expected_url):
         proxy_path = tmp_path / "proxy-test.jsonl"
-        raw_url = "https://user:pass@example.com/v1/search?token=secret#fragment"
+
+        logging_utils.log_proxy_entry(
+            str(proxy_path),
+            "warn",
+            "url diagnostic",
+            url=raw_url,
+            extra_field="value",
+        )
+
+        [entry] = read_jsonl_entries_after_flush(proxy_path)
+        assert entry["message"] == "url diagnostic"
+        assert entry["url"] == expected_url
+        assert entry["extra_field"] == "value"
+        serialized = json.dumps(entry)
+        assert "user:pass" not in serialized
+        assert "first@" not in serialized
+        assert "token=secret" not in serialized
+        assert "#fragment" not in serialized
+
+    def test_only_sanitizes_exact_url_field(self, tmp_path):
+        proxy_path = tmp_path / "proxy-test.jsonl"
+        raw_url = "https://user:pass@example.com/path?token=secret#fragment"
 
         logging_utils.log_proxy_entry(
             str(proxy_path),
@@ -125,8 +238,7 @@ class TestLogProxyEntry:
         )
 
         [entry] = read_jsonl_entries_after_flush(proxy_path)
-        assert entry["message"] == "url diagnostic"
-        assert entry["url"] == "https://example.com/v1/search"
+        assert entry["url"] == "https://example.com/path"
         assert entry["raw_url_copy"] == raw_url
 
     def test_appends_multiple_entries(self, tmp_path):

--- a/crates/runner/mitm-addon/tests/test_logging_utils.py
+++ b/crates/runner/mitm-addon/tests/test_logging_utils.py
@@ -163,9 +163,19 @@ class TestLogProxyEntry:
                 id="mixed-separators",
             ),
             pytest.param(
+                r"https://\/user:pass@example.com/path?token=secret#fragment",
+                "https://example.com/path",
+                id="separator-only-netloc",
+            ),
+            pytest.param(
                 "///user:pass@example.com/path?token=secret#fragment",
                 "//example.com/path",
                 id="extra-protocol-relative-slash",
+            ),
+            pytest.param(
+                r"//\/user:pass@example.com/path?token=secret#fragment",
+                "//example.com/path",
+                id="separator-only-protocol-relative-netloc",
             ),
             pytest.param(
                 "\x00 https:////user:pass@example.com/path?token=secret#fragment",
@@ -201,6 +211,11 @@ class TestLogProxyEntry:
                 "https:////example.com/users/alice@example.com?token=secret#fragment",
                 "https://example.com/users/alice@example.com",
                 id="at-sign-after-malformed-authority",
+            ),
+            pytest.param(
+                r"https://\/example.com/users/alice@example.com?token=secret#fragment",
+                r"https://\/example.com/users/alice@example.com",
+                id="at-sign-after-separator-only-netloc",
             ),
         ],
     )

--- a/crates/runner/mitm-addon/tests/test_response_handler.py
+++ b/crates/runner/mitm-addon/tests/test_response_handler.py
@@ -976,6 +976,15 @@ class TestResponseHandler:
                 "https://user:pass@target.example.com:9443/path?access_token=secret#fragment",
                 "https://target.example.com:9443/path",
             ),
+            (
+                "https:////user:pass@target.example.com:9443/path?access_token=secret#fragment",
+                "https://target.example.com:9443/path",
+            ),
+            (
+                "https://target.example.com:9443/users/alice@example.com"
+                "?access_token=secret#fragment",
+                "https://target.example.com:9443/users/alice@example.com",
+            ),
         ],
     )
     def test_network_log_target_url_strips_query_and_fragment(

--- a/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
+++ b/crates/runner/mitm-addon/tests/test_webhook_http_delivery.py
@@ -84,6 +84,41 @@ def test_rejects_invalid_url_before_open(tmp_path, sync_usage_executor):
     )
 
 
+def test_rejects_malformed_sensitive_url_without_logging_credentials(tmp_path, sync_usage_executor):
+    proxy_log = tmp_path / "proxy.jsonl"
+    raw_url = "https:////user:pass@api.vm0.ai/path?token=secret#frag"
+    sanitized_url = "https://api.vm0.ai/path"
+    payload = {"runId": "run-1", "events": []}
+    payload_bytes = len(json.dumps(payload).encode())
+
+    with patch.object(urllib.request.OpenerDirector, "open") as mock_open:
+        assert usage.webhook.enqueue_webhook_delivery(
+            raw_url,
+            "tok",
+            payload,
+            str(proxy_log),
+            "usage_event",
+        )
+        with pytest.raises(ValueError, match="absolute http"):
+            sync_usage_executor.shutdown(wait=True)
+
+    mock_open.assert_not_called()
+    entries = read_jsonl_entries_after_flush(proxy_log)
+    error_entry = entries[-1]
+    assert error_entry["url"] == sanitized_url
+    assert sanitized_url in error_entry["message"]
+    assert "absolute http" in error_entry["error"]
+    assert "non-retryable" in error_entry["message"]
+    assert_body_free_webhook_entry(
+        error_entry,
+        run_id="run-1",
+        event_count=0,
+        payload_bytes=payload_bytes,
+    )
+    for entry in entries:
+        assert_sensitive_webhook_url_parts_absent(entry)
+
+
 def test_closes_http_error_response(tmp_path, real_flow, sync_usage_executor, usage_webhook_api):
     flow = model_usage_flow(real_flow, tmp_path)
 


### PR DESCRIPTION
## Summary

- Remove authority-position userinfo from malformed HTTP(S) and protocol-relative URL diagnostics when `urlsplit()` classifies it as path text or leaves only malformed separators in `netloc`.
- Normalize security-relevant URL preprocessing across supported Python versions while preserving ordinary later-path `@` values.
- Cover the shared JSONL boundary, webhook invalid-URL diagnostics, network-log output, and unchanged raw runtime metadata.

## Scope

- This changes persistent log rendering only. Request URLs, webhook retries, delivery accounting, firewall behavior, billing, and raw runtime metadata are unchanged.
- This does not add blanket path redaction, a new URL parser, a schema change, or a deployment migration.

## Validation

- `ruff format --check .`
- `ruff check .`
- `basedpyright`
- `pytest -q tests/test_logging_utils.py tests/test_webhook_http_delivery.py tests/test_response_handler.py` (`145 passed`)
- `pytest -q tests/` (`3883 passed`)
- Applicable staged lefthook jobs: Ruff format/lint, file-size validation, and generated-firewall validation

Closes #21261
