### PR TITLE
perf(mitm-addon): reuse parsed built-in host policies

### DIFF
--- a/crates/runner/mitm-addon/src/builtin_host_policy.py
+++ b/crates/runner/mitm-addon/src/builtin_host_policy.py
@@ -61,7 +61,28 @@ class _PublicDestinationHostPolicy:
     pass
 
 
-_ParsedHostPolicy = _ProviderOwnedHostPolicy | _PublicDestinationHostPolicy | None
+_ConfiguredHostPolicy = _ProviderOwnedHostPolicy | _PublicDestinationHostPolicy
+_ParsedHostPolicy = _ConfiguredHostPolicy | None
+
+
+@dataclass(frozen=True)
+class CompiledBuiltinHostPolicy:
+    """Opaque validated host policy owned by one resolved registry snapshot."""
+
+    _policy: _ConfiguredHostPolicy
+
+
+def _compiled_host_policy_value(
+    *,
+    firewall_name: str,
+    compiled: CompiledBuiltinHostPolicy,
+) -> _ConfiguredHostPolicy:
+    policy = compiled._policy
+    if isinstance(policy, (_ProviderOwnedHostPolicy, _PublicDestinationHostPolicy)):
+        return policy
+    raise BuiltinHostPolicyError(
+        f'builtin firewall "{firewall_name}" runtime host policy state is invalid'
+    )
 
 
 def validate_credentialed_builtin_base(
@@ -70,9 +91,9 @@ def validate_credentialed_builtin_base(
     base: str,
     auth_config: object,
     host_policy: object,
-) -> None:
+) -> CompiledBuiltinHostPolicy | None:
     if not auth_config_injects_credentials(auth_config):
-        return
+        return None
     try:
         parsed = urllib.parse.urlsplit(base)
     except ValueError as e:
@@ -95,6 +116,9 @@ def validate_credentialed_builtin_base(
         parsed=parsed,
         host_policy=parsed_host_policy,
     )
