### PR TITLE
feat(workflows): enable webhook trigger creation globally

### DIFF
--- a/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
+++ b/turbo/apps/api/src/signals/routes/__tests__/zero-workflow-triggers.test.ts
@@ -761,7 +761,10 @@ describe("zero workflow triggers", () => {
   });
 
   it("rejects webhook event triggers when webhook trigger creation is disabled", async () => {
-    const { workflowId } = await setupFixture();
+    const { fixture, workflowId } = await setupFixture();
+    await updateFeatureSwitchesForUser(context, fixture, {
+      [FeatureSwitchKey.WorkflowWebhookTriggers]: false,
+    });
     const rejected = await accept(
       triggersClient().create({
         headers: authHeaders(),

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -55,11 +55,6 @@ describe("isFeatureEnabled", () => {
       }),
     ).toBe(true);
     expect(
-      isFeatureEnabled(FeatureSwitchKey.WorkflowWebhookTriggers, {
-        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
-      }),
-    ).toBe(true);
-    expect(
       isFeatureEnabled(FeatureSwitchKey.ApiKeys, {
         orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
       }),
@@ -69,11 +64,6 @@ describe("isFeatureEnabled", () => {
   it("should return false when orgId does not match enabledOrgIdHashes", () => {
     expect(
       isFeatureEnabled(FeatureSwitchKey.Lab, {
-        orgId: "org_nonexistent",
-      }),
-    ).toBe(false);
-    expect(
-      isFeatureEnabled(FeatureSwitchKey.WorkflowWebhookTriggers, {
         orgId: "org_nonexistent",
       }),
     ).toBe(false);
@@ -164,9 +154,8 @@ describe("getAllFeatureStates", () => {
       otherOrgStates[FeatureSwitchKey.NintendoSwitchParentalControlsConnector],
     ).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.Lab]).toBe(false);
-    expect(otherOrgStates[FeatureSwitchKey.WorkflowWebhookTriggers]).toBe(
-      false,
-    );
+    // WorkflowWebhookTriggers is globally enabled, so it is on for every org
+    expect(otherOrgStates[FeatureSwitchKey.WorkflowWebhookTriggers]).toBe(true);
     expect(otherOrgStates[FeatureSwitchKey.ApiKeys]).toBe(false);
     expect(otherOrgStates[FeatureSwitchKey.CodexFrameworkForMinimax]).toBe(
       false,

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -262,8 +262,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description:
       "Enable creation of inbound webhook workflow triggers. Existing webhook triggers remain visible and dispatch under the workflow automation gate.",
-    enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+    enabled: true,
   },
   [FeatureSwitchKey.NotionWorkflowTriggers]: {
     maintainer: "lancy@vm0.ai",


### PR DESCRIPTION
## What

Flips the `workflowWebhookTriggers` feature switch from **staff-org-only** (`enabled: false` + `enabledOrgIdHashes: STAFF_ORG_ID_HASHES`) to **globally enabled** (`enabled: true`).

## Why

We want to open inbound webhook workflow triggers to all customers on paid plans (a Team-plan trial team needs it now). Until now the switch defaulted off and was only on for the staff org, so external orgs couldn't create webhook triggers even on a Team plan. There is no org-scoped self-serve toggle for this switch, so a global default flip is the correct rollout mechanism.

## User-visible impact

- Any workspace can now **create** inbound webhook workflow triggers, subject to the two independent gates that remain unchanged:
  - **Plan gate**: creation still requires a **Team or Custom** workspace (Free/Pro get `TEAM_REQUIRED` / `paid_plan_required`).
  - **Dispatch gate**: whether existing webhook triggers actually fire is still governed separately by the workflow automation entitlement.
- Downgrading below Team still disables existing webhook triggers as before.

## Implementation

- `packages/core/src/feature-switch.ts`: set `WorkflowWebhookTriggers.enabled = true` and drop the now-redundant `enabledOrgIdHashes` allow-list.
- Updated `packages/core` feature-switch tests: `WorkflowWebhookTriggers` is no longer an org-hash-gated example; the rollout matrix now expects it on for every org.
- Updated `apps/api` `zero-workflow-triggers` test "rejects webhook event triggers when webhook trigger creation is disabled" to explicitly set the per-user override to `false`, since it previously relied on the default-off state.

## Verification

Reasoned through all test files referencing `WorkflowWebhookTriggers`; the rest set the switch explicitly and are unaffected. Local dependencies weren't installed in this environment, so relying on the PR pipeline (lint + type-check + tests) for full verification.