### PR TITLE
fix(platform): correct artifact card proportions

### DIFF
--- a/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import {
   artifactsContract,
   type ArtifactItem,
@@ -573,12 +573,12 @@ describe("artifacts page", () => {
     expect(screen.getByText("hosted site")).toBeInTheDocument();
     expect(screen.queryByText(/Jan 15/u)).not.toBeInTheDocument();
     expect(screen.getByTitle("launch-plan.html preview")).toHaveStyle({
-      height: "1280px",
+      height: "800px",
       width: "1280px",
     });
   });
 
-  it("renders preview images without cropping while preserving the HTML iframe fallback", async () => {
+  it("renders unified 16:10 previews above card metadata while preserving the HTML fallback", async () => {
     setupTeam();
     const scope = testAuthScope("preview-image");
     const previewImageUrl =
@@ -613,23 +613,89 @@ describe("artifacts page", () => {
     await screen.findByText("static-preview.html");
     await screen.findByText("full-image.png");
     await screen.findByText("fallback-preview.html");
-    for (const src of [previewImageUrl, imageUrl]) {
-      const previewImages = Array.from(
-        document.querySelectorAll<HTMLImageElement>(`img[src="${src}"]`),
-      );
-      expect(previewImages).toHaveLength(1);
-      expect(previewImages[0]).toHaveClass(
-        "h-full",
-        "w-full",
-        "object-contain",
-      );
-      expect(previewImages[0]).not.toHaveClass("object-cover");
-    }
+    const staticCard = buttonByLabel("Preview static-preview.html");
+    const staticPreview = within(staticCard).getByTestId(
+      "artifact-card-preview",
+    );
+    const staticDetails = within(staticCard).getByTestId(
+      "artifact-card-details",
+    );
+    expect(staticCard).toHaveClass("flex", "flex-col");
+    expect(staticCard).not.toHaveClass("aspect-square");
+    expect(staticPreview).toHaveClass(
+      "aspect-[16/10]",
+      "w-full",
+      "shrink-0",
+      "overflow-hidden",
+    );
+    expect(staticPreview.nextElementSibling).toBe(staticDetails);
+    expect(staticDetails).not.toHaveClass("absolute");
+    expect(staticDetails).toHaveClass("h-16", "shrink-0");
+    expect(
+      within(staticDetails).getByRole("heading", {
+        name: "static-preview.html",
+      }),
+    ).toBeInTheDocument();
+    const htmlPreviewImages = Array.from(
+      document.querySelectorAll<HTMLImageElement>(
+        `img[src="${previewImageUrl}"]`,
+      ),
+    );
+    expect(htmlPreviewImages).toHaveLength(1);
+    expect(htmlPreviewImages[0]).toHaveClass(
+      "h-full",
+      "w-full",
+      "object-cover",
+    );
+    const artifactImages = Array.from(
+      document.querySelectorAll<HTMLImageElement>(`img[src="${imageUrl}"]`),
+    );
+    expect(artifactImages).toHaveLength(1);
+    expect(artifactImages[0]).toHaveClass("h-full", "w-full", "object-cover");
     expect(screen.queryByTitle("static-preview.html preview")).toBeNull();
     expect(screen.getByTitle("fallback-preview.html preview")).toHaveAttribute(
       "src",
       "https://artifacts.example.com/fallback-preview.html",
     );
+  });
+
+  it("keeps card widths fluid without squeezing in a third column", async () => {
+    setupTeam();
+    const scope = testAuthScope("fluid-grid-width");
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(
+      function (this: HTMLElement) {
+        return this.dataset.testid === "artifacts-virtual-grid" ? 700 : 0;
+      },
+    );
+    mockArtifacts([
+      createArtifact({
+        artifactItemId: "fluid-grid-1:file-1",
+        runId: "fluid-grid-1",
+        filename: "fluid-grid-1.html",
+      }),
+      createArtifact({
+        artifactItemId: "fluid-grid-2:file-1",
+        runId: "fluid-grid-2",
+        filename: "fluid-grid-2.html",
+      }),
+      createArtifact({
+        artifactItemId: "fluid-grid-3:file-1",
+        runId: "fluid-grid-3",
+        filename: "fluid-grid-3.html",
+      }),
+    ]);
+
+    setupArtifactsPage({ scope });
+
+    await screen.findByText("fluid-grid-1.html");
+    await waitFor(() => {
+      expect(screen.getByTestId("artifacts-virtual-grid-items")).toHaveStyle({
+        gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+      });
+      expect(screen.getByTestId("artifacts-virtual-grid")).toHaveStyle({
+        height: "571.5px",
+      });
+    });
   });
 
   it("loads CDN image cards as thumbnails while preserving original previews", async () => {
@@ -638,7 +704,7 @@ describe("artifacts page", () => {
     const cdnImageUrl =
       "https://cdn.vm7.io/artifacts/user/image-run/generated.png";
     const thumbnailUrl =
-      "https://cdn.vm7.io/cdn-cgi/image/width=640,height=640,fit=cover,format=auto,quality=85,metadata=none/artifacts/user/image-run/generated.png";
+      "https://cdn.vm7.io/cdn-cgi/image/width=640,height=400,fit=scale-down,format=auto,quality=85,metadata=none/artifacts/user/image-run/generated.png";
     const externalImageUrl =
       "https://images.example.com/artifacts/external-image.png";
     const unsupportedCdnImageUrl =
@@ -914,6 +980,10 @@ describe("artifacts page", () => {
       },
     );
     expect(posterImages).toHaveLength(1);
+    expect(posterImages[0]).toHaveClass("object-cover");
+    expect(
+      posterImages[0]?.closest('[data-testid="artifact-card-preview"]'),
+    ).toHaveClass("aspect-[16/10]");
     expect(
       document.querySelector(".tabler-icon-player-play-filled"),
     ).not.toBeInTheDocument();
@@ -1090,7 +1160,11 @@ describe("artifacts page", () => {
     await screen.findByText("favorite-brief.html");
     await screen.findByText("archive.html");
 
-    click(buttonByLabel("Add launch-plan.html to favorites"));
+    const favoriteButton = buttonByLabel("Add launch-plan.html to favorites");
+    expect(
+      favoriteButton.closest('[data-testid="artifact-card-details"]'),
+    ).not.toBeNull();
+    click(favoriteButton);
     await waitFor(() => {
       expect(favoriteBody).toStrictEqual({ artifactUrl: launch.url });
       expect(
@@ -1422,33 +1496,33 @@ describe("artifacts page", () => {
 
     await screen.findByText("windowed-000.html");
     expect(screen.queryByText("Load more")).not.toBeInTheDocument();
-    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(24);
 
     const scrollViewport = screen.getByRole("main");
     const setScrollMetrics = mockScrollViewport(scrollViewport, {
       clientHeight: 800,
-      scrollHeight: 6068,
-      scrollTop: 5300,
+      scrollHeight: 5173,
+      scrollTop: 4373,
     });
     fireEvent.scroll(scrollViewport);
 
     await screen.findByText("windowed-064.html");
     expect(screen.queryByText("windowed-000.html")).not.toBeInTheDocument();
-    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(24);
 
-    setScrollMetrics({ scrollHeight: 12_148, scrollTop: 11_400 });
+    setScrollMetrics({ scrollHeight: 10_358, scrollTop: 9558 });
     fireEvent.scroll(scrollViewport);
 
     await screen.findByText("windowed-119.html");
     expect(screen.queryByText("windowed-064.html")).not.toBeInTheDocument();
-    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(24);
 
-    setScrollMetrics({ scrollHeight: 18_228, scrollTop: 17_400 });
+    setScrollMetrics({ scrollHeight: 15_543, scrollTop: 14_743 });
     fireEvent.scroll(scrollViewport);
 
     await screen.findByText("windowed-179.html");
     expect(screen.queryByText("windowed-119.html")).not.toBeInTheDocument();
-    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(21);
+    expect(document.querySelectorAll("article").length).toBeLessThanOrEqual(24);
   });
 
   it("continues keyboard navigation through virtualized artifacts", async () => {
@@ -1478,9 +1552,9 @@ describe("artifacts page", () => {
     fireEvent.focus(buttonByText("Continue browsing artifacts"));
 
     await waitFor(() => {
-      expect(focusedArtifactIndex()).toBe("15");
+      expect(focusedArtifactIndex()).toBe("18");
     });
-    await screen.findByText("keyboard-windowed-015.html");
+    await screen.findByText("keyboard-windowed-018.html");
 
     setScrollMetrics({ scrollHeight: 20_000, scrollTop: 4560 });
     fireEvent.scroll(scrollViewport);

--- a/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
+++ b/turbo/apps/platform/src/views/artifacts-page/artifacts-page.tsx
@@ -101,14 +101,19 @@ import { publicAttachmentUrl } from "../zero-page/zero-attachment-url.ts";
 type ArtifactPreviewKind = "image" | "html" | "pdf" | "video" | "file";
 type ArtifactTypeIconKind = "presentation" | "html" | "image" | "video";
 
-const DESKTOP_ARTIFACT_PREVIEW_SIZE = 1280;
+const DESKTOP_ARTIFACT_PREVIEW_WIDTH = 1280;
+const DESKTOP_ARTIFACT_PREVIEW_HEIGHT = 800;
 const ARTIFACT_AUTO_LOAD_THRESHOLD_PX = 800;
 const ARTIFACT_GRID_GAP_PX = 12;
-const ARTIFACT_GRID_MIN_CARD_WIDTH_PX = 220;
+const ARTIFACT_GRID_MIN_CARD_WIDTH_PX = 292;
 const ARTIFACT_GRID_OVERSCAN_ROWS = 2;
 const ARTIFACT_GRID_FALLBACK_WIDTH_PX = 900;
 const ARTIFACT_GRID_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
-const ARTIFACT_CARD_IMAGE_SIZE = 640;
+const ARTIFACT_CARD_IMAGE_WIDTH = 640;
+const ARTIFACT_CARD_IMAGE_HEIGHT = 400;
+const ARTIFACT_CARD_PREVIEW_ASPECT_RATIO = 16 / 10;
+const ARTIFACT_CARD_DETAILS_HEIGHT_PX = 64;
+const ARTIFACT_CARD_BORDER_WIDTH_PX = 1;
 const ARTIFACT_CATEGORY_OPTIONS: readonly {
   readonly ariaLabel: string;
   readonly label: string;
@@ -414,9 +419,9 @@ function DesktopArtifactPreviewFrame({
         sandbox="allow-same-origin allow-scripts"
         tabIndex={-1}
         style={{
-          height: `${DESKTOP_ARTIFACT_PREVIEW_SIZE}px`,
-          scale: `calc(100cqw / ${DESKTOP_ARTIFACT_PREVIEW_SIZE}px)`,
-          width: `${DESKTOP_ARTIFACT_PREVIEW_SIZE}px`,
+          height: `${DESKTOP_ARTIFACT_PREVIEW_HEIGHT}px`,
+          scale: `calc(100cqw / ${DESKTOP_ARTIFACT_PREVIEW_WIDTH}px)`,
+          width: `${DESKTOP_ARTIFACT_PREVIEW_WIDTH}px`,
         }}
         className="pointer-events-none absolute left-0 top-0 block origin-top-left scale-[0.22] border-0 bg-background"
       />
@@ -480,7 +485,7 @@ function ArtifactPreview({ item }: { readonly item: ArtifactItem }) {
           src={item.previewImageUrl}
           alt=""
           loading="lazy"
-          className="h-full w-full object-contain"
+          className="h-full w-full object-cover"
         />
       </ArtifactPreviewSurface>
     );
@@ -489,9 +494,9 @@ function ArtifactPreview({ item }: { readonly item: ArtifactItem }) {
   if (previewKind === "image") {
     const thumbnailUrl = artifactCardImageSupportsTransform(item)
       ? r2ImageTransformUrl(previewUrl, {
-          width: ARTIFACT_CARD_IMAGE_SIZE,
-          height: ARTIFACT_CARD_IMAGE_SIZE,
-          fit: "cover",
+          width: ARTIFACT_CARD_IMAGE_WIDTH,
+          height: ARTIFACT_CARD_IMAGE_HEIGHT,
+          fit: "scale-down",
         })
       : previewUrl;
     return (
@@ -500,7 +505,7 @@ function ArtifactPreview({ item }: { readonly item: ArtifactItem }) {
           src={thumbnailUrl}
           alt=""
           loading="lazy"
-          className="h-full w-full object-contain"
+          className="h-full w-full object-cover"
         />
       </ArtifactPreviewSurface>
     );
@@ -730,32 +735,38 @@ function ArtifactCard({
           : undefined
       }
       className={cn(
-        "group relative aspect-square overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-colors hover:border-foreground/20",
+        "group flex flex-col overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-colors hover:border-foreground/20",
         previewable &&
           "cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       )}
     >
-      <ArtifactPreview item={item} />
-      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-background via-background/95 to-transparent p-3 pt-14">
-        <div className="flex min-w-0 items-end gap-2">
-          <div className="min-w-0 flex-1">
-            <h2 className="truncate text-sm font-semibold text-foreground">
-              {item.filename}
-            </h2>
-            <p className="mt-1 truncate text-[11px] text-muted-foreground/80">
-              {contextLabel}
-            </p>
-          </div>
-          <ArtifactCardActions
-            favorited={favorited}
-            item={item}
-            previewUrl={previewUrl}
-            showFavoriteAction={showFavoriteAction}
-            onOpenChat={onOpenChat}
-            onStartChat={onStartChat}
-            onToggleFavorite={onToggleFavorite}
-          />
+      <div
+        data-testid="artifact-card-preview"
+        className="relative aspect-[16/10] w-full shrink-0 overflow-hidden bg-background"
+      >
+        <ArtifactPreview item={item} />
+      </div>
+      <div
+        data-testid="artifact-card-details"
+        className="flex h-16 min-w-0 shrink-0 items-center gap-2 border-t border-border p-3"
+      >
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold text-foreground">
+            {item.filename}
+          </h2>
+          <p className="mt-1 truncate text-[11px] text-muted-foreground/80">
+            {contextLabel}
+          </p>
         </div>
+        <ArtifactCardActions
+          favorited={favorited}
+          item={item}
+          previewUrl={previewUrl}
+          showFavoriteAction={showFavoriteAction}
+          onOpenChat={onOpenChat}
+          onStartChat={onStartChat}
+          onToggleFavorite={onToggleFavorite}
+        />
       </div>
     </article>
   );
@@ -764,23 +775,23 @@ function ArtifactCard({
 function ArtifactsLoadingState() {
   return (
     <div
-      className="grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-3"
+      className="grid gap-3"
       aria-label="Loading artifacts"
+      style={{
+        gridTemplateColumns: `repeat(auto-fit, minmax(min(100%, ${String(ARTIFACT_GRID_MIN_CARD_WIDTH_PX)}px), 1fr))`,
+      }}
     >
       {Array.from({ length: 8 }, (_, index) => {
         return (
           <div
             key={index}
-            className="aspect-square overflow-hidden rounded-lg border border-border bg-card"
+            className="flex flex-col overflow-hidden rounded-lg border border-border bg-card"
           >
-            <div className="h-full bg-muted/30">
-              <div className="flex h-full flex-col justify-end p-3">
-                <div className="h-4 w-3/4 rounded bg-background/70" />
-                <div className="mt-2 h-3 w-1/2 rounded bg-background/60" />
-                <div className="mt-3 flex gap-1.5">
-                  <div className="h-5 w-16 rounded border border-border/40 bg-background/60" />
-                  <div className="h-5 w-20 rounded border border-border/40 bg-background/60" />
-                </div>
+            <div className="aspect-[16/10] w-full shrink-0 bg-muted/30" />
+            <div className="flex h-16 shrink-0 items-center p-3">
+              <div className="w-full">
+                <div className="h-4 w-3/4 rounded bg-muted/60" />
+                <div className="mt-2 h-3 w-1/2 rounded bg-muted/40" />
               </div>
             </div>
           </div>
@@ -825,11 +836,19 @@ function getArtifactGridDimensions(containerWidth: number) {
         (ARTIFACT_GRID_MIN_CARD_WIDTH_PX + ARTIFACT_GRID_GAP_PX),
     ),
   );
-  const cardSize =
+  const cardWidth =
     (containerWidth - ARTIFACT_GRID_GAP_PX * (columnCount - 1)) / columnCount;
+  const cardContentWidth = Math.max(
+    0,
+    cardWidth - ARTIFACT_CARD_BORDER_WIDTH_PX * 2,
+  );
+  const cardHeight =
+    cardContentWidth / ARTIFACT_CARD_PREVIEW_ASPECT_RATIO +
+    ARTIFACT_CARD_DETAILS_HEIGHT_PX +
+    ARTIFACT_CARD_BORDER_WIDTH_PX * 2;
   return {
     columnCount,
-    rowHeight: cardSize + ARTIFACT_GRID_GAP_PX,
+    rowHeight: cardHeight + ARTIFACT_GRID_GAP_PX,
   };
 }
 


### PR DESCRIPTION
## Summary
- render artifact previews at a consistent 16:10 ratio with fixed-height metadata below
- use cover rendering for image, HTML screenshot, and video poster previews
- keep card widths fluid while preventing the grid from squeezing in undersized columns
- synchronize virtual row measurements with the real preview and details geometry
- preserve favorite and overflow actions in the card details area

## Tests
- pnpm -F @vm0/app exec vitest run src/views/artifacts-page/__tests__/artifacts-page.test.tsx --silent=passed-only (20 passed)
- pnpm -F @vm0/app lint
- pnpm -F @vm0/app check-types
- pnpm knip --workspace @vm0/app
- pnpm exec prettier --write apps/platform/src/views/artifacts-page/artifacts-page.tsx apps/platform/src/views/artifacts-page/__tests__/artifacts-page.test.tsx

## Local test note
The full app run completed 993 of 996 tests successfully. Three failures were isolated to the unchanged zero-page chat composer test file; the artifacts page has no dependency path to that test, and the failing asynchronous assertion varied across reruns. CI remains the source of truth for the complete suite.