+    if parsed_host_policy is None:
+        return None
+    return CompiledBuiltinHostPolicy(parsed_host_policy)
 
 
 def validate_credentialed_builtin_request_destination(
@@ -109,10 +133,16 @@ def validate_credentialed_builtin_request_destination(
     if not auth_config_injects_ordinary_upstream_credentials(auth_config):
         return
     try:
-        parsed_host_policy = _parse_host_policy(
-            firewall_name=firewall_name,
-            host_policy=host_policy,
-        )
+        if isinstance(host_policy, CompiledBuiltinHostPolicy):
+            parsed_host_policy = _compiled_host_policy_value(
+                firewall_name=firewall_name,
+                compiled=host_policy,
+            )
+        else:
+            parsed_host_policy = _parse_host_policy(
+                firewall_name=firewall_name,
+                host_policy=host_policy,
+            )
         _validate_builtin_runtime_host_policy(
             firewall_name=firewall_name,
             trusted_host=trusted_host,

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -542,10 +542,19 @@ def _builtin_host_policy_error_for_firewall_allow(
     flow: http.HTTPFlow,
     allow: matching.FirewallAllow,
 ) -> builtin_host_policy.BuiltinRuntimeHostPolicyError | None:
-    if allow.api_entry.get(builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER) is not True:
+    marker_name = builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER
+    if marker_name not in allow.api_entry:
         return None
     if not _firewall_allow_injects_ordinary_upstream_credentials(allow):
         return None
+    runtime_host_policy = allow.api_entry[marker_name]
+    if runtime_host_policy is True:
+        runtime_host_policy = allow.api_entry.get("hostPolicy")
+    elif not isinstance(runtime_host_policy, builtin_host_policy.CompiledBuiltinHostPolicy):
+        return builtin_host_policy.BuiltinRuntimeHostPolicyError(
+            reason="invalid_host_policy",
+            message=(f'builtin firewall "{allow.name}" runtime host policy state is invalid'),
+        )
     trusted_host = flow_metadata.trusted_authority_host(flow.metadata)
     if not trusted_host:
         return builtin_host_policy.BuiltinRuntimeHostPolicyError(
@@ -562,7 +571,7 @@ def _builtin_host_policy_error_for_firewall_allow(
             trusted_host=trusted_host,
             trusted_port=flow.request.port,
             auth_config=allow.api_entry.get("auth"),
-            host_policy=allow.api_entry.get("hostPolicy"),
+            host_policy=runtime_host_policy,
             upstream_endpoint=upstream_endpoint,
         )
     except builtin_host_policy.BuiltinRuntimeHostPolicyError as e:

--- a/crates/runner/mitm-addon/src/registry_firewalls.py
+++ b/crates/runner/mitm-addon/src/registry_firewalls.py
@@ -173,7 +173,7 @@ def _resolve_builtin_firewall_entry(
                 base=raw_base,
                 vars_map=vars_map,
             )
-            builtin_host_policy.validate_credentialed_builtin_base(
+            compiled_host_policy = builtin_host_policy.validate_credentialed_builtin_base(
                 firewall_name=raw_name,
                 base=resolved_base,
                 auth_config=api.get("auth"),
@@ -186,7 +186,9 @@ def _resolve_builtin_firewall_entry(
             raise _resolution_error(e) from e
         api["base"] = resolved_base
         if api.get("hostPolicy") is not None:
-            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] = True
+            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] = (
+                compiled_host_policy if compiled_host_policy is not None else True
+            )
         resolved_bases.append(resolved_base)
 
     return _ResolvedBuiltinFirewallEntry(

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_base_url_vars.py
@@ -270,7 +270,10 @@ class TestRegistryBuiltinBaseUrlVars:
         vm_info, compiled_firewalls, _ = context
         assert compiled_firewalls is not None
         api = vm_info["firewalls"][0]["apis"][0]
-        assert api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] is True
+        assert isinstance(
+            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER],
+            builtin_host_policy.CompiledBuiltinHostPolicy,
+        )
 
     def test_builtin_provider_owned_accepts_idna_dot_equivalent_host(self, tmp_path):
         for index, dot in enumerate(("\u3002", "\uff0e", "\uff61")):

--- a/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
+++ b/crates/runner/mitm-addon/tests/test_registry_builtin_cache.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import builtin_firewall_cache
+import builtin_host_policy
 import matching
 import registry
 import registry_firewalls
@@ -251,7 +252,10 @@ class TestRegistryBuiltinCache:
         assert api["base"] == "https://cache-only.example.com"
         assert api["auth"]["awsSigv4"]["accessKeyId"] == "${{ secrets.AWS_ACCESS_KEY_ID }}"
         assert api["hostPolicy"]["exactHosts"] == ["cache-only.example.com"]
-        assert api["_builtinHostPolicyRuntime"] is True
+        assert isinstance(
+            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER],
+            builtin_host_policy.CompiledBuiltinHostPolicy,
+        )
 
     def test_catalog_api_ids_are_reassigned_per_vm(self, tmp_path, mitm_ctx):
         registry_path = tmp_path / "registry.json"
@@ -857,8 +861,21 @@ class TestRegistryBuiltinCache:
         second_vm_info, second_compiled, _ = second_context
         assert first_compiled is not None
         assert second_compiled is not None
-        assert first_vm_info["firewalls"][0]["apis"][0]["base"] == "https://cache-a.example.com"
-        assert second_vm_info["firewalls"][0]["apis"][0]["base"] == "https://cache-b.example.com"
+        first_api = first_vm_info["firewalls"][0]["apis"][0]
+        second_api = second_vm_info["firewalls"][0]["apis"][0]
+        assert first_api["base"] == "https://cache-a.example.com"
+        assert second_api["base"] == "https://cache-b.example.com"
+        first_runtime_policy = first_api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER]
+        second_runtime_policy = second_api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER]
+        assert isinstance(
+            first_runtime_policy,
+            builtin_host_policy.CompiledBuiltinHostPolicy,
+        )
+        assert isinstance(
+            second_runtime_policy,
+            builtin_host_policy.CompiledBuiltinHostPolicy,
+        )
+        assert first_runtime_policy is not second_runtime_policy
         assert _first_firewall_core(first_compiled) is not _first_firewall_core(second_compiled)
 
     def test_runner_catalog_cache_change_recompiles_core_when_metadata_is_unchanged(

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -35,6 +35,11 @@ class _FailOnIterationList(list[str]):
         raise AssertionError("resolved host policy lists must not be reparsed during requests")
 
 
+class _FailOnIterationDict(dict[str, object]):
+    def __iter__(self) -> Iterator[str]:
+        raise AssertionError("resolved host policy objects must not be reparsed during requests")
+
+
 def _write_test_oauth_registry(tmp_path):
     return _write_registry(
         tmp_path,
@@ -90,7 +95,13 @@ def _write_host_policy_registry(
     )
 
 
-def _write_resolved_host_policy_registry(tmp_path):
+def _write_resolved_host_policy_registry(
+    tmp_path,
+    *,
+    firewall_name: str,
+    base: str,
+    host_policy: dict[str, object],
+):
     registry_path = _write_registry(
         tmp_path,
         client_ip="10.200.0.5",
@@ -100,9 +111,9 @@ def _write_resolved_host_policy_registry(tmp_path):
             "encryptedSecrets": "iv:tag:data",
             "networkLogPath": str(tmp_path / "net.jsonl"),
             "proxyLogPath": str(tmp_path / "proxy.jsonl"),
-            "firewalls": [{"kind": "builtin", "name": "jira"}],
+            "firewalls": [{"kind": "builtin", "name": firewall_name}],
             "networkPolicies": {
-                "jira": {
+                firewall_name: {
                     "allow": ["full-access"],
                     "deny": [],
                     "ask": [],
@@ -122,18 +133,15 @@ def _write_resolved_host_policy_registry(tmp_path):
                 "catalogVersion": "catalog-test",
                 "updatedAt": "2026-07-07T00:00:00.000Z",
                 "firewalls": {
-                    "jira": {
-                        "name": "jira",
+                    firewall_name: {
+                        "name": firewall_name,
                         "apis": [
                             {
-                                "base": "https://acme.atlassian.net",
+                                "base": base,
                                 "auth": {
                                     "headers": {"Authorization": "Bearer ${{ secrets.TEST_TOKEN }}"}
                                 },
-                                "hostPolicy": {
-                                    "kind": "providerOwned",
-                                    "suffixes": ["atlassian.net"],
-                                },
+                                "hostPolicy": host_policy,
                                 "permissions": [
                                     {
                                         "name": "full-access",
@@ -473,7 +481,12 @@ async def test_runtime_host_policy_allows_provider_owned_request_authority(
 async def test_resolved_host_policy_reuses_compiled_policy_across_requests(
     tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
 ):
-    reg_path = _write_resolved_host_policy_registry(tmp_path)
+    reg_path = _write_resolved_host_policy_registry(
+        tmp_path,
+        firewall_name="jira",
+        base="https://acme.atlassian.net",
+        host_policy={"kind": "providerOwned", "suffixes": ["atlassian.net"]},
+    )
     flows = [
         real_flow(
             with_response=False,
@@ -512,6 +525,49 @@ async def test_resolved_host_policy_reuses_compiled_policy_across_requests(
         assert flow.request.headers["Authorization"] == "Bearer x"
         assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     assert auth_fetch.await_count == 2
+
+
+async def test_resolved_public_destination_host_policy_uses_compiled_policy(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_resolved_host_policy_registry(
+        tmp_path,
+        firewall_name="strapi",
+        base="https://strapi.example.com",
+        host_policy={"kind": "publicDestination"},
+    )
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="8.8.8.8",
+        sni="strapi.example.com",
+        path="/api/articles",
+        request_headers=headers(("Host", "strapi.example.com")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        context = registry.get_vm_context("10.200.0.5", str(reg_path))
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        api = vm_info["firewalls"][0]["apis"][0]
+        assert isinstance(
+            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER],
+            builtin_host_policy.CompiledBuiltinHostPolicy,
+        )
+        raw_host_policy = api["hostPolicy"]
+        assert raw_host_policy == {"kind": "publicDestination"}
+        api["hostPolicy"] = _FailOnIterationDict({"kind": "publicDestination"})
+
+        await mitm_addon.request(flow)
+
+    assert flow.response is None
+    assert flow.request.headers["Authorization"] == "Bearer x"
+    assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    auth_fetch.assert_awaited_once()
 
 
 async def test_runtime_host_policy_rejects_invalid_runtime_marker(

--- a/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
+++ b/crates/runner/mitm-addon/tests/test_request_handler_authority_validation.py
@@ -2,6 +2,7 @@
 
 import ipaddress
 import json
+from collections.abc import Iterator
 from typing import cast
 from unittest.mock import patch
 
@@ -11,9 +12,11 @@ from mitmproxy import connection
 import builtin_host_policy
 import flow_metadata_keys as metadata_keys
 import mitm_addon
+import registry
 import upstream_admission
 import upstream_destination_binding
 from tests.jsonl_log_helpers import read_jsonl_entries_after_flush
+from tests.registry_helpers import write_trusted_catalog_cache_text
 from tests.request_handler_helpers import (
     _single_firewall_vm,
     _write_github_firewall_registry,
@@ -25,6 +28,11 @@ _BROWSER_USER_AGENT = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) HeadlessChrome/126.0.0.0 Safari/537.36"
 )
+
+
+class _FailOnIterationList(list[str]):
+    def __iter__(self) -> Iterator[str]:
+        raise AssertionError("resolved host policy lists must not be reparsed during requests")
 
 
 def _write_test_oauth_registry(tmp_path):
@@ -80,6 +88,67 @@ def _write_host_policy_registry(
             },
         ),
     )
+
+
+def _write_resolved_host_policy_registry(tmp_path):
+    registry_path = _write_registry(
+        tmp_path,
+        client_ip="10.200.0.5",
+        vm_info={
+            "runId": "run-resolved-host-policy",
+            "sandboxToken": "tok-resolved-host-policy",
+            "encryptedSecrets": "iv:tag:data",
+            "networkLogPath": str(tmp_path / "net.jsonl"),
+            "proxyLogPath": str(tmp_path / "proxy.jsonl"),
+            "firewalls": [{"kind": "builtin", "name": "jira"}],
+            "networkPolicies": {
+                "jira": {
+                    "allow": ["full-access"],
+                    "deny": [],
+                    "ask": [],
+                    "unknownPolicy": "deny",
+                }
+            },
+        },
+    )
+    write_trusted_catalog_cache_text(
+        tmp_path / "builtin-firewall-catalog-cache.json",
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "catalogDigest": (
+                    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                "catalogVersion": "catalog-test",
+                "updatedAt": "2026-07-07T00:00:00.000Z",
+                "firewalls": {
+                    "jira": {
+                        "name": "jira",
+                        "apis": [
+                            {
+                                "base": "https://acme.atlassian.net",
+                                "auth": {
+                                    "headers": {"Authorization": "Bearer ${{ secrets.TEST_TOKEN }}"}
+                                },
+                                "hostPolicy": {
+                                    "kind": "providerOwned",
+                                    "suffixes": ["atlassian.net"],
+                                },
+                                "permissions": [
+                                    {
+                                        "name": "full-access",
+                                        "rules": ["ANY /{path+}"],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+            },
+            sort_keys=True,
+        ),
+    )
+    return registry_path
 
 
 def _bind_flow_upstream(
@@ -399,6 +468,87 @@ async def test_runtime_host_policy_allows_provider_owned_request_authority(
     assert flow.request.headers["Authorization"] == "Bearer x"
     assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
     auth_fetch.assert_awaited_once()
+
+
+async def test_resolved_host_policy_reuses_compiled_policy_across_requests(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_resolved_host_policy_registry(tmp_path)
+    flows = [
+        real_flow(
+            with_response=False,
+            client_ip="10.200.0.5",
+            host="203.0.113.10",
+            sni="acme.atlassian.net",
+            path=f"/rest/api/3/items/{index}",
+            request_headers=headers(("Host", "acme.atlassian.net")),
+        )
+        for index in range(2)
+    ]
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        context = registry.get_vm_context("10.200.0.5", str(reg_path))
+        assert context is not None
+        vm_info, compiled_firewalls, _ = context
+        assert compiled_firewalls is not None
+        api = vm_info["firewalls"][0]["apis"][0]
+        assert isinstance(
+            api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER],
+            builtin_host_policy.CompiledBuiltinHostPolicy,
+        )
+        raw_host_policy = api["hostPolicy"]
+        assert isinstance(raw_host_policy, dict)
+        assert raw_host_policy["suffixes"] == ["atlassian.net"]
+        raw_host_policy["suffixes"] = _FailOnIterationList(["atlassian.net"])
+
+        for flow in flows:
+            await mitm_addon.request(flow)
+
+    for flow in flows:
+        assert flow.response is None
+        assert flow.request.headers["Authorization"] == "Bearer x"
+        assert flow.metadata[metadata_keys.FIREWALL_ACTION] == "ALLOW"
+    assert auth_fetch.await_count == 2
+
+
+async def test_runtime_host_policy_rejects_invalid_runtime_marker(
+    tmp_path, real_flow, mitm_ctx, fake_firewall_headers, headers
+):
+    reg_path = _write_host_policy_registry(
+        tmp_path,
+        firewall_name="jira",
+        base="https://acme.atlassian.net",
+        host_policy={"kind": "providerOwned", "suffixes": ["atlassian.net"]},
+    )
+    registry_data = json.loads(reg_path.read_text())
+    api = registry_data["vms"]["10.200.0.5"]["firewalls"][0]["firewall"]["apis"][0]
+    api[builtin_host_policy.BUILTIN_HOST_POLICY_RUNTIME_MARKER] = "invalid"
+    reg_path.write_text(json.dumps(registry_data))
+    flow = real_flow(
+        with_response=False,
+        client_ip="10.200.0.5",
+        host="203.0.113.10",
+        sni="acme.atlassian.net",
+        path="/rest/api/3/myself",
+        request_headers=headers(("Host", "acme.atlassian.net")),
+    )
+
+    with (
+        mitm_ctx(registry_path=str(reg_path), api_url="https://api.vm0.ai"),
+        fake_firewall_headers() as auth_fetch,
+    ):
+        await mitm_addon.request(flow)
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    body = json.loads(flow.response.content)
+    assert body["error"] == "builtin_host_policy_denied"
+    assert body["reason"] == "invalid_host_policy"
+    auth_fetch.assert_not_called()
+    assert "Authorization" not in flow.request.headers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- retain the immutable parsed built-in host policy produced during resolved-base validation and publish it with the resolved registry snapshot
- reuse that policy during ordinary credentialed requests while preserving the existing raw-policy compatibility path
- fail closed when an ordinary-credential entry contains a present but unsupported runtime-policy marker
- cover both resolved policy variants across real request hooks and token replacement after catalog refresh

## Compatibility

- raw `hostPolicy` JSON remains unchanged for routing identity and request classification
- registry/catalog refresh creates a new policy token with the new snapshot
- no API, schema, persisted JSON, TypeScript, Rust, matcher, queue, or deployment-protocol changes

## Validation

- `.venv/bin/ruff format --check .`
- `.venv/bin/ruff check .`
- `.venv/bin/basedpyright`
- `.venv/bin/python -m pytest tests/test_builtin_host_policy_contract.py tests/test_registry_builtin_base_url_vars.py tests/test_registry_builtin_cache.py tests/test_request_handler_authority_validation.py tests/test_request_headers_handler.py` (217 passed)
- `.venv/bin/python -m pytest tests/` (3863 passed)
- local non-gating validator benchmark: 15.05 µs/request with raw parsing versus 0.81 µs/request with the retained policy (18.6x for this isolated validation step, not end-to-end request performance)

Closes #21259